### PR TITLE
upgrade grafana agent

### DIFF
--- a/charts/k8s-monitoring/Chart.yaml
+++ b/charts/k8s-monitoring/Chart.yaml
@@ -13,7 +13,7 @@ maintainers:
     name: skl
 dependencies:
 - name: grafana-agent
-  version: 0.18.0
+  version: 0.19.0
   repository: https://grafana.github.io/helm-charts
 - name: kube-state-metrics
   version: 5.10.1

--- a/charts/k8s-monitoring/README.md
+++ b/charts/k8s-monitoring/README.md
@@ -55,7 +55,7 @@ The Prometheus and Loki services may be hosted on the same cluster, or remotely 
 
 | Repository | Name | Version |
 |------------|------|---------|
-| https://grafana.github.io/helm-charts | grafana-agent | 0.18.0 |
+| https://grafana.github.io/helm-charts | grafana-agent | 0.19.0 |
 | https://opencost.github.io/opencost-helm-chart | opencost | 1.18.0 |
 | https://prometheus-community.github.io/helm-charts | kube-state-metrics | 5.10.1 |
 | https://prometheus-community.github.io/helm-charts | prometheus-node-exporter | 4.21.0 |


### PR DESCRIPTION
grafana-agent 0.19 added support for nodeSelector on the controller, letting it run on clusters with windows