### PR TITLE
feat: include 'tenantId' field in values for on-prem mimir & loki auth

### DIFF
--- a/charts/k8s-monitoring/Chart.yaml
+++ b/charts/k8s-monitoring/Chart.yaml
@@ -3,7 +3,7 @@ name: k8s-monitoring
 description: A Helm chart for gathering, scraping, and forwarding Kubernetes infrastructure metrics and logs to a Grafana Stack.
 type: application
 
-version: 0.1.7
+version: 0.1.8
 appVersion: 1.2.0
 icon: https://raw.githubusercontent.com/grafana/grafana/main/public/img/grafana_icon.svg
 maintainers:

--- a/charts/k8s-monitoring/README.md
+++ b/charts/k8s-monitoring/README.md
@@ -1,6 +1,6 @@
 # k8s-monitoring
 
-![Version: 0.1.7](https://img.shields.io/badge/Version-0.1.7-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.2.0](https://img.shields.io/badge/AppVersion-1.2.0-informational?style=flat-square)
+![Version: 0.1.8](https://img.shields.io/badge/Version-0.1.8-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.2.0](https://img.shields.io/badge/AppVersion-1.2.0-informational?style=flat-square)
 
 A Helm chart for gathering, scraping, and forwarding Kubernetes infrastructure metrics and logs to a Grafana Stack.
 
@@ -73,11 +73,13 @@ The Prometheus and Loki services may be hosted on the same cluster, or remotely 
 | externalServices.loki.basicAuth.username | string | `""` | Loki basic auth username |
 | externalServices.loki.externalLabels | object | `{}` | Custom labels to be added to all logs and events |
 | externalServices.loki.host | string | `""` | (required) Loki host where logs and events will be sent |
+| externalServices.loki.tenantId | string | `""` | (optional) Loki tenant ID |
 | externalServices.loki.writeEndpoint | string | `"/loki/api/v1/push"` | Loki logs write endpoint |
 | externalServices.prometheus.basicAuth.password | string | `""` | Prometheus basic auth password |
 | externalServices.prometheus.basicAuth.username | string | `""` | Prometheus basic auth username |
 | externalServices.prometheus.externalLabels | object | `{}` | Custom labels to be added to all time series |
 | externalServices.prometheus.host | string | `""` | (required) Prometheus host where metrics will be sent |
+| externalServices.prometheus.tenantId | string | `""` | (optional) Sets the X-Scope-OrgID header when sending metrics |
 | externalServices.prometheus.writeEndpoint | string | `"/api/prom/push"` | Prometheus metrics write endpoint |
 | extraConfig | string | `nil` | Extra configuration that will be added to the Grafana Agent configuration file. See [Adding custom Flow configuration](#adding-custom-flow-configuration) for an example. |
 | kube-state-metrics.enabled | bool | `true` | Should this helm chart deploy Kube State Metrics to the cluster. Set this to false if your cluster already has Kube State Metrics, or if you do not want to scrape metrics from Kube State Metrics. |

--- a/charts/k8s-monitoring/templates/agent_config/_loki.river.txt
+++ b/charts/k8s-monitoring/templates/agent_config/_loki.river.txt
@@ -21,11 +21,10 @@ local.file "loki_tenantid" {
   is_secret = true
 }
 {{- end }}
-
 loki.write "grafana_cloud_loki" {
   endpoint {
     url = nonsensitive(local.file.loki_host.content) + "{{ .writeEndpoint }}"
-{{ if .tenantId }}
+{{- if .tenantId }}
     tenant_id = local.file.loki_tenantid.content
 {{- end }}
 {{ if .basicAuth }}
@@ -34,6 +33,7 @@ loki.write "grafana_cloud_loki" {
       {{ if .basicAuth.password }}password = local.file.loki_password.content{{ end }}
     }
 {{- end }}
+  }
 {{- end }}
   external_labels = {
     cluster = {{ required ".Values.cluster.name is a required value. Please set it and try again." .Values.cluster.name | quote }},

--- a/charts/k8s-monitoring/templates/agent_config/_loki.river.txt
+++ b/charts/k8s-monitoring/templates/agent_config/_loki.river.txt
@@ -15,17 +15,26 @@ local.file "loki_password" {
   is_secret = true
 }
 {{- end }}
+{{ if .tenantId }}
+local.file "loki_tenantid" {
+  filename  = "/etc/grafana-agent-credentials/loki_tenantId"
+  is_secret = true
+}
+{{- end }}
 
 loki.write "grafana_cloud_loki" {
   endpoint {
     url = nonsensitive(local.file.loki_host.content) + "{{ .writeEndpoint }}"
+{{ if .tenantId }}
+    tenant_id = local.file.loki_tenantid.content
+{{- end }}
 {{ if .basicAuth }}
     basic_auth {
       {{ if .basicAuth.username }}username = local.file.loki_username.content{{ end }}
       {{ if .basicAuth.password }}password = local.file.loki_password.content{{ end }}
     }
-  }
 {{- end }}
+  }
 }
 {{- end }}
 {{ end }}

--- a/charts/k8s-monitoring/templates/agent_config/_prometheus.river.txt
+++ b/charts/k8s-monitoring/templates/agent_config/_prometheus.river.txt
@@ -15,7 +15,7 @@ local.file "prometheus_password" {
   is_secret = true
 }
 {{- end }}
-{{ if .basicAuth.password }}
+{{ if .tenantId }}
 local.file "prometheus_tenantid" {
   filename  = "/etc/grafana-agent-credentials/prometheus_tenantId"
   is_secret = true

--- a/charts/k8s-monitoring/templates/agent_config/_prometheus.river.txt
+++ b/charts/k8s-monitoring/templates/agent_config/_prometheus.river.txt
@@ -15,17 +15,26 @@ local.file "prometheus_password" {
   is_secret = true
 }
 {{- end }}
+{{ if .basicAuth.password }}
+local.file "prometheus_tenantid" {
+  filename  = "/etc/grafana-agent-credentials/prometheus_tenantId"
+  is_secret = true
+}
+{{- end }}
 
 prometheus.remote_write "grafana_cloud_prometheus" {
   endpoint {
     url = nonsensitive(local.file.prometheus_host.content) + "{{ .writeEndpoint }}"
+{{ if .tenantId }}
+    headers = { "X-Scope-OrgID" = local.file.prometheus_tenantid.content }
+{{- end }}
 {{ if .basicAuth }}
     basic_auth {
       {{ if .basicAuth.username }}username = local.file.prometheus_username.content{{ end }}
       {{ if .basicAuth.password }}password = local.file.prometheus_password.content{{ end }}
     }
-  }
 {{- end }}
+  }
 }
 {{- end }}
 {{ end }}

--- a/charts/k8s-monitoring/templates/agent_config/_prometheus.river.txt
+++ b/charts/k8s-monitoring/templates/agent_config/_prometheus.river.txt
@@ -21,11 +21,10 @@ local.file "prometheus_tenantid" {
   is_secret = true
 }
 {{- end }}
-
 prometheus.remote_write "grafana_cloud_prometheus" {
   endpoint {
     url = nonsensitive(local.file.prometheus_host.content) + "{{ .writeEndpoint }}"
-{{ if .tenantId }}
+{{- if .tenantId }}
     headers = { "X-Scope-OrgID" = local.file.prometheus_tenantid.content }
 {{- end }}
 {{ if .basicAuth }}
@@ -34,6 +33,7 @@ prometheus.remote_write "grafana_cloud_prometheus" {
       {{ if .basicAuth.password }}password = local.file.prometheus_password.content{{ end }}
     }
 {{- end }}
+  }
 {{- end }}
   external_labels = {
     cluster = {{ required ".Values.cluster.name is a required value. Please set it and try again." .Values.cluster.name | quote }},

--- a/charts/k8s-monitoring/templates/credentials.yaml
+++ b/charts/k8s-monitoring/templates/credentials.yaml
@@ -13,6 +13,9 @@ data:
   {{- if .Values.externalServices.prometheus.basicAuth.password }}
   prometheus_password: {{ .Values.externalServices.prometheus.basicAuth.password | toString | b64enc | quote }}
   {{- end }}
+  {{- if .Values.externalServices.prometheus.tenantId }}
+  prometheus_tenantId: {{ .Values.externalServices.prometheus.tenantId | toString | b64enc | quote }}
+  {{- end }}
 {{- end }}
 {{- if .Values.logs.enabled }}
   loki_host: {{ required ".Values.externalServices.loki.host is required to use logs or events. Please set it and try again."  .Values.externalServices.loki.host | b64enc | quote }}
@@ -21,5 +24,8 @@ data:
   {{- end }}
   {{- if .Values.externalServices.loki.basicAuth.password }}
   loki_password: {{ .Values.externalServices.loki.basicAuth.password | toString | b64enc | quote }}
+  {{- end }}
+  {{- if .Values.externalServices.loki.tenantId }}
+  loki_tenantId: {{ .Values.externalServices.loki.tenantId | toString | b64enc | quote }}
   {{- end }}
 {{- end }}

--- a/charts/k8s-monitoring/values.yaml
+++ b/charts/k8s-monitoring/values.yaml
@@ -12,6 +12,9 @@ externalServices:
     # -- Prometheus metrics write endpoint
     writeEndpoint: /api/prom/push
 
+    # -- (string) (optional) Mimir tenant ID
+    tenantId: ""
+
     # Authenticate to Prometheus using basic authentication
     basicAuth:
       # -- (string) Prometheus basic auth username
@@ -26,6 +29,9 @@ externalServices:
     host: ""
     # -- Loki logs write endpoint
     writeEndpoint: /loki/api/v1/push
+
+    # -- (string) (optional) Loki tenant ID
+    tenantId: ""
 
     # Authenticate to Loki using basic authentication
     basicAuth:

--- a/charts/k8s-monitoring/values.yaml
+++ b/charts/k8s-monitoring/values.yaml
@@ -17,7 +17,7 @@ externalServices:
     # -- Custom labels to be added to all time series
     externalLabels: {}
 
-    # -- (string) (optional) Mimir tenant ID
+    # -- (string) (optional) Sets the X-Scope-OrgID header when sending metrics
     tenantId: ""
 
     # Authenticate to Prometheus using basic authentication

--- a/examples/logs-only/logs.river
+++ b/examples/logs-only/logs.river
@@ -70,9 +70,14 @@ local.file "loki_password" {
   is_secret = true
 }
 
+local.file "loki_tenantid" {
+  filename  = "/etc/grafana-agent-credentials/loki_tenantId"
+  is_secret = true
+}
 loki.write "grafana_cloud_loki" {
   endpoint {
     url = nonsensitive(local.file.loki_host.content) + "/loki/api/v1/push"
+    tenant_id = local.file.loki_tenantid.content
 
     basic_auth {
       username = local.file.loki_username.content

--- a/examples/logs-only/output.yaml
+++ b/examples/logs-only/output.yaml
@@ -34,6 +34,7 @@ data:
   loki_host: "aHR0cHM6Ly9sb2tpLmV4YW1wbGUuY29t"
   loki_username: "MTIzNDU="
   loki_password: "SXQncyBhIHNlY3JldCB0byBldmVyeW9uZQ=="
+  loki_tenantId: "MjAwMA=="
 ---
 # Source: k8s-monitoring/templates/grafana-agent-config.yaml
 apiVersion: v1
@@ -135,9 +136,14 @@ data:
       is_secret = true
     }
     
+    local.file "loki_tenantid" {
+      filename  = "/etc/grafana-agent-credentials/loki_tenantId"
+      is_secret = true
+    }
     loki.write "grafana_cloud_loki" {
       endpoint {
         url = nonsensitive(local.file.loki_host.content) + "/loki/api/v1/push"
+        tenant_id = local.file.loki_tenantid.content
     
         basic_auth {
           username = local.file.loki_username.content

--- a/examples/logs-only/values.yaml
+++ b/examples/logs-only/values.yaml
@@ -4,6 +4,7 @@ cluster:
 externalServices:
   loki:
     host: https://loki.example.com
+    tenantId: 2000
     basicAuth:
       username: "12345"
       password: "It's a secret to everyone"

--- a/examples/metrics-only/metrics.river
+++ b/examples/metrics-only/metrics.river
@@ -244,9 +244,14 @@ local.file "prometheus_password" {
   is_secret = true
 }
 
+local.file "prometheus_tenantid" {
+  filename  = "/etc/grafana-agent-credentials/prometheus_tenantId"
+  is_secret = true
+}
 prometheus.remote_write "grafana_cloud_prometheus" {
   endpoint {
     url = nonsensitive(local.file.prometheus_host.content) + "/api/prom/push"
+    headers = { "X-Scope-OrgID" = local.file.prometheus_tenantid.content }
 
     basic_auth {
       username = local.file.prometheus_username.content

--- a/examples/metrics-only/output.yaml
+++ b/examples/metrics-only/output.yaml
@@ -67,6 +67,7 @@ data:
   prometheus_host: "aHR0cHM6Ly9wcm9tZXRoZXVzLmV4YW1wbGUuY29t"
   prometheus_username: "MTIzNDU="
   prometheus_password: "SXQncyBhIHNlY3JldCB0byBldmVyeW9uZQ=="
+  prometheus_tenantId: "MTAwMA=="
 ---
 # Source: k8s-monitoring/templates/grafana-agent-config.yaml
 apiVersion: v1
@@ -322,9 +323,14 @@ data:
       is_secret = true
     }
     
+    local.file "prometheus_tenantid" {
+      filename  = "/etc/grafana-agent-credentials/prometheus_tenantId"
+      is_secret = true
+    }
     prometheus.remote_write "grafana_cloud_prometheus" {
       endpoint {
         url = nonsensitive(local.file.prometheus_host.content) + "/api/prom/push"
+        headers = { "X-Scope-OrgID" = local.file.prometheus_tenantid.content }
     
         basic_auth {
           username = local.file.prometheus_username.content

--- a/examples/metrics-only/values.yaml
+++ b/examples/metrics-only/values.yaml
@@ -4,6 +4,7 @@ cluster:
 externalServices:
   prometheus:
     host: https://prometheus.example.com
+    tenantId: 1000
     basicAuth:
       username: "12345"
       password: "It's a secret to everyone"


### PR DESCRIPTION
This MR adds the ability to push tenant IDs with the Loki & Prometheus configs in the format Mimir and Loki allow for.

This is to make the system usable by people like us who run Mimir & Loki OSS on-prem, and need to set the tenant IDs in the Grafana Agent config.