### PR TITLE
Split Grafana Agent into two

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,8 @@ SHELL := /bin/bash
 
 INPUT_FILES = $(wildcard examples/*/values.yaml)
 OUTPUT_FILES = $(subst values.yaml,output.yaml,$(INPUT_FILES))
+METRIC_CONFIG_FILES = $(subst values.yaml,metrics.river,$(INPUT_FILES))
+LOG_CONFIG_FILES = $(subst values.yaml,logs.river,$(INPUT_FILES))
 
 CT_CONFIGFILE ?= .github/configs/ct.yaml
 LINT_CONFIGFILE ?= .github/configs/lintconf.yaml
@@ -15,7 +17,7 @@ else
 endif
 
 lint-config: scripts/lint-configs.sh
-	./scripts/lint-configs.sh $(OUTPUT_FILES)
+	./scripts/lint-configs.sh $(METRIC_CONFIG_FILES) $(LOG_CONFIG_FILES)
 
 test: scripts/test-runner.sh lint-chart lint-config
 	./scripts/test-runner.sh --show-diffs
@@ -23,9 +25,22 @@ test: scripts/test-runner.sh lint-chart lint-config
 %/output.yaml: %/values.yaml
 	helm template k8smon charts/k8s-monitoring -f $< > $@
 
+%/metrics.river: %/output.yaml
+	yq -r "select(.metadata.name==\"k8smon-grafana-agent\") | .data[\"config.river\"] | select( . != null )" $< > $@
+
+%/logs.river: %/output.yaml
+	yq -r "select(.metadata.name==\"k8smon-grafana-agent-logs\") | .data[\"config.river\"] | select( . != null )" $< > $@
+
+clean-example-outputs:
+	rm -f $(METRIC_CONFIG_FILES) $(LOG_CONFIG_FILES)
+
+generate-agent-configs: $(METRIC_CONFIG_FILES) $(LOG_CONFIG_FILES)
+
+regenerate-agent-configs: clean-example-outputs generate-agent-configs
+
 clean-example-outputs:
 	rm -f $(OUTPUT_FILES)
 
 generate-example-outputs: $(OUTPUT_FILES)
 
-regenerate-example-outputs: clean-example-outputs generate-example-outputs
+regenerate-example-outputs: clean-example-outputs generate-example-outputs regenerate-agent-configs

--- a/README.md
+++ b/README.md
@@ -35,9 +35,11 @@ If you make changes to this chart, please ensure that you've done the following:
 
 Required tools:
 
+* [chart-testing](https://github.com/helm/chart-testing)
 * [Helm](https://helm.sh/docs/intro/install/)
 * [helm-docs](https://github.com/norwoodj/helm-docs)
 * [Grafana Agent](https://github.com/grafana/agent) (used for linting the generated config files)
+* [yamllint](https://yamllint.readthedocs.io/en/stable/index.html)
 * [yq](https://pypi.org/project/yq/)
 
 ## Links

--- a/charts/k8s-monitoring/Chart.lock
+++ b/charts/k8s-monitoring/Chart.lock
@@ -20,5 +20,5 @@ dependencies:
 - name: opencost
   repository: https://opencost.github.io/opencost-helm-chart
   version: 1.18.0
-digest: sha256:43d5dbcfe6babdcf0498c52ec45d489b3a909e97a2ec30d4e68f22a3bbac2071
-generated: "2023-08-14T15:01:59.561711-05:00"
+digest: sha256:5959a6de6ae065b5cf28b3b5ee98bed157852a3b22b53c1ea0d519d2c62f31cc
+generated: "2023-08-14T16:10:03.931068-05:00"

--- a/charts/k8s-monitoring/Chart.lock
+++ b/charts/k8s-monitoring/Chart.lock
@@ -2,6 +2,9 @@ dependencies:
 - name: grafana-agent
   repository: https://grafana.github.io/helm-charts
   version: 0.19.0
+- name: grafana-agent
+  repository: https://grafana.github.io/helm-charts
+  version: 0.19.0
 - name: kube-state-metrics
   repository: https://prometheus-community.github.io/helm-charts
   version: 5.10.1
@@ -17,5 +20,5 @@ dependencies:
 - name: opencost
   repository: https://opencost.github.io/opencost-helm-chart
   version: 1.18.0
-digest: sha256:50cebe3103d2b9b823dd783254de0640cd563a03b8dc020c3ffbae115ecdd7ac
-generated: "2023-08-02T08:57:00.059065-05:00"
+digest: sha256:43d5dbcfe6babdcf0498c52ec45d489b3a909e97a2ec30d4e68f22a3bbac2071
+generated: "2023-08-14T15:01:59.561711-05:00"

--- a/charts/k8s-monitoring/Chart.yaml
+++ b/charts/k8s-monitoring/Chart.yaml
@@ -19,7 +19,7 @@ dependencies:
   name: grafana-agent
   version: 0.19.0
   repository: https://grafana.github.io/helm-charts
-  condition: pod_logs.enabled
+  condition: logs.pod_logs.enabled
 - name: kube-state-metrics
   version: 5.10.1
   repository: https://prometheus-community.github.io/helm-charts

--- a/charts/k8s-monitoring/Chart.yaml
+++ b/charts/k8s-monitoring/Chart.yaml
@@ -3,7 +3,7 @@ name: k8s-monitoring
 description: A Helm chart for gathering, scraping, and forwarding Kubernetes infrastructure metrics and logs to a Grafana Stack.
 type: application
 
-version: 0.0.15
+version: 0.1.0
 appVersion: 1.2.0
 icon: https://raw.githubusercontent.com/grafana/grafana/main/public/img/grafana_icon.svg
 maintainers:
@@ -15,6 +15,11 @@ dependencies:
 - name: grafana-agent
   version: 0.19.0
   repository: https://grafana.github.io/helm-charts
+- alias: grafana-agent-logs
+  name: grafana-agent
+  version: 0.19.0
+  repository: https://grafana.github.io/helm-charts
+  condition: pod_logs.enabled
 - name: kube-state-metrics
   version: 5.10.1
   repository: https://prometheus-community.github.io/helm-charts

--- a/charts/k8s-monitoring/README.md
+++ b/charts/k8s-monitoring/README.md
@@ -1,6 +1,6 @@
 # k8s-monitoring
 
-![Version: 0.0.15](https://img.shields.io/badge/Version-0.0.15-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.2.0](https://img.shields.io/badge/AppVersion-1.2.0-informational?style=flat-square)
+![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.2.0](https://img.shields.io/badge/AppVersion-1.2.0-informational?style=flat-square)
 
 A Helm chart for gathering, scraping, and forwarding Kubernetes infrastructure metrics and logs to a Grafana Stack.
 
@@ -56,6 +56,7 @@ The Prometheus and Loki services may be hosted on the same cluster, or remotely 
 | Repository | Name | Version |
 |------------|------|---------|
 | https://grafana.github.io/helm-charts | grafana-agent | 0.19.0 |
+| https://grafana.github.io/helm-charts | grafana-agent-logs(grafana-agent) | 0.19.0 |
 | https://opencost.github.io/opencost-helm-chart | opencost | 1.18.0 |
 | https://prometheus-community.github.io/helm-charts | kube-state-metrics | 5.10.1 |
 | https://prometheus-community.github.io/helm-charts | prometheus-node-exporter | 4.21.0 |
@@ -67,6 +68,7 @@ The Prometheus and Loki services may be hosted on the same cluster, or remotely 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | cluster.name | string | `""` | (required) The name of this cluster, which will be set in all labels |
+| cluster_events.enabled | bool | `true` | Scrape Kubernetes cluster events |
 | externalServices.loki.basicAuth.password | string | `""` | Loki basic auth password |
 | externalServices.loki.basicAuth.username | string | `""` | Loki basic auth username |
 | externalServices.loki.host | string | `""` | (required) Loki host where logs and events will be sent |
@@ -77,10 +79,6 @@ The Prometheus and Loki services may be hosted on the same cluster, or remotely 
 | externalServices.prometheus.writeEndpoint | string | `"/api/prom/push"` | Prometheus metrics write endpoint |
 | extraConfig | string | `nil` | Extra configuration that will be added to the Grafana Agent configuration file. <details> <summary>+ Example</summary> An example extraConfig to discover and scrape metrics from a service: ```text discovery.relabel "my-service" {   targets = discovery.kubernetes.services.targets   rule {     source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_name"]     regex = "my-service"     action = "keep"   } }  prometheus.scrape "my-service" {   job_name   = "integrations/my-service"   targets    = discovery.relabel.my-service.output   forward_to = [prometheus.relabel.add_cluster_label.receiver] } ``` Note: "discovery.kubernetes.services" and       "prometheus.relabel.add_cluster_label" are pre-defined by this chart. </details> |
 | kube-state-metrics.enabled | bool | `true` | Should this helm chart deploy Kube State Metrics to the cluster. Set this to false if your cluster already has Kube State Metrics, or if you do not want to scrape metrics from Kube State Metrics. |
-| logs.cluster_events.enabled | bool | `true` | Scrape Kubernetes cluster events |
-| logs.enabled | bool | `true` | Capture and forward logs |
-| logs.pod_logs.enabled | bool | `true` | Capture and forward logs from Kubernetes pods |
-| logs.pod_logs.loggingFormat | string | `"docker"` | The log parsing format. Must be one of null, 'cri', or 'docker' See documentation: https://grafana.com/docs/agent/latest/flow/reference/components/loki.process/#stagecri-block |
 | metrics.cadvisor.allowList | list | See [Allow List for cAdvisor](#allow-list-for-cadvisor) | The list of cAdvisor metrics that will be scraped by the Agent |
 | metrics.cadvisor.enabled | bool | `true` | Scrape container metrics from cAdvisor |
 | metrics.cost.allowList | list | See [Allow List for OpenCost](#allow-list-for-opencost) | The list of OpenCost metrics that will be scraped by the Agent |
@@ -105,6 +103,8 @@ The Prometheus and Loki services may be hosted on the same cluster, or remotely 
 | metrics.windows-exporter.labelMatchers | object | `{"app.kubernetes.io/name":"prometheus-windows-exporter.*"}` | Label matchers used by the Grafana Agent to select the Windows Exporter pods |
 | opencost.enabled | bool | `true` | Should this Helm chart deploy OpenCost to the cluster. Set this to false if your cluster already has OpenCost, or if you do not want to scrape metrics from OpenCost. |
 | opencost.opencost.prometheus.external.url | string | `"https://prom.example.com/api/prom"` | The URL for Prometheus queries. It should match externalService.prometheus.host + "/api/prom" |
+| pod_logs.enabled | bool | `true` | Capture and forward logs from Kubernetes pods |
+| pod_logs.loggingFormat | string | `"docker"` | The log parsing format. Must be one of null, 'cri', or 'docker' See documentation: https://grafana.com/docs/agent/latest/flow/reference/components/loki.process/#stagecri-block |
 | prometheus-node-exporter.enabled | bool | `true` | Should this helm chart deploy Node Exporter to the cluster. Set this to false if your cluster already has Node Exporter, or if you do not want to scrape metrics from Node Exporter. |
 | prometheus-operator-crds.enabled | bool | `true` | Should this helm chart deploy the Prometheus Operator CRDs to the cluster. Set this to false if your cluster already has the CRDs, or if you do not to have the Grafana Agent scrape metrics from PodMonitors or ServiceMonitors. |
 | prometheus-windows-exporter.config | string | `"collectors:\n  enabled: cpu,cs,container,logical_disk,memory,net,os\ncollector:\n  service:\n    services-where: \"Name='containerd' or Name='kubelet'\""` |  |

--- a/charts/k8s-monitoring/README.md
+++ b/charts/k8s-monitoring/README.md
@@ -68,7 +68,6 @@ The Prometheus and Loki services may be hosted on the same cluster, or remotely 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | cluster.name | string | `""` | (required) The name of this cluster, which will be set in all labels |
-| cluster_events.enabled | bool | `true` | Scrape Kubernetes cluster events |
 | externalServices.loki.basicAuth.password | string | `""` | Loki basic auth password |
 | externalServices.loki.basicAuth.username | string | `""` | Loki basic auth username |
 | externalServices.loki.host | string | `""` | (required) Loki host where logs and events will be sent |
@@ -79,6 +78,10 @@ The Prometheus and Loki services may be hosted on the same cluster, or remotely 
 | externalServices.prometheus.writeEndpoint | string | `"/api/prom/push"` | Prometheus metrics write endpoint |
 | extraConfig | string | `nil` | Extra configuration that will be added to the Grafana Agent configuration file. <details> <summary>+ Example</summary> An example extraConfig to discover and scrape metrics from a service: ```text discovery.relabel "my-service" {   targets = discovery.kubernetes.services.targets   rule {     source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_name"]     regex = "my-service"     action = "keep"   } }  prometheus.scrape "my-service" {   job_name   = "integrations/my-service"   targets    = discovery.relabel.my-service.output   forward_to = [prometheus.relabel.add_cluster_label.receiver] } ``` Note: "discovery.kubernetes.services" and       "prometheus.relabel.add_cluster_label" are pre-defined by this chart. </details> |
 | kube-state-metrics.enabled | bool | `true` | Should this helm chart deploy Kube State Metrics to the cluster. Set this to false if your cluster already has Kube State Metrics, or if you do not want to scrape metrics from Kube State Metrics. |
+| logs.cluster_events.enabled | bool | `true` | Scrape Kubernetes cluster events |
+| logs.enabled | bool | `true` | Capture and forward logs |
+| logs.pod_logs.enabled | bool | `true` | Capture and forward logs from Kubernetes pods |
+| logs.pod_logs.loggingFormat | string | `"docker"` | The log parsing format. Must be one of null, 'cri', or 'docker' See documentation: https://grafana.com/docs/agent/latest/flow/reference/components/loki.process/#stagecri-block |
 | metrics.cadvisor.allowList | list | See [Allow List for cAdvisor](#allow-list-for-cadvisor) | The list of cAdvisor metrics that will be scraped by the Agent |
 | metrics.cadvisor.enabled | bool | `true` | Scrape container metrics from cAdvisor |
 | metrics.cost.allowList | list | See [Allow List for OpenCost](#allow-list-for-opencost) | The list of OpenCost metrics that will be scraped by the Agent |
@@ -103,8 +106,6 @@ The Prometheus and Loki services may be hosted on the same cluster, or remotely 
 | metrics.windows-exporter.labelMatchers | object | `{"app.kubernetes.io/name":"prometheus-windows-exporter.*"}` | Label matchers used by the Grafana Agent to select the Windows Exporter pods |
 | opencost.enabled | bool | `true` | Should this Helm chart deploy OpenCost to the cluster. Set this to false if your cluster already has OpenCost, or if you do not want to scrape metrics from OpenCost. |
 | opencost.opencost.prometheus.external.url | string | `"https://prom.example.com/api/prom"` | The URL for Prometheus queries. It should match externalService.prometheus.host + "/api/prom" |
-| pod_logs.enabled | bool | `true` | Capture and forward logs from Kubernetes pods |
-| pod_logs.loggingFormat | string | `"docker"` | The log parsing format. Must be one of null, 'cri', or 'docker' See documentation: https://grafana.com/docs/agent/latest/flow/reference/components/loki.process/#stagecri-block |
 | prometheus-node-exporter.enabled | bool | `true` | Should this helm chart deploy Node Exporter to the cluster. Set this to false if your cluster already has Node Exporter, or if you do not want to scrape metrics from Node Exporter. |
 | prometheus-operator-crds.enabled | bool | `true` | Should this helm chart deploy the Prometheus Operator CRDs to the cluster. Set this to false if your cluster already has the CRDs, or if you do not to have the Grafana Agent scrape metrics from PodMonitors or ServiceMonitors. |
 | prometheus-windows-exporter.config | string | `"collectors:\n  enabled: cpu,cs,container,logical_disk,memory,net,os\ncollector:\n  service:\n    services-where: \"Name='containerd' or Name='kubelet'\""` |  |

--- a/charts/k8s-monitoring/templates/agent_config/_cluster_events.river.txt
+++ b/charts/k8s-monitoring/templates/agent_config/_cluster_events.river.txt
@@ -1,4 +1,4 @@
-{{ define "agent.config.cluster_events" }}
+{{ define "agent.config.logs.cluster_events" }}
 // Cluster Events
 loki.source.kubernetes_events "cluster_events" {
   job_name   = "integrations/kubernetes/eventhandler"

--- a/charts/k8s-monitoring/templates/agent_config/_cluster_events.river.txt
+++ b/charts/k8s-monitoring/templates/agent_config/_cluster_events.river.txt
@@ -1,4 +1,4 @@
-{{ define "agent.config.logs.cluster_events" }}
+{{ define "agent.config.cluster_events" }}
 // Cluster Events
 loki.source.kubernetes_events "cluster_events" {
   job_name   = "integrations/kubernetes/eventhandler"

--- a/charts/k8s-monitoring/templates/agent_config/_pod_logs.river.txt
+++ b/charts/k8s-monitoring/templates/agent_config/_pod_logs.river.txt
@@ -27,7 +27,8 @@ discovery.relabel "pod_logs" {
   }
   rule {
     source_labels = ["__meta_kubernetes_pod_node_name"]
-    target_label = "__host__"
+    action = "keep"
+    regex = env("HOSTNAME")
   }
   rule {
     source_labels = ["__meta_kubernetes_pod_uid", "__meta_kubernetes_pod_container_name"]
@@ -38,8 +39,12 @@ discovery.relabel "pod_logs" {
   }
 }
 
+local.file_match "pod_logs" {
+  path_targets = discovery.relabel.pod_logs.output
+}
+
 loki.source.file "pod_logs" {
-  targets    = discovery.relabel.pod_logs.output
+  targets    = local.file_match.pod_logs.targets
   forward_to = [loki.process.pod_logs.receiver]
 }
 

--- a/charts/k8s-monitoring/templates/agent_config/_pod_logs.river.txt
+++ b/charts/k8s-monitoring/templates/agent_config/_pod_logs.river.txt
@@ -1,4 +1,4 @@
-{{ define "agent.config.pod_logs" }}
+{{ define "agent.config.logs.pod_logs" }}
 // Pod Logs
 discovery.relabel "pod_logs" {
   targets = discovery.kubernetes.pods.targets
@@ -55,7 +55,7 @@ loki.process "pod_logs" {
     }
   }
 
-  stage.{{- .Values.pod_logs.loggingFormat }} {}
+  stage.{{- .Values.logs.pod_logs.loggingFormat }} {}
   forward_to = [loki.write.grafana_cloud_loki.receiver]
 }
 {{ end }}

--- a/charts/k8s-monitoring/templates/credentials.yaml
+++ b/charts/k8s-monitoring/templates/credentials.yaml
@@ -14,7 +14,7 @@ data:
   prometheus_password: {{ .Values.externalServices.prometheus.basicAuth.password | toString | b64enc | quote }}
   {{- end }}
 {{- end }}
-{{- if or .Values.pod_logs.enabled .Values.cluster_events.enabled }}
+{{- if and .Values.logs.enabled (or .Values.logs.pod_logs.enabled .Values.logs.cluster_events.enabled) }}
   loki_host: {{ required ".Values.externalServices.loki.host is required to use logs or events. Please set it and try again."  .Values.externalServices.loki.host | b64enc | quote }}
   {{- if .Values.externalServices.loki.basicAuth.username }}
   loki_username: {{ .Values.externalServices.loki.basicAuth.username | toString | b64enc | quote }}

--- a/charts/k8s-monitoring/templates/credentials.yaml
+++ b/charts/k8s-monitoring/templates/credentials.yaml
@@ -14,7 +14,7 @@ data:
   prometheus_password: {{ .Values.externalServices.prometheus.basicAuth.password | toString | b64enc | quote }}
   {{- end }}
 {{- end }}
-{{- if .Values.logs.enabled }}
+{{- if or .Values.pod_logs.enabled .Values.cluster_events.enabled }}
   loki_host: {{ required ".Values.externalServices.loki.host is required to use logs or events. Please set it and try again."  .Values.externalServices.loki.host | b64enc | quote }}
   {{- if .Values.externalServices.loki.basicAuth.username }}
   loki_username: {{ .Values.externalServices.loki.basicAuth.username | toString | b64enc | quote }}

--- a/charts/k8s-monitoring/templates/grafana-agent-config.yaml
+++ b/charts/k8s-monitoring/templates/grafana-agent-config.yaml
@@ -47,21 +47,13 @@ data:
   {{- end }}
 
   {{- include "agent.config.prometheus" . | indent 4 }}
-  {{- end }}
 
-  {{- if .Values.logs.enabled }}
-
-  {{- if .Values.logs.pod_logs.enabled }}
-    {{- include "agent.config.logs.pod_logs" . | indent 4}}
-  {{- end }}
-
-  {{- if .Values.logs.cluster_events.enabled }}
-    {{- include "agent.config.logs.cluster_events" . | indent 4}}
-  {{- end }}
-
+{{- if .Values.cluster_events.enabled }}
+  {{- include "agent.config.cluster_events" . | indent 4}}
   {{- include "agent.config.loki" . | indent 4 }}
 {{- end }}
-
+{{- end }}
 {{- if .Values.extraConfig }}
 {{ .Values.extraConfig | indent 4 }}
 {{ end }}
+

--- a/charts/k8s-monitoring/templates/grafana-agent-config.yaml
+++ b/charts/k8s-monitoring/templates/grafana-agent-config.yaml
@@ -48,8 +48,8 @@ data:
 
   {{- include "agent.config.prometheus" . | indent 4 }}
 
-{{- if .Values.cluster_events.enabled }}
-  {{- include "agent.config.cluster_events" . | indent 4}}
+{{- if and .Values.logs.enabled .Values.logs.cluster_events.enabled }}
+  {{- include "agent.config.logs.cluster_events" . | indent 4}}
   {{- include "agent.config.loki" . | indent 4 }}
 {{- end }}
 {{- end }}

--- a/charts/k8s-monitoring/templates/grafana-agent-logs-config.yaml
+++ b/charts/k8s-monitoring/templates/grafana-agent-logs-config.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.pod_logs.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "grafana-agent.fullname" (index .Subcharts "grafana-agent-logs") }}
+  namespace: {{ .Release.Namespace }}
+data:
+  config.river: |-
+{{- include "agent.config.pods" . | indent 4}}
+{{- include "agent.config.pod_logs" . | indent 4}}
+{{- include "agent.config.loki" . | indent 4 }}
+{{- end }}

--- a/charts/k8s-monitoring/templates/grafana-agent-logs-config.yaml
+++ b/charts/k8s-monitoring/templates/grafana-agent-logs-config.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.pod_logs.enabled }}
+{{- if and .Values.logs.enabled .Values.logs.pod_logs.enabled }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -7,6 +7,6 @@ metadata:
 data:
   config.river: |-
 {{- include "agent.config.pods" . | indent 4}}
-{{- include "agent.config.pod_logs" . | indent 4}}
+{{- include "agent.config.logs.pod_logs" . | indent 4}}
 {{- include "agent.config.loki" . | indent 4 }}
 {{- end }}

--- a/charts/k8s-monitoring/values.yaml
+++ b/charts/k8s-monitoring/values.yaml
@@ -245,20 +245,25 @@ metrics:
     # -- Include service discovery for ServiceMonitor objects
     enabled: true
 
-# Settings for Kubernetes pod logs
-pod_logs:
-  # -- Capture and forward logs from Kubernetes pods
+# Settings related to capturing and forwarding logs
+logs:
+  # -- Capture and forward logs
   enabled: true
 
-  # -- The log parsing format.
-  # Must be one of null, 'cri', or 'docker'
-  # See documentation: https://grafana.com/docs/agent/latest/flow/reference/components/loki.process/#stagecri-block
-  loggingFormat: docker
+  # Settings for Kubernetes pod logs
+  pod_logs:
+    # -- Capture and forward logs from Kubernetes pods
+    enabled: true
 
-# Settings for scraping Kubernetes cluster events
-cluster_events:
-  # -- Scrape Kubernetes cluster events
-  enabled: true
+    # -- The log parsing format.
+    # Must be one of null, 'cri', or 'docker'
+    # See documentation: https://grafana.com/docs/agent/latest/flow/reference/components/loki.process/#stagecri-block
+    loggingFormat: docker
+
+  # Settings for scraping Kubernetes cluster events
+  cluster_events:
+    # -- Scrape Kubernetes cluster events
+    enabled: true
 
 # -- (string) Extra configuration that will be added to the Grafana Agent configuration file.
 # <details>

--- a/charts/k8s-monitoring/values.yaml
+++ b/charts/k8s-monitoring/values.yaml
@@ -430,10 +430,14 @@ grafana-agent-logs:
     nodeSelector:
       kubernetes.io/os: linux
 
+    tolerations:
+      - effect: NoSchedule
+        operator: Exists
+
     # This chart creates the credentials for Prometheus and Loki. This section
     # connects those credentials into the Grafana Agent pod.
     volumes:
       extra:
-        - name: grafana-agent-credentials
-          secret:
-            secretName: grafana-agent-credentials
+      - name: grafana-agent-credentials
+        secret:
+          secretName: grafana-agent-credentials

--- a/charts/k8s-monitoring/values.yaml
+++ b/charts/k8s-monitoring/values.yaml
@@ -245,25 +245,20 @@ metrics:
     # -- Include service discovery for ServiceMonitor objects
     enabled: true
 
-# Settings related to capturing and forwarding logs
-logs:
-  # -- Capture and forward logs
+# Settings for Kubernetes pod logs
+pod_logs:
+  # -- Capture and forward logs from Kubernetes pods
   enabled: true
 
-  # Settings for Kubernetes pod logs
-  pod_logs:
-    # -- Capture and forward logs from Kubernetes pods
-    enabled: true
+  # -- The log parsing format.
+  # Must be one of null, 'cri', or 'docker'
+  # See documentation: https://grafana.com/docs/agent/latest/flow/reference/components/loki.process/#stagecri-block
+  loggingFormat: docker
 
-    # -- The log parsing format.
-    # Must be one of null, 'cri', or 'docker'
-    # See documentation: https://grafana.com/docs/agent/latest/flow/reference/components/loki.process/#stagecri-block
-    loggingFormat: docker
-
-  # Settings for scraping cluster evenrts
-  cluster_events:
-    # -- Scrape Kubernetes cluster events
-    enabled: true
+# Settings for scraping Kubernetes cluster events
+cluster_events:
+  # -- Scrape Kubernetes cluster events
+  enabled: true
 
 # -- (string) Extra configuration that will be added to the Grafana Agent configuration file.
 # <details>
@@ -387,6 +382,9 @@ grafana-agent:
     # not need to.
     configMap: {create: false}
 
+    clustering:
+      enabled: true
+
     # This chart creates the credentials for Prometheus and Loki. This section
     # mounts those credentials into the Grafana Agent container.
     mounts:
@@ -395,6 +393,7 @@ grafana-agent:
         mountPath: /etc/grafana-agent-credentials
 
   controller:
+    type: statefulset
     nodeSelector:
       kubernetes.io/os: linux
 
@@ -405,3 +404,36 @@ grafana-agent:
       - name: grafana-agent-credentials
         secret:
           secretName: grafana-agent-credentials
+
+# Settings for the Grafana Agent deployment
+# You can use this sections to make modifications to the Grafana Agent deployment.
+# See https://github.com/grafana/agent/tree/main/operations/helm/charts/grafana-agent for available values.
+# @ignored
+grafana-agent-logs:
+  agent:
+    # This chart is creating the configuration, so the grafana-agent chart does
+    # not need to.
+    configMap:
+      create: false
+
+    # This chart creates the credentials for Prometheus and Loki. This section
+    # mounts those credentials into the Grafana Agent container.
+    mounts:
+      varlog: true
+      dockercontainers: true
+      extra:
+        - name: grafana-agent-credentials
+          mountPath: /etc/grafana-agent-credentials
+
+  controller:
+    type: daemonset
+    nodeSelector:
+      kubernetes.io/os: linux
+
+    # This chart creates the credentials for Prometheus and Loki. This section
+    # connects those credentials into the Grafana Agent pod.
+    volumes:
+      extra:
+        - name: grafana-agent-credentials
+          secret:
+            secretName: grafana-agent-credentials

--- a/examples/custom-allow-lists/metrics.river
+++ b/examples/custom-allow-lists/metrics.river
@@ -1,0 +1,277 @@
+discovery.kubernetes "nodes" {
+  role = "node"
+}
+    
+discovery.kubernetes "pods" {
+  role = "pod"
+}
+    
+discovery.kubernetes "services" {
+  role = "service"
+}
+    
+// Grafana Agent
+discovery.relabel "agent" {
+  targets = discovery.kubernetes.services.targets
+  rule {
+    source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_instance"]
+    regex = "k8smon"
+    action = "keep"
+  }
+  rule {
+    source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_name"]
+    regex = "grafana-agent"
+    action = "keep"
+  }
+  rule {
+    source_labels = ["__meta_kubernetes_service_port_name"]
+    regex = "http-metrics"
+    action = "keep"
+  }
+  rule {
+    source_labels = ["__name__"]
+    replacement   = "custom-allow-lists-test"
+    target_label  = "cluster"
+  }
+}
+
+prometheus.scrape "agent" {
+  job_name   = "integrations/agent"
+  targets  = discovery.relabel.agent.output
+  forward_to = [prometheus.relabel.agent.receiver]
+}
+
+prometheus.relabel "agent" {
+  rule {
+    source_labels = ["__name__"]
+    regex = "up|agent_build_info"
+    action = "keep"
+  }
+  forward_to = [prometheus.remote_write.grafana_cloud_prometheus.receiver]
+}
+    
+// Kubelet
+discovery.relabel "kubelet" {
+  targets = discovery.kubernetes.nodes.targets
+  rule {
+    target_label = "__address__"
+    replacement  = "kubernetes.default.svc.cluster.local:443"
+  }
+  rule {
+    source_labels = ["__meta_kubernetes_node_name"]
+    regex         = "(.+)"
+    replacement   = "/api/v1/nodes/${1}/proxy/metrics"
+    target_label  = "__metrics_path__"
+  }
+  rule {
+    source_labels = ["__name__"]
+    replacement   = "custom-allow-lists-test"
+    target_label  = "cluster"
+  }
+}
+
+prometheus.scrape "kubelet" {
+  job_name   = "integrations/kubernetes/kubelet"
+  targets  = discovery.relabel.kubelet.output
+  scheme   = "https"
+  bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+  tls_config {
+    insecure_skip_verify = true
+  }
+  forward_to = [prometheus.relabel.kubelet.receiver]
+}
+
+prometheus.relabel "kubelet" {
+  rule {
+    source_labels = ["__name__"]
+    regex = "up|kubelet_node_name|kubernetes_build_info"
+    action = "keep"
+  }
+  forward_to = [prometheus.remote_write.grafana_cloud_prometheus.receiver]
+}
+    
+// cAdvisor
+discovery.relabel "cadvisor" {
+  targets = discovery.kubernetes.nodes.targets
+  rule {
+    target_label = "__address__"
+    replacement  = "kubernetes.default.svc.cluster.local:443"
+  }
+  rule {
+    source_labels = ["__meta_kubernetes_node_name"]
+    regex         = "(.+)"
+    replacement   = "/api/v1/nodes/${1}/proxy/metrics/cadvisor"
+    target_label  = "__metrics_path__"
+  }
+  rule {
+    source_labels = ["__name__"]
+    replacement   = "custom-allow-lists-test"
+    target_label  = "cluster"
+  }
+}
+
+prometheus.scrape "cadvisor" {
+  job_name   = "integrations/kubernetes/cadvisor"
+  targets    = discovery.relabel.cadvisor.output
+  scheme     = "https"
+  bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+  tls_config {
+    insecure_skip_verify = true
+  }
+  forward_to = [prometheus.relabel.cadvisor.receiver]
+}
+
+prometheus.relabel "cadvisor" {
+  rule {
+    source_labels = ["__name__"]
+    regex = "up|container_memory_cache|container_memory_rss|container_memory_swap"
+    action = "keep"
+  }
+  forward_to = [prometheus.remote_write.grafana_cloud_prometheus.receiver]
+}
+    
+// Kube State Metrics
+discovery.relabel "kube_state_metrics" {
+  targets = discovery.kubernetes.services.targets
+  rule {
+    source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_instance"]
+    regex = "k8smon"
+    action = "keep"
+  }
+  rule {
+    source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_name"]
+    regex = "kube-state-metrics"
+    action = "keep"
+  }
+  rule {
+    source_labels = ["__meta_kubernetes_service_port_name"]
+    regex = "http"
+    action = "keep"
+  }
+  rule {
+    source_labels = ["__name__"]
+    replacement   = "custom-allow-lists-test"
+    target_label  = "cluster"
+  }
+}
+
+prometheus.scrape "kube_state_metrics" {
+  job_name   = "integrations/kubernetes/kube-state-metrics"
+  targets    = discovery.relabel.kube_state_metrics.output
+  forward_to = [prometheus.relabel.kube_state_metrics.receiver]
+}
+
+prometheus.relabel "kube_state_metrics" {
+  rule {
+    source_labels = ["__name__"]
+    regex = "up|*"
+    action = "keep"
+  }
+  forward_to = [prometheus.remote_write.grafana_cloud_prometheus.receiver]
+}
+    
+// Node Exporter
+discovery.relabel "node_exporter" {
+  targets = discovery.kubernetes.pods.targets
+  rule {
+    source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_instance"]
+    regex = "k8smon"
+    action = "keep"
+  }
+  rule {
+    source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+    regex = "prometheus-node-exporter.*"
+    action = "keep"
+  }
+  rule {
+    source_labels = ["__meta_kubernetes_pod_node_name"]
+    action = "replace"
+    target_label = "instance"
+  }
+  rule {
+    source_labels = ["__name__"]
+    replacement   = "custom-allow-lists-test"
+    target_label  = "cluster"
+  }
+}
+
+prometheus.scrape "node_exporter" {
+  job_name   = "integrations/node_exporter"
+  targets  = discovery.relabel.node_exporter.output
+  forward_to = [prometheus.relabel.node_exporter.receiver]
+}
+
+prometheus.relabel "node_exporter" {
+  rule {
+    source_labels = ["__name__"]
+    regex = "up|node_*"
+    action = "keep"
+  }
+  forward_to = [prometheus.remote_write.grafana_cloud_prometheus.receiver]
+}
+    
+// OpenCost
+discovery.relabel "opencost" {
+  targets = discovery.kubernetes.services.targets
+  rule {
+    source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_instance"]
+    regex = "k8smon"
+    action = "keep"
+  }
+  rule {
+    source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_name"]
+    regex = "opencost"
+    action = "keep"
+  }
+  rule {
+    source_labels = ["__meta_kubernetes_service_port_name"]
+    regex = "http"
+    action = "keep"
+  }
+  rule {
+    source_labels = ["__name__"]
+    replacement   = "custom-allow-lists-test"
+    target_label  = "cluster"
+  }
+}
+
+prometheus.scrape "opencost" {
+  job_name   = "integrations/kubernetes/opencost"
+  targets    = discovery.relabel.opencost.output
+  forward_to = [prometheus.remote_write.grafana_cloud_prometheus.receiver]
+}
+    
+// PodMonitor
+prometheus.operator.podmonitors "pod_monitors" {
+  forward_to = [prometheus.remote_write.grafana_cloud_prometheus.receiver]
+}
+    
+// ServiceMonitor
+prometheus.operator.servicemonitors "service_monitors" {
+  forward_to = [prometheus.remote_write.grafana_cloud_prometheus.receiver]
+}
+    
+// Grafana Cloud Prometheus
+local.file "prometheus_host" {
+  filename  = "/etc/grafana-agent-credentials/prometheus_host"
+}
+
+local.file "prometheus_username" {
+  filename  = "/etc/grafana-agent-credentials/prometheus_username"
+}
+
+local.file "prometheus_password" {
+  filename  = "/etc/grafana-agent-credentials/prometheus_password"
+  is_secret = true
+}
+
+prometheus.remote_write "grafana_cloud_prometheus" {
+  endpoint {
+    url = nonsensitive(local.file.prometheus_host.content) + "/api/prom/push"
+
+    basic_auth {
+      username = local.file.prometheus_username.content
+      password = local.file.prometheus_password.content
+    }
+  }
+}

--- a/examples/custom-allow-lists/output.yaml
+++ b/examples/custom-allow-lists/output.yaml
@@ -39762,6 +39762,35 @@ subjects:
     name: k8smon-opencost
     namespace: default
 ---
+# Source: k8s-monitoring/charts/grafana-agent/templates/cluster_service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: k8smon-grafana-agent-cluster
+  labels:
+    helm.sh/chart: grafana-agent-0.19.0
+    app.kubernetes.io/name: grafana-agent
+    app.kubernetes.io/instance: k8smon
+    app.kubernetes.io/version: "v0.35.2"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  type: ClusterIP
+  clusterIP: 'None'
+  selector:
+    app.kubernetes.io/name: grafana-agent
+    app.kubernetes.io/instance: k8smon
+  ports:
+    # Do not include the -metrics suffix in the port name, otherwise metrics
+    # can be double-collected with the non-headless Service if it's also
+    # enabled.
+    #
+    # This service should only be used for clustering, and not metric
+    # collection.
+    - name: http
+      port: 80
+      targetPort: 80
+      protocol: "TCP"
+---
 # Source: k8s-monitoring/charts/grafana-agent/templates/service.yaml
 apiVersion: v1
 kind: Service
@@ -39860,84 +39889,6 @@ spec:
   selector:
     app.kubernetes.io/name: prometheus-node-exporter
     app.kubernetes.io/instance: k8smon
----
-# Source: k8s-monitoring/charts/grafana-agent/templates/controllers/daemonset.yaml
-apiVersion: apps/v1
-kind: DaemonSet
-metadata:
-  name: k8smon-grafana-agent
-  labels:
-    helm.sh/chart: grafana-agent-0.19.0
-    app.kubernetes.io/name: grafana-agent
-    app.kubernetes.io/instance: k8smon
-    app.kubernetes.io/version: "v0.35.2"
-    app.kubernetes.io/managed-by: Helm
-spec:
-  minReadySeconds: 10
-  selector:
-    matchLabels:
-      app.kubernetes.io/name: grafana-agent
-      app.kubernetes.io/instance: k8smon
-  template:
-    metadata:
-      labels:
-        app.kubernetes.io/name: grafana-agent
-        app.kubernetes.io/instance: k8smon
-    spec:
-      serviceAccountName: k8smon-grafana-agent
-      containers:
-        - name: grafana-agent
-          image: docker.io/grafana/agent:v0.35.2
-          imagePullPolicy: IfNotPresent
-          args:
-            - run
-            - /etc/agent/config.river
-            - --storage.path=/tmp/agent
-            - --server.http.listen-addr=0.0.0.0:80
-          env:
-            - name: AGENT_MODE
-              value: flow
-            - name: HOSTNAME
-              valueFrom:
-                fieldRef:
-                  fieldPath: spec.nodeName
-          ports:
-            - containerPort: 80
-              name: http-metrics
-          readinessProbe:
-            httpGet:
-              path: /-/ready
-              port: 80
-            initialDelaySeconds: 10
-            timeoutSeconds: 1
-          volumeMounts:
-            - name: config
-              mountPath: /etc/agent
-            -
-              mountPath: /etc/grafana-agent-credentials
-              name: grafana-agent-credentials
-        - name: config-reloader
-          image: docker.io/jimmidyson/configmap-reload:v0.8.0
-          args:
-            - --volume-dir=/etc/agent
-            - --webhook-url=http://localhost:80/-/reload
-          volumeMounts:
-            - name: config
-              mountPath: /etc/agent
-          resources:
-            requests:
-              cpu: 1m
-              memory: 5Mi
-      dnsPolicy: ClusterFirst
-      nodeSelector:
-        kubernetes.io/os: linux
-      volumes:
-        - name: config
-          configMap:
-            name: k8smon-grafana-agent
-        - name: grafana-agent-credentials
-          secret:
-            secretName: grafana-agent-credentials
 ---
 # Source: k8s-monitoring/charts/prometheus-node-exporter/templates/daemonset.yaml
 apiVersion: apps/v1
@@ -40203,6 +40154,88 @@ spec:
               value: "true"
             - name: PROM_CLUSTER_ID_LABEL
               value: "cluster"
+---
+# Source: k8s-monitoring/charts/grafana-agent/templates/controllers/statefulset.yaml
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: k8smon-grafana-agent
+  labels:
+    helm.sh/chart: grafana-agent-0.19.0
+    app.kubernetes.io/name: grafana-agent
+    app.kubernetes.io/instance: k8smon
+    app.kubernetes.io/version: "v0.35.2"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  replicas: 1
+  minReadySeconds: 10
+  serviceName: k8smon-grafana-agent
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: grafana-agent
+      app.kubernetes.io/instance: k8smon
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: grafana-agent
+        app.kubernetes.io/instance: k8smon
+    spec:
+      serviceAccountName: k8smon-grafana-agent
+      containers:
+        - name: grafana-agent
+          image: docker.io/grafana/agent:v0.35.2
+          imagePullPolicy: IfNotPresent
+          args:
+            - run
+            - /etc/agent/config.river
+            - --storage.path=/tmp/agent
+            - --server.http.listen-addr=0.0.0.0:80
+            - --cluster.enabled=true
+            - --cluster.join-addresses=k8smon-grafana-agent-cluster
+          env:
+            - name: AGENT_MODE
+              value: flow
+            - name: HOSTNAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+          ports:
+            - containerPort: 80
+              name: http-metrics
+          readinessProbe:
+            httpGet:
+              path: /-/ready
+              port: 80
+            initialDelaySeconds: 10
+            timeoutSeconds: 1
+          volumeMounts:
+            - name: config
+              mountPath: /etc/agent
+            -
+              mountPath: /etc/grafana-agent-credentials
+              name: grafana-agent-credentials
+        - name: config-reloader
+          image: docker.io/jimmidyson/configmap-reload:v0.8.0
+          args:
+            - --volume-dir=/etc/agent
+            - --webhook-url=http://localhost:80/-/reload
+          volumeMounts:
+            - name: config
+              mountPath: /etc/agent
+          resources:
+            requests:
+              cpu: 1m
+              memory: 5Mi
+      dnsPolicy: ClusterFirst
+      nodeSelector:
+        kubernetes.io/os: linux
+      volumes:
+        - name: config
+          configMap:
+            name: k8smon-grafana-agent
+        - name: grafana-agent-credentials
+          secret:
+            secretName: grafana-agent-credentials
 ---
 # Source: k8s-monitoring/charts/prometheus-operator-crds/templates/crd-alertmanagerconfigs.yaml
 # https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.66.0/example/prometheus-operator-crd/monitoring.coreos.com_alertmanagerconfigs.yaml

--- a/examples/custom-allow-lists/values.yaml
+++ b/examples/custom-allow-lists/values.yaml
@@ -24,5 +24,8 @@ metrics:
     allowList: []
   enabled: true
 
-logs:
+pod_logs:
+  enabled: false
+
+cluster_events:
   enabled: false

--- a/examples/custom-allow-lists/values.yaml
+++ b/examples/custom-allow-lists/values.yaml
@@ -24,8 +24,9 @@ metrics:
     allowList: []
   enabled: true
 
-pod_logs:
-  enabled: false
+logs:
+  pod_logs:
+    enabled: false
 
-cluster_events:
-  enabled: false
+  cluster_events:
+    enabled: false

--- a/examples/custom-config/logs.river
+++ b/examples/custom-config/logs.river
@@ -1,4 +1,7 @@
-{{ define "agent.config.pod_logs" }}
+discovery.kubernetes "pods" {
+  role = "pod"
+}
+    
 // Pod Logs
 discovery.relabel "pod_logs" {
   targets = discovery.kubernetes.pods.targets
@@ -46,11 +49,35 @@ loki.source.file "pod_logs" {
 loki.process "pod_logs" {
   stage.static_labels {
     values = {
-      cluster = {{ required ".Values.cluster.name is a required value. Please set it and try again." .Values.cluster.name | quote }},
+      cluster = "custom-config-test",
     }
   }
 
-  stage.{{- .Values.pod_logs.loggingFormat }} {}
+  stage.docker {}
   forward_to = [loki.write.grafana_cloud_loki.receiver]
 }
-{{ end }}
+    
+// Grafana Cloud Loki
+local.file "loki_host" {
+  filename  = "/etc/grafana-agent-credentials/loki_host"
+}
+
+local.file "loki_username" {
+  filename  = "/etc/grafana-agent-credentials/loki_username"
+}
+
+local.file "loki_password" {
+  filename  = "/etc/grafana-agent-credentials/loki_password"
+  is_secret = true
+}
+
+loki.write "grafana_cloud_loki" {
+  endpoint {
+    url = nonsensitive(local.file.loki_host.content) + "/loki/api/v1/push"
+
+    basic_auth {
+      username = local.file.loki_username.content
+      password = local.file.loki_password.content
+    }
+  }
+}

--- a/examples/custom-config/logs.river
+++ b/examples/custom-config/logs.river
@@ -30,7 +30,8 @@ discovery.relabel "pod_logs" {
   }
   rule {
     source_labels = ["__meta_kubernetes_pod_node_name"]
-    target_label = "__host__"
+    action = "keep"
+    regex = env("HOSTNAME")
   }
   rule {
     source_labels = ["__meta_kubernetes_pod_uid", "__meta_kubernetes_pod_container_name"]
@@ -41,8 +42,12 @@ discovery.relabel "pod_logs" {
   }
 }
 
+local.file_match "pod_logs" {
+  path_targets = discovery.relabel.pod_logs.output
+}
+
 loki.source.file "pod_logs" {
-  targets    = discovery.relabel.pod_logs.output
+  targets    = local.file_match.pod_logs.targets
   forward_to = [loki.process.pod_logs.receiver]
 }
 

--- a/examples/custom-config/metrics.river
+++ b/examples/custom-config/metrics.river
@@ -1,0 +1,352 @@
+discovery.kubernetes "nodes" {
+  role = "node"
+}
+    
+discovery.kubernetes "pods" {
+  role = "pod"
+}
+    
+discovery.kubernetes "services" {
+  role = "service"
+}
+    
+// Grafana Agent
+discovery.relabel "agent" {
+  targets = discovery.kubernetes.services.targets
+  rule {
+    source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_instance"]
+    regex = "k8smon"
+    action = "keep"
+  }
+  rule {
+    source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_name"]
+    regex = "grafana-agent"
+    action = "keep"
+  }
+  rule {
+    source_labels = ["__meta_kubernetes_service_port_name"]
+    regex = "http-metrics"
+    action = "keep"
+  }
+  rule {
+    source_labels = ["__name__"]
+    replacement   = "custom-config-test"
+    target_label  = "cluster"
+  }
+}
+
+prometheus.scrape "agent" {
+  job_name   = "integrations/agent"
+  targets  = discovery.relabel.agent.output
+  forward_to = [prometheus.relabel.agent.receiver]
+}
+
+prometheus.relabel "agent" {
+  rule {
+    source_labels = ["__name__"]
+    regex = "up|agent_build_info"
+    action = "keep"
+  }
+  forward_to = [prometheus.remote_write.grafana_cloud_prometheus.receiver]
+}
+    
+// Kubelet
+discovery.relabel "kubelet" {
+  targets = discovery.kubernetes.nodes.targets
+  rule {
+    target_label = "__address__"
+    replacement  = "kubernetes.default.svc.cluster.local:443"
+  }
+  rule {
+    source_labels = ["__meta_kubernetes_node_name"]
+    regex         = "(.+)"
+    replacement   = "/api/v1/nodes/${1}/proxy/metrics"
+    target_label  = "__metrics_path__"
+  }
+  rule {
+    source_labels = ["__name__"]
+    replacement   = "custom-config-test"
+    target_label  = "cluster"
+  }
+}
+
+prometheus.scrape "kubelet" {
+  job_name   = "integrations/kubernetes/kubelet"
+  targets  = discovery.relabel.kubelet.output
+  scheme   = "https"
+  bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+  tls_config {
+    insecure_skip_verify = true
+  }
+  forward_to = [prometheus.relabel.kubelet.receiver]
+}
+
+prometheus.relabel "kubelet" {
+  rule {
+    source_labels = ["__name__"]
+    regex = "up|container_cpu_usage_seconds_total|kubelet_certificate_manager_client_expiration_renew_errors|kubelet_certificate_manager_client_ttl_seconds|kubelet_certificate_manager_server_ttl_seconds|kubelet_cgroup_manager_duration_seconds_bucket|kubelet_cgroup_manager_duration_seconds_count|kubelet_node_config_error|kubelet_node_name|kubelet_pleg_relist_duration_seconds_bucket|kubelet_pleg_relist_duration_seconds_count|kubelet_pleg_relist_interval_seconds_bucket|kubelet_pod_start_duration_seconds_bucket|kubelet_pod_start_duration_seconds_count|kubelet_pod_worker_duration_seconds_bucket|kubelet_pod_worker_duration_seconds_count|kubelet_running_container_count|kubelet_running_containers|kubelet_running_pod_count|kubelet_running_pods|kubelet_runtime_operations_errors_total|kubelet_runtime_operations_total|kubelet_server_expiration_renew_errors|kubelet_volume_stats_available_bytes|kubelet_volume_stats_capacity_bytes|kubelet_volume_stats_inodes|kubelet_volume_stats_inodes_used|kubernetes_build_info|namespace_workload_pod|rest_client_requests_total|storage_operation_duration_seconds_count|storage_operation_errors_total|volume_manager_total_volumes"
+    action = "keep"
+  }
+  forward_to = [prometheus.remote_write.grafana_cloud_prometheus.receiver]
+}
+    
+// cAdvisor
+discovery.relabel "cadvisor" {
+  targets = discovery.kubernetes.nodes.targets
+  rule {
+    target_label = "__address__"
+    replacement  = "kubernetes.default.svc.cluster.local:443"
+  }
+  rule {
+    source_labels = ["__meta_kubernetes_node_name"]
+    regex         = "(.+)"
+    replacement   = "/api/v1/nodes/${1}/proxy/metrics/cadvisor"
+    target_label  = "__metrics_path__"
+  }
+  rule {
+    source_labels = ["__name__"]
+    replacement   = "custom-config-test"
+    target_label  = "cluster"
+  }
+}
+
+prometheus.scrape "cadvisor" {
+  job_name   = "integrations/kubernetes/cadvisor"
+  targets    = discovery.relabel.cadvisor.output
+  scheme     = "https"
+  bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+  tls_config {
+    insecure_skip_verify = true
+  }
+  forward_to = [prometheus.relabel.cadvisor.receiver]
+}
+
+prometheus.relabel "cadvisor" {
+  rule {
+    source_labels = ["__name__"]
+    regex = "up|container_cpu_cfs_periods_total|container_cpu_cfs_throttled_periods_total|container_cpu_usage_seconds_total|container_fs_reads_bytes_total|container_fs_reads_total|container_fs_writes_bytes_total|container_fs_writes_total|container_memory_cache|container_memory_rss|container_memory_swap|container_memory_working_set_bytes|container_network_receive_bytes_total|container_network_receive_packets_dropped_total|container_network_receive_packets_total|container_network_transmit_bytes_total|container_network_transmit_packets_dropped_total|container_network_transmit_packets_total|machine_memory_bytes"
+    action = "keep"
+  }
+  forward_to = [prometheus.remote_write.grafana_cloud_prometheus.receiver]
+}
+    
+// Kube State Metrics
+discovery.relabel "kube_state_metrics" {
+  targets = discovery.kubernetes.services.targets
+  rule {
+    source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_instance"]
+    regex = "k8smon"
+    action = "keep"
+  }
+  rule {
+    source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_name"]
+    regex = "kube-state-metrics"
+    action = "keep"
+  }
+  rule {
+    source_labels = ["__meta_kubernetes_service_port_name"]
+    regex = "http"
+    action = "keep"
+  }
+  rule {
+    source_labels = ["__name__"]
+    replacement   = "custom-config-test"
+    target_label  = "cluster"
+  }
+}
+
+prometheus.scrape "kube_state_metrics" {
+  job_name   = "integrations/kubernetes/kube-state-metrics"
+  targets    = discovery.relabel.kube_state_metrics.output
+  forward_to = [prometheus.relabel.kube_state_metrics.receiver]
+}
+
+prometheus.relabel "kube_state_metrics" {
+  rule {
+    source_labels = ["__name__"]
+    regex = "up|kube_daemonset.*|kube_deployment_metadata_generation|kube_deployment_spec_replicas|kube_deployment_status_observed_generation|kube_deployment_status_replicas_available|kube_deployment_status_replicas_updated|kube_horizontalpodautoscaler_spec_max_replicas|kube_horizontalpodautoscaler_spec_min_replicas|kube_horizontalpodautoscaler_status_current_replicas|kube_horizontalpodautoscaler_status_desired_replicas|kube_job.*|kube_namespace_status_phase|kube_namespace_status_phase|kube_node.*|kube_persistentvolumeclaim_resource_requests_storage_bytes|kube_pod_container_info|kube_pod_container_resource_limits|kube_pod_container_resource_requests|kube_pod_container_status_restarts_total|kube_pod_container_status_waiting_reason|kube_pod_container_status_waiting_reason|kube_pod_info|kube_pod_owner|kube_pod_start_time|kube_pod_status_phase|kube_pod_status_phase|kube_pod_status_reason|kube_replicaset.*|kube_resourcequota|kube_statefulset.*"
+    action = "keep"
+  }
+  forward_to = [prometheus.remote_write.grafana_cloud_prometheus.receiver]
+}
+    
+// Node Exporter
+discovery.relabel "node_exporter" {
+  targets = discovery.kubernetes.pods.targets
+  rule {
+    source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_instance"]
+    regex = "k8smon"
+    action = "keep"
+  }
+  rule {
+    source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+    regex = "prometheus-node-exporter.*"
+    action = "keep"
+  }
+  rule {
+    source_labels = ["__meta_kubernetes_pod_node_name"]
+    action = "replace"
+    target_label = "instance"
+  }
+  rule {
+    source_labels = ["__name__"]
+    replacement   = "custom-config-test"
+    target_label  = "cluster"
+  }
+}
+
+prometheus.scrape "node_exporter" {
+  job_name   = "integrations/node_exporter"
+  targets  = discovery.relabel.node_exporter.output
+  forward_to = [prometheus.relabel.node_exporter.receiver]
+}
+
+prometheus.relabel "node_exporter" {
+  rule {
+    source_labels = ["__name__"]
+    regex = "up|node_cpu.*|node_exporter_build_info|node_filesystem.*|node_memory.*|process_cpu_seconds_total|process_resident_memory_bytes"
+    action = "keep"
+  }
+  forward_to = [prometheus.remote_write.grafana_cloud_prometheus.receiver]
+}
+    
+// OpenCost
+discovery.relabel "opencost" {
+  targets = discovery.kubernetes.services.targets
+  rule {
+    source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_instance"]
+    regex = "k8smon"
+    action = "keep"
+  }
+  rule {
+    source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_name"]
+    regex = "opencost"
+    action = "keep"
+  }
+  rule {
+    source_labels = ["__meta_kubernetes_service_port_name"]
+    regex = "http"
+    action = "keep"
+  }
+  rule {
+    source_labels = ["__name__"]
+    replacement   = "custom-config-test"
+    target_label  = "cluster"
+  }
+}
+
+prometheus.scrape "opencost" {
+  job_name   = "integrations/kubernetes/opencost"
+  targets    = discovery.relabel.opencost.output
+  forward_to = [prometheus.relabel.opencost.receiver]
+}
+
+prometheus.relabel "opencost" {
+  rule {
+    source_labels = ["__name__"]
+    regex = "up|container_cpu_allocation|container_gpu_allocation|container_memory_allocation_bytes|deployment_match_labels|kubecost_cluster_info|kubecost_cluster_management_cost|kubecost_cluster_memory_working_set_bytes|kubecost_http_requests_total|kubecost_http_response_size_bytes|kubecost_http_response_time_seconds|kubecost_load_balancer_cost|kubecost_network_internet_egress_cost|kubecost_network_region_egress_cost|kubecost_network_zone_egress_cost|kubecost_node_is_spot|node_cpu_hourly_cost|node_gpu_count|node_gpu_hourly_cost|node_ram_hourly_cost|node_total_hourly_cost|opencost_build_info|pod_pvc_allocation|pv_hourly_cost|service_selector_labels|statefulSet_match_labels"
+    action = "keep"
+  }
+  forward_to = [prometheus.remote_write.grafana_cloud_prometheus.receiver]
+}
+    
+// PodMonitor
+prometheus.operator.podmonitors "pod_monitors" {
+  forward_to = [prometheus.remote_write.grafana_cloud_prometheus.receiver]
+}
+    
+// ServiceMonitor
+prometheus.operator.servicemonitors "service_monitors" {
+  forward_to = [prometheus.remote_write.grafana_cloud_prometheus.receiver]
+}
+    
+// Grafana Cloud Prometheus
+local.file "prometheus_host" {
+  filename  = "/etc/grafana-agent-credentials/prometheus_host"
+}
+
+local.file "prometheus_username" {
+  filename  = "/etc/grafana-agent-credentials/prometheus_username"
+}
+
+local.file "prometheus_password" {
+  filename  = "/etc/grafana-agent-credentials/prometheus_password"
+  is_secret = true
+}
+
+prometheus.remote_write "grafana_cloud_prometheus" {
+  endpoint {
+    url = nonsensitive(local.file.prometheus_host.content) + "/api/prom/push"
+
+    basic_auth {
+      username = local.file.prometheus_username.content
+      password = local.file.prometheus_password.content
+    }
+  }
+}
+    
+// Cluster Events
+loki.source.kubernetes_events "cluster_events" {
+  job_name   = "integrations/kubernetes/eventhandler"
+  forward_to = [loki.process.cluster_events.receiver]
+}
+
+loki.process "cluster_events" {
+  stage.static_labels {
+    values = {
+      cluster = "custom-config-test",
+    }
+  }
+
+  forward_to = [loki.write.grafana_cloud_loki.receiver]
+}
+    
+// Grafana Cloud Loki
+local.file "loki_host" {
+  filename  = "/etc/grafana-agent-credentials/loki_host"
+}
+
+local.file "loki_username" {
+  filename  = "/etc/grafana-agent-credentials/loki_username"
+}
+
+local.file "loki_password" {
+  filename  = "/etc/grafana-agent-credentials/loki_password"
+  is_secret = true
+}
+
+loki.write "grafana_cloud_loki" {
+  endpoint {
+    url = nonsensitive(local.file.loki_host.content) + "/loki/api/v1/push"
+
+    basic_auth {
+      username = local.file.loki_username.content
+      password = local.file.loki_password.content
+    }
+  }
+}
+
+discovery.relabel "my_webapp" {
+  targets = discovery.kubernetes.services.targets
+  rule {
+  source_labels = ["__meta_kubernetes_service_label_app"]
+  regex = "my-webapp"
+  action = "keep"
+  }
+  rule {
+  source_labels = ["__meta_kubernetes_service_name"]
+  regex = "my-webapp-metrics"
+  action = "keep"
+  }
+  rule {
+  source_labels = ["__name__"]
+  replacement   = local.file.cluster_name.content
+  target_label  = "cluster"
+  }
+}
+
+prometheus.scrape "my_webapp" {
+  job_name   = "my_webapp"
+  targets    = discovery.relabel.my_webapp.output
+  forward_to = [prometheus.remote_write.grafana_cloud_prometheus.receiver]
+}

--- a/examples/custom-config/output.yaml
+++ b/examples/custom-config/output.yaml
@@ -1,4 +1,16 @@
 ---
+# Source: k8s-monitoring/charts/grafana-agent-logs/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: k8smon-grafana-agent-logs
+  labels:
+    helm.sh/chart: grafana-agent-logs-0.19.0
+    app.kubernetes.io/name: grafana-agent-logs
+    app.kubernetes.io/instance: k8smon
+    app.kubernetes.io/version: "v0.35.2"
+    app.kubernetes.io/managed-by: Helm
+---
 # Source: k8s-monitoring/charts/grafana-agent/templates/serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount
@@ -366,50 +378,6 @@ data:
       }
     }
         
-    // Pod Logs
-    discovery.relabel "pod_logs" {
-      targets = discovery.kubernetes.pods.targets
-    
-      rule {
-        source_labels = ["__meta_kubernetes_namespace"]
-        action = "replace"
-        target_label = "namespace"
-      }
-      rule {
-        source_labels = ["__meta_kubernetes_pod_name"]
-        action = "replace"
-        target_label = "pod"
-      }
-      rule {
-        source_labels = ["__meta_kubernetes_pod_container_name"]
-        action = "replace"
-        target_label = "container"
-      }
-      rule {
-        source_labels = ["__meta_kubernetes_namespace", "__meta_kubernetes_pod_name"]
-        separator = "/"
-        action = "replace"
-        replacement = "$1"
-        target_label = "job"
-      }
-    }
-    
-    loki.source.kubernetes "pod_logs" {
-      targets    = discovery.relabel.pod_logs.output
-      forward_to = [loki.process.pod_logs.receiver]
-    }
-    
-    loki.process "pod_logs" {
-      stage.static_labels {
-        values = {
-          cluster = "custom-config-test",
-        }
-      }
-    
-      stage.docker {}
-      forward_to = [loki.write.grafana_cloud_loki.receiver]
-    }
-        
     // Cluster Events
     loki.source.kubernetes_events "cluster_events" {
       job_name   = "integrations/kubernetes/eventhandler"
@@ -474,6 +442,98 @@ data:
       job_name   = "my_webapp"
       targets    = discovery.relabel.my_webapp.output
       forward_to = [prometheus.remote_write.grafana_cloud_prometheus.receiver]
+    }
+---
+# Source: k8s-monitoring/templates/grafana-agent-logs-config.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: k8smon-grafana-agent-logs
+  namespace: default
+data:
+  config.river: |-    
+    discovery.kubernetes "pods" {
+      role = "pod"
+    }
+        
+    // Pod Logs
+    discovery.relabel "pod_logs" {
+      targets = discovery.kubernetes.pods.targets
+    
+      rule {
+        source_labels = ["__meta_kubernetes_namespace"]
+        action = "replace"
+        target_label = "namespace"
+      }
+      rule {
+        source_labels = ["__meta_kubernetes_pod_name"]
+        action = "replace"
+        target_label = "pod"
+      }
+      rule {
+        source_labels = ["__meta_kubernetes_pod_container_name"]
+        action = "replace"
+        target_label = "container"
+      }
+      rule {
+        source_labels = ["__meta_kubernetes_namespace", "__meta_kubernetes_pod_name"]
+        separator = "/"
+        action = "replace"
+        replacement = "$1"
+        target_label = "job"
+      }
+      rule {
+        source_labels = ["__meta_kubernetes_pod_node_name"]
+        target_label = "__host__"
+      }
+      rule {
+        source_labels = ["__meta_kubernetes_pod_uid", "__meta_kubernetes_pod_container_name"]
+        separator = "/"
+        action = "replace"
+        replacement = "/var/log/pods/*$1/*.log"
+        target_label = "__path__"
+      }
+    }
+    
+    loki.source.file "pod_logs" {
+      targets    = discovery.relabel.pod_logs.output
+      forward_to = [loki.process.pod_logs.receiver]
+    }
+    
+    loki.process "pod_logs" {
+      stage.static_labels {
+        values = {
+          cluster = "custom-config-test",
+        }
+      }
+    
+      stage.docker {}
+      forward_to = [loki.write.grafana_cloud_loki.receiver]
+    }
+        
+    // Grafana Cloud Loki
+    local.file "loki_host" {
+      filename  = "/etc/grafana-agent-credentials/loki_host"
+    }
+    
+    local.file "loki_username" {
+      filename  = "/etc/grafana-agent-credentials/loki_username"
+    }
+    
+    local.file "loki_password" {
+      filename  = "/etc/grafana-agent-credentials/loki_password"
+      is_secret = true
+    }
+    
+    loki.write "grafana_cloud_loki" {
+      endpoint {
+        url = nonsensitive(local.file.loki_host.content) + "/loki/api/v1/push"
+    
+        basic_auth {
+          username = local.file.loki_username.content
+          password = local.file.loki_password.content
+        }
+      }
     }
 ---
 # Source: k8s-monitoring/charts/prometheus-operator-crds/templates/crd-alertmanagerconfigs.yaml
@@ -39498,6 +39558,87 @@ spec:
     subresources:
       status: {}
 ---
+# Source: k8s-monitoring/charts/grafana-agent-logs/templates/rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: k8smon-grafana-agent-logs
+  labels:
+    helm.sh/chart: grafana-agent-logs-0.19.0
+    app.kubernetes.io/name: grafana-agent-logs
+    app.kubernetes.io/instance: k8smon
+    app.kubernetes.io/version: "v0.35.2"
+    app.kubernetes.io/managed-by: Helm
+rules:
+  # Rules which allow discovery.kubernetes to function.
+  - apiGroups:
+      - ""
+      - "discovery.k8s.io"
+      - "networking.k8s.io"
+    resources:
+      - endpoints
+      - endpointslices
+      - ingresses
+      - nodes
+      - nodes/proxy
+      - nodes/metrics
+      - pods
+      - services
+    verbs:
+      - get
+      - list
+      - watch
+  # Rules which allow loki.source.kubernetes and loki.source.podlogs to work.
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+      - pods/log
+      - namespaces
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - "monitoring.grafana.com"
+    resources:
+      - podlogs
+    verbs:
+      - get
+      - list
+      - watch
+  # Rules which allow mimir.rules.kubernetes to work.
+  - apiGroups: ["monitoring.coreos.com"]
+    resources:
+      - prometheusrules
+    verbs:
+      - get
+      - list
+      - watch
+  - nonResourceURLs:
+      - /metrics
+    verbs:
+      - get
+  # Rules for prometheus.kubernetes.*
+  - apiGroups: ["monitoring.coreos.com"]
+    resources:
+      - podmonitors
+      - servicemonitors
+      - probes
+    verbs:
+      - get
+      - list
+      - watch
+  # Rules which allow eventhandler to work.
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - get
+      - list
+      - watch
+---
 # Source: k8s-monitoring/charts/grafana-agent/templates/rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -39821,6 +39962,26 @@ rules:
       - list
       - watch
 ---
+# Source: k8s-monitoring/charts/grafana-agent-logs/templates/rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: k8smon-grafana-agent-logs
+  labels:
+    helm.sh/chart: grafana-agent-logs-0.19.0
+    app.kubernetes.io/name: grafana-agent-logs
+    app.kubernetes.io/instance: k8smon
+    app.kubernetes.io/version: "v0.35.2"
+    app.kubernetes.io/managed-by: Helm
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: k8smon-grafana-agent-logs
+subjects:
+  - kind: ServiceAccount
+    name: k8smon-grafana-agent-logs
+    namespace: default
+---
 # Source: k8s-monitoring/charts/grafana-agent/templates/rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -39883,6 +40044,57 @@ subjects:
   - kind: ServiceAccount
     name: k8smon-opencost
     namespace: default
+---
+# Source: k8s-monitoring/charts/grafana-agent-logs/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: k8smon-grafana-agent-logs
+  labels:
+    helm.sh/chart: grafana-agent-logs-0.19.0
+    app.kubernetes.io/name: grafana-agent-logs
+    app.kubernetes.io/instance: k8smon
+    app.kubernetes.io/version: "v0.35.2"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: grafana-agent-logs
+    app.kubernetes.io/instance: k8smon
+  ports:
+    - name: http-metrics
+      port: 80
+      targetPort: 80
+      protocol: "TCP"
+---
+# Source: k8s-monitoring/charts/grafana-agent/templates/cluster_service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: k8smon-grafana-agent-cluster
+  labels:
+    helm.sh/chart: grafana-agent-0.19.0
+    app.kubernetes.io/name: grafana-agent
+    app.kubernetes.io/instance: k8smon
+    app.kubernetes.io/version: "v0.35.2"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  type: ClusterIP
+  clusterIP: 'None'
+  selector:
+    app.kubernetes.io/name: grafana-agent
+    app.kubernetes.io/instance: k8smon
+  ports:
+    # Do not include the -metrics suffix in the port name, otherwise metrics
+    # can be double-collected with the non-headless Service if it's also
+    # enabled.
+    #
+    # This service should only be used for clustering, and not metric
+    # collection.
+    - name: http
+      port: 80
+      targetPort: 80
+      protocol: "TCP"
 ---
 # Source: k8s-monitoring/charts/grafana-agent/templates/service.yaml
 apiVersion: v1
@@ -39983,14 +40195,14 @@ spec:
     app.kubernetes.io/name: prometheus-node-exporter
     app.kubernetes.io/instance: k8smon
 ---
-# Source: k8s-monitoring/charts/grafana-agent/templates/controllers/daemonset.yaml
+# Source: k8s-monitoring/charts/grafana-agent-logs/templates/controllers/daemonset.yaml
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
-  name: k8smon-grafana-agent
+  name: k8smon-grafana-agent-logs
   labels:
-    helm.sh/chart: grafana-agent-0.19.0
-    app.kubernetes.io/name: grafana-agent
+    helm.sh/chart: grafana-agent-logs-0.19.0
+    app.kubernetes.io/name: grafana-agent-logs
     app.kubernetes.io/instance: k8smon
     app.kubernetes.io/version: "v0.35.2"
     app.kubernetes.io/managed-by: Helm
@@ -39998,15 +40210,15 @@ spec:
   minReadySeconds: 10
   selector:
     matchLabels:
-      app.kubernetes.io/name: grafana-agent
+      app.kubernetes.io/name: grafana-agent-logs
       app.kubernetes.io/instance: k8smon
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: grafana-agent
+        app.kubernetes.io/name: grafana-agent-logs
         app.kubernetes.io/instance: k8smon
     spec:
-      serviceAccountName: k8smon-grafana-agent
+      serviceAccountName: k8smon-grafana-agent-logs
       containers:
         - name: grafana-agent
           image: docker.io/grafana/agent:v0.35.2
@@ -40035,6 +40247,12 @@ spec:
           volumeMounts:
             - name: config
               mountPath: /etc/agent
+            - name: varlog
+              mountPath: /var/log
+              readOnly: true
+            - name: dockercontainers
+              mountPath: /var/lib/docker/containers
+              readOnly: true
             -
               mountPath: /etc/grafana-agent-credentials
               name: grafana-agent-credentials
@@ -40056,7 +40274,13 @@ spec:
       volumes:
         - name: config
           configMap:
-            name: k8smon-grafana-agent
+            name: k8smon-grafana-agent-logs
+        - name: varlog
+          hostPath:
+            path: /var/log
+        - name: dockercontainers
+          hostPath:
+            path: /var/lib/docker/containers
         - name: grafana-agent-credentials
           secret:
             secretName: grafana-agent-credentials
@@ -40325,6 +40549,88 @@ spec:
               value: "true"
             - name: PROM_CLUSTER_ID_LABEL
               value: "cluster"
+---
+# Source: k8s-monitoring/charts/grafana-agent/templates/controllers/statefulset.yaml
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: k8smon-grafana-agent
+  labels:
+    helm.sh/chart: grafana-agent-0.19.0
+    app.kubernetes.io/name: grafana-agent
+    app.kubernetes.io/instance: k8smon
+    app.kubernetes.io/version: "v0.35.2"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  replicas: 1
+  minReadySeconds: 10
+  serviceName: k8smon-grafana-agent
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: grafana-agent
+      app.kubernetes.io/instance: k8smon
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: grafana-agent
+        app.kubernetes.io/instance: k8smon
+    spec:
+      serviceAccountName: k8smon-grafana-agent
+      containers:
+        - name: grafana-agent
+          image: docker.io/grafana/agent:v0.35.2
+          imagePullPolicy: IfNotPresent
+          args:
+            - run
+            - /etc/agent/config.river
+            - --storage.path=/tmp/agent
+            - --server.http.listen-addr=0.0.0.0:80
+            - --cluster.enabled=true
+            - --cluster.join-addresses=k8smon-grafana-agent-cluster
+          env:
+            - name: AGENT_MODE
+              value: flow
+            - name: HOSTNAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+          ports:
+            - containerPort: 80
+              name: http-metrics
+          readinessProbe:
+            httpGet:
+              path: /-/ready
+              port: 80
+            initialDelaySeconds: 10
+            timeoutSeconds: 1
+          volumeMounts:
+            - name: config
+              mountPath: /etc/agent
+            -
+              mountPath: /etc/grafana-agent-credentials
+              name: grafana-agent-credentials
+        - name: config-reloader
+          image: docker.io/jimmidyson/configmap-reload:v0.8.0
+          args:
+            - --volume-dir=/etc/agent
+            - --webhook-url=http://localhost:80/-/reload
+          volumeMounts:
+            - name: config
+              mountPath: /etc/agent
+          resources:
+            requests:
+              cpu: 1m
+              memory: 5Mi
+      dnsPolicy: ClusterFirst
+      nodeSelector:
+        kubernetes.io/os: linux
+      volumes:
+        - name: config
+          configMap:
+            name: k8smon-grafana-agent
+        - name: grafana-agent-credentials
+          secret:
+            secretName: grafana-agent-credentials
 ---
 # Source: k8s-monitoring/charts/prometheus-operator-crds/templates/crd-alertmanagerconfigs.yaml
 # https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.66.0/example/prometheus-operator-crd/monitoring.coreos.com_alertmanagerconfigs.yaml

--- a/examples/custom-config/output.yaml
+++ b/examples/custom-config/output.yaml
@@ -40276,6 +40276,9 @@ spec:
       dnsPolicy: ClusterFirst
       nodeSelector:
         kubernetes.io/os: linux
+      tolerations:
+        - effect: NoSchedule
+          operator: Exists
       volumes:
         - name: config
           configMap:

--- a/examples/custom-config/output.yaml
+++ b/examples/custom-config/output.yaml
@@ -484,7 +484,8 @@ data:
       }
       rule {
         source_labels = ["__meta_kubernetes_pod_node_name"]
-        target_label = "__host__"
+        action = "keep"
+        regex = env("HOSTNAME")
       }
       rule {
         source_labels = ["__meta_kubernetes_pod_uid", "__meta_kubernetes_pod_container_name"]
@@ -495,8 +496,12 @@ data:
       }
     }
     
+    local.file_match "pod_logs" {
+      path_targets = discovery.relabel.pod_logs.output
+    }
+    
     loki.source.file "pod_logs" {
-      targets    = discovery.relabel.pod_logs.output
+      targets    = local.file_match.pod_logs.targets
       forward_to = [loki.process.pod_logs.receiver]
     }
     

--- a/examples/default-values/logs.river
+++ b/examples/default-values/logs.river
@@ -30,7 +30,8 @@ discovery.relabel "pod_logs" {
   }
   rule {
     source_labels = ["__meta_kubernetes_pod_node_name"]
-    target_label = "__host__"
+    action = "keep"
+    regex = env("HOSTNAME")
   }
   rule {
     source_labels = ["__meta_kubernetes_pod_uid", "__meta_kubernetes_pod_container_name"]
@@ -41,8 +42,12 @@ discovery.relabel "pod_logs" {
   }
 }
 
+local.file_match "pod_logs" {
+  path_targets = discovery.relabel.pod_logs.output
+}
+
 loki.source.file "pod_logs" {
-  targets    = discovery.relabel.pod_logs.output
+  targets    = local.file_match.pod_logs.targets
   forward_to = [loki.process.pod_logs.receiver]
 }
 

--- a/examples/default-values/logs.river
+++ b/examples/default-values/logs.river
@@ -1,4 +1,7 @@
-{{ define "agent.config.pod_logs" }}
+discovery.kubernetes "pods" {
+  role = "pod"
+}
+    
 // Pod Logs
 discovery.relabel "pod_logs" {
   targets = discovery.kubernetes.pods.targets
@@ -46,11 +49,35 @@ loki.source.file "pod_logs" {
 loki.process "pod_logs" {
   stage.static_labels {
     values = {
-      cluster = {{ required ".Values.cluster.name is a required value. Please set it and try again." .Values.cluster.name | quote }},
+      cluster = "default-values-test",
     }
   }
 
-  stage.{{- .Values.pod_logs.loggingFormat }} {}
+  stage.docker {}
   forward_to = [loki.write.grafana_cloud_loki.receiver]
 }
-{{ end }}
+    
+// Grafana Cloud Loki
+local.file "loki_host" {
+  filename  = "/etc/grafana-agent-credentials/loki_host"
+}
+
+local.file "loki_username" {
+  filename  = "/etc/grafana-agent-credentials/loki_username"
+}
+
+local.file "loki_password" {
+  filename  = "/etc/grafana-agent-credentials/loki_password"
+  is_secret = true
+}
+
+loki.write "grafana_cloud_loki" {
+  endpoint {
+    url = nonsensitive(local.file.loki_host.content) + "/loki/api/v1/push"
+
+    basic_auth {
+      username = local.file.loki_username.content
+      password = local.file.loki_password.content
+    }
+  }
+}

--- a/examples/default-values/metrics.river
+++ b/examples/default-values/metrics.river
@@ -1,0 +1,327 @@
+discovery.kubernetes "nodes" {
+  role = "node"
+}
+    
+discovery.kubernetes "pods" {
+  role = "pod"
+}
+    
+discovery.kubernetes "services" {
+  role = "service"
+}
+    
+// Grafana Agent
+discovery.relabel "agent" {
+  targets = discovery.kubernetes.services.targets
+  rule {
+    source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_instance"]
+    regex = "k8smon"
+    action = "keep"
+  }
+  rule {
+    source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_name"]
+    regex = "grafana-agent"
+    action = "keep"
+  }
+  rule {
+    source_labels = ["__meta_kubernetes_service_port_name"]
+    regex = "http-metrics"
+    action = "keep"
+  }
+  rule {
+    source_labels = ["__name__"]
+    replacement   = "default-values-test"
+    target_label  = "cluster"
+  }
+}
+
+prometheus.scrape "agent" {
+  job_name   = "integrations/agent"
+  targets  = discovery.relabel.agent.output
+  forward_to = [prometheus.relabel.agent.receiver]
+}
+
+prometheus.relabel "agent" {
+  rule {
+    source_labels = ["__name__"]
+    regex = "up|agent_build_info"
+    action = "keep"
+  }
+  forward_to = [prometheus.remote_write.grafana_cloud_prometheus.receiver]
+}
+    
+// Kubelet
+discovery.relabel "kubelet" {
+  targets = discovery.kubernetes.nodes.targets
+  rule {
+    target_label = "__address__"
+    replacement  = "kubernetes.default.svc.cluster.local:443"
+  }
+  rule {
+    source_labels = ["__meta_kubernetes_node_name"]
+    regex         = "(.+)"
+    replacement   = "/api/v1/nodes/${1}/proxy/metrics"
+    target_label  = "__metrics_path__"
+  }
+  rule {
+    source_labels = ["__name__"]
+    replacement   = "default-values-test"
+    target_label  = "cluster"
+  }
+}
+
+prometheus.scrape "kubelet" {
+  job_name   = "integrations/kubernetes/kubelet"
+  targets  = discovery.relabel.kubelet.output
+  scheme   = "https"
+  bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+  tls_config {
+    insecure_skip_verify = true
+  }
+  forward_to = [prometheus.relabel.kubelet.receiver]
+}
+
+prometheus.relabel "kubelet" {
+  rule {
+    source_labels = ["__name__"]
+    regex = "up|container_cpu_usage_seconds_total|kubelet_certificate_manager_client_expiration_renew_errors|kubelet_certificate_manager_client_ttl_seconds|kubelet_certificate_manager_server_ttl_seconds|kubelet_cgroup_manager_duration_seconds_bucket|kubelet_cgroup_manager_duration_seconds_count|kubelet_node_config_error|kubelet_node_name|kubelet_pleg_relist_duration_seconds_bucket|kubelet_pleg_relist_duration_seconds_count|kubelet_pleg_relist_interval_seconds_bucket|kubelet_pod_start_duration_seconds_bucket|kubelet_pod_start_duration_seconds_count|kubelet_pod_worker_duration_seconds_bucket|kubelet_pod_worker_duration_seconds_count|kubelet_running_container_count|kubelet_running_containers|kubelet_running_pod_count|kubelet_running_pods|kubelet_runtime_operations_errors_total|kubelet_runtime_operations_total|kubelet_server_expiration_renew_errors|kubelet_volume_stats_available_bytes|kubelet_volume_stats_capacity_bytes|kubelet_volume_stats_inodes|kubelet_volume_stats_inodes_used|kubernetes_build_info|namespace_workload_pod|rest_client_requests_total|storage_operation_duration_seconds_count|storage_operation_errors_total|volume_manager_total_volumes"
+    action = "keep"
+  }
+  forward_to = [prometheus.remote_write.grafana_cloud_prometheus.receiver]
+}
+    
+// cAdvisor
+discovery.relabel "cadvisor" {
+  targets = discovery.kubernetes.nodes.targets
+  rule {
+    target_label = "__address__"
+    replacement  = "kubernetes.default.svc.cluster.local:443"
+  }
+  rule {
+    source_labels = ["__meta_kubernetes_node_name"]
+    regex         = "(.+)"
+    replacement   = "/api/v1/nodes/${1}/proxy/metrics/cadvisor"
+    target_label  = "__metrics_path__"
+  }
+  rule {
+    source_labels = ["__name__"]
+    replacement   = "default-values-test"
+    target_label  = "cluster"
+  }
+}
+
+prometheus.scrape "cadvisor" {
+  job_name   = "integrations/kubernetes/cadvisor"
+  targets    = discovery.relabel.cadvisor.output
+  scheme     = "https"
+  bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+  tls_config {
+    insecure_skip_verify = true
+  }
+  forward_to = [prometheus.relabel.cadvisor.receiver]
+}
+
+prometheus.relabel "cadvisor" {
+  rule {
+    source_labels = ["__name__"]
+    regex = "up|container_cpu_cfs_periods_total|container_cpu_cfs_throttled_periods_total|container_cpu_usage_seconds_total|container_fs_reads_bytes_total|container_fs_reads_total|container_fs_writes_bytes_total|container_fs_writes_total|container_memory_cache|container_memory_rss|container_memory_swap|container_memory_working_set_bytes|container_network_receive_bytes_total|container_network_receive_packets_dropped_total|container_network_receive_packets_total|container_network_transmit_bytes_total|container_network_transmit_packets_dropped_total|container_network_transmit_packets_total|machine_memory_bytes"
+    action = "keep"
+  }
+  forward_to = [prometheus.remote_write.grafana_cloud_prometheus.receiver]
+}
+    
+// Kube State Metrics
+discovery.relabel "kube_state_metrics" {
+  targets = discovery.kubernetes.services.targets
+  rule {
+    source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_instance"]
+    regex = "k8smon"
+    action = "keep"
+  }
+  rule {
+    source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_name"]
+    regex = "kube-state-metrics"
+    action = "keep"
+  }
+  rule {
+    source_labels = ["__meta_kubernetes_service_port_name"]
+    regex = "http"
+    action = "keep"
+  }
+  rule {
+    source_labels = ["__name__"]
+    replacement   = "default-values-test"
+    target_label  = "cluster"
+  }
+}
+
+prometheus.scrape "kube_state_metrics" {
+  job_name   = "integrations/kubernetes/kube-state-metrics"
+  targets    = discovery.relabel.kube_state_metrics.output
+  forward_to = [prometheus.relabel.kube_state_metrics.receiver]
+}
+
+prometheus.relabel "kube_state_metrics" {
+  rule {
+    source_labels = ["__name__"]
+    regex = "up|kube_daemonset.*|kube_deployment_metadata_generation|kube_deployment_spec_replicas|kube_deployment_status_observed_generation|kube_deployment_status_replicas_available|kube_deployment_status_replicas_updated|kube_horizontalpodautoscaler_spec_max_replicas|kube_horizontalpodautoscaler_spec_min_replicas|kube_horizontalpodautoscaler_status_current_replicas|kube_horizontalpodautoscaler_status_desired_replicas|kube_job.*|kube_namespace_status_phase|kube_namespace_status_phase|kube_node.*|kube_persistentvolumeclaim_resource_requests_storage_bytes|kube_pod_container_info|kube_pod_container_resource_limits|kube_pod_container_resource_requests|kube_pod_container_status_restarts_total|kube_pod_container_status_waiting_reason|kube_pod_container_status_waiting_reason|kube_pod_info|kube_pod_owner|kube_pod_start_time|kube_pod_status_phase|kube_pod_status_phase|kube_pod_status_reason|kube_replicaset.*|kube_resourcequota|kube_statefulset.*"
+    action = "keep"
+  }
+  forward_to = [prometheus.remote_write.grafana_cloud_prometheus.receiver]
+}
+    
+// Node Exporter
+discovery.relabel "node_exporter" {
+  targets = discovery.kubernetes.pods.targets
+  rule {
+    source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_instance"]
+    regex = "k8smon"
+    action = "keep"
+  }
+  rule {
+    source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+    regex = "prometheus-node-exporter.*"
+    action = "keep"
+  }
+  rule {
+    source_labels = ["__meta_kubernetes_pod_node_name"]
+    action = "replace"
+    target_label = "instance"
+  }
+  rule {
+    source_labels = ["__name__"]
+    replacement   = "default-values-test"
+    target_label  = "cluster"
+  }
+}
+
+prometheus.scrape "node_exporter" {
+  job_name   = "integrations/node_exporter"
+  targets  = discovery.relabel.node_exporter.output
+  forward_to = [prometheus.relabel.node_exporter.receiver]
+}
+
+prometheus.relabel "node_exporter" {
+  rule {
+    source_labels = ["__name__"]
+    regex = "up|node_cpu.*|node_exporter_build_info|node_filesystem.*|node_memory.*|process_cpu_seconds_total|process_resident_memory_bytes"
+    action = "keep"
+  }
+  forward_to = [prometheus.remote_write.grafana_cloud_prometheus.receiver]
+}
+    
+// OpenCost
+discovery.relabel "opencost" {
+  targets = discovery.kubernetes.services.targets
+  rule {
+    source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_instance"]
+    regex = "k8smon"
+    action = "keep"
+  }
+  rule {
+    source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_name"]
+    regex = "opencost"
+    action = "keep"
+  }
+  rule {
+    source_labels = ["__meta_kubernetes_service_port_name"]
+    regex = "http"
+    action = "keep"
+  }
+  rule {
+    source_labels = ["__name__"]
+    replacement   = "default-values-test"
+    target_label  = "cluster"
+  }
+}
+
+prometheus.scrape "opencost" {
+  job_name   = "integrations/kubernetes/opencost"
+  targets    = discovery.relabel.opencost.output
+  forward_to = [prometheus.relabel.opencost.receiver]
+}
+
+prometheus.relabel "opencost" {
+  rule {
+    source_labels = ["__name__"]
+    regex = "up|container_cpu_allocation|container_gpu_allocation|container_memory_allocation_bytes|deployment_match_labels|kubecost_cluster_info|kubecost_cluster_management_cost|kubecost_cluster_memory_working_set_bytes|kubecost_http_requests_total|kubecost_http_response_size_bytes|kubecost_http_response_time_seconds|kubecost_load_balancer_cost|kubecost_network_internet_egress_cost|kubecost_network_region_egress_cost|kubecost_network_zone_egress_cost|kubecost_node_is_spot|node_cpu_hourly_cost|node_gpu_count|node_gpu_hourly_cost|node_ram_hourly_cost|node_total_hourly_cost|opencost_build_info|pod_pvc_allocation|pv_hourly_cost|service_selector_labels|statefulSet_match_labels"
+    action = "keep"
+  }
+  forward_to = [prometheus.remote_write.grafana_cloud_prometheus.receiver]
+}
+    
+// PodMonitor
+prometheus.operator.podmonitors "pod_monitors" {
+  forward_to = [prometheus.remote_write.grafana_cloud_prometheus.receiver]
+}
+    
+// ServiceMonitor
+prometheus.operator.servicemonitors "service_monitors" {
+  forward_to = [prometheus.remote_write.grafana_cloud_prometheus.receiver]
+}
+    
+// Grafana Cloud Prometheus
+local.file "prometheus_host" {
+  filename  = "/etc/grafana-agent-credentials/prometheus_host"
+}
+
+local.file "prometheus_username" {
+  filename  = "/etc/grafana-agent-credentials/prometheus_username"
+}
+
+local.file "prometheus_password" {
+  filename  = "/etc/grafana-agent-credentials/prometheus_password"
+  is_secret = true
+}
+
+prometheus.remote_write "grafana_cloud_prometheus" {
+  endpoint {
+    url = nonsensitive(local.file.prometheus_host.content) + "/api/prom/push"
+
+    basic_auth {
+      username = local.file.prometheus_username.content
+      password = local.file.prometheus_password.content
+    }
+  }
+}
+    
+// Cluster Events
+loki.source.kubernetes_events "cluster_events" {
+  job_name   = "integrations/kubernetes/eventhandler"
+  forward_to = [loki.process.cluster_events.receiver]
+}
+
+loki.process "cluster_events" {
+  stage.static_labels {
+    values = {
+      cluster = "default-values-test",
+    }
+  }
+
+  forward_to = [loki.write.grafana_cloud_loki.receiver]
+}
+    
+// Grafana Cloud Loki
+local.file "loki_host" {
+  filename  = "/etc/grafana-agent-credentials/loki_host"
+}
+
+local.file "loki_username" {
+  filename  = "/etc/grafana-agent-credentials/loki_username"
+}
+
+local.file "loki_password" {
+  filename  = "/etc/grafana-agent-credentials/loki_password"
+  is_secret = true
+}
+
+loki.write "grafana_cloud_loki" {
+  endpoint {
+    url = nonsensitive(local.file.loki_host.content) + "/loki/api/v1/push"
+
+    basic_auth {
+      username = local.file.loki_username.content
+      password = local.file.loki_password.content
+    }
+  }
+}

--- a/examples/default-values/output.yaml
+++ b/examples/default-values/output.yaml
@@ -1,4 +1,16 @@
 ---
+# Source: k8s-monitoring/charts/grafana-agent-logs/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: k8smon-grafana-agent-logs
+  labels:
+    helm.sh/chart: grafana-agent-logs-0.19.0
+    app.kubernetes.io/name: grafana-agent-logs
+    app.kubernetes.io/instance: k8smon
+    app.kubernetes.io/version: "v0.35.2"
+    app.kubernetes.io/managed-by: Helm
+---
 # Source: k8s-monitoring/charts/grafana-agent/templates/serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount
@@ -366,6 +378,59 @@ data:
       }
     }
         
+    // Cluster Events
+    loki.source.kubernetes_events "cluster_events" {
+      job_name   = "integrations/kubernetes/eventhandler"
+      forward_to = [loki.process.cluster_events.receiver]
+    }
+    
+    loki.process "cluster_events" {
+      stage.static_labels {
+        values = {
+          cluster = "default-values-test",
+        }
+      }
+    
+      forward_to = [loki.write.grafana_cloud_loki.receiver]
+    }
+        
+    // Grafana Cloud Loki
+    local.file "loki_host" {
+      filename  = "/etc/grafana-agent-credentials/loki_host"
+    }
+    
+    local.file "loki_username" {
+      filename  = "/etc/grafana-agent-credentials/loki_username"
+    }
+    
+    local.file "loki_password" {
+      filename  = "/etc/grafana-agent-credentials/loki_password"
+      is_secret = true
+    }
+    
+    loki.write "grafana_cloud_loki" {
+      endpoint {
+        url = nonsensitive(local.file.loki_host.content) + "/loki/api/v1/push"
+    
+        basic_auth {
+          username = local.file.loki_username.content
+          password = local.file.loki_password.content
+        }
+      }
+    }
+---
+# Source: k8s-monitoring/templates/grafana-agent-logs-config.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: k8smon-grafana-agent-logs
+  namespace: default
+data:
+  config.river: |-    
+    discovery.kubernetes "pods" {
+      role = "pod"
+    }
+        
     // Pod Logs
     discovery.relabel "pod_logs" {
       targets = discovery.kubernetes.pods.targets
@@ -392,9 +457,20 @@ data:
         replacement = "$1"
         target_label = "job"
       }
+      rule {
+        source_labels = ["__meta_kubernetes_pod_node_name"]
+        target_label = "__host__"
+      }
+      rule {
+        source_labels = ["__meta_kubernetes_pod_uid", "__meta_kubernetes_pod_container_name"]
+        separator = "/"
+        action = "replace"
+        replacement = "/var/log/pods/*$1/*.log"
+        target_label = "__path__"
+      }
     }
     
-    loki.source.kubernetes "pod_logs" {
+    loki.source.file "pod_logs" {
       targets    = discovery.relabel.pod_logs.output
       forward_to = [loki.process.pod_logs.receiver]
     }
@@ -407,22 +483,6 @@ data:
       }
     
       stage.docker {}
-      forward_to = [loki.write.grafana_cloud_loki.receiver]
-    }
-        
-    // Cluster Events
-    loki.source.kubernetes_events "cluster_events" {
-      job_name   = "integrations/kubernetes/eventhandler"
-      forward_to = [loki.process.cluster_events.receiver]
-    }
-    
-    loki.process "cluster_events" {
-      stage.static_labels {
-        values = {
-          cluster = "default-values-test",
-        }
-      }
-    
       forward_to = [loki.write.grafana_cloud_loki.receiver]
     }
         
@@ -39473,6 +39533,87 @@ spec:
     subresources:
       status: {}
 ---
+# Source: k8s-monitoring/charts/grafana-agent-logs/templates/rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: k8smon-grafana-agent-logs
+  labels:
+    helm.sh/chart: grafana-agent-logs-0.19.0
+    app.kubernetes.io/name: grafana-agent-logs
+    app.kubernetes.io/instance: k8smon
+    app.kubernetes.io/version: "v0.35.2"
+    app.kubernetes.io/managed-by: Helm
+rules:
+  # Rules which allow discovery.kubernetes to function.
+  - apiGroups:
+      - ""
+      - "discovery.k8s.io"
+      - "networking.k8s.io"
+    resources:
+      - endpoints
+      - endpointslices
+      - ingresses
+      - nodes
+      - nodes/proxy
+      - nodes/metrics
+      - pods
+      - services
+    verbs:
+      - get
+      - list
+      - watch
+  # Rules which allow loki.source.kubernetes and loki.source.podlogs to work.
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+      - pods/log
+      - namespaces
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - "monitoring.grafana.com"
+    resources:
+      - podlogs
+    verbs:
+      - get
+      - list
+      - watch
+  # Rules which allow mimir.rules.kubernetes to work.
+  - apiGroups: ["monitoring.coreos.com"]
+    resources:
+      - prometheusrules
+    verbs:
+      - get
+      - list
+      - watch
+  - nonResourceURLs:
+      - /metrics
+    verbs:
+      - get
+  # Rules for prometheus.kubernetes.*
+  - apiGroups: ["monitoring.coreos.com"]
+    resources:
+      - podmonitors
+      - servicemonitors
+      - probes
+    verbs:
+      - get
+      - list
+      - watch
+  # Rules which allow eventhandler to work.
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - get
+      - list
+      - watch
+---
 # Source: k8s-monitoring/charts/grafana-agent/templates/rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -39796,6 +39937,26 @@ rules:
       - list
       - watch
 ---
+# Source: k8s-monitoring/charts/grafana-agent-logs/templates/rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: k8smon-grafana-agent-logs
+  labels:
+    helm.sh/chart: grafana-agent-logs-0.19.0
+    app.kubernetes.io/name: grafana-agent-logs
+    app.kubernetes.io/instance: k8smon
+    app.kubernetes.io/version: "v0.35.2"
+    app.kubernetes.io/managed-by: Helm
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: k8smon-grafana-agent-logs
+subjects:
+  - kind: ServiceAccount
+    name: k8smon-grafana-agent-logs
+    namespace: default
+---
 # Source: k8s-monitoring/charts/grafana-agent/templates/rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -39858,6 +40019,57 @@ subjects:
   - kind: ServiceAccount
     name: k8smon-opencost
     namespace: default
+---
+# Source: k8s-monitoring/charts/grafana-agent-logs/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: k8smon-grafana-agent-logs
+  labels:
+    helm.sh/chart: grafana-agent-logs-0.19.0
+    app.kubernetes.io/name: grafana-agent-logs
+    app.kubernetes.io/instance: k8smon
+    app.kubernetes.io/version: "v0.35.2"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: grafana-agent-logs
+    app.kubernetes.io/instance: k8smon
+  ports:
+    - name: http-metrics
+      port: 80
+      targetPort: 80
+      protocol: "TCP"
+---
+# Source: k8s-monitoring/charts/grafana-agent/templates/cluster_service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: k8smon-grafana-agent-cluster
+  labels:
+    helm.sh/chart: grafana-agent-0.19.0
+    app.kubernetes.io/name: grafana-agent
+    app.kubernetes.io/instance: k8smon
+    app.kubernetes.io/version: "v0.35.2"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  type: ClusterIP
+  clusterIP: 'None'
+  selector:
+    app.kubernetes.io/name: grafana-agent
+    app.kubernetes.io/instance: k8smon
+  ports:
+    # Do not include the -metrics suffix in the port name, otherwise metrics
+    # can be double-collected with the non-headless Service if it's also
+    # enabled.
+    #
+    # This service should only be used for clustering, and not metric
+    # collection.
+    - name: http
+      port: 80
+      targetPort: 80
+      protocol: "TCP"
 ---
 # Source: k8s-monitoring/charts/grafana-agent/templates/service.yaml
 apiVersion: v1
@@ -39958,14 +40170,14 @@ spec:
     app.kubernetes.io/name: prometheus-node-exporter
     app.kubernetes.io/instance: k8smon
 ---
-# Source: k8s-monitoring/charts/grafana-agent/templates/controllers/daemonset.yaml
+# Source: k8s-monitoring/charts/grafana-agent-logs/templates/controllers/daemonset.yaml
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
-  name: k8smon-grafana-agent
+  name: k8smon-grafana-agent-logs
   labels:
-    helm.sh/chart: grafana-agent-0.19.0
-    app.kubernetes.io/name: grafana-agent
+    helm.sh/chart: grafana-agent-logs-0.19.0
+    app.kubernetes.io/name: grafana-agent-logs
     app.kubernetes.io/instance: k8smon
     app.kubernetes.io/version: "v0.35.2"
     app.kubernetes.io/managed-by: Helm
@@ -39973,15 +40185,15 @@ spec:
   minReadySeconds: 10
   selector:
     matchLabels:
-      app.kubernetes.io/name: grafana-agent
+      app.kubernetes.io/name: grafana-agent-logs
       app.kubernetes.io/instance: k8smon
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: grafana-agent
+        app.kubernetes.io/name: grafana-agent-logs
         app.kubernetes.io/instance: k8smon
     spec:
-      serviceAccountName: k8smon-grafana-agent
+      serviceAccountName: k8smon-grafana-agent-logs
       containers:
         - name: grafana-agent
           image: docker.io/grafana/agent:v0.35.2
@@ -40010,6 +40222,12 @@ spec:
           volumeMounts:
             - name: config
               mountPath: /etc/agent
+            - name: varlog
+              mountPath: /var/log
+              readOnly: true
+            - name: dockercontainers
+              mountPath: /var/lib/docker/containers
+              readOnly: true
             -
               mountPath: /etc/grafana-agent-credentials
               name: grafana-agent-credentials
@@ -40031,7 +40249,13 @@ spec:
       volumes:
         - name: config
           configMap:
-            name: k8smon-grafana-agent
+            name: k8smon-grafana-agent-logs
+        - name: varlog
+          hostPath:
+            path: /var/log
+        - name: dockercontainers
+          hostPath:
+            path: /var/lib/docker/containers
         - name: grafana-agent-credentials
           secret:
             secretName: grafana-agent-credentials
@@ -40300,6 +40524,88 @@ spec:
               value: "true"
             - name: PROM_CLUSTER_ID_LABEL
               value: "cluster"
+---
+# Source: k8s-monitoring/charts/grafana-agent/templates/controllers/statefulset.yaml
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: k8smon-grafana-agent
+  labels:
+    helm.sh/chart: grafana-agent-0.19.0
+    app.kubernetes.io/name: grafana-agent
+    app.kubernetes.io/instance: k8smon
+    app.kubernetes.io/version: "v0.35.2"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  replicas: 1
+  minReadySeconds: 10
+  serviceName: k8smon-grafana-agent
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: grafana-agent
+      app.kubernetes.io/instance: k8smon
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: grafana-agent
+        app.kubernetes.io/instance: k8smon
+    spec:
+      serviceAccountName: k8smon-grafana-agent
+      containers:
+        - name: grafana-agent
+          image: docker.io/grafana/agent:v0.35.2
+          imagePullPolicy: IfNotPresent
+          args:
+            - run
+            - /etc/agent/config.river
+            - --storage.path=/tmp/agent
+            - --server.http.listen-addr=0.0.0.0:80
+            - --cluster.enabled=true
+            - --cluster.join-addresses=k8smon-grafana-agent-cluster
+          env:
+            - name: AGENT_MODE
+              value: flow
+            - name: HOSTNAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+          ports:
+            - containerPort: 80
+              name: http-metrics
+          readinessProbe:
+            httpGet:
+              path: /-/ready
+              port: 80
+            initialDelaySeconds: 10
+            timeoutSeconds: 1
+          volumeMounts:
+            - name: config
+              mountPath: /etc/agent
+            -
+              mountPath: /etc/grafana-agent-credentials
+              name: grafana-agent-credentials
+        - name: config-reloader
+          image: docker.io/jimmidyson/configmap-reload:v0.8.0
+          args:
+            - --volume-dir=/etc/agent
+            - --webhook-url=http://localhost:80/-/reload
+          volumeMounts:
+            - name: config
+              mountPath: /etc/agent
+          resources:
+            requests:
+              cpu: 1m
+              memory: 5Mi
+      dnsPolicy: ClusterFirst
+      nodeSelector:
+        kubernetes.io/os: linux
+      volumes:
+        - name: config
+          configMap:
+            name: k8smon-grafana-agent
+        - name: grafana-agent-credentials
+          secret:
+            secretName: grafana-agent-credentials
 ---
 # Source: k8s-monitoring/charts/prometheus-operator-crds/templates/crd-alertmanagerconfigs.yaml
 # https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.66.0/example/prometheus-operator-crd/monitoring.coreos.com_alertmanagerconfigs.yaml

--- a/examples/default-values/output.yaml
+++ b/examples/default-values/output.yaml
@@ -40251,6 +40251,9 @@ spec:
       dnsPolicy: ClusterFirst
       nodeSelector:
         kubernetes.io/os: linux
+      tolerations:
+        - effect: NoSchedule
+          operator: Exists
       volumes:
         - name: config
           configMap:

--- a/examples/default-values/output.yaml
+++ b/examples/default-values/output.yaml
@@ -459,7 +459,8 @@ data:
       }
       rule {
         source_labels = ["__meta_kubernetes_pod_node_name"]
-        target_label = "__host__"
+        action = "keep"
+        regex = env("HOSTNAME")
       }
       rule {
         source_labels = ["__meta_kubernetes_pod_uid", "__meta_kubernetes_pod_container_name"]
@@ -470,8 +471,12 @@ data:
       }
     }
     
+    local.file_match "pod_logs" {
+      path_targets = discovery.relabel.pod_logs.output
+    }
+    
     loki.source.file "pod_logs" {
-      targets    = discovery.relabel.pod_logs.output
+      targets    = local.file_match.pod_logs.targets
       forward_to = [loki.process.pod_logs.receiver]
     }
     

--- a/examples/logs-only/logs.river
+++ b/examples/logs-only/logs.river
@@ -1,4 +1,7 @@
-{{ define "agent.config.pod_logs" }}
+discovery.kubernetes "pods" {
+  role = "pod"
+}
+    
 // Pod Logs
 discovery.relabel "pod_logs" {
   targets = discovery.kubernetes.pods.targets
@@ -46,11 +49,35 @@ loki.source.file "pod_logs" {
 loki.process "pod_logs" {
   stage.static_labels {
     values = {
-      cluster = {{ required ".Values.cluster.name is a required value. Please set it and try again." .Values.cluster.name | quote }},
+      cluster = "logs-only-test",
     }
   }
 
-  stage.{{- .Values.pod_logs.loggingFormat }} {}
+  stage.docker {}
   forward_to = [loki.write.grafana_cloud_loki.receiver]
 }
-{{ end }}
+    
+// Grafana Cloud Loki
+local.file "loki_host" {
+  filename  = "/etc/grafana-agent-credentials/loki_host"
+}
+
+local.file "loki_username" {
+  filename  = "/etc/grafana-agent-credentials/loki_username"
+}
+
+local.file "loki_password" {
+  filename  = "/etc/grafana-agent-credentials/loki_password"
+  is_secret = true
+}
+
+loki.write "grafana_cloud_loki" {
+  endpoint {
+    url = nonsensitive(local.file.loki_host.content) + "/loki/api/v1/push"
+
+    basic_auth {
+      username = local.file.loki_username.content
+      password = local.file.loki_password.content
+    }
+  }
+}

--- a/examples/logs-only/logs.river
+++ b/examples/logs-only/logs.river
@@ -30,7 +30,8 @@ discovery.relabel "pod_logs" {
   }
   rule {
     source_labels = ["__meta_kubernetes_pod_node_name"]
-    target_label = "__host__"
+    action = "keep"
+    regex = env("HOSTNAME")
   }
   rule {
     source_labels = ["__meta_kubernetes_pod_uid", "__meta_kubernetes_pod_container_name"]
@@ -41,8 +42,12 @@ discovery.relabel "pod_logs" {
   }
 }
 
+local.file_match "pod_logs" {
+  path_targets = discovery.relabel.pod_logs.output
+}
+
 loki.source.file "pod_logs" {
-  targets    = discovery.relabel.pod_logs.output
+  targets    = local.file_match.pod_logs.targets
   forward_to = [loki.process.pod_logs.receiver]
 }
 

--- a/examples/logs-only/metrics.river
+++ b/examples/logs-only/metrics.river
@@ -1,0 +1,11 @@
+discovery.kubernetes "nodes" {
+  role = "node"
+}
+    
+discovery.kubernetes "pods" {
+  role = "pod"
+}
+    
+discovery.kubernetes "services" {
+  role = "service"
+}

--- a/examples/logs-only/output.yaml
+++ b/examples/logs-only/output.yaml
@@ -1,4 +1,16 @@
 ---
+# Source: k8s-monitoring/charts/grafana-agent-logs/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: k8smon-grafana-agent-logs
+  labels:
+    helm.sh/chart: grafana-agent-logs-0.19.0
+    app.kubernetes.io/name: grafana-agent-logs
+    app.kubernetes.io/instance: k8smon
+    app.kubernetes.io/version: "v0.35.2"
+    app.kubernetes.io/managed-by: Helm
+---
 # Source: k8s-monitoring/charts/grafana-agent/templates/serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount
@@ -42,6 +54,18 @@ data:
     discovery.kubernetes "services" {
       role = "service"
     }
+---
+# Source: k8s-monitoring/templates/grafana-agent-logs-config.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: k8smon-grafana-agent-logs
+  namespace: default
+data:
+  config.river: |-    
+    discovery.kubernetes "pods" {
+      role = "pod"
+    }
         
     // Pod Logs
     discovery.relabel "pod_logs" {
@@ -69,9 +93,20 @@ data:
         replacement = "$1"
         target_label = "job"
       }
+      rule {
+        source_labels = ["__meta_kubernetes_pod_node_name"]
+        target_label = "__host__"
+      }
+      rule {
+        source_labels = ["__meta_kubernetes_pod_uid", "__meta_kubernetes_pod_container_name"]
+        separator = "/"
+        action = "replace"
+        replacement = "/var/log/pods/*$1/*.log"
+        target_label = "__path__"
+      }
     }
     
-    loki.source.kubernetes "pod_logs" {
+    loki.source.file "pod_logs" {
       targets    = discovery.relabel.pod_logs.output
       forward_to = [loki.process.pod_logs.receiver]
     }
@@ -84,22 +119,6 @@ data:
       }
     
       stage.docker {}
-      forward_to = [loki.write.grafana_cloud_loki.receiver]
-    }
-        
-    // Cluster Events
-    loki.source.kubernetes_events "cluster_events" {
-      job_name   = "integrations/kubernetes/eventhandler"
-      forward_to = [loki.process.cluster_events.receiver]
-    }
-    
-    loki.process "cluster_events" {
-      stage.static_labels {
-        values = {
-          cluster = "logs-only-test",
-        }
-      }
-    
       forward_to = [loki.write.grafana_cloud_loki.receiver]
     }
         
@@ -127,6 +146,87 @@ data:
         }
       }
     }
+---
+# Source: k8s-monitoring/charts/grafana-agent-logs/templates/rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: k8smon-grafana-agent-logs
+  labels:
+    helm.sh/chart: grafana-agent-logs-0.19.0
+    app.kubernetes.io/name: grafana-agent-logs
+    app.kubernetes.io/instance: k8smon
+    app.kubernetes.io/version: "v0.35.2"
+    app.kubernetes.io/managed-by: Helm
+rules:
+  # Rules which allow discovery.kubernetes to function.
+  - apiGroups:
+      - ""
+      - "discovery.k8s.io"
+      - "networking.k8s.io"
+    resources:
+      - endpoints
+      - endpointslices
+      - ingresses
+      - nodes
+      - nodes/proxy
+      - nodes/metrics
+      - pods
+      - services
+    verbs:
+      - get
+      - list
+      - watch
+  # Rules which allow loki.source.kubernetes and loki.source.podlogs to work.
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+      - pods/log
+      - namespaces
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - "monitoring.grafana.com"
+    resources:
+      - podlogs
+    verbs:
+      - get
+      - list
+      - watch
+  # Rules which allow mimir.rules.kubernetes to work.
+  - apiGroups: ["monitoring.coreos.com"]
+    resources:
+      - prometheusrules
+    verbs:
+      - get
+      - list
+      - watch
+  - nonResourceURLs:
+      - /metrics
+    verbs:
+      - get
+  # Rules for prometheus.kubernetes.*
+  - apiGroups: ["monitoring.coreos.com"]
+    resources:
+      - podmonitors
+      - servicemonitors
+      - probes
+    verbs:
+      - get
+      - list
+      - watch
+  # Rules which allow eventhandler to work.
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - get
+      - list
+      - watch
 ---
 # Source: k8s-monitoring/charts/grafana-agent/templates/rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -209,6 +309,26 @@ rules:
       - list
       - watch
 ---
+# Source: k8s-monitoring/charts/grafana-agent-logs/templates/rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: k8smon-grafana-agent-logs
+  labels:
+    helm.sh/chart: grafana-agent-logs-0.19.0
+    app.kubernetes.io/name: grafana-agent-logs
+    app.kubernetes.io/instance: k8smon
+    app.kubernetes.io/version: "v0.35.2"
+    app.kubernetes.io/managed-by: Helm
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: k8smon-grafana-agent-logs
+subjects:
+  - kind: ServiceAccount
+    name: k8smon-grafana-agent-logs
+    namespace: default
+---
 # Source: k8s-monitoring/charts/grafana-agent/templates/rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -228,6 +348,57 @@ subjects:
   - kind: ServiceAccount
     name: k8smon-grafana-agent
     namespace: default
+---
+# Source: k8s-monitoring/charts/grafana-agent-logs/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: k8smon-grafana-agent-logs
+  labels:
+    helm.sh/chart: grafana-agent-logs-0.19.0
+    app.kubernetes.io/name: grafana-agent-logs
+    app.kubernetes.io/instance: k8smon
+    app.kubernetes.io/version: "v0.35.2"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: grafana-agent-logs
+    app.kubernetes.io/instance: k8smon
+  ports:
+    - name: http-metrics
+      port: 80
+      targetPort: 80
+      protocol: "TCP"
+---
+# Source: k8s-monitoring/charts/grafana-agent/templates/cluster_service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: k8smon-grafana-agent-cluster
+  labels:
+    helm.sh/chart: grafana-agent-0.19.0
+    app.kubernetes.io/name: grafana-agent
+    app.kubernetes.io/instance: k8smon
+    app.kubernetes.io/version: "v0.35.2"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  type: ClusterIP
+  clusterIP: 'None'
+  selector:
+    app.kubernetes.io/name: grafana-agent
+    app.kubernetes.io/instance: k8smon
+  ports:
+    # Do not include the -metrics suffix in the port name, otherwise metrics
+    # can be double-collected with the non-headless Service if it's also
+    # enabled.
+    #
+    # This service should only be used for clustering, and not metric
+    # collection.
+    - name: http
+      port: 80
+      targetPort: 80
+      protocol: "TCP"
 ---
 # Source: k8s-monitoring/charts/grafana-agent/templates/service.yaml
 apiVersion: v1
@@ -251,9 +422,99 @@ spec:
       targetPort: 80
       protocol: "TCP"
 ---
-# Source: k8s-monitoring/charts/grafana-agent/templates/controllers/daemonset.yaml
+# Source: k8s-monitoring/charts/grafana-agent-logs/templates/controllers/daemonset.yaml
 apiVersion: apps/v1
 kind: DaemonSet
+metadata:
+  name: k8smon-grafana-agent-logs
+  labels:
+    helm.sh/chart: grafana-agent-logs-0.19.0
+    app.kubernetes.io/name: grafana-agent-logs
+    app.kubernetes.io/instance: k8smon
+    app.kubernetes.io/version: "v0.35.2"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  minReadySeconds: 10
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: grafana-agent-logs
+      app.kubernetes.io/instance: k8smon
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: grafana-agent-logs
+        app.kubernetes.io/instance: k8smon
+    spec:
+      serviceAccountName: k8smon-grafana-agent-logs
+      containers:
+        - name: grafana-agent
+          image: docker.io/grafana/agent:v0.35.2
+          imagePullPolicy: IfNotPresent
+          args:
+            - run
+            - /etc/agent/config.river
+            - --storage.path=/tmp/agent
+            - --server.http.listen-addr=0.0.0.0:80
+          env:
+            - name: AGENT_MODE
+              value: flow
+            - name: HOSTNAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+          ports:
+            - containerPort: 80
+              name: http-metrics
+          readinessProbe:
+            httpGet:
+              path: /-/ready
+              port: 80
+            initialDelaySeconds: 10
+            timeoutSeconds: 1
+          volumeMounts:
+            - name: config
+              mountPath: /etc/agent
+            - name: varlog
+              mountPath: /var/log
+              readOnly: true
+            - name: dockercontainers
+              mountPath: /var/lib/docker/containers
+              readOnly: true
+            -
+              mountPath: /etc/grafana-agent-credentials
+              name: grafana-agent-credentials
+        - name: config-reloader
+          image: docker.io/jimmidyson/configmap-reload:v0.8.0
+          args:
+            - --volume-dir=/etc/agent
+            - --webhook-url=http://localhost:80/-/reload
+          volumeMounts:
+            - name: config
+              mountPath: /etc/agent
+          resources:
+            requests:
+              cpu: 1m
+              memory: 5Mi
+      dnsPolicy: ClusterFirst
+      nodeSelector:
+        kubernetes.io/os: linux
+      volumes:
+        - name: config
+          configMap:
+            name: k8smon-grafana-agent-logs
+        - name: varlog
+          hostPath:
+            path: /var/log
+        - name: dockercontainers
+          hostPath:
+            path: /var/lib/docker/containers
+        - name: grafana-agent-credentials
+          secret:
+            secretName: grafana-agent-credentials
+---
+# Source: k8s-monitoring/charts/grafana-agent/templates/controllers/statefulset.yaml
+apiVersion: apps/v1
+kind: StatefulSet
 metadata:
   name: k8smon-grafana-agent
   labels:
@@ -263,7 +524,9 @@ metadata:
     app.kubernetes.io/version: "v0.35.2"
     app.kubernetes.io/managed-by: Helm
 spec:
+  replicas: 1
   minReadySeconds: 10
+  serviceName: k8smon-grafana-agent
   selector:
     matchLabels:
       app.kubernetes.io/name: grafana-agent
@@ -284,6 +547,8 @@ spec:
             - /etc/agent/config.river
             - --storage.path=/tmp/agent
             - --server.http.listen-addr=0.0.0.0:80
+            - --cluster.enabled=true
+            - --cluster.join-addresses=k8smon-grafana-agent-cluster
           env:
             - name: AGENT_MODE
               value: flow

--- a/examples/logs-only/output.yaml
+++ b/examples/logs-only/output.yaml
@@ -95,7 +95,8 @@ data:
       }
       rule {
         source_labels = ["__meta_kubernetes_pod_node_name"]
-        target_label = "__host__"
+        action = "keep"
+        regex = env("HOSTNAME")
       }
       rule {
         source_labels = ["__meta_kubernetes_pod_uid", "__meta_kubernetes_pod_container_name"]
@@ -106,8 +107,12 @@ data:
       }
     }
     
+    local.file_match "pod_logs" {
+      path_targets = discovery.relabel.pod_logs.output
+    }
+    
     loki.source.file "pod_logs" {
-      targets    = discovery.relabel.pod_logs.output
+      targets    = local.file_match.pod_logs.targets
       forward_to = [loki.process.pod_logs.receiver]
     }
     

--- a/examples/logs-only/output.yaml
+++ b/examples/logs-only/output.yaml
@@ -503,6 +503,9 @@ spec:
       dnsPolicy: ClusterFirst
       nodeSelector:
         kubernetes.io/os: linux
+      tolerations:
+        - effect: NoSchedule
+          operator: Exists
       volumes:
         - name: config
           configMap:

--- a/examples/metrics-only/metrics.river
+++ b/examples/metrics-only/metrics.river
@@ -1,0 +1,286 @@
+discovery.kubernetes "nodes" {
+  role = "node"
+}
+    
+discovery.kubernetes "pods" {
+  role = "pod"
+}
+    
+discovery.kubernetes "services" {
+  role = "service"
+}
+    
+// Grafana Agent
+discovery.relabel "agent" {
+  targets = discovery.kubernetes.services.targets
+  rule {
+    source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_instance"]
+    regex = "k8smon"
+    action = "keep"
+  }
+  rule {
+    source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_name"]
+    regex = "grafana-agent"
+    action = "keep"
+  }
+  rule {
+    source_labels = ["__meta_kubernetes_service_port_name"]
+    regex = "http-metrics"
+    action = "keep"
+  }
+  rule {
+    source_labels = ["__name__"]
+    replacement   = "metrics-only-test"
+    target_label  = "cluster"
+  }
+}
+
+prometheus.scrape "agent" {
+  job_name   = "integrations/agent"
+  targets  = discovery.relabel.agent.output
+  forward_to = [prometheus.relabel.agent.receiver]
+}
+
+prometheus.relabel "agent" {
+  rule {
+    source_labels = ["__name__"]
+    regex = "up|agent_build_info"
+    action = "keep"
+  }
+  forward_to = [prometheus.remote_write.grafana_cloud_prometheus.receiver]
+}
+    
+// Kubelet
+discovery.relabel "kubelet" {
+  targets = discovery.kubernetes.nodes.targets
+  rule {
+    target_label = "__address__"
+    replacement  = "kubernetes.default.svc.cluster.local:443"
+  }
+  rule {
+    source_labels = ["__meta_kubernetes_node_name"]
+    regex         = "(.+)"
+    replacement   = "/api/v1/nodes/${1}/proxy/metrics"
+    target_label  = "__metrics_path__"
+  }
+  rule {
+    source_labels = ["__name__"]
+    replacement   = "metrics-only-test"
+    target_label  = "cluster"
+  }
+}
+
+prometheus.scrape "kubelet" {
+  job_name   = "integrations/kubernetes/kubelet"
+  targets  = discovery.relabel.kubelet.output
+  scheme   = "https"
+  bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+  tls_config {
+    insecure_skip_verify = true
+  }
+  forward_to = [prometheus.relabel.kubelet.receiver]
+}
+
+prometheus.relabel "kubelet" {
+  rule {
+    source_labels = ["__name__"]
+    regex = "up|container_cpu_usage_seconds_total|kubelet_certificate_manager_client_expiration_renew_errors|kubelet_certificate_manager_client_ttl_seconds|kubelet_certificate_manager_server_ttl_seconds|kubelet_cgroup_manager_duration_seconds_bucket|kubelet_cgroup_manager_duration_seconds_count|kubelet_node_config_error|kubelet_node_name|kubelet_pleg_relist_duration_seconds_bucket|kubelet_pleg_relist_duration_seconds_count|kubelet_pleg_relist_interval_seconds_bucket|kubelet_pod_start_duration_seconds_bucket|kubelet_pod_start_duration_seconds_count|kubelet_pod_worker_duration_seconds_bucket|kubelet_pod_worker_duration_seconds_count|kubelet_running_container_count|kubelet_running_containers|kubelet_running_pod_count|kubelet_running_pods|kubelet_runtime_operations_errors_total|kubelet_runtime_operations_total|kubelet_server_expiration_renew_errors|kubelet_volume_stats_available_bytes|kubelet_volume_stats_capacity_bytes|kubelet_volume_stats_inodes|kubelet_volume_stats_inodes_used|kubernetes_build_info|namespace_workload_pod|rest_client_requests_total|storage_operation_duration_seconds_count|storage_operation_errors_total|volume_manager_total_volumes"
+    action = "keep"
+  }
+  forward_to = [prometheus.remote_write.grafana_cloud_prometheus.receiver]
+}
+    
+// cAdvisor
+discovery.relabel "cadvisor" {
+  targets = discovery.kubernetes.nodes.targets
+  rule {
+    target_label = "__address__"
+    replacement  = "kubernetes.default.svc.cluster.local:443"
+  }
+  rule {
+    source_labels = ["__meta_kubernetes_node_name"]
+    regex         = "(.+)"
+    replacement   = "/api/v1/nodes/${1}/proxy/metrics/cadvisor"
+    target_label  = "__metrics_path__"
+  }
+  rule {
+    source_labels = ["__name__"]
+    replacement   = "metrics-only-test"
+    target_label  = "cluster"
+  }
+}
+
+prometheus.scrape "cadvisor" {
+  job_name   = "integrations/kubernetes/cadvisor"
+  targets    = discovery.relabel.cadvisor.output
+  scheme     = "https"
+  bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+  tls_config {
+    insecure_skip_verify = true
+  }
+  forward_to = [prometheus.relabel.cadvisor.receiver]
+}
+
+prometheus.relabel "cadvisor" {
+  rule {
+    source_labels = ["__name__"]
+    regex = "up|container_cpu_cfs_periods_total|container_cpu_cfs_throttled_periods_total|container_cpu_usage_seconds_total|container_fs_reads_bytes_total|container_fs_reads_total|container_fs_writes_bytes_total|container_fs_writes_total|container_memory_cache|container_memory_rss|container_memory_swap|container_memory_working_set_bytes|container_network_receive_bytes_total|container_network_receive_packets_dropped_total|container_network_receive_packets_total|container_network_transmit_bytes_total|container_network_transmit_packets_dropped_total|container_network_transmit_packets_total|machine_memory_bytes"
+    action = "keep"
+  }
+  forward_to = [prometheus.remote_write.grafana_cloud_prometheus.receiver]
+}
+    
+// Kube State Metrics
+discovery.relabel "kube_state_metrics" {
+  targets = discovery.kubernetes.services.targets
+  rule {
+    source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_instance"]
+    regex = "k8smon"
+    action = "keep"
+  }
+  rule {
+    source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_name"]
+    regex = "kube-state-metrics"
+    action = "keep"
+  }
+  rule {
+    source_labels = ["__meta_kubernetes_service_port_name"]
+    regex = "http"
+    action = "keep"
+  }
+  rule {
+    source_labels = ["__name__"]
+    replacement   = "metrics-only-test"
+    target_label  = "cluster"
+  }
+}
+
+prometheus.scrape "kube_state_metrics" {
+  job_name   = "integrations/kubernetes/kube-state-metrics"
+  targets    = discovery.relabel.kube_state_metrics.output
+  forward_to = [prometheus.relabel.kube_state_metrics.receiver]
+}
+
+prometheus.relabel "kube_state_metrics" {
+  rule {
+    source_labels = ["__name__"]
+    regex = "up|kube_daemonset.*|kube_deployment_metadata_generation|kube_deployment_spec_replicas|kube_deployment_status_observed_generation|kube_deployment_status_replicas_available|kube_deployment_status_replicas_updated|kube_horizontalpodautoscaler_spec_max_replicas|kube_horizontalpodautoscaler_spec_min_replicas|kube_horizontalpodautoscaler_status_current_replicas|kube_horizontalpodautoscaler_status_desired_replicas|kube_job.*|kube_namespace_status_phase|kube_namespace_status_phase|kube_node.*|kube_persistentvolumeclaim_resource_requests_storage_bytes|kube_pod_container_info|kube_pod_container_resource_limits|kube_pod_container_resource_requests|kube_pod_container_status_restarts_total|kube_pod_container_status_waiting_reason|kube_pod_container_status_waiting_reason|kube_pod_info|kube_pod_owner|kube_pod_start_time|kube_pod_status_phase|kube_pod_status_phase|kube_pod_status_reason|kube_replicaset.*|kube_resourcequota|kube_statefulset.*"
+    action = "keep"
+  }
+  forward_to = [prometheus.remote_write.grafana_cloud_prometheus.receiver]
+}
+    
+// Node Exporter
+discovery.relabel "node_exporter" {
+  targets = discovery.kubernetes.pods.targets
+  rule {
+    source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_instance"]
+    regex = "k8smon"
+    action = "keep"
+  }
+  rule {
+    source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+    regex = "prometheus-node-exporter.*"
+    action = "keep"
+  }
+  rule {
+    source_labels = ["__meta_kubernetes_pod_node_name"]
+    action = "replace"
+    target_label = "instance"
+  }
+  rule {
+    source_labels = ["__name__"]
+    replacement   = "metrics-only-test"
+    target_label  = "cluster"
+  }
+}
+
+prometheus.scrape "node_exporter" {
+  job_name   = "integrations/node_exporter"
+  targets  = discovery.relabel.node_exporter.output
+  forward_to = [prometheus.relabel.node_exporter.receiver]
+}
+
+prometheus.relabel "node_exporter" {
+  rule {
+    source_labels = ["__name__"]
+    regex = "up|node_cpu.*|node_exporter_build_info|node_filesystem.*|node_memory.*|process_cpu_seconds_total|process_resident_memory_bytes"
+    action = "keep"
+  }
+  forward_to = [prometheus.remote_write.grafana_cloud_prometheus.receiver]
+}
+    
+// OpenCost
+discovery.relabel "opencost" {
+  targets = discovery.kubernetes.services.targets
+  rule {
+    source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_instance"]
+    regex = "k8smon"
+    action = "keep"
+  }
+  rule {
+    source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_name"]
+    regex = "opencost"
+    action = "keep"
+  }
+  rule {
+    source_labels = ["__meta_kubernetes_service_port_name"]
+    regex = "http"
+    action = "keep"
+  }
+  rule {
+    source_labels = ["__name__"]
+    replacement   = "metrics-only-test"
+    target_label  = "cluster"
+  }
+}
+
+prometheus.scrape "opencost" {
+  job_name   = "integrations/kubernetes/opencost"
+  targets    = discovery.relabel.opencost.output
+  forward_to = [prometheus.relabel.opencost.receiver]
+}
+
+prometheus.relabel "opencost" {
+  rule {
+    source_labels = ["__name__"]
+    regex = "up|container_cpu_allocation|container_gpu_allocation|container_memory_allocation_bytes|deployment_match_labels|kubecost_cluster_info|kubecost_cluster_management_cost|kubecost_cluster_memory_working_set_bytes|kubecost_http_requests_total|kubecost_http_response_size_bytes|kubecost_http_response_time_seconds|kubecost_load_balancer_cost|kubecost_network_internet_egress_cost|kubecost_network_region_egress_cost|kubecost_network_zone_egress_cost|kubecost_node_is_spot|node_cpu_hourly_cost|node_gpu_count|node_gpu_hourly_cost|node_ram_hourly_cost|node_total_hourly_cost|opencost_build_info|pod_pvc_allocation|pv_hourly_cost|service_selector_labels|statefulSet_match_labels"
+    action = "keep"
+  }
+  forward_to = [prometheus.remote_write.grafana_cloud_prometheus.receiver]
+}
+    
+// PodMonitor
+prometheus.operator.podmonitors "pod_monitors" {
+  forward_to = [prometheus.remote_write.grafana_cloud_prometheus.receiver]
+}
+    
+// ServiceMonitor
+prometheus.operator.servicemonitors "service_monitors" {
+  forward_to = [prometheus.remote_write.grafana_cloud_prometheus.receiver]
+}
+    
+// Grafana Cloud Prometheus
+local.file "prometheus_host" {
+  filename  = "/etc/grafana-agent-credentials/prometheus_host"
+}
+
+local.file "prometheus_username" {
+  filename  = "/etc/grafana-agent-credentials/prometheus_username"
+}
+
+local.file "prometheus_password" {
+  filename  = "/etc/grafana-agent-credentials/prometheus_password"
+  is_secret = true
+}
+
+prometheus.remote_write "grafana_cloud_prometheus" {
+  endpoint {
+    url = nonsensitive(local.file.prometheus_host.content) + "/api/prom/push"
+
+    basic_auth {
+      username = local.file.prometheus_username.content
+      password = local.file.prometheus_password.content
+    }
+  }
+}

--- a/examples/metrics-only/output.yaml
+++ b/examples/metrics-only/output.yaml
@@ -39771,6 +39771,35 @@ subjects:
     name: k8smon-opencost
     namespace: default
 ---
+# Source: k8s-monitoring/charts/grafana-agent/templates/cluster_service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: k8smon-grafana-agent-cluster
+  labels:
+    helm.sh/chart: grafana-agent-0.19.0
+    app.kubernetes.io/name: grafana-agent
+    app.kubernetes.io/instance: k8smon
+    app.kubernetes.io/version: "v0.35.2"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  type: ClusterIP
+  clusterIP: 'None'
+  selector:
+    app.kubernetes.io/name: grafana-agent
+    app.kubernetes.io/instance: k8smon
+  ports:
+    # Do not include the -metrics suffix in the port name, otherwise metrics
+    # can be double-collected with the non-headless Service if it's also
+    # enabled.
+    #
+    # This service should only be used for clustering, and not metric
+    # collection.
+    - name: http
+      port: 80
+      targetPort: 80
+      protocol: "TCP"
+---
 # Source: k8s-monitoring/charts/grafana-agent/templates/service.yaml
 apiVersion: v1
 kind: Service
@@ -39869,84 +39898,6 @@ spec:
   selector:
     app.kubernetes.io/name: prometheus-node-exporter
     app.kubernetes.io/instance: k8smon
----
-# Source: k8s-monitoring/charts/grafana-agent/templates/controllers/daemonset.yaml
-apiVersion: apps/v1
-kind: DaemonSet
-metadata:
-  name: k8smon-grafana-agent
-  labels:
-    helm.sh/chart: grafana-agent-0.19.0
-    app.kubernetes.io/name: grafana-agent
-    app.kubernetes.io/instance: k8smon
-    app.kubernetes.io/version: "v0.35.2"
-    app.kubernetes.io/managed-by: Helm
-spec:
-  minReadySeconds: 10
-  selector:
-    matchLabels:
-      app.kubernetes.io/name: grafana-agent
-      app.kubernetes.io/instance: k8smon
-  template:
-    metadata:
-      labels:
-        app.kubernetes.io/name: grafana-agent
-        app.kubernetes.io/instance: k8smon
-    spec:
-      serviceAccountName: k8smon-grafana-agent
-      containers:
-        - name: grafana-agent
-          image: docker.io/grafana/agent:v0.35.2
-          imagePullPolicy: IfNotPresent
-          args:
-            - run
-            - /etc/agent/config.river
-            - --storage.path=/tmp/agent
-            - --server.http.listen-addr=0.0.0.0:80
-          env:
-            - name: AGENT_MODE
-              value: flow
-            - name: HOSTNAME
-              valueFrom:
-                fieldRef:
-                  fieldPath: spec.nodeName
-          ports:
-            - containerPort: 80
-              name: http-metrics
-          readinessProbe:
-            httpGet:
-              path: /-/ready
-              port: 80
-            initialDelaySeconds: 10
-            timeoutSeconds: 1
-          volumeMounts:
-            - name: config
-              mountPath: /etc/agent
-            -
-              mountPath: /etc/grafana-agent-credentials
-              name: grafana-agent-credentials
-        - name: config-reloader
-          image: docker.io/jimmidyson/configmap-reload:v0.8.0
-          args:
-            - --volume-dir=/etc/agent
-            - --webhook-url=http://localhost:80/-/reload
-          volumeMounts:
-            - name: config
-              mountPath: /etc/agent
-          resources:
-            requests:
-              cpu: 1m
-              memory: 5Mi
-      dnsPolicy: ClusterFirst
-      nodeSelector:
-        kubernetes.io/os: linux
-      volumes:
-        - name: config
-          configMap:
-            name: k8smon-grafana-agent
-        - name: grafana-agent-credentials
-          secret:
-            secretName: grafana-agent-credentials
 ---
 # Source: k8s-monitoring/charts/prometheus-node-exporter/templates/daemonset.yaml
 apiVersion: apps/v1
@@ -40212,6 +40163,88 @@ spec:
               value: "true"
             - name: PROM_CLUSTER_ID_LABEL
               value: "cluster"
+---
+# Source: k8s-monitoring/charts/grafana-agent/templates/controllers/statefulset.yaml
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: k8smon-grafana-agent
+  labels:
+    helm.sh/chart: grafana-agent-0.19.0
+    app.kubernetes.io/name: grafana-agent
+    app.kubernetes.io/instance: k8smon
+    app.kubernetes.io/version: "v0.35.2"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  replicas: 1
+  minReadySeconds: 10
+  serviceName: k8smon-grafana-agent
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: grafana-agent
+      app.kubernetes.io/instance: k8smon
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: grafana-agent
+        app.kubernetes.io/instance: k8smon
+    spec:
+      serviceAccountName: k8smon-grafana-agent
+      containers:
+        - name: grafana-agent
+          image: docker.io/grafana/agent:v0.35.2
+          imagePullPolicy: IfNotPresent
+          args:
+            - run
+            - /etc/agent/config.river
+            - --storage.path=/tmp/agent
+            - --server.http.listen-addr=0.0.0.0:80
+            - --cluster.enabled=true
+            - --cluster.join-addresses=k8smon-grafana-agent-cluster
+          env:
+            - name: AGENT_MODE
+              value: flow
+            - name: HOSTNAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+          ports:
+            - containerPort: 80
+              name: http-metrics
+          readinessProbe:
+            httpGet:
+              path: /-/ready
+              port: 80
+            initialDelaySeconds: 10
+            timeoutSeconds: 1
+          volumeMounts:
+            - name: config
+              mountPath: /etc/agent
+            -
+              mountPath: /etc/grafana-agent-credentials
+              name: grafana-agent-credentials
+        - name: config-reloader
+          image: docker.io/jimmidyson/configmap-reload:v0.8.0
+          args:
+            - --volume-dir=/etc/agent
+            - --webhook-url=http://localhost:80/-/reload
+          volumeMounts:
+            - name: config
+              mountPath: /etc/agent
+          resources:
+            requests:
+              cpu: 1m
+              memory: 5Mi
+      dnsPolicy: ClusterFirst
+      nodeSelector:
+        kubernetes.io/os: linux
+      volumes:
+        - name: config
+          configMap:
+            name: k8smon-grafana-agent
+        - name: grafana-agent-credentials
+          secret:
+            secretName: grafana-agent-credentials
 ---
 # Source: k8s-monitoring/charts/prometheus-operator-crds/templates/crd-alertmanagerconfigs.yaml
 # https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.66.0/example/prometheus-operator-crd/monitoring.coreos.com_alertmanagerconfigs.yaml

--- a/examples/metrics-only/values.yaml
+++ b/examples/metrics-only/values.yaml
@@ -8,5 +8,8 @@ externalServices:
       username: "12345"
       password: "It's a secret to everyone"
 
-logs:
+pod_logs:
+  enabled: false
+
+cluster_events:
   enabled: false

--- a/examples/metrics-only/values.yaml
+++ b/examples/metrics-only/values.yaml
@@ -8,8 +8,9 @@ externalServices:
       username: "12345"
       password: "It's a secret to everyone"
 
-pod_logs:
-  enabled: false
+logs:
+  pod_logs:
+    enabled: false
 
-cluster_events:
-  enabled: false
+  cluster_events:
+    enabled: false

--- a/examples/openshift-compatible/logs.river
+++ b/examples/openshift-compatible/logs.river
@@ -30,7 +30,8 @@ discovery.relabel "pod_logs" {
   }
   rule {
     source_labels = ["__meta_kubernetes_pod_node_name"]
-    target_label = "__host__"
+    action = "keep"
+    regex = env("HOSTNAME")
   }
   rule {
     source_labels = ["__meta_kubernetes_pod_uid", "__meta_kubernetes_pod_container_name"]
@@ -41,8 +42,12 @@ discovery.relabel "pod_logs" {
   }
 }
 
+local.file_match "pod_logs" {
+  path_targets = discovery.relabel.pod_logs.output
+}
+
 loki.source.file "pod_logs" {
-  targets    = discovery.relabel.pod_logs.output
+  targets    = local.file_match.pod_logs.targets
   forward_to = [loki.process.pod_logs.receiver]
 }
 

--- a/examples/openshift-compatible/logs.river
+++ b/examples/openshift-compatible/logs.river
@@ -1,4 +1,7 @@
-{{ define "agent.config.pod_logs" }}
+discovery.kubernetes "pods" {
+  role = "pod"
+}
+    
 // Pod Logs
 discovery.relabel "pod_logs" {
   targets = discovery.kubernetes.pods.targets
@@ -46,11 +49,35 @@ loki.source.file "pod_logs" {
 loki.process "pod_logs" {
   stage.static_labels {
     values = {
-      cluster = {{ required ".Values.cluster.name is a required value. Please set it and try again." .Values.cluster.name | quote }},
+      cluster = "openshift-compatible-test",
     }
   }
 
-  stage.{{- .Values.pod_logs.loggingFormat }} {}
+  stage.docker {}
   forward_to = [loki.write.grafana_cloud_loki.receiver]
 }
-{{ end }}
+    
+// Grafana Cloud Loki
+local.file "loki_host" {
+  filename  = "/etc/grafana-agent-credentials/loki_host"
+}
+
+local.file "loki_username" {
+  filename  = "/etc/grafana-agent-credentials/loki_username"
+}
+
+local.file "loki_password" {
+  filename  = "/etc/grafana-agent-credentials/loki_password"
+  is_secret = true
+}
+
+loki.write "grafana_cloud_loki" {
+  endpoint {
+    url = nonsensitive(local.file.loki_host.content) + "/loki/api/v1/push"
+
+    basic_auth {
+      username = local.file.loki_username.content
+      password = local.file.loki_password.content
+    }
+  }
+}

--- a/examples/openshift-compatible/metrics.river
+++ b/examples/openshift-compatible/metrics.river
@@ -1,0 +1,328 @@
+discovery.kubernetes "nodes" {
+  role = "node"
+}
+    
+discovery.kubernetes "pods" {
+  role = "pod"
+}
+    
+discovery.kubernetes "services" {
+  role = "service"
+}
+    
+// Grafana Agent
+discovery.relabel "agent" {
+  targets = discovery.kubernetes.services.targets
+  rule {
+    source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_instance"]
+    regex = "k8smon"
+    action = "keep"
+  }
+  rule {
+    source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_name"]
+    regex = "grafana-agent"
+    action = "keep"
+  }
+  rule {
+    source_labels = ["__meta_kubernetes_service_port_name"]
+    regex = "http-metrics"
+    action = "keep"
+  }
+  rule {
+    source_labels = ["__name__"]
+    replacement   = "openshift-compatible-test"
+    target_label  = "cluster"
+  }
+}
+
+prometheus.scrape "agent" {
+  job_name   = "integrations/agent"
+  targets  = discovery.relabel.agent.output
+  forward_to = [prometheus.relabel.agent.receiver]
+}
+
+prometheus.relabel "agent" {
+  rule {
+    source_labels = ["__name__"]
+    regex = "up|agent_build_info"
+    action = "keep"
+  }
+  forward_to = [prometheus.remote_write.grafana_cloud_prometheus.receiver]
+}
+    
+// Kubelet
+discovery.relabel "kubelet" {
+  targets = discovery.kubernetes.nodes.targets
+  rule {
+    target_label = "__address__"
+    replacement  = "kubernetes.default.svc.cluster.local:443"
+  }
+  rule {
+    source_labels = ["__meta_kubernetes_node_name"]
+    regex         = "(.+)"
+    replacement   = "/api/v1/nodes/${1}/proxy/metrics"
+    target_label  = "__metrics_path__"
+  }
+  rule {
+    source_labels = ["__name__"]
+    replacement   = "openshift-compatible-test"
+    target_label  = "cluster"
+  }
+}
+
+prometheus.scrape "kubelet" {
+  job_name   = "integrations/kubernetes/kubelet"
+  targets  = discovery.relabel.kubelet.output
+  scheme   = "https"
+  bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+  tls_config {
+    insecure_skip_verify = true
+  }
+  forward_to = [prometheus.relabel.kubelet.receiver]
+}
+
+prometheus.relabel "kubelet" {
+  rule {
+    source_labels = ["__name__"]
+    regex = "up|container_cpu_usage_seconds_total|kubelet_certificate_manager_client_expiration_renew_errors|kubelet_certificate_manager_client_ttl_seconds|kubelet_certificate_manager_server_ttl_seconds|kubelet_cgroup_manager_duration_seconds_bucket|kubelet_cgroup_manager_duration_seconds_count|kubelet_node_config_error|kubelet_node_name|kubelet_pleg_relist_duration_seconds_bucket|kubelet_pleg_relist_duration_seconds_count|kubelet_pleg_relist_interval_seconds_bucket|kubelet_pod_start_duration_seconds_bucket|kubelet_pod_start_duration_seconds_count|kubelet_pod_worker_duration_seconds_bucket|kubelet_pod_worker_duration_seconds_count|kubelet_running_container_count|kubelet_running_containers|kubelet_running_pod_count|kubelet_running_pods|kubelet_runtime_operations_errors_total|kubelet_runtime_operations_total|kubelet_server_expiration_renew_errors|kubelet_volume_stats_available_bytes|kubelet_volume_stats_capacity_bytes|kubelet_volume_stats_inodes|kubelet_volume_stats_inodes_used|kubernetes_build_info|namespace_workload_pod|rest_client_requests_total|storage_operation_duration_seconds_count|storage_operation_errors_total|volume_manager_total_volumes"
+    action = "keep"
+  }
+  forward_to = [prometheus.remote_write.grafana_cloud_prometheus.receiver]
+}
+    
+// cAdvisor
+discovery.relabel "cadvisor" {
+  targets = discovery.kubernetes.nodes.targets
+  rule {
+    target_label = "__address__"
+    replacement  = "kubernetes.default.svc.cluster.local:443"
+  }
+  rule {
+    source_labels = ["__meta_kubernetes_node_name"]
+    regex         = "(.+)"
+    replacement   = "/api/v1/nodes/${1}/proxy/metrics/cadvisor"
+    target_label  = "__metrics_path__"
+  }
+  rule {
+    source_labels = ["__name__"]
+    replacement   = "openshift-compatible-test"
+    target_label  = "cluster"
+  }
+}
+
+prometheus.scrape "cadvisor" {
+  job_name   = "integrations/kubernetes/cadvisor"
+  targets    = discovery.relabel.cadvisor.output
+  scheme     = "https"
+  bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+  tls_config {
+    insecure_skip_verify = true
+  }
+  forward_to = [prometheus.relabel.cadvisor.receiver]
+}
+
+prometheus.relabel "cadvisor" {
+  rule {
+    source_labels = ["__name__"]
+    regex = "up|container_cpu_cfs_periods_total|container_cpu_cfs_throttled_periods_total|container_cpu_usage_seconds_total|container_fs_reads_bytes_total|container_fs_reads_total|container_fs_writes_bytes_total|container_fs_writes_total|container_memory_cache|container_memory_rss|container_memory_swap|container_memory_working_set_bytes|container_network_receive_bytes_total|container_network_receive_packets_dropped_total|container_network_receive_packets_total|container_network_transmit_bytes_total|container_network_transmit_packets_dropped_total|container_network_transmit_packets_total|machine_memory_bytes"
+    action = "keep"
+  }
+  forward_to = [prometheus.remote_write.grafana_cloud_prometheus.receiver]
+}
+    
+// Kube State Metrics
+discovery.relabel "kube_state_metrics" {
+  targets = discovery.kubernetes.services.targets
+  rule {
+    source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_name"]
+    regex = "kube-state-metrics"
+    action = "keep"
+  }
+  rule {
+    source_labels = ["__meta_kubernetes_service_port_name"]
+    regex = "https-main"
+    action = "keep"
+  }
+  rule {
+    source_labels = ["__name__"]
+    replacement   = "openshift-compatible-test"
+    target_label  = "cluster"
+  }
+}
+
+prometheus.scrape "kube_state_metrics" {
+  job_name   = "integrations/kubernetes/kube-state-metrics"
+  targets    = discovery.relabel.kube_state_metrics.output
+  forward_to = [prometheus.relabel.kube_state_metrics.receiver]
+  scheme     = "https"
+  bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+  tls_config {
+    insecure_skip_verify = true
+  }
+}
+
+prometheus.relabel "kube_state_metrics" {
+  rule {
+    source_labels = ["__name__"]
+    regex = "up|kube_daemonset.*|kube_deployment_metadata_generation|kube_deployment_spec_replicas|kube_deployment_status_observed_generation|kube_deployment_status_replicas_available|kube_deployment_status_replicas_updated|kube_horizontalpodautoscaler_spec_max_replicas|kube_horizontalpodautoscaler_spec_min_replicas|kube_horizontalpodautoscaler_status_current_replicas|kube_horizontalpodautoscaler_status_desired_replicas|kube_job.*|kube_namespace_status_phase|kube_namespace_status_phase|kube_node.*|kube_persistentvolumeclaim_resource_requests_storage_bytes|kube_pod_container_info|kube_pod_container_resource_limits|kube_pod_container_resource_requests|kube_pod_container_status_restarts_total|kube_pod_container_status_waiting_reason|kube_pod_container_status_waiting_reason|kube_pod_info|kube_pod_owner|kube_pod_start_time|kube_pod_status_phase|kube_pod_status_phase|kube_pod_status_reason|kube_replicaset.*|kube_resourcequota|kube_statefulset.*"
+    action = "keep"
+  }
+  forward_to = [prometheus.remote_write.grafana_cloud_prometheus.receiver]
+}
+    
+// Node Exporter
+discovery.relabel "node_exporter" {
+  targets = discovery.kubernetes.pods.targets
+  rule {
+    source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+    regex = "node-exporter"
+    action = "keep"
+  }
+  rule {
+    source_labels = ["__meta_kubernetes_pod_node_name"]
+    action = "replace"
+    target_label = "instance"
+  }
+  rule {
+    source_labels = ["__name__"]
+    replacement   = "openshift-compatible-test"
+    target_label  = "cluster"
+  }
+}
+
+prometheus.scrape "node_exporter" {
+  job_name   = "integrations/node_exporter"
+  targets  = discovery.relabel.node_exporter.output
+  forward_to = [prometheus.relabel.node_exporter.receiver]
+  scheme     = "https"
+  bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+  tls_config {
+    ca_file = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+    insecure_skip_verify = true
+  }
+}
+
+prometheus.relabel "node_exporter" {
+  rule {
+    source_labels = ["__name__"]
+    regex = "up|node_cpu.*|node_exporter_build_info|node_filesystem.*|node_memory.*|process_cpu_seconds_total|process_resident_memory_bytes"
+    action = "keep"
+  }
+  forward_to = [prometheus.remote_write.grafana_cloud_prometheus.receiver]
+}
+    
+// OpenCost
+discovery.relabel "opencost" {
+  targets = discovery.kubernetes.services.targets
+  rule {
+    source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_instance"]
+    regex = "k8smon"
+    action = "keep"
+  }
+  rule {
+    source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_name"]
+    regex = "opencost"
+    action = "keep"
+  }
+  rule {
+    source_labels = ["__meta_kubernetes_service_port_name"]
+    regex = "http"
+    action = "keep"
+  }
+  rule {
+    source_labels = ["__name__"]
+    replacement   = "openshift-compatible-test"
+    target_label  = "cluster"
+  }
+}
+
+prometheus.scrape "opencost" {
+  job_name   = "integrations/kubernetes/opencost"
+  targets    = discovery.relabel.opencost.output
+  forward_to = [prometheus.relabel.opencost.receiver]
+}
+
+prometheus.relabel "opencost" {
+  rule {
+    source_labels = ["__name__"]
+    regex = "up|container_cpu_allocation|container_gpu_allocation|container_memory_allocation_bytes|deployment_match_labels|kubecost_cluster_info|kubecost_cluster_management_cost|kubecost_cluster_memory_working_set_bytes|kubecost_http_requests_total|kubecost_http_response_size_bytes|kubecost_http_response_time_seconds|kubecost_load_balancer_cost|kubecost_network_internet_egress_cost|kubecost_network_region_egress_cost|kubecost_network_zone_egress_cost|kubecost_node_is_spot|node_cpu_hourly_cost|node_gpu_count|node_gpu_hourly_cost|node_ram_hourly_cost|node_total_hourly_cost|opencost_build_info|pod_pvc_allocation|pv_hourly_cost|service_selector_labels|statefulSet_match_labels"
+    action = "keep"
+  }
+  forward_to = [prometheus.remote_write.grafana_cloud_prometheus.receiver]
+}
+    
+// PodMonitor
+prometheus.operator.podmonitors "pod_monitors" {
+  forward_to = [prometheus.remote_write.grafana_cloud_prometheus.receiver]
+}
+    
+// ServiceMonitor
+prometheus.operator.servicemonitors "service_monitors" {
+  forward_to = [prometheus.remote_write.grafana_cloud_prometheus.receiver]
+}
+    
+// Grafana Cloud Prometheus
+local.file "prometheus_host" {
+  filename  = "/etc/grafana-agent-credentials/prometheus_host"
+}
+
+local.file "prometheus_username" {
+  filename  = "/etc/grafana-agent-credentials/prometheus_username"
+}
+
+local.file "prometheus_password" {
+  filename  = "/etc/grafana-agent-credentials/prometheus_password"
+  is_secret = true
+}
+
+prometheus.remote_write "grafana_cloud_prometheus" {
+  endpoint {
+    url = nonsensitive(local.file.prometheus_host.content) + "/api/prom/push"
+
+    basic_auth {
+      username = local.file.prometheus_username.content
+      password = local.file.prometheus_password.content
+    }
+  }
+}
+    
+// Cluster Events
+loki.source.kubernetes_events "cluster_events" {
+  job_name   = "integrations/kubernetes/eventhandler"
+  forward_to = [loki.process.cluster_events.receiver]
+}
+
+loki.process "cluster_events" {
+  stage.static_labels {
+    values = {
+      cluster = "openshift-compatible-test",
+    }
+  }
+
+  forward_to = [loki.write.grafana_cloud_loki.receiver]
+}
+    
+// Grafana Cloud Loki
+local.file "loki_host" {
+  filename  = "/etc/grafana-agent-credentials/loki_host"
+}
+
+local.file "loki_username" {
+  filename  = "/etc/grafana-agent-credentials/loki_username"
+}
+
+local.file "loki_password" {
+  filename  = "/etc/grafana-agent-credentials/loki_password"
+  is_secret = true
+}
+
+loki.write "grafana_cloud_loki" {
+  endpoint {
+    url = nonsensitive(local.file.loki_host.content) + "/loki/api/v1/push"
+
+    basic_auth {
+      username = local.file.loki_username.content
+      password = local.file.loki_password.content
+    }
+  }
+}

--- a/examples/openshift-compatible/output.yaml
+++ b/examples/openshift-compatible/output.yaml
@@ -39989,6 +39989,9 @@ spec:
       dnsPolicy: ClusterFirst
       nodeSelector:
         kubernetes.io/os: linux
+      tolerations:
+        - effect: NoSchedule
+          operator: Exists
       volumes:
         - name: config
           configMap:

--- a/examples/openshift-compatible/output.yaml
+++ b/examples/openshift-compatible/output.yaml
@@ -429,7 +429,8 @@ data:
       }
       rule {
         source_labels = ["__meta_kubernetes_pod_node_name"]
-        target_label = "__host__"
+        action = "keep"
+        regex = env("HOSTNAME")
       }
       rule {
         source_labels = ["__meta_kubernetes_pod_uid", "__meta_kubernetes_pod_container_name"]
@@ -440,8 +441,12 @@ data:
       }
     }
     
+    local.file_match "pod_logs" {
+      path_targets = discovery.relabel.pod_logs.output
+    }
+    
     loki.source.file "pod_logs" {
-      targets    = discovery.relabel.pod_logs.output
+      targets    = local.file_match.pod_logs.targets
       forward_to = [loki.process.pod_logs.receiver]
     }
     

--- a/examples/openshift-compatible/output.yaml
+++ b/examples/openshift-compatible/output.yaml
@@ -1,4 +1,16 @@
 ---
+# Source: k8s-monitoring/charts/grafana-agent-logs/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: k8smon-grafana-agent-logs
+  labels:
+    helm.sh/chart: grafana-agent-logs-0.19.0
+    app.kubernetes.io/name: grafana-agent-logs
+    app.kubernetes.io/instance: k8smon
+    app.kubernetes.io/version: "v0.35.2"
+    app.kubernetes.io/managed-by: Helm
+---
 # Source: k8s-monitoring/charts/grafana-agent/templates/serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount
@@ -336,6 +348,59 @@ data:
       }
     }
         
+    // Cluster Events
+    loki.source.kubernetes_events "cluster_events" {
+      job_name   = "integrations/kubernetes/eventhandler"
+      forward_to = [loki.process.cluster_events.receiver]
+    }
+    
+    loki.process "cluster_events" {
+      stage.static_labels {
+        values = {
+          cluster = "openshift-compatible-test",
+        }
+      }
+    
+      forward_to = [loki.write.grafana_cloud_loki.receiver]
+    }
+        
+    // Grafana Cloud Loki
+    local.file "loki_host" {
+      filename  = "/etc/grafana-agent-credentials/loki_host"
+    }
+    
+    local.file "loki_username" {
+      filename  = "/etc/grafana-agent-credentials/loki_username"
+    }
+    
+    local.file "loki_password" {
+      filename  = "/etc/grafana-agent-credentials/loki_password"
+      is_secret = true
+    }
+    
+    loki.write "grafana_cloud_loki" {
+      endpoint {
+        url = nonsensitive(local.file.loki_host.content) + "/loki/api/v1/push"
+    
+        basic_auth {
+          username = local.file.loki_username.content
+          password = local.file.loki_password.content
+        }
+      }
+    }
+---
+# Source: k8s-monitoring/templates/grafana-agent-logs-config.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: k8smon-grafana-agent-logs
+  namespace: default
+data:
+  config.river: |-    
+    discovery.kubernetes "pods" {
+      role = "pod"
+    }
+        
     // Pod Logs
     discovery.relabel "pod_logs" {
       targets = discovery.kubernetes.pods.targets
@@ -362,9 +427,20 @@ data:
         replacement = "$1"
         target_label = "job"
       }
+      rule {
+        source_labels = ["__meta_kubernetes_pod_node_name"]
+        target_label = "__host__"
+      }
+      rule {
+        source_labels = ["__meta_kubernetes_pod_uid", "__meta_kubernetes_pod_container_name"]
+        separator = "/"
+        action = "replace"
+        replacement = "/var/log/pods/*$1/*.log"
+        target_label = "__path__"
+      }
     }
     
-    loki.source.kubernetes "pod_logs" {
+    loki.source.file "pod_logs" {
       targets    = discovery.relabel.pod_logs.output
       forward_to = [loki.process.pod_logs.receiver]
     }
@@ -377,22 +453,6 @@ data:
       }
     
       stage.docker {}
-      forward_to = [loki.write.grafana_cloud_loki.receiver]
-    }
-        
-    // Cluster Events
-    loki.source.kubernetes_events "cluster_events" {
-      job_name   = "integrations/kubernetes/eventhandler"
-      forward_to = [loki.process.cluster_events.receiver]
-    }
-    
-    loki.process "cluster_events" {
-      stage.static_labels {
-        values = {
-          cluster = "openshift-compatible-test",
-        }
-      }
-    
       forward_to = [loki.write.grafana_cloud_loki.receiver]
     }
         
@@ -39443,6 +39503,87 @@ spec:
     subresources:
       status: {}
 ---
+# Source: k8s-monitoring/charts/grafana-agent-logs/templates/rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: k8smon-grafana-agent-logs
+  labels:
+    helm.sh/chart: grafana-agent-logs-0.19.0
+    app.kubernetes.io/name: grafana-agent-logs
+    app.kubernetes.io/instance: k8smon
+    app.kubernetes.io/version: "v0.35.2"
+    app.kubernetes.io/managed-by: Helm
+rules:
+  # Rules which allow discovery.kubernetes to function.
+  - apiGroups:
+      - ""
+      - "discovery.k8s.io"
+      - "networking.k8s.io"
+    resources:
+      - endpoints
+      - endpointslices
+      - ingresses
+      - nodes
+      - nodes/proxy
+      - nodes/metrics
+      - pods
+      - services
+    verbs:
+      - get
+      - list
+      - watch
+  # Rules which allow loki.source.kubernetes and loki.source.podlogs to work.
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+      - pods/log
+      - namespaces
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - "monitoring.grafana.com"
+    resources:
+      - podlogs
+    verbs:
+      - get
+      - list
+      - watch
+  # Rules which allow mimir.rules.kubernetes to work.
+  - apiGroups: ["monitoring.coreos.com"]
+    resources:
+      - prometheusrules
+    verbs:
+      - get
+      - list
+      - watch
+  - nonResourceURLs:
+      - /metrics
+    verbs:
+      - get
+  # Rules for prometheus.kubernetes.*
+  - apiGroups: ["monitoring.coreos.com"]
+    resources:
+      - podmonitors
+      - servicemonitors
+      - probes
+    verbs:
+      - get
+      - list
+      - watch
+  # Rules which allow eventhandler to work.
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - get
+      - list
+      - watch
+---
 # Source: k8s-monitoring/charts/grafana-agent/templates/rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -39611,6 +39752,26 @@ rules:
       - list
       - watch
 ---
+# Source: k8s-monitoring/charts/grafana-agent-logs/templates/rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: k8smon-grafana-agent-logs
+  labels:
+    helm.sh/chart: grafana-agent-logs-0.19.0
+    app.kubernetes.io/name: grafana-agent-logs
+    app.kubernetes.io/instance: k8smon
+    app.kubernetes.io/version: "v0.35.2"
+    app.kubernetes.io/managed-by: Helm
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: k8smon-grafana-agent-logs
+subjects:
+  - kind: ServiceAccount
+    name: k8smon-grafana-agent-logs
+    namespace: default
+---
 # Source: k8s-monitoring/charts/grafana-agent/templates/rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -39651,6 +39812,57 @@ subjects:
   - kind: ServiceAccount
     name: k8smon-opencost
     namespace: default
+---
+# Source: k8s-monitoring/charts/grafana-agent-logs/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: k8smon-grafana-agent-logs
+  labels:
+    helm.sh/chart: grafana-agent-logs-0.19.0
+    app.kubernetes.io/name: grafana-agent-logs
+    app.kubernetes.io/instance: k8smon
+    app.kubernetes.io/version: "v0.35.2"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: grafana-agent-logs
+    app.kubernetes.io/instance: k8smon
+  ports:
+    - name: http-metrics
+      port: 80
+      targetPort: 80
+      protocol: "TCP"
+---
+# Source: k8s-monitoring/charts/grafana-agent/templates/cluster_service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: k8smon-grafana-agent-cluster
+  labels:
+    helm.sh/chart: grafana-agent-0.19.0
+    app.kubernetes.io/name: grafana-agent
+    app.kubernetes.io/instance: k8smon
+    app.kubernetes.io/version: "v0.35.2"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  type: ClusterIP
+  clusterIP: 'None'
+  selector:
+    app.kubernetes.io/name: grafana-agent
+    app.kubernetes.io/instance: k8smon
+  ports:
+    # Do not include the -metrics suffix in the port name, otherwise metrics
+    # can be double-collected with the non-headless Service if it's also
+    # enabled.
+    #
+    # This service should only be used for clustering, and not metric
+    # collection.
+    - name: http
+      port: 8080
+      targetPort: 8080
+      protocol: "TCP"
 ---
 # Source: k8s-monitoring/charts/grafana-agent/templates/service.yaml
 apiVersion: v1
@@ -39696,14 +39908,14 @@ spec:
       port: 9003
       targetPort: 9003
 ---
-# Source: k8s-monitoring/charts/grafana-agent/templates/controllers/daemonset.yaml
+# Source: k8s-monitoring/charts/grafana-agent-logs/templates/controllers/daemonset.yaml
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
-  name: k8smon-grafana-agent
+  name: k8smon-grafana-agent-logs
   labels:
-    helm.sh/chart: grafana-agent-0.19.0
-    app.kubernetes.io/name: grafana-agent
+    helm.sh/chart: grafana-agent-logs-0.19.0
+    app.kubernetes.io/name: grafana-agent-logs
     app.kubernetes.io/instance: k8smon
     app.kubernetes.io/version: "v0.35.2"
     app.kubernetes.io/managed-by: Helm
@@ -39711,15 +39923,15 @@ spec:
   minReadySeconds: 10
   selector:
     matchLabels:
-      app.kubernetes.io/name: grafana-agent
+      app.kubernetes.io/name: grafana-agent-logs
       app.kubernetes.io/instance: k8smon
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: grafana-agent
+        app.kubernetes.io/name: grafana-agent-logs
         app.kubernetes.io/instance: k8smon
     spec:
-      serviceAccountName: k8smon-grafana-agent
+      serviceAccountName: k8smon-grafana-agent-logs
       containers:
         - name: grafana-agent
           image: docker.io/grafana/agent:v0.35.2
@@ -39728,7 +39940,7 @@ spec:
             - run
             - /etc/agent/config.river
             - --storage.path=/tmp/agent
-            - --server.http.listen-addr=0.0.0.0:8080
+            - --server.http.listen-addr=0.0.0.0:80
           env:
             - name: AGENT_MODE
               value: flow
@@ -39737,17 +39949,23 @@ spec:
                 fieldRef:
                   fieldPath: spec.nodeName
           ports:
-            - containerPort: 8080
+            - containerPort: 80
               name: http-metrics
           readinessProbe:
             httpGet:
               path: /-/ready
-              port: 8080
+              port: 80
             initialDelaySeconds: 10
             timeoutSeconds: 1
           volumeMounts:
             - name: config
               mountPath: /etc/agent
+            - name: varlog
+              mountPath: /var/log
+              readOnly: true
+            - name: dockercontainers
+              mountPath: /var/lib/docker/containers
+              readOnly: true
             -
               mountPath: /etc/grafana-agent-credentials
               name: grafana-agent-credentials
@@ -39755,7 +39973,7 @@ spec:
           image: docker.io/jimmidyson/configmap-reload:v0.8.0
           args:
             - --volume-dir=/etc/agent
-            - --webhook-url=http://localhost:8080/-/reload
+            - --webhook-url=http://localhost:80/-/reload
           volumeMounts:
             - name: config
               mountPath: /etc/agent
@@ -39769,7 +39987,13 @@ spec:
       volumes:
         - name: config
           configMap:
-            name: k8smon-grafana-agent
+            name: k8smon-grafana-agent-logs
+        - name: varlog
+          hostPath:
+            path: /var/log
+        - name: dockercontainers
+          hostPath:
+            path: /var/lib/docker/containers
         - name: grafana-agent-credentials
           secret:
             secretName: grafana-agent-credentials
@@ -39857,6 +40081,88 @@ spec:
               value: "true"
             - name: PROM_CLUSTER_ID_LABEL
               value: "cluster"
+---
+# Source: k8s-monitoring/charts/grafana-agent/templates/controllers/statefulset.yaml
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: k8smon-grafana-agent
+  labels:
+    helm.sh/chart: grafana-agent-0.19.0
+    app.kubernetes.io/name: grafana-agent
+    app.kubernetes.io/instance: k8smon
+    app.kubernetes.io/version: "v0.35.2"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  replicas: 1
+  minReadySeconds: 10
+  serviceName: k8smon-grafana-agent
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: grafana-agent
+      app.kubernetes.io/instance: k8smon
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: grafana-agent
+        app.kubernetes.io/instance: k8smon
+    spec:
+      serviceAccountName: k8smon-grafana-agent
+      containers:
+        - name: grafana-agent
+          image: docker.io/grafana/agent:v0.35.2
+          imagePullPolicy: IfNotPresent
+          args:
+            - run
+            - /etc/agent/config.river
+            - --storage.path=/tmp/agent
+            - --server.http.listen-addr=0.0.0.0:8080
+            - --cluster.enabled=true
+            - --cluster.join-addresses=k8smon-grafana-agent-cluster
+          env:
+            - name: AGENT_MODE
+              value: flow
+            - name: HOSTNAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+          ports:
+            - containerPort: 8080
+              name: http-metrics
+          readinessProbe:
+            httpGet:
+              path: /-/ready
+              port: 8080
+            initialDelaySeconds: 10
+            timeoutSeconds: 1
+          volumeMounts:
+            - name: config
+              mountPath: /etc/agent
+            -
+              mountPath: /etc/grafana-agent-credentials
+              name: grafana-agent-credentials
+        - name: config-reloader
+          image: docker.io/jimmidyson/configmap-reload:v0.8.0
+          args:
+            - --volume-dir=/etc/agent
+            - --webhook-url=http://localhost:8080/-/reload
+          volumeMounts:
+            - name: config
+              mountPath: /etc/agent
+          resources:
+            requests:
+              cpu: 1m
+              memory: 5Mi
+      dnsPolicy: ClusterFirst
+      nodeSelector:
+        kubernetes.io/os: linux
+      volumes:
+        - name: config
+          configMap:
+            name: k8smon-grafana-agent
+        - name: grafana-agent-credentials
+          secret:
+            secretName: grafana-agent-credentials
 ---
 # Source: k8s-monitoring/charts/prometheus-operator-crds/templates/crd-alertmanagerconfigs.yaml
 # https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.66.0/example/prometheus-operator-crd/monitoring.coreos.com_alertmanagerconfigs.yaml

--- a/examples/otel-collector/logs.river
+++ b/examples/otel-collector/logs.river
@@ -1,4 +1,7 @@
-{{ define "agent.config.pod_logs" }}
+discovery.kubernetes "pods" {
+  role = "pod"
+}
+    
 // Pod Logs
 discovery.relabel "pod_logs" {
   targets = discovery.kubernetes.pods.targets
@@ -46,11 +49,35 @@ loki.source.file "pod_logs" {
 loki.process "pod_logs" {
   stage.static_labels {
     values = {
-      cluster = {{ required ".Values.cluster.name is a required value. Please set it and try again." .Values.cluster.name | quote }},
+      cluster = "otel-collector-test",
     }
   }
 
-  stage.{{- .Values.pod_logs.loggingFormat }} {}
+  stage.docker {}
   forward_to = [loki.write.grafana_cloud_loki.receiver]
 }
-{{ end }}
+    
+// Grafana Cloud Loki
+local.file "loki_host" {
+  filename  = "/etc/grafana-agent-credentials/loki_host"
+}
+
+local.file "loki_username" {
+  filename  = "/etc/grafana-agent-credentials/loki_username"
+}
+
+local.file "loki_password" {
+  filename  = "/etc/grafana-agent-credentials/loki_password"
+  is_secret = true
+}
+
+loki.write "grafana_cloud_loki" {
+  endpoint {
+    url = nonsensitive(local.file.loki_host.content) + "/loki/api/v1/push"
+
+    basic_auth {
+      username = local.file.loki_username.content
+      password = local.file.loki_password.content
+    }
+  }
+}

--- a/examples/otel-collector/logs.river
+++ b/examples/otel-collector/logs.river
@@ -30,7 +30,8 @@ discovery.relabel "pod_logs" {
   }
   rule {
     source_labels = ["__meta_kubernetes_pod_node_name"]
-    target_label = "__host__"
+    action = "keep"
+    regex = env("HOSTNAME")
   }
   rule {
     source_labels = ["__meta_kubernetes_pod_uid", "__meta_kubernetes_pod_container_name"]
@@ -41,8 +42,12 @@ discovery.relabel "pod_logs" {
   }
 }
 
+local.file_match "pod_logs" {
+  path_targets = discovery.relabel.pod_logs.output
+}
+
 loki.source.file "pod_logs" {
-  targets    = discovery.relabel.pod_logs.output
+  targets    = local.file_match.pod_logs.targets
   forward_to = [loki.process.pod_logs.receiver]
 }
 

--- a/examples/otel-collector/metrics.river
+++ b/examples/otel-collector/metrics.river
@@ -1,0 +1,327 @@
+discovery.kubernetes "nodes" {
+  role = "node"
+}
+    
+discovery.kubernetes "pods" {
+  role = "pod"
+}
+    
+discovery.kubernetes "services" {
+  role = "service"
+}
+    
+// Grafana Agent
+discovery.relabel "agent" {
+  targets = discovery.kubernetes.services.targets
+  rule {
+    source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_instance"]
+    regex = "k8smon"
+    action = "keep"
+  }
+  rule {
+    source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_name"]
+    regex = "grafana-agent"
+    action = "keep"
+  }
+  rule {
+    source_labels = ["__meta_kubernetes_service_port_name"]
+    regex = "http-metrics"
+    action = "keep"
+  }
+  rule {
+    source_labels = ["__name__"]
+    replacement   = "otel-collector-test"
+    target_label  = "cluster"
+  }
+}
+
+prometheus.scrape "agent" {
+  job_name   = "integrations/agent"
+  targets  = discovery.relabel.agent.output
+  forward_to = [prometheus.relabel.agent.receiver]
+}
+
+prometheus.relabel "agent" {
+  rule {
+    source_labels = ["__name__"]
+    regex = "up|agent_build_info"
+    action = "keep"
+  }
+  forward_to = [prometheus.remote_write.grafana_cloud_prometheus.receiver]
+}
+    
+// Kubelet
+discovery.relabel "kubelet" {
+  targets = discovery.kubernetes.nodes.targets
+  rule {
+    target_label = "__address__"
+    replacement  = "kubernetes.default.svc.cluster.local:443"
+  }
+  rule {
+    source_labels = ["__meta_kubernetes_node_name"]
+    regex         = "(.+)"
+    replacement   = "/api/v1/nodes/${1}/proxy/metrics"
+    target_label  = "__metrics_path__"
+  }
+  rule {
+    source_labels = ["__name__"]
+    replacement   = "otel-collector-test"
+    target_label  = "cluster"
+  }
+}
+
+prometheus.scrape "kubelet" {
+  job_name   = "integrations/kubernetes/kubelet"
+  targets  = discovery.relabel.kubelet.output
+  scheme   = "https"
+  bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+  tls_config {
+    insecure_skip_verify = true
+  }
+  forward_to = [prometheus.relabel.kubelet.receiver]
+}
+
+prometheus.relabel "kubelet" {
+  rule {
+    source_labels = ["__name__"]
+    regex = "up|container_cpu_usage_seconds_total|kubelet_certificate_manager_client_expiration_renew_errors|kubelet_certificate_manager_client_ttl_seconds|kubelet_certificate_manager_server_ttl_seconds|kubelet_cgroup_manager_duration_seconds_bucket|kubelet_cgroup_manager_duration_seconds_count|kubelet_node_config_error|kubelet_node_name|kubelet_pleg_relist_duration_seconds_bucket|kubelet_pleg_relist_duration_seconds_count|kubelet_pleg_relist_interval_seconds_bucket|kubelet_pod_start_duration_seconds_bucket|kubelet_pod_start_duration_seconds_count|kubelet_pod_worker_duration_seconds_bucket|kubelet_pod_worker_duration_seconds_count|kubelet_running_container_count|kubelet_running_containers|kubelet_running_pod_count|kubelet_running_pods|kubelet_runtime_operations_errors_total|kubelet_runtime_operations_total|kubelet_server_expiration_renew_errors|kubelet_volume_stats_available_bytes|kubelet_volume_stats_capacity_bytes|kubelet_volume_stats_inodes|kubelet_volume_stats_inodes_used|kubernetes_build_info|namespace_workload_pod|rest_client_requests_total|storage_operation_duration_seconds_count|storage_operation_errors_total|volume_manager_total_volumes"
+    action = "keep"
+  }
+  forward_to = [prometheus.remote_write.grafana_cloud_prometheus.receiver]
+}
+    
+// cAdvisor
+discovery.relabel "cadvisor" {
+  targets = discovery.kubernetes.nodes.targets
+  rule {
+    target_label = "__address__"
+    replacement  = "kubernetes.default.svc.cluster.local:443"
+  }
+  rule {
+    source_labels = ["__meta_kubernetes_node_name"]
+    regex         = "(.+)"
+    replacement   = "/api/v1/nodes/${1}/proxy/metrics/cadvisor"
+    target_label  = "__metrics_path__"
+  }
+  rule {
+    source_labels = ["__name__"]
+    replacement   = "otel-collector-test"
+    target_label  = "cluster"
+  }
+}
+
+prometheus.scrape "cadvisor" {
+  job_name   = "integrations/kubernetes/cadvisor"
+  targets    = discovery.relabel.cadvisor.output
+  scheme     = "https"
+  bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+  tls_config {
+    insecure_skip_verify = true
+  }
+  forward_to = [prometheus.relabel.cadvisor.receiver]
+}
+
+prometheus.relabel "cadvisor" {
+  rule {
+    source_labels = ["__name__"]
+    regex = "up|container_cpu_cfs_periods_total|container_cpu_cfs_throttled_periods_total|container_cpu_usage_seconds_total|container_fs_reads_bytes_total|container_fs_reads_total|container_fs_writes_bytes_total|container_fs_writes_total|container_memory_cache|container_memory_rss|container_memory_swap|container_memory_working_set_bytes|container_network_receive_bytes_total|container_network_receive_packets_dropped_total|container_network_receive_packets_total|container_network_transmit_bytes_total|container_network_transmit_packets_dropped_total|container_network_transmit_packets_total|machine_memory_bytes"
+    action = "keep"
+  }
+  forward_to = [prometheus.remote_write.grafana_cloud_prometheus.receiver]
+}
+    
+// Kube State Metrics
+discovery.relabel "kube_state_metrics" {
+  targets = discovery.kubernetes.services.targets
+  rule {
+    source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_instance"]
+    regex = "k8smon"
+    action = "keep"
+  }
+  rule {
+    source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_name"]
+    regex = "kube-state-metrics"
+    action = "keep"
+  }
+  rule {
+    source_labels = ["__meta_kubernetes_service_port_name"]
+    regex = "http"
+    action = "keep"
+  }
+  rule {
+    source_labels = ["__name__"]
+    replacement   = "otel-collector-test"
+    target_label  = "cluster"
+  }
+}
+
+prometheus.scrape "kube_state_metrics" {
+  job_name   = "integrations/kubernetes/kube-state-metrics"
+  targets    = discovery.relabel.kube_state_metrics.output
+  forward_to = [prometheus.relabel.kube_state_metrics.receiver]
+}
+
+prometheus.relabel "kube_state_metrics" {
+  rule {
+    source_labels = ["__name__"]
+    regex = "up|kube_daemonset.*|kube_deployment_metadata_generation|kube_deployment_spec_replicas|kube_deployment_status_observed_generation|kube_deployment_status_replicas_available|kube_deployment_status_replicas_updated|kube_horizontalpodautoscaler_spec_max_replicas|kube_horizontalpodautoscaler_spec_min_replicas|kube_horizontalpodautoscaler_status_current_replicas|kube_horizontalpodautoscaler_status_desired_replicas|kube_job.*|kube_namespace_status_phase|kube_namespace_status_phase|kube_node.*|kube_persistentvolumeclaim_resource_requests_storage_bytes|kube_pod_container_info|kube_pod_container_resource_limits|kube_pod_container_resource_requests|kube_pod_container_status_restarts_total|kube_pod_container_status_waiting_reason|kube_pod_container_status_waiting_reason|kube_pod_info|kube_pod_owner|kube_pod_start_time|kube_pod_status_phase|kube_pod_status_phase|kube_pod_status_reason|kube_replicaset.*|kube_resourcequota|kube_statefulset.*"
+    action = "keep"
+  }
+  forward_to = [prometheus.remote_write.grafana_cloud_prometheus.receiver]
+}
+    
+// Node Exporter
+discovery.relabel "node_exporter" {
+  targets = discovery.kubernetes.pods.targets
+  rule {
+    source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_instance"]
+    regex = "k8smon"
+    action = "keep"
+  }
+  rule {
+    source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+    regex = "prometheus-node-exporter.*"
+    action = "keep"
+  }
+  rule {
+    source_labels = ["__meta_kubernetes_pod_node_name"]
+    action = "replace"
+    target_label = "instance"
+  }
+  rule {
+    source_labels = ["__name__"]
+    replacement   = "otel-collector-test"
+    target_label  = "cluster"
+  }
+}
+
+prometheus.scrape "node_exporter" {
+  job_name   = "integrations/node_exporter"
+  targets  = discovery.relabel.node_exporter.output
+  forward_to = [prometheus.relabel.node_exporter.receiver]
+}
+
+prometheus.relabel "node_exporter" {
+  rule {
+    source_labels = ["__name__"]
+    regex = "up|node_cpu.*|node_exporter_build_info|node_filesystem.*|node_memory.*|process_cpu_seconds_total|process_resident_memory_bytes"
+    action = "keep"
+  }
+  forward_to = [prometheus.remote_write.grafana_cloud_prometheus.receiver]
+}
+    
+// OpenCost
+discovery.relabel "opencost" {
+  targets = discovery.kubernetes.services.targets
+  rule {
+    source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_instance"]
+    regex = "k8smon"
+    action = "keep"
+  }
+  rule {
+    source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_name"]
+    regex = "opencost"
+    action = "keep"
+  }
+  rule {
+    source_labels = ["__meta_kubernetes_service_port_name"]
+    regex = "http"
+    action = "keep"
+  }
+  rule {
+    source_labels = ["__name__"]
+    replacement   = "otel-collector-test"
+    target_label  = "cluster"
+  }
+}
+
+prometheus.scrape "opencost" {
+  job_name   = "integrations/kubernetes/opencost"
+  targets    = discovery.relabel.opencost.output
+  forward_to = [prometheus.relabel.opencost.receiver]
+}
+
+prometheus.relabel "opencost" {
+  rule {
+    source_labels = ["__name__"]
+    regex = "up|container_cpu_allocation|container_gpu_allocation|container_memory_allocation_bytes|deployment_match_labels|kubecost_cluster_info|kubecost_cluster_management_cost|kubecost_cluster_memory_working_set_bytes|kubecost_http_requests_total|kubecost_http_response_size_bytes|kubecost_http_response_time_seconds|kubecost_load_balancer_cost|kubecost_network_internet_egress_cost|kubecost_network_region_egress_cost|kubecost_network_zone_egress_cost|kubecost_node_is_spot|node_cpu_hourly_cost|node_gpu_count|node_gpu_hourly_cost|node_ram_hourly_cost|node_total_hourly_cost|opencost_build_info|pod_pvc_allocation|pv_hourly_cost|service_selector_labels|statefulSet_match_labels"
+    action = "keep"
+  }
+  forward_to = [prometheus.remote_write.grafana_cloud_prometheus.receiver]
+}
+    
+// PodMonitor
+prometheus.operator.podmonitors "pod_monitors" {
+  forward_to = [prometheus.remote_write.grafana_cloud_prometheus.receiver]
+}
+    
+// ServiceMonitor
+prometheus.operator.servicemonitors "service_monitors" {
+  forward_to = [prometheus.remote_write.grafana_cloud_prometheus.receiver]
+}
+    
+// Grafana Cloud Prometheus
+local.file "prometheus_host" {
+  filename  = "/etc/grafana-agent-credentials/prometheus_host"
+}
+
+local.file "prometheus_username" {
+  filename  = "/etc/grafana-agent-credentials/prometheus_username"
+}
+
+local.file "prometheus_password" {
+  filename  = "/etc/grafana-agent-credentials/prometheus_password"
+  is_secret = true
+}
+
+prometheus.remote_write "grafana_cloud_prometheus" {
+  endpoint {
+    url = nonsensitive(local.file.prometheus_host.content) + "/api/prom/push"
+
+    basic_auth {
+      username = local.file.prometheus_username.content
+      password = local.file.prometheus_password.content
+    }
+  }
+}
+    
+// Cluster Events
+loki.source.kubernetes_events "cluster_events" {
+  job_name   = "integrations/kubernetes/eventhandler"
+  forward_to = [loki.process.cluster_events.receiver]
+}
+
+loki.process "cluster_events" {
+  stage.static_labels {
+    values = {
+      cluster = "otel-collector-test",
+    }
+  }
+
+  forward_to = [loki.write.grafana_cloud_loki.receiver]
+}
+    
+// Grafana Cloud Loki
+local.file "loki_host" {
+  filename  = "/etc/grafana-agent-credentials/loki_host"
+}
+
+local.file "loki_username" {
+  filename  = "/etc/grafana-agent-credentials/loki_username"
+}
+
+local.file "loki_password" {
+  filename  = "/etc/grafana-agent-credentials/loki_password"
+  is_secret = true
+}
+
+loki.write "grafana_cloud_loki" {
+  endpoint {
+    url = nonsensitive(local.file.loki_host.content) + "/loki/api/v1/push"
+
+    basic_auth {
+      username = local.file.loki_username.content
+      password = local.file.loki_password.content
+    }
+  }
+}

--- a/examples/otel-collector/output.yaml
+++ b/examples/otel-collector/output.yaml
@@ -1229,6 +1229,9 @@ spec:
       dnsPolicy: ClusterFirst
       nodeSelector:
         kubernetes.io/os: linux
+      tolerations:
+        - effect: NoSchedule
+          operator: Exists
       volumes:
         - name: config
           configMap:

--- a/examples/otel-collector/output.yaml
+++ b/examples/otel-collector/output.yaml
@@ -1426,6 +1426,8 @@ spec:
           capabilities:
             drop:
             - ALL
+      nodeSelector:
+        kubernetes.io/os: linux
 ---
 # Source: k8s-monitoring/charts/opencost/templates/deployment.yaml
 apiVersion: apps/v1
@@ -1457,6 +1459,8 @@ spec:
         app.kubernetes.io/instance: k8smon
     spec:
       serviceAccountName: k8smon-opencost
+      nodeSelector:
+        kubernetes.io/os: linux
       containers:
         - name: k8smon-opencost
           image: "quay.io/kubecost1/kubecost-cost-model:prod-1.105.0"

--- a/examples/otel-collector/output.yaml
+++ b/examples/otel-collector/output.yaml
@@ -1,0 +1,1586 @@
+---
+# Source: k8s-monitoring/charts/grafana-agent-logs/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: k8smon-grafana-agent-logs
+  labels:
+    helm.sh/chart: grafana-agent-logs-0.19.0
+    app.kubernetes.io/name: grafana-agent-logs
+    app.kubernetes.io/instance: k8smon
+    app.kubernetes.io/version: "v0.35.2"
+    app.kubernetes.io/managed-by: Helm
+---
+# Source: k8s-monitoring/charts/grafana-agent/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: k8smon-grafana-agent
+  labels:
+    helm.sh/chart: grafana-agent-0.19.0
+    app.kubernetes.io/name: grafana-agent
+    app.kubernetes.io/instance: k8smon
+    app.kubernetes.io/version: "v0.35.2"
+    app.kubernetes.io/managed-by: Helm
+---
+# Source: k8s-monitoring/charts/kube-state-metrics/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:    
+    helm.sh/chart: kube-state-metrics-5.10.1
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: metrics
+    app.kubernetes.io/part-of: kube-state-metrics
+    app.kubernetes.io/name: kube-state-metrics
+    app.kubernetes.io/instance: k8smon
+    app.kubernetes.io/version: "2.9.2"
+  name: k8smon-kube-state-metrics
+  namespace: default
+imagePullSecrets:
+---
+# Source: k8s-monitoring/charts/opencost/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: k8smon-opencost
+  labels:
+    helm.sh/chart: opencost-1.18.0
+    app.kubernetes.io/name: opencost
+    app.kubernetes.io/instance: k8smon
+    app.kubernetes.io/version: "1.105.0"
+    app.kubernetes.io/part-of: opencost
+    app.kubernetes.io/managed-by: Helm
+automountServiceAccountToken: true
+---
+# Source: k8s-monitoring/charts/prometheus-node-exporter/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: k8smon-prometheus-node-exporter
+  namespace: default
+  labels:
+    helm.sh/chart: prometheus-node-exporter-4.21.0
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: metrics
+    app.kubernetes.io/part-of: prometheus-node-exporter
+    app.kubernetes.io/name: prometheus-node-exporter
+    app.kubernetes.io/instance: k8smon
+    app.kubernetes.io/version: "1.6.0"
+---
+# Source: k8s-monitoring/templates/credentials.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: grafana-agent-credentials
+  namespace: default
+type: Opaque
+data:
+  prometheus_host: "aHR0cHM6Ly9wcm9tZXRoZXVzLWRldi0wMS1kZXYtdXMtY2VudHJhbC0wLmdyYWZhbmEtZGV2Lm5ldA=="
+  prometheus_username: "MTIxMTk="
+  prometheus_password: "Z2xjX2Rldl9leUp2SWpvaU16TTRJaXdpYmlJNkltOTBaV3d0ZEdWemRDSXNJbXNpT2lJelozUkdOVGMwYlRFemVsWnRVa2hUYWpOVlpqUTBNSEFpTENKdElqcDdJbklpT2lKa1pYWXRkWE10WTJWdWRISmhiQ0o5ZlE9PQ=="
+  loki_host: "aHR0cHM6Ly9sb2dzLWRldi0wMDUuZ3JhZmFuYS1kZXYubmV0"
+  loki_username: "MTQ2MjA1"
+  loki_password: "Z2xjX2Rldl9leUp2SWpvaU16TTRJaXdpYmlJNkltOTBaV3d0ZEdWemRDSXNJbXNpT2lJelozUkdOVGMwYlRFemVsWnRVa2hUYWpOVlpqUTBNSEFpTENKdElqcDdJbklpT2lKa1pYWXRkWE10WTJWdWRISmhiQ0o5ZlE9PQ=="
+---
+# Source: k8s-monitoring/templates/grafana-agent-config.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: k8smon-grafana-agent
+  namespace: default
+data:
+  config.river: |-    
+    discovery.kubernetes "nodes" {
+      role = "node"
+    }
+        
+    discovery.kubernetes "pods" {
+      role = "pod"
+    }
+        
+    discovery.kubernetes "services" {
+      role = "service"
+    }
+        
+    // Grafana Agent
+    discovery.relabel "agent" {
+      targets = discovery.kubernetes.services.targets
+      rule {
+        source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_instance"]
+        regex = "k8smon"
+        action = "keep"
+      }
+      rule {
+        source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_name"]
+        regex = "grafana-agent"
+        action = "keep"
+      }
+      rule {
+        source_labels = ["__meta_kubernetes_service_port_name"]
+        regex = "http-metrics"
+        action = "keep"
+      }
+      rule {
+        source_labels = ["__name__"]
+        replacement   = "otel-collector-test"
+        target_label  = "cluster"
+      }
+    }
+    
+    prometheus.scrape "agent" {
+      job_name   = "integrations/agent"
+      targets  = discovery.relabel.agent.output
+      forward_to = [prometheus.relabel.agent.receiver]
+    }
+    
+    prometheus.relabel "agent" {
+      rule {
+        source_labels = ["__name__"]
+        regex = "up|agent_build_info"
+        action = "keep"
+      }
+      forward_to = [prometheus.remote_write.grafana_cloud_prometheus.receiver]
+    }
+        
+    // Kubelet
+    discovery.relabel "kubelet" {
+      targets = discovery.kubernetes.nodes.targets
+      rule {
+        target_label = "__address__"
+        replacement  = "kubernetes.default.svc.cluster.local:443"
+      }
+      rule {
+        source_labels = ["__meta_kubernetes_node_name"]
+        regex         = "(.+)"
+        replacement   = "/api/v1/nodes/${1}/proxy/metrics"
+        target_label  = "__metrics_path__"
+      }
+      rule {
+        source_labels = ["__name__"]
+        replacement   = "otel-collector-test"
+        target_label  = "cluster"
+      }
+    }
+    
+    prometheus.scrape "kubelet" {
+      job_name   = "integrations/kubernetes/kubelet"
+      targets  = discovery.relabel.kubelet.output
+      scheme   = "https"
+      bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+      tls_config {
+        insecure_skip_verify = true
+      }
+      forward_to = [prometheus.relabel.kubelet.receiver]
+    }
+    
+    prometheus.relabel "kubelet" {
+      rule {
+        source_labels = ["__name__"]
+        regex = "up|container_cpu_usage_seconds_total|kubelet_certificate_manager_client_expiration_renew_errors|kubelet_certificate_manager_client_ttl_seconds|kubelet_certificate_manager_server_ttl_seconds|kubelet_cgroup_manager_duration_seconds_bucket|kubelet_cgroup_manager_duration_seconds_count|kubelet_node_config_error|kubelet_node_name|kubelet_pleg_relist_duration_seconds_bucket|kubelet_pleg_relist_duration_seconds_count|kubelet_pleg_relist_interval_seconds_bucket|kubelet_pod_start_duration_seconds_bucket|kubelet_pod_start_duration_seconds_count|kubelet_pod_worker_duration_seconds_bucket|kubelet_pod_worker_duration_seconds_count|kubelet_running_container_count|kubelet_running_containers|kubelet_running_pod_count|kubelet_running_pods|kubelet_runtime_operations_errors_total|kubelet_runtime_operations_total|kubelet_server_expiration_renew_errors|kubelet_volume_stats_available_bytes|kubelet_volume_stats_capacity_bytes|kubelet_volume_stats_inodes|kubelet_volume_stats_inodes_used|kubernetes_build_info|namespace_workload_pod|rest_client_requests_total|storage_operation_duration_seconds_count|storage_operation_errors_total|volume_manager_total_volumes"
+        action = "keep"
+      }
+      forward_to = [prometheus.remote_write.grafana_cloud_prometheus.receiver]
+    }
+        
+    // cAdvisor
+    discovery.relabel "cadvisor" {
+      targets = discovery.kubernetes.nodes.targets
+      rule {
+        target_label = "__address__"
+        replacement  = "kubernetes.default.svc.cluster.local:443"
+      }
+      rule {
+        source_labels = ["__meta_kubernetes_node_name"]
+        regex         = "(.+)"
+        replacement   = "/api/v1/nodes/${1}/proxy/metrics/cadvisor"
+        target_label  = "__metrics_path__"
+      }
+      rule {
+        source_labels = ["__name__"]
+        replacement   = "otel-collector-test"
+        target_label  = "cluster"
+      }
+    }
+    
+    prometheus.scrape "cadvisor" {
+      job_name   = "integrations/kubernetes/cadvisor"
+      targets    = discovery.relabel.cadvisor.output
+      scheme     = "https"
+      bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+      tls_config {
+        insecure_skip_verify = true
+      }
+      forward_to = [prometheus.relabel.cadvisor.receiver]
+    }
+    
+    prometheus.relabel "cadvisor" {
+      rule {
+        source_labels = ["__name__"]
+        regex = "up|container_cpu_cfs_periods_total|container_cpu_cfs_throttled_periods_total|container_cpu_usage_seconds_total|container_fs_reads_bytes_total|container_fs_reads_total|container_fs_writes_bytes_total|container_fs_writes_total|container_memory_cache|container_memory_rss|container_memory_swap|container_memory_working_set_bytes|container_network_receive_bytes_total|container_network_receive_packets_dropped_total|container_network_receive_packets_total|container_network_transmit_bytes_total|container_network_transmit_packets_dropped_total|container_network_transmit_packets_total|machine_memory_bytes"
+        action = "keep"
+      }
+      forward_to = [prometheus.remote_write.grafana_cloud_prometheus.receiver]
+    }
+        
+    // Kube State Metrics
+    discovery.relabel "kube_state_metrics" {
+      targets = discovery.kubernetes.services.targets
+      rule {
+        source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_instance"]
+        regex = "k8smon"
+        action = "keep"
+      }
+      rule {
+        source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_name"]
+        regex = "kube-state-metrics"
+        action = "keep"
+      }
+      rule {
+        source_labels = ["__meta_kubernetes_service_port_name"]
+        regex = "http"
+        action = "keep"
+      }
+      rule {
+        source_labels = ["__name__"]
+        replacement   = "otel-collector-test"
+        target_label  = "cluster"
+      }
+    }
+    
+    prometheus.scrape "kube_state_metrics" {
+      job_name   = "integrations/kubernetes/kube-state-metrics"
+      targets    = discovery.relabel.kube_state_metrics.output
+      forward_to = [prometheus.relabel.kube_state_metrics.receiver]
+    }
+    
+    prometheus.relabel "kube_state_metrics" {
+      rule {
+        source_labels = ["__name__"]
+        regex = "up|kube_daemonset.*|kube_deployment_metadata_generation|kube_deployment_spec_replicas|kube_deployment_status_observed_generation|kube_deployment_status_replicas_available|kube_deployment_status_replicas_updated|kube_horizontalpodautoscaler_spec_max_replicas|kube_horizontalpodautoscaler_spec_min_replicas|kube_horizontalpodautoscaler_status_current_replicas|kube_horizontalpodautoscaler_status_desired_replicas|kube_job.*|kube_namespace_status_phase|kube_namespace_status_phase|kube_node.*|kube_persistentvolumeclaim_resource_requests_storage_bytes|kube_pod_container_info|kube_pod_container_resource_limits|kube_pod_container_resource_requests|kube_pod_container_status_restarts_total|kube_pod_container_status_waiting_reason|kube_pod_container_status_waiting_reason|kube_pod_info|kube_pod_owner|kube_pod_start_time|kube_pod_status_phase|kube_pod_status_phase|kube_pod_status_reason|kube_replicaset.*|kube_resourcequota|kube_statefulset.*"
+        action = "keep"
+      }
+      forward_to = [prometheus.remote_write.grafana_cloud_prometheus.receiver]
+    }
+        
+    // Node Exporter
+    discovery.relabel "node_exporter" {
+      targets = discovery.kubernetes.pods.targets
+      rule {
+        source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_instance"]
+        regex = "k8smon"
+        action = "keep"
+      }
+      rule {
+        source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+        regex = "prometheus-node-exporter.*"
+        action = "keep"
+      }
+      rule {
+        source_labels = ["__meta_kubernetes_pod_node_name"]
+        action = "replace"
+        target_label = "instance"
+      }
+      rule {
+        source_labels = ["__name__"]
+        replacement   = "otel-collector-test"
+        target_label  = "cluster"
+      }
+    }
+    
+    prometheus.scrape "node_exporter" {
+      job_name   = "integrations/node_exporter"
+      targets  = discovery.relabel.node_exporter.output
+      forward_to = [prometheus.relabel.node_exporter.receiver]
+    }
+    
+    prometheus.relabel "node_exporter" {
+      rule {
+        source_labels = ["__name__"]
+        regex = "up|node_cpu.*|node_exporter_build_info|node_filesystem.*|node_memory.*|process_cpu_seconds_total|process_resident_memory_bytes"
+        action = "keep"
+      }
+      forward_to = [prometheus.remote_write.grafana_cloud_prometheus.receiver]
+    }
+        
+    // OpenCost
+    discovery.relabel "opencost" {
+      targets = discovery.kubernetes.services.targets
+      rule {
+        source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_instance"]
+        regex = "k8smon"
+        action = "keep"
+      }
+      rule {
+        source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_name"]
+        regex = "opencost"
+        action = "keep"
+      }
+      rule {
+        source_labels = ["__meta_kubernetes_service_port_name"]
+        regex = "http"
+        action = "keep"
+      }
+      rule {
+        source_labels = ["__name__"]
+        replacement   = "otel-collector-test"
+        target_label  = "cluster"
+      }
+    }
+    
+    prometheus.scrape "opencost" {
+      job_name   = "integrations/kubernetes/opencost"
+      targets    = discovery.relabel.opencost.output
+      forward_to = [prometheus.relabel.opencost.receiver]
+    }
+    
+    prometheus.relabel "opencost" {
+      rule {
+        source_labels = ["__name__"]
+        regex = "up|container_cpu_allocation|container_gpu_allocation|container_memory_allocation_bytes|deployment_match_labels|kubecost_cluster_info|kubecost_cluster_management_cost|kubecost_cluster_memory_working_set_bytes|kubecost_http_requests_total|kubecost_http_response_size_bytes|kubecost_http_response_time_seconds|kubecost_load_balancer_cost|kubecost_network_internet_egress_cost|kubecost_network_region_egress_cost|kubecost_network_zone_egress_cost|kubecost_node_is_spot|node_cpu_hourly_cost|node_gpu_count|node_gpu_hourly_cost|node_ram_hourly_cost|node_total_hourly_cost|opencost_build_info|pod_pvc_allocation|pv_hourly_cost|service_selector_labels|statefulSet_match_labels"
+        action = "keep"
+      }
+      forward_to = [prometheus.remote_write.grafana_cloud_prometheus.receiver]
+    }
+        
+    // PodMonitor
+    prometheus.operator.podmonitors "pod_monitors" {
+      forward_to = [prometheus.remote_write.grafana_cloud_prometheus.receiver]
+    }
+        
+    // ServiceMonitor
+    prometheus.operator.servicemonitors "service_monitors" {
+      forward_to = [prometheus.remote_write.grafana_cloud_prometheus.receiver]
+    }
+        
+    // Grafana Cloud Prometheus
+    local.file "prometheus_host" {
+      filename  = "/etc/grafana-agent-credentials/prometheus_host"
+    }
+    
+    local.file "prometheus_username" {
+      filename  = "/etc/grafana-agent-credentials/prometheus_username"
+    }
+    
+    local.file "prometheus_password" {
+      filename  = "/etc/grafana-agent-credentials/prometheus_password"
+      is_secret = true
+    }
+    
+    prometheus.remote_write "grafana_cloud_prometheus" {
+      endpoint {
+        url = nonsensitive(local.file.prometheus_host.content) + "/api/prom/push"
+    
+        basic_auth {
+          username = local.file.prometheus_username.content
+          password = local.file.prometheus_password.content
+        }
+      }
+    }
+        
+    // Cluster Events
+    loki.source.kubernetes_events "cluster_events" {
+      job_name   = "integrations/kubernetes/eventhandler"
+      forward_to = [loki.process.cluster_events.receiver]
+    }
+    
+    loki.process "cluster_events" {
+      stage.static_labels {
+        values = {
+          cluster = "otel-collector-test",
+        }
+      }
+    
+      forward_to = [loki.write.grafana_cloud_loki.receiver]
+    }
+        
+    // Grafana Cloud Loki
+    local.file "loki_host" {
+      filename  = "/etc/grafana-agent-credentials/loki_host"
+    }
+    
+    local.file "loki_username" {
+      filename  = "/etc/grafana-agent-credentials/loki_username"
+    }
+    
+    local.file "loki_password" {
+      filename  = "/etc/grafana-agent-credentials/loki_password"
+      is_secret = true
+    }
+    
+    loki.write "grafana_cloud_loki" {
+      endpoint {
+        url = nonsensitive(local.file.loki_host.content) + "/loki/api/v1/push"
+    
+        basic_auth {
+          username = local.file.loki_username.content
+          password = local.file.loki_password.content
+        }
+      }
+    }
+---
+# Source: k8s-monitoring/templates/grafana-agent-logs-config.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: k8smon-grafana-agent-logs
+  namespace: default
+data:
+  config.river: |-    
+    discovery.kubernetes "pods" {
+      role = "pod"
+    }
+        
+    // Pod Logs
+    discovery.relabel "pod_logs" {
+      targets = discovery.kubernetes.pods.targets
+    
+      rule {
+        source_labels = ["__meta_kubernetes_namespace"]
+        action = "replace"
+        target_label = "namespace"
+      }
+      rule {
+        source_labels = ["__meta_kubernetes_pod_name"]
+        action = "replace"
+        target_label = "pod"
+      }
+      rule {
+        source_labels = ["__meta_kubernetes_pod_container_name"]
+        action = "replace"
+        target_label = "container"
+      }
+      rule {
+        source_labels = ["__meta_kubernetes_namespace", "__meta_kubernetes_pod_name"]
+        separator = "/"
+        action = "replace"
+        replacement = "$1"
+        target_label = "job"
+      }
+      rule {
+        source_labels = ["__meta_kubernetes_pod_node_name"]
+        target_label = "__host__"
+      }
+      rule {
+        source_labels = ["__meta_kubernetes_pod_uid", "__meta_kubernetes_pod_container_name"]
+        separator = "/"
+        action = "replace"
+        replacement = "/var/log/pods/*$1/*.log"
+        target_label = "__path__"
+      }
+    }
+    
+    loki.source.file "pod_logs" {
+      targets    = discovery.relabel.pod_logs.output
+      forward_to = [loki.process.pod_logs.receiver]
+    }
+    
+    loki.process "pod_logs" {
+      stage.static_labels {
+        values = {
+          cluster = "otel-collector-test",
+        }
+      }
+    
+      stage.docker {}
+      forward_to = [loki.write.grafana_cloud_loki.receiver]
+    }
+        
+    // Grafana Cloud Loki
+    local.file "loki_host" {
+      filename  = "/etc/grafana-agent-credentials/loki_host"
+    }
+    
+    local.file "loki_username" {
+      filename  = "/etc/grafana-agent-credentials/loki_username"
+    }
+    
+    local.file "loki_password" {
+      filename  = "/etc/grafana-agent-credentials/loki_password"
+      is_secret = true
+    }
+    
+    loki.write "grafana_cloud_loki" {
+      endpoint {
+        url = nonsensitive(local.file.loki_host.content) + "/loki/api/v1/push"
+    
+        basic_auth {
+          username = local.file.loki_username.content
+          password = local.file.loki_password.content
+        }
+      }
+    }
+---
+# Source: k8s-monitoring/charts/grafana-agent-logs/templates/rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: k8smon-grafana-agent-logs
+  labels:
+    helm.sh/chart: grafana-agent-logs-0.19.0
+    app.kubernetes.io/name: grafana-agent-logs
+    app.kubernetes.io/instance: k8smon
+    app.kubernetes.io/version: "v0.35.2"
+    app.kubernetes.io/managed-by: Helm
+rules:
+  # Rules which allow discovery.kubernetes to function.
+  - apiGroups:
+      - ""
+      - "discovery.k8s.io"
+      - "networking.k8s.io"
+    resources:
+      - endpoints
+      - endpointslices
+      - ingresses
+      - nodes
+      - nodes/proxy
+      - nodes/metrics
+      - pods
+      - services
+    verbs:
+      - get
+      - list
+      - watch
+  # Rules which allow loki.source.kubernetes and loki.source.podlogs to work.
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+      - pods/log
+      - namespaces
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - "monitoring.grafana.com"
+    resources:
+      - podlogs
+    verbs:
+      - get
+      - list
+      - watch
+  # Rules which allow mimir.rules.kubernetes to work.
+  - apiGroups: ["monitoring.coreos.com"]
+    resources:
+      - prometheusrules
+    verbs:
+      - get
+      - list
+      - watch
+  - nonResourceURLs:
+      - /metrics
+    verbs:
+      - get
+  # Rules for prometheus.kubernetes.*
+  - apiGroups: ["monitoring.coreos.com"]
+    resources:
+      - podmonitors
+      - servicemonitors
+      - probes
+    verbs:
+      - get
+      - list
+      - watch
+  # Rules which allow eventhandler to work.
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - get
+      - list
+      - watch
+---
+# Source: k8s-monitoring/charts/grafana-agent/templates/rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: k8smon-grafana-agent
+  labels:
+    helm.sh/chart: grafana-agent-0.19.0
+    app.kubernetes.io/name: grafana-agent
+    app.kubernetes.io/instance: k8smon
+    app.kubernetes.io/version: "v0.35.2"
+    app.kubernetes.io/managed-by: Helm
+rules:
+  # Rules which allow discovery.kubernetes to function.
+  - apiGroups:
+      - ""
+      - "discovery.k8s.io"
+      - "networking.k8s.io"
+    resources:
+      - endpoints
+      - endpointslices
+      - ingresses
+      - nodes
+      - nodes/proxy
+      - nodes/metrics
+      - pods
+      - services
+    verbs:
+      - get
+      - list
+      - watch
+  # Rules which allow loki.source.kubernetes and loki.source.podlogs to work.
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+      - pods/log
+      - namespaces
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - "monitoring.grafana.com"
+    resources:
+      - podlogs
+    verbs:
+      - get
+      - list
+      - watch
+  # Rules which allow mimir.rules.kubernetes to work.
+  - apiGroups: ["monitoring.coreos.com"]
+    resources:
+      - prometheusrules
+    verbs:
+      - get
+      - list
+      - watch
+  - nonResourceURLs:
+      - /metrics
+    verbs:
+      - get
+  # Rules for prometheus.kubernetes.*
+  - apiGroups: ["monitoring.coreos.com"]
+    resources:
+      - podmonitors
+      - servicemonitors
+      - probes
+    verbs:
+      - get
+      - list
+      - watch
+  # Rules which allow eventhandler to work.
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - get
+      - list
+      - watch
+---
+# Source: k8s-monitoring/charts/kube-state-metrics/templates/role.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:    
+    helm.sh/chart: kube-state-metrics-5.10.1
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: metrics
+    app.kubernetes.io/part-of: kube-state-metrics
+    app.kubernetes.io/name: kube-state-metrics
+    app.kubernetes.io/instance: k8smon
+    app.kubernetes.io/version: "2.9.2"
+  name: k8smon-kube-state-metrics
+rules:
+
+- apiGroups: ["certificates.k8s.io"]
+  resources:
+  - certificatesigningrequests
+  verbs: ["list", "watch"]
+
+- apiGroups: [""]
+  resources:
+  - configmaps
+  verbs: ["list", "watch"]
+
+- apiGroups: ["batch"]
+  resources:
+  - cronjobs
+  verbs: ["list", "watch"]
+
+- apiGroups: ["extensions", "apps"]
+  resources:
+  - daemonsets
+  verbs: ["list", "watch"]
+
+- apiGroups: ["extensions", "apps"]
+  resources:
+  - deployments
+  verbs: ["list", "watch"]
+
+- apiGroups: [""]
+  resources:
+  - endpoints
+  verbs: ["list", "watch"]
+
+- apiGroups: ["autoscaling"]
+  resources:
+  - horizontalpodautoscalers
+  verbs: ["list", "watch"]
+
+- apiGroups: ["extensions", "networking.k8s.io"]
+  resources:
+  - ingresses
+  verbs: ["list", "watch"]
+
+- apiGroups: ["batch"]
+  resources:
+  - jobs
+  verbs: ["list", "watch"]
+
+- apiGroups: ["coordination.k8s.io"]
+  resources:
+  - leases
+  verbs: ["list", "watch"]
+
+- apiGroups: [""]
+  resources:
+  - limitranges
+  verbs: ["list", "watch"]
+
+- apiGroups: ["admissionregistration.k8s.io"]
+  resources:
+    - mutatingwebhookconfigurations
+  verbs: ["list", "watch"]
+
+- apiGroups: [""]
+  resources:
+  - namespaces
+  verbs: ["list", "watch"]
+
+- apiGroups: ["networking.k8s.io"]
+  resources:
+  - networkpolicies
+  verbs: ["list", "watch"]
+
+- apiGroups: [""]
+  resources:
+  - nodes
+  verbs: ["list", "watch"]
+
+- apiGroups: [""]
+  resources:
+  - persistentvolumeclaims
+  verbs: ["list", "watch"]
+
+- apiGroups: [""]
+  resources:
+  - persistentvolumes
+  verbs: ["list", "watch"]
+
+- apiGroups: ["policy"]
+  resources:
+    - poddisruptionbudgets
+  verbs: ["list", "watch"]
+
+- apiGroups: [""]
+  resources:
+  - pods
+  verbs: ["list", "watch"]
+
+- apiGroups: ["extensions", "apps"]
+  resources:
+  - replicasets
+  verbs: ["list", "watch"]
+
+- apiGroups: [""]
+  resources:
+  - replicationcontrollers
+  verbs: ["list", "watch"]
+
+- apiGroups: [""]
+  resources:
+  - resourcequotas
+  verbs: ["list", "watch"]
+
+- apiGroups: [""]
+  resources:
+  - secrets
+  verbs: ["list", "watch"]
+
+- apiGroups: [""]
+  resources:
+  - services
+  verbs: ["list", "watch"]
+
+- apiGroups: ["apps"]
+  resources:
+  - statefulsets
+  verbs: ["list", "watch"]
+
+- apiGroups: ["storage.k8s.io"]
+  resources:
+    - storageclasses
+  verbs: ["list", "watch"]
+
+- apiGroups: ["admissionregistration.k8s.io"]
+  resources:
+    - validatingwebhookconfigurations
+  verbs: ["list", "watch"]
+
+- apiGroups: ["storage.k8s.io"]
+  resources:
+    - volumeattachments
+  verbs: ["list", "watch"]
+---
+# Source: k8s-monitoring/charts/opencost/templates/clusterrole.yaml
+# Cluster role giving opencost to get, list, watch required resources
+# No write permissions are required
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: k8smon-opencost
+  labels:
+    helm.sh/chart: opencost-1.18.0
+    app.kubernetes.io/name: opencost
+    app.kubernetes.io/instance: k8smon
+    app.kubernetes.io/version: "1.105.0"
+    app.kubernetes.io/part-of: opencost
+    app.kubernetes.io/managed-by: Helm
+rules:
+  - apiGroups: [""]
+    resources:
+      - configmaps
+      - deployments
+      - nodes
+      - pods
+      - services
+      - resourcequotas
+      - replicationcontrollers
+      - limitranges
+      - persistentvolumeclaims
+      - persistentvolumes
+      - namespaces
+      - endpoints
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - extensions
+    resources:
+      - daemonsets
+      - deployments
+      - replicasets
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - apps
+    resources:
+      - statefulsets
+      - deployments
+      - daemonsets
+      - replicasets
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - batch
+    resources:
+      - cronjobs
+      - jobs
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - autoscaling
+    resources:
+      - horizontalpodautoscalers
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - policy
+    resources:
+      - poddisruptionbudgets
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - storage.k8s.io
+    resources:
+      - storageclasses
+    verbs:
+      - get
+      - list
+      - watch
+---
+# Source: k8s-monitoring/charts/grafana-agent-logs/templates/rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: k8smon-grafana-agent-logs
+  labels:
+    helm.sh/chart: grafana-agent-logs-0.19.0
+    app.kubernetes.io/name: grafana-agent-logs
+    app.kubernetes.io/instance: k8smon
+    app.kubernetes.io/version: "v0.35.2"
+    app.kubernetes.io/managed-by: Helm
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: k8smon-grafana-agent-logs
+subjects:
+  - kind: ServiceAccount
+    name: k8smon-grafana-agent-logs
+    namespace: default
+---
+# Source: k8s-monitoring/charts/grafana-agent/templates/rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: k8smon-grafana-agent
+  labels:
+    helm.sh/chart: grafana-agent-0.19.0
+    app.kubernetes.io/name: grafana-agent
+    app.kubernetes.io/instance: k8smon
+    app.kubernetes.io/version: "v0.35.2"
+    app.kubernetes.io/managed-by: Helm
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: k8smon-grafana-agent
+subjects:
+  - kind: ServiceAccount
+    name: k8smon-grafana-agent
+    namespace: default
+---
+# Source: k8s-monitoring/charts/kube-state-metrics/templates/clusterrolebinding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:    
+    helm.sh/chart: kube-state-metrics-5.10.1
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: metrics
+    app.kubernetes.io/part-of: kube-state-metrics
+    app.kubernetes.io/name: kube-state-metrics
+    app.kubernetes.io/instance: k8smon
+    app.kubernetes.io/version: "2.9.2"
+  name: k8smon-kube-state-metrics
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: k8smon-kube-state-metrics
+subjects:
+- kind: ServiceAccount
+  name: k8smon-kube-state-metrics
+  namespace: default
+---
+# Source: k8s-monitoring/charts/opencost/templates/clusterrolebinding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: k8smon-opencost
+  labels:
+    helm.sh/chart: opencost-1.18.0
+    app.kubernetes.io/name: opencost
+    app.kubernetes.io/instance: k8smon
+    app.kubernetes.io/version: "1.105.0"
+    app.kubernetes.io/part-of: opencost
+    app.kubernetes.io/managed-by: Helm
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: k8smon-opencost
+subjects:
+  - kind: ServiceAccount
+    name: k8smon-opencost
+    namespace: default
+---
+# Source: k8s-monitoring/charts/grafana-agent-logs/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: k8smon-grafana-agent-logs
+  labels:
+    helm.sh/chart: grafana-agent-logs-0.19.0
+    app.kubernetes.io/name: grafana-agent-logs
+    app.kubernetes.io/instance: k8smon
+    app.kubernetes.io/version: "v0.35.2"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: grafana-agent-logs
+    app.kubernetes.io/instance: k8smon
+  ports:
+    - name: http-metrics
+      port: 80
+      targetPort: 80
+      protocol: "TCP"
+---
+# Source: k8s-monitoring/charts/grafana-agent/templates/cluster_service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: k8smon-grafana-agent-cluster
+  labels:
+    helm.sh/chart: grafana-agent-0.19.0
+    app.kubernetes.io/name: grafana-agent
+    app.kubernetes.io/instance: k8smon
+    app.kubernetes.io/version: "v0.35.2"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  type: ClusterIP
+  clusterIP: 'None'
+  selector:
+    app.kubernetes.io/name: grafana-agent
+    app.kubernetes.io/instance: k8smon
+  ports:
+    # Do not include the -metrics suffix in the port name, otherwise metrics
+    # can be double-collected with the non-headless Service if it's also
+    # enabled.
+    #
+    # This service should only be used for clustering, and not metric
+    # collection.
+    - name: http
+      port: 80
+      targetPort: 80
+      protocol: "TCP"
+---
+# Source: k8s-monitoring/charts/grafana-agent/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: k8smon-grafana-agent
+  labels:
+    helm.sh/chart: grafana-agent-0.19.0
+    app.kubernetes.io/name: grafana-agent
+    app.kubernetes.io/instance: k8smon
+    app.kubernetes.io/version: "v0.35.2"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: grafana-agent
+    app.kubernetes.io/instance: k8smon
+  ports:
+    - name: http-metrics
+      port: 80
+      targetPort: 80
+      protocol: "TCP"
+---
+# Source: k8s-monitoring/charts/kube-state-metrics/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: k8smon-kube-state-metrics
+  namespace: default
+  labels:    
+    helm.sh/chart: kube-state-metrics-5.10.1
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: metrics
+    app.kubernetes.io/part-of: kube-state-metrics
+    app.kubernetes.io/name: kube-state-metrics
+    app.kubernetes.io/instance: k8smon
+    app.kubernetes.io/version: "2.9.2"
+  annotations:
+    prometheus.io/scrape: 'true'
+spec:
+  type: "ClusterIP"
+  ports:
+  - name: "http"
+    protocol: TCP
+    port: 8080
+    targetPort: 8080
+  
+  selector:    
+    app.kubernetes.io/name: kube-state-metrics
+    app.kubernetes.io/instance: k8smon
+---
+# Source: k8s-monitoring/charts/opencost/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: k8smon-opencost
+  labels:
+    helm.sh/chart: opencost-1.18.0
+    app.kubernetes.io/name: opencost
+    app.kubernetes.io/instance: k8smon
+    app.kubernetes.io/version: "1.105.0"
+    app.kubernetes.io/part-of: opencost
+    app.kubernetes.io/managed-by: Helm
+spec:
+  selector:
+    app.kubernetes.io/name: opencost
+    app.kubernetes.io/instance: k8smon
+  type: ClusterIP
+  ports:
+    - name: http
+      port: 9003
+      targetPort: 9003
+---
+# Source: k8s-monitoring/charts/prometheus-node-exporter/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: k8smon-prometheus-node-exporter
+  namespace: default
+  labels:
+    helm.sh/chart: prometheus-node-exporter-4.21.0
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: metrics
+    app.kubernetes.io/part-of: prometheus-node-exporter
+    app.kubernetes.io/name: prometheus-node-exporter
+    app.kubernetes.io/instance: k8smon
+    app.kubernetes.io/version: "1.6.0"
+  annotations:
+    prometheus.io/scrape: "true"
+spec:
+  type: ClusterIP
+  ports:
+    - port: 9100
+      targetPort: 9100
+      protocol: TCP
+      name: metrics
+  selector:
+    app.kubernetes.io/name: prometheus-node-exporter
+    app.kubernetes.io/instance: k8smon
+---
+# Source: k8s-monitoring/charts/grafana-agent-logs/templates/controllers/daemonset.yaml
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: k8smon-grafana-agent-logs
+  labels:
+    helm.sh/chart: grafana-agent-logs-0.19.0
+    app.kubernetes.io/name: grafana-agent-logs
+    app.kubernetes.io/instance: k8smon
+    app.kubernetes.io/version: "v0.35.2"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  minReadySeconds: 10
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: grafana-agent-logs
+      app.kubernetes.io/instance: k8smon
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: grafana-agent-logs
+        app.kubernetes.io/instance: k8smon
+    spec:
+      serviceAccountName: k8smon-grafana-agent-logs
+      containers:
+        - name: grafana-agent
+          image: docker.io/grafana/agent:v0.35.2
+          imagePullPolicy: IfNotPresent
+          args:
+            - run
+            - /etc/agent/config.river
+            - --storage.path=/tmp/agent
+            - --server.http.listen-addr=0.0.0.0:80
+          env:
+            - name: AGENT_MODE
+              value: flow
+            - name: HOSTNAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+          ports:
+            - containerPort: 80
+              name: http-metrics
+          readinessProbe:
+            httpGet:
+              path: /-/ready
+              port: 80
+            initialDelaySeconds: 10
+            timeoutSeconds: 1
+          volumeMounts:
+            - name: config
+              mountPath: /etc/agent
+            - name: varlog
+              mountPath: /var/log
+              readOnly: true
+            - name: dockercontainers
+              mountPath: /var/lib/docker/containers
+              readOnly: true
+            -
+              mountPath: /etc/grafana-agent-credentials
+              name: grafana-agent-credentials
+        - name: config-reloader
+          image: docker.io/jimmidyson/configmap-reload:v0.8.0
+          args:
+            - --volume-dir=/etc/agent
+            - --webhook-url=http://localhost:80/-/reload
+          volumeMounts:
+            - name: config
+              mountPath: /etc/agent
+          resources:
+            requests:
+              cpu: 1m
+              memory: 5Mi
+      dnsPolicy: ClusterFirst
+      nodeSelector:
+        kubernetes.io/os: linux
+      volumes:
+        - name: config
+          configMap:
+            name: k8smon-grafana-agent-logs
+        - name: varlog
+          hostPath:
+            path: /var/log
+        - name: dockercontainers
+          hostPath:
+            path: /var/lib/docker/containers
+        - name: grafana-agent-credentials
+          secret:
+            secretName: grafana-agent-credentials
+---
+# Source: k8s-monitoring/charts/prometheus-node-exporter/templates/daemonset.yaml
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: k8smon-prometheus-node-exporter
+  namespace: default
+  labels:
+    helm.sh/chart: prometheus-node-exporter-4.21.0
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: metrics
+    app.kubernetes.io/part-of: prometheus-node-exporter
+    app.kubernetes.io/name: prometheus-node-exporter
+    app.kubernetes.io/instance: k8smon
+    app.kubernetes.io/version: "1.6.0"
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: prometheus-node-exporter
+      app.kubernetes.io/instance: k8smon
+  updateStrategy:
+    rollingUpdate:
+      maxUnavailable: 1
+    type: RollingUpdate
+  template:
+    metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
+      labels:
+        helm.sh/chart: prometheus-node-exporter-4.21.0
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/component: metrics
+        app.kubernetes.io/part-of: prometheus-node-exporter
+        app.kubernetes.io/name: prometheus-node-exporter
+        app.kubernetes.io/instance: k8smon
+        app.kubernetes.io/version: "1.6.0"
+    spec:
+      automountServiceAccountToken: false
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+      serviceAccountName: k8smon-prometheus-node-exporter
+      containers:
+        - name: node-exporter
+          image: quay.io/prometheus/node-exporter:v1.6.0
+          imagePullPolicy: IfNotPresent
+          args:
+            - --path.procfs=/host/proc
+            - --path.sysfs=/host/sys
+            - --path.rootfs=/host/root
+            - --path.udev.data=/host/root/run/udev/data
+            - --web.listen-address=[$(HOST_IP)]:9100
+          securityContext:
+            readOnlyRootFilesystem: true
+          env:
+            - name: HOST_IP
+              value: 0.0.0.0
+          ports:
+            - name: metrics
+              containerPort: 9100
+              protocol: TCP
+          livenessProbe:
+            failureThreshold: 3
+            httpGet:
+              httpHeaders:
+              path: /
+              port: 9100
+              scheme: HTTP
+            initialDelaySeconds: 0
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          readinessProbe:
+            failureThreshold: 3
+            httpGet:
+              httpHeaders:
+              path: /
+              port: 9100
+              scheme: HTTP
+            initialDelaySeconds: 0
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          volumeMounts:
+            - name: proc
+              mountPath: /host/proc
+              readOnly:  true
+            - name: sys
+              mountPath: /host/sys
+              readOnly: true
+            - name: root
+              mountPath: /host/root
+              mountPropagation: HostToContainer
+              readOnly: true
+      hostNetwork: true
+      hostPID: true
+      nodeSelector:
+        kubernetes.io/os: linux
+      tolerations:
+        - effect: NoSchedule
+          operator: Exists
+      volumes:
+        - name: proc
+          hostPath:
+            path: /proc
+        - name: sys
+          hostPath:
+            path: /sys
+        - name: root
+          hostPath:
+            path: /
+---
+# Source: k8s-monitoring/charts/kube-state-metrics/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: k8smon-kube-state-metrics
+  namespace: default
+  labels:    
+    helm.sh/chart: kube-state-metrics-5.10.1
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: metrics
+    app.kubernetes.io/part-of: kube-state-metrics
+    app.kubernetes.io/name: kube-state-metrics
+    app.kubernetes.io/instance: k8smon
+    app.kubernetes.io/version: "2.9.2"
+spec:
+  selector:
+    matchLabels:      
+      app.kubernetes.io/name: kube-state-metrics
+      app.kubernetes.io/instance: k8smon
+  replicas: 1
+  template:
+    metadata:
+      labels:        
+        helm.sh/chart: kube-state-metrics-5.10.1
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/component: metrics
+        app.kubernetes.io/part-of: kube-state-metrics
+        app.kubernetes.io/name: kube-state-metrics
+        app.kubernetes.io/instance: k8smon
+        app.kubernetes.io/version: "2.9.2"
+    spec:
+      hostNetwork: false
+      serviceAccountName: k8smon-kube-state-metrics
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+      - name: kube-state-metrics
+        args:
+        - --port=8080
+        - --resources=certificatesigningrequests,configmaps,cronjobs,daemonsets,deployments,endpoints,horizontalpodautoscalers,ingresses,jobs,leases,limitranges,mutatingwebhookconfigurations,namespaces,networkpolicies,nodes,persistentvolumeclaims,persistentvolumes,poddisruptionbudgets,pods,replicasets,replicationcontrollers,resourcequotas,secrets,services,statefulsets,storageclasses,validatingwebhookconfigurations,volumeattachments
+        imagePullPolicy: IfNotPresent
+        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.9.2
+        ports:
+        - containerPort: 8080
+          name: "http"
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8080
+          initialDelaySeconds: 5
+          timeoutSeconds: 5
+        readinessProbe:
+          httpGet:
+            path: /
+            port: 8080
+          initialDelaySeconds: 5
+          timeoutSeconds: 5
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+---
+# Source: k8s-monitoring/charts/opencost/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: k8smon-opencost
+  labels:
+    helm.sh/chart: opencost-1.18.0
+    app.kubernetes.io/name: opencost
+    app.kubernetes.io/instance: k8smon
+    app.kubernetes.io/version: "1.105.0"
+    app.kubernetes.io/part-of: opencost
+    app.kubernetes.io/managed-by: Helm
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: opencost
+      app.kubernetes.io/instance: k8smon
+  strategy:
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 1
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: opencost
+        app.kubernetes.io/instance: k8smon
+    spec:
+      serviceAccountName: k8smon-opencost
+      containers:
+        - name: k8smon-opencost
+          image: "quay.io/kubecost1/kubecost-cost-model:prod-1.105.0"
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 9003
+              name: http
+          resources:
+            limits:
+              cpu: 999m
+              memory: 1Gi
+            requests:
+              cpu: 10m
+              memory: 55Mi
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 9003
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: 9003
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            failureThreshold: 3
+          env:
+            - name: PROMETHEUS_SERVER_ENDPOINT
+              value: "https://prom.example.com/api/prom"
+            - name: CLUSTER_ID
+              value: "default-cluster"
+            # If username, password or bearer_token are defined, pull from secrets
+            - name: DB_BASIC_AUTH_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: grafana-agent-credentials
+                  key: prometheus_username
+            - name: DB_BASIC_AUTH_PW
+              valueFrom:
+                secretKeyRef:
+                  name: grafana-agent-credentials
+                  key: prometheus_password
+            # Add any additional provided variables
+            - name: CLOUD_PROVIDER_API_KEY
+              value: "AIzaSyD29bGxmHAVEOBYtgd8sYM2gM2ekfxQX4U"
+            - name: EMIT_KSM_V1_METRICS
+              value: "false"
+            - name: EMIT_KSM_V1_METRICS_ONLY
+              value: "true"
+            - name: PROM_CLUSTER_ID_LABEL
+              value: "cluster"
+---
+# Source: k8s-monitoring/charts/grafana-agent/templates/controllers/statefulset.yaml
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: k8smon-grafana-agent
+  labels:
+    helm.sh/chart: grafana-agent-0.19.0
+    app.kubernetes.io/name: grafana-agent
+    app.kubernetes.io/instance: k8smon
+    app.kubernetes.io/version: "v0.35.2"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  replicas: 1
+  minReadySeconds: 10
+  serviceName: k8smon-grafana-agent
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: grafana-agent
+      app.kubernetes.io/instance: k8smon
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: grafana-agent
+        app.kubernetes.io/instance: k8smon
+    spec:
+      serviceAccountName: k8smon-grafana-agent
+      containers:
+        - name: grafana-agent
+          image: docker.io/grafana/agent:v0.35.2
+          imagePullPolicy: IfNotPresent
+          args:
+            - run
+            - /etc/agent/config.river
+            - --storage.path=/tmp/agent
+            - --server.http.listen-addr=0.0.0.0:80
+            - --cluster.enabled=true
+            - --cluster.join-addresses=k8smon-grafana-agent-cluster
+          env:
+            - name: AGENT_MODE
+              value: flow
+            - name: HOSTNAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+          ports:
+            - containerPort: 80
+              name: http-metrics
+          readinessProbe:
+            httpGet:
+              path: /-/ready
+              port: 80
+            initialDelaySeconds: 10
+            timeoutSeconds: 1
+          volumeMounts:
+            - name: config
+              mountPath: /etc/agent
+            -
+              mountPath: /etc/grafana-agent-credentials
+              name: grafana-agent-credentials
+        - name: config-reloader
+          image: docker.io/jimmidyson/configmap-reload:v0.8.0
+          args:
+            - --volume-dir=/etc/agent
+            - --webhook-url=http://localhost:80/-/reload
+          volumeMounts:
+            - name: config
+              mountPath: /etc/agent
+          resources:
+            requests:
+              cpu: 1m
+              memory: 5Mi
+      dnsPolicy: ClusterFirst
+      nodeSelector:
+        kubernetes.io/os: linux
+      volumes:
+        - name: config
+          configMap:
+            name: k8smon-grafana-agent
+        - name: grafana-agent-credentials
+          secret:
+            secretName: grafana-agent-credentials

--- a/examples/otel-collector/output.yaml
+++ b/examples/otel-collector/output.yaml
@@ -459,7 +459,8 @@ data:
       }
       rule {
         source_labels = ["__meta_kubernetes_pod_node_name"]
-        target_label = "__host__"
+        action = "keep"
+        regex = env("HOSTNAME")
       }
       rule {
         source_labels = ["__meta_kubernetes_pod_uid", "__meta_kubernetes_pod_container_name"]
@@ -470,8 +471,12 @@ data:
       }
     }
     
+    local.file_match "pod_logs" {
+      path_targets = discovery.relabel.pod_logs.output
+    }
+    
     loki.source.file "pod_logs" {
-      targets    = discovery.relabel.pod_logs.output
+      targets    = local.file_match.pod_logs.targets
       forward_to = [loki.process.pod_logs.receiver]
     }
     

--- a/examples/otel-collector/values.yaml
+++ b/examples/otel-collector/values.yaml
@@ -1,0 +1,25 @@
+cluster:
+  name: otel-collector-test
+
+collector:
+  type: otel
+
+externalServices:
+  prometheus:
+    host: https://prometheus-dev-01-dev-us-central-0.grafana-dev.net
+    basicAuth:
+      username: 12119
+      password: glc_dev_eyJvIjoiMzM4IiwibiI6Im90ZWwtdGVzdCIsImsiOiIzZ3RGNTc0bTEzelZtUkhTajNVZjQ0MHAiLCJtIjp7InIiOiJkZXYtdXMtY2VudHJhbCJ9fQ==
+
+  loki:
+    host: https://logs-dev-005.grafana-dev.net
+    basicAuth:
+      username: 146205
+      password: glc_dev_eyJvIjoiMzM4IiwibiI6Im90ZWwtdGVzdCIsImsiOiIzZ3RGNTc0bTEzelZtUkhTajNVZjQ0MHAiLCJtIjp7InIiOiJkZXYtdXMtY2VudHJhbCJ9fQ==
+
+prometheus-operator-crds:
+  enabled: false
+grafana-agent:
+  enabled: false
+opentelemetry-collector:
+  enabled: true

--- a/examples/windows-exporter/logs.river
+++ b/examples/windows-exporter/logs.river
@@ -30,7 +30,8 @@ discovery.relabel "pod_logs" {
   }
   rule {
     source_labels = ["__meta_kubernetes_pod_node_name"]
-    target_label = "__host__"
+    action = "keep"
+    regex = env("HOSTNAME")
   }
   rule {
     source_labels = ["__meta_kubernetes_pod_uid", "__meta_kubernetes_pod_container_name"]
@@ -41,8 +42,12 @@ discovery.relabel "pod_logs" {
   }
 }
 
+local.file_match "pod_logs" {
+  path_targets = discovery.relabel.pod_logs.output
+}
+
 loki.source.file "pod_logs" {
-  targets    = discovery.relabel.pod_logs.output
+  targets    = local.file_match.pod_logs.targets
   forward_to = [loki.process.pod_logs.receiver]
 }
 

--- a/examples/windows-exporter/logs.river
+++ b/examples/windows-exporter/logs.river
@@ -1,4 +1,7 @@
-{{ define "agent.config.pod_logs" }}
+discovery.kubernetes "pods" {
+  role = "pod"
+}
+    
 // Pod Logs
 discovery.relabel "pod_logs" {
   targets = discovery.kubernetes.pods.targets
@@ -46,11 +49,35 @@ loki.source.file "pod_logs" {
 loki.process "pod_logs" {
   stage.static_labels {
     values = {
-      cluster = {{ required ".Values.cluster.name is a required value. Please set it and try again." .Values.cluster.name | quote }},
+      cluster = "default-values-test",
     }
   }
 
-  stage.{{- .Values.pod_logs.loggingFormat }} {}
+  stage.docker {}
   forward_to = [loki.write.grafana_cloud_loki.receiver]
 }
-{{ end }}
+    
+// Grafana Cloud Loki
+local.file "loki_host" {
+  filename  = "/etc/grafana-agent-credentials/loki_host"
+}
+
+local.file "loki_username" {
+  filename  = "/etc/grafana-agent-credentials/loki_username"
+}
+
+local.file "loki_password" {
+  filename  = "/etc/grafana-agent-credentials/loki_password"
+  is_secret = true
+}
+
+loki.write "grafana_cloud_loki" {
+  endpoint {
+    url = nonsensitive(local.file.loki_host.content) + "/loki/api/v1/push"
+
+    basic_auth {
+      username = local.file.loki_username.content
+      password = local.file.loki_password.content
+    }
+  }
+}

--- a/examples/windows-exporter/metrics.river
+++ b/examples/windows-exporter/metrics.river
@@ -1,0 +1,396 @@
+discovery.kubernetes "nodes" {
+  role = "node"
+}
+    
+discovery.kubernetes "pods" {
+  role = "pod"
+}
+    
+discovery.kubernetes "services" {
+  role = "service"
+}
+    
+// Grafana Agent
+discovery.relabel "agent" {
+  targets = discovery.kubernetes.services.targets
+  rule {
+    source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_instance"]
+    regex = "k8smon"
+    action = "keep"
+  }
+  rule {
+    source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_name"]
+    regex = "grafana-agent"
+    action = "keep"
+  }
+  rule {
+    source_labels = ["__meta_kubernetes_service_port_name"]
+    regex = "http-metrics"
+    action = "keep"
+  }
+  rule {
+    source_labels = ["__name__"]
+    replacement   = "default-values-test"
+    target_label  = "cluster"
+  }
+}
+
+prometheus.scrape "agent" {
+  job_name   = "integrations/agent"
+  targets  = discovery.relabel.agent.output
+  forward_to = [prometheus.relabel.agent.receiver]
+}
+
+prometheus.relabel "agent" {
+  rule {
+    source_labels = ["__name__"]
+    regex = "up|agent_build_info"
+    action = "keep"
+  }
+  forward_to = [prometheus.remote_write.grafana_cloud_prometheus.receiver]
+}
+    
+// Kubelet
+discovery.relabel "kubelet" {
+  targets = discovery.kubernetes.nodes.targets
+  rule {
+    target_label = "__address__"
+    replacement  = "kubernetes.default.svc.cluster.local:443"
+  }
+  rule {
+    source_labels = ["__meta_kubernetes_node_name"]
+    regex         = "(.+)"
+    replacement   = "/api/v1/nodes/${1}/proxy/metrics"
+    target_label  = "__metrics_path__"
+  }
+  rule {
+    source_labels = ["__name__"]
+    replacement   = "default-values-test"
+    target_label  = "cluster"
+  }
+}
+
+prometheus.scrape "kubelet" {
+  job_name   = "integrations/kubernetes/kubelet"
+  targets  = discovery.relabel.kubelet.output
+  scheme   = "https"
+  bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+  tls_config {
+    insecure_skip_verify = true
+  }
+  forward_to = [prometheus.relabel.kubelet.receiver]
+}
+
+prometheus.relabel "kubelet" {
+  rule {
+    source_labels = ["__name__"]
+    regex = "up|container_cpu_usage_seconds_total|kubelet_certificate_manager_client_expiration_renew_errors|kubelet_certificate_manager_client_ttl_seconds|kubelet_certificate_manager_server_ttl_seconds|kubelet_cgroup_manager_duration_seconds_bucket|kubelet_cgroup_manager_duration_seconds_count|kubelet_node_config_error|kubelet_node_name|kubelet_pleg_relist_duration_seconds_bucket|kubelet_pleg_relist_duration_seconds_count|kubelet_pleg_relist_interval_seconds_bucket|kubelet_pod_start_duration_seconds_bucket|kubelet_pod_start_duration_seconds_count|kubelet_pod_worker_duration_seconds_bucket|kubelet_pod_worker_duration_seconds_count|kubelet_running_container_count|kubelet_running_containers|kubelet_running_pod_count|kubelet_running_pods|kubelet_runtime_operations_errors_total|kubelet_runtime_operations_total|kubelet_server_expiration_renew_errors|kubelet_volume_stats_available_bytes|kubelet_volume_stats_capacity_bytes|kubelet_volume_stats_inodes|kubelet_volume_stats_inodes_used|kubernetes_build_info|namespace_workload_pod|rest_client_requests_total|storage_operation_duration_seconds_count|storage_operation_errors_total|volume_manager_total_volumes"
+    action = "keep"
+  }
+  forward_to = [prometheus.remote_write.grafana_cloud_prometheus.receiver]
+}
+    
+// cAdvisor
+discovery.relabel "cadvisor" {
+  targets = discovery.kubernetes.nodes.targets
+  rule {
+    target_label = "__address__"
+    replacement  = "kubernetes.default.svc.cluster.local:443"
+  }
+  rule {
+    source_labels = ["__meta_kubernetes_node_name"]
+    regex         = "(.+)"
+    replacement   = "/api/v1/nodes/${1}/proxy/metrics/cadvisor"
+    target_label  = "__metrics_path__"
+  }
+  rule {
+    source_labels = ["__name__"]
+    replacement   = "default-values-test"
+    target_label  = "cluster"
+  }
+}
+
+prometheus.scrape "cadvisor" {
+  job_name   = "integrations/kubernetes/cadvisor"
+  targets    = discovery.relabel.cadvisor.output
+  scheme     = "https"
+  bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+  tls_config {
+    insecure_skip_verify = true
+  }
+  forward_to = [prometheus.relabel.cadvisor.receiver]
+}
+
+prometheus.relabel "cadvisor" {
+  rule {
+    source_labels = ["__name__"]
+    regex = "up|container_cpu_cfs_periods_total|container_cpu_cfs_throttled_periods_total|container_cpu_usage_seconds_total|container_fs_reads_bytes_total|container_fs_reads_total|container_fs_writes_bytes_total|container_fs_writes_total|container_memory_cache|container_memory_rss|container_memory_swap|container_memory_working_set_bytes|container_network_receive_bytes_total|container_network_receive_packets_dropped_total|container_network_receive_packets_total|container_network_transmit_bytes_total|container_network_transmit_packets_dropped_total|container_network_transmit_packets_total|machine_memory_bytes"
+    action = "keep"
+  }
+  forward_to = [prometheus.remote_write.grafana_cloud_prometheus.receiver]
+}
+    
+// Kube State Metrics
+discovery.relabel "kube_state_metrics" {
+  targets = discovery.kubernetes.services.targets
+  rule {
+    source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_instance"]
+    regex = "k8smon"
+    action = "keep"
+  }
+  rule {
+    source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_name"]
+    regex = "kube-state-metrics"
+    action = "keep"
+  }
+  rule {
+    source_labels = ["__meta_kubernetes_service_port_name"]
+    regex = "http"
+    action = "keep"
+  }
+  rule {
+    source_labels = ["__name__"]
+    replacement   = "default-values-test"
+    target_label  = "cluster"
+  }
+}
+
+prometheus.scrape "kube_state_metrics" {
+  job_name   = "integrations/kubernetes/kube-state-metrics"
+  targets    = discovery.relabel.kube_state_metrics.output
+  forward_to = [prometheus.relabel.kube_state_metrics.receiver]
+}
+
+prometheus.relabel "kube_state_metrics" {
+  rule {
+    source_labels = ["__name__"]
+    regex = "up|kube_daemonset.*|kube_deployment_metadata_generation|kube_deployment_spec_replicas|kube_deployment_status_observed_generation|kube_deployment_status_replicas_available|kube_deployment_status_replicas_updated|kube_horizontalpodautoscaler_spec_max_replicas|kube_horizontalpodautoscaler_spec_min_replicas|kube_horizontalpodautoscaler_status_current_replicas|kube_horizontalpodautoscaler_status_desired_replicas|kube_job.*|kube_namespace_status_phase|kube_namespace_status_phase|kube_node.*|kube_persistentvolumeclaim_resource_requests_storage_bytes|kube_pod_container_info|kube_pod_container_resource_limits|kube_pod_container_resource_requests|kube_pod_container_status_restarts_total|kube_pod_container_status_waiting_reason|kube_pod_container_status_waiting_reason|kube_pod_info|kube_pod_owner|kube_pod_start_time|kube_pod_status_phase|kube_pod_status_phase|kube_pod_status_reason|kube_replicaset.*|kube_resourcequota|kube_statefulset.*"
+    action = "keep"
+  }
+  forward_to = [prometheus.remote_write.grafana_cloud_prometheus.receiver]
+}
+    
+// Node Exporter
+discovery.relabel "node_exporter" {
+  targets = discovery.kubernetes.pods.targets
+  rule {
+    source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_instance"]
+    regex = "k8smon"
+    action = "keep"
+  }
+  rule {
+    source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+    regex = "prometheus-node-exporter.*"
+    action = "keep"
+  }
+  rule {
+    source_labels = ["__meta_kubernetes_pod_node_name"]
+    action = "replace"
+    target_label = "instance"
+  }
+  rule {
+    source_labels = ["__name__"]
+    replacement   = "default-values-test"
+    target_label  = "cluster"
+  }
+}
+
+prometheus.scrape "node_exporter" {
+  job_name   = "integrations/node_exporter"
+  targets  = discovery.relabel.node_exporter.output
+  forward_to = [prometheus.relabel.node_exporter.receiver]
+}
+
+prometheus.relabel "node_exporter" {
+  rule {
+    source_labels = ["__name__"]
+    regex = "up|node_cpu.*|node_exporter_build_info|node_filesystem.*|node_memory.*|process_cpu_seconds_total|process_resident_memory_bytes"
+    action = "keep"
+  }
+  forward_to = [prometheus.remote_write.grafana_cloud_prometheus.receiver]
+}
+    
+// Windows Exporter
+discovery.relabel "windows_exporter" {
+  targets = discovery.kubernetes.pods.targets
+  rule {
+    source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_instance"]
+    regex = "k8smon"
+    action = "keep"
+  }
+  rule {
+    source_labels = ["__meta_kubernetes_pod_container_port_name"]
+    regex = "metrics"
+    action = "keep"
+  }
+  rule {
+    source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+    regex = "prometheus-windows-exporter.*"
+    action = "keep"
+  }
+  rule {
+    source_labels = ["__meta_kubernetes_pod_node_name"]
+    action = "replace"
+    target_label = "instance"
+  }
+  rule {
+    source_labels = ["__name__"]
+    replacement   = "default-values-test"
+    target_label  = "cluster"
+  }
+}
+
+prometheus.scrape "windows_exporter" {
+  job_name   = "integrations/kubernetes/windows-exporter"
+  targets  = discovery.relabel.windows_exporter.output
+  forward_to = [prometheus.relabel.windows_exporter.receiver]
+}
+
+prometheus.relabel "windows_exporter" {
+  rule {
+    source_labels = ["__name__"]
+    regex = "windows_cpu_time_total"
+    replacement = "node_cpu_seconds_total"
+    target_label = "__name__"
+  }
+  rule {
+    source_labels = ["volume"]
+    regex = "windows_logical_disk_size_bytes"
+    replacement = "mountpoint"
+    target_label = "mountpoint"
+  }
+  rule {
+    source_labels = ["__name__"]
+    regex = "windows_logical_disk_size_bytes"
+    replacement = "node_filesystem_size_bytes"
+    target_label = "__name__"
+  }
+  rule {
+    source_labels = ["__name__"]
+    regex = "windows_logical_disk_free_bytes"
+    replacement = "node_filesystem_avail_bytes"
+    target_label = "__name__"
+  }
+  rule {
+    source_labels = ["__name__"]
+    regex = "up|windows_.*|node_cpu_seconds_total|node_filesystem_size_bytes|node_filesystem_avail_bytes|container_cpu_usage_seconds_total"
+    action = "keep"
+  }
+  forward_to = [prometheus.remote_write.grafana_cloud_prometheus.receiver]
+}
+    
+// OpenCost
+discovery.relabel "opencost" {
+  targets = discovery.kubernetes.services.targets
+  rule {
+    source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_instance"]
+    regex = "k8smon"
+    action = "keep"
+  }
+  rule {
+    source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_name"]
+    regex = "opencost"
+    action = "keep"
+  }
+  rule {
+    source_labels = ["__meta_kubernetes_service_port_name"]
+    regex = "http"
+    action = "keep"
+  }
+  rule {
+    source_labels = ["__name__"]
+    replacement   = "default-values-test"
+    target_label  = "cluster"
+  }
+}
+
+prometheus.scrape "opencost" {
+  job_name   = "integrations/kubernetes/opencost"
+  targets    = discovery.relabel.opencost.output
+  forward_to = [prometheus.relabel.opencost.receiver]
+}
+
+prometheus.relabel "opencost" {
+  rule {
+    source_labels = ["__name__"]
+    regex = "up|container_cpu_allocation|container_gpu_allocation|container_memory_allocation_bytes|deployment_match_labels|kubecost_cluster_info|kubecost_cluster_management_cost|kubecost_cluster_memory_working_set_bytes|kubecost_http_requests_total|kubecost_http_response_size_bytes|kubecost_http_response_time_seconds|kubecost_load_balancer_cost|kubecost_network_internet_egress_cost|kubecost_network_region_egress_cost|kubecost_network_zone_egress_cost|kubecost_node_is_spot|node_cpu_hourly_cost|node_gpu_count|node_gpu_hourly_cost|node_ram_hourly_cost|node_total_hourly_cost|opencost_build_info|pod_pvc_allocation|pv_hourly_cost|service_selector_labels|statefulSet_match_labels"
+    action = "keep"
+  }
+  forward_to = [prometheus.remote_write.grafana_cloud_prometheus.receiver]
+}
+    
+// PodMonitor
+prometheus.operator.podmonitors "pod_monitors" {
+  forward_to = [prometheus.remote_write.grafana_cloud_prometheus.receiver]
+}
+    
+// ServiceMonitor
+prometheus.operator.servicemonitors "service_monitors" {
+  forward_to = [prometheus.remote_write.grafana_cloud_prometheus.receiver]
+}
+    
+// Grafana Cloud Prometheus
+local.file "prometheus_host" {
+  filename  = "/etc/grafana-agent-credentials/prometheus_host"
+}
+
+local.file "prometheus_username" {
+  filename  = "/etc/grafana-agent-credentials/prometheus_username"
+}
+
+local.file "prometheus_password" {
+  filename  = "/etc/grafana-agent-credentials/prometheus_password"
+  is_secret = true
+}
+
+prometheus.remote_write "grafana_cloud_prometheus" {
+  endpoint {
+    url = nonsensitive(local.file.prometheus_host.content) + "/api/prom/push"
+
+    basic_auth {
+      username = local.file.prometheus_username.content
+      password = local.file.prometheus_password.content
+    }
+  }
+}
+    
+// Cluster Events
+loki.source.kubernetes_events "cluster_events" {
+  job_name   = "integrations/kubernetes/eventhandler"
+  forward_to = [loki.process.cluster_events.receiver]
+}
+
+loki.process "cluster_events" {
+  stage.static_labels {
+    values = {
+      cluster = "default-values-test",
+    }
+  }
+
+  forward_to = [loki.write.grafana_cloud_loki.receiver]
+}
+    
+// Grafana Cloud Loki
+local.file "loki_host" {
+  filename  = "/etc/grafana-agent-credentials/loki_host"
+}
+
+local.file "loki_username" {
+  filename  = "/etc/grafana-agent-credentials/loki_username"
+}
+
+local.file "loki_password" {
+  filename  = "/etc/grafana-agent-credentials/loki_password"
+  is_secret = true
+}
+
+loki.write "grafana_cloud_loki" {
+  endpoint {
+    url = nonsensitive(local.file.loki_host.content) + "/loki/api/v1/push"
+
+    basic_auth {
+      username = local.file.loki_username.content
+      password = local.file.loki_password.content
+    }
+  }
+}

--- a/examples/windows-exporter/output.yaml
+++ b/examples/windows-exporter/output.yaml
@@ -40385,6 +40385,9 @@ spec:
       dnsPolicy: ClusterFirst
       nodeSelector:
         kubernetes.io/os: linux
+      tolerations:
+        - effect: NoSchedule
+          operator: Exists
       volumes:
         - name: config
           configMap:

--- a/examples/windows-exporter/output.yaml
+++ b/examples/windows-exporter/output.yaml
@@ -1,4 +1,16 @@
 ---
+# Source: k8s-monitoring/charts/grafana-agent-logs/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: k8smon-grafana-agent-logs
+  labels:
+    helm.sh/chart: grafana-agent-logs-0.19.0
+    app.kubernetes.io/name: grafana-agent-logs
+    app.kubernetes.io/instance: k8smon
+    app.kubernetes.io/version: "v0.35.2"
+    app.kubernetes.io/managed-by: Helm
+---
 # Source: k8s-monitoring/charts/grafana-agent/templates/serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount
@@ -472,6 +484,59 @@ data:
       }
     }
         
+    // Cluster Events
+    loki.source.kubernetes_events "cluster_events" {
+      job_name   = "integrations/kubernetes/eventhandler"
+      forward_to = [loki.process.cluster_events.receiver]
+    }
+    
+    loki.process "cluster_events" {
+      stage.static_labels {
+        values = {
+          cluster = "default-values-test",
+        }
+      }
+    
+      forward_to = [loki.write.grafana_cloud_loki.receiver]
+    }
+        
+    // Grafana Cloud Loki
+    local.file "loki_host" {
+      filename  = "/etc/grafana-agent-credentials/loki_host"
+    }
+    
+    local.file "loki_username" {
+      filename  = "/etc/grafana-agent-credentials/loki_username"
+    }
+    
+    local.file "loki_password" {
+      filename  = "/etc/grafana-agent-credentials/loki_password"
+      is_secret = true
+    }
+    
+    loki.write "grafana_cloud_loki" {
+      endpoint {
+        url = nonsensitive(local.file.loki_host.content) + "/loki/api/v1/push"
+    
+        basic_auth {
+          username = local.file.loki_username.content
+          password = local.file.loki_password.content
+        }
+      }
+    }
+---
+# Source: k8s-monitoring/templates/grafana-agent-logs-config.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: k8smon-grafana-agent-logs
+  namespace: default
+data:
+  config.river: |-    
+    discovery.kubernetes "pods" {
+      role = "pod"
+    }
+        
     // Pod Logs
     discovery.relabel "pod_logs" {
       targets = discovery.kubernetes.pods.targets
@@ -498,9 +563,20 @@ data:
         replacement = "$1"
         target_label = "job"
       }
+      rule {
+        source_labels = ["__meta_kubernetes_pod_node_name"]
+        target_label = "__host__"
+      }
+      rule {
+        source_labels = ["__meta_kubernetes_pod_uid", "__meta_kubernetes_pod_container_name"]
+        separator = "/"
+        action = "replace"
+        replacement = "/var/log/pods/*$1/*.log"
+        target_label = "__path__"
+      }
     }
     
-    loki.source.kubernetes "pod_logs" {
+    loki.source.file "pod_logs" {
       targets    = discovery.relabel.pod_logs.output
       forward_to = [loki.process.pod_logs.receiver]
     }
@@ -513,22 +589,6 @@ data:
       }
     
       stage.docker {}
-      forward_to = [loki.write.grafana_cloud_loki.receiver]
-    }
-        
-    // Cluster Events
-    loki.source.kubernetes_events "cluster_events" {
-      job_name   = "integrations/kubernetes/eventhandler"
-      forward_to = [loki.process.cluster_events.receiver]
-    }
-    
-    loki.process "cluster_events" {
-      stage.static_labels {
-        values = {
-          cluster = "default-values-test",
-        }
-      }
-    
       forward_to = [loki.write.grafana_cloud_loki.receiver]
     }
         
@@ -39579,6 +39639,87 @@ spec:
     subresources:
       status: {}
 ---
+# Source: k8s-monitoring/charts/grafana-agent-logs/templates/rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: k8smon-grafana-agent-logs
+  labels:
+    helm.sh/chart: grafana-agent-logs-0.19.0
+    app.kubernetes.io/name: grafana-agent-logs
+    app.kubernetes.io/instance: k8smon
+    app.kubernetes.io/version: "v0.35.2"
+    app.kubernetes.io/managed-by: Helm
+rules:
+  # Rules which allow discovery.kubernetes to function.
+  - apiGroups:
+      - ""
+      - "discovery.k8s.io"
+      - "networking.k8s.io"
+    resources:
+      - endpoints
+      - endpointslices
+      - ingresses
+      - nodes
+      - nodes/proxy
+      - nodes/metrics
+      - pods
+      - services
+    verbs:
+      - get
+      - list
+      - watch
+  # Rules which allow loki.source.kubernetes and loki.source.podlogs to work.
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+      - pods/log
+      - namespaces
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - "monitoring.grafana.com"
+    resources:
+      - podlogs
+    verbs:
+      - get
+      - list
+      - watch
+  # Rules which allow mimir.rules.kubernetes to work.
+  - apiGroups: ["monitoring.coreos.com"]
+    resources:
+      - prometheusrules
+    verbs:
+      - get
+      - list
+      - watch
+  - nonResourceURLs:
+      - /metrics
+    verbs:
+      - get
+  # Rules for prometheus.kubernetes.*
+  - apiGroups: ["monitoring.coreos.com"]
+    resources:
+      - podmonitors
+      - servicemonitors
+      - probes
+    verbs:
+      - get
+      - list
+      - watch
+  # Rules which allow eventhandler to work.
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - get
+      - list
+      - watch
+---
 # Source: k8s-monitoring/charts/grafana-agent/templates/rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -39902,6 +40043,26 @@ rules:
       - list
       - watch
 ---
+# Source: k8s-monitoring/charts/grafana-agent-logs/templates/rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: k8smon-grafana-agent-logs
+  labels:
+    helm.sh/chart: grafana-agent-logs-0.19.0
+    app.kubernetes.io/name: grafana-agent-logs
+    app.kubernetes.io/instance: k8smon
+    app.kubernetes.io/version: "v0.35.2"
+    app.kubernetes.io/managed-by: Helm
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: k8smon-grafana-agent-logs
+subjects:
+  - kind: ServiceAccount
+    name: k8smon-grafana-agent-logs
+    namespace: default
+---
 # Source: k8s-monitoring/charts/grafana-agent/templates/rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -39964,6 +40125,57 @@ subjects:
   - kind: ServiceAccount
     name: k8smon-opencost
     namespace: default
+---
+# Source: k8s-monitoring/charts/grafana-agent-logs/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: k8smon-grafana-agent-logs
+  labels:
+    helm.sh/chart: grafana-agent-logs-0.19.0
+    app.kubernetes.io/name: grafana-agent-logs
+    app.kubernetes.io/instance: k8smon
+    app.kubernetes.io/version: "v0.35.2"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: grafana-agent-logs
+    app.kubernetes.io/instance: k8smon
+  ports:
+    - name: http-metrics
+      port: 80
+      targetPort: 80
+      protocol: "TCP"
+---
+# Source: k8s-monitoring/charts/grafana-agent/templates/cluster_service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: k8smon-grafana-agent-cluster
+  labels:
+    helm.sh/chart: grafana-agent-0.19.0
+    app.kubernetes.io/name: grafana-agent
+    app.kubernetes.io/instance: k8smon
+    app.kubernetes.io/version: "v0.35.2"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  type: ClusterIP
+  clusterIP: 'None'
+  selector:
+    app.kubernetes.io/name: grafana-agent
+    app.kubernetes.io/instance: k8smon
+  ports:
+    # Do not include the -metrics suffix in the port name, otherwise metrics
+    # can be double-collected with the non-headless Service if it's also
+    # enabled.
+    #
+    # This service should only be used for clustering, and not metric
+    # collection.
+    - name: http
+      port: 80
+      targetPort: 80
+      protocol: "TCP"
 ---
 # Source: k8s-monitoring/charts/grafana-agent/templates/service.yaml
 apiVersion: v1
@@ -40092,14 +40304,14 @@ spec:
     app.kubernetes.io/name: prometheus-windows-exporter
     app.kubernetes.io/instance: k8smon
 ---
-# Source: k8s-monitoring/charts/grafana-agent/templates/controllers/daemonset.yaml
+# Source: k8s-monitoring/charts/grafana-agent-logs/templates/controllers/daemonset.yaml
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
-  name: k8smon-grafana-agent
+  name: k8smon-grafana-agent-logs
   labels:
-    helm.sh/chart: grafana-agent-0.19.0
-    app.kubernetes.io/name: grafana-agent
+    helm.sh/chart: grafana-agent-logs-0.19.0
+    app.kubernetes.io/name: grafana-agent-logs
     app.kubernetes.io/instance: k8smon
     app.kubernetes.io/version: "v0.35.2"
     app.kubernetes.io/managed-by: Helm
@@ -40107,15 +40319,15 @@ spec:
   minReadySeconds: 10
   selector:
     matchLabels:
-      app.kubernetes.io/name: grafana-agent
+      app.kubernetes.io/name: grafana-agent-logs
       app.kubernetes.io/instance: k8smon
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: grafana-agent
+        app.kubernetes.io/name: grafana-agent-logs
         app.kubernetes.io/instance: k8smon
     spec:
-      serviceAccountName: k8smon-grafana-agent
+      serviceAccountName: k8smon-grafana-agent-logs
       containers:
         - name: grafana-agent
           image: docker.io/grafana/agent:v0.35.2
@@ -40144,6 +40356,12 @@ spec:
           volumeMounts:
             - name: config
               mountPath: /etc/agent
+            - name: varlog
+              mountPath: /var/log
+              readOnly: true
+            - name: dockercontainers
+              mountPath: /var/lib/docker/containers
+              readOnly: true
             -
               mountPath: /etc/grafana-agent-credentials
               name: grafana-agent-credentials
@@ -40165,7 +40383,13 @@ spec:
       volumes:
         - name: config
           configMap:
-            name: k8smon-grafana-agent
+            name: k8smon-grafana-agent-logs
+        - name: varlog
+          hostPath:
+            path: /var/log
+        - name: dockercontainers
+          hostPath:
+            path: /var/lib/docker/containers
         - name: grafana-agent-credentials
           secret:
             secretName: grafana-agent-credentials
@@ -40532,6 +40756,88 @@ spec:
               value: "true"
             - name: PROM_CLUSTER_ID_LABEL
               value: "cluster"
+---
+# Source: k8s-monitoring/charts/grafana-agent/templates/controllers/statefulset.yaml
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: k8smon-grafana-agent
+  labels:
+    helm.sh/chart: grafana-agent-0.19.0
+    app.kubernetes.io/name: grafana-agent
+    app.kubernetes.io/instance: k8smon
+    app.kubernetes.io/version: "v0.35.2"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  replicas: 1
+  minReadySeconds: 10
+  serviceName: k8smon-grafana-agent
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: grafana-agent
+      app.kubernetes.io/instance: k8smon
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: grafana-agent
+        app.kubernetes.io/instance: k8smon
+    spec:
+      serviceAccountName: k8smon-grafana-agent
+      containers:
+        - name: grafana-agent
+          image: docker.io/grafana/agent:v0.35.2
+          imagePullPolicy: IfNotPresent
+          args:
+            - run
+            - /etc/agent/config.river
+            - --storage.path=/tmp/agent
+            - --server.http.listen-addr=0.0.0.0:80
+            - --cluster.enabled=true
+            - --cluster.join-addresses=k8smon-grafana-agent-cluster
+          env:
+            - name: AGENT_MODE
+              value: flow
+            - name: HOSTNAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+          ports:
+            - containerPort: 80
+              name: http-metrics
+          readinessProbe:
+            httpGet:
+              path: /-/ready
+              port: 80
+            initialDelaySeconds: 10
+            timeoutSeconds: 1
+          volumeMounts:
+            - name: config
+              mountPath: /etc/agent
+            -
+              mountPath: /etc/grafana-agent-credentials
+              name: grafana-agent-credentials
+        - name: config-reloader
+          image: docker.io/jimmidyson/configmap-reload:v0.8.0
+          args:
+            - --volume-dir=/etc/agent
+            - --webhook-url=http://localhost:80/-/reload
+          volumeMounts:
+            - name: config
+              mountPath: /etc/agent
+          resources:
+            requests:
+              cpu: 1m
+              memory: 5Mi
+      dnsPolicy: ClusterFirst
+      nodeSelector:
+        kubernetes.io/os: linux
+      volumes:
+        - name: config
+          configMap:
+            name: k8smon-grafana-agent
+        - name: grafana-agent-credentials
+          secret:
+            secretName: grafana-agent-credentials
 ---
 # Source: k8s-monitoring/charts/prometheus-operator-crds/templates/crd-alertmanagerconfigs.yaml
 # https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.66.0/example/prometheus-operator-crd/monitoring.coreos.com_alertmanagerconfigs.yaml

--- a/examples/windows-exporter/output.yaml
+++ b/examples/windows-exporter/output.yaml
@@ -565,7 +565,8 @@ data:
       }
       rule {
         source_labels = ["__meta_kubernetes_pod_node_name"]
-        target_label = "__host__"
+        action = "keep"
+        regex = env("HOSTNAME")
       }
       rule {
         source_labels = ["__meta_kubernetes_pod_uid", "__meta_kubernetes_pod_container_name"]
@@ -576,8 +577,12 @@ data:
       }
     }
     
+    local.file_match "pod_logs" {
+      path_targets = discovery.relabel.pod_logs.output
+    }
+    
     loki.source.file "pod_logs" {
-      targets    = discovery.relabel.pod_logs.output
+      targets    = local.file_match.pod_logs.targets
       forward_to = [loki.process.pod_logs.receiver]
     }
     

--- a/scripts/lint-configs.sh
+++ b/scripts/lint-configs.sh
@@ -7,12 +7,10 @@ usage() {
 }
 
 export AGENT_MODE=flow
-configMapName=k8smon-grafana-agent
-
 for file in "$@";
 do
   echo "Linting Agent config in ${file}...";
-  if ! grafana-agent fmt <(yq -r "select(.metadata.name==\"${configMapName}\") | .data[\"config.river\"] | select( . != null )" "${file}") > /dev/null; then
+  if ! grafana-agent fmt "${file}" > /dev/null; then
     exit 1
   fi
 done


### PR DESCRIPTION
This PR splits the deployed Grafana Agent into:
* A clustered statefulset for metrics and events
* A daemonset for Pod logs

Stop using loki.source.kubernetes.

Fixes #60 
Fixes #61 