### PR TITLE
Fix external labels

### DIFF
--- a/charts/k8s-monitoring/Chart.yaml
+++ b/charts/k8s-monitoring/Chart.yaml
@@ -3,7 +3,7 @@ name: k8s-monitoring
 description: A Helm chart for gathering, scraping, and forwarding Kubernetes infrastructure metrics and logs to a Grafana Stack.
 type: application
 
-version: 0.1.2
+version: 0.1.3
 appVersion: 1.2.0
 icon: https://raw.githubusercontent.com/grafana/grafana/main/public/img/grafana_icon.svg
 maintainers:

--- a/charts/k8s-monitoring/templates/agent_config/_loki.river.txt
+++ b/charts/k8s-monitoring/templates/agent_config/_loki.river.txt
@@ -27,8 +27,8 @@ loki.write "grafana_cloud_loki" {
   }
 {{- end }}
 {{- end }}
-  external_labels {
-    cluster = {{ required ".Values.cluster.name is a required value. Please set it and try again." .Values.cluster.name | quote }}
+  external_labels = {
+    cluster = {{ required ".Values.cluster.name is a required value. Please set it and try again." .Values.cluster.name | quote }},
   }
 }
 {{ end }}

--- a/charts/k8s-monitoring/templates/agent_config/_prometheus.river.txt
+++ b/charts/k8s-monitoring/templates/agent_config/_prometheus.river.txt
@@ -27,8 +27,8 @@ prometheus.remote_write "grafana_cloud_prometheus" {
   }
 {{- end }}
 {{- end }}
-  external_labels {
-    cluster = {{ required ".Values.cluster.name is a required value. Please set it and try again." .Values.cluster.name | quote }}
+  external_labels = {
+    cluster = {{ required ".Values.cluster.name is a required value. Please set it and try again." .Values.cluster.name | quote }},
   }
 }
 {{ end }}


### PR DESCRIPTION
This PR addresses an invalid generated config for both the metrics and logs pod.

```
grafana-agent Error: /etc/agent/config.river:290:3: "external_labels" must be an attribute, but is used as a block

grafana-agent
grafana-agent 289 |     }
grafana-agent 290 |     external_labels {
grafana-agent     |  ___^^^^^^^^^^^^^^^^^
grafana-agent 291 | |     cluster = "foobar"
grafana-agent 292 | |   }
grafana-agent     | |_^^^
grafana-agent 293 |   }
```