### PR TITLE
feat: Custom External Labels for Prometheus metrics and Loki logs

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
 examples/** linguist-generated=true
+examples/**/values.yaml linguist-generated=false

--- a/charts/k8s-monitoring/Chart.yaml
+++ b/charts/k8s-monitoring/Chart.yaml
@@ -3,7 +3,7 @@ name: k8s-monitoring
 description: A Helm chart for gathering, scraping, and forwarding Kubernetes infrastructure metrics and logs to a Grafana Stack.
 type: application
 
-version: 0.1.6
+version: 0.1.7
 appVersion: 1.2.0
 icon: https://raw.githubusercontent.com/grafana/grafana/main/public/img/grafana_icon.svg
 maintainers:

--- a/charts/k8s-monitoring/README.md
+++ b/charts/k8s-monitoring/README.md
@@ -1,6 +1,6 @@
 # k8s-monitoring
 
-![Version: 0.1.6](https://img.shields.io/badge/Version-0.1.6-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.2.0](https://img.shields.io/badge/AppVersion-1.2.0-informational?style=flat-square)
+![Version: 0.1.7](https://img.shields.io/badge/Version-0.1.7-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.2.0](https://img.shields.io/badge/AppVersion-1.2.0-informational?style=flat-square)
 
 A Helm chart for gathering, scraping, and forwarding Kubernetes infrastructure metrics and logs to a Grafana Stack.
 

--- a/charts/k8s-monitoring/README.md
+++ b/charts/k8s-monitoring/README.md
@@ -71,10 +71,12 @@ The Prometheus and Loki services may be hosted on the same cluster, or remotely 
 | cluster.name | string | `""` | (required) The name of this cluster, which will be set in all labels |
 | externalServices.loki.basicAuth.password | string | `""` | Loki basic auth password |
 | externalServices.loki.basicAuth.username | string | `""` | Loki basic auth username |
+| externalServices.loki.externalLabels | object | `{}` |  |
 | externalServices.loki.host | string | `""` | (required) Loki host where logs and events will be sent |
 | externalServices.loki.writeEndpoint | string | `"/loki/api/v1/push"` | Loki logs write endpoint |
 | externalServices.prometheus.basicAuth.password | string | `""` | Prometheus basic auth password |
 | externalServices.prometheus.basicAuth.username | string | `""` | Prometheus basic auth username |
+| externalServices.prometheus.externalLabels | object | `{}` |  |
 | externalServices.prometheus.host | string | `""` | (required) Prometheus host where metrics will be sent |
 | externalServices.prometheus.writeEndpoint | string | `"/api/prom/push"` | Prometheus metrics write endpoint |
 | extraConfig | string | `nil` | Extra configuration that will be added to the Grafana Agent configuration file. See [Adding custom Flow configuration](#adding-custom-flow-configuration) for an example. |

--- a/charts/k8s-monitoring/README.md
+++ b/charts/k8s-monitoring/README.md
@@ -71,12 +71,12 @@ The Prometheus and Loki services may be hosted on the same cluster, or remotely 
 | cluster.name | string | `""` | (required) The name of this cluster, which will be set in all labels |
 | externalServices.loki.basicAuth.password | string | `""` | Loki basic auth password |
 | externalServices.loki.basicAuth.username | string | `""` | Loki basic auth username |
-| externalServices.loki.externalLabels | object | `{}` |  |
+| externalServices.loki.externalLabels | object | `{}` | Custom labels to be added to all logs and events |
 | externalServices.loki.host | string | `""` | (required) Loki host where logs and events will be sent |
 | externalServices.loki.writeEndpoint | string | `"/loki/api/v1/push"` | Loki logs write endpoint |
 | externalServices.prometheus.basicAuth.password | string | `""` | Prometheus basic auth password |
 | externalServices.prometheus.basicAuth.username | string | `""` | Prometheus basic auth username |
-| externalServices.prometheus.externalLabels | object | `{}` |  |
+| externalServices.prometheus.externalLabels | object | `{}` | Custom labels to be added to all time series |
 | externalServices.prometheus.host | string | `""` | (required) Prometheus host where metrics will be sent |
 | externalServices.prometheus.writeEndpoint | string | `"/api/prom/push"` | Prometheus metrics write endpoint |
 | extraConfig | string | `nil` | Extra configuration that will be added to the Grafana Agent configuration file. See [Adding custom Flow configuration](#adding-custom-flow-configuration) for an example. |

--- a/charts/k8s-monitoring/templates/agent_config/_loki.river.txt
+++ b/charts/k8s-monitoring/templates/agent_config/_loki.river.txt
@@ -29,6 +29,9 @@ loki.write "grafana_cloud_loki" {
 {{- end }}
   external_labels = {
     cluster = {{ required ".Values.cluster.name is a required value. Please set it and try again." .Values.cluster.name | quote }},
+    {{- range $k, $v := .Values.externalServices.loki.externalLabels }}
+    {{ $k }} = {{ $v | quote }},
+    {{- end }}
   }
 }
 {{ end }}

--- a/charts/k8s-monitoring/templates/agent_config/_prometheus.river.txt
+++ b/charts/k8s-monitoring/templates/agent_config/_prometheus.river.txt
@@ -29,6 +29,9 @@ prometheus.remote_write "grafana_cloud_prometheus" {
 {{- end }}
   external_labels = {
     cluster = {{ required ".Values.cluster.name is a required value. Please set it and try again." .Values.cluster.name | quote }},
+    {{- range $k, $v := .Values.externalServices.prometheus.externalLabels }}
+    {{ $k }} = {{ $v | quote }},
+    {{- end }}
   }
 }
 {{ end }}

--- a/charts/k8s-monitoring/values.yaml
+++ b/charts/k8s-monitoring/values.yaml
@@ -14,6 +14,7 @@ externalServices:
     host: ""
     # -- Prometheus metrics write endpoint
     writeEndpoint: /api/prom/push
+    externalLabels: {}
 
     # Authenticate to Prometheus using basic authentication
     basicAuth:
@@ -29,6 +30,7 @@ externalServices:
     host: ""
     # -- Loki logs write endpoint
     writeEndpoint: /loki/api/v1/push
+    externalLabels: {}
 
     # Authenticate to Loki using basic authentication
     basicAuth:

--- a/charts/k8s-monitoring/values.yaml
+++ b/charts/k8s-monitoring/values.yaml
@@ -14,6 +14,7 @@ externalServices:
     host: ""
     # -- Prometheus metrics write endpoint
     writeEndpoint: /api/prom/push
+    # -- Custom labels to be added to all time series
     externalLabels: {}
 
     # Authenticate to Prometheus using basic authentication
@@ -30,6 +31,7 @@ externalServices:
     host: ""
     # -- Loki logs write endpoint
     writeEndpoint: /loki/api/v1/push
+    # -- Custom labels to be added to all logs and events
     externalLabels: {}
 
     # Authenticate to Loki using basic authentication

--- a/examples/custom-config/logs.river
+++ b/examples/custom-config/logs.river
@@ -81,6 +81,8 @@ loki.write "grafana_cloud_loki" {
   }
   external_labels = {
     cluster = "custom-config-test",
+    key3 = "value3",
+    key4 = "value4",
   }
 }
 

--- a/examples/custom-config/logs.river
+++ b/examples/custom-config/logs.river
@@ -81,8 +81,8 @@ loki.write "grafana_cloud_loki" {
   }
   external_labels = {
     cluster = "custom-config-test",
-    key3 = "value3",
-    key4 = "value4",
+    region = "southwest",
+    tenant = "widgetco",
   }
 }
 

--- a/examples/custom-config/metrics.river
+++ b/examples/custom-config/metrics.river
@@ -255,8 +255,8 @@ prometheus.remote_write "grafana_cloud_prometheus" {
   }
   external_labels = {
     cluster = "custom-config-test",
-    key1 = "value1",
-    key2 = "value2",
+    region = "southwest",
+    tenant = "widgetco",
   }
 }
     
@@ -291,8 +291,8 @@ loki.write "grafana_cloud_loki" {
   }
   external_labels = {
     cluster = "custom-config-test",
-    key3 = "value3",
-    key4 = "value4",
+    region = "southwest",
+    tenant = "widgetco",
   }
 }
 

--- a/examples/custom-config/metrics.river
+++ b/examples/custom-config/metrics.river
@@ -255,6 +255,8 @@ prometheus.remote_write "grafana_cloud_prometheus" {
   }
   external_labels = {
     cluster = "custom-config-test",
+    key1 = "value1",
+    key2 = "value2",
   }
 }
     
@@ -289,6 +291,8 @@ loki.write "grafana_cloud_loki" {
   }
   external_labels = {
     cluster = "custom-config-test",
+    key3 = "value3",
+    key4 = "value4",
   }
 }
 

--- a/examples/custom-config/output.yaml
+++ b/examples/custom-config/output.yaml
@@ -348,6 +348,8 @@ data:
       }
       external_labels = {
         cluster = "custom-config-test",
+        key1 = "value1",
+        key2 = "value2",
       }
     }
         
@@ -382,6 +384,8 @@ data:
       }
       external_labels = {
         cluster = "custom-config-test",
+        key3 = "value3",
+        key4 = "value4",
       }
     }
     
@@ -501,6 +505,8 @@ data:
       }
       external_labels = {
         cluster = "custom-config-test",
+        key3 = "value3",
+        key4 = "value4",
       }
     }
     

--- a/examples/custom-config/output.yaml
+++ b/examples/custom-config/output.yaml
@@ -348,8 +348,8 @@ data:
       }
       external_labels = {
         cluster = "custom-config-test",
-        key1 = "value1",
-        key2 = "value2",
+        region = "southwest",
+        tenant = "widgetco",
       }
     }
         
@@ -384,8 +384,8 @@ data:
       }
       external_labels = {
         cluster = "custom-config-test",
-        key3 = "value3",
-        key4 = "value4",
+        region = "southwest",
+        tenant = "widgetco",
       }
     }
     
@@ -505,8 +505,8 @@ data:
       }
       external_labels = {
         cluster = "custom-config-test",
-        key3 = "value3",
-        key4 = "value4",
+        region = "southwest",
+        tenant = "widgetco",
       }
     }
     

--- a/examples/custom-config/values.yaml
+++ b/examples/custom-config/values.yaml
@@ -8,16 +8,16 @@ externalServices:
       username: 12345
       password: "It's a secret to everyone"
     externalLabels:
-      key1: value1
-      key2: value2
+      region: southwest
+      tenant: widgetco
   loki:
     host: https://loki.example.com
     basicAuth:
       username: 12345
       password: "It's a secret to everyone"
     externalLabels:
-      key3: value3
-      key4: value4
+      region: southwest
+      tenant: widgetco
 
 extraConfig: |-
   discovery.relabel "my_webapp" {

--- a/examples/custom-config/values.yaml
+++ b/examples/custom-config/values.yaml
@@ -7,11 +7,17 @@ externalServices:
     basicAuth:
       username: 12345
       password: "It's a secret to everyone"
+    externalLabels:
+      key1: value1
+      key2: value2
   loki:
     host: https://loki.example.com
     basicAuth:
       username: 12345
       password: "It's a secret to everyone"
+    externalLabels:
+      key3: value3
+      key4: value4
 
 extraConfig: |-
   discovery.relabel "my_webapp" {


### PR DESCRIPTION
This pull request introduces the feature to include custom external labels (e.g. region, cloud, ) to all time series and/or logs forwarded to external systems such as Grafana Cloud.  
Presently only the `cluster` label is specified which is not sufficient when working with multiple clusters and agents.  