### PR TITLE
Enable CI testing for PRs

### DIFF
--- a/.github/configs/grafana.yaml
+++ b/.github/configs/grafana.yaml
@@ -1,0 +1,23 @@
+datasources:
+  datasources.yaml:
+    apiVersion: 1
+    datasources:
+      - name: Mimir
+        type: prometheus
+        url: 	http://mimir-nginx.mimir.svc:80/prometheus
+        isDefault: true
+        basicAuth: true
+        basicAuthUser: mimir
+        secureJsonData:
+          basicAuthPassword: mimirpassword
+
+      - name: Loki
+        type: loki
+        url: 	http://loki-gateway.loki.svc:80
+        basicAuth: true
+        basicAuthUser: loki
+        jsonData:
+          httpHeaderName1: X-Scope-OrgID
+        secureJsonData:
+          basicAuthPassword: lokipassword
+          httpHeaderValue1: "1"

--- a/.github/configs/loki.yaml
+++ b/.github/configs/loki.yaml
@@ -1,0 +1,21 @@
+loki:
+  commonConfig:
+    replication_factor: 1
+  storage:
+    type: 'filesystem'
+singleBinary:
+  replicas: 1
+
+gateway:
+  basicAuth:
+    enabled: true
+    username: loki
+    password: lokipassword
+
+test:
+  enabled: false
+monitoring:
+  selfMonitoring:
+    enabled: false
+    grafanaAgent:
+      installOperator: false

--- a/.github/configs/mimir.yaml
+++ b/.github/configs/mimir.yaml
@@ -1,0 +1,15 @@
+ingester:
+  replicas: 1
+
+querier:
+  replicas: 1
+
+query_scheduler:
+  replicas: 1
+
+nginx:
+  basic_auth:
+    enabled: true
+    username: mimir
+    password: mimirpassword
+

--- a/.github/workflows/helm-release.yml
+++ b/.github/workflows/helm-release.yml
@@ -1,7 +1,6 @@
 name: Release Helm chart
 on:
-  push:
-    branches: [main]
+  workflow_dispatch:
 env:
   CR_CONFIGFILE: "${{ github.workspace }}/source/.github/configs/cr.yaml"
   CT_CONFIGFILE: "${{ github.workspace }}/source/.github/configs/ct.yaml"

--- a/.github/workflows/helm-test.yml
+++ b/.github/workflows/helm-test.yml
@@ -11,6 +11,9 @@ on:
 env:
   CT_CONFIGFILE: "${{ github.workspace }}/.github/configs/ct.yaml"
   LINT_CONFIGFILE: "${{ github.workspace }}/.github/configs/lintconf.yaml"
+  MIMIR_VALUES: "${{ github.workspace }}/.github/configs/mimir.yaml"
+  LOKI_VALUES: "${{ github.workspace }}/.github/configs/loki.yaml"
+  GRAFANA_VALUES: "${{ github.workspace }}/.github/configs/grafana.yaml"
 
 jobs:
   check-for-doc-changes:
@@ -84,40 +87,59 @@ jobs:
       run: make test
 
   # TODO: Install prometheus and loki locally, then install our chart so it's connected to those services
-#  test-chart:
-#    runs-on: ubuntu-latest
-#    steps:
-#    - name: Checkout
-#      uses: actions/checkout@v3
-#      with:
-#        fetch-depth: 0
-#
-#    - name: Set up Helm
-#      uses: azure/setup-helm@v3
-#
-#    - name: Set up Python
-#      uses: actions/setup-python@v4
-#      with:
-#        python-version: '3.9'
-#        check-latest: true
-#
-#    - name: Set up chart-testing
-#      uses: helm/chart-testing-action@v2.4.0
-#
-#    - name: List changed charts
-#      id: list-changed
-#      run: |
-#        changed=$(ct list-changed --config "${CT_CONFIGFILE}")
-#        if [[ -n "$changed" ]]; then
-#          echo "changed=true" >> "${GITHUB_OUTPUT}"
-#        fi
-#
-#    - name: Create kind cluster
-#      uses: helm/kind-action@v1.5.0
-#      if: steps.list-changed.outputs.changed == 'true'
-#
-#    - name: Install prometheus and loki
-#      run: TODO
-#
-#    - name: Test charts
-#      run: ct install --config ./operations/helm/ct.yaml
+  test-chart:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+
+    - name: Set up Helm
+      uses: azure/setup-helm@v3
+
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.9'
+        check-latest: true
+
+    - name: Set up chart-testing
+      uses: helm/chart-testing-action@v2.4.0
+
+    - name: List changed charts
+      id: list-changed
+      run: |
+        changed=$(ct list-changed --config "${CT_CONFIGFILE}")
+        if [[ -n "$changed" ]]; then
+          echo "changed=true" >> "${GITHUB_OUTPUT}"
+        fi
+
+    - name: Create kind cluster
+      uses: helm/kind-action@v1.5.0
+      if: steps.list-changed.outputs.changed == 'true'
+
+    - name: Set up Grafana Helm repository
+      if: steps.list-changed.outputs.changed == 'true'
+      run: |
+        helm repo add grafana https://grafana.github.io/helm-charts
+        helm repo update
+
+    - name: Deploy Mimir
+      if: steps.list-changed.outputs.changed == 'true'
+      run: |
+        helm install mimir grafana/mimir-distributed -f "${MIMIR_VALUES}" -n mimir --create-namespace
+
+    - name: Deploy Loki
+      if: steps.list-changed.outputs.changed == 'true'
+      run: |
+        helm install loki grafana/loki -f "${LOKI_VALUES}" -n loki --create-namespace
+
+    - name: Deploy Grafana
+      if: steps.list-changed.outputs.changed == 'true'
+      run: |
+        helm install grafana grafana/grafana -f "${GRAFANA_VALUES}" -n grafana --create-namespace
+
+    - name: Test chart
+      if: steps.list-changed.outputs.changed == 'true'
+      run: ct install --config "${CT_CONFIGFILE}"

--- a/Makefile
+++ b/Makefile
@@ -10,11 +10,7 @@ CT_CONFIGFILE ?= .github/configs/ct.yaml
 LINT_CONFIGFILE ?= .github/configs/lintconf.yaml
 
 lint-chart:
-ifeq ($(GITHUB_HEAD_REF),main)
-	ct lint --debug --config "$(CT_CONFIGFILE)" --lint-conf "$(LINT_CONFIGFILE)"
-else
 	ct lint --debug --config "$(CT_CONFIGFILE)" --lint-conf "$(LINT_CONFIGFILE)" --check-version-increment=false
-endif
 
 lint-config: scripts/lint-configs.sh
 	./scripts/lint-configs.sh $(METRIC_CONFIG_FILES) $(LOG_CONFIG_FILES)

--- a/charts/k8s-monitoring/.helmignore
+++ b/charts/k8s-monitoring/.helmignore
@@ -1,3 +1,4 @@
 .git
 .gitignore
 .idea
+ci

--- a/charts/k8s-monitoring/ci/ci-values.yaml
+++ b/charts/k8s-monitoring/ci/ci-values.yaml
@@ -1,0 +1,21 @@
+cluster:
+  name: ci-test-cluster
+
+externalServices:
+  prometheus:
+    host: http://mimir-nginx.mimir.svc:80
+    basicAuth:
+      username: mimir
+      password: mimirpassword
+    writeEndpoint: /api/v1/push
+  loki:
+    host: http://loki.loki.svc:3100
+    tenantId: 1
+    basicAuth:
+      username: loki
+      password: lokipassword
+
+opencost:
+  prometheus:
+    external:
+      url: http://mimir-nginx.mimir.svc:80/api/v1


### PR DESCRIPTION
This PR does the following:
* Stop auto-releasing on merges to main (fixes #68)
* On PRs and merges to main, use GitHub action to deploy the helm chart and test that the pods come online.
  * Create a cluster with Kind
  * Deploy Mimir
  * Deploy Loki
  * Deploy Grafana (not really needed, but useful for connecting the above and when testing locally)
  * Deploy the Kubernetes Monitoring Helm chart