### PR TITLE
Fix: Treat TenantIDs as strings, not secrets

### DIFF
--- a/charts/k8s-monitoring/Chart.yaml
+++ b/charts/k8s-monitoring/Chart.yaml
@@ -3,7 +3,7 @@ name: k8s-monitoring
 description: A Helm chart for gathering, scraping, and forwarding Kubernetes infrastructure metrics and logs to a Grafana Stack.
 type: application
 
-version: 0.1.8
+version: 0.1.9
 appVersion: 1.2.0
 icon: https://raw.githubusercontent.com/grafana/grafana/main/public/img/grafana_icon.svg
 maintainers:

--- a/charts/k8s-monitoring/README.md
+++ b/charts/k8s-monitoring/README.md
@@ -1,6 +1,6 @@
 # k8s-monitoring
 
-![Version: 0.1.8](https://img.shields.io/badge/Version-0.1.8-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.2.0](https://img.shields.io/badge/AppVersion-1.2.0-informational?style=flat-square)
+![Version: 0.1.9](https://img.shields.io/badge/Version-0.1.9-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.2.0](https://img.shields.io/badge/AppVersion-1.2.0-informational?style=flat-square)
 
 A Helm chart for gathering, scraping, and forwarding Kubernetes infrastructure metrics and logs to a Grafana Stack.
 

--- a/charts/k8s-monitoring/templates/agent_config/_loki.river.txt
+++ b/charts/k8s-monitoring/templates/agent_config/_loki.river.txt
@@ -18,7 +18,6 @@ local.file "loki_password" {
 {{ if .tenantId }}
 local.file "loki_tenantid" {
   filename  = "/etc/grafana-agent-credentials/loki_tenantId"
-  is_secret = true
 }
 {{- end }}
 loki.write "grafana_cloud_loki" {

--- a/charts/k8s-monitoring/templates/agent_config/_prometheus.river.txt
+++ b/charts/k8s-monitoring/templates/agent_config/_prometheus.river.txt
@@ -18,7 +18,6 @@ local.file "prometheus_password" {
 {{ if .tenantId }}
 local.file "prometheus_tenantid" {
   filename  = "/etc/grafana-agent-credentials/prometheus_tenantId"
-  is_secret = true
 }
 {{- end }}
 prometheus.remote_write "grafana_cloud_prometheus" {

--- a/examples/logs-only/logs.river
+++ b/examples/logs-only/logs.river
@@ -72,7 +72,6 @@ local.file "loki_password" {
 
 local.file "loki_tenantid" {
   filename  = "/etc/grafana-agent-credentials/loki_tenantId"
-  is_secret = true
 }
 loki.write "grafana_cloud_loki" {
   endpoint {

--- a/examples/logs-only/output.yaml
+++ b/examples/logs-only/output.yaml
@@ -138,7 +138,6 @@ data:
     
     local.file "loki_tenantid" {
       filename  = "/etc/grafana-agent-credentials/loki_tenantId"
-      is_secret = true
     }
     loki.write "grafana_cloud_loki" {
       endpoint {

--- a/examples/metrics-only/metrics.river
+++ b/examples/metrics-only/metrics.river
@@ -246,7 +246,6 @@ local.file "prometheus_password" {
 
 local.file "prometheus_tenantid" {
   filename  = "/etc/grafana-agent-credentials/prometheus_tenantId"
-  is_secret = true
 }
 prometheus.remote_write "grafana_cloud_prometheus" {
   endpoint {

--- a/examples/metrics-only/output.yaml
+++ b/examples/metrics-only/output.yaml
@@ -325,7 +325,6 @@ data:
     
     local.file "prometheus_tenantid" {
       filename  = "/etc/grafana-agent-credentials/prometheus_tenantId"
-      is_secret = true
     }
     prometheus.remote_write "grafana_cloud_prometheus" {
       endpoint {


### PR DESCRIPTION
Tenant IDs cannot be secrets, because that conflicts with the agent flow type system which expects them to be strings