### PR TITLE
Enable clustering in the scrape components

### DIFF
--- a/charts/k8s-monitoring/Chart.yaml
+++ b/charts/k8s-monitoring/Chart.yaml
@@ -3,7 +3,7 @@ name: k8s-monitoring
 description: A Helm chart for gathering, scraping, and forwarding Kubernetes infrastructure metrics and logs to a Grafana Stack.
 type: application
 
-version: 0.1.14
+version: 0.1.15
 appVersion: 1.2.0
 icon: https://raw.githubusercontent.com/grafana/grafana/main/public/img/grafana_icon.svg
 maintainers:

--- a/charts/k8s-monitoring/README.md
+++ b/charts/k8s-monitoring/README.md
@@ -1,6 +1,6 @@
 # k8s-monitoring
 
-![Version: 0.1.14](https://img.shields.io/badge/Version-0.1.14-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.2.0](https://img.shields.io/badge/AppVersion-1.2.0-informational?style=flat-square)
+![Version: 0.1.15](https://img.shields.io/badge/Version-0.1.15-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.2.0](https://img.shields.io/badge/AppVersion-1.2.0-informational?style=flat-square)
 
 A Helm chart for gathering, scraping, and forwarding Kubernetes infrastructure metrics and logs to a Grafana Stack.
 

--- a/charts/k8s-monitoring/templates/agent_config/_agent.river.txt
+++ b/charts/k8s-monitoring/templates/agent_config/_agent.river.txt
@@ -23,6 +23,11 @@ prometheus.scrape "agent" {
   job_name   = "integrations/agent"
   targets  = discovery.relabel.agent.output
   forward_to = [prometheus.relabel.agent.receiver]
+{{- if (index .Values "grafana-agent").agent.clustering.enabled }}
+  clustering {
+    enabled = true
+  }
+{{- end }}
 }
 
 prometheus.relabel "agent" {

--- a/charts/k8s-monitoring/templates/agent_config/_cadvisor.river.txt
+++ b/charts/k8s-monitoring/templates/agent_config/_cadvisor.river.txt
@@ -28,6 +28,11 @@ prometheus.scrape "cadvisor" {
   tls_config {
     insecure_skip_verify = true
   }
+{{- if (index .Values "grafana-agent").agent.clustering.enabled }}
+  clustering {
+    enabled = true
+  }
+{{- end }}
   forward_to = [prometheus.relabel.cadvisor.receiver]
 }
 

--- a/charts/k8s-monitoring/templates/agent_config/_kube_state_metrics.river.txt
+++ b/charts/k8s-monitoring/templates/agent_config/_kube_state_metrics.river.txt
@@ -32,6 +32,11 @@ discovery.relabel "kube_state_metrics" {
 prometheus.scrape "kube_state_metrics" {
   job_name   = "integrations/kubernetes/kube-state-metrics"
   targets    = discovery.relabel.kube_state_metrics.output
+{{- if (index .Values "grafana-agent").agent.clustering.enabled }}
+  clustering {
+    enabled = true
+  }
+{{- end }}
 {{- if (index .Values.metrics "kube-state-metrics").service.isTLS }}
   scheme     = "https"
   bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"

--- a/charts/k8s-monitoring/templates/agent_config/_kubelet.river.txt
+++ b/charts/k8s-monitoring/templates/agent_config/_kubelet.river.txt
@@ -28,6 +28,11 @@ prometheus.scrape "kubelet" {
   tls_config {
     insecure_skip_verify = true
   }
+{{- if (index .Values "grafana-agent").agent.clustering.enabled }}
+  clustering {
+    enabled = true
+  }
+{{- end }}
   forward_to = [prometheus.relabel.kubelet.receiver]
 }
 

--- a/charts/k8s-monitoring/templates/agent_config/_node_exporter.river.txt
+++ b/charts/k8s-monitoring/templates/agent_config/_node_exporter.river.txt
@@ -32,6 +32,11 @@ discovery.relabel "node_exporter" {
 prometheus.scrape "node_exporter" {
   job_name   = "integrations/node_exporter"
   targets  = discovery.relabel.node_exporter.output
+{{- if (index .Values "grafana-agent").agent.clustering.enabled }}
+  clustering {
+    enabled = true
+  }
+{{- end }}
   forward_to = [prometheus.relabel.node_exporter.receiver]
 {{- if (index .Values.metrics "node-exporter").service.isTLS }}
   scheme     = "https"

--- a/charts/k8s-monitoring/templates/agent_config/_opencost.txt
+++ b/charts/k8s-monitoring/templates/agent_config/_opencost.txt
@@ -30,6 +30,11 @@ discovery.relabel "opencost" {
 prometheus.scrape "opencost" {
   job_name   = "integrations/kubernetes/opencost"
   targets    = discovery.relabel.opencost.output
+{{- if (index .Values "grafana-agent").agent.clustering.enabled }}
+  clustering {
+    enabled = true
+  }
+{{- end }}
   forward_to = [prometheus.relabel.opencost.receiver]
 }
 

--- a/charts/k8s-monitoring/templates/agent_config/_pod_monitors.txt
+++ b/charts/k8s-monitoring/templates/agent_config/_pod_monitors.txt
@@ -2,6 +2,11 @@
 // PodMonitor
 prometheus.operator.podmonitors "pod_monitors" {
   forward_to = [prometheus.relabel.podmonitors.receiver]
+{{- if (index .Values "grafana-agent").agent.clustering.enabled }}
+  clustering {
+    enabled = true
+  }
+{{- end }}
 }
 
 prometheus.relabel "podmonitors" {

--- a/charts/k8s-monitoring/templates/agent_config/_service_monitors.txt
+++ b/charts/k8s-monitoring/templates/agent_config/_service_monitors.txt
@@ -2,6 +2,11 @@
 // ServiceMonitor
 prometheus.operator.servicemonitors "service_monitors" {
   forward_to = [prometheus.relabel.servicemonitors.receiver]
+{{- if (index .Values "grafana-agent").agent.clustering.enabled }}
+  clustering {
+    enabled = true
+  }
+{{- end }}
 }
 
 prometheus.relabel "servicemonitors" {

--- a/charts/k8s-monitoring/templates/agent_config/_windows_exporter.river.txt
+++ b/charts/k8s-monitoring/templates/agent_config/_windows_exporter.river.txt
@@ -37,6 +37,11 @@ discovery.relabel "windows_exporter" {
 prometheus.scrape "windows_exporter" {
   job_name   = "integrations/kubernetes/windows-exporter"
   targets  = discovery.relabel.windows_exporter.output
+{{- if (index .Values "grafana-agent").agent.clustering.enabled }}
+  clustering {
+    enabled = true
+  }
+{{- end }}
   forward_to = [prometheus.relabel.windows_exporter.receiver]
 }
 

--- a/examples/custom-allow-lists/metrics.river
+++ b/examples/custom-allow-lists/metrics.river
@@ -34,6 +34,9 @@ prometheus.scrape "agent" {
   job_name   = "integrations/agent"
   targets  = discovery.relabel.agent.output
   forward_to = [prometheus.relabel.agent.receiver]
+  clustering {
+    enabled = true
+  }
 }
 
 prometheus.relabel "agent" {
@@ -67,6 +70,9 @@ prometheus.scrape "kubelet" {
   bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
   tls_config {
     insecure_skip_verify = true
+  }
+  clustering {
+    enabled = true
   }
   forward_to = [prometheus.relabel.kubelet.receiver]
 }
@@ -103,6 +109,9 @@ prometheus.scrape "cadvisor" {
   tls_config {
     insecure_skip_verify = true
   }
+  clustering {
+    enabled = true
+  }
   forward_to = [prometheus.relabel.cadvisor.receiver]
 }
 
@@ -138,6 +147,9 @@ discovery.relabel "kube_state_metrics" {
 prometheus.scrape "kube_state_metrics" {
   job_name   = "integrations/kubernetes/kube-state-metrics"
   targets    = discovery.relabel.kube_state_metrics.output
+  clustering {
+    enabled = true
+  }
   forward_to = [prometheus.relabel.kube_state_metrics.receiver]
 }
 
@@ -173,6 +185,9 @@ discovery.relabel "node_exporter" {
 prometheus.scrape "node_exporter" {
   job_name   = "integrations/node_exporter"
   targets  = discovery.relabel.node_exporter.output
+  clustering {
+    enabled = true
+  }
   forward_to = [prometheus.relabel.node_exporter.receiver]
 }
 
@@ -208,6 +223,9 @@ discovery.relabel "opencost" {
 prometheus.scrape "opencost" {
   job_name   = "integrations/kubernetes/opencost"
   targets    = discovery.relabel.opencost.output
+  clustering {
+    enabled = true
+  }
   forward_to = [prometheus.relabel.opencost.receiver]
 }
 
@@ -218,6 +236,9 @@ prometheus.relabel "opencost" {
 // PodMonitor
 prometheus.operator.podmonitors "pod_monitors" {
   forward_to = [prometheus.relabel.podmonitors.receiver]
+  clustering {
+    enabled = true
+  }
 }
 
 prometheus.relabel "podmonitors" {
@@ -227,6 +248,9 @@ prometheus.relabel "podmonitors" {
 // ServiceMonitor
 prometheus.operator.servicemonitors "service_monitors" {
   forward_to = [prometheus.relabel.servicemonitors.receiver]
+  clustering {
+    enabled = true
+  }
 }
 
 prometheus.relabel "servicemonitors" {

--- a/examples/custom-allow-lists/output.yaml
+++ b/examples/custom-allow-lists/output.yaml
@@ -112,6 +112,9 @@ data:
       job_name   = "integrations/agent"
       targets  = discovery.relabel.agent.output
       forward_to = [prometheus.relabel.agent.receiver]
+      clustering {
+        enabled = true
+      }
     }
     
     prometheus.relabel "agent" {
@@ -145,6 +148,9 @@ data:
       bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
       tls_config {
         insecure_skip_verify = true
+      }
+      clustering {
+        enabled = true
       }
       forward_to = [prometheus.relabel.kubelet.receiver]
     }
@@ -181,6 +187,9 @@ data:
       tls_config {
         insecure_skip_verify = true
       }
+      clustering {
+        enabled = true
+      }
       forward_to = [prometheus.relabel.cadvisor.receiver]
     }
     
@@ -216,6 +225,9 @@ data:
     prometheus.scrape "kube_state_metrics" {
       job_name   = "integrations/kubernetes/kube-state-metrics"
       targets    = discovery.relabel.kube_state_metrics.output
+      clustering {
+        enabled = true
+      }
       forward_to = [prometheus.relabel.kube_state_metrics.receiver]
     }
     
@@ -251,6 +263,9 @@ data:
     prometheus.scrape "node_exporter" {
       job_name   = "integrations/node_exporter"
       targets  = discovery.relabel.node_exporter.output
+      clustering {
+        enabled = true
+      }
       forward_to = [prometheus.relabel.node_exporter.receiver]
     }
     
@@ -286,6 +301,9 @@ data:
     prometheus.scrape "opencost" {
       job_name   = "integrations/kubernetes/opencost"
       targets    = discovery.relabel.opencost.output
+      clustering {
+        enabled = true
+      }
       forward_to = [prometheus.relabel.opencost.receiver]
     }
     
@@ -296,6 +314,9 @@ data:
     // PodMonitor
     prometheus.operator.podmonitors "pod_monitors" {
       forward_to = [prometheus.relabel.podmonitors.receiver]
+      clustering {
+        enabled = true
+      }
     }
     
     prometheus.relabel "podmonitors" {
@@ -305,6 +326,9 @@ data:
     // ServiceMonitor
     prometheus.operator.servicemonitors "service_monitors" {
       forward_to = [prometheus.relabel.servicemonitors.receiver]
+      clustering {
+        enabled = true
+      }
     }
     
     prometheus.relabel "servicemonitors" {

--- a/examples/custom-config/metrics.river
+++ b/examples/custom-config/metrics.river
@@ -34,6 +34,9 @@ prometheus.scrape "agent" {
   job_name   = "integrations/agent"
   targets  = discovery.relabel.agent.output
   forward_to = [prometheus.relabel.agent.receiver]
+  clustering {
+    enabled = true
+  }
 }
 
 prometheus.relabel "agent" {
@@ -67,6 +70,9 @@ prometheus.scrape "kubelet" {
   bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
   tls_config {
     insecure_skip_verify = true
+  }
+  clustering {
+    enabled = true
   }
   forward_to = [prometheus.relabel.kubelet.receiver]
 }
@@ -103,6 +109,9 @@ prometheus.scrape "cadvisor" {
   tls_config {
     insecure_skip_verify = true
   }
+  clustering {
+    enabled = true
+  }
   forward_to = [prometheus.relabel.cadvisor.receiver]
 }
 
@@ -138,6 +147,9 @@ discovery.relabel "kube_state_metrics" {
 prometheus.scrape "kube_state_metrics" {
   job_name   = "integrations/kubernetes/kube-state-metrics"
   targets    = discovery.relabel.kube_state_metrics.output
+  clustering {
+    enabled = true
+  }
   forward_to = [prometheus.relabel.kube_state_metrics.receiver]
 }
 
@@ -173,6 +185,9 @@ discovery.relabel "node_exporter" {
 prometheus.scrape "node_exporter" {
   job_name   = "integrations/node_exporter"
   targets  = discovery.relabel.node_exporter.output
+  clustering {
+    enabled = true
+  }
   forward_to = [prometheus.relabel.node_exporter.receiver]
 }
 
@@ -208,6 +223,9 @@ discovery.relabel "opencost" {
 prometheus.scrape "opencost" {
   job_name   = "integrations/kubernetes/opencost"
   targets    = discovery.relabel.opencost.output
+  clustering {
+    enabled = true
+  }
   forward_to = [prometheus.relabel.opencost.receiver]
 }
 
@@ -223,6 +241,9 @@ prometheus.relabel "opencost" {
 // PodMonitor
 prometheus.operator.podmonitors "pod_monitors" {
   forward_to = [prometheus.relabel.podmonitors.receiver]
+  clustering {
+    enabled = true
+  }
 }
 
 prometheus.relabel "podmonitors" {
@@ -232,6 +253,9 @@ prometheus.relabel "podmonitors" {
 // ServiceMonitor
 prometheus.operator.servicemonitors "service_monitors" {
   forward_to = [prometheus.relabel.servicemonitors.receiver]
+  clustering {
+    enabled = true
+  }
 }
 
 prometheus.relabel "servicemonitors" {

--- a/examples/custom-config/output.yaml
+++ b/examples/custom-config/output.yaml
@@ -127,6 +127,9 @@ data:
       job_name   = "integrations/agent"
       targets  = discovery.relabel.agent.output
       forward_to = [prometheus.relabel.agent.receiver]
+      clustering {
+        enabled = true
+      }
     }
     
     prometheus.relabel "agent" {
@@ -160,6 +163,9 @@ data:
       bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
       tls_config {
         insecure_skip_verify = true
+      }
+      clustering {
+        enabled = true
       }
       forward_to = [prometheus.relabel.kubelet.receiver]
     }
@@ -196,6 +202,9 @@ data:
       tls_config {
         insecure_skip_verify = true
       }
+      clustering {
+        enabled = true
+      }
       forward_to = [prometheus.relabel.cadvisor.receiver]
     }
     
@@ -231,6 +240,9 @@ data:
     prometheus.scrape "kube_state_metrics" {
       job_name   = "integrations/kubernetes/kube-state-metrics"
       targets    = discovery.relabel.kube_state_metrics.output
+      clustering {
+        enabled = true
+      }
       forward_to = [prometheus.relabel.kube_state_metrics.receiver]
     }
     
@@ -266,6 +278,9 @@ data:
     prometheus.scrape "node_exporter" {
       job_name   = "integrations/node_exporter"
       targets  = discovery.relabel.node_exporter.output
+      clustering {
+        enabled = true
+      }
       forward_to = [prometheus.relabel.node_exporter.receiver]
     }
     
@@ -301,6 +316,9 @@ data:
     prometheus.scrape "opencost" {
       job_name   = "integrations/kubernetes/opencost"
       targets    = discovery.relabel.opencost.output
+      clustering {
+        enabled = true
+      }
       forward_to = [prometheus.relabel.opencost.receiver]
     }
     
@@ -316,6 +334,9 @@ data:
     // PodMonitor
     prometheus.operator.podmonitors "pod_monitors" {
       forward_to = [prometheus.relabel.podmonitors.receiver]
+      clustering {
+        enabled = true
+      }
     }
     
     prometheus.relabel "podmonitors" {
@@ -325,6 +346,9 @@ data:
     // ServiceMonitor
     prometheus.operator.servicemonitors "service_monitors" {
       forward_to = [prometheus.relabel.servicemonitors.receiver]
+      clustering {
+        enabled = true
+      }
     }
     
     prometheus.relabel "servicemonitors" {

--- a/examples/default-values/metrics.river
+++ b/examples/default-values/metrics.river
@@ -34,6 +34,9 @@ prometheus.scrape "agent" {
   job_name   = "integrations/agent"
   targets  = discovery.relabel.agent.output
   forward_to = [prometheus.relabel.agent.receiver]
+  clustering {
+    enabled = true
+  }
 }
 
 prometheus.relabel "agent" {
@@ -67,6 +70,9 @@ prometheus.scrape "kubelet" {
   bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
   tls_config {
     insecure_skip_verify = true
+  }
+  clustering {
+    enabled = true
   }
   forward_to = [prometheus.relabel.kubelet.receiver]
 }
@@ -103,6 +109,9 @@ prometheus.scrape "cadvisor" {
   tls_config {
     insecure_skip_verify = true
   }
+  clustering {
+    enabled = true
+  }
   forward_to = [prometheus.relabel.cadvisor.receiver]
 }
 
@@ -138,6 +147,9 @@ discovery.relabel "kube_state_metrics" {
 prometheus.scrape "kube_state_metrics" {
   job_name   = "integrations/kubernetes/kube-state-metrics"
   targets    = discovery.relabel.kube_state_metrics.output
+  clustering {
+    enabled = true
+  }
   forward_to = [prometheus.relabel.kube_state_metrics.receiver]
 }
 
@@ -173,6 +185,9 @@ discovery.relabel "node_exporter" {
 prometheus.scrape "node_exporter" {
   job_name   = "integrations/node_exporter"
   targets  = discovery.relabel.node_exporter.output
+  clustering {
+    enabled = true
+  }
   forward_to = [prometheus.relabel.node_exporter.receiver]
 }
 
@@ -208,6 +223,9 @@ discovery.relabel "opencost" {
 prometheus.scrape "opencost" {
   job_name   = "integrations/kubernetes/opencost"
   targets    = discovery.relabel.opencost.output
+  clustering {
+    enabled = true
+  }
   forward_to = [prometheus.relabel.opencost.receiver]
 }
 
@@ -223,6 +241,9 @@ prometheus.relabel "opencost" {
 // PodMonitor
 prometheus.operator.podmonitors "pod_monitors" {
   forward_to = [prometheus.relabel.podmonitors.receiver]
+  clustering {
+    enabled = true
+  }
 }
 
 prometheus.relabel "podmonitors" {
@@ -232,6 +253,9 @@ prometheus.relabel "podmonitors" {
 // ServiceMonitor
 prometheus.operator.servicemonitors "service_monitors" {
   forward_to = [prometheus.relabel.servicemonitors.receiver]
+  clustering {
+    enabled = true
+  }
 }
 
 prometheus.relabel "servicemonitors" {

--- a/examples/default-values/output.yaml
+++ b/examples/default-values/output.yaml
@@ -127,6 +127,9 @@ data:
       job_name   = "integrations/agent"
       targets  = discovery.relabel.agent.output
       forward_to = [prometheus.relabel.agent.receiver]
+      clustering {
+        enabled = true
+      }
     }
     
     prometheus.relabel "agent" {
@@ -160,6 +163,9 @@ data:
       bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
       tls_config {
         insecure_skip_verify = true
+      }
+      clustering {
+        enabled = true
       }
       forward_to = [prometheus.relabel.kubelet.receiver]
     }
@@ -196,6 +202,9 @@ data:
       tls_config {
         insecure_skip_verify = true
       }
+      clustering {
+        enabled = true
+      }
       forward_to = [prometheus.relabel.cadvisor.receiver]
     }
     
@@ -231,6 +240,9 @@ data:
     prometheus.scrape "kube_state_metrics" {
       job_name   = "integrations/kubernetes/kube-state-metrics"
       targets    = discovery.relabel.kube_state_metrics.output
+      clustering {
+        enabled = true
+      }
       forward_to = [prometheus.relabel.kube_state_metrics.receiver]
     }
     
@@ -266,6 +278,9 @@ data:
     prometheus.scrape "node_exporter" {
       job_name   = "integrations/node_exporter"
       targets  = discovery.relabel.node_exporter.output
+      clustering {
+        enabled = true
+      }
       forward_to = [prometheus.relabel.node_exporter.receiver]
     }
     
@@ -301,6 +316,9 @@ data:
     prometheus.scrape "opencost" {
       job_name   = "integrations/kubernetes/opencost"
       targets    = discovery.relabel.opencost.output
+      clustering {
+        enabled = true
+      }
       forward_to = [prometheus.relabel.opencost.receiver]
     }
     
@@ -316,6 +334,9 @@ data:
     // PodMonitor
     prometheus.operator.podmonitors "pod_monitors" {
       forward_to = [prometheus.relabel.podmonitors.receiver]
+      clustering {
+        enabled = true
+      }
     }
     
     prometheus.relabel "podmonitors" {
@@ -325,6 +346,9 @@ data:
     // ServiceMonitor
     prometheus.operator.servicemonitors "service_monitors" {
       forward_to = [prometheus.relabel.servicemonitors.receiver]
+      clustering {
+        enabled = true
+      }
     }
     
     prometheus.relabel "servicemonitors" {

--- a/examples/extra-rules/metrics.river
+++ b/examples/extra-rules/metrics.river
@@ -34,6 +34,9 @@ prometheus.scrape "agent" {
   job_name   = "integrations/agent"
   targets  = discovery.relabel.agent.output
   forward_to = [prometheus.relabel.agent.receiver]
+  clustering {
+    enabled = true
+  }
 }
 
 prometheus.relabel "agent" {
@@ -72,6 +75,9 @@ prometheus.scrape "kubelet" {
   bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
   tls_config {
     insecure_skip_verify = true
+  }
+  clustering {
+    enabled = true
   }
   forward_to = [prometheus.relabel.kubelet.receiver]
 }
@@ -118,6 +124,9 @@ prometheus.scrape "cadvisor" {
   tls_config {
     insecure_skip_verify = true
   }
+  clustering {
+    enabled = true
+  }
   forward_to = [prometheus.relabel.cadvisor.receiver]
 }
 
@@ -158,6 +167,9 @@ discovery.relabel "kube_state_metrics" {
 prometheus.scrape "kube_state_metrics" {
   job_name   = "integrations/kubernetes/kube-state-metrics"
   targets    = discovery.relabel.kube_state_metrics.output
+  clustering {
+    enabled = true
+  }
   forward_to = [prometheus.relabel.kube_state_metrics.receiver]
 }
 
@@ -203,6 +215,9 @@ discovery.relabel "node_exporter" {
 prometheus.scrape "node_exporter" {
   job_name   = "integrations/node_exporter"
   targets  = discovery.relabel.node_exporter.output
+  clustering {
+    enabled = true
+  }
   forward_to = [prometheus.relabel.node_exporter.receiver]
 }
 
@@ -243,6 +258,9 @@ discovery.relabel "opencost" {
 prometheus.scrape "opencost" {
   job_name   = "integrations/kubernetes/opencost"
   targets    = discovery.relabel.opencost.output
+  clustering {
+    enabled = true
+  }
   forward_to = [prometheus.relabel.opencost.receiver]
 }
 
@@ -258,6 +276,9 @@ prometheus.relabel "opencost" {
 // PodMonitor
 prometheus.operator.podmonitors "pod_monitors" {
   forward_to = [prometheus.relabel.podmonitors.receiver]
+  clustering {
+    enabled = true
+  }
 }
 
 prometheus.relabel "podmonitors" {
@@ -267,6 +288,9 @@ prometheus.relabel "podmonitors" {
 // ServiceMonitor
 prometheus.operator.servicemonitors "service_monitors" {
   forward_to = [prometheus.relabel.servicemonitors.receiver]
+  clustering {
+    enabled = true
+  }
 }
 
 prometheus.relabel "servicemonitors" {

--- a/examples/extra-rules/output.yaml
+++ b/examples/extra-rules/output.yaml
@@ -128,6 +128,9 @@ data:
       job_name   = "integrations/agent"
       targets  = discovery.relabel.agent.output
       forward_to = [prometheus.relabel.agent.receiver]
+      clustering {
+        enabled = true
+      }
     }
     
     prometheus.relabel "agent" {
@@ -166,6 +169,9 @@ data:
       bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
       tls_config {
         insecure_skip_verify = true
+      }
+      clustering {
+        enabled = true
       }
       forward_to = [prometheus.relabel.kubelet.receiver]
     }
@@ -212,6 +218,9 @@ data:
       tls_config {
         insecure_skip_verify = true
       }
+      clustering {
+        enabled = true
+      }
       forward_to = [prometheus.relabel.cadvisor.receiver]
     }
     
@@ -252,6 +261,9 @@ data:
     prometheus.scrape "kube_state_metrics" {
       job_name   = "integrations/kubernetes/kube-state-metrics"
       targets    = discovery.relabel.kube_state_metrics.output
+      clustering {
+        enabled = true
+      }
       forward_to = [prometheus.relabel.kube_state_metrics.receiver]
     }
     
@@ -297,6 +309,9 @@ data:
     prometheus.scrape "node_exporter" {
       job_name   = "integrations/node_exporter"
       targets  = discovery.relabel.node_exporter.output
+      clustering {
+        enabled = true
+      }
       forward_to = [prometheus.relabel.node_exporter.receiver]
     }
     
@@ -337,6 +352,9 @@ data:
     prometheus.scrape "opencost" {
       job_name   = "integrations/kubernetes/opencost"
       targets    = discovery.relabel.opencost.output
+      clustering {
+        enabled = true
+      }
       forward_to = [prometheus.relabel.opencost.receiver]
     }
     
@@ -352,6 +370,9 @@ data:
     // PodMonitor
     prometheus.operator.podmonitors "pod_monitors" {
       forward_to = [prometheus.relabel.podmonitors.receiver]
+      clustering {
+        enabled = true
+      }
     }
     
     prometheus.relabel "podmonitors" {
@@ -361,6 +382,9 @@ data:
     // ServiceMonitor
     prometheus.operator.servicemonitors "service_monitors" {
       forward_to = [prometheus.relabel.servicemonitors.receiver]
+      clustering {
+        enabled = true
+      }
     }
     
     prometheus.relabel "servicemonitors" {

--- a/examples/metrics-only/metrics.river
+++ b/examples/metrics-only/metrics.river
@@ -34,6 +34,9 @@ prometheus.scrape "agent" {
   job_name   = "integrations/agent"
   targets  = discovery.relabel.agent.output
   forward_to = [prometheus.relabel.agent.receiver]
+  clustering {
+    enabled = true
+  }
 }
 
 prometheus.relabel "agent" {
@@ -67,6 +70,9 @@ prometheus.scrape "kubelet" {
   bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
   tls_config {
     insecure_skip_verify = true
+  }
+  clustering {
+    enabled = true
   }
   forward_to = [prometheus.relabel.kubelet.receiver]
 }
@@ -103,6 +109,9 @@ prometheus.scrape "cadvisor" {
   tls_config {
     insecure_skip_verify = true
   }
+  clustering {
+    enabled = true
+  }
   forward_to = [prometheus.relabel.cadvisor.receiver]
 }
 
@@ -138,6 +147,9 @@ discovery.relabel "kube_state_metrics" {
 prometheus.scrape "kube_state_metrics" {
   job_name   = "integrations/kubernetes/kube-state-metrics"
   targets    = discovery.relabel.kube_state_metrics.output
+  clustering {
+    enabled = true
+  }
   forward_to = [prometheus.relabel.kube_state_metrics.receiver]
 }
 
@@ -173,6 +185,9 @@ discovery.relabel "node_exporter" {
 prometheus.scrape "node_exporter" {
   job_name   = "integrations/node_exporter"
   targets  = discovery.relabel.node_exporter.output
+  clustering {
+    enabled = true
+  }
   forward_to = [prometheus.relabel.node_exporter.receiver]
 }
 
@@ -208,6 +223,9 @@ discovery.relabel "opencost" {
 prometheus.scrape "opencost" {
   job_name   = "integrations/kubernetes/opencost"
   targets    = discovery.relabel.opencost.output
+  clustering {
+    enabled = true
+  }
   forward_to = [prometheus.relabel.opencost.receiver]
 }
 
@@ -223,6 +241,9 @@ prometheus.relabel "opencost" {
 // PodMonitor
 prometheus.operator.podmonitors "pod_monitors" {
   forward_to = [prometheus.relabel.podmonitors.receiver]
+  clustering {
+    enabled = true
+  }
 }
 
 prometheus.relabel "podmonitors" {
@@ -232,6 +253,9 @@ prometheus.relabel "podmonitors" {
 // ServiceMonitor
 prometheus.operator.servicemonitors "service_monitors" {
   forward_to = [prometheus.relabel.servicemonitors.receiver]
+  clustering {
+    enabled = true
+  }
 }
 
 prometheus.relabel "servicemonitors" {

--- a/examples/metrics-only/output.yaml
+++ b/examples/metrics-only/output.yaml
@@ -113,6 +113,9 @@ data:
       job_name   = "integrations/agent"
       targets  = discovery.relabel.agent.output
       forward_to = [prometheus.relabel.agent.receiver]
+      clustering {
+        enabled = true
+      }
     }
     
     prometheus.relabel "agent" {
@@ -146,6 +149,9 @@ data:
       bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
       tls_config {
         insecure_skip_verify = true
+      }
+      clustering {
+        enabled = true
       }
       forward_to = [prometheus.relabel.kubelet.receiver]
     }
@@ -182,6 +188,9 @@ data:
       tls_config {
         insecure_skip_verify = true
       }
+      clustering {
+        enabled = true
+      }
       forward_to = [prometheus.relabel.cadvisor.receiver]
     }
     
@@ -217,6 +226,9 @@ data:
     prometheus.scrape "kube_state_metrics" {
       job_name   = "integrations/kubernetes/kube-state-metrics"
       targets    = discovery.relabel.kube_state_metrics.output
+      clustering {
+        enabled = true
+      }
       forward_to = [prometheus.relabel.kube_state_metrics.receiver]
     }
     
@@ -252,6 +264,9 @@ data:
     prometheus.scrape "node_exporter" {
       job_name   = "integrations/node_exporter"
       targets  = discovery.relabel.node_exporter.output
+      clustering {
+        enabled = true
+      }
       forward_to = [prometheus.relabel.node_exporter.receiver]
     }
     
@@ -287,6 +302,9 @@ data:
     prometheus.scrape "opencost" {
       job_name   = "integrations/kubernetes/opencost"
       targets    = discovery.relabel.opencost.output
+      clustering {
+        enabled = true
+      }
       forward_to = [prometheus.relabel.opencost.receiver]
     }
     
@@ -302,6 +320,9 @@ data:
     // PodMonitor
     prometheus.operator.podmonitors "pod_monitors" {
       forward_to = [prometheus.relabel.podmonitors.receiver]
+      clustering {
+        enabled = true
+      }
     }
     
     prometheus.relabel "podmonitors" {
@@ -311,6 +332,9 @@ data:
     // ServiceMonitor
     prometheus.operator.servicemonitors "service_monitors" {
       forward_to = [prometheus.relabel.servicemonitors.receiver]
+      clustering {
+        enabled = true
+      }
     }
     
     prometheus.relabel "servicemonitors" {

--- a/examples/openshift-compatible/metrics.river
+++ b/examples/openshift-compatible/metrics.river
@@ -34,6 +34,9 @@ prometheus.scrape "agent" {
   job_name   = "integrations/agent"
   targets  = discovery.relabel.agent.output
   forward_to = [prometheus.relabel.agent.receiver]
+  clustering {
+    enabled = true
+  }
 }
 
 prometheus.relabel "agent" {
@@ -67,6 +70,9 @@ prometheus.scrape "kubelet" {
   bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
   tls_config {
     insecure_skip_verify = true
+  }
+  clustering {
+    enabled = true
   }
   forward_to = [prometheus.relabel.kubelet.receiver]
 }
@@ -103,6 +109,9 @@ prometheus.scrape "cadvisor" {
   tls_config {
     insecure_skip_verify = true
   }
+  clustering {
+    enabled = true
+  }
   forward_to = [prometheus.relabel.cadvisor.receiver]
 }
 
@@ -133,6 +142,9 @@ discovery.relabel "kube_state_metrics" {
 prometheus.scrape "kube_state_metrics" {
   job_name   = "integrations/kubernetes/kube-state-metrics"
   targets    = discovery.relabel.kube_state_metrics.output
+  clustering {
+    enabled = true
+  }
   scheme     = "https"
   bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
   tls_config {
@@ -168,6 +180,9 @@ discovery.relabel "node_exporter" {
 prometheus.scrape "node_exporter" {
   job_name   = "integrations/node_exporter"
   targets  = discovery.relabel.node_exporter.output
+  clustering {
+    enabled = true
+  }
   forward_to = [prometheus.relabel.node_exporter.receiver]
   scheme     = "https"
   bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
@@ -209,6 +224,9 @@ discovery.relabel "opencost" {
 prometheus.scrape "opencost" {
   job_name   = "integrations/kubernetes/opencost"
   targets    = discovery.relabel.opencost.output
+  clustering {
+    enabled = true
+  }
   forward_to = [prometheus.relabel.opencost.receiver]
 }
 
@@ -224,6 +242,9 @@ prometheus.relabel "opencost" {
 // PodMonitor
 prometheus.operator.podmonitors "pod_monitors" {
   forward_to = [prometheus.relabel.podmonitors.receiver]
+  clustering {
+    enabled = true
+  }
 }
 
 prometheus.relabel "podmonitors" {
@@ -233,6 +254,9 @@ prometheus.relabel "podmonitors" {
 // ServiceMonitor
 prometheus.operator.servicemonitors "service_monitors" {
   forward_to = [prometheus.relabel.servicemonitors.receiver]
+  clustering {
+    enabled = true
+  }
 }
 
 prometheus.relabel "servicemonitors" {

--- a/examples/openshift-compatible/output.yaml
+++ b/examples/openshift-compatible/output.yaml
@@ -96,6 +96,9 @@ data:
       job_name   = "integrations/agent"
       targets  = discovery.relabel.agent.output
       forward_to = [prometheus.relabel.agent.receiver]
+      clustering {
+        enabled = true
+      }
     }
     
     prometheus.relabel "agent" {
@@ -129,6 +132,9 @@ data:
       bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
       tls_config {
         insecure_skip_verify = true
+      }
+      clustering {
+        enabled = true
       }
       forward_to = [prometheus.relabel.kubelet.receiver]
     }
@@ -165,6 +171,9 @@ data:
       tls_config {
         insecure_skip_verify = true
       }
+      clustering {
+        enabled = true
+      }
       forward_to = [prometheus.relabel.cadvisor.receiver]
     }
     
@@ -195,6 +204,9 @@ data:
     prometheus.scrape "kube_state_metrics" {
       job_name   = "integrations/kubernetes/kube-state-metrics"
       targets    = discovery.relabel.kube_state_metrics.output
+      clustering {
+        enabled = true
+      }
       scheme     = "https"
       bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
       tls_config {
@@ -230,6 +242,9 @@ data:
     prometheus.scrape "node_exporter" {
       job_name   = "integrations/node_exporter"
       targets  = discovery.relabel.node_exporter.output
+      clustering {
+        enabled = true
+      }
       forward_to = [prometheus.relabel.node_exporter.receiver]
       scheme     = "https"
       bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
@@ -271,6 +286,9 @@ data:
     prometheus.scrape "opencost" {
       job_name   = "integrations/kubernetes/opencost"
       targets    = discovery.relabel.opencost.output
+      clustering {
+        enabled = true
+      }
       forward_to = [prometheus.relabel.opencost.receiver]
     }
     
@@ -286,6 +304,9 @@ data:
     // PodMonitor
     prometheus.operator.podmonitors "pod_monitors" {
       forward_to = [prometheus.relabel.podmonitors.receiver]
+      clustering {
+        enabled = true
+      }
     }
     
     prometheus.relabel "podmonitors" {
@@ -295,6 +316,9 @@ data:
     // ServiceMonitor
     prometheus.operator.servicemonitors "service_monitors" {
       forward_to = [prometheus.relabel.servicemonitors.receiver]
+      clustering {
+        enabled = true
+      }
     }
     
     prometheus.relabel "servicemonitors" {

--- a/examples/windows-exporter/metrics.river
+++ b/examples/windows-exporter/metrics.river
@@ -34,6 +34,9 @@ prometheus.scrape "agent" {
   job_name   = "integrations/agent"
   targets  = discovery.relabel.agent.output
   forward_to = [prometheus.relabel.agent.receiver]
+  clustering {
+    enabled = true
+  }
 }
 
 prometheus.relabel "agent" {
@@ -67,6 +70,9 @@ prometheus.scrape "kubelet" {
   bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
   tls_config {
     insecure_skip_verify = true
+  }
+  clustering {
+    enabled = true
   }
   forward_to = [prometheus.relabel.kubelet.receiver]
 }
@@ -103,6 +109,9 @@ prometheus.scrape "cadvisor" {
   tls_config {
     insecure_skip_verify = true
   }
+  clustering {
+    enabled = true
+  }
   forward_to = [prometheus.relabel.cadvisor.receiver]
 }
 
@@ -138,6 +147,9 @@ discovery.relabel "kube_state_metrics" {
 prometheus.scrape "kube_state_metrics" {
   job_name   = "integrations/kubernetes/kube-state-metrics"
   targets    = discovery.relabel.kube_state_metrics.output
+  clustering {
+    enabled = true
+  }
   forward_to = [prometheus.relabel.kube_state_metrics.receiver]
 }
 
@@ -173,6 +185,9 @@ discovery.relabel "node_exporter" {
 prometheus.scrape "node_exporter" {
   job_name   = "integrations/node_exporter"
   targets  = discovery.relabel.node_exporter.output
+  clustering {
+    enabled = true
+  }
   forward_to = [prometheus.relabel.node_exporter.receiver]
 }
 
@@ -213,6 +228,9 @@ discovery.relabel "windows_exporter" {
 prometheus.scrape "windows_exporter" {
   job_name   = "integrations/kubernetes/windows-exporter"
   targets  = discovery.relabel.windows_exporter.output
+  clustering {
+    enabled = true
+  }
   forward_to = [prometheus.relabel.windows_exporter.receiver]
 }
 
@@ -272,6 +290,9 @@ discovery.relabel "opencost" {
 prometheus.scrape "opencost" {
   job_name   = "integrations/kubernetes/opencost"
   targets    = discovery.relabel.opencost.output
+  clustering {
+    enabled = true
+  }
   forward_to = [prometheus.relabel.opencost.receiver]
 }
 
@@ -287,6 +308,9 @@ prometheus.relabel "opencost" {
 // PodMonitor
 prometheus.operator.podmonitors "pod_monitors" {
   forward_to = [prometheus.relabel.podmonitors.receiver]
+  clustering {
+    enabled = true
+  }
 }
 
 prometheus.relabel "podmonitors" {
@@ -296,6 +320,9 @@ prometheus.relabel "podmonitors" {
 // ServiceMonitor
 prometheus.operator.servicemonitors "service_monitors" {
   forward_to = [prometheus.relabel.servicemonitors.receiver]
+  clustering {
+    enabled = true
+  }
 }
 
 prometheus.relabel "servicemonitors" {

--- a/examples/windows-exporter/output.yaml
+++ b/examples/windows-exporter/output.yaml
@@ -164,6 +164,9 @@ data:
       job_name   = "integrations/agent"
       targets  = discovery.relabel.agent.output
       forward_to = [prometheus.relabel.agent.receiver]
+      clustering {
+        enabled = true
+      }
     }
     
     prometheus.relabel "agent" {
@@ -197,6 +200,9 @@ data:
       bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
       tls_config {
         insecure_skip_verify = true
+      }
+      clustering {
+        enabled = true
       }
       forward_to = [prometheus.relabel.kubelet.receiver]
     }
@@ -233,6 +239,9 @@ data:
       tls_config {
         insecure_skip_verify = true
       }
+      clustering {
+        enabled = true
+      }
       forward_to = [prometheus.relabel.cadvisor.receiver]
     }
     
@@ -268,6 +277,9 @@ data:
     prometheus.scrape "kube_state_metrics" {
       job_name   = "integrations/kubernetes/kube-state-metrics"
       targets    = discovery.relabel.kube_state_metrics.output
+      clustering {
+        enabled = true
+      }
       forward_to = [prometheus.relabel.kube_state_metrics.receiver]
     }
     
@@ -303,6 +315,9 @@ data:
     prometheus.scrape "node_exporter" {
       job_name   = "integrations/node_exporter"
       targets  = discovery.relabel.node_exporter.output
+      clustering {
+        enabled = true
+      }
       forward_to = [prometheus.relabel.node_exporter.receiver]
     }
     
@@ -343,6 +358,9 @@ data:
     prometheus.scrape "windows_exporter" {
       job_name   = "integrations/kubernetes/windows-exporter"
       targets  = discovery.relabel.windows_exporter.output
+      clustering {
+        enabled = true
+      }
       forward_to = [prometheus.relabel.windows_exporter.receiver]
     }
     
@@ -402,6 +420,9 @@ data:
     prometheus.scrape "opencost" {
       job_name   = "integrations/kubernetes/opencost"
       targets    = discovery.relabel.opencost.output
+      clustering {
+        enabled = true
+      }
       forward_to = [prometheus.relabel.opencost.receiver]
     }
     
@@ -417,6 +438,9 @@ data:
     // PodMonitor
     prometheus.operator.podmonitors "pod_monitors" {
       forward_to = [prometheus.relabel.podmonitors.receiver]
+      clustering {
+        enabled = true
+      }
     }
     
     prometheus.relabel "podmonitors" {
@@ -426,6 +450,9 @@ data:
     // ServiceMonitor
     prometheus.operator.servicemonitors "service_monitors" {
       forward_to = [prometheus.relabel.servicemonitors.receiver]
+      clustering {
+        enabled = true
+      }
     }
     
     prometheus.relabel "servicemonitors" {


### PR DESCRIPTION
While the Agent StatefulSet was told to enable clustering, none of the `prometheus.scrape` components enabled it. This fixes it.

Note to reviewers: To see the generated config, expand any of the `metrics.river` files. This only affects the grafana agent StatefulSet that processes metrics, not the Daemonset that processes logs.