### PR TITLE
Add github action to update dependencies

### DIFF
--- a/.github/configs/updatecli.d/grafana-agent.yaml
+++ b/.github/configs/updatecli.d/grafana-agent.yaml
@@ -1,0 +1,39 @@
+name: Bump dependency "grafana-agent" for Helm chart "k8s-monitoring"
+sources:
+    grafana-agent:
+        name: Get latest "grafana-agent" Helm chart version
+        kind: helmchart
+        spec:
+            name: grafana-agent
+            url: https://grafana.github.io/helm-charts
+            versionfilter:
+                kind: semver
+                pattern: '*'
+conditions:
+    grafana-agent:
+        name: Ensure Helm chart dependency "grafana-agent" is specified
+        kind: yaml
+        spec:
+            file: charts/k8s-monitoring/Chart.yaml
+            key: $.dependencies[0].name
+            value: grafana-agent
+        disablesourceinput: true
+targets:
+    grafana-agent:
+        name: Bump Helm chart dependency "grafana-agent" for Helm chart "k8s-monitoring"
+        kind: helmchart
+        spec:
+            file: Chart.yaml
+            key: $.dependencies[0].version
+            name: charts/k8s-monitoring
+            versionincrement: none
+        sourceid: grafana-agent
+    grafana-agent-logs:
+        name: Bump Helm chart dependency "grafana-agent-logs" for Helm chart "k8s-monitoring"
+        kind: helmchart
+        spec:
+            file: Chart.yaml
+            key: $.dependencies[1].version
+            name: charts/k8s-monitoring
+            versionincrement: none
+        sourceid: grafana-agent

--- a/.github/configs/updatecli.d/kube-state-metrics.yaml
+++ b/.github/configs/updatecli.d/kube-state-metrics.yaml
@@ -1,0 +1,31 @@
+name: Bump dependency "kube-state-metrics" for Helm chart "k8s-monitoring"
+sources:
+    kube-state-metrics:
+        name: Get latest "kube-state-metrics" Helm chart version
+        kind: helmchart
+        spec:
+            name: kube-state-metrics
+            url: https://prometheus-community.github.io/helm-charts
+            versionfilter:
+                kind: semver
+                pattern: '*'
+conditions:
+    kube-state-metrics:
+        name: Ensure Helm chart dependency "kube-state-metrics" is specified
+        kind: yaml
+        spec:
+            file: charts/k8s-monitoring/Chart.yaml
+            key: $.dependencies[2].name
+            value: kube-state-metrics
+        disablesourceinput: true
+targets:
+    kube-state-metrics:
+        name: Bump Helm chart dependency "kube-state-metrics" for Helm chart "k8s-monitoring"
+        kind: helmchart
+        spec:
+            file: Chart.yaml
+            key: $.dependencies[2].version
+            name: charts/k8s-monitoring
+            versionincrement: none
+        sourceid: kube-state-metrics
+

--- a/.github/configs/updatecli.d/node-exporter.yaml
+++ b/.github/configs/updatecli.d/node-exporter.yaml
@@ -1,0 +1,32 @@
+name: Bump dependency "prometheus-node-exporter" for Helm chart "k8s-monitoring"
+sources:
+    prometheus-node-exporter:
+        name: Get latest "prometheus-node-exporter" Helm chart version
+        kind: helmchart
+        spec:
+            name: prometheus-node-exporter
+            url: https://prometheus-community.github.io/helm-charts
+            versionfilter:
+                kind: semver
+                pattern: '*'
+
+conditions:
+    prometheus-node-exporter:
+        name: Ensure Helm chart dependency "prometheus-node-exporter" is specified
+        kind: yaml
+        spec:
+            file: charts/k8s-monitoring/Chart.yaml
+            key: $.dependencies[3].name
+            value: prometheus-node-exporter
+        disablesourceinput: true
+
+targets:
+    prometheus-node-exporter:
+        name: Bump Helm chart dependency "prometheus-node-exporter" for Helm chart "k8s-monitoring"
+        kind: helmchart
+        spec:
+            file: Chart.yaml
+            key: $.dependencies[3].version
+            name: charts/k8s-monitoring
+            versionincrement: none
+        sourceid: prometheus-node-exporter

--- a/.github/configs/updatecli.d/opencost.yaml
+++ b/.github/configs/updatecli.d/opencost.yaml
@@ -1,0 +1,30 @@
+name: Bump dependency "opencost" for Helm chart "k8s-monitoring"
+sources:
+    opencost:
+        name: Get latest "opencost" Helm chart version
+        kind: helmchart
+        spec:
+            name: opencost
+            url: https://opencost.github.io/opencost-helm-chart
+            versionfilter:
+                kind: semver
+                pattern: '*'
+conditions:
+    opencost:
+        name: Ensure Helm chart dependency "opencost" is specified
+        kind: yaml
+        spec:
+            file: charts/k8s-monitoring/Chart.yaml
+            key: $.dependencies[6].name
+            value: opencost
+        disablesourceinput: true
+targets:
+    opencost:
+        name: Bump Helm chart dependency "opencost" for Helm chart "k8s-monitoring"
+        kind: helmchart
+        spec:
+            file: Chart.yaml
+            key: $.dependencies[6].version
+            name: charts/k8s-monitoring
+            versionincrement: none
+        sourceid: opencost

--- a/.github/configs/updatecli.d/prometheus-operator-crds.yaml
+++ b/.github/configs/updatecli.d/prometheus-operator-crds.yaml
@@ -1,0 +1,30 @@
+name: Bump dependency "prometheus-operator-crds" for Helm chart "k8s-monitoring"
+sources:
+    prometheus-operator-crds:
+        name: Get latest "prometheus-operator-crds" Helm chart version
+        kind: helmchart
+        spec:
+            name: prometheus-operator-crds
+            url: https://prometheus-community.github.io/helm-charts
+            versionfilter:
+                kind: semver
+                pattern: '*'
+conditions:
+    prometheus-operator-crds:
+        name: Ensure Helm chart dependency "prometheus-operator-crds" is specified
+        kind: yaml
+        spec:
+            file: charts/k8s-monitoring/Chart.yaml
+            key: $.dependencies[4].name
+            value: prometheus-operator-crds
+        disablesourceinput: true
+targets:
+    prometheus-operator-crds:
+        name: Bump Helm chart dependency "prometheus-operator-crds" for Helm chart "k8s-monitoring"
+        kind: helmchart
+        spec:
+            file: Chart.yaml
+            key: $.dependencies[4].version
+            name: charts/k8s-monitoring
+            versionincrement: none
+        sourceid: prometheus-operator-crds

--- a/.github/configs/updatecli.d/windows-exporter.yaml
+++ b/.github/configs/updatecli.d/windows-exporter.yaml
@@ -1,0 +1,30 @@
+name: Bump dependency "prometheus-windows-exporter" for Helm chart "k8s-monitoring"
+sources:
+    prometheus-windows-exporter:
+        name: Get latest "prometheus-windows-exporter" Helm chart version
+        kind: helmchart
+        spec:
+            name: prometheus-windows-exporter
+            url: https://prometheus-community.github.io/helm-charts
+            versionfilter:
+                kind: semver
+                pattern: '*'
+conditions:
+    prometheus-windows-exporter:
+        name: Ensure Helm chart dependency "prometheus-windows-exporter" is specified
+        kind: yaml
+        spec:
+            file: charts/k8s-monitoring/Chart.yaml
+            key: $.dependencies[5].name
+            value: prometheus-windows-exporter
+        disablesourceinput: true
+targets:
+    prometheus-windows-exporter:
+        name: Bump Helm chart dependency "prometheus-windows-exporter" for Helm chart "k8s-monitoring"
+        kind: helmchart
+        spec:
+            file: Chart.yaml
+            key: $.dependencies[5].version
+            name: charts/k8s-monitoring
+            versionincrement: none
+        sourceid: prometheus-windows-exporter

--- a/.github/workflows/check-for-dependency-updates.yaml
+++ b/.github/workflows/check-for-dependency-updates.yaml
@@ -1,0 +1,233 @@
+---
+name: Check for dependency updates
+
+on:
+  workflow_dispatch:
+  schedule:
+    # Run once a day
+    - cron: '0 0 * * *'
+
+permissions:
+  contents: "write"
+  pull-requests: "write"
+
+env:
+  UPDATECLI_CONFIG_DIR: "${{ github.workspace }}/.github/configs/updatecli.d"
+
+jobs:
+  updateGrafanaAgent:
+    name: Update Grafana Agent
+    runs-on: "ubuntu-latest"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Install Helm
+        uses: azure/setup-helm@v3
+
+      - name: Install Updatecli
+        uses: updatecli/updatecli-action@v2
+
+      - name: Run Updatecli
+        run: "updatecli apply --config ${UPDATECLI_CONFIG_DIR}/grafana-agent.yaml"
+        env:
+          UPDATECLI_GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+
+      - name: Regenerate docs
+        run: docker run --rm -v "$(pwd)/charts/k8s-monitoring:/helm-docs" -u "$(id -u)" jnorwood/helm-docs
+
+      - name: Regenerate examples
+        run: make regenerate-example-outputs
+
+      - name: Create pull request
+        uses: peter-evans/create-pull-request@v5
+        with:
+          title: "[dependency] Update Grafana Agent"
+          body: ""
+          base: main
+          author: "${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>"
+          committer: "GitHub <noreply@github.com>"
+          commit-message: Update Grafana Agent
+          labels: dependencies
+          branch: chore/update-grafana-agent
+          delete-branch: true
+
+  updateKubeStateMetrics:
+    name: Update Kube State Metrics
+    runs-on: "ubuntu-latest"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Install Helm
+        uses: azure/setup-helm@v3
+
+      - name: Install Updatecli
+        uses: updatecli/updatecli-action@v2
+
+      - name: Run Updatecli
+        run: "updatecli apply --config ${UPDATECLI_CONFIG_DIR}/kube-state-metrics.yaml"
+        env:
+          UPDATECLI_GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+
+      - name: Regenerate docs
+        run: docker run --rm -v "$(pwd)/charts/k8s-monitoring:/helm-docs" -u "$(id -u)" jnorwood/helm-docs
+
+      - name: Regenerate examples
+        run: make regenerate-example-outputs
+
+      - name: Create pull request
+        uses: peter-evans/create-pull-request@v5
+        with:
+          title: "[dependency] Update Kube State Metrics"
+          base: main
+          author: "${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>"
+          committer: "GitHub <noreply@github.com>"
+          commit-message: Update Kube State Metrics
+          labels: dependencies
+          branch: chore/update-kube-state-metrics
+          delete-branch: true
+
+  updateNodeExporter:
+    name: Update Node Exporter
+    runs-on: "ubuntu-latest"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Install Helm
+        uses: azure/setup-helm@v3
+
+      - name: Install Updatecli
+        uses: updatecli/updatecli-action@v2
+
+      - name: Run Updatecli
+        run: "updatecli apply --config ${UPDATECLI_CONFIG_DIR}/node-exporter.yaml"
+        env:
+          UPDATECLI_GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+
+      - name: Regenerate docs
+        run: docker run --rm -v "$(pwd)/charts/k8s-monitoring:/helm-docs" -u "$(id -u)" jnorwood/helm-docs
+
+      - name: Regenerate examples
+        run: make regenerate-example-outputs
+
+      - name: Create pull request
+        uses: peter-evans/create-pull-request@v5
+        with:
+          title: "[dependency] Update Node Exporter"
+          base: main
+          author: "${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>"
+          committer: "GitHub <noreply@github.com>"
+          commit-message: Update Node Exporter
+          labels: dependencies
+          branch: chore/update-node-exporter
+          delete-branch: true
+
+  updateOpenCost:
+    name: Update OpenCost
+    runs-on: "ubuntu-latest"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Install Helm
+        uses: azure/setup-helm@v3
+
+      - name: Install Updatecli
+        uses: updatecli/updatecli-action@v2
+
+      - name: Run Updatecli
+        run: "updatecli apply --config ${UPDATECLI_CONFIG_DIR}/opencost.yaml"
+        env:
+          UPDATECLI_GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+
+      - name: Regenerate docs
+        run: docker run --rm -v "$(pwd)/charts/k8s-monitoring:/helm-docs" -u "$(id -u)" jnorwood/helm-docs
+
+      - name: Regenerate examples
+        run: make regenerate-example-outputs
+
+      - name: Create pull request
+        uses: peter-evans/create-pull-request@v5
+        with:
+          title: "[dependency] Update OpenCost"
+          base: main
+          author: "${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>"
+          committer: "GitHub <noreply@github.com>"
+          commit-message: Update OpenCost
+          labels: dependencies
+          branch: chore/update-opencost
+          delete-branch: true
+
+  updatePrometheusOperatorCRDs:
+    name: Update Prometheus Operator CRDs
+    runs-on: "ubuntu-latest"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Install Helm
+        uses: azure/setup-helm@v3
+
+      - name: Install Updatecli
+        uses: updatecli/updatecli-action@v2
+
+      - name: Run Updatecli
+        run: "updatecli apply --config ${UPDATECLI_CONFIG_DIR}/prometheus-operator-crds.yaml"
+        env:
+          UPDATECLI_GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+
+      - name: Regenerate docs
+        run: docker run --rm -v "$(pwd)/charts/k8s-monitoring:/helm-docs" -u "$(id -u)" jnorwood/helm-docs
+
+      - name: Regenerate examples
+        run: make regenerate-example-outputs
+
+      - name: Create pull request
+        uses: peter-evans/create-pull-request@v5
+        with:
+          title: "[dependency] Update Prometheus Operator CRDs"
+          base: main
+          author: "${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>"
+          committer: "GitHub <noreply@github.com>"
+          commit-message: Update Prometheus Operator CRDs
+          labels: dependencies
+          branch: chore/update-prometheus-operator-crds
+          delete-branch: true
+
+  updateWindowsExporter:
+    name: Update Windows Exporter
+    runs-on: "ubuntu-latest"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Install Helm
+        uses: azure/setup-helm@v3
+
+      - name: Install Updatecli
+        uses: updatecli/updatecli-action@v2
+
+      - name: Run Updatecli
+        run: "updatecli apply --config ${UPDATECLI_CONFIG_DIR}/windows-exporter.yaml"
+        env:
+          UPDATECLI_GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+
+      - name: Regenerate docs
+        run: docker run --rm -v "$(pwd)/charts/k8s-monitoring:/helm-docs" -u "$(id -u)" jnorwood/helm-docs
+
+      - name: Regenerate examples
+        run: make regenerate-example-outputs
+
+      - name: Create pull request
+        uses: peter-evans/create-pull-request@v5
+        with:
+          title: "[dependency] Update Windows Exporter"
+          base: main
+          author: "${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>"
+          committer: "GitHub <noreply@github.com>"
+          commit-message: Update Windows Exporter
+          labels: dependencies
+          branch: chore/update-windows-exporter
+          delete-branch: true

--- a/.github/workflows/check-for-dependency-updates.yaml
+++ b/.github/workflows/check-for-dependency-updates.yaml
@@ -51,7 +51,7 @@ jobs:
         uses: peter-evans/create-pull-request@v5
         with:
           title: "[dependency] Update Grafana Agent"
-          body: ""
+          body: "Updates the Grafana Agent subchart"
           base: main
           author: "${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>"
           committer: "GitHub <noreply@github.com>"
@@ -95,6 +95,7 @@ jobs:
         uses: peter-evans/create-pull-request@v5
         with:
           title: "[dependency] Update Kube State Metrics"
+          body: "Updates the Kube State Metrics subchart"
           base: main
           author: "${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>"
           committer: "GitHub <noreply@github.com>"
@@ -138,6 +139,7 @@ jobs:
         uses: peter-evans/create-pull-request@v5
         with:
           title: "[dependency] Update Node Exporter"
+          body: "Updates the Node Exporter subchart"
           base: main
           author: "${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>"
           committer: "GitHub <noreply@github.com>"
@@ -181,6 +183,7 @@ jobs:
         uses: peter-evans/create-pull-request@v5
         with:
           title: "[dependency] Update OpenCost"
+          body: "Updates the OpenCost subchart"
           base: main
           author: "${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>"
           committer: "GitHub <noreply@github.com>"
@@ -224,6 +227,7 @@ jobs:
         uses: peter-evans/create-pull-request@v5
         with:
           title: "[dependency] Update Prometheus Operator CRDs"
+          body: "Updates the Prometheus Operator CRD subchart"
           base: main
           author: "${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>"
           committer: "GitHub <noreply@github.com>"
@@ -267,6 +271,7 @@ jobs:
         uses: peter-evans/create-pull-request@v5
         with:
           title: "[dependency] Update Windows Exporter"
+          body: "Updates the Windows Exporter subchart"
           base: main
           author: "${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>"
           committer: "GitHub <noreply@github.com>"

--- a/.github/workflows/check-for-dependency-updates.yaml
+++ b/.github/workflows/check-for-dependency-updates.yaml
@@ -22,24 +22,32 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
-      - name: Install Helm
-        uses: azure/setup-helm@v3
-
       - name: Install Updatecli
         uses: updatecli/updatecli-action@v2
 
       - name: Run Updatecli
-        run: "updatecli apply --config ${UPDATECLI_CONFIG_DIR}/grafana-agent.yaml"
+        id: update-grafana-agent
+        run: |
+          updatecli apply --config ${UPDATECLI_CONFIG_DIR}/grafana-agent.yaml
+          if ! git diff --exit-code > /dev/null; then
+            echo "changed=true" >> "${GITHUB_OUTPUT}"
+          fi
         env:
           UPDATECLI_GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
 
       - name: Regenerate docs
+        if: steps.update-grafana-agent.outputs.changed == 'true'
         run: docker run --rm -v "$(pwd)/charts/k8s-monitoring:/helm-docs" -u "$(id -u)" jnorwood/helm-docs
 
+      - name: Install Helm
+        uses: azure/setup-helm@v3
+
       - name: Regenerate examples
+        if: steps.update-grafana-agent.outputs.changed == 'true'
         run: make regenerate-example-outputs
 
       - name: Create pull request
+        if: steps.update-grafana-agent.outputs.changed == 'true'
         uses: peter-evans/create-pull-request@v5
         with:
           title: "[dependency] Update Grafana Agent"
@@ -59,24 +67,32 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
-      - name: Install Helm
-        uses: azure/setup-helm@v3
-
       - name: Install Updatecli
         uses: updatecli/updatecli-action@v2
 
       - name: Run Updatecli
-        run: "updatecli apply --config ${UPDATECLI_CONFIG_DIR}/kube-state-metrics.yaml"
+        id: update-kube-state-metrics
+        run: |
+          updatecli apply --config ${UPDATECLI_CONFIG_DIR}/kube-state-metrics.yaml
+          if ! git diff --exit-code > /dev/null; then
+            echo "changed=true" >> "${GITHUB_OUTPUT}"
+          fi
         env:
           UPDATECLI_GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
 
       - name: Regenerate docs
+        if: steps.update-kube-state-metrics.outputs.changed == 'true'
         run: docker run --rm -v "$(pwd)/charts/k8s-monitoring:/helm-docs" -u "$(id -u)" jnorwood/helm-docs
 
+      - name: Install Helm
+        uses: azure/setup-helm@v3
+
       - name: Regenerate examples
+        if: steps.update-kube-state-metrics.outputs.changed == 'true'
         run: make regenerate-example-outputs
 
       - name: Create pull request
+        if: steps.update-kube-state-metrics.outputs.changed == 'true'
         uses: peter-evans/create-pull-request@v5
         with:
           title: "[dependency] Update Kube State Metrics"
@@ -95,24 +111,32 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
-      - name: Install Helm
-        uses: azure/setup-helm@v3
-
       - name: Install Updatecli
         uses: updatecli/updatecli-action@v2
 
       - name: Run Updatecli
-        run: "updatecli apply --config ${UPDATECLI_CONFIG_DIR}/node-exporter.yaml"
+        id: update-node-exporter
+        run: |
+          updatecli apply --config ${UPDATECLI_CONFIG_DIR}/node-exporter.yaml
+          if ! git diff --exit-code > /dev/null; then
+            echo "changed=true" >> "${GITHUB_OUTPUT}"
+          fi
         env:
           UPDATECLI_GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
 
       - name: Regenerate docs
+        if: steps.update-node-exporter.outputs.changed == 'true'
         run: docker run --rm -v "$(pwd)/charts/k8s-monitoring:/helm-docs" -u "$(id -u)" jnorwood/helm-docs
 
+      - name: Install Helm
+        uses: azure/setup-helm@v3
+
       - name: Regenerate examples
+        if: steps.update-node-exporter.outputs.changed == 'true'
         run: make regenerate-example-outputs
 
       - name: Create pull request
+        if: steps.update-node-exporter.outputs.changed == 'true'
         uses: peter-evans/create-pull-request@v5
         with:
           title: "[dependency] Update Node Exporter"
@@ -131,24 +155,32 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
-      - name: Install Helm
-        uses: azure/setup-helm@v3
-
       - name: Install Updatecli
         uses: updatecli/updatecli-action@v2
 
       - name: Run Updatecli
-        run: "updatecli apply --config ${UPDATECLI_CONFIG_DIR}/opencost.yaml"
+        id: update-opencost
+        run: |
+          updatecli apply --config ${UPDATECLI_CONFIG_DIR}/opencost.yaml
+          if ! git diff --exit-code > /dev/null; then
+            echo "changed=true" >> "${GITHUB_OUTPUT}"
+          fi
         env:
           UPDATECLI_GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
 
       - name: Regenerate docs
+        if: steps.update-opencost.outputs.changed == 'true'
         run: docker run --rm -v "$(pwd)/charts/k8s-monitoring:/helm-docs" -u "$(id -u)" jnorwood/helm-docs
 
+      - name: Install Helm
+        uses: azure/setup-helm@v3
+
       - name: Regenerate examples
+        if: steps.update-opencost.outputs.changed == 'true'
         run: make regenerate-example-outputs
 
       - name: Create pull request
+        if: steps.update-opencost.outputs.changed == 'true'
         uses: peter-evans/create-pull-request@v5
         with:
           title: "[dependency] Update OpenCost"
@@ -167,24 +199,32 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
-      - name: Install Helm
-        uses: azure/setup-helm@v3
-
       - name: Install Updatecli
         uses: updatecli/updatecli-action@v2
 
       - name: Run Updatecli
-        run: "updatecli apply --config ${UPDATECLI_CONFIG_DIR}/prometheus-operator-crds.yaml"
+        id: update-prometheus-operator-crds
+        run: |
+          updatecli apply --config ${UPDATECLI_CONFIG_DIR}/prometheus-operator-crds.yaml
+          if ! git diff --exit-code > /dev/null; then
+            echo "changed=true" >> "${GITHUB_OUTPUT}"
+          fi
         env:
           UPDATECLI_GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
 
       - name: Regenerate docs
+        if: steps.update-prometheus-operator-crds.outputs.changed == 'true'
         run: docker run --rm -v "$(pwd)/charts/k8s-monitoring:/helm-docs" -u "$(id -u)" jnorwood/helm-docs
 
+      - name: Install Helm
+        uses: azure/setup-helm@v3
+
       - name: Regenerate examples
+        if: steps.update-prometheus-operator-crds.outputs.changed == 'true'
         run: make regenerate-example-outputs
 
       - name: Create pull request
+        if: steps.update-prometheus-operator-crds.outputs.changed == 'true'
         uses: peter-evans/create-pull-request@v5
         with:
           title: "[dependency] Update Prometheus Operator CRDs"
@@ -203,24 +243,32 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
-      - name: Install Helm
-        uses: azure/setup-helm@v3
-
       - name: Install Updatecli
         uses: updatecli/updatecli-action@v2
 
       - name: Run Updatecli
-        run: "updatecli apply --config ${UPDATECLI_CONFIG_DIR}/windows-exporter.yaml"
+        id: update-windows-exporter
+        run: |
+          updatecli apply --config ${UPDATECLI_CONFIG_DIR}/windows-exporter.yaml
+          if ! git diff --exit-code > /dev/null; then
+            echo "changed=true" >> "${GITHUB_OUTPUT}"
+          fi
         env:
           UPDATECLI_GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
 
       - name: Regenerate docs
+        if: steps.update-windows-exporter.outputs.changed == 'true'
         run: docker run --rm -v "$(pwd)/charts/k8s-monitoring:/helm-docs" -u "$(id -u)" jnorwood/helm-docs
 
+      - name: Install Helm
+        uses: azure/setup-helm@v3
+
       - name: Regenerate examples
+        if: steps.update-windows-exporter.outputs.changed == 'true'
         run: make regenerate-example-outputs
 
       - name: Create pull request
+        if: steps.update-windows-exporter.outputs.changed == 'true'
         uses: peter-evans/create-pull-request@v5
         with:
           title: "[dependency] Update Windows Exporter"

--- a/.github/workflows/check-for-dependency-updates.yaml
+++ b/.github/workflows/check-for-dependency-updates.yaml
@@ -40,6 +40,7 @@ jobs:
         run: docker run --rm -v "$(pwd)/charts/k8s-monitoring:/helm-docs" -u "$(id -u)" jnorwood/helm-docs
 
       - name: Install Helm
+        if: steps.update-grafana-agent.outputs.changed == 'true'
         uses: azure/setup-helm@v3
 
       - name: Regenerate examples
@@ -85,6 +86,7 @@ jobs:
         run: docker run --rm -v "$(pwd)/charts/k8s-monitoring:/helm-docs" -u "$(id -u)" jnorwood/helm-docs
 
       - name: Install Helm
+        if: steps.update-kube-state-metrics.outputs.changed == 'true'
         uses: azure/setup-helm@v3
 
       - name: Regenerate examples
@@ -129,6 +131,7 @@ jobs:
         run: docker run --rm -v "$(pwd)/charts/k8s-monitoring:/helm-docs" -u "$(id -u)" jnorwood/helm-docs
 
       - name: Install Helm
+        if: steps.update-node-exporter.outputs.changed == 'true'
         uses: azure/setup-helm@v3
 
       - name: Regenerate examples
@@ -173,6 +176,7 @@ jobs:
         run: docker run --rm -v "$(pwd)/charts/k8s-monitoring:/helm-docs" -u "$(id -u)" jnorwood/helm-docs
 
       - name: Install Helm
+        if: steps.update-opencost.outputs.changed == 'true'
         uses: azure/setup-helm@v3
 
       - name: Regenerate examples
@@ -217,6 +221,7 @@ jobs:
         run: docker run --rm -v "$(pwd)/charts/k8s-monitoring:/helm-docs" -u "$(id -u)" jnorwood/helm-docs
 
       - name: Install Helm
+        if: steps.update-prometheus-operator-crds.outputs.changed == 'true'
         uses: azure/setup-helm@v3
 
       - name: Regenerate examples
@@ -261,6 +266,7 @@ jobs:
         run: docker run --rm -v "$(pwd)/charts/k8s-monitoring:/helm-docs" -u "$(id -u)" jnorwood/helm-docs
 
       - name: Install Helm
+        if: steps.update-windows-exporter.outputs.changed == 'true'
         uses: azure/setup-helm@v3
 
       - name: Regenerate examples

--- a/.github/workflows/check-for-dependency-updates.yaml
+++ b/.github/workflows/check-for-dependency-updates.yaml
@@ -13,6 +13,7 @@ permissions:
 
 env:
   UPDATECLI_CONFIG_DIR: "${{ github.workspace }}/.github/configs/updatecli.d"
+  UPDATECLI_GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
 
 jobs:
   updateGrafanaAgent:
@@ -32,8 +33,6 @@ jobs:
           if ! git diff --exit-code > /dev/null; then
             echo "changed=true" >> "${GITHUB_OUTPUT}"
           fi
-        env:
-          UPDATECLI_GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
 
       - name: Regenerate docs
         if: steps.update-grafana-agent.outputs.changed == 'true'
@@ -78,8 +77,6 @@ jobs:
           if ! git diff --exit-code > /dev/null; then
             echo "changed=true" >> "${GITHUB_OUTPUT}"
           fi
-        env:
-          UPDATECLI_GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
 
       - name: Regenerate docs
         if: steps.update-kube-state-metrics.outputs.changed == 'true'
@@ -123,8 +120,6 @@ jobs:
           if ! git diff --exit-code > /dev/null; then
             echo "changed=true" >> "${GITHUB_OUTPUT}"
           fi
-        env:
-          UPDATECLI_GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
 
       - name: Regenerate docs
         if: steps.update-node-exporter.outputs.changed == 'true'
@@ -168,8 +163,6 @@ jobs:
           if ! git diff --exit-code > /dev/null; then
             echo "changed=true" >> "${GITHUB_OUTPUT}"
           fi
-        env:
-          UPDATECLI_GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
 
       - name: Regenerate docs
         if: steps.update-opencost.outputs.changed == 'true'
@@ -213,8 +206,6 @@ jobs:
           if ! git diff --exit-code > /dev/null; then
             echo "changed=true" >> "${GITHUB_OUTPUT}"
           fi
-        env:
-          UPDATECLI_GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
 
       - name: Regenerate docs
         if: steps.update-prometheus-operator-crds.outputs.changed == 'true'
@@ -258,8 +249,6 @@ jobs:
           if ! git diff --exit-code > /dev/null; then
             echo "changed=true" >> "${GITHUB_OUTPUT}"
           fi
-        env:
-          UPDATECLI_GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
 
       - name: Regenerate docs
         if: steps.update-windows-exporter.outputs.changed == 'true'


### PR DESCRIPTION
Fixes #106 

This action generated the `[dependency] ...` Pull Requests that are open right now.

Note for reviewers:
* Updatecli (if you're not familiar) knows how to check helm chart repositories for updates and will locally modify our helm chart source with the updated version. It seems to have the ability to create PRs, but we need to run `helm-docs` and regenerate the examples before making the PR.  Also, their docs on PR creation are outdated and I couldn't get it to work reliably.
* Each .github/configs/updatecli.d/* and their associated section in the workflow are nearly identical. Review for clarity of a single flow, then check for copy-paste errors.