### PR TITLE
Add a check for Helm version. It'll give a better error message on Helm CLIs earlier than 3.7

### DIFF
--- a/charts/k8s-monitoring/templates/_helpers.tpl
+++ b/charts/k8s-monitoring/templates/_helpers.tpl
@@ -1,3 +1,12 @@
+{{/* This function checks for the minimum Helm CLI version 3.7 */}}
+{{/*   The use of .Subcharts requires 3.7 */}}
+{{/*   The use of multi-line strings (in the fail below) requires 3.6 */}}
+{{- define "checkHelmVersion" -}}
+{{ if semverCompare "<3.7" .Capabilities.HelmVersion.Version }}
+{{ fail "Helm version 3.7 or later is required for this chart" }}
+{{- end }}
+{{- end }}
+
 {{/* This template checks that the port defined in .Values.traces.receiver.port is in the targetPort list on .grafana-agent */}}
 {{- define "checkForTracePort" -}}
   {{- $tracePort := .Values.traces.receiver.port -}}
@@ -8,17 +17,7 @@
     {{- end }}
   {{- end }}
   {{- if not $found }}
-    {{- fail (print
-    "Trace port not opened on the Grafana Agent.\n"
-    "In order for traces to work, the " $tracePort " port needs to be opened on the Grafana Agent. For example, set this in your values file:\n"
-    "grafana-agent:\n"
-    "  agent:\n"
-    "    extraPorts:\n"
-    "      - name: \"otlp-traces\"\n"
-    "        port: " $tracePort "\n"
-    "        targetPort: " $tracePort "\n"
-    "        protocol: \"TCP\"\n"
-    "For more examples, see https://github.com/grafana/k8s-monitoring-helm/tree/main/examples/traces-enabled") -}}
+    {{- fail (print "Trace port not opened on the Grafana Agent.\nIn order for traces to work, the " $tracePort " port needs to be opened on the Grafana Agent. For example, set this in your values file:\ngrafana-agent:\n  agent:\n    extraPorts:\n      - name: \"otlp-traces\"\n        port: " $tracePort "\n        targetPort: " $tracePort "\n        protocol: \"TCP\"\nFor more examples, see https://github.com/grafana/k8s-monitoring-helm/tree/main/examples/traces-enabled") -}}
   {{- end -}}
 {{- end -}}
 

--- a/charts/k8s-monitoring/templates/grafana-agent-config.yaml
+++ b/charts/k8s-monitoring/templates/grafana-agent-config.yaml
@@ -1,3 +1,4 @@
+{{- include "checkHelmVersion" . -}}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/charts/k8s-monitoring/templates/grafana-agent-logs-config.yaml
+++ b/charts/k8s-monitoring/templates/grafana-agent-logs-config.yaml
@@ -1,3 +1,4 @@
+{{- include "checkHelmVersion" . -}}
 {{- if and .Values.logs.enabled .Values.logs.pod_logs.enabled }}
 apiVersion: v1
 kind: ConfigMap


### PR DESCRIPTION
Tested with Helm 3.5:
```
% docker run -it --rm -v $(pwd):/src alpine/helm:3.5.4 template k8smon /src/charts/k8s-monitoring -f /src/examples/default-values/values.yaml
Error: template: k8s-monitoring/templates/grafana-agent-logs-config.yaml:1:4: executing "k8s-monitoring/templates/grafana-agent-logs-config.yaml" at <include "checkHelmVersion" .>: error calling include: template: k8s-monitoring/templates/_helpers.tpl:6:3: executing "checkHelmVersion" at <fail "Helm version 3.7 or later is required for this chart">: error calling fail: Helm version 3.7 or later is required for this chart

Use --debug flag to render out invalid YAML
```

Tested with Helm 3.6:
```
% docker run -it --rm -v $(pwd):/src alpine/helm:3.6.3 template k8smon /src/charts/k8s-monitoring -f /src/examples/default-values/values.yaml
Error: execution error at (k8s-monitoring/templates/grafana-agent-logs-config.yaml:1:4): Helm version 3.7 or later is required for this chart

Use --debug flag to render out invalid YAML
```

Tested with Helm 3.7:
```
% docker run -it --rm -v $(pwd):/src alpine/helm:3.7.1 template k8smon /src/charts/k8s-monitoring -f /src/examples/default-values/values.yaml
... (it works)
```