### PR TITLE
Add static telemetry metric with informaiton about chart version and enabled features

### DIFF
--- a/charts/k8s-monitoring/README.md
+++ b/charts/k8s-monitoring/README.md
@@ -134,6 +134,7 @@ The Prometheus and Loki services may be hosted on the same cluster, or remotely 
 | metrics.kubelet.extraMetricRelabelingRules | string | `nil` | Rule blocks to be added to the prometheus.relabel component for Kubelet. See https://grafana.com/docs/agent/latest/flow/reference/components/prometheus.relabel/#rule-block |
 | metrics.kubelet.extraRelabelingRules | string | `nil` | Rule blocks to be added to the discovery.relabel component for Kubelet. See https://grafana.com/docs/agent/latest/flow/reference/components/discovery.relabel/#rule-block |
 | metrics.kubelet.scrapeInterval | string | 60s | How frequently to scrape metrics from the Kubelet. Overrides metrics.scrapeInterval |
+| metrics.kubernetesMonitoring.enabled | bool | `true` | Report telemetry about this Kubernetes Monitoring chart as a metric. |
 | metrics.node-exporter.allowList | list | See [Allow List for Node Exporter](#allow-list-for-node-exporter) | The list of Node Exporter metrics that will be scraped by the Agent |
 | metrics.node-exporter.enabled | bool | `true` | Scrape node metrics |
 | metrics.node-exporter.extraMetricRelabelingRules | string | `nil` | Rule blocks to be added to the prometheus.relabel component for Node Exporter. See https://grafana.com/docs/agent/latest/flow/reference/components/prometheus.relabel/#rule-block |

--- a/charts/k8s-monitoring/templates/_helpers.tpl
+++ b/charts/k8s-monitoring/templates/_helpers.tpl
@@ -32,6 +32,10 @@
       {{- include "agent.config.agent" . }}
     {{- end }}
 
+    {{- if .Values.metrics.kubernetesMonitoring.enabled }}
+      {{- include "agent.config.kubernetes_monitoring_telemetry" . }}
+    {{- end }}
+
     {{- if .Values.metrics.kubelet.enabled }}
       {{- include "agent.config.kubelet" . }}
     {{- end }}
@@ -96,3 +100,46 @@
     {{- print "\n" .Values.logs.extraConfig }}
   {{- end }}
 {{- end -}}
+
+{{- define "kubernetes_monitoring_telemetry.metrics" -}}
+{{- $metrics := list -}}
+{{- if .Values.metrics.enabled -}}
+  {{- $metrics = append $metrics "enabled" -}}
+  {{- if .Values.metrics.agent.enabled -}}{{- $metrics = append $metrics "agent" -}}{{- end -}}
+  {{- if index (index .Values.metrics "kube-state-metrics").enabled -}}{{- $metrics = append $metrics "kube-state-metrics" -}}{{- end -}}
+  {{- if index (index .Values.metrics "node-exporter").enabled -}}{{- $metrics = append $metrics "node-exporter" -}}{{- end -}}
+  {{- if index (index .Values.metrics "windows-exporter").enabled -}}{{- $metrics = append $metrics "windows-exporter" -}}{{- end -}}
+  {{- if .Values.metrics.kubelet.enabled -}}{{- $metrics = append $metrics "kubelet" -}}{{- end -}}
+  {{- if .Values.metrics.cadvisor.enabled -}}{{- $metrics = append $metrics "cadvisor" -}}{{- end -}}
+  {{- if .Values.metrics.cost.enabled -}}{{- $metrics = append $metrics "cost" }}{{ end -}}
+{{- else -}}
+  {{- $metrics = append $metrics "disabled" -}}
+{{- end -}}
+{{- join "," $metrics -}}
+{{- end }}
+
+{{- define "kubernetes_monitoring_telemetry.logs" -}}
+{{- $logs := list -}}
+{{- if .Values.logs.enabled -}}
+  {{- $logs = append $logs "enabled" -}}
+  {{- if .Values.logs.cluster_events.enabled }}{{- $logs = append $logs "events" -}}{{- end -}}
+  {{- if .Values.logs.pod_logs.enabled }}{{- $logs = append $logs "pod_logs" -}}{{- end -}}
+{{- else -}}
+  {{- $logs = append $logs "disabled" -}}
+{{- end -}}
+{{- join "," $logs -}}
+{{- end }}
+
+{{- define "kubernetes_monitoring_telemetry.traces" -}}
+{{- if .Values.traces.enabled }}enabled{{- else -}}disabled{{- end -}}
+{{- end }}
+
+{{- define "kubernetes_monitoring_telemetry.deployments" -}}
+{{- $deployments := list -}}
+{{- if index (index .Values "kube-state-metrics").enabled -}}{{- $deployments = append $deployments "kube-state-metrics" -}}{{- end -}}
+{{- if index (index .Values "prometheus-node-exporter").enabled -}}{{- $deployments = append $deployments "prometheus-node-exporter" -}}{{- end -}}
+{{- if index (index .Values "prometheus-windows-exporter").enabled -}}{{- $deployments = append $deployments "prometheus-windows-exporter" -}}{{- end -}}
+{{- if index (index .Values "prometheus-operator-crds").enabled -}}{{- $deployments = append $deployments "prometheus-operator-crds" -}}{{- end -}}
+{{- if index (index .Values "opencost").enabled -}}{{- $deployments = append $deployments "opencost" -}}{{- end -}}
+{{- join "," $deployments -}}
+{{- end }}

--- a/charts/k8s-monitoring/templates/agent_config/_kubernetes_monitoring_telemetry.river.txt
+++ b/charts/k8s-monitoring/templates/agent_config/_kubernetes_monitoring_telemetry.river.txt
@@ -1,0 +1,28 @@
+{{ define "agent.config.kubernetes_monitoring_telemetry" }}
+// Kubernetes Monitoring Telemetry
+prometheus.exporter.unix {
+  set_collectors = ["textfile"]
+  textfile {
+    directory = "/etc/kubernetes-monitoring-telemetry"
+  }
+}
+
+prometheus.scrape "kubernetes_monitoring_telemetry" {
+  job_name   = "integrations/kubernetes/kubernetes_monitoring_telemetry"
+  targets    = prometheus.exporter.unix.targets
+  scrape_interval = {{ .Values.metrics.scrapeInterval | quote }}
+{{- if (index .Values "grafana-agent").agent.clustering.enabled }}
+  clustering {
+    enabled = true
+  }
+{{- end }}
+  forward_to = [prometheus.relabel.kubernetes_monitoring_telemetry.receiver]
+}
+
+prometheus.relabel "kubernetes_monitoring_telemetry" {
+{{- if .Values.metrics.extraMetricRelabelingRules }}
+{{ .Values.metrics.extraMetricRelabelingRules | indent 2 }}
+{{- end }}
+  forward_to = [prometheus.remote_write.grafana_cloud_prometheus.receiver]
+}
+{{ end }}

--- a/charts/k8s-monitoring/templates/kubernetes-monitoring-telemetry.yaml
+++ b/charts/k8s-monitoring/templates/kubernetes-monitoring-telemetry.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kubernetes-monitoring-telemetry
+  namespace: {{ .Release.Namespace }}
+data:
+  metrics.prom: |
+    # HELP grafana_kubernetes_monitoring_build_info A metric to report the version of the Kubernetes Monitoring Helm chart as well as a summary of enabled features
+    # TYPE grafana_kubernetes_monitoring_build_info gauge
+    grafana_kubernetes_monitoring_build_info{version="{{ .Chart.Version }}", metrics="{{ include "kubernetes_monitoring_telemetry.metrics" . }}", logs="{{ include "kubernetes_monitoring_telemetry.logs" . }}", traces="{{ include "kubernetes_monitoring_telemetry.traces" . }}", deployments="{{ include "kubernetes_monitoring_telemetry.deployments" . }}"} 1

--- a/charts/k8s-monitoring/values.yaml
+++ b/charts/k8s-monitoring/values.yaml
@@ -406,6 +406,10 @@ metrics:
     # -- Which namespaces to look for ServiceMonitor objects.
     namespaces: []
 
+  kubernetesMonitoring:
+    # -- Report telemetry about this Kubernetes Monitoring chart as a metric.
+    enabled: true
+
 # Settings related to capturing and forwarding logs
 logs:
   # -- Capture and forward logs
@@ -584,6 +588,8 @@ grafana-agent:
       extra:
       - name: grafana-agent-credentials
         mountPath: /etc/grafana-agent-credentials
+      - name: kubernetes-monitoring-telemetry
+        mountPath: /etc/kubernetes-monitoring-telemetry
 
   controller:
     type: statefulset
@@ -597,6 +603,9 @@ grafana-agent:
       - name: grafana-agent-credentials
         secret:
           secretName: grafana-agent-credentials
+      - name: kubernetes-monitoring-telemetry
+        configMap:
+          name: kubernetes-monitoring-telemetry
 
 # Settings for the Grafana Agent deployment
 # You can use this sections to make modifications to the Grafana Agent deployment.

--- a/examples/custom-allow-lists/metrics.river
+++ b/examples/custom-allow-lists/metrics.river
@@ -61,6 +61,28 @@ prometheus.relabel "agent" {
   forward_to = [prometheus.remote_write.grafana_cloud_prometheus.receiver]
 }
 
+// Kubernetes Monitoring Telemetry
+prometheus.exporter.unix {
+  set_collectors = ["textfile"]
+  textfile {
+    directory = "/etc/kubernetes-monitoring-telemetry"
+  }
+}
+
+prometheus.scrape "kubernetes_monitoring_telemetry" {
+  job_name   = "integrations/kubernetes/kubernetes_monitoring_telemetry"
+  targets    = prometheus.exporter.unix.targets
+  scrape_interval = "60s"
+  clustering {
+    enabled = true
+  }
+  forward_to = [prometheus.relabel.kubernetes_monitoring_telemetry.receiver]
+}
+
+prometheus.relabel "kubernetes_monitoring_telemetry" {
+  forward_to = [prometheus.remote_write.grafana_cloud_prometheus.receiver]
+}
+
 // Kubelet
 discovery.relabel "kubelet" {
   targets = discovery.kubernetes.nodes.targets

--- a/examples/custom-allow-lists/output.yaml
+++ b/examples/custom-allow-lists/output.yaml
@@ -139,6 +139,28 @@ data:
       forward_to = [prometheus.remote_write.grafana_cloud_prometheus.receiver]
     }
     
+    // Kubernetes Monitoring Telemetry
+    prometheus.exporter.unix {
+      set_collectors = ["textfile"]
+      textfile {
+        directory = "/etc/kubernetes-monitoring-telemetry"
+      }
+    }
+    
+    prometheus.scrape "kubernetes_monitoring_telemetry" {
+      job_name   = "integrations/kubernetes/kubernetes_monitoring_telemetry"
+      targets    = prometheus.exporter.unix.targets
+      scrape_interval = "60s"
+      clustering {
+        enabled = true
+      }
+      forward_to = [prometheus.relabel.kubernetes_monitoring_telemetry.receiver]
+    }
+    
+    prometheus.relabel "kubernetes_monitoring_telemetry" {
+      forward_to = [prometheus.remote_write.grafana_cloud_prometheus.receiver]
+    }
+    
     // Kubelet
     discovery.relabel "kubelet" {
       targets = discovery.kubernetes.nodes.targets
@@ -395,6 +417,18 @@ data:
         cluster = "custom-allow-lists-test",
       }
     }
+---
+# Source: k8s-monitoring/templates/kubernetes-monitoring-telemetry.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kubernetes-monitoring-telemetry
+  namespace: default
+data:
+  metrics.prom: |
+    # HELP grafana_kubernetes_monitoring_build_info A metric to report the version of the Kubernetes Monitoring Helm chart as well as a summary of enabled features
+    # TYPE grafana_kubernetes_monitoring_build_info gauge
+    grafana_kubernetes_monitoring_build_info{version="0.2.6", metrics="enabled,agent,kube-state-metrics,node-exporter,kubelet,cadvisor,cost", logs="enabled", traces="disabled", deployments="kube-state-metrics,prometheus-node-exporter,prometheus-operator-crds,opencost"} 1
 ---
 # Source: k8s-monitoring/charts/prometheus-operator-crds/charts/crds/templates/crd-alertmanagerconfigs.yaml
 apiVersion: apiextensions.k8s.io/v1
@@ -42441,6 +42475,9 @@ spec:
             -
               mountPath: /etc/grafana-agent-credentials
               name: grafana-agent-credentials
+            -
+              mountPath: /etc/kubernetes-monitoring-telemetry
+              name: kubernetes-monitoring-telemetry
         - name: config-reloader
           image: docker.io/jimmidyson/configmap-reload:v0.8.0
           args:
@@ -42463,6 +42500,9 @@ spec:
         - name: grafana-agent-credentials
           secret:
             secretName: grafana-agent-credentials
+        - configMap:
+            name: kubernetes-monitoring-telemetry
+          name: kubernetes-monitoring-telemetry
 ---
 # Source: k8s-monitoring/charts/prometheus-operator-crds/charts/crds/templates/crd-alertmanagerconfigs.yaml
 # https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.68.0/example/prometheus-operator-crd/monitoring.coreos.com_alertmanagerconfigs.yaml

--- a/examples/custom-config/metrics.river
+++ b/examples/custom-config/metrics.river
@@ -61,6 +61,28 @@ prometheus.relabel "agent" {
   forward_to = [prometheus.remote_write.grafana_cloud_prometheus.receiver]
 }
 
+// Kubernetes Monitoring Telemetry
+prometheus.exporter.unix {
+  set_collectors = ["textfile"]
+  textfile {
+    directory = "/etc/kubernetes-monitoring-telemetry"
+  }
+}
+
+prometheus.scrape "kubernetes_monitoring_telemetry" {
+  job_name   = "integrations/kubernetes/kubernetes_monitoring_telemetry"
+  targets    = prometheus.exporter.unix.targets
+  scrape_interval = "60s"
+  clustering {
+    enabled = true
+  }
+  forward_to = [prometheus.relabel.kubernetes_monitoring_telemetry.receiver]
+}
+
+prometheus.relabel "kubernetes_monitoring_telemetry" {
+  forward_to = [prometheus.remote_write.grafana_cloud_prometheus.receiver]
+}
+
 // Kubelet
 discovery.relabel "kubelet" {
   targets = discovery.kubernetes.nodes.targets

--- a/examples/custom-config/output.yaml
+++ b/examples/custom-config/output.yaml
@@ -154,6 +154,28 @@ data:
       forward_to = [prometheus.remote_write.grafana_cloud_prometheus.receiver]
     }
     
+    // Kubernetes Monitoring Telemetry
+    prometheus.exporter.unix {
+      set_collectors = ["textfile"]
+      textfile {
+        directory = "/etc/kubernetes-monitoring-telemetry"
+      }
+    }
+    
+    prometheus.scrape "kubernetes_monitoring_telemetry" {
+      job_name   = "integrations/kubernetes/kubernetes_monitoring_telemetry"
+      targets    = prometheus.exporter.unix.targets
+      scrape_interval = "60s"
+      clustering {
+        enabled = true
+      }
+      forward_to = [prometheus.relabel.kubernetes_monitoring_telemetry.receiver]
+    }
+    
+    prometheus.relabel "kubernetes_monitoring_telemetry" {
+      forward_to = [prometheus.remote_write.grafana_cloud_prometheus.receiver]
+    }
+    
     // Kubelet
     discovery.relabel "kubelet" {
       targets = discovery.kubernetes.nodes.targets
@@ -644,6 +666,18 @@ data:
       }
       forward_to = [loki.write.grafana_cloud_loki.receiver]
     }
+---
+# Source: k8s-monitoring/templates/kubernetes-monitoring-telemetry.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kubernetes-monitoring-telemetry
+  namespace: default
+data:
+  metrics.prom: |
+    # HELP grafana_kubernetes_monitoring_build_info A metric to report the version of the Kubernetes Monitoring Helm chart as well as a summary of enabled features
+    # TYPE grafana_kubernetes_monitoring_build_info gauge
+    grafana_kubernetes_monitoring_build_info{version="0.2.6", metrics="enabled,agent,kube-state-metrics,node-exporter,kubelet,cadvisor,cost", logs="enabled,events,pod_logs", traces="disabled", deployments="kube-state-metrics,prometheus-node-exporter,prometheus-operator-crds,opencost"} 1
 ---
 # Source: k8s-monitoring/charts/prometheus-operator-crds/charts/crds/templates/crd-alertmanagerconfigs.yaml
 apiVersion: apiextensions.k8s.io/v1
@@ -42906,6 +42940,9 @@ spec:
             -
               mountPath: /etc/grafana-agent-credentials
               name: grafana-agent-credentials
+            -
+              mountPath: /etc/kubernetes-monitoring-telemetry
+              name: kubernetes-monitoring-telemetry
         - name: config-reloader
           image: docker.io/jimmidyson/configmap-reload:v0.8.0
           args:
@@ -42928,6 +42965,9 @@ spec:
         - name: grafana-agent-credentials
           secret:
             secretName: grafana-agent-credentials
+        - configMap:
+            name: kubernetes-monitoring-telemetry
+          name: kubernetes-monitoring-telemetry
 ---
 # Source: k8s-monitoring/charts/prometheus-operator-crds/charts/crds/templates/crd-alertmanagerconfigs.yaml
 # https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.68.0/example/prometheus-operator-crd/monitoring.coreos.com_alertmanagerconfigs.yaml

--- a/examples/default-values/metrics.river
+++ b/examples/default-values/metrics.river
@@ -61,6 +61,28 @@ prometheus.relabel "agent" {
   forward_to = [prometheus.remote_write.grafana_cloud_prometheus.receiver]
 }
 
+// Kubernetes Monitoring Telemetry
+prometheus.exporter.unix {
+  set_collectors = ["textfile"]
+  textfile {
+    directory = "/etc/kubernetes-monitoring-telemetry"
+  }
+}
+
+prometheus.scrape "kubernetes_monitoring_telemetry" {
+  job_name   = "integrations/kubernetes/kubernetes_monitoring_telemetry"
+  targets    = prometheus.exporter.unix.targets
+  scrape_interval = "60s"
+  clustering {
+    enabled = true
+  }
+  forward_to = [prometheus.relabel.kubernetes_monitoring_telemetry.receiver]
+}
+
+prometheus.relabel "kubernetes_monitoring_telemetry" {
+  forward_to = [prometheus.remote_write.grafana_cloud_prometheus.receiver]
+}
+
 // Kubelet
 discovery.relabel "kubelet" {
   targets = discovery.kubernetes.nodes.targets

--- a/examples/default-values/output.yaml
+++ b/examples/default-values/output.yaml
@@ -154,6 +154,28 @@ data:
       forward_to = [prometheus.remote_write.grafana_cloud_prometheus.receiver]
     }
     
+    // Kubernetes Monitoring Telemetry
+    prometheus.exporter.unix {
+      set_collectors = ["textfile"]
+      textfile {
+        directory = "/etc/kubernetes-monitoring-telemetry"
+      }
+    }
+    
+    prometheus.scrape "kubernetes_monitoring_telemetry" {
+      job_name   = "integrations/kubernetes/kubernetes_monitoring_telemetry"
+      targets    = prometheus.exporter.unix.targets
+      scrape_interval = "60s"
+      clustering {
+        enabled = true
+      }
+      forward_to = [prometheus.relabel.kubernetes_monitoring_telemetry.receiver]
+    }
+    
+    prometheus.relabel "kubernetes_monitoring_telemetry" {
+      forward_to = [prometheus.remote_write.grafana_cloud_prometheus.receiver]
+    }
+    
     // Kubelet
     discovery.relabel "kubelet" {
       targets = discovery.kubernetes.nodes.targets
@@ -583,6 +605,18 @@ data:
         cluster = "default-values-test",
       }
     }
+---
+# Source: k8s-monitoring/templates/kubernetes-monitoring-telemetry.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kubernetes-monitoring-telemetry
+  namespace: default
+data:
+  metrics.prom: |
+    # HELP grafana_kubernetes_monitoring_build_info A metric to report the version of the Kubernetes Monitoring Helm chart as well as a summary of enabled features
+    # TYPE grafana_kubernetes_monitoring_build_info gauge
+    grafana_kubernetes_monitoring_build_info{version="0.2.6", metrics="enabled,agent,kube-state-metrics,node-exporter,kubelet,cadvisor,cost", logs="enabled,events,pod_logs", traces="disabled", deployments="kube-state-metrics,prometheus-node-exporter,prometheus-operator-crds,opencost"} 1
 ---
 # Source: k8s-monitoring/charts/prometheus-operator-crds/charts/crds/templates/crd-alertmanagerconfigs.yaml
 apiVersion: apiextensions.k8s.io/v1
@@ -42845,6 +42879,9 @@ spec:
             -
               mountPath: /etc/grafana-agent-credentials
               name: grafana-agent-credentials
+            -
+              mountPath: /etc/kubernetes-monitoring-telemetry
+              name: kubernetes-monitoring-telemetry
         - name: config-reloader
           image: docker.io/jimmidyson/configmap-reload:v0.8.0
           args:
@@ -42867,6 +42904,9 @@ spec:
         - name: grafana-agent-credentials
           secret:
             secretName: grafana-agent-credentials
+        - configMap:
+            name: kubernetes-monitoring-telemetry
+          name: kubernetes-monitoring-telemetry
 ---
 # Source: k8s-monitoring/charts/prometheus-operator-crds/charts/crds/templates/crd-alertmanagerconfigs.yaml
 # https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.68.0/example/prometheus-operator-crd/monitoring.coreos.com_alertmanagerconfigs.yaml

--- a/examples/extra-rules/metrics.river
+++ b/examples/extra-rules/metrics.river
@@ -66,6 +66,28 @@ prometheus.relabel "agent" {
   forward_to = [prometheus.remote_write.grafana_cloud_prometheus.receiver]
 }
 
+// Kubernetes Monitoring Telemetry
+prometheus.exporter.unix {
+  set_collectors = ["textfile"]
+  textfile {
+    directory = "/etc/kubernetes-monitoring-telemetry"
+  }
+}
+
+prometheus.scrape "kubernetes_monitoring_telemetry" {
+  job_name   = "integrations/kubernetes/kubernetes_monitoring_telemetry"
+  targets    = prometheus.exporter.unix.targets
+  scrape_interval = "60s"
+  clustering {
+    enabled = true
+  }
+  forward_to = [prometheus.relabel.kubernetes_monitoring_telemetry.receiver]
+}
+
+prometheus.relabel "kubernetes_monitoring_telemetry" {
+  forward_to = [prometheus.remote_write.grafana_cloud_prometheus.receiver]
+}
+
 // Kubelet
 discovery.relabel "kubelet" {
   targets = discovery.kubernetes.nodes.targets

--- a/examples/extra-rules/output.yaml
+++ b/examples/extra-rules/output.yaml
@@ -160,6 +160,28 @@ data:
       forward_to = [prometheus.remote_write.grafana_cloud_prometheus.receiver]
     }
     
+    // Kubernetes Monitoring Telemetry
+    prometheus.exporter.unix {
+      set_collectors = ["textfile"]
+      textfile {
+        directory = "/etc/kubernetes-monitoring-telemetry"
+      }
+    }
+    
+    prometheus.scrape "kubernetes_monitoring_telemetry" {
+      job_name   = "integrations/kubernetes/kubernetes_monitoring_telemetry"
+      targets    = prometheus.exporter.unix.targets
+      scrape_interval = "60s"
+      clustering {
+        enabled = true
+      }
+      forward_to = [prometheus.relabel.kubernetes_monitoring_telemetry.receiver]
+    }
+    
+    prometheus.relabel "kubernetes_monitoring_telemetry" {
+      forward_to = [prometheus.remote_write.grafana_cloud_prometheus.receiver]
+    }
+    
     // Kubelet
     discovery.relabel "kubelet" {
       targets = discovery.kubernetes.nodes.targets
@@ -662,6 +684,18 @@ data:
         cluster = "extra-rules-test",
       }
     }
+---
+# Source: k8s-monitoring/templates/kubernetes-monitoring-telemetry.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kubernetes-monitoring-telemetry
+  namespace: default
+data:
+  metrics.prom: |
+    # HELP grafana_kubernetes_monitoring_build_info A metric to report the version of the Kubernetes Monitoring Helm chart as well as a summary of enabled features
+    # TYPE grafana_kubernetes_monitoring_build_info gauge
+    grafana_kubernetes_monitoring_build_info{version="0.2.6", metrics="enabled,agent,kube-state-metrics,node-exporter,kubelet,cadvisor,cost", logs="enabled,events,pod_logs", traces="disabled", deployments="kube-state-metrics,prometheus-node-exporter,prometheus-operator-crds,opencost"} 1
 ---
 # Source: k8s-monitoring/charts/prometheus-operator-crds/charts/crds/templates/crd-alertmanagerconfigs.yaml
 apiVersion: apiextensions.k8s.io/v1
@@ -42924,6 +42958,9 @@ spec:
             -
               mountPath: /etc/grafana-agent-credentials
               name: grafana-agent-credentials
+            -
+              mountPath: /etc/kubernetes-monitoring-telemetry
+              name: kubernetes-monitoring-telemetry
         - name: config-reloader
           image: docker.io/jimmidyson/configmap-reload:v0.8.0
           args:
@@ -42946,6 +42983,9 @@ spec:
         - name: grafana-agent-credentials
           secret:
             secretName: grafana-agent-credentials
+        - configMap:
+            name: kubernetes-monitoring-telemetry
+          name: kubernetes-monitoring-telemetry
 ---
 # Source: k8s-monitoring/charts/prometheus-operator-crds/charts/crds/templates/crd-alertmanagerconfigs.yaml
 # https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.68.0/example/prometheus-operator-crd/monitoring.coreos.com_alertmanagerconfigs.yaml

--- a/examples/logs-only/output.yaml
+++ b/examples/logs-only/output.yaml
@@ -232,6 +232,18 @@ data:
       }
     }
 ---
+# Source: k8s-monitoring/templates/kubernetes-monitoring-telemetry.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kubernetes-monitoring-telemetry
+  namespace: default
+data:
+  metrics.prom: |
+    # HELP grafana_kubernetes_monitoring_build_info A metric to report the version of the Kubernetes Monitoring Helm chart as well as a summary of enabled features
+    # TYPE grafana_kubernetes_monitoring_build_info gauge
+    grafana_kubernetes_monitoring_build_info{version="0.2.6", metrics="disabled", logs="enabled,events,pod_logs", traces="disabled", deployments=""} 1
+---
 # Source: k8s-monitoring/charts/grafana-agent-logs/templates/rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -660,6 +672,9 @@ spec:
             -
               mountPath: /etc/grafana-agent-credentials
               name: grafana-agent-credentials
+            -
+              mountPath: /etc/kubernetes-monitoring-telemetry
+              name: kubernetes-monitoring-telemetry
         - name: config-reloader
           image: docker.io/jimmidyson/configmap-reload:v0.8.0
           args:
@@ -682,3 +697,6 @@ spec:
         - name: grafana-agent-credentials
           secret:
             secretName: grafana-agent-credentials
+        - configMap:
+            name: kubernetes-monitoring-telemetry
+          name: kubernetes-monitoring-telemetry

--- a/examples/metrics-only/metrics.river
+++ b/examples/metrics-only/metrics.river
@@ -61,6 +61,28 @@ prometheus.relabel "agent" {
   forward_to = [prometheus.remote_write.grafana_cloud_prometheus.receiver]
 }
 
+// Kubernetes Monitoring Telemetry
+prometheus.exporter.unix {
+  set_collectors = ["textfile"]
+  textfile {
+    directory = "/etc/kubernetes-monitoring-telemetry"
+  }
+}
+
+prometheus.scrape "kubernetes_monitoring_telemetry" {
+  job_name   = "integrations/kubernetes/kubernetes_monitoring_telemetry"
+  targets    = prometheus.exporter.unix.targets
+  scrape_interval = "60s"
+  clustering {
+    enabled = true
+  }
+  forward_to = [prometheus.relabel.kubernetes_monitoring_telemetry.receiver]
+}
+
+prometheus.relabel "kubernetes_monitoring_telemetry" {
+  forward_to = [prometheus.remote_write.grafana_cloud_prometheus.receiver]
+}
+
 // Kubelet
 discovery.relabel "kubelet" {
   targets = discovery.kubernetes.nodes.targets

--- a/examples/metrics-only/output.yaml
+++ b/examples/metrics-only/output.yaml
@@ -140,6 +140,28 @@ data:
       forward_to = [prometheus.remote_write.grafana_cloud_prometheus.receiver]
     }
     
+    // Kubernetes Monitoring Telemetry
+    prometheus.exporter.unix {
+      set_collectors = ["textfile"]
+      textfile {
+        directory = "/etc/kubernetes-monitoring-telemetry"
+      }
+    }
+    
+    prometheus.scrape "kubernetes_monitoring_telemetry" {
+      job_name   = "integrations/kubernetes/kubernetes_monitoring_telemetry"
+      targets    = prometheus.exporter.unix.targets
+      scrape_interval = "60s"
+      clustering {
+        enabled = true
+      }
+      forward_to = [prometheus.relabel.kubernetes_monitoring_telemetry.receiver]
+    }
+    
+    prometheus.relabel "kubernetes_monitoring_telemetry" {
+      forward_to = [prometheus.remote_write.grafana_cloud_prometheus.receiver]
+    }
+    
     // Kubelet
     discovery.relabel "kubelet" {
       targets = discovery.kubernetes.nodes.targets
@@ -405,6 +427,18 @@ data:
         cluster = "metrics-only-test",
       }
     }
+---
+# Source: k8s-monitoring/templates/kubernetes-monitoring-telemetry.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kubernetes-monitoring-telemetry
+  namespace: default
+data:
+  metrics.prom: |
+    # HELP grafana_kubernetes_monitoring_build_info A metric to report the version of the Kubernetes Monitoring Helm chart as well as a summary of enabled features
+    # TYPE grafana_kubernetes_monitoring_build_info gauge
+    grafana_kubernetes_monitoring_build_info{version="0.2.6", metrics="enabled,agent,kube-state-metrics,node-exporter,kubelet,cadvisor,cost", logs="enabled", traces="disabled", deployments="kube-state-metrics,prometheus-node-exporter,prometheus-operator-crds,opencost"} 1
 ---
 # Source: k8s-monitoring/charts/prometheus-operator-crds/charts/crds/templates/crd-alertmanagerconfigs.yaml
 apiVersion: apiextensions.k8s.io/v1
@@ -42451,6 +42485,9 @@ spec:
             -
               mountPath: /etc/grafana-agent-credentials
               name: grafana-agent-credentials
+            -
+              mountPath: /etc/kubernetes-monitoring-telemetry
+              name: kubernetes-monitoring-telemetry
         - name: config-reloader
           image: docker.io/jimmidyson/configmap-reload:v0.8.0
           args:
@@ -42473,6 +42510,9 @@ spec:
         - name: grafana-agent-credentials
           secret:
             secretName: grafana-agent-credentials
+        - configMap:
+            name: kubernetes-monitoring-telemetry
+          name: kubernetes-monitoring-telemetry
 ---
 # Source: k8s-monitoring/charts/prometheus-operator-crds/charts/crds/templates/crd-alertmanagerconfigs.yaml
 # https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.68.0/example/prometheus-operator-crd/monitoring.coreos.com_alertmanagerconfigs.yaml

--- a/examples/openshift-compatible/metrics.river
+++ b/examples/openshift-compatible/metrics.river
@@ -61,6 +61,28 @@ prometheus.relabel "agent" {
   forward_to = [prometheus.remote_write.grafana_cloud_prometheus.receiver]
 }
 
+// Kubernetes Monitoring Telemetry
+prometheus.exporter.unix {
+  set_collectors = ["textfile"]
+  textfile {
+    directory = "/etc/kubernetes-monitoring-telemetry"
+  }
+}
+
+prometheus.scrape "kubernetes_monitoring_telemetry" {
+  job_name   = "integrations/kubernetes/kubernetes_monitoring_telemetry"
+  targets    = prometheus.exporter.unix.targets
+  scrape_interval = "60s"
+  clustering {
+    enabled = true
+  }
+  forward_to = [prometheus.relabel.kubernetes_monitoring_telemetry.receiver]
+}
+
+prometheus.relabel "kubernetes_monitoring_telemetry" {
+  forward_to = [prometheus.remote_write.grafana_cloud_prometheus.receiver]
+}
+
 // Kubelet
 discovery.relabel "kubelet" {
   targets = discovery.kubernetes.nodes.targets

--- a/examples/openshift-compatible/output.yaml
+++ b/examples/openshift-compatible/output.yaml
@@ -123,6 +123,28 @@ data:
       forward_to = [prometheus.remote_write.grafana_cloud_prometheus.receiver]
     }
     
+    // Kubernetes Monitoring Telemetry
+    prometheus.exporter.unix {
+      set_collectors = ["textfile"]
+      textfile {
+        directory = "/etc/kubernetes-monitoring-telemetry"
+      }
+    }
+    
+    prometheus.scrape "kubernetes_monitoring_telemetry" {
+      job_name   = "integrations/kubernetes/kubernetes_monitoring_telemetry"
+      targets    = prometheus.exporter.unix.targets
+      scrape_interval = "60s"
+      clustering {
+        enabled = true
+      }
+      forward_to = [prometheus.relabel.kubernetes_monitoring_telemetry.receiver]
+    }
+    
+    prometheus.relabel "kubernetes_monitoring_telemetry" {
+      forward_to = [prometheus.remote_write.grafana_cloud_prometheus.receiver]
+    }
+    
     // Kubelet
     discovery.relabel "kubelet" {
       targets = discovery.kubernetes.nodes.targets
@@ -556,6 +578,18 @@ data:
         cluster = "openshift-compatible-test",
       }
     }
+---
+# Source: k8s-monitoring/templates/kubernetes-monitoring-telemetry.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kubernetes-monitoring-telemetry
+  namespace: default
+data:
+  metrics.prom: |
+    # HELP grafana_kubernetes_monitoring_build_info A metric to report the version of the Kubernetes Monitoring Helm chart as well as a summary of enabled features
+    # TYPE grafana_kubernetes_monitoring_build_info gauge
+    grafana_kubernetes_monitoring_build_info{version="0.2.6", metrics="enabled,agent,kube-state-metrics,node-exporter,kubelet,cadvisor,cost", logs="enabled,events,pod_logs", traces="disabled", deployments="prometheus-operator-crds,opencost"} 1
 ---
 # Source: k8s-monitoring/charts/prometheus-operator-crds/charts/crds/templates/crd-alertmanagerconfigs.yaml
 apiVersion: apiextensions.k8s.io/v1
@@ -42399,6 +42433,9 @@ spec:
             -
               mountPath: /etc/grafana-agent-credentials
               name: grafana-agent-credentials
+            -
+              mountPath: /etc/kubernetes-monitoring-telemetry
+              name: kubernetes-monitoring-telemetry
         - name: config-reloader
           image: docker.io/jimmidyson/configmap-reload:v0.8.0
           args:
@@ -42421,6 +42458,9 @@ spec:
         - name: grafana-agent-credentials
           secret:
             secretName: grafana-agent-credentials
+        - configMap:
+            name: kubernetes-monitoring-telemetry
+          name: kubernetes-monitoring-telemetry
 ---
 # Source: k8s-monitoring/charts/prometheus-operator-crds/charts/crds/templates/crd-alertmanagerconfigs.yaml
 # https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.68.0/example/prometheus-operator-crd/monitoring.coreos.com_alertmanagerconfigs.yaml

--- a/examples/scrape-intervals/metrics.river
+++ b/examples/scrape-intervals/metrics.river
@@ -61,6 +61,28 @@ prometheus.relabel "agent" {
   forward_to = [prometheus.remote_write.grafana_cloud_prometheus.receiver]
 }
 
+// Kubernetes Monitoring Telemetry
+prometheus.exporter.unix {
+  set_collectors = ["textfile"]
+  textfile {
+    directory = "/etc/kubernetes-monitoring-telemetry"
+  }
+}
+
+prometheus.scrape "kubernetes_monitoring_telemetry" {
+  job_name   = "integrations/kubernetes/kubernetes_monitoring_telemetry"
+  targets    = prometheus.exporter.unix.targets
+  scrape_interval = "2m"
+  clustering {
+    enabled = true
+  }
+  forward_to = [prometheus.relabel.kubernetes_monitoring_telemetry.receiver]
+}
+
+prometheus.relabel "kubernetes_monitoring_telemetry" {
+  forward_to = [prometheus.remote_write.grafana_cloud_prometheus.receiver]
+}
+
 // Kubelet
 discovery.relabel "kubelet" {
   targets = discovery.kubernetes.nodes.targets

--- a/examples/scrape-intervals/output.yaml
+++ b/examples/scrape-intervals/output.yaml
@@ -139,6 +139,28 @@ data:
       forward_to = [prometheus.remote_write.grafana_cloud_prometheus.receiver]
     }
     
+    // Kubernetes Monitoring Telemetry
+    prometheus.exporter.unix {
+      set_collectors = ["textfile"]
+      textfile {
+        directory = "/etc/kubernetes-monitoring-telemetry"
+      }
+    }
+    
+    prometheus.scrape "kubernetes_monitoring_telemetry" {
+      job_name   = "integrations/kubernetes/kubernetes_monitoring_telemetry"
+      targets    = prometheus.exporter.unix.targets
+      scrape_interval = "2m"
+      clustering {
+        enabled = true
+      }
+      forward_to = [prometheus.relabel.kubernetes_monitoring_telemetry.receiver]
+    }
+    
+    prometheus.relabel "kubernetes_monitoring_telemetry" {
+      forward_to = [prometheus.remote_write.grafana_cloud_prometheus.receiver]
+    }
+    
     // Kubelet
     discovery.relabel "kubelet" {
       targets = discovery.kubernetes.nodes.targets
@@ -400,6 +422,18 @@ data:
         cluster = "custom-scrape-intervals-test",
       }
     }
+---
+# Source: k8s-monitoring/templates/kubernetes-monitoring-telemetry.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kubernetes-monitoring-telemetry
+  namespace: default
+data:
+  metrics.prom: |
+    # HELP grafana_kubernetes_monitoring_build_info A metric to report the version of the Kubernetes Monitoring Helm chart as well as a summary of enabled features
+    # TYPE grafana_kubernetes_monitoring_build_info gauge
+    grafana_kubernetes_monitoring_build_info{version="0.2.6", metrics="enabled,agent,kube-state-metrics,node-exporter,kubelet,cadvisor,cost", logs="enabled", traces="disabled", deployments="kube-state-metrics,prometheus-node-exporter,prometheus-operator-crds,opencost"} 1
 ---
 # Source: k8s-monitoring/charts/prometheus-operator-crds/charts/crds/templates/crd-alertmanagerconfigs.yaml
 apiVersion: apiextensions.k8s.io/v1
@@ -42446,6 +42480,9 @@ spec:
             -
               mountPath: /etc/grafana-agent-credentials
               name: grafana-agent-credentials
+            -
+              mountPath: /etc/kubernetes-monitoring-telemetry
+              name: kubernetes-monitoring-telemetry
         - name: config-reloader
           image: docker.io/jimmidyson/configmap-reload:v0.8.0
           args:
@@ -42468,6 +42505,9 @@ spec:
         - name: grafana-agent-credentials
           secret:
             secretName: grafana-agent-credentials
+        - configMap:
+            name: kubernetes-monitoring-telemetry
+          name: kubernetes-monitoring-telemetry
 ---
 # Source: k8s-monitoring/charts/prometheus-operator-crds/charts/crds/templates/crd-alertmanagerconfigs.yaml
 # https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.68.0/example/prometheus-operator-crd/monitoring.coreos.com_alertmanagerconfigs.yaml

--- a/examples/specific-namespace/metrics.river
+++ b/examples/specific-namespace/metrics.river
@@ -66,6 +66,33 @@ prometheus.relabel "agent" {
   forward_to = [prometheus.remote_write.grafana_cloud_prometheus.receiver]
 }
 
+// Kubernetes Monitoring Telemetry
+prometheus.exporter.unix {
+  set_collectors = ["textfile"]
+  textfile {
+    directory = "/etc/kubernetes-monitoring-telemetry"
+  }
+}
+
+prometheus.scrape "kubernetes_monitoring_telemetry" {
+  job_name   = "integrations/kubernetes/kubernetes_monitoring_telemetry"
+  targets    = prometheus.exporter.unix.targets
+  scrape_interval = "60s"
+  clustering {
+    enabled = true
+  }
+  forward_to = [prometheus.relabel.kubernetes_monitoring_telemetry.receiver]
+}
+
+prometheus.relabel "kubernetes_monitoring_telemetry" {
+  rule {
+      source_labels = ["namespace"]
+      regex = "^$|production|staging"
+      action = "keep"
+  }
+  forward_to = [prometheus.remote_write.grafana_cloud_prometheus.receiver]
+}
+
 // Kubelet
 discovery.relabel "kubelet" {
   targets = discovery.kubernetes.nodes.targets

--- a/examples/specific-namespace/output.yaml
+++ b/examples/specific-namespace/output.yaml
@@ -159,6 +159,33 @@ data:
       forward_to = [prometheus.remote_write.grafana_cloud_prometheus.receiver]
     }
     
+    // Kubernetes Monitoring Telemetry
+    prometheus.exporter.unix {
+      set_collectors = ["textfile"]
+      textfile {
+        directory = "/etc/kubernetes-monitoring-telemetry"
+      }
+    }
+    
+    prometheus.scrape "kubernetes_monitoring_telemetry" {
+      job_name   = "integrations/kubernetes/kubernetes_monitoring_telemetry"
+      targets    = prometheus.exporter.unix.targets
+      scrape_interval = "60s"
+      clustering {
+        enabled = true
+      }
+      forward_to = [prometheus.relabel.kubernetes_monitoring_telemetry.receiver]
+    }
+    
+    prometheus.relabel "kubernetes_monitoring_telemetry" {
+      rule {
+          source_labels = ["namespace"]
+          regex = "^$|production|staging"
+          action = "keep"
+      }
+      forward_to = [prometheus.remote_write.grafana_cloud_prometheus.receiver]
+    }
+    
     // Kubelet
     discovery.relabel "kubelet" {
       targets = discovery.kubernetes.nodes.targets
@@ -629,6 +656,18 @@ data:
         cluster = "specific-namespace-test",
       }
     }
+---
+# Source: k8s-monitoring/templates/kubernetes-monitoring-telemetry.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kubernetes-monitoring-telemetry
+  namespace: default
+data:
+  metrics.prom: |
+    # HELP grafana_kubernetes_monitoring_build_info A metric to report the version of the Kubernetes Monitoring Helm chart as well as a summary of enabled features
+    # TYPE grafana_kubernetes_monitoring_build_info gauge
+    grafana_kubernetes_monitoring_build_info{version="0.2.6", metrics="enabled,agent,kube-state-metrics,node-exporter,kubelet,cadvisor,cost", logs="enabled,events,pod_logs", traces="disabled", deployments="kube-state-metrics,prometheus-node-exporter,prometheus-operator-crds,opencost"} 1
 ---
 # Source: k8s-monitoring/charts/prometheus-operator-crds/charts/crds/templates/crd-alertmanagerconfigs.yaml
 apiVersion: apiextensions.k8s.io/v1
@@ -42891,6 +42930,9 @@ spec:
             -
               mountPath: /etc/grafana-agent-credentials
               name: grafana-agent-credentials
+            -
+              mountPath: /etc/kubernetes-monitoring-telemetry
+              name: kubernetes-monitoring-telemetry
         - name: config-reloader
           image: docker.io/jimmidyson/configmap-reload:v0.8.0
           args:
@@ -42913,6 +42955,9 @@ spec:
         - name: grafana-agent-credentials
           secret:
             secretName: grafana-agent-credentials
+        - configMap:
+            name: kubernetes-monitoring-telemetry
+          name: kubernetes-monitoring-telemetry
 ---
 # Source: k8s-monitoring/charts/prometheus-operator-crds/charts/crds/templates/crd-alertmanagerconfigs.yaml
 # https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.68.0/example/prometheus-operator-crd/monitoring.coreos.com_alertmanagerconfigs.yaml

--- a/examples/traces-enabled/metrics.river
+++ b/examples/traces-enabled/metrics.river
@@ -61,6 +61,28 @@ prometheus.relabel "agent" {
   forward_to = [prometheus.remote_write.grafana_cloud_prometheus.receiver]
 }
 
+// Kubernetes Monitoring Telemetry
+prometheus.exporter.unix {
+  set_collectors = ["textfile"]
+  textfile {
+    directory = "/etc/kubernetes-monitoring-telemetry"
+  }
+}
+
+prometheus.scrape "kubernetes_monitoring_telemetry" {
+  job_name   = "integrations/kubernetes/kubernetes_monitoring_telemetry"
+  targets    = prometheus.exporter.unix.targets
+  scrape_interval = "60s"
+  clustering {
+    enabled = true
+  }
+  forward_to = [prometheus.relabel.kubernetes_monitoring_telemetry.receiver]
+}
+
+prometheus.relabel "kubernetes_monitoring_telemetry" {
+  forward_to = [prometheus.remote_write.grafana_cloud_prometheus.receiver]
+}
+
 // Kubelet
 discovery.relabel "kubelet" {
   targets = discovery.kubernetes.nodes.targets

--- a/examples/traces-enabled/output.yaml
+++ b/examples/traces-enabled/output.yaml
@@ -157,6 +157,28 @@ data:
       forward_to = [prometheus.remote_write.grafana_cloud_prometheus.receiver]
     }
     
+    // Kubernetes Monitoring Telemetry
+    prometheus.exporter.unix {
+      set_collectors = ["textfile"]
+      textfile {
+        directory = "/etc/kubernetes-monitoring-telemetry"
+      }
+    }
+    
+    prometheus.scrape "kubernetes_monitoring_telemetry" {
+      job_name   = "integrations/kubernetes/kubernetes_monitoring_telemetry"
+      targets    = prometheus.exporter.unix.targets
+      scrape_interval = "60s"
+      clustering {
+        enabled = true
+      }
+      forward_to = [prometheus.relabel.kubernetes_monitoring_telemetry.receiver]
+    }
+    
+    prometheus.relabel "kubernetes_monitoring_telemetry" {
+      forward_to = [prometheus.remote_write.grafana_cloud_prometheus.receiver]
+    }
+    
     // Kubelet
     discovery.relabel "kubelet" {
       targets = discovery.kubernetes.nodes.targets
@@ -644,6 +666,18 @@ data:
         cluster = "traces-enabled-test",
       }
     }
+---
+# Source: k8s-monitoring/templates/kubernetes-monitoring-telemetry.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kubernetes-monitoring-telemetry
+  namespace: default
+data:
+  metrics.prom: |
+    # HELP grafana_kubernetes_monitoring_build_info A metric to report the version of the Kubernetes Monitoring Helm chart as well as a summary of enabled features
+    # TYPE grafana_kubernetes_monitoring_build_info gauge
+    grafana_kubernetes_monitoring_build_info{version="0.2.6", metrics="enabled,agent,kube-state-metrics,node-exporter,kubelet,cadvisor,cost", logs="enabled,events,pod_logs", traces="enabled", deployments="kube-state-metrics,prometheus-node-exporter,prometheus-operator-crds,opencost"} 1
 ---
 # Source: k8s-monitoring/charts/prometheus-operator-crds/charts/crds/templates/crd-alertmanagerconfigs.yaml
 apiVersion: apiextensions.k8s.io/v1
@@ -42928,6 +42962,9 @@ spec:
             -
               mountPath: /etc/grafana-agent-credentials
               name: grafana-agent-credentials
+            -
+              mountPath: /etc/kubernetes-monitoring-telemetry
+              name: kubernetes-monitoring-telemetry
         - name: config-reloader
           image: docker.io/jimmidyson/configmap-reload:v0.8.0
           args:
@@ -42950,6 +42987,9 @@ spec:
         - name: grafana-agent-credentials
           secret:
             secretName: grafana-agent-credentials
+        - configMap:
+            name: kubernetes-monitoring-telemetry
+          name: kubernetes-monitoring-telemetry
 ---
 # Source: k8s-monitoring/charts/prometheus-operator-crds/charts/crds/templates/crd-alertmanagerconfigs.yaml
 # https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.68.0/example/prometheus-operator-crd/monitoring.coreos.com_alertmanagerconfigs.yaml

--- a/examples/windows-exporter/metrics.river
+++ b/examples/windows-exporter/metrics.river
@@ -61,6 +61,28 @@ prometheus.relabel "agent" {
   forward_to = [prometheus.remote_write.grafana_cloud_prometheus.receiver]
 }
 
+// Kubernetes Monitoring Telemetry
+prometheus.exporter.unix {
+  set_collectors = ["textfile"]
+  textfile {
+    directory = "/etc/kubernetes-monitoring-telemetry"
+  }
+}
+
+prometheus.scrape "kubernetes_monitoring_telemetry" {
+  job_name   = "integrations/kubernetes/kubernetes_monitoring_telemetry"
+  targets    = prometheus.exporter.unix.targets
+  scrape_interval = "60s"
+  clustering {
+    enabled = true
+  }
+  forward_to = [prometheus.relabel.kubernetes_monitoring_telemetry.receiver]
+}
+
+prometheus.relabel "kubernetes_monitoring_telemetry" {
+  forward_to = [prometheus.remote_write.grafana_cloud_prometheus.receiver]
+}
+
 // Kubelet
 discovery.relabel "kubelet" {
   targets = discovery.kubernetes.nodes.targets

--- a/examples/windows-exporter/output.yaml
+++ b/examples/windows-exporter/output.yaml
@@ -191,6 +191,28 @@ data:
       forward_to = [prometheus.remote_write.grafana_cloud_prometheus.receiver]
     }
     
+    // Kubernetes Monitoring Telemetry
+    prometheus.exporter.unix {
+      set_collectors = ["textfile"]
+      textfile {
+        directory = "/etc/kubernetes-monitoring-telemetry"
+      }
+    }
+    
+    prometheus.scrape "kubernetes_monitoring_telemetry" {
+      job_name   = "integrations/kubernetes/kubernetes_monitoring_telemetry"
+      targets    = prometheus.exporter.unix.targets
+      scrape_interval = "60s"
+      clustering {
+        enabled = true
+      }
+      forward_to = [prometheus.relabel.kubernetes_monitoring_telemetry.receiver]
+    }
+    
+    prometheus.relabel "kubernetes_monitoring_telemetry" {
+      forward_to = [prometheus.remote_write.grafana_cloud_prometheus.receiver]
+    }
+    
     // Kubelet
     discovery.relabel "kubelet" {
       targets = discovery.kubernetes.nodes.targets
@@ -688,6 +710,18 @@ data:
         cluster = "default-values-test",
       }
     }
+---
+# Source: k8s-monitoring/templates/kubernetes-monitoring-telemetry.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kubernetes-monitoring-telemetry
+  namespace: default
+data:
+  metrics.prom: |
+    # HELP grafana_kubernetes_monitoring_build_info A metric to report the version of the Kubernetes Monitoring Helm chart as well as a summary of enabled features
+    # TYPE grafana_kubernetes_monitoring_build_info gauge
+    grafana_kubernetes_monitoring_build_info{version="0.2.6", metrics="enabled,agent,kube-state-metrics,node-exporter,windows-exporter,kubelet,cadvisor,cost", logs="enabled,events,pod_logs", traces="disabled", deployments="kube-state-metrics,prometheus-node-exporter,prometheus-windows-exporter,prometheus-operator-crds,opencost"} 1
 ---
 # Source: k8s-monitoring/charts/prometheus-operator-crds/charts/crds/templates/crd-alertmanagerconfigs.yaml
 apiVersion: apiextensions.k8s.io/v1
@@ -43076,6 +43110,9 @@ spec:
             -
               mountPath: /etc/grafana-agent-credentials
               name: grafana-agent-credentials
+            -
+              mountPath: /etc/kubernetes-monitoring-telemetry
+              name: kubernetes-monitoring-telemetry
         - name: config-reloader
           image: docker.io/jimmidyson/configmap-reload:v0.8.0
           args:
@@ -43098,6 +43135,9 @@ spec:
         - name: grafana-agent-credentials
           secret:
             secretName: grafana-agent-credentials
+        - configMap:
+            name: kubernetes-monitoring-telemetry
+          name: kubernetes-monitoring-telemetry
 ---
 # Source: k8s-monitoring/charts/prometheus-operator-crds/charts/crds/templates/crd-alertmanagerconfigs.yaml
 # https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.68.0/example/prometheus-operator-crd/monitoring.coreos.com_alertmanagerconfigs.yaml


### PR DESCRIPTION
This creates a config map with a static metric defined: `grafana_kubernetes_monitoring_build_info`.
That metric has five labels:
* `version` - the chart version
* `metrics` - If metrics are enabled, will list the metric sources that are also enabled: "agent", "kube-state-metrics", "node-exporter", "windows-exporter", "kubelet", "cadvisor", "cost"
* `logs` - If logs are enabled, will list "events" and/or "pod_logs"
* `traces` - "enabled" or "disabled" based on the state of `.Values.traces.enabled`
* `deployments` - The list of subcharts that are being deployed

The configmap is mounted to the agent pod, then scraped using `prometheus.exporter.unix`'s textfile scraper.

Fixes #143 