### PR TITLE
Remove version check

### DIFF
--- a/charts/k8s-monitoring/templates/_helpers.tpl
+++ b/charts/k8s-monitoring/templates/_helpers.tpl
@@ -1,12 +1,3 @@
-{{/* This function checks for the minimum Helm CLI version 3.7 */}}
-{{/*   The use of .Subcharts requires 3.7 */}}
-{{/*   The use of multi-line strings (in the fail below) requires 3.6 */}}
-{{- define "checkHelmVersion" -}}
-{{ if semverCompare "<3.7" .Capabilities.HelmVersion.Version }}
-{{ fail "Helm version 3.7 or later is required for this chart" }}
-{{- end }}
-{{- end }}
-
 {{/* This template checks that the port defined in .Values.traces.receiver.port is in the targetPort list on .grafana-agent */}}
 {{- define "checkforTracePort" -}}
   {{- $port := .port -}}

--- a/charts/k8s-monitoring/templates/grafana-agent-config.yaml
+++ b/charts/k8s-monitoring/templates/grafana-agent-config.yaml
@@ -1,4 +1,3 @@
-{{- include "checkHelmVersion" . -}}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/charts/k8s-monitoring/templates/grafana-agent-logs-config.yaml
+++ b/charts/k8s-monitoring/templates/grafana-agent-logs-config.yaml
@@ -1,4 +1,3 @@
-{{- include "checkHelmVersion" . -}}
 {{- if and .Values.logs.enabled .Values.logs.pod_logs.enabled }}
 apiVersion: v1
 kind: ConfigMap


### PR DESCRIPTION
The idea was to check that we're running a version of Helm after 3.7, but the .Capabilities.HelmVersion wasn't added until 3.9. Meaning this check will either:
* Always pass on versions 3.9 or later
* Will fail on versions 3.8 or earlier