### PR TITLE
Add check for the Prometheus Operator CRDs and print a friendly error message if they're already present

### DIFF
--- a/charts/k8s-monitoring/templates/crds/check-for-crds.yaml
+++ b/charts/k8s-monitoring/templates/crds/check-for-crds.yaml
@@ -1,0 +1,3 @@
+{{- if and (index .Values "prometheus-operator-crds").enabled (.Capabilities.APIVersions.Has "monitoring.coreos.com/v1/ServiceMonitor") -}}
+  {{ fail "This chart is attempting to deploy the Prometheus Operator CRDs, but they have already been installed on this cluster.\nPlease set: \nprometheus-operator-crds:\n  enabled: false\nand re-deploy" }}
+{{- end -}}


### PR DESCRIPTION
```
% helm ls -A                      
NAME            NAMESPACE       REVISION        UPDATED                                 STATUS          CHART                           APP VERSION
promcrds        default         1               2023-10-04 08:50:25.602548 -0500 CDT    deployed        prometheus-operator-crds-6.0.0  v0.68.0    
% helm install k8smon -n monitoring --create-namespace ~/src/grafana/k8s-monitoring-helm/charts/k8s-monitoring -f local-values.yaml
Error: INSTALLATION FAILED: execution error at (k8s-monitoring/templates/crds/check-for-crds.yaml:2:5): This chart is attempting to deploy the Prometheus Operator CRDs, but they have already been installed on this cluster.
Please set: 
prometheus-operator-crds:
  enabled: false
and re-deploy
% echo "prometheus-operator-crds:" >> local-values.yaml 
% echo "  enabled: false" >> local-values.yaml 
% helm install k8smon -n monitoring --create-namespace ~/src/grafana/k8s-monitoring-helm/charts/k8s-monitoring -f local-values.yaml
NAME: k8smon
LAST DEPLOYED: Wed Oct  4 09:14:59 2023
NAMESPACE: monitoring
STATUS: deployed
REVISION: 1
TEST SUITE: None
```