### PR TITLE
Add GKE Autopilot example, which just skips Node Exporter.

### DIFF
--- a/charts/k8s-monitoring/values.yaml
+++ b/charts/k8s-monitoring/values.yaml
@@ -620,11 +620,12 @@ grafana-agent-logs:
     configMap:
       create: false
 
-    # This chart creates the credentials for Prometheus and Loki. This section
-    # mounts those credentials into the Grafana Agent container.
     mounts:
+      # Loads /var/log as a hostPath volume to find and scrape pod logs
       varlog: true
-      dockercontainers: true
+
+      # The k8s-monitoring chart creates the credentials for Prometheus and Loki. This section
+      # mounts those credentials into the Grafana Agent container.
       extra:
         - name: grafana-agent-credentials
           mountPath: /etc/grafana-agent-credentials

--- a/examples/default-values/output.yaml
+++ b/examples/default-values/output.yaml
@@ -42728,9 +42728,6 @@ spec:
             - name: varlog
               mountPath: /var/log
               readOnly: true
-            - name: dockercontainers
-              mountPath: /var/lib/docker/containers
-              readOnly: true
             -
               mountPath: /etc/grafana-agent-credentials
               name: grafana-agent-credentials
@@ -42759,9 +42756,6 @@ spec:
         - name: varlog
           hostPath:
             path: /var/log
-        - name: dockercontainers
-          hostPath:
-            path: /var/lib/docker/containers
         - name: grafana-agent-credentials
           secret:
             secretName: grafana-agent-credentials

--- a/examples/extra-rules/output.yaml
+++ b/examples/extra-rules/output.yaml
@@ -42807,9 +42807,6 @@ spec:
             - name: varlog
               mountPath: /var/log
               readOnly: true
-            - name: dockercontainers
-              mountPath: /var/lib/docker/containers
-              readOnly: true
             -
               mountPath: /etc/grafana-agent-credentials
               name: grafana-agent-credentials
@@ -42838,9 +42835,6 @@ spec:
         - name: varlog
           hostPath:
             path: /var/log
-        - name: dockercontainers
-          hostPath:
-            path: /var/lib/docker/containers
         - name: grafana-agent-credentials
           secret:
             secretName: grafana-agent-credentials

--- a/examples/gke-autopilot/README.md
+++ b/examples/gke-autopilot/README.md
@@ -1,0 +1,31 @@
+# GKE Autopilot
+
+Kubernetes Clusters with fully managed control planes like [GKE Autopilot](https://cloud.google.com/kubernetes-engine/docs/concepts/autopilot-overview)
+need special consideration because they often have special restrictions around DaemonSets and node access. This prevents
+services like Node Exporter from working properly.
+
+This example shows how to disable Node Exporter. Obviously, you won't see node metrics, 
+
+```yaml
+cluster:
+  name: gke-autopilot-test
+
+externalServices:
+  prometheus:
+    host: https://prometheus.example.com
+    basicAuth:
+      username: 12345
+      password: "It's a secret to everyone"
+  loki:
+    host: https://loki.example.com
+    basicAuth:
+      username: 12345
+      password: "It's a secret to everyone"
+
+metrics:
+  node-exporter:
+    enabled: false
+
+prometheus-node-exporter:
+  enabled: false
+```

--- a/examples/gke-autopilot/logs.river
+++ b/examples/gke-autopilot/logs.river
@@ -1,0 +1,125 @@
+discovery.kubernetes "pods" {
+  role = "pod"
+}
+
+// Pod Logs
+discovery.relabel "pod_logs" {
+  targets = discovery.kubernetes.pods.targets
+
+  rule {
+    source_labels = ["__meta_kubernetes_namespace"]
+    action = "replace"
+    target_label = "namespace"
+  }
+  rule {
+    source_labels = ["__meta_kubernetes_pod_name"]
+    action = "replace"
+    target_label = "pod"
+  }
+  rule {
+    source_labels = ["__meta_kubernetes_pod_container_name"]
+    action = "replace"
+    target_label = "container"
+  }
+  rule {
+    source_labels = ["__meta_kubernetes_namespace", "__meta_kubernetes_pod_name"]
+    separator = "/"
+    action = "replace"
+    replacement = "$1"
+    target_label = "job"
+  }
+  rule {
+    source_labels = ["__meta_kubernetes_pod_node_name"]
+    action = "keep"
+    regex = env("HOSTNAME")
+  }
+  rule {
+    source_labels = ["__meta_kubernetes_pod_uid", "__meta_kubernetes_pod_container_name"]
+    separator = "/"
+    action = "replace"
+    replacement = "/var/log/pods/*$1/*.log"
+    target_label = "__path__"
+  }
+
+  // set the container runtime as a label
+  rule {
+    action = "replace"
+    source_labels = ["__meta_kubernetes_pod_container_id"]
+    regex = "^(\\w+):\\/\\/.+$"
+    replacement = "$1"
+    target_label = "tmp_container_runtime"
+  }
+}
+
+local.file_match "pod_logs" {
+  path_targets = discovery.relabel.pod_logs.output
+}
+
+loki.source.file "pod_logs" {
+  targets    = local.file_match.pod_logs.targets
+  forward_to = [loki.process.pod_logs.receiver]
+}
+
+loki.process "pod_logs" {
+  stage.match {
+    selector = "{tmp_container_runtime=\"containerd\"}"
+    // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
+    stage.cri {}
+
+    // Set the extract flags and stream values as labels
+    stage.labels {
+      values = {
+        flags  = "",
+        stream  = "",
+      }
+    }
+  }
+
+  // if the label tmp_container_runtime from above is docker parse using docker
+  stage.match {
+    selector = "{tmp_container_runtime=\"docker\"}"
+    // the docker processing stage extracts the following k/v pairs: log, stream, time
+    stage.docker {}
+
+    // Set the extract stream value as a label
+    stage.labels {
+      values = {
+        stream  = "",
+      }
+    }
+  }
+
+  // drop the temporary container runtime label as it is no longer needed
+  stage.label_drop {
+    values = ["tmp_container_runtime"]
+  }
+  forward_to = [loki.write.grafana_cloud_loki.receiver]
+}
+
+// Grafana Cloud Loki
+local.file "loki_host" {
+  filename  = "/etc/grafana-agent-credentials/loki_host"
+}
+
+local.file "loki_username" {
+  filename  = "/etc/grafana-agent-credentials/loki_username"
+}
+
+local.file "loki_password" {
+  filename  = "/etc/grafana-agent-credentials/loki_password"
+  is_secret = true
+}
+
+loki.write "grafana_cloud_loki" {
+  endpoint {
+    url = nonsensitive(local.file.loki_host.content) + "/loki/api/v1/push"
+
+    basic_auth {
+      username = local.file.loki_username.content
+      password = local.file.loki_password.content
+    }
+  }
+  external_labels = {
+    cluster = "gke-autopilot-test",
+  }
+}

--- a/examples/gke-autopilot/metrics.river
+++ b/examples/gke-autopilot/metrics.river
@@ -1,0 +1,356 @@
+discovery.kubernetes "nodes" {
+  role = "node"
+}
+
+discovery.kubernetes "pods" {
+  role = "pod"
+}
+
+discovery.kubernetes "services" {
+  role = "service"
+}
+
+// Grafana Agent
+discovery.relabel "agent" {
+  targets = discovery.kubernetes.pods.targets
+  rule {
+    source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_instance"]
+    regex = "k8smon"
+    action = "keep"
+  }
+  rule {
+    source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+    regex = "grafana-agent.*"
+    action = "keep"
+  }
+  rule {
+    source_labels = ["__meta_kubernetes_pod_container_port_name"]
+    regex = "http-metrics"
+    action = "keep"
+  }
+  rule {
+    source_labels = ["__meta_kubernetes_namespace"]
+    target_label  = "namespace"
+  }
+  rule {
+    source_labels = ["__meta_kubernetes_pod_name"]
+    target_label  = "pod"
+  }
+  rule {
+    source_labels = ["__meta_kubernetes_pod_container_name"]
+    target_label  = "container"
+  }
+}
+
+prometheus.scrape "agent" {
+  job_name = "integrations/agent"
+  targets = discovery.relabel.agent.output
+  scrape_interval = "60s"
+  forward_to = [prometheus.relabel.agent.receiver]
+  clustering {
+    enabled = true
+  }
+}
+
+prometheus.relabel "agent" {
+  rule {
+    source_labels = ["__name__"]
+    regex = "up|agent_build_info"
+    action = "keep"
+  }
+  forward_to = [prometheus.remote_write.grafana_cloud_prometheus.receiver]
+}
+
+// Kubernetes Monitoring Telemetry
+prometheus.exporter.unix "kubernetes_monitoring_telemetry" {
+  set_collectors = ["textfile"]
+  textfile {
+    directory = "/etc/kubernetes-monitoring-telemetry"
+  }
+}
+
+prometheus.scrape "kubernetes_monitoring_telemetry" {
+  job_name   = "integrations/kubernetes/kubernetes_monitoring_telemetry"
+  targets    = prometheus.exporter.unix.kubernetes_monitoring_telemetry.targets
+  scrape_interval = "60s"
+  clustering {
+    enabled = true
+  }
+  forward_to = [prometheus.relabel.kubernetes_monitoring_telemetry.receiver]
+}
+
+prometheus.relabel "kubernetes_monitoring_telemetry" {
+  rule {
+    target_label = "job"
+    action = "replace"
+    replacement = "integrations/kubernetes/kubernetes_monitoring_telemetry"
+  }
+  rule {
+    target_label = "instance"
+    action = "replace"
+    replacement = "k8smon"
+  }
+  rule {
+    source_labels = ["__name__"]
+    regex = "up|grafana_kubernetes_monitoring_.*"
+    action = "keep"
+  }
+  forward_to = [prometheus.remote_write.grafana_cloud_prometheus.receiver]
+}
+
+// Kubelet
+discovery.relabel "kubelet" {
+  targets = discovery.kubernetes.nodes.targets
+  rule {
+    target_label = "__address__"
+    replacement  = "kubernetes.default.svc.cluster.local:443"
+  }
+  rule {
+    source_labels = ["__meta_kubernetes_node_name"]
+    regex         = "(.+)"
+    replacement   = "/api/v1/nodes/${1}/proxy/metrics"
+    target_label  = "__metrics_path__"
+  }
+}
+
+prometheus.scrape "kubelet" {
+  job_name   = "integrations/kubernetes/kubelet"
+  targets  = discovery.relabel.kubelet.output
+  scheme   = "https"
+  scrape_interval = "60s"
+  bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+  tls_config {
+    insecure_skip_verify = true
+  }
+  clustering {
+    enabled = true
+  }
+  forward_to = [prometheus.relabel.kubelet.receiver]
+}
+
+prometheus.relabel "kubelet" {
+  rule {
+    source_labels = ["__name__"]
+    regex = "up|container_cpu_usage_seconds_total|kubelet_certificate_manager_client_expiration_renew_errors|kubelet_certificate_manager_client_ttl_seconds|kubelet_certificate_manager_server_ttl_seconds|kubelet_cgroup_manager_duration_seconds_bucket|kubelet_cgroup_manager_duration_seconds_count|kubelet_node_config_error|kubelet_node_name|kubelet_pleg_relist_duration_seconds_bucket|kubelet_pleg_relist_duration_seconds_count|kubelet_pleg_relist_interval_seconds_bucket|kubelet_pod_start_duration_seconds_bucket|kubelet_pod_start_duration_seconds_count|kubelet_pod_worker_duration_seconds_bucket|kubelet_pod_worker_duration_seconds_count|kubelet_running_container_count|kubelet_running_containers|kubelet_running_pod_count|kubelet_running_pods|kubelet_runtime_operations_errors_total|kubelet_runtime_operations_total|kubelet_server_expiration_renew_errors|kubelet_volume_stats_available_bytes|kubelet_volume_stats_capacity_bytes|kubelet_volume_stats_inodes|kubelet_volume_stats_inodes_used|kubernetes_build_info|namespace_workload_pod|rest_client_requests_total|storage_operation_duration_seconds_count|storage_operation_errors_total|volume_manager_total_volumes"
+    action = "keep"
+  }
+  forward_to = [prometheus.remote_write.grafana_cloud_prometheus.receiver]
+}
+
+// cAdvisor
+discovery.relabel "cadvisor" {
+  targets = discovery.kubernetes.nodes.targets
+  rule {
+    target_label = "__address__"
+    replacement  = "kubernetes.default.svc.cluster.local:443"
+  }
+  rule {
+    source_labels = ["__meta_kubernetes_node_name"]
+    regex         = "(.+)"
+    replacement   = "/api/v1/nodes/${1}/proxy/metrics/cadvisor"
+    target_label  = "__metrics_path__"
+  }
+}
+
+prometheus.scrape "cadvisor" {
+  job_name   = "integrations/kubernetes/cadvisor"
+  targets    = discovery.relabel.cadvisor.output
+  scheme     = "https"
+  scrape_interval = "60s"
+  bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+  tls_config {
+    insecure_skip_verify = true
+  }
+  clustering {
+    enabled = true
+  }
+  forward_to = [prometheus.relabel.cadvisor.receiver]
+}
+
+prometheus.relabel "cadvisor" {
+  rule {
+    source_labels = ["__name__"]
+    regex = "up|container_cpu_cfs_periods_total|container_cpu_cfs_throttled_periods_total|container_cpu_usage_seconds_total|container_fs_reads_bytes_total|container_fs_reads_total|container_fs_writes_bytes_total|container_fs_writes_total|container_memory_cache|container_memory_rss|container_memory_swap|container_memory_working_set_bytes|container_network_receive_bytes_total|container_network_receive_packets_dropped_total|container_network_receive_packets_total|container_network_transmit_bytes_total|container_network_transmit_packets_dropped_total|container_network_transmit_packets_total|machine_memory_bytes"
+    action = "keep"
+  }
+  forward_to = [prometheus.remote_write.grafana_cloud_prometheus.receiver]
+}
+
+// Kube State Metrics
+discovery.relabel "kube_state_metrics" {
+  targets = discovery.kubernetes.services.targets
+  rule {
+    source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_instance"]
+    regex = "k8smon"
+    action = "keep"
+  }
+  rule {
+    source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_name"]
+    regex = "kube-state-metrics"
+    action = "keep"
+  }
+  rule {
+    source_labels = ["__meta_kubernetes_service_port_name"]
+    regex = "http"
+    action = "keep"
+  }
+}
+
+prometheus.scrape "kube_state_metrics" {
+  job_name   = "integrations/kubernetes/kube-state-metrics"
+  targets    = discovery.relabel.kube_state_metrics.output
+  scrape_interval = "60s"
+  clustering {
+    enabled = true
+  }
+  forward_to = [prometheus.relabel.kube_state_metrics.receiver]
+}
+
+prometheus.relabel "kube_state_metrics" {
+  rule {
+    source_labels = ["__name__"]
+    regex = "up|kube_daemonset.*|kube_deployment_metadata_generation|kube_deployment_spec_replicas|kube_deployment_status_observed_generation|kube_deployment_status_replicas_available|kube_deployment_status_replicas_updated|kube_horizontalpodautoscaler_spec_max_replicas|kube_horizontalpodautoscaler_spec_min_replicas|kube_horizontalpodautoscaler_status_current_replicas|kube_horizontalpodautoscaler_status_desired_replicas|kube_job.*|kube_namespace_status_phase|kube_namespace_status_phase|kube_node.*|kube_persistentvolumeclaim_resource_requests_storage_bytes|kube_pod_container_info|kube_pod_container_resource_limits|kube_pod_container_resource_requests|kube_pod_container_status_restarts_total|kube_pod_container_status_waiting_reason|kube_pod_container_status_waiting_reason|kube_pod_info|kube_pod_owner|kube_pod_start_time|kube_pod_status_phase|kube_pod_status_phase|kube_pod_status_reason|kube_replicaset.*|kube_resourcequota|kube_statefulset.*"
+    action = "keep"
+  }
+  forward_to = [prometheus.remote_write.grafana_cloud_prometheus.receiver]
+}
+
+// OpenCost
+discovery.relabel "opencost" {
+  targets = discovery.kubernetes.services.targets
+  rule {
+    source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_instance"]
+    regex = "k8smon"
+    action = "keep"
+  }
+  rule {
+    source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_name"]
+    regex = "opencost"
+    action = "keep"
+  }
+  rule {
+    source_labels = ["__meta_kubernetes_service_port_name"]
+    regex = "http"
+    action = "keep"
+  }
+}
+
+prometheus.scrape "opencost" {
+  job_name   = "integrations/kubernetes/opencost"
+  targets    = discovery.relabel.opencost.output
+  scrape_interval = "60s"
+  clustering {
+    enabled = true
+  }
+  forward_to = [prometheus.relabel.opencost.receiver]
+}
+
+prometheus.relabel "opencost" {
+  rule {
+    source_labels = ["__name__"]
+    regex = "up|container_cpu_allocation|container_gpu_allocation|container_memory_allocation_bytes|deployment_match_labels|kubecost_cluster_info|kubecost_cluster_management_cost|kubecost_cluster_memory_working_set_bytes|kubecost_http_requests_total|kubecost_http_response_size_bytes|kubecost_http_response_time_seconds|kubecost_load_balancer_cost|kubecost_network_internet_egress_cost|kubecost_network_region_egress_cost|kubecost_network_zone_egress_cost|kubecost_node_is_spot|node_cpu_hourly_cost|node_gpu_count|node_gpu_hourly_cost|node_ram_hourly_cost|node_total_hourly_cost|opencost_build_info|pod_pvc_allocation|pv_hourly_cost|service_selector_labels|statefulSet_match_labels"
+    action = "keep"
+  }
+  forward_to = [prometheus.remote_write.grafana_cloud_prometheus.receiver]
+}
+
+// PodMonitor
+prometheus.operator.podmonitors "pod_monitors" {
+  forward_to = [prometheus.relabel.podmonitors.receiver]
+  clustering {
+    enabled = true
+  }
+}
+
+prometheus.relabel "podmonitors" {
+  forward_to = [prometheus.remote_write.grafana_cloud_prometheus.receiver]
+}
+
+// Prometheus Operator Probe objects
+prometheus.operator.probes "probes" {
+  namespaces = []
+  forward_to = [prometheus.relabel.probes.receiver]
+  clustering {
+    enabled = true
+  }
+}
+
+prometheus.relabel "probes" {
+  forward_to = [prometheus.remote_write.grafana_cloud_prometheus.receiver]
+}
+
+// Prometheus Operator ServiceMonitor objects
+prometheus.operator.servicemonitors "service_monitors" {
+  namespaces = []
+  forward_to = [prometheus.relabel.servicemonitors.receiver]
+  clustering {
+    enabled = true
+  }
+}
+
+prometheus.relabel "servicemonitors" {
+  forward_to = [prometheus.remote_write.grafana_cloud_prometheus.receiver]
+}
+
+// Grafana Cloud Prometheus
+local.file "prometheus_host" {
+  filename  = "/etc/grafana-agent-credentials/prometheus_host"
+}
+
+local.file "prometheus_username" {
+  filename  = "/etc/grafana-agent-credentials/prometheus_username"
+}
+
+local.file "prometheus_password" {
+  filename  = "/etc/grafana-agent-credentials/prometheus_password"
+  is_secret = true
+}
+
+prometheus.remote_write "grafana_cloud_prometheus" {
+  endpoint {
+    url = nonsensitive(local.file.prometheus_host.content) + "/api/prom/push"
+
+    basic_auth {
+      username = local.file.prometheus_username.content
+      password = local.file.prometheus_password.content
+    }
+
+  }
+  external_labels = {
+    cluster = "gke-autopilot-test",
+  }
+}
+
+// Cluster Events
+loki.source.kubernetes_events "cluster_events" {
+  job_name   = "integrations/kubernetes/eventhandler"
+  forward_to = [loki.write.grafana_cloud_loki.receiver]
+}
+
+// Grafana Cloud Loki
+local.file "loki_host" {
+  filename  = "/etc/grafana-agent-credentials/loki_host"
+}
+
+local.file "loki_username" {
+  filename  = "/etc/grafana-agent-credentials/loki_username"
+}
+
+local.file "loki_password" {
+  filename  = "/etc/grafana-agent-credentials/loki_password"
+  is_secret = true
+}
+
+loki.write "grafana_cloud_loki" {
+  endpoint {
+    url = nonsensitive(local.file.loki_host.content) + "/loki/api/v1/push"
+
+    basic_auth {
+      username = local.file.loki_username.content
+      password = local.file.loki_password.content
+    }
+  }
+  external_labels = {
+    cluster = "gke-autopilot-test",
+  }
+}

--- a/examples/gke-autopilot/output.yaml
+++ b/examples/gke-autopilot/output.yaml
@@ -53,21 +53,6 @@ metadata:
     app.kubernetes.io/managed-by: Helm
 automountServiceAccountToken: true
 ---
-# Source: k8s-monitoring/charts/prometheus-node-exporter/templates/serviceaccount.yaml
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: k8smon-prometheus-node-exporter
-  namespace: default
-  labels:
-    helm.sh/chart: prometheus-node-exporter-4.23.2
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/component: metrics
-    app.kubernetes.io/part-of: prometheus-node-exporter
-    app.kubernetes.io/name: prometheus-node-exporter
-    app.kubernetes.io/instance: k8smon
-    app.kubernetes.io/version: "1.6.1"
----
 # Source: k8s-monitoring/templates/credentials.yaml
 apiVersion: v1
 kind: Secret
@@ -308,45 +293,6 @@ data:
       forward_to = [prometheus.remote_write.grafana_cloud_prometheus.receiver]
     }
     
-    // Node Exporter
-    discovery.relabel "node_exporter" {
-      targets = discovery.kubernetes.pods.targets
-      rule {
-        source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_instance"]
-        regex = "k8smon"
-        action = "keep"
-      }
-      rule {
-        source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
-        regex = "prometheus-node-exporter.*"
-        action = "keep"
-      }
-      rule {
-        source_labels = ["__meta_kubernetes_pod_node_name"]
-        action = "replace"
-        target_label = "instance"
-      }
-    }
-    
-    prometheus.scrape "node_exporter" {
-      job_name   = "integrations/node_exporter"
-      targets  = discovery.relabel.node_exporter.output
-      scrape_interval = "60s"
-      clustering {
-        enabled = true
-      }
-      forward_to = [prometheus.relabel.node_exporter.receiver]
-    }
-    
-    prometheus.relabel "node_exporter" {
-      rule {
-        source_labels = ["__name__"]
-        regex = "up|node_cpu.*|node_exporter_build_info|node_filesystem.*|node_memory.*|process_cpu_seconds_total|process_resident_memory_bytes"
-        action = "keep"
-      }
-      forward_to = [prometheus.remote_write.grafana_cloud_prometheus.receiver]
-    }
-    
     // OpenCost
     discovery.relabel "opencost" {
       targets = discovery.kubernetes.services.targets
@@ -449,9 +395,7 @@ data:
     
       }
       external_labels = {
-        region = "southwest",
-        tenant = "widgetco",
-        cluster = "custom-config-test",
+        cluster = "gke-autopilot-test",
       }
     }
     
@@ -485,30 +429,8 @@ data:
         }
       }
       external_labels = {
-        region = "southwest",
-        tenant = "widgetco",
-        cluster = "custom-config-test",
+        cluster = "gke-autopilot-test",
       }
-    }
-    
-    discovery.relabel "animal_service" {
-      targets = discovery.kubernetes.services.targets
-      rule {
-        source_labels = ["__meta_kubernetes_service_label_app"]
-        regex = "animal-service"
-        action = "keep"
-      }
-      rule {
-        source_labels = ["__meta_kubernetes_service_name"]
-        regex = "animal-service-metrics"
-        action = "keep"
-      }
-    }
-    
-    prometheus.scrape "animal_service" {
-      job_name   = "animal_service"
-      targets    = discovery.relabel.animal_service.output
-      forward_to = [prometheus.remote_write.grafana_cloud_prometheus.receiver]
     }
 ---
 # Source: k8s-monitoring/templates/grafana-agent-logs-config.yaml
@@ -641,45 +563,8 @@ data:
         }
       }
       external_labels = {
-        region = "southwest",
-        tenant = "widgetco",
-        cluster = "custom-config-test",
+        cluster = "gke-autopilot-test",
       }
-    }
-    
-    discovery.relabel "postgres_logs" {
-      targets = discovery.relabel.pod_logs.output
-      
-      rule {
-        source_labels = ["namespace"]
-        regex = "postgres"
-        action = "keep"
-      }
-      rule {
-        source_labels = ["__meta_kubernetes_pod_label_app"]
-        regex = "database"
-        action = "keep"
-      }
-    }
-    
-    local.file_match "postgres_logs" {
-      path_targets = discovery.relabel.postgres_logs.output
-    }
-    
-    loki.source.file "postgres_logs" {
-      targets    = local.file_match.postgres_logs.targets
-      forward_to = [loki.process.postgres_logs.receiver]
-    }
-    
-    loki.process "postgres_logs" {
-      stage.cri {}
-      stage.static_labels {
-        values = {
-          job = "integrations/postgres_exporter",
-          instance = "animaldb",
-        }
-      }
-      forward_to = [loki.write.grafana_cloud_loki.receiver]
     }
 ---
 # Source: k8s-monitoring/templates/kubernetes-monitoring-telemetry.yaml
@@ -692,7 +577,7 @@ data:
   metrics.prom: |
     # HELP grafana_kubernetes_monitoring_build_info A metric to report the version of the Kubernetes Monitoring Helm chart as well as a summary of enabled features
     # TYPE grafana_kubernetes_monitoring_build_info gauge
-    grafana_kubernetes_monitoring_build_info{version="0.2.8", namespace="default", metrics="enabled,agent,kube-state-metrics,node-exporter,kubelet,cadvisor,cost,extraConfig", logs="enabled,events,pod_logs,extraConfig", traces="disabled", deployments="kube-state-metrics,prometheus-node-exporter,prometheus-operator-crds,opencost"} 1
+    grafana_kubernetes_monitoring_build_info{version="0.2.8", namespace="default", metrics="enabled,agent,kube-state-metrics,kubelet,cadvisor,cost", logs="enabled,events,pod_logs", traces="disabled", deployments="kube-state-metrics,prometheus-operator-crds,opencost"} 1
 ---
 # Source: k8s-monitoring/charts/grafana-agent/charts/crds/templates/monitoring.grafana.com_podlogs.yaml
 apiVersion: apiextensions.k8s.io/v1
@@ -42707,33 +42592,6 @@ spec:
       port: 9003
       targetPort: 9003
 ---
-# Source: k8s-monitoring/charts/prometheus-node-exporter/templates/service.yaml
-apiVersion: v1
-kind: Service
-metadata:
-  name: k8smon-prometheus-node-exporter
-  namespace: default
-  labels:
-    helm.sh/chart: prometheus-node-exporter-4.23.2
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/component: metrics
-    app.kubernetes.io/part-of: prometheus-node-exporter
-    app.kubernetes.io/name: prometheus-node-exporter
-    app.kubernetes.io/instance: k8smon
-    app.kubernetes.io/version: "1.6.1"
-  annotations:
-    prometheus.io/scrape: "true"
-spec:
-  type: ClusterIP
-  ports:
-    - port: 9100
-      targetPort: 9100
-      protocol: TCP
-      name: metrics
-  selector:
-    app.kubernetes.io/name: prometheus-node-exporter
-    app.kubernetes.io/instance: k8smon
----
 # Source: k8s-monitoring/charts/grafana-agent-logs/templates/controllers/daemonset.yaml
 apiVersion: apps/v1
 kind: DaemonSet
@@ -42820,120 +42678,6 @@ spec:
         - name: grafana-agent-credentials
           secret:
             secretName: grafana-agent-credentials
----
-# Source: k8s-monitoring/charts/prometheus-node-exporter/templates/daemonset.yaml
-apiVersion: apps/v1
-kind: DaemonSet
-metadata:
-  name: k8smon-prometheus-node-exporter
-  namespace: default
-  labels:
-    helm.sh/chart: prometheus-node-exporter-4.23.2
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/component: metrics
-    app.kubernetes.io/part-of: prometheus-node-exporter
-    app.kubernetes.io/name: prometheus-node-exporter
-    app.kubernetes.io/instance: k8smon
-    app.kubernetes.io/version: "1.6.1"
-spec:
-  selector:
-    matchLabels:
-      app.kubernetes.io/name: prometheus-node-exporter
-      app.kubernetes.io/instance: k8smon
-  revisionHistoryLimit: 10
-  updateStrategy:
-    rollingUpdate:
-      maxUnavailable: 1
-    type: RollingUpdate
-  template:
-    metadata:
-      annotations:
-        cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
-      labels:
-        helm.sh/chart: prometheus-node-exporter-4.23.2
-        app.kubernetes.io/managed-by: Helm
-        app.kubernetes.io/component: metrics
-        app.kubernetes.io/part-of: prometheus-node-exporter
-        app.kubernetes.io/name: prometheus-node-exporter
-        app.kubernetes.io/instance: k8smon
-        app.kubernetes.io/version: "1.6.1"
-    spec:
-      automountServiceAccountToken: false
-      securityContext:
-        fsGroup: 65534
-        runAsGroup: 65534
-        runAsNonRoot: true
-        runAsUser: 65534
-      serviceAccountName: k8smon-prometheus-node-exporter
-      containers:
-        - name: node-exporter
-          image: quay.io/prometheus/node-exporter:v1.6.1
-          imagePullPolicy: IfNotPresent
-          args:
-            - --path.procfs=/host/proc
-            - --path.sysfs=/host/sys
-            - --path.rootfs=/host/root
-            - --path.udev.data=/host/root/run/udev/data
-            - --web.listen-address=[$(HOST_IP)]:9100
-          securityContext:
-            readOnlyRootFilesystem: true
-          env:
-            - name: HOST_IP
-              value: 0.0.0.0
-          ports:
-            - name: metrics
-              containerPort: 9100
-              protocol: TCP
-          livenessProbe:
-            failureThreshold: 3
-            httpGet:
-              httpHeaders:
-              path: /
-              port: 9100
-              scheme: HTTP
-            initialDelaySeconds: 0
-            periodSeconds: 10
-            successThreshold: 1
-            timeoutSeconds: 1
-          readinessProbe:
-            failureThreshold: 3
-            httpGet:
-              httpHeaders:
-              path: /
-              port: 9100
-              scheme: HTTP
-            initialDelaySeconds: 0
-            periodSeconds: 10
-            successThreshold: 1
-            timeoutSeconds: 1
-          volumeMounts:
-            - name: proc
-              mountPath: /host/proc
-              readOnly:  true
-            - name: sys
-              mountPath: /host/sys
-              readOnly: true
-            - name: root
-              mountPath: /host/root
-              mountPropagation: HostToContainer
-              readOnly: true
-      hostNetwork: true
-      hostPID: true
-      nodeSelector:
-        kubernetes.io/os: linux
-      tolerations:
-        - effect: NoSchedule
-          operator: Exists
-      volumes:
-        - name: proc
-          hostPath:
-            path: /proc
-        - name: sys
-          hostPath:
-            path: /sys
-        - name: root
-          hostPath:
-            path: /
 ---
 # Source: k8s-monitoring/charts/kube-state-metrics/templates/deployment.yaml
 apiVersion: apps/v1
@@ -43447,45 +43191,6 @@ data:
       forward_to = [prometheus.remote_write.grafana_cloud_prometheus.receiver]
     }
     
-    // Node Exporter
-    discovery.relabel "node_exporter" {
-      targets = discovery.kubernetes.pods.targets
-      rule {
-        source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_instance"]
-        regex = "k8smon"
-        action = "keep"
-      }
-      rule {
-        source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
-        regex = "prometheus-node-exporter.*"
-        action = "keep"
-      }
-      rule {
-        source_labels = ["__meta_kubernetes_pod_node_name"]
-        action = "replace"
-        target_label = "instance"
-      }
-    }
-    
-    prometheus.scrape "node_exporter" {
-      job_name   = "integrations/node_exporter"
-      targets  = discovery.relabel.node_exporter.output
-      scrape_interval = "60s"
-      clustering {
-        enabled = true
-      }
-      forward_to = [prometheus.relabel.node_exporter.receiver]
-    }
-    
-    prometheus.relabel "node_exporter" {
-      rule {
-        source_labels = ["__name__"]
-        regex = "up|node_cpu.*|node_exporter_build_info|node_filesystem.*|node_memory.*|process_cpu_seconds_total|process_resident_memory_bytes"
-        action = "keep"
-      }
-      forward_to = [prometheus.remote_write.grafana_cloud_prometheus.receiver]
-    }
-    
     // OpenCost
     discovery.relabel "opencost" {
       targets = discovery.kubernetes.services.targets
@@ -43588,9 +43293,7 @@ data:
     
       }
       external_labels = {
-        region = "southwest",
-        tenant = "widgetco",
-        cluster = "custom-config-test",
+        cluster = "gke-autopilot-test",
       }
     }
     
@@ -43624,30 +43327,8 @@ data:
         }
       }
       external_labels = {
-        region = "southwest",
-        tenant = "widgetco",
-        cluster = "custom-config-test",
+        cluster = "gke-autopilot-test",
       }
-    }
-    
-    discovery.relabel "animal_service" {
-      targets = discovery.kubernetes.services.targets
-      rule {
-        source_labels = ["__meta_kubernetes_service_label_app"]
-        regex = "animal-service"
-        action = "keep"
-      }
-      rule {
-        source_labels = ["__meta_kubernetes_service_name"]
-        regex = "animal-service-metrics"
-        action = "keep"
-      }
-    }
-    
-    prometheus.scrape "animal_service" {
-      job_name   = "animal_service"
-      targets    = discovery.relabel.animal_service.output
-      forward_to = [prometheus.remote_write.grafana_cloud_prometheus.receiver]
     }
 ---
 # Source: k8s-monitoring/templates/hooks/grafana-agent-config-test.yaml
@@ -43789,45 +43470,8 @@ data:
         }
       }
       external_labels = {
-        region = "southwest",
-        tenant = "widgetco",
-        cluster = "custom-config-test",
+        cluster = "gke-autopilot-test",
       }
-    }
-    
-    discovery.relabel "postgres_logs" {
-      targets = discovery.relabel.pod_logs.output
-      
-      rule {
-        source_labels = ["namespace"]
-        regex = "postgres"
-        action = "keep"
-      }
-      rule {
-        source_labels = ["__meta_kubernetes_pod_label_app"]
-        regex = "database"
-        action = "keep"
-      }
-    }
-    
-    local.file_match "postgres_logs" {
-      path_targets = discovery.relabel.postgres_logs.output
-    }
-    
-    loki.source.file "postgres_logs" {
-      targets    = local.file_match.postgres_logs.targets
-      forward_to = [loki.process.postgres_logs.receiver]
-    }
-    
-    loki.process "postgres_logs" {
-      stage.cri {}
-      stage.static_labels {
-        values = {
-          job = "integrations/postgres_exporter",
-          instance = "animaldb",
-        }
-      }
-      forward_to = [loki.write.grafana_cloud_loki.receiver]
     }
 ---
 # Source: k8s-monitoring/templates/tests/test.yaml
@@ -43874,28 +43518,25 @@ data:
     {
       "queries": [
         {
-          "query": "up{cluster=\"custom-config-test\"}"
+          "query": "up{cluster=\"gke-autopilot-test\"}"
         },
         {
-          "query": "agent_build_info{cluster=\"custom-config-test\"}"
+          "query": "agent_build_info{cluster=\"gke-autopilot-test\"}"
         },
         {
-          "query": "kubernetes_build_info{cluster=\"custom-config-test\"}"
+          "query": "kubernetes_build_info{cluster=\"gke-autopilot-test\"}"
         },
         {
-          "query": "machine_memory_bytes{cluster=\"custom-config-test\"}"
+          "query": "machine_memory_bytes{cluster=\"gke-autopilot-test\"}"
         },
         {
-          "query": "kube_node_info{cluster=\"custom-config-test\"}"
+          "query": "kube_node_info{cluster=\"gke-autopilot-test\"}"
         },
         {
-          "query": "node_exporter_build_info{cluster=\"custom-config-test\"}"
+          "query": "opencost_build_info{cluster=\"gke-autopilot-test\"}"
         },
         {
-          "query": "opencost_build_info{cluster=\"custom-config-test\"}"
-        },
-        {
-          "query": "grafana_kubernetes_monitoring_build_info{cluster=\"custom-config-test\"}"
+          "query": "grafana_kubernetes_monitoring_build_info{cluster=\"gke-autopilot-test\"}"
         }
       ]
     }

--- a/examples/gke-autopilot/values.yaml
+++ b/examples/gke-autopilot/values.yaml
@@ -1,0 +1,21 @@
+cluster:
+  name: gke-autopilot-test
+
+externalServices:
+  prometheus:
+    host: https://prometheus.example.com
+    basicAuth:
+      username: 12345
+      password: "It's a secret to everyone"
+  loki:
+    host: https://loki.example.com
+    basicAuth:
+      username: 12345
+      password: "It's a secret to everyone"
+
+metrics:
+  node-exporter:
+    enabled: false
+
+prometheus-node-exporter:
+  enabled: false

--- a/examples/logs-only/output.yaml
+++ b/examples/logs-only/output.yaml
@@ -779,9 +779,6 @@ spec:
             - name: varlog
               mountPath: /var/log
               readOnly: true
-            - name: dockercontainers
-              mountPath: /var/lib/docker/containers
-              readOnly: true
             -
               mountPath: /etc/grafana-agent-credentials
               name: grafana-agent-credentials
@@ -810,9 +807,6 @@ spec:
         - name: varlog
           hostPath:
             path: /var/log
-        - name: dockercontainers
-          hostPath:
-            path: /var/lib/docker/containers
         - name: grafana-agent-credentials
           secret:
             secretName: grafana-agent-credentials

--- a/examples/openshift-compatible/output.yaml
+++ b/examples/openshift-compatible/output.yaml
@@ -42469,9 +42469,6 @@ spec:
             - name: varlog
               mountPath: /var/log
               readOnly: true
-            - name: dockercontainers
-              mountPath: /var/lib/docker/containers
-              readOnly: true
             -
               mountPath: /etc/grafana-agent-credentials
               name: grafana-agent-credentials
@@ -42500,9 +42497,6 @@ spec:
         - name: varlog
           hostPath:
             path: /var/log
-        - name: dockercontainers
-          hostPath:
-            path: /var/lib/docker/containers
         - name: grafana-agent-credentials
           secret:
             secretName: grafana-agent-credentials

--- a/examples/private-image-registry/output.yaml
+++ b/examples/private-image-registry/output.yaml
@@ -42728,9 +42728,6 @@ spec:
             - name: varlog
               mountPath: /var/log
               readOnly: true
-            - name: dockercontainers
-              mountPath: /var/lib/docker/containers
-              readOnly: true
             -
               mountPath: /etc/grafana-agent-credentials
               name: grafana-agent-credentials
@@ -42759,9 +42756,6 @@ spec:
         - name: varlog
           hostPath:
             path: /var/log
-        - name: dockercontainers
-          hostPath:
-            path: /var/lib/docker/containers
         - name: grafana-agent-credentials
           secret:
             secretName: grafana-agent-credentials

--- a/examples/specific-namespace/output.yaml
+++ b/examples/specific-namespace/output.yaml
@@ -42779,9 +42779,6 @@ spec:
             - name: varlog
               mountPath: /var/log
               readOnly: true
-            - name: dockercontainers
-              mountPath: /var/lib/docker/containers
-              readOnly: true
             -
               mountPath: /etc/grafana-agent-credentials
               name: grafana-agent-credentials
@@ -42810,9 +42807,6 @@ spec:
         - name: varlog
           hostPath:
             path: /var/log
-        - name: dockercontainers
-          hostPath:
-            path: /var/lib/docker/containers
         - name: grafana-agent-credentials
           secret:
             secretName: grafana-agent-credentials

--- a/examples/traces-enabled/output.yaml
+++ b/examples/traces-enabled/output.yaml
@@ -42805,9 +42805,6 @@ spec:
             - name: varlog
               mountPath: /var/log
               readOnly: true
-            - name: dockercontainers
-              mountPath: /var/lib/docker/containers
-              readOnly: true
             -
               mountPath: /etc/grafana-agent-credentials
               name: grafana-agent-credentials
@@ -42836,9 +42833,6 @@ spec:
         - name: varlog
           hostPath:
             path: /var/log
-        - name: dockercontainers
-          hostPath:
-            path: /var/lib/docker/containers
         - name: grafana-agent-credentials
           secret:
             secretName: grafana-agent-credentials

--- a/examples/windows-exporter/output.yaml
+++ b/examples/windows-exporter/output.yaml
@@ -42861,9 +42861,6 @@ spec:
             - name: varlog
               mountPath: /var/log
               readOnly: true
-            - name: dockercontainers
-              mountPath: /var/lib/docker/containers
-              readOnly: true
             -
               mountPath: /etc/grafana-agent-credentials
               name: grafana-agent-credentials
@@ -42892,9 +42889,6 @@ spec:
         - name: varlog
           hostPath:
             path: /var/log
-        - name: dockercontainers
-          hostPath:
-            path: /var/lib/docker/containers
         - name: grafana-agent-credentials
           secret:
             secretName: grafana-agent-credentials


### PR DESCRIPTION
Also stop mounting `/var/lib/docker/containers`, which is not allowed on autopilot cluster. I don't think it is necessary anymore anyway.