### PR TITLE
fix readme

### DIFF
--- a/charts/k8s-monitoring/README.md
+++ b/charts/k8s-monitoring/README.md
@@ -25,12 +25,14 @@ cluster:
 externalServices:
   prometheus:
     host: https://prometheus.example.com
-    username: "12345"
-    password: "It's a secret to everyone"
+    basicAuth:
+      username: "12345"
+      password: "It's a secret to everyone"
   loki:
     host: https://loki.example.com
-    username: "67890"
-    password: "It's a secret to everyone"
+    basicAuth:
+      username: "67890"
+      password: "It's a secret to everyone"
 EOF
 helm install my-release grafana/k8s-monitoring --values values.yaml
 ```

--- a/charts/k8s-monitoring/README.md.gotmpl
+++ b/charts/k8s-monitoring/README.md.gotmpl
@@ -28,12 +28,14 @@ cluster:
 externalServices:
   prometheus:
     host: https://prometheus.example.com
-    username: "12345"
-    password: "It's a secret to everyone"
+    basicAuth:
+      username: "12345"
+      password: "It's a secret to everyone"
   loki:
     host: https://loki.example.com
-    username: "67890"
-    password: "It's a secret to everyone"
+    basicAuth:
+      username: "67890"
+      password: "It's a secret to everyone"
 EOF
 helm install my-release grafana/{{ template "chart.name" . }} --values values.yaml
 ```


### PR DESCRIPTION
While deploying to my cluster I noticed that the example values.yaml in the readme is not correct. 
The `username` and `password` values should be under the key `basicAuth` for both loki and prometheus.