### PR TITLE
fix basicauth check

### DIFF
--- a/charts/k8s-monitoring/templates/agent_config/_loki.river.txt
+++ b/charts/k8s-monitoring/templates/agent_config/_loki.river.txt
@@ -29,7 +29,7 @@ loki.write "grafana_cloud_loki" {
 {{- if .proxyURL }}
     proxy_url = {{ .proxyURL | quote }}
 {{- end }}
-{{ if .basicAuth }}
+{{ if or (.basicAuth.username) (.basicAuth.password) }}
     basic_auth {
       {{ if .basicAuth.username }}username = local.file.loki_username.content{{ end }}
       {{ if .basicAuth.password }}password = local.file.loki_password.content{{ end }}

--- a/charts/k8s-monitoring/templates/agent_config/_prometheus.river.txt
+++ b/charts/k8s-monitoring/templates/agent_config/_prometheus.river.txt
@@ -29,7 +29,7 @@ prometheus.remote_write "grafana_cloud_prometheus" {
 {{- if .proxyURL }}
     proxy_url = {{ .proxyURL | quote }}
 {{- end }}
-{{ if .basicAuth }}
+{{ if or (.basicAuth.username) (.basicAuth.password) }}
     basic_auth {
       {{ if .basicAuth.username }}username = local.file.prometheus_username.content{{ end }}
       {{ if .basicAuth.password }}password = local.file.prometheus_password.content{{ end }}

--- a/charts/k8s-monitoring/templates/agent_config/_tempo.river.txt
+++ b/charts/k8s-monitoring/templates/agent_config/_tempo.river.txt
@@ -15,7 +15,7 @@ local.file "tempo_password" {
   is_secret = true
 }
 {{- end }}
-{{ if .basicAuth }}
+{{ if or (.basicAuth.username) (.basicAuth.password) }}
 otelcol.auth.basic "tempo" {
   {{ if .basicAuth.username }}username = local.file.tempo_username.content{{ end }}
   {{ if .basicAuth.password }}password = local.file.tempo_password.content{{ end }}
@@ -25,7 +25,7 @@ otelcol.auth.basic "tempo" {
 otelcol.exporter.otlp "tempo" {
   client {
     endpoint = nonsensitive(local.file.tempo_host.content)
-{{ if .basicAuth }}
+{{ if or (.basicAuth.username) (.basicAuth.password) }}
     auth = otelcol.auth.basic.tempo.handler
 {{- end }}
   }


### PR DESCRIPTION
Instead of checkking for the .basicAuth object, check that the fields have been set.  The current checks still produce basicAuth config even if the values file doesn't set the credentials, leading to errors.