### PR TITLE
Add the ability to set the max batch size for traces

### DIFF
--- a/charts/k8s-monitoring/README.md
+++ b/charts/k8s-monitoring/README.md
@@ -177,6 +177,7 @@ The Prometheus and Loki services may be hosted on the same cluster, or remotely 
 | test.image.registry | string | `"docker.io"` | Test job image registry |
 | test.image.tag | string | `"jammy"` | Test job image tag |
 | traces.enabled | bool | `false` | Receive and forward traces. |
+| traces.processors.batch.maxSize | int | `0` | The upper limit of the amount of data contained in a single batch, in bytes. When set to 0, batches can be any size. |
 | traces.processors.batch.size | int | `16384` | What batch size to use, in bytes |
 | traces.processors.batch.timeout | string | `"2s"` | How long before sending |
 | traces.receiver.grpc.enabled | bool | `true` | Should the Grafana Agent receive traces over gRPC? |

--- a/charts/k8s-monitoring/templates/agent_config/_traces.river.txt
+++ b/charts/k8s-monitoring/templates/agent_config/_traces.river.txt
@@ -27,6 +27,7 @@ otelcol.receiver.otlp "trace_receiver" {
 {{- with .Values.traces }}
 otelcol.processor.batch "trace_batch_processor" {
   send_batch_size = {{ .processors.batch.size | int }}
+  send_batch_max_size = {{ .processors.batch.maxSize | int }}
   timeout = {{ .processors.batch.timeout | quote}}
   output {
     traces = [otelcol.processor.attributes.trace_attributes_processor.input]

--- a/charts/k8s-monitoring/values.schema.json
+++ b/charts/k8s-monitoring/values.schema.json
@@ -794,6 +794,9 @@
                                 "size": {
                                     "type": "integer"
                                 },
+                                "maxSize": {
+                                    "type": "integer"
+                                },
                                 "timeout": {
                                     "type": "string"
                                 }

--- a/charts/k8s-monitoring/values.yaml
+++ b/charts/k8s-monitoring/values.yaml
@@ -503,6 +503,8 @@ traces:
     batch:
       # -- What batch size to use, in bytes
       size: 16384
+      # -- The upper limit of the amount of data contained in a single batch, in bytes. When set to 0, batches can be any size.
+      maxSize: 0
       # -- How long before sending
       timeout: 2s
 

--- a/examples/traces-enabled/metrics.river
+++ b/examples/traces-enabled/metrics.river
@@ -408,6 +408,7 @@ http {
 }
 otelcol.processor.batch "trace_batch_processor" {
   send_batch_size = 16384
+  send_batch_max_size = 0
   timeout = "2s"
   output {
     traces = [otelcol.processor.attributes.trace_attributes_processor.input]

--- a/examples/traces-enabled/output.yaml
+++ b/examples/traces-enabled/output.yaml
@@ -504,6 +504,7 @@ data:
     }
     otelcol.processor.batch "trace_batch_processor" {
       send_batch_size = 16384
+      send_batch_max_size = 0
       timeout = "2s"
       output {
         traces = [otelcol.processor.attributes.trace_attributes_processor.input]
@@ -43686,6 +43687,7 @@ data:
     }
     otelcol.processor.batch "trace_batch_processor" {
       send_batch_size = 16384
+      send_batch_max_size = 0
       timeout = "2s"
       output {
         traces = [otelcol.processor.attributes.trace_attributes_processor.input]


### PR DESCRIPTION
Exposes this parameter: https://grafana.com/docs/agent/latest/flow/reference/components/otelcol.processor.batch/