### PR TITLE
Rename the config validator and the helm test hooks.

### DIFF
--- a/charts/k8s-monitoring/templates/hooks/_helpers.tpl
+++ b/charts/k8s-monitoring/templates/hooks/_helpers.tpl
@@ -1,0 +1,12 @@
+{{/*
+Create a default fully qualified name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "config-validator.fullname" -}}
+  {{- if contains .Chart.Name .Release.Name }}
+    {{- printf "validate-%s" .Release.Name | trunc 63 | trimSuffix "-" }}
+  {{- else }}
+    {{- printf "validate-%s-%s" .Release.Name .Chart.Name | trunc 63 | trimSuffix "-" }}
+  {{- end }}
+{{- end }}

--- a/charts/k8s-monitoring/templates/hooks/grafana-agent-config-test.yaml
+++ b/charts/k8s-monitoring/templates/hooks/grafana-agent-config-test.yaml
@@ -2,7 +2,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: "{{ .Release.Name }}-test-config"
+  name: {{ include "config-validator.fullname" . | quote }}
   namespace: {{ .Release.Namespace }}
   labels:
     app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
@@ -17,7 +17,7 @@ spec:
   backoffLimit: 0
   template:
     metadata:
-      name: "{{ .Release.Name }}-test-config"
+      name: {{ include "config-validator.fullname" . | quote }}
       labels:
         app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
         app.kubernetes.io/instance: {{ .Release.Name | quote }}
@@ -27,9 +27,14 @@ spec:
       containers:
         - name: grafana-agent
           image: "{{ (index .Values "grafana-agent").global.image.registry | default (index .Values "grafana-agent").image.registry }}/{{ (index .Values "grafana-agent").image.repository }}{{ include "grafana-agent.imageId" (index .Subcharts "grafana-agent") }}"
-          args:
-            - fmt
-            - /etc/agent/config.river
+          command:
+          - bash
+          - -c
+          - |
+            grafana-agent fmt /etc/agent/config.river
+{{- if and .Values.logs.enabled .Values.logs.pod_logs.enabled }}
+            grafana-agent fmt /etc/agent/logs.river
+{{- end }}
           env:
             - name: AGENT_MODE
               value: flow
@@ -39,12 +44,12 @@ spec:
       volumes:
         - name: config
           configMap:
-            name: {{ include "grafana-agent.fullname" (index .Subcharts "grafana-agent") }}-test
+            name: {{ include "config-validator.fullname" . | quote }}
 ---
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ include "grafana-agent.fullname" (index .Subcharts "grafana-agent") }}-test
+  name: {{ include "config-validator.fullname" . | quote }}
   namespace: {{ .Release.Namespace }}
   labels:
     app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
@@ -59,64 +64,6 @@ data:
   config.river: |-
     {{- include "agentConfig" . | trim | nindent 4 }}
 {{- if and .Values.logs.enabled .Values.logs.pod_logs.enabled }}
----
-apiVersion: batch/v1
-kind: Job
-metadata:
-  name: "{{ .Release.Name }}-test-logs-config"
-  namespace: {{ .Release.Namespace }}
-  labels:
-    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
-    app.kubernetes.io/instance: {{ .Release.Name | quote }}
-    app.kubernetes.io/version: {{ .Chart.AppVersion }}
-    helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
-  annotations:
-    "helm.sh/hook": pre-install,pre-upgrade
-    "helm.sh/hook-weight": "-5"
-    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
-spec:
-  backoffLimit: 0
-  template:
-    metadata:
-      name: "{{ .Release.Name }}-test-logs-config"
-      labels:
-        app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
-        app.kubernetes.io/instance: {{ .Release.Name | quote }}
-        helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
-    spec:
-      restartPolicy: Never
-      containers:
-        - name: grafana-agent
-          image: "{{ (index .Values "grafana-agent").global.image.registry | default (index .Values "grafana-agent-logs").image.registry }}/{{ (index .Values "grafana-agent-logs").image.repository }}{{ include "grafana-agent.imageId" (index .Subcharts "grafana-agent-logs") }}"
-          args:
-            - fmt
-            - /etc/agent/config.river
-          env:
-            - name: AGENT_MODE
-              value: flow
-          volumeMounts:
-            - name: config
-              mountPath: /etc/agent
-      volumes:
-        - name: config
-          configMap:
-            name: {{ include "grafana-agent.fullname" (index .Subcharts "grafana-agent-logs") }}-test
----
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: {{ include "grafana-agent.fullname" (index .Subcharts "grafana-agent-logs") }}-test
-  namespace: {{ .Release.Namespace }}
-  labels:
-    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
-    app.kubernetes.io/instance: {{ .Release.Name | quote }}
-    app.kubernetes.io/version: {{ .Chart.AppVersion }}
-    helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
-  annotations:
-    "helm.sh/hook": pre-install,pre-upgrade
-    "helm.sh/hook-weight": "-5"
-    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
-data:
-  config.river: |-
+  logs.river: |-
     {{- include "agentLogsConfig" . | trim | nindent 4 }}
 {{- end }}

--- a/charts/k8s-monitoring/templates/hooks/validate-configuration.yaml
+++ b/charts/k8s-monitoring/templates/hooks/validate-configuration.yaml
@@ -29,10 +29,12 @@ spec:
           image: "{{ (index .Values "grafana-agent").global.image.registry | default (index .Values "grafana-agent").image.registry }}/{{ (index .Values "grafana-agent").image.repository }}{{ include "grafana-agent.imageId" (index .Subcharts "grafana-agent") }}"
           command:
           - bash
-          - -c
+          - -ec
           - |
+            echo Validating config file
             grafana-agent fmt /etc/agent/config.river
 {{- if and .Values.logs.enabled .Values.logs.pod_logs.enabled }}
+            echo Validating logs config file
             grafana-agent fmt /etc/agent/logs.river
 {{- end }}
           env:

--- a/charts/k8s-monitoring/templates/tests/_helpers.tpl
+++ b/charts/k8s-monitoring/templates/tests/_helpers.tpl
@@ -1,0 +1,12 @@
+{{/*
+Create a default fully qualified name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "kubernetes-monitoring-test.fullname" -}}
+  {{- if contains .Chart.Name .Release.Name }}
+    {{- printf "test-%s" .Release.Name | trunc 63 | trimSuffix "-" }}
+  {{- else }}
+    {{- printf "test-%s-%s" .Release.Name .Chart.Name | trunc 63 | trimSuffix "-" }}
+  {{- end }}
+{{- end }}

--- a/charts/k8s-monitoring/templates/tests/test.yaml
+++ b/charts/k8s-monitoring/templates/tests/test.yaml
@@ -68,7 +68,7 @@ echo "All queries passed!"
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: "{{ .Release.Name }}-test"
+  name: {{ include "kubernetes-monitoring-test.fullname" . | quote }}
   namespace: {{ .Release.Namespace }}
   labels:
     app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
@@ -81,7 +81,7 @@ metadata:
 spec:
   template:
     metadata:
-      name: "{{ .Release.Name }}-test-config"
+      name: {{ include "kubernetes-monitoring-test.fullname" . | quote }}
       labels:
         app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
         app.kubernetes.io/instance: {{ .Release.Name | quote }}
@@ -114,12 +114,12 @@ spec:
       volumes:
         - name: test-plan
           configMap:
-            name: {{ .Release.Name }}-test
+            name: {{ include "kubernetes-monitoring-test.fullname" . | quote }}
 ---
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: "{{ .Release.Name }}-test"
+  name: {{ include "kubernetes-monitoring-test.fullname" . | quote }}
   namespace: {{ .Release.Namespace }}
   labels:
     app.kubernetes.io/managed-by: {{ .Release.Service | quote }}

--- a/examples/control-plane-metrics/output.yaml
+++ b/examples/control-plane-metrics/output.yaml
@@ -43216,7 +43216,7 @@ spec:
 # Source: k8s-monitoring/charts/prometheus-operator-crds/charts/crds/templates/crd-thanosrulers.yaml
 # https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.68.0/example/prometheus-operator-crd/monitoring.coreos.com_thanosrulers.yaml
 ---
-# Source: k8s-monitoring/templates/hooks/grafana-agent-config-test.yaml
+# Source: k8s-monitoring/templates/hooks/validate-configuration.yaml
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -43872,7 +43872,7 @@ data:
       ]
     }
 ---
-# Source: k8s-monitoring/templates/hooks/grafana-agent-config-test.yaml
+# Source: k8s-monitoring/templates/hooks/validate-configuration.yaml
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -43903,9 +43903,11 @@ spec:
           image: "docker.io/grafana/agent:v0.37.2"
           command:
           - bash
-          - -c
+          - -ec
           - |
+            echo Validating config file
             grafana-agent fmt /etc/agent/config.river
+            echo Validating logs config file
             grafana-agent fmt /etc/agent/logs.river
           env:
             - name: AGENT_MODE

--- a/examples/control-plane-metrics/output.yaml
+++ b/examples/control-plane-metrics/output.yaml
@@ -43220,7 +43220,7 @@ spec:
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: k8smon-grafana-agent-test
+  name: "validate-k8smon-k8s-monitoring"
   namespace: default
   labels:
     app.kubernetes.io/managed-by: "Helm"
@@ -43672,24 +43672,7 @@ data:
         cluster = "control-plane-metrics-test",
       }
     }
----
-# Source: k8s-monitoring/templates/hooks/grafana-agent-config-test.yaml
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: k8smon-grafana-agent-logs-test
-  namespace: default
-  labels:
-    app.kubernetes.io/managed-by: "Helm"
-    app.kubernetes.io/instance: "k8smon"
-    app.kubernetes.io/version: 1.3.2
-    helm.sh/chart: "k8s-monitoring-0.2.12"
-  annotations:
-    "helm.sh/hook": pre-install,pre-upgrade
-    "helm.sh/hook-weight": "-5"
-    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
-data:
-  config.river: |-
+  logs.river: |-
     discovery.kubernetes "pods" {
       role = "pod"
     }
@@ -43820,7 +43803,7 @@ data:
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: "k8smon-test"
+  name: "test-k8smon-k8s-monitoring"
   namespace: default
   labels:
     app.kubernetes.io/managed-by: "Helm"
@@ -43893,7 +43876,7 @@ data:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: "k8smon-test-config"
+  name: "validate-k8smon-k8s-monitoring"
   namespace: default
   labels:
     app.kubernetes.io/managed-by: "Helm"
@@ -43908,7 +43891,7 @@ spec:
   backoffLimit: 0
   template:
     metadata:
-      name: "k8smon-test-config"
+      name: "validate-k8smon-k8s-monitoring"
       labels:
         app.kubernetes.io/managed-by: "Helm"
         app.kubernetes.io/instance: "k8smon"
@@ -43918,9 +43901,12 @@ spec:
       containers:
         - name: grafana-agent
           image: "docker.io/grafana/agent:v0.37.2"
-          args:
-            - fmt
-            - /etc/agent/config.river
+          command:
+          - bash
+          - -c
+          - |
+            grafana-agent fmt /etc/agent/config.river
+            grafana-agent fmt /etc/agent/logs.river
           env:
             - name: AGENT_MODE
               value: flow
@@ -43930,56 +43916,13 @@ spec:
       volumes:
         - name: config
           configMap:
-            name: k8smon-grafana-agent-test
----
-# Source: k8s-monitoring/templates/hooks/grafana-agent-config-test.yaml
-apiVersion: batch/v1
-kind: Job
-metadata:
-  name: "k8smon-test-logs-config"
-  namespace: default
-  labels:
-    app.kubernetes.io/managed-by: "Helm"
-    app.kubernetes.io/instance: "k8smon"
-    app.kubernetes.io/version: 1.3.2
-    helm.sh/chart: "k8s-monitoring-0.2.12"
-  annotations:
-    "helm.sh/hook": pre-install,pre-upgrade
-    "helm.sh/hook-weight": "-5"
-    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
-spec:
-  backoffLimit: 0
-  template:
-    metadata:
-      name: "k8smon-test-logs-config"
-      labels:
-        app.kubernetes.io/managed-by: "Helm"
-        app.kubernetes.io/instance: "k8smon"
-        helm.sh/chart: "k8s-monitoring-0.2.12"
-    spec:
-      restartPolicy: Never
-      containers:
-        - name: grafana-agent
-          image: "docker.io/grafana/agent:v0.37.2"
-          args:
-            - fmt
-            - /etc/agent/config.river
-          env:
-            - name: AGENT_MODE
-              value: flow
-          volumeMounts:
-            - name: config
-              mountPath: /etc/agent
-      volumes:
-        - name: config
-          configMap:
-            name: k8smon-grafana-agent-logs-test
+            name: "validate-k8smon-k8s-monitoring"
 ---
 # Source: k8s-monitoring/templates/tests/test.yaml
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: "k8smon-test"
+  name: "test-k8smon-k8s-monitoring"
   namespace: default
   labels:
     app.kubernetes.io/managed-by: "Helm"
@@ -43992,7 +43935,7 @@ metadata:
 spec:
   template:
     metadata:
-      name: "k8smon-test-config"
+      name: "test-k8smon-k8s-monitoring"
       labels:
         app.kubernetes.io/managed-by: "Helm"
         app.kubernetes.io/instance: "k8smon"
@@ -44025,4 +43968,4 @@ spec:
       volumes:
         - name: test-plan
           configMap:
-            name: k8smon-test
+            name: "test-k8smon-k8s-monitoring"

--- a/examples/custom-allow-lists/output.yaml
+++ b/examples/custom-allow-lists/output.yaml
@@ -42765,7 +42765,7 @@ spec:
 # Source: k8s-monitoring/charts/prometheus-operator-crds/charts/crds/templates/crd-thanosrulers.yaml
 # https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.68.0/example/prometheus-operator-crd/monitoring.coreos.com_thanosrulers.yaml
 ---
-# Source: k8s-monitoring/templates/hooks/grafana-agent-config-test.yaml
+# Source: k8s-monitoring/templates/hooks/validate-configuration.yaml
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -43210,7 +43210,7 @@ data:
       ]
     }
 ---
-# Source: k8s-monitoring/templates/hooks/grafana-agent-config-test.yaml
+# Source: k8s-monitoring/templates/hooks/validate-configuration.yaml
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -43241,8 +43241,9 @@ spec:
           image: "docker.io/grafana/agent:v0.37.2"
           command:
           - bash
-          - -c
+          - -ec
           - |
+            echo Validating config file
             grafana-agent fmt /etc/agent/config.river
           env:
             - name: AGENT_MODE

--- a/examples/custom-allow-lists/output.yaml
+++ b/examples/custom-allow-lists/output.yaml
@@ -42769,7 +42769,7 @@ spec:
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: k8smon-grafana-agent-test
+  name: "validate-k8smon-k8s-monitoring"
   namespace: default
   labels:
     app.kubernetes.io/managed-by: "Helm"
@@ -43144,7 +43144,7 @@ data:
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: "k8smon-test"
+  name: "test-k8smon-k8s-monitoring"
   namespace: default
   labels:
     app.kubernetes.io/managed-by: "Helm"
@@ -43214,7 +43214,7 @@ data:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: "k8smon-test-config"
+  name: "validate-k8smon-k8s-monitoring"
   namespace: default
   labels:
     app.kubernetes.io/managed-by: "Helm"
@@ -43229,7 +43229,7 @@ spec:
   backoffLimit: 0
   template:
     metadata:
-      name: "k8smon-test-config"
+      name: "validate-k8smon-k8s-monitoring"
       labels:
         app.kubernetes.io/managed-by: "Helm"
         app.kubernetes.io/instance: "k8smon"
@@ -43239,9 +43239,11 @@ spec:
       containers:
         - name: grafana-agent
           image: "docker.io/grafana/agent:v0.37.2"
-          args:
-            - fmt
-            - /etc/agent/config.river
+          command:
+          - bash
+          - -c
+          - |
+            grafana-agent fmt /etc/agent/config.river
           env:
             - name: AGENT_MODE
               value: flow
@@ -43251,13 +43253,13 @@ spec:
       volumes:
         - name: config
           configMap:
-            name: k8smon-grafana-agent-test
+            name: "validate-k8smon-k8s-monitoring"
 ---
 # Source: k8s-monitoring/templates/tests/test.yaml
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: "k8smon-test"
+  name: "test-k8smon-k8s-monitoring"
   namespace: default
   labels:
     app.kubernetes.io/managed-by: "Helm"
@@ -43270,7 +43272,7 @@ metadata:
 spec:
   template:
     metadata:
-      name: "k8smon-test-config"
+      name: "test-k8smon-k8s-monitoring"
       labels:
         app.kubernetes.io/managed-by: "Helm"
         app.kubernetes.io/instance: "k8smon"
@@ -43303,4 +43305,4 @@ spec:
       volumes:
         - name: test-plan
           configMap:
-            name: k8smon-test
+            name: "test-k8smon-k8s-monitoring"

--- a/examples/custom-config/output.yaml
+++ b/examples/custom-config/output.yaml
@@ -43233,7 +43233,7 @@ spec:
 # Source: k8s-monitoring/charts/prometheus-operator-crds/charts/crds/templates/crd-thanosrulers.yaml
 # https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.68.0/example/prometheus-operator-crd/monitoring.coreos.com_thanosrulers.yaml
 ---
-# Source: k8s-monitoring/templates/hooks/grafana-agent-config-test.yaml
+# Source: k8s-monitoring/templates/hooks/validate-configuration.yaml
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -43904,7 +43904,7 @@ data:
       ]
     }
 ---
-# Source: k8s-monitoring/templates/hooks/grafana-agent-config-test.yaml
+# Source: k8s-monitoring/templates/hooks/validate-configuration.yaml
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -43935,9 +43935,11 @@ spec:
           image: "docker.io/grafana/agent:v0.37.2"
           command:
           - bash
-          - -c
+          - -ec
           - |
+            echo Validating config file
             grafana-agent fmt /etc/agent/config.river
+            echo Validating logs config file
             grafana-agent fmt /etc/agent/logs.river
           env:
             - name: AGENT_MODE

--- a/examples/custom-config/output.yaml
+++ b/examples/custom-config/output.yaml
@@ -43237,7 +43237,7 @@ spec:
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: k8smon-grafana-agent-test
+  name: "validate-k8smon-k8s-monitoring"
   namespace: default
   labels:
     app.kubernetes.io/managed-by: "Helm"
@@ -43670,24 +43670,7 @@ data:
       targets    = discovery.relabel.animal_service.output
       forward_to = [prometheus.remote_write.grafana_cloud_prometheus.receiver]
     }
----
-# Source: k8s-monitoring/templates/hooks/grafana-agent-config-test.yaml
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: k8smon-grafana-agent-logs-test
-  namespace: default
-  labels:
-    app.kubernetes.io/managed-by: "Helm"
-    app.kubernetes.io/instance: "k8smon"
-    app.kubernetes.io/version: 1.3.2
-    helm.sh/chart: "k8s-monitoring-0.2.12"
-  annotations:
-    "helm.sh/hook": pre-install,pre-upgrade
-    "helm.sh/hook-weight": "-5"
-    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
-data:
-  config.river: |-
+  logs.river: |-
     discovery.kubernetes "pods" {
       role = "pod"
     }
@@ -43855,7 +43838,7 @@ data:
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: "k8smon-test"
+  name: "test-k8smon-k8s-monitoring"
   namespace: default
   labels:
     app.kubernetes.io/managed-by: "Helm"
@@ -43925,7 +43908,7 @@ data:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: "k8smon-test-config"
+  name: "validate-k8smon-k8s-monitoring"
   namespace: default
   labels:
     app.kubernetes.io/managed-by: "Helm"
@@ -43940,7 +43923,7 @@ spec:
   backoffLimit: 0
   template:
     metadata:
-      name: "k8smon-test-config"
+      name: "validate-k8smon-k8s-monitoring"
       labels:
         app.kubernetes.io/managed-by: "Helm"
         app.kubernetes.io/instance: "k8smon"
@@ -43950,9 +43933,12 @@ spec:
       containers:
         - name: grafana-agent
           image: "docker.io/grafana/agent:v0.37.2"
-          args:
-            - fmt
-            - /etc/agent/config.river
+          command:
+          - bash
+          - -c
+          - |
+            grafana-agent fmt /etc/agent/config.river
+            grafana-agent fmt /etc/agent/logs.river
           env:
             - name: AGENT_MODE
               value: flow
@@ -43962,56 +43948,13 @@ spec:
       volumes:
         - name: config
           configMap:
-            name: k8smon-grafana-agent-test
----
-# Source: k8s-monitoring/templates/hooks/grafana-agent-config-test.yaml
-apiVersion: batch/v1
-kind: Job
-metadata:
-  name: "k8smon-test-logs-config"
-  namespace: default
-  labels:
-    app.kubernetes.io/managed-by: "Helm"
-    app.kubernetes.io/instance: "k8smon"
-    app.kubernetes.io/version: 1.3.2
-    helm.sh/chart: "k8s-monitoring-0.2.12"
-  annotations:
-    "helm.sh/hook": pre-install,pre-upgrade
-    "helm.sh/hook-weight": "-5"
-    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
-spec:
-  backoffLimit: 0
-  template:
-    metadata:
-      name: "k8smon-test-logs-config"
-      labels:
-        app.kubernetes.io/managed-by: "Helm"
-        app.kubernetes.io/instance: "k8smon"
-        helm.sh/chart: "k8s-monitoring-0.2.12"
-    spec:
-      restartPolicy: Never
-      containers:
-        - name: grafana-agent
-          image: "docker.io/grafana/agent:v0.37.2"
-          args:
-            - fmt
-            - /etc/agent/config.river
-          env:
-            - name: AGENT_MODE
-              value: flow
-          volumeMounts:
-            - name: config
-              mountPath: /etc/agent
-      volumes:
-        - name: config
-          configMap:
-            name: k8smon-grafana-agent-logs-test
+            name: "validate-k8smon-k8s-monitoring"
 ---
 # Source: k8s-monitoring/templates/tests/test.yaml
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: "k8smon-test"
+  name: "test-k8smon-k8s-monitoring"
   namespace: default
   labels:
     app.kubernetes.io/managed-by: "Helm"
@@ -44024,7 +43967,7 @@ metadata:
 spec:
   template:
     metadata:
-      name: "k8smon-test-config"
+      name: "test-k8smon-k8s-monitoring"
       labels:
         app.kubernetes.io/managed-by: "Helm"
         app.kubernetes.io/instance: "k8smon"
@@ -44057,4 +44000,4 @@ spec:
       volumes:
         - name: test-plan
           configMap:
-            name: k8smon-test
+            name: "test-k8smon-k8s-monitoring"

--- a/examples/default-values/output.yaml
+++ b/examples/default-values/output.yaml
@@ -43172,7 +43172,7 @@ spec:
 # Source: k8s-monitoring/charts/prometheus-operator-crds/charts/crds/templates/crd-thanosrulers.yaml
 # https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.68.0/example/prometheus-operator-crd/monitoring.coreos.com_thanosrulers.yaml
 ---
-# Source: k8s-monitoring/templates/hooks/grafana-agent-config-test.yaml
+# Source: k8s-monitoring/templates/hooks/validate-configuration.yaml
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -43782,7 +43782,7 @@ data:
       ]
     }
 ---
-# Source: k8s-monitoring/templates/hooks/grafana-agent-config-test.yaml
+# Source: k8s-monitoring/templates/hooks/validate-configuration.yaml
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -43813,9 +43813,11 @@ spec:
           image: "docker.io/grafana/agent:v0.37.2"
           command:
           - bash
-          - -c
+          - -ec
           - |
+            echo Validating config file
             grafana-agent fmt /etc/agent/config.river
+            echo Validating logs config file
             grafana-agent fmt /etc/agent/logs.river
           env:
             - name: AGENT_MODE

--- a/examples/default-values/output.yaml
+++ b/examples/default-values/output.yaml
@@ -43176,7 +43176,7 @@ spec:
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: k8smon-grafana-agent-test
+  name: "validate-k8smon-k8s-monitoring"
   namespace: default
   labels:
     app.kubernetes.io/managed-by: "Helm"
@@ -43585,24 +43585,7 @@ data:
         cluster = "default-values-test",
       }
     }
----
-# Source: k8s-monitoring/templates/hooks/grafana-agent-config-test.yaml
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: k8smon-grafana-agent-logs-test
-  namespace: default
-  labels:
-    app.kubernetes.io/managed-by: "Helm"
-    app.kubernetes.io/instance: "k8smon"
-    app.kubernetes.io/version: 1.3.2
-    helm.sh/chart: "k8s-monitoring-0.2.12"
-  annotations:
-    "helm.sh/hook": pre-install,pre-upgrade
-    "helm.sh/hook-weight": "-5"
-    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
-data:
-  config.river: |-
+  logs.river: |-
     discovery.kubernetes "pods" {
       role = "pod"
     }
@@ -43733,7 +43716,7 @@ data:
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: "k8smon-test"
+  name: "test-k8smon-k8s-monitoring"
   namespace: default
   labels:
     app.kubernetes.io/managed-by: "Helm"
@@ -43803,7 +43786,7 @@ data:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: "k8smon-test-config"
+  name: "validate-k8smon-k8s-monitoring"
   namespace: default
   labels:
     app.kubernetes.io/managed-by: "Helm"
@@ -43818,7 +43801,7 @@ spec:
   backoffLimit: 0
   template:
     metadata:
-      name: "k8smon-test-config"
+      name: "validate-k8smon-k8s-monitoring"
       labels:
         app.kubernetes.io/managed-by: "Helm"
         app.kubernetes.io/instance: "k8smon"
@@ -43828,9 +43811,12 @@ spec:
       containers:
         - name: grafana-agent
           image: "docker.io/grafana/agent:v0.37.2"
-          args:
-            - fmt
-            - /etc/agent/config.river
+          command:
+          - bash
+          - -c
+          - |
+            grafana-agent fmt /etc/agent/config.river
+            grafana-agent fmt /etc/agent/logs.river
           env:
             - name: AGENT_MODE
               value: flow
@@ -43840,56 +43826,13 @@ spec:
       volumes:
         - name: config
           configMap:
-            name: k8smon-grafana-agent-test
----
-# Source: k8s-monitoring/templates/hooks/grafana-agent-config-test.yaml
-apiVersion: batch/v1
-kind: Job
-metadata:
-  name: "k8smon-test-logs-config"
-  namespace: default
-  labels:
-    app.kubernetes.io/managed-by: "Helm"
-    app.kubernetes.io/instance: "k8smon"
-    app.kubernetes.io/version: 1.3.2
-    helm.sh/chart: "k8s-monitoring-0.2.12"
-  annotations:
-    "helm.sh/hook": pre-install,pre-upgrade
-    "helm.sh/hook-weight": "-5"
-    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
-spec:
-  backoffLimit: 0
-  template:
-    metadata:
-      name: "k8smon-test-logs-config"
-      labels:
-        app.kubernetes.io/managed-by: "Helm"
-        app.kubernetes.io/instance: "k8smon"
-        helm.sh/chart: "k8s-monitoring-0.2.12"
-    spec:
-      restartPolicy: Never
-      containers:
-        - name: grafana-agent
-          image: "docker.io/grafana/agent:v0.37.2"
-          args:
-            - fmt
-            - /etc/agent/config.river
-          env:
-            - name: AGENT_MODE
-              value: flow
-          volumeMounts:
-            - name: config
-              mountPath: /etc/agent
-      volumes:
-        - name: config
-          configMap:
-            name: k8smon-grafana-agent-logs-test
+            name: "validate-k8smon-k8s-monitoring"
 ---
 # Source: k8s-monitoring/templates/tests/test.yaml
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: "k8smon-test"
+  name: "test-k8smon-k8s-monitoring"
   namespace: default
   labels:
     app.kubernetes.io/managed-by: "Helm"
@@ -43902,7 +43845,7 @@ metadata:
 spec:
   template:
     metadata:
-      name: "k8smon-test-config"
+      name: "test-k8smon-k8s-monitoring"
       labels:
         app.kubernetes.io/managed-by: "Helm"
         app.kubernetes.io/instance: "k8smon"
@@ -43935,4 +43878,4 @@ spec:
       volumes:
         - name: test-plan
           configMap:
-            name: k8smon-test
+            name: "test-k8smon-k8s-monitoring"

--- a/examples/extra-rules/output.yaml
+++ b/examples/extra-rules/output.yaml
@@ -43251,7 +43251,7 @@ spec:
 # Source: k8s-monitoring/charts/prometheus-operator-crds/charts/crds/templates/crd-thanosrulers.yaml
 # https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.68.0/example/prometheus-operator-crd/monitoring.coreos.com_thanosrulers.yaml
 ---
-# Source: k8s-monitoring/templates/hooks/grafana-agent-config-test.yaml
+# Source: k8s-monitoring/templates/hooks/validate-configuration.yaml
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -43939,7 +43939,7 @@ data:
       ]
     }
 ---
-# Source: k8s-monitoring/templates/hooks/grafana-agent-config-test.yaml
+# Source: k8s-monitoring/templates/hooks/validate-configuration.yaml
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -43970,9 +43970,11 @@ spec:
           image: "docker.io/grafana/agent:v0.37.2"
           command:
           - bash
-          - -c
+          - -ec
           - |
+            echo Validating config file
             grafana-agent fmt /etc/agent/config.river
+            echo Validating logs config file
             grafana-agent fmt /etc/agent/logs.river
           env:
             - name: AGENT_MODE

--- a/examples/extra-rules/output.yaml
+++ b/examples/extra-rules/output.yaml
@@ -43255,7 +43255,7 @@ spec:
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: k8smon-grafana-agent-test
+  name: "validate-k8smon-k8s-monitoring"
   namespace: default
   labels:
     app.kubernetes.io/managed-by: "Helm"
@@ -43714,24 +43714,7 @@ data:
         cluster = "extra-rules-test",
       }
     }
----
-# Source: k8s-monitoring/templates/hooks/grafana-agent-config-test.yaml
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: k8smon-grafana-agent-logs-test
-  namespace: default
-  labels:
-    app.kubernetes.io/managed-by: "Helm"
-    app.kubernetes.io/instance: "k8smon"
-    app.kubernetes.io/version: 1.3.2
-    helm.sh/chart: "k8s-monitoring-0.2.12"
-  annotations:
-    "helm.sh/hook": pre-install,pre-upgrade
-    "helm.sh/hook-weight": "-5"
-    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
-data:
-  config.river: |-
+  logs.river: |-
     discovery.kubernetes "pods" {
       role = "pod"
     }
@@ -43890,7 +43873,7 @@ data:
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: "k8smon-test"
+  name: "test-k8smon-k8s-monitoring"
   namespace: default
   labels:
     app.kubernetes.io/managed-by: "Helm"
@@ -43960,7 +43943,7 @@ data:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: "k8smon-test-config"
+  name: "validate-k8smon-k8s-monitoring"
   namespace: default
   labels:
     app.kubernetes.io/managed-by: "Helm"
@@ -43975,7 +43958,7 @@ spec:
   backoffLimit: 0
   template:
     metadata:
-      name: "k8smon-test-config"
+      name: "validate-k8smon-k8s-monitoring"
       labels:
         app.kubernetes.io/managed-by: "Helm"
         app.kubernetes.io/instance: "k8smon"
@@ -43985,9 +43968,12 @@ spec:
       containers:
         - name: grafana-agent
           image: "docker.io/grafana/agent:v0.37.2"
-          args:
-            - fmt
-            - /etc/agent/config.river
+          command:
+          - bash
+          - -c
+          - |
+            grafana-agent fmt /etc/agent/config.river
+            grafana-agent fmt /etc/agent/logs.river
           env:
             - name: AGENT_MODE
               value: flow
@@ -43997,56 +43983,13 @@ spec:
       volumes:
         - name: config
           configMap:
-            name: k8smon-grafana-agent-test
----
-# Source: k8s-monitoring/templates/hooks/grafana-agent-config-test.yaml
-apiVersion: batch/v1
-kind: Job
-metadata:
-  name: "k8smon-test-logs-config"
-  namespace: default
-  labels:
-    app.kubernetes.io/managed-by: "Helm"
-    app.kubernetes.io/instance: "k8smon"
-    app.kubernetes.io/version: 1.3.2
-    helm.sh/chart: "k8s-monitoring-0.2.12"
-  annotations:
-    "helm.sh/hook": pre-install,pre-upgrade
-    "helm.sh/hook-weight": "-5"
-    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
-spec:
-  backoffLimit: 0
-  template:
-    metadata:
-      name: "k8smon-test-logs-config"
-      labels:
-        app.kubernetes.io/managed-by: "Helm"
-        app.kubernetes.io/instance: "k8smon"
-        helm.sh/chart: "k8s-monitoring-0.2.12"
-    spec:
-      restartPolicy: Never
-      containers:
-        - name: grafana-agent
-          image: "docker.io/grafana/agent:v0.37.2"
-          args:
-            - fmt
-            - /etc/agent/config.river
-          env:
-            - name: AGENT_MODE
-              value: flow
-          volumeMounts:
-            - name: config
-              mountPath: /etc/agent
-      volumes:
-        - name: config
-          configMap:
-            name: k8smon-grafana-agent-logs-test
+            name: "validate-k8smon-k8s-monitoring"
 ---
 # Source: k8s-monitoring/templates/tests/test.yaml
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: "k8smon-test"
+  name: "test-k8smon-k8s-monitoring"
   namespace: default
   labels:
     app.kubernetes.io/managed-by: "Helm"
@@ -44059,7 +44002,7 @@ metadata:
 spec:
   template:
     metadata:
-      name: "k8smon-test-config"
+      name: "test-k8smon-k8s-monitoring"
       labels:
         app.kubernetes.io/managed-by: "Helm"
         app.kubernetes.io/instance: "k8smon"
@@ -44092,4 +44035,4 @@ spec:
       volumes:
         - name: test-plan
           configMap:
-            name: k8smon-test
+            name: "test-k8smon-k8s-monitoring"

--- a/examples/gke-autopilot/output.yaml
+++ b/examples/gke-autopilot/output.yaml
@@ -42977,7 +42977,7 @@ spec:
 # Source: k8s-monitoring/charts/prometheus-operator-crds/charts/crds/templates/crd-thanosrulers.yaml
 # https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.68.0/example/prometheus-operator-crd/monitoring.coreos.com_thanosrulers.yaml
 ---
-# Source: k8s-monitoring/templates/hooks/grafana-agent-config-test.yaml
+# Source: k8s-monitoring/templates/hooks/validate-configuration.yaml
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -43545,7 +43545,7 @@ data:
       ]
     }
 ---
-# Source: k8s-monitoring/templates/hooks/grafana-agent-config-test.yaml
+# Source: k8s-monitoring/templates/hooks/validate-configuration.yaml
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -43576,9 +43576,11 @@ spec:
           image: "docker.io/grafana/agent:v0.37.2"
           command:
           - bash
-          - -c
+          - -ec
           - |
+            echo Validating config file
             grafana-agent fmt /etc/agent/config.river
+            echo Validating logs config file
             grafana-agent fmt /etc/agent/logs.river
           env:
             - name: AGENT_MODE

--- a/examples/gke-autopilot/output.yaml
+++ b/examples/gke-autopilot/output.yaml
@@ -42981,7 +42981,7 @@ spec:
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: k8smon-grafana-agent-test
+  name: "validate-k8smon-k8s-monitoring"
   namespace: default
   labels:
     app.kubernetes.io/managed-by: "Helm"
@@ -43351,24 +43351,7 @@ data:
         cluster = "gke-autopilot-test",
       }
     }
----
-# Source: k8s-monitoring/templates/hooks/grafana-agent-config-test.yaml
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: k8smon-grafana-agent-logs-test
-  namespace: default
-  labels:
-    app.kubernetes.io/managed-by: "Helm"
-    app.kubernetes.io/instance: "k8smon"
-    app.kubernetes.io/version: 1.3.2
-    helm.sh/chart: "k8s-monitoring-0.2.12"
-  annotations:
-    "helm.sh/hook": pre-install,pre-upgrade
-    "helm.sh/hook-weight": "-5"
-    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
-data:
-  config.river: |-
+  logs.river: |-
     discovery.kubernetes "pods" {
       role = "pod"
     }
@@ -43499,7 +43482,7 @@ data:
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: "k8smon-test"
+  name: "test-k8smon-k8s-monitoring"
   namespace: default
   labels:
     app.kubernetes.io/managed-by: "Helm"
@@ -43566,7 +43549,7 @@ data:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: "k8smon-test-config"
+  name: "validate-k8smon-k8s-monitoring"
   namespace: default
   labels:
     app.kubernetes.io/managed-by: "Helm"
@@ -43581,7 +43564,7 @@ spec:
   backoffLimit: 0
   template:
     metadata:
-      name: "k8smon-test-config"
+      name: "validate-k8smon-k8s-monitoring"
       labels:
         app.kubernetes.io/managed-by: "Helm"
         app.kubernetes.io/instance: "k8smon"
@@ -43591,9 +43574,12 @@ spec:
       containers:
         - name: grafana-agent
           image: "docker.io/grafana/agent:v0.37.2"
-          args:
-            - fmt
-            - /etc/agent/config.river
+          command:
+          - bash
+          - -c
+          - |
+            grafana-agent fmt /etc/agent/config.river
+            grafana-agent fmt /etc/agent/logs.river
           env:
             - name: AGENT_MODE
               value: flow
@@ -43603,56 +43589,13 @@ spec:
       volumes:
         - name: config
           configMap:
-            name: k8smon-grafana-agent-test
----
-# Source: k8s-monitoring/templates/hooks/grafana-agent-config-test.yaml
-apiVersion: batch/v1
-kind: Job
-metadata:
-  name: "k8smon-test-logs-config"
-  namespace: default
-  labels:
-    app.kubernetes.io/managed-by: "Helm"
-    app.kubernetes.io/instance: "k8smon"
-    app.kubernetes.io/version: 1.3.2
-    helm.sh/chart: "k8s-monitoring-0.2.12"
-  annotations:
-    "helm.sh/hook": pre-install,pre-upgrade
-    "helm.sh/hook-weight": "-5"
-    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
-spec:
-  backoffLimit: 0
-  template:
-    metadata:
-      name: "k8smon-test-logs-config"
-      labels:
-        app.kubernetes.io/managed-by: "Helm"
-        app.kubernetes.io/instance: "k8smon"
-        helm.sh/chart: "k8s-monitoring-0.2.12"
-    spec:
-      restartPolicy: Never
-      containers:
-        - name: grafana-agent
-          image: "docker.io/grafana/agent:v0.37.2"
-          args:
-            - fmt
-            - /etc/agent/config.river
-          env:
-            - name: AGENT_MODE
-              value: flow
-          volumeMounts:
-            - name: config
-              mountPath: /etc/agent
-      volumes:
-        - name: config
-          configMap:
-            name: k8smon-grafana-agent-logs-test
+            name: "validate-k8smon-k8s-monitoring"
 ---
 # Source: k8s-monitoring/templates/tests/test.yaml
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: "k8smon-test"
+  name: "test-k8smon-k8s-monitoring"
   namespace: default
   labels:
     app.kubernetes.io/managed-by: "Helm"
@@ -43665,7 +43608,7 @@ metadata:
 spec:
   template:
     metadata:
-      name: "k8smon-test-config"
+      name: "test-k8smon-k8s-monitoring"
       labels:
         app.kubernetes.io/managed-by: "Helm"
         app.kubernetes.io/instance: "k8smon"
@@ -43698,4 +43641,4 @@ spec:
       volumes:
         - name: test-plan
           configMap:
-            name: k8smon-test
+            name: "test-k8smon-k8s-monitoring"

--- a/examples/logs-only/output.yaml
+++ b/examples/logs-only/output.yaml
@@ -918,7 +918,7 @@ spec:
             name: kubernetes-monitoring-telemetry
           name: kubernetes-monitoring-telemetry
 ---
-# Source: k8s-monitoring/templates/hooks/grafana-agent-config-test.yaml
+# Source: k8s-monitoring/templates/hooks/validate-configuration.yaml
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -1160,7 +1160,7 @@ data:
       "queries": null
     }
 ---
-# Source: k8s-monitoring/templates/hooks/grafana-agent-config-test.yaml
+# Source: k8s-monitoring/templates/hooks/validate-configuration.yaml
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -1191,9 +1191,11 @@ spec:
           image: "docker.io/grafana/agent:v0.37.2"
           command:
           - bash
-          - -c
+          - -ec
           - |
+            echo Validating config file
             grafana-agent fmt /etc/agent/config.river
+            echo Validating logs config file
             grafana-agent fmt /etc/agent/logs.river
           env:
             - name: AGENT_MODE

--- a/examples/logs-only/output.yaml
+++ b/examples/logs-only/output.yaml
@@ -922,7 +922,7 @@ spec:
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: k8smon-grafana-agent-test
+  name: "validate-k8smon-k8s-monitoring"
   namespace: default
   labels:
     app.kubernetes.io/managed-by: "Helm"
@@ -984,24 +984,7 @@ data:
         cluster = "logs-only-test",
       }
     }
----
-# Source: k8s-monitoring/templates/hooks/grafana-agent-config-test.yaml
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: k8smon-grafana-agent-logs-test
-  namespace: default
-  labels:
-    app.kubernetes.io/managed-by: "Helm"
-    app.kubernetes.io/instance: "k8smon"
-    app.kubernetes.io/version: 1.3.2
-    helm.sh/chart: "k8s-monitoring-0.2.12"
-  annotations:
-    "helm.sh/hook": pre-install,pre-upgrade
-    "helm.sh/hook-weight": "-5"
-    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
-data:
-  config.river: |-
+  logs.river: |-
     discovery.kubernetes "pods" {
       role = "pod"
     }
@@ -1136,7 +1119,7 @@ data:
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: "k8smon-test"
+  name: "test-k8smon-k8s-monitoring"
   namespace: default
   labels:
     app.kubernetes.io/managed-by: "Helm"
@@ -1181,7 +1164,7 @@ data:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: "k8smon-test-config"
+  name: "validate-k8smon-k8s-monitoring"
   namespace: default
   labels:
     app.kubernetes.io/managed-by: "Helm"
@@ -1196,7 +1179,7 @@ spec:
   backoffLimit: 0
   template:
     metadata:
-      name: "k8smon-test-config"
+      name: "validate-k8smon-k8s-monitoring"
       labels:
         app.kubernetes.io/managed-by: "Helm"
         app.kubernetes.io/instance: "k8smon"
@@ -1206,9 +1189,12 @@ spec:
       containers:
         - name: grafana-agent
           image: "docker.io/grafana/agent:v0.37.2"
-          args:
-            - fmt
-            - /etc/agent/config.river
+          command:
+          - bash
+          - -c
+          - |
+            grafana-agent fmt /etc/agent/config.river
+            grafana-agent fmt /etc/agent/logs.river
           env:
             - name: AGENT_MODE
               value: flow
@@ -1218,56 +1204,13 @@ spec:
       volumes:
         - name: config
           configMap:
-            name: k8smon-grafana-agent-test
----
-# Source: k8s-monitoring/templates/hooks/grafana-agent-config-test.yaml
-apiVersion: batch/v1
-kind: Job
-metadata:
-  name: "k8smon-test-logs-config"
-  namespace: default
-  labels:
-    app.kubernetes.io/managed-by: "Helm"
-    app.kubernetes.io/instance: "k8smon"
-    app.kubernetes.io/version: 1.3.2
-    helm.sh/chart: "k8s-monitoring-0.2.12"
-  annotations:
-    "helm.sh/hook": pre-install,pre-upgrade
-    "helm.sh/hook-weight": "-5"
-    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
-spec:
-  backoffLimit: 0
-  template:
-    metadata:
-      name: "k8smon-test-logs-config"
-      labels:
-        app.kubernetes.io/managed-by: "Helm"
-        app.kubernetes.io/instance: "k8smon"
-        helm.sh/chart: "k8s-monitoring-0.2.12"
-    spec:
-      restartPolicy: Never
-      containers:
-        - name: grafana-agent
-          image: "docker.io/grafana/agent:v0.37.2"
-          args:
-            - fmt
-            - /etc/agent/config.river
-          env:
-            - name: AGENT_MODE
-              value: flow
-          volumeMounts:
-            - name: config
-              mountPath: /etc/agent
-      volumes:
-        - name: config
-          configMap:
-            name: k8smon-grafana-agent-logs-test
+            name: "validate-k8smon-k8s-monitoring"
 ---
 # Source: k8s-monitoring/templates/tests/test.yaml
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: "k8smon-test"
+  name: "test-k8smon-k8s-monitoring"
   namespace: default
   labels:
     app.kubernetes.io/managed-by: "Helm"
@@ -1280,7 +1223,7 @@ metadata:
 spec:
   template:
     metadata:
-      name: "k8smon-test-config"
+      name: "test-k8smon-k8s-monitoring"
       labels:
         app.kubernetes.io/managed-by: "Helm"
         app.kubernetes.io/instance: "k8smon"
@@ -1313,4 +1256,4 @@ spec:
       volumes:
         - name: test-plan
           configMap:
-            name: k8smon-test
+            name: "test-k8smon-k8s-monitoring"

--- a/examples/metrics-only/output.yaml
+++ b/examples/metrics-only/output.yaml
@@ -42775,7 +42775,7 @@ spec:
 # Source: k8s-monitoring/charts/prometheus-operator-crds/charts/crds/templates/crd-thanosrulers.yaml
 # https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.68.0/example/prometheus-operator-crd/monitoring.coreos.com_thanosrulers.yaml
 ---
-# Source: k8s-monitoring/templates/hooks/grafana-agent-config-test.yaml
+# Source: k8s-monitoring/templates/hooks/validate-configuration.yaml
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -43229,7 +43229,7 @@ data:
       ]
     }
 ---
-# Source: k8s-monitoring/templates/hooks/grafana-agent-config-test.yaml
+# Source: k8s-monitoring/templates/hooks/validate-configuration.yaml
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -43260,8 +43260,9 @@ spec:
           image: "docker.io/grafana/agent:v0.37.2"
           command:
           - bash
-          - -c
+          - -ec
           - |
+            echo Validating config file
             grafana-agent fmt /etc/agent/config.river
           env:
             - name: AGENT_MODE

--- a/examples/metrics-only/output.yaml
+++ b/examples/metrics-only/output.yaml
@@ -42779,7 +42779,7 @@ spec:
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: k8smon-grafana-agent-test
+  name: "validate-k8smon-k8s-monitoring"
   namespace: default
   labels:
     app.kubernetes.io/managed-by: "Helm"
@@ -43163,7 +43163,7 @@ data:
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: "k8smon-test"
+  name: "test-k8smon-k8s-monitoring"
   namespace: default
   labels:
     app.kubernetes.io/managed-by: "Helm"
@@ -43233,7 +43233,7 @@ data:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: "k8smon-test-config"
+  name: "validate-k8smon-k8s-monitoring"
   namespace: default
   labels:
     app.kubernetes.io/managed-by: "Helm"
@@ -43248,7 +43248,7 @@ spec:
   backoffLimit: 0
   template:
     metadata:
-      name: "k8smon-test-config"
+      name: "validate-k8smon-k8s-monitoring"
       labels:
         app.kubernetes.io/managed-by: "Helm"
         app.kubernetes.io/instance: "k8smon"
@@ -43258,9 +43258,11 @@ spec:
       containers:
         - name: grafana-agent
           image: "docker.io/grafana/agent:v0.37.2"
-          args:
-            - fmt
-            - /etc/agent/config.river
+          command:
+          - bash
+          - -c
+          - |
+            grafana-agent fmt /etc/agent/config.river
           env:
             - name: AGENT_MODE
               value: flow
@@ -43270,13 +43272,13 @@ spec:
       volumes:
         - name: config
           configMap:
-            name: k8smon-grafana-agent-test
+            name: "validate-k8smon-k8s-monitoring"
 ---
 # Source: k8s-monitoring/templates/tests/test.yaml
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: "k8smon-test"
+  name: "test-k8smon-k8s-monitoring"
   namespace: default
   labels:
     app.kubernetes.io/managed-by: "Helm"
@@ -43289,7 +43291,7 @@ metadata:
 spec:
   template:
     metadata:
-      name: "k8smon-test-config"
+      name: "test-k8smon-k8s-monitoring"
       labels:
         app.kubernetes.io/managed-by: "Helm"
         app.kubernetes.io/instance: "k8smon"
@@ -43322,4 +43324,4 @@ spec:
       volumes:
         - name: test-plan
           configMap:
-            name: k8smon-test
+            name: "test-k8smon-k8s-monitoring"

--- a/examples/openshift-compatible/output.yaml
+++ b/examples/openshift-compatible/output.yaml
@@ -42821,7 +42821,7 @@ volumes:
 - projected
 - secret
 ---
-# Source: k8s-monitoring/templates/hooks/grafana-agent-config-test.yaml
+# Source: k8s-monitoring/templates/hooks/validate-configuration.yaml
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -43435,7 +43435,7 @@ data:
       ]
     }
 ---
-# Source: k8s-monitoring/templates/hooks/grafana-agent-config-test.yaml
+# Source: k8s-monitoring/templates/hooks/validate-configuration.yaml
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -43466,9 +43466,11 @@ spec:
           image: "docker.io/grafana/agent:v0.37.2"
           command:
           - bash
-          - -c
+          - -ec
           - |
+            echo Validating config file
             grafana-agent fmt /etc/agent/config.river
+            echo Validating logs config file
             grafana-agent fmt /etc/agent/logs.river
           env:
             - name: AGENT_MODE

--- a/examples/openshift-compatible/output.yaml
+++ b/examples/openshift-compatible/output.yaml
@@ -42825,7 +42825,7 @@ volumes:
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: k8smon-grafana-agent-test
+  name: "validate-k8smon-k8s-monitoring"
   namespace: default
   labels:
     app.kubernetes.io/managed-by: "Helm"
@@ -43237,24 +43237,7 @@ data:
         cluster = "openshift-compatible-test",
       }
     }
----
-# Source: k8s-monitoring/templates/hooks/grafana-agent-config-test.yaml
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: k8smon-grafana-agent-logs-test
-  namespace: default
-  labels:
-    app.kubernetes.io/managed-by: "Helm"
-    app.kubernetes.io/instance: "k8smon"
-    app.kubernetes.io/version: 1.3.2
-    helm.sh/chart: "k8s-monitoring-0.2.12"
-  annotations:
-    "helm.sh/hook": pre-install,pre-upgrade
-    "helm.sh/hook-weight": "-5"
-    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
-data:
-  config.river: |-
+  logs.river: |-
     discovery.kubernetes "pods" {
       role = "pod"
     }
@@ -43386,7 +43369,7 @@ data:
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: "k8smon-test"
+  name: "test-k8smon-k8s-monitoring"
   namespace: default
   labels:
     app.kubernetes.io/managed-by: "Helm"
@@ -43456,7 +43439,7 @@ data:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: "k8smon-test-config"
+  name: "validate-k8smon-k8s-monitoring"
   namespace: default
   labels:
     app.kubernetes.io/managed-by: "Helm"
@@ -43471,7 +43454,7 @@ spec:
   backoffLimit: 0
   template:
     metadata:
-      name: "k8smon-test-config"
+      name: "validate-k8smon-k8s-monitoring"
       labels:
         app.kubernetes.io/managed-by: "Helm"
         app.kubernetes.io/instance: "k8smon"
@@ -43481,9 +43464,12 @@ spec:
       containers:
         - name: grafana-agent
           image: "docker.io/grafana/agent:v0.37.2"
-          args:
-            - fmt
-            - /etc/agent/config.river
+          command:
+          - bash
+          - -c
+          - |
+            grafana-agent fmt /etc/agent/config.river
+            grafana-agent fmt /etc/agent/logs.river
           env:
             - name: AGENT_MODE
               value: flow
@@ -43493,56 +43479,13 @@ spec:
       volumes:
         - name: config
           configMap:
-            name: k8smon-grafana-agent-test
----
-# Source: k8s-monitoring/templates/hooks/grafana-agent-config-test.yaml
-apiVersion: batch/v1
-kind: Job
-metadata:
-  name: "k8smon-test-logs-config"
-  namespace: default
-  labels:
-    app.kubernetes.io/managed-by: "Helm"
-    app.kubernetes.io/instance: "k8smon"
-    app.kubernetes.io/version: 1.3.2
-    helm.sh/chart: "k8s-monitoring-0.2.12"
-  annotations:
-    "helm.sh/hook": pre-install,pre-upgrade
-    "helm.sh/hook-weight": "-5"
-    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
-spec:
-  backoffLimit: 0
-  template:
-    metadata:
-      name: "k8smon-test-logs-config"
-      labels:
-        app.kubernetes.io/managed-by: "Helm"
-        app.kubernetes.io/instance: "k8smon"
-        helm.sh/chart: "k8s-monitoring-0.2.12"
-    spec:
-      restartPolicy: Never
-      containers:
-        - name: grafana-agent
-          image: "docker.io/grafana/agent:v0.37.2"
-          args:
-            - fmt
-            - /etc/agent/config.river
-          env:
-            - name: AGENT_MODE
-              value: flow
-          volumeMounts:
-            - name: config
-              mountPath: /etc/agent
-      volumes:
-        - name: config
-          configMap:
-            name: k8smon-grafana-agent-logs-test
+            name: "validate-k8smon-k8s-monitoring"
 ---
 # Source: k8s-monitoring/templates/tests/test.yaml
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: "k8smon-test"
+  name: "test-k8smon-k8s-monitoring"
   namespace: default
   labels:
     app.kubernetes.io/managed-by: "Helm"
@@ -43555,7 +43498,7 @@ metadata:
 spec:
   template:
     metadata:
-      name: "k8smon-test-config"
+      name: "test-k8smon-k8s-monitoring"
       labels:
         app.kubernetes.io/managed-by: "Helm"
         app.kubernetes.io/instance: "k8smon"
@@ -43588,4 +43531,4 @@ spec:
       volumes:
         - name: test-plan
           configMap:
-            name: k8smon-test
+            name: "test-k8smon-k8s-monitoring"

--- a/examples/private-image-registry/output.yaml
+++ b/examples/private-image-registry/output.yaml
@@ -43176,7 +43176,7 @@ spec:
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: k8smon-grafana-agent-test
+  name: "validate-k8smon-k8s-monitoring"
   namespace: default
   labels:
     app.kubernetes.io/managed-by: "Helm"
@@ -43585,24 +43585,7 @@ data:
         cluster = "private-image-regristry-test",
       }
     }
----
-# Source: k8s-monitoring/templates/hooks/grafana-agent-config-test.yaml
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: k8smon-grafana-agent-logs-test
-  namespace: default
-  labels:
-    app.kubernetes.io/managed-by: "Helm"
-    app.kubernetes.io/instance: "k8smon"
-    app.kubernetes.io/version: 1.3.2
-    helm.sh/chart: "k8s-monitoring-0.2.12"
-  annotations:
-    "helm.sh/hook": pre-install,pre-upgrade
-    "helm.sh/hook-weight": "-5"
-    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
-data:
-  config.river: |-
+  logs.river: |-
     discovery.kubernetes "pods" {
       role = "pod"
     }
@@ -43733,7 +43716,7 @@ data:
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: "k8smon-test"
+  name: "test-k8smon-k8s-monitoring"
   namespace: default
   labels:
     app.kubernetes.io/managed-by: "Helm"
@@ -43803,7 +43786,7 @@ data:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: "k8smon-test-config"
+  name: "validate-k8smon-k8s-monitoring"
   namespace: default
   labels:
     app.kubernetes.io/managed-by: "Helm"
@@ -43818,7 +43801,7 @@ spec:
   backoffLimit: 0
   template:
     metadata:
-      name: "k8smon-test-config"
+      name: "validate-k8smon-k8s-monitoring"
       labels:
         app.kubernetes.io/managed-by: "Helm"
         app.kubernetes.io/instance: "k8smon"
@@ -43828,9 +43811,12 @@ spec:
       containers:
         - name: grafana-agent
           image: "my.registry.com/agent/grafana/agent:v0.37.2"
-          args:
-            - fmt
-            - /etc/agent/config.river
+          command:
+          - bash
+          - -c
+          - |
+            grafana-agent fmt /etc/agent/config.river
+            grafana-agent fmt /etc/agent/logs.river
           env:
             - name: AGENT_MODE
               value: flow
@@ -43840,56 +43826,13 @@ spec:
       volumes:
         - name: config
           configMap:
-            name: k8smon-grafana-agent-test
----
-# Source: k8s-monitoring/templates/hooks/grafana-agent-config-test.yaml
-apiVersion: batch/v1
-kind: Job
-metadata:
-  name: "k8smon-test-logs-config"
-  namespace: default
-  labels:
-    app.kubernetes.io/managed-by: "Helm"
-    app.kubernetes.io/instance: "k8smon"
-    app.kubernetes.io/version: 1.3.2
-    helm.sh/chart: "k8s-monitoring-0.2.12"
-  annotations:
-    "helm.sh/hook": pre-install,pre-upgrade
-    "helm.sh/hook-weight": "-5"
-    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
-spec:
-  backoffLimit: 0
-  template:
-    metadata:
-      name: "k8smon-test-logs-config"
-      labels:
-        app.kubernetes.io/managed-by: "Helm"
-        app.kubernetes.io/instance: "k8smon"
-        helm.sh/chart: "k8s-monitoring-0.2.12"
-    spec:
-      restartPolicy: Never
-      containers:
-        - name: grafana-agent
-          image: "my.registry.com/agent/grafana/agent:v0.37.2"
-          args:
-            - fmt
-            - /etc/agent/config.river
-          env:
-            - name: AGENT_MODE
-              value: flow
-          volumeMounts:
-            - name: config
-              mountPath: /etc/agent
-      volumes:
-        - name: config
-          configMap:
-            name: k8smon-grafana-agent-logs-test
+            name: "validate-k8smon-k8s-monitoring"
 ---
 # Source: k8s-monitoring/templates/tests/test.yaml
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: "k8smon-test"
+  name: "test-k8smon-k8s-monitoring"
   namespace: default
   labels:
     app.kubernetes.io/managed-by: "Helm"
@@ -43902,7 +43845,7 @@ metadata:
 spec:
   template:
     metadata:
-      name: "k8smon-test-config"
+      name: "test-k8smon-k8s-monitoring"
       labels:
         app.kubernetes.io/managed-by: "Helm"
         app.kubernetes.io/instance: "k8smon"
@@ -43935,4 +43878,4 @@ spec:
       volumes:
         - name: test-plan
           configMap:
-            name: k8smon-test
+            name: "test-k8smon-k8s-monitoring"

--- a/examples/private-image-registry/output.yaml
+++ b/examples/private-image-registry/output.yaml
@@ -43172,7 +43172,7 @@ spec:
 # Source: k8s-monitoring/charts/prometheus-operator-crds/charts/crds/templates/crd-thanosrulers.yaml
 # https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.68.0/example/prometheus-operator-crd/monitoring.coreos.com_thanosrulers.yaml
 ---
-# Source: k8s-monitoring/templates/hooks/grafana-agent-config-test.yaml
+# Source: k8s-monitoring/templates/hooks/validate-configuration.yaml
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -43782,7 +43782,7 @@ data:
       ]
     }
 ---
-# Source: k8s-monitoring/templates/hooks/grafana-agent-config-test.yaml
+# Source: k8s-monitoring/templates/hooks/validate-configuration.yaml
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -43813,9 +43813,11 @@ spec:
           image: "my.registry.com/agent/grafana/agent:v0.37.2"
           command:
           - bash
-          - -c
+          - -ec
           - |
+            echo Validating config file
             grafana-agent fmt /etc/agent/config.river
+            echo Validating logs config file
             grafana-agent fmt /etc/agent/logs.river
           env:
             - name: AGENT_MODE

--- a/examples/scrape-intervals/output.yaml
+++ b/examples/scrape-intervals/output.yaml
@@ -42770,7 +42770,7 @@ spec:
 # Source: k8s-monitoring/charts/prometheus-operator-crds/charts/crds/templates/crd-thanosrulers.yaml
 # https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.68.0/example/prometheus-operator-crd/monitoring.coreos.com_thanosrulers.yaml
 ---
-# Source: k8s-monitoring/templates/hooks/grafana-agent-config-test.yaml
+# Source: k8s-monitoring/templates/hooks/validate-configuration.yaml
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -43220,7 +43220,7 @@ data:
       ]
     }
 ---
-# Source: k8s-monitoring/templates/hooks/grafana-agent-config-test.yaml
+# Source: k8s-monitoring/templates/hooks/validate-configuration.yaml
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -43251,8 +43251,9 @@ spec:
           image: "docker.io/grafana/agent:v0.37.2"
           command:
           - bash
-          - -c
+          - -ec
           - |
+            echo Validating config file
             grafana-agent fmt /etc/agent/config.river
           env:
             - name: AGENT_MODE

--- a/examples/scrape-intervals/output.yaml
+++ b/examples/scrape-intervals/output.yaml
@@ -42774,7 +42774,7 @@ spec:
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: k8smon-grafana-agent-test
+  name: "validate-k8smon-k8s-monitoring"
   namespace: default
   labels:
     app.kubernetes.io/managed-by: "Helm"
@@ -43154,7 +43154,7 @@ data:
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: "k8smon-test"
+  name: "test-k8smon-k8s-monitoring"
   namespace: default
   labels:
     app.kubernetes.io/managed-by: "Helm"
@@ -43224,7 +43224,7 @@ data:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: "k8smon-test-config"
+  name: "validate-k8smon-k8s-monitoring"
   namespace: default
   labels:
     app.kubernetes.io/managed-by: "Helm"
@@ -43239,7 +43239,7 @@ spec:
   backoffLimit: 0
   template:
     metadata:
-      name: "k8smon-test-config"
+      name: "validate-k8smon-k8s-monitoring"
       labels:
         app.kubernetes.io/managed-by: "Helm"
         app.kubernetes.io/instance: "k8smon"
@@ -43249,9 +43249,11 @@ spec:
       containers:
         - name: grafana-agent
           image: "docker.io/grafana/agent:v0.37.2"
-          args:
-            - fmt
-            - /etc/agent/config.river
+          command:
+          - bash
+          - -c
+          - |
+            grafana-agent fmt /etc/agent/config.river
           env:
             - name: AGENT_MODE
               value: flow
@@ -43261,13 +43263,13 @@ spec:
       volumes:
         - name: config
           configMap:
-            name: k8smon-grafana-agent-test
+            name: "validate-k8smon-k8s-monitoring"
 ---
 # Source: k8s-monitoring/templates/tests/test.yaml
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: "k8smon-test"
+  name: "test-k8smon-k8s-monitoring"
   namespace: default
   labels:
     app.kubernetes.io/managed-by: "Helm"
@@ -43280,7 +43282,7 @@ metadata:
 spec:
   template:
     metadata:
-      name: "k8smon-test-config"
+      name: "test-k8smon-k8s-monitoring"
       labels:
         app.kubernetes.io/managed-by: "Helm"
         app.kubernetes.io/instance: "k8smon"
@@ -43313,4 +43315,4 @@ spec:
       volumes:
         - name: test-plan
           configMap:
-            name: k8smon-test
+            name: "test-k8smon-k8s-monitoring"

--- a/examples/specific-namespace/output.yaml
+++ b/examples/specific-namespace/output.yaml
@@ -43223,7 +43223,7 @@ spec:
 # Source: k8s-monitoring/charts/prometheus-operator-crds/charts/crds/templates/crd-thanosrulers.yaml
 # https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.68.0/example/prometheus-operator-crd/monitoring.coreos.com_thanosrulers.yaml
 ---
-# Source: k8s-monitoring/templates/hooks/grafana-agent-config-test.yaml
+# Source: k8s-monitoring/templates/hooks/validate-configuration.yaml
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -43884,7 +43884,7 @@ data:
       ]
     }
 ---
-# Source: k8s-monitoring/templates/hooks/grafana-agent-config-test.yaml
+# Source: k8s-monitoring/templates/hooks/validate-configuration.yaml
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -43915,9 +43915,11 @@ spec:
           image: "docker.io/grafana/agent:v0.37.2"
           command:
           - bash
-          - -c
+          - -ec
           - |
+            echo Validating config file
             grafana-agent fmt /etc/agent/config.river
+            echo Validating logs config file
             grafana-agent fmt /etc/agent/logs.river
           env:
             - name: AGENT_MODE

--- a/examples/specific-namespace/output.yaml
+++ b/examples/specific-namespace/output.yaml
@@ -43227,7 +43227,7 @@ spec:
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: k8smon-grafana-agent-test
+  name: "validate-k8smon-k8s-monitoring"
   namespace: default
   labels:
     app.kubernetes.io/managed-by: "Helm"
@@ -43682,24 +43682,7 @@ data:
         cluster = "specific-namespace-test",
       }
     }
----
-# Source: k8s-monitoring/templates/hooks/grafana-agent-config-test.yaml
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: k8smon-grafana-agent-logs-test
-  namespace: default
-  labels:
-    app.kubernetes.io/managed-by: "Helm"
-    app.kubernetes.io/instance: "k8smon"
-    app.kubernetes.io/version: 1.3.2
-    helm.sh/chart: "k8s-monitoring-0.2.12"
-  annotations:
-    "helm.sh/hook": pre-install,pre-upgrade
-    "helm.sh/hook-weight": "-5"
-    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
-data:
-  config.river: |-
+  logs.river: |-
     discovery.kubernetes "pods" {
       role = "pod"
     }
@@ -43835,7 +43818,7 @@ data:
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: "k8smon-test"
+  name: "test-k8smon-k8s-monitoring"
   namespace: default
   labels:
     app.kubernetes.io/managed-by: "Helm"
@@ -43905,7 +43888,7 @@ data:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: "k8smon-test-config"
+  name: "validate-k8smon-k8s-monitoring"
   namespace: default
   labels:
     app.kubernetes.io/managed-by: "Helm"
@@ -43920,7 +43903,7 @@ spec:
   backoffLimit: 0
   template:
     metadata:
-      name: "k8smon-test-config"
+      name: "validate-k8smon-k8s-monitoring"
       labels:
         app.kubernetes.io/managed-by: "Helm"
         app.kubernetes.io/instance: "k8smon"
@@ -43930,9 +43913,12 @@ spec:
       containers:
         - name: grafana-agent
           image: "docker.io/grafana/agent:v0.37.2"
-          args:
-            - fmt
-            - /etc/agent/config.river
+          command:
+          - bash
+          - -c
+          - |
+            grafana-agent fmt /etc/agent/config.river
+            grafana-agent fmt /etc/agent/logs.river
           env:
             - name: AGENT_MODE
               value: flow
@@ -43942,56 +43928,13 @@ spec:
       volumes:
         - name: config
           configMap:
-            name: k8smon-grafana-agent-test
----
-# Source: k8s-monitoring/templates/hooks/grafana-agent-config-test.yaml
-apiVersion: batch/v1
-kind: Job
-metadata:
-  name: "k8smon-test-logs-config"
-  namespace: default
-  labels:
-    app.kubernetes.io/managed-by: "Helm"
-    app.kubernetes.io/instance: "k8smon"
-    app.kubernetes.io/version: 1.3.2
-    helm.sh/chart: "k8s-monitoring-0.2.12"
-  annotations:
-    "helm.sh/hook": pre-install,pre-upgrade
-    "helm.sh/hook-weight": "-5"
-    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
-spec:
-  backoffLimit: 0
-  template:
-    metadata:
-      name: "k8smon-test-logs-config"
-      labels:
-        app.kubernetes.io/managed-by: "Helm"
-        app.kubernetes.io/instance: "k8smon"
-        helm.sh/chart: "k8s-monitoring-0.2.12"
-    spec:
-      restartPolicy: Never
-      containers:
-        - name: grafana-agent
-          image: "docker.io/grafana/agent:v0.37.2"
-          args:
-            - fmt
-            - /etc/agent/config.river
-          env:
-            - name: AGENT_MODE
-              value: flow
-          volumeMounts:
-            - name: config
-              mountPath: /etc/agent
-      volumes:
-        - name: config
-          configMap:
-            name: k8smon-grafana-agent-logs-test
+            name: "validate-k8smon-k8s-monitoring"
 ---
 # Source: k8s-monitoring/templates/tests/test.yaml
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: "k8smon-test"
+  name: "test-k8smon-k8s-monitoring"
   namespace: default
   labels:
     app.kubernetes.io/managed-by: "Helm"
@@ -44004,7 +43947,7 @@ metadata:
 spec:
   template:
     metadata:
-      name: "k8smon-test-config"
+      name: "test-k8smon-k8s-monitoring"
       labels:
         app.kubernetes.io/managed-by: "Helm"
         app.kubernetes.io/instance: "k8smon"
@@ -44037,4 +43980,4 @@ spec:
       volumes:
         - name: test-plan
           configMap:
-            name: k8smon-test
+            name: "test-k8smon-k8s-monitoring"

--- a/examples/traces-enabled/output.yaml
+++ b/examples/traces-enabled/output.yaml
@@ -43282,7 +43282,7 @@ spec:
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: k8smon-grafana-agent-test
+  name: "validate-k8smon-k8s-monitoring"
   namespace: default
   labels:
     app.kubernetes.io/managed-by: "Helm"
@@ -43761,24 +43761,7 @@ data:
         auth = otelcol.auth.basic.tempo.handler
       }
     }
----
-# Source: k8s-monitoring/templates/hooks/grafana-agent-config-test.yaml
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: k8smon-grafana-agent-logs-test
-  namespace: default
-  labels:
-    app.kubernetes.io/managed-by: "Helm"
-    app.kubernetes.io/instance: "k8smon"
-    app.kubernetes.io/version: 1.3.2
-    helm.sh/chart: "k8s-monitoring-0.2.12"
-  annotations:
-    "helm.sh/hook": pre-install,pre-upgrade
-    "helm.sh/hook-weight": "-5"
-    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
-data:
-  config.river: |-
+  logs.river: |-
     discovery.kubernetes "pods" {
       role = "pod"
     }
@@ -43909,7 +43892,7 @@ data:
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: "k8smon-test"
+  name: "test-k8smon-k8s-monitoring"
   namespace: default
   labels:
     app.kubernetes.io/managed-by: "Helm"
@@ -43979,7 +43962,7 @@ data:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: "k8smon-test-config"
+  name: "validate-k8smon-k8s-monitoring"
   namespace: default
   labels:
     app.kubernetes.io/managed-by: "Helm"
@@ -43994,7 +43977,7 @@ spec:
   backoffLimit: 0
   template:
     metadata:
-      name: "k8smon-test-config"
+      name: "validate-k8smon-k8s-monitoring"
       labels:
         app.kubernetes.io/managed-by: "Helm"
         app.kubernetes.io/instance: "k8smon"
@@ -44004,9 +43987,12 @@ spec:
       containers:
         - name: grafana-agent
           image: "docker.io/grafana/agent:v0.37.2"
-          args:
-            - fmt
-            - /etc/agent/config.river
+          command:
+          - bash
+          - -c
+          - |
+            grafana-agent fmt /etc/agent/config.river
+            grafana-agent fmt /etc/agent/logs.river
           env:
             - name: AGENT_MODE
               value: flow
@@ -44016,56 +44002,13 @@ spec:
       volumes:
         - name: config
           configMap:
-            name: k8smon-grafana-agent-test
----
-# Source: k8s-monitoring/templates/hooks/grafana-agent-config-test.yaml
-apiVersion: batch/v1
-kind: Job
-metadata:
-  name: "k8smon-test-logs-config"
-  namespace: default
-  labels:
-    app.kubernetes.io/managed-by: "Helm"
-    app.kubernetes.io/instance: "k8smon"
-    app.kubernetes.io/version: 1.3.2
-    helm.sh/chart: "k8s-monitoring-0.2.12"
-  annotations:
-    "helm.sh/hook": pre-install,pre-upgrade
-    "helm.sh/hook-weight": "-5"
-    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
-spec:
-  backoffLimit: 0
-  template:
-    metadata:
-      name: "k8smon-test-logs-config"
-      labels:
-        app.kubernetes.io/managed-by: "Helm"
-        app.kubernetes.io/instance: "k8smon"
-        helm.sh/chart: "k8s-monitoring-0.2.12"
-    spec:
-      restartPolicy: Never
-      containers:
-        - name: grafana-agent
-          image: "docker.io/grafana/agent:v0.37.2"
-          args:
-            - fmt
-            - /etc/agent/config.river
-          env:
-            - name: AGENT_MODE
-              value: flow
-          volumeMounts:
-            - name: config
-              mountPath: /etc/agent
-      volumes:
-        - name: config
-          configMap:
-            name: k8smon-grafana-agent-logs-test
+            name: "validate-k8smon-k8s-monitoring"
 ---
 # Source: k8s-monitoring/templates/tests/test.yaml
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: "k8smon-test"
+  name: "test-k8smon-k8s-monitoring"
   namespace: default
   labels:
     app.kubernetes.io/managed-by: "Helm"
@@ -44078,7 +44021,7 @@ metadata:
 spec:
   template:
     metadata:
-      name: "k8smon-test-config"
+      name: "test-k8smon-k8s-monitoring"
       labels:
         app.kubernetes.io/managed-by: "Helm"
         app.kubernetes.io/instance: "k8smon"
@@ -44111,4 +44054,4 @@ spec:
       volumes:
         - name: test-plan
           configMap:
-            name: k8smon-test
+            name: "test-k8smon-k8s-monitoring"

--- a/examples/traces-enabled/output.yaml
+++ b/examples/traces-enabled/output.yaml
@@ -43278,7 +43278,7 @@ spec:
 # Source: k8s-monitoring/charts/prometheus-operator-crds/charts/crds/templates/crd-thanosrulers.yaml
 # https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.68.0/example/prometheus-operator-crd/monitoring.coreos.com_thanosrulers.yaml
 ---
-# Source: k8s-monitoring/templates/hooks/grafana-agent-config-test.yaml
+# Source: k8s-monitoring/templates/hooks/validate-configuration.yaml
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -43958,7 +43958,7 @@ data:
       ]
     }
 ---
-# Source: k8s-monitoring/templates/hooks/grafana-agent-config-test.yaml
+# Source: k8s-monitoring/templates/hooks/validate-configuration.yaml
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -43989,9 +43989,11 @@ spec:
           image: "docker.io/grafana/agent:v0.37.2"
           command:
           - bash
-          - -c
+          - -ec
           - |
+            echo Validating config file
             grafana-agent fmt /etc/agent/config.river
+            echo Validating logs config file
             grafana-agent fmt /etc/agent/logs.river
           env:
             - name: AGENT_MODE

--- a/examples/windows-exporter/output.yaml
+++ b/examples/windows-exporter/output.yaml
@@ -43403,7 +43403,7 @@ spec:
 # Source: k8s-monitoring/charts/prometheus-operator-crds/charts/crds/templates/crd-thanosrulers.yaml
 # https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.68.0/example/prometheus-operator-crd/monitoring.coreos.com_thanosrulers.yaml
 ---
-# Source: k8s-monitoring/templates/hooks/grafana-agent-config-test.yaml
+# Source: k8s-monitoring/templates/hooks/validate-configuration.yaml
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -44084,7 +44084,7 @@ data:
       ]
     }
 ---
-# Source: k8s-monitoring/templates/hooks/grafana-agent-config-test.yaml
+# Source: k8s-monitoring/templates/hooks/validate-configuration.yaml
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -44115,9 +44115,11 @@ spec:
           image: "docker.io/grafana/agent:v0.37.2"
           command:
           - bash
-          - -c
+          - -ec
           - |
+            echo Validating config file
             grafana-agent fmt /etc/agent/config.river
+            echo Validating logs config file
             grafana-agent fmt /etc/agent/logs.river
           env:
             - name: AGENT_MODE

--- a/examples/windows-exporter/output.yaml
+++ b/examples/windows-exporter/output.yaml
@@ -43407,7 +43407,7 @@ spec:
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: k8smon-grafana-agent-test
+  name: "validate-k8smon-k8s-monitoring"
   namespace: default
   labels:
     app.kubernetes.io/managed-by: "Helm"
@@ -43884,24 +43884,7 @@ data:
         cluster = "default-values-test",
       }
     }
----
-# Source: k8s-monitoring/templates/hooks/grafana-agent-config-test.yaml
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: k8smon-grafana-agent-logs-test
-  namespace: default
-  labels:
-    app.kubernetes.io/managed-by: "Helm"
-    app.kubernetes.io/instance: "k8smon"
-    app.kubernetes.io/version: 1.3.2
-    helm.sh/chart: "k8s-monitoring-0.2.12"
-  annotations:
-    "helm.sh/hook": pre-install,pre-upgrade
-    "helm.sh/hook-weight": "-5"
-    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
-data:
-  config.river: |-
+  logs.river: |-
     discovery.kubernetes "pods" {
       role = "pod"
     }
@@ -44032,7 +44015,7 @@ data:
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: "k8smon-test"
+  name: "test-k8smon-k8s-monitoring"
   namespace: default
   labels:
     app.kubernetes.io/managed-by: "Helm"
@@ -44105,7 +44088,7 @@ data:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: "k8smon-test-config"
+  name: "validate-k8smon-k8s-monitoring"
   namespace: default
   labels:
     app.kubernetes.io/managed-by: "Helm"
@@ -44120,7 +44103,7 @@ spec:
   backoffLimit: 0
   template:
     metadata:
-      name: "k8smon-test-config"
+      name: "validate-k8smon-k8s-monitoring"
       labels:
         app.kubernetes.io/managed-by: "Helm"
         app.kubernetes.io/instance: "k8smon"
@@ -44130,9 +44113,12 @@ spec:
       containers:
         - name: grafana-agent
           image: "docker.io/grafana/agent:v0.37.2"
-          args:
-            - fmt
-            - /etc/agent/config.river
+          command:
+          - bash
+          - -c
+          - |
+            grafana-agent fmt /etc/agent/config.river
+            grafana-agent fmt /etc/agent/logs.river
           env:
             - name: AGENT_MODE
               value: flow
@@ -44142,56 +44128,13 @@ spec:
       volumes:
         - name: config
           configMap:
-            name: k8smon-grafana-agent-test
----
-# Source: k8s-monitoring/templates/hooks/grafana-agent-config-test.yaml
-apiVersion: batch/v1
-kind: Job
-metadata:
-  name: "k8smon-test-logs-config"
-  namespace: default
-  labels:
-    app.kubernetes.io/managed-by: "Helm"
-    app.kubernetes.io/instance: "k8smon"
-    app.kubernetes.io/version: 1.3.2
-    helm.sh/chart: "k8s-monitoring-0.2.12"
-  annotations:
-    "helm.sh/hook": pre-install,pre-upgrade
-    "helm.sh/hook-weight": "-5"
-    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
-spec:
-  backoffLimit: 0
-  template:
-    metadata:
-      name: "k8smon-test-logs-config"
-      labels:
-        app.kubernetes.io/managed-by: "Helm"
-        app.kubernetes.io/instance: "k8smon"
-        helm.sh/chart: "k8s-monitoring-0.2.12"
-    spec:
-      restartPolicy: Never
-      containers:
-        - name: grafana-agent
-          image: "docker.io/grafana/agent:v0.37.2"
-          args:
-            - fmt
-            - /etc/agent/config.river
-          env:
-            - name: AGENT_MODE
-              value: flow
-          volumeMounts:
-            - name: config
-              mountPath: /etc/agent
-      volumes:
-        - name: config
-          configMap:
-            name: k8smon-grafana-agent-logs-test
+            name: "validate-k8smon-k8s-monitoring"
 ---
 # Source: k8s-monitoring/templates/tests/test.yaml
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: "k8smon-test"
+  name: "test-k8smon-k8s-monitoring"
   namespace: default
   labels:
     app.kubernetes.io/managed-by: "Helm"
@@ -44204,7 +44147,7 @@ metadata:
 spec:
   template:
     metadata:
-      name: "k8smon-test-config"
+      name: "test-k8smon-k8s-monitoring"
       labels:
         app.kubernetes.io/managed-by: "Helm"
         app.kubernetes.io/instance: "k8smon"
@@ -44237,4 +44180,4 @@ spec:
       volumes:
         - name: test-plan
           configMap:
-            name: k8smon-test
+            name: "test-k8smon-k8s-monitoring"

--- a/tests/spec/trace-port-check_spec.sh
+++ b/tests/spec/trace-port-check_spec.sh
@@ -3,7 +3,7 @@ Describe 'Trace Port Check'
     It 'prints a friendly error message'
       When call helm template k8smon ../charts/k8s-monitoring -f "spec/missing-otel-grpc-port_values.yaml"
       The status should be failure
-      The error should equal 'Error: execution error at (k8s-monitoring/templates/hooks/grafana-agent-config-test.yaml:60:8): OTLP gRPC trace port not opened on the Grafana Agent.
+      The error should include 'OTLP gRPC trace port not opened on the Grafana Agent.
 In order for traces to work, the 4317 port needs to be opened on the Grafana Agent. For example, set this in your values file:
 grafana-agent:
   agent:
@@ -22,7 +22,7 @@ Use --debug flag to render out invalid YAML'
     It 'prints a friendly error message'
       When call helm template k8smon ../charts/k8s-monitoring -f "spec/missing-otel-http-port_values.yaml"
       The status should be failure
-      The error should equal 'Error: execution error at (k8s-monitoring/templates/hooks/grafana-agent-config-test.yaml:60:8): OTLP HTTP trace port not opened on the Grafana Agent.
+      The error should include 'OTLP HTTP trace port not opened on the Grafana Agent.
 In order for traces to work, the 4318 port needs to be opened on the Grafana Agent. For example, set this in your values file:
 grafana-agent:
   agent:
@@ -41,7 +41,7 @@ Use --debug flag to render out invalid YAML'
     It 'prints a friendly error message'
       When call helm template k8smon ../charts/k8s-monitoring -f "spec/missing-zipkin-port_values.yaml"
       The status should be failure
-      The error should equal 'Error: execution error at (k8s-monitoring/templates/hooks/grafana-agent-config-test.yaml:60:8): Zipkin trace port not opened on the Grafana Agent.
+      The error should include 'Zipkin trace port not opened on the Grafana Agent.
 In order for traces to work, the 9411 port needs to be opened on the Grafana Agent. For example, set this in your values file:
 grafana-agent:
   agent:


### PR DESCRIPTION
Also, consolidate the config test into a single job

This should eliminate issues with conflicting configmaps.

Fixes #207 