### PR TITLE
For pod logs, filter to the pods only on the same node

### DIFF
--- a/charts/k8s-monitoring/templates/_helpers.tpl
+++ b/charts/k8s-monitoring/templates/_helpers.tpl
@@ -87,7 +87,6 @@
 
 {{/* Grafana Agent Logs config */}}
 {{- define "agentLogsConfig" -}}
-  {{- include "agent.config.pods" . }}
   {{- include "agent.config.logs.pod_logs" . }}
   {{- include "agent.config.loki" . }}
 

--- a/charts/k8s-monitoring/templates/agent_config/_pod_logs.river.txt
+++ b/charts/k8s-monitoring/templates/agent_config/_pod_logs.river.txt
@@ -1,8 +1,14 @@
 {{ define "agent.config.logs.pod_logs" }}
 {{- with .Values.logs.pod_logs }}
 // Pod Logs
+discovery.kubelet "pods" {
+{{- if .namespaces }}
+  namespaces = {{ .namespaces | toStrings | toJson }}
+{{- end }}
+}
+
 discovery.relabel "pod_logs" {
-  targets = discovery.kubernetes.pods.targets
+  targets = discovery.kubelet.pods.targets
 
   rule {
     source_labels = ["__meta_kubernetes_namespace"]
@@ -27,24 +33,12 @@ discovery.relabel "pod_logs" {
     target_label = "job"
   }
   rule {
-    source_labels = ["__meta_kubernetes_pod_node_name"]
-    action = "keep"
-    regex = env("HOSTNAME")
-  }
-  rule {
     source_labels = ["__meta_kubernetes_pod_uid", "__meta_kubernetes_pod_container_name"]
     separator = "/"
     action = "replace"
     replacement = "/var/log/pods/*$1/*.log"
     target_label = "__path__"
   }
-{{- if .namespaces }}
-  rule {
-    source_labels = ["namespace"]
-    regex = "{{ .namespaces | join "|" }}"
-    action = "keep"
-  }
-{{- end }}
 
   // set the container runtime as a label
   rule {

--- a/charts/k8s-monitoring/templates/agent_config/_pod_logs.river.txt
+++ b/charts/k8s-monitoring/templates/agent_config/_pod_logs.river.txt
@@ -8,7 +8,7 @@ discovery.kubernetes "pods" {
     field = "spec.nodeName=" + env("HOSTNAME")
   }
 }
-``
+
 discovery.relabel "pod_logs" {
   targets = discovery.kubernetes.pods.targets
 {{ if .namespaces }}

--- a/charts/k8s-monitoring/templates/agent_config/_pod_logs.river.txt
+++ b/charts/k8s-monitoring/templates/agent_config/_pod_logs.river.txt
@@ -1,15 +1,23 @@
 {{ define "agent.config.logs.pod_logs" }}
 {{- with .Values.logs.pod_logs }}
 // Pod Logs
-discovery.kubelet "pods" {
-{{- if .namespaces }}
-  namespaces = {{ .namespaces | toStrings | toJson }}
-{{- end }}
+discovery.kubernetes "pods" {
+    role = "pod"
+  selectors {
+    role = "pod"
+    field = "spec.nodeName=" + env("HOSTNAME")
+  }
 }
-
+``
 discovery.relabel "pod_logs" {
-  targets = discovery.kubelet.pods.targets
-
+  targets = discovery.kubernetes.pods.targets
+{{ if .namespaces }}
+  rule {
+    source_labels = ["namespace"]
+    regex = "{{ .namespaces | join "|" }}"
+    action = "keep"
+  }
+{{- end }}
   rule {
     source_labels = ["__meta_kubernetes_namespace"]
     action = "replace"

--- a/examples/control-plane-metrics/logs.river
+++ b/examples/control-plane-metrics/logs.river
@@ -1,9 +1,14 @@
 // Pod Logs
-discovery.kubelet "pods" {
+discovery.kubernetes "pods" {
+    role = "pod"
+  selectors {
+    role = "pod"
+    field = "spec.nodeName=" + env("HOSTNAME")
+  }
 }
-
+``
 discovery.relabel "pod_logs" {
-  targets = discovery.kubelet.pods.targets
+  targets = discovery.kubernetes.pods.targets
 
   rule {
     source_labels = ["__meta_kubernetes_namespace"]

--- a/examples/control-plane-metrics/logs.river
+++ b/examples/control-plane-metrics/logs.river
@@ -6,7 +6,7 @@ discovery.kubernetes "pods" {
     field = "spec.nodeName=" + env("HOSTNAME")
   }
 }
-``
+
 discovery.relabel "pod_logs" {
   targets = discovery.kubernetes.pods.targets
 

--- a/examples/control-plane-metrics/logs.river
+++ b/examples/control-plane-metrics/logs.river
@@ -1,10 +1,9 @@
-discovery.kubernetes "pods" {
-  role = "pod"
+// Pod Logs
+discovery.kubelet "pods" {
 }
 
-// Pod Logs
 discovery.relabel "pod_logs" {
-  targets = discovery.kubernetes.pods.targets
+  targets = discovery.kubelet.pods.targets
 
   rule {
     source_labels = ["__meta_kubernetes_namespace"]
@@ -27,11 +26,6 @@ discovery.relabel "pod_logs" {
     action = "replace"
     replacement = "$1"
     target_label = "job"
-  }
-  rule {
-    source_labels = ["__meta_kubernetes_pod_node_name"]
-    action = "keep"
-    regex = env("HOSTNAME")
   }
   rule {
     source_labels = ["__meta_kubernetes_pod_uid", "__meta_kubernetes_pod_container_name"]

--- a/examples/control-plane-metrics/output.yaml
+++ b/examples/control-plane-metrics/output.yaml
@@ -540,13 +540,12 @@ metadata:
   namespace: default
 data:
   config.river: |-
-    discovery.kubernetes "pods" {
-      role = "pod"
+    // Pod Logs
+    discovery.kubelet "pods" {
     }
     
-    // Pod Logs
     discovery.relabel "pod_logs" {
-      targets = discovery.kubernetes.pods.targets
+      targets = discovery.kubelet.pods.targets
     
       rule {
         source_labels = ["__meta_kubernetes_namespace"]
@@ -569,11 +568,6 @@ data:
         action = "replace"
         replacement = "$1"
         target_label = "job"
-      }
-      rule {
-        source_labels = ["__meta_kubernetes_pod_node_name"]
-        action = "keep"
-        regex = env("HOSTNAME")
       }
       rule {
         source_labels = ["__meta_kubernetes_pod_uid", "__meta_kubernetes_pod_container_name"]
@@ -43673,13 +43667,12 @@ data:
       }
     }
   logs.river: |-
-    discovery.kubernetes "pods" {
-      role = "pod"
+    // Pod Logs
+    discovery.kubelet "pods" {
     }
     
-    // Pod Logs
     discovery.relabel "pod_logs" {
-      targets = discovery.kubernetes.pods.targets
+      targets = discovery.kubelet.pods.targets
     
       rule {
         source_labels = ["__meta_kubernetes_namespace"]
@@ -43702,11 +43695,6 @@ data:
         action = "replace"
         replacement = "$1"
         target_label = "job"
-      }
-      rule {
-        source_labels = ["__meta_kubernetes_pod_node_name"]
-        action = "keep"
-        regex = env("HOSTNAME")
       }
       rule {
         source_labels = ["__meta_kubernetes_pod_uid", "__meta_kubernetes_pod_container_name"]

--- a/examples/control-plane-metrics/output.yaml
+++ b/examples/control-plane-metrics/output.yaml
@@ -548,7 +548,7 @@ data:
         field = "spec.nodeName=" + env("HOSTNAME")
       }
     }
-    ``
+    
     discovery.relabel "pod_logs" {
       targets = discovery.kubernetes.pods.targets
     
@@ -43680,7 +43680,7 @@ data:
         field = "spec.nodeName=" + env("HOSTNAME")
       }
     }
-    ``
+    
     discovery.relabel "pod_logs" {
       targets = discovery.kubernetes.pods.targets
     

--- a/examples/control-plane-metrics/output.yaml
+++ b/examples/control-plane-metrics/output.yaml
@@ -541,11 +541,16 @@ metadata:
 data:
   config.river: |-
     // Pod Logs
-    discovery.kubelet "pods" {
+    discovery.kubernetes "pods" {
+        role = "pod"
+      selectors {
+        role = "pod"
+        field = "spec.nodeName=" + env("HOSTNAME")
+      }
     }
-    
+    ``
     discovery.relabel "pod_logs" {
-      targets = discovery.kubelet.pods.targets
+      targets = discovery.kubernetes.pods.targets
     
       rule {
         source_labels = ["__meta_kubernetes_namespace"]
@@ -43668,11 +43673,16 @@ data:
     }
   logs.river: |-
     // Pod Logs
-    discovery.kubelet "pods" {
+    discovery.kubernetes "pods" {
+        role = "pod"
+      selectors {
+        role = "pod"
+        field = "spec.nodeName=" + env("HOSTNAME")
+      }
     }
-    
+    ``
     discovery.relabel "pod_logs" {
-      targets = discovery.kubelet.pods.targets
+      targets = discovery.kubernetes.pods.targets
     
       rule {
         source_labels = ["__meta_kubernetes_namespace"]

--- a/examples/custom-config/logs.river
+++ b/examples/custom-config/logs.river
@@ -1,9 +1,14 @@
 // Pod Logs
-discovery.kubelet "pods" {
+discovery.kubernetes "pods" {
+    role = "pod"
+  selectors {
+    role = "pod"
+    field = "spec.nodeName=" + env("HOSTNAME")
+  }
 }
-
+``
 discovery.relabel "pod_logs" {
-  targets = discovery.kubelet.pods.targets
+  targets = discovery.kubernetes.pods.targets
 
   rule {
     source_labels = ["__meta_kubernetes_namespace"]

--- a/examples/custom-config/logs.river
+++ b/examples/custom-config/logs.river
@@ -6,7 +6,7 @@ discovery.kubernetes "pods" {
     field = "spec.nodeName=" + env("HOSTNAME")
   }
 }
-``
+
 discovery.relabel "pod_logs" {
   targets = discovery.kubernetes.pods.targets
 

--- a/examples/custom-config/logs.river
+++ b/examples/custom-config/logs.river
@@ -1,10 +1,9 @@
-discovery.kubernetes "pods" {
-  role = "pod"
+// Pod Logs
+discovery.kubelet "pods" {
 }
 
-// Pod Logs
 discovery.relabel "pod_logs" {
-  targets = discovery.kubernetes.pods.targets
+  targets = discovery.kubelet.pods.targets
 
   rule {
     source_labels = ["__meta_kubernetes_namespace"]
@@ -27,11 +26,6 @@ discovery.relabel "pod_logs" {
     action = "replace"
     replacement = "$1"
     target_label = "job"
-  }
-  rule {
-    source_labels = ["__meta_kubernetes_pod_node_name"]
-    action = "keep"
-    regex = env("HOSTNAME")
   }
   rule {
     source_labels = ["__meta_kubernetes_pod_uid", "__meta_kubernetes_pod_container_name"]

--- a/examples/custom-config/output.yaml
+++ b/examples/custom-config/output.yaml
@@ -521,11 +521,16 @@ metadata:
 data:
   config.river: |-
     // Pod Logs
-    discovery.kubelet "pods" {
+    discovery.kubernetes "pods" {
+        role = "pod"
+      selectors {
+        role = "pod"
+        field = "spec.nodeName=" + env("HOSTNAME")
+      }
     }
-    
+    ``
     discovery.relabel "pod_logs" {
-      targets = discovery.kubelet.pods.targets
+      targets = discovery.kubernetes.pods.targets
     
       rule {
         source_labels = ["__meta_kubernetes_namespace"]
@@ -43666,11 +43671,16 @@ data:
     }
   logs.river: |-
     // Pod Logs
-    discovery.kubelet "pods" {
+    discovery.kubernetes "pods" {
+        role = "pod"
+      selectors {
+        role = "pod"
+        field = "spec.nodeName=" + env("HOSTNAME")
+      }
     }
-    
+    ``
     discovery.relabel "pod_logs" {
-      targets = discovery.kubelet.pods.targets
+      targets = discovery.kubernetes.pods.targets
     
       rule {
         source_labels = ["__meta_kubernetes_namespace"]

--- a/examples/custom-config/output.yaml
+++ b/examples/custom-config/output.yaml
@@ -528,7 +528,7 @@ data:
         field = "spec.nodeName=" + env("HOSTNAME")
       }
     }
-    ``
+    
     discovery.relabel "pod_logs" {
       targets = discovery.kubernetes.pods.targets
     
@@ -43678,7 +43678,7 @@ data:
         field = "spec.nodeName=" + env("HOSTNAME")
       }
     }
-    ``
+    
     discovery.relabel "pod_logs" {
       targets = discovery.kubernetes.pods.targets
     

--- a/examples/custom-config/output.yaml
+++ b/examples/custom-config/output.yaml
@@ -520,13 +520,12 @@ metadata:
   namespace: default
 data:
   config.river: |-
-    discovery.kubernetes "pods" {
-      role = "pod"
+    // Pod Logs
+    discovery.kubelet "pods" {
     }
     
-    // Pod Logs
     discovery.relabel "pod_logs" {
-      targets = discovery.kubernetes.pods.targets
+      targets = discovery.kubelet.pods.targets
     
       rule {
         source_labels = ["__meta_kubernetes_namespace"]
@@ -549,11 +548,6 @@ data:
         action = "replace"
         replacement = "$1"
         target_label = "job"
-      }
-      rule {
-        source_labels = ["__meta_kubernetes_pod_node_name"]
-        action = "keep"
-        regex = env("HOSTNAME")
       }
       rule {
         source_labels = ["__meta_kubernetes_pod_uid", "__meta_kubernetes_pod_container_name"]
@@ -43671,13 +43665,12 @@ data:
       forward_to = [prometheus.remote_write.grafana_cloud_prometheus.receiver]
     }
   logs.river: |-
-    discovery.kubernetes "pods" {
-      role = "pod"
+    // Pod Logs
+    discovery.kubelet "pods" {
     }
     
-    // Pod Logs
     discovery.relabel "pod_logs" {
-      targets = discovery.kubernetes.pods.targets
+      targets = discovery.kubelet.pods.targets
     
       rule {
         source_labels = ["__meta_kubernetes_namespace"]
@@ -43700,11 +43693,6 @@ data:
         action = "replace"
         replacement = "$1"
         target_label = "job"
-      }
-      rule {
-        source_labels = ["__meta_kubernetes_pod_node_name"]
-        action = "keep"
-        regex = env("HOSTNAME")
       }
       rule {
         source_labels = ["__meta_kubernetes_pod_uid", "__meta_kubernetes_pod_container_name"]

--- a/examples/default-values/logs.river
+++ b/examples/default-values/logs.river
@@ -1,9 +1,14 @@
 // Pod Logs
-discovery.kubelet "pods" {
+discovery.kubernetes "pods" {
+    role = "pod"
+  selectors {
+    role = "pod"
+    field = "spec.nodeName=" + env("HOSTNAME")
+  }
 }
-
+``
 discovery.relabel "pod_logs" {
-  targets = discovery.kubelet.pods.targets
+  targets = discovery.kubernetes.pods.targets
 
   rule {
     source_labels = ["__meta_kubernetes_namespace"]

--- a/examples/default-values/logs.river
+++ b/examples/default-values/logs.river
@@ -6,7 +6,7 @@ discovery.kubernetes "pods" {
     field = "spec.nodeName=" + env("HOSTNAME")
   }
 }
-``
+
 discovery.relabel "pod_logs" {
   targets = discovery.kubernetes.pods.targets
 

--- a/examples/default-values/logs.river
+++ b/examples/default-values/logs.river
@@ -1,10 +1,9 @@
-discovery.kubernetes "pods" {
-  role = "pod"
+// Pod Logs
+discovery.kubelet "pods" {
 }
 
-// Pod Logs
 discovery.relabel "pod_logs" {
-  targets = discovery.kubernetes.pods.targets
+  targets = discovery.kubelet.pods.targets
 
   rule {
     source_labels = ["__meta_kubernetes_namespace"]
@@ -27,11 +26,6 @@ discovery.relabel "pod_logs" {
     action = "replace"
     replacement = "$1"
     target_label = "job"
-  }
-  rule {
-    source_labels = ["__meta_kubernetes_pod_node_name"]
-    action = "keep"
-    regex = env("HOSTNAME")
   }
   rule {
     source_labels = ["__meta_kubernetes_pod_uid", "__meta_kubernetes_pod_container_name"]

--- a/examples/default-values/output.yaml
+++ b/examples/default-values/output.yaml
@@ -497,11 +497,16 @@ metadata:
 data:
   config.river: |-
     // Pod Logs
-    discovery.kubelet "pods" {
+    discovery.kubernetes "pods" {
+        role = "pod"
+      selectors {
+        role = "pod"
+        field = "spec.nodeName=" + env("HOSTNAME")
+      }
     }
-    
+    ``
     discovery.relabel "pod_logs" {
-      targets = discovery.kubelet.pods.targets
+      targets = discovery.kubernetes.pods.targets
     
       rule {
         source_labels = ["__meta_kubernetes_namespace"]
@@ -43581,11 +43586,16 @@ data:
     }
   logs.river: |-
     // Pod Logs
-    discovery.kubelet "pods" {
+    discovery.kubernetes "pods" {
+        role = "pod"
+      selectors {
+        role = "pod"
+        field = "spec.nodeName=" + env("HOSTNAME")
+      }
     }
-    
+    ``
     discovery.relabel "pod_logs" {
-      targets = discovery.kubelet.pods.targets
+      targets = discovery.kubernetes.pods.targets
     
       rule {
         source_labels = ["__meta_kubernetes_namespace"]

--- a/examples/default-values/output.yaml
+++ b/examples/default-values/output.yaml
@@ -504,7 +504,7 @@ data:
         field = "spec.nodeName=" + env("HOSTNAME")
       }
     }
-    ``
+    
     discovery.relabel "pod_logs" {
       targets = discovery.kubernetes.pods.targets
     
@@ -43593,7 +43593,7 @@ data:
         field = "spec.nodeName=" + env("HOSTNAME")
       }
     }
-    ``
+    
     discovery.relabel "pod_logs" {
       targets = discovery.kubernetes.pods.targets
     

--- a/examples/default-values/output.yaml
+++ b/examples/default-values/output.yaml
@@ -496,13 +496,12 @@ metadata:
   namespace: default
 data:
   config.river: |-
-    discovery.kubernetes "pods" {
-      role = "pod"
+    // Pod Logs
+    discovery.kubelet "pods" {
     }
     
-    // Pod Logs
     discovery.relabel "pod_logs" {
-      targets = discovery.kubernetes.pods.targets
+      targets = discovery.kubelet.pods.targets
     
       rule {
         source_labels = ["__meta_kubernetes_namespace"]
@@ -525,11 +524,6 @@ data:
         action = "replace"
         replacement = "$1"
         target_label = "job"
-      }
-      rule {
-        source_labels = ["__meta_kubernetes_pod_node_name"]
-        action = "keep"
-        regex = env("HOSTNAME")
       }
       rule {
         source_labels = ["__meta_kubernetes_pod_uid", "__meta_kubernetes_pod_container_name"]
@@ -43586,13 +43580,12 @@ data:
       }
     }
   logs.river: |-
-    discovery.kubernetes "pods" {
-      role = "pod"
+    // Pod Logs
+    discovery.kubelet "pods" {
     }
     
-    // Pod Logs
     discovery.relabel "pod_logs" {
-      targets = discovery.kubernetes.pods.targets
+      targets = discovery.kubelet.pods.targets
     
       rule {
         source_labels = ["__meta_kubernetes_namespace"]
@@ -43615,11 +43608,6 @@ data:
         action = "replace"
         replacement = "$1"
         target_label = "job"
-      }
-      rule {
-        source_labels = ["__meta_kubernetes_pod_node_name"]
-        action = "keep"
-        regex = env("HOSTNAME")
       }
       rule {
         source_labels = ["__meta_kubernetes_pod_uid", "__meta_kubernetes_pod_container_name"]

--- a/examples/extra-rules/logs.river
+++ b/examples/extra-rules/logs.river
@@ -1,9 +1,14 @@
 // Pod Logs
-discovery.kubelet "pods" {
+discovery.kubernetes "pods" {
+    role = "pod"
+  selectors {
+    role = "pod"
+    field = "spec.nodeName=" + env("HOSTNAME")
+  }
 }
-
+``
 discovery.relabel "pod_logs" {
-  targets = discovery.kubelet.pods.targets
+  targets = discovery.kubernetes.pods.targets
 
   rule {
     source_labels = ["__meta_kubernetes_namespace"]

--- a/examples/extra-rules/logs.river
+++ b/examples/extra-rules/logs.river
@@ -6,7 +6,7 @@ discovery.kubernetes "pods" {
     field = "spec.nodeName=" + env("HOSTNAME")
   }
 }
-``
+
 discovery.relabel "pod_logs" {
   targets = discovery.kubernetes.pods.targets
 

--- a/examples/extra-rules/logs.river
+++ b/examples/extra-rules/logs.river
@@ -1,10 +1,9 @@
-discovery.kubernetes "pods" {
-  role = "pod"
+// Pod Logs
+discovery.kubelet "pods" {
 }
 
-// Pod Logs
 discovery.relabel "pod_logs" {
-  targets = discovery.kubernetes.pods.targets
+  targets = discovery.kubelet.pods.targets
 
   rule {
     source_labels = ["__meta_kubernetes_namespace"]
@@ -27,11 +26,6 @@ discovery.relabel "pod_logs" {
     action = "replace"
     replacement = "$1"
     target_label = "job"
-  }
-  rule {
-    source_labels = ["__meta_kubernetes_pod_node_name"]
-    action = "keep"
-    regex = env("HOSTNAME")
   }
   rule {
     source_labels = ["__meta_kubernetes_pod_uid", "__meta_kubernetes_pod_container_name"]

--- a/examples/extra-rules/output.yaml
+++ b/examples/extra-rules/output.yaml
@@ -548,11 +548,16 @@ metadata:
 data:
   config.river: |-
     // Pod Logs
-    discovery.kubelet "pods" {
+    discovery.kubernetes "pods" {
+        role = "pod"
+      selectors {
+        role = "pod"
+        field = "spec.nodeName=" + env("HOSTNAME")
+      }
     }
-    
+    ``
     discovery.relabel "pod_logs" {
-      targets = discovery.kubelet.pods.targets
+      targets = discovery.kubernetes.pods.targets
     
       rule {
         source_labels = ["__meta_kubernetes_namespace"]
@@ -43710,11 +43715,16 @@ data:
     }
   logs.river: |-
     // Pod Logs
-    discovery.kubelet "pods" {
+    discovery.kubernetes "pods" {
+        role = "pod"
+      selectors {
+        role = "pod"
+        field = "spec.nodeName=" + env("HOSTNAME")
+      }
     }
-    
+    ``
     discovery.relabel "pod_logs" {
-      targets = discovery.kubelet.pods.targets
+      targets = discovery.kubernetes.pods.targets
     
       rule {
         source_labels = ["__meta_kubernetes_namespace"]

--- a/examples/extra-rules/output.yaml
+++ b/examples/extra-rules/output.yaml
@@ -547,13 +547,12 @@ metadata:
   namespace: default
 data:
   config.river: |-
-    discovery.kubernetes "pods" {
-      role = "pod"
+    // Pod Logs
+    discovery.kubelet "pods" {
     }
     
-    // Pod Logs
     discovery.relabel "pod_logs" {
-      targets = discovery.kubernetes.pods.targets
+      targets = discovery.kubelet.pods.targets
     
       rule {
         source_labels = ["__meta_kubernetes_namespace"]
@@ -576,11 +575,6 @@ data:
         action = "replace"
         replacement = "$1"
         target_label = "job"
-      }
-      rule {
-        source_labels = ["__meta_kubernetes_pod_node_name"]
-        action = "keep"
-        regex = env("HOSTNAME")
       }
       rule {
         source_labels = ["__meta_kubernetes_pod_uid", "__meta_kubernetes_pod_container_name"]
@@ -43715,13 +43709,12 @@ data:
       }
     }
   logs.river: |-
-    discovery.kubernetes "pods" {
-      role = "pod"
+    // Pod Logs
+    discovery.kubelet "pods" {
     }
     
-    // Pod Logs
     discovery.relabel "pod_logs" {
-      targets = discovery.kubernetes.pods.targets
+      targets = discovery.kubelet.pods.targets
     
       rule {
         source_labels = ["__meta_kubernetes_namespace"]
@@ -43744,11 +43737,6 @@ data:
         action = "replace"
         replacement = "$1"
         target_label = "job"
-      }
-      rule {
-        source_labels = ["__meta_kubernetes_pod_node_name"]
-        action = "keep"
-        regex = env("HOSTNAME")
       }
       rule {
         source_labels = ["__meta_kubernetes_pod_uid", "__meta_kubernetes_pod_container_name"]

--- a/examples/extra-rules/output.yaml
+++ b/examples/extra-rules/output.yaml
@@ -555,7 +555,7 @@ data:
         field = "spec.nodeName=" + env("HOSTNAME")
       }
     }
-    ``
+    
     discovery.relabel "pod_logs" {
       targets = discovery.kubernetes.pods.targets
     
@@ -43722,7 +43722,7 @@ data:
         field = "spec.nodeName=" + env("HOSTNAME")
       }
     }
-    ``
+    
     discovery.relabel "pod_logs" {
       targets = discovery.kubernetes.pods.targets
     

--- a/examples/gke-autopilot/logs.river
+++ b/examples/gke-autopilot/logs.river
@@ -1,9 +1,14 @@
 // Pod Logs
-discovery.kubelet "pods" {
+discovery.kubernetes "pods" {
+    role = "pod"
+  selectors {
+    role = "pod"
+    field = "spec.nodeName=" + env("HOSTNAME")
+  }
 }
-
+``
 discovery.relabel "pod_logs" {
-  targets = discovery.kubelet.pods.targets
+  targets = discovery.kubernetes.pods.targets
 
   rule {
     source_labels = ["__meta_kubernetes_namespace"]

--- a/examples/gke-autopilot/logs.river
+++ b/examples/gke-autopilot/logs.river
@@ -6,7 +6,7 @@ discovery.kubernetes "pods" {
     field = "spec.nodeName=" + env("HOSTNAME")
   }
 }
-``
+
 discovery.relabel "pod_logs" {
   targets = discovery.kubernetes.pods.targets
 

--- a/examples/gke-autopilot/logs.river
+++ b/examples/gke-autopilot/logs.river
@@ -1,10 +1,9 @@
-discovery.kubernetes "pods" {
-  role = "pod"
+// Pod Logs
+discovery.kubelet "pods" {
 }
 
-// Pod Logs
 discovery.relabel "pod_logs" {
-  targets = discovery.kubernetes.pods.targets
+  targets = discovery.kubelet.pods.targets
 
   rule {
     source_labels = ["__meta_kubernetes_namespace"]
@@ -27,11 +26,6 @@ discovery.relabel "pod_logs" {
     action = "replace"
     replacement = "$1"
     target_label = "job"
-  }
-  rule {
-    source_labels = ["__meta_kubernetes_pod_node_name"]
-    action = "keep"
-    regex = env("HOSTNAME")
   }
   rule {
     source_labels = ["__meta_kubernetes_pod_uid", "__meta_kubernetes_pod_container_name"]

--- a/examples/gke-autopilot/output.yaml
+++ b/examples/gke-autopilot/output.yaml
@@ -442,13 +442,12 @@ metadata:
   namespace: default
 data:
   config.river: |-
-    discovery.kubernetes "pods" {
-      role = "pod"
+    // Pod Logs
+    discovery.kubelet "pods" {
     }
     
-    // Pod Logs
     discovery.relabel "pod_logs" {
-      targets = discovery.kubernetes.pods.targets
+      targets = discovery.kubelet.pods.targets
     
       rule {
         source_labels = ["__meta_kubernetes_namespace"]
@@ -471,11 +470,6 @@ data:
         action = "replace"
         replacement = "$1"
         target_label = "job"
-      }
-      rule {
-        source_labels = ["__meta_kubernetes_pod_node_name"]
-        action = "keep"
-        regex = env("HOSTNAME")
       }
       rule {
         source_labels = ["__meta_kubernetes_pod_uid", "__meta_kubernetes_pod_container_name"]
@@ -43352,13 +43346,12 @@ data:
       }
     }
   logs.river: |-
-    discovery.kubernetes "pods" {
-      role = "pod"
+    // Pod Logs
+    discovery.kubelet "pods" {
     }
     
-    // Pod Logs
     discovery.relabel "pod_logs" {
-      targets = discovery.kubernetes.pods.targets
+      targets = discovery.kubelet.pods.targets
     
       rule {
         source_labels = ["__meta_kubernetes_namespace"]
@@ -43381,11 +43374,6 @@ data:
         action = "replace"
         replacement = "$1"
         target_label = "job"
-      }
-      rule {
-        source_labels = ["__meta_kubernetes_pod_node_name"]
-        action = "keep"
-        regex = env("HOSTNAME")
       }
       rule {
         source_labels = ["__meta_kubernetes_pod_uid", "__meta_kubernetes_pod_container_name"]

--- a/examples/gke-autopilot/output.yaml
+++ b/examples/gke-autopilot/output.yaml
@@ -450,7 +450,7 @@ data:
         field = "spec.nodeName=" + env("HOSTNAME")
       }
     }
-    ``
+    
     discovery.relabel "pod_logs" {
       targets = discovery.kubernetes.pods.targets
     
@@ -43359,7 +43359,7 @@ data:
         field = "spec.nodeName=" + env("HOSTNAME")
       }
     }
-    ``
+    
     discovery.relabel "pod_logs" {
       targets = discovery.kubernetes.pods.targets
     

--- a/examples/gke-autopilot/output.yaml
+++ b/examples/gke-autopilot/output.yaml
@@ -443,11 +443,16 @@ metadata:
 data:
   config.river: |-
     // Pod Logs
-    discovery.kubelet "pods" {
+    discovery.kubernetes "pods" {
+        role = "pod"
+      selectors {
+        role = "pod"
+        field = "spec.nodeName=" + env("HOSTNAME")
+      }
     }
-    
+    ``
     discovery.relabel "pod_logs" {
-      targets = discovery.kubelet.pods.targets
+      targets = discovery.kubernetes.pods.targets
     
       rule {
         source_labels = ["__meta_kubernetes_namespace"]
@@ -43347,11 +43352,16 @@ data:
     }
   logs.river: |-
     // Pod Logs
-    discovery.kubelet "pods" {
+    discovery.kubernetes "pods" {
+        role = "pod"
+      selectors {
+        role = "pod"
+        field = "spec.nodeName=" + env("HOSTNAME")
+      }
     }
-    
+    ``
     discovery.relabel "pod_logs" {
-      targets = discovery.kubelet.pods.targets
+      targets = discovery.kubernetes.pods.targets
     
       rule {
         source_labels = ["__meta_kubernetes_namespace"]

--- a/examples/logs-only/logs.river
+++ b/examples/logs-only/logs.river
@@ -1,9 +1,14 @@
 // Pod Logs
-discovery.kubelet "pods" {
+discovery.kubernetes "pods" {
+    role = "pod"
+  selectors {
+    role = "pod"
+    field = "spec.nodeName=" + env("HOSTNAME")
+  }
 }
-
+``
 discovery.relabel "pod_logs" {
-  targets = discovery.kubelet.pods.targets
+  targets = discovery.kubernetes.pods.targets
 
   rule {
     source_labels = ["__meta_kubernetes_namespace"]

--- a/examples/logs-only/logs.river
+++ b/examples/logs-only/logs.river
@@ -6,7 +6,7 @@ discovery.kubernetes "pods" {
     field = "spec.nodeName=" + env("HOSTNAME")
   }
 }
-``
+
 discovery.relabel "pod_logs" {
   targets = discovery.kubernetes.pods.targets
 

--- a/examples/logs-only/logs.river
+++ b/examples/logs-only/logs.river
@@ -1,10 +1,9 @@
-discovery.kubernetes "pods" {
-  role = "pod"
+// Pod Logs
+discovery.kubelet "pods" {
 }
 
-// Pod Logs
 discovery.relabel "pod_logs" {
-  targets = discovery.kubernetes.pods.targets
+  targets = discovery.kubelet.pods.targets
 
   rule {
     source_labels = ["__meta_kubernetes_namespace"]
@@ -27,11 +26,6 @@ discovery.relabel "pod_logs" {
     action = "replace"
     replacement = "$1"
     target_label = "job"
-  }
-  rule {
-    source_labels = ["__meta_kubernetes_pod_node_name"]
-    action = "keep"
-    regex = env("HOSTNAME")
   }
   rule {
     source_labels = ["__meta_kubernetes_pod_uid", "__meta_kubernetes_pod_container_name"]

--- a/examples/logs-only/output.yaml
+++ b/examples/logs-only/output.yaml
@@ -110,7 +110,7 @@ data:
         field = "spec.nodeName=" + env("HOSTNAME")
       }
     }
-    ``
+    
     discovery.relabel "pod_logs" {
       targets = discovery.kubernetes.pods.targets
     
@@ -992,7 +992,7 @@ data:
         field = "spec.nodeName=" + env("HOSTNAME")
       }
     }
-    ``
+    
     discovery.relabel "pod_logs" {
       targets = discovery.kubernetes.pods.targets
     

--- a/examples/logs-only/output.yaml
+++ b/examples/logs-only/output.yaml
@@ -102,13 +102,12 @@ metadata:
   namespace: default
 data:
   config.river: |-
-    discovery.kubernetes "pods" {
-      role = "pod"
+    // Pod Logs
+    discovery.kubelet "pods" {
     }
     
-    // Pod Logs
     discovery.relabel "pod_logs" {
-      targets = discovery.kubernetes.pods.targets
+      targets = discovery.kubelet.pods.targets
     
       rule {
         source_labels = ["__meta_kubernetes_namespace"]
@@ -131,11 +130,6 @@ data:
         action = "replace"
         replacement = "$1"
         target_label = "job"
-      }
-      rule {
-        source_labels = ["__meta_kubernetes_pod_node_name"]
-        action = "keep"
-        regex = env("HOSTNAME")
       }
       rule {
         source_labels = ["__meta_kubernetes_pod_uid", "__meta_kubernetes_pod_container_name"]
@@ -985,13 +979,12 @@ data:
       }
     }
   logs.river: |-
-    discovery.kubernetes "pods" {
-      role = "pod"
+    // Pod Logs
+    discovery.kubelet "pods" {
     }
     
-    // Pod Logs
     discovery.relabel "pod_logs" {
-      targets = discovery.kubernetes.pods.targets
+      targets = discovery.kubelet.pods.targets
     
       rule {
         source_labels = ["__meta_kubernetes_namespace"]
@@ -1014,11 +1007,6 @@ data:
         action = "replace"
         replacement = "$1"
         target_label = "job"
-      }
-      rule {
-        source_labels = ["__meta_kubernetes_pod_node_name"]
-        action = "keep"
-        regex = env("HOSTNAME")
       }
       rule {
         source_labels = ["__meta_kubernetes_pod_uid", "__meta_kubernetes_pod_container_name"]

--- a/examples/logs-only/output.yaml
+++ b/examples/logs-only/output.yaml
@@ -103,11 +103,16 @@ metadata:
 data:
   config.river: |-
     // Pod Logs
-    discovery.kubelet "pods" {
+    discovery.kubernetes "pods" {
+        role = "pod"
+      selectors {
+        role = "pod"
+        field = "spec.nodeName=" + env("HOSTNAME")
+      }
     }
-    
+    ``
     discovery.relabel "pod_logs" {
-      targets = discovery.kubelet.pods.targets
+      targets = discovery.kubernetes.pods.targets
     
       rule {
         source_labels = ["__meta_kubernetes_namespace"]
@@ -980,11 +985,16 @@ data:
     }
   logs.river: |-
     // Pod Logs
-    discovery.kubelet "pods" {
+    discovery.kubernetes "pods" {
+        role = "pod"
+      selectors {
+        role = "pod"
+        field = "spec.nodeName=" + env("HOSTNAME")
+      }
     }
-    
+    ``
     discovery.relabel "pod_logs" {
-      targets = discovery.kubelet.pods.targets
+      targets = discovery.kubernetes.pods.targets
     
       rule {
         source_labels = ["__meta_kubernetes_namespace"]

--- a/examples/openshift-compatible/logs.river
+++ b/examples/openshift-compatible/logs.river
@@ -1,9 +1,14 @@
 // Pod Logs
-discovery.kubelet "pods" {
+discovery.kubernetes "pods" {
+    role = "pod"
+  selectors {
+    role = "pod"
+    field = "spec.nodeName=" + env("HOSTNAME")
+  }
 }
-
+``
 discovery.relabel "pod_logs" {
-  targets = discovery.kubelet.pods.targets
+  targets = discovery.kubernetes.pods.targets
 
   rule {
     source_labels = ["__meta_kubernetes_namespace"]

--- a/examples/openshift-compatible/logs.river
+++ b/examples/openshift-compatible/logs.river
@@ -6,7 +6,7 @@ discovery.kubernetes "pods" {
     field = "spec.nodeName=" + env("HOSTNAME")
   }
 }
-``
+
 discovery.relabel "pod_logs" {
   targets = discovery.kubernetes.pods.targets
 

--- a/examples/openshift-compatible/logs.river
+++ b/examples/openshift-compatible/logs.river
@@ -1,10 +1,9 @@
-discovery.kubernetes "pods" {
-  role = "pod"
+// Pod Logs
+discovery.kubelet "pods" {
 }
 
-// Pod Logs
 discovery.relabel "pod_logs" {
-  targets = discovery.kubernetes.pods.targets
+  targets = discovery.kubelet.pods.targets
 
   rule {
     source_labels = ["__meta_kubernetes_namespace"]
@@ -27,11 +26,6 @@ discovery.relabel "pod_logs" {
     action = "replace"
     replacement = "$1"
     target_label = "job"
-  }
-  rule {
-    source_labels = ["__meta_kubernetes_pod_node_name"]
-    action = "keep"
-    regex = env("HOSTNAME")
   }
   rule {
     source_labels = ["__meta_kubernetes_pod_uid", "__meta_kubernetes_pod_container_name"]

--- a/examples/openshift-compatible/output.yaml
+++ b/examples/openshift-compatible/output.yaml
@@ -468,13 +468,12 @@ metadata:
   namespace: default
 data:
   config.river: |-
-    discovery.kubernetes "pods" {
-      role = "pod"
+    // Pod Logs
+    discovery.kubelet "pods" {
     }
     
-    // Pod Logs
     discovery.relabel "pod_logs" {
-      targets = discovery.kubernetes.pods.targets
+      targets = discovery.kubelet.pods.targets
     
       rule {
         source_labels = ["__meta_kubernetes_namespace"]
@@ -497,11 +496,6 @@ data:
         action = "replace"
         replacement = "$1"
         target_label = "job"
-      }
-      rule {
-        source_labels = ["__meta_kubernetes_pod_node_name"]
-        action = "keep"
-        regex = env("HOSTNAME")
       }
       rule {
         source_labels = ["__meta_kubernetes_pod_uid", "__meta_kubernetes_pod_container_name"]
@@ -43238,13 +43232,12 @@ data:
       }
     }
   logs.river: |-
-    discovery.kubernetes "pods" {
-      role = "pod"
+    // Pod Logs
+    discovery.kubelet "pods" {
     }
     
-    // Pod Logs
     discovery.relabel "pod_logs" {
-      targets = discovery.kubernetes.pods.targets
+      targets = discovery.kubelet.pods.targets
     
       rule {
         source_labels = ["__meta_kubernetes_namespace"]
@@ -43267,11 +43260,6 @@ data:
         action = "replace"
         replacement = "$1"
         target_label = "job"
-      }
-      rule {
-        source_labels = ["__meta_kubernetes_pod_node_name"]
-        action = "keep"
-        regex = env("HOSTNAME")
       }
       rule {
         source_labels = ["__meta_kubernetes_pod_uid", "__meta_kubernetes_pod_container_name"]

--- a/examples/openshift-compatible/output.yaml
+++ b/examples/openshift-compatible/output.yaml
@@ -476,7 +476,7 @@ data:
         field = "spec.nodeName=" + env("HOSTNAME")
       }
     }
-    ``
+    
     discovery.relabel "pod_logs" {
       targets = discovery.kubernetes.pods.targets
     
@@ -43245,7 +43245,7 @@ data:
         field = "spec.nodeName=" + env("HOSTNAME")
       }
     }
-    ``
+    
     discovery.relabel "pod_logs" {
       targets = discovery.kubernetes.pods.targets
     

--- a/examples/openshift-compatible/output.yaml
+++ b/examples/openshift-compatible/output.yaml
@@ -469,11 +469,16 @@ metadata:
 data:
   config.river: |-
     // Pod Logs
-    discovery.kubelet "pods" {
+    discovery.kubernetes "pods" {
+        role = "pod"
+      selectors {
+        role = "pod"
+        field = "spec.nodeName=" + env("HOSTNAME")
+      }
     }
-    
+    ``
     discovery.relabel "pod_logs" {
-      targets = discovery.kubelet.pods.targets
+      targets = discovery.kubernetes.pods.targets
     
       rule {
         source_labels = ["__meta_kubernetes_namespace"]
@@ -43233,11 +43238,16 @@ data:
     }
   logs.river: |-
     // Pod Logs
-    discovery.kubelet "pods" {
+    discovery.kubernetes "pods" {
+        role = "pod"
+      selectors {
+        role = "pod"
+        field = "spec.nodeName=" + env("HOSTNAME")
+      }
     }
-    
+    ``
     discovery.relabel "pod_logs" {
-      targets = discovery.kubelet.pods.targets
+      targets = discovery.kubernetes.pods.targets
     
       rule {
         source_labels = ["__meta_kubernetes_namespace"]

--- a/examples/private-image-registry/logs.river
+++ b/examples/private-image-registry/logs.river
@@ -1,9 +1,14 @@
 // Pod Logs
-discovery.kubelet "pods" {
+discovery.kubernetes "pods" {
+    role = "pod"
+  selectors {
+    role = "pod"
+    field = "spec.nodeName=" + env("HOSTNAME")
+  }
 }
-
+``
 discovery.relabel "pod_logs" {
-  targets = discovery.kubelet.pods.targets
+  targets = discovery.kubernetes.pods.targets
 
   rule {
     source_labels = ["__meta_kubernetes_namespace"]

--- a/examples/private-image-registry/logs.river
+++ b/examples/private-image-registry/logs.river
@@ -6,7 +6,7 @@ discovery.kubernetes "pods" {
     field = "spec.nodeName=" + env("HOSTNAME")
   }
 }
-``
+
 discovery.relabel "pod_logs" {
   targets = discovery.kubernetes.pods.targets
 

--- a/examples/private-image-registry/logs.river
+++ b/examples/private-image-registry/logs.river
@@ -1,10 +1,9 @@
-discovery.kubernetes "pods" {
-  role = "pod"
+// Pod Logs
+discovery.kubelet "pods" {
 }
 
-// Pod Logs
 discovery.relabel "pod_logs" {
-  targets = discovery.kubernetes.pods.targets
+  targets = discovery.kubelet.pods.targets
 
   rule {
     source_labels = ["__meta_kubernetes_namespace"]
@@ -27,11 +26,6 @@ discovery.relabel "pod_logs" {
     action = "replace"
     replacement = "$1"
     target_label = "job"
-  }
-  rule {
-    source_labels = ["__meta_kubernetes_pod_node_name"]
-    action = "keep"
-    regex = env("HOSTNAME")
   }
   rule {
     source_labels = ["__meta_kubernetes_pod_uid", "__meta_kubernetes_pod_container_name"]

--- a/examples/private-image-registry/output.yaml
+++ b/examples/private-image-registry/output.yaml
@@ -497,11 +497,16 @@ metadata:
 data:
   config.river: |-
     // Pod Logs
-    discovery.kubelet "pods" {
+    discovery.kubernetes "pods" {
+        role = "pod"
+      selectors {
+        role = "pod"
+        field = "spec.nodeName=" + env("HOSTNAME")
+      }
     }
-    
+    ``
     discovery.relabel "pod_logs" {
-      targets = discovery.kubelet.pods.targets
+      targets = discovery.kubernetes.pods.targets
     
       rule {
         source_labels = ["__meta_kubernetes_namespace"]
@@ -43581,11 +43586,16 @@ data:
     }
   logs.river: |-
     // Pod Logs
-    discovery.kubelet "pods" {
+    discovery.kubernetes "pods" {
+        role = "pod"
+      selectors {
+        role = "pod"
+        field = "spec.nodeName=" + env("HOSTNAME")
+      }
     }
-    
+    ``
     discovery.relabel "pod_logs" {
-      targets = discovery.kubelet.pods.targets
+      targets = discovery.kubernetes.pods.targets
     
       rule {
         source_labels = ["__meta_kubernetes_namespace"]

--- a/examples/private-image-registry/output.yaml
+++ b/examples/private-image-registry/output.yaml
@@ -504,7 +504,7 @@ data:
         field = "spec.nodeName=" + env("HOSTNAME")
       }
     }
-    ``
+    
     discovery.relabel "pod_logs" {
       targets = discovery.kubernetes.pods.targets
     
@@ -43593,7 +43593,7 @@ data:
         field = "spec.nodeName=" + env("HOSTNAME")
       }
     }
-    ``
+    
     discovery.relabel "pod_logs" {
       targets = discovery.kubernetes.pods.targets
     

--- a/examples/private-image-registry/output.yaml
+++ b/examples/private-image-registry/output.yaml
@@ -496,13 +496,12 @@ metadata:
   namespace: default
 data:
   config.river: |-
-    discovery.kubernetes "pods" {
-      role = "pod"
+    // Pod Logs
+    discovery.kubelet "pods" {
     }
     
-    // Pod Logs
     discovery.relabel "pod_logs" {
-      targets = discovery.kubernetes.pods.targets
+      targets = discovery.kubelet.pods.targets
     
       rule {
         source_labels = ["__meta_kubernetes_namespace"]
@@ -525,11 +524,6 @@ data:
         action = "replace"
         replacement = "$1"
         target_label = "job"
-      }
-      rule {
-        source_labels = ["__meta_kubernetes_pod_node_name"]
-        action = "keep"
-        regex = env("HOSTNAME")
       }
       rule {
         source_labels = ["__meta_kubernetes_pod_uid", "__meta_kubernetes_pod_container_name"]
@@ -43586,13 +43580,12 @@ data:
       }
     }
   logs.river: |-
-    discovery.kubernetes "pods" {
-      role = "pod"
+    // Pod Logs
+    discovery.kubelet "pods" {
     }
     
-    // Pod Logs
     discovery.relabel "pod_logs" {
-      targets = discovery.kubernetes.pods.targets
+      targets = discovery.kubelet.pods.targets
     
       rule {
         source_labels = ["__meta_kubernetes_namespace"]
@@ -43615,11 +43608,6 @@ data:
         action = "replace"
         replacement = "$1"
         target_label = "job"
-      }
-      rule {
-        source_labels = ["__meta_kubernetes_pod_node_name"]
-        action = "keep"
-        regex = env("HOSTNAME")
       }
       rule {
         source_labels = ["__meta_kubernetes_pod_uid", "__meta_kubernetes_pod_container_name"]

--- a/examples/specific-namespace/logs.river
+++ b/examples/specific-namespace/logs.river
@@ -1,11 +1,20 @@
 // Pod Logs
-discovery.kubelet "pods" {
-  namespaces = ["production","staging"]
+discovery.kubernetes "pods" {
+    role = "pod"
+  selectors {
+    role = "pod"
+    field = "spec.nodeName=" + env("HOSTNAME")
+  }
 }
-
+``
 discovery.relabel "pod_logs" {
-  targets = discovery.kubelet.pods.targets
+  targets = discovery.kubernetes.pods.targets
 
+  rule {
+    source_labels = ["namespace"]
+    regex = "production|staging"
+    action = "keep"
+  }
   rule {
     source_labels = ["__meta_kubernetes_namespace"]
     action = "replace"

--- a/examples/specific-namespace/logs.river
+++ b/examples/specific-namespace/logs.river
@@ -1,10 +1,10 @@
-discovery.kubernetes "pods" {
-  role = "pod"
+// Pod Logs
+discovery.kubelet "pods" {
+  namespaces = ["production","staging"]
 }
 
-// Pod Logs
 discovery.relabel "pod_logs" {
-  targets = discovery.kubernetes.pods.targets
+  targets = discovery.kubelet.pods.targets
 
   rule {
     source_labels = ["__meta_kubernetes_namespace"]
@@ -29,21 +29,11 @@ discovery.relabel "pod_logs" {
     target_label = "job"
   }
   rule {
-    source_labels = ["__meta_kubernetes_pod_node_name"]
-    action = "keep"
-    regex = env("HOSTNAME")
-  }
-  rule {
     source_labels = ["__meta_kubernetes_pod_uid", "__meta_kubernetes_pod_container_name"]
     separator = "/"
     action = "replace"
     replacement = "/var/log/pods/*$1/*.log"
     target_label = "__path__"
-  }
-  rule {
-    source_labels = ["namespace"]
-    regex = "production|staging"
-    action = "keep"
   }
 
   // set the container runtime as a label

--- a/examples/specific-namespace/logs.river
+++ b/examples/specific-namespace/logs.river
@@ -6,7 +6,7 @@ discovery.kubernetes "pods" {
     field = "spec.nodeName=" + env("HOSTNAME")
   }
 }
-``
+
 discovery.relabel "pod_logs" {
   targets = discovery.kubernetes.pods.targets
 

--- a/examples/specific-namespace/output.yaml
+++ b/examples/specific-namespace/output.yaml
@@ -542,13 +542,13 @@ metadata:
   namespace: default
 data:
   config.river: |-
-    discovery.kubernetes "pods" {
-      role = "pod"
+    // Pod Logs
+    discovery.kubelet "pods" {
+      namespaces = ["production","staging"]
     }
     
-    // Pod Logs
     discovery.relabel "pod_logs" {
-      targets = discovery.kubernetes.pods.targets
+      targets = discovery.kubelet.pods.targets
     
       rule {
         source_labels = ["__meta_kubernetes_namespace"]
@@ -573,21 +573,11 @@ data:
         target_label = "job"
       }
       rule {
-        source_labels = ["__meta_kubernetes_pod_node_name"]
-        action = "keep"
-        regex = env("HOSTNAME")
-      }
-      rule {
         source_labels = ["__meta_kubernetes_pod_uid", "__meta_kubernetes_pod_container_name"]
         separator = "/"
         action = "replace"
         replacement = "/var/log/pods/*$1/*.log"
         target_label = "__path__"
-      }
-      rule {
-        source_labels = ["namespace"]
-        regex = "production|staging"
-        action = "keep"
       }
     
       // set the container runtime as a label
@@ -43683,13 +43673,13 @@ data:
       }
     }
   logs.river: |-
-    discovery.kubernetes "pods" {
-      role = "pod"
+    // Pod Logs
+    discovery.kubelet "pods" {
+      namespaces = ["production","staging"]
     }
     
-    // Pod Logs
     discovery.relabel "pod_logs" {
-      targets = discovery.kubernetes.pods.targets
+      targets = discovery.kubelet.pods.targets
     
       rule {
         source_labels = ["__meta_kubernetes_namespace"]
@@ -43714,21 +43704,11 @@ data:
         target_label = "job"
       }
       rule {
-        source_labels = ["__meta_kubernetes_pod_node_name"]
-        action = "keep"
-        regex = env("HOSTNAME")
-      }
-      rule {
         source_labels = ["__meta_kubernetes_pod_uid", "__meta_kubernetes_pod_container_name"]
         separator = "/"
         action = "replace"
         replacement = "/var/log/pods/*$1/*.log"
         target_label = "__path__"
-      }
-      rule {
-        source_labels = ["namespace"]
-        regex = "production|staging"
-        action = "keep"
       }
     
       // set the container runtime as a label

--- a/examples/specific-namespace/output.yaml
+++ b/examples/specific-namespace/output.yaml
@@ -543,13 +543,22 @@ metadata:
 data:
   config.river: |-
     // Pod Logs
-    discovery.kubelet "pods" {
-      namespaces = ["production","staging"]
+    discovery.kubernetes "pods" {
+        role = "pod"
+      selectors {
+        role = "pod"
+        field = "spec.nodeName=" + env("HOSTNAME")
+      }
     }
-    
+    ``
     discovery.relabel "pod_logs" {
-      targets = discovery.kubelet.pods.targets
+      targets = discovery.kubernetes.pods.targets
     
+      rule {
+        source_labels = ["namespace"]
+        regex = "production|staging"
+        action = "keep"
+      }
       rule {
         source_labels = ["__meta_kubernetes_namespace"]
         action = "replace"
@@ -43674,13 +43683,22 @@ data:
     }
   logs.river: |-
     // Pod Logs
-    discovery.kubelet "pods" {
-      namespaces = ["production","staging"]
+    discovery.kubernetes "pods" {
+        role = "pod"
+      selectors {
+        role = "pod"
+        field = "spec.nodeName=" + env("HOSTNAME")
+      }
     }
-    
+    ``
     discovery.relabel "pod_logs" {
-      targets = discovery.kubelet.pods.targets
+      targets = discovery.kubernetes.pods.targets
     
+      rule {
+        source_labels = ["namespace"]
+        regex = "production|staging"
+        action = "keep"
+      }
       rule {
         source_labels = ["__meta_kubernetes_namespace"]
         action = "replace"

--- a/examples/specific-namespace/output.yaml
+++ b/examples/specific-namespace/output.yaml
@@ -550,7 +550,7 @@ data:
         field = "spec.nodeName=" + env("HOSTNAME")
       }
     }
-    ``
+    
     discovery.relabel "pod_logs" {
       targets = discovery.kubernetes.pods.targets
     
@@ -43690,7 +43690,7 @@ data:
         field = "spec.nodeName=" + env("HOSTNAME")
       }
     }
-    ``
+    
     discovery.relabel "pod_logs" {
       targets = discovery.kubernetes.pods.targets
     

--- a/examples/traces-enabled/logs.river
+++ b/examples/traces-enabled/logs.river
@@ -1,9 +1,14 @@
 // Pod Logs
-discovery.kubelet "pods" {
+discovery.kubernetes "pods" {
+    role = "pod"
+  selectors {
+    role = "pod"
+    field = "spec.nodeName=" + env("HOSTNAME")
+  }
 }
-
+``
 discovery.relabel "pod_logs" {
-  targets = discovery.kubelet.pods.targets
+  targets = discovery.kubernetes.pods.targets
 
   rule {
     source_labels = ["__meta_kubernetes_namespace"]

--- a/examples/traces-enabled/logs.river
+++ b/examples/traces-enabled/logs.river
@@ -6,7 +6,7 @@ discovery.kubernetes "pods" {
     field = "spec.nodeName=" + env("HOSTNAME")
   }
 }
-``
+
 discovery.relabel "pod_logs" {
   targets = discovery.kubernetes.pods.targets
 

--- a/examples/traces-enabled/logs.river
+++ b/examples/traces-enabled/logs.river
@@ -1,10 +1,9 @@
-discovery.kubernetes "pods" {
-  role = "pod"
+// Pod Logs
+discovery.kubelet "pods" {
 }
 
-// Pod Logs
 discovery.relabel "pod_logs" {
-  targets = discovery.kubernetes.pods.targets
+  targets = discovery.kubelet.pods.targets
 
   rule {
     source_labels = ["__meta_kubernetes_namespace"]
@@ -27,11 +26,6 @@ discovery.relabel "pod_logs" {
     action = "replace"
     replacement = "$1"
     target_label = "job"
-  }
-  rule {
-    source_labels = ["__meta_kubernetes_pod_node_name"]
-    action = "keep"
-    regex = env("HOSTNAME")
   }
   rule {
     source_labels = ["__meta_kubernetes_pod_uid", "__meta_kubernetes_pod_container_name"]

--- a/examples/traces-enabled/output.yaml
+++ b/examples/traces-enabled/output.yaml
@@ -569,13 +569,12 @@ metadata:
   namespace: default
 data:
   config.river: |-
-    discovery.kubernetes "pods" {
-      role = "pod"
+    // Pod Logs
+    discovery.kubelet "pods" {
     }
     
-    // Pod Logs
     discovery.relabel "pod_logs" {
-      targets = discovery.kubernetes.pods.targets
+      targets = discovery.kubelet.pods.targets
     
       rule {
         source_labels = ["__meta_kubernetes_namespace"]
@@ -598,11 +597,6 @@ data:
         action = "replace"
         replacement = "$1"
         target_label = "job"
-      }
-      rule {
-        source_labels = ["__meta_kubernetes_pod_node_name"]
-        action = "keep"
-        regex = env("HOSTNAME")
       }
       rule {
         source_labels = ["__meta_kubernetes_pod_uid", "__meta_kubernetes_pod_container_name"]
@@ -43762,13 +43756,12 @@ data:
       }
     }
   logs.river: |-
-    discovery.kubernetes "pods" {
-      role = "pod"
+    // Pod Logs
+    discovery.kubelet "pods" {
     }
     
-    // Pod Logs
     discovery.relabel "pod_logs" {
-      targets = discovery.kubernetes.pods.targets
+      targets = discovery.kubelet.pods.targets
     
       rule {
         source_labels = ["__meta_kubernetes_namespace"]
@@ -43791,11 +43784,6 @@ data:
         action = "replace"
         replacement = "$1"
         target_label = "job"
-      }
-      rule {
-        source_labels = ["__meta_kubernetes_pod_node_name"]
-        action = "keep"
-        regex = env("HOSTNAME")
       }
       rule {
         source_labels = ["__meta_kubernetes_pod_uid", "__meta_kubernetes_pod_container_name"]

--- a/examples/traces-enabled/output.yaml
+++ b/examples/traces-enabled/output.yaml
@@ -570,11 +570,16 @@ metadata:
 data:
   config.river: |-
     // Pod Logs
-    discovery.kubelet "pods" {
+    discovery.kubernetes "pods" {
+        role = "pod"
+      selectors {
+        role = "pod"
+        field = "spec.nodeName=" + env("HOSTNAME")
+      }
     }
-    
+    ``
     discovery.relabel "pod_logs" {
-      targets = discovery.kubelet.pods.targets
+      targets = discovery.kubernetes.pods.targets
     
       rule {
         source_labels = ["__meta_kubernetes_namespace"]
@@ -43757,11 +43762,16 @@ data:
     }
   logs.river: |-
     // Pod Logs
-    discovery.kubelet "pods" {
+    discovery.kubernetes "pods" {
+        role = "pod"
+      selectors {
+        role = "pod"
+        field = "spec.nodeName=" + env("HOSTNAME")
+      }
     }
-    
+    ``
     discovery.relabel "pod_logs" {
-      targets = discovery.kubelet.pods.targets
+      targets = discovery.kubernetes.pods.targets
     
       rule {
         source_labels = ["__meta_kubernetes_namespace"]

--- a/examples/traces-enabled/output.yaml
+++ b/examples/traces-enabled/output.yaml
@@ -577,7 +577,7 @@ data:
         field = "spec.nodeName=" + env("HOSTNAME")
       }
     }
-    ``
+    
     discovery.relabel "pod_logs" {
       targets = discovery.kubernetes.pods.targets
     
@@ -43769,7 +43769,7 @@ data:
         field = "spec.nodeName=" + env("HOSTNAME")
       }
     }
-    ``
+    
     discovery.relabel "pod_logs" {
       targets = discovery.kubernetes.pods.targets
     

--- a/examples/windows-exporter/logs.river
+++ b/examples/windows-exporter/logs.river
@@ -1,9 +1,14 @@
 // Pod Logs
-discovery.kubelet "pods" {
+discovery.kubernetes "pods" {
+    role = "pod"
+  selectors {
+    role = "pod"
+    field = "spec.nodeName=" + env("HOSTNAME")
+  }
 }
-
+``
 discovery.relabel "pod_logs" {
-  targets = discovery.kubelet.pods.targets
+  targets = discovery.kubernetes.pods.targets
 
   rule {
     source_labels = ["__meta_kubernetes_namespace"]

--- a/examples/windows-exporter/logs.river
+++ b/examples/windows-exporter/logs.river
@@ -6,7 +6,7 @@ discovery.kubernetes "pods" {
     field = "spec.nodeName=" + env("HOSTNAME")
   }
 }
-``
+
 discovery.relabel "pod_logs" {
   targets = discovery.kubernetes.pods.targets
 

--- a/examples/windows-exporter/logs.river
+++ b/examples/windows-exporter/logs.river
@@ -1,10 +1,9 @@
-discovery.kubernetes "pods" {
-  role = "pod"
+// Pod Logs
+discovery.kubelet "pods" {
 }
 
-// Pod Logs
 discovery.relabel "pod_logs" {
-  targets = discovery.kubernetes.pods.targets
+  targets = discovery.kubelet.pods.targets
 
   rule {
     source_labels = ["__meta_kubernetes_namespace"]
@@ -27,11 +26,6 @@ discovery.relabel "pod_logs" {
     action = "replace"
     replacement = "$1"
     target_label = "job"
-  }
-  rule {
-    source_labels = ["__meta_kubernetes_pod_node_name"]
-    action = "keep"
-    regex = env("HOSTNAME")
   }
   rule {
     source_labels = ["__meta_kubernetes_pod_uid", "__meta_kubernetes_pod_container_name"]

--- a/examples/windows-exporter/output.yaml
+++ b/examples/windows-exporter/output.yaml
@@ -602,11 +602,16 @@ metadata:
 data:
   config.river: |-
     // Pod Logs
-    discovery.kubelet "pods" {
+    discovery.kubernetes "pods" {
+        role = "pod"
+      selectors {
+        role = "pod"
+        field = "spec.nodeName=" + env("HOSTNAME")
+      }
     }
-    
+    ``
     discovery.relabel "pod_logs" {
-      targets = discovery.kubelet.pods.targets
+      targets = discovery.kubernetes.pods.targets
     
       rule {
         source_labels = ["__meta_kubernetes_namespace"]
@@ -43880,11 +43885,16 @@ data:
     }
   logs.river: |-
     // Pod Logs
-    discovery.kubelet "pods" {
+    discovery.kubernetes "pods" {
+        role = "pod"
+      selectors {
+        role = "pod"
+        field = "spec.nodeName=" + env("HOSTNAME")
+      }
     }
-    
+    ``
     discovery.relabel "pod_logs" {
-      targets = discovery.kubelet.pods.targets
+      targets = discovery.kubernetes.pods.targets
     
       rule {
         source_labels = ["__meta_kubernetes_namespace"]

--- a/examples/windows-exporter/output.yaml
+++ b/examples/windows-exporter/output.yaml
@@ -601,13 +601,12 @@ metadata:
   namespace: default
 data:
   config.river: |-
-    discovery.kubernetes "pods" {
-      role = "pod"
+    // Pod Logs
+    discovery.kubelet "pods" {
     }
     
-    // Pod Logs
     discovery.relabel "pod_logs" {
-      targets = discovery.kubernetes.pods.targets
+      targets = discovery.kubelet.pods.targets
     
       rule {
         source_labels = ["__meta_kubernetes_namespace"]
@@ -630,11 +629,6 @@ data:
         action = "replace"
         replacement = "$1"
         target_label = "job"
-      }
-      rule {
-        source_labels = ["__meta_kubernetes_pod_node_name"]
-        action = "keep"
-        regex = env("HOSTNAME")
       }
       rule {
         source_labels = ["__meta_kubernetes_pod_uid", "__meta_kubernetes_pod_container_name"]
@@ -43885,13 +43879,12 @@ data:
       }
     }
   logs.river: |-
-    discovery.kubernetes "pods" {
-      role = "pod"
+    // Pod Logs
+    discovery.kubelet "pods" {
     }
     
-    // Pod Logs
     discovery.relabel "pod_logs" {
-      targets = discovery.kubernetes.pods.targets
+      targets = discovery.kubelet.pods.targets
     
       rule {
         source_labels = ["__meta_kubernetes_namespace"]
@@ -43914,11 +43907,6 @@ data:
         action = "replace"
         replacement = "$1"
         target_label = "job"
-      }
-      rule {
-        source_labels = ["__meta_kubernetes_pod_node_name"]
-        action = "keep"
-        regex = env("HOSTNAME")
       }
       rule {
         source_labels = ["__meta_kubernetes_pod_uid", "__meta_kubernetes_pod_container_name"]

--- a/examples/windows-exporter/output.yaml
+++ b/examples/windows-exporter/output.yaml
@@ -609,7 +609,7 @@ data:
         field = "spec.nodeName=" + env("HOSTNAME")
       }
     }
-    ``
+    
     discovery.relabel "pod_logs" {
       targets = discovery.kubernetes.pods.targets
     
@@ -43892,7 +43892,7 @@ data:
         field = "spec.nodeName=" + env("HOSTNAME")
       }
     }
-    ``
+    
     discovery.relabel "pod_logs" {
       targets = discovery.kubernetes.pods.targets
     


### PR DESCRIPTION
Limit the amount of pods discovered by filtering to only the pods on the same node as the agent. This reduces the amount of pods that need to be filtered out later on.