### PR TITLE
Add support for otel metrics push with prometheus and otlphttp

### DIFF
--- a/charts/k8s-monitoring/README.md
+++ b/charts/k8s-monitoring/README.md
@@ -83,6 +83,11 @@ The Prometheus and Loki services may be hosted on the same cluster, or remotely 
 | externalServices.loki.proxyURL | string | `""` | HTTP proxy to proxy requests to Loki through. |
 | externalServices.loki.tenantId | string | `""` | (optional) Loki tenant ID |
 | externalServices.loki.writeEndpoint | string | `"/loki/api/v1/push"` | Loki logs write endpoint |
+| externalServices.otlphttp.basicAuth.password | string | `""` | OTLP HTTP basic auth password |
+| externalServices.otlphttp.basicAuth.username | string | `""` | OTLP HTTP basic auth username |
+| externalServices.otlphttp.host | string | `""` | (required) OTLP HTTP host where traces/metrics will be sent |
+| externalServices.otlphttp.tenantId | string | `""` | (optional) OTLP HTTP tenant ID |
+| externalServices.otlphttp.tlsOptions | string | `""` | Define the TLS block. See https://grafana.com/docs/agent/latest/flow/reference/components/otelcol.exporter.otlphttp/#tls-block for options. Example: tlsOptions: insecure = true |
 | externalServices.prometheus.basicAuth.password | string | `""` | Prometheus basic auth password |
 | externalServices.prometheus.basicAuth.username | string | `""` | Prometheus basic auth username |
 | externalServices.prometheus.externalLabels | object | `{}` | Custom labels to be added to all time series |
@@ -185,6 +190,12 @@ The Prometheus and Loki services may be hosted on the same cluster, or remotely 
 | test.image.registry | string | `"docker.io"` | Test job image registry |
 | test.image.tag | string | `"jammy"` | Test job image tag |
 | traces.enabled | bool | `false` | Receive and forward traces. |
+| traces.otelMetrics.enabled | bool | `false` | Receive otel metrics from OTEL Instrumentation |
+| traces.otelMetrics.exporter.otlphttp.enabled | bool | `false` | Forward metrics via OTLP HTTP |
+| traces.otelMetrics.exporter.prometheus.enabled | bool | `true` | Forward metrics via prometheus rewrite exporter |
+| traces.otelMetrics.processors.batch.maxSize | int | `0` | The upper limit of the amount of data contained in a single batch, in bytes. When set to 0, batches can be any size. |
+| traces.otelMetrics.processors.batch.size | int | `16384` | What batch size to use, in bytes |
+| traces.otelMetrics.processors.batch.timeout | string | `"2s"` | How long before sending |
 | traces.processors.batch.maxSize | int | `0` | The upper limit of the amount of data contained in a single batch, in bytes. When set to 0, batches can be any size. |
 | traces.processors.batch.size | int | `16384` | What batch size to use, in bytes |
 | traces.processors.batch.timeout | string | `"2s"` | How long before sending |

--- a/charts/k8s-monitoring/templates/_helpers.tpl
+++ b/charts/k8s-monitoring/templates/_helpers.tpl
@@ -78,6 +78,9 @@
   {{- if and .Values.traces.enabled }}
     {{- include "agent.config.traces" . }}
     {{- include "agent.config.tempo" . }}
+    {{- if and .Values.traces.otelMetrics.exporter.otlphttp.enabled }}
+      {{- include "agent.config.otlphttp" . }}
+    {{- end }}
   {{- end }}
 
   {{- if .Values.extraConfig }}

--- a/charts/k8s-monitoring/templates/agent_config/_otlphttp.river.txt
+++ b/charts/k8s-monitoring/templates/agent_config/_otlphttp.river.txt
@@ -1,0 +1,47 @@
+{{ define "agent.config.otlphttp" }}
+{{- with .Values.externalServices.otlphttp }}
+// otlphttp
+local.file "otlphttp_host" {
+  filename  = "/etc/grafana-agent-credentials/otlphttp_host"
+}
+{{ if .basicAuth.username }}
+local.file "otlphttp_username" {
+  filename  = "/etc/grafana-agent-credentials/otlphttp_username"
+}
+{{- end }}
+{{ if .basicAuth.password }}
+local.file "otlphttp_password" {
+  filename  = "/etc/grafana-agent-credentials/otlphttp_password"
+  is_secret = true
+}
+{{- end }}
+{{ if .tenantId }}
+local.file "otlphttp_tenantid" {
+  filename  = "/etc/grafana-agent-credentials/otlphttp_tenantId"
+}
+{{- end }}
+{{ if or (.basicAuth.username) (.basicAuth.password) }}
+otelcol.auth.basic "otlphttp" {
+  {{ if .basicAuth.username }}username = local.file.otlphttp_username.content{{ end }}
+  {{ if .basicAuth.password }}password = local.file.otlphttp_password.content{{ end }}
+}
+{{- end }}
+
+otelcol.exporter.otlphttp "grafana_cloud_otlphttp" {
+  client {
+    endpoint = nonsensitive(local.file.otlphttp_host.content)
+{{ if or (.basicAuth.username) (.basicAuth.password) }}
+    auth = otelcol.auth.basic.otlphttp.handler
+{{- end }}
+{{- if .tenantId }}
+    headers = { "X-Scope-OrgID" = local.file.otlphttp_tenantid.content }
+{{- end }}
+{{- if .tlsOptions }}
+    tls {
+{{ .tlsOptions | indent 6 }}
+    }
+{{- end }}
+  }
+}
+{{- end }}
+{{ end }}

--- a/charts/k8s-monitoring/templates/agent_config/_traces.river.txt
+++ b/charts/k8s-monitoring/templates/agent_config/_traces.river.txt
@@ -22,6 +22,9 @@ otelcol.receiver.otlp "trace_receiver" {
 {{- end }}
   output {
     traces = [otelcol.processor.batch.trace_batch_processor.input]
+    {{- if .Values.traces.otelMetrics.enabled }}
+    metrics = [otelcol.processor.batch.metrics_batch_processor.input]
+    {{- end }}
   }
 }
 {{- end }}
@@ -63,4 +66,63 @@ otelcol.processor.attributes "trace_attributes_processor" {
     traces = [otelcol.exporter.otlp.tempo.input]
   }
 }
+
+{{- if .Values.traces.otelMetrics.enabled }}
+{{- if not (or .Values.traces.otelMetrics.exporter.prometheus.enabled .Values.traces.otelMetrics.exporter.otlphttp.enabled) }}
+  {{- fail "You must enable either prometheus, otlphttp exporter" -}}
+{{- end }}
+
+{{- with .Values.traces.otelMetrics }}
+otelcol.processor.batch "metrics_batch_processor" {
+  send_batch_size = {{ .processors.batch.size | int }}
+  send_batch_max_size = {{ .processors.batch.maxSize | int }}
+  timeout = {{ .processors.batch.timeout | quote}}
+  output {
+    metrics = [otelcol.processor.attributes.metrics_attributes_processor.input]
+  }
+}
+{{- end }}
+
+otelcol.processor.attributes "metrics_attributes_processor" {
+  action {
+    key = "cluster"
+    value = {{ required ".Values.cluster.name is a required value. Please set it and try again." .Values.cluster.name | quote }}
+    action = "insert"
+  }
+  action {
+    key = "k8s.cluster.name"
+    value = {{ required ".Values.cluster.name is a required value. Please set it and try again." .Values.cluster.name | quote }}
+    action = "upsert"
+  }
+
+  {{- if .Values.traces.otelMetrics.exporter.prometheus.enabled }}
+  action {
+    key = "exporter.job"
+    value = "prometheus"
+    action = "upsert"
+  }
+  {{- else if .Values.traces.otelMetrics.exporter.otlphttp.enabled }}
+  action {
+    key = "exporter.job"
+    value = "otlphttp"
+    action = "upsert"
+  }
+  {{- end }}
+  output {
+
+    {{- if (and .Values.traces.otelMetrics.exporter.prometheus.enabled .Values.traces.otelMetrics.exporter.otlphttp.enabled) }}
+      metrics = [
+        prometheus.remote_write.grafana_cloud_prometheus.receiver,
+        otelcol.exporter.otlphttp.grafana_cloud_otlphttp.input,
+      ]
+    {{- else if .Values.traces.otelMetrics.exporter.prometheus.enabled }}
+      metrics = [prometheus.remote_write.grafana_cloud_prometheus.receiver]
+    {{- else if .Values.traces.otelMetrics.exporter.otlphttp.enabled }}
+      metrics = [otelcol.exporter.otlphttp.grafana_cloud_otlphttp.input]
+    {{- end }}
+  }
+}
+
+{{- end }}
+
 {{- end }}

--- a/charts/k8s-monitoring/templates/credentials.yaml
+++ b/charts/k8s-monitoring/templates/credentials.yaml
@@ -40,4 +40,14 @@ data:
   {{- if .Values.externalServices.tempo.tenantId }}
   tempo_tenantId: {{ .Values.externalServices.tempo.tenantId | toString | b64enc | quote }}
   {{- end }}
+  otlphttp_host: {{ required ".Values.externalServices.otlphttp.host is required to use traces. Please set it and try again."  .Values.externalServices.otlphttp.host | b64enc | quote }}
+  {{- if .Values.externalServices.otlphttp.basicAuth.username }}
+  otlphttp_username: {{ .Values.externalServices.otlphttp.basicAuth.username | toString | b64enc | quote }}
+  {{- end }}
+  {{- if .Values.externalServices.otlphttp.basicAuth.password }}
+  otlphttp_password: {{ .Values.externalServices.otlphttp.basicAuth.password | toString | b64enc | quote }}
+  {{- end }}
+  {{- if .Values.externalServices.otlphttp.tenantId }}
+  otlphttp_tenantId: {{ .Values.externalServices.tempo.tenantId | toString | b64enc | quote }}
+  {{- end }}
 {{- end }}

--- a/charts/k8s-monitoring/values.yaml
+++ b/charts/k8s-monitoring/values.yaml
@@ -109,6 +109,26 @@ externalServices:
     # tlsOptions: insecure = true
     tlsOptions: ""
 
+  # Connection information for OTLP HTTP endpoint
+  otlphttp:
+    # -- (string) (required) OTLP HTTP host where traces/metrics will be sent
+    host: ""
+
+    # -- (string) (optional) OTLP HTTP tenant ID
+    tenantId: ""
+
+    # Authenticate to OTLP HTTP using basic authentication
+    basicAuth:
+      # -- (string) OTLP HTTP basic auth username
+      username: ""
+      # -- (string) OTLP HTTP basic auth password
+      password: ""
+
+    # -- (string) Define the TLS block. See https://grafana.com/docs/agent/latest/flow/reference/components/otelcol.exporter.otlphttp/#tls-block for options.
+    # Example:
+    # tlsOptions: insecure = true
+    tlsOptions: ""
+
 # Settings related to capturing and forwarding metrics
 metrics:
   # -- Capture and forward metrics
@@ -543,6 +563,26 @@ traces:
       # -- How long before sending
       timeout: 2s
 
+  # Metrics from the OTEL Instrumentation
+  otelMetrics:
+    # -- Receive otel metrics from OTEL Instrumentation
+    enabled: false
+    exporter: 
+      prometheus: 
+        # -- Forward metrics via prometheus rewrite exporter
+        enabled: true
+      otlphttp: 
+        # -- Forward metrics via OTLP HTTP
+        enabled: false
+    processors:
+      # OTLP Metrics batch processor settings
+      batch:
+        # -- What batch size to use, in bytes
+        size: 16384
+        # -- The upper limit of the amount of data contained in a single batch, in bytes. When set to 0, batches can be any size.
+        maxSize: 0
+        # -- How long before sending
+        timeout: 2s
 # -- (string) Extra configuration that will be added to the Grafana Agent configuration file. See [Adding custom Flow configuration](#adding-custom-flow-configuration) for an example.
 extraConfig:
 

--- a/examples/traces-enabled/metrics.river
+++ b/examples/traces-enabled/metrics.river
@@ -411,6 +411,7 @@ http {
   }
   output {
     traces = [otelcol.processor.batch.trace_batch_processor.input]
+    metrics = [otelcol.processor.batch.metrics_batch_processor.input]
   }
 }
 otelcol.receiver.zipkin "trace_receiver" {
@@ -443,6 +444,38 @@ otelcol.processor.attributes "trace_attributes_processor" {
     traces = [otelcol.exporter.otlp.tempo.input]
   }
 }
+otelcol.processor.batch "metrics_batch_processor" {
+  send_batch_size = 16384
+  send_batch_max_size = 0
+  timeout = "2s"
+  output {
+    metrics = [otelcol.processor.attributes.metrics_attributes_processor.input]
+  }
+}
+
+otelcol.processor.attributes "metrics_attributes_processor" {
+  action {
+    key = "cluster"
+    value = "traces-enabled-test"
+    action = "insert"
+  }
+  action {
+    key = "k8s.cluster.name"
+    value = "traces-enabled-test"
+    action = "upsert"
+  }
+  action {
+    key = "exporter.job"
+    value = "prometheus"
+    action = "upsert"
+  }
+  output {
+      metrics = [
+        prometheus.remote_write.grafana_cloud_prometheus.receiver,
+        otelcol.exporter.otlphttp.grafana_cloud_otlphttp.input,
+      ]
+  }
+}
 // Tempo
 local.file "tempo_host" {
   filename  = "/etc/grafana-agent-credentials/tempo_host"
@@ -468,5 +501,33 @@ otelcol.exporter.otlp "tempo" {
     endpoint = nonsensitive(local.file.tempo_host.content)
 
     auth = otelcol.auth.basic.tempo.handler
+  }
+}
+
+// otlphttp
+local.file "otlphttp_host" {
+  filename  = "/etc/grafana-agent-credentials/otlphttp_host"
+}
+
+local.file "otlphttp_username" {
+  filename  = "/etc/grafana-agent-credentials/otlphttp_username"
+}
+
+local.file "otlphttp_password" {
+  filename  = "/etc/grafana-agent-credentials/otlphttp_password"
+  is_secret = true
+}
+
+
+otelcol.auth.basic "otlphttp" {
+  username = local.file.otlphttp_username.content
+  password = local.file.otlphttp_password.content
+}
+
+otelcol.exporter.otlphttp "grafana_cloud_otlphttp" {
+  client {
+    endpoint = nonsensitive(local.file.otlphttp_host.content)
+
+    auth = otelcol.auth.basic.otlphttp.handler
   }
 }

--- a/examples/traces-enabled/output.yaml
+++ b/examples/traces-enabled/output.yaml
@@ -85,6 +85,9 @@ data:
   tempo_host: "aHR0cHM6Ly90ZW1wby5leGFtcGxlLmNvbQ=="
   tempo_username: "MTIzNDU="
   tempo_password: "SXQncyBhIHNlY3JldCB0byBldmVyeW9uZQ=="
+  otlphttp_host: "aHR0cHM6Ly90ZW1wby5leGFtcGxlLmNvbS9vdGxw"
+  otlphttp_username: "MTIzNDU="
+  otlphttp_password: "SXQncyBhIHNlY3JldCB0byBldmVyeW9uZQ=="
 ---
 # Source: k8s-monitoring/templates/grafana-agent-config.yaml
 apiVersion: v1
@@ -507,6 +510,7 @@ data:
       }
       output {
         traces = [otelcol.processor.batch.trace_batch_processor.input]
+        metrics = [otelcol.processor.batch.metrics_batch_processor.input]
       }
     }
     otelcol.receiver.zipkin "trace_receiver" {
@@ -539,6 +543,38 @@ data:
         traces = [otelcol.exporter.otlp.tempo.input]
       }
     }
+    otelcol.processor.batch "metrics_batch_processor" {
+      send_batch_size = 16384
+      send_batch_max_size = 0
+      timeout = "2s"
+      output {
+        metrics = [otelcol.processor.attributes.metrics_attributes_processor.input]
+      }
+    }
+    
+    otelcol.processor.attributes "metrics_attributes_processor" {
+      action {
+        key = "cluster"
+        value = "traces-enabled-test"
+        action = "insert"
+      }
+      action {
+        key = "k8s.cluster.name"
+        value = "traces-enabled-test"
+        action = "upsert"
+      }
+      action {
+        key = "exporter.job"
+        value = "prometheus"
+        action = "upsert"
+      }
+      output {
+          metrics = [
+            prometheus.remote_write.grafana_cloud_prometheus.receiver,
+            otelcol.exporter.otlphttp.grafana_cloud_otlphttp.input,
+          ]
+      }
+    }
     // Tempo
     local.file "tempo_host" {
       filename  = "/etc/grafana-agent-credentials/tempo_host"
@@ -564,6 +600,34 @@ data:
         endpoint = nonsensitive(local.file.tempo_host.content)
     
         auth = otelcol.auth.basic.tempo.handler
+      }
+    }
+    
+    // otlphttp
+    local.file "otlphttp_host" {
+      filename  = "/etc/grafana-agent-credentials/otlphttp_host"
+    }
+    
+    local.file "otlphttp_username" {
+      filename  = "/etc/grafana-agent-credentials/otlphttp_username"
+    }
+    
+    local.file "otlphttp_password" {
+      filename  = "/etc/grafana-agent-credentials/otlphttp_password"
+      is_secret = true
+    }
+    
+    
+    otelcol.auth.basic "otlphttp" {
+      username = local.file.otlphttp_username.content
+      password = local.file.otlphttp_password.content
+    }
+    
+    otelcol.exporter.otlphttp "grafana_cloud_otlphttp" {
+      client {
+        endpoint = nonsensitive(local.file.otlphttp_host.content)
+    
+        auth = otelcol.auth.basic.otlphttp.handler
       }
     }
 ---
@@ -43508,6 +43572,7 @@ data:
       }
       output {
         traces = [otelcol.processor.batch.trace_batch_processor.input]
+        metrics = [otelcol.processor.batch.metrics_batch_processor.input]
       }
     }
     otelcol.receiver.zipkin "trace_receiver" {
@@ -43540,6 +43605,38 @@ data:
         traces = [otelcol.exporter.otlp.tempo.input]
       }
     }
+    otelcol.processor.batch "metrics_batch_processor" {
+      send_batch_size = 16384
+      send_batch_max_size = 0
+      timeout = "2s"
+      output {
+        metrics = [otelcol.processor.attributes.metrics_attributes_processor.input]
+      }
+    }
+    
+    otelcol.processor.attributes "metrics_attributes_processor" {
+      action {
+        key = "cluster"
+        value = "traces-enabled-test"
+        action = "insert"
+      }
+      action {
+        key = "k8s.cluster.name"
+        value = "traces-enabled-test"
+        action = "upsert"
+      }
+      action {
+        key = "exporter.job"
+        value = "prometheus"
+        action = "upsert"
+      }
+      output {
+          metrics = [
+            prometheus.remote_write.grafana_cloud_prometheus.receiver,
+            otelcol.exporter.otlphttp.grafana_cloud_otlphttp.input,
+          ]
+      }
+    }
     // Tempo
     local.file "tempo_host" {
       filename  = "/etc/grafana-agent-credentials/tempo_host"
@@ -43565,6 +43662,34 @@ data:
         endpoint = nonsensitive(local.file.tempo_host.content)
     
         auth = otelcol.auth.basic.tempo.handler
+      }
+    }
+    
+    // otlphttp
+    local.file "otlphttp_host" {
+      filename  = "/etc/grafana-agent-credentials/otlphttp_host"
+    }
+    
+    local.file "otlphttp_username" {
+      filename  = "/etc/grafana-agent-credentials/otlphttp_username"
+    }
+    
+    local.file "otlphttp_password" {
+      filename  = "/etc/grafana-agent-credentials/otlphttp_password"
+      is_secret = true
+    }
+    
+    
+    otelcol.auth.basic "otlphttp" {
+      username = local.file.otlphttp_username.content
+      password = local.file.otlphttp_password.content
+    }
+    
+    otelcol.exporter.otlphttp "grafana_cloud_otlphttp" {
+      client {
+        endpoint = nonsensitive(local.file.otlphttp_host.content)
+    
+        auth = otelcol.auth.basic.otlphttp.handler
       }
     }
   logs.river: |-

--- a/examples/traces-enabled/values.yaml
+++ b/examples/traces-enabled/values.yaml
@@ -17,9 +17,21 @@ externalServices:
     basicAuth:
       username: 12345
       password: "It's a secret to everyone"
+  otlphttp:
+    host: https://tempo.example.com/otlp
+    basicAuth:
+      username: 12345
+      password: "It's a secret to everyone"
 
 traces:
   enabled: true
+  otelMetrics:
+    enabled: true
+    exporter:
+      prometheus: 
+        enabled: true
+      otlphttp: 
+        enabled: true
 
 grafana-agent:
   agent:


### PR DESCRIPTION
This PR provides the ability to publish metrics collected via opentelemetry instrumentation to prometheus via promethues rewrite or otelcol.exporter.otlphttp or to both simultaneously