### PR TITLE
Add k8s.cluster.name through resource attributes

### DIFF
--- a/charts/k8s-monitoring/templates/agent_config/_traces.river.txt
+++ b/charts/k8s-monitoring/templates/agent_config/_traces.river.txt
@@ -43,7 +43,20 @@ otelcol.processor.batch "trace_batch_processor" {
   send_batch_max_size = {{ .processors.batch.maxSize | int }}
   timeout = {{ .processors.batch.timeout | quote}}
   output {
-    traces = [otelcol.processor.attributes.trace_attributes_processor.input]
+    traces = [otelcol.processor.attributes.trace_transform_processor.input]
+  }
+}
+
+otelcol.processor.transform "trace_transform_processor" {
+  trace_statements {
+    context = "resource"
+    statements = [
+      // Accessing a map with a key that does not exist will return nil. 
+      "set(attributes[\"k8s.cluster.name\"], {{ required ".Values.cluster.name is a required value. Please set it and try again." .Values.cluster.name | quote }}) where attributes[\"k8s.cluster.name\"] == nil"
+    ]
+  }
+  output {
+    traces  = [otelcol.processor.attributes.trace_attributes_processor.input]
   }
 }
 {{- end }}
@@ -53,11 +66,6 @@ otelcol.processor.attributes "trace_attributes_processor" {
     key = "cluster"
     value = {{ required ".Values.cluster.name is a required value. Please set it and try again." .Values.cluster.name | quote }}
     action = "insert"
-  }
-  action {
-    key = "k8s.cluster.name"
-    value = {{ required ".Values.cluster.name is a required value. Please set it and try again." .Values.cluster.name | quote }}
-    action = "upsert"
   }
   output {
     traces = [otelcol.exporter.otlp.tempo.input]

--- a/charts/k8s-monitoring/templates/agent_config/_traces.river.txt
+++ b/charts/k8s-monitoring/templates/agent_config/_traces.river.txt
@@ -54,7 +54,7 @@ otelcol.processor.transform "trace_transform_processor" {
     context = "resource"
     statements = [
       // Accessing a map with a key that does not exist will return nil.
-      "set(attributes[\"k8s.cluster.name\"], \"{{ required ".Values.cluster.name is a required value. Please set it and try again." .Values.cluster.name }}\") where attributes[\"k8s.cluster.name\"] == nil"
+      "set(attributes[\"k8s.cluster.name\"], \"{{ required ".Values.cluster.name is a required value. Please set it and try again." .Values.cluster.name }}\") where attributes[\"k8s.cluster.name\"] == nil",
     ]
   }
   output {

--- a/charts/k8s-monitoring/templates/agent_config/_traces.river.txt
+++ b/charts/k8s-monitoring/templates/agent_config/_traces.river.txt
@@ -47,19 +47,20 @@ otelcol.processor.batch "trace_batch_processor" {
   }
 }
 
+{{- end }}
+
 otelcol.processor.transform "trace_transform_processor" {
   trace_statements {
     context = "resource"
     statements = [
-      // Accessing a map with a key that does not exist will return nil. 
-      "set(attributes[\"k8s.cluster.name\"], {{ required ".Values.cluster.name is a required value. Please set it and try again." .Values.cluster.name | quote }}) where attributes[\"k8s.cluster.name\"] == nil"
+      // Accessing a map with a key that does not exist will return nil.
+      "set(attributes[\"k8s.cluster.name\"], \"{{ required ".Values.cluster.name is a required value. Please set it and try again." .Values.cluster.name }}\") where attributes[\"k8s.cluster.name\"] == nil"
     ]
   }
   output {
     traces  = [otelcol.processor.attributes.trace_attributes_processor.input]
   }
 }
-{{- end }}
 
 otelcol.processor.attributes "trace_attributes_processor" {
   action {

--- a/examples/traces-enabled/metrics.river
+++ b/examples/traces-enabled/metrics.river
@@ -433,7 +433,7 @@ otelcol.processor.transform "trace_transform_processor" {
     context = "resource"
     statements = [
       // Accessing a map with a key that does not exist will return nil.
-      "set(attributes[\"k8s.cluster.name\"], \"traces-enabled-test\") where attributes[\"k8s.cluster.name\"] == nil"
+      "set(attributes[\"k8s.cluster.name\"], \"traces-enabled-test\") where attributes[\"k8s.cluster.name\"] == nil",
     ]
   }
   output {

--- a/examples/traces-enabled/metrics.river
+++ b/examples/traces-enabled/metrics.river
@@ -424,7 +424,20 @@ otelcol.processor.batch "trace_batch_processor" {
   send_batch_max_size = 0
   timeout = "2s"
   output {
-    traces = [otelcol.processor.attributes.trace_attributes_processor.input]
+    traces = [otelcol.processor.attributes.trace_transform_processor.input]
+  }
+}
+
+otelcol.processor.transform "trace_transform_processor" {
+  trace_statements {
+    context = "resource"
+    statements = [
+      // Accessing a map with a key that does not exist will return nil.
+      "set(attributes[\"k8s.cluster.name\"], \"traces-enabled-test\") where attributes[\"k8s.cluster.name\"] == nil"
+    ]
+  }
+  output {
+    traces  = [otelcol.processor.attributes.trace_attributes_processor.input]
   }
 }
 
@@ -433,11 +446,6 @@ otelcol.processor.attributes "trace_attributes_processor" {
     key = "cluster"
     value = "traces-enabled-test"
     action = "insert"
-  }
-  action {
-    key = "k8s.cluster.name"
-    value = "traces-enabled-test"
-    action = "upsert"
   }
   output {
     traces = [otelcol.exporter.otlp.tempo.input]

--- a/examples/traces-enabled/output.yaml
+++ b/examples/traces-enabled/output.yaml
@@ -520,7 +520,20 @@ data:
       send_batch_max_size = 0
       timeout = "2s"
       output {
-        traces = [otelcol.processor.attributes.trace_attributes_processor.input]
+        traces = [otelcol.processor.attributes.trace_transform_processor.input]
+      }
+    }
+    
+    otelcol.processor.transform "trace_transform_processor" {
+      trace_statements {
+        context = "resource"
+        statements = [
+          // Accessing a map with a key that does not exist will return nil.
+          "set(attributes[\"k8s.cluster.name\"], \"traces-enabled-test\") where attributes[\"k8s.cluster.name\"] == nil"
+        ]
+      }
+      output {
+        traces  = [otelcol.processor.attributes.trace_attributes_processor.input]
       }
     }
     
@@ -529,11 +542,6 @@ data:
         key = "cluster"
         value = "traces-enabled-test"
         action = "insert"
-      }
-      action {
-        key = "k8s.cluster.name"
-        value = "traces-enabled-test"
-        action = "upsert"
       }
       output {
         traces = [otelcol.exporter.otlp.tempo.input]
@@ -43521,7 +43529,20 @@ data:
       send_batch_max_size = 0
       timeout = "2s"
       output {
-        traces = [otelcol.processor.attributes.trace_attributes_processor.input]
+        traces = [otelcol.processor.attributes.trace_transform_processor.input]
+      }
+    }
+    
+    otelcol.processor.transform "trace_transform_processor" {
+      trace_statements {
+        context = "resource"
+        statements = [
+          // Accessing a map with a key that does not exist will return nil.
+          "set(attributes[\"k8s.cluster.name\"], \"traces-enabled-test\") where attributes[\"k8s.cluster.name\"] == nil"
+        ]
+      }
+      output {
+        traces  = [otelcol.processor.attributes.trace_attributes_processor.input]
       }
     }
     
@@ -43530,11 +43551,6 @@ data:
         key = "cluster"
         value = "traces-enabled-test"
         action = "insert"
-      }
-      action {
-        key = "k8s.cluster.name"
-        value = "traces-enabled-test"
-        action = "upsert"
       }
       output {
         traces = [otelcol.exporter.otlp.tempo.input]

--- a/examples/traces-enabled/output.yaml
+++ b/examples/traces-enabled/output.yaml
@@ -529,7 +529,7 @@ data:
         context = "resource"
         statements = [
           // Accessing a map with a key that does not exist will return nil.
-          "set(attributes[\"k8s.cluster.name\"], \"traces-enabled-test\") where attributes[\"k8s.cluster.name\"] == nil"
+          "set(attributes[\"k8s.cluster.name\"], \"traces-enabled-test\") where attributes[\"k8s.cluster.name\"] == nil",
         ]
       }
       output {
@@ -43538,7 +43538,7 @@ data:
         context = "resource"
         statements = [
           // Accessing a map with a key that does not exist will return nil.
-          "set(attributes[\"k8s.cluster.name\"], \"traces-enabled-test\") where attributes[\"k8s.cluster.name\"] == nil"
+          "set(attributes[\"k8s.cluster.name\"], \"traces-enabled-test\") where attributes[\"k8s.cluster.name\"] == nil",
         ]
       }
       output {


### PR DESCRIPTION
The concrete change here is injecting a new transform processor because the attributes processor cannot write to/access the resource.