### PR TITLE
Improve the Helm test job so it can run LogQL queries

### DIFF
--- a/charts/k8s-monitoring/README.md
+++ b/charts/k8s-monitoring/README.md
@@ -188,7 +188,7 @@ The Prometheus and Loki services may be hosted on the same cluster, or remotely 
 | prometheus-operator-crds.enabled | bool | `true` | Should this helm chart deploy the Prometheus Operator CRDs to the cluster. Set this to false if your cluster already has the CRDs, or if you do not to have the Grafana Agent scrape metrics from PodMonitors, Probes, or ServiceMonitors. |
 | prometheus-windows-exporter.config | string | `"collectors:\n  enabled: cpu,cs,container,logical_disk,memory,net,os\ncollector:\n  service:\n    services-where: \"Name='containerd' or Name='kubelet'\""` |  |
 | prometheus-windows-exporter.enabled | bool | `false` | Should this helm chart deploy Windows Exporter to the cluster. Set this to false if your cluster already has Windows Exporter, or if you do not want to scrape metrics from Windows Exporter. |
-| test.extraQueries | list | `[]` | Additional queries that will be run with `helm test`. Example: extraQueries:   - query: prometheus_metric{cluster="my-cluster-name"} |
+| test.extraQueries | list | `[]` | Additional queries that will be run with `helm test`. NOTE that this uses the host, username, and password in the externalServices section. The user account must have the ability to run queries. Example: extraQueries:   - query: prometheus_metric{cluster="my-cluster-name"}     type: [promql|logql] |
 | test.image.image | string | `"ubuntu"` | Test job image repository |
 | test.image.registry | string | `"docker.io"` | Test job image registry |
 | test.image.tag | string | `"jammy"` | Test job image tag |

--- a/charts/k8s-monitoring/ci/ci-values.yaml
+++ b/charts/k8s-monitoring/ci/ci-values.yaml
@@ -29,7 +29,12 @@ metrics:
 
 test:
   extraQueries:
-  - query: kube_deployment_spec_replicas{cluster="ci-test-cluster"}
+  # Check for cluster events
+  - query: "{cluster=\"ci-test-cluster\", job=\"integrations/kubernetes/eventhandler\"}"
+    type: logql
+  # Check for pod logs
+  - query: "{cluster=\"ci-test-cluster\", job!=\"integrations/kubernetes/eventhandler\"}"
+    type: logql
 
 opencost:
   prometheus:

--- a/charts/k8s-monitoring/scripts/query-test.sh
+++ b/charts/k8s-monitoring/scripts/query-test.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+set -eo pipefail
+
+function metrics_query {
+  echo "Running PromQL query: ${PROMETHEUS_URL}?query=${1}..."
+  result=$(curl -skX POST -u "${PROMETHEUS_USER}:${PROMETHEUS_PASS}" "${PROMETHEUS_URL}" --data-urlencode "query=${1}")
+  status=$(echo $result | jq -r .status)
+  if [ "${status}" != "success" ]; then
+    echo "Query failed!"
+    echo "$result"
+    exit 1
+  fi
+
+  resultCount=$(echo $result | jq '.data.result | length')
+  if [ "${resultCount}" -eq 0 ]; then
+    echo "Query returned no results"
+    echo "$result"
+    exit 1
+  fi
+}
+
+function logs_query {
+  echo "Running LogQL query: ${LOKI_URL}?query=${1}..."
+  result=$(curl -s --get -H "X-Scope-OrgID:${LOKI_TENANTID}" -u "${LOKI_USER}:${LOKI_PASS}" "${LOKI_URL}" --data-urlencode "query=${1}")
+  status=$(echo $result | jq -r .status)
+  if [ "${status}" != "success" ]; then
+    echo "Query failed!"
+    echo "$result"
+    exit 1
+  fi
+
+  resultCount=$(echo $result | jq '.data.result | length')
+  if [ "${resultCount}" -eq 0 ]; then
+    echo "Query returned no results"
+    echo "$result"
+    exit 1
+  fi
+}
+
+count=$(jq -r ".queries | length-1" "${1}")
+for i in $(seq 0 "${count}"); do
+  query=$(jq -r --argjson i "${i}" '.queries[$i].query' "${1}")
+  type=$(jq -r --argjson i "${i}" '.queries[$i] | .type // "promql"' "${1}")
+
+  case "${type}" in
+    promql)
+      metrics_query "${query}"
+      ;;
+    logql)
+      logs_query "${query}"
+      ;;
+    *)
+      echo "Query type ${type} is not yet supported in this test"
+      ;;
+  esac
+done
+
+echo "All queries passed!"

--- a/charts/k8s-monitoring/templates/tests/test.yaml
+++ b/charts/k8s-monitoring/templates/tests/test.yaml
@@ -74,7 +74,7 @@ spec:
       containers:
         - name: test-runner
           image: {{ .Values.test.image.registry }}/{{ .Values.test.image.image }}:{{ .Values.test.image.tag }}
-          command: ["bash", "-c", "apt-get update && apt-get install -y -y curl jq && bash /etc/test/test.sh /etc/test/queries.json"]
+          command: ["bash", "-c", "apt-get update && apt-get install -y curl jq && bash /etc/test/test.sh /etc/test/queries.json"]
           volumeMounts:
             - name: test-plan
               mountPath: /etc/test

--- a/charts/k8s-monitoring/templates/tests/test.yaml
+++ b/charts/k8s-monitoring/templates/tests/test.yaml
@@ -2,68 +2,51 @@
 queries:
   {{- if .Values.metrics.enabled }}
   - query: up{cluster={{ .Values.cluster.name | quote}}}
+    type: promql
     {{- if .Values.metrics.agent.enabled }}
   - query: agent_build_info{cluster={{ .Values.cluster.name | quote}}}
+    type: promql
     {{- end }}
     {{- if .Values.metrics.kubelet.enabled }}
   - query: kubernetes_build_info{cluster={{ .Values.cluster.name | quote}}}
+    type: promql
     {{- end }}
     {{- if .Values.metrics.cadvisor.enabled }}
   - query: machine_memory_bytes{cluster={{ .Values.cluster.name | quote}}}
+    type: promql
     {{- end }}
     {{- if (index .Values.metrics "kube-state-metrics").enabled }}
   - query: kube_node_info{cluster={{ .Values.cluster.name | quote}}}
+    type: promql
     {{- end }}
     {{- if (index .Values.metrics "node-exporter").enabled }}
   - query: node_exporter_build_info{cluster={{ .Values.cluster.name | quote}}}
+    type: promql
     {{- end }}
     {{- if (index .Values.metrics "windows-exporter").enabled }}
   - query: windows_exporter_build_info{cluster={{ .Values.cluster.name | quote}}}
+    type: promql
     {{- end }}
     {{- if .Values.metrics.apiserver.enabled }}
   - query: apiserver_request_total{cluster={{ .Values.cluster.name | quote}}}
+    type: promql
     {{- end }}
     {{- if .Values.metrics.cost.enabled }}
   - query: opencost_build_info{cluster={{ .Values.cluster.name | quote}}}
+    type: promql
     {{- end }}
     {{- if .Values.metrics.kubernetesMonitoring.enabled }}
   - query: grafana_kubernetes_monitoring_build_info{cluster={{ .Values.cluster.name | quote}}}
+    type: promql
     {{- end }}
 {{- if .Values.test.extraQueries }}
   {{- range .Values.test.extraQueries }}
-  - query: {{ .query }}
+  - query: {{ .query | quote }}
+    type: {{ .type | default "promql" }}
   {{- end }}
 {{- end }}
   {{- end }}
 {{- end -}}
-
-
-{{- define "test.script" -}}
-#!/bin/bash
-set -eo pipefail
-apt-get update && apt-get install -y curl jq
-
-queries=$(jq -r '.queries[].query' "$1")
-for query in $queries; do
-  echo "Running query: ${PROMETHEUS_HOST}{{ .Values.externalServices.prometheus.queryEndpoint }}?query=$query..."
-  result=$(curl -skX POST -u "${PROMETHEUS_USER}:${PROMETHEUS_PASS}" "${PROMETHEUS_HOST}{{ .Values.externalServices.prometheus.queryEndpoint }}?query=$(jq -rn --arg x "${query}" '$x|@uri')")
-  status=$(echo $result | jq -r .status)
-  if [ "${status}" != "success" ]; then
-    echo "Query failed!"
-    echo "$result"
-    exit 1
-  fi
-
-  resultCount=$(echo $result | jq '.data.result | length')
-  if [ "${resultCount}" -eq 0 ]; then
-    echo "Query returned no results"
-    echo "$result"
-    exit 1
-  fi
-done
-
-echo "All queries passed!"
-{{- end }}
 ---
 apiVersion: batch/v1
 kind: Job
@@ -91,7 +74,7 @@ spec:
       containers:
         - name: test-runner
           image: {{ .Values.test.image.registry }}/{{ .Values.test.image.image }}:{{ .Values.test.image.tag }}
-          command: ["bash", "-c", "bash /etc/test/test.sh /etc/test/queries.json"]
+          command: ["bash", "-c", "apt-get update && apt-get install -y -y curl jq && bash /etc/test/test.sh /etc/test/queries.json"]
           volumeMounts:
             - name: test-plan
               mountPath: /etc/test
@@ -101,16 +84,48 @@ spec:
                 secretKeyRef:
                   name: grafana-agent-credentials
                   key: prometheus_host
+                  optional: true
+            - name: PROMETHEUS_URL
+              value: $(PROMETHEUS_HOST){{ .Values.externalServices.prometheus.queryEndpoint }}
             - name: PROMETHEUS_USER
               valueFrom:
                 secretKeyRef:
                   name: grafana-agent-credentials
                   key: prometheus_username
+                  optional: true
             - name: PROMETHEUS_PASS
               valueFrom:
                 secretKeyRef:
                   name: grafana-agent-credentials
                   key: prometheus_password
+                  optional: true
+
+            - name: LOKI_HOST
+              valueFrom:
+                secretKeyRef:
+                  name: grafana-agent-credentials
+                  key: loki_host
+            - name: LOKI_URL
+              value: $(LOKI_HOST)/loki/api/v1/query
+            - name: LOKI_USER
+              valueFrom:
+                secretKeyRef:
+                  name: grafana-agent-credentials
+                  key: loki_username
+                  optional: true
+            - name: LOKI_PASS
+              valueFrom:
+                secretKeyRef:
+                  name: grafana-agent-credentials
+                  key: loki_password
+                  optional: true
+            - name: LOKI_TENANTID
+              valueFrom:
+                secretKeyRef:
+                  name: grafana-agent-credentials
+                  key: loki_tenantId
+                  optional: true
+
       volumes:
         - name: test-plan
           configMap:
@@ -131,6 +146,6 @@ metadata:
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 data:
   test.sh: |-
-    {{- include "test.script" . | trim | nindent 4 }}
+{{ .Files.Get "scripts/query-test.sh" | indent 4 }}
   queries.json: |-
-    {{- include "test.queryList" . | fromYaml | toPrettyJson | nindent 4 }}
+{{- include "test.queryList" . | fromYaml | toPrettyJson | nindent 4 }}

--- a/charts/k8s-monitoring/values.yaml
+++ b/charts/k8s-monitoring/values.yaml
@@ -549,9 +549,12 @@ extraConfig:
 # Settings for the test job, runnable by "helm test"
 test:
   # -- Additional queries that will be run with `helm test`.
+  # NOTE that this uses the host, username, and password in the externalServices section.
+  # The user account must have the ability to run queries.
   # Example:
   # extraQueries:
   #   - query: prometheus_metric{cluster="my-cluster-name"}
+  #     type: [promql|logql]
   extraQueries: []
 
   image:

--- a/examples/control-plane-metrics/output.yaml
+++ b/examples/control-plane-metrics/output.yaml
@@ -43622,12 +43622,10 @@ data:
   test.sh: |-
     #!/bin/bash
     set -eo pipefail
-    apt-get update && apt-get install -y curl jq
     
-    queries=$(jq -r '.queries[].query' "$1")
-    for query in $queries; do
-      echo "Running query: ${PROMETHEUS_HOST}/api/prom/api/v1/query?query=$query..."
-      result=$(curl -skX POST -u "${PROMETHEUS_USER}:${PROMETHEUS_PASS}" "${PROMETHEUS_HOST}/api/prom/api/v1/query?query=$(jq -rn --arg x "${query}" '$x|@uri')")
+    function metrics_query {
+      echo "Running PromQL query: ${PROMETHEUS_URL}?query=${1}..."
+      result=$(curl -skX POST -u "${PROMETHEUS_USER}:${PROMETHEUS_PASS}" "${PROMETHEUS_URL}" --data-urlencode "query=${1}")
       status=$(echo $result | jq -r .status)
       if [ "${status}" != "success" ]; then
         echo "Query failed!"
@@ -43641,6 +43639,42 @@ data:
         echo "$result"
         exit 1
       fi
+    }
+    
+    function logs_query {
+      echo "Running LogQL query: ${LOKI_URL}?query=${1}..."
+      result=$(curl -s --get -H "X-Scope-OrgID:${LOKI_TENANTID}" -u "${LOKI_USER}:${LOKI_PASS}" "${LOKI_URL}" --data-urlencode "query=${1}")
+      status=$(echo $result | jq -r .status)
+      if [ "${status}" != "success" ]; then
+        echo "Query failed!"
+        echo "$result"
+        exit 1
+      fi
+    
+      resultCount=$(echo $result | jq '.data.result | length')
+      if [ "${resultCount}" -eq 0 ]; then
+        echo "Query returned no results"
+        echo "$result"
+        exit 1
+      fi
+    }
+    
+    count=$(jq -r ".queries | length-1" "${1}")
+    for i in $(seq 0 "${count}"); do
+      query=$(jq -r --argjson i "${i}" '.queries[$i].query' "${1}")
+      type=$(jq -r --argjson i "${i}" '.queries[$i] | .type // "promql"' "${1}")
+    
+      case "${type}" in
+        promql)
+          metrics_query "${query}"
+          ;;
+        logql)
+          logs_query "${query}"
+          ;;
+        *)
+          echo "Query type ${type} is not yet supported in this test"
+          ;;
+      esac
     done
     
     echo "All queries passed!"
@@ -43648,31 +43682,40 @@ data:
     {
       "queries": [
         {
-          "query": "up{cluster=\"control-plane-metrics-test\"}"
+          "query": "up{cluster=\"control-plane-metrics-test\"}",
+          "type": "promql"
         },
         {
-          "query": "agent_build_info{cluster=\"control-plane-metrics-test\"}"
+          "query": "agent_build_info{cluster=\"control-plane-metrics-test\"}",
+          "type": "promql"
         },
         {
-          "query": "kubernetes_build_info{cluster=\"control-plane-metrics-test\"}"
+          "query": "kubernetes_build_info{cluster=\"control-plane-metrics-test\"}",
+          "type": "promql"
         },
         {
-          "query": "machine_memory_bytes{cluster=\"control-plane-metrics-test\"}"
+          "query": "machine_memory_bytes{cluster=\"control-plane-metrics-test\"}",
+          "type": "promql"
         },
         {
-          "query": "kube_node_info{cluster=\"control-plane-metrics-test\"}"
+          "query": "kube_node_info{cluster=\"control-plane-metrics-test\"}",
+          "type": "promql"
         },
         {
-          "query": "node_exporter_build_info{cluster=\"control-plane-metrics-test\"}"
+          "query": "node_exporter_build_info{cluster=\"control-plane-metrics-test\"}",
+          "type": "promql"
         },
         {
-          "query": "apiserver_request_total{cluster=\"control-plane-metrics-test\"}"
+          "query": "apiserver_request_total{cluster=\"control-plane-metrics-test\"}",
+          "type": "promql"
         },
         {
-          "query": "opencost_build_info{cluster=\"control-plane-metrics-test\"}"
+          "query": "opencost_build_info{cluster=\"control-plane-metrics-test\"}",
+          "type": "promql"
         },
         {
-          "query": "grafana_kubernetes_monitoring_build_info{cluster=\"control-plane-metrics-test\"}"
+          "query": "grafana_kubernetes_monitoring_build_info{cluster=\"control-plane-metrics-test\"}",
+          "type": "promql"
         }
       ]
     }
@@ -43752,7 +43795,7 @@ spec:
       containers:
         - name: test-runner
           image: docker.io/ubuntu:jammy
-          command: ["bash", "-c", "bash /etc/test/test.sh /etc/test/queries.json"]
+          command: ["bash", "-c", "apt-get update && apt-get install -y -y curl jq && bash /etc/test/test.sh /etc/test/queries.json"]
           volumeMounts:
             - name: test-plan
               mountPath: /etc/test
@@ -43762,16 +43805,48 @@ spec:
                 secretKeyRef:
                   name: grafana-agent-credentials
                   key: prometheus_host
+                  optional: true
+            - name: PROMETHEUS_URL
+              value: $(PROMETHEUS_HOST)/api/prom/api/v1/query
             - name: PROMETHEUS_USER
               valueFrom:
                 secretKeyRef:
                   name: grafana-agent-credentials
                   key: prometheus_username
+                  optional: true
             - name: PROMETHEUS_PASS
               valueFrom:
                 secretKeyRef:
                   name: grafana-agent-credentials
                   key: prometheus_password
+                  optional: true
+
+            - name: LOKI_HOST
+              valueFrom:
+                secretKeyRef:
+                  name: grafana-agent-credentials
+                  key: loki_host
+            - name: LOKI_URL
+              value: $(LOKI_HOST)/loki/api/v1/query
+            - name: LOKI_USER
+              valueFrom:
+                secretKeyRef:
+                  name: grafana-agent-credentials
+                  key: loki_username
+                  optional: true
+            - name: LOKI_PASS
+              valueFrom:
+                secretKeyRef:
+                  name: grafana-agent-credentials
+                  key: loki_password
+                  optional: true
+            - name: LOKI_TENANTID
+              valueFrom:
+                secretKeyRef:
+                  name: grafana-agent-credentials
+                  key: loki_tenantId
+                  optional: true
+
       volumes:
         - name: test-plan
           configMap:

--- a/examples/custom-allow-lists/output.yaml
+++ b/examples/custom-allow-lists/output.yaml
@@ -42965,12 +42965,10 @@ data:
   test.sh: |-
     #!/bin/bash
     set -eo pipefail
-    apt-get update && apt-get install -y curl jq
     
-    queries=$(jq -r '.queries[].query' "$1")
-    for query in $queries; do
-      echo "Running query: ${PROMETHEUS_HOST}/api/prom/api/v1/query?query=$query..."
-      result=$(curl -skX POST -u "${PROMETHEUS_USER}:${PROMETHEUS_PASS}" "${PROMETHEUS_HOST}/api/prom/api/v1/query?query=$(jq -rn --arg x "${query}" '$x|@uri')")
+    function metrics_query {
+      echo "Running PromQL query: ${PROMETHEUS_URL}?query=${1}..."
+      result=$(curl -skX POST -u "${PROMETHEUS_USER}:${PROMETHEUS_PASS}" "${PROMETHEUS_URL}" --data-urlencode "query=${1}")
       status=$(echo $result | jq -r .status)
       if [ "${status}" != "success" ]; then
         echo "Query failed!"
@@ -42984,6 +42982,42 @@ data:
         echo "$result"
         exit 1
       fi
+    }
+    
+    function logs_query {
+      echo "Running LogQL query: ${LOKI_URL}?query=${1}..."
+      result=$(curl -s --get -H "X-Scope-OrgID:${LOKI_TENANTID}" -u "${LOKI_USER}:${LOKI_PASS}" "${LOKI_URL}" --data-urlencode "query=${1}")
+      status=$(echo $result | jq -r .status)
+      if [ "${status}" != "success" ]; then
+        echo "Query failed!"
+        echo "$result"
+        exit 1
+      fi
+    
+      resultCount=$(echo $result | jq '.data.result | length')
+      if [ "${resultCount}" -eq 0 ]; then
+        echo "Query returned no results"
+        echo "$result"
+        exit 1
+      fi
+    }
+    
+    count=$(jq -r ".queries | length-1" "${1}")
+    for i in $(seq 0 "${count}"); do
+      query=$(jq -r --argjson i "${i}" '.queries[$i].query' "${1}")
+      type=$(jq -r --argjson i "${i}" '.queries[$i] | .type // "promql"' "${1}")
+    
+      case "${type}" in
+        promql)
+          metrics_query "${query}"
+          ;;
+        logql)
+          logs_query "${query}"
+          ;;
+        *)
+          echo "Query type ${type} is not yet supported in this test"
+          ;;
+      esac
     done
     
     echo "All queries passed!"
@@ -42991,28 +43025,36 @@ data:
     {
       "queries": [
         {
-          "query": "up{cluster=\"custom-allow-lists-test\"}"
+          "query": "up{cluster=\"custom-allow-lists-test\"}",
+          "type": "promql"
         },
         {
-          "query": "agent_build_info{cluster=\"custom-allow-lists-test\"}"
+          "query": "agent_build_info{cluster=\"custom-allow-lists-test\"}",
+          "type": "promql"
         },
         {
-          "query": "kubernetes_build_info{cluster=\"custom-allow-lists-test\"}"
+          "query": "kubernetes_build_info{cluster=\"custom-allow-lists-test\"}",
+          "type": "promql"
         },
         {
-          "query": "machine_memory_bytes{cluster=\"custom-allow-lists-test\"}"
+          "query": "machine_memory_bytes{cluster=\"custom-allow-lists-test\"}",
+          "type": "promql"
         },
         {
-          "query": "kube_node_info{cluster=\"custom-allow-lists-test\"}"
+          "query": "kube_node_info{cluster=\"custom-allow-lists-test\"}",
+          "type": "promql"
         },
         {
-          "query": "node_exporter_build_info{cluster=\"custom-allow-lists-test\"}"
+          "query": "node_exporter_build_info{cluster=\"custom-allow-lists-test\"}",
+          "type": "promql"
         },
         {
-          "query": "opencost_build_info{cluster=\"custom-allow-lists-test\"}"
+          "query": "opencost_build_info{cluster=\"custom-allow-lists-test\"}",
+          "type": "promql"
         },
         {
-          "query": "grafana_kubernetes_monitoring_build_info{cluster=\"custom-allow-lists-test\"}"
+          "query": "grafana_kubernetes_monitoring_build_info{cluster=\"custom-allow-lists-test\"}",
+          "type": "promql"
         }
       ]
     }
@@ -43090,7 +43132,7 @@ spec:
       containers:
         - name: test-runner
           image: docker.io/ubuntu:jammy
-          command: ["bash", "-c", "bash /etc/test/test.sh /etc/test/queries.json"]
+          command: ["bash", "-c", "apt-get update && apt-get install -y -y curl jq && bash /etc/test/test.sh /etc/test/queries.json"]
           volumeMounts:
             - name: test-plan
               mountPath: /etc/test
@@ -43100,16 +43142,48 @@ spec:
                 secretKeyRef:
                   name: grafana-agent-credentials
                   key: prometheus_host
+                  optional: true
+            - name: PROMETHEUS_URL
+              value: $(PROMETHEUS_HOST)/api/prom/api/v1/query
             - name: PROMETHEUS_USER
               valueFrom:
                 secretKeyRef:
                   name: grafana-agent-credentials
                   key: prometheus_username
+                  optional: true
             - name: PROMETHEUS_PASS
               valueFrom:
                 secretKeyRef:
                   name: grafana-agent-credentials
                   key: prometheus_password
+                  optional: true
+
+            - name: LOKI_HOST
+              valueFrom:
+                secretKeyRef:
+                  name: grafana-agent-credentials
+                  key: loki_host
+            - name: LOKI_URL
+              value: $(LOKI_HOST)/loki/api/v1/query
+            - name: LOKI_USER
+              valueFrom:
+                secretKeyRef:
+                  name: grafana-agent-credentials
+                  key: loki_username
+                  optional: true
+            - name: LOKI_PASS
+              valueFrom:
+                secretKeyRef:
+                  name: grafana-agent-credentials
+                  key: loki_password
+                  optional: true
+            - name: LOKI_TENANTID
+              valueFrom:
+                secretKeyRef:
+                  name: grafana-agent-credentials
+                  key: loki_tenantId
+                  optional: true
+
       volumes:
         - name: test-plan
           configMap:

--- a/examples/custom-config/output.yaml
+++ b/examples/custom-config/output.yaml
@@ -43657,12 +43657,10 @@ data:
   test.sh: |-
     #!/bin/bash
     set -eo pipefail
-    apt-get update && apt-get install -y curl jq
     
-    queries=$(jq -r '.queries[].query' "$1")
-    for query in $queries; do
-      echo "Running query: ${PROMETHEUS_HOST}/api/prom/api/v1/query?query=$query..."
-      result=$(curl -skX POST -u "${PROMETHEUS_USER}:${PROMETHEUS_PASS}" "${PROMETHEUS_HOST}/api/prom/api/v1/query?query=$(jq -rn --arg x "${query}" '$x|@uri')")
+    function metrics_query {
+      echo "Running PromQL query: ${PROMETHEUS_URL}?query=${1}..."
+      result=$(curl -skX POST -u "${PROMETHEUS_USER}:${PROMETHEUS_PASS}" "${PROMETHEUS_URL}" --data-urlencode "query=${1}")
       status=$(echo $result | jq -r .status)
       if [ "${status}" != "success" ]; then
         echo "Query failed!"
@@ -43676,6 +43674,42 @@ data:
         echo "$result"
         exit 1
       fi
+    }
+    
+    function logs_query {
+      echo "Running LogQL query: ${LOKI_URL}?query=${1}..."
+      result=$(curl -s --get -H "X-Scope-OrgID:${LOKI_TENANTID}" -u "${LOKI_USER}:${LOKI_PASS}" "${LOKI_URL}" --data-urlencode "query=${1}")
+      status=$(echo $result | jq -r .status)
+      if [ "${status}" != "success" ]; then
+        echo "Query failed!"
+        echo "$result"
+        exit 1
+      fi
+    
+      resultCount=$(echo $result | jq '.data.result | length')
+      if [ "${resultCount}" -eq 0 ]; then
+        echo "Query returned no results"
+        echo "$result"
+        exit 1
+      fi
+    }
+    
+    count=$(jq -r ".queries | length-1" "${1}")
+    for i in $(seq 0 "${count}"); do
+      query=$(jq -r --argjson i "${i}" '.queries[$i].query' "${1}")
+      type=$(jq -r --argjson i "${i}" '.queries[$i] | .type // "promql"' "${1}")
+    
+      case "${type}" in
+        promql)
+          metrics_query "${query}"
+          ;;
+        logql)
+          logs_query "${query}"
+          ;;
+        *)
+          echo "Query type ${type} is not yet supported in this test"
+          ;;
+      esac
     done
     
     echo "All queries passed!"
@@ -43683,28 +43717,36 @@ data:
     {
       "queries": [
         {
-          "query": "up{cluster=\"custom-config-test\"}"
+          "query": "up{cluster=\"custom-config-test\"}",
+          "type": "promql"
         },
         {
-          "query": "agent_build_info{cluster=\"custom-config-test\"}"
+          "query": "agent_build_info{cluster=\"custom-config-test\"}",
+          "type": "promql"
         },
         {
-          "query": "kubernetes_build_info{cluster=\"custom-config-test\"}"
+          "query": "kubernetes_build_info{cluster=\"custom-config-test\"}",
+          "type": "promql"
         },
         {
-          "query": "machine_memory_bytes{cluster=\"custom-config-test\"}"
+          "query": "machine_memory_bytes{cluster=\"custom-config-test\"}",
+          "type": "promql"
         },
         {
-          "query": "kube_node_info{cluster=\"custom-config-test\"}"
+          "query": "kube_node_info{cluster=\"custom-config-test\"}",
+          "type": "promql"
         },
         {
-          "query": "node_exporter_build_info{cluster=\"custom-config-test\"}"
+          "query": "node_exporter_build_info{cluster=\"custom-config-test\"}",
+          "type": "promql"
         },
         {
-          "query": "opencost_build_info{cluster=\"custom-config-test\"}"
+          "query": "opencost_build_info{cluster=\"custom-config-test\"}",
+          "type": "promql"
         },
         {
-          "query": "grafana_kubernetes_monitoring_build_info{cluster=\"custom-config-test\"}"
+          "query": "grafana_kubernetes_monitoring_build_info{cluster=\"custom-config-test\"}",
+          "type": "promql"
         }
       ]
     }
@@ -43784,7 +43826,7 @@ spec:
       containers:
         - name: test-runner
           image: docker.io/ubuntu:jammy
-          command: ["bash", "-c", "bash /etc/test/test.sh /etc/test/queries.json"]
+          command: ["bash", "-c", "apt-get update && apt-get install -y -y curl jq && bash /etc/test/test.sh /etc/test/queries.json"]
           volumeMounts:
             - name: test-plan
               mountPath: /etc/test
@@ -43794,16 +43836,48 @@ spec:
                 secretKeyRef:
                   name: grafana-agent-credentials
                   key: prometheus_host
+                  optional: true
+            - name: PROMETHEUS_URL
+              value: $(PROMETHEUS_HOST)/api/prom/api/v1/query
             - name: PROMETHEUS_USER
               valueFrom:
                 secretKeyRef:
                   name: grafana-agent-credentials
                   key: prometheus_username
+                  optional: true
             - name: PROMETHEUS_PASS
               valueFrom:
                 secretKeyRef:
                   name: grafana-agent-credentials
                   key: prometheus_password
+                  optional: true
+
+            - name: LOKI_HOST
+              valueFrom:
+                secretKeyRef:
+                  name: grafana-agent-credentials
+                  key: loki_host
+            - name: LOKI_URL
+              value: $(LOKI_HOST)/loki/api/v1/query
+            - name: LOKI_USER
+              valueFrom:
+                secretKeyRef:
+                  name: grafana-agent-credentials
+                  key: loki_username
+                  optional: true
+            - name: LOKI_PASS
+              valueFrom:
+                secretKeyRef:
+                  name: grafana-agent-credentials
+                  key: loki_password
+                  optional: true
+            - name: LOKI_TENANTID
+              valueFrom:
+                secretKeyRef:
+                  name: grafana-agent-credentials
+                  key: loki_tenantId
+                  optional: true
+
       volumes:
         - name: test-plan
           configMap:

--- a/examples/default-values/output.yaml
+++ b/examples/default-values/output.yaml
@@ -43535,12 +43535,10 @@ data:
   test.sh: |-
     #!/bin/bash
     set -eo pipefail
-    apt-get update && apt-get install -y curl jq
     
-    queries=$(jq -r '.queries[].query' "$1")
-    for query in $queries; do
-      echo "Running query: ${PROMETHEUS_HOST}/api/prom/api/v1/query?query=$query..."
-      result=$(curl -skX POST -u "${PROMETHEUS_USER}:${PROMETHEUS_PASS}" "${PROMETHEUS_HOST}/api/prom/api/v1/query?query=$(jq -rn --arg x "${query}" '$x|@uri')")
+    function metrics_query {
+      echo "Running PromQL query: ${PROMETHEUS_URL}?query=${1}..."
+      result=$(curl -skX POST -u "${PROMETHEUS_USER}:${PROMETHEUS_PASS}" "${PROMETHEUS_URL}" --data-urlencode "query=${1}")
       status=$(echo $result | jq -r .status)
       if [ "${status}" != "success" ]; then
         echo "Query failed!"
@@ -43554,6 +43552,42 @@ data:
         echo "$result"
         exit 1
       fi
+    }
+    
+    function logs_query {
+      echo "Running LogQL query: ${LOKI_URL}?query=${1}..."
+      result=$(curl -s --get -H "X-Scope-OrgID:${LOKI_TENANTID}" -u "${LOKI_USER}:${LOKI_PASS}" "${LOKI_URL}" --data-urlencode "query=${1}")
+      status=$(echo $result | jq -r .status)
+      if [ "${status}" != "success" ]; then
+        echo "Query failed!"
+        echo "$result"
+        exit 1
+      fi
+    
+      resultCount=$(echo $result | jq '.data.result | length')
+      if [ "${resultCount}" -eq 0 ]; then
+        echo "Query returned no results"
+        echo "$result"
+        exit 1
+      fi
+    }
+    
+    count=$(jq -r ".queries | length-1" "${1}")
+    for i in $(seq 0 "${count}"); do
+      query=$(jq -r --argjson i "${i}" '.queries[$i].query' "${1}")
+      type=$(jq -r --argjson i "${i}" '.queries[$i] | .type // "promql"' "${1}")
+    
+      case "${type}" in
+        promql)
+          metrics_query "${query}"
+          ;;
+        logql)
+          logs_query "${query}"
+          ;;
+        *)
+          echo "Query type ${type} is not yet supported in this test"
+          ;;
+      esac
     done
     
     echo "All queries passed!"
@@ -43561,28 +43595,36 @@ data:
     {
       "queries": [
         {
-          "query": "up{cluster=\"default-values-test\"}"
+          "query": "up{cluster=\"default-values-test\"}",
+          "type": "promql"
         },
         {
-          "query": "agent_build_info{cluster=\"default-values-test\"}"
+          "query": "agent_build_info{cluster=\"default-values-test\"}",
+          "type": "promql"
         },
         {
-          "query": "kubernetes_build_info{cluster=\"default-values-test\"}"
+          "query": "kubernetes_build_info{cluster=\"default-values-test\"}",
+          "type": "promql"
         },
         {
-          "query": "machine_memory_bytes{cluster=\"default-values-test\"}"
+          "query": "machine_memory_bytes{cluster=\"default-values-test\"}",
+          "type": "promql"
         },
         {
-          "query": "kube_node_info{cluster=\"default-values-test\"}"
+          "query": "kube_node_info{cluster=\"default-values-test\"}",
+          "type": "promql"
         },
         {
-          "query": "node_exporter_build_info{cluster=\"default-values-test\"}"
+          "query": "node_exporter_build_info{cluster=\"default-values-test\"}",
+          "type": "promql"
         },
         {
-          "query": "opencost_build_info{cluster=\"default-values-test\"}"
+          "query": "opencost_build_info{cluster=\"default-values-test\"}",
+          "type": "promql"
         },
         {
-          "query": "grafana_kubernetes_monitoring_build_info{cluster=\"default-values-test\"}"
+          "query": "grafana_kubernetes_monitoring_build_info{cluster=\"default-values-test\"}",
+          "type": "promql"
         }
       ]
     }
@@ -43662,7 +43704,7 @@ spec:
       containers:
         - name: test-runner
           image: docker.io/ubuntu:jammy
-          command: ["bash", "-c", "bash /etc/test/test.sh /etc/test/queries.json"]
+          command: ["bash", "-c", "apt-get update && apt-get install -y -y curl jq && bash /etc/test/test.sh /etc/test/queries.json"]
           volumeMounts:
             - name: test-plan
               mountPath: /etc/test
@@ -43672,16 +43714,48 @@ spec:
                 secretKeyRef:
                   name: grafana-agent-credentials
                   key: prometheus_host
+                  optional: true
+            - name: PROMETHEUS_URL
+              value: $(PROMETHEUS_HOST)/api/prom/api/v1/query
             - name: PROMETHEUS_USER
               valueFrom:
                 secretKeyRef:
                   name: grafana-agent-credentials
                   key: prometheus_username
+                  optional: true
             - name: PROMETHEUS_PASS
               valueFrom:
                 secretKeyRef:
                   name: grafana-agent-credentials
                   key: prometheus_password
+                  optional: true
+
+            - name: LOKI_HOST
+              valueFrom:
+                secretKeyRef:
+                  name: grafana-agent-credentials
+                  key: loki_host
+            - name: LOKI_URL
+              value: $(LOKI_HOST)/loki/api/v1/query
+            - name: LOKI_USER
+              valueFrom:
+                secretKeyRef:
+                  name: grafana-agent-credentials
+                  key: loki_username
+                  optional: true
+            - name: LOKI_PASS
+              valueFrom:
+                secretKeyRef:
+                  name: grafana-agent-credentials
+                  key: loki_password
+                  optional: true
+            - name: LOKI_TENANTID
+              valueFrom:
+                secretKeyRef:
+                  name: grafana-agent-credentials
+                  key: loki_tenantId
+                  optional: true
+
       volumes:
         - name: test-plan
           configMap:

--- a/examples/eks-fargate/output.yaml
+++ b/examples/eks-fargate/output.yaml
@@ -42812,12 +42812,10 @@ data:
   test.sh: |-
     #!/bin/bash
     set -eo pipefail
-    apt-get update && apt-get install -y curl jq
     
-    queries=$(jq -r '.queries[].query' "$1")
-    for query in $queries; do
-      echo "Running query: ${PROMETHEUS_HOST}/api/prom/api/v1/query?query=$query..."
-      result=$(curl -skX POST -u "${PROMETHEUS_USER}:${PROMETHEUS_PASS}" "${PROMETHEUS_HOST}/api/prom/api/v1/query?query=$(jq -rn --arg x "${query}" '$x|@uri')")
+    function metrics_query {
+      echo "Running PromQL query: ${PROMETHEUS_URL}?query=${1}..."
+      result=$(curl -skX POST -u "${PROMETHEUS_USER}:${PROMETHEUS_PASS}" "${PROMETHEUS_URL}" --data-urlencode "query=${1}")
       status=$(echo $result | jq -r .status)
       if [ "${status}" != "success" ]; then
         echo "Query failed!"
@@ -42831,6 +42829,42 @@ data:
         echo "$result"
         exit 1
       fi
+    }
+    
+    function logs_query {
+      echo "Running LogQL query: ${LOKI_URL}?query=${1}..."
+      result=$(curl -s --get -H "X-Scope-OrgID:${LOKI_TENANTID}" -u "${LOKI_USER}:${LOKI_PASS}" "${LOKI_URL}" --data-urlencode "query=${1}")
+      status=$(echo $result | jq -r .status)
+      if [ "${status}" != "success" ]; then
+        echo "Query failed!"
+        echo "$result"
+        exit 1
+      fi
+    
+      resultCount=$(echo $result | jq '.data.result | length')
+      if [ "${resultCount}" -eq 0 ]; then
+        echo "Query returned no results"
+        echo "$result"
+        exit 1
+      fi
+    }
+    
+    count=$(jq -r ".queries | length-1" "${1}")
+    for i in $(seq 0 "${count}"); do
+      query=$(jq -r --argjson i "${i}" '.queries[$i].query' "${1}")
+      type=$(jq -r --argjson i "${i}" '.queries[$i] | .type // "promql"' "${1}")
+    
+      case "${type}" in
+        promql)
+          metrics_query "${query}"
+          ;;
+        logql)
+          logs_query "${query}"
+          ;;
+        *)
+          echo "Query type ${type} is not yet supported in this test"
+          ;;
+      esac
     done
     
     echo "All queries passed!"
@@ -42838,25 +42872,32 @@ data:
     {
       "queries": [
         {
-          "query": "up{cluster=\"eks-fargate-test\"}"
+          "query": "up{cluster=\"eks-fargate-test\"}",
+          "type": "promql"
         },
         {
-          "query": "agent_build_info{cluster=\"eks-fargate-test\"}"
+          "query": "agent_build_info{cluster=\"eks-fargate-test\"}",
+          "type": "promql"
         },
         {
-          "query": "kubernetes_build_info{cluster=\"eks-fargate-test\"}"
+          "query": "kubernetes_build_info{cluster=\"eks-fargate-test\"}",
+          "type": "promql"
         },
         {
-          "query": "machine_memory_bytes{cluster=\"eks-fargate-test\"}"
+          "query": "machine_memory_bytes{cluster=\"eks-fargate-test\"}",
+          "type": "promql"
         },
         {
-          "query": "kube_node_info{cluster=\"eks-fargate-test\"}"
+          "query": "kube_node_info{cluster=\"eks-fargate-test\"}",
+          "type": "promql"
         },
         {
-          "query": "opencost_build_info{cluster=\"eks-fargate-test\"}"
+          "query": "opencost_build_info{cluster=\"eks-fargate-test\"}",
+          "type": "promql"
         },
         {
-          "query": "grafana_kubernetes_monitoring_build_info{cluster=\"eks-fargate-test\"}"
+          "query": "grafana_kubernetes_monitoring_build_info{cluster=\"eks-fargate-test\"}",
+          "type": "promql"
         }
       ]
     }
@@ -42934,7 +42975,7 @@ spec:
       containers:
         - name: test-runner
           image: docker.io/ubuntu:jammy
-          command: ["bash", "-c", "bash /etc/test/test.sh /etc/test/queries.json"]
+          command: ["bash", "-c", "apt-get update && apt-get install -y -y curl jq && bash /etc/test/test.sh /etc/test/queries.json"]
           volumeMounts:
             - name: test-plan
               mountPath: /etc/test
@@ -42944,16 +42985,48 @@ spec:
                 secretKeyRef:
                   name: grafana-agent-credentials
                   key: prometheus_host
+                  optional: true
+            - name: PROMETHEUS_URL
+              value: $(PROMETHEUS_HOST)/api/prom/api/v1/query
             - name: PROMETHEUS_USER
               valueFrom:
                 secretKeyRef:
                   name: grafana-agent-credentials
                   key: prometheus_username
+                  optional: true
             - name: PROMETHEUS_PASS
               valueFrom:
                 secretKeyRef:
                   name: grafana-agent-credentials
                   key: prometheus_password
+                  optional: true
+
+            - name: LOKI_HOST
+              valueFrom:
+                secretKeyRef:
+                  name: grafana-agent-credentials
+                  key: loki_host
+            - name: LOKI_URL
+              value: $(LOKI_HOST)/loki/api/v1/query
+            - name: LOKI_USER
+              valueFrom:
+                secretKeyRef:
+                  name: grafana-agent-credentials
+                  key: loki_username
+                  optional: true
+            - name: LOKI_PASS
+              valueFrom:
+                secretKeyRef:
+                  name: grafana-agent-credentials
+                  key: loki_password
+                  optional: true
+            - name: LOKI_TENANTID
+              valueFrom:
+                secretKeyRef:
+                  name: grafana-agent-credentials
+                  key: loki_tenantId
+                  optional: true
+
       volumes:
         - name: test-plan
           configMap:

--- a/examples/extra-rules/output.yaml
+++ b/examples/extra-rules/output.yaml
@@ -43692,12 +43692,10 @@ data:
   test.sh: |-
     #!/bin/bash
     set -eo pipefail
-    apt-get update && apt-get install -y curl jq
     
-    queries=$(jq -r '.queries[].query' "$1")
-    for query in $queries; do
-      echo "Running query: ${PROMETHEUS_HOST}/api/prom/api/v1/query?query=$query..."
-      result=$(curl -skX POST -u "${PROMETHEUS_USER}:${PROMETHEUS_PASS}" "${PROMETHEUS_HOST}/api/prom/api/v1/query?query=$(jq -rn --arg x "${query}" '$x|@uri')")
+    function metrics_query {
+      echo "Running PromQL query: ${PROMETHEUS_URL}?query=${1}..."
+      result=$(curl -skX POST -u "${PROMETHEUS_USER}:${PROMETHEUS_PASS}" "${PROMETHEUS_URL}" --data-urlencode "query=${1}")
       status=$(echo $result | jq -r .status)
       if [ "${status}" != "success" ]; then
         echo "Query failed!"
@@ -43711,6 +43709,42 @@ data:
         echo "$result"
         exit 1
       fi
+    }
+    
+    function logs_query {
+      echo "Running LogQL query: ${LOKI_URL}?query=${1}..."
+      result=$(curl -s --get -H "X-Scope-OrgID:${LOKI_TENANTID}" -u "${LOKI_USER}:${LOKI_PASS}" "${LOKI_URL}" --data-urlencode "query=${1}")
+      status=$(echo $result | jq -r .status)
+      if [ "${status}" != "success" ]; then
+        echo "Query failed!"
+        echo "$result"
+        exit 1
+      fi
+    
+      resultCount=$(echo $result | jq '.data.result | length')
+      if [ "${resultCount}" -eq 0 ]; then
+        echo "Query returned no results"
+        echo "$result"
+        exit 1
+      fi
+    }
+    
+    count=$(jq -r ".queries | length-1" "${1}")
+    for i in $(seq 0 "${count}"); do
+      query=$(jq -r --argjson i "${i}" '.queries[$i].query' "${1}")
+      type=$(jq -r --argjson i "${i}" '.queries[$i] | .type // "promql"' "${1}")
+    
+      case "${type}" in
+        promql)
+          metrics_query "${query}"
+          ;;
+        logql)
+          logs_query "${query}"
+          ;;
+        *)
+          echo "Query type ${type} is not yet supported in this test"
+          ;;
+      esac
     done
     
     echo "All queries passed!"
@@ -43718,28 +43752,36 @@ data:
     {
       "queries": [
         {
-          "query": "up{cluster=\"extra-rules-test\"}"
+          "query": "up{cluster=\"extra-rules-test\"}",
+          "type": "promql"
         },
         {
-          "query": "agent_build_info{cluster=\"extra-rules-test\"}"
+          "query": "agent_build_info{cluster=\"extra-rules-test\"}",
+          "type": "promql"
         },
         {
-          "query": "kubernetes_build_info{cluster=\"extra-rules-test\"}"
+          "query": "kubernetes_build_info{cluster=\"extra-rules-test\"}",
+          "type": "promql"
         },
         {
-          "query": "machine_memory_bytes{cluster=\"extra-rules-test\"}"
+          "query": "machine_memory_bytes{cluster=\"extra-rules-test\"}",
+          "type": "promql"
         },
         {
-          "query": "kube_node_info{cluster=\"extra-rules-test\"}"
+          "query": "kube_node_info{cluster=\"extra-rules-test\"}",
+          "type": "promql"
         },
         {
-          "query": "node_exporter_build_info{cluster=\"extra-rules-test\"}"
+          "query": "node_exporter_build_info{cluster=\"extra-rules-test\"}",
+          "type": "promql"
         },
         {
-          "query": "opencost_build_info{cluster=\"extra-rules-test\"}"
+          "query": "opencost_build_info{cluster=\"extra-rules-test\"}",
+          "type": "promql"
         },
         {
-          "query": "grafana_kubernetes_monitoring_build_info{cluster=\"extra-rules-test\"}"
+          "query": "grafana_kubernetes_monitoring_build_info{cluster=\"extra-rules-test\"}",
+          "type": "promql"
         }
       ]
     }
@@ -43819,7 +43861,7 @@ spec:
       containers:
         - name: test-runner
           image: docker.io/ubuntu:jammy
-          command: ["bash", "-c", "bash /etc/test/test.sh /etc/test/queries.json"]
+          command: ["bash", "-c", "apt-get update && apt-get install -y -y curl jq && bash /etc/test/test.sh /etc/test/queries.json"]
           volumeMounts:
             - name: test-plan
               mountPath: /etc/test
@@ -43829,16 +43871,48 @@ spec:
                 secretKeyRef:
                   name: grafana-agent-credentials
                   key: prometheus_host
+                  optional: true
+            - name: PROMETHEUS_URL
+              value: $(PROMETHEUS_HOST)/api/prom/api/v1/query
             - name: PROMETHEUS_USER
               valueFrom:
                 secretKeyRef:
                   name: grafana-agent-credentials
                   key: prometheus_username
+                  optional: true
             - name: PROMETHEUS_PASS
               valueFrom:
                 secretKeyRef:
                   name: grafana-agent-credentials
                   key: prometheus_password
+                  optional: true
+
+            - name: LOKI_HOST
+              valueFrom:
+                secretKeyRef:
+                  name: grafana-agent-credentials
+                  key: loki_host
+            - name: LOKI_URL
+              value: $(LOKI_HOST)/loki/api/v1/query
+            - name: LOKI_USER
+              valueFrom:
+                secretKeyRef:
+                  name: grafana-agent-credentials
+                  key: loki_username
+                  optional: true
+            - name: LOKI_PASS
+              valueFrom:
+                secretKeyRef:
+                  name: grafana-agent-credentials
+                  key: loki_password
+                  optional: true
+            - name: LOKI_TENANTID
+              valueFrom:
+                secretKeyRef:
+                  name: grafana-agent-credentials
+                  key: loki_tenantId
+                  optional: true
+
       volumes:
         - name: test-plan
           configMap:

--- a/examples/gke-autopilot/output.yaml
+++ b/examples/gke-autopilot/output.yaml
@@ -43301,12 +43301,10 @@ data:
   test.sh: |-
     #!/bin/bash
     set -eo pipefail
-    apt-get update && apt-get install -y curl jq
     
-    queries=$(jq -r '.queries[].query' "$1")
-    for query in $queries; do
-      echo "Running query: ${PROMETHEUS_HOST}/api/prom/api/v1/query?query=$query..."
-      result=$(curl -skX POST -u "${PROMETHEUS_USER}:${PROMETHEUS_PASS}" "${PROMETHEUS_HOST}/api/prom/api/v1/query?query=$(jq -rn --arg x "${query}" '$x|@uri')")
+    function metrics_query {
+      echo "Running PromQL query: ${PROMETHEUS_URL}?query=${1}..."
+      result=$(curl -skX POST -u "${PROMETHEUS_USER}:${PROMETHEUS_PASS}" "${PROMETHEUS_URL}" --data-urlencode "query=${1}")
       status=$(echo $result | jq -r .status)
       if [ "${status}" != "success" ]; then
         echo "Query failed!"
@@ -43320,6 +43318,42 @@ data:
         echo "$result"
         exit 1
       fi
+    }
+    
+    function logs_query {
+      echo "Running LogQL query: ${LOKI_URL}?query=${1}..."
+      result=$(curl -s --get -H "X-Scope-OrgID:${LOKI_TENANTID}" -u "${LOKI_USER}:${LOKI_PASS}" "${LOKI_URL}" --data-urlencode "query=${1}")
+      status=$(echo $result | jq -r .status)
+      if [ "${status}" != "success" ]; then
+        echo "Query failed!"
+        echo "$result"
+        exit 1
+      fi
+    
+      resultCount=$(echo $result | jq '.data.result | length')
+      if [ "${resultCount}" -eq 0 ]; then
+        echo "Query returned no results"
+        echo "$result"
+        exit 1
+      fi
+    }
+    
+    count=$(jq -r ".queries | length-1" "${1}")
+    for i in $(seq 0 "${count}"); do
+      query=$(jq -r --argjson i "${i}" '.queries[$i].query' "${1}")
+      type=$(jq -r --argjson i "${i}" '.queries[$i] | .type // "promql"' "${1}")
+    
+      case "${type}" in
+        promql)
+          metrics_query "${query}"
+          ;;
+        logql)
+          logs_query "${query}"
+          ;;
+        *)
+          echo "Query type ${type} is not yet supported in this test"
+          ;;
+      esac
     done
     
     echo "All queries passed!"
@@ -43327,25 +43361,32 @@ data:
     {
       "queries": [
         {
-          "query": "up{cluster=\"gke-autopilot-test\"}"
+          "query": "up{cluster=\"gke-autopilot-test\"}",
+          "type": "promql"
         },
         {
-          "query": "agent_build_info{cluster=\"gke-autopilot-test\"}"
+          "query": "agent_build_info{cluster=\"gke-autopilot-test\"}",
+          "type": "promql"
         },
         {
-          "query": "kubernetes_build_info{cluster=\"gke-autopilot-test\"}"
+          "query": "kubernetes_build_info{cluster=\"gke-autopilot-test\"}",
+          "type": "promql"
         },
         {
-          "query": "machine_memory_bytes{cluster=\"gke-autopilot-test\"}"
+          "query": "machine_memory_bytes{cluster=\"gke-autopilot-test\"}",
+          "type": "promql"
         },
         {
-          "query": "kube_node_info{cluster=\"gke-autopilot-test\"}"
+          "query": "kube_node_info{cluster=\"gke-autopilot-test\"}",
+          "type": "promql"
         },
         {
-          "query": "opencost_build_info{cluster=\"gke-autopilot-test\"}"
+          "query": "opencost_build_info{cluster=\"gke-autopilot-test\"}",
+          "type": "promql"
         },
         {
-          "query": "grafana_kubernetes_monitoring_build_info{cluster=\"gke-autopilot-test\"}"
+          "query": "grafana_kubernetes_monitoring_build_info{cluster=\"gke-autopilot-test\"}",
+          "type": "promql"
         }
       ]
     }
@@ -43425,7 +43466,7 @@ spec:
       containers:
         - name: test-runner
           image: docker.io/ubuntu:jammy
-          command: ["bash", "-c", "bash /etc/test/test.sh /etc/test/queries.json"]
+          command: ["bash", "-c", "apt-get update && apt-get install -y -y curl jq && bash /etc/test/test.sh /etc/test/queries.json"]
           volumeMounts:
             - name: test-plan
               mountPath: /etc/test
@@ -43435,16 +43476,48 @@ spec:
                 secretKeyRef:
                   name: grafana-agent-credentials
                   key: prometheus_host
+                  optional: true
+            - name: PROMETHEUS_URL
+              value: $(PROMETHEUS_HOST)/api/prom/api/v1/query
             - name: PROMETHEUS_USER
               valueFrom:
                 secretKeyRef:
                   name: grafana-agent-credentials
                   key: prometheus_username
+                  optional: true
             - name: PROMETHEUS_PASS
               valueFrom:
                 secretKeyRef:
                   name: grafana-agent-credentials
                   key: prometheus_password
+                  optional: true
+
+            - name: LOKI_HOST
+              valueFrom:
+                secretKeyRef:
+                  name: grafana-agent-credentials
+                  key: loki_host
+            - name: LOKI_URL
+              value: $(LOKI_HOST)/loki/api/v1/query
+            - name: LOKI_USER
+              valueFrom:
+                secretKeyRef:
+                  name: grafana-agent-credentials
+                  key: loki_username
+                  optional: true
+            - name: LOKI_PASS
+              valueFrom:
+                secretKeyRef:
+                  name: grafana-agent-credentials
+                  key: loki_password
+                  optional: true
+            - name: LOKI_TENANTID
+              valueFrom:
+                secretKeyRef:
+                  name: grafana-agent-credentials
+                  key: loki_tenantId
+                  optional: true
+
       volumes:
         - name: test-plan
           configMap:

--- a/examples/logs-only/output.yaml
+++ b/examples/logs-only/output.yaml
@@ -926,12 +926,10 @@ data:
   test.sh: |-
     #!/bin/bash
     set -eo pipefail
-    apt-get update && apt-get install -y curl jq
     
-    queries=$(jq -r '.queries[].query' "$1")
-    for query in $queries; do
-      echo "Running query: ${PROMETHEUS_HOST}/api/prom/api/v1/query?query=$query..."
-      result=$(curl -skX POST -u "${PROMETHEUS_USER}:${PROMETHEUS_PASS}" "${PROMETHEUS_HOST}/api/prom/api/v1/query?query=$(jq -rn --arg x "${query}" '$x|@uri')")
+    function metrics_query {
+      echo "Running PromQL query: ${PROMETHEUS_URL}?query=${1}..."
+      result=$(curl -skX POST -u "${PROMETHEUS_USER}:${PROMETHEUS_PASS}" "${PROMETHEUS_URL}" --data-urlencode "query=${1}")
       status=$(echo $result | jq -r .status)
       if [ "${status}" != "success" ]; then
         echo "Query failed!"
@@ -945,6 +943,42 @@ data:
         echo "$result"
         exit 1
       fi
+    }
+    
+    function logs_query {
+      echo "Running LogQL query: ${LOKI_URL}?query=${1}..."
+      result=$(curl -s --get -H "X-Scope-OrgID:${LOKI_TENANTID}" -u "${LOKI_USER}:${LOKI_PASS}" "${LOKI_URL}" --data-urlencode "query=${1}")
+      status=$(echo $result | jq -r .status)
+      if [ "${status}" != "success" ]; then
+        echo "Query failed!"
+        echo "$result"
+        exit 1
+      fi
+    
+      resultCount=$(echo $result | jq '.data.result | length')
+      if [ "${resultCount}" -eq 0 ]; then
+        echo "Query returned no results"
+        echo "$result"
+        exit 1
+      fi
+    }
+    
+    count=$(jq -r ".queries | length-1" "${1}")
+    for i in $(seq 0 "${count}"); do
+      query=$(jq -r --argjson i "${i}" '.queries[$i].query' "${1}")
+      type=$(jq -r --argjson i "${i}" '.queries[$i] | .type // "promql"' "${1}")
+    
+      case "${type}" in
+        promql)
+          metrics_query "${query}"
+          ;;
+        logql)
+          logs_query "${query}"
+          ;;
+        *)
+          echo "Query type ${type} is not yet supported in this test"
+          ;;
+      esac
     done
     
     echo "All queries passed!"
@@ -1028,7 +1062,7 @@ spec:
       containers:
         - name: test-runner
           image: docker.io/ubuntu:jammy
-          command: ["bash", "-c", "bash /etc/test/test.sh /etc/test/queries.json"]
+          command: ["bash", "-c", "apt-get update && apt-get install -y -y curl jq && bash /etc/test/test.sh /etc/test/queries.json"]
           volumeMounts:
             - name: test-plan
               mountPath: /etc/test
@@ -1038,16 +1072,48 @@ spec:
                 secretKeyRef:
                   name: grafana-agent-credentials
                   key: prometheus_host
+                  optional: true
+            - name: PROMETHEUS_URL
+              value: $(PROMETHEUS_HOST)/api/prom/api/v1/query
             - name: PROMETHEUS_USER
               valueFrom:
                 secretKeyRef:
                   name: grafana-agent-credentials
                   key: prometheus_username
+                  optional: true
             - name: PROMETHEUS_PASS
               valueFrom:
                 secretKeyRef:
                   name: grafana-agent-credentials
                   key: prometheus_password
+                  optional: true
+
+            - name: LOKI_HOST
+              valueFrom:
+                secretKeyRef:
+                  name: grafana-agent-credentials
+                  key: loki_host
+            - name: LOKI_URL
+              value: $(LOKI_HOST)/loki/api/v1/query
+            - name: LOKI_USER
+              valueFrom:
+                secretKeyRef:
+                  name: grafana-agent-credentials
+                  key: loki_username
+                  optional: true
+            - name: LOKI_PASS
+              valueFrom:
+                secretKeyRef:
+                  name: grafana-agent-credentials
+                  key: loki_password
+                  optional: true
+            - name: LOKI_TENANTID
+              valueFrom:
+                secretKeyRef:
+                  name: grafana-agent-credentials
+                  key: loki_tenantId
+                  optional: true
+
       volumes:
         - name: test-plan
           configMap:

--- a/examples/metrics-only/output.yaml
+++ b/examples/metrics-only/output.yaml
@@ -42984,12 +42984,10 @@ data:
   test.sh: |-
     #!/bin/bash
     set -eo pipefail
-    apt-get update && apt-get install -y curl jq
     
-    queries=$(jq -r '.queries[].query' "$1")
-    for query in $queries; do
-      echo "Running query: ${PROMETHEUS_HOST}/api/prom/api/v1/query?query=$query..."
-      result=$(curl -skX POST -u "${PROMETHEUS_USER}:${PROMETHEUS_PASS}" "${PROMETHEUS_HOST}/api/prom/api/v1/query?query=$(jq -rn --arg x "${query}" '$x|@uri')")
+    function metrics_query {
+      echo "Running PromQL query: ${PROMETHEUS_URL}?query=${1}..."
+      result=$(curl -skX POST -u "${PROMETHEUS_USER}:${PROMETHEUS_PASS}" "${PROMETHEUS_URL}" --data-urlencode "query=${1}")
       status=$(echo $result | jq -r .status)
       if [ "${status}" != "success" ]; then
         echo "Query failed!"
@@ -43003,6 +43001,42 @@ data:
         echo "$result"
         exit 1
       fi
+    }
+    
+    function logs_query {
+      echo "Running LogQL query: ${LOKI_URL}?query=${1}..."
+      result=$(curl -s --get -H "X-Scope-OrgID:${LOKI_TENANTID}" -u "${LOKI_USER}:${LOKI_PASS}" "${LOKI_URL}" --data-urlencode "query=${1}")
+      status=$(echo $result | jq -r .status)
+      if [ "${status}" != "success" ]; then
+        echo "Query failed!"
+        echo "$result"
+        exit 1
+      fi
+    
+      resultCount=$(echo $result | jq '.data.result | length')
+      if [ "${resultCount}" -eq 0 ]; then
+        echo "Query returned no results"
+        echo "$result"
+        exit 1
+      fi
+    }
+    
+    count=$(jq -r ".queries | length-1" "${1}")
+    for i in $(seq 0 "${count}"); do
+      query=$(jq -r --argjson i "${i}" '.queries[$i].query' "${1}")
+      type=$(jq -r --argjson i "${i}" '.queries[$i] | .type // "promql"' "${1}")
+    
+      case "${type}" in
+        promql)
+          metrics_query "${query}"
+          ;;
+        logql)
+          logs_query "${query}"
+          ;;
+        *)
+          echo "Query type ${type} is not yet supported in this test"
+          ;;
+      esac
     done
     
     echo "All queries passed!"
@@ -43010,28 +43044,36 @@ data:
     {
       "queries": [
         {
-          "query": "up{cluster=\"metrics-only-test\"}"
+          "query": "up{cluster=\"metrics-only-test\"}",
+          "type": "promql"
         },
         {
-          "query": "agent_build_info{cluster=\"metrics-only-test\"}"
+          "query": "agent_build_info{cluster=\"metrics-only-test\"}",
+          "type": "promql"
         },
         {
-          "query": "kubernetes_build_info{cluster=\"metrics-only-test\"}"
+          "query": "kubernetes_build_info{cluster=\"metrics-only-test\"}",
+          "type": "promql"
         },
         {
-          "query": "machine_memory_bytes{cluster=\"metrics-only-test\"}"
+          "query": "machine_memory_bytes{cluster=\"metrics-only-test\"}",
+          "type": "promql"
         },
         {
-          "query": "kube_node_info{cluster=\"metrics-only-test\"}"
+          "query": "kube_node_info{cluster=\"metrics-only-test\"}",
+          "type": "promql"
         },
         {
-          "query": "node_exporter_build_info{cluster=\"metrics-only-test\"}"
+          "query": "node_exporter_build_info{cluster=\"metrics-only-test\"}",
+          "type": "promql"
         },
         {
-          "query": "opencost_build_info{cluster=\"metrics-only-test\"}"
+          "query": "opencost_build_info{cluster=\"metrics-only-test\"}",
+          "type": "promql"
         },
         {
-          "query": "grafana_kubernetes_monitoring_build_info{cluster=\"metrics-only-test\"}"
+          "query": "grafana_kubernetes_monitoring_build_info{cluster=\"metrics-only-test\"}",
+          "type": "promql"
         }
       ]
     }
@@ -43109,7 +43151,7 @@ spec:
       containers:
         - name: test-runner
           image: docker.io/ubuntu:jammy
-          command: ["bash", "-c", "bash /etc/test/test.sh /etc/test/queries.json"]
+          command: ["bash", "-c", "apt-get update && apt-get install -y -y curl jq && bash /etc/test/test.sh /etc/test/queries.json"]
           volumeMounts:
             - name: test-plan
               mountPath: /etc/test
@@ -43119,16 +43161,48 @@ spec:
                 secretKeyRef:
                   name: grafana-agent-credentials
                   key: prometheus_host
+                  optional: true
+            - name: PROMETHEUS_URL
+              value: $(PROMETHEUS_HOST)/api/prom/api/v1/query
             - name: PROMETHEUS_USER
               valueFrom:
                 secretKeyRef:
                   name: grafana-agent-credentials
                   key: prometheus_username
+                  optional: true
             - name: PROMETHEUS_PASS
               valueFrom:
                 secretKeyRef:
                   name: grafana-agent-credentials
                   key: prometheus_password
+                  optional: true
+
+            - name: LOKI_HOST
+              valueFrom:
+                secretKeyRef:
+                  name: grafana-agent-credentials
+                  key: loki_host
+            - name: LOKI_URL
+              value: $(LOKI_HOST)/loki/api/v1/query
+            - name: LOKI_USER
+              valueFrom:
+                secretKeyRef:
+                  name: grafana-agent-credentials
+                  key: loki_username
+                  optional: true
+            - name: LOKI_PASS
+              valueFrom:
+                secretKeyRef:
+                  name: grafana-agent-credentials
+                  key: loki_password
+                  optional: true
+            - name: LOKI_TENANTID
+              valueFrom:
+                secretKeyRef:
+                  name: grafana-agent-credentials
+                  key: loki_tenantId
+                  optional: true
+
       volumes:
         - name: test-plan
           configMap:

--- a/examples/openshift-compatible/output.yaml
+++ b/examples/openshift-compatible/output.yaml
@@ -43188,12 +43188,10 @@ data:
   test.sh: |-
     #!/bin/bash
     set -eo pipefail
-    apt-get update && apt-get install -y curl jq
     
-    queries=$(jq -r '.queries[].query' "$1")
-    for query in $queries; do
-      echo "Running query: ${PROMETHEUS_HOST}/api/prom/api/v1/query?query=$query..."
-      result=$(curl -skX POST -u "${PROMETHEUS_USER}:${PROMETHEUS_PASS}" "${PROMETHEUS_HOST}/api/prom/api/v1/query?query=$(jq -rn --arg x "${query}" '$x|@uri')")
+    function metrics_query {
+      echo "Running PromQL query: ${PROMETHEUS_URL}?query=${1}..."
+      result=$(curl -skX POST -u "${PROMETHEUS_USER}:${PROMETHEUS_PASS}" "${PROMETHEUS_URL}" --data-urlencode "query=${1}")
       status=$(echo $result | jq -r .status)
       if [ "${status}" != "success" ]; then
         echo "Query failed!"
@@ -43207,6 +43205,42 @@ data:
         echo "$result"
         exit 1
       fi
+    }
+    
+    function logs_query {
+      echo "Running LogQL query: ${LOKI_URL}?query=${1}..."
+      result=$(curl -s --get -H "X-Scope-OrgID:${LOKI_TENANTID}" -u "${LOKI_USER}:${LOKI_PASS}" "${LOKI_URL}" --data-urlencode "query=${1}")
+      status=$(echo $result | jq -r .status)
+      if [ "${status}" != "success" ]; then
+        echo "Query failed!"
+        echo "$result"
+        exit 1
+      fi
+    
+      resultCount=$(echo $result | jq '.data.result | length')
+      if [ "${resultCount}" -eq 0 ]; then
+        echo "Query returned no results"
+        echo "$result"
+        exit 1
+      fi
+    }
+    
+    count=$(jq -r ".queries | length-1" "${1}")
+    for i in $(seq 0 "${count}"); do
+      query=$(jq -r --argjson i "${i}" '.queries[$i].query' "${1}")
+      type=$(jq -r --argjson i "${i}" '.queries[$i] | .type // "promql"' "${1}")
+    
+      case "${type}" in
+        promql)
+          metrics_query "${query}"
+          ;;
+        logql)
+          logs_query "${query}"
+          ;;
+        *)
+          echo "Query type ${type} is not yet supported in this test"
+          ;;
+      esac
     done
     
     echo "All queries passed!"
@@ -43214,28 +43248,36 @@ data:
     {
       "queries": [
         {
-          "query": "up{cluster=\"openshift-compatible-test\"}"
+          "query": "up{cluster=\"openshift-compatible-test\"}",
+          "type": "promql"
         },
         {
-          "query": "agent_build_info{cluster=\"openshift-compatible-test\"}"
+          "query": "agent_build_info{cluster=\"openshift-compatible-test\"}",
+          "type": "promql"
         },
         {
-          "query": "kubernetes_build_info{cluster=\"openshift-compatible-test\"}"
+          "query": "kubernetes_build_info{cluster=\"openshift-compatible-test\"}",
+          "type": "promql"
         },
         {
-          "query": "machine_memory_bytes{cluster=\"openshift-compatible-test\"}"
+          "query": "machine_memory_bytes{cluster=\"openshift-compatible-test\"}",
+          "type": "promql"
         },
         {
-          "query": "kube_node_info{cluster=\"openshift-compatible-test\"}"
+          "query": "kube_node_info{cluster=\"openshift-compatible-test\"}",
+          "type": "promql"
         },
         {
-          "query": "node_exporter_build_info{cluster=\"openshift-compatible-test\"}"
+          "query": "node_exporter_build_info{cluster=\"openshift-compatible-test\"}",
+          "type": "promql"
         },
         {
-          "query": "opencost_build_info{cluster=\"openshift-compatible-test\"}"
+          "query": "opencost_build_info{cluster=\"openshift-compatible-test\"}",
+          "type": "promql"
         },
         {
-          "query": "grafana_kubernetes_monitoring_build_info{cluster=\"openshift-compatible-test\"}"
+          "query": "grafana_kubernetes_monitoring_build_info{cluster=\"openshift-compatible-test\"}",
+          "type": "promql"
         }
       ]
     }
@@ -43315,7 +43357,7 @@ spec:
       containers:
         - name: test-runner
           image: docker.io/ubuntu:jammy
-          command: ["bash", "-c", "bash /etc/test/test.sh /etc/test/queries.json"]
+          command: ["bash", "-c", "apt-get update && apt-get install -y -y curl jq && bash /etc/test/test.sh /etc/test/queries.json"]
           volumeMounts:
             - name: test-plan
               mountPath: /etc/test
@@ -43325,16 +43367,48 @@ spec:
                 secretKeyRef:
                   name: grafana-agent-credentials
                   key: prometheus_host
+                  optional: true
+            - name: PROMETHEUS_URL
+              value: $(PROMETHEUS_HOST)/api/prom/api/v1/query
             - name: PROMETHEUS_USER
               valueFrom:
                 secretKeyRef:
                   name: grafana-agent-credentials
                   key: prometheus_username
+                  optional: true
             - name: PROMETHEUS_PASS
               valueFrom:
                 secretKeyRef:
                   name: grafana-agent-credentials
                   key: prometheus_password
+                  optional: true
+
+            - name: LOKI_HOST
+              valueFrom:
+                secretKeyRef:
+                  name: grafana-agent-credentials
+                  key: loki_host
+            - name: LOKI_URL
+              value: $(LOKI_HOST)/loki/api/v1/query
+            - name: LOKI_USER
+              valueFrom:
+                secretKeyRef:
+                  name: grafana-agent-credentials
+                  key: loki_username
+                  optional: true
+            - name: LOKI_PASS
+              valueFrom:
+                secretKeyRef:
+                  name: grafana-agent-credentials
+                  key: loki_password
+                  optional: true
+            - name: LOKI_TENANTID
+              valueFrom:
+                secretKeyRef:
+                  name: grafana-agent-credentials
+                  key: loki_tenantId
+                  optional: true
+
       volumes:
         - name: test-plan
           configMap:

--- a/examples/otel-metrics-service/output.yaml
+++ b/examples/otel-metrics-service/output.yaml
@@ -43615,12 +43615,10 @@ data:
   test.sh: |-
     #!/bin/bash
     set -eo pipefail
-    apt-get update && apt-get install -y curl jq
     
-    queries=$(jq -r '.queries[].query' "$1")
-    for query in $queries; do
-      echo "Running query: ${PROMETHEUS_HOST}/api/v1/query?query=$query..."
-      result=$(curl -skX POST -u "${PROMETHEUS_USER}:${PROMETHEUS_PASS}" "${PROMETHEUS_HOST}/api/v1/query?query=$(jq -rn --arg x "${query}" '$x|@uri')")
+    function metrics_query {
+      echo "Running PromQL query: ${PROMETHEUS_URL}?query=${1}..."
+      result=$(curl -skX POST -u "${PROMETHEUS_USER}:${PROMETHEUS_PASS}" "${PROMETHEUS_URL}" --data-urlencode "query=${1}")
       status=$(echo $result | jq -r .status)
       if [ "${status}" != "success" ]; then
         echo "Query failed!"
@@ -43634,6 +43632,42 @@ data:
         echo "$result"
         exit 1
       fi
+    }
+    
+    function logs_query {
+      echo "Running LogQL query: ${LOKI_URL}?query=${1}..."
+      result=$(curl -s --get -H "X-Scope-OrgID:${LOKI_TENANTID}" -u "${LOKI_USER}:${LOKI_PASS}" "${LOKI_URL}" --data-urlencode "query=${1}")
+      status=$(echo $result | jq -r .status)
+      if [ "${status}" != "success" ]; then
+        echo "Query failed!"
+        echo "$result"
+        exit 1
+      fi
+    
+      resultCount=$(echo $result | jq '.data.result | length')
+      if [ "${resultCount}" -eq 0 ]; then
+        echo "Query returned no results"
+        echo "$result"
+        exit 1
+      fi
+    }
+    
+    count=$(jq -r ".queries | length-1" "${1}")
+    for i in $(seq 0 "${count}"); do
+      query=$(jq -r --argjson i "${i}" '.queries[$i].query' "${1}")
+      type=$(jq -r --argjson i "${i}" '.queries[$i] | .type // "promql"' "${1}")
+    
+      case "${type}" in
+        promql)
+          metrics_query "${query}"
+          ;;
+        logql)
+          logs_query "${query}"
+          ;;
+        *)
+          echo "Query type ${type} is not yet supported in this test"
+          ;;
+      esac
     done
     
     echo "All queries passed!"
@@ -43641,28 +43675,36 @@ data:
     {
       "queries": [
         {
-          "query": "up{cluster=\"otel-metrics-service-test\"}"
+          "query": "up{cluster=\"otel-metrics-service-test\"}",
+          "type": "promql"
         },
         {
-          "query": "agent_build_info{cluster=\"otel-metrics-service-test\"}"
+          "query": "agent_build_info{cluster=\"otel-metrics-service-test\"}",
+          "type": "promql"
         },
         {
-          "query": "kubernetes_build_info{cluster=\"otel-metrics-service-test\"}"
+          "query": "kubernetes_build_info{cluster=\"otel-metrics-service-test\"}",
+          "type": "promql"
         },
         {
-          "query": "machine_memory_bytes{cluster=\"otel-metrics-service-test\"}"
+          "query": "machine_memory_bytes{cluster=\"otel-metrics-service-test\"}",
+          "type": "promql"
         },
         {
-          "query": "kube_node_info{cluster=\"otel-metrics-service-test\"}"
+          "query": "kube_node_info{cluster=\"otel-metrics-service-test\"}",
+          "type": "promql"
         },
         {
-          "query": "node_exporter_build_info{cluster=\"otel-metrics-service-test\"}"
+          "query": "node_exporter_build_info{cluster=\"otel-metrics-service-test\"}",
+          "type": "promql"
         },
         {
-          "query": "opencost_build_info{cluster=\"otel-metrics-service-test\"}"
+          "query": "opencost_build_info{cluster=\"otel-metrics-service-test\"}",
+          "type": "promql"
         },
         {
-          "query": "grafana_kubernetes_monitoring_build_info{cluster=\"otel-metrics-service-test\"}"
+          "query": "grafana_kubernetes_monitoring_build_info{cluster=\"otel-metrics-service-test\"}",
+          "type": "promql"
         }
       ]
     }
@@ -43742,7 +43784,7 @@ spec:
       containers:
         - name: test-runner
           image: docker.io/ubuntu:jammy
-          command: ["bash", "-c", "bash /etc/test/test.sh /etc/test/queries.json"]
+          command: ["bash", "-c", "apt-get update && apt-get install -y -y curl jq && bash /etc/test/test.sh /etc/test/queries.json"]
           volumeMounts:
             - name: test-plan
               mountPath: /etc/test
@@ -43752,16 +43794,48 @@ spec:
                 secretKeyRef:
                   name: grafana-agent-credentials
                   key: prometheus_host
+                  optional: true
+            - name: PROMETHEUS_URL
+              value: $(PROMETHEUS_HOST)/api/v1/query
             - name: PROMETHEUS_USER
               valueFrom:
                 secretKeyRef:
                   name: grafana-agent-credentials
                   key: prometheus_username
+                  optional: true
             - name: PROMETHEUS_PASS
               valueFrom:
                 secretKeyRef:
                   name: grafana-agent-credentials
                   key: prometheus_password
+                  optional: true
+
+            - name: LOKI_HOST
+              valueFrom:
+                secretKeyRef:
+                  name: grafana-agent-credentials
+                  key: loki_host
+            - name: LOKI_URL
+              value: $(LOKI_HOST)/loki/api/v1/query
+            - name: LOKI_USER
+              valueFrom:
+                secretKeyRef:
+                  name: grafana-agent-credentials
+                  key: loki_username
+                  optional: true
+            - name: LOKI_PASS
+              valueFrom:
+                secretKeyRef:
+                  name: grafana-agent-credentials
+                  key: loki_password
+                  optional: true
+            - name: LOKI_TENANTID
+              valueFrom:
+                secretKeyRef:
+                  name: grafana-agent-credentials
+                  key: loki_tenantId
+                  optional: true
+
       volumes:
         - name: test-plan
           configMap:

--- a/examples/private-image-registry/output.yaml
+++ b/examples/private-image-registry/output.yaml
@@ -43535,12 +43535,10 @@ data:
   test.sh: |-
     #!/bin/bash
     set -eo pipefail
-    apt-get update && apt-get install -y curl jq
     
-    queries=$(jq -r '.queries[].query' "$1")
-    for query in $queries; do
-      echo "Running query: ${PROMETHEUS_HOST}/api/prom/api/v1/query?query=$query..."
-      result=$(curl -skX POST -u "${PROMETHEUS_USER}:${PROMETHEUS_PASS}" "${PROMETHEUS_HOST}/api/prom/api/v1/query?query=$(jq -rn --arg x "${query}" '$x|@uri')")
+    function metrics_query {
+      echo "Running PromQL query: ${PROMETHEUS_URL}?query=${1}..."
+      result=$(curl -skX POST -u "${PROMETHEUS_USER}:${PROMETHEUS_PASS}" "${PROMETHEUS_URL}" --data-urlencode "query=${1}")
       status=$(echo $result | jq -r .status)
       if [ "${status}" != "success" ]; then
         echo "Query failed!"
@@ -43554,6 +43552,42 @@ data:
         echo "$result"
         exit 1
       fi
+    }
+    
+    function logs_query {
+      echo "Running LogQL query: ${LOKI_URL}?query=${1}..."
+      result=$(curl -s --get -H "X-Scope-OrgID:${LOKI_TENANTID}" -u "${LOKI_USER}:${LOKI_PASS}" "${LOKI_URL}" --data-urlencode "query=${1}")
+      status=$(echo $result | jq -r .status)
+      if [ "${status}" != "success" ]; then
+        echo "Query failed!"
+        echo "$result"
+        exit 1
+      fi
+    
+      resultCount=$(echo $result | jq '.data.result | length')
+      if [ "${resultCount}" -eq 0 ]; then
+        echo "Query returned no results"
+        echo "$result"
+        exit 1
+      fi
+    }
+    
+    count=$(jq -r ".queries | length-1" "${1}")
+    for i in $(seq 0 "${count}"); do
+      query=$(jq -r --argjson i "${i}" '.queries[$i].query' "${1}")
+      type=$(jq -r --argjson i "${i}" '.queries[$i] | .type // "promql"' "${1}")
+    
+      case "${type}" in
+        promql)
+          metrics_query "${query}"
+          ;;
+        logql)
+          logs_query "${query}"
+          ;;
+        *)
+          echo "Query type ${type} is not yet supported in this test"
+          ;;
+      esac
     done
     
     echo "All queries passed!"
@@ -43561,28 +43595,36 @@ data:
     {
       "queries": [
         {
-          "query": "up{cluster=\"private-image-regristry-test\"}"
+          "query": "up{cluster=\"private-image-regristry-test\"}",
+          "type": "promql"
         },
         {
-          "query": "agent_build_info{cluster=\"private-image-regristry-test\"}"
+          "query": "agent_build_info{cluster=\"private-image-regristry-test\"}",
+          "type": "promql"
         },
         {
-          "query": "kubernetes_build_info{cluster=\"private-image-regristry-test\"}"
+          "query": "kubernetes_build_info{cluster=\"private-image-regristry-test\"}",
+          "type": "promql"
         },
         {
-          "query": "machine_memory_bytes{cluster=\"private-image-regristry-test\"}"
+          "query": "machine_memory_bytes{cluster=\"private-image-regristry-test\"}",
+          "type": "promql"
         },
         {
-          "query": "kube_node_info{cluster=\"private-image-regristry-test\"}"
+          "query": "kube_node_info{cluster=\"private-image-regristry-test\"}",
+          "type": "promql"
         },
         {
-          "query": "node_exporter_build_info{cluster=\"private-image-regristry-test\"}"
+          "query": "node_exporter_build_info{cluster=\"private-image-regristry-test\"}",
+          "type": "promql"
         },
         {
-          "query": "opencost_build_info{cluster=\"private-image-regristry-test\"}"
+          "query": "opencost_build_info{cluster=\"private-image-regristry-test\"}",
+          "type": "promql"
         },
         {
-          "query": "grafana_kubernetes_monitoring_build_info{cluster=\"private-image-regristry-test\"}"
+          "query": "grafana_kubernetes_monitoring_build_info{cluster=\"private-image-regristry-test\"}",
+          "type": "promql"
         }
       ]
     }
@@ -43662,7 +43704,7 @@ spec:
       containers:
         - name: test-runner
           image: my.registry.com/test/ubuntu:jammy
-          command: ["bash", "-c", "bash /etc/test/test.sh /etc/test/queries.json"]
+          command: ["bash", "-c", "apt-get update && apt-get install -y -y curl jq && bash /etc/test/test.sh /etc/test/queries.json"]
           volumeMounts:
             - name: test-plan
               mountPath: /etc/test
@@ -43672,16 +43714,48 @@ spec:
                 secretKeyRef:
                   name: grafana-agent-credentials
                   key: prometheus_host
+                  optional: true
+            - name: PROMETHEUS_URL
+              value: $(PROMETHEUS_HOST)/api/prom/api/v1/query
             - name: PROMETHEUS_USER
               valueFrom:
                 secretKeyRef:
                   name: grafana-agent-credentials
                   key: prometheus_username
+                  optional: true
             - name: PROMETHEUS_PASS
               valueFrom:
                 secretKeyRef:
                   name: grafana-agent-credentials
                   key: prometheus_password
+                  optional: true
+
+            - name: LOKI_HOST
+              valueFrom:
+                secretKeyRef:
+                  name: grafana-agent-credentials
+                  key: loki_host
+            - name: LOKI_URL
+              value: $(LOKI_HOST)/loki/api/v1/query
+            - name: LOKI_USER
+              valueFrom:
+                secretKeyRef:
+                  name: grafana-agent-credentials
+                  key: loki_username
+                  optional: true
+            - name: LOKI_PASS
+              valueFrom:
+                secretKeyRef:
+                  name: grafana-agent-credentials
+                  key: loki_password
+                  optional: true
+            - name: LOKI_TENANTID
+              valueFrom:
+                secretKeyRef:
+                  name: grafana-agent-credentials
+                  key: loki_tenantId
+                  optional: true
+
       volumes:
         - name: test-plan
           configMap:

--- a/examples/scrape-intervals/output.yaml
+++ b/examples/scrape-intervals/output.yaml
@@ -42975,12 +42975,10 @@ data:
   test.sh: |-
     #!/bin/bash
     set -eo pipefail
-    apt-get update && apt-get install -y curl jq
     
-    queries=$(jq -r '.queries[].query' "$1")
-    for query in $queries; do
-      echo "Running query: ${PROMETHEUS_HOST}/api/prom/api/v1/query?query=$query..."
-      result=$(curl -skX POST -u "${PROMETHEUS_USER}:${PROMETHEUS_PASS}" "${PROMETHEUS_HOST}/api/prom/api/v1/query?query=$(jq -rn --arg x "${query}" '$x|@uri')")
+    function metrics_query {
+      echo "Running PromQL query: ${PROMETHEUS_URL}?query=${1}..."
+      result=$(curl -skX POST -u "${PROMETHEUS_USER}:${PROMETHEUS_PASS}" "${PROMETHEUS_URL}" --data-urlencode "query=${1}")
       status=$(echo $result | jq -r .status)
       if [ "${status}" != "success" ]; then
         echo "Query failed!"
@@ -42994,6 +42992,42 @@ data:
         echo "$result"
         exit 1
       fi
+    }
+    
+    function logs_query {
+      echo "Running LogQL query: ${LOKI_URL}?query=${1}..."
+      result=$(curl -s --get -H "X-Scope-OrgID:${LOKI_TENANTID}" -u "${LOKI_USER}:${LOKI_PASS}" "${LOKI_URL}" --data-urlencode "query=${1}")
+      status=$(echo $result | jq -r .status)
+      if [ "${status}" != "success" ]; then
+        echo "Query failed!"
+        echo "$result"
+        exit 1
+      fi
+    
+      resultCount=$(echo $result | jq '.data.result | length')
+      if [ "${resultCount}" -eq 0 ]; then
+        echo "Query returned no results"
+        echo "$result"
+        exit 1
+      fi
+    }
+    
+    count=$(jq -r ".queries | length-1" "${1}")
+    for i in $(seq 0 "${count}"); do
+      query=$(jq -r --argjson i "${i}" '.queries[$i].query' "${1}")
+      type=$(jq -r --argjson i "${i}" '.queries[$i] | .type // "promql"' "${1}")
+    
+      case "${type}" in
+        promql)
+          metrics_query "${query}"
+          ;;
+        logql)
+          logs_query "${query}"
+          ;;
+        *)
+          echo "Query type ${type} is not yet supported in this test"
+          ;;
+      esac
     done
     
     echo "All queries passed!"
@@ -43001,28 +43035,36 @@ data:
     {
       "queries": [
         {
-          "query": "up{cluster=\"custom-scrape-intervals-test\"}"
+          "query": "up{cluster=\"custom-scrape-intervals-test\"}",
+          "type": "promql"
         },
         {
-          "query": "agent_build_info{cluster=\"custom-scrape-intervals-test\"}"
+          "query": "agent_build_info{cluster=\"custom-scrape-intervals-test\"}",
+          "type": "promql"
         },
         {
-          "query": "kubernetes_build_info{cluster=\"custom-scrape-intervals-test\"}"
+          "query": "kubernetes_build_info{cluster=\"custom-scrape-intervals-test\"}",
+          "type": "promql"
         },
         {
-          "query": "machine_memory_bytes{cluster=\"custom-scrape-intervals-test\"}"
+          "query": "machine_memory_bytes{cluster=\"custom-scrape-intervals-test\"}",
+          "type": "promql"
         },
         {
-          "query": "kube_node_info{cluster=\"custom-scrape-intervals-test\"}"
+          "query": "kube_node_info{cluster=\"custom-scrape-intervals-test\"}",
+          "type": "promql"
         },
         {
-          "query": "node_exporter_build_info{cluster=\"custom-scrape-intervals-test\"}"
+          "query": "node_exporter_build_info{cluster=\"custom-scrape-intervals-test\"}",
+          "type": "promql"
         },
         {
-          "query": "opencost_build_info{cluster=\"custom-scrape-intervals-test\"}"
+          "query": "opencost_build_info{cluster=\"custom-scrape-intervals-test\"}",
+          "type": "promql"
         },
         {
-          "query": "grafana_kubernetes_monitoring_build_info{cluster=\"custom-scrape-intervals-test\"}"
+          "query": "grafana_kubernetes_monitoring_build_info{cluster=\"custom-scrape-intervals-test\"}",
+          "type": "promql"
         }
       ]
     }
@@ -43100,7 +43142,7 @@ spec:
       containers:
         - name: test-runner
           image: docker.io/ubuntu:jammy
-          command: ["bash", "-c", "bash /etc/test/test.sh /etc/test/queries.json"]
+          command: ["bash", "-c", "apt-get update && apt-get install -y -y curl jq && bash /etc/test/test.sh /etc/test/queries.json"]
           volumeMounts:
             - name: test-plan
               mountPath: /etc/test
@@ -43110,16 +43152,48 @@ spec:
                 secretKeyRef:
                   name: grafana-agent-credentials
                   key: prometheus_host
+                  optional: true
+            - name: PROMETHEUS_URL
+              value: $(PROMETHEUS_HOST)/api/prom/api/v1/query
             - name: PROMETHEUS_USER
               valueFrom:
                 secretKeyRef:
                   name: grafana-agent-credentials
                   key: prometheus_username
+                  optional: true
             - name: PROMETHEUS_PASS
               valueFrom:
                 secretKeyRef:
                   name: grafana-agent-credentials
                   key: prometheus_password
+                  optional: true
+
+            - name: LOKI_HOST
+              valueFrom:
+                secretKeyRef:
+                  name: grafana-agent-credentials
+                  key: loki_host
+            - name: LOKI_URL
+              value: $(LOKI_HOST)/loki/api/v1/query
+            - name: LOKI_USER
+              valueFrom:
+                secretKeyRef:
+                  name: grafana-agent-credentials
+                  key: loki_username
+                  optional: true
+            - name: LOKI_PASS
+              valueFrom:
+                secretKeyRef:
+                  name: grafana-agent-credentials
+                  key: loki_password
+                  optional: true
+            - name: LOKI_TENANTID
+              valueFrom:
+                secretKeyRef:
+                  name: grafana-agent-credentials
+                  key: loki_tenantId
+                  optional: true
+
       volumes:
         - name: test-plan
           configMap:

--- a/examples/specific-namespace/output.yaml
+++ b/examples/specific-namespace/output.yaml
@@ -43637,12 +43637,10 @@ data:
   test.sh: |-
     #!/bin/bash
     set -eo pipefail
-    apt-get update && apt-get install -y curl jq
     
-    queries=$(jq -r '.queries[].query' "$1")
-    for query in $queries; do
-      echo "Running query: ${PROMETHEUS_HOST}/api/prom/api/v1/query?query=$query..."
-      result=$(curl -skX POST -u "${PROMETHEUS_USER}:${PROMETHEUS_PASS}" "${PROMETHEUS_HOST}/api/prom/api/v1/query?query=$(jq -rn --arg x "${query}" '$x|@uri')")
+    function metrics_query {
+      echo "Running PromQL query: ${PROMETHEUS_URL}?query=${1}..."
+      result=$(curl -skX POST -u "${PROMETHEUS_USER}:${PROMETHEUS_PASS}" "${PROMETHEUS_URL}" --data-urlencode "query=${1}")
       status=$(echo $result | jq -r .status)
       if [ "${status}" != "success" ]; then
         echo "Query failed!"
@@ -43656,6 +43654,42 @@ data:
         echo "$result"
         exit 1
       fi
+    }
+    
+    function logs_query {
+      echo "Running LogQL query: ${LOKI_URL}?query=${1}..."
+      result=$(curl -s --get -H "X-Scope-OrgID:${LOKI_TENANTID}" -u "${LOKI_USER}:${LOKI_PASS}" "${LOKI_URL}" --data-urlencode "query=${1}")
+      status=$(echo $result | jq -r .status)
+      if [ "${status}" != "success" ]; then
+        echo "Query failed!"
+        echo "$result"
+        exit 1
+      fi
+    
+      resultCount=$(echo $result | jq '.data.result | length')
+      if [ "${resultCount}" -eq 0 ]; then
+        echo "Query returned no results"
+        echo "$result"
+        exit 1
+      fi
+    }
+    
+    count=$(jq -r ".queries | length-1" "${1}")
+    for i in $(seq 0 "${count}"); do
+      query=$(jq -r --argjson i "${i}" '.queries[$i].query' "${1}")
+      type=$(jq -r --argjson i "${i}" '.queries[$i] | .type // "promql"' "${1}")
+    
+      case "${type}" in
+        promql)
+          metrics_query "${query}"
+          ;;
+        logql)
+          logs_query "${query}"
+          ;;
+        *)
+          echo "Query type ${type} is not yet supported in this test"
+          ;;
+      esac
     done
     
     echo "All queries passed!"
@@ -43663,28 +43697,36 @@ data:
     {
       "queries": [
         {
-          "query": "up{cluster=\"specific-namespace-test\"}"
+          "query": "up{cluster=\"specific-namespace-test\"}",
+          "type": "promql"
         },
         {
-          "query": "agent_build_info{cluster=\"specific-namespace-test\"}"
+          "query": "agent_build_info{cluster=\"specific-namespace-test\"}",
+          "type": "promql"
         },
         {
-          "query": "kubernetes_build_info{cluster=\"specific-namespace-test\"}"
+          "query": "kubernetes_build_info{cluster=\"specific-namespace-test\"}",
+          "type": "promql"
         },
         {
-          "query": "machine_memory_bytes{cluster=\"specific-namespace-test\"}"
+          "query": "machine_memory_bytes{cluster=\"specific-namespace-test\"}",
+          "type": "promql"
         },
         {
-          "query": "kube_node_info{cluster=\"specific-namespace-test\"}"
+          "query": "kube_node_info{cluster=\"specific-namespace-test\"}",
+          "type": "promql"
         },
         {
-          "query": "node_exporter_build_info{cluster=\"specific-namespace-test\"}"
+          "query": "node_exporter_build_info{cluster=\"specific-namespace-test\"}",
+          "type": "promql"
         },
         {
-          "query": "opencost_build_info{cluster=\"specific-namespace-test\"}"
+          "query": "opencost_build_info{cluster=\"specific-namespace-test\"}",
+          "type": "promql"
         },
         {
-          "query": "grafana_kubernetes_monitoring_build_info{cluster=\"specific-namespace-test\"}"
+          "query": "grafana_kubernetes_monitoring_build_info{cluster=\"specific-namespace-test\"}",
+          "type": "promql"
         }
       ]
     }
@@ -43764,7 +43806,7 @@ spec:
       containers:
         - name: test-runner
           image: docker.io/ubuntu:jammy
-          command: ["bash", "-c", "bash /etc/test/test.sh /etc/test/queries.json"]
+          command: ["bash", "-c", "apt-get update && apt-get install -y -y curl jq && bash /etc/test/test.sh /etc/test/queries.json"]
           volumeMounts:
             - name: test-plan
               mountPath: /etc/test
@@ -43774,16 +43816,48 @@ spec:
                 secretKeyRef:
                   name: grafana-agent-credentials
                   key: prometheus_host
+                  optional: true
+            - name: PROMETHEUS_URL
+              value: $(PROMETHEUS_HOST)/api/prom/api/v1/query
             - name: PROMETHEUS_USER
               valueFrom:
                 secretKeyRef:
                   name: grafana-agent-credentials
                   key: prometheus_username
+                  optional: true
             - name: PROMETHEUS_PASS
               valueFrom:
                 secretKeyRef:
                   name: grafana-agent-credentials
                   key: prometheus_password
+                  optional: true
+
+            - name: LOKI_HOST
+              valueFrom:
+                secretKeyRef:
+                  name: grafana-agent-credentials
+                  key: loki_host
+            - name: LOKI_URL
+              value: $(LOKI_HOST)/loki/api/v1/query
+            - name: LOKI_USER
+              valueFrom:
+                secretKeyRef:
+                  name: grafana-agent-credentials
+                  key: loki_username
+                  optional: true
+            - name: LOKI_PASS
+              valueFrom:
+                secretKeyRef:
+                  name: grafana-agent-credentials
+                  key: loki_password
+                  optional: true
+            - name: LOKI_TENANTID
+              valueFrom:
+                secretKeyRef:
+                  name: grafana-agent-credentials
+                  key: loki_tenantId
+                  optional: true
+
       volumes:
         - name: test-plan
           configMap:

--- a/examples/traces-enabled/output.yaml
+++ b/examples/traces-enabled/output.yaml
@@ -43711,12 +43711,10 @@ data:
   test.sh: |-
     #!/bin/bash
     set -eo pipefail
-    apt-get update && apt-get install -y curl jq
     
-    queries=$(jq -r '.queries[].query' "$1")
-    for query in $queries; do
-      echo "Running query: ${PROMETHEUS_HOST}/api/prom/api/v1/query?query=$query..."
-      result=$(curl -skX POST -u "${PROMETHEUS_USER}:${PROMETHEUS_PASS}" "${PROMETHEUS_HOST}/api/prom/api/v1/query?query=$(jq -rn --arg x "${query}" '$x|@uri')")
+    function metrics_query {
+      echo "Running PromQL query: ${PROMETHEUS_URL}?query=${1}..."
+      result=$(curl -skX POST -u "${PROMETHEUS_USER}:${PROMETHEUS_PASS}" "${PROMETHEUS_URL}" --data-urlencode "query=${1}")
       status=$(echo $result | jq -r .status)
       if [ "${status}" != "success" ]; then
         echo "Query failed!"
@@ -43730,6 +43728,42 @@ data:
         echo "$result"
         exit 1
       fi
+    }
+    
+    function logs_query {
+      echo "Running LogQL query: ${LOKI_URL}?query=${1}..."
+      result=$(curl -s --get -H "X-Scope-OrgID:${LOKI_TENANTID}" -u "${LOKI_USER}:${LOKI_PASS}" "${LOKI_URL}" --data-urlencode "query=${1}")
+      status=$(echo $result | jq -r .status)
+      if [ "${status}" != "success" ]; then
+        echo "Query failed!"
+        echo "$result"
+        exit 1
+      fi
+    
+      resultCount=$(echo $result | jq '.data.result | length')
+      if [ "${resultCount}" -eq 0 ]; then
+        echo "Query returned no results"
+        echo "$result"
+        exit 1
+      fi
+    }
+    
+    count=$(jq -r ".queries | length-1" "${1}")
+    for i in $(seq 0 "${count}"); do
+      query=$(jq -r --argjson i "${i}" '.queries[$i].query' "${1}")
+      type=$(jq -r --argjson i "${i}" '.queries[$i] | .type // "promql"' "${1}")
+    
+      case "${type}" in
+        promql)
+          metrics_query "${query}"
+          ;;
+        logql)
+          logs_query "${query}"
+          ;;
+        *)
+          echo "Query type ${type} is not yet supported in this test"
+          ;;
+      esac
     done
     
     echo "All queries passed!"
@@ -43737,28 +43771,36 @@ data:
     {
       "queries": [
         {
-          "query": "up{cluster=\"traces-enabled-test\"}"
+          "query": "up{cluster=\"traces-enabled-test\"}",
+          "type": "promql"
         },
         {
-          "query": "agent_build_info{cluster=\"traces-enabled-test\"}"
+          "query": "agent_build_info{cluster=\"traces-enabled-test\"}",
+          "type": "promql"
         },
         {
-          "query": "kubernetes_build_info{cluster=\"traces-enabled-test\"}"
+          "query": "kubernetes_build_info{cluster=\"traces-enabled-test\"}",
+          "type": "promql"
         },
         {
-          "query": "machine_memory_bytes{cluster=\"traces-enabled-test\"}"
+          "query": "machine_memory_bytes{cluster=\"traces-enabled-test\"}",
+          "type": "promql"
         },
         {
-          "query": "kube_node_info{cluster=\"traces-enabled-test\"}"
+          "query": "kube_node_info{cluster=\"traces-enabled-test\"}",
+          "type": "promql"
         },
         {
-          "query": "node_exporter_build_info{cluster=\"traces-enabled-test\"}"
+          "query": "node_exporter_build_info{cluster=\"traces-enabled-test\"}",
+          "type": "promql"
         },
         {
-          "query": "opencost_build_info{cluster=\"traces-enabled-test\"}"
+          "query": "opencost_build_info{cluster=\"traces-enabled-test\"}",
+          "type": "promql"
         },
         {
-          "query": "grafana_kubernetes_monitoring_build_info{cluster=\"traces-enabled-test\"}"
+          "query": "grafana_kubernetes_monitoring_build_info{cluster=\"traces-enabled-test\"}",
+          "type": "promql"
         }
       ]
     }
@@ -43838,7 +43880,7 @@ spec:
       containers:
         - name: test-runner
           image: docker.io/ubuntu:jammy
-          command: ["bash", "-c", "bash /etc/test/test.sh /etc/test/queries.json"]
+          command: ["bash", "-c", "apt-get update && apt-get install -y -y curl jq && bash /etc/test/test.sh /etc/test/queries.json"]
           volumeMounts:
             - name: test-plan
               mountPath: /etc/test
@@ -43848,16 +43890,48 @@ spec:
                 secretKeyRef:
                   name: grafana-agent-credentials
                   key: prometheus_host
+                  optional: true
+            - name: PROMETHEUS_URL
+              value: $(PROMETHEUS_HOST)/api/prom/api/v1/query
             - name: PROMETHEUS_USER
               valueFrom:
                 secretKeyRef:
                   name: grafana-agent-credentials
                   key: prometheus_username
+                  optional: true
             - name: PROMETHEUS_PASS
               valueFrom:
                 secretKeyRef:
                   name: grafana-agent-credentials
                   key: prometheus_password
+                  optional: true
+
+            - name: LOKI_HOST
+              valueFrom:
+                secretKeyRef:
+                  name: grafana-agent-credentials
+                  key: loki_host
+            - name: LOKI_URL
+              value: $(LOKI_HOST)/loki/api/v1/query
+            - name: LOKI_USER
+              valueFrom:
+                secretKeyRef:
+                  name: grafana-agent-credentials
+                  key: loki_username
+                  optional: true
+            - name: LOKI_PASS
+              valueFrom:
+                secretKeyRef:
+                  name: grafana-agent-credentials
+                  key: loki_password
+                  optional: true
+            - name: LOKI_TENANTID
+              valueFrom:
+                secretKeyRef:
+                  name: grafana-agent-credentials
+                  key: loki_tenantId
+                  optional: true
+
       volumes:
         - name: test-plan
           configMap:

--- a/examples/windows-exporter/output.yaml
+++ b/examples/windows-exporter/output.yaml
@@ -43834,12 +43834,10 @@ data:
   test.sh: |-
     #!/bin/bash
     set -eo pipefail
-    apt-get update && apt-get install -y curl jq
     
-    queries=$(jq -r '.queries[].query' "$1")
-    for query in $queries; do
-      echo "Running query: ${PROMETHEUS_HOST}/api/prom/api/v1/query?query=$query..."
-      result=$(curl -skX POST -u "${PROMETHEUS_USER}:${PROMETHEUS_PASS}" "${PROMETHEUS_HOST}/api/prom/api/v1/query?query=$(jq -rn --arg x "${query}" '$x|@uri')")
+    function metrics_query {
+      echo "Running PromQL query: ${PROMETHEUS_URL}?query=${1}..."
+      result=$(curl -skX POST -u "${PROMETHEUS_USER}:${PROMETHEUS_PASS}" "${PROMETHEUS_URL}" --data-urlencode "query=${1}")
       status=$(echo $result | jq -r .status)
       if [ "${status}" != "success" ]; then
         echo "Query failed!"
@@ -43853,6 +43851,42 @@ data:
         echo "$result"
         exit 1
       fi
+    }
+    
+    function logs_query {
+      echo "Running LogQL query: ${LOKI_URL}?query=${1}..."
+      result=$(curl -s --get -H "X-Scope-OrgID:${LOKI_TENANTID}" -u "${LOKI_USER}:${LOKI_PASS}" "${LOKI_URL}" --data-urlencode "query=${1}")
+      status=$(echo $result | jq -r .status)
+      if [ "${status}" != "success" ]; then
+        echo "Query failed!"
+        echo "$result"
+        exit 1
+      fi
+    
+      resultCount=$(echo $result | jq '.data.result | length')
+      if [ "${resultCount}" -eq 0 ]; then
+        echo "Query returned no results"
+        echo "$result"
+        exit 1
+      fi
+    }
+    
+    count=$(jq -r ".queries | length-1" "${1}")
+    for i in $(seq 0 "${count}"); do
+      query=$(jq -r --argjson i "${i}" '.queries[$i].query' "${1}")
+      type=$(jq -r --argjson i "${i}" '.queries[$i] | .type // "promql"' "${1}")
+    
+      case "${type}" in
+        promql)
+          metrics_query "${query}"
+          ;;
+        logql)
+          logs_query "${query}"
+          ;;
+        *)
+          echo "Query type ${type} is not yet supported in this test"
+          ;;
+      esac
     done
     
     echo "All queries passed!"
@@ -43860,31 +43894,40 @@ data:
     {
       "queries": [
         {
-          "query": "up{cluster=\"default-values-test\"}"
+          "query": "up{cluster=\"default-values-test\"}",
+          "type": "promql"
         },
         {
-          "query": "agent_build_info{cluster=\"default-values-test\"}"
+          "query": "agent_build_info{cluster=\"default-values-test\"}",
+          "type": "promql"
         },
         {
-          "query": "kubernetes_build_info{cluster=\"default-values-test\"}"
+          "query": "kubernetes_build_info{cluster=\"default-values-test\"}",
+          "type": "promql"
         },
         {
-          "query": "machine_memory_bytes{cluster=\"default-values-test\"}"
+          "query": "machine_memory_bytes{cluster=\"default-values-test\"}",
+          "type": "promql"
         },
         {
-          "query": "kube_node_info{cluster=\"default-values-test\"}"
+          "query": "kube_node_info{cluster=\"default-values-test\"}",
+          "type": "promql"
         },
         {
-          "query": "node_exporter_build_info{cluster=\"default-values-test\"}"
+          "query": "node_exporter_build_info{cluster=\"default-values-test\"}",
+          "type": "promql"
         },
         {
-          "query": "windows_exporter_build_info{cluster=\"default-values-test\"}"
+          "query": "windows_exporter_build_info{cluster=\"default-values-test\"}",
+          "type": "promql"
         },
         {
-          "query": "opencost_build_info{cluster=\"default-values-test\"}"
+          "query": "opencost_build_info{cluster=\"default-values-test\"}",
+          "type": "promql"
         },
         {
-          "query": "grafana_kubernetes_monitoring_build_info{cluster=\"default-values-test\"}"
+          "query": "grafana_kubernetes_monitoring_build_info{cluster=\"default-values-test\"}",
+          "type": "promql"
         }
       ]
     }
@@ -43964,7 +44007,7 @@ spec:
       containers:
         - name: test-runner
           image: docker.io/ubuntu:jammy
-          command: ["bash", "-c", "bash /etc/test/test.sh /etc/test/queries.json"]
+          command: ["bash", "-c", "apt-get update && apt-get install -y -y curl jq && bash /etc/test/test.sh /etc/test/queries.json"]
           volumeMounts:
             - name: test-plan
               mountPath: /etc/test
@@ -43974,16 +44017,48 @@ spec:
                 secretKeyRef:
                   name: grafana-agent-credentials
                   key: prometheus_host
+                  optional: true
+            - name: PROMETHEUS_URL
+              value: $(PROMETHEUS_HOST)/api/prom/api/v1/query
             - name: PROMETHEUS_USER
               valueFrom:
                 secretKeyRef:
                   name: grafana-agent-credentials
                   key: prometheus_username
+                  optional: true
             - name: PROMETHEUS_PASS
               valueFrom:
                 secretKeyRef:
                   name: grafana-agent-credentials
                   key: prometheus_password
+                  optional: true
+
+            - name: LOKI_HOST
+              valueFrom:
+                secretKeyRef:
+                  name: grafana-agent-credentials
+                  key: loki_host
+            - name: LOKI_URL
+              value: $(LOKI_HOST)/loki/api/v1/query
+            - name: LOKI_USER
+              valueFrom:
+                secretKeyRef:
+                  name: grafana-agent-credentials
+                  key: loki_username
+                  optional: true
+            - name: LOKI_PASS
+              valueFrom:
+                secretKeyRef:
+                  name: grafana-agent-credentials
+                  key: loki_password
+                  optional: true
+            - name: LOKI_TENANTID
+              valueFrom:
+                secretKeyRef:
+                  name: grafana-agent-credentials
+                  key: loki_tenantId
+                  optional: true
+
       volumes:
         - name: test-plan
           configMap:


### PR DESCRIPTION
This PR extracts the script that does the testing into its own file. That let's people run it on the CLI if they want.
It also adds a `type` field that lets the tests run PromQL or LogQL tests.

I'm not adding the LogQL queries for cluster events or pod logs to the default set of queries, though, because that requires the access token to be able to read logs from loki. By default, our access token only has write permissions to grafana cloud loki.