### PR TITLE
fix: Missing nonsensitive() wrapper around tenantIdKey

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Required tools:
 * [Helm](https://helm.sh/docs/intro/install/)
 * [helm-docs](https://github.com/norwoodj/helm-docs)
 * [Grafana Agent](https://github.com/grafana/agent) (used for linting the generated config files)
+* [shellspec](https://github.com/shellspec/shellspec)
 * [yamllint](https://yamllint.readthedocs.io/en/stable/index.html)
 * [yq](https://pypi.org/project/yq/)
 

--- a/charts/k8s-monitoring/templates/agent_config/_metrics_service_otlp.river.txt
+++ b/charts/k8s-monitoring/templates/agent_config/_metrics_service_otlp.river.txt
@@ -62,7 +62,7 @@ otelcol.exporter.otlphttp "metrics_service" {
     auth = otelcol.auth.basic.metrics_service.handler
 {{- end }}
 {{- if .tenantId }}
-    headers = { "X-Scope-OrgID" = remote.kubernetes.secret.metrics_service.data[{{ .tenantIdKey | quote }}] }
+    headers = { "X-Scope-OrgID" = nonsensitive(remote.kubernetes.secret.metrics_service.data[{{ .tenantIdKey | quote }}]) }
 {{- end }}
 {{- if .tls }}
     tls {

--- a/charts/k8s-monitoring/templates/agent_config/_metrics_service_remote_write.river.txt
+++ b/charts/k8s-monitoring/templates/agent_config/_metrics_service_remote_write.river.txt
@@ -3,7 +3,7 @@
 prometheus.remote_write "metrics_service" {
   endpoint {
     url = nonsensitive(remote.kubernetes.secret.metrics_service.data[{{ .hostKey | quote }}]) + "{{ .writeEndpoint }}"
-    headers = { "X-Scope-OrgID" = remote.kubernetes.secret.metrics_service.data[{{ .tenantIdKey | quote }}] }
+    headers = { "X-Scope-OrgID" = nonsensitive(remote.kubernetes.secret.metrics_service.data[{{ .tenantIdKey | quote }}]) }
 {{- if .proxyURL }}
     proxy_url = {{ .proxyURL | quote }}
 {{- end }}

--- a/charts/k8s-monitoring/templates/agent_config/_traces_service.river.txt
+++ b/charts/k8s-monitoring/templates/agent_config/_traces_service.river.txt
@@ -22,7 +22,7 @@ otelcol.exporter.otlphttp "traces_service" {
 {{ if eq .authMode "basic" }}
     auth = otelcol.auth.basic.traces_service.handler
 {{- end }}
-    headers = { "X-Scope-OrgID" = remote.kubernetes.secret.traces_service.data[{{ .tenantIdKey | quote }}] }
+    headers = { "X-Scope-OrgID" = nonsensitive(remote.kubernetes.secret.traces_service.data[{{ .tenantIdKey | quote }}]) }
 {{- if .tlsOptions }}
     tls {
 {{ .tlsOptions | indent 6 }}

--- a/examples/control-plane-metrics/metrics.river
+++ b/examples/control-plane-metrics/metrics.river
@@ -497,7 +497,7 @@ prometheus.relabel "metrics_service" {
 prometheus.remote_write "metrics_service" {
   endpoint {
     url = nonsensitive(remote.kubernetes.secret.metrics_service.data["host"]) + "/api/prom/push"
-    headers = { "X-Scope-OrgID" = remote.kubernetes.secret.metrics_service.data["tenantId"] }
+    headers = { "X-Scope-OrgID" = nonsensitive(remote.kubernetes.secret.metrics_service.data["tenantId"]) }
 
     basic_auth {
       username = nonsensitive(remote.kubernetes.secret.metrics_service.data["username"])

--- a/examples/control-plane-metrics/output.yaml
+++ b/examples/control-plane-metrics/output.yaml
@@ -604,7 +604,7 @@ data:
     prometheus.remote_write "metrics_service" {
       endpoint {
         url = nonsensitive(remote.kubernetes.secret.metrics_service.data["host"]) + "/api/prom/push"
-        headers = { "X-Scope-OrgID" = remote.kubernetes.secret.metrics_service.data["tenantId"] }
+        headers = { "X-Scope-OrgID" = nonsensitive(remote.kubernetes.secret.metrics_service.data["tenantId"]) }
     
         basic_auth {
           username = nonsensitive(remote.kubernetes.secret.metrics_service.data["username"])
@@ -44299,7 +44299,7 @@ data:
     prometheus.remote_write "metrics_service" {
       endpoint {
         url = nonsensitive(remote.kubernetes.secret.metrics_service.data["host"]) + "/api/prom/push"
-        headers = { "X-Scope-OrgID" = remote.kubernetes.secret.metrics_service.data["tenantId"] }
+        headers = { "X-Scope-OrgID" = nonsensitive(remote.kubernetes.secret.metrics_service.data["tenantId"]) }
     
         basic_auth {
           username = nonsensitive(remote.kubernetes.secret.metrics_service.data["username"])

--- a/examples/custom-allow-lists/metrics.river
+++ b/examples/custom-allow-lists/metrics.river
@@ -340,7 +340,7 @@ prometheus.relabel "metrics_service" {
 prometheus.remote_write "metrics_service" {
   endpoint {
     url = nonsensitive(remote.kubernetes.secret.metrics_service.data["host"]) + "/api/prom/push"
-    headers = { "X-Scope-OrgID" = remote.kubernetes.secret.metrics_service.data["tenantId"] }
+    headers = { "X-Scope-OrgID" = nonsensitive(remote.kubernetes.secret.metrics_service.data["tenantId"]) }
 
     basic_auth {
       username = nonsensitive(remote.kubernetes.secret.metrics_service.data["username"])

--- a/examples/custom-allow-lists/output.yaml
+++ b/examples/custom-allow-lists/output.yaml
@@ -420,7 +420,7 @@ data:
     prometheus.remote_write "metrics_service" {
       endpoint {
         url = nonsensitive(remote.kubernetes.secret.metrics_service.data["host"]) + "/api/prom/push"
-        headers = { "X-Scope-OrgID" = remote.kubernetes.secret.metrics_service.data["tenantId"] }
+        headers = { "X-Scope-OrgID" = nonsensitive(remote.kubernetes.secret.metrics_service.data["tenantId"]) }
     
         basic_auth {
           username = nonsensitive(remote.kubernetes.secret.metrics_service.data["username"])
@@ -43587,7 +43587,7 @@ data:
     prometheus.remote_write "metrics_service" {
       endpoint {
         url = nonsensitive(remote.kubernetes.secret.metrics_service.data["host"]) + "/api/prom/push"
-        headers = { "X-Scope-OrgID" = remote.kubernetes.secret.metrics_service.data["tenantId"] }
+        headers = { "X-Scope-OrgID" = nonsensitive(remote.kubernetes.secret.metrics_service.data["tenantId"]) }
     
         basic_auth {
           username = nonsensitive(remote.kubernetes.secret.metrics_service.data["username"])

--- a/examples/custom-config/metrics.river
+++ b/examples/custom-config/metrics.river
@@ -345,7 +345,7 @@ prometheus.relabel "metrics_service" {
 prometheus.remote_write "metrics_service" {
   endpoint {
     url = nonsensitive(remote.kubernetes.secret.metrics_service.data["host"]) + "/api/prom/push"
-    headers = { "X-Scope-OrgID" = remote.kubernetes.secret.metrics_service.data["tenantId"] }
+    headers = { "X-Scope-OrgID" = nonsensitive(remote.kubernetes.secret.metrics_service.data["tenantId"]) }
 
     basic_auth {
       username = nonsensitive(remote.kubernetes.secret.metrics_service.data["username"])

--- a/examples/custom-config/output.yaml
+++ b/examples/custom-config/output.yaml
@@ -451,7 +451,7 @@ data:
     prometheus.remote_write "metrics_service" {
       endpoint {
         url = nonsensitive(remote.kubernetes.secret.metrics_service.data["host"]) + "/api/prom/push"
-        headers = { "X-Scope-OrgID" = remote.kubernetes.secret.metrics_service.data["tenantId"] }
+        headers = { "X-Scope-OrgID" = nonsensitive(remote.kubernetes.secret.metrics_service.data["tenantId"]) }
     
         basic_auth {
           username = nonsensitive(remote.kubernetes.secret.metrics_service.data["username"])
@@ -44055,7 +44055,7 @@ data:
     prometheus.remote_write "metrics_service" {
       endpoint {
         url = nonsensitive(remote.kubernetes.secret.metrics_service.data["host"]) + "/api/prom/push"
-        headers = { "X-Scope-OrgID" = remote.kubernetes.secret.metrics_service.data["tenantId"] }
+        headers = { "X-Scope-OrgID" = nonsensitive(remote.kubernetes.secret.metrics_service.data["tenantId"]) }
     
         basic_auth {
           username = nonsensitive(remote.kubernetes.secret.metrics_service.data["username"])

--- a/examples/default-values/metrics.river
+++ b/examples/default-values/metrics.river
@@ -345,7 +345,7 @@ prometheus.relabel "metrics_service" {
 prometheus.remote_write "metrics_service" {
   endpoint {
     url = nonsensitive(remote.kubernetes.secret.metrics_service.data["host"]) + "/api/prom/push"
-    headers = { "X-Scope-OrgID" = remote.kubernetes.secret.metrics_service.data["tenantId"] }
+    headers = { "X-Scope-OrgID" = nonsensitive(remote.kubernetes.secret.metrics_service.data["tenantId"]) }
 
     basic_auth {
       username = nonsensitive(remote.kubernetes.secret.metrics_service.data["username"])

--- a/examples/default-values/output.yaml
+++ b/examples/default-values/output.yaml
@@ -451,7 +451,7 @@ data:
     prometheus.remote_write "metrics_service" {
       endpoint {
         url = nonsensitive(remote.kubernetes.secret.metrics_service.data["host"]) + "/api/prom/push"
-        headers = { "X-Scope-OrgID" = remote.kubernetes.secret.metrics_service.data["tenantId"] }
+        headers = { "X-Scope-OrgID" = nonsensitive(remote.kubernetes.secret.metrics_service.data["tenantId"]) }
     
         basic_auth {
           username = nonsensitive(remote.kubernetes.secret.metrics_service.data["username"])
@@ -43994,7 +43994,7 @@ data:
     prometheus.remote_write "metrics_service" {
       endpoint {
         url = nonsensitive(remote.kubernetes.secret.metrics_service.data["host"]) + "/api/prom/push"
-        headers = { "X-Scope-OrgID" = remote.kubernetes.secret.metrics_service.data["tenantId"] }
+        headers = { "X-Scope-OrgID" = nonsensitive(remote.kubernetes.secret.metrics_service.data["tenantId"]) }
     
         basic_auth {
           username = nonsensitive(remote.kubernetes.secret.metrics_service.data["username"])

--- a/examples/eks-fargate/metrics.river
+++ b/examples/eks-fargate/metrics.river
@@ -306,7 +306,7 @@ prometheus.relabel "metrics_service" {
 prometheus.remote_write "metrics_service" {
   endpoint {
     url = nonsensitive(remote.kubernetes.secret.metrics_service.data["host"]) + "/api/prom/push"
-    headers = { "X-Scope-OrgID" = remote.kubernetes.secret.metrics_service.data["tenantId"] }
+    headers = { "X-Scope-OrgID" = nonsensitive(remote.kubernetes.secret.metrics_service.data["tenantId"]) }
 
     basic_auth {
       username = nonsensitive(remote.kubernetes.secret.metrics_service.data["username"])

--- a/examples/eks-fargate/output.yaml
+++ b/examples/eks-fargate/output.yaml
@@ -384,7 +384,7 @@ data:
     prometheus.remote_write "metrics_service" {
       endpoint {
         url = nonsensitive(remote.kubernetes.secret.metrics_service.data["host"]) + "/api/prom/push"
-        headers = { "X-Scope-OrgID" = remote.kubernetes.secret.metrics_service.data["tenantId"] }
+        headers = { "X-Scope-OrgID" = nonsensitive(remote.kubernetes.secret.metrics_service.data["tenantId"]) }
     
         basic_auth {
           username = nonsensitive(remote.kubernetes.secret.metrics_service.data["username"])
@@ -43402,7 +43402,7 @@ data:
     prometheus.remote_write "metrics_service" {
       endpoint {
         url = nonsensitive(remote.kubernetes.secret.metrics_service.data["host"]) + "/api/prom/push"
-        headers = { "X-Scope-OrgID" = remote.kubernetes.secret.metrics_service.data["tenantId"] }
+        headers = { "X-Scope-OrgID" = nonsensitive(remote.kubernetes.secret.metrics_service.data["tenantId"]) }
     
         basic_auth {
           username = nonsensitive(remote.kubernetes.secret.metrics_service.data["username"])

--- a/examples/extra-rules/metrics.river
+++ b/examples/extra-rules/metrics.river
@@ -385,7 +385,7 @@ prometheus.relabel "metrics_service" {
 prometheus.remote_write "metrics_service" {
   endpoint {
     url = nonsensitive(remote.kubernetes.secret.metrics_service.data["host"]) + "/api/prom/push"
-    headers = { "X-Scope-OrgID" = remote.kubernetes.secret.metrics_service.data["tenantId"] }
+    headers = { "X-Scope-OrgID" = nonsensitive(remote.kubernetes.secret.metrics_service.data["tenantId"]) }
 
     basic_auth {
       username = nonsensitive(remote.kubernetes.secret.metrics_service.data["username"])

--- a/examples/extra-rules/output.yaml
+++ b/examples/extra-rules/output.yaml
@@ -492,7 +492,7 @@ data:
     prometheus.remote_write "metrics_service" {
       endpoint {
         url = nonsensitive(remote.kubernetes.secret.metrics_service.data["host"]) + "/api/prom/push"
-        headers = { "X-Scope-OrgID" = remote.kubernetes.secret.metrics_service.data["tenantId"] }
+        headers = { "X-Scope-OrgID" = nonsensitive(remote.kubernetes.secret.metrics_service.data["tenantId"]) }
     
         basic_auth {
           username = nonsensitive(remote.kubernetes.secret.metrics_service.data["username"])
@@ -44105,7 +44105,7 @@ data:
     prometheus.remote_write "metrics_service" {
       endpoint {
         url = nonsensitive(remote.kubernetes.secret.metrics_service.data["host"]) + "/api/prom/push"
-        headers = { "X-Scope-OrgID" = remote.kubernetes.secret.metrics_service.data["tenantId"] }
+        headers = { "X-Scope-OrgID" = nonsensitive(remote.kubernetes.secret.metrics_service.data["tenantId"]) }
     
         basic_auth {
           username = nonsensitive(remote.kubernetes.secret.metrics_service.data["username"])

--- a/examples/gke-autopilot/metrics.river
+++ b/examples/gke-autopilot/metrics.river
@@ -306,7 +306,7 @@ prometheus.relabel "metrics_service" {
 prometheus.remote_write "metrics_service" {
   endpoint {
     url = nonsensitive(remote.kubernetes.secret.metrics_service.data["host"]) + "/api/prom/push"
-    headers = { "X-Scope-OrgID" = remote.kubernetes.secret.metrics_service.data["tenantId"] }
+    headers = { "X-Scope-OrgID" = nonsensitive(remote.kubernetes.secret.metrics_service.data["tenantId"]) }
 
     basic_auth {
       username = nonsensitive(remote.kubernetes.secret.metrics_service.data["username"])

--- a/examples/gke-autopilot/output.yaml
+++ b/examples/gke-autopilot/output.yaml
@@ -397,7 +397,7 @@ data:
     prometheus.remote_write "metrics_service" {
       endpoint {
         url = nonsensitive(remote.kubernetes.secret.metrics_service.data["host"]) + "/api/prom/push"
-        headers = { "X-Scope-OrgID" = remote.kubernetes.secret.metrics_service.data["tenantId"] }
+        headers = { "X-Scope-OrgID" = nonsensitive(remote.kubernetes.secret.metrics_service.data["tenantId"]) }
     
         basic_auth {
           username = nonsensitive(remote.kubernetes.secret.metrics_service.data["username"])
@@ -43760,7 +43760,7 @@ data:
     prometheus.remote_write "metrics_service" {
       endpoint {
         url = nonsensitive(remote.kubernetes.secret.metrics_service.data["host"]) + "/api/prom/push"
-        headers = { "X-Scope-OrgID" = remote.kubernetes.secret.metrics_service.data["tenantId"] }
+        headers = { "X-Scope-OrgID" = nonsensitive(remote.kubernetes.secret.metrics_service.data["tenantId"]) }
     
         basic_auth {
           username = nonsensitive(remote.kubernetes.secret.metrics_service.data["username"])

--- a/examples/metrics-only/metrics.river
+++ b/examples/metrics-only/metrics.river
@@ -345,7 +345,7 @@ prometheus.relabel "metrics_service" {
 prometheus.remote_write "metrics_service" {
   endpoint {
     url = nonsensitive(remote.kubernetes.secret.metrics_service.data["host"]) + "/api/prom/push"
-    headers = { "X-Scope-OrgID" = remote.kubernetes.secret.metrics_service.data["tenantId"] }
+    headers = { "X-Scope-OrgID" = nonsensitive(remote.kubernetes.secret.metrics_service.data["tenantId"]) }
 
     basic_auth {
       username = nonsensitive(remote.kubernetes.secret.metrics_service.data["username"])

--- a/examples/metrics-only/output.yaml
+++ b/examples/metrics-only/output.yaml
@@ -426,7 +426,7 @@ data:
     prometheus.remote_write "metrics_service" {
       endpoint {
         url = nonsensitive(remote.kubernetes.secret.metrics_service.data["host"]) + "/api/prom/push"
-        headers = { "X-Scope-OrgID" = remote.kubernetes.secret.metrics_service.data["tenantId"] }
+        headers = { "X-Scope-OrgID" = nonsensitive(remote.kubernetes.secret.metrics_service.data["tenantId"]) }
     
         basic_auth {
           username = nonsensitive(remote.kubernetes.secret.metrics_service.data["username"])
@@ -43598,7 +43598,7 @@ data:
     prometheus.remote_write "metrics_service" {
       endpoint {
         url = nonsensitive(remote.kubernetes.secret.metrics_service.data["host"]) + "/api/prom/push"
-        headers = { "X-Scope-OrgID" = remote.kubernetes.secret.metrics_service.data["tenantId"] }
+        headers = { "X-Scope-OrgID" = nonsensitive(remote.kubernetes.secret.metrics_service.data["tenantId"]) }
     
         basic_auth {
           username = nonsensitive(remote.kubernetes.secret.metrics_service.data["username"])

--- a/examples/openshift-compatible/metrics.river
+++ b/examples/openshift-compatible/metrics.river
@@ -346,7 +346,7 @@ prometheus.relabel "metrics_service" {
 prometheus.remote_write "metrics_service" {
   endpoint {
     url = nonsensitive(remote.kubernetes.secret.metrics_service.data["host"]) + "/api/prom/push"
-    headers = { "X-Scope-OrgID" = remote.kubernetes.secret.metrics_service.data["tenantId"] }
+    headers = { "X-Scope-OrgID" = nonsensitive(remote.kubernetes.secret.metrics_service.data["tenantId"]) }
     proxy_url = "http://192.168.1.100:8080"
 
     basic_auth {

--- a/examples/openshift-compatible/output.yaml
+++ b/examples/openshift-compatible/output.yaml
@@ -421,7 +421,7 @@ data:
     prometheus.remote_write "metrics_service" {
       endpoint {
         url = nonsensitive(remote.kubernetes.secret.metrics_service.data["host"]) + "/api/prom/push"
-        headers = { "X-Scope-OrgID" = remote.kubernetes.secret.metrics_service.data["tenantId"] }
+        headers = { "X-Scope-OrgID" = nonsensitive(remote.kubernetes.secret.metrics_service.data["tenantId"]) }
         proxy_url = "http://192.168.1.100:8080"
     
         basic_auth {
@@ -43644,7 +43644,7 @@ data:
     prometheus.remote_write "metrics_service" {
       endpoint {
         url = nonsensitive(remote.kubernetes.secret.metrics_service.data["host"]) + "/api/prom/push"
-        headers = { "X-Scope-OrgID" = remote.kubernetes.secret.metrics_service.data["tenantId"] }
+        headers = { "X-Scope-OrgID" = nonsensitive(remote.kubernetes.secret.metrics_service.data["tenantId"]) }
         proxy_url = "http://192.168.1.100:8080"
     
         basic_auth {

--- a/examples/private-image-registry/metrics.river
+++ b/examples/private-image-registry/metrics.river
@@ -345,7 +345,7 @@ prometheus.relabel "metrics_service" {
 prometheus.remote_write "metrics_service" {
   endpoint {
     url = nonsensitive(remote.kubernetes.secret.metrics_service.data["host"]) + "/api/prom/push"
-    headers = { "X-Scope-OrgID" = remote.kubernetes.secret.metrics_service.data["tenantId"] }
+    headers = { "X-Scope-OrgID" = nonsensitive(remote.kubernetes.secret.metrics_service.data["tenantId"]) }
 
     basic_auth {
       username = nonsensitive(remote.kubernetes.secret.metrics_service.data["username"])

--- a/examples/private-image-registry/output.yaml
+++ b/examples/private-image-registry/output.yaml
@@ -454,7 +454,7 @@ data:
     prometheus.remote_write "metrics_service" {
       endpoint {
         url = nonsensitive(remote.kubernetes.secret.metrics_service.data["host"]) + "/api/prom/push"
-        headers = { "X-Scope-OrgID" = remote.kubernetes.secret.metrics_service.data["tenantId"] }
+        headers = { "X-Scope-OrgID" = nonsensitive(remote.kubernetes.secret.metrics_service.data["tenantId"]) }
     
         basic_auth {
           username = nonsensitive(remote.kubernetes.secret.metrics_service.data["username"])
@@ -44007,7 +44007,7 @@ data:
     prometheus.remote_write "metrics_service" {
       endpoint {
         url = nonsensitive(remote.kubernetes.secret.metrics_service.data["host"]) + "/api/prom/push"
-        headers = { "X-Scope-OrgID" = remote.kubernetes.secret.metrics_service.data["tenantId"] }
+        headers = { "X-Scope-OrgID" = nonsensitive(remote.kubernetes.secret.metrics_service.data["tenantId"]) }
     
         basic_auth {
           username = nonsensitive(remote.kubernetes.secret.metrics_service.data["username"])

--- a/examples/proxies/metrics.river
+++ b/examples/proxies/metrics.river
@@ -345,7 +345,7 @@ prometheus.relabel "metrics_service" {
 prometheus.remote_write "metrics_service" {
   endpoint {
     url = nonsensitive(remote.kubernetes.secret.metrics_service.data["host"]) + "/api/prom/push"
-    headers = { "X-Scope-OrgID" = remote.kubernetes.secret.metrics_service.data["tenantId"] }
+    headers = { "X-Scope-OrgID" = nonsensitive(remote.kubernetes.secret.metrics_service.data["tenantId"]) }
     proxy_url = "https://localhost:8080"
 
     basic_auth {

--- a/examples/proxies/output.yaml
+++ b/examples/proxies/output.yaml
@@ -451,7 +451,7 @@ data:
     prometheus.remote_write "metrics_service" {
       endpoint {
         url = nonsensitive(remote.kubernetes.secret.metrics_service.data["host"]) + "/api/prom/push"
-        headers = { "X-Scope-OrgID" = remote.kubernetes.secret.metrics_service.data["tenantId"] }
+        headers = { "X-Scope-OrgID" = nonsensitive(remote.kubernetes.secret.metrics_service.data["tenantId"]) }
         proxy_url = "https://localhost:8080"
     
         basic_auth {
@@ -44006,7 +44006,7 @@ data:
     prometheus.remote_write "metrics_service" {
       endpoint {
         url = nonsensitive(remote.kubernetes.secret.metrics_service.data["host"]) + "/api/prom/push"
-        headers = { "X-Scope-OrgID" = remote.kubernetes.secret.metrics_service.data["tenantId"] }
+        headers = { "X-Scope-OrgID" = nonsensitive(remote.kubernetes.secret.metrics_service.data["tenantId"]) }
         proxy_url = "https://localhost:8080"
     
         basic_auth {

--- a/examples/scrape-intervals/metrics.river
+++ b/examples/scrape-intervals/metrics.river
@@ -345,7 +345,7 @@ prometheus.relabel "metrics_service" {
 prometheus.remote_write "metrics_service" {
   endpoint {
     url = nonsensitive(remote.kubernetes.secret.metrics_service.data["host"]) + "/api/prom/push"
-    headers = { "X-Scope-OrgID" = remote.kubernetes.secret.metrics_service.data["tenantId"] }
+    headers = { "X-Scope-OrgID" = nonsensitive(remote.kubernetes.secret.metrics_service.data["tenantId"]) }
 
     basic_auth {
       username = nonsensitive(remote.kubernetes.secret.metrics_service.data["username"])

--- a/examples/scrape-intervals/output.yaml
+++ b/examples/scrape-intervals/output.yaml
@@ -425,7 +425,7 @@ data:
     prometheus.remote_write "metrics_service" {
       endpoint {
         url = nonsensitive(remote.kubernetes.secret.metrics_service.data["host"]) + "/api/prom/push"
-        headers = { "X-Scope-OrgID" = remote.kubernetes.secret.metrics_service.data["tenantId"] }
+        headers = { "X-Scope-OrgID" = nonsensitive(remote.kubernetes.secret.metrics_service.data["tenantId"]) }
     
         basic_auth {
           username = nonsensitive(remote.kubernetes.secret.metrics_service.data["username"])
@@ -43597,7 +43597,7 @@ data:
     prometheus.remote_write "metrics_service" {
       endpoint {
         url = nonsensitive(remote.kubernetes.secret.metrics_service.data["host"]) + "/api/prom/push"
-        headers = { "X-Scope-OrgID" = remote.kubernetes.secret.metrics_service.data["tenantId"] }
+        headers = { "X-Scope-OrgID" = nonsensitive(remote.kubernetes.secret.metrics_service.data["tenantId"]) }
     
         basic_auth {
           username = nonsensitive(remote.kubernetes.secret.metrics_service.data["username"])

--- a/examples/specific-namespace/metrics.river
+++ b/examples/specific-namespace/metrics.river
@@ -390,7 +390,7 @@ prometheus.relabel "metrics_service" {
 prometheus.remote_write "metrics_service" {
   endpoint {
     url = nonsensitive(remote.kubernetes.secret.metrics_service.data["host"]) + "/api/prom/push"
-    headers = { "X-Scope-OrgID" = remote.kubernetes.secret.metrics_service.data["tenantId"] }
+    headers = { "X-Scope-OrgID" = nonsensitive(remote.kubernetes.secret.metrics_service.data["tenantId"]) }
 
     basic_auth {
       username = nonsensitive(remote.kubernetes.secret.metrics_service.data["username"])

--- a/examples/specific-namespace/output.yaml
+++ b/examples/specific-namespace/output.yaml
@@ -496,7 +496,7 @@ data:
     prometheus.remote_write "metrics_service" {
       endpoint {
         url = nonsensitive(remote.kubernetes.secret.metrics_service.data["host"]) + "/api/prom/push"
-        headers = { "X-Scope-OrgID" = remote.kubernetes.secret.metrics_service.data["tenantId"] }
+        headers = { "X-Scope-OrgID" = nonsensitive(remote.kubernetes.secret.metrics_service.data["tenantId"]) }
     
         basic_auth {
           username = nonsensitive(remote.kubernetes.secret.metrics_service.data["username"])
@@ -44090,7 +44090,7 @@ data:
     prometheus.remote_write "metrics_service" {
       endpoint {
         url = nonsensitive(remote.kubernetes.secret.metrics_service.data["host"]) + "/api/prom/push"
-        headers = { "X-Scope-OrgID" = remote.kubernetes.secret.metrics_service.data["tenantId"] }
+        headers = { "X-Scope-OrgID" = nonsensitive(remote.kubernetes.secret.metrics_service.data["tenantId"]) }
     
         basic_auth {
           username = nonsensitive(remote.kubernetes.secret.metrics_service.data["username"])

--- a/examples/traces-enabled/metrics.river
+++ b/examples/traces-enabled/metrics.river
@@ -345,7 +345,7 @@ prometheus.relabel "metrics_service" {
 prometheus.remote_write "metrics_service" {
   endpoint {
     url = nonsensitive(remote.kubernetes.secret.metrics_service.data["host"]) + "/api/prom/push"
-    headers = { "X-Scope-OrgID" = remote.kubernetes.secret.metrics_service.data["tenantId"] }
+    headers = { "X-Scope-OrgID" = nonsensitive(remote.kubernetes.secret.metrics_service.data["tenantId"]) }
 
     basic_auth {
       username = nonsensitive(remote.kubernetes.secret.metrics_service.data["username"])
@@ -443,6 +443,6 @@ otelcol.exporter.otlp "traces_service" {
     endpoint = nonsensitive(remote.kubernetes.secret.traces_service.data["host"])
 
     auth = otelcol.auth.basic.traces_service.handler
-    headers = { "X-Scope-OrgID" = remote.kubernetes.secret.traces_service.data["tenantId"] }
+    headers = { "X-Scope-OrgID" = nonsensitive(remote.kubernetes.secret.traces_service.data["tenantId"]) }
   }
 }

--- a/examples/traces-enabled/output.yaml
+++ b/examples/traces-enabled/output.yaml
@@ -464,7 +464,7 @@ data:
     prometheus.remote_write "metrics_service" {
       endpoint {
         url = nonsensitive(remote.kubernetes.secret.metrics_service.data["host"]) + "/api/prom/push"
-        headers = { "X-Scope-OrgID" = remote.kubernetes.secret.metrics_service.data["tenantId"] }
+        headers = { "X-Scope-OrgID" = nonsensitive(remote.kubernetes.secret.metrics_service.data["tenantId"]) }
     
         basic_auth {
           username = nonsensitive(remote.kubernetes.secret.metrics_service.data["username"])
@@ -562,7 +562,7 @@ data:
         endpoint = nonsensitive(remote.kubernetes.secret.traces_service.data["host"])
     
         auth = otelcol.auth.basic.traces_service.handler
-        headers = { "X-Scope-OrgID" = remote.kubernetes.secret.traces_service.data["tenantId"] }
+        headers = { "X-Scope-OrgID" = nonsensitive(remote.kubernetes.secret.traces_service.data["tenantId"]) }
       }
     }
 ---
@@ -44102,7 +44102,7 @@ data:
     prometheus.remote_write "metrics_service" {
       endpoint {
         url = nonsensitive(remote.kubernetes.secret.metrics_service.data["host"]) + "/api/prom/push"
-        headers = { "X-Scope-OrgID" = remote.kubernetes.secret.metrics_service.data["tenantId"] }
+        headers = { "X-Scope-OrgID" = nonsensitive(remote.kubernetes.secret.metrics_service.data["tenantId"]) }
     
         basic_auth {
           username = nonsensitive(remote.kubernetes.secret.metrics_service.data["username"])
@@ -44200,7 +44200,7 @@ data:
         endpoint = nonsensitive(remote.kubernetes.secret.traces_service.data["host"])
     
         auth = otelcol.auth.basic.traces_service.handler
-        headers = { "X-Scope-OrgID" = remote.kubernetes.secret.traces_service.data["tenantId"] }
+        headers = { "X-Scope-OrgID" = nonsensitive(remote.kubernetes.secret.traces_service.data["tenantId"]) }
       }
     }
   logs.river: |-

--- a/examples/windows-exporter/metrics.river
+++ b/examples/windows-exporter/metrics.river
@@ -413,7 +413,7 @@ prometheus.relabel "metrics_service" {
 prometheus.remote_write "metrics_service" {
   endpoint {
     url = nonsensitive(remote.kubernetes.secret.metrics_service.data["host"]) + "/api/prom/push"
-    headers = { "X-Scope-OrgID" = remote.kubernetes.secret.metrics_service.data["tenantId"] }
+    headers = { "X-Scope-OrgID" = nonsensitive(remote.kubernetes.secret.metrics_service.data["tenantId"]) }
 
     basic_auth {
       username = nonsensitive(remote.kubernetes.secret.metrics_service.data["username"])

--- a/examples/windows-exporter/output.yaml
+++ b/examples/windows-exporter/output.yaml
@@ -556,7 +556,7 @@ data:
     prometheus.remote_write "metrics_service" {
       endpoint {
         url = nonsensitive(remote.kubernetes.secret.metrics_service.data["host"]) + "/api/prom/push"
-        headers = { "X-Scope-OrgID" = remote.kubernetes.secret.metrics_service.data["tenantId"] }
+        headers = { "X-Scope-OrgID" = nonsensitive(remote.kubernetes.secret.metrics_service.data["tenantId"]) }
     
         basic_auth {
           username = nonsensitive(remote.kubernetes.secret.metrics_service.data["username"])
@@ -44293,7 +44293,7 @@ data:
     prometheus.remote_write "metrics_service" {
       endpoint {
         url = nonsensitive(remote.kubernetes.secret.metrics_service.data["host"]) + "/api/prom/push"
-        headers = { "X-Scope-OrgID" = remote.kubernetes.secret.metrics_service.data["tenantId"] }
+        headers = { "X-Scope-OrgID" = nonsensitive(remote.kubernetes.secret.metrics_service.data["tenantId"]) }
     
         basic_auth {
           username = nonsensitive(remote.kubernetes.secret.metrics_service.data["username"])

--- a/scripts/install-deps.sh
+++ b/scripts/install-deps.sh
@@ -2,7 +2,7 @@
 
 if [ "$(uname)" == "Darwin" ]; then
   echo "Using brew to install dependencies"
-  brew install chart-testing grafana-agent helm norwoodj/tap/helm-docs yamllint python-yq
+  brew install chart-testing grafana-agent helm norwoodj/tap/helm-docs shellspec yamllint python-yq
 else 
   echo "Not on a Mac, skipping brew installs"
 fi


### PR DESCRIPTION
Missing `nonsensitive()` wrapper, I fixed all occurrences found by the following search:

```shell
git grep remote.kubernetes.secret.metrics_service.data | grep -v nonsensitive | grep -v password
```

CI doesn't seem to fail, not sure why, so I validated manually locally:

```shell
$ helm install -f examples/metrics-only/values.yaml skl ./charts/k8s-monitoring

$ k get po
NAME                                      READY   STATUS    RESTARTS   AGE
skl-grafana-agent-0                       2/2     Running   0          8m53s
```

Fixes #258