### PR TITLE
fix: Prepare for agent inverting default debug_metrics value

### DIFF
--- a/charts/k8s-monitoring/templates/agent_config/_traces.river.txt
+++ b/charts/k8s-monitoring/templates/agent_config/_traces.river.txt
@@ -5,12 +5,13 @@
 // Traces
 {{- if (or .Values.traces.receiver.grpc.enabled .Values.traces.receiver.http.enabled) }}
 otelcol.receiver.otlp "trace_receiver" {
-
-{{- if or .Values.traces.receiver.grpc.disable_debug_metrics .Values.traces.receiver.http.disable_debug_metrics }}
   debug_metrics {
+    {{- if or .Values.traces.receiver.grpc.disable_debug_metrics .Values.traces.receiver.http.disable_debug_metrics }}
     disable_high_cardinality_metrics = true
+    {{- else }}
+    disable_high_cardinality_metrics = false
+    {{- end }}
   }
-{{- end }}
 
 {{- if or .Values.traces.receiver.port .Values.traces.receiver.grpc.enabled }}
 {{$data := dict "port" (.Values.traces.receiver.port | default .Values.traces.receiver.grpc.port) "type" "OTLP gRPC" "agent" (index .Values "grafana-agent").agent }}
@@ -34,11 +35,9 @@ otelcol.receiver.otlp "trace_receiver" {
 
 {{- if .Values.traces.receiver.zipkin.enabled }}
 otelcol.receiver.zipkin "trace_receiver" {
-{{- if .Values.traces.receiver.zipkin.disable_debug_metrics }}
   debug_metrics {
-    disable_high_cardinality_metrics = true
+    disable_high_cardinality_metrics = {{ .Values.traces.receiver.zipkin.disable_debug_metrics }}
   }
-{{- end }}
 
 {{$data := dict "port" .Values.traces.receiver.zipkin.port "type" "Zipkin" "agent" (index .Values "grafana-agent").agent }}
 


### PR DESCRIPTION
See [internal slack discussion](https://raintank-corp.slack.com/archives/CSN5HV0CQ/p1700825749658259?thread_ts=1700746376.176619&cid=CSN5HV0CQ), Agent team is looking at disabling debug metrics by default, which is the opposite of the current default.

This means a slight change in logic required for the recent change introduced in #262, to be explict about the value instead of relying on the default.