### PR TITLE
When determining when to run the tests, check against the latest release, not against main

### DIFF
--- a/.github/workflows/helm-test.yml
+++ b/.github/workflows/helm-test.yml
@@ -124,7 +124,8 @@ jobs:
     - name: List changed charts
       id: list-changed
       run: |
-        changed=$(ct list-changed --config "${CT_CONFIGFILE}")
+        latestRelease=$(git describe --abbrev=0 --tags)
+        changed=$(ct list-changed --config "${CT_CONFIGFILE}" --since "${latestRelease}")
         if [[ -n "$changed" ]]; then
           echo "changed=true" >> "${GITHUB_OUTPUT}"
         fi


### PR DESCRIPTION
`git describe --abbrev=0 --tags` gets the latest release (as a git tag).
`ct list-changes` takes a `--since` which uses a git tag.