### PR TITLE
feat: add support for forwarding cluster events as `json` logs

### DIFF
--- a/charts/k8s-monitoring/README.md
+++ b/charts/k8s-monitoring/README.md
@@ -162,6 +162,7 @@ The Prometheus and Loki services may be hosted on the same cluster, or remotely 
 | global.image.registry | string | `""` | Global image registry to use if it needs to be overriden for some specific use cases (e.g local registries, custom images, ...) |
 | kube-state-metrics.enabled | bool | `true` | Should this helm chart deploy Kube State Metrics to the cluster. Set this to false if your cluster already has Kube State Metrics, or if you do not want to scrape metrics from Kube State Metrics. |
 | logs.cluster_events.enabled | bool | `true` | Scrape Kubernetes cluster events |
+| logs.cluster_events.logFormat | string | `"logfmt"` | Log format used to forward cluster events. Allowed values: `logfmt` (default), `json`. |
 | logs.cluster_events.namespaces | list | `[]` | List of namespaces to watch for events (`[]` means all namespaces) |
 | logs.enabled | bool | `true` | Capture and forward logs |
 | logs.extraConfig | string | `""` | Extra configuration that will be added to Grafana Agent Logs configuration file. This cannot be used to modify the generated configuration values, only append new components. See [Adding custom Flow configuration](#adding-custom-flow-configuration) for an example. |

--- a/charts/k8s-monitoring/templates/agent_config/_cluster_events.river.txt
+++ b/charts/k8s-monitoring/templates/agent_config/_cluster_events.river.txt
@@ -3,6 +3,7 @@
 // Cluster Events
 loki.source.kubernetes_events "cluster_events" {
   job_name   = "integrations/kubernetes/eventhandler"
+  log_format = "{{ .logFormat }}"
 {{- if .namespaces }}
   namespaces = {{ .namespaces | toJson }}
 {{- end }}

--- a/charts/k8s-monitoring/values.schema.json
+++ b/charts/k8s-monitoring/values.schema.json
@@ -385,6 +385,13 @@
                         "enabled": {
                             "type": "boolean"
                         },
+                        "logFormat": {
+                            "type": "string",
+                            "enum": [
+                                "logfmt",
+                                "json"
+                            ]
+                        },
                         "namespaces": {
                             "type": "array"
                         }

--- a/charts/k8s-monitoring/values.yaml
+++ b/charts/k8s-monitoring/values.yaml
@@ -726,6 +726,9 @@ logs:
     # -- Scrape Kubernetes cluster events
     enabled: true
 
+    # -- Log format used to forward cluster events. Allowed values: `logfmt` (default), `json`.
+    logFormat: "logfmt"
+
     # -- List of namespaces to watch for events (`[]` means all namespaces)
     namespaces: []
 

--- a/examples/control-plane-metrics/events.river
+++ b/examples/control-plane-metrics/events.river
@@ -1,6 +1,7 @@
 // Cluster Events
 loki.source.kubernetes_events "cluster_events" {
   job_name   = "integrations/kubernetes/eventhandler"
+  log_format = "logfmt"
   forward_to = [loki.write.grafana_cloud_loki.receiver]
 }
 

--- a/examples/control-plane-metrics/output.yaml
+++ b/examples/control-plane-metrics/output.yaml
@@ -926,6 +926,7 @@ data:
     // Cluster Events
     loki.source.kubernetes_events "cluster_events" {
       job_name   = "integrations/kubernetes/eventhandler"
+      log_format = "logfmt"
       forward_to = [loki.write.grafana_cloud_loki.receiver]
     }
     
@@ -45625,6 +45626,7 @@ data:
     // Cluster Events
     loki.source.kubernetes_events "cluster_events" {
       job_name   = "integrations/kubernetes/eventhandler"
+      log_format = "logfmt"
       forward_to = [loki.write.grafana_cloud_loki.receiver]
     }
     

--- a/examples/custom-config/events.river
+++ b/examples/custom-config/events.river
@@ -1,6 +1,7 @@
 // Cluster Events
 loki.source.kubernetes_events "cluster_events" {
   job_name   = "integrations/kubernetes/eventhandler"
+  log_format = "logfmt"
   forward_to = [loki.write.grafana_cloud_loki.receiver]
 }
 

--- a/examples/custom-config/output.yaml
+++ b/examples/custom-config/output.yaml
@@ -797,6 +797,7 @@ data:
     // Cluster Events
     loki.source.kubernetes_events "cluster_events" {
       job_name   = "integrations/kubernetes/eventhandler"
+      log_format = "logfmt"
       forward_to = [loki.write.grafana_cloud_loki.receiver]
     }
     
@@ -45407,6 +45408,7 @@ data:
     // Cluster Events
     loki.source.kubernetes_events "cluster_events" {
       job_name   = "integrations/kubernetes/eventhandler"
+      log_format = "logfmt"
       forward_to = [loki.write.grafana_cloud_loki.receiver]
     }
     

--- a/examples/default-values/events.river
+++ b/examples/default-values/events.river
@@ -1,6 +1,7 @@
 // Cluster Events
 loki.source.kubernetes_events "cluster_events" {
   job_name   = "integrations/kubernetes/eventhandler"
+  log_format = "logfmt"
   forward_to = [loki.write.grafana_cloud_loki.receiver]
 }
 

--- a/examples/default-values/output.yaml
+++ b/examples/default-values/output.yaml
@@ -773,6 +773,7 @@ data:
     // Cluster Events
     loki.source.kubernetes_events "cluster_events" {
       job_name   = "integrations/kubernetes/eventhandler"
+      log_format = "logfmt"
       forward_to = [loki.write.grafana_cloud_loki.receiver]
     }
     
@@ -45320,6 +45321,7 @@ data:
     // Cluster Events
     loki.source.kubernetes_events "cluster_events" {
       job_name   = "integrations/kubernetes/eventhandler"
+      log_format = "logfmt"
       forward_to = [loki.write.grafana_cloud_loki.receiver]
     }
     

--- a/examples/eks-fargate/events.river
+++ b/examples/eks-fargate/events.river
@@ -1,6 +1,7 @@
 // Cluster Events
 loki.source.kubernetes_events "cluster_events" {
   job_name   = "integrations/kubernetes/eventhandler"
+  log_format = "logfmt"
   forward_to = [loki.write.grafana_cloud_loki.receiver]
 }
 

--- a/examples/eks-fargate/output.yaml
+++ b/examples/eks-fargate/output.yaml
@@ -719,6 +719,7 @@ data:
     // Cluster Events
     loki.source.kubernetes_events "cluster_events" {
       job_name   = "integrations/kubernetes/eventhandler"
+      log_format = "logfmt"
       forward_to = [loki.write.grafana_cloud_loki.receiver]
     }
     
@@ -45100,6 +45101,7 @@ data:
     // Cluster Events
     loki.source.kubernetes_events "cluster_events" {
       job_name   = "integrations/kubernetes/eventhandler"
+      log_format = "logfmt"
       forward_to = [loki.write.grafana_cloud_loki.receiver]
     }
     

--- a/examples/extra-rules/events.river
+++ b/examples/extra-rules/events.river
@@ -1,6 +1,7 @@
 // Cluster Events
 loki.source.kubernetes_events "cluster_events" {
   job_name   = "integrations/kubernetes/eventhandler"
+  log_format = "logfmt"
   forward_to = [loki.write.grafana_cloud_loki.receiver]
 }
 

--- a/examples/extra-rules/output.yaml
+++ b/examples/extra-rules/output.yaml
@@ -830,6 +830,7 @@ data:
     // Cluster Events
     loki.source.kubernetes_events "cluster_events" {
       job_name   = "integrations/kubernetes/eventhandler"
+      log_format = "logfmt"
       forward_to = [loki.write.grafana_cloud_loki.receiver]
     }
     
@@ -45457,6 +45458,7 @@ data:
     // Cluster Events
     loki.source.kubernetes_events "cluster_events" {
       job_name   = "integrations/kubernetes/eventhandler"
+      log_format = "logfmt"
       forward_to = [loki.write.grafana_cloud_loki.receiver]
     }
     

--- a/examples/gke-autopilot/events.river
+++ b/examples/gke-autopilot/events.river
@@ -1,6 +1,7 @@
 // Cluster Events
 loki.source.kubernetes_events "cluster_events" {
   job_name   = "integrations/kubernetes/eventhandler"
+  log_format = "logfmt"
   forward_to = [loki.write.grafana_cloud_loki.receiver]
 }
 

--- a/examples/gke-autopilot/output.yaml
+++ b/examples/gke-autopilot/output.yaml
@@ -719,6 +719,7 @@ data:
     // Cluster Events
     loki.source.kubernetes_events "cluster_events" {
       job_name   = "integrations/kubernetes/eventhandler"
+      log_format = "logfmt"
       forward_to = [loki.write.grafana_cloud_loki.receiver]
     }
     
@@ -45086,6 +45087,7 @@ data:
     // Cluster Events
     loki.source.kubernetes_events "cluster_events" {
       job_name   = "integrations/kubernetes/eventhandler"
+      log_format = "logfmt"
       forward_to = [loki.write.grafana_cloud_loki.receiver]
     }
     

--- a/examples/ibm-cloud/events.river
+++ b/examples/ibm-cloud/events.river
@@ -1,6 +1,7 @@
 // Cluster Events
 loki.source.kubernetes_events "cluster_events" {
   job_name   = "integrations/kubernetes/eventhandler"
+  log_format = "logfmt"
   forward_to = [loki.write.grafana_cloud_loki.receiver]
 }
 

--- a/examples/ibm-cloud/output.yaml
+++ b/examples/ibm-cloud/output.yaml
@@ -773,6 +773,7 @@ data:
     // Cluster Events
     loki.source.kubernetes_events "cluster_events" {
       job_name   = "integrations/kubernetes/eventhandler"
+      log_format = "logfmt"
       forward_to = [loki.write.grafana_cloud_loki.receiver]
     }
     
@@ -45326,6 +45327,7 @@ data:
     // Cluster Events
     loki.source.kubernetes_events "cluster_events" {
       job_name   = "integrations/kubernetes/eventhandler"
+      log_format = "logfmt"
       forward_to = [loki.write.grafana_cloud_loki.receiver]
     }
     

--- a/examples/logs-only/events.river
+++ b/examples/logs-only/events.river
@@ -1,6 +1,7 @@
 // Cluster Events
 loki.source.kubernetes_events "cluster_events" {
   job_name   = "integrations/kubernetes/eventhandler"
+  log_format = "logfmt"
   forward_to = [loki.write.grafana_cloud_loki.receiver]
 }
 

--- a/examples/logs-only/output.yaml
+++ b/examples/logs-only/output.yaml
@@ -169,6 +169,7 @@ data:
     // Cluster Events
     loki.source.kubernetes_events "cluster_events" {
       job_name   = "integrations/kubernetes/eventhandler"
+      log_format = "logfmt"
       forward_to = [loki.write.grafana_cloud_loki.receiver]
     }
     
@@ -1215,6 +1216,7 @@ data:
     // Cluster Events
     loki.source.kubernetes_events "cluster_events" {
       job_name   = "integrations/kubernetes/eventhandler"
+      log_format = "logfmt"
       forward_to = [loki.write.grafana_cloud_loki.receiver]
     }
     

--- a/examples/openshift-compatible/events.river
+++ b/examples/openshift-compatible/events.river
@@ -1,6 +1,7 @@
 // Cluster Events
 loki.source.kubernetes_events "cluster_events" {
   job_name   = "integrations/kubernetes/eventhandler"
+  log_format = "logfmt"
   forward_to = [loki.write.grafana_cloud_loki.receiver]
 }
 

--- a/examples/openshift-compatible/output.yaml
+++ b/examples/openshift-compatible/output.yaml
@@ -746,6 +746,7 @@ data:
     // Cluster Events
     loki.source.kubernetes_events "cluster_events" {
       job_name   = "integrations/kubernetes/eventhandler"
+      log_format = "logfmt"
       forward_to = [loki.write.grafana_cloud_loki.receiver]
     }
     
@@ -44974,6 +44975,7 @@ data:
     // Cluster Events
     loki.source.kubernetes_events "cluster_events" {
       job_name   = "integrations/kubernetes/eventhandler"
+      log_format = "logfmt"
       forward_to = [loki.write.grafana_cloud_loki.receiver]
     }
     

--- a/examples/otel-metrics-service/events.river
+++ b/examples/otel-metrics-service/events.river
@@ -1,6 +1,7 @@
 // Cluster Events
 loki.source.kubernetes_events "cluster_events" {
   job_name   = "integrations/kubernetes/eventhandler"
+  log_format = "logfmt"
   forward_to = [loki.write.grafana_cloud_loki.receiver]
 }
 

--- a/examples/otel-metrics-service/output.yaml
+++ b/examples/otel-metrics-service/output.yaml
@@ -809,6 +809,7 @@ data:
     // Cluster Events
     loki.source.kubernetes_events "cluster_events" {
       job_name   = "integrations/kubernetes/eventhandler"
+      log_format = "logfmt"
       forward_to = [loki.write.grafana_cloud_loki.receiver]
     }
     
@@ -45392,6 +45393,7 @@ data:
     // Cluster Events
     loki.source.kubernetes_events "cluster_events" {
       job_name   = "integrations/kubernetes/eventhandler"
+      log_format = "logfmt"
       forward_to = [loki.write.grafana_cloud_loki.receiver]
     }
     

--- a/examples/private-image-registry/events.river
+++ b/examples/private-image-registry/events.river
@@ -1,6 +1,7 @@
 // Cluster Events
 loki.source.kubernetes_events "cluster_events" {
   job_name   = "integrations/kubernetes/eventhandler"
+  log_format = "logfmt"
   forward_to = [loki.write.grafana_cloud_loki.receiver]
 }
 

--- a/examples/private-image-registry/output.yaml
+++ b/examples/private-image-registry/output.yaml
@@ -777,6 +777,7 @@ data:
     // Cluster Events
     loki.source.kubernetes_events "cluster_events" {
       job_name   = "integrations/kubernetes/eventhandler"
+      log_format = "logfmt"
       forward_to = [loki.write.grafana_cloud_loki.receiver]
     }
     
@@ -45336,6 +45337,7 @@ data:
     // Cluster Events
     loki.source.kubernetes_events "cluster_events" {
       job_name   = "integrations/kubernetes/eventhandler"
+      log_format = "logfmt"
       forward_to = [loki.write.grafana_cloud_loki.receiver]
     }
     

--- a/examples/proxies/events.river
+++ b/examples/proxies/events.river
@@ -1,6 +1,7 @@
 // Cluster Events
 loki.source.kubernetes_events "cluster_events" {
   job_name   = "integrations/kubernetes/eventhandler"
+  log_format = "logfmt"
   forward_to = [loki.write.grafana_cloud_loki.receiver]
 }
 

--- a/examples/proxies/output.yaml
+++ b/examples/proxies/output.yaml
@@ -781,6 +781,7 @@ data:
     // Cluster Events
     loki.source.kubernetes_events "cluster_events" {
       job_name   = "integrations/kubernetes/eventhandler"
+      log_format = "logfmt"
       forward_to = [loki.write.grafana_cloud_loki.receiver]
     }
     
@@ -45344,6 +45345,7 @@ data:
     // Cluster Events
     loki.source.kubernetes_events "cluster_events" {
       job_name   = "integrations/kubernetes/eventhandler"
+      log_format = "logfmt"
       forward_to = [loki.write.grafana_cloud_loki.receiver]
     }
     

--- a/examples/service-integrations/events.river
+++ b/examples/service-integrations/events.river
@@ -1,6 +1,7 @@
 // Cluster Events
 loki.source.kubernetes_events "cluster_events" {
   job_name   = "integrations/kubernetes/eventhandler"
+  log_format = "logfmt"
   forward_to = [loki.write.grafana_cloud_loki.receiver]
 }
 

--- a/examples/service-integrations/output.yaml
+++ b/examples/service-integrations/output.yaml
@@ -793,6 +793,7 @@ data:
     // Cluster Events
     loki.source.kubernetes_events "cluster_events" {
       job_name   = "integrations/kubernetes/eventhandler"
+      log_format = "logfmt"
       forward_to = [loki.write.grafana_cloud_loki.receiver]
     }
     
@@ -45375,6 +45376,7 @@ data:
     // Cluster Events
     loki.source.kubernetes_events "cluster_events" {
       job_name   = "integrations/kubernetes/eventhandler"
+      log_format = "logfmt"
       forward_to = [loki.write.grafana_cloud_loki.receiver]
     }
     

--- a/examples/specific-namespace/events.river
+++ b/examples/specific-namespace/events.river
@@ -1,6 +1,7 @@
 // Cluster Events
 loki.source.kubernetes_events "cluster_events" {
   job_name   = "integrations/kubernetes/eventhandler"
+  log_format = "logfmt"
   namespaces = ["production","staging"]
   forward_to = [loki.write.grafana_cloud_loki.receiver]
 }

--- a/examples/specific-namespace/output.yaml
+++ b/examples/specific-namespace/output.yaml
@@ -823,6 +823,7 @@ data:
     // Cluster Events
     loki.source.kubernetes_events "cluster_events" {
       job_name   = "integrations/kubernetes/eventhandler"
+      log_format = "logfmt"
       namespaces = ["production","staging"]
       forward_to = [loki.write.grafana_cloud_loki.receiver]
     }
@@ -45426,6 +45427,7 @@ data:
     // Cluster Events
     loki.source.kubernetes_events "cluster_events" {
       job_name   = "integrations/kubernetes/eventhandler"
+      log_format = "logfmt"
       namespaces = ["production","staging"]
       forward_to = [loki.write.grafana_cloud_loki.receiver]
     }

--- a/examples/traces-enabled/events.river
+++ b/examples/traces-enabled/events.river
@@ -1,6 +1,7 @@
 // Cluster Events
 loki.source.kubernetes_events "cluster_events" {
   job_name   = "integrations/kubernetes/eventhandler"
+  log_format = "logfmt"
   forward_to = [loki.write.grafana_cloud_loki.receiver]
 }
 

--- a/examples/traces-enabled/output.yaml
+++ b/examples/traces-enabled/output.yaml
@@ -834,6 +834,7 @@ data:
     // Cluster Events
     loki.source.kubernetes_events "cluster_events" {
       job_name   = "integrations/kubernetes/eventhandler"
+      log_format = "logfmt"
       forward_to = [loki.write.grafana_cloud_loki.receiver]
     }
     
@@ -45429,6 +45430,7 @@ data:
     // Cluster Events
     loki.source.kubernetes_events "cluster_events" {
       job_name   = "integrations/kubernetes/eventhandler"
+      log_format = "logfmt"
       forward_to = [loki.write.grafana_cloud_loki.receiver]
     }
     

--- a/examples/windows-exporter/events.river
+++ b/examples/windows-exporter/events.river
@@ -1,6 +1,7 @@
 // Cluster Events
 loki.source.kubernetes_events "cluster_events" {
   job_name   = "integrations/kubernetes/eventhandler"
+  log_format = "logfmt"
   forward_to = [loki.write.grafana_cloud_loki.receiver]
 }
 

--- a/examples/windows-exporter/output.yaml
+++ b/examples/windows-exporter/output.yaml
@@ -878,6 +878,7 @@ data:
     // Cluster Events
     loki.source.kubernetes_events "cluster_events" {
       job_name   = "integrations/kubernetes/eventhandler"
+      log_format = "logfmt"
       forward_to = [loki.write.grafana_cloud_loki.receiver]
     }
     
@@ -45619,6 +45620,7 @@ data:
     // Cluster Events
     loki.source.kubernetes_events "cluster_events" {
       job_name   = "integrations/kubernetes/eventhandler"
+      log_format = "logfmt"
       forward_to = [loki.write.grafana_cloud_loki.receiver]
     }
     


### PR DESCRIPTION
### Summary

Add support for forwarding cluster events as `json` logs by adding a `logs.cluster_events.logFormat` input value.

### Notes

- This change is not breaking as it respects the current default log format (`logfmt`).
- `log_format` is a [field](https://grafana.com/docs/agent/latest/flow/reference/components/loki.source.kubernetes_events/#arguments) already supported by the `kubernetes_events` component.