### PR TITLE
Fix schema for annotations extra rules

### DIFF
--- a/charts/k8s-monitoring/README.md
+++ b/charts/k8s-monitoring/README.md
@@ -193,8 +193,8 @@ The Prometheus and Loki services may be hosted on the same cluster, or remotely 
 | metrics.autoDiscover.annotations.metricsScheme | string | `"k8s.grafana.com/metrics.scheme"` | Annotation for setting the metrics scheme, default: http. |
 | metrics.autoDiscover.annotations.scrape | string | `"k8s.grafana.com/scrape"` | Annotation for enabling scraping for this service or pod. Value should be either "true" or "false" |
 | metrics.autoDiscover.enabled | bool | `true` |  |
-| metrics.autoDiscover.extraMetricRelabelingRules | string | `nil` | Rule blocks to be added to the prometheus.relabel component for auto-discovered entities. See https://grafana.com/docs/agent/latest/flow/reference/components/prometheus.relabel/#rule-block |
-| metrics.autoDiscover.extraRelabelingRules | string | `nil` | Rule blocks to be added to the discovery.relabel component for auto-discovered entities. See https://grafana.com/docs/agent/latest/flow/reference/components/discovery.relabel/#rule-block |
+| metrics.autoDiscover.extraMetricRelabelingRules | string | `""` | Rule blocks to be added to the prometheus.relabel component for auto-discovered entities. See https://grafana.com/docs/agent/latest/flow/reference/components/prometheus.relabel/#rule-block |
+| metrics.autoDiscover.extraRelabelingRules | string | `""` | Rule blocks to be added to the discovery.relabel component for auto-discovered entities. See https://grafana.com/docs/agent/latest/flow/reference/components/discovery.relabel/#rule-block |
 | metrics.cadvisor.allowList | list | See [Allow List for cAdvisor](#allow-list-for-cadvisor) | The list of cAdvisor metrics that will be scraped by the Agent |
 | metrics.cadvisor.enabled | bool | `true` | Scrape container metrics from cAdvisor |
 | metrics.cadvisor.extraMetricRelabelingRules | string | `""` | Rule blocks to be added to the prometheus.relabel component for cAdvisor. See https://grafana.com/docs/agent/latest/flow/reference/components/prometheus.relabel/#rule-block |

--- a/charts/k8s-monitoring/values.schema.json
+++ b/charts/k8s-monitoring/values.schema.json
@@ -526,10 +526,10 @@
                             "type": "boolean"
                         },
                         "extraMetricRelabelingRules": {
-                            "type": "null"
+                            "type": "string"
                         },
                         "extraRelabelingRules": {
-                            "type": "null"
+                            "type": "string"
                         }
                     }
                 },

--- a/charts/k8s-monitoring/values.yaml
+++ b/charts/k8s-monitoring/values.yaml
@@ -211,11 +211,11 @@ metrics:
 
     # -- Rule blocks to be added to the discovery.relabel component for auto-discovered entities.
     # See https://grafana.com/docs/agent/latest/flow/reference/components/discovery.relabel/#rule-block
-    extraRelabelingRules:
+    extraRelabelingRules: ""
 
     # -- Rule blocks to be added to the prometheus.relabel component for auto-discovered entities.
     # See https://grafana.com/docs/agent/latest/flow/reference/components/prometheus.relabel/#rule-block
-    extraMetricRelabelingRules:
+    extraMetricRelabelingRules: ""
 
     # -- Annotations that are used to discover and configure metric scraping targets. Add these annotations
     # to your services or pods to control how autodiscovery will find and scrape metrics from your service or pod.


### PR DESCRIPTION
Because the values file entry was empty, the schema was generated to use "null" not "string".