### PR TITLE
feat: add support for customizing wal settings

### DIFF
--- a/charts/k8s-monitoring/README.md
+++ b/charts/k8s-monitoring/README.md
@@ -139,6 +139,9 @@ The Prometheus and Loki services may be hosted on the same cluster, or remotely 
 | externalServices.prometheus.tenantId | string | `""` | Sets the X-Scope-OrgID header when sending metrics |
 | externalServices.prometheus.tenantIdKey | string | `"tenantId"` | The key for the tenant ID property in the secret |
 | externalServices.prometheus.tls | object | `{}` | TLS setting to configure for the metrics service. For remoteWrite protocol, refer to https://grafana.com/docs/agent/latest/flow/reference/components/prometheus.remote_write/#tls_config-block For otlp protocol, refer to https://grafana.com/docs/agent/latest/flow/reference/components/otelcol.exporter.otlp/#tls-block For otlphttp protocol, refer to https://grafana.com/docs/agent/latest/flow/reference/components/otelcol.exporter.otlphttp/#tls-block |
+| externalServices.prometheus.wal.maxKeepaliveTime | string | `"8h"` | Maximum time to keep data in the WAL before removing it. |
+| externalServices.prometheus.wal.minKeepaliveTime | string | `"5m"` | Minimum time to keep data in the WAL before it can be removed. |
+| externalServices.prometheus.wal.truncateFrequency | string | `"2h"` | How frequently to clean up the WAL. |
 | externalServices.prometheus.writeEndpoint | string | `"/api/prom/push"` | Prometheus metrics write endpoint. Preset for Grafana Cloud Metrics instances. |
 | externalServices.prometheus.writeRelabelConfigRules | string | `""` | Rule blocks to be added to the write_relabel_config block of the prometheus.remote_write component. See https://grafana.com/docs/agent/latest/flow/reference/components/prometheus.remote_write/#write_relabel_config-block |
 | externalServices.tempo.authMode | string | `"basic"` | one of "none", "basic" |

--- a/charts/k8s-monitoring/templates/agent_config/_metrics_service_remote_write.river.txt
+++ b/charts/k8s-monitoring/templates/agent_config/_metrics_service_remote_write.river.txt
@@ -25,6 +25,12 @@ prometheus.remote_write "metrics_service" {
 {{- end }}
   }
 
+  wal {
+    truncate_frequency = {{ .wal.truncateFrequency | quote }}
+    min_keepalive_time = {{ .wal.minKeepaliveTime | quote }}
+    max_keepalive_time = {{ .wal.maxKeepaliveTime | quote }}
+  }
+
   external_labels = {
   {{- range $key, $value := .externalLabels }}
     {{ $key }} = {{ $value | quote }},

--- a/charts/k8s-monitoring/values.schema.json
+++ b/charts/k8s-monitoring/values.schema.json
@@ -228,6 +228,20 @@
                         "tls": {
                             "type": "object"
                         },
+                        "wal": {
+                            "type": "object",
+                            "properties": {
+                                "truncateFrequency": {
+                                    "type": "string"
+                                },
+                                "minKeepaliveTime": {
+                                    "type": "string"
+                                },
+                                "maxKeepaliveTime": {
+                                    "type": "string"
+                                }
+                            }
+                        },
                         "writeEndpoint": {
                             "type": "string"
                         },

--- a/charts/k8s-monitoring/values.yaml
+++ b/charts/k8s-monitoring/values.yaml
@@ -85,6 +85,17 @@ externalServices:
         checkInterval: 1s
         # -- Maximum amount of memory targeted to be allocated by the process heap.
         limit: 0MiB
+    
+    # Write-Ahead Log (WAL) settings. Only applies when protocol is "remote_write"
+    wal:
+      # -- How frequently to clean up the WAL.
+      truncateFrequency: 2h
+
+      # -- Minimum time to keep data in the WAL before it can be removed.
+      minKeepaliveTime: 5m
+
+      # -- Maximum time to keep data in the WAL before removing it.
+      maxKeepaliveTime: 8h
 
   # Connection information for Grafana Loki
   loki:

--- a/examples/control-plane-metrics/metrics.river
+++ b/examples/control-plane-metrics/metrics.river
@@ -768,6 +768,12 @@ prometheus.remote_write "metrics_service" {
 
   }
 
+  wal {
+    truncate_frequency = "2h"
+    min_keepalive_time = "5m"
+    max_keepalive_time = "8h"
+  }
+
   external_labels = {
   }
 }

--- a/examples/control-plane-metrics/output.yaml
+++ b/examples/control-plane-metrics/output.yaml
@@ -887,6 +887,12 @@ data:
     
       }
     
+      wal {
+        truncate_frequency = "2h"
+        min_keepalive_time = "5m"
+        max_keepalive_time = "8h"
+      }
+    
       external_labels = {
       }
     }
@@ -45593,6 +45599,12 @@ data:
           password = remote.kubernetes.secret.metrics_service.data["password"]
         }
     
+      }
+    
+      wal {
+        truncate_frequency = "2h"
+        min_keepalive_time = "5m"
+        max_keepalive_time = "8h"
       }
     
       external_labels = {

--- a/examples/custom-allow-lists/metrics.river
+++ b/examples/custom-allow-lists/metrics.river
@@ -611,6 +611,12 @@ prometheus.remote_write "metrics_service" {
 
   }
 
+  wal {
+    truncate_frequency = "2h"
+    min_keepalive_time = "5m"
+    max_keepalive_time = "8h"
+  }
+
   external_labels = {
   }
 }

--- a/examples/custom-allow-lists/output.yaml
+++ b/examples/custom-allow-lists/output.yaml
@@ -690,6 +690,12 @@ data:
     
       }
     
+      wal {
+        truncate_frequency = "2h"
+        min_keepalive_time = "5m"
+        max_keepalive_time = "8h"
+      }
+    
       external_labels = {
       }
     }
@@ -44614,6 +44620,12 @@ data:
           password = remote.kubernetes.secret.metrics_service.data["password"]
         }
     
+      }
+    
+      wal {
+        truncate_frequency = "2h"
+        min_keepalive_time = "5m"
+        max_keepalive_time = "8h"
       }
     
       external_labels = {

--- a/examples/custom-config/metrics.river
+++ b/examples/custom-config/metrics.river
@@ -616,6 +616,12 @@ prometheus.remote_write "metrics_service" {
 
   }
 
+  wal {
+    truncate_frequency = "2h"
+    min_keepalive_time = "5m"
+    max_keepalive_time = "8h"
+  }
+
   external_labels = {
     region = "southwest",
     tenant = "widgetco",

--- a/examples/custom-config/output.yaml
+++ b/examples/custom-config/output.yaml
@@ -734,6 +734,12 @@ data:
     
       }
     
+      wal {
+        truncate_frequency = "2h"
+        min_keepalive_time = "5m"
+        max_keepalive_time = "8h"
+      }
+    
       external_labels = {
         region = "southwest",
         tenant = "widgetco",
@@ -45351,6 +45357,12 @@ data:
           password = remote.kubernetes.secret.metrics_service.data["password"]
         }
     
+      }
+    
+      wal {
+        truncate_frequency = "2h"
+        min_keepalive_time = "5m"
+        max_keepalive_time = "8h"
       }
     
       external_labels = {

--- a/examples/default-values/metrics.river
+++ b/examples/default-values/metrics.river
@@ -616,6 +616,12 @@ prometheus.remote_write "metrics_service" {
 
   }
 
+  wal {
+    truncate_frequency = "2h"
+    min_keepalive_time = "5m"
+    max_keepalive_time = "8h"
+  }
+
   external_labels = {
   }
 }

--- a/examples/default-values/output.yaml
+++ b/examples/default-values/output.yaml
@@ -734,6 +734,12 @@ data:
     
       }
     
+      wal {
+        truncate_frequency = "2h"
+        min_keepalive_time = "5m"
+        max_keepalive_time = "8h"
+      }
+    
       external_labels = {
       }
     }
@@ -45288,6 +45294,12 @@ data:
           password = remote.kubernetes.secret.metrics_service.data["password"]
         }
     
+      }
+    
+      wal {
+        truncate_frequency = "2h"
+        min_keepalive_time = "5m"
+        max_keepalive_time = "8h"
       }
     
       external_labels = {

--- a/examples/eks-fargate/metrics.river
+++ b/examples/eks-fargate/metrics.river
@@ -577,6 +577,12 @@ prometheus.remote_write "metrics_service" {
 
   }
 
+  wal {
+    truncate_frequency = "2h"
+    min_keepalive_time = "5m"
+    max_keepalive_time = "8h"
+  }
+
   external_labels = {
   }
 }

--- a/examples/eks-fargate/output.yaml
+++ b/examples/eks-fargate/output.yaml
@@ -680,6 +680,12 @@ data:
     
       }
     
+      wal {
+        truncate_frequency = "2h"
+        min_keepalive_time = "5m"
+        max_keepalive_time = "8h"
+      }
+    
       external_labels = {
       }
     }
@@ -45068,6 +45074,12 @@ data:
           password = remote.kubernetes.secret.metrics_service.data["password"]
         }
     
+      }
+    
+      wal {
+        truncate_frequency = "2h"
+        min_keepalive_time = "5m"
+        max_keepalive_time = "8h"
       }
     
       external_labels = {

--- a/examples/extra-rules/metrics.river
+++ b/examples/extra-rules/metrics.river
@@ -671,6 +671,12 @@ prometheus.remote_write "metrics_service" {
     }
   }
 
+  wal {
+    truncate_frequency = "2h"
+    min_keepalive_time = "5m"
+    max_keepalive_time = "8h"
+  }
+
   external_labels = {
     site = "northwest",
   }

--- a/examples/extra-rules/output.yaml
+++ b/examples/extra-rules/output.yaml
@@ -790,6 +790,12 @@ data:
         }
       }
     
+      wal {
+        truncate_frequency = "2h"
+        min_keepalive_time = "5m"
+        max_keepalive_time = "8h"
+      }
+    
       external_labels = {
         site = "northwest",
       }
@@ -45424,6 +45430,12 @@ data:
           regex = "metric_to_drop|another_metric_to_drop"
           action = "drop"
         }
+      }
+    
+      wal {
+        truncate_frequency = "2h"
+        min_keepalive_time = "5m"
+        max_keepalive_time = "8h"
       }
     
       external_labels = {

--- a/examples/gke-autopilot/metrics.river
+++ b/examples/gke-autopilot/metrics.river
@@ -577,6 +577,12 @@ prometheus.remote_write "metrics_service" {
 
   }
 
+  wal {
+    truncate_frequency = "2h"
+    min_keepalive_time = "5m"
+    max_keepalive_time = "8h"
+  }
+
   external_labels = {
   }
 }

--- a/examples/gke-autopilot/output.yaml
+++ b/examples/gke-autopilot/output.yaml
@@ -680,6 +680,12 @@ data:
     
       }
     
+      wal {
+        truncate_frequency = "2h"
+        min_keepalive_time = "5m"
+        max_keepalive_time = "8h"
+      }
+    
       external_labels = {
       }
     }
@@ -45054,6 +45060,12 @@ data:
           password = remote.kubernetes.secret.metrics_service.data["password"]
         }
     
+      }
+    
+      wal {
+        truncate_frequency = "2h"
+        min_keepalive_time = "5m"
+        max_keepalive_time = "8h"
       }
     
       external_labels = {

--- a/examples/ibm-cloud/metrics.river
+++ b/examples/ibm-cloud/metrics.river
@@ -616,6 +616,12 @@ prometheus.remote_write "metrics_service" {
 
   }
 
+  wal {
+    truncate_frequency = "2h"
+    min_keepalive_time = "5m"
+    max_keepalive_time = "8h"
+  }
+
   external_labels = {
   }
 }

--- a/examples/ibm-cloud/output.yaml
+++ b/examples/ibm-cloud/output.yaml
@@ -734,6 +734,12 @@ data:
     
       }
     
+      wal {
+        truncate_frequency = "2h"
+        min_keepalive_time = "5m"
+        max_keepalive_time = "8h"
+      }
+    
       external_labels = {
       }
     }
@@ -45294,6 +45300,12 @@ data:
           password = remote.kubernetes.secret.metrics_service.data["password"]
         }
     
+      }
+    
+      wal {
+        truncate_frequency = "2h"
+        min_keepalive_time = "5m"
+        max_keepalive_time = "8h"
       }
     
       external_labels = {

--- a/examples/metrics-only/metrics.river
+++ b/examples/metrics-only/metrics.river
@@ -616,6 +616,12 @@ prometheus.remote_write "metrics_service" {
 
   }
 
+  wal {
+    truncate_frequency = "2h"
+    min_keepalive_time = "5m"
+    max_keepalive_time = "8h"
+  }
+
   external_labels = {
   }
 }

--- a/examples/metrics-only/output.yaml
+++ b/examples/metrics-only/output.yaml
@@ -696,6 +696,12 @@ data:
     
       }
     
+      wal {
+        truncate_frequency = "2h"
+        min_keepalive_time = "5m"
+        max_keepalive_time = "8h"
+      }
+    
       external_labels = {
       }
     }
@@ -44625,6 +44631,12 @@ data:
           password = remote.kubernetes.secret.metrics_service.data["password"]
         }
     
+      }
+    
+      wal {
+        truncate_frequency = "2h"
+        min_keepalive_time = "5m"
+        max_keepalive_time = "8h"
       }
     
       external_labels = {

--- a/examples/openshift-compatible/metrics.river
+++ b/examples/openshift-compatible/metrics.river
@@ -618,6 +618,12 @@ prometheus.remote_write "metrics_service" {
 
   }
 
+  wal {
+    truncate_frequency = "2h"
+    min_keepalive_time = "5m"
+    max_keepalive_time = "8h"
+  }
+
   external_labels = {
   }
 }

--- a/examples/openshift-compatible/output.yaml
+++ b/examples/openshift-compatible/output.yaml
@@ -706,6 +706,12 @@ data:
     
       }
     
+      wal {
+        truncate_frequency = "2h"
+        min_keepalive_time = "5m"
+        max_keepalive_time = "8h"
+      }
+    
       external_labels = {
       }
     }
@@ -44941,6 +44947,12 @@ data:
           password = remote.kubernetes.secret.metrics_service.data["password"]
         }
     
+      }
+    
+      wal {
+        truncate_frequency = "2h"
+        min_keepalive_time = "5m"
+        max_keepalive_time = "8h"
       }
     
       external_labels = {

--- a/examples/private-image-registry/metrics.river
+++ b/examples/private-image-registry/metrics.river
@@ -616,6 +616,12 @@ prometheus.remote_write "metrics_service" {
 
   }
 
+  wal {
+    truncate_frequency = "2h"
+    min_keepalive_time = "5m"
+    max_keepalive_time = "8h"
+  }
+
   external_labels = {
   }
 }

--- a/examples/private-image-registry/output.yaml
+++ b/examples/private-image-registry/output.yaml
@@ -738,6 +738,12 @@ data:
     
       }
     
+      wal {
+        truncate_frequency = "2h"
+        min_keepalive_time = "5m"
+        max_keepalive_time = "8h"
+      }
+    
       external_labels = {
       }
     }
@@ -45304,6 +45310,12 @@ data:
           password = remote.kubernetes.secret.metrics_service.data["password"]
         }
     
+      }
+    
+      wal {
+        truncate_frequency = "2h"
+        min_keepalive_time = "5m"
+        max_keepalive_time = "8h"
       }
     
       external_labels = {

--- a/examples/proxies/metrics.river
+++ b/examples/proxies/metrics.river
@@ -620,6 +620,12 @@ prometheus.remote_write "metrics_service" {
     }
   }
 
+  wal {
+    truncate_frequency = "2h"
+    min_keepalive_time = "5m"
+    max_keepalive_time = "8h"
+  }
+
   external_labels = {
   }
 }

--- a/examples/proxies/output.yaml
+++ b/examples/proxies/output.yaml
@@ -738,6 +738,12 @@ data:
         }
       }
     
+      wal {
+        truncate_frequency = "2h"
+        min_keepalive_time = "5m"
+        max_keepalive_time = "8h"
+      }
+    
       external_labels = {
       }
     }
@@ -45308,6 +45314,12 @@ data:
         tls_config {
           insecure_skip_verify = true
         }
+      }
+    
+      wal {
+        truncate_frequency = "2h"
+        min_keepalive_time = "5m"
+        max_keepalive_time = "8h"
       }
     
       external_labels = {

--- a/examples/scrape-intervals/metrics.river
+++ b/examples/scrape-intervals/metrics.river
@@ -616,6 +616,12 @@ prometheus.remote_write "metrics_service" {
 
   }
 
+  wal {
+    truncate_frequency = "2h"
+    min_keepalive_time = "5m"
+    max_keepalive_time = "8h"
+  }
+
   external_labels = {
   }
 }

--- a/examples/scrape-intervals/output.yaml
+++ b/examples/scrape-intervals/output.yaml
@@ -695,6 +695,12 @@ data:
     
       }
     
+      wal {
+        truncate_frequency = "2h"
+        min_keepalive_time = "5m"
+        max_keepalive_time = "8h"
+      }
+    
       external_labels = {
       }
     }
@@ -44624,6 +44630,12 @@ data:
           password = remote.kubernetes.secret.metrics_service.data["password"]
         }
     
+      }
+    
+      wal {
+        truncate_frequency = "2h"
+        min_keepalive_time = "5m"
+        max_keepalive_time = "8h"
       }
     
       external_labels = {

--- a/examples/service-integrations/metrics.river
+++ b/examples/service-integrations/metrics.river
@@ -616,6 +616,12 @@ prometheus.remote_write "metrics_service" {
 
   }
 
+  wal {
+    truncate_frequency = "2h"
+    min_keepalive_time = "5m"
+    max_keepalive_time = "8h"
+  }
+
   external_labels = {
   }
 }

--- a/examples/service-integrations/output.yaml
+++ b/examples/service-integrations/output.yaml
@@ -734,6 +734,12 @@ data:
     
       }
     
+      wal {
+        truncate_frequency = "2h"
+        min_keepalive_time = "5m"
+        max_keepalive_time = "8h"
+      }
+    
       external_labels = {
       }
     }
@@ -45323,6 +45329,12 @@ data:
           password = remote.kubernetes.secret.metrics_service.data["password"]
         }
     
+      }
+    
+      wal {
+        truncate_frequency = "2h"
+        min_keepalive_time = "5m"
+        max_keepalive_time = "8h"
       }
     
       external_labels = {

--- a/examples/specific-namespace/metrics.river
+++ b/examples/specific-namespace/metrics.river
@@ -666,6 +666,12 @@ prometheus.remote_write "metrics_service" {
 
   }
 
+  wal {
+    truncate_frequency = "2h"
+    min_keepalive_time = "5m"
+    max_keepalive_time = "8h"
+  }
+
   external_labels = {
   }
 }

--- a/examples/specific-namespace/output.yaml
+++ b/examples/specific-namespace/output.yaml
@@ -784,6 +784,12 @@ data:
     
       }
     
+      wal {
+        truncate_frequency = "2h"
+        min_keepalive_time = "5m"
+        max_keepalive_time = "8h"
+      }
+    
       external_labels = {
       }
     }
@@ -45394,6 +45400,12 @@ data:
           password = remote.kubernetes.secret.metrics_service.data["password"]
         }
     
+      }
+    
+      wal {
+        truncate_frequency = "2h"
+        min_keepalive_time = "5m"
+        max_keepalive_time = "8h"
       }
     
       external_labels = {

--- a/examples/traces-enabled/metrics.river
+++ b/examples/traces-enabled/metrics.river
@@ -619,6 +619,12 @@ prometheus.remote_write "metrics_service" {
 
   }
 
+  wal {
+    truncate_frequency = "2h"
+    min_keepalive_time = "5m"
+    max_keepalive_time = "8h"
+  }
+
   external_labels = {
   }
 }

--- a/examples/traces-enabled/output.yaml
+++ b/examples/traces-enabled/output.yaml
@@ -750,6 +750,12 @@ data:
     
       }
     
+      wal {
+        truncate_frequency = "2h"
+        min_keepalive_time = "5m"
+        max_keepalive_time = "8h"
+      }
+    
       external_labels = {
       }
     }
@@ -45352,6 +45358,12 @@ data:
           password = remote.kubernetes.secret.metrics_service.data["password"]
         }
     
+      }
+    
+      wal {
+        truncate_frequency = "2h"
+        min_keepalive_time = "5m"
+        max_keepalive_time = "8h"
       }
     
       external_labels = {

--- a/examples/windows-exporter/metrics.river
+++ b/examples/windows-exporter/metrics.river
@@ -684,6 +684,12 @@ prometheus.remote_write "metrics_service" {
 
   }
 
+  wal {
+    truncate_frequency = "2h"
+    min_keepalive_time = "5m"
+    max_keepalive_time = "8h"
+  }
+
   external_labels = {
   }
 }

--- a/examples/windows-exporter/output.yaml
+++ b/examples/windows-exporter/output.yaml
@@ -839,6 +839,12 @@ data:
     
       }
     
+      wal {
+        truncate_frequency = "2h"
+        min_keepalive_time = "5m"
+        max_keepalive_time = "8h"
+      }
+    
       external_labels = {
       }
     }
@@ -45587,6 +45593,12 @@ data:
           password = remote.kubernetes.secret.metrics_service.data["password"]
         }
     
+      }
+    
+      wal {
+        truncate_frequency = "2h"
+        min_keepalive_time = "5m"
+        max_keepalive_time = "8h"
       }
     
       external_labels = {


### PR DESCRIPTION
### Summary

This PR aims to add support for customizing the WAL (Write-Ahead Log) settings. This allows, for example, to tweak the settings to ensure a small WAL size is always guaranteed, even during outages of the remote-write endpoint.

This release is **not** breaking because it respects [the default values](https://grafana.com/docs/agent/latest/flow/reference/components/prometheus.remote_write/#wal-block) of the `prometheus.remote_write` Grafana Agent Flow component.