### PR TITLE
Create dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
We can use Dependabot to keep our GitHub actions up to date.
Unfortunately, we can't use it for helm dependencies, but we have a GitHub action to run [Updatecli](https://www.updatecli.io/) for that.