### PR TITLE
add k8s.cluster.name resource attribute to metrics and logs

### DIFF
--- a/charts/k8s-monitoring/templates/agent_config/_receivers.river.txt
+++ b/charts/k8s-monitoring/templates/agent_config/_receivers.river.txt
@@ -77,6 +77,8 @@ otelcol.processor.transform "add_attributes" {
       "set(attributes[\"pod\"], attributes[\"k8s.pod.name\"])",
       "set(attributes[\"namespace\"], attributes[\"k8s.namespace.name\"])",
       "set(attributes[\"loki.resource.labels\"], \"pod, namespace, cluster, job\")",
+      // Accessing a map with a key that does not exist will return nil.
+      "set(attributes[\"k8s.cluster.name\"], \"{{ required ".Values.cluster.name is a required value. Please set it and try again." .Values.cluster.name }}\") where attributes[\"k8s.cluster.name\"] == nil",
     ]
   }
   output {
@@ -98,6 +100,13 @@ otelcol.processor.transform "add_metric_attributes" {
     statements = [
       "set(attributes[\"deployment.environment\"], resource.attributes[\"deployment.environment\"])",
       "set(attributes[\"service.version\"], resource.attributes[\"service.version\"])",
+    ]
+  }
+  metric_statements {
+    context = "resource"
+    statements = [
+      // Accessing a map with a key that does not exist will return nil.
+      "set(attributes[\"k8s.cluster.name\"], \"{{ required ".Values.cluster.name is a required value. Please set it and try again." .Values.cluster.name }}\") where attributes[\"k8s.cluster.name\"] == nil",
     ]
   }
   output {

--- a/examples/cluster-with-pvc/metrics.river
+++ b/examples/cluster-with-pvc/metrics.river
@@ -66,6 +66,8 @@ otelcol.processor.transform "add_attributes" {
       "set(attributes[\"pod\"], attributes[\"k8s.pod.name\"])",
       "set(attributes[\"namespace\"], attributes[\"k8s.namespace.name\"])",
       "set(attributes[\"loki.resource.labels\"], \"pod, namespace, cluster, job\")",
+      // Accessing a map with a key that does not exist will return nil.
+      "set(attributes[\"k8s.cluster.name\"], \"cluster-with-pvc-test\") where attributes[\"k8s.cluster.name\"] == nil",
     ]
   }
   output {
@@ -79,6 +81,13 @@ otelcol.processor.transform "add_metric_attributes" {
     statements = [
       "set(attributes[\"deployment.environment\"], resource.attributes[\"deployment.environment\"])",
       "set(attributes[\"service.version\"], resource.attributes[\"service.version\"])",
+    ]
+  }
+  metric_statements {
+    context = "resource"
+    statements = [
+      // Accessing a map with a key that does not exist will return nil.
+      "set(attributes[\"k8s.cluster.name\"], \"cluster-with-pvc-test\") where attributes[\"k8s.cluster.name\"] == nil",
     ]
   }
   output {

--- a/examples/cluster-with-pvc/output.yaml
+++ b/examples/cluster-with-pvc/output.yaml
@@ -187,6 +187,8 @@ data:
           "set(attributes[\"pod\"], attributes[\"k8s.pod.name\"])",
           "set(attributes[\"namespace\"], attributes[\"k8s.namespace.name\"])",
           "set(attributes[\"loki.resource.labels\"], \"pod, namespace, cluster, job\")",
+          // Accessing a map with a key that does not exist will return nil.
+          "set(attributes[\"k8s.cluster.name\"], \"cluster-with-pvc-test\") where attributes[\"k8s.cluster.name\"] == nil",
         ]
       }
       output {
@@ -200,6 +202,13 @@ data:
         statements = [
           "set(attributes[\"deployment.environment\"], resource.attributes[\"deployment.environment\"])",
           "set(attributes[\"service.version\"], resource.attributes[\"service.version\"])",
+        ]
+      }
+      metric_statements {
+        context = "resource"
+        statements = [
+          // Accessing a map with a key that does not exist will return nil.
+          "set(attributes[\"k8s.cluster.name\"], \"cluster-with-pvc-test\") where attributes[\"k8s.cluster.name\"] == nil",
         ]
       }
       output {
@@ -44804,6 +44813,8 @@ data:
           "set(attributes[\"pod\"], attributes[\"k8s.pod.name\"])",
           "set(attributes[\"namespace\"], attributes[\"k8s.namespace.name\"])",
           "set(attributes[\"loki.resource.labels\"], \"pod, namespace, cluster, job\")",
+          // Accessing a map with a key that does not exist will return nil.
+          "set(attributes[\"k8s.cluster.name\"], \"cluster-with-pvc-test\") where attributes[\"k8s.cluster.name\"] == nil",
         ]
       }
       output {
@@ -44817,6 +44828,13 @@ data:
         statements = [
           "set(attributes[\"deployment.environment\"], resource.attributes[\"deployment.environment\"])",
           "set(attributes[\"service.version\"], resource.attributes[\"service.version\"])",
+        ]
+      }
+      metric_statements {
+        context = "resource"
+        statements = [
+          // Accessing a map with a key that does not exist will return nil.
+          "set(attributes[\"k8s.cluster.name\"], \"cluster-with-pvc-test\") where attributes[\"k8s.cluster.name\"] == nil",
         ]
       }
       output {

--- a/examples/control-plane-metrics/metrics.river
+++ b/examples/control-plane-metrics/metrics.river
@@ -66,6 +66,8 @@ otelcol.processor.transform "add_attributes" {
       "set(attributes[\"pod\"], attributes[\"k8s.pod.name\"])",
       "set(attributes[\"namespace\"], attributes[\"k8s.namespace.name\"])",
       "set(attributes[\"loki.resource.labels\"], \"pod, namespace, cluster, job\")",
+      // Accessing a map with a key that does not exist will return nil.
+      "set(attributes[\"k8s.cluster.name\"], \"control-plane-metrics-test\") where attributes[\"k8s.cluster.name\"] == nil",
     ]
   }
   output {
@@ -79,6 +81,13 @@ otelcol.processor.transform "add_metric_attributes" {
     statements = [
       "set(attributes[\"deployment.environment\"], resource.attributes[\"deployment.environment\"])",
       "set(attributes[\"service.version\"], resource.attributes[\"service.version\"])",
+    ]
+  }
+  metric_statements {
+    context = "resource"
+    statements = [
+      // Accessing a map with a key that does not exist will return nil.
+      "set(attributes[\"k8s.cluster.name\"], \"control-plane-metrics-test\") where attributes[\"k8s.cluster.name\"] == nil",
     ]
   }
   output {

--- a/examples/control-plane-metrics/output.yaml
+++ b/examples/control-plane-metrics/output.yaml
@@ -188,6 +188,8 @@ data:
           "set(attributes[\"pod\"], attributes[\"k8s.pod.name\"])",
           "set(attributes[\"namespace\"], attributes[\"k8s.namespace.name\"])",
           "set(attributes[\"loki.resource.labels\"], \"pod, namespace, cluster, job\")",
+          // Accessing a map with a key that does not exist will return nil.
+          "set(attributes[\"k8s.cluster.name\"], \"control-plane-metrics-test\") where attributes[\"k8s.cluster.name\"] == nil",
         ]
       }
       output {
@@ -201,6 +203,13 @@ data:
         statements = [
           "set(attributes[\"deployment.environment\"], resource.attributes[\"deployment.environment\"])",
           "set(attributes[\"service.version\"], resource.attributes[\"service.version\"])",
+        ]
+      }
+      metric_statements {
+        context = "resource"
+        statements = [
+          // Accessing a map with a key that does not exist will return nil.
+          "set(attributes[\"k8s.cluster.name\"], \"control-plane-metrics-test\") where attributes[\"k8s.cluster.name\"] == nil",
         ]
       }
       output {
@@ -44902,6 +44911,8 @@ data:
           "set(attributes[\"pod\"], attributes[\"k8s.pod.name\"])",
           "set(attributes[\"namespace\"], attributes[\"k8s.namespace.name\"])",
           "set(attributes[\"loki.resource.labels\"], \"pod, namespace, cluster, job\")",
+          // Accessing a map with a key that does not exist will return nil.
+          "set(attributes[\"k8s.cluster.name\"], \"control-plane-metrics-test\") where attributes[\"k8s.cluster.name\"] == nil",
         ]
       }
       output {
@@ -44915,6 +44926,13 @@ data:
         statements = [
           "set(attributes[\"deployment.environment\"], resource.attributes[\"deployment.environment\"])",
           "set(attributes[\"service.version\"], resource.attributes[\"service.version\"])",
+        ]
+      }
+      metric_statements {
+        context = "resource"
+        statements = [
+          // Accessing a map with a key that does not exist will return nil.
+          "set(attributes[\"k8s.cluster.name\"], \"control-plane-metrics-test\") where attributes[\"k8s.cluster.name\"] == nil",
         ]
       }
       output {

--- a/examples/custom-allow-lists/metrics.river
+++ b/examples/custom-allow-lists/metrics.river
@@ -66,6 +66,8 @@ otelcol.processor.transform "add_attributes" {
       "set(attributes[\"pod\"], attributes[\"k8s.pod.name\"])",
       "set(attributes[\"namespace\"], attributes[\"k8s.namespace.name\"])",
       "set(attributes[\"loki.resource.labels\"], \"pod, namespace, cluster, job\")",
+      // Accessing a map with a key that does not exist will return nil.
+      "set(attributes[\"k8s.cluster.name\"], \"custom-allow-lists-test\") where attributes[\"k8s.cluster.name\"] == nil",
     ]
   }
   output {
@@ -79,6 +81,13 @@ otelcol.processor.transform "add_metric_attributes" {
     statements = [
       "set(attributes[\"deployment.environment\"], resource.attributes[\"deployment.environment\"])",
       "set(attributes[\"service.version\"], resource.attributes[\"service.version\"])",
+    ]
+  }
+  metric_statements {
+    context = "resource"
+    statements = [
+      // Accessing a map with a key that does not exist will return nil.
+      "set(attributes[\"k8s.cluster.name\"], \"custom-allow-lists-test\") where attributes[\"k8s.cluster.name\"] == nil",
     ]
   }
   output {

--- a/examples/custom-allow-lists/output.yaml
+++ b/examples/custom-allow-lists/output.yaml
@@ -146,6 +146,8 @@ data:
           "set(attributes[\"pod\"], attributes[\"k8s.pod.name\"])",
           "set(attributes[\"namespace\"], attributes[\"k8s.namespace.name\"])",
           "set(attributes[\"loki.resource.labels\"], \"pod, namespace, cluster, job\")",
+          // Accessing a map with a key that does not exist will return nil.
+          "set(attributes[\"k8s.cluster.name\"], \"custom-allow-lists-test\") where attributes[\"k8s.cluster.name\"] == nil",
         ]
       }
       output {
@@ -159,6 +161,13 @@ data:
         statements = [
           "set(attributes[\"deployment.environment\"], resource.attributes[\"deployment.environment\"])",
           "set(attributes[\"service.version\"], resource.attributes[\"service.version\"])",
+        ]
+      }
+      metric_statements {
+        context = "resource"
+        statements = [
+          // Accessing a map with a key that does not exist will return nil.
+          "set(attributes[\"k8s.cluster.name\"], \"custom-allow-lists-test\") where attributes[\"k8s.cluster.name\"] == nil",
         ]
       }
       output {
@@ -44078,6 +44087,8 @@ data:
           "set(attributes[\"pod\"], attributes[\"k8s.pod.name\"])",
           "set(attributes[\"namespace\"], attributes[\"k8s.namespace.name\"])",
           "set(attributes[\"loki.resource.labels\"], \"pod, namespace, cluster, job\")",
+          // Accessing a map with a key that does not exist will return nil.
+          "set(attributes[\"k8s.cluster.name\"], \"custom-allow-lists-test\") where attributes[\"k8s.cluster.name\"] == nil",
         ]
       }
       output {
@@ -44091,6 +44102,13 @@ data:
         statements = [
           "set(attributes[\"deployment.environment\"], resource.attributes[\"deployment.environment\"])",
           "set(attributes[\"service.version\"], resource.attributes[\"service.version\"])",
+        ]
+      }
+      metric_statements {
+        context = "resource"
+        statements = [
+          // Accessing a map with a key that does not exist will return nil.
+          "set(attributes[\"k8s.cluster.name\"], \"custom-allow-lists-test\") where attributes[\"k8s.cluster.name\"] == nil",
         ]
       }
       output {

--- a/examples/custom-config/metrics.river
+++ b/examples/custom-config/metrics.river
@@ -66,6 +66,8 @@ otelcol.processor.transform "add_attributes" {
       "set(attributes[\"pod\"], attributes[\"k8s.pod.name\"])",
       "set(attributes[\"namespace\"], attributes[\"k8s.namespace.name\"])",
       "set(attributes[\"loki.resource.labels\"], \"pod, namespace, cluster, job\")",
+      // Accessing a map with a key that does not exist will return nil.
+      "set(attributes[\"k8s.cluster.name\"], \"custom-config-test\") where attributes[\"k8s.cluster.name\"] == nil",
     ]
   }
   output {
@@ -79,6 +81,13 @@ otelcol.processor.transform "add_metric_attributes" {
     statements = [
       "set(attributes[\"deployment.environment\"], resource.attributes[\"deployment.environment\"])",
       "set(attributes[\"service.version\"], resource.attributes[\"service.version\"])",
+    ]
+  }
+  metric_statements {
+    context = "resource"
+    statements = [
+      // Accessing a map with a key that does not exist will return nil.
+      "set(attributes[\"k8s.cluster.name\"], \"custom-config-test\") where attributes[\"k8s.cluster.name\"] == nil",
     ]
   }
   output {

--- a/examples/custom-config/output.yaml
+++ b/examples/custom-config/output.yaml
@@ -187,6 +187,8 @@ data:
           "set(attributes[\"pod\"], attributes[\"k8s.pod.name\"])",
           "set(attributes[\"namespace\"], attributes[\"k8s.namespace.name\"])",
           "set(attributes[\"loki.resource.labels\"], \"pod, namespace, cluster, job\")",
+          // Accessing a map with a key that does not exist will return nil.
+          "set(attributes[\"k8s.cluster.name\"], \"custom-config-test\") where attributes[\"k8s.cluster.name\"] == nil",
         ]
       }
       output {
@@ -200,6 +202,13 @@ data:
         statements = [
           "set(attributes[\"deployment.environment\"], resource.attributes[\"deployment.environment\"])",
           "set(attributes[\"service.version\"], resource.attributes[\"service.version\"])",
+        ]
+      }
+      metric_statements {
+        context = "resource"
+        statements = [
+          // Accessing a map with a key that does not exist will return nil.
+          "set(attributes[\"k8s.cluster.name\"], \"custom-config-test\") where attributes[\"k8s.cluster.name\"] == nil",
         ]
       }
       output {
@@ -44812,6 +44821,8 @@ data:
           "set(attributes[\"pod\"], attributes[\"k8s.pod.name\"])",
           "set(attributes[\"namespace\"], attributes[\"k8s.namespace.name\"])",
           "set(attributes[\"loki.resource.labels\"], \"pod, namespace, cluster, job\")",
+          // Accessing a map with a key that does not exist will return nil.
+          "set(attributes[\"k8s.cluster.name\"], \"custom-config-test\") where attributes[\"k8s.cluster.name\"] == nil",
         ]
       }
       output {
@@ -44825,6 +44836,13 @@ data:
         statements = [
           "set(attributes[\"deployment.environment\"], resource.attributes[\"deployment.environment\"])",
           "set(attributes[\"service.version\"], resource.attributes[\"service.version\"])",
+        ]
+      }
+      metric_statements {
+        context = "resource"
+        statements = [
+          // Accessing a map with a key that does not exist will return nil.
+          "set(attributes[\"k8s.cluster.name\"], \"custom-config-test\") where attributes[\"k8s.cluster.name\"] == nil",
         ]
       }
       output {

--- a/examples/default-values/metrics.river
+++ b/examples/default-values/metrics.river
@@ -66,6 +66,8 @@ otelcol.processor.transform "add_attributes" {
       "set(attributes[\"pod\"], attributes[\"k8s.pod.name\"])",
       "set(attributes[\"namespace\"], attributes[\"k8s.namespace.name\"])",
       "set(attributes[\"loki.resource.labels\"], \"pod, namespace, cluster, job\")",
+      // Accessing a map with a key that does not exist will return nil.
+      "set(attributes[\"k8s.cluster.name\"], \"default-values-test\") where attributes[\"k8s.cluster.name\"] == nil",
     ]
   }
   output {
@@ -79,6 +81,13 @@ otelcol.processor.transform "add_metric_attributes" {
     statements = [
       "set(attributes[\"deployment.environment\"], resource.attributes[\"deployment.environment\"])",
       "set(attributes[\"service.version\"], resource.attributes[\"service.version\"])",
+    ]
+  }
+  metric_statements {
+    context = "resource"
+    statements = [
+      // Accessing a map with a key that does not exist will return nil.
+      "set(attributes[\"k8s.cluster.name\"], \"default-values-test\") where attributes[\"k8s.cluster.name\"] == nil",
     ]
   }
   output {

--- a/examples/default-values/output.yaml
+++ b/examples/default-values/output.yaml
@@ -187,6 +187,8 @@ data:
           "set(attributes[\"pod\"], attributes[\"k8s.pod.name\"])",
           "set(attributes[\"namespace\"], attributes[\"k8s.namespace.name\"])",
           "set(attributes[\"loki.resource.labels\"], \"pod, namespace, cluster, job\")",
+          // Accessing a map with a key that does not exist will return nil.
+          "set(attributes[\"k8s.cluster.name\"], \"default-values-test\") where attributes[\"k8s.cluster.name\"] == nil",
         ]
       }
       output {
@@ -200,6 +202,13 @@ data:
         statements = [
           "set(attributes[\"deployment.environment\"], resource.attributes[\"deployment.environment\"])",
           "set(attributes[\"service.version\"], resource.attributes[\"service.version\"])",
+        ]
+      }
+      metric_statements {
+        context = "resource"
+        statements = [
+          // Accessing a map with a key that does not exist will return nil.
+          "set(attributes[\"k8s.cluster.name\"], \"default-values-test\") where attributes[\"k8s.cluster.name\"] == nil",
         ]
       }
       output {
@@ -44749,6 +44758,8 @@ data:
           "set(attributes[\"pod\"], attributes[\"k8s.pod.name\"])",
           "set(attributes[\"namespace\"], attributes[\"k8s.namespace.name\"])",
           "set(attributes[\"loki.resource.labels\"], \"pod, namespace, cluster, job\")",
+          // Accessing a map with a key that does not exist will return nil.
+          "set(attributes[\"k8s.cluster.name\"], \"default-values-test\") where attributes[\"k8s.cluster.name\"] == nil",
         ]
       }
       output {
@@ -44762,6 +44773,13 @@ data:
         statements = [
           "set(attributes[\"deployment.environment\"], resource.attributes[\"deployment.environment\"])",
           "set(attributes[\"service.version\"], resource.attributes[\"service.version\"])",
+        ]
+      }
+      metric_statements {
+        context = "resource"
+        statements = [
+          // Accessing a map with a key that does not exist will return nil.
+          "set(attributes[\"k8s.cluster.name\"], \"default-values-test\") where attributes[\"k8s.cluster.name\"] == nil",
         ]
       }
       output {

--- a/examples/eks-fargate/metrics.river
+++ b/examples/eks-fargate/metrics.river
@@ -66,6 +66,8 @@ otelcol.processor.transform "add_attributes" {
       "set(attributes[\"pod\"], attributes[\"k8s.pod.name\"])",
       "set(attributes[\"namespace\"], attributes[\"k8s.namespace.name\"])",
       "set(attributes[\"loki.resource.labels\"], \"pod, namespace, cluster, job\")",
+      // Accessing a map with a key that does not exist will return nil.
+      "set(attributes[\"k8s.cluster.name\"], \"eks-fargate-test\") where attributes[\"k8s.cluster.name\"] == nil",
     ]
   }
   output {
@@ -79,6 +81,13 @@ otelcol.processor.transform "add_metric_attributes" {
     statements = [
       "set(attributes[\"deployment.environment\"], resource.attributes[\"deployment.environment\"])",
       "set(attributes[\"service.version\"], resource.attributes[\"service.version\"])",
+    ]
+  }
+  metric_statements {
+    context = "resource"
+    statements = [
+      // Accessing a map with a key that does not exist will return nil.
+      "set(attributes[\"k8s.cluster.name\"], \"eks-fargate-test\") where attributes[\"k8s.cluster.name\"] == nil",
     ]
   }
   output {

--- a/examples/eks-fargate/output.yaml
+++ b/examples/eks-fargate/output.yaml
@@ -172,6 +172,8 @@ data:
           "set(attributes[\"pod\"], attributes[\"k8s.pod.name\"])",
           "set(attributes[\"namespace\"], attributes[\"k8s.namespace.name\"])",
           "set(attributes[\"loki.resource.labels\"], \"pod, namespace, cluster, job\")",
+          // Accessing a map with a key that does not exist will return nil.
+          "set(attributes[\"k8s.cluster.name\"], \"eks-fargate-test\") where attributes[\"k8s.cluster.name\"] == nil",
         ]
       }
       output {
@@ -185,6 +187,13 @@ data:
         statements = [
           "set(attributes[\"deployment.environment\"], resource.attributes[\"deployment.environment\"])",
           "set(attributes[\"service.version\"], resource.attributes[\"service.version\"])",
+        ]
+      }
+      metric_statements {
+        context = "resource"
+        statements = [
+          // Accessing a map with a key that does not exist will return nil.
+          "set(attributes[\"k8s.cluster.name\"], \"eks-fargate-test\") where attributes[\"k8s.cluster.name\"] == nil",
         ]
       }
       output {
@@ -44568,6 +44577,8 @@ data:
           "set(attributes[\"pod\"], attributes[\"k8s.pod.name\"])",
           "set(attributes[\"namespace\"], attributes[\"k8s.namespace.name\"])",
           "set(attributes[\"loki.resource.labels\"], \"pod, namespace, cluster, job\")",
+          // Accessing a map with a key that does not exist will return nil.
+          "set(attributes[\"k8s.cluster.name\"], \"eks-fargate-test\") where attributes[\"k8s.cluster.name\"] == nil",
         ]
       }
       output {
@@ -44581,6 +44592,13 @@ data:
         statements = [
           "set(attributes[\"deployment.environment\"], resource.attributes[\"deployment.environment\"])",
           "set(attributes[\"service.version\"], resource.attributes[\"service.version\"])",
+        ]
+      }
+      metric_statements {
+        context = "resource"
+        statements = [
+          // Accessing a map with a key that does not exist will return nil.
+          "set(attributes[\"k8s.cluster.name\"], \"eks-fargate-test\") where attributes[\"k8s.cluster.name\"] == nil",
         ]
       }
       output {

--- a/examples/extra-rules/metrics.river
+++ b/examples/extra-rules/metrics.river
@@ -66,6 +66,8 @@ otelcol.processor.transform "add_attributes" {
       "set(attributes[\"pod\"], attributes[\"k8s.pod.name\"])",
       "set(attributes[\"namespace\"], attributes[\"k8s.namespace.name\"])",
       "set(attributes[\"loki.resource.labels\"], \"pod, namespace, cluster, job\")",
+      // Accessing a map with a key that does not exist will return nil.
+      "set(attributes[\"k8s.cluster.name\"], \"extra-rules-test\") where attributes[\"k8s.cluster.name\"] == nil",
     ]
   }
   output {
@@ -79,6 +81,13 @@ otelcol.processor.transform "add_metric_attributes" {
     statements = [
       "set(attributes[\"deployment.environment\"], resource.attributes[\"deployment.environment\"])",
       "set(attributes[\"service.version\"], resource.attributes[\"service.version\"])",
+    ]
+  }
+  metric_statements {
+    context = "resource"
+    statements = [
+      // Accessing a map with a key that does not exist will return nil.
+      "set(attributes[\"k8s.cluster.name\"], \"extra-rules-test\") where attributes[\"k8s.cluster.name\"] == nil",
     ]
   }
   output {

--- a/examples/extra-rules/output.yaml
+++ b/examples/extra-rules/output.yaml
@@ -188,6 +188,8 @@ data:
           "set(attributes[\"pod\"], attributes[\"k8s.pod.name\"])",
           "set(attributes[\"namespace\"], attributes[\"k8s.namespace.name\"])",
           "set(attributes[\"loki.resource.labels\"], \"pod, namespace, cluster, job\")",
+          // Accessing a map with a key that does not exist will return nil.
+          "set(attributes[\"k8s.cluster.name\"], \"extra-rules-test\") where attributes[\"k8s.cluster.name\"] == nil",
         ]
       }
       output {
@@ -201,6 +203,13 @@ data:
         statements = [
           "set(attributes[\"deployment.environment\"], resource.attributes[\"deployment.environment\"])",
           "set(attributes[\"service.version\"], resource.attributes[\"service.version\"])",
+        ]
+      }
+      metric_statements {
+        context = "resource"
+        statements = [
+          // Accessing a map with a key that does not exist will return nil.
+          "set(attributes[\"k8s.cluster.name\"], \"extra-rules-test\") where attributes[\"k8s.cluster.name\"] == nil",
         ]
       }
       output {
@@ -44830,6 +44839,8 @@ data:
           "set(attributes[\"pod\"], attributes[\"k8s.pod.name\"])",
           "set(attributes[\"namespace\"], attributes[\"k8s.namespace.name\"])",
           "set(attributes[\"loki.resource.labels\"], \"pod, namespace, cluster, job\")",
+          // Accessing a map with a key that does not exist will return nil.
+          "set(attributes[\"k8s.cluster.name\"], \"extra-rules-test\") where attributes[\"k8s.cluster.name\"] == nil",
         ]
       }
       output {
@@ -44843,6 +44854,13 @@ data:
         statements = [
           "set(attributes[\"deployment.environment\"], resource.attributes[\"deployment.environment\"])",
           "set(attributes[\"service.version\"], resource.attributes[\"service.version\"])",
+        ]
+      }
+      metric_statements {
+        context = "resource"
+        statements = [
+          // Accessing a map with a key that does not exist will return nil.
+          "set(attributes[\"k8s.cluster.name\"], \"extra-rules-test\") where attributes[\"k8s.cluster.name\"] == nil",
         ]
       }
       output {

--- a/examples/gke-autopilot/metrics.river
+++ b/examples/gke-autopilot/metrics.river
@@ -66,6 +66,8 @@ otelcol.processor.transform "add_attributes" {
       "set(attributes[\"pod\"], attributes[\"k8s.pod.name\"])",
       "set(attributes[\"namespace\"], attributes[\"k8s.namespace.name\"])",
       "set(attributes[\"loki.resource.labels\"], \"pod, namespace, cluster, job\")",
+      // Accessing a map with a key that does not exist will return nil.
+      "set(attributes[\"k8s.cluster.name\"], \"gke-autopilot-test\") where attributes[\"k8s.cluster.name\"] == nil",
     ]
   }
   output {
@@ -79,6 +81,13 @@ otelcol.processor.transform "add_metric_attributes" {
     statements = [
       "set(attributes[\"deployment.environment\"], resource.attributes[\"deployment.environment\"])",
       "set(attributes[\"service.version\"], resource.attributes[\"service.version\"])",
+    ]
+  }
+  metric_statements {
+    context = "resource"
+    statements = [
+      // Accessing a map with a key that does not exist will return nil.
+      "set(attributes[\"k8s.cluster.name\"], \"gke-autopilot-test\") where attributes[\"k8s.cluster.name\"] == nil",
     ]
   }
   output {

--- a/examples/gke-autopilot/output.yaml
+++ b/examples/gke-autopilot/output.yaml
@@ -172,6 +172,8 @@ data:
           "set(attributes[\"pod\"], attributes[\"k8s.pod.name\"])",
           "set(attributes[\"namespace\"], attributes[\"k8s.namespace.name\"])",
           "set(attributes[\"loki.resource.labels\"], \"pod, namespace, cluster, job\")",
+          // Accessing a map with a key that does not exist will return nil.
+          "set(attributes[\"k8s.cluster.name\"], \"gke-autopilot-test\") where attributes[\"k8s.cluster.name\"] == nil",
         ]
       }
       output {
@@ -185,6 +187,13 @@ data:
         statements = [
           "set(attributes[\"deployment.environment\"], resource.attributes[\"deployment.environment\"])",
           "set(attributes[\"service.version\"], resource.attributes[\"service.version\"])",
+        ]
+      }
+      metric_statements {
+        context = "resource"
+        statements = [
+          // Accessing a map with a key that does not exist will return nil.
+          "set(attributes[\"k8s.cluster.name\"], \"gke-autopilot-test\") where attributes[\"k8s.cluster.name\"] == nil",
         ]
       }
       output {
@@ -44554,6 +44563,8 @@ data:
           "set(attributes[\"pod\"], attributes[\"k8s.pod.name\"])",
           "set(attributes[\"namespace\"], attributes[\"k8s.namespace.name\"])",
           "set(attributes[\"loki.resource.labels\"], \"pod, namespace, cluster, job\")",
+          // Accessing a map with a key that does not exist will return nil.
+          "set(attributes[\"k8s.cluster.name\"], \"gke-autopilot-test\") where attributes[\"k8s.cluster.name\"] == nil",
         ]
       }
       output {
@@ -44567,6 +44578,13 @@ data:
         statements = [
           "set(attributes[\"deployment.environment\"], resource.attributes[\"deployment.environment\"])",
           "set(attributes[\"service.version\"], resource.attributes[\"service.version\"])",
+        ]
+      }
+      metric_statements {
+        context = "resource"
+        statements = [
+          // Accessing a map with a key that does not exist will return nil.
+          "set(attributes[\"k8s.cluster.name\"], \"gke-autopilot-test\") where attributes[\"k8s.cluster.name\"] == nil",
         ]
       }
       output {

--- a/examples/ibm-cloud/metrics.river
+++ b/examples/ibm-cloud/metrics.river
@@ -66,6 +66,8 @@ otelcol.processor.transform "add_attributes" {
       "set(attributes[\"pod\"], attributes[\"k8s.pod.name\"])",
       "set(attributes[\"namespace\"], attributes[\"k8s.namespace.name\"])",
       "set(attributes[\"loki.resource.labels\"], \"pod, namespace, cluster, job\")",
+      // Accessing a map with a key that does not exist will return nil.
+      "set(attributes[\"k8s.cluster.name\"], \"ibm-cloud-test\") where attributes[\"k8s.cluster.name\"] == nil",
     ]
   }
   output {
@@ -79,6 +81,13 @@ otelcol.processor.transform "add_metric_attributes" {
     statements = [
       "set(attributes[\"deployment.environment\"], resource.attributes[\"deployment.environment\"])",
       "set(attributes[\"service.version\"], resource.attributes[\"service.version\"])",
+    ]
+  }
+  metric_statements {
+    context = "resource"
+    statements = [
+      // Accessing a map with a key that does not exist will return nil.
+      "set(attributes[\"k8s.cluster.name\"], \"ibm-cloud-test\") where attributes[\"k8s.cluster.name\"] == nil",
     ]
   }
   output {

--- a/examples/ibm-cloud/output.yaml
+++ b/examples/ibm-cloud/output.yaml
@@ -187,6 +187,8 @@ data:
           "set(attributes[\"pod\"], attributes[\"k8s.pod.name\"])",
           "set(attributes[\"namespace\"], attributes[\"k8s.namespace.name\"])",
           "set(attributes[\"loki.resource.labels\"], \"pod, namespace, cluster, job\")",
+          // Accessing a map with a key that does not exist will return nil.
+          "set(attributes[\"k8s.cluster.name\"], \"ibm-cloud-test\") where attributes[\"k8s.cluster.name\"] == nil",
         ]
       }
       output {
@@ -200,6 +202,13 @@ data:
         statements = [
           "set(attributes[\"deployment.environment\"], resource.attributes[\"deployment.environment\"])",
           "set(attributes[\"service.version\"], resource.attributes[\"service.version\"])",
+        ]
+      }
+      metric_statements {
+        context = "resource"
+        statements = [
+          // Accessing a map with a key that does not exist will return nil.
+          "set(attributes[\"k8s.cluster.name\"], \"ibm-cloud-test\") where attributes[\"k8s.cluster.name\"] == nil",
         ]
       }
       output {
@@ -44755,6 +44764,8 @@ data:
           "set(attributes[\"pod\"], attributes[\"k8s.pod.name\"])",
           "set(attributes[\"namespace\"], attributes[\"k8s.namespace.name\"])",
           "set(attributes[\"loki.resource.labels\"], \"pod, namespace, cluster, job\")",
+          // Accessing a map with a key that does not exist will return nil.
+          "set(attributes[\"k8s.cluster.name\"], \"ibm-cloud-test\") where attributes[\"k8s.cluster.name\"] == nil",
         ]
       }
       output {
@@ -44768,6 +44779,13 @@ data:
         statements = [
           "set(attributes[\"deployment.environment\"], resource.attributes[\"deployment.environment\"])",
           "set(attributes[\"service.version\"], resource.attributes[\"service.version\"])",
+        ]
+      }
+      metric_statements {
+        context = "resource"
+        statements = [
+          // Accessing a map with a key that does not exist will return nil.
+          "set(attributes[\"k8s.cluster.name\"], \"ibm-cloud-test\") where attributes[\"k8s.cluster.name\"] == nil",
         ]
       }
       output {

--- a/examples/logs-only/metrics.river
+++ b/examples/logs-only/metrics.river
@@ -65,6 +65,8 @@ otelcol.processor.transform "add_attributes" {
       "set(attributes[\"pod\"], attributes[\"k8s.pod.name\"])",
       "set(attributes[\"namespace\"], attributes[\"k8s.namespace.name\"])",
       "set(attributes[\"loki.resource.labels\"], \"pod, namespace, cluster, job\")",
+      // Accessing a map with a key that does not exist will return nil.
+      "set(attributes[\"k8s.cluster.name\"], \"logs-only-test\") where attributes[\"k8s.cluster.name\"] == nil",
     ]
   }
   output {

--- a/examples/logs-only/output.yaml
+++ b/examples/logs-only/output.yaml
@@ -130,6 +130,8 @@ data:
           "set(attributes[\"pod\"], attributes[\"k8s.pod.name\"])",
           "set(attributes[\"namespace\"], attributes[\"k8s.namespace.name\"])",
           "set(attributes[\"loki.resource.labels\"], \"pod, namespace, cluster, job\")",
+          // Accessing a map with a key that does not exist will return nil.
+          "set(attributes[\"k8s.cluster.name\"], \"logs-only-test\") where attributes[\"k8s.cluster.name\"] == nil",
         ]
       }
       output {
@@ -1185,6 +1187,8 @@ data:
           "set(attributes[\"pod\"], attributes[\"k8s.pod.name\"])",
           "set(attributes[\"namespace\"], attributes[\"k8s.namespace.name\"])",
           "set(attributes[\"loki.resource.labels\"], \"pod, namespace, cluster, job\")",
+          // Accessing a map with a key that does not exist will return nil.
+          "set(attributes[\"k8s.cluster.name\"], \"logs-only-test\") where attributes[\"k8s.cluster.name\"] == nil",
         ]
       }
       output {

--- a/examples/metrics-only/metrics.river
+++ b/examples/metrics-only/metrics.river
@@ -66,6 +66,8 @@ otelcol.processor.transform "add_attributes" {
       "set(attributes[\"pod\"], attributes[\"k8s.pod.name\"])",
       "set(attributes[\"namespace\"], attributes[\"k8s.namespace.name\"])",
       "set(attributes[\"loki.resource.labels\"], \"pod, namespace, cluster, job\")",
+      // Accessing a map with a key that does not exist will return nil.
+      "set(attributes[\"k8s.cluster.name\"], \"metrics-only-test\") where attributes[\"k8s.cluster.name\"] == nil",
     ]
   }
   output {
@@ -79,6 +81,13 @@ otelcol.processor.transform "add_metric_attributes" {
     statements = [
       "set(attributes[\"deployment.environment\"], resource.attributes[\"deployment.environment\"])",
       "set(attributes[\"service.version\"], resource.attributes[\"service.version\"])",
+    ]
+  }
+  metric_statements {
+    context = "resource"
+    statements = [
+      // Accessing a map with a key that does not exist will return nil.
+      "set(attributes[\"k8s.cluster.name\"], \"metrics-only-test\") where attributes[\"k8s.cluster.name\"] == nil",
     ]
   }
   output {

--- a/examples/metrics-only/output.yaml
+++ b/examples/metrics-only/output.yaml
@@ -147,6 +147,8 @@ data:
           "set(attributes[\"pod\"], attributes[\"k8s.pod.name\"])",
           "set(attributes[\"namespace\"], attributes[\"k8s.namespace.name\"])",
           "set(attributes[\"loki.resource.labels\"], \"pod, namespace, cluster, job\")",
+          // Accessing a map with a key that does not exist will return nil.
+          "set(attributes[\"k8s.cluster.name\"], \"metrics-only-test\") where attributes[\"k8s.cluster.name\"] == nil",
         ]
       }
       output {
@@ -160,6 +162,13 @@ data:
         statements = [
           "set(attributes[\"deployment.environment\"], resource.attributes[\"deployment.environment\"])",
           "set(attributes[\"service.version\"], resource.attributes[\"service.version\"])",
+        ]
+      }
+      metric_statements {
+        context = "resource"
+        statements = [
+          // Accessing a map with a key that does not exist will return nil.
+          "set(attributes[\"k8s.cluster.name\"], \"metrics-only-test\") where attributes[\"k8s.cluster.name\"] == nil",
         ]
       }
       output {
@@ -44084,6 +44093,8 @@ data:
           "set(attributes[\"pod\"], attributes[\"k8s.pod.name\"])",
           "set(attributes[\"namespace\"], attributes[\"k8s.namespace.name\"])",
           "set(attributes[\"loki.resource.labels\"], \"pod, namespace, cluster, job\")",
+          // Accessing a map with a key that does not exist will return nil.
+          "set(attributes[\"k8s.cluster.name\"], \"metrics-only-test\") where attributes[\"k8s.cluster.name\"] == nil",
         ]
       }
       output {
@@ -44097,6 +44108,13 @@ data:
         statements = [
           "set(attributes[\"deployment.environment\"], resource.attributes[\"deployment.environment\"])",
           "set(attributes[\"service.version\"], resource.attributes[\"service.version\"])",
+        ]
+      }
+      metric_statements {
+        context = "resource"
+        statements = [
+          // Accessing a map with a key that does not exist will return nil.
+          "set(attributes[\"k8s.cluster.name\"], \"metrics-only-test\") where attributes[\"k8s.cluster.name\"] == nil",
         ]
       }
       output {

--- a/examples/openshift-compatible/metrics.river
+++ b/examples/openshift-compatible/metrics.river
@@ -66,6 +66,8 @@ otelcol.processor.transform "add_attributes" {
       "set(attributes[\"pod\"], attributes[\"k8s.pod.name\"])",
       "set(attributes[\"namespace\"], attributes[\"k8s.namespace.name\"])",
       "set(attributes[\"loki.resource.labels\"], \"pod, namespace, cluster, job\")",
+      // Accessing a map with a key that does not exist will return nil.
+      "set(attributes[\"k8s.cluster.name\"], \"openshift-compatible-test\") where attributes[\"k8s.cluster.name\"] == nil",
     ]
   }
   output {
@@ -79,6 +81,13 @@ otelcol.processor.transform "add_metric_attributes" {
     statements = [
       "set(attributes[\"deployment.environment\"], resource.attributes[\"deployment.environment\"])",
       "set(attributes[\"service.version\"], resource.attributes[\"service.version\"])",
+    ]
+  }
+  metric_statements {
+    context = "resource"
+    statements = [
+      // Accessing a map with a key that does not exist will return nil.
+      "set(attributes[\"k8s.cluster.name\"], \"openshift-compatible-test\") where attributes[\"k8s.cluster.name\"] == nil",
     ]
   }
   output {

--- a/examples/openshift-compatible/output.yaml
+++ b/examples/openshift-compatible/output.yaml
@@ -157,6 +157,8 @@ data:
           "set(attributes[\"pod\"], attributes[\"k8s.pod.name\"])",
           "set(attributes[\"namespace\"], attributes[\"k8s.namespace.name\"])",
           "set(attributes[\"loki.resource.labels\"], \"pod, namespace, cluster, job\")",
+          // Accessing a map with a key that does not exist will return nil.
+          "set(attributes[\"k8s.cluster.name\"], \"openshift-compatible-test\") where attributes[\"k8s.cluster.name\"] == nil",
         ]
       }
       output {
@@ -170,6 +172,13 @@ data:
         statements = [
           "set(attributes[\"deployment.environment\"], resource.attributes[\"deployment.environment\"])",
           "set(attributes[\"service.version\"], resource.attributes[\"service.version\"])",
+        ]
+      }
+      metric_statements {
+        context = "resource"
+        statements = [
+          // Accessing a map with a key that does not exist will return nil.
+          "set(attributes[\"k8s.cluster.name\"], \"openshift-compatible-test\") where attributes[\"k8s.cluster.name\"] == nil",
         ]
       }
       output {
@@ -44400,6 +44409,8 @@ data:
           "set(attributes[\"pod\"], attributes[\"k8s.pod.name\"])",
           "set(attributes[\"namespace\"], attributes[\"k8s.namespace.name\"])",
           "set(attributes[\"loki.resource.labels\"], \"pod, namespace, cluster, job\")",
+          // Accessing a map with a key that does not exist will return nil.
+          "set(attributes[\"k8s.cluster.name\"], \"openshift-compatible-test\") where attributes[\"k8s.cluster.name\"] == nil",
         ]
       }
       output {
@@ -44413,6 +44424,13 @@ data:
         statements = [
           "set(attributes[\"deployment.environment\"], resource.attributes[\"deployment.environment\"])",
           "set(attributes[\"service.version\"], resource.attributes[\"service.version\"])",
+        ]
+      }
+      metric_statements {
+        context = "resource"
+        statements = [
+          // Accessing a map with a key that does not exist will return nil.
+          "set(attributes[\"k8s.cluster.name\"], \"openshift-compatible-test\") where attributes[\"k8s.cluster.name\"] == nil",
         ]
       }
       output {

--- a/examples/otel-metrics-service/metrics.river
+++ b/examples/otel-metrics-service/metrics.river
@@ -66,6 +66,8 @@ otelcol.processor.transform "add_attributes" {
       "set(attributes[\"pod\"], attributes[\"k8s.pod.name\"])",
       "set(attributes[\"namespace\"], attributes[\"k8s.namespace.name\"])",
       "set(attributes[\"loki.resource.labels\"], \"pod, namespace, cluster, job\")",
+      // Accessing a map with a key that does not exist will return nil.
+      "set(attributes[\"k8s.cluster.name\"], \"otel-metrics-service-test\") where attributes[\"k8s.cluster.name\"] == nil",
     ]
   }
   output {
@@ -79,6 +81,13 @@ otelcol.processor.transform "add_metric_attributes" {
     statements = [
       "set(attributes[\"deployment.environment\"], resource.attributes[\"deployment.environment\"])",
       "set(attributes[\"service.version\"], resource.attributes[\"service.version\"])",
+    ]
+  }
+  metric_statements {
+    context = "resource"
+    statements = [
+      // Accessing a map with a key that does not exist will return nil.
+      "set(attributes[\"k8s.cluster.name\"], \"otel-metrics-service-test\") where attributes[\"k8s.cluster.name\"] == nil",
     ]
   }
   output {

--- a/examples/otel-metrics-service/output.yaml
+++ b/examples/otel-metrics-service/output.yaml
@@ -187,6 +187,8 @@ data:
           "set(attributes[\"pod\"], attributes[\"k8s.pod.name\"])",
           "set(attributes[\"namespace\"], attributes[\"k8s.namespace.name\"])",
           "set(attributes[\"loki.resource.labels\"], \"pod, namespace, cluster, job\")",
+          // Accessing a map with a key that does not exist will return nil.
+          "set(attributes[\"k8s.cluster.name\"], \"otel-metrics-service-test\") where attributes[\"k8s.cluster.name\"] == nil",
         ]
       }
       output {
@@ -200,6 +202,13 @@ data:
         statements = [
           "set(attributes[\"deployment.environment\"], resource.attributes[\"deployment.environment\"])",
           "set(attributes[\"service.version\"], resource.attributes[\"service.version\"])",
+        ]
+      }
+      metric_statements {
+        context = "resource"
+        statements = [
+          // Accessing a map with a key that does not exist will return nil.
+          "set(attributes[\"k8s.cluster.name\"], \"otel-metrics-service-test\") where attributes[\"k8s.cluster.name\"] == nil",
         ]
       }
       output {
@@ -44779,6 +44788,8 @@ data:
           "set(attributes[\"pod\"], attributes[\"k8s.pod.name\"])",
           "set(attributes[\"namespace\"], attributes[\"k8s.namespace.name\"])",
           "set(attributes[\"loki.resource.labels\"], \"pod, namespace, cluster, job\")",
+          // Accessing a map with a key that does not exist will return nil.
+          "set(attributes[\"k8s.cluster.name\"], \"otel-metrics-service-test\") where attributes[\"k8s.cluster.name\"] == nil",
         ]
       }
       output {
@@ -44792,6 +44803,13 @@ data:
         statements = [
           "set(attributes[\"deployment.environment\"], resource.attributes[\"deployment.environment\"])",
           "set(attributes[\"service.version\"], resource.attributes[\"service.version\"])",
+        ]
+      }
+      metric_statements {
+        context = "resource"
+        statements = [
+          // Accessing a map with a key that does not exist will return nil.
+          "set(attributes[\"k8s.cluster.name\"], \"otel-metrics-service-test\") where attributes[\"k8s.cluster.name\"] == nil",
         ]
       }
       output {

--- a/examples/private-image-registry/metrics.river
+++ b/examples/private-image-registry/metrics.river
@@ -66,6 +66,8 @@ otelcol.processor.transform "add_attributes" {
       "set(attributes[\"pod\"], attributes[\"k8s.pod.name\"])",
       "set(attributes[\"namespace\"], attributes[\"k8s.namespace.name\"])",
       "set(attributes[\"loki.resource.labels\"], \"pod, namespace, cluster, job\")",
+      // Accessing a map with a key that does not exist will return nil.
+      "set(attributes[\"k8s.cluster.name\"], \"private-image-registry-test\") where attributes[\"k8s.cluster.name\"] == nil",
     ]
   }
   output {
@@ -79,6 +81,13 @@ otelcol.processor.transform "add_metric_attributes" {
     statements = [
       "set(attributes[\"deployment.environment\"], resource.attributes[\"deployment.environment\"])",
       "set(attributes[\"service.version\"], resource.attributes[\"service.version\"])",
+    ]
+  }
+  metric_statements {
+    context = "resource"
+    statements = [
+      // Accessing a map with a key that does not exist will return nil.
+      "set(attributes[\"k8s.cluster.name\"], \"private-image-registry-test\") where attributes[\"k8s.cluster.name\"] == nil",
     ]
   }
   output {

--- a/examples/private-image-registry/output.yaml
+++ b/examples/private-image-registry/output.yaml
@@ -191,6 +191,8 @@ data:
           "set(attributes[\"pod\"], attributes[\"k8s.pod.name\"])",
           "set(attributes[\"namespace\"], attributes[\"k8s.namespace.name\"])",
           "set(attributes[\"loki.resource.labels\"], \"pod, namespace, cluster, job\")",
+          // Accessing a map with a key that does not exist will return nil.
+          "set(attributes[\"k8s.cluster.name\"], \"private-image-registry-test\") where attributes[\"k8s.cluster.name\"] == nil",
         ]
       }
       output {
@@ -204,6 +206,13 @@ data:
         statements = [
           "set(attributes[\"deployment.environment\"], resource.attributes[\"deployment.environment\"])",
           "set(attributes[\"service.version\"], resource.attributes[\"service.version\"])",
+        ]
+      }
+      metric_statements {
+        context = "resource"
+        statements = [
+          // Accessing a map with a key that does not exist will return nil.
+          "set(attributes[\"k8s.cluster.name\"], \"private-image-registry-test\") where attributes[\"k8s.cluster.name\"] == nil",
         ]
       }
       output {
@@ -44765,6 +44774,8 @@ data:
           "set(attributes[\"pod\"], attributes[\"k8s.pod.name\"])",
           "set(attributes[\"namespace\"], attributes[\"k8s.namespace.name\"])",
           "set(attributes[\"loki.resource.labels\"], \"pod, namespace, cluster, job\")",
+          // Accessing a map with a key that does not exist will return nil.
+          "set(attributes[\"k8s.cluster.name\"], \"private-image-registry-test\") where attributes[\"k8s.cluster.name\"] == nil",
         ]
       }
       output {
@@ -44778,6 +44789,13 @@ data:
         statements = [
           "set(attributes[\"deployment.environment\"], resource.attributes[\"deployment.environment\"])",
           "set(attributes[\"service.version\"], resource.attributes[\"service.version\"])",
+        ]
+      }
+      metric_statements {
+        context = "resource"
+        statements = [
+          // Accessing a map with a key that does not exist will return nil.
+          "set(attributes[\"k8s.cluster.name\"], \"private-image-registry-test\") where attributes[\"k8s.cluster.name\"] == nil",
         ]
       }
       output {

--- a/examples/proxies/metrics.river
+++ b/examples/proxies/metrics.river
@@ -66,6 +66,8 @@ otelcol.processor.transform "add_attributes" {
       "set(attributes[\"pod\"], attributes[\"k8s.pod.name\"])",
       "set(attributes[\"namespace\"], attributes[\"k8s.namespace.name\"])",
       "set(attributes[\"loki.resource.labels\"], \"pod, namespace, cluster, job\")",
+      // Accessing a map with a key that does not exist will return nil.
+      "set(attributes[\"k8s.cluster.name\"], \"proxies-test\") where attributes[\"k8s.cluster.name\"] == nil",
     ]
   }
   output {
@@ -79,6 +81,13 @@ otelcol.processor.transform "add_metric_attributes" {
     statements = [
       "set(attributes[\"deployment.environment\"], resource.attributes[\"deployment.environment\"])",
       "set(attributes[\"service.version\"], resource.attributes[\"service.version\"])",
+    ]
+  }
+  metric_statements {
+    context = "resource"
+    statements = [
+      // Accessing a map with a key that does not exist will return nil.
+      "set(attributes[\"k8s.cluster.name\"], \"proxies-test\") where attributes[\"k8s.cluster.name\"] == nil",
     ]
   }
   output {

--- a/examples/proxies/output.yaml
+++ b/examples/proxies/output.yaml
@@ -187,6 +187,8 @@ data:
           "set(attributes[\"pod\"], attributes[\"k8s.pod.name\"])",
           "set(attributes[\"namespace\"], attributes[\"k8s.namespace.name\"])",
           "set(attributes[\"loki.resource.labels\"], \"pod, namespace, cluster, job\")",
+          // Accessing a map with a key that does not exist will return nil.
+          "set(attributes[\"k8s.cluster.name\"], \"proxies-test\") where attributes[\"k8s.cluster.name\"] == nil",
         ]
       }
       output {
@@ -200,6 +202,13 @@ data:
         statements = [
           "set(attributes[\"deployment.environment\"], resource.attributes[\"deployment.environment\"])",
           "set(attributes[\"service.version\"], resource.attributes[\"service.version\"])",
+        ]
+      }
+      metric_statements {
+        context = "resource"
+        statements = [
+          // Accessing a map with a key that does not exist will return nil.
+          "set(attributes[\"k8s.cluster.name\"], \"proxies-test\") where attributes[\"k8s.cluster.name\"] == nil",
         ]
       }
       output {
@@ -44765,6 +44774,8 @@ data:
           "set(attributes[\"pod\"], attributes[\"k8s.pod.name\"])",
           "set(attributes[\"namespace\"], attributes[\"k8s.namespace.name\"])",
           "set(attributes[\"loki.resource.labels\"], \"pod, namespace, cluster, job\")",
+          // Accessing a map with a key that does not exist will return nil.
+          "set(attributes[\"k8s.cluster.name\"], \"proxies-test\") where attributes[\"k8s.cluster.name\"] == nil",
         ]
       }
       output {
@@ -44778,6 +44789,13 @@ data:
         statements = [
           "set(attributes[\"deployment.environment\"], resource.attributes[\"deployment.environment\"])",
           "set(attributes[\"service.version\"], resource.attributes[\"service.version\"])",
+        ]
+      }
+      metric_statements {
+        context = "resource"
+        statements = [
+          // Accessing a map with a key that does not exist will return nil.
+          "set(attributes[\"k8s.cluster.name\"], \"proxies-test\") where attributes[\"k8s.cluster.name\"] == nil",
         ]
       }
       output {

--- a/examples/scrape-intervals/metrics.river
+++ b/examples/scrape-intervals/metrics.river
@@ -66,6 +66,8 @@ otelcol.processor.transform "add_attributes" {
       "set(attributes[\"pod\"], attributes[\"k8s.pod.name\"])",
       "set(attributes[\"namespace\"], attributes[\"k8s.namespace.name\"])",
       "set(attributes[\"loki.resource.labels\"], \"pod, namespace, cluster, job\")",
+      // Accessing a map with a key that does not exist will return nil.
+      "set(attributes[\"k8s.cluster.name\"], \"custom-scrape-intervals-test\") where attributes[\"k8s.cluster.name\"] == nil",
     ]
   }
   output {
@@ -79,6 +81,13 @@ otelcol.processor.transform "add_metric_attributes" {
     statements = [
       "set(attributes[\"deployment.environment\"], resource.attributes[\"deployment.environment\"])",
       "set(attributes[\"service.version\"], resource.attributes[\"service.version\"])",
+    ]
+  }
+  metric_statements {
+    context = "resource"
+    statements = [
+      // Accessing a map with a key that does not exist will return nil.
+      "set(attributes[\"k8s.cluster.name\"], \"custom-scrape-intervals-test\") where attributes[\"k8s.cluster.name\"] == nil",
     ]
   }
   output {

--- a/examples/scrape-intervals/output.yaml
+++ b/examples/scrape-intervals/output.yaml
@@ -146,6 +146,8 @@ data:
           "set(attributes[\"pod\"], attributes[\"k8s.pod.name\"])",
           "set(attributes[\"namespace\"], attributes[\"k8s.namespace.name\"])",
           "set(attributes[\"loki.resource.labels\"], \"pod, namespace, cluster, job\")",
+          // Accessing a map with a key that does not exist will return nil.
+          "set(attributes[\"k8s.cluster.name\"], \"custom-scrape-intervals-test\") where attributes[\"k8s.cluster.name\"] == nil",
         ]
       }
       output {
@@ -159,6 +161,13 @@ data:
         statements = [
           "set(attributes[\"deployment.environment\"], resource.attributes[\"deployment.environment\"])",
           "set(attributes[\"service.version\"], resource.attributes[\"service.version\"])",
+        ]
+      }
+      metric_statements {
+        context = "resource"
+        statements = [
+          // Accessing a map with a key that does not exist will return nil.
+          "set(attributes[\"k8s.cluster.name\"], \"custom-scrape-intervals-test\") where attributes[\"k8s.cluster.name\"] == nil",
         ]
       }
       output {
@@ -44083,6 +44092,8 @@ data:
           "set(attributes[\"pod\"], attributes[\"k8s.pod.name\"])",
           "set(attributes[\"namespace\"], attributes[\"k8s.namespace.name\"])",
           "set(attributes[\"loki.resource.labels\"], \"pod, namespace, cluster, job\")",
+          // Accessing a map with a key that does not exist will return nil.
+          "set(attributes[\"k8s.cluster.name\"], \"custom-scrape-intervals-test\") where attributes[\"k8s.cluster.name\"] == nil",
         ]
       }
       output {
@@ -44096,6 +44107,13 @@ data:
         statements = [
           "set(attributes[\"deployment.environment\"], resource.attributes[\"deployment.environment\"])",
           "set(attributes[\"service.version\"], resource.attributes[\"service.version\"])",
+        ]
+      }
+      metric_statements {
+        context = "resource"
+        statements = [
+          // Accessing a map with a key that does not exist will return nil.
+          "set(attributes[\"k8s.cluster.name\"], \"custom-scrape-intervals-test\") where attributes[\"k8s.cluster.name\"] == nil",
         ]
       }
       output {

--- a/examples/service-integrations/metrics.river
+++ b/examples/service-integrations/metrics.river
@@ -66,6 +66,8 @@ otelcol.processor.transform "add_attributes" {
       "set(attributes[\"pod\"], attributes[\"k8s.pod.name\"])",
       "set(attributes[\"namespace\"], attributes[\"k8s.namespace.name\"])",
       "set(attributes[\"loki.resource.labels\"], \"pod, namespace, cluster, job\")",
+      // Accessing a map with a key that does not exist will return nil.
+      "set(attributes[\"k8s.cluster.name\"], \"service-integrations-test\") where attributes[\"k8s.cluster.name\"] == nil",
     ]
   }
   output {
@@ -79,6 +81,13 @@ otelcol.processor.transform "add_metric_attributes" {
     statements = [
       "set(attributes[\"deployment.environment\"], resource.attributes[\"deployment.environment\"])",
       "set(attributes[\"service.version\"], resource.attributes[\"service.version\"])",
+    ]
+  }
+  metric_statements {
+    context = "resource"
+    statements = [
+      // Accessing a map with a key that does not exist will return nil.
+      "set(attributes[\"k8s.cluster.name\"], \"service-integrations-test\") where attributes[\"k8s.cluster.name\"] == nil",
     ]
   }
   output {

--- a/examples/service-integrations/output.yaml
+++ b/examples/service-integrations/output.yaml
@@ -187,6 +187,8 @@ data:
           "set(attributes[\"pod\"], attributes[\"k8s.pod.name\"])",
           "set(attributes[\"namespace\"], attributes[\"k8s.namespace.name\"])",
           "set(attributes[\"loki.resource.labels\"], \"pod, namespace, cluster, job\")",
+          // Accessing a map with a key that does not exist will return nil.
+          "set(attributes[\"k8s.cluster.name\"], \"service-integrations-test\") where attributes[\"k8s.cluster.name\"] == nil",
         ]
       }
       output {
@@ -200,6 +202,13 @@ data:
         statements = [
           "set(attributes[\"deployment.environment\"], resource.attributes[\"deployment.environment\"])",
           "set(attributes[\"service.version\"], resource.attributes[\"service.version\"])",
+        ]
+      }
+      metric_statements {
+        context = "resource"
+        statements = [
+          // Accessing a map with a key that does not exist will return nil.
+          "set(attributes[\"k8s.cluster.name\"], \"service-integrations-test\") where attributes[\"k8s.cluster.name\"] == nil",
         ]
       }
       output {
@@ -44784,6 +44793,8 @@ data:
           "set(attributes[\"pod\"], attributes[\"k8s.pod.name\"])",
           "set(attributes[\"namespace\"], attributes[\"k8s.namespace.name\"])",
           "set(attributes[\"loki.resource.labels\"], \"pod, namespace, cluster, job\")",
+          // Accessing a map with a key that does not exist will return nil.
+          "set(attributes[\"k8s.cluster.name\"], \"service-integrations-test\") where attributes[\"k8s.cluster.name\"] == nil",
         ]
       }
       output {
@@ -44797,6 +44808,13 @@ data:
         statements = [
           "set(attributes[\"deployment.environment\"], resource.attributes[\"deployment.environment\"])",
           "set(attributes[\"service.version\"], resource.attributes[\"service.version\"])",
+        ]
+      }
+      metric_statements {
+        context = "resource"
+        statements = [
+          // Accessing a map with a key that does not exist will return nil.
+          "set(attributes[\"k8s.cluster.name\"], \"service-integrations-test\") where attributes[\"k8s.cluster.name\"] == nil",
         ]
       }
       output {

--- a/examples/specific-namespace/metrics.river
+++ b/examples/specific-namespace/metrics.river
@@ -66,6 +66,8 @@ otelcol.processor.transform "add_attributes" {
       "set(attributes[\"pod\"], attributes[\"k8s.pod.name\"])",
       "set(attributes[\"namespace\"], attributes[\"k8s.namespace.name\"])",
       "set(attributes[\"loki.resource.labels\"], \"pod, namespace, cluster, job\")",
+      // Accessing a map with a key that does not exist will return nil.
+      "set(attributes[\"k8s.cluster.name\"], \"specific-namespace-test\") where attributes[\"k8s.cluster.name\"] == nil",
     ]
   }
   output {
@@ -79,6 +81,13 @@ otelcol.processor.transform "add_metric_attributes" {
     statements = [
       "set(attributes[\"deployment.environment\"], resource.attributes[\"deployment.environment\"])",
       "set(attributes[\"service.version\"], resource.attributes[\"service.version\"])",
+    ]
+  }
+  metric_statements {
+    context = "resource"
+    statements = [
+      // Accessing a map with a key that does not exist will return nil.
+      "set(attributes[\"k8s.cluster.name\"], \"specific-namespace-test\") where attributes[\"k8s.cluster.name\"] == nil",
     ]
   }
   output {

--- a/examples/specific-namespace/output.yaml
+++ b/examples/specific-namespace/output.yaml
@@ -187,6 +187,8 @@ data:
           "set(attributes[\"pod\"], attributes[\"k8s.pod.name\"])",
           "set(attributes[\"namespace\"], attributes[\"k8s.namespace.name\"])",
           "set(attributes[\"loki.resource.labels\"], \"pod, namespace, cluster, job\")",
+          // Accessing a map with a key that does not exist will return nil.
+          "set(attributes[\"k8s.cluster.name\"], \"specific-namespace-test\") where attributes[\"k8s.cluster.name\"] == nil",
         ]
       }
       output {
@@ -200,6 +202,13 @@ data:
         statements = [
           "set(attributes[\"deployment.environment\"], resource.attributes[\"deployment.environment\"])",
           "set(attributes[\"service.version\"], resource.attributes[\"service.version\"])",
+        ]
+      }
+      metric_statements {
+        context = "resource"
+        statements = [
+          // Accessing a map with a key that does not exist will return nil.
+          "set(attributes[\"k8s.cluster.name\"], \"specific-namespace-test\") where attributes[\"k8s.cluster.name\"] == nil",
         ]
       }
       output {
@@ -44805,6 +44814,8 @@ data:
           "set(attributes[\"pod\"], attributes[\"k8s.pod.name\"])",
           "set(attributes[\"namespace\"], attributes[\"k8s.namespace.name\"])",
           "set(attributes[\"loki.resource.labels\"], \"pod, namespace, cluster, job\")",
+          // Accessing a map with a key that does not exist will return nil.
+          "set(attributes[\"k8s.cluster.name\"], \"specific-namespace-test\") where attributes[\"k8s.cluster.name\"] == nil",
         ]
       }
       output {
@@ -44818,6 +44829,13 @@ data:
         statements = [
           "set(attributes[\"deployment.environment\"], resource.attributes[\"deployment.environment\"])",
           "set(attributes[\"service.version\"], resource.attributes[\"service.version\"])",
+        ]
+      }
+      metric_statements {
+        context = "resource"
+        statements = [
+          // Accessing a map with a key that does not exist will return nil.
+          "set(attributes[\"k8s.cluster.name\"], \"specific-namespace-test\") where attributes[\"k8s.cluster.name\"] == nil",
         ]
       }
       output {

--- a/examples/traces-enabled/metrics.river
+++ b/examples/traces-enabled/metrics.river
@@ -68,6 +68,8 @@ otelcol.processor.transform "add_attributes" {
       "set(attributes[\"pod\"], attributes[\"k8s.pod.name\"])",
       "set(attributes[\"namespace\"], attributes[\"k8s.namespace.name\"])",
       "set(attributes[\"loki.resource.labels\"], \"pod, namespace, cluster, job\")",
+      // Accessing a map with a key that does not exist will return nil.
+      "set(attributes[\"k8s.cluster.name\"], \"traces-enabled-test\") where attributes[\"k8s.cluster.name\"] == nil",
     ]
   }
   output {
@@ -82,6 +84,13 @@ otelcol.processor.transform "add_metric_attributes" {
     statements = [
       "set(attributes[\"deployment.environment\"], resource.attributes[\"deployment.environment\"])",
       "set(attributes[\"service.version\"], resource.attributes[\"service.version\"])",
+    ]
+  }
+  metric_statements {
+    context = "resource"
+    statements = [
+      // Accessing a map with a key that does not exist will return nil.
+      "set(attributes[\"k8s.cluster.name\"], \"traces-enabled-test\") where attributes[\"k8s.cluster.name\"] == nil",
     ]
   }
   output {

--- a/examples/traces-enabled/output.yaml
+++ b/examples/traces-enabled/output.yaml
@@ -202,6 +202,8 @@ data:
           "set(attributes[\"pod\"], attributes[\"k8s.pod.name\"])",
           "set(attributes[\"namespace\"], attributes[\"k8s.namespace.name\"])",
           "set(attributes[\"loki.resource.labels\"], \"pod, namespace, cluster, job\")",
+          // Accessing a map with a key that does not exist will return nil.
+          "set(attributes[\"k8s.cluster.name\"], \"traces-enabled-test\") where attributes[\"k8s.cluster.name\"] == nil",
         ]
       }
       output {
@@ -216,6 +218,13 @@ data:
         statements = [
           "set(attributes[\"deployment.environment\"], resource.attributes[\"deployment.environment\"])",
           "set(attributes[\"service.version\"], resource.attributes[\"service.version\"])",
+        ]
+      }
+      metric_statements {
+        context = "resource"
+        statements = [
+          // Accessing a map with a key that does not exist will return nil.
+          "set(attributes[\"k8s.cluster.name\"], \"traces-enabled-test\") where attributes[\"k8s.cluster.name\"] == nil",
         ]
       }
       output {
@@ -44813,6 +44822,8 @@ data:
           "set(attributes[\"pod\"], attributes[\"k8s.pod.name\"])",
           "set(attributes[\"namespace\"], attributes[\"k8s.namespace.name\"])",
           "set(attributes[\"loki.resource.labels\"], \"pod, namespace, cluster, job\")",
+          // Accessing a map with a key that does not exist will return nil.
+          "set(attributes[\"k8s.cluster.name\"], \"traces-enabled-test\") where attributes[\"k8s.cluster.name\"] == nil",
         ]
       }
       output {
@@ -44827,6 +44838,13 @@ data:
         statements = [
           "set(attributes[\"deployment.environment\"], resource.attributes[\"deployment.environment\"])",
           "set(attributes[\"service.version\"], resource.attributes[\"service.version\"])",
+        ]
+      }
+      metric_statements {
+        context = "resource"
+        statements = [
+          // Accessing a map with a key that does not exist will return nil.
+          "set(attributes[\"k8s.cluster.name\"], \"traces-enabled-test\") where attributes[\"k8s.cluster.name\"] == nil",
         ]
       }
       output {

--- a/examples/windows-exporter/metrics.river
+++ b/examples/windows-exporter/metrics.river
@@ -66,6 +66,8 @@ otelcol.processor.transform "add_attributes" {
       "set(attributes[\"pod\"], attributes[\"k8s.pod.name\"])",
       "set(attributes[\"namespace\"], attributes[\"k8s.namespace.name\"])",
       "set(attributes[\"loki.resource.labels\"], \"pod, namespace, cluster, job\")",
+      // Accessing a map with a key that does not exist will return nil.
+      "set(attributes[\"k8s.cluster.name\"], \"default-values-test\") where attributes[\"k8s.cluster.name\"] == nil",
     ]
   }
   output {
@@ -79,6 +81,13 @@ otelcol.processor.transform "add_metric_attributes" {
     statements = [
       "set(attributes[\"deployment.environment\"], resource.attributes[\"deployment.environment\"])",
       "set(attributes[\"service.version\"], resource.attributes[\"service.version\"])",
+    ]
+  }
+  metric_statements {
+    context = "resource"
+    statements = [
+      // Accessing a map with a key that does not exist will return nil.
+      "set(attributes[\"k8s.cluster.name\"], \"default-values-test\") where attributes[\"k8s.cluster.name\"] == nil",
     ]
   }
   output {

--- a/examples/windows-exporter/output.yaml
+++ b/examples/windows-exporter/output.yaml
@@ -224,6 +224,8 @@ data:
           "set(attributes[\"pod\"], attributes[\"k8s.pod.name\"])",
           "set(attributes[\"namespace\"], attributes[\"k8s.namespace.name\"])",
           "set(attributes[\"loki.resource.labels\"], \"pod, namespace, cluster, job\")",
+          // Accessing a map with a key that does not exist will return nil.
+          "set(attributes[\"k8s.cluster.name\"], \"default-values-test\") where attributes[\"k8s.cluster.name\"] == nil",
         ]
       }
       output {
@@ -237,6 +239,13 @@ data:
         statements = [
           "set(attributes[\"deployment.environment\"], resource.attributes[\"deployment.environment\"])",
           "set(attributes[\"service.version\"], resource.attributes[\"service.version\"])",
+        ]
+      }
+      metric_statements {
+        context = "resource"
+        statements = [
+          // Accessing a map with a key that does not exist will return nil.
+          "set(attributes[\"k8s.cluster.name\"], \"default-values-test\") where attributes[\"k8s.cluster.name\"] == nil",
         ]
       }
       output {
@@ -44980,6 +44989,8 @@ data:
           "set(attributes[\"pod\"], attributes[\"k8s.pod.name\"])",
           "set(attributes[\"namespace\"], attributes[\"k8s.namespace.name\"])",
           "set(attributes[\"loki.resource.labels\"], \"pod, namespace, cluster, job\")",
+          // Accessing a map with a key that does not exist will return nil.
+          "set(attributes[\"k8s.cluster.name\"], \"default-values-test\") where attributes[\"k8s.cluster.name\"] == nil",
         ]
       }
       output {
@@ -44993,6 +45004,13 @@ data:
         statements = [
           "set(attributes[\"deployment.environment\"], resource.attributes[\"deployment.environment\"])",
           "set(attributes[\"service.version\"], resource.attributes[\"service.version\"])",
+        ]
+      }
+      metric_statements {
+        context = "resource"
+        statements = [
+          // Accessing a map with a key that does not exist will return nil.
+          "set(attributes[\"k8s.cluster.name\"], \"default-values-test\") where attributes[\"k8s.cluster.name\"] == nil",
         ]
       }
       output {


### PR DESCRIPTION
This is a follow-up PR for https://github.com/grafana/k8s-monitoring-helm/pull/342
It sets k8s.cluster.name resource attributes to logs and metrics. It will allow app o11y users to filter their data by k8s.cluster.name resource attribute