### PR TITLE
Improve how the log gathering annotation behaves.

### DIFF
--- a/charts/k8s-monitoring/README.md
+++ b/charts/k8s-monitoring/README.md
@@ -186,8 +186,8 @@ The Prometheus and Loki services may be hosted on the same cluster, or remotely 
 | logs.cluster_events.namespaces | list | `[]` | List of namespaces to watch for events (`[]` means all namespaces) |
 | logs.enabled | bool | `true` | Capture and forward logs |
 | logs.extraConfig | string | `""` | Extra configuration that will be added to Grafana Agent Logs configuration file. This cannot be used to modify the generated configuration values, only append new components. See [Adding custom Flow configuration](#adding-custom-flow-configuration) for an example. |
-| logs.pod_logs.annotation | string | `"k8s.grafana.com/logs.autogather"` |  |
-| logs.pod_logs.discovery | string | `"all"` |  |
+| logs.pod_logs.annotation | string | `"k8s.grafana.com/logs.autogather"` | Pod annotation to use for controlling log discovery. |
+| logs.pod_logs.discovery | string | `"all"` | Controls the behavior of discovering pods for logs. |
 | logs.pod_logs.enabled | bool | `true` | Capture and forward logs from Kubernetes pods |
 | logs.pod_logs.extraRelabelingRules | string | `""` | Rule blocks to be added to the discovery.relabel component for pod logs. See https://grafana.com/docs/agent/latest/flow/reference/components/discovery.relabel/#rule-block |
 | logs.pod_logs.extraStageBlocks | string | `""` | Stage blocks to be added to the loki.process component for pod logs. See https://grafana.com/docs/agent/latest/flow/reference/components/loki.process/#blocks |
@@ -216,7 +216,7 @@ The Prometheus and Loki services may be hosted on the same cluster, or remotely 
 | metrics.autoDiscover.annotations.metricsPortNumber | string | `"k8s.grafana.com/metrics.portNumber"` | Annotation for setting the metrics port by number. |
 | metrics.autoDiscover.annotations.metricsScheme | string | `"k8s.grafana.com/metrics.scheme"` | Annotation for setting the metrics scheme, default: http. |
 | metrics.autoDiscover.annotations.scrape | string | `"k8s.grafana.com/scrape"` | Annotation for enabling scraping for this service or pod. Value should be either "true" or "false" |
-| metrics.autoDiscover.enabled | bool | `true` |  |
+| metrics.autoDiscover.enabled | bool | `true` | Enable annotation-based autodiscovery |
 | metrics.autoDiscover.extraMetricRelabelingRules | string | `""` | Rule blocks to be added to the prometheus.relabel component for auto-discovered entities. See https://grafana.com/docs/agent/latest/flow/reference/components/prometheus.relabel/#rule-block |
 | metrics.autoDiscover.extraRelabelingRules | string | `""` | Rule blocks to be added to the discovery.relabel component for auto-discovered entities. See https://grafana.com/docs/agent/latest/flow/reference/components/discovery.relabel/#rule-block |
 | metrics.autoDiscover.metricsTuning.excludeMetrics | list | `[]` | Metrics to drop. Can use regex. |
@@ -322,7 +322,7 @@ The Prometheus and Loki services may be hosted on the same cluster, or remotely 
 | opencost.opencost.prometheus.username_key | string | `"username"` | The key for the username property in the secret. |
 | prometheus-node-exporter.enabled | bool | `true` | Should this helm chart deploy Node Exporter to the cluster. Set this to false if your cluster already has Node Exporter, or if you do not want to scrape metrics from Node Exporter. |
 | prometheus-operator-crds.enabled | bool | `true` | Should this helm chart deploy the Prometheus Operator CRDs to the cluster. Set this to false if your cluster already has the CRDs, or if you do not to have the Grafana Agent scrape metrics from PodMonitors, Probes, or ServiceMonitors. |
-| prometheus-windows-exporter.config | string | `"collectors:\n  enabled: cpu,cs,container,logical_disk,memory,net,os\ncollector:\n  service:\n    services-where: \"Name='containerd' or Name='kubelet'\""` |  |
+| prometheus-windows-exporter.config | string | `"collectors:\n  enabled: cpu,cs,container,logical_disk,memory,net,os\ncollector:\n  service:\n    services-where: \"Name='containerd' or Name='kubelet'\""` | Windows Exporter configuration |
 | prometheus-windows-exporter.enabled | bool | `false` | Should this helm chart deploy Windows Exporter to the cluster. Set this to false if your cluster already has Windows Exporter, or if you do not want to scrape metrics from Windows Exporter. |
 | receivers.grpc.disable_debug_metrics | bool | `true` | It removes attributes which could cause high cardinality metrics. For example, attributes with IP addresses and port numbers in metrics about HTTP and gRPC connections will be removed. |
 | receivers.grpc.enabled | bool | `true` | Receive telemetry data over gRPC? |

--- a/charts/k8s-monitoring/templates/agent_config/_pod_logs.river.txt
+++ b/charts/k8s-monitoring/templates/agent_config/_pod_logs.river.txt
@@ -67,16 +67,15 @@ discovery.relabel "pod_logs" {
 
 discovery.relabel "filtered_pod_logs" {
   targets = discovery.relabel.pod_logs.output
-{{- if eq .Values.logs.pod_logs.discovery "all" }}
-  rule {
+  rule {  // Drop anything with a "falsy" annotation value
     source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_autogather"]
-    regex = "skip"
+    regex = "(false|no|skip)"
     action = "drop"
   }
-{{- else if eq .Values.logs.pod_logs.discovery "annotation" }}
-  rule {
+{{- if eq .Values.logs.pod_logs.discovery "annotation" }}
+  rule {  // If discovering via annotation, then only keep pods with annotation values
     source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_autogather"]
-    regex = "gather"
+    regex = ".+"
     action = "keep"
   }
 {{- end }}

--- a/charts/k8s-monitoring/values.yaml
+++ b/charts/k8s-monitoring/values.yaml
@@ -217,7 +217,7 @@ metrics:
   # Annotation-based autodiscovery allows for discovering metric sources solely on their annotations and does
   # not require adding any extra configuration.
   autoDiscover:
-    # Enable annotation-based autodiscovery
+    # -- Enable annotation-based autodiscovery
     enabled: true
 
     # -- Rule blocks to be added to the discovery.relabel component for auto-discovered entities.
@@ -664,15 +664,18 @@ logs:
     # -- Capture and forward logs from Kubernetes pods
     enabled: true
 
-    # Controls the behavior of discovering pods for logs.
     # When set to "all", every pod (filtered by the namespaces list below) will have their logs gathered, but you can
     # use the annotation to remove a pod from that list.
-    # When set to "annotation", only pods with the annotation set to true will be gathered.
+    # e.g. Pods with the annotation k8s.grafana.com/logs.autogather: false will not have their logs gathered.
+    # When set to "annotation", only pods with the annotation set to something other than "false", "no" or "skip" will
+    # have their logs gathered.
     # Possible values: "all" "annotation"
+    # -- Controls the behavior of discovering pods for logs.
     discovery: "all"
 
-    # The annotation to control the behavior of gathering logs from this pod. If you put this annotation on to your pod,
-    # it will either enable or disable auto gathering of logs from this pod.
+    # The annotation to control the behavior of gathering logs from this pod. If a pod has this annotation, it will
+    # either enable or disable gathering of logs.
+    # -- Pod annotation to use for controlling log discovery.
     annotation: "k8s.grafana.com/logs.autogather"
 
     # -- Only capture logs from pods in these namespaces (`[]` means all namespaces)
@@ -870,6 +873,7 @@ prometheus-windows-exporter:
   # not want to scrape metrics from Windows Exporter.
   enabled: false
 
+  # -- Windows Exporter configuration
   config: |-
     collectors:
       enabled: cpu,cs,container,logical_disk,memory,net,os

--- a/examples/cluster-with-pvc/logs.river
+++ b/examples/cluster-with-pvc/logs.river
@@ -52,9 +52,9 @@ discovery.relabel "pod_logs" {
 
 discovery.relabel "filtered_pod_logs" {
   targets = discovery.relabel.pod_logs.output
-  rule {
+  rule {  // Drop anything with a "falsy" annotation value
     source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_autogather"]
-    regex = "skip"
+    regex = "(false|no|skip)"
     action = "drop"
   }
 }

--- a/examples/cluster-with-pvc/output.yaml
+++ b/examples/cluster-with-pvc/output.yaml
@@ -962,9 +962,9 @@ data:
     
     discovery.relabel "filtered_pod_logs" {
       targets = discovery.relabel.pod_logs.output
-      rule {
+      rule {  // Drop anything with a "falsy" annotation value
         source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_autogather"]
-        regex = "skip"
+        regex = "(false|no|skip)"
         action = "drop"
       }
     }
@@ -45653,9 +45653,9 @@ data:
     
     discovery.relabel "filtered_pod_logs" {
       targets = discovery.relabel.pod_logs.output
-      rule {
+      rule {  // Drop anything with a "falsy" annotation value
         source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_autogather"]
-        regex = "skip"
+        regex = "(false|no|skip)"
         action = "drop"
       }
     }

--- a/examples/control-plane-metrics/logs.river
+++ b/examples/control-plane-metrics/logs.river
@@ -52,9 +52,9 @@ discovery.relabel "pod_logs" {
 
 discovery.relabel "filtered_pod_logs" {
   targets = discovery.relabel.pod_logs.output
-  rule {
+  rule {  // Drop anything with a "falsy" annotation value
     source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_autogather"]
-    regex = "skip"
+    regex = "(false|no|skip)"
     action = "drop"
   }
 }

--- a/examples/control-plane-metrics/output.yaml
+++ b/examples/control-plane-metrics/output.yaml
@@ -1109,9 +1109,9 @@ data:
     
     discovery.relabel "filtered_pod_logs" {
       targets = discovery.relabel.pod_logs.output
-      rule {
+      rule {  // Drop anything with a "falsy" annotation value
         source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_autogather"]
-        regex = "skip"
+        regex = "(false|no|skip)"
         action = "drop"
       }
     }
@@ -45897,9 +45897,9 @@ data:
     
     discovery.relabel "filtered_pod_logs" {
       targets = discovery.relabel.pod_logs.output
-      rule {
+      rule {  // Drop anything with a "falsy" annotation value
         source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_autogather"]
-        regex = "skip"
+        regex = "(false|no|skip)"
         action = "drop"
       }
     }

--- a/examples/custom-config/logs.river
+++ b/examples/custom-config/logs.river
@@ -52,9 +52,9 @@ discovery.relabel "pod_logs" {
 
 discovery.relabel "filtered_pod_logs" {
   targets = discovery.relabel.pod_logs.output
-  rule {
+  rule {  // Drop anything with a "falsy" annotation value
     source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_autogather"]
-    regex = "skip"
+    regex = "(false|no|skip)"
     action = "drop"
   }
 }

--- a/examples/custom-config/output.yaml
+++ b/examples/custom-config/output.yaml
@@ -982,9 +982,9 @@ data:
     
     discovery.relabel "filtered_pod_logs" {
       targets = discovery.relabel.pod_logs.output
-      rule {
+      rule {  // Drop anything with a "falsy" annotation value
         source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_autogather"]
-        regex = "skip"
+        regex = "(false|no|skip)"
         action = "drop"
       }
     }
@@ -45681,9 +45681,9 @@ data:
     
     discovery.relabel "filtered_pod_logs" {
       targets = discovery.relabel.pod_logs.output
-      rule {
+      rule {  // Drop anything with a "falsy" annotation value
         source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_autogather"]
-        regex = "skip"
+        regex = "(false|no|skip)"
         action = "drop"
       }
     }

--- a/examples/default-values/logs.river
+++ b/examples/default-values/logs.river
@@ -52,9 +52,9 @@ discovery.relabel "pod_logs" {
 
 discovery.relabel "filtered_pod_logs" {
   targets = discovery.relabel.pod_logs.output
-  rule {
+  rule {  // Drop anything with a "falsy" annotation value
     source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_autogather"]
-    regex = "skip"
+    regex = "(false|no|skip)"
     action = "drop"
   }
 }

--- a/examples/default-values/output.yaml
+++ b/examples/default-values/output.yaml
@@ -956,9 +956,9 @@ data:
     
     discovery.relabel "filtered_pod_logs" {
       targets = discovery.relabel.pod_logs.output
-      rule {
+      rule {  // Drop anything with a "falsy" annotation value
         source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_autogather"]
-        regex = "skip"
+        regex = "(false|no|skip)"
         action = "drop"
       }
     }
@@ -45592,9 +45592,9 @@ data:
     
     discovery.relabel "filtered_pod_logs" {
       targets = discovery.relabel.pod_logs.output
-      rule {
+      rule {  // Drop anything with a "falsy" annotation value
         source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_autogather"]
-        regex = "skip"
+        regex = "(false|no|skip)"
         action = "drop"
       }
     }

--- a/examples/eks-fargate/logs.river
+++ b/examples/eks-fargate/logs.river
@@ -41,9 +41,9 @@ discovery.relabel "pod_logs" {
 
 discovery.relabel "filtered_pod_logs" {
   targets = discovery.relabel.pod_logs.output
-  rule {
+  rule {  // Drop anything with a "falsy" annotation value
     source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_autogather"]
-    regex = "skip"
+    regex = "(false|no|skip)"
     action = "drop"
   }
 }

--- a/examples/eks-fargate/output.yaml
+++ b/examples/eks-fargate/output.yaml
@@ -884,9 +884,9 @@ data:
     
     discovery.relabel "filtered_pod_logs" {
       targets = discovery.relabel.pod_logs.output
-      rule {
+      rule {  // Drop anything with a "falsy" annotation value
         source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_autogather"]
-        regex = "skip"
+        regex = "(false|no|skip)"
         action = "drop"
       }
     }
@@ -45347,9 +45347,9 @@ data:
     
     discovery.relabel "filtered_pod_logs" {
       targets = discovery.relabel.pod_logs.output
-      rule {
+      rule {  // Drop anything with a "falsy" annotation value
         source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_autogather"]
-        regex = "skip"
+        regex = "(false|no|skip)"
         action = "drop"
       }
     }

--- a/examples/extra-rules/logs.river
+++ b/examples/extra-rules/logs.river
@@ -57,9 +57,9 @@ discovery.relabel "pod_logs" {
 
 discovery.relabel "filtered_pod_logs" {
   targets = discovery.relabel.pod_logs.output
-  rule {
+  rule {  // Drop anything with a "falsy" annotation value
     source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_autogather"]
-    regex = "skip"
+    regex = "(false|no|skip)"
     action = "drop"
   }
 }

--- a/examples/extra-rules/output.yaml
+++ b/examples/extra-rules/output.yaml
@@ -1018,9 +1018,9 @@ data:
     
     discovery.relabel "filtered_pod_logs" {
       targets = discovery.relabel.pod_logs.output
-      rule {
+      rule {  // Drop anything with a "falsy" annotation value
         source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_autogather"]
-        regex = "skip"
+        regex = "(false|no|skip)"
         action = "drop"
       }
     }
@@ -45734,9 +45734,9 @@ data:
     
     discovery.relabel "filtered_pod_logs" {
       targets = discovery.relabel.pod_logs.output
-      rule {
+      rule {  // Drop anything with a "falsy" annotation value
         source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_autogather"]
-        regex = "skip"
+        regex = "(false|no|skip)"
         action = "drop"
       }
     }

--- a/examples/gke-autopilot/logs.river
+++ b/examples/gke-autopilot/logs.river
@@ -52,9 +52,9 @@ discovery.relabel "pod_logs" {
 
 discovery.relabel "filtered_pod_logs" {
   targets = discovery.relabel.pod_logs.output
-  rule {
+  rule {  // Drop anything with a "falsy" annotation value
     source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_autogather"]
-    regex = "skip"
+    regex = "(false|no|skip)"
     action = "drop"
   }
 }

--- a/examples/gke-autopilot/output.yaml
+++ b/examples/gke-autopilot/output.yaml
@@ -895,9 +895,9 @@ data:
     
     discovery.relabel "filtered_pod_logs" {
       targets = discovery.relabel.pod_logs.output
-      rule {
+      rule {  // Drop anything with a "falsy" annotation value
         source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_autogather"]
-        regex = "skip"
+        regex = "(false|no|skip)"
         action = "drop"
       }
     }
@@ -45344,9 +45344,9 @@ data:
     
     discovery.relabel "filtered_pod_logs" {
       targets = discovery.relabel.pod_logs.output
-      rule {
+      rule {  // Drop anything with a "falsy" annotation value
         source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_autogather"]
-        regex = "skip"
+        regex = "(false|no|skip)"
         action = "drop"
       }
     }

--- a/examples/ibm-cloud/logs.river
+++ b/examples/ibm-cloud/logs.river
@@ -52,9 +52,9 @@ discovery.relabel "pod_logs" {
 
 discovery.relabel "filtered_pod_logs" {
   targets = discovery.relabel.pod_logs.output
-  rule {
+  rule {  // Drop anything with a "falsy" annotation value
     source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_autogather"]
-    regex = "skip"
+    regex = "(false|no|skip)"
     action = "drop"
   }
 }

--- a/examples/ibm-cloud/output.yaml
+++ b/examples/ibm-cloud/output.yaml
@@ -956,9 +956,9 @@ data:
     
     discovery.relabel "filtered_pod_logs" {
       targets = discovery.relabel.pod_logs.output
-      rule {
+      rule {  // Drop anything with a "falsy" annotation value
         source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_autogather"]
-        regex = "skip"
+        regex = "(false|no|skip)"
         action = "drop"
       }
     }
@@ -45598,9 +45598,9 @@ data:
     
     discovery.relabel "filtered_pod_logs" {
       targets = discovery.relabel.pod_logs.output
-      rule {
+      rule {  // Drop anything with a "falsy" annotation value
         source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_autogather"]
-        regex = "skip"
+        regex = "(false|no|skip)"
         action = "drop"
       }
     }

--- a/examples/logs-only/logs.river
+++ b/examples/logs-only/logs.river
@@ -52,9 +52,9 @@ discovery.relabel "pod_logs" {
 
 discovery.relabel "filtered_pod_logs" {
   targets = discovery.relabel.pod_logs.output
-  rule {
+  rule {  // Drop anything with a "falsy" annotation value
     source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_autogather"]
-    regex = "skip"
+    regex = "(false|no|skip)"
     action = "drop"
   }
 }

--- a/examples/logs-only/output.yaml
+++ b/examples/logs-only/output.yaml
@@ -264,9 +264,9 @@ data:
     
     discovery.relabel "filtered_pod_logs" {
       targets = discovery.relabel.pod_logs.output
-      rule {
+      rule {  // Drop anything with a "falsy" annotation value
         source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_autogather"]
-        regex = "skip"
+        regex = "(false|no|skip)"
         action = "drop"
       }
     }
@@ -1311,9 +1311,9 @@ data:
     
     discovery.relabel "filtered_pod_logs" {
       targets = discovery.relabel.pod_logs.output
-      rule {
+      rule {  // Drop anything with a "falsy" annotation value
         source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_autogather"]
-        regex = "skip"
+        regex = "(false|no|skip)"
         action = "drop"
       }
     }

--- a/examples/openshift-compatible/logs.river
+++ b/examples/openshift-compatible/logs.river
@@ -52,9 +52,9 @@ discovery.relabel "pod_logs" {
 
 discovery.relabel "filtered_pod_logs" {
   targets = discovery.relabel.pod_logs.output
-  rule {
+  rule {  // Drop anything with a "falsy" annotation value
     source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_autogather"]
-    regex = "skip"
+    regex = "(false|no|skip)"
     action = "drop"
   }
 }

--- a/examples/openshift-compatible/output.yaml
+++ b/examples/openshift-compatible/output.yaml
@@ -930,9 +930,9 @@ data:
     
     discovery.relabel "filtered_pod_logs" {
       targets = discovery.relabel.pod_logs.output
-      rule {
+      rule {  // Drop anything with a "falsy" annotation value
         source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_autogather"]
-        regex = "skip"
+        regex = "(false|no|skip)"
         action = "drop"
       }
     }
@@ -45247,9 +45247,9 @@ data:
     
     discovery.relabel "filtered_pod_logs" {
       targets = discovery.relabel.pod_logs.output
-      rule {
+      rule {  // Drop anything with a "falsy" annotation value
         source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_autogather"]
-        regex = "skip"
+        regex = "(false|no|skip)"
         action = "drop"
       }
     }

--- a/examples/otel-metrics-service/logs.river
+++ b/examples/otel-metrics-service/logs.river
@@ -52,9 +52,9 @@ discovery.relabel "pod_logs" {
 
 discovery.relabel "filtered_pod_logs" {
   targets = discovery.relabel.pod_logs.output
-  rule {
+  rule {  // Drop anything with a "falsy" annotation value
     source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_autogather"]
-    regex = "skip"
+    regex = "(false|no|skip)"
     action = "drop"
   }
 }

--- a/examples/otel-metrics-service/output.yaml
+++ b/examples/otel-metrics-service/output.yaml
@@ -986,9 +986,9 @@ data:
     
     discovery.relabel "filtered_pod_logs" {
       targets = discovery.relabel.pod_logs.output
-      rule {
+      rule {  // Drop anything with a "falsy" annotation value
         source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_autogather"]
-        regex = "skip"
+        regex = "(false|no|skip)"
         action = "drop"
       }
     }
@@ -45652,9 +45652,9 @@ data:
     
     discovery.relabel "filtered_pod_logs" {
       targets = discovery.relabel.pod_logs.output
-      rule {
+      rule {  // Drop anything with a "falsy" annotation value
         source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_autogather"]
-        regex = "skip"
+        regex = "(false|no|skip)"
         action = "drop"
       }
     }

--- a/examples/private-image-registry/logs.river
+++ b/examples/private-image-registry/logs.river
@@ -52,9 +52,9 @@ discovery.relabel "pod_logs" {
 
 discovery.relabel "filtered_pod_logs" {
   targets = discovery.relabel.pod_logs.output
-  rule {
+  rule {  // Drop anything with a "falsy" annotation value
     source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_autogather"]
-    regex = "skip"
+    regex = "(false|no|skip)"
     action = "drop"
   }
 }

--- a/examples/private-image-registry/output.yaml
+++ b/examples/private-image-registry/output.yaml
@@ -960,9 +960,9 @@ data:
     
     discovery.relabel "filtered_pod_logs" {
       targets = discovery.relabel.pod_logs.output
-      rule {
+      rule {  // Drop anything with a "falsy" annotation value
         source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_autogather"]
-        regex = "skip"
+        regex = "(false|no|skip)"
         action = "drop"
       }
     }
@@ -45608,9 +45608,9 @@ data:
     
     discovery.relabel "filtered_pod_logs" {
       targets = discovery.relabel.pod_logs.output
-      rule {
+      rule {  // Drop anything with a "falsy" annotation value
         source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_autogather"]
-        regex = "skip"
+        regex = "(false|no|skip)"
         action = "drop"
       }
     }

--- a/examples/proxies/logs.river
+++ b/examples/proxies/logs.river
@@ -52,9 +52,9 @@ discovery.relabel "pod_logs" {
 
 discovery.relabel "filtered_pod_logs" {
   targets = discovery.relabel.pod_logs.output
-  rule {
+  rule {  // Drop anything with a "falsy" annotation value
     source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_autogather"]
-    regex = "skip"
+    regex = "(false|no|skip)"
     action = "drop"
   }
 }

--- a/examples/proxies/output.yaml
+++ b/examples/proxies/output.yaml
@@ -968,9 +968,9 @@ data:
     
     discovery.relabel "filtered_pod_logs" {
       targets = discovery.relabel.pod_logs.output
-      rule {
+      rule {  // Drop anything with a "falsy" annotation value
         source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_autogather"]
-        regex = "skip"
+        regex = "(false|no|skip)"
         action = "drop"
       }
     }
@@ -45620,9 +45620,9 @@ data:
     
     discovery.relabel "filtered_pod_logs" {
       targets = discovery.relabel.pod_logs.output
-      rule {
+      rule {  // Drop anything with a "falsy" annotation value
         source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_autogather"]
-        regex = "skip"
+        regex = "(false|no|skip)"
         action = "drop"
       }
     }

--- a/examples/service-integrations/logs.river
+++ b/examples/service-integrations/logs.river
@@ -52,9 +52,9 @@ discovery.relabel "pod_logs" {
 
 discovery.relabel "filtered_pod_logs" {
   targets = discovery.relabel.pod_logs.output
-  rule {
+  rule {  // Drop anything with a "falsy" annotation value
     source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_autogather"]
-    regex = "skip"
+    regex = "(false|no|skip)"
     action = "drop"
   }
 }

--- a/examples/service-integrations/output.yaml
+++ b/examples/service-integrations/output.yaml
@@ -976,9 +976,9 @@ data:
     
     discovery.relabel "filtered_pod_logs" {
       targets = discovery.relabel.pod_logs.output
-      rule {
+      rule {  // Drop anything with a "falsy" annotation value
         source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_autogather"]
-        regex = "skip"
+        regex = "(false|no|skip)"
         action = "drop"
       }
     }
@@ -45647,9 +45647,9 @@ data:
     
     discovery.relabel "filtered_pod_logs" {
       targets = discovery.relabel.pod_logs.output
-      rule {
+      rule {  // Drop anything with a "falsy" annotation value
         source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_autogather"]
-        regex = "skip"
+        regex = "(false|no|skip)"
         action = "drop"
       }
     }

--- a/examples/specific-namespace/logs.river
+++ b/examples/specific-namespace/logs.river
@@ -57,9 +57,9 @@ discovery.relabel "pod_logs" {
 
 discovery.relabel "filtered_pod_logs" {
   targets = discovery.relabel.pod_logs.output
-  rule {
+  rule {  // Drop anything with a "falsy" annotation value
     source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_autogather"]
-    regex = "skip"
+    regex = "(false|no|skip)"
     action = "drop"
   }
 }

--- a/examples/specific-namespace/output.yaml
+++ b/examples/specific-namespace/output.yaml
@@ -1012,9 +1012,9 @@ data:
     
     discovery.relabel "filtered_pod_logs" {
       targets = discovery.relabel.pod_logs.output
-      rule {
+      rule {  // Drop anything with a "falsy" annotation value
         source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_autogather"]
-        regex = "skip"
+        regex = "(false|no|skip)"
         action = "drop"
       }
     }
@@ -45704,9 +45704,9 @@ data:
     
     discovery.relabel "filtered_pod_logs" {
       targets = discovery.relabel.pod_logs.output
-      rule {
+      rule {  // Drop anything with a "falsy" annotation value
         source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_autogather"]
-        regex = "skip"
+        regex = "(false|no|skip)"
         action = "drop"
       }
     }

--- a/examples/traces-enabled/logs.river
+++ b/examples/traces-enabled/logs.river
@@ -52,9 +52,9 @@ discovery.relabel "pod_logs" {
 
 discovery.relabel "filtered_pod_logs" {
   targets = discovery.relabel.pod_logs.output
-  rule {
+  rule {  // Drop anything with a "falsy" annotation value
     source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_autogather"]
-    regex = "skip"
+    regex = "(false|no|skip)"
     action = "drop"
   }
 }

--- a/examples/traces-enabled/output.yaml
+++ b/examples/traces-enabled/output.yaml
@@ -1018,9 +1018,9 @@ data:
     
     discovery.relabel "filtered_pod_logs" {
       targets = discovery.relabel.pod_logs.output
-      rule {
+      rule {  // Drop anything with a "falsy" annotation value
         source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_autogather"]
-        regex = "skip"
+        regex = "(false|no|skip)"
         action = "drop"
       }
     }
@@ -45703,9 +45703,9 @@ data:
     
     discovery.relabel "filtered_pod_logs" {
       targets = discovery.relabel.pod_logs.output
-      rule {
+      rule {  // Drop anything with a "falsy" annotation value
         source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_autogather"]
-        regex = "skip"
+        regex = "(false|no|skip)"
         action = "drop"
       }
     }

--- a/examples/windows-exporter/logs.river
+++ b/examples/windows-exporter/logs.river
@@ -52,9 +52,9 @@ discovery.relabel "pod_logs" {
 
 discovery.relabel "filtered_pod_logs" {
   targets = discovery.relabel.pod_logs.output
-  rule {
+  rule {  // Drop anything with a "falsy" annotation value
     source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_autogather"]
-    regex = "skip"
+    regex = "(false|no|skip)"
     action = "drop"
   }
 }

--- a/examples/windows-exporter/output.yaml
+++ b/examples/windows-exporter/output.yaml
@@ -1061,9 +1061,9 @@ data:
     
     discovery.relabel "filtered_pod_logs" {
       targets = discovery.relabel.pod_logs.output
-      rule {
+      rule {  // Drop anything with a "falsy" annotation value
         source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_autogather"]
-        regex = "skip"
+        regex = "(false|no|skip)"
         action = "drop"
       }
     }
@@ -45891,9 +45891,9 @@ data:
     
     discovery.relabel "filtered_pod_logs" {
       targets = discovery.relabel.pod_logs.output
-      rule {
+      rule {  // Drop anything with a "falsy" annotation value
         source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_autogather"]
-        regex = "skip"
+        regex = "(false|no|skip)"
         action = "drop"
       }
     }


### PR DESCRIPTION
We can configure the Grafana Agent to gather logs in two ways (by setting `logs.pod_logs.discovery`

## `logs.pod_logs.discovery=all`

Currently, logs from all pods will be gathered, except when the annotation `k8s.grafana.com/logs.autogather: skip`
After the change, the value of the annotation can be `false`, `no`, or `skip`

## `logs.pod_logs.discovery=annotation`

Currently, only logs from pods with the annotation `k8s.grafana.com/logs.autogather: gather` will be gathered.
After the change, the value of the annotation can be anything *except* `false`, `no`, or `skip`