### PR TITLE
Make it so helm test queries can assert values

### DIFF
--- a/charts/k8s-monitoring/Chart.yaml
+++ b/charts/k8s-monitoring/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: k8s-monitoring
 description: A Helm chart for gathering, scraping, and forwarding Kubernetes infrastructure metrics and logs to a Grafana Stack.
 type: application
-version: 0.9.0
+version: 0.9.1
 appVersion: 1.7.0
 icon: https://raw.githubusercontent.com/grafana/grafana/main/public/img/grafana_icon.svg
 sources:

--- a/charts/k8s-monitoring/README.md
+++ b/charts/k8s-monitoring/README.md
@@ -3,7 +3,7 @@
 
 # k8s-monitoring
 
-![Version: 0.9.0](https://img.shields.io/badge/Version-0.9.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.7.0](https://img.shields.io/badge/AppVersion-1.7.0-informational?style=flat-square)
+![Version: 0.9.1](https://img.shields.io/badge/Version-0.9.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.7.0](https://img.shields.io/badge/AppVersion-1.7.0-informational?style=flat-square)
 
 A Helm chart for gathering, scraping, and forwarding Kubernetes infrastructure metrics and logs to a Grafana Stack.
 

--- a/charts/k8s-monitoring/ci/ci-2-values.yaml
+++ b/charts/k8s-monitoring/ci/ci-2-values.yaml
@@ -67,8 +67,11 @@ test:
   attempts: 20
   extraQueries:
   # Check that the external label is properly being set
-  - query: "kube_node_info{cluster=\"ci-test-cluster-2\", color=\"blue\"}"
+  - query: "count(kube_pod_info{cluster=\"ci-test-cluster-2\", color=\"blue\"})"
     type: promql
+    expect:
+      operator: >
+      value: 1
 
   # Check for cluster events
   - query: "{cluster=\"ci-test-cluster-2\", job=\"integrations/kubernetes/eventhandler\"}"

--- a/charts/k8s-monitoring/ci/ci-2-values.yaml
+++ b/charts/k8s-monitoring/ci/ci-2-values.yaml
@@ -70,7 +70,7 @@ test:
   - query: "count(kube_pod_info{cluster=\"ci-test-cluster-2\", color=\"blue\"})"
     type: promql
     expect:
-      operator: >
+      operator: ">"
       value: 1
 
   # Check for cluster events

--- a/charts/k8s-monitoring/ci/ci-integrations-values.yaml
+++ b/charts/k8s-monitoring/ci/ci-integrations-values.yaml
@@ -101,7 +101,7 @@ test:
   - query: "mysqld_exporter_build_info{cluster=\"ci-integrations-cluster\"}"
     type: promql
 
-  # Check for LOki metrics, discovered by its ServiceMonitor object
+  # Check for Loki metrics, discovered by its ServiceMonitor object
   - query: "loki_build_info{source=\"service-monitor\"}"
     type: promql
 

--- a/charts/k8s-monitoring/ci/ci-values.yaml
+++ b/charts/k8s-monitoring/ci/ci-values.yaml
@@ -41,6 +41,10 @@ metrics:
     enabled: true
   kubeScheduler:
     enabled: true
+  kube-state-metrics:
+    metricsTuning:
+      excludeMetrics:
+        - kube_pod_info
 
 traces:
   enabled: true
@@ -52,8 +56,12 @@ test:
     - query: "count(kube_node_info{cluster=\"ci-test-cluster\", color=\"red\"})"
       type: promql
       expect:
-        operator: ==
         value: 1
+    # Check that the metrics exclusion list is working
+    - query: "kube_pod_info{cluster=\"ci-test-cluster\"}"
+      type: promql
+      expect:
+        count: 0
     # Check for cluster events
     - query: "{cluster=\"ci-test-cluster\", job=\"integrations/kubernetes/eventhandler\"}"
       type: logql

--- a/charts/k8s-monitoring/ci/ci-values.yaml
+++ b/charts/k8s-monitoring/ci/ci-values.yaml
@@ -49,8 +49,11 @@ test:
   attempts: 20
   extraQueries:
     # Check that the external label is properly being set
-    - query: "kube_node_info{cluster=\"ci-test-cluster\", color=\"red\"}"
+    - query: "count(kube_node_info{cluster=\"ci-test-cluster\", color=\"red\"})"
       type: promql
+      expect:
+        operator: ==
+        value: 1
     # Check for cluster events
     - query: "{cluster=\"ci-test-cluster\", job=\"integrations/kubernetes/eventhandler\"}"
       type: logql

--- a/charts/k8s-monitoring/templates/tests/test.yaml
+++ b/charts/k8s-monitoring/templates/tests/test.yaml
@@ -51,12 +51,9 @@ queries:
   - query: grafana_kubernetes_monitoring_build_info{cluster={{ .Values.cluster.name | quote}}}
     type: promql
     {{- end }}
-{{- if .Values.test.extraQueries }}
-  {{- range .Values.test.extraQueries }}
-  - query: {{ .query | quote }}
-    type: {{ .type | default "promql" }}
-  {{- end }}
-{{- end }}
+    {{- if .Values.test.extraQueries }}
+{{ .Values.test.extraQueries | toYaml | indent 2 }}
+    {{- end }}
   {{- end }}
 {{- end -}}
 ---

--- a/charts/k8s-monitoring/test/query-test.sh
+++ b/charts/k8s-monitoring/test/query-test.sh
@@ -1,6 +1,61 @@
 #!/bin/bash
 
+if [ -z "${1}" ] || [ "${1}" == "-h" ]; then
+  echo "USAGE: query-test.sh queries.json"
+  echo "Run a set of queries against Prometheus, Loki, or Tempo"
+  echo
+  echo "Required environment variables:"
+  echo "  If using any PromQL queries:"
+  echo "  PROMETHEUS_URL - The query URL for your Prometheus service (e.g. localhost:9090/api/v1/query"
+  echo "  PROMETHEUS_USER - The username for running PromQL queries"
+  echo "  PROMETHEUS_PASS - The password for running PromQL queries"
+  echo
+  echo "  If using any LogQL queries:"
+  echo "  LOKI_URL - The query URL for your Loki service (e.g. localhost:9090/api/v1/query"
+  echo "  LOKI_USER - The username for running LogQL queries"
+  echo "  LOKI_PASS - The password for running LogQL queries"
+  echo
+  echo "  If using any TraceQL queries:"
+  echo "  TEMPO_URL - The query URL for your Tempo service (e.g. localhost:9090/api/v1/query"
+  echo "  TEMPO_USER - The username for running TraceQL queries"
+  echo "  TEMPO_PASS - The password for running TraceQL queries"
+  echo
+  echo "queries.json is the queries file, and should be in the format:"
+  echo '{"queries": [<query>]}'
+  echo
+  echo "Each query has this format:"
+  echo '{'
+  echo '  "query": "<query string>",'
+  echo '  "type": "[promql (default)|logql|traceql]",'
+  echo '}'
+  echo
+  echo 'You can add an "expect" section to the query to validate the returned value'
+  echo '  "expect": {'
+  echo '    "operator": "[<, <=, ==, !=, =>, >]",'
+  echo '    "value": <expected value>'
+  echo '  }'
+fi
+
+function check_value {
+  local actualValue=$1
+  local expectedValue=$2
+  local operator=$3
+
+  set -x
+  if test "! ${actualValue} ${operator} ${expectedValue}"; then
+    echo "  Expected ${expectedValue} ${operator} ${expectedValue}"
+    return 1
+  fi
+  set +x
+  return 0
+}
+
 function metrics_query {
+  if [ -z "${PROMETHEUS_URL}" ]; then
+    echo "PROMETHEUS_URL is not defined. Unable to run PromQL queries!"
+    return 1
+  fi
+
   echo "Running PromQL query: ${PROMETHEUS_URL}?query=${1}..."
   result=$(curl -skX POST -u "${PROMETHEUS_USER}:${PROMETHEUS_PASS}" "${PROMETHEUS_URL}" --data-urlencode "query=${1}")
   status=$(echo "${result}" | jq -r .status)
@@ -15,6 +70,10 @@ function metrics_query {
     echo "Query returned no results"
     echo "Result: ${result}"
     return 1
+  fi
+
+  if [ -n "${2}" ]; then
+    check_value "$(echo "${result}" | jq -r '.data.result[0].value[1] | tostring')" "${2}" "${3}"
   fi
 }
 
@@ -51,10 +110,12 @@ count=$(jq -r ".queries | length-1" "${1}")
 for i in $(seq 0 "${count}"); do
   query=$(jq -r --argjson i "${i}" '.queries[$i].query' "${1}")
   type=$(jq -r --argjson i "${i}" '.queries[$i] | .type // "promql"' "${1}")
+  expectedValue=$(jq -r --argjson i "${i}" '.queries[$i].expect.value | tostring' "${1}")
+  expectedOperator=$(jq -r --argjson i "${i}" '.queries[$i].expect | .operator // "=="' "${1}")
 
   case "${type}" in
     promql)
-      if ! metrics_query "${query}"; then
+      if ! metrics_query "${query}" "${expectedValue}" "${expectedOperator}"; then
         exit 1
       fi
       ;;

--- a/charts/k8s-monitoring/test/query-test.sh
+++ b/charts/k8s-monitoring/test/query-test.sh
@@ -47,6 +47,7 @@ function check_value {
   "<")  operator="-lt" ;;
   "<=") operator="-le" ;;
   "=")  operator="-eq" ;;
+  "==")  operator="-eq" ;;
   "!=") operator="-ne" ;;
   ">=") operator="-ge" ;;
   ">")  operator="-gt" ;;
@@ -83,8 +84,9 @@ function metrics_query {
 
   resultCount=$(echo "${result}" | jq '.data.result | length')
   if [ -n "${expectedCount}" ]; then
+    echo "  Expected ${expectedCount} results. Found ${resultCount} results."
     if [ "${resultCount}" -ne "${expectedCount}" ]; then
-      echo "Expected query to return ${expectedCount} result, but returned ${resultCount}"
+      echo "  Unexpected number of results returned!"
       echo "Result: ${result}"
       return 1
     fi

--- a/examples/cluster-with-pvc/output.yaml
+++ b/examples/cluster-with-pvc/output.yaml
@@ -1052,7 +1052,7 @@ data:
   metrics.prom: |
     # HELP grafana_kubernetes_monitoring_build_info A metric to report the version of the Kubernetes Monitoring Helm chart as well as a summary of enabled features
     # TYPE grafana_kubernetes_monitoring_build_info gauge
-    grafana_kubernetes_monitoring_build_info{version="0.9.0", namespace="default", metrics="enabled,agent,autoDiscover,kube-state-metrics,node-exporter,kubelet,cadvisor,cost", logs="enabled,events,pod_logs", traces="disabled", deployments="kube-state-metrics,prometheus-node-exporter,prometheus-operator-crds,opencost"} 1
+    grafana_kubernetes_monitoring_build_info{version="0.9.1", namespace="default", metrics="enabled,agent,autoDiscover,kube-state-metrics,node-exporter,kubelet,cadvisor,cost", logs="enabled,events,pod_logs", traces="disabled", deployments="kube-state-metrics,prometheus-node-exporter,prometheus-operator-crds,opencost"} 1
 ---
 # Source: k8s-monitoring/charts/prometheus-operator-crds/charts/crds/templates/crd-alertmanagerconfigs.yaml
 apiVersion: apiextensions.k8s.io/v1
@@ -44819,7 +44819,7 @@ metadata:
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/instance: "k8smon"
     app.kubernetes.io/version: 1.7.0
-    helm.sh/chart: "k8s-monitoring-0.9.0"
+    helm.sh/chart: "k8s-monitoring-0.9.1"
   annotations:
     "helm.sh/hook": pre-install,pre-upgrade
     "helm.sh/hook-weight": "-5"
@@ -45743,7 +45743,7 @@ metadata:
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/instance: "k8smon"
     app.kubernetes.io/version: 1.7.0
-    helm.sh/chart: "k8s-monitoring-0.9.0"
+    helm.sh/chart: "k8s-monitoring-0.9.1"
   annotations:
     "helm.sh/hook": test
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
@@ -45797,7 +45797,7 @@ metadata:
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/instance: "k8smon"
     app.kubernetes.io/version: 1.7.0
-    helm.sh/chart: "k8s-monitoring-0.9.0"
+    helm.sh/chart: "k8s-monitoring-0.9.1"
   annotations:
     "helm.sh/hook": test
     "helm.sh/hook-delete-policy": before-hook-creation
@@ -45808,7 +45808,7 @@ spec:
         kubernetes.io/os: linux
   containers:
     - name: config-analysis
-      image: ghcr.io/grafana/k8s-monitoring-test:0.9.0
+      image: ghcr.io/grafana/k8s-monitoring-test:0.9.1
       command: [/etc/bin/config-analysis.sh]
       env:
         - name: AGENT_HOST
@@ -45824,7 +45824,7 @@ metadata:
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/instance: "k8smon"
     app.kubernetes.io/version: 1.7.0
-    helm.sh/chart: "k8s-monitoring-0.9.0"
+    helm.sh/chart: "k8s-monitoring-0.9.1"
   annotations:
     "helm.sh/hook": test
     "helm.sh/hook-delete-policy": before-hook-creation
@@ -45835,7 +45835,7 @@ spec:
         kubernetes.io/os: linux
   containers:
     - name: query-test
-      image: ghcr.io/grafana/k8s-monitoring-test:0.9.0
+      image: ghcr.io/grafana/k8s-monitoring-test:0.9.1
       command: ["bash", "-c", "/etc/bin/query-test.sh /etc/test/testQueries.json"]
       volumeMounts:
         - name: test-files
@@ -45922,7 +45922,7 @@ metadata:
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/instance: "k8smon"
     app.kubernetes.io/version: 1.7.0
-    helm.sh/chart: "k8s-monitoring-0.9.0"
+    helm.sh/chart: "k8s-monitoring-0.9.1"
   annotations:
     "helm.sh/hook": pre-install,pre-upgrade
     "helm.sh/hook-weight": "-5"
@@ -45935,7 +45935,7 @@ spec:
       labels:
         app.kubernetes.io/managed-by: "Helm"
         app.kubernetes.io/instance: "k8smon"
-        helm.sh/chart: "k8s-monitoring-0.9.0"
+        helm.sh/chart: "k8s-monitoring-0.9.1"
     spec:
       restartPolicy: Never
       nodeSelector:

--- a/examples/control-plane-metrics/output.yaml
+++ b/examples/control-plane-metrics/output.yaml
@@ -1197,7 +1197,7 @@ data:
   metrics.prom: |
     # HELP grafana_kubernetes_monitoring_build_info A metric to report the version of the Kubernetes Monitoring Helm chart as well as a summary of enabled features
     # TYPE grafana_kubernetes_monitoring_build_info gauge
-    grafana_kubernetes_monitoring_build_info{version="0.9.0", namespace="default", metrics="enabled,agent,autoDiscover,kube-state-metrics,node-exporter,kubelet,cadvisor,apiserver,cost", logs="enabled,events,pod_logs", traces="disabled", deployments="kube-state-metrics,prometheus-node-exporter,prometheus-operator-crds,opencost"} 1
+    grafana_kubernetes_monitoring_build_info{version="0.9.1", namespace="default", metrics="enabled,agent,autoDiscover,kube-state-metrics,node-exporter,kubelet,cadvisor,apiserver,cost", logs="enabled,events,pod_logs", traces="disabled", deployments="kube-state-metrics,prometheus-node-exporter,prometheus-operator-crds,opencost"} 1
 ---
 # Source: k8s-monitoring/charts/prometheus-operator-crds/charts/crds/templates/crd-alertmanagerconfigs.yaml
 apiVersion: apiextensions.k8s.io/v1
@@ -44917,7 +44917,7 @@ metadata:
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/instance: "k8smon"
     app.kubernetes.io/version: 1.7.0
-    helm.sh/chart: "k8s-monitoring-0.9.0"
+    helm.sh/chart: "k8s-monitoring-0.9.1"
   annotations:
     "helm.sh/hook": pre-install,pre-upgrade
     "helm.sh/hook-weight": "-5"
@@ -45985,7 +45985,7 @@ metadata:
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/instance: "k8smon"
     app.kubernetes.io/version: 1.7.0
-    helm.sh/chart: "k8s-monitoring-0.9.0"
+    helm.sh/chart: "k8s-monitoring-0.9.1"
   annotations:
     "helm.sh/hook": test
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
@@ -46055,7 +46055,7 @@ metadata:
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/instance: "k8smon"
     app.kubernetes.io/version: 1.7.0
-    helm.sh/chart: "k8s-monitoring-0.9.0"
+    helm.sh/chart: "k8s-monitoring-0.9.1"
   annotations:
     "helm.sh/hook": test
     "helm.sh/hook-delete-policy": before-hook-creation
@@ -46066,7 +46066,7 @@ spec:
         kubernetes.io/os: linux
   containers:
     - name: config-analysis
-      image: ghcr.io/grafana/k8s-monitoring-test:0.9.0
+      image: ghcr.io/grafana/k8s-monitoring-test:0.9.1
       command: [/etc/bin/config-analysis.sh]
       env:
         - name: AGENT_HOST
@@ -46082,7 +46082,7 @@ metadata:
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/instance: "k8smon"
     app.kubernetes.io/version: 1.7.0
-    helm.sh/chart: "k8s-monitoring-0.9.0"
+    helm.sh/chart: "k8s-monitoring-0.9.1"
   annotations:
     "helm.sh/hook": test
     "helm.sh/hook-delete-policy": before-hook-creation
@@ -46093,7 +46093,7 @@ spec:
         kubernetes.io/os: linux
   containers:
     - name: query-test
-      image: ghcr.io/grafana/k8s-monitoring-test:0.9.0
+      image: ghcr.io/grafana/k8s-monitoring-test:0.9.1
       command: ["bash", "-c", "/etc/bin/query-test.sh /etc/test/testQueries.json"]
       volumeMounts:
         - name: test-files
@@ -46180,7 +46180,7 @@ metadata:
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/instance: "k8smon"
     app.kubernetes.io/version: 1.7.0
-    helm.sh/chart: "k8s-monitoring-0.9.0"
+    helm.sh/chart: "k8s-monitoring-0.9.1"
   annotations:
     "helm.sh/hook": pre-install,pre-upgrade
     "helm.sh/hook-weight": "-5"
@@ -46193,7 +46193,7 @@ spec:
       labels:
         app.kubernetes.io/managed-by: "Helm"
         app.kubernetes.io/instance: "k8smon"
-        helm.sh/chart: "k8s-monitoring-0.9.0"
+        helm.sh/chart: "k8s-monitoring-0.9.1"
     spec:
       restartPolicy: Never
       nodeSelector:

--- a/examples/custom-config/output.yaml
+++ b/examples/custom-config/output.yaml
@@ -1107,7 +1107,7 @@ data:
   metrics.prom: |
     # HELP grafana_kubernetes_monitoring_build_info A metric to report the version of the Kubernetes Monitoring Helm chart as well as a summary of enabled features
     # TYPE grafana_kubernetes_monitoring_build_info gauge
-    grafana_kubernetes_monitoring_build_info{version="0.9.0", namespace="default", metrics="enabled,agent,autoDiscover,kube-state-metrics,node-exporter,kubelet,cadvisor,cost,extraConfig", logs="enabled,events,pod_logs,extraConfig", traces="disabled", deployments="kube-state-metrics,prometheus-node-exporter,prometheus-operator-crds,opencost"} 1
+    grafana_kubernetes_monitoring_build_info{version="0.9.1", namespace="default", metrics="enabled,agent,autoDiscover,kube-state-metrics,node-exporter,kubelet,cadvisor,cost,extraConfig", logs="enabled,events,pod_logs,extraConfig", traces="disabled", deployments="kube-state-metrics,prometheus-node-exporter,prometheus-operator-crds,opencost"} 1
 ---
 # Source: k8s-monitoring/charts/prometheus-operator-crds/charts/crds/templates/crd-alertmanagerconfigs.yaml
 apiVersion: apiextensions.k8s.io/v1
@@ -44827,7 +44827,7 @@ metadata:
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/instance: "k8smon"
     app.kubernetes.io/version: 1.7.0
-    helm.sh/chart: "k8s-monitoring-0.9.0"
+    helm.sh/chart: "k8s-monitoring-0.9.1"
   annotations:
     "helm.sh/hook": pre-install,pre-upgrade
     "helm.sh/hook-weight": "-5"
@@ -45806,7 +45806,7 @@ metadata:
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/instance: "k8smon"
     app.kubernetes.io/version: 1.7.0
-    helm.sh/chart: "k8s-monitoring-0.9.0"
+    helm.sh/chart: "k8s-monitoring-0.9.1"
   annotations:
     "helm.sh/hook": test
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
@@ -45860,7 +45860,7 @@ metadata:
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/instance: "k8smon"
     app.kubernetes.io/version: 1.7.0
-    helm.sh/chart: "k8s-monitoring-0.9.0"
+    helm.sh/chart: "k8s-monitoring-0.9.1"
   annotations:
     "helm.sh/hook": test
     "helm.sh/hook-delete-policy": before-hook-creation
@@ -45871,7 +45871,7 @@ spec:
         kubernetes.io/os: linux
   containers:
     - name: config-analysis
-      image: ghcr.io/grafana/k8s-monitoring-test:0.9.0
+      image: ghcr.io/grafana/k8s-monitoring-test:0.9.1
       command: [/etc/bin/config-analysis.sh]
       env:
         - name: AGENT_HOST
@@ -45887,7 +45887,7 @@ metadata:
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/instance: "k8smon"
     app.kubernetes.io/version: 1.7.0
-    helm.sh/chart: "k8s-monitoring-0.9.0"
+    helm.sh/chart: "k8s-monitoring-0.9.1"
   annotations:
     "helm.sh/hook": test
     "helm.sh/hook-delete-policy": before-hook-creation
@@ -45898,7 +45898,7 @@ spec:
         kubernetes.io/os: linux
   containers:
     - name: query-test
-      image: ghcr.io/grafana/k8s-monitoring-test:0.9.0
+      image: ghcr.io/grafana/k8s-monitoring-test:0.9.1
       command: ["bash", "-c", "/etc/bin/query-test.sh /etc/test/testQueries.json"]
       volumeMounts:
         - name: test-files
@@ -45985,7 +45985,7 @@ metadata:
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/instance: "k8smon"
     app.kubernetes.io/version: 1.7.0
-    helm.sh/chart: "k8s-monitoring-0.9.0"
+    helm.sh/chart: "k8s-monitoring-0.9.1"
   annotations:
     "helm.sh/hook": pre-install,pre-upgrade
     "helm.sh/hook-weight": "-5"
@@ -45998,7 +45998,7 @@ spec:
       labels:
         app.kubernetes.io/managed-by: "Helm"
         app.kubernetes.io/instance: "k8smon"
-        helm.sh/chart: "k8s-monitoring-0.9.0"
+        helm.sh/chart: "k8s-monitoring-0.9.1"
     spec:
       restartPolicy: Never
       nodeSelector:

--- a/examples/custom-metrics-tuning/output.yaml
+++ b/examples/custom-metrics-tuning/output.yaml
@@ -819,7 +819,7 @@ data:
   metrics.prom: |
     # HELP grafana_kubernetes_monitoring_build_info A metric to report the version of the Kubernetes Monitoring Helm chart as well as a summary of enabled features
     # TYPE grafana_kubernetes_monitoring_build_info gauge
-    grafana_kubernetes_monitoring_build_info{version="0.9.0", namespace="default", metrics="enabled,agent,autoDiscover,kube-state-metrics,node-exporter,kubelet,cadvisor,cost", logs="enabled", traces="disabled", deployments="kube-state-metrics,prometheus-node-exporter,prometheus-operator-crds,opencost"} 1
+    grafana_kubernetes_monitoring_build_info{version="0.9.1", namespace="default", metrics="enabled,agent,autoDiscover,kube-state-metrics,node-exporter,kubelet,cadvisor,cost", logs="enabled", traces="disabled", deployments="kube-state-metrics,prometheus-node-exporter,prometheus-operator-crds,opencost"} 1
 ---
 # Source: k8s-monitoring/charts/prometheus-operator-crds/charts/crds/templates/crd-alertmanagerconfigs.yaml
 apiVersion: apiextensions.k8s.io/v1
@@ -44089,7 +44089,7 @@ metadata:
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/instance: "k8smon"
     app.kubernetes.io/version: 1.7.0
-    helm.sh/chart: "k8s-monitoring-0.9.0"
+    helm.sh/chart: "k8s-monitoring-0.9.1"
   annotations:
     "helm.sh/hook": pre-install,pre-upgrade
     "helm.sh/hook-weight": "-5"
@@ -44837,7 +44837,7 @@ metadata:
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/instance: "k8smon"
     app.kubernetes.io/version: 1.7.0
-    helm.sh/chart: "k8s-monitoring-0.9.0"
+    helm.sh/chart: "k8s-monitoring-0.9.1"
   annotations:
     "helm.sh/hook": test
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
@@ -44891,7 +44891,7 @@ metadata:
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/instance: "k8smon"
     app.kubernetes.io/version: 1.7.0
-    helm.sh/chart: "k8s-monitoring-0.9.0"
+    helm.sh/chart: "k8s-monitoring-0.9.1"
   annotations:
     "helm.sh/hook": test
     "helm.sh/hook-delete-policy": before-hook-creation
@@ -44902,7 +44902,7 @@ spec:
         kubernetes.io/os: linux
   containers:
     - name: config-analysis
-      image: ghcr.io/grafana/k8s-monitoring-test:0.9.0
+      image: ghcr.io/grafana/k8s-monitoring-test:0.9.1
       command: [/etc/bin/config-analysis.sh]
       env:
         - name: AGENT_HOST
@@ -44918,7 +44918,7 @@ metadata:
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/instance: "k8smon"
     app.kubernetes.io/version: 1.7.0
-    helm.sh/chart: "k8s-monitoring-0.9.0"
+    helm.sh/chart: "k8s-monitoring-0.9.1"
   annotations:
     "helm.sh/hook": test
     "helm.sh/hook-delete-policy": before-hook-creation
@@ -44929,7 +44929,7 @@ spec:
         kubernetes.io/os: linux
   containers:
     - name: query-test
-      image: ghcr.io/grafana/k8s-monitoring-test:0.9.0
+      image: ghcr.io/grafana/k8s-monitoring-test:0.9.1
       command: ["bash", "-c", "/etc/bin/query-test.sh /etc/test/testQueries.json"]
       volumeMounts:
         - name: test-files
@@ -45016,7 +45016,7 @@ metadata:
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/instance: "k8smon"
     app.kubernetes.io/version: 1.7.0
-    helm.sh/chart: "k8s-monitoring-0.9.0"
+    helm.sh/chart: "k8s-monitoring-0.9.1"
   annotations:
     "helm.sh/hook": pre-install,pre-upgrade
     "helm.sh/hook-weight": "-5"
@@ -45029,7 +45029,7 @@ spec:
       labels:
         app.kubernetes.io/managed-by: "Helm"
         app.kubernetes.io/instance: "k8smon"
-        helm.sh/chart: "k8s-monitoring-0.9.0"
+        helm.sh/chart: "k8s-monitoring-0.9.1"
     spec:
       restartPolicy: Never
       nodeSelector:

--- a/examples/default-values/output.yaml
+++ b/examples/default-values/output.yaml
@@ -1044,7 +1044,7 @@ data:
   metrics.prom: |
     # HELP grafana_kubernetes_monitoring_build_info A metric to report the version of the Kubernetes Monitoring Helm chart as well as a summary of enabled features
     # TYPE grafana_kubernetes_monitoring_build_info gauge
-    grafana_kubernetes_monitoring_build_info{version="0.9.0", namespace="default", metrics="enabled,agent,autoDiscover,kube-state-metrics,node-exporter,kubelet,cadvisor,cost", logs="enabled,events,pod_logs", traces="disabled", deployments="kube-state-metrics,prometheus-node-exporter,prometheus-operator-crds,opencost"} 1
+    grafana_kubernetes_monitoring_build_info{version="0.9.1", namespace="default", metrics="enabled,agent,autoDiscover,kube-state-metrics,node-exporter,kubelet,cadvisor,cost", logs="enabled,events,pod_logs", traces="disabled", deployments="kube-state-metrics,prometheus-node-exporter,prometheus-operator-crds,opencost"} 1
 ---
 # Source: k8s-monitoring/charts/prometheus-operator-crds/charts/crds/templates/crd-alertmanagerconfigs.yaml
 apiVersion: apiextensions.k8s.io/v1
@@ -44764,7 +44764,7 @@ metadata:
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/instance: "k8smon"
     app.kubernetes.io/version: 1.7.0
-    helm.sh/chart: "k8s-monitoring-0.9.0"
+    helm.sh/chart: "k8s-monitoring-0.9.1"
   annotations:
     "helm.sh/hook": pre-install,pre-upgrade
     "helm.sh/hook-weight": "-5"
@@ -45680,7 +45680,7 @@ metadata:
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/instance: "k8smon"
     app.kubernetes.io/version: 1.7.0
-    helm.sh/chart: "k8s-monitoring-0.9.0"
+    helm.sh/chart: "k8s-monitoring-0.9.1"
   annotations:
     "helm.sh/hook": test
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
@@ -45734,7 +45734,7 @@ metadata:
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/instance: "k8smon"
     app.kubernetes.io/version: 1.7.0
-    helm.sh/chart: "k8s-monitoring-0.9.0"
+    helm.sh/chart: "k8s-monitoring-0.9.1"
   annotations:
     "helm.sh/hook": test
     "helm.sh/hook-delete-policy": before-hook-creation
@@ -45745,7 +45745,7 @@ spec:
         kubernetes.io/os: linux
   containers:
     - name: config-analysis
-      image: ghcr.io/grafana/k8s-monitoring-test:0.9.0
+      image: ghcr.io/grafana/k8s-monitoring-test:0.9.1
       command: [/etc/bin/config-analysis.sh]
       env:
         - name: AGENT_HOST
@@ -45761,7 +45761,7 @@ metadata:
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/instance: "k8smon"
     app.kubernetes.io/version: 1.7.0
-    helm.sh/chart: "k8s-monitoring-0.9.0"
+    helm.sh/chart: "k8s-monitoring-0.9.1"
   annotations:
     "helm.sh/hook": test
     "helm.sh/hook-delete-policy": before-hook-creation
@@ -45772,7 +45772,7 @@ spec:
         kubernetes.io/os: linux
   containers:
     - name: query-test
-      image: ghcr.io/grafana/k8s-monitoring-test:0.9.0
+      image: ghcr.io/grafana/k8s-monitoring-test:0.9.1
       command: ["bash", "-c", "/etc/bin/query-test.sh /etc/test/testQueries.json"]
       volumeMounts:
         - name: test-files
@@ -45859,7 +45859,7 @@ metadata:
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/instance: "k8smon"
     app.kubernetes.io/version: 1.7.0
-    helm.sh/chart: "k8s-monitoring-0.9.0"
+    helm.sh/chart: "k8s-monitoring-0.9.1"
   annotations:
     "helm.sh/hook": pre-install,pre-upgrade
     "helm.sh/hook-weight": "-5"
@@ -45872,7 +45872,7 @@ spec:
       labels:
         app.kubernetes.io/managed-by: "Helm"
         app.kubernetes.io/instance: "k8smon"
-        helm.sh/chart: "k8s-monitoring-0.9.0"
+        helm.sh/chart: "k8s-monitoring-0.9.1"
     spec:
       restartPolicy: Never
       nodeSelector:

--- a/examples/eks-fargate/output.yaml
+++ b/examples/eks-fargate/output.yaml
@@ -970,7 +970,7 @@ data:
   metrics.prom: |
     # HELP grafana_kubernetes_monitoring_build_info A metric to report the version of the Kubernetes Monitoring Helm chart as well as a summary of enabled features
     # TYPE grafana_kubernetes_monitoring_build_info gauge
-    grafana_kubernetes_monitoring_build_info{version="0.9.0", namespace="default", metrics="enabled,agent,autoDiscover,kube-state-metrics,kubelet,cadvisor,cost", logs="enabled,events,pod_logs", traces="disabled", deployments="kube-state-metrics,prometheus-operator-crds,opencost"} 1
+    grafana_kubernetes_monitoring_build_info{version="0.9.1", namespace="default", metrics="enabled,agent,autoDiscover,kube-state-metrics,kubelet,cadvisor,cost", logs="enabled,events,pod_logs", traces="disabled", deployments="kube-state-metrics,prometheus-operator-crds,opencost"} 1
 ---
 # Source: k8s-monitoring/charts/prometheus-operator-crds/charts/crds/templates/crd-alertmanagerconfigs.yaml
 apiVersion: apiextensions.k8s.io/v1
@@ -44576,7 +44576,7 @@ metadata:
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/instance: "k8smon"
     app.kubernetes.io/version: 1.7.0
-    helm.sh/chart: "k8s-monitoring-0.9.0"
+    helm.sh/chart: "k8s-monitoring-0.9.1"
   annotations:
     "helm.sh/hook": pre-install,pre-upgrade
     "helm.sh/hook-weight": "-5"
@@ -45433,7 +45433,7 @@ metadata:
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/instance: "k8smon"
     app.kubernetes.io/version: 1.7.0
-    helm.sh/chart: "k8s-monitoring-0.9.0"
+    helm.sh/chart: "k8s-monitoring-0.9.1"
   annotations:
     "helm.sh/hook": test
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
@@ -45483,7 +45483,7 @@ metadata:
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/instance: "k8smon"
     app.kubernetes.io/version: 1.7.0
-    helm.sh/chart: "k8s-monitoring-0.9.0"
+    helm.sh/chart: "k8s-monitoring-0.9.1"
   annotations:
     "helm.sh/hook": test
     "helm.sh/hook-delete-policy": before-hook-creation
@@ -45494,7 +45494,7 @@ spec:
         kubernetes.io/os: linux
   containers:
     - name: config-analysis
-      image: ghcr.io/grafana/k8s-monitoring-test:0.9.0
+      image: ghcr.io/grafana/k8s-monitoring-test:0.9.1
       command: [/etc/bin/config-analysis.sh]
       env:
         - name: AGENT_HOST
@@ -45510,7 +45510,7 @@ metadata:
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/instance: "k8smon"
     app.kubernetes.io/version: 1.7.0
-    helm.sh/chart: "k8s-monitoring-0.9.0"
+    helm.sh/chart: "k8s-monitoring-0.9.1"
   annotations:
     "helm.sh/hook": test
     "helm.sh/hook-delete-policy": before-hook-creation
@@ -45521,7 +45521,7 @@ spec:
         kubernetes.io/os: linux
   containers:
     - name: query-test
-      image: ghcr.io/grafana/k8s-monitoring-test:0.9.0
+      image: ghcr.io/grafana/k8s-monitoring-test:0.9.1
       command: ["bash", "-c", "/etc/bin/query-test.sh /etc/test/testQueries.json"]
       volumeMounts:
         - name: test-files
@@ -45608,7 +45608,7 @@ metadata:
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/instance: "k8smon"
     app.kubernetes.io/version: 1.7.0
-    helm.sh/chart: "k8s-monitoring-0.9.0"
+    helm.sh/chart: "k8s-monitoring-0.9.1"
   annotations:
     "helm.sh/hook": pre-install,pre-upgrade
     "helm.sh/hook-weight": "-5"
@@ -45621,7 +45621,7 @@ spec:
       labels:
         app.kubernetes.io/managed-by: "Helm"
         app.kubernetes.io/instance: "k8smon"
-        helm.sh/chart: "k8s-monitoring-0.9.0"
+        helm.sh/chart: "k8s-monitoring-0.9.1"
     spec:
       restartPolicy: Never
       nodeSelector:

--- a/examples/extra-rules/output.yaml
+++ b/examples/extra-rules/output.yaml
@@ -1125,7 +1125,7 @@ data:
   metrics.prom: |
     # HELP grafana_kubernetes_monitoring_build_info A metric to report the version of the Kubernetes Monitoring Helm chart as well as a summary of enabled features
     # TYPE grafana_kubernetes_monitoring_build_info gauge
-    grafana_kubernetes_monitoring_build_info{version="0.9.0", namespace="default", metrics="enabled,agent,autoDiscover,kube-state-metrics,node-exporter,kubelet,cadvisor,cost", logs="enabled,events,pod_logs", traces="disabled", deployments="kube-state-metrics,prometheus-node-exporter,prometheus-operator-crds,opencost"} 1
+    grafana_kubernetes_monitoring_build_info{version="0.9.1", namespace="default", metrics="enabled,agent,autoDiscover,kube-state-metrics,node-exporter,kubelet,cadvisor,cost", logs="enabled,events,pod_logs", traces="disabled", deployments="kube-state-metrics,prometheus-node-exporter,prometheus-operator-crds,opencost"} 1
 ---
 # Source: k8s-monitoring/charts/prometheus-operator-crds/charts/crds/templates/crd-alertmanagerconfigs.yaml
 apiVersion: apiextensions.k8s.io/v1
@@ -44845,7 +44845,7 @@ metadata:
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/instance: "k8smon"
     app.kubernetes.io/version: 1.7.0
-    helm.sh/chart: "k8s-monitoring-0.9.0"
+    helm.sh/chart: "k8s-monitoring-0.9.1"
   annotations:
     "helm.sh/hook": pre-install,pre-upgrade
     "helm.sh/hook-weight": "-5"
@@ -45841,7 +45841,7 @@ metadata:
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/instance: "k8smon"
     app.kubernetes.io/version: 1.7.0
-    helm.sh/chart: "k8s-monitoring-0.9.0"
+    helm.sh/chart: "k8s-monitoring-0.9.1"
   annotations:
     "helm.sh/hook": test
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
@@ -45895,7 +45895,7 @@ metadata:
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/instance: "k8smon"
     app.kubernetes.io/version: 1.7.0
-    helm.sh/chart: "k8s-monitoring-0.9.0"
+    helm.sh/chart: "k8s-monitoring-0.9.1"
   annotations:
     "helm.sh/hook": test
     "helm.sh/hook-delete-policy": before-hook-creation
@@ -45906,7 +45906,7 @@ spec:
         kubernetes.io/os: linux
   containers:
     - name: config-analysis
-      image: ghcr.io/grafana/k8s-monitoring-test:0.9.0
+      image: ghcr.io/grafana/k8s-monitoring-test:0.9.1
       command: [/etc/bin/config-analysis.sh]
       env:
         - name: AGENT_HOST
@@ -45922,7 +45922,7 @@ metadata:
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/instance: "k8smon"
     app.kubernetes.io/version: 1.7.0
-    helm.sh/chart: "k8s-monitoring-0.9.0"
+    helm.sh/chart: "k8s-monitoring-0.9.1"
   annotations:
     "helm.sh/hook": test
     "helm.sh/hook-delete-policy": before-hook-creation
@@ -45933,7 +45933,7 @@ spec:
         kubernetes.io/os: linux
   containers:
     - name: query-test
-      image: ghcr.io/grafana/k8s-monitoring-test:0.9.0
+      image: ghcr.io/grafana/k8s-monitoring-test:0.9.1
       command: ["bash", "-c", "/etc/bin/query-test.sh /etc/test/testQueries.json"]
       volumeMounts:
         - name: test-files
@@ -46020,7 +46020,7 @@ metadata:
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/instance: "k8smon"
     app.kubernetes.io/version: 1.7.0
-    helm.sh/chart: "k8s-monitoring-0.9.0"
+    helm.sh/chart: "k8s-monitoring-0.9.1"
   annotations:
     "helm.sh/hook": pre-install,pre-upgrade
     "helm.sh/hook-weight": "-5"
@@ -46033,7 +46033,7 @@ spec:
       labels:
         app.kubernetes.io/managed-by: "Helm"
         app.kubernetes.io/instance: "k8smon"
-        helm.sh/chart: "k8s-monitoring-0.9.0"
+        helm.sh/chart: "k8s-monitoring-0.9.1"
     spec:
       restartPolicy: Never
       nodeSelector:

--- a/examples/gke-autopilot/output.yaml
+++ b/examples/gke-autopilot/output.yaml
@@ -983,7 +983,7 @@ data:
   metrics.prom: |
     # HELP grafana_kubernetes_monitoring_build_info A metric to report the version of the Kubernetes Monitoring Helm chart as well as a summary of enabled features
     # TYPE grafana_kubernetes_monitoring_build_info gauge
-    grafana_kubernetes_monitoring_build_info{version="0.9.0", namespace="default", metrics="enabled,agent,autoDiscover,kube-state-metrics,kubelet,cadvisor,cost", logs="enabled,events,pod_logs", traces="disabled", deployments="kube-state-metrics,prometheus-operator-crds,opencost"} 1
+    grafana_kubernetes_monitoring_build_info{version="0.9.1", namespace="default", metrics="enabled,agent,autoDiscover,kube-state-metrics,kubelet,cadvisor,cost", logs="enabled,events,pod_logs", traces="disabled", deployments="kube-state-metrics,prometheus-operator-crds,opencost"} 1
 ---
 # Source: k8s-monitoring/charts/prometheus-operator-crds/charts/crds/templates/crd-alertmanagerconfigs.yaml
 apiVersion: apiextensions.k8s.io/v1
@@ -44562,7 +44562,7 @@ metadata:
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/instance: "k8smon"
     app.kubernetes.io/version: 1.7.0
-    helm.sh/chart: "k8s-monitoring-0.9.0"
+    helm.sh/chart: "k8s-monitoring-0.9.1"
   annotations:
     "helm.sh/hook": pre-install,pre-upgrade
     "helm.sh/hook-weight": "-5"
@@ -45432,7 +45432,7 @@ metadata:
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/instance: "k8smon"
     app.kubernetes.io/version: 1.7.0
-    helm.sh/chart: "k8s-monitoring-0.9.0"
+    helm.sh/chart: "k8s-monitoring-0.9.1"
   annotations:
     "helm.sh/hook": test
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
@@ -45482,7 +45482,7 @@ metadata:
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/instance: "k8smon"
     app.kubernetes.io/version: 1.7.0
-    helm.sh/chart: "k8s-monitoring-0.9.0"
+    helm.sh/chart: "k8s-monitoring-0.9.1"
   annotations:
     "helm.sh/hook": test
     "helm.sh/hook-delete-policy": before-hook-creation
@@ -45493,7 +45493,7 @@ spec:
         kubernetes.io/os: linux
   containers:
     - name: config-analysis
-      image: ghcr.io/grafana/k8s-monitoring-test:0.9.0
+      image: ghcr.io/grafana/k8s-monitoring-test:0.9.1
       command: [/etc/bin/config-analysis.sh]
       env:
         - name: AGENT_HOST
@@ -45509,7 +45509,7 @@ metadata:
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/instance: "k8smon"
     app.kubernetes.io/version: 1.7.0
-    helm.sh/chart: "k8s-monitoring-0.9.0"
+    helm.sh/chart: "k8s-monitoring-0.9.1"
   annotations:
     "helm.sh/hook": test
     "helm.sh/hook-delete-policy": before-hook-creation
@@ -45520,7 +45520,7 @@ spec:
         kubernetes.io/os: linux
   containers:
     - name: query-test
-      image: ghcr.io/grafana/k8s-monitoring-test:0.9.0
+      image: ghcr.io/grafana/k8s-monitoring-test:0.9.1
       command: ["bash", "-c", "/etc/bin/query-test.sh /etc/test/testQueries.json"]
       volumeMounts:
         - name: test-files
@@ -45607,7 +45607,7 @@ metadata:
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/instance: "k8smon"
     app.kubernetes.io/version: 1.7.0
-    helm.sh/chart: "k8s-monitoring-0.9.0"
+    helm.sh/chart: "k8s-monitoring-0.9.1"
   annotations:
     "helm.sh/hook": pre-install,pre-upgrade
     "helm.sh/hook-weight": "-5"
@@ -45620,7 +45620,7 @@ spec:
       labels:
         app.kubernetes.io/managed-by: "Helm"
         app.kubernetes.io/instance: "k8smon"
-        helm.sh/chart: "k8s-monitoring-0.9.0"
+        helm.sh/chart: "k8s-monitoring-0.9.1"
     spec:
       restartPolicy: Never
       nodeSelector:

--- a/examples/ibm-cloud/output.yaml
+++ b/examples/ibm-cloud/output.yaml
@@ -1044,7 +1044,7 @@ data:
   metrics.prom: |
     # HELP grafana_kubernetes_monitoring_build_info A metric to report the version of the Kubernetes Monitoring Helm chart as well as a summary of enabled features
     # TYPE grafana_kubernetes_monitoring_build_info gauge
-    grafana_kubernetes_monitoring_build_info{version="0.9.0", namespace="default", metrics="enabled,agent,autoDiscover,kube-state-metrics,node-exporter,kubelet,cadvisor,cost", logs="enabled,events,pod_logs", traces="disabled", deployments="kube-state-metrics,prometheus-node-exporter,prometheus-operator-crds,opencost"} 1
+    grafana_kubernetes_monitoring_build_info{version="0.9.1", namespace="default", metrics="enabled,agent,autoDiscover,kube-state-metrics,node-exporter,kubelet,cadvisor,cost", logs="enabled,events,pod_logs", traces="disabled", deployments="kube-state-metrics,prometheus-node-exporter,prometheus-operator-crds,opencost"} 1
 ---
 # Source: k8s-monitoring/charts/prometheus-operator-crds/charts/crds/templates/crd-alertmanagerconfigs.yaml
 apiVersion: apiextensions.k8s.io/v1
@@ -44770,7 +44770,7 @@ metadata:
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/instance: "k8smon"
     app.kubernetes.io/version: 1.7.0
-    helm.sh/chart: "k8s-monitoring-0.9.0"
+    helm.sh/chart: "k8s-monitoring-0.9.1"
   annotations:
     "helm.sh/hook": pre-install,pre-upgrade
     "helm.sh/hook-weight": "-5"
@@ -45686,7 +45686,7 @@ metadata:
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/instance: "k8smon"
     app.kubernetes.io/version: 1.7.0
-    helm.sh/chart: "k8s-monitoring-0.9.0"
+    helm.sh/chart: "k8s-monitoring-0.9.1"
   annotations:
     "helm.sh/hook": test
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
@@ -45740,7 +45740,7 @@ metadata:
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/instance: "k8smon"
     app.kubernetes.io/version: 1.7.0
-    helm.sh/chart: "k8s-monitoring-0.9.0"
+    helm.sh/chart: "k8s-monitoring-0.9.1"
   annotations:
     "helm.sh/hook": test
     "helm.sh/hook-delete-policy": before-hook-creation
@@ -45751,7 +45751,7 @@ spec:
         kubernetes.io/os: linux
   containers:
     - name: config-analysis
-      image: ghcr.io/grafana/k8s-monitoring-test:0.9.0
+      image: ghcr.io/grafana/k8s-monitoring-test:0.9.1
       command: [/etc/bin/config-analysis.sh]
       env:
         - name: AGENT_HOST
@@ -45767,7 +45767,7 @@ metadata:
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/instance: "k8smon"
     app.kubernetes.io/version: 1.7.0
-    helm.sh/chart: "k8s-monitoring-0.9.0"
+    helm.sh/chart: "k8s-monitoring-0.9.1"
   annotations:
     "helm.sh/hook": test
     "helm.sh/hook-delete-policy": before-hook-creation
@@ -45778,7 +45778,7 @@ spec:
         kubernetes.io/os: linux
   containers:
     - name: query-test
-      image: ghcr.io/grafana/k8s-monitoring-test:0.9.0
+      image: ghcr.io/grafana/k8s-monitoring-test:0.9.1
       command: ["bash", "-c", "/etc/bin/query-test.sh /etc/test/testQueries.json"]
       volumeMounts:
         - name: test-files
@@ -45865,7 +45865,7 @@ metadata:
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/instance: "k8smon"
     app.kubernetes.io/version: 1.7.0
-    helm.sh/chart: "k8s-monitoring-0.9.0"
+    helm.sh/chart: "k8s-monitoring-0.9.1"
   annotations:
     "helm.sh/hook": pre-install,pre-upgrade
     "helm.sh/hook-weight": "-5"
@@ -45878,7 +45878,7 @@ spec:
       labels:
         app.kubernetes.io/managed-by: "Helm"
         app.kubernetes.io/instance: "k8smon"
-        helm.sh/chart: "k8s-monitoring-0.9.0"
+        helm.sh/chart: "k8s-monitoring-0.9.1"
     spec:
       restartPolicy: Never
       nodeSelector:

--- a/examples/logs-only/output.yaml
+++ b/examples/logs-only/output.yaml
@@ -352,7 +352,7 @@ data:
   metrics.prom: |
     # HELP grafana_kubernetes_monitoring_build_info A metric to report the version of the Kubernetes Monitoring Helm chart as well as a summary of enabled features
     # TYPE grafana_kubernetes_monitoring_build_info gauge
-    grafana_kubernetes_monitoring_build_info{version="0.9.0", namespace="default", metrics="disabled", logs="enabled,events,pod_logs", traces="disabled", deployments=""} 1
+    grafana_kubernetes_monitoring_build_info{version="0.9.1", namespace="default", metrics="disabled", logs="enabled,events,pod_logs", traces="disabled", deployments=""} 1
 ---
 # Source: k8s-monitoring/charts/grafana-agent-events/templates/rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -1119,7 +1119,7 @@ metadata:
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/instance: "k8smon"
     app.kubernetes.io/version: 1.7.0
-    helm.sh/chart: "k8s-monitoring-0.9.0"
+    helm.sh/chart: "k8s-monitoring-0.9.1"
   annotations:
     "helm.sh/hook": pre-install,pre-upgrade
     "helm.sh/hook-weight": "-5"
@@ -1399,7 +1399,7 @@ metadata:
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/instance: "k8smon"
     app.kubernetes.io/version: 1.7.0
-    helm.sh/chart: "k8s-monitoring-0.9.0"
+    helm.sh/chart: "k8s-monitoring-0.9.1"
   annotations:
     "helm.sh/hook": test
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
@@ -1420,7 +1420,7 @@ metadata:
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/instance: "k8smon"
     app.kubernetes.io/version: 1.7.0
-    helm.sh/chart: "k8s-monitoring-0.9.0"
+    helm.sh/chart: "k8s-monitoring-0.9.1"
   annotations:
     "helm.sh/hook": test
     "helm.sh/hook-delete-policy": before-hook-creation
@@ -1431,7 +1431,7 @@ spec:
         kubernetes.io/os: linux
   containers:
     - name: config-analysis
-      image: ghcr.io/grafana/k8s-monitoring-test:0.9.0
+      image: ghcr.io/grafana/k8s-monitoring-test:0.9.1
       command: [/etc/bin/config-analysis.sh]
       env:
         - name: AGENT_HOST
@@ -1447,7 +1447,7 @@ metadata:
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/instance: "k8smon"
     app.kubernetes.io/version: 1.7.0
-    helm.sh/chart: "k8s-monitoring-0.9.0"
+    helm.sh/chart: "k8s-monitoring-0.9.1"
   annotations:
     "helm.sh/hook": test
     "helm.sh/hook-delete-policy": before-hook-creation
@@ -1458,7 +1458,7 @@ spec:
         kubernetes.io/os: linux
   containers:
     - name: query-test
-      image: ghcr.io/grafana/k8s-monitoring-test:0.9.0
+      image: ghcr.io/grafana/k8s-monitoring-test:0.9.1
       command: ["bash", "-c", "/etc/bin/query-test.sh /etc/test/testQueries.json"]
       volumeMounts:
         - name: test-files
@@ -1545,7 +1545,7 @@ metadata:
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/instance: "k8smon"
     app.kubernetes.io/version: 1.7.0
-    helm.sh/chart: "k8s-monitoring-0.9.0"
+    helm.sh/chart: "k8s-monitoring-0.9.1"
   annotations:
     "helm.sh/hook": pre-install,pre-upgrade
     "helm.sh/hook-weight": "-5"
@@ -1558,7 +1558,7 @@ spec:
       labels:
         app.kubernetes.io/managed-by: "Helm"
         app.kubernetes.io/instance: "k8smon"
-        helm.sh/chart: "k8s-monitoring-0.9.0"
+        helm.sh/chart: "k8s-monitoring-0.9.1"
     spec:
       restartPolicy: Never
       nodeSelector:

--- a/examples/metrics-only/output.yaml
+++ b/examples/metrics-only/output.yaml
@@ -825,7 +825,7 @@ data:
   metrics.prom: |
     # HELP grafana_kubernetes_monitoring_build_info A metric to report the version of the Kubernetes Monitoring Helm chart as well as a summary of enabled features
     # TYPE grafana_kubernetes_monitoring_build_info gauge
-    grafana_kubernetes_monitoring_build_info{version="0.9.0", namespace="default", metrics="enabled,agent,autoDiscover,kube-state-metrics,node-exporter,kubelet,cadvisor,cost", logs="enabled", traces="disabled", deployments="kube-state-metrics,prometheus-node-exporter,prometheus-operator-crds,opencost"} 1
+    grafana_kubernetes_monitoring_build_info{version="0.9.1", namespace="default", metrics="enabled,agent,autoDiscover,kube-state-metrics,node-exporter,kubelet,cadvisor,cost", logs="enabled", traces="disabled", deployments="kube-state-metrics,prometheus-node-exporter,prometheus-operator-crds,opencost"} 1
 ---
 # Source: k8s-monitoring/charts/prometheus-operator-crds/charts/crds/templates/crd-alertmanagerconfigs.yaml
 apiVersion: apiextensions.k8s.io/v1
@@ -44095,7 +44095,7 @@ metadata:
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/instance: "k8smon"
     app.kubernetes.io/version: 1.7.0
-    helm.sh/chart: "k8s-monitoring-0.9.0"
+    helm.sh/chart: "k8s-monitoring-0.9.1"
   annotations:
     "helm.sh/hook": pre-install,pre-upgrade
     "helm.sh/hook-weight": "-5"
@@ -44848,7 +44848,7 @@ metadata:
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/instance: "k8smon"
     app.kubernetes.io/version: 1.7.0
-    helm.sh/chart: "k8s-monitoring-0.9.0"
+    helm.sh/chart: "k8s-monitoring-0.9.1"
   annotations:
     "helm.sh/hook": test
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
@@ -44902,7 +44902,7 @@ metadata:
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/instance: "k8smon"
     app.kubernetes.io/version: 1.7.0
-    helm.sh/chart: "k8s-monitoring-0.9.0"
+    helm.sh/chart: "k8s-monitoring-0.9.1"
   annotations:
     "helm.sh/hook": test
     "helm.sh/hook-delete-policy": before-hook-creation
@@ -44913,7 +44913,7 @@ spec:
         kubernetes.io/os: linux
   containers:
     - name: config-analysis
-      image: ghcr.io/grafana/k8s-monitoring-test:0.9.0
+      image: ghcr.io/grafana/k8s-monitoring-test:0.9.1
       command: [/etc/bin/config-analysis.sh]
       env:
         - name: AGENT_HOST
@@ -44929,7 +44929,7 @@ metadata:
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/instance: "k8smon"
     app.kubernetes.io/version: 1.7.0
-    helm.sh/chart: "k8s-monitoring-0.9.0"
+    helm.sh/chart: "k8s-monitoring-0.9.1"
   annotations:
     "helm.sh/hook": test
     "helm.sh/hook-delete-policy": before-hook-creation
@@ -44940,7 +44940,7 @@ spec:
         kubernetes.io/os: linux
   containers:
     - name: query-test
-      image: ghcr.io/grafana/k8s-monitoring-test:0.9.0
+      image: ghcr.io/grafana/k8s-monitoring-test:0.9.1
       command: ["bash", "-c", "/etc/bin/query-test.sh /etc/test/testQueries.json"]
       volumeMounts:
         - name: test-files
@@ -45027,7 +45027,7 @@ metadata:
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/instance: "k8smon"
     app.kubernetes.io/version: 1.7.0
-    helm.sh/chart: "k8s-monitoring-0.9.0"
+    helm.sh/chart: "k8s-monitoring-0.9.1"
   annotations:
     "helm.sh/hook": pre-install,pre-upgrade
     "helm.sh/hook-weight": "-5"
@@ -45040,7 +45040,7 @@ spec:
       labels:
         app.kubernetes.io/managed-by: "Helm"
         app.kubernetes.io/instance: "k8smon"
-        helm.sh/chart: "k8s-monitoring-0.9.0"
+        helm.sh/chart: "k8s-monitoring-0.9.1"
     spec:
       restartPolicy: Never
       nodeSelector:

--- a/examples/openshift-compatible/output.yaml
+++ b/examples/openshift-compatible/output.yaml
@@ -1019,7 +1019,7 @@ data:
   metrics.prom: |
     # HELP grafana_kubernetes_monitoring_build_info A metric to report the version of the Kubernetes Monitoring Helm chart as well as a summary of enabled features
     # TYPE grafana_kubernetes_monitoring_build_info gauge
-    grafana_kubernetes_monitoring_build_info{version="0.9.0", namespace="default", metrics="enabled,agent,autoDiscover,kube-state-metrics,node-exporter,kubelet,cadvisor,cost", logs="enabled,events,pod_logs", traces="disabled", deployments="prometheus-operator-crds,opencost"} 1
+    grafana_kubernetes_monitoring_build_info{version="0.9.1", namespace="default", metrics="enabled,agent,autoDiscover,kube-state-metrics,node-exporter,kubelet,cadvisor,cost", logs="enabled,events,pod_logs", traces="disabled", deployments="prometheus-operator-crds,opencost"} 1
 ---
 # Source: k8s-monitoring/charts/prometheus-operator-crds/charts/crds/templates/crd-alertmanagerconfigs.yaml
 apiVersion: apiextensions.k8s.io/v1
@@ -44415,7 +44415,7 @@ metadata:
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/instance: "k8smon"
     app.kubernetes.io/version: 1.7.0
-    helm.sh/chart: "k8s-monitoring-0.9.0"
+    helm.sh/chart: "k8s-monitoring-0.9.1"
   annotations:
     "helm.sh/hook": pre-install,pre-upgrade
     "helm.sh/hook-weight": "-5"
@@ -45336,7 +45336,7 @@ metadata:
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/instance: "k8smon"
     app.kubernetes.io/version: 1.7.0
-    helm.sh/chart: "k8s-monitoring-0.9.0"
+    helm.sh/chart: "k8s-monitoring-0.9.1"
   annotations:
     "helm.sh/hook": test
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
@@ -45390,7 +45390,7 @@ metadata:
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/instance: "k8smon"
     app.kubernetes.io/version: 1.7.0
-    helm.sh/chart: "k8s-monitoring-0.9.0"
+    helm.sh/chart: "k8s-monitoring-0.9.1"
   annotations:
     "helm.sh/hook": test
     "helm.sh/hook-delete-policy": before-hook-creation
@@ -45401,7 +45401,7 @@ spec:
         kubernetes.io/os: linux
   containers:
     - name: config-analysis
-      image: ghcr.io/grafana/k8s-monitoring-test:0.9.0
+      image: ghcr.io/grafana/k8s-monitoring-test:0.9.1
       command: [/etc/bin/config-analysis.sh]
       env:
         - name: AGENT_HOST
@@ -45417,7 +45417,7 @@ metadata:
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/instance: "k8smon"
     app.kubernetes.io/version: 1.7.0
-    helm.sh/chart: "k8s-monitoring-0.9.0"
+    helm.sh/chart: "k8s-monitoring-0.9.1"
   annotations:
     "helm.sh/hook": test
     "helm.sh/hook-delete-policy": before-hook-creation
@@ -45428,7 +45428,7 @@ spec:
         kubernetes.io/os: linux
   containers:
     - name: query-test
-      image: ghcr.io/grafana/k8s-monitoring-test:0.9.0
+      image: ghcr.io/grafana/k8s-monitoring-test:0.9.1
       command: ["bash", "-c", "/etc/bin/query-test.sh /etc/test/testQueries.json"]
       volumeMounts:
         - name: test-files
@@ -45515,7 +45515,7 @@ metadata:
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/instance: "k8smon"
     app.kubernetes.io/version: 1.7.0
-    helm.sh/chart: "k8s-monitoring-0.9.0"
+    helm.sh/chart: "k8s-monitoring-0.9.1"
   annotations:
     "helm.sh/hook": pre-install,pre-upgrade
     "helm.sh/hook-weight": "-5"
@@ -45528,7 +45528,7 @@ spec:
       labels:
         app.kubernetes.io/managed-by: "Helm"
         app.kubernetes.io/instance: "k8smon"
-        helm.sh/chart: "k8s-monitoring-0.9.0"
+        helm.sh/chart: "k8s-monitoring-0.9.1"
     spec:
       restartPolicy: Never
       nodeSelector:

--- a/examples/otel-metrics-service/output.yaml
+++ b/examples/otel-metrics-service/output.yaml
@@ -1074,7 +1074,7 @@ data:
   metrics.prom: |
     # HELP grafana_kubernetes_monitoring_build_info A metric to report the version of the Kubernetes Monitoring Helm chart as well as a summary of enabled features
     # TYPE grafana_kubernetes_monitoring_build_info gauge
-    grafana_kubernetes_monitoring_build_info{version="0.9.0", namespace="default", metrics="enabled,agent,autoDiscover,kube-state-metrics,node-exporter,kubelet,cadvisor,cost", logs="enabled,events,pod_logs", traces="disabled", deployments="kube-state-metrics,prometheus-node-exporter,prometheus-operator-crds,opencost"} 1
+    grafana_kubernetes_monitoring_build_info{version="0.9.1", namespace="default", metrics="enabled,agent,autoDiscover,kube-state-metrics,node-exporter,kubelet,cadvisor,cost", logs="enabled,events,pod_logs", traces="disabled", deployments="kube-state-metrics,prometheus-node-exporter,prometheus-operator-crds,opencost"} 1
 ---
 # Source: k8s-monitoring/charts/prometheus-operator-crds/charts/crds/templates/crd-alertmanagerconfigs.yaml
 apiVersion: apiextensions.k8s.io/v1
@@ -44794,7 +44794,7 @@ metadata:
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/instance: "k8smon"
     app.kubernetes.io/version: 1.7.0
-    helm.sh/chart: "k8s-monitoring-0.9.0"
+    helm.sh/chart: "k8s-monitoring-0.9.1"
   annotations:
     "helm.sh/hook": pre-install,pre-upgrade
     "helm.sh/hook-weight": "-5"
@@ -45740,7 +45740,7 @@ metadata:
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/instance: "k8smon"
     app.kubernetes.io/version: 1.7.0
-    helm.sh/chart: "k8s-monitoring-0.9.0"
+    helm.sh/chart: "k8s-monitoring-0.9.1"
   annotations:
     "helm.sh/hook": test
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
@@ -45794,7 +45794,7 @@ metadata:
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/instance: "k8smon"
     app.kubernetes.io/version: 1.7.0
-    helm.sh/chart: "k8s-monitoring-0.9.0"
+    helm.sh/chart: "k8s-monitoring-0.9.1"
   annotations:
     "helm.sh/hook": test
     "helm.sh/hook-delete-policy": before-hook-creation
@@ -45805,7 +45805,7 @@ spec:
         kubernetes.io/os: linux
   containers:
     - name: config-analysis
-      image: ghcr.io/grafana/k8s-monitoring-test:0.9.0
+      image: ghcr.io/grafana/k8s-monitoring-test:0.9.1
       command: [/etc/bin/config-analysis.sh]
       env:
         - name: AGENT_HOST
@@ -45821,7 +45821,7 @@ metadata:
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/instance: "k8smon"
     app.kubernetes.io/version: 1.7.0
-    helm.sh/chart: "k8s-monitoring-0.9.0"
+    helm.sh/chart: "k8s-monitoring-0.9.1"
   annotations:
     "helm.sh/hook": test
     "helm.sh/hook-delete-policy": before-hook-creation
@@ -45832,7 +45832,7 @@ spec:
         kubernetes.io/os: linux
   containers:
     - name: query-test
-      image: ghcr.io/grafana/k8s-monitoring-test:0.9.0
+      image: ghcr.io/grafana/k8s-monitoring-test:0.9.1
       command: ["bash", "-c", "/etc/bin/query-test.sh /etc/test/testQueries.json"]
       volumeMounts:
         - name: test-files
@@ -45919,7 +45919,7 @@ metadata:
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/instance: "k8smon"
     app.kubernetes.io/version: 1.7.0
-    helm.sh/chart: "k8s-monitoring-0.9.0"
+    helm.sh/chart: "k8s-monitoring-0.9.1"
   annotations:
     "helm.sh/hook": pre-install,pre-upgrade
     "helm.sh/hook-weight": "-5"
@@ -45932,7 +45932,7 @@ spec:
       labels:
         app.kubernetes.io/managed-by: "Helm"
         app.kubernetes.io/instance: "k8smon"
-        helm.sh/chart: "k8s-monitoring-0.9.0"
+        helm.sh/chart: "k8s-monitoring-0.9.1"
     spec:
       restartPolicy: Never
       nodeSelector:

--- a/examples/private-image-registry/output.yaml
+++ b/examples/private-image-registry/output.yaml
@@ -1048,7 +1048,7 @@ data:
   metrics.prom: |
     # HELP grafana_kubernetes_monitoring_build_info A metric to report the version of the Kubernetes Monitoring Helm chart as well as a summary of enabled features
     # TYPE grafana_kubernetes_monitoring_build_info gauge
-    grafana_kubernetes_monitoring_build_info{version="0.9.0", namespace="default", metrics="enabled,agent,autoDiscover,kube-state-metrics,node-exporter,kubelet,cadvisor,cost", logs="enabled,events,pod_logs", traces="disabled", deployments="kube-state-metrics,prometheus-node-exporter,prometheus-operator-crds,opencost"} 1
+    grafana_kubernetes_monitoring_build_info{version="0.9.1", namespace="default", metrics="enabled,agent,autoDiscover,kube-state-metrics,node-exporter,kubelet,cadvisor,cost", logs="enabled,events,pod_logs", traces="disabled", deployments="kube-state-metrics,prometheus-node-exporter,prometheus-operator-crds,opencost"} 1
 ---
 # Source: k8s-monitoring/charts/prometheus-operator-crds/charts/crds/templates/crd-alertmanagerconfigs.yaml
 apiVersion: apiextensions.k8s.io/v1
@@ -44780,7 +44780,7 @@ metadata:
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/instance: "k8smon"
     app.kubernetes.io/version: 1.7.0
-    helm.sh/chart: "k8s-monitoring-0.9.0"
+    helm.sh/chart: "k8s-monitoring-0.9.1"
   annotations:
     "helm.sh/hook": pre-install,pre-upgrade
     "helm.sh/hook-weight": "-5"
@@ -45696,7 +45696,7 @@ metadata:
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/instance: "k8smon"
     app.kubernetes.io/version: 1.7.0
-    helm.sh/chart: "k8s-monitoring-0.9.0"
+    helm.sh/chart: "k8s-monitoring-0.9.1"
   annotations:
     "helm.sh/hook": test
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
@@ -45750,7 +45750,7 @@ metadata:
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/instance: "k8smon"
     app.kubernetes.io/version: 1.7.0
-    helm.sh/chart: "k8s-monitoring-0.9.0"
+    helm.sh/chart: "k8s-monitoring-0.9.1"
   annotations:
     "helm.sh/hook": test
     "helm.sh/hook-delete-policy": before-hook-creation
@@ -45763,7 +45763,7 @@ spec:
         kubernetes.io/os: linux
   containers:
     - name: config-analysis
-      image: my.registry.com/grafana/k8s-monitoring-test:0.9.0
+      image: my.registry.com/grafana/k8s-monitoring-test:0.9.1
       command: [/etc/bin/config-analysis.sh]
       env:
         - name: AGENT_HOST
@@ -45779,7 +45779,7 @@ metadata:
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/instance: "k8smon"
     app.kubernetes.io/version: 1.7.0
-    helm.sh/chart: "k8s-monitoring-0.9.0"
+    helm.sh/chart: "k8s-monitoring-0.9.1"
   annotations:
     "helm.sh/hook": test
     "helm.sh/hook-delete-policy": before-hook-creation
@@ -45792,7 +45792,7 @@ spec:
         kubernetes.io/os: linux
   containers:
     - name: query-test
-      image: my.registry.com/grafana/k8s-monitoring-test:0.9.0
+      image: my.registry.com/grafana/k8s-monitoring-test:0.9.1
       command: ["bash", "-c", "/etc/bin/query-test.sh /etc/test/testQueries.json"]
       volumeMounts:
         - name: test-files
@@ -45879,7 +45879,7 @@ metadata:
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/instance: "k8smon"
     app.kubernetes.io/version: 1.7.0
-    helm.sh/chart: "k8s-monitoring-0.9.0"
+    helm.sh/chart: "k8s-monitoring-0.9.1"
   annotations:
     "helm.sh/hook": pre-install,pre-upgrade
     "helm.sh/hook-weight": "-5"
@@ -45892,7 +45892,7 @@ spec:
       labels:
         app.kubernetes.io/managed-by: "Helm"
         app.kubernetes.io/instance: "k8smon"
-        helm.sh/chart: "k8s-monitoring-0.9.0"
+        helm.sh/chart: "k8s-monitoring-0.9.1"
     spec:
       imagePullSecrets:
         - name: my-registry-creds

--- a/examples/proxies/output.yaml
+++ b/examples/proxies/output.yaml
@@ -1060,7 +1060,7 @@ data:
   metrics.prom: |
     # HELP grafana_kubernetes_monitoring_build_info A metric to report the version of the Kubernetes Monitoring Helm chart as well as a summary of enabled features
     # TYPE grafana_kubernetes_monitoring_build_info gauge
-    grafana_kubernetes_monitoring_build_info{version="0.9.0", namespace="default", metrics="enabled,agent,autoDiscover,kube-state-metrics,node-exporter,kubelet,cadvisor,cost", logs="enabled,events,pod_logs", traces="disabled", deployments="kube-state-metrics,prometheus-node-exporter,prometheus-operator-crds,opencost"} 1
+    grafana_kubernetes_monitoring_build_info{version="0.9.1", namespace="default", metrics="enabled,agent,autoDiscover,kube-state-metrics,node-exporter,kubelet,cadvisor,cost", logs="enabled,events,pod_logs", traces="disabled", deployments="kube-state-metrics,prometheus-node-exporter,prometheus-operator-crds,opencost"} 1
 ---
 # Source: k8s-monitoring/charts/prometheus-operator-crds/charts/crds/templates/crd-alertmanagerconfigs.yaml
 apiVersion: apiextensions.k8s.io/v1
@@ -44780,7 +44780,7 @@ metadata:
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/instance: "k8smon"
     app.kubernetes.io/version: 1.7.0
-    helm.sh/chart: "k8s-monitoring-0.9.0"
+    helm.sh/chart: "k8s-monitoring-0.9.1"
   annotations:
     "helm.sh/hook": pre-install,pre-upgrade
     "helm.sh/hook-weight": "-5"
@@ -45712,7 +45712,7 @@ metadata:
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/instance: "k8smon"
     app.kubernetes.io/version: 1.7.0
-    helm.sh/chart: "k8s-monitoring-0.9.0"
+    helm.sh/chart: "k8s-monitoring-0.9.1"
   annotations:
     "helm.sh/hook": test
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
@@ -45766,7 +45766,7 @@ metadata:
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/instance: "k8smon"
     app.kubernetes.io/version: 1.7.0
-    helm.sh/chart: "k8s-monitoring-0.9.0"
+    helm.sh/chart: "k8s-monitoring-0.9.1"
   annotations:
     "helm.sh/hook": test
     "helm.sh/hook-delete-policy": before-hook-creation
@@ -45777,7 +45777,7 @@ spec:
         kubernetes.io/os: linux
   containers:
     - name: config-analysis
-      image: ghcr.io/grafana/k8s-monitoring-test:0.9.0
+      image: ghcr.io/grafana/k8s-monitoring-test:0.9.1
       command: [/etc/bin/config-analysis.sh]
       env:
         - name: AGENT_HOST
@@ -45793,7 +45793,7 @@ metadata:
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/instance: "k8smon"
     app.kubernetes.io/version: 1.7.0
-    helm.sh/chart: "k8s-monitoring-0.9.0"
+    helm.sh/chart: "k8s-monitoring-0.9.1"
   annotations:
     "helm.sh/hook": test
     "helm.sh/hook-delete-policy": before-hook-creation
@@ -45804,7 +45804,7 @@ spec:
         kubernetes.io/os: linux
   containers:
     - name: query-test
-      image: ghcr.io/grafana/k8s-monitoring-test:0.9.0
+      image: ghcr.io/grafana/k8s-monitoring-test:0.9.1
       command: ["bash", "-c", "/etc/bin/query-test.sh /etc/test/testQueries.json"]
       volumeMounts:
         - name: test-files
@@ -45891,7 +45891,7 @@ metadata:
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/instance: "k8smon"
     app.kubernetes.io/version: 1.7.0
-    helm.sh/chart: "k8s-monitoring-0.9.0"
+    helm.sh/chart: "k8s-monitoring-0.9.1"
   annotations:
     "helm.sh/hook": pre-install,pre-upgrade
     "helm.sh/hook-weight": "-5"
@@ -45904,7 +45904,7 @@ spec:
       labels:
         app.kubernetes.io/managed-by: "Helm"
         app.kubernetes.io/instance: "k8smon"
-        helm.sh/chart: "k8s-monitoring-0.9.0"
+        helm.sh/chart: "k8s-monitoring-0.9.1"
     spec:
       restartPolicy: Never
       nodeSelector:

--- a/examples/scrape-intervals/output.yaml
+++ b/examples/scrape-intervals/output.yaml
@@ -824,7 +824,7 @@ data:
   metrics.prom: |
     # HELP grafana_kubernetes_monitoring_build_info A metric to report the version of the Kubernetes Monitoring Helm chart as well as a summary of enabled features
     # TYPE grafana_kubernetes_monitoring_build_info gauge
-    grafana_kubernetes_monitoring_build_info{version="0.9.0", namespace="default", metrics="enabled,agent,autoDiscover,kube-state-metrics,node-exporter,kubelet,cadvisor,cost", logs="enabled", traces="disabled", deployments="kube-state-metrics,prometheus-node-exporter,prometheus-operator-crds,opencost"} 1
+    grafana_kubernetes_monitoring_build_info{version="0.9.1", namespace="default", metrics="enabled,agent,autoDiscover,kube-state-metrics,node-exporter,kubelet,cadvisor,cost", logs="enabled", traces="disabled", deployments="kube-state-metrics,prometheus-node-exporter,prometheus-operator-crds,opencost"} 1
 ---
 # Source: k8s-monitoring/charts/prometheus-operator-crds/charts/crds/templates/crd-alertmanagerconfigs.yaml
 apiVersion: apiextensions.k8s.io/v1
@@ -44094,7 +44094,7 @@ metadata:
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/instance: "k8smon"
     app.kubernetes.io/version: 1.7.0
-    helm.sh/chart: "k8s-monitoring-0.9.0"
+    helm.sh/chart: "k8s-monitoring-0.9.1"
   annotations:
     "helm.sh/hook": pre-install,pre-upgrade
     "helm.sh/hook-weight": "-5"
@@ -44847,7 +44847,7 @@ metadata:
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/instance: "k8smon"
     app.kubernetes.io/version: 1.7.0
-    helm.sh/chart: "k8s-monitoring-0.9.0"
+    helm.sh/chart: "k8s-monitoring-0.9.1"
   annotations:
     "helm.sh/hook": test
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
@@ -44901,7 +44901,7 @@ metadata:
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/instance: "k8smon"
     app.kubernetes.io/version: 1.7.0
-    helm.sh/chart: "k8s-monitoring-0.9.0"
+    helm.sh/chart: "k8s-monitoring-0.9.1"
   annotations:
     "helm.sh/hook": test
     "helm.sh/hook-delete-policy": before-hook-creation
@@ -44912,7 +44912,7 @@ spec:
         kubernetes.io/os: linux
   containers:
     - name: config-analysis
-      image: ghcr.io/grafana/k8s-monitoring-test:0.9.0
+      image: ghcr.io/grafana/k8s-monitoring-test:0.9.1
       command: [/etc/bin/config-analysis.sh]
       env:
         - name: AGENT_HOST
@@ -44928,7 +44928,7 @@ metadata:
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/instance: "k8smon"
     app.kubernetes.io/version: 1.7.0
-    helm.sh/chart: "k8s-monitoring-0.9.0"
+    helm.sh/chart: "k8s-monitoring-0.9.1"
   annotations:
     "helm.sh/hook": test
     "helm.sh/hook-delete-policy": before-hook-creation
@@ -44939,7 +44939,7 @@ spec:
         kubernetes.io/os: linux
   containers:
     - name: query-test
-      image: ghcr.io/grafana/k8s-monitoring-test:0.9.0
+      image: ghcr.io/grafana/k8s-monitoring-test:0.9.1
       command: ["bash", "-c", "/etc/bin/query-test.sh /etc/test/testQueries.json"]
       volumeMounts:
         - name: test-files
@@ -45026,7 +45026,7 @@ metadata:
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/instance: "k8smon"
     app.kubernetes.io/version: 1.7.0
-    helm.sh/chart: "k8s-monitoring-0.9.0"
+    helm.sh/chart: "k8s-monitoring-0.9.1"
   annotations:
     "helm.sh/hook": pre-install,pre-upgrade
     "helm.sh/hook-weight": "-5"
@@ -45039,7 +45039,7 @@ spec:
       labels:
         app.kubernetes.io/managed-by: "Helm"
         app.kubernetes.io/instance: "k8smon"
-        helm.sh/chart: "k8s-monitoring-0.9.0"
+        helm.sh/chart: "k8s-monitoring-0.9.1"
     spec:
       restartPolicy: Never
       nodeSelector:

--- a/examples/service-integrations/output.yaml
+++ b/examples/service-integrations/output.yaml
@@ -1079,7 +1079,7 @@ data:
   metrics.prom: |
     # HELP grafana_kubernetes_monitoring_build_info A metric to report the version of the Kubernetes Monitoring Helm chart as well as a summary of enabled features
     # TYPE grafana_kubernetes_monitoring_build_info gauge
-    grafana_kubernetes_monitoring_build_info{version="0.9.0", namespace="default", metrics="enabled,agent,autoDiscover,kube-state-metrics,node-exporter,kubelet,cadvisor,cost,extraConfig", logs="enabled,events,pod_logs,extraConfig", traces="disabled", deployments="kube-state-metrics,prometheus-node-exporter,prometheus-operator-crds,opencost"} 1
+    grafana_kubernetes_monitoring_build_info{version="0.9.1", namespace="default", metrics="enabled,agent,autoDiscover,kube-state-metrics,node-exporter,kubelet,cadvisor,cost,extraConfig", logs="enabled,events,pod_logs,extraConfig", traces="disabled", deployments="kube-state-metrics,prometheus-node-exporter,prometheus-operator-crds,opencost"} 1
 ---
 # Source: k8s-monitoring/charts/prometheus-operator-crds/charts/crds/templates/crd-alertmanagerconfigs.yaml
 apiVersion: apiextensions.k8s.io/v1
@@ -44799,7 +44799,7 @@ metadata:
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/instance: "k8smon"
     app.kubernetes.io/version: 1.7.0
-    helm.sh/chart: "k8s-monitoring-0.9.0"
+    helm.sh/chart: "k8s-monitoring-0.9.1"
   annotations:
     "helm.sh/hook": pre-install,pre-upgrade
     "helm.sh/hook-weight": "-5"
@@ -45750,7 +45750,7 @@ metadata:
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/instance: "k8smon"
     app.kubernetes.io/version: 1.7.0
-    helm.sh/chart: "k8s-monitoring-0.9.0"
+    helm.sh/chart: "k8s-monitoring-0.9.1"
   annotations:
     "helm.sh/hook": test
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
@@ -45816,7 +45816,7 @@ metadata:
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/instance: "k8smon"
     app.kubernetes.io/version: 1.7.0
-    helm.sh/chart: "k8s-monitoring-0.9.0"
+    helm.sh/chart: "k8s-monitoring-0.9.1"
   annotations:
     "helm.sh/hook": test
     "helm.sh/hook-delete-policy": before-hook-creation
@@ -45827,7 +45827,7 @@ spec:
         kubernetes.io/os: linux
   containers:
     - name: config-analysis
-      image: ghcr.io/grafana/k8s-monitoring-test:0.9.0
+      image: ghcr.io/grafana/k8s-monitoring-test:0.9.1
       command: [/etc/bin/config-analysis.sh]
       env:
         - name: AGENT_HOST
@@ -45843,7 +45843,7 @@ metadata:
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/instance: "k8smon"
     app.kubernetes.io/version: 1.7.0
-    helm.sh/chart: "k8s-monitoring-0.9.0"
+    helm.sh/chart: "k8s-monitoring-0.9.1"
   annotations:
     "helm.sh/hook": test
     "helm.sh/hook-delete-policy": before-hook-creation
@@ -45854,7 +45854,7 @@ spec:
         kubernetes.io/os: linux
   containers:
     - name: query-test
-      image: ghcr.io/grafana/k8s-monitoring-test:0.9.0
+      image: ghcr.io/grafana/k8s-monitoring-test:0.9.1
       command: ["bash", "-c", "/etc/bin/query-test.sh /etc/test/testQueries.json"]
       volumeMounts:
         - name: test-files
@@ -45941,7 +45941,7 @@ metadata:
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/instance: "k8smon"
     app.kubernetes.io/version: 1.7.0
-    helm.sh/chart: "k8s-monitoring-0.9.0"
+    helm.sh/chart: "k8s-monitoring-0.9.1"
   annotations:
     "helm.sh/hook": pre-install,pre-upgrade
     "helm.sh/hook-weight": "-5"
@@ -45954,7 +45954,7 @@ spec:
       labels:
         app.kubernetes.io/managed-by: "Helm"
         app.kubernetes.io/instance: "k8smon"
-        helm.sh/chart: "k8s-monitoring-0.9.0"
+        helm.sh/chart: "k8s-monitoring-0.9.1"
     spec:
       restartPolicy: Never
       nodeSelector:

--- a/examples/specific-namespace/output.yaml
+++ b/examples/specific-namespace/output.yaml
@@ -1100,7 +1100,7 @@ data:
   metrics.prom: |
     # HELP grafana_kubernetes_monitoring_build_info A metric to report the version of the Kubernetes Monitoring Helm chart as well as a summary of enabled features
     # TYPE grafana_kubernetes_monitoring_build_info gauge
-    grafana_kubernetes_monitoring_build_info{version="0.9.0", namespace="default", metrics="enabled,agent,autoDiscover,kube-state-metrics,node-exporter,kubelet,cadvisor,cost", logs="enabled,events,pod_logs", traces="disabled", deployments="kube-state-metrics,prometheus-node-exporter,prometheus-operator-crds,opencost"} 1
+    grafana_kubernetes_monitoring_build_info{version="0.9.1", namespace="default", metrics="enabled,agent,autoDiscover,kube-state-metrics,node-exporter,kubelet,cadvisor,cost", logs="enabled,events,pod_logs", traces="disabled", deployments="kube-state-metrics,prometheus-node-exporter,prometheus-operator-crds,opencost"} 1
 ---
 # Source: k8s-monitoring/charts/prometheus-operator-crds/charts/crds/templates/crd-alertmanagerconfigs.yaml
 apiVersion: apiextensions.k8s.io/v1
@@ -44820,7 +44820,7 @@ metadata:
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/instance: "k8smon"
     app.kubernetes.io/version: 1.7.0
-    helm.sh/chart: "k8s-monitoring-0.9.0"
+    helm.sh/chart: "k8s-monitoring-0.9.1"
   annotations:
     "helm.sh/hook": pre-install,pre-upgrade
     "helm.sh/hook-weight": "-5"
@@ -45792,7 +45792,7 @@ metadata:
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/instance: "k8smon"
     app.kubernetes.io/version: 1.7.0
-    helm.sh/chart: "k8s-monitoring-0.9.0"
+    helm.sh/chart: "k8s-monitoring-0.9.1"
   annotations:
     "helm.sh/hook": test
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
@@ -45846,7 +45846,7 @@ metadata:
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/instance: "k8smon"
     app.kubernetes.io/version: 1.7.0
-    helm.sh/chart: "k8s-monitoring-0.9.0"
+    helm.sh/chart: "k8s-monitoring-0.9.1"
   annotations:
     "helm.sh/hook": test
     "helm.sh/hook-delete-policy": before-hook-creation
@@ -45857,7 +45857,7 @@ spec:
         kubernetes.io/os: linux
   containers:
     - name: config-analysis
-      image: ghcr.io/grafana/k8s-monitoring-test:0.9.0
+      image: ghcr.io/grafana/k8s-monitoring-test:0.9.1
       command: [/etc/bin/config-analysis.sh]
       env:
         - name: AGENT_HOST
@@ -45873,7 +45873,7 @@ metadata:
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/instance: "k8smon"
     app.kubernetes.io/version: 1.7.0
-    helm.sh/chart: "k8s-monitoring-0.9.0"
+    helm.sh/chart: "k8s-monitoring-0.9.1"
   annotations:
     "helm.sh/hook": test
     "helm.sh/hook-delete-policy": before-hook-creation
@@ -45884,7 +45884,7 @@ spec:
         kubernetes.io/os: linux
   containers:
     - name: query-test
-      image: ghcr.io/grafana/k8s-monitoring-test:0.9.0
+      image: ghcr.io/grafana/k8s-monitoring-test:0.9.1
       command: ["bash", "-c", "/etc/bin/query-test.sh /etc/test/testQueries.json"]
       volumeMounts:
         - name: test-files
@@ -45971,7 +45971,7 @@ metadata:
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/instance: "k8smon"
     app.kubernetes.io/version: 1.7.0
-    helm.sh/chart: "k8s-monitoring-0.9.0"
+    helm.sh/chart: "k8s-monitoring-0.9.1"
   annotations:
     "helm.sh/hook": pre-install,pre-upgrade
     "helm.sh/hook-weight": "-5"
@@ -45984,7 +45984,7 @@ spec:
       labels:
         app.kubernetes.io/managed-by: "Helm"
         app.kubernetes.io/instance: "k8smon"
-        helm.sh/chart: "k8s-monitoring-0.9.0"
+        helm.sh/chart: "k8s-monitoring-0.9.1"
     spec:
       restartPolicy: Never
       nodeSelector:

--- a/examples/traces-enabled/output.yaml
+++ b/examples/traces-enabled/output.yaml
@@ -1106,7 +1106,7 @@ data:
   metrics.prom: |
     # HELP grafana_kubernetes_monitoring_build_info A metric to report the version of the Kubernetes Monitoring Helm chart as well as a summary of enabled features
     # TYPE grafana_kubernetes_monitoring_build_info gauge
-    grafana_kubernetes_monitoring_build_info{version="0.9.0", namespace="default", metrics="enabled,agent,autoDiscover,kube-state-metrics,node-exporter,kubelet,cadvisor,cost", logs="enabled,events,pod_logs", traces="enabled", deployments="kube-state-metrics,prometheus-node-exporter,prometheus-operator-crds,opencost"} 1
+    grafana_kubernetes_monitoring_build_info{version="0.9.1", namespace="default", metrics="enabled,agent,autoDiscover,kube-state-metrics,node-exporter,kubelet,cadvisor,cost", logs="enabled,events,pod_logs", traces="enabled", deployments="kube-state-metrics,prometheus-node-exporter,prometheus-operator-crds,opencost"} 1
 ---
 # Source: k8s-monitoring/charts/prometheus-operator-crds/charts/crds/templates/crd-alertmanagerconfigs.yaml
 apiVersion: apiextensions.k8s.io/v1
@@ -44826,7 +44826,7 @@ metadata:
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/instance: "k8smon"
     app.kubernetes.io/version: 1.7.0
-    helm.sh/chart: "k8s-monitoring-0.9.0"
+    helm.sh/chart: "k8s-monitoring-0.9.1"
   annotations:
     "helm.sh/hook": pre-install,pre-upgrade
     "helm.sh/hook-weight": "-5"
@@ -45791,7 +45791,7 @@ metadata:
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/instance: "k8smon"
     app.kubernetes.io/version: 1.7.0
-    helm.sh/chart: "k8s-monitoring-0.9.0"
+    helm.sh/chart: "k8s-monitoring-0.9.1"
   annotations:
     "helm.sh/hook": test
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
@@ -45845,7 +45845,7 @@ metadata:
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/instance: "k8smon"
     app.kubernetes.io/version: 1.7.0
-    helm.sh/chart: "k8s-monitoring-0.9.0"
+    helm.sh/chart: "k8s-monitoring-0.9.1"
   annotations:
     "helm.sh/hook": test
     "helm.sh/hook-delete-policy": before-hook-creation
@@ -45856,7 +45856,7 @@ spec:
         kubernetes.io/os: linux
   containers:
     - name: config-analysis
-      image: ghcr.io/grafana/k8s-monitoring-test:0.9.0
+      image: ghcr.io/grafana/k8s-monitoring-test:0.9.1
       command: [/etc/bin/config-analysis.sh]
       env:
         - name: AGENT_HOST
@@ -45872,7 +45872,7 @@ metadata:
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/instance: "k8smon"
     app.kubernetes.io/version: 1.7.0
-    helm.sh/chart: "k8s-monitoring-0.9.0"
+    helm.sh/chart: "k8s-monitoring-0.9.1"
   annotations:
     "helm.sh/hook": test
     "helm.sh/hook-delete-policy": before-hook-creation
@@ -45883,7 +45883,7 @@ spec:
         kubernetes.io/os: linux
   containers:
     - name: query-test
-      image: ghcr.io/grafana/k8s-monitoring-test:0.9.0
+      image: ghcr.io/grafana/k8s-monitoring-test:0.9.1
       command: ["bash", "-c", "/etc/bin/query-test.sh /etc/test/testQueries.json"]
       volumeMounts:
         - name: test-files
@@ -45970,7 +45970,7 @@ metadata:
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/instance: "k8smon"
     app.kubernetes.io/version: 1.7.0
-    helm.sh/chart: "k8s-monitoring-0.9.0"
+    helm.sh/chart: "k8s-monitoring-0.9.1"
   annotations:
     "helm.sh/hook": pre-install,pre-upgrade
     "helm.sh/hook-weight": "-5"
@@ -45983,7 +45983,7 @@ spec:
       labels:
         app.kubernetes.io/managed-by: "Helm"
         app.kubernetes.io/instance: "k8smon"
-        helm.sh/chart: "k8s-monitoring-0.9.0"
+        helm.sh/chart: "k8s-monitoring-0.9.1"
     spec:
       restartPolicy: Never
       nodeSelector:

--- a/examples/windows-exporter/output.yaml
+++ b/examples/windows-exporter/output.yaml
@@ -1149,7 +1149,7 @@ data:
   metrics.prom: |
     # HELP grafana_kubernetes_monitoring_build_info A metric to report the version of the Kubernetes Monitoring Helm chart as well as a summary of enabled features
     # TYPE grafana_kubernetes_monitoring_build_info gauge
-    grafana_kubernetes_monitoring_build_info{version="0.9.0", namespace="default", metrics="enabled,agent,autoDiscover,kube-state-metrics,node-exporter,windows-exporter,kubelet,cadvisor,cost", logs="enabled,events,pod_logs", traces="disabled", deployments="kube-state-metrics,prometheus-node-exporter,prometheus-windows-exporter,prometheus-operator-crds,opencost"} 1
+    grafana_kubernetes_monitoring_build_info{version="0.9.1", namespace="default", metrics="enabled,agent,autoDiscover,kube-state-metrics,node-exporter,windows-exporter,kubelet,cadvisor,cost", logs="enabled,events,pod_logs", traces="disabled", deployments="kube-state-metrics,prometheus-node-exporter,prometheus-windows-exporter,prometheus-operator-crds,opencost"} 1
 ---
 # Source: k8s-monitoring/charts/prometheus-operator-crds/charts/crds/templates/crd-alertmanagerconfigs.yaml
 apiVersion: apiextensions.k8s.io/v1
@@ -44995,7 +44995,7 @@ metadata:
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/instance: "k8smon"
     app.kubernetes.io/version: 1.7.0
-    helm.sh/chart: "k8s-monitoring-0.9.0"
+    helm.sh/chart: "k8s-monitoring-0.9.1"
   annotations:
     "helm.sh/hook": pre-install,pre-upgrade
     "helm.sh/hook-weight": "-5"
@@ -45979,7 +45979,7 @@ metadata:
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/instance: "k8smon"
     app.kubernetes.io/version: 1.7.0
-    helm.sh/chart: "k8s-monitoring-0.9.0"
+    helm.sh/chart: "k8s-monitoring-0.9.1"
   annotations:
     "helm.sh/hook": test
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
@@ -46037,7 +46037,7 @@ metadata:
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/instance: "k8smon"
     app.kubernetes.io/version: 1.7.0
-    helm.sh/chart: "k8s-monitoring-0.9.0"
+    helm.sh/chart: "k8s-monitoring-0.9.1"
   annotations:
     "helm.sh/hook": test
     "helm.sh/hook-delete-policy": before-hook-creation
@@ -46048,7 +46048,7 @@ spec:
         kubernetes.io/os: linux
   containers:
     - name: config-analysis
-      image: ghcr.io/grafana/k8s-monitoring-test:0.9.0
+      image: ghcr.io/grafana/k8s-monitoring-test:0.9.1
       command: [/etc/bin/config-analysis.sh]
       env:
         - name: AGENT_HOST
@@ -46064,7 +46064,7 @@ metadata:
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/instance: "k8smon"
     app.kubernetes.io/version: 1.7.0
-    helm.sh/chart: "k8s-monitoring-0.9.0"
+    helm.sh/chart: "k8s-monitoring-0.9.1"
   annotations:
     "helm.sh/hook": test
     "helm.sh/hook-delete-policy": before-hook-creation
@@ -46075,7 +46075,7 @@ spec:
         kubernetes.io/os: linux
   containers:
     - name: query-test
-      image: ghcr.io/grafana/k8s-monitoring-test:0.9.0
+      image: ghcr.io/grafana/k8s-monitoring-test:0.9.1
       command: ["bash", "-c", "/etc/bin/query-test.sh /etc/test/testQueries.json"]
       volumeMounts:
         - name: test-files
@@ -46162,7 +46162,7 @@ metadata:
     app.kubernetes.io/managed-by: "Helm"
     app.kubernetes.io/instance: "k8smon"
     app.kubernetes.io/version: 1.7.0
-    helm.sh/chart: "k8s-monitoring-0.9.0"
+    helm.sh/chart: "k8s-monitoring-0.9.1"
   annotations:
     "helm.sh/hook": pre-install,pre-upgrade
     "helm.sh/hook-weight": "-5"
@@ -46175,7 +46175,7 @@ spec:
       labels:
         app.kubernetes.io/managed-by: "Helm"
         app.kubernetes.io/instance: "k8smon"
-        helm.sh/chart: "k8s-monitoring-0.9.0"
+        helm.sh/chart: "k8s-monitoring-0.9.1"
     spec:
       restartPolicy: Never
       nodeSelector:


### PR DESCRIPTION
This change adds the ability to support an `expect` section in the test queries.
For example:
```
  - query: "count(kube_pod_info{cluster=\"ci-test-cluster-2\", color=\"blue\"})"
    type: promql
    expect:
      operator: ">"
      value: 1
```
Will not only check that the query returns successfully, but will assert that the value is greater than 1.

Also supported are counting the number of results, such as:

```
metrics:
  kube-state-metrics:
    metricsTuning:
      excludeMetrics:
        - kube_pod_info

test:
  attempts: 20
  extraQueries:
    # Check that the metrics exclusion list is working
    - query: "kube_pod_info{cluster=\"ci-test-cluster\"}"
      type: promql
      expect:
        count: 0
```
Which allows us to do negative testing for the first time.