### PR TITLE
Disable the prometheus.io/scrape annotations on Kube State Metrics and Node Exporter

### DIFF
--- a/.github/workflows/check-for-dependency-updates.yaml
+++ b/.github/workflows/check-for-dependency-updates.yaml
@@ -40,7 +40,9 @@ jobs:
 
       - name: Install Helm
         if: steps.update-grafana-agent.outputs.changed == 'true'
-        uses: azure/setup-helm@v3.5
+        uses: azure/setup-helm@v3
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Regenerate examples
         if: steps.update-grafana-agent.outputs.changed == 'true'
@@ -84,7 +86,9 @@ jobs:
 
       - name: Install Helm
         if: steps.update-kube-state-metrics.outputs.changed == 'true'
-        uses: azure/setup-helm@v3.5
+        uses: azure/setup-helm@v3
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Regenerate examples
         if: steps.update-kube-state-metrics.outputs.changed == 'true'
@@ -128,7 +132,9 @@ jobs:
 
       - name: Install Helm
         if: steps.update-node-exporter.outputs.changed == 'true'
-        uses: azure/setup-helm@v3.5
+        uses: azure/setup-helm@v3
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Regenerate examples
         if: steps.update-node-exporter.outputs.changed == 'true'
@@ -172,7 +178,9 @@ jobs:
 
       - name: Install Helm
         if: steps.update-opencost.outputs.changed == 'true'
-        uses: azure/setup-helm@v3.5
+        uses: azure/setup-helm@v3
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Regenerate examples
         if: steps.update-opencost.outputs.changed == 'true'
@@ -216,7 +224,9 @@ jobs:
 
       - name: Install Helm
         if: steps.update-prometheus-operator-crds.outputs.changed == 'true'
-        uses: azure/setup-helm@v3.5
+        uses: azure/setup-helm@v3
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Regenerate examples
         if: steps.update-prometheus-operator-crds.outputs.changed == 'true'
@@ -260,7 +270,9 @@ jobs:
 
       - name: Install Helm
         if: steps.update-windows-exporter.outputs.changed == 'true'
-        uses: azure/setup-helm@v3.5
+        uses: azure/setup-helm@v3
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Regenerate examples
         if: steps.update-windows-exporter.outputs.changed == 'true'

--- a/.github/workflows/check-for-dependency-updates.yaml
+++ b/.github/workflows/check-for-dependency-updates.yaml
@@ -40,7 +40,7 @@ jobs:
 
       - name: Install Helm
         if: steps.update-grafana-agent.outputs.changed == 'true'
-        uses: azure/setup-helm@v3
+        uses: azure/setup-helm@v3.5
 
       - name: Regenerate examples
         if: steps.update-grafana-agent.outputs.changed == 'true'
@@ -84,7 +84,7 @@ jobs:
 
       - name: Install Helm
         if: steps.update-kube-state-metrics.outputs.changed == 'true'
-        uses: azure/setup-helm@v3
+        uses: azure/setup-helm@v3.5
 
       - name: Regenerate examples
         if: steps.update-kube-state-metrics.outputs.changed == 'true'
@@ -128,7 +128,7 @@ jobs:
 
       - name: Install Helm
         if: steps.update-node-exporter.outputs.changed == 'true'
-        uses: azure/setup-helm@v3
+        uses: azure/setup-helm@v3.5
 
       - name: Regenerate examples
         if: steps.update-node-exporter.outputs.changed == 'true'
@@ -172,7 +172,7 @@ jobs:
 
       - name: Install Helm
         if: steps.update-opencost.outputs.changed == 'true'
-        uses: azure/setup-helm@v3
+        uses: azure/setup-helm@v3.5
 
       - name: Regenerate examples
         if: steps.update-opencost.outputs.changed == 'true'
@@ -216,7 +216,7 @@ jobs:
 
       - name: Install Helm
         if: steps.update-prometheus-operator-crds.outputs.changed == 'true'
-        uses: azure/setup-helm@v3
+        uses: azure/setup-helm@v3.5
 
       - name: Regenerate examples
         if: steps.update-prometheus-operator-crds.outputs.changed == 'true'
@@ -260,7 +260,7 @@ jobs:
 
       - name: Install Helm
         if: steps.update-windows-exporter.outputs.changed == 'true'
-        uses: azure/setup-helm@v3
+        uses: azure/setup-helm@v3.5
 
       - name: Regenerate examples
         if: steps.update-windows-exporter.outputs.changed == 'true'

--- a/.github/workflows/helm-release.yml
+++ b/.github/workflows/helm-release.yml
@@ -90,7 +90,7 @@ jobs:
         git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
 
     - name: Set up Helm
-      uses: azure/setup-helm@v3
+      uses: azure/setup-helm@v3.5
 
     - name: Parse Chart.yaml
       id: parse-chart

--- a/.github/workflows/helm-release.yml
+++ b/.github/workflows/helm-release.yml
@@ -90,7 +90,9 @@ jobs:
         git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
 
     - name: Set up Helm
-      uses: azure/setup-helm@v3.5
+      uses: azure/setup-helm@v3
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Parse Chart.yaml
       id: parse-chart

--- a/.github/workflows/helm-test.yml
+++ b/.github/workflows/helm-test.yml
@@ -50,7 +50,7 @@ jobs:
       uses: actions/checkout@v4
 
     - name: Install Helm
-      uses: azure/setup-helm@v3
+      uses: azure/setup-helm@v3.5
 
     - name: Check for example output changes
       run: |
@@ -69,7 +69,7 @@ jobs:
         fetch-depth: 0  # Required for `ct lint` to work
 
     - name: Install Helm
-      uses: azure/setup-helm@v3
+      uses: azure/setup-helm@v3.5
 
     - name: Set up Python
       uses: actions/setup-python@v5
@@ -100,7 +100,6 @@ jobs:
     - name: Run tests
       run: make test
 
-  # TODO: Install prometheus and loki locally, then install our chart so it's connected to those services
   test-chart:
     runs-on: ubuntu-latest
     steps:
@@ -110,7 +109,7 @@ jobs:
         fetch-depth: 0
 
     - name: Set up Helm
-      uses: azure/setup-helm@v3
+      uses: azure/setup-helm@v3.5
 
     - name: Set up Python
       uses: actions/setup-python@v5

--- a/.github/workflows/helm-test.yml
+++ b/.github/workflows/helm-test.yml
@@ -50,7 +50,9 @@ jobs:
       uses: actions/checkout@v4
 
     - name: Install Helm
-      uses: azure/setup-helm@v3.5
+      uses: azure/setup-helm@v3
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Check for example output changes
       run: |
@@ -69,7 +71,9 @@ jobs:
         fetch-depth: 0  # Required for `ct lint` to work
 
     - name: Install Helm
-      uses: azure/setup-helm@v3.5
+      uses: azure/setup-helm@v3
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Set up Python
       uses: actions/setup-python@v5
@@ -109,7 +113,9 @@ jobs:
         fetch-depth: 0
 
     - name: Set up Helm
-      uses: azure/setup-helm@v3.5
+      uses: azure/setup-helm@v3
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Set up Python
       uses: actions/setup-python@v5

--- a/charts/k8s-monitoring/Makefile
+++ b/charts/k8s-monitoring/Makefile
@@ -11,8 +11,10 @@ values.schema.json: values.yaml schema-mods/enums-and-types.json schema-mods/req
 			| del(.properties["grafana-agent-logs"]) \
 			| del(.properties["kube-state-metrics"].properties.autosharding) \
 			| del(.properties["kube-state-metrics"].properties.nodeSelector) \
+			| del(.properties["kube-state-metrics"].properties.prometheusScrape) \
 			| del(.properties["kube-state-metrics"].properties.updateStrategy) \
 			| del(.properties["prometheus-node-exporter"].properties.nodeSelector) \
+			| del(.properties["prometheus-node-exporter"].properties.service) \
 			| del(.properties["prometheus-windows-exporter"].properties.config) \
 			| del(.properties.opencost.properties.opencost)' values.schema.generated.json) \
 		schema-mods/enums-and-types.json \

--- a/charts/k8s-monitoring/values.yaml
+++ b/charts/k8s-monitoring/values.yaml
@@ -859,6 +859,9 @@ kube-state-metrics:
   # @ignored - Recreate on update, eliminates the potential for duplicate metrics
   updateStrategy: Recreate
 
+  # @ignored - Disable prometheus.io/scrape annotation
+  prometheusScrape: false
+
 # Settings for the Node Exporter deployment
 # You can use this sections to make modifications to the Node Exporter deployment.
 # See https://github.com/prometheus-community/helm-charts/tree/main/charts/prometheus-node-exporter for available values.
@@ -870,6 +873,11 @@ prometheus-node-exporter:
   # @ignored
   nodeSelector:
     kubernetes.io/os: linux
+
+  # @ignored - Disable prometheus.io/scrape annotation
+  service:
+    annotations:
+      prometheus.io/scrape: null
 
 # Settings for the Windows Exporter deployment
 # You can use this sections to make modifications to the Windows Exporter deployment.

--- a/examples/cluster-with-pvc/output.yaml
+++ b/examples/cluster-with-pvc/output.yaml
@@ -44113,7 +44113,6 @@ metadata:
     app.kubernetes.io/instance: k8smon
     app.kubernetes.io/version: "2.10.1"
   annotations:
-    prometheus.io/scrape: 'true'
 spec:
   type: "ClusterIP"
   ports:
@@ -44162,8 +44161,6 @@ metadata:
     app.kubernetes.io/name: prometheus-node-exporter
     app.kubernetes.io/instance: k8smon
     app.kubernetes.io/version: "1.7.0"
-  annotations:
-    prometheus.io/scrape: "true"
 spec:
   type: ClusterIP
   ports:

--- a/examples/control-plane-metrics/output.yaml
+++ b/examples/control-plane-metrics/output.yaml
@@ -44258,7 +44258,6 @@ metadata:
     app.kubernetes.io/instance: k8smon
     app.kubernetes.io/version: "2.10.1"
   annotations:
-    prometheus.io/scrape: 'true'
 spec:
   type: "ClusterIP"
   ports:
@@ -44307,8 +44306,6 @@ metadata:
     app.kubernetes.io/name: prometheus-node-exporter
     app.kubernetes.io/instance: k8smon
     app.kubernetes.io/version: "1.7.0"
-  annotations:
-    prometheus.io/scrape: "true"
 spec:
   type: ClusterIP
   ports:

--- a/examples/custom-config/output.yaml
+++ b/examples/custom-config/output.yaml
@@ -44168,7 +44168,6 @@ metadata:
     app.kubernetes.io/instance: k8smon
     app.kubernetes.io/version: "2.10.1"
   annotations:
-    prometheus.io/scrape: 'true'
 spec:
   type: "ClusterIP"
   ports:
@@ -44217,8 +44216,6 @@ metadata:
     app.kubernetes.io/name: prometheus-node-exporter
     app.kubernetes.io/instance: k8smon
     app.kubernetes.io/version: "1.7.0"
-  annotations:
-    prometheus.io/scrape: "true"
 spec:
   type: ClusterIP
   ports:

--- a/examples/custom-metrics-tuning/output.yaml
+++ b/examples/custom-metrics-tuning/output.yaml
@@ -43596,7 +43596,6 @@ metadata:
     app.kubernetes.io/instance: k8smon
     app.kubernetes.io/version: "2.10.1"
   annotations:
-    prometheus.io/scrape: 'true'
 spec:
   type: "ClusterIP"
   ports:
@@ -43645,8 +43644,6 @@ metadata:
     app.kubernetes.io/name: prometheus-node-exporter
     app.kubernetes.io/instance: k8smon
     app.kubernetes.io/version: "1.7.0"
-  annotations:
-    prometheus.io/scrape: "true"
 spec:
   type: ClusterIP
   ports:

--- a/examples/default-values/output.yaml
+++ b/examples/default-values/output.yaml
@@ -44105,7 +44105,6 @@ metadata:
     app.kubernetes.io/instance: k8smon
     app.kubernetes.io/version: "2.10.1"
   annotations:
-    prometheus.io/scrape: 'true'
 spec:
   type: "ClusterIP"
   ports:
@@ -44154,8 +44153,6 @@ metadata:
     app.kubernetes.io/name: prometheus-node-exporter
     app.kubernetes.io/instance: k8smon
     app.kubernetes.io/version: "1.7.0"
-  annotations:
-    prometheus.io/scrape: "true"
 spec:
   type: ClusterIP
   ports:

--- a/examples/eks-fargate/output.yaml
+++ b/examples/eks-fargate/output.yaml
@@ -44061,7 +44061,6 @@ metadata:
     app.kubernetes.io/instance: k8smon
     app.kubernetes.io/version: "2.10.1"
   annotations:
-    prometheus.io/scrape: 'true'
 spec:
   type: "ClusterIP"
   ports:

--- a/examples/extra-rules/output.yaml
+++ b/examples/extra-rules/output.yaml
@@ -44186,7 +44186,6 @@ metadata:
     app.kubernetes.io/instance: k8smon
     app.kubernetes.io/version: "2.10.1"
   annotations:
-    prometheus.io/scrape: 'true'
 spec:
   type: "ClusterIP"
   ports:
@@ -44235,8 +44234,6 @@ metadata:
     app.kubernetes.io/name: prometheus-node-exporter
     app.kubernetes.io/instance: k8smon
     app.kubernetes.io/version: "1.7.0"
-  annotations:
-    prometheus.io/scrape: "true"
 spec:
   type: ClusterIP
   ports:

--- a/examples/gke-autopilot/output.yaml
+++ b/examples/gke-autopilot/output.yaml
@@ -44044,7 +44044,6 @@ metadata:
     app.kubernetes.io/instance: k8smon
     app.kubernetes.io/version: "2.10.1"
   annotations:
-    prometheus.io/scrape: 'true'
 spec:
   type: "ClusterIP"
   ports:

--- a/examples/ibm-cloud/output.yaml
+++ b/examples/ibm-cloud/output.yaml
@@ -44105,7 +44105,6 @@ metadata:
     app.kubernetes.io/instance: k8smon
     app.kubernetes.io/version: "2.10.1"
   annotations:
-    prometheus.io/scrape: 'true'
 spec:
   type: "ClusterIP"
   ports:
@@ -44154,8 +44153,6 @@ metadata:
     app.kubernetes.io/name: prometheus-node-exporter
     app.kubernetes.io/instance: k8smon
     app.kubernetes.io/version: "1.7.0"
-  annotations:
-    prometheus.io/scrape: "true"
 spec:
   type: ClusterIP
   ports:

--- a/examples/metrics-only/output.yaml
+++ b/examples/metrics-only/output.yaml
@@ -43602,7 +43602,6 @@ metadata:
     app.kubernetes.io/instance: k8smon
     app.kubernetes.io/version: "2.10.1"
   annotations:
-    prometheus.io/scrape: 'true'
 spec:
   type: "ClusterIP"
   ports:
@@ -43651,8 +43650,6 @@ metadata:
     app.kubernetes.io/name: prometheus-node-exporter
     app.kubernetes.io/instance: k8smon
     app.kubernetes.io/version: "1.7.0"
-  annotations:
-    prometheus.io/scrape: "true"
 spec:
   type: ClusterIP
   ports:

--- a/examples/otel-metrics-service/output.yaml
+++ b/examples/otel-metrics-service/output.yaml
@@ -44135,7 +44135,6 @@ metadata:
     app.kubernetes.io/instance: k8smon
     app.kubernetes.io/version: "2.10.1"
   annotations:
-    prometheus.io/scrape: 'true'
 spec:
   type: "ClusterIP"
   ports:
@@ -44184,8 +44183,6 @@ metadata:
     app.kubernetes.io/name: prometheus-node-exporter
     app.kubernetes.io/instance: k8smon
     app.kubernetes.io/version: "1.7.0"
-  annotations:
-    prometheus.io/scrape: "true"
 spec:
   type: ClusterIP
   ports:

--- a/examples/private-image-registry/output.yaml
+++ b/examples/private-image-registry/output.yaml
@@ -44109,7 +44109,6 @@ metadata:
     app.kubernetes.io/instance: k8smon
     app.kubernetes.io/version: "2.10.1"
   annotations:
-    prometheus.io/scrape: 'true'
 spec:
   type: "ClusterIP"
   ports:
@@ -44158,8 +44157,6 @@ metadata:
     app.kubernetes.io/name: prometheus-node-exporter
     app.kubernetes.io/instance: k8smon
     app.kubernetes.io/version: "1.7.0"
-  annotations:
-    prometheus.io/scrape: "true"
 spec:
   type: ClusterIP
   ports:

--- a/examples/proxies/output.yaml
+++ b/examples/proxies/output.yaml
@@ -44121,7 +44121,6 @@ metadata:
     app.kubernetes.io/instance: k8smon
     app.kubernetes.io/version: "2.10.1"
   annotations:
-    prometheus.io/scrape: 'true'
 spec:
   type: "ClusterIP"
   ports:
@@ -44170,8 +44169,6 @@ metadata:
     app.kubernetes.io/name: prometheus-node-exporter
     app.kubernetes.io/instance: k8smon
     app.kubernetes.io/version: "1.7.0"
-  annotations:
-    prometheus.io/scrape: "true"
 spec:
   type: ClusterIP
   ports:

--- a/examples/scrape-intervals/output.yaml
+++ b/examples/scrape-intervals/output.yaml
@@ -43601,7 +43601,6 @@ metadata:
     app.kubernetes.io/instance: k8smon
     app.kubernetes.io/version: "2.10.1"
   annotations:
-    prometheus.io/scrape: 'true'
 spec:
   type: "ClusterIP"
   ports:
@@ -43650,8 +43649,6 @@ metadata:
     app.kubernetes.io/name: prometheus-node-exporter
     app.kubernetes.io/instance: k8smon
     app.kubernetes.io/version: "1.7.0"
-  annotations:
-    prometheus.io/scrape: "true"
 spec:
   type: ClusterIP
   ports:

--- a/examples/service-integrations/output.yaml
+++ b/examples/service-integrations/output.yaml
@@ -44140,7 +44140,6 @@ metadata:
     app.kubernetes.io/instance: k8smon
     app.kubernetes.io/version: "2.10.1"
   annotations:
-    prometheus.io/scrape: 'true'
 spec:
   type: "ClusterIP"
   ports:
@@ -44189,8 +44188,6 @@ metadata:
     app.kubernetes.io/name: prometheus-node-exporter
     app.kubernetes.io/instance: k8smon
     app.kubernetes.io/version: "1.7.0"
-  annotations:
-    prometheus.io/scrape: "true"
 spec:
   type: ClusterIP
   ports:

--- a/examples/specific-namespace/output.yaml
+++ b/examples/specific-namespace/output.yaml
@@ -44161,7 +44161,6 @@ metadata:
     app.kubernetes.io/instance: k8smon
     app.kubernetes.io/version: "2.10.1"
   annotations:
-    prometheus.io/scrape: 'true'
 spec:
   type: "ClusterIP"
   ports:
@@ -44210,8 +44209,6 @@ metadata:
     app.kubernetes.io/name: prometheus-node-exporter
     app.kubernetes.io/instance: k8smon
     app.kubernetes.io/version: "1.7.0"
-  annotations:
-    prometheus.io/scrape: "true"
 spec:
   type: ClusterIP
   ports:

--- a/examples/traces-enabled/output.yaml
+++ b/examples/traces-enabled/output.yaml
@@ -44167,7 +44167,6 @@ metadata:
     app.kubernetes.io/instance: k8smon
     app.kubernetes.io/version: "2.10.1"
   annotations:
-    prometheus.io/scrape: 'true'
 spec:
   type: "ClusterIP"
   ports:
@@ -44216,8 +44215,6 @@ metadata:
     app.kubernetes.io/name: prometheus-node-exporter
     app.kubernetes.io/instance: k8smon
     app.kubernetes.io/version: "1.7.0"
-  annotations:
-    prometheus.io/scrape: "true"
 spec:
   type: ClusterIP
   ports:

--- a/examples/windows-exporter/output.yaml
+++ b/examples/windows-exporter/output.yaml
@@ -44210,7 +44210,6 @@ metadata:
     app.kubernetes.io/instance: k8smon
     app.kubernetes.io/version: "2.10.1"
   annotations:
-    prometheus.io/scrape: 'true'
 spec:
   type: "ClusterIP"
   ports:
@@ -44259,8 +44258,6 @@ metadata:
     app.kubernetes.io/name: prometheus-node-exporter
     app.kubernetes.io/instance: k8smon
     app.kubernetes.io/version: "1.7.0"
-  annotations:
-    prometheus.io/scrape: "true"
 spec:
   type: ClusterIP
   ports:


### PR DESCRIPTION
We should disable these annotations.
In the case that the user changes the default annotation auto discovery annotations to:
```
metrics:
  autoDiscover:
    annotations:
      scrape: "prometheus.io/scrape"
```
It'll discover KSM and Node Exporter services, leading to duplicated metrics.

Fixes #356