### PR TITLE
fix: use the port of the annotation when specified

### DIFF
--- a/charts/k8s-monitoring/templates/agent_config/_annotation_autodiscovery.river.txt
+++ b/charts/k8s-monitoring/templates/agent_config/_annotation_autodiscovery.river.txt
@@ -24,6 +24,8 @@ discovery.relabel "annotation_autodiscovery_pods" {
   }
 
   // Choose the pod port
+  // The discovery generates a target for each declared container port of the pod.
+  // If the metricsPortName annotation has value, keep only the target where the port name matches the one of the annotation.
   rule {
     source_labels = ["__meta_kubernetes_pod_container_port_name"]
     target_label = "__tmp_port"
@@ -39,19 +41,19 @@ discovery.relabel "annotation_autodiscovery_pods" {
     target_label = "__tmp_port"
   }
 
+  // If the metricsPortNumber annotation has value, override the target address to use it,
+  // independently from the declared container ports of the pod.
   rule {
-    source_labels = ["__meta_kubernetes_pod_container_port_number"]
-    target_label = "__tmp_port"
+    source_labels = ["__meta_kubernetes_pod_annotation_{{ include "escape_label" .Values.metrics.autoDiscover.annotations.metricsPortNumber }}", "__meta_kubernetes_pod_ip"]
+    regex = "(\\d+);(([A-Fa-f0-9]{1,4}::?){1,7}[A-Fa-f0-9]{1,4})"
+    replacement = "[$2]:$1" // IPv6
+    target_label = "__address__"
   }
   rule {
-    source_labels = ["__meta_kubernetes_pod_annotation_{{ include "escape_label" .Values.metrics.autoDiscover.annotations.metricsPortNumber }}"]
-    regex = "(.+)"
-    target_label = "__tmp_port"
-  }
-  rule {
-    source_labels = ["__meta_kubernetes_pod_container_port_number"]
-    action = "keepequal"
-    target_label = "__tmp_port"
+    source_labels = ["__meta_kubernetes_pod_annotation_{{ include "escape_label" .Values.metrics.autoDiscover.annotations.metricsPortNumber }}", "__meta_kubernetes_pod_ip"]
+    regex = "(\\d+);((([0-9]+?)(\\.|$)){4})" // IPv4, takes priority over IPv6 when both exists
+    replacement = "$2:$1"
+    target_label = "__address__"
   }
 
   rule {

--- a/examples/cluster-with-pvc/metrics.river
+++ b/examples/cluster-with-pvc/metrics.river
@@ -120,6 +120,8 @@ discovery.relabel "annotation_autodiscovery_pods" {
   }
 
   // Choose the pod port
+  // The discovery generates a target for each declared container port of the pod.
+  // If the metricsPortName annotation has value, keep only the target where the port name matches the one of the annotation.
   rule {
     source_labels = ["__meta_kubernetes_pod_container_port_name"]
     target_label = "__tmp_port"
@@ -135,19 +137,19 @@ discovery.relabel "annotation_autodiscovery_pods" {
     target_label = "__tmp_port"
   }
 
+  // If the metricsPortNumber annotation has value, override the target address to use it,
+  // independently from the declared container ports of the pod.
   rule {
-    source_labels = ["__meta_kubernetes_pod_container_port_number"]
-    target_label = "__tmp_port"
+    source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_portNumber", "__meta_kubernetes_pod_ip"]
+    regex = "(\\d+);(([A-Fa-f0-9]{1,4}::?){1,7}[A-Fa-f0-9]{1,4})"
+    replacement = "[$2]:$1" // IPv6
+    target_label = "__address__"
   }
   rule {
-    source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_portNumber"]
-    regex = "(.+)"
-    target_label = "__tmp_port"
-  }
-  rule {
-    source_labels = ["__meta_kubernetes_pod_container_port_number"]
-    action = "keepequal"
-    target_label = "__tmp_port"
+    source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_portNumber", "__meta_kubernetes_pod_ip"]
+    regex = "(\\d+);((([0-9]+?)(\\.|$)){4})" // IPv4, takes priority over IPv6 when both exists
+    replacement = "$2:$1"
+    target_label = "__address__"
   }
 
   rule {

--- a/examples/cluster-with-pvc/output.yaml
+++ b/examples/cluster-with-pvc/output.yaml
@@ -241,6 +241,8 @@ data:
       }
     
       // Choose the pod port
+      // The discovery generates a target for each declared container port of the pod.
+      // If the metricsPortName annotation has value, keep only the target where the port name matches the one of the annotation.
       rule {
         source_labels = ["__meta_kubernetes_pod_container_port_name"]
         target_label = "__tmp_port"
@@ -256,19 +258,19 @@ data:
         target_label = "__tmp_port"
       }
     
+      // If the metricsPortNumber annotation has value, override the target address to use it,
+      // independently from the declared container ports of the pod.
       rule {
-        source_labels = ["__meta_kubernetes_pod_container_port_number"]
-        target_label = "__tmp_port"
+        source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_portNumber", "__meta_kubernetes_pod_ip"]
+        regex = "(\\d+);(([A-Fa-f0-9]{1,4}::?){1,7}[A-Fa-f0-9]{1,4})"
+        replacement = "[$2]:$1" // IPv6
+        target_label = "__address__"
       }
       rule {
-        source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_portNumber"]
-        regex = "(.+)"
-        target_label = "__tmp_port"
-      }
-      rule {
-        source_labels = ["__meta_kubernetes_pod_container_port_number"]
-        action = "keepequal"
-        target_label = "__tmp_port"
+        source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_portNumber", "__meta_kubernetes_pod_ip"]
+        regex = "(\\d+);((([0-9]+?)(\\.|$)){4})" // IPv4, takes priority over IPv6 when both exists
+        replacement = "$2:$1"
+        target_label = "__address__"
       }
     
       rule {
@@ -44945,6 +44947,8 @@ data:
       }
     
       // Choose the pod port
+      // The discovery generates a target for each declared container port of the pod.
+      // If the metricsPortName annotation has value, keep only the target where the port name matches the one of the annotation.
       rule {
         source_labels = ["__meta_kubernetes_pod_container_port_name"]
         target_label = "__tmp_port"
@@ -44960,19 +44964,19 @@ data:
         target_label = "__tmp_port"
       }
     
+      // If the metricsPortNumber annotation has value, override the target address to use it,
+      // independently from the declared container ports of the pod.
       rule {
-        source_labels = ["__meta_kubernetes_pod_container_port_number"]
-        target_label = "__tmp_port"
+        source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_portNumber", "__meta_kubernetes_pod_ip"]
+        regex = "(\\d+);(([A-Fa-f0-9]{1,4}::?){1,7}[A-Fa-f0-9]{1,4})"
+        replacement = "[$2]:$1" // IPv6
+        target_label = "__address__"
       }
       rule {
-        source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_portNumber"]
-        regex = "(.+)"
-        target_label = "__tmp_port"
-      }
-      rule {
-        source_labels = ["__meta_kubernetes_pod_container_port_number"]
-        action = "keepequal"
-        target_label = "__tmp_port"
+        source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_portNumber", "__meta_kubernetes_pod_ip"]
+        regex = "(\\d+);((([0-9]+?)(\\.|$)){4})" // IPv4, takes priority over IPv6 when both exists
+        replacement = "$2:$1"
+        target_label = "__address__"
       }
     
       rule {

--- a/examples/control-plane-metrics/metrics.river
+++ b/examples/control-plane-metrics/metrics.river
@@ -120,6 +120,8 @@ discovery.relabel "annotation_autodiscovery_pods" {
   }
 
   // Choose the pod port
+  // The discovery generates a target for each declared container port of the pod.
+  // If the metricsPortName annotation has value, keep only the target where the port name matches the one of the annotation.
   rule {
     source_labels = ["__meta_kubernetes_pod_container_port_name"]
     target_label = "__tmp_port"
@@ -135,19 +137,19 @@ discovery.relabel "annotation_autodiscovery_pods" {
     target_label = "__tmp_port"
   }
 
+  // If the metricsPortNumber annotation has value, override the target address to use it,
+  // independently from the declared container ports of the pod.
   rule {
-    source_labels = ["__meta_kubernetes_pod_container_port_number"]
-    target_label = "__tmp_port"
+    source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_portNumber", "__meta_kubernetes_pod_ip"]
+    regex = "(\\d+);(([A-Fa-f0-9]{1,4}::?){1,7}[A-Fa-f0-9]{1,4})"
+    replacement = "[$2]:$1" // IPv6
+    target_label = "__address__"
   }
   rule {
-    source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_portNumber"]
-    regex = "(.+)"
-    target_label = "__tmp_port"
-  }
-  rule {
-    source_labels = ["__meta_kubernetes_pod_container_port_number"]
-    action = "keepequal"
-    target_label = "__tmp_port"
+    source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_portNumber", "__meta_kubernetes_pod_ip"]
+    regex = "(\\d+);((([0-9]+?)(\\.|$)){4})" // IPv4, takes priority over IPv6 when both exists
+    replacement = "$2:$1"
+    target_label = "__address__"
   }
 
   rule {

--- a/examples/control-plane-metrics/output.yaml
+++ b/examples/control-plane-metrics/output.yaml
@@ -242,6 +242,8 @@ data:
       }
     
       // Choose the pod port
+      // The discovery generates a target for each declared container port of the pod.
+      // If the metricsPortName annotation has value, keep only the target where the port name matches the one of the annotation.
       rule {
         source_labels = ["__meta_kubernetes_pod_container_port_name"]
         target_label = "__tmp_port"
@@ -257,19 +259,19 @@ data:
         target_label = "__tmp_port"
       }
     
+      // If the metricsPortNumber annotation has value, override the target address to use it,
+      // independently from the declared container ports of the pod.
       rule {
-        source_labels = ["__meta_kubernetes_pod_container_port_number"]
-        target_label = "__tmp_port"
+        source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_portNumber", "__meta_kubernetes_pod_ip"]
+        regex = "(\\d+);(([A-Fa-f0-9]{1,4}::?){1,7}[A-Fa-f0-9]{1,4})"
+        replacement = "[$2]:$1" // IPv6
+        target_label = "__address__"
       }
       rule {
-        source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_portNumber"]
-        regex = "(.+)"
-        target_label = "__tmp_port"
-      }
-      rule {
-        source_labels = ["__meta_kubernetes_pod_container_port_number"]
-        action = "keepequal"
-        target_label = "__tmp_port"
+        source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_portNumber", "__meta_kubernetes_pod_ip"]
+        regex = "(\\d+);((([0-9]+?)(\\.|$)){4})" // IPv4, takes priority over IPv6 when both exists
+        replacement = "$2:$1"
+        target_label = "__address__"
       }
     
       rule {
@@ -45043,6 +45045,8 @@ data:
       }
     
       // Choose the pod port
+      // The discovery generates a target for each declared container port of the pod.
+      // If the metricsPortName annotation has value, keep only the target where the port name matches the one of the annotation.
       rule {
         source_labels = ["__meta_kubernetes_pod_container_port_name"]
         target_label = "__tmp_port"
@@ -45058,19 +45062,19 @@ data:
         target_label = "__tmp_port"
       }
     
+      // If the metricsPortNumber annotation has value, override the target address to use it,
+      // independently from the declared container ports of the pod.
       rule {
-        source_labels = ["__meta_kubernetes_pod_container_port_number"]
-        target_label = "__tmp_port"
+        source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_portNumber", "__meta_kubernetes_pod_ip"]
+        regex = "(\\d+);(([A-Fa-f0-9]{1,4}::?){1,7}[A-Fa-f0-9]{1,4})"
+        replacement = "[$2]:$1" // IPv6
+        target_label = "__address__"
       }
       rule {
-        source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_portNumber"]
-        regex = "(.+)"
-        target_label = "__tmp_port"
-      }
-      rule {
-        source_labels = ["__meta_kubernetes_pod_container_port_number"]
-        action = "keepequal"
-        target_label = "__tmp_port"
+        source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_portNumber", "__meta_kubernetes_pod_ip"]
+        regex = "(\\d+);((([0-9]+?)(\\.|$)){4})" // IPv4, takes priority over IPv6 when both exists
+        replacement = "$2:$1"
+        target_label = "__address__"
       }
     
       rule {

--- a/examples/custom-config/metrics.river
+++ b/examples/custom-config/metrics.river
@@ -120,6 +120,8 @@ discovery.relabel "annotation_autodiscovery_pods" {
   }
 
   // Choose the pod port
+  // The discovery generates a target for each declared container port of the pod.
+  // If the metricsPortName annotation has value, keep only the target where the port name matches the one of the annotation.
   rule {
     source_labels = ["__meta_kubernetes_pod_container_port_name"]
     target_label = "__tmp_port"
@@ -135,19 +137,19 @@ discovery.relabel "annotation_autodiscovery_pods" {
     target_label = "__tmp_port"
   }
 
+  // If the metricsPortNumber annotation has value, override the target address to use it,
+  // independently from the declared container ports of the pod.
   rule {
-    source_labels = ["__meta_kubernetes_pod_container_port_number"]
-    target_label = "__tmp_port"
+    source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_portNumber", "__meta_kubernetes_pod_ip"]
+    regex = "(\\d+);(([A-Fa-f0-9]{1,4}::?){1,7}[A-Fa-f0-9]{1,4})"
+    replacement = "[$2]:$1" // IPv6
+    target_label = "__address__"
   }
   rule {
-    source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_portNumber"]
-    regex = "(.+)"
-    target_label = "__tmp_port"
-  }
-  rule {
-    source_labels = ["__meta_kubernetes_pod_container_port_number"]
-    action = "keepequal"
-    target_label = "__tmp_port"
+    source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_portNumber", "__meta_kubernetes_pod_ip"]
+    regex = "(\\d+);((([0-9]+?)(\\.|$)){4})" // IPv4, takes priority over IPv6 when both exists
+    replacement = "$2:$1"
+    target_label = "__address__"
   }
 
   rule {

--- a/examples/custom-config/output.yaml
+++ b/examples/custom-config/output.yaml
@@ -241,6 +241,8 @@ data:
       }
     
       // Choose the pod port
+      // The discovery generates a target for each declared container port of the pod.
+      // If the metricsPortName annotation has value, keep only the target where the port name matches the one of the annotation.
       rule {
         source_labels = ["__meta_kubernetes_pod_container_port_name"]
         target_label = "__tmp_port"
@@ -256,19 +258,19 @@ data:
         target_label = "__tmp_port"
       }
     
+      // If the metricsPortNumber annotation has value, override the target address to use it,
+      // independently from the declared container ports of the pod.
       rule {
-        source_labels = ["__meta_kubernetes_pod_container_port_number"]
-        target_label = "__tmp_port"
+        source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_portNumber", "__meta_kubernetes_pod_ip"]
+        regex = "(\\d+);(([A-Fa-f0-9]{1,4}::?){1,7}[A-Fa-f0-9]{1,4})"
+        replacement = "[$2]:$1" // IPv6
+        target_label = "__address__"
       }
       rule {
-        source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_portNumber"]
-        regex = "(.+)"
-        target_label = "__tmp_port"
-      }
-      rule {
-        source_labels = ["__meta_kubernetes_pod_container_port_number"]
-        action = "keepequal"
-        target_label = "__tmp_port"
+        source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_portNumber", "__meta_kubernetes_pod_ip"]
+        regex = "(\\d+);((([0-9]+?)(\\.|$)){4})" // IPv4, takes priority over IPv6 when both exists
+        replacement = "$2:$1"
+        target_label = "__address__"
       }
     
       rule {
@@ -44953,6 +44955,8 @@ data:
       }
     
       // Choose the pod port
+      // The discovery generates a target for each declared container port of the pod.
+      // If the metricsPortName annotation has value, keep only the target where the port name matches the one of the annotation.
       rule {
         source_labels = ["__meta_kubernetes_pod_container_port_name"]
         target_label = "__tmp_port"
@@ -44968,19 +44972,19 @@ data:
         target_label = "__tmp_port"
       }
     
+      // If the metricsPortNumber annotation has value, override the target address to use it,
+      // independently from the declared container ports of the pod.
       rule {
-        source_labels = ["__meta_kubernetes_pod_container_port_number"]
-        target_label = "__tmp_port"
+        source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_portNumber", "__meta_kubernetes_pod_ip"]
+        regex = "(\\d+);(([A-Fa-f0-9]{1,4}::?){1,7}[A-Fa-f0-9]{1,4})"
+        replacement = "[$2]:$1" // IPv6
+        target_label = "__address__"
       }
       rule {
-        source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_portNumber"]
-        regex = "(.+)"
-        target_label = "__tmp_port"
-      }
-      rule {
-        source_labels = ["__meta_kubernetes_pod_container_port_number"]
-        action = "keepequal"
-        target_label = "__tmp_port"
+        source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_portNumber", "__meta_kubernetes_pod_ip"]
+        regex = "(\\d+);((([0-9]+?)(\\.|$)){4})" // IPv4, takes priority over IPv6 when both exists
+        replacement = "$2:$1"
+        target_label = "__address__"
       }
     
       rule {

--- a/examples/custom-metrics-tuning/metrics.river
+++ b/examples/custom-metrics-tuning/metrics.river
@@ -120,6 +120,8 @@ discovery.relabel "annotation_autodiscovery_pods" {
   }
 
   // Choose the pod port
+  // The discovery generates a target for each declared container port of the pod.
+  // If the metricsPortName annotation has value, keep only the target where the port name matches the one of the annotation.
   rule {
     source_labels = ["__meta_kubernetes_pod_container_port_name"]
     target_label = "__tmp_port"
@@ -135,19 +137,19 @@ discovery.relabel "annotation_autodiscovery_pods" {
     target_label = "__tmp_port"
   }
 
+  // If the metricsPortNumber annotation has value, override the target address to use it,
+  // independently from the declared container ports of the pod.
   rule {
-    source_labels = ["__meta_kubernetes_pod_container_port_number"]
-    target_label = "__tmp_port"
+    source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_portNumber", "__meta_kubernetes_pod_ip"]
+    regex = "(\\d+);(([A-Fa-f0-9]{1,4}::?){1,7}[A-Fa-f0-9]{1,4})"
+    replacement = "[$2]:$1" // IPv6
+    target_label = "__address__"
   }
   rule {
-    source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_portNumber"]
-    regex = "(.+)"
-    target_label = "__tmp_port"
-  }
-  rule {
-    source_labels = ["__meta_kubernetes_pod_container_port_number"]
-    action = "keepequal"
-    target_label = "__tmp_port"
+    source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_portNumber", "__meta_kubernetes_pod_ip"]
+    regex = "(\\d+);((([0-9]+?)(\\.|$)){4})" // IPv4, takes priority over IPv6 when both exists
+    replacement = "$2:$1"
+    target_label = "__address__"
   }
 
   rule {

--- a/examples/custom-metrics-tuning/output.yaml
+++ b/examples/custom-metrics-tuning/output.yaml
@@ -200,6 +200,8 @@ data:
       }
     
       // Choose the pod port
+      // The discovery generates a target for each declared container port of the pod.
+      // If the metricsPortName annotation has value, keep only the target where the port name matches the one of the annotation.
       rule {
         source_labels = ["__meta_kubernetes_pod_container_port_name"]
         target_label = "__tmp_port"
@@ -215,19 +217,19 @@ data:
         target_label = "__tmp_port"
       }
     
+      // If the metricsPortNumber annotation has value, override the target address to use it,
+      // independently from the declared container ports of the pod.
       rule {
-        source_labels = ["__meta_kubernetes_pod_container_port_number"]
-        target_label = "__tmp_port"
+        source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_portNumber", "__meta_kubernetes_pod_ip"]
+        regex = "(\\d+);(([A-Fa-f0-9]{1,4}::?){1,7}[A-Fa-f0-9]{1,4})"
+        replacement = "[$2]:$1" // IPv6
+        target_label = "__address__"
       }
       rule {
-        source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_portNumber"]
-        regex = "(.+)"
-        target_label = "__tmp_port"
-      }
-      rule {
-        source_labels = ["__meta_kubernetes_pod_container_port_number"]
-        action = "keepequal"
-        target_label = "__tmp_port"
+        source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_portNumber", "__meta_kubernetes_pod_ip"]
+        regex = "(\\d+);((([0-9]+?)(\\.|$)){4})" // IPv4, takes priority over IPv6 when both exists
+        replacement = "$2:$1"
+        target_label = "__address__"
       }
     
       rule {
@@ -44215,6 +44217,8 @@ data:
       }
     
       // Choose the pod port
+      // The discovery generates a target for each declared container port of the pod.
+      // If the metricsPortName annotation has value, keep only the target where the port name matches the one of the annotation.
       rule {
         source_labels = ["__meta_kubernetes_pod_container_port_name"]
         target_label = "__tmp_port"
@@ -44230,19 +44234,19 @@ data:
         target_label = "__tmp_port"
       }
     
+      // If the metricsPortNumber annotation has value, override the target address to use it,
+      // independently from the declared container ports of the pod.
       rule {
-        source_labels = ["__meta_kubernetes_pod_container_port_number"]
-        target_label = "__tmp_port"
+        source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_portNumber", "__meta_kubernetes_pod_ip"]
+        regex = "(\\d+);(([A-Fa-f0-9]{1,4}::?){1,7}[A-Fa-f0-9]{1,4})"
+        replacement = "[$2]:$1" // IPv6
+        target_label = "__address__"
       }
       rule {
-        source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_portNumber"]
-        regex = "(.+)"
-        target_label = "__tmp_port"
-      }
-      rule {
-        source_labels = ["__meta_kubernetes_pod_container_port_number"]
-        action = "keepequal"
-        target_label = "__tmp_port"
+        source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_portNumber", "__meta_kubernetes_pod_ip"]
+        regex = "(\\d+);((([0-9]+?)(\\.|$)){4})" // IPv4, takes priority over IPv6 when both exists
+        replacement = "$2:$1"
+        target_label = "__address__"
       }
     
       rule {

--- a/examples/default-values/metrics.river
+++ b/examples/default-values/metrics.river
@@ -120,6 +120,8 @@ discovery.relabel "annotation_autodiscovery_pods" {
   }
 
   // Choose the pod port
+  // The discovery generates a target for each declared container port of the pod.
+  // If the metricsPortName annotation has value, keep only the target where the port name matches the one of the annotation.
   rule {
     source_labels = ["__meta_kubernetes_pod_container_port_name"]
     target_label = "__tmp_port"
@@ -135,19 +137,19 @@ discovery.relabel "annotation_autodiscovery_pods" {
     target_label = "__tmp_port"
   }
 
+  // If the metricsPortNumber annotation has value, override the target address to use it,
+  // independently from the declared container ports of the pod.
   rule {
-    source_labels = ["__meta_kubernetes_pod_container_port_number"]
-    target_label = "__tmp_port"
+    source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_portNumber", "__meta_kubernetes_pod_ip"]
+    regex = "(\\d+);(([A-Fa-f0-9]{1,4}::?){1,7}[A-Fa-f0-9]{1,4})"
+    replacement = "[$2]:$1" // IPv6
+    target_label = "__address__"
   }
   rule {
-    source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_portNumber"]
-    regex = "(.+)"
-    target_label = "__tmp_port"
-  }
-  rule {
-    source_labels = ["__meta_kubernetes_pod_container_port_number"]
-    action = "keepequal"
-    target_label = "__tmp_port"
+    source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_portNumber", "__meta_kubernetes_pod_ip"]
+    regex = "(\\d+);((([0-9]+?)(\\.|$)){4})" // IPv4, takes priority over IPv6 when both exists
+    replacement = "$2:$1"
+    target_label = "__address__"
   }
 
   rule {

--- a/examples/default-values/output.yaml
+++ b/examples/default-values/output.yaml
@@ -241,6 +241,8 @@ data:
       }
     
       // Choose the pod port
+      // The discovery generates a target for each declared container port of the pod.
+      // If the metricsPortName annotation has value, keep only the target where the port name matches the one of the annotation.
       rule {
         source_labels = ["__meta_kubernetes_pod_container_port_name"]
         target_label = "__tmp_port"
@@ -256,19 +258,19 @@ data:
         target_label = "__tmp_port"
       }
     
+      // If the metricsPortNumber annotation has value, override the target address to use it,
+      // independently from the declared container ports of the pod.
       rule {
-        source_labels = ["__meta_kubernetes_pod_container_port_number"]
-        target_label = "__tmp_port"
+        source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_portNumber", "__meta_kubernetes_pod_ip"]
+        regex = "(\\d+);(([A-Fa-f0-9]{1,4}::?){1,7}[A-Fa-f0-9]{1,4})"
+        replacement = "[$2]:$1" // IPv6
+        target_label = "__address__"
       }
       rule {
-        source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_portNumber"]
-        regex = "(.+)"
-        target_label = "__tmp_port"
-      }
-      rule {
-        source_labels = ["__meta_kubernetes_pod_container_port_number"]
-        action = "keepequal"
-        target_label = "__tmp_port"
+        source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_portNumber", "__meta_kubernetes_pod_ip"]
+        regex = "(\\d+);((([0-9]+?)(\\.|$)){4})" // IPv4, takes priority over IPv6 when both exists
+        replacement = "$2:$1"
+        target_label = "__address__"
       }
     
       rule {
@@ -44890,6 +44892,8 @@ data:
       }
     
       // Choose the pod port
+      // The discovery generates a target for each declared container port of the pod.
+      // If the metricsPortName annotation has value, keep only the target where the port name matches the one of the annotation.
       rule {
         source_labels = ["__meta_kubernetes_pod_container_port_name"]
         target_label = "__tmp_port"
@@ -44905,19 +44909,19 @@ data:
         target_label = "__tmp_port"
       }
     
+      // If the metricsPortNumber annotation has value, override the target address to use it,
+      // independently from the declared container ports of the pod.
       rule {
-        source_labels = ["__meta_kubernetes_pod_container_port_number"]
-        target_label = "__tmp_port"
+        source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_portNumber", "__meta_kubernetes_pod_ip"]
+        regex = "(\\d+);(([A-Fa-f0-9]{1,4}::?){1,7}[A-Fa-f0-9]{1,4})"
+        replacement = "[$2]:$1" // IPv6
+        target_label = "__address__"
       }
       rule {
-        source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_portNumber"]
-        regex = "(.+)"
-        target_label = "__tmp_port"
-      }
-      rule {
-        source_labels = ["__meta_kubernetes_pod_container_port_number"]
-        action = "keepequal"
-        target_label = "__tmp_port"
+        source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_portNumber", "__meta_kubernetes_pod_ip"]
+        regex = "(\\d+);((([0-9]+?)(\\.|$)){4})" // IPv4, takes priority over IPv6 when both exists
+        replacement = "$2:$1"
+        target_label = "__address__"
       }
     
       rule {

--- a/examples/eks-fargate/metrics.river
+++ b/examples/eks-fargate/metrics.river
@@ -120,6 +120,8 @@ discovery.relabel "annotation_autodiscovery_pods" {
   }
 
   // Choose the pod port
+  // The discovery generates a target for each declared container port of the pod.
+  // If the metricsPortName annotation has value, keep only the target where the port name matches the one of the annotation.
   rule {
     source_labels = ["__meta_kubernetes_pod_container_port_name"]
     target_label = "__tmp_port"
@@ -135,19 +137,19 @@ discovery.relabel "annotation_autodiscovery_pods" {
     target_label = "__tmp_port"
   }
 
+  // If the metricsPortNumber annotation has value, override the target address to use it,
+  // independently from the declared container ports of the pod.
   rule {
-    source_labels = ["__meta_kubernetes_pod_container_port_number"]
-    target_label = "__tmp_port"
+    source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_portNumber", "__meta_kubernetes_pod_ip"]
+    regex = "(\\d+);(([A-Fa-f0-9]{1,4}::?){1,7}[A-Fa-f0-9]{1,4})"
+    replacement = "[$2]:$1" // IPv6
+    target_label = "__address__"
   }
   rule {
-    source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_portNumber"]
-    regex = "(.+)"
-    target_label = "__tmp_port"
-  }
-  rule {
-    source_labels = ["__meta_kubernetes_pod_container_port_number"]
-    action = "keepequal"
-    target_label = "__tmp_port"
+    source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_portNumber", "__meta_kubernetes_pod_ip"]
+    regex = "(\\d+);((([0-9]+?)(\\.|$)){4})" // IPv4, takes priority over IPv6 when both exists
+    replacement = "$2:$1"
+    target_label = "__address__"
   }
 
   rule {

--- a/examples/eks-fargate/output.yaml
+++ b/examples/eks-fargate/output.yaml
@@ -226,6 +226,8 @@ data:
       }
     
       // Choose the pod port
+      // The discovery generates a target for each declared container port of the pod.
+      // If the metricsPortName annotation has value, keep only the target where the port name matches the one of the annotation.
       rule {
         source_labels = ["__meta_kubernetes_pod_container_port_name"]
         target_label = "__tmp_port"
@@ -241,19 +243,19 @@ data:
         target_label = "__tmp_port"
       }
     
+      // If the metricsPortNumber annotation has value, override the target address to use it,
+      // independently from the declared container ports of the pod.
       rule {
-        source_labels = ["__meta_kubernetes_pod_container_port_number"]
-        target_label = "__tmp_port"
+        source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_portNumber", "__meta_kubernetes_pod_ip"]
+        regex = "(\\d+);(([A-Fa-f0-9]{1,4}::?){1,7}[A-Fa-f0-9]{1,4})"
+        replacement = "[$2]:$1" // IPv6
+        target_label = "__address__"
       }
       rule {
-        source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_portNumber"]
-        regex = "(.+)"
-        target_label = "__tmp_port"
-      }
-      rule {
-        source_labels = ["__meta_kubernetes_pod_container_port_number"]
-        action = "keepequal"
-        target_label = "__tmp_port"
+        source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_portNumber", "__meta_kubernetes_pod_ip"]
+        regex = "(\\d+);((([0-9]+?)(\\.|$)){4})" // IPv4, takes priority over IPv6 when both exists
+        replacement = "$2:$1"
+        target_label = "__address__"
       }
     
       rule {
@@ -44704,6 +44706,8 @@ data:
       }
     
       // Choose the pod port
+      // The discovery generates a target for each declared container port of the pod.
+      // If the metricsPortName annotation has value, keep only the target where the port name matches the one of the annotation.
       rule {
         source_labels = ["__meta_kubernetes_pod_container_port_name"]
         target_label = "__tmp_port"
@@ -44719,19 +44723,19 @@ data:
         target_label = "__tmp_port"
       }
     
+      // If the metricsPortNumber annotation has value, override the target address to use it,
+      // independently from the declared container ports of the pod.
       rule {
-        source_labels = ["__meta_kubernetes_pod_container_port_number"]
-        target_label = "__tmp_port"
+        source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_portNumber", "__meta_kubernetes_pod_ip"]
+        regex = "(\\d+);(([A-Fa-f0-9]{1,4}::?){1,7}[A-Fa-f0-9]{1,4})"
+        replacement = "[$2]:$1" // IPv6
+        target_label = "__address__"
       }
       rule {
-        source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_portNumber"]
-        regex = "(.+)"
-        target_label = "__tmp_port"
-      }
-      rule {
-        source_labels = ["__meta_kubernetes_pod_container_port_number"]
-        action = "keepequal"
-        target_label = "__tmp_port"
+        source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_portNumber", "__meta_kubernetes_pod_ip"]
+        regex = "(\\d+);((([0-9]+?)(\\.|$)){4})" // IPv4, takes priority over IPv6 when both exists
+        replacement = "$2:$1"
+        target_label = "__address__"
       }
     
       rule {

--- a/examples/extra-rules/metrics.river
+++ b/examples/extra-rules/metrics.river
@@ -120,6 +120,8 @@ discovery.relabel "annotation_autodiscovery_pods" {
   }
 
   // Choose the pod port
+  // The discovery generates a target for each declared container port of the pod.
+  // If the metricsPortName annotation has value, keep only the target where the port name matches the one of the annotation.
   rule {
     source_labels = ["__meta_kubernetes_pod_container_port_name"]
     target_label = "__tmp_port"
@@ -135,19 +137,19 @@ discovery.relabel "annotation_autodiscovery_pods" {
     target_label = "__tmp_port"
   }
 
+  // If the metricsPortNumber annotation has value, override the target address to use it,
+  // independently from the declared container ports of the pod.
   rule {
-    source_labels = ["__meta_kubernetes_pod_container_port_number"]
-    target_label = "__tmp_port"
+    source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_portNumber", "__meta_kubernetes_pod_ip"]
+    regex = "(\\d+);(([A-Fa-f0-9]{1,4}::?){1,7}[A-Fa-f0-9]{1,4})"
+    replacement = "[$2]:$1" // IPv6
+    target_label = "__address__"
   }
   rule {
-    source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_portNumber"]
-    regex = "(.+)"
-    target_label = "__tmp_port"
-  }
-  rule {
-    source_labels = ["__meta_kubernetes_pod_container_port_number"]
-    action = "keepequal"
-    target_label = "__tmp_port"
+    source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_portNumber", "__meta_kubernetes_pod_ip"]
+    regex = "(\\d+);((([0-9]+?)(\\.|$)){4})" // IPv4, takes priority over IPv6 when both exists
+    replacement = "$2:$1"
+    target_label = "__address__"
   }
 
   rule {

--- a/examples/extra-rules/output.yaml
+++ b/examples/extra-rules/output.yaml
@@ -242,6 +242,8 @@ data:
       }
     
       // Choose the pod port
+      // The discovery generates a target for each declared container port of the pod.
+      // If the metricsPortName annotation has value, keep only the target where the port name matches the one of the annotation.
       rule {
         source_labels = ["__meta_kubernetes_pod_container_port_name"]
         target_label = "__tmp_port"
@@ -257,19 +259,19 @@ data:
         target_label = "__tmp_port"
       }
     
+      // If the metricsPortNumber annotation has value, override the target address to use it,
+      // independently from the declared container ports of the pod.
       rule {
-        source_labels = ["__meta_kubernetes_pod_container_port_number"]
-        target_label = "__tmp_port"
+        source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_portNumber", "__meta_kubernetes_pod_ip"]
+        regex = "(\\d+);(([A-Fa-f0-9]{1,4}::?){1,7}[A-Fa-f0-9]{1,4})"
+        replacement = "[$2]:$1" // IPv6
+        target_label = "__address__"
       }
       rule {
-        source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_portNumber"]
-        regex = "(.+)"
-        target_label = "__tmp_port"
-      }
-      rule {
-        source_labels = ["__meta_kubernetes_pod_container_port_number"]
-        action = "keepequal"
-        target_label = "__tmp_port"
+        source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_portNumber", "__meta_kubernetes_pod_ip"]
+        regex = "(\\d+);((([0-9]+?)(\\.|$)){4})" // IPv4, takes priority over IPv6 when both exists
+        replacement = "$2:$1"
+        target_label = "__address__"
       }
     
       rule {
@@ -44971,6 +44973,8 @@ data:
       }
     
       // Choose the pod port
+      // The discovery generates a target for each declared container port of the pod.
+      // If the metricsPortName annotation has value, keep only the target where the port name matches the one of the annotation.
       rule {
         source_labels = ["__meta_kubernetes_pod_container_port_name"]
         target_label = "__tmp_port"
@@ -44986,19 +44990,19 @@ data:
         target_label = "__tmp_port"
       }
     
+      // If the metricsPortNumber annotation has value, override the target address to use it,
+      // independently from the declared container ports of the pod.
       rule {
-        source_labels = ["__meta_kubernetes_pod_container_port_number"]
-        target_label = "__tmp_port"
+        source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_portNumber", "__meta_kubernetes_pod_ip"]
+        regex = "(\\d+);(([A-Fa-f0-9]{1,4}::?){1,7}[A-Fa-f0-9]{1,4})"
+        replacement = "[$2]:$1" // IPv6
+        target_label = "__address__"
       }
       rule {
-        source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_portNumber"]
-        regex = "(.+)"
-        target_label = "__tmp_port"
-      }
-      rule {
-        source_labels = ["__meta_kubernetes_pod_container_port_number"]
-        action = "keepequal"
-        target_label = "__tmp_port"
+        source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_portNumber", "__meta_kubernetes_pod_ip"]
+        regex = "(\\d+);((([0-9]+?)(\\.|$)){4})" // IPv4, takes priority over IPv6 when both exists
+        replacement = "$2:$1"
+        target_label = "__address__"
       }
     
       rule {

--- a/examples/gke-autopilot/metrics.river
+++ b/examples/gke-autopilot/metrics.river
@@ -120,6 +120,8 @@ discovery.relabel "annotation_autodiscovery_pods" {
   }
 
   // Choose the pod port
+  // The discovery generates a target for each declared container port of the pod.
+  // If the metricsPortName annotation has value, keep only the target where the port name matches the one of the annotation.
   rule {
     source_labels = ["__meta_kubernetes_pod_container_port_name"]
     target_label = "__tmp_port"
@@ -135,19 +137,19 @@ discovery.relabel "annotation_autodiscovery_pods" {
     target_label = "__tmp_port"
   }
 
+  // If the metricsPortNumber annotation has value, override the target address to use it,
+  // independently from the declared container ports of the pod.
   rule {
-    source_labels = ["__meta_kubernetes_pod_container_port_number"]
-    target_label = "__tmp_port"
+    source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_portNumber", "__meta_kubernetes_pod_ip"]
+    regex = "(\\d+);(([A-Fa-f0-9]{1,4}::?){1,7}[A-Fa-f0-9]{1,4})"
+    replacement = "[$2]:$1" // IPv6
+    target_label = "__address__"
   }
   rule {
-    source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_portNumber"]
-    regex = "(.+)"
-    target_label = "__tmp_port"
-  }
-  rule {
-    source_labels = ["__meta_kubernetes_pod_container_port_number"]
-    action = "keepequal"
-    target_label = "__tmp_port"
+    source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_portNumber", "__meta_kubernetes_pod_ip"]
+    regex = "(\\d+);((([0-9]+?)(\\.|$)){4})" // IPv4, takes priority over IPv6 when both exists
+    replacement = "$2:$1"
+    target_label = "__address__"
   }
 
   rule {

--- a/examples/gke-autopilot/output.yaml
+++ b/examples/gke-autopilot/output.yaml
@@ -226,6 +226,8 @@ data:
       }
     
       // Choose the pod port
+      // The discovery generates a target for each declared container port of the pod.
+      // If the metricsPortName annotation has value, keep only the target where the port name matches the one of the annotation.
       rule {
         source_labels = ["__meta_kubernetes_pod_container_port_name"]
         target_label = "__tmp_port"
@@ -241,19 +243,19 @@ data:
         target_label = "__tmp_port"
       }
     
+      // If the metricsPortNumber annotation has value, override the target address to use it,
+      // independently from the declared container ports of the pod.
       rule {
-        source_labels = ["__meta_kubernetes_pod_container_port_number"]
-        target_label = "__tmp_port"
+        source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_portNumber", "__meta_kubernetes_pod_ip"]
+        regex = "(\\d+);(([A-Fa-f0-9]{1,4}::?){1,7}[A-Fa-f0-9]{1,4})"
+        replacement = "[$2]:$1" // IPv6
+        target_label = "__address__"
       }
       rule {
-        source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_portNumber"]
-        regex = "(.+)"
-        target_label = "__tmp_port"
-      }
-      rule {
-        source_labels = ["__meta_kubernetes_pod_container_port_number"]
-        action = "keepequal"
-        target_label = "__tmp_port"
+        source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_portNumber", "__meta_kubernetes_pod_ip"]
+        regex = "(\\d+);((([0-9]+?)(\\.|$)){4})" // IPv4, takes priority over IPv6 when both exists
+        replacement = "$2:$1"
+        target_label = "__address__"
       }
     
       rule {
@@ -44690,6 +44692,8 @@ data:
       }
     
       // Choose the pod port
+      // The discovery generates a target for each declared container port of the pod.
+      // If the metricsPortName annotation has value, keep only the target where the port name matches the one of the annotation.
       rule {
         source_labels = ["__meta_kubernetes_pod_container_port_name"]
         target_label = "__tmp_port"
@@ -44705,19 +44709,19 @@ data:
         target_label = "__tmp_port"
       }
     
+      // If the metricsPortNumber annotation has value, override the target address to use it,
+      // independently from the declared container ports of the pod.
       rule {
-        source_labels = ["__meta_kubernetes_pod_container_port_number"]
-        target_label = "__tmp_port"
+        source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_portNumber", "__meta_kubernetes_pod_ip"]
+        regex = "(\\d+);(([A-Fa-f0-9]{1,4}::?){1,7}[A-Fa-f0-9]{1,4})"
+        replacement = "[$2]:$1" // IPv6
+        target_label = "__address__"
       }
       rule {
-        source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_portNumber"]
-        regex = "(.+)"
-        target_label = "__tmp_port"
-      }
-      rule {
-        source_labels = ["__meta_kubernetes_pod_container_port_number"]
-        action = "keepequal"
-        target_label = "__tmp_port"
+        source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_portNumber", "__meta_kubernetes_pod_ip"]
+        regex = "(\\d+);((([0-9]+?)(\\.|$)){4})" // IPv4, takes priority over IPv6 when both exists
+        replacement = "$2:$1"
+        target_label = "__address__"
       }
     
       rule {

--- a/examples/ibm-cloud/metrics.river
+++ b/examples/ibm-cloud/metrics.river
@@ -120,6 +120,8 @@ discovery.relabel "annotation_autodiscovery_pods" {
   }
 
   // Choose the pod port
+  // The discovery generates a target for each declared container port of the pod.
+  // If the metricsPortName annotation has value, keep only the target where the port name matches the one of the annotation.
   rule {
     source_labels = ["__meta_kubernetes_pod_container_port_name"]
     target_label = "__tmp_port"
@@ -135,19 +137,19 @@ discovery.relabel "annotation_autodiscovery_pods" {
     target_label = "__tmp_port"
   }
 
+  // If the metricsPortNumber annotation has value, override the target address to use it,
+  // independently from the declared container ports of the pod.
   rule {
-    source_labels = ["__meta_kubernetes_pod_container_port_number"]
-    target_label = "__tmp_port"
+    source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_portNumber", "__meta_kubernetes_pod_ip"]
+    regex = "(\\d+);(([A-Fa-f0-9]{1,4}::?){1,7}[A-Fa-f0-9]{1,4})"
+    replacement = "[$2]:$1" // IPv6
+    target_label = "__address__"
   }
   rule {
-    source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_portNumber"]
-    regex = "(.+)"
-    target_label = "__tmp_port"
-  }
-  rule {
-    source_labels = ["__meta_kubernetes_pod_container_port_number"]
-    action = "keepequal"
-    target_label = "__tmp_port"
+    source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_portNumber", "__meta_kubernetes_pod_ip"]
+    regex = "(\\d+);((([0-9]+?)(\\.|$)){4})" // IPv4, takes priority over IPv6 when both exists
+    replacement = "$2:$1"
+    target_label = "__address__"
   }
 
   rule {

--- a/examples/ibm-cloud/output.yaml
+++ b/examples/ibm-cloud/output.yaml
@@ -241,6 +241,8 @@ data:
       }
     
       // Choose the pod port
+      // The discovery generates a target for each declared container port of the pod.
+      // If the metricsPortName annotation has value, keep only the target where the port name matches the one of the annotation.
       rule {
         source_labels = ["__meta_kubernetes_pod_container_port_name"]
         target_label = "__tmp_port"
@@ -256,19 +258,19 @@ data:
         target_label = "__tmp_port"
       }
     
+      // If the metricsPortNumber annotation has value, override the target address to use it,
+      // independently from the declared container ports of the pod.
       rule {
-        source_labels = ["__meta_kubernetes_pod_container_port_number"]
-        target_label = "__tmp_port"
+        source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_portNumber", "__meta_kubernetes_pod_ip"]
+        regex = "(\\d+);(([A-Fa-f0-9]{1,4}::?){1,7}[A-Fa-f0-9]{1,4})"
+        replacement = "[$2]:$1" // IPv6
+        target_label = "__address__"
       }
       rule {
-        source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_portNumber"]
-        regex = "(.+)"
-        target_label = "__tmp_port"
-      }
-      rule {
-        source_labels = ["__meta_kubernetes_pod_container_port_number"]
-        action = "keepequal"
-        target_label = "__tmp_port"
+        source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_portNumber", "__meta_kubernetes_pod_ip"]
+        regex = "(\\d+);((([0-9]+?)(\\.|$)){4})" // IPv4, takes priority over IPv6 when both exists
+        replacement = "$2:$1"
+        target_label = "__address__"
       }
     
       rule {
@@ -44896,6 +44898,8 @@ data:
       }
     
       // Choose the pod port
+      // The discovery generates a target for each declared container port of the pod.
+      // If the metricsPortName annotation has value, keep only the target where the port name matches the one of the annotation.
       rule {
         source_labels = ["__meta_kubernetes_pod_container_port_name"]
         target_label = "__tmp_port"
@@ -44911,19 +44915,19 @@ data:
         target_label = "__tmp_port"
       }
     
+      // If the metricsPortNumber annotation has value, override the target address to use it,
+      // independently from the declared container ports of the pod.
       rule {
-        source_labels = ["__meta_kubernetes_pod_container_port_number"]
-        target_label = "__tmp_port"
+        source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_portNumber", "__meta_kubernetes_pod_ip"]
+        regex = "(\\d+);(([A-Fa-f0-9]{1,4}::?){1,7}[A-Fa-f0-9]{1,4})"
+        replacement = "[$2]:$1" // IPv6
+        target_label = "__address__"
       }
       rule {
-        source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_portNumber"]
-        regex = "(.+)"
-        target_label = "__tmp_port"
-      }
-      rule {
-        source_labels = ["__meta_kubernetes_pod_container_port_number"]
-        action = "keepequal"
-        target_label = "__tmp_port"
+        source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_portNumber", "__meta_kubernetes_pod_ip"]
+        regex = "(\\d+);((([0-9]+?)(\\.|$)){4})" // IPv4, takes priority over IPv6 when both exists
+        replacement = "$2:$1"
+        target_label = "__address__"
       }
     
       rule {

--- a/examples/metrics-only/metrics.river
+++ b/examples/metrics-only/metrics.river
@@ -120,6 +120,8 @@ discovery.relabel "annotation_autodiscovery_pods" {
   }
 
   // Choose the pod port
+  // The discovery generates a target for each declared container port of the pod.
+  // If the metricsPortName annotation has value, keep only the target where the port name matches the one of the annotation.
   rule {
     source_labels = ["__meta_kubernetes_pod_container_port_name"]
     target_label = "__tmp_port"
@@ -135,19 +137,19 @@ discovery.relabel "annotation_autodiscovery_pods" {
     target_label = "__tmp_port"
   }
 
+  // If the metricsPortNumber annotation has value, override the target address to use it,
+  // independently from the declared container ports of the pod.
   rule {
-    source_labels = ["__meta_kubernetes_pod_container_port_number"]
-    target_label = "__tmp_port"
+    source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_portNumber", "__meta_kubernetes_pod_ip"]
+    regex = "(\\d+);(([A-Fa-f0-9]{1,4}::?){1,7}[A-Fa-f0-9]{1,4})"
+    replacement = "[$2]:$1" // IPv6
+    target_label = "__address__"
   }
   rule {
-    source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_portNumber"]
-    regex = "(.+)"
-    target_label = "__tmp_port"
-  }
-  rule {
-    source_labels = ["__meta_kubernetes_pod_container_port_number"]
-    action = "keepequal"
-    target_label = "__tmp_port"
+    source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_portNumber", "__meta_kubernetes_pod_ip"]
+    regex = "(\\d+);((([0-9]+?)(\\.|$)){4})" // IPv4, takes priority over IPv6 when both exists
+    replacement = "$2:$1"
+    target_label = "__address__"
   }
 
   rule {

--- a/examples/metrics-only/output.yaml
+++ b/examples/metrics-only/output.yaml
@@ -201,6 +201,8 @@ data:
       }
     
       // Choose the pod port
+      // The discovery generates a target for each declared container port of the pod.
+      // If the metricsPortName annotation has value, keep only the target where the port name matches the one of the annotation.
       rule {
         source_labels = ["__meta_kubernetes_pod_container_port_name"]
         target_label = "__tmp_port"
@@ -216,19 +218,19 @@ data:
         target_label = "__tmp_port"
       }
     
+      // If the metricsPortNumber annotation has value, override the target address to use it,
+      // independently from the declared container ports of the pod.
       rule {
-        source_labels = ["__meta_kubernetes_pod_container_port_number"]
-        target_label = "__tmp_port"
+        source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_portNumber", "__meta_kubernetes_pod_ip"]
+        regex = "(\\d+);(([A-Fa-f0-9]{1,4}::?){1,7}[A-Fa-f0-9]{1,4})"
+        replacement = "[$2]:$1" // IPv6
+        target_label = "__address__"
       }
       rule {
-        source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_portNumber"]
-        regex = "(.+)"
-        target_label = "__tmp_port"
-      }
-      rule {
-        source_labels = ["__meta_kubernetes_pod_container_port_number"]
-        action = "keepequal"
-        target_label = "__tmp_port"
+        source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_portNumber", "__meta_kubernetes_pod_ip"]
+        regex = "(\\d+);((([0-9]+?)(\\.|$)){4})" // IPv4, takes priority over IPv6 when both exists
+        replacement = "$2:$1"
+        target_label = "__address__"
       }
     
       rule {
@@ -44221,6 +44223,8 @@ data:
       }
     
       // Choose the pod port
+      // The discovery generates a target for each declared container port of the pod.
+      // If the metricsPortName annotation has value, keep only the target where the port name matches the one of the annotation.
       rule {
         source_labels = ["__meta_kubernetes_pod_container_port_name"]
         target_label = "__tmp_port"
@@ -44236,19 +44240,19 @@ data:
         target_label = "__tmp_port"
       }
     
+      // If the metricsPortNumber annotation has value, override the target address to use it,
+      // independently from the declared container ports of the pod.
       rule {
-        source_labels = ["__meta_kubernetes_pod_container_port_number"]
-        target_label = "__tmp_port"
+        source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_portNumber", "__meta_kubernetes_pod_ip"]
+        regex = "(\\d+);(([A-Fa-f0-9]{1,4}::?){1,7}[A-Fa-f0-9]{1,4})"
+        replacement = "[$2]:$1" // IPv6
+        target_label = "__address__"
       }
       rule {
-        source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_portNumber"]
-        regex = "(.+)"
-        target_label = "__tmp_port"
-      }
-      rule {
-        source_labels = ["__meta_kubernetes_pod_container_port_number"]
-        action = "keepequal"
-        target_label = "__tmp_port"
+        source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_portNumber", "__meta_kubernetes_pod_ip"]
+        regex = "(\\d+);((([0-9]+?)(\\.|$)){4})" // IPv4, takes priority over IPv6 when both exists
+        replacement = "$2:$1"
+        target_label = "__address__"
       }
     
       rule {

--- a/examples/openshift-compatible/metrics.river
+++ b/examples/openshift-compatible/metrics.river
@@ -120,6 +120,8 @@ discovery.relabel "annotation_autodiscovery_pods" {
   }
 
   // Choose the pod port
+  // The discovery generates a target for each declared container port of the pod.
+  // If the metricsPortName annotation has value, keep only the target where the port name matches the one of the annotation.
   rule {
     source_labels = ["__meta_kubernetes_pod_container_port_name"]
     target_label = "__tmp_port"
@@ -135,19 +137,19 @@ discovery.relabel "annotation_autodiscovery_pods" {
     target_label = "__tmp_port"
   }
 
+  // If the metricsPortNumber annotation has value, override the target address to use it,
+  // independently from the declared container ports of the pod.
   rule {
-    source_labels = ["__meta_kubernetes_pod_container_port_number"]
-    target_label = "__tmp_port"
+    source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_portNumber", "__meta_kubernetes_pod_ip"]
+    regex = "(\\d+);(([A-Fa-f0-9]{1,4}::?){1,7}[A-Fa-f0-9]{1,4})"
+    replacement = "[$2]:$1" // IPv6
+    target_label = "__address__"
   }
   rule {
-    source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_portNumber"]
-    regex = "(.+)"
-    target_label = "__tmp_port"
-  }
-  rule {
-    source_labels = ["__meta_kubernetes_pod_container_port_number"]
-    action = "keepequal"
-    target_label = "__tmp_port"
+    source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_portNumber", "__meta_kubernetes_pod_ip"]
+    regex = "(\\d+);((([0-9]+?)(\\.|$)){4})" // IPv4, takes priority over IPv6 when both exists
+    replacement = "$2:$1"
+    target_label = "__address__"
   }
 
   rule {

--- a/examples/openshift-compatible/output.yaml
+++ b/examples/openshift-compatible/output.yaml
@@ -211,6 +211,8 @@ data:
       }
     
       // Choose the pod port
+      // The discovery generates a target for each declared container port of the pod.
+      // If the metricsPortName annotation has value, keep only the target where the port name matches the one of the annotation.
       rule {
         source_labels = ["__meta_kubernetes_pod_container_port_name"]
         target_label = "__tmp_port"
@@ -226,19 +228,19 @@ data:
         target_label = "__tmp_port"
       }
     
+      // If the metricsPortNumber annotation has value, override the target address to use it,
+      // independently from the declared container ports of the pod.
       rule {
-        source_labels = ["__meta_kubernetes_pod_container_port_number"]
-        target_label = "__tmp_port"
+        source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_portNumber", "__meta_kubernetes_pod_ip"]
+        regex = "(\\d+);(([A-Fa-f0-9]{1,4}::?){1,7}[A-Fa-f0-9]{1,4})"
+        replacement = "[$2]:$1" // IPv6
+        target_label = "__address__"
       }
       rule {
-        source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_portNumber"]
-        regex = "(.+)"
-        target_label = "__tmp_port"
-      }
-      rule {
-        source_labels = ["__meta_kubernetes_pod_container_port_number"]
-        action = "keepequal"
-        target_label = "__tmp_port"
+        source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_portNumber", "__meta_kubernetes_pod_ip"]
+        regex = "(\\d+);((([0-9]+?)(\\.|$)){4})" // IPv4, takes priority over IPv6 when both exists
+        replacement = "$2:$1"
+        target_label = "__address__"
       }
     
       rule {
@@ -44544,6 +44546,8 @@ data:
       }
     
       // Choose the pod port
+      // The discovery generates a target for each declared container port of the pod.
+      // If the metricsPortName annotation has value, keep only the target where the port name matches the one of the annotation.
       rule {
         source_labels = ["__meta_kubernetes_pod_container_port_name"]
         target_label = "__tmp_port"
@@ -44559,19 +44563,19 @@ data:
         target_label = "__tmp_port"
       }
     
+      // If the metricsPortNumber annotation has value, override the target address to use it,
+      // independently from the declared container ports of the pod.
       rule {
-        source_labels = ["__meta_kubernetes_pod_container_port_number"]
-        target_label = "__tmp_port"
+        source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_portNumber", "__meta_kubernetes_pod_ip"]
+        regex = "(\\d+);(([A-Fa-f0-9]{1,4}::?){1,7}[A-Fa-f0-9]{1,4})"
+        replacement = "[$2]:$1" // IPv6
+        target_label = "__address__"
       }
       rule {
-        source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_portNumber"]
-        regex = "(.+)"
-        target_label = "__tmp_port"
-      }
-      rule {
-        source_labels = ["__meta_kubernetes_pod_container_port_number"]
-        action = "keepequal"
-        target_label = "__tmp_port"
+        source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_portNumber", "__meta_kubernetes_pod_ip"]
+        regex = "(\\d+);((([0-9]+?)(\\.|$)){4})" // IPv4, takes priority over IPv6 when both exists
+        replacement = "$2:$1"
+        target_label = "__address__"
       }
     
       rule {

--- a/examples/otel-metrics-service/metrics.river
+++ b/examples/otel-metrics-service/metrics.river
@@ -120,6 +120,8 @@ discovery.relabel "annotation_autodiscovery_pods" {
   }
 
   // Choose the pod port
+  // The discovery generates a target for each declared container port of the pod.
+  // If the metricsPortName annotation has value, keep only the target where the port name matches the one of the annotation.
   rule {
     source_labels = ["__meta_kubernetes_pod_container_port_name"]
     target_label = "__tmp_port"
@@ -135,19 +137,19 @@ discovery.relabel "annotation_autodiscovery_pods" {
     target_label = "__tmp_port"
   }
 
+  // If the metricsPortNumber annotation has value, override the target address to use it,
+  // independently from the declared container ports of the pod.
   rule {
-    source_labels = ["__meta_kubernetes_pod_container_port_number"]
-    target_label = "__tmp_port"
+    source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_portNumber", "__meta_kubernetes_pod_ip"]
+    regex = "(\\d+);(([A-Fa-f0-9]{1,4}::?){1,7}[A-Fa-f0-9]{1,4})"
+    replacement = "[$2]:$1" // IPv6
+    target_label = "__address__"
   }
   rule {
-    source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_portNumber"]
-    regex = "(.+)"
-    target_label = "__tmp_port"
-  }
-  rule {
-    source_labels = ["__meta_kubernetes_pod_container_port_number"]
-    action = "keepequal"
-    target_label = "__tmp_port"
+    source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_portNumber", "__meta_kubernetes_pod_ip"]
+    regex = "(\\d+);((([0-9]+?)(\\.|$)){4})" // IPv4, takes priority over IPv6 when both exists
+    replacement = "$2:$1"
+    target_label = "__address__"
   }
 
   rule {

--- a/examples/otel-metrics-service/output.yaml
+++ b/examples/otel-metrics-service/output.yaml
@@ -241,6 +241,8 @@ data:
       }
     
       // Choose the pod port
+      // The discovery generates a target for each declared container port of the pod.
+      // If the metricsPortName annotation has value, keep only the target where the port name matches the one of the annotation.
       rule {
         source_labels = ["__meta_kubernetes_pod_container_port_name"]
         target_label = "__tmp_port"
@@ -256,19 +258,19 @@ data:
         target_label = "__tmp_port"
       }
     
+      // If the metricsPortNumber annotation has value, override the target address to use it,
+      // independently from the declared container ports of the pod.
       rule {
-        source_labels = ["__meta_kubernetes_pod_container_port_number"]
-        target_label = "__tmp_port"
+        source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_portNumber", "__meta_kubernetes_pod_ip"]
+        regex = "(\\d+);(([A-Fa-f0-9]{1,4}::?){1,7}[A-Fa-f0-9]{1,4})"
+        replacement = "[$2]:$1" // IPv6
+        target_label = "__address__"
       }
       rule {
-        source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_portNumber"]
-        regex = "(.+)"
-        target_label = "__tmp_port"
-      }
-      rule {
-        source_labels = ["__meta_kubernetes_pod_container_port_number"]
-        action = "keepequal"
-        target_label = "__tmp_port"
+        source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_portNumber", "__meta_kubernetes_pod_ip"]
+        regex = "(\\d+);((([0-9]+?)(\\.|$)){4})" // IPv4, takes priority over IPv6 when both exists
+        replacement = "$2:$1"
+        target_label = "__address__"
       }
     
       rule {
@@ -44920,6 +44922,8 @@ data:
       }
     
       // Choose the pod port
+      // The discovery generates a target for each declared container port of the pod.
+      // If the metricsPortName annotation has value, keep only the target where the port name matches the one of the annotation.
       rule {
         source_labels = ["__meta_kubernetes_pod_container_port_name"]
         target_label = "__tmp_port"
@@ -44935,19 +44939,19 @@ data:
         target_label = "__tmp_port"
       }
     
+      // If the metricsPortNumber annotation has value, override the target address to use it,
+      // independently from the declared container ports of the pod.
       rule {
-        source_labels = ["__meta_kubernetes_pod_container_port_number"]
-        target_label = "__tmp_port"
+        source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_portNumber", "__meta_kubernetes_pod_ip"]
+        regex = "(\\d+);(([A-Fa-f0-9]{1,4}::?){1,7}[A-Fa-f0-9]{1,4})"
+        replacement = "[$2]:$1" // IPv6
+        target_label = "__address__"
       }
       rule {
-        source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_portNumber"]
-        regex = "(.+)"
-        target_label = "__tmp_port"
-      }
-      rule {
-        source_labels = ["__meta_kubernetes_pod_container_port_number"]
-        action = "keepequal"
-        target_label = "__tmp_port"
+        source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_portNumber", "__meta_kubernetes_pod_ip"]
+        regex = "(\\d+);((([0-9]+?)(\\.|$)){4})" // IPv4, takes priority over IPv6 when both exists
+        replacement = "$2:$1"
+        target_label = "__address__"
       }
     
       rule {

--- a/examples/private-image-registry/metrics.river
+++ b/examples/private-image-registry/metrics.river
@@ -120,6 +120,8 @@ discovery.relabel "annotation_autodiscovery_pods" {
   }
 
   // Choose the pod port
+  // The discovery generates a target for each declared container port of the pod.
+  // If the metricsPortName annotation has value, keep only the target where the port name matches the one of the annotation.
   rule {
     source_labels = ["__meta_kubernetes_pod_container_port_name"]
     target_label = "__tmp_port"
@@ -135,19 +137,19 @@ discovery.relabel "annotation_autodiscovery_pods" {
     target_label = "__tmp_port"
   }
 
+  // If the metricsPortNumber annotation has value, override the target address to use it,
+  // independently from the declared container ports of the pod.
   rule {
-    source_labels = ["__meta_kubernetes_pod_container_port_number"]
-    target_label = "__tmp_port"
+    source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_portNumber", "__meta_kubernetes_pod_ip"]
+    regex = "(\\d+);(([A-Fa-f0-9]{1,4}::?){1,7}[A-Fa-f0-9]{1,4})"
+    replacement = "[$2]:$1" // IPv6
+    target_label = "__address__"
   }
   rule {
-    source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_portNumber"]
-    regex = "(.+)"
-    target_label = "__tmp_port"
-  }
-  rule {
-    source_labels = ["__meta_kubernetes_pod_container_port_number"]
-    action = "keepequal"
-    target_label = "__tmp_port"
+    source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_portNumber", "__meta_kubernetes_pod_ip"]
+    regex = "(\\d+);((([0-9]+?)(\\.|$)){4})" // IPv4, takes priority over IPv6 when both exists
+    replacement = "$2:$1"
+    target_label = "__address__"
   }
 
   rule {

--- a/examples/private-image-registry/output.yaml
+++ b/examples/private-image-registry/output.yaml
@@ -245,6 +245,8 @@ data:
       }
     
       // Choose the pod port
+      // The discovery generates a target for each declared container port of the pod.
+      // If the metricsPortName annotation has value, keep only the target where the port name matches the one of the annotation.
       rule {
         source_labels = ["__meta_kubernetes_pod_container_port_name"]
         target_label = "__tmp_port"
@@ -260,19 +262,19 @@ data:
         target_label = "__tmp_port"
       }
     
+      // If the metricsPortNumber annotation has value, override the target address to use it,
+      // independently from the declared container ports of the pod.
       rule {
-        source_labels = ["__meta_kubernetes_pod_container_port_number"]
-        target_label = "__tmp_port"
+        source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_portNumber", "__meta_kubernetes_pod_ip"]
+        regex = "(\\d+);(([A-Fa-f0-9]{1,4}::?){1,7}[A-Fa-f0-9]{1,4})"
+        replacement = "[$2]:$1" // IPv6
+        target_label = "__address__"
       }
       rule {
-        source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_portNumber"]
-        regex = "(.+)"
-        target_label = "__tmp_port"
-      }
-      rule {
-        source_labels = ["__meta_kubernetes_pod_container_port_number"]
-        action = "keepequal"
-        target_label = "__tmp_port"
+        source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_portNumber", "__meta_kubernetes_pod_ip"]
+        regex = "(\\d+);((([0-9]+?)(\\.|$)){4})" // IPv4, takes priority over IPv6 when both exists
+        replacement = "$2:$1"
+        target_label = "__address__"
       }
     
       rule {
@@ -44906,6 +44908,8 @@ data:
       }
     
       // Choose the pod port
+      // The discovery generates a target for each declared container port of the pod.
+      // If the metricsPortName annotation has value, keep only the target where the port name matches the one of the annotation.
       rule {
         source_labels = ["__meta_kubernetes_pod_container_port_name"]
         target_label = "__tmp_port"
@@ -44921,19 +44925,19 @@ data:
         target_label = "__tmp_port"
       }
     
+      // If the metricsPortNumber annotation has value, override the target address to use it,
+      // independently from the declared container ports of the pod.
       rule {
-        source_labels = ["__meta_kubernetes_pod_container_port_number"]
-        target_label = "__tmp_port"
+        source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_portNumber", "__meta_kubernetes_pod_ip"]
+        regex = "(\\d+);(([A-Fa-f0-9]{1,4}::?){1,7}[A-Fa-f0-9]{1,4})"
+        replacement = "[$2]:$1" // IPv6
+        target_label = "__address__"
       }
       rule {
-        source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_portNumber"]
-        regex = "(.+)"
-        target_label = "__tmp_port"
-      }
-      rule {
-        source_labels = ["__meta_kubernetes_pod_container_port_number"]
-        action = "keepequal"
-        target_label = "__tmp_port"
+        source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_portNumber", "__meta_kubernetes_pod_ip"]
+        regex = "(\\d+);((([0-9]+?)(\\.|$)){4})" // IPv4, takes priority over IPv6 when both exists
+        replacement = "$2:$1"
+        target_label = "__address__"
       }
     
       rule {

--- a/examples/proxies/metrics.river
+++ b/examples/proxies/metrics.river
@@ -120,6 +120,8 @@ discovery.relabel "annotation_autodiscovery_pods" {
   }
 
   // Choose the pod port
+  // The discovery generates a target for each declared container port of the pod.
+  // If the metricsPortName annotation has value, keep only the target where the port name matches the one of the annotation.
   rule {
     source_labels = ["__meta_kubernetes_pod_container_port_name"]
     target_label = "__tmp_port"
@@ -135,19 +137,19 @@ discovery.relabel "annotation_autodiscovery_pods" {
     target_label = "__tmp_port"
   }
 
+  // If the metricsPortNumber annotation has value, override the target address to use it,
+  // independently from the declared container ports of the pod.
   rule {
-    source_labels = ["__meta_kubernetes_pod_container_port_number"]
-    target_label = "__tmp_port"
+    source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_portNumber", "__meta_kubernetes_pod_ip"]
+    regex = "(\\d+);(([A-Fa-f0-9]{1,4}::?){1,7}[A-Fa-f0-9]{1,4})"
+    replacement = "[$2]:$1" // IPv6
+    target_label = "__address__"
   }
   rule {
-    source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_portNumber"]
-    regex = "(.+)"
-    target_label = "__tmp_port"
-  }
-  rule {
-    source_labels = ["__meta_kubernetes_pod_container_port_number"]
-    action = "keepequal"
-    target_label = "__tmp_port"
+    source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_portNumber", "__meta_kubernetes_pod_ip"]
+    regex = "(\\d+);((([0-9]+?)(\\.|$)){4})" // IPv4, takes priority over IPv6 when both exists
+    replacement = "$2:$1"
+    target_label = "__address__"
   }
 
   rule {

--- a/examples/proxies/output.yaml
+++ b/examples/proxies/output.yaml
@@ -241,6 +241,8 @@ data:
       }
     
       // Choose the pod port
+      // The discovery generates a target for each declared container port of the pod.
+      // If the metricsPortName annotation has value, keep only the target where the port name matches the one of the annotation.
       rule {
         source_labels = ["__meta_kubernetes_pod_container_port_name"]
         target_label = "__tmp_port"
@@ -256,19 +258,19 @@ data:
         target_label = "__tmp_port"
       }
     
+      // If the metricsPortNumber annotation has value, override the target address to use it,
+      // independently from the declared container ports of the pod.
       rule {
-        source_labels = ["__meta_kubernetes_pod_container_port_number"]
-        target_label = "__tmp_port"
+        source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_portNumber", "__meta_kubernetes_pod_ip"]
+        regex = "(\\d+);(([A-Fa-f0-9]{1,4}::?){1,7}[A-Fa-f0-9]{1,4})"
+        replacement = "[$2]:$1" // IPv6
+        target_label = "__address__"
       }
       rule {
-        source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_portNumber"]
-        regex = "(.+)"
-        target_label = "__tmp_port"
-      }
-      rule {
-        source_labels = ["__meta_kubernetes_pod_container_port_number"]
-        action = "keepequal"
-        target_label = "__tmp_port"
+        source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_portNumber", "__meta_kubernetes_pod_ip"]
+        regex = "(\\d+);((([0-9]+?)(\\.|$)){4})" // IPv4, takes priority over IPv6 when both exists
+        replacement = "$2:$1"
+        target_label = "__address__"
       }
     
       rule {
@@ -44906,6 +44908,8 @@ data:
       }
     
       // Choose the pod port
+      // The discovery generates a target for each declared container port of the pod.
+      // If the metricsPortName annotation has value, keep only the target where the port name matches the one of the annotation.
       rule {
         source_labels = ["__meta_kubernetes_pod_container_port_name"]
         target_label = "__tmp_port"
@@ -44921,19 +44925,19 @@ data:
         target_label = "__tmp_port"
       }
     
+      // If the metricsPortNumber annotation has value, override the target address to use it,
+      // independently from the declared container ports of the pod.
       rule {
-        source_labels = ["__meta_kubernetes_pod_container_port_number"]
-        target_label = "__tmp_port"
+        source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_portNumber", "__meta_kubernetes_pod_ip"]
+        regex = "(\\d+);(([A-Fa-f0-9]{1,4}::?){1,7}[A-Fa-f0-9]{1,4})"
+        replacement = "[$2]:$1" // IPv6
+        target_label = "__address__"
       }
       rule {
-        source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_portNumber"]
-        regex = "(.+)"
-        target_label = "__tmp_port"
-      }
-      rule {
-        source_labels = ["__meta_kubernetes_pod_container_port_number"]
-        action = "keepequal"
-        target_label = "__tmp_port"
+        source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_portNumber", "__meta_kubernetes_pod_ip"]
+        regex = "(\\d+);((([0-9]+?)(\\.|$)){4})" // IPv4, takes priority over IPv6 when both exists
+        replacement = "$2:$1"
+        target_label = "__address__"
       }
     
       rule {

--- a/examples/scrape-intervals/metrics.river
+++ b/examples/scrape-intervals/metrics.river
@@ -120,6 +120,8 @@ discovery.relabel "annotation_autodiscovery_pods" {
   }
 
   // Choose the pod port
+  // The discovery generates a target for each declared container port of the pod.
+  // If the metricsPortName annotation has value, keep only the target where the port name matches the one of the annotation.
   rule {
     source_labels = ["__meta_kubernetes_pod_container_port_name"]
     target_label = "__tmp_port"
@@ -135,19 +137,19 @@ discovery.relabel "annotation_autodiscovery_pods" {
     target_label = "__tmp_port"
   }
 
+  // If the metricsPortNumber annotation has value, override the target address to use it,
+  // independently from the declared container ports of the pod.
   rule {
-    source_labels = ["__meta_kubernetes_pod_container_port_number"]
-    target_label = "__tmp_port"
+    source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_portNumber", "__meta_kubernetes_pod_ip"]
+    regex = "(\\d+);(([A-Fa-f0-9]{1,4}::?){1,7}[A-Fa-f0-9]{1,4})"
+    replacement = "[$2]:$1" // IPv6
+    target_label = "__address__"
   }
   rule {
-    source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_portNumber"]
-    regex = "(.+)"
-    target_label = "__tmp_port"
-  }
-  rule {
-    source_labels = ["__meta_kubernetes_pod_container_port_number"]
-    action = "keepequal"
-    target_label = "__tmp_port"
+    source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_portNumber", "__meta_kubernetes_pod_ip"]
+    regex = "(\\d+);((([0-9]+?)(\\.|$)){4})" // IPv4, takes priority over IPv6 when both exists
+    replacement = "$2:$1"
+    target_label = "__address__"
   }
 
   rule {

--- a/examples/scrape-intervals/output.yaml
+++ b/examples/scrape-intervals/output.yaml
@@ -200,6 +200,8 @@ data:
       }
     
       // Choose the pod port
+      // The discovery generates a target for each declared container port of the pod.
+      // If the metricsPortName annotation has value, keep only the target where the port name matches the one of the annotation.
       rule {
         source_labels = ["__meta_kubernetes_pod_container_port_name"]
         target_label = "__tmp_port"
@@ -215,19 +217,19 @@ data:
         target_label = "__tmp_port"
       }
     
+      // If the metricsPortNumber annotation has value, override the target address to use it,
+      // independently from the declared container ports of the pod.
       rule {
-        source_labels = ["__meta_kubernetes_pod_container_port_number"]
-        target_label = "__tmp_port"
+        source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_portNumber", "__meta_kubernetes_pod_ip"]
+        regex = "(\\d+);(([A-Fa-f0-9]{1,4}::?){1,7}[A-Fa-f0-9]{1,4})"
+        replacement = "[$2]:$1" // IPv6
+        target_label = "__address__"
       }
       rule {
-        source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_portNumber"]
-        regex = "(.+)"
-        target_label = "__tmp_port"
-      }
-      rule {
-        source_labels = ["__meta_kubernetes_pod_container_port_number"]
-        action = "keepequal"
-        target_label = "__tmp_port"
+        source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_portNumber", "__meta_kubernetes_pod_ip"]
+        regex = "(\\d+);((([0-9]+?)(\\.|$)){4})" // IPv4, takes priority over IPv6 when both exists
+        replacement = "$2:$1"
+        target_label = "__address__"
       }
     
       rule {
@@ -44220,6 +44222,8 @@ data:
       }
     
       // Choose the pod port
+      // The discovery generates a target for each declared container port of the pod.
+      // If the metricsPortName annotation has value, keep only the target where the port name matches the one of the annotation.
       rule {
         source_labels = ["__meta_kubernetes_pod_container_port_name"]
         target_label = "__tmp_port"
@@ -44235,19 +44239,19 @@ data:
         target_label = "__tmp_port"
       }
     
+      // If the metricsPortNumber annotation has value, override the target address to use it,
+      // independently from the declared container ports of the pod.
       rule {
-        source_labels = ["__meta_kubernetes_pod_container_port_number"]
-        target_label = "__tmp_port"
+        source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_portNumber", "__meta_kubernetes_pod_ip"]
+        regex = "(\\d+);(([A-Fa-f0-9]{1,4}::?){1,7}[A-Fa-f0-9]{1,4})"
+        replacement = "[$2]:$1" // IPv6
+        target_label = "__address__"
       }
       rule {
-        source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_portNumber"]
-        regex = "(.+)"
-        target_label = "__tmp_port"
-      }
-      rule {
-        source_labels = ["__meta_kubernetes_pod_container_port_number"]
-        action = "keepequal"
-        target_label = "__tmp_port"
+        source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_portNumber", "__meta_kubernetes_pod_ip"]
+        regex = "(\\d+);((([0-9]+?)(\\.|$)){4})" // IPv4, takes priority over IPv6 when both exists
+        replacement = "$2:$1"
+        target_label = "__address__"
       }
     
       rule {

--- a/examples/service-integrations/metrics.river
+++ b/examples/service-integrations/metrics.river
@@ -120,6 +120,8 @@ discovery.relabel "annotation_autodiscovery_pods" {
   }
 
   // Choose the pod port
+  // The discovery generates a target for each declared container port of the pod.
+  // If the metricsPortName annotation has value, keep only the target where the port name matches the one of the annotation.
   rule {
     source_labels = ["__meta_kubernetes_pod_container_port_name"]
     target_label = "__tmp_port"
@@ -135,19 +137,19 @@ discovery.relabel "annotation_autodiscovery_pods" {
     target_label = "__tmp_port"
   }
 
+  // If the metricsPortNumber annotation has value, override the target address to use it,
+  // independently from the declared container ports of the pod.
   rule {
-    source_labels = ["__meta_kubernetes_pod_container_port_number"]
-    target_label = "__tmp_port"
+    source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_portNumber", "__meta_kubernetes_pod_ip"]
+    regex = "(\\d+);(([A-Fa-f0-9]{1,4}::?){1,7}[A-Fa-f0-9]{1,4})"
+    replacement = "[$2]:$1" // IPv6
+    target_label = "__address__"
   }
   rule {
-    source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_portNumber"]
-    regex = "(.+)"
-    target_label = "__tmp_port"
-  }
-  rule {
-    source_labels = ["__meta_kubernetes_pod_container_port_number"]
-    action = "keepequal"
-    target_label = "__tmp_port"
+    source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_portNumber", "__meta_kubernetes_pod_ip"]
+    regex = "(\\d+);((([0-9]+?)(\\.|$)){4})" // IPv4, takes priority over IPv6 when both exists
+    replacement = "$2:$1"
+    target_label = "__address__"
   }
 
   rule {

--- a/examples/service-integrations/output.yaml
+++ b/examples/service-integrations/output.yaml
@@ -241,6 +241,8 @@ data:
       }
     
       // Choose the pod port
+      // The discovery generates a target for each declared container port of the pod.
+      // If the metricsPortName annotation has value, keep only the target where the port name matches the one of the annotation.
       rule {
         source_labels = ["__meta_kubernetes_pod_container_port_name"]
         target_label = "__tmp_port"
@@ -256,19 +258,19 @@ data:
         target_label = "__tmp_port"
       }
     
+      // If the metricsPortNumber annotation has value, override the target address to use it,
+      // independently from the declared container ports of the pod.
       rule {
-        source_labels = ["__meta_kubernetes_pod_container_port_number"]
-        target_label = "__tmp_port"
+        source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_portNumber", "__meta_kubernetes_pod_ip"]
+        regex = "(\\d+);(([A-Fa-f0-9]{1,4}::?){1,7}[A-Fa-f0-9]{1,4})"
+        replacement = "[$2]:$1" // IPv6
+        target_label = "__address__"
       }
       rule {
-        source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_portNumber"]
-        regex = "(.+)"
-        target_label = "__tmp_port"
-      }
-      rule {
-        source_labels = ["__meta_kubernetes_pod_container_port_number"]
-        action = "keepequal"
-        target_label = "__tmp_port"
+        source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_portNumber", "__meta_kubernetes_pod_ip"]
+        regex = "(\\d+);((([0-9]+?)(\\.|$)){4})" // IPv4, takes priority over IPv6 when both exists
+        replacement = "$2:$1"
+        target_label = "__address__"
       }
     
       rule {
@@ -44925,6 +44927,8 @@ data:
       }
     
       // Choose the pod port
+      // The discovery generates a target for each declared container port of the pod.
+      // If the metricsPortName annotation has value, keep only the target where the port name matches the one of the annotation.
       rule {
         source_labels = ["__meta_kubernetes_pod_container_port_name"]
         target_label = "__tmp_port"
@@ -44940,19 +44944,19 @@ data:
         target_label = "__tmp_port"
       }
     
+      // If the metricsPortNumber annotation has value, override the target address to use it,
+      // independently from the declared container ports of the pod.
       rule {
-        source_labels = ["__meta_kubernetes_pod_container_port_number"]
-        target_label = "__tmp_port"
+        source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_portNumber", "__meta_kubernetes_pod_ip"]
+        regex = "(\\d+);(([A-Fa-f0-9]{1,4}::?){1,7}[A-Fa-f0-9]{1,4})"
+        replacement = "[$2]:$1" // IPv6
+        target_label = "__address__"
       }
       rule {
-        source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_portNumber"]
-        regex = "(.+)"
-        target_label = "__tmp_port"
-      }
-      rule {
-        source_labels = ["__meta_kubernetes_pod_container_port_number"]
-        action = "keepequal"
-        target_label = "__tmp_port"
+        source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_portNumber", "__meta_kubernetes_pod_ip"]
+        regex = "(\\d+);((([0-9]+?)(\\.|$)){4})" // IPv4, takes priority over IPv6 when both exists
+        replacement = "$2:$1"
+        target_label = "__address__"
       }
     
       rule {

--- a/examples/specific-namespace/metrics.river
+++ b/examples/specific-namespace/metrics.river
@@ -120,6 +120,8 @@ discovery.relabel "annotation_autodiscovery_pods" {
   }
 
   // Choose the pod port
+  // The discovery generates a target for each declared container port of the pod.
+  // If the metricsPortName annotation has value, keep only the target where the port name matches the one of the annotation.
   rule {
     source_labels = ["__meta_kubernetes_pod_container_port_name"]
     target_label = "__tmp_port"
@@ -135,19 +137,19 @@ discovery.relabel "annotation_autodiscovery_pods" {
     target_label = "__tmp_port"
   }
 
+  // If the metricsPortNumber annotation has value, override the target address to use it,
+  // independently from the declared container ports of the pod.
   rule {
-    source_labels = ["__meta_kubernetes_pod_container_port_number"]
-    target_label = "__tmp_port"
+    source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_portNumber", "__meta_kubernetes_pod_ip"]
+    regex = "(\\d+);(([A-Fa-f0-9]{1,4}::?){1,7}[A-Fa-f0-9]{1,4})"
+    replacement = "[$2]:$1" // IPv6
+    target_label = "__address__"
   }
   rule {
-    source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_portNumber"]
-    regex = "(.+)"
-    target_label = "__tmp_port"
-  }
-  rule {
-    source_labels = ["__meta_kubernetes_pod_container_port_number"]
-    action = "keepequal"
-    target_label = "__tmp_port"
+    source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_portNumber", "__meta_kubernetes_pod_ip"]
+    regex = "(\\d+);((([0-9]+?)(\\.|$)){4})" // IPv4, takes priority over IPv6 when both exists
+    replacement = "$2:$1"
+    target_label = "__address__"
   }
 
   rule {

--- a/examples/specific-namespace/output.yaml
+++ b/examples/specific-namespace/output.yaml
@@ -241,6 +241,8 @@ data:
       }
     
       // Choose the pod port
+      // The discovery generates a target for each declared container port of the pod.
+      // If the metricsPortName annotation has value, keep only the target where the port name matches the one of the annotation.
       rule {
         source_labels = ["__meta_kubernetes_pod_container_port_name"]
         target_label = "__tmp_port"
@@ -256,19 +258,19 @@ data:
         target_label = "__tmp_port"
       }
     
+      // If the metricsPortNumber annotation has value, override the target address to use it,
+      // independently from the declared container ports of the pod.
       rule {
-        source_labels = ["__meta_kubernetes_pod_container_port_number"]
-        target_label = "__tmp_port"
+        source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_portNumber", "__meta_kubernetes_pod_ip"]
+        regex = "(\\d+);(([A-Fa-f0-9]{1,4}::?){1,7}[A-Fa-f0-9]{1,4})"
+        replacement = "[$2]:$1" // IPv6
+        target_label = "__address__"
       }
       rule {
-        source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_portNumber"]
-        regex = "(.+)"
-        target_label = "__tmp_port"
-      }
-      rule {
-        source_labels = ["__meta_kubernetes_pod_container_port_number"]
-        action = "keepequal"
-        target_label = "__tmp_port"
+        source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_portNumber", "__meta_kubernetes_pod_ip"]
+        regex = "(\\d+);((([0-9]+?)(\\.|$)){4})" // IPv4, takes priority over IPv6 when both exists
+        replacement = "$2:$1"
+        target_label = "__address__"
       }
     
       rule {
@@ -44946,6 +44948,8 @@ data:
       }
     
       // Choose the pod port
+      // The discovery generates a target for each declared container port of the pod.
+      // If the metricsPortName annotation has value, keep only the target where the port name matches the one of the annotation.
       rule {
         source_labels = ["__meta_kubernetes_pod_container_port_name"]
         target_label = "__tmp_port"
@@ -44961,19 +44965,19 @@ data:
         target_label = "__tmp_port"
       }
     
+      // If the metricsPortNumber annotation has value, override the target address to use it,
+      // independently from the declared container ports of the pod.
       rule {
-        source_labels = ["__meta_kubernetes_pod_container_port_number"]
-        target_label = "__tmp_port"
+        source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_portNumber", "__meta_kubernetes_pod_ip"]
+        regex = "(\\d+);(([A-Fa-f0-9]{1,4}::?){1,7}[A-Fa-f0-9]{1,4})"
+        replacement = "[$2]:$1" // IPv6
+        target_label = "__address__"
       }
       rule {
-        source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_portNumber"]
-        regex = "(.+)"
-        target_label = "__tmp_port"
-      }
-      rule {
-        source_labels = ["__meta_kubernetes_pod_container_port_number"]
-        action = "keepequal"
-        target_label = "__tmp_port"
+        source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_portNumber", "__meta_kubernetes_pod_ip"]
+        regex = "(\\d+);((([0-9]+?)(\\.|$)){4})" // IPv4, takes priority over IPv6 when both exists
+        replacement = "$2:$1"
+        target_label = "__address__"
       }
     
       rule {

--- a/examples/traces-enabled/metrics.river
+++ b/examples/traces-enabled/metrics.river
@@ -123,6 +123,8 @@ discovery.relabel "annotation_autodiscovery_pods" {
   }
 
   // Choose the pod port
+  // The discovery generates a target for each declared container port of the pod.
+  // If the metricsPortName annotation has value, keep only the target where the port name matches the one of the annotation.
   rule {
     source_labels = ["__meta_kubernetes_pod_container_port_name"]
     target_label = "__tmp_port"
@@ -138,19 +140,19 @@ discovery.relabel "annotation_autodiscovery_pods" {
     target_label = "__tmp_port"
   }
 
+  // If the metricsPortNumber annotation has value, override the target address to use it,
+  // independently from the declared container ports of the pod.
   rule {
-    source_labels = ["__meta_kubernetes_pod_container_port_number"]
-    target_label = "__tmp_port"
+    source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_portNumber", "__meta_kubernetes_pod_ip"]
+    regex = "(\\d+);(([A-Fa-f0-9]{1,4}::?){1,7}[A-Fa-f0-9]{1,4})"
+    replacement = "[$2]:$1" // IPv6
+    target_label = "__address__"
   }
   rule {
-    source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_portNumber"]
-    regex = "(.+)"
-    target_label = "__tmp_port"
-  }
-  rule {
-    source_labels = ["__meta_kubernetes_pod_container_port_number"]
-    action = "keepequal"
-    target_label = "__tmp_port"
+    source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_portNumber", "__meta_kubernetes_pod_ip"]
+    regex = "(\\d+);((([0-9]+?)(\\.|$)){4})" // IPv4, takes priority over IPv6 when both exists
+    replacement = "$2:$1"
+    target_label = "__address__"
   }
 
   rule {

--- a/examples/traces-enabled/output.yaml
+++ b/examples/traces-enabled/output.yaml
@@ -257,6 +257,8 @@ data:
       }
     
       // Choose the pod port
+      // The discovery generates a target for each declared container port of the pod.
+      // If the metricsPortName annotation has value, keep only the target where the port name matches the one of the annotation.
       rule {
         source_labels = ["__meta_kubernetes_pod_container_port_name"]
         target_label = "__tmp_port"
@@ -272,19 +274,19 @@ data:
         target_label = "__tmp_port"
       }
     
+      // If the metricsPortNumber annotation has value, override the target address to use it,
+      // independently from the declared container ports of the pod.
       rule {
-        source_labels = ["__meta_kubernetes_pod_container_port_number"]
-        target_label = "__tmp_port"
+        source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_portNumber", "__meta_kubernetes_pod_ip"]
+        regex = "(\\d+);(([A-Fa-f0-9]{1,4}::?){1,7}[A-Fa-f0-9]{1,4})"
+        replacement = "[$2]:$1" // IPv6
+        target_label = "__address__"
       }
       rule {
-        source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_portNumber"]
-        regex = "(.+)"
-        target_label = "__tmp_port"
-      }
-      rule {
-        source_labels = ["__meta_kubernetes_pod_container_port_number"]
-        action = "keepequal"
-        target_label = "__tmp_port"
+        source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_portNumber", "__meta_kubernetes_pod_ip"]
+        regex = "(\\d+);((([0-9]+?)(\\.|$)){4})" // IPv4, takes priority over IPv6 when both exists
+        replacement = "$2:$1"
+        target_label = "__address__"
       }
     
       rule {
@@ -44955,6 +44957,8 @@ data:
       }
     
       // Choose the pod port
+      // The discovery generates a target for each declared container port of the pod.
+      // If the metricsPortName annotation has value, keep only the target where the port name matches the one of the annotation.
       rule {
         source_labels = ["__meta_kubernetes_pod_container_port_name"]
         target_label = "__tmp_port"
@@ -44970,19 +44974,19 @@ data:
         target_label = "__tmp_port"
       }
     
+      // If the metricsPortNumber annotation has value, override the target address to use it,
+      // independently from the declared container ports of the pod.
       rule {
-        source_labels = ["__meta_kubernetes_pod_container_port_number"]
-        target_label = "__tmp_port"
+        source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_portNumber", "__meta_kubernetes_pod_ip"]
+        regex = "(\\d+);(([A-Fa-f0-9]{1,4}::?){1,7}[A-Fa-f0-9]{1,4})"
+        replacement = "[$2]:$1" // IPv6
+        target_label = "__address__"
       }
       rule {
-        source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_portNumber"]
-        regex = "(.+)"
-        target_label = "__tmp_port"
-      }
-      rule {
-        source_labels = ["__meta_kubernetes_pod_container_port_number"]
-        action = "keepequal"
-        target_label = "__tmp_port"
+        source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_portNumber", "__meta_kubernetes_pod_ip"]
+        regex = "(\\d+);((([0-9]+?)(\\.|$)){4})" // IPv4, takes priority over IPv6 when both exists
+        replacement = "$2:$1"
+        target_label = "__address__"
       }
     
       rule {

--- a/examples/windows-exporter/metrics.river
+++ b/examples/windows-exporter/metrics.river
@@ -120,6 +120,8 @@ discovery.relabel "annotation_autodiscovery_pods" {
   }
 
   // Choose the pod port
+  // The discovery generates a target for each declared container port of the pod.
+  // If the metricsPortName annotation has value, keep only the target where the port name matches the one of the annotation.
   rule {
     source_labels = ["__meta_kubernetes_pod_container_port_name"]
     target_label = "__tmp_port"
@@ -135,19 +137,19 @@ discovery.relabel "annotation_autodiscovery_pods" {
     target_label = "__tmp_port"
   }
 
+  // If the metricsPortNumber annotation has value, override the target address to use it,
+  // independently from the declared container ports of the pod.
   rule {
-    source_labels = ["__meta_kubernetes_pod_container_port_number"]
-    target_label = "__tmp_port"
+    source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_portNumber", "__meta_kubernetes_pod_ip"]
+    regex = "(\\d+);(([A-Fa-f0-9]{1,4}::?){1,7}[A-Fa-f0-9]{1,4})"
+    replacement = "[$2]:$1" // IPv6
+    target_label = "__address__"
   }
   rule {
-    source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_portNumber"]
-    regex = "(.+)"
-    target_label = "__tmp_port"
-  }
-  rule {
-    source_labels = ["__meta_kubernetes_pod_container_port_number"]
-    action = "keepequal"
-    target_label = "__tmp_port"
+    source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_portNumber", "__meta_kubernetes_pod_ip"]
+    regex = "(\\d+);((([0-9]+?)(\\.|$)){4})" // IPv4, takes priority over IPv6 when both exists
+    replacement = "$2:$1"
+    target_label = "__address__"
   }
 
   rule {

--- a/examples/windows-exporter/output.yaml
+++ b/examples/windows-exporter/output.yaml
@@ -278,6 +278,8 @@ data:
       }
     
       // Choose the pod port
+      // The discovery generates a target for each declared container port of the pod.
+      // If the metricsPortName annotation has value, keep only the target where the port name matches the one of the annotation.
       rule {
         source_labels = ["__meta_kubernetes_pod_container_port_name"]
         target_label = "__tmp_port"
@@ -293,19 +295,19 @@ data:
         target_label = "__tmp_port"
       }
     
+      // If the metricsPortNumber annotation has value, override the target address to use it,
+      // independently from the declared container ports of the pod.
       rule {
-        source_labels = ["__meta_kubernetes_pod_container_port_number"]
-        target_label = "__tmp_port"
+        source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_portNumber", "__meta_kubernetes_pod_ip"]
+        regex = "(\\d+);(([A-Fa-f0-9]{1,4}::?){1,7}[A-Fa-f0-9]{1,4})"
+        replacement = "[$2]:$1" // IPv6
+        target_label = "__address__"
       }
       rule {
-        source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_portNumber"]
-        regex = "(.+)"
-        target_label = "__tmp_port"
-      }
-      rule {
-        source_labels = ["__meta_kubernetes_pod_container_port_number"]
-        action = "keepequal"
-        target_label = "__tmp_port"
+        source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_portNumber", "__meta_kubernetes_pod_ip"]
+        regex = "(\\d+);((([0-9]+?)(\\.|$)){4})" // IPv4, takes priority over IPv6 when both exists
+        replacement = "$2:$1"
+        target_label = "__address__"
       }
     
       rule {
@@ -45121,6 +45123,8 @@ data:
       }
     
       // Choose the pod port
+      // The discovery generates a target for each declared container port of the pod.
+      // If the metricsPortName annotation has value, keep only the target where the port name matches the one of the annotation.
       rule {
         source_labels = ["__meta_kubernetes_pod_container_port_name"]
         target_label = "__tmp_port"
@@ -45136,19 +45140,19 @@ data:
         target_label = "__tmp_port"
       }
     
+      // If the metricsPortNumber annotation has value, override the target address to use it,
+      // independently from the declared container ports of the pod.
       rule {
-        source_labels = ["__meta_kubernetes_pod_container_port_number"]
-        target_label = "__tmp_port"
+        source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_portNumber", "__meta_kubernetes_pod_ip"]
+        regex = "(\\d+);(([A-Fa-f0-9]{1,4}::?){1,7}[A-Fa-f0-9]{1,4})"
+        replacement = "[$2]:$1" // IPv6
+        target_label = "__address__"
       }
       rule {
-        source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_portNumber"]
-        regex = "(.+)"
-        target_label = "__tmp_port"
-      }
-      rule {
-        source_labels = ["__meta_kubernetes_pod_container_port_number"]
-        action = "keepequal"
-        target_label = "__tmp_port"
+        source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_portNumber", "__meta_kubernetes_pod_ip"]
+        regex = "(\\d+);((([0-9]+?)(\\.|$)){4})" // IPv4, takes priority over IPv6 when both exists
+        replacement = "$2:$1"
+        target_label = "__address__"
       }
     
       rule {


### PR DESCRIPTION
## Summary

This change aims at fixing an issue where the pod is not scraped despite the `k8s.grafana.com/metrics.portNumber` annotation (or equivalent annotation specified in the `metrics.autoDiscover.annotations.metricsPortNumber` value, such as `promethus.io/port`), when the Pod doesn't declare that port among the container ports.

### Why this is important

**All customers using Istio are affected.**
When the Istio controller mutates the pod to inject the istio-proxy container, it reads the `prometheus.io/port` value. It uses it to scrape application metrics from the main container and re-expose the [merged metrics](https://istio.io/latest/docs/ops/integrations/prometheus/#option-1-metrics-merging) (istio-proxy Envoy metrics + main container metrics) on port 15020, which is set as the value for the `prometheus.io/port` annotation. However, the `istio-proxy` container only declares port 15090, exposing Envoy-only metrics.
This behavior is well explained in an [issue](https://github.com/istio/istio/issues/47882) on the Istio repository.

#### What happens with the Grafana Agent

As in Prometheus, the pod discovery of the Grafana Agent generates a target for each declared container port of the pod.
The Grafana Agent configurations of this Chart then discard all the pod-port couples whose port doesn't match the one in the annotations. Theoretically, only a couple should survive, the one with the port specified in the annotation. However, if that port is not declared, that target doesn't exist in all possible couples, and none survives. Consequently, all the pods part of the Istio mesh (all but a few system pods) are dropped from the scrape targets.

## Proposed change

When the `metricsPortNumber` annotation value is set, always use that port for the scraping, ignoring the declared container ports of the pod.

This is the [current Prometheus approach](https://github.com/prometheus-community/helm-charts/blob/cd640243eb03787fab11cf2883534f604787f760/charts/prometheus/values.yaml#L1068-L1077) and ensures the pod is scraped even if the container port is not declared.

### Detailed explanation

- If the annotation specified in the `metricsPortName` value exists on the pod, then discard all couples but that port.
  - I didn't change this behavior because the annotation specifies the port name, so the only way to get the number is by looking at declared ports.
  - If the pod doesn't specify that label, no action is taken: the [regex](https://github.com/grafana/k8s-monitoring-helm/blob/469eceee5e61c5a2fea9c4a914974d83cf6c1252/charts/k8s-monitoring/templates/agent_config/_annotation_autodiscovery.river.txt#L33) doesn't match and as per [doc](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config:~:text=If%20regex%20does%20not%20match%2C%20no%20replacement%20takes%20place.) the replace doesn't happen. Consequently, `__tmp_port` retains the previous value, equal to `__meta_kubernetes_pod_container_port_name`, and the `keepequal` doesn't discard the couple.
  - Istio doesn't require such annotation, so customers using Istio only need not to specify it and won't be affected by this rule.
- If the annotation specified in the `metricsPortName` value exists on the pod, then replace `__address__` with `podIp:port`, where the port is the annotation value.
  - In this way, all the pod-port couples will be replaced with the same value, and since they are duplicates, only one is kept. Thus, the final result is the same: only the target with the port of the annotation survives.
  - When the port from the annotation is not in the declared port, now the target is correctly set.
  - _If a container has no specified ports, a port-free target per container is created_ ([ref](https://grafana.com/docs/agent/latest/flow/reference/components/discovery.kubernetes/#pod-role)). Previously, _These targets must have a port manually injected using a discovery.relabel[ component](https://grafana.com/docs/agent/latest/flow/reference/components/discovery.relabel/) before metrics can be collected from them._ Now, if the port annotation is specified, the correct target is already generated without additional rules.