### PR TITLE
Fix the inclusion criteria for pod logs processor if pod logs is disabled

### DIFF
--- a/charts/k8s-monitoring/templates/_configs.tpl
+++ b/charts/k8s-monitoring/templates/_configs.tpl
@@ -76,7 +76,7 @@
     {{- include "agent.config.metricsService" . }}
   {{- end }}
 
-  {{- if and .Values.logs.enabled .Values.logs.pod_logs.enabled }}
+  {{- if and .Values.logs.enabled (or .Values.receivers.grpc.enabled .Values.receivers.http.enabled .Values.receivers.zipkin.enabled) }}
     {{- include "agent.config.logs.pod_logs_processor" . }}
     {{- include "agent.config.loki" . }}
   {{- end }}

--- a/charts/k8s-monitoring/templates/agent_config/_processors.river.txt
+++ b/charts/k8s-monitoring/templates/agent_config/_processors.river.txt
@@ -1,6 +1,6 @@
 {{ define "agent.config.processors" }}
 // Processors
-{{- if (or .Values.receivers.grpc.enabled .Values.receivers.http.enabled) }}
+{{- if or .Values.receivers.grpc.enabled .Values.receivers.http.enabled .Values.receivers.zipkin.enabled }}
 {{- if .Values.metrics.enabled }}
 otelcol.processor.transform "add_metric_datapoint_attributes" {
   // Grafana Cloud Kubernetes monitoring expects Loki labels `cluster`, `pod`, and `namespace`
@@ -177,18 +177,16 @@ otelcol.processor.batch "batch_processor" {
 {{- end }}
   }
 }
-{{- end }}
 
 {{- if .Values.metrics.enabled }}
 otelcol.exporter.prometheus "metrics_converter" {
   forward_to = [prometheus.relabel.metrics_service.receiver]
 }
 {{- end }}
-
 {{- if .Values.logs.enabled }}
 otelcol.exporter.loki "logs_converter" {
   forward_to = [loki.process.pod_logs.receiver]
 }
 {{- end }}
-
+{{- end }}
 {{- end }}

--- a/examples/custom-metrics-tuning/metrics.river
+++ b/examples/custom-metrics-tuning/metrics.river
@@ -731,3 +731,61 @@ prometheus.remote_write "metrics_service" {
   external_labels = {
   }
 }
+
+loki.process "pod_logs" {
+  stage.match {
+    selector = "{tmp_container_runtime=\"containerd\"}"
+    // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
+    stage.cri {}
+
+    // Set the extract flags and stream values as labels
+    stage.labels {
+      values = {
+        flags  = "",
+        stream  = "",
+      }
+    }
+  }
+
+  // if the label tmp_container_runtime from above is docker parse using docker
+  stage.match {
+    selector = "{tmp_container_runtime=\"docker\"}"
+    // the docker processing stage extracts the following k/v pairs: log, stream, time
+    stage.docker {}
+
+    // Set the extract stream value as a label
+    stage.labels {
+      values = {
+        stream  = "",
+      }
+    }
+  }
+
+  // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have
+  // cluster, namespace, pod, and container labels.
+  // Also drop the temporary container runtime label as it is no longer needed.
+  stage.label_drop {
+    values = ["filename", "tmp_container_runtime"]
+  }
+  forward_to = [loki.write.grafana_cloud_loki.receiver]
+}
+
+// Loki
+remote.kubernetes.secret "logs_service" {
+  name = "loki-k8s-monitoring"
+  namespace = "default"
+}
+loki.write "grafana_cloud_loki" {
+  endpoint {
+    url = nonsensitive(remote.kubernetes.secret.logs_service.data["host"]) + "/loki/api/v1/push"
+    tenant_id = nonsensitive(remote.kubernetes.secret.logs_service.data["tenantId"])
+
+    basic_auth {
+      username = nonsensitive(remote.kubernetes.secret.logs_service.data["username"])
+      password = remote.kubernetes.secret.logs_service.data["password"]
+    }
+  }
+  external_labels = {
+    cluster = "custom-allow-lists-test",
+  }
+}

--- a/examples/custom-metrics-tuning/output.yaml
+++ b/examples/custom-metrics-tuning/output.yaml
@@ -811,6 +811,64 @@ data:
       external_labels = {
       }
     }
+    
+    loki.process "pod_logs" {
+      stage.match {
+        selector = "{tmp_container_runtime=\"containerd\"}"
+        // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
+        stage.cri {}
+    
+        // Set the extract flags and stream values as labels
+        stage.labels {
+          values = {
+            flags  = "",
+            stream  = "",
+          }
+        }
+      }
+    
+      // if the label tmp_container_runtime from above is docker parse using docker
+      stage.match {
+        selector = "{tmp_container_runtime=\"docker\"}"
+        // the docker processing stage extracts the following k/v pairs: log, stream, time
+        stage.docker {}
+    
+        // Set the extract stream value as a label
+        stage.labels {
+          values = {
+            stream  = "",
+          }
+        }
+      }
+    
+      // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have
+      // cluster, namespace, pod, and container labels.
+      // Also drop the temporary container runtime label as it is no longer needed.
+      stage.label_drop {
+        values = ["filename", "tmp_container_runtime"]
+      }
+      forward_to = [loki.write.grafana_cloud_loki.receiver]
+    }
+    
+    // Loki
+    remote.kubernetes.secret "logs_service" {
+      name = "loki-k8s-monitoring"
+      namespace = "default"
+    }
+    loki.write "grafana_cloud_loki" {
+      endpoint {
+        url = nonsensitive(remote.kubernetes.secret.logs_service.data["host"]) + "/loki/api/v1/push"
+        tenant_id = nonsensitive(remote.kubernetes.secret.logs_service.data["tenantId"])
+    
+        basic_auth {
+          username = nonsensitive(remote.kubernetes.secret.logs_service.data["username"])
+          password = remote.kubernetes.secret.logs_service.data["password"]
+        }
+      }
+      external_labels = {
+        cluster = "custom-allow-lists-test",
+      }
+    }
 ---
 # Source: k8s-monitoring/templates/kubernetes-monitoring-telemetry.yaml
 apiVersion: v1
@@ -44836,6 +44894,64 @@ data:
       }
     
       external_labels = {
+      }
+    }
+    
+    loki.process "pod_logs" {
+      stage.match {
+        selector = "{tmp_container_runtime=\"containerd\"}"
+        // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
+        stage.cri {}
+    
+        // Set the extract flags and stream values as labels
+        stage.labels {
+          values = {
+            flags  = "",
+            stream  = "",
+          }
+        }
+      }
+    
+      // if the label tmp_container_runtime from above is docker parse using docker
+      stage.match {
+        selector = "{tmp_container_runtime=\"docker\"}"
+        // the docker processing stage extracts the following k/v pairs: log, stream, time
+        stage.docker {}
+    
+        // Set the extract stream value as a label
+        stage.labels {
+          values = {
+            stream  = "",
+          }
+        }
+      }
+    
+      // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have
+      // cluster, namespace, pod, and container labels.
+      // Also drop the temporary container runtime label as it is no longer needed.
+      stage.label_drop {
+        values = ["filename", "tmp_container_runtime"]
+      }
+      forward_to = [loki.write.grafana_cloud_loki.receiver]
+    }
+    
+    // Loki
+    remote.kubernetes.secret "logs_service" {
+      name = "loki-k8s-monitoring"
+      namespace = "default"
+    }
+    loki.write "grafana_cloud_loki" {
+      endpoint {
+        url = nonsensitive(remote.kubernetes.secret.logs_service.data["host"]) + "/loki/api/v1/push"
+        tenant_id = nonsensitive(remote.kubernetes.secret.logs_service.data["tenantId"])
+    
+        basic_auth {
+          username = nonsensitive(remote.kubernetes.secret.logs_service.data["username"])
+          password = remote.kubernetes.secret.logs_service.data["password"]
+        }
+      }
+      external_labels = {
+        cluster = "custom-allow-lists-test",
       }
     }
 ---

--- a/examples/metrics-only/metrics.river
+++ b/examples/metrics-only/metrics.river
@@ -736,3 +736,61 @@ prometheus.remote_write "metrics_service" {
   external_labels = {
   }
 }
+
+loki.process "pod_logs" {
+  stage.match {
+    selector = "{tmp_container_runtime=\"containerd\"}"
+    // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
+    stage.cri {}
+
+    // Set the extract flags and stream values as labels
+    stage.labels {
+      values = {
+        flags  = "",
+        stream  = "",
+      }
+    }
+  }
+
+  // if the label tmp_container_runtime from above is docker parse using docker
+  stage.match {
+    selector = "{tmp_container_runtime=\"docker\"}"
+    // the docker processing stage extracts the following k/v pairs: log, stream, time
+    stage.docker {}
+
+    // Set the extract stream value as a label
+    stage.labels {
+      values = {
+        stream  = "",
+      }
+    }
+  }
+
+  // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have
+  // cluster, namespace, pod, and container labels.
+  // Also drop the temporary container runtime label as it is no longer needed.
+  stage.label_drop {
+    values = ["filename", "tmp_container_runtime"]
+  }
+  forward_to = [loki.write.grafana_cloud_loki.receiver]
+}
+
+// Loki
+remote.kubernetes.secret "logs_service" {
+  name = "loki-k8s-monitoring"
+  namespace = "default"
+}
+loki.write "grafana_cloud_loki" {
+  endpoint {
+    url = nonsensitive(remote.kubernetes.secret.logs_service.data["host"]) + "/loki/api/v1/push"
+    tenant_id = nonsensitive(remote.kubernetes.secret.logs_service.data["tenantId"])
+
+    basic_auth {
+      username = nonsensitive(remote.kubernetes.secret.logs_service.data["username"])
+      password = remote.kubernetes.secret.logs_service.data["password"]
+    }
+  }
+  external_labels = {
+    cluster = "metrics-only-test",
+  }
+}

--- a/examples/metrics-only/output.yaml
+++ b/examples/metrics-only/output.yaml
@@ -817,6 +817,64 @@ data:
       external_labels = {
       }
     }
+    
+    loki.process "pod_logs" {
+      stage.match {
+        selector = "{tmp_container_runtime=\"containerd\"}"
+        // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
+        stage.cri {}
+    
+        // Set the extract flags and stream values as labels
+        stage.labels {
+          values = {
+            flags  = "",
+            stream  = "",
+          }
+        }
+      }
+    
+      // if the label tmp_container_runtime from above is docker parse using docker
+      stage.match {
+        selector = "{tmp_container_runtime=\"docker\"}"
+        // the docker processing stage extracts the following k/v pairs: log, stream, time
+        stage.docker {}
+    
+        // Set the extract stream value as a label
+        stage.labels {
+          values = {
+            stream  = "",
+          }
+        }
+      }
+    
+      // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have
+      // cluster, namespace, pod, and container labels.
+      // Also drop the temporary container runtime label as it is no longer needed.
+      stage.label_drop {
+        values = ["filename", "tmp_container_runtime"]
+      }
+      forward_to = [loki.write.grafana_cloud_loki.receiver]
+    }
+    
+    // Loki
+    remote.kubernetes.secret "logs_service" {
+      name = "loki-k8s-monitoring"
+      namespace = "default"
+    }
+    loki.write "grafana_cloud_loki" {
+      endpoint {
+        url = nonsensitive(remote.kubernetes.secret.logs_service.data["host"]) + "/loki/api/v1/push"
+        tenant_id = nonsensitive(remote.kubernetes.secret.logs_service.data["tenantId"])
+    
+        basic_auth {
+          username = nonsensitive(remote.kubernetes.secret.logs_service.data["username"])
+          password = remote.kubernetes.secret.logs_service.data["password"]
+        }
+      }
+      external_labels = {
+        cluster = "metrics-only-test",
+      }
+    }
 ---
 # Source: k8s-monitoring/templates/kubernetes-monitoring-telemetry.yaml
 apiVersion: v1
@@ -44847,6 +44905,64 @@ data:
       }
     
       external_labels = {
+      }
+    }
+    
+    loki.process "pod_logs" {
+      stage.match {
+        selector = "{tmp_container_runtime=\"containerd\"}"
+        // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
+        stage.cri {}
+    
+        // Set the extract flags and stream values as labels
+        stage.labels {
+          values = {
+            flags  = "",
+            stream  = "",
+          }
+        }
+      }
+    
+      // if the label tmp_container_runtime from above is docker parse using docker
+      stage.match {
+        selector = "{tmp_container_runtime=\"docker\"}"
+        // the docker processing stage extracts the following k/v pairs: log, stream, time
+        stage.docker {}
+    
+        // Set the extract stream value as a label
+        stage.labels {
+          values = {
+            stream  = "",
+          }
+        }
+      }
+    
+      // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have
+      // cluster, namespace, pod, and container labels.
+      // Also drop the temporary container runtime label as it is no longer needed.
+      stage.label_drop {
+        values = ["filename", "tmp_container_runtime"]
+      }
+      forward_to = [loki.write.grafana_cloud_loki.receiver]
+    }
+    
+    // Loki
+    remote.kubernetes.secret "logs_service" {
+      name = "loki-k8s-monitoring"
+      namespace = "default"
+    }
+    loki.write "grafana_cloud_loki" {
+      endpoint {
+        url = nonsensitive(remote.kubernetes.secret.logs_service.data["host"]) + "/loki/api/v1/push"
+        tenant_id = nonsensitive(remote.kubernetes.secret.logs_service.data["tenantId"])
+    
+        basic_auth {
+          username = nonsensitive(remote.kubernetes.secret.logs_service.data["username"])
+          password = remote.kubernetes.secret.logs_service.data["password"]
+        }
+      }
+      external_labels = {
+        cluster = "metrics-only-test",
       }
     }
 ---

--- a/examples/scrape-intervals/metrics.river
+++ b/examples/scrape-intervals/metrics.river
@@ -736,3 +736,61 @@ prometheus.remote_write "metrics_service" {
   external_labels = {
   }
 }
+
+loki.process "pod_logs" {
+  stage.match {
+    selector = "{tmp_container_runtime=\"containerd\"}"
+    // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
+    stage.cri {}
+
+    // Set the extract flags and stream values as labels
+    stage.labels {
+      values = {
+        flags  = "",
+        stream  = "",
+      }
+    }
+  }
+
+  // if the label tmp_container_runtime from above is docker parse using docker
+  stage.match {
+    selector = "{tmp_container_runtime=\"docker\"}"
+    // the docker processing stage extracts the following k/v pairs: log, stream, time
+    stage.docker {}
+
+    // Set the extract stream value as a label
+    stage.labels {
+      values = {
+        stream  = "",
+      }
+    }
+  }
+
+  // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have
+  // cluster, namespace, pod, and container labels.
+  // Also drop the temporary container runtime label as it is no longer needed.
+  stage.label_drop {
+    values = ["filename", "tmp_container_runtime"]
+  }
+  forward_to = [loki.write.grafana_cloud_loki.receiver]
+}
+
+// Loki
+remote.kubernetes.secret "logs_service" {
+  name = "loki-k8s-monitoring"
+  namespace = "default"
+}
+loki.write "grafana_cloud_loki" {
+  endpoint {
+    url = nonsensitive(remote.kubernetes.secret.logs_service.data["host"]) + "/loki/api/v1/push"
+    tenant_id = nonsensitive(remote.kubernetes.secret.logs_service.data["tenantId"])
+
+    basic_auth {
+      username = nonsensitive(remote.kubernetes.secret.logs_service.data["username"])
+      password = remote.kubernetes.secret.logs_service.data["password"]
+    }
+  }
+  external_labels = {
+    cluster = "custom-scrape-intervals-test",
+  }
+}

--- a/examples/scrape-intervals/output.yaml
+++ b/examples/scrape-intervals/output.yaml
@@ -816,6 +816,64 @@ data:
       external_labels = {
       }
     }
+    
+    loki.process "pod_logs" {
+      stage.match {
+        selector = "{tmp_container_runtime=\"containerd\"}"
+        // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
+        stage.cri {}
+    
+        // Set the extract flags and stream values as labels
+        stage.labels {
+          values = {
+            flags  = "",
+            stream  = "",
+          }
+        }
+      }
+    
+      // if the label tmp_container_runtime from above is docker parse using docker
+      stage.match {
+        selector = "{tmp_container_runtime=\"docker\"}"
+        // the docker processing stage extracts the following k/v pairs: log, stream, time
+        stage.docker {}
+    
+        // Set the extract stream value as a label
+        stage.labels {
+          values = {
+            stream  = "",
+          }
+        }
+      }
+    
+      // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have
+      // cluster, namespace, pod, and container labels.
+      // Also drop the temporary container runtime label as it is no longer needed.
+      stage.label_drop {
+        values = ["filename", "tmp_container_runtime"]
+      }
+      forward_to = [loki.write.grafana_cloud_loki.receiver]
+    }
+    
+    // Loki
+    remote.kubernetes.secret "logs_service" {
+      name = "loki-k8s-monitoring"
+      namespace = "default"
+    }
+    loki.write "grafana_cloud_loki" {
+      endpoint {
+        url = nonsensitive(remote.kubernetes.secret.logs_service.data["host"]) + "/loki/api/v1/push"
+        tenant_id = nonsensitive(remote.kubernetes.secret.logs_service.data["tenantId"])
+    
+        basic_auth {
+          username = nonsensitive(remote.kubernetes.secret.logs_service.data["username"])
+          password = remote.kubernetes.secret.logs_service.data["password"]
+        }
+      }
+      external_labels = {
+        cluster = "custom-scrape-intervals-test",
+      }
+    }
 ---
 # Source: k8s-monitoring/templates/kubernetes-monitoring-telemetry.yaml
 apiVersion: v1
@@ -44846,6 +44904,64 @@ data:
       }
     
       external_labels = {
+      }
+    }
+    
+    loki.process "pod_logs" {
+      stage.match {
+        selector = "{tmp_container_runtime=\"containerd\"}"
+        // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
+        stage.cri {}
+    
+        // Set the extract flags and stream values as labels
+        stage.labels {
+          values = {
+            flags  = "",
+            stream  = "",
+          }
+        }
+      }
+    
+      // if the label tmp_container_runtime from above is docker parse using docker
+      stage.match {
+        selector = "{tmp_container_runtime=\"docker\"}"
+        // the docker processing stage extracts the following k/v pairs: log, stream, time
+        stage.docker {}
+    
+        // Set the extract stream value as a label
+        stage.labels {
+          values = {
+            stream  = "",
+          }
+        }
+      }
+    
+      // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have
+      // cluster, namespace, pod, and container labels.
+      // Also drop the temporary container runtime label as it is no longer needed.
+      stage.label_drop {
+        values = ["filename", "tmp_container_runtime"]
+      }
+      forward_to = [loki.write.grafana_cloud_loki.receiver]
+    }
+    
+    // Loki
+    remote.kubernetes.secret "logs_service" {
+      name = "loki-k8s-monitoring"
+      namespace = "default"
+    }
+    loki.write "grafana_cloud_loki" {
+      endpoint {
+        url = nonsensitive(remote.kubernetes.secret.logs_service.data["host"]) + "/loki/api/v1/push"
+        tenant_id = nonsensitive(remote.kubernetes.secret.logs_service.data["tenantId"])
+    
+        basic_auth {
+          username = nonsensitive(remote.kubernetes.secret.logs_service.data["username"])
+          password = remote.kubernetes.secret.logs_service.data["password"]
+        }
+      }
+      external_labels = {
+        cluster = "custom-scrape-intervals-test",
       }
     }
 ---

--- a/scripts/lint-configs.sh
+++ b/scripts/lint-configs.sh
@@ -9,8 +9,23 @@ usage() {
 export AGENT_MODE=flow
 for file in "$@";
 do
+  # Skip missing or empty files
+  if [ ! -s "${file}" ]; then
+    continue
+  fi
+
   echo "Linting Agent config in ${file}...";
+
+  # Use the fmt action to validate the config file's river format
   if ! grafana-agent fmt "${file}" > /dev/null; then
+    exit 1
+  fi
+
+  # Attempt to run with the config file.
+  # A "successful" attempt will fail because we're not running in Kubernetes
+  output=$(grafana-agent run "${file}" 2>&1)
+  if ! echo "${output}" | grep "KUBERNETES_SERVICE_HOST and KUBERNETES_SERVICE_PORT must be defined" >/dev/null; then
+    echo "${output}"
     exit 1
   fi
 done


### PR DESCRIPTION
This should make it so the log processor is available in the metrics agent if and only if `logs.enabled=true` and if the receivers are enabled.

Also, improve the lint-config script so it actually tries to run the config file, which will find broken component references in the config file.

Finally, improve the cluster creation script to optionally be able to deploy the k8s-mon chart if you pass a values file to it.