### PR TITLE
Allow for option to get cadvisor and kubelet metrics directly from the node, rather than the proxy

### DIFF
--- a/charts/k8s-monitoring/README.md
+++ b/charts/k8s-monitoring/README.md
@@ -233,6 +233,7 @@ The Prometheus and Loki services may be hosted on the same cluster, or remotely 
 | metrics.cadvisor.metricsTuning.keepPhysicalNetworkDevices | list | `["en[ospx][0-9].*","wlan[0-9].*","eth[0-9].*"]` | Only keep network metrics that use the following physical devices |
 | metrics.cadvisor.metricsTuning.normalizeUnnecessaryLabels | list | `[{"labels":["boot_id","system_uuid"],"metric":"machine_memory_bytes"}]` | Normalize labels to the same value for the given metric and label pairs |
 | metrics.cadvisor.metricsTuning.useDefaultAllowList | bool | `true` | Filter the list of metrics from cAdvisor to the minimal set required for Kubernetes Monitoring. See [Allow List for cAdvisor](#allow-list-for-cadvisor) |
+| metrics.cadvisor.nodeAddressFormat | string | `"direct"` | How to access the node services, either direct (use node IP, requires nodes/metrics) or via proxy (requires nodes/proxy) |
 | metrics.cadvisor.scrapeInterval | string | 60s | How frequently to scrape metrics from cAdvisor. Overrides metrics.scrapeInterval |
 | metrics.cost.enabled | bool | `true` | Scrape cost metrics from OpenCost |
 | metrics.cost.extraMetricRelabelingRules | string | `""` | Rule blocks to be added to the prometheus.relabel component for OpenCost. See https://grafana.com/docs/agent/latest/flow/reference/components/prometheus.relabel/#rule-block |
@@ -282,6 +283,7 @@ The Prometheus and Loki services may be hosted on the same cluster, or remotely 
 | metrics.kubelet.metricsTuning.excludeMetrics | list | `[]` | Metrics to drop. Can use regex. |
 | metrics.kubelet.metricsTuning.includeMetrics | list | `[]` | Metrics to keep. Can use regex. |
 | metrics.kubelet.metricsTuning.useDefaultAllowList | bool | `true` | Filter the list of metrics from the Kubelet to the minimal set required for Kubernetes Monitoring. See [Allow List for Kubelet](#allow-list-for-kubelet) |
+| metrics.kubelet.nodeAddressFormat | string | `"direct"` | How to access the node services, either direct (use node IP, requires nodes/metrics) or via proxy (requires nodes/proxy) |
 | metrics.kubelet.scrapeInterval | string | 60s | How frequently to scrape metrics from the Kubelet. Overrides metrics.scrapeInterval |
 | metrics.kubernetesMonitoring.enabled | bool | `true` | Report telemetry about this Kubernetes Monitoring chart as a metric. |
 | metrics.node-exporter.enabled | bool | `true` | Scrape node metrics |

--- a/charts/k8s-monitoring/ci/ci-2-values.yaml
+++ b/charts/k8s-monitoring/ci/ci-2-values.yaml
@@ -2,6 +2,7 @@
 # This values file will test the following features:
 # * Sending metrics via OTLP HTTP
 # * Sending traces via OTLP HTTP
+# * Access kubelet and cadvisor metrics using the proxy
 # * Filtering pod logs by namespace
 # * Custom test queries, including LogQL and TraceQL queries
 #
@@ -36,6 +37,11 @@ externalServices:
       insecure_skip_verify = true
 
 metrics:
+  kubelet:
+    nodeAddressFormat: proxy
+  cadvisor:
+    nodeAddressFormat: proxy
+
   cost:
     enabled: false
 

--- a/charts/k8s-monitoring/schema-mods/enums-and-types.json
+++ b/charts/k8s-monitoring/schema-mods/enums-and-types.json
@@ -90,6 +90,9 @@
         },
         "cadvisor": {
           "properties": {
+            "nodeAddressFormat": {
+              "enum": ["direct", "proxy"]
+            },
             "metricsTuning": {
               "properties": {
                 "excludeMetrics": {"items": {"type": "string"}},
@@ -150,6 +153,9 @@
         },
         "kubelet": {
           "properties": {
+            "nodeAddressFormat": {
+              "enum": ["direct", "proxy"]
+            },
             "metricsTuning": {
               "properties": {
                 "excludeMetrics": {"items": {"type": "string"}},

--- a/charts/k8s-monitoring/templates/agent_config/_cadvisor.river.txt
+++ b/charts/k8s-monitoring/templates/agent_config/_cadvisor.river.txt
@@ -11,6 +11,7 @@
 // cAdvisor
 discovery.relabel "cadvisor" {
   targets = discovery.kubernetes.nodes.targets
+{{- if eq .Values.metrics.cadvisor.nodeAddressFormat "proxy" }}
   rule {
     target_label = "__address__"
     replacement  = "{{ .Values.cluster.kubernetesAPIService }}"
@@ -21,6 +22,7 @@ discovery.relabel "cadvisor" {
     replacement   = "/api/v1/nodes/${1}/proxy/metrics/cadvisor"
     target_label  = "__metrics_path__"
   }
+{{- end }}
 {{- if .Values.metrics.extraRelabelingRules }}
 {{ .Values.metrics.extraRelabelingRules | indent 2 }}
 {{- end }}

--- a/charts/k8s-monitoring/templates/agent_config/_cadvisor.river.txt
+++ b/charts/k8s-monitoring/templates/agent_config/_cadvisor.river.txt
@@ -22,6 +22,11 @@ discovery.relabel "cadvisor" {
     replacement   = "/api/v1/nodes/${1}/proxy/metrics/cadvisor"
     target_label  = "__metrics_path__"
   }
+{{ else if eq .Values.metrics.cadvisor.nodeAddressFormat "direct" }}
+  rule {
+    replacement   = "/metrics/cadvisor"
+    target_label  = "__metrics_path__"
+  }
 {{- end }}
 {{- if .Values.metrics.extraRelabelingRules }}
 {{ .Values.metrics.extraRelabelingRules | indent 2 }}

--- a/charts/k8s-monitoring/templates/agent_config/_kubelet.river.txt
+++ b/charts/k8s-monitoring/templates/agent_config/_kubelet.river.txt
@@ -11,6 +11,7 @@
 // Kubelet
 discovery.relabel "kubelet" {
   targets = discovery.kubernetes.nodes.targets
+{{- if eq .Values.metrics.kubelet.nodeAddressFormat "proxy" }}
   rule {
     target_label = "__address__"
     replacement  = "{{ .Values.cluster.kubernetesAPIService }}"
@@ -21,6 +22,7 @@ discovery.relabel "kubelet" {
     replacement   = "/api/v1/nodes/${1}/proxy/metrics"
     target_label  = "__metrics_path__"
   }
+{{- end }}
 {{- if .Values.metrics.extraRelabelingRules }}
 {{ .Values.metrics.extraRelabelingRules | indent 2 }}
 {{- end }}

--- a/charts/k8s-monitoring/values.schema.json
+++ b/charts/k8s-monitoring/values.schema.json
@@ -411,6 +411,19 @@
                             "type": "array"
                         }
                     }
+                },
+                "receiver": {
+                    "type": "object",
+                    "properties": {
+                        "filters": {
+                            "type": "object",
+                            "properties": {
+                                "log_record": {
+                                    "type": "array"
+                                }
+                            }
+                        }
+                    }
                 }
             }
         },
@@ -622,6 +635,13 @@
                                     "type": "boolean"
                                 }
                             }
+                        },
+                        "nodeAddressFormat": {
+                            "type": "string",
+                            "enum": [
+                                "direct",
+                                "proxy"
+                            ]
                         },
                         "scrapeInterval": {
                             "type": "string"
@@ -881,6 +901,13 @@
                                 }
                             }
                         },
+                        "nodeAddressFormat": {
+                            "type": "string",
+                            "enum": [
+                                "direct",
+                                "proxy"
+                            ]
+                        },
                         "scrapeInterval": {
                             "type": "string"
                         }
@@ -990,6 +1017,22 @@
                         }
                     }
                 },
+                "receiver": {
+                    "type": "object",
+                    "properties": {
+                        "filters": {
+                            "type": "object",
+                            "properties": {
+                                "datapoint": {
+                                    "type": "array"
+                                },
+                                "metric": {
+                                    "type": "array"
+                                }
+                            }
+                        }
+                    }
+                },
                 "scrapeInterval": {
                     "type": "string"
                 },
@@ -1068,6 +1111,49 @@
         "prometheus-node-exporter": {
             "type": "object",
             "properties": {
+                "affinity": {
+                    "type": "object",
+                    "properties": {
+                        "nodeAffinity": {
+                            "type": "object",
+                            "properties": {
+                                "requiredDuringSchedulingIgnoredDuringExecution": {
+                                    "type": "object",
+                                    "properties": {
+                                        "nodeSelectorTerms": {
+                                            "type": "array",
+                                            "items": {
+                                                "type": "object",
+                                                "properties": {
+                                                    "matchExpressions": {
+                                                        "type": "array",
+                                                        "items": {
+                                                            "type": "object",
+                                                            "properties": {
+                                                                "key": {
+                                                                    "type": "string"
+                                                                },
+                                                                "operator": {
+                                                                    "type": "string"
+                                                                },
+                                                                "values": {
+                                                                    "type": "array",
+                                                                    "items": {
+                                                                        "type": "string"
+                                                                    }
+                                                                }
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
                 "enabled": {
                     "type": "boolean"
                 }
@@ -1117,6 +1203,25 @@
                         },
                         "port": {
                             "type": "integer"
+                        }
+                    }
+                },
+                "processors": {
+                    "type": "object",
+                    "properties": {
+                        "batch": {
+                            "type": "object",
+                            "properties": {
+                                "maxSize": {
+                                    "type": "integer"
+                                },
+                                "size": {
+                                    "type": "integer"
+                                },
+                                "timeout": {
+                                    "type": "string"
+                                }
+                            }
                         }
                     }
                 },
@@ -1212,20 +1317,17 @@
                 "enabled": {
                     "type": "boolean"
                 },
-                "processors": {
+                "receiver": {
                     "type": "object",
                     "properties": {
-                        "batch": {
+                        "filters": {
                             "type": "object",
                             "properties": {
-                                "maxSize": {
-                                    "type": "integer"
+                                "span": {
+                                    "type": "array"
                                 },
-                                "size": {
-                                    "type": "integer"
-                                },
-                                "timeout": {
-                                    "type": "string"
+                                "spanevent": {
+                                    "type": "array"
                                 }
                             }
                         }

--- a/charts/k8s-monitoring/values.yaml
+++ b/charts/k8s-monitoring/values.yaml
@@ -405,6 +405,9 @@ metrics:
     # -- Scrape cluster metrics from the Kubelet
     enabled: true
 
+    # -- How to access the node services, either direct (use node IP, requires nodes/metrics) or via proxy (requires nodes/proxy)
+    nodeAddressFormat: direct
+
     # -- How frequently to scrape metrics from the Kubelet.
     # Overrides metrics.scrapeInterval
     # @default -- 60s
@@ -432,6 +435,9 @@ metrics:
   cadvisor:
     # -- Scrape container metrics from cAdvisor
     enabled: true
+
+    # -- How to access the node services, either direct (use node IP, requires nodes/metrics) or via proxy (requires nodes/proxy)
+    nodeAddressFormat: direct
 
     # -- How frequently to scrape metrics from cAdvisor.
     # Overrides metrics.scrapeInterval

--- a/examples/cluster-with-pvc/metrics.river
+++ b/examples/cluster-with-pvc/metrics.river
@@ -384,16 +384,6 @@ prometheus.relabel "kubernetes_monitoring_telemetry" {
 // Kubelet
 discovery.relabel "kubelet" {
   targets = discovery.kubernetes.nodes.targets
-  rule {
-    target_label = "__address__"
-    replacement  = "kubernetes.default.svc.cluster.local:443"
-  }
-  rule {
-    source_labels = ["__meta_kubernetes_node_name"]
-    regex         = "(.+)"
-    replacement   = "/api/v1/nodes/${1}/proxy/metrics"
-    target_label  = "__metrics_path__"
-  }
 }
 
 prometheus.scrape "kubelet" {
@@ -423,16 +413,6 @@ prometheus.relabel "kubelet" {
 // cAdvisor
 discovery.relabel "cadvisor" {
   targets = discovery.kubernetes.nodes.targets
-  rule {
-    target_label = "__address__"
-    replacement  = "kubernetes.default.svc.cluster.local:443"
-  }
-  rule {
-    source_labels = ["__meta_kubernetes_node_name"]
-    regex         = "(.+)"
-    replacement   = "/api/v1/nodes/${1}/proxy/metrics/cadvisor"
-    target_label  = "__metrics_path__"
-  }
 }
 
 prometheus.scrape "cadvisor" {

--- a/examples/cluster-with-pvc/metrics.river
+++ b/examples/cluster-with-pvc/metrics.river
@@ -413,6 +413,10 @@ prometheus.relabel "kubelet" {
 // cAdvisor
 discovery.relabel "cadvisor" {
   targets = discovery.kubernetes.nodes.targets
+  rule {
+    replacement   = "/metrics/cadvisor"
+    target_label  = "__metrics_path__"
+  }
 }
 
 prometheus.scrape "cadvisor" {

--- a/examples/cluster-with-pvc/output.yaml
+++ b/examples/cluster-with-pvc/output.yaml
@@ -534,6 +534,10 @@ data:
     // cAdvisor
     discovery.relabel "cadvisor" {
       targets = discovery.kubernetes.nodes.targets
+      rule {
+        replacement   = "/metrics/cadvisor"
+        target_label  = "__metrics_path__"
+      }
     }
     
     prometheus.scrape "cadvisor" {
@@ -45312,6 +45316,10 @@ data:
     // cAdvisor
     discovery.relabel "cadvisor" {
       targets = discovery.kubernetes.nodes.targets
+      rule {
+        replacement   = "/metrics/cadvisor"
+        target_label  = "__metrics_path__"
+      }
     }
     
     prometheus.scrape "cadvisor" {

--- a/examples/cluster-with-pvc/output.yaml
+++ b/examples/cluster-with-pvc/output.yaml
@@ -505,16 +505,6 @@ data:
     // Kubelet
     discovery.relabel "kubelet" {
       targets = discovery.kubernetes.nodes.targets
-      rule {
-        target_label = "__address__"
-        replacement  = "kubernetes.default.svc.cluster.local:443"
-      }
-      rule {
-        source_labels = ["__meta_kubernetes_node_name"]
-        regex         = "(.+)"
-        replacement   = "/api/v1/nodes/${1}/proxy/metrics"
-        target_label  = "__metrics_path__"
-      }
     }
     
     prometheus.scrape "kubelet" {
@@ -544,16 +534,6 @@ data:
     // cAdvisor
     discovery.relabel "cadvisor" {
       targets = discovery.kubernetes.nodes.targets
-      rule {
-        target_label = "__address__"
-        replacement  = "kubernetes.default.svc.cluster.local:443"
-      }
-      rule {
-        source_labels = ["__meta_kubernetes_node_name"]
-        regex         = "(.+)"
-        replacement   = "/api/v1/nodes/${1}/proxy/metrics/cadvisor"
-        target_label  = "__metrics_path__"
-      }
     }
     
     prometheus.scrape "cadvisor" {
@@ -45303,16 +45283,6 @@ data:
     // Kubelet
     discovery.relabel "kubelet" {
       targets = discovery.kubernetes.nodes.targets
-      rule {
-        target_label = "__address__"
-        replacement  = "kubernetes.default.svc.cluster.local:443"
-      }
-      rule {
-        source_labels = ["__meta_kubernetes_node_name"]
-        regex         = "(.+)"
-        replacement   = "/api/v1/nodes/${1}/proxy/metrics"
-        target_label  = "__metrics_path__"
-      }
     }
     
     prometheus.scrape "kubelet" {
@@ -45342,16 +45312,6 @@ data:
     // cAdvisor
     discovery.relabel "cadvisor" {
       targets = discovery.kubernetes.nodes.targets
-      rule {
-        target_label = "__address__"
-        replacement  = "kubernetes.default.svc.cluster.local:443"
-      }
-      rule {
-        source_labels = ["__meta_kubernetes_node_name"]
-        regex         = "(.+)"
-        replacement   = "/api/v1/nodes/${1}/proxy/metrics/cadvisor"
-        target_label  = "__metrics_path__"
-      }
     }
     
     prometheus.scrape "cadvisor" {

--- a/examples/control-plane-metrics/metrics.river
+++ b/examples/control-plane-metrics/metrics.river
@@ -384,16 +384,6 @@ prometheus.relabel "kubernetes_monitoring_telemetry" {
 // Kubelet
 discovery.relabel "kubelet" {
   targets = discovery.kubernetes.nodes.targets
-  rule {
-    target_label = "__address__"
-    replacement  = "kubernetes.default.svc.cluster.local:443"
-  }
-  rule {
-    source_labels = ["__meta_kubernetes_node_name"]
-    regex         = "(.+)"
-    replacement   = "/api/v1/nodes/${1}/proxy/metrics"
-    target_label  = "__metrics_path__"
-  }
 }
 
 prometheus.scrape "kubelet" {
@@ -423,16 +413,6 @@ prometheus.relabel "kubelet" {
 // cAdvisor
 discovery.relabel "cadvisor" {
   targets = discovery.kubernetes.nodes.targets
-  rule {
-    target_label = "__address__"
-    replacement  = "kubernetes.default.svc.cluster.local:443"
-  }
-  rule {
-    source_labels = ["__meta_kubernetes_node_name"]
-    regex         = "(.+)"
-    replacement   = "/api/v1/nodes/${1}/proxy/metrics/cadvisor"
-    target_label  = "__metrics_path__"
-  }
 }
 
 prometheus.scrape "cadvisor" {

--- a/examples/control-plane-metrics/metrics.river
+++ b/examples/control-plane-metrics/metrics.river
@@ -413,6 +413,10 @@ prometheus.relabel "kubelet" {
 // cAdvisor
 discovery.relabel "cadvisor" {
   targets = discovery.kubernetes.nodes.targets
+  rule {
+    replacement   = "/metrics/cadvisor"
+    target_label  = "__metrics_path__"
+  }
 }
 
 prometheus.scrape "cadvisor" {

--- a/examples/control-plane-metrics/output.yaml
+++ b/examples/control-plane-metrics/output.yaml
@@ -535,6 +535,10 @@ data:
     // cAdvisor
     discovery.relabel "cadvisor" {
       targets = discovery.kubernetes.nodes.targets
+      rule {
+        replacement   = "/metrics/cadvisor"
+        target_label  = "__metrics_path__"
+      }
     }
     
     prometheus.scrape "cadvisor" {
@@ -45410,6 +45414,10 @@ data:
     // cAdvisor
     discovery.relabel "cadvisor" {
       targets = discovery.kubernetes.nodes.targets
+      rule {
+        replacement   = "/metrics/cadvisor"
+        target_label  = "__metrics_path__"
+      }
     }
     
     prometheus.scrape "cadvisor" {

--- a/examples/control-plane-metrics/output.yaml
+++ b/examples/control-plane-metrics/output.yaml
@@ -506,16 +506,6 @@ data:
     // Kubelet
     discovery.relabel "kubelet" {
       targets = discovery.kubernetes.nodes.targets
-      rule {
-        target_label = "__address__"
-        replacement  = "kubernetes.default.svc.cluster.local:443"
-      }
-      rule {
-        source_labels = ["__meta_kubernetes_node_name"]
-        regex         = "(.+)"
-        replacement   = "/api/v1/nodes/${1}/proxy/metrics"
-        target_label  = "__metrics_path__"
-      }
     }
     
     prometheus.scrape "kubelet" {
@@ -545,16 +535,6 @@ data:
     // cAdvisor
     discovery.relabel "cadvisor" {
       targets = discovery.kubernetes.nodes.targets
-      rule {
-        target_label = "__address__"
-        replacement  = "kubernetes.default.svc.cluster.local:443"
-      }
-      rule {
-        source_labels = ["__meta_kubernetes_node_name"]
-        regex         = "(.+)"
-        replacement   = "/api/v1/nodes/${1}/proxy/metrics/cadvisor"
-        target_label  = "__metrics_path__"
-      }
     }
     
     prometheus.scrape "cadvisor" {
@@ -45401,16 +45381,6 @@ data:
     // Kubelet
     discovery.relabel "kubelet" {
       targets = discovery.kubernetes.nodes.targets
-      rule {
-        target_label = "__address__"
-        replacement  = "kubernetes.default.svc.cluster.local:443"
-      }
-      rule {
-        source_labels = ["__meta_kubernetes_node_name"]
-        regex         = "(.+)"
-        replacement   = "/api/v1/nodes/${1}/proxy/metrics"
-        target_label  = "__metrics_path__"
-      }
     }
     
     prometheus.scrape "kubelet" {
@@ -45440,16 +45410,6 @@ data:
     // cAdvisor
     discovery.relabel "cadvisor" {
       targets = discovery.kubernetes.nodes.targets
-      rule {
-        target_label = "__address__"
-        replacement  = "kubernetes.default.svc.cluster.local:443"
-      }
-      rule {
-        source_labels = ["__meta_kubernetes_node_name"]
-        regex         = "(.+)"
-        replacement   = "/api/v1/nodes/${1}/proxy/metrics/cadvisor"
-        target_label  = "__metrics_path__"
-      }
     }
     
     prometheus.scrape "cadvisor" {

--- a/examples/custom-config/metrics.river
+++ b/examples/custom-config/metrics.river
@@ -384,16 +384,6 @@ prometheus.relabel "kubernetes_monitoring_telemetry" {
 // Kubelet
 discovery.relabel "kubelet" {
   targets = discovery.kubernetes.nodes.targets
-  rule {
-    target_label = "__address__"
-    replacement  = "kubernetes.default.svc.cluster.local:443"
-  }
-  rule {
-    source_labels = ["__meta_kubernetes_node_name"]
-    regex         = "(.+)"
-    replacement   = "/api/v1/nodes/${1}/proxy/metrics"
-    target_label  = "__metrics_path__"
-  }
 }
 
 prometheus.scrape "kubelet" {
@@ -423,16 +413,6 @@ prometheus.relabel "kubelet" {
 // cAdvisor
 discovery.relabel "cadvisor" {
   targets = discovery.kubernetes.nodes.targets
-  rule {
-    target_label = "__address__"
-    replacement  = "kubernetes.default.svc.cluster.local:443"
-  }
-  rule {
-    source_labels = ["__meta_kubernetes_node_name"]
-    regex         = "(.+)"
-    replacement   = "/api/v1/nodes/${1}/proxy/metrics/cadvisor"
-    target_label  = "__metrics_path__"
-  }
 }
 
 prometheus.scrape "cadvisor" {

--- a/examples/custom-config/metrics.river
+++ b/examples/custom-config/metrics.river
@@ -413,6 +413,10 @@ prometheus.relabel "kubelet" {
 // cAdvisor
 discovery.relabel "cadvisor" {
   targets = discovery.kubernetes.nodes.targets
+  rule {
+    replacement   = "/metrics/cadvisor"
+    target_label  = "__metrics_path__"
+  }
 }
 
 prometheus.scrape "cadvisor" {

--- a/examples/custom-config/output.yaml
+++ b/examples/custom-config/output.yaml
@@ -534,6 +534,10 @@ data:
     // cAdvisor
     discovery.relabel "cadvisor" {
       targets = discovery.kubernetes.nodes.targets
+      rule {
+        replacement   = "/metrics/cadvisor"
+        target_label  = "__metrics_path__"
+      }
     }
     
     prometheus.scrape "cadvisor" {
@@ -45320,6 +45324,10 @@ data:
     // cAdvisor
     discovery.relabel "cadvisor" {
       targets = discovery.kubernetes.nodes.targets
+      rule {
+        replacement   = "/metrics/cadvisor"
+        target_label  = "__metrics_path__"
+      }
     }
     
     prometheus.scrape "cadvisor" {

--- a/examples/custom-config/output.yaml
+++ b/examples/custom-config/output.yaml
@@ -505,16 +505,6 @@ data:
     // Kubelet
     discovery.relabel "kubelet" {
       targets = discovery.kubernetes.nodes.targets
-      rule {
-        target_label = "__address__"
-        replacement  = "kubernetes.default.svc.cluster.local:443"
-      }
-      rule {
-        source_labels = ["__meta_kubernetes_node_name"]
-        regex         = "(.+)"
-        replacement   = "/api/v1/nodes/${1}/proxy/metrics"
-        target_label  = "__metrics_path__"
-      }
     }
     
     prometheus.scrape "kubelet" {
@@ -544,16 +534,6 @@ data:
     // cAdvisor
     discovery.relabel "cadvisor" {
       targets = discovery.kubernetes.nodes.targets
-      rule {
-        target_label = "__address__"
-        replacement  = "kubernetes.default.svc.cluster.local:443"
-      }
-      rule {
-        source_labels = ["__meta_kubernetes_node_name"]
-        regex         = "(.+)"
-        replacement   = "/api/v1/nodes/${1}/proxy/metrics/cadvisor"
-        target_label  = "__metrics_path__"
-      }
     }
     
     prometheus.scrape "cadvisor" {
@@ -45311,16 +45291,6 @@ data:
     // Kubelet
     discovery.relabel "kubelet" {
       targets = discovery.kubernetes.nodes.targets
-      rule {
-        target_label = "__address__"
-        replacement  = "kubernetes.default.svc.cluster.local:443"
-      }
-      rule {
-        source_labels = ["__meta_kubernetes_node_name"]
-        regex         = "(.+)"
-        replacement   = "/api/v1/nodes/${1}/proxy/metrics"
-        target_label  = "__metrics_path__"
-      }
     }
     
     prometheus.scrape "kubelet" {
@@ -45350,16 +45320,6 @@ data:
     // cAdvisor
     discovery.relabel "cadvisor" {
       targets = discovery.kubernetes.nodes.targets
-      rule {
-        target_label = "__address__"
-        replacement  = "kubernetes.default.svc.cluster.local:443"
-      }
-      rule {
-        source_labels = ["__meta_kubernetes_node_name"]
-        regex         = "(.+)"
-        replacement   = "/api/v1/nodes/${1}/proxy/metrics/cadvisor"
-        target_label  = "__metrics_path__"
-      }
     }
     
     prometheus.scrape "cadvisor" {

--- a/examples/custom-metrics-tuning/metrics.river
+++ b/examples/custom-metrics-tuning/metrics.river
@@ -384,16 +384,6 @@ prometheus.relabel "kubernetes_monitoring_telemetry" {
 // Kubelet
 discovery.relabel "kubelet" {
   targets = discovery.kubernetes.nodes.targets
-  rule {
-    target_label = "__address__"
-    replacement  = "kubernetes.default.svc.cluster.local:443"
-  }
-  rule {
-    source_labels = ["__meta_kubernetes_node_name"]
-    regex         = "(.+)"
-    replacement   = "/api/v1/nodes/${1}/proxy/metrics"
-    target_label  = "__metrics_path__"
-  }
 }
 
 prometheus.scrape "kubelet" {
@@ -423,16 +413,6 @@ prometheus.relabel "kubelet" {
 // cAdvisor
 discovery.relabel "cadvisor" {
   targets = discovery.kubernetes.nodes.targets
-  rule {
-    target_label = "__address__"
-    replacement  = "kubernetes.default.svc.cluster.local:443"
-  }
-  rule {
-    source_labels = ["__meta_kubernetes_node_name"]
-    regex         = "(.+)"
-    replacement   = "/api/v1/nodes/${1}/proxy/metrics/cadvisor"
-    target_label  = "__metrics_path__"
-  }
 }
 
 prometheus.scrape "cadvisor" {

--- a/examples/custom-metrics-tuning/metrics.river
+++ b/examples/custom-metrics-tuning/metrics.river
@@ -413,6 +413,10 @@ prometheus.relabel "kubelet" {
 // cAdvisor
 discovery.relabel "cadvisor" {
   targets = discovery.kubernetes.nodes.targets
+  rule {
+    replacement   = "/metrics/cadvisor"
+    target_label  = "__metrics_path__"
+  }
 }
 
 prometheus.scrape "cadvisor" {

--- a/examples/custom-metrics-tuning/output.yaml
+++ b/examples/custom-metrics-tuning/output.yaml
@@ -493,6 +493,10 @@ data:
     // cAdvisor
     discovery.relabel "cadvisor" {
       targets = discovery.kubernetes.nodes.targets
+      rule {
+        replacement   = "/metrics/cadvisor"
+        target_label  = "__metrics_path__"
+      }
     }
     
     prometheus.scrape "cadvisor" {
@@ -44558,6 +44562,10 @@ data:
     // cAdvisor
     discovery.relabel "cadvisor" {
       targets = discovery.kubernetes.nodes.targets
+      rule {
+        replacement   = "/metrics/cadvisor"
+        target_label  = "__metrics_path__"
+      }
     }
     
     prometheus.scrape "cadvisor" {

--- a/examples/custom-metrics-tuning/output.yaml
+++ b/examples/custom-metrics-tuning/output.yaml
@@ -464,16 +464,6 @@ data:
     // Kubelet
     discovery.relabel "kubelet" {
       targets = discovery.kubernetes.nodes.targets
-      rule {
-        target_label = "__address__"
-        replacement  = "kubernetes.default.svc.cluster.local:443"
-      }
-      rule {
-        source_labels = ["__meta_kubernetes_node_name"]
-        regex         = "(.+)"
-        replacement   = "/api/v1/nodes/${1}/proxy/metrics"
-        target_label  = "__metrics_path__"
-      }
     }
     
     prometheus.scrape "kubelet" {
@@ -503,16 +493,6 @@ data:
     // cAdvisor
     discovery.relabel "cadvisor" {
       targets = discovery.kubernetes.nodes.targets
-      rule {
-        target_label = "__address__"
-        replacement  = "kubernetes.default.svc.cluster.local:443"
-      }
-      rule {
-        source_labels = ["__meta_kubernetes_node_name"]
-        regex         = "(.+)"
-        replacement   = "/api/v1/nodes/${1}/proxy/metrics/cadvisor"
-        target_label  = "__metrics_path__"
-      }
     }
     
     prometheus.scrape "cadvisor" {
@@ -44549,16 +44529,6 @@ data:
     // Kubelet
     discovery.relabel "kubelet" {
       targets = discovery.kubernetes.nodes.targets
-      rule {
-        target_label = "__address__"
-        replacement  = "kubernetes.default.svc.cluster.local:443"
-      }
-      rule {
-        source_labels = ["__meta_kubernetes_node_name"]
-        regex         = "(.+)"
-        replacement   = "/api/v1/nodes/${1}/proxy/metrics"
-        target_label  = "__metrics_path__"
-      }
     }
     
     prometheus.scrape "kubelet" {
@@ -44588,16 +44558,6 @@ data:
     // cAdvisor
     discovery.relabel "cadvisor" {
       targets = discovery.kubernetes.nodes.targets
-      rule {
-        target_label = "__address__"
-        replacement  = "kubernetes.default.svc.cluster.local:443"
-      }
-      rule {
-        source_labels = ["__meta_kubernetes_node_name"]
-        regex         = "(.+)"
-        replacement   = "/api/v1/nodes/${1}/proxy/metrics/cadvisor"
-        target_label  = "__metrics_path__"
-      }
     }
     
     prometheus.scrape "cadvisor" {

--- a/examples/default-values/metrics.river
+++ b/examples/default-values/metrics.river
@@ -384,16 +384,6 @@ prometheus.relabel "kubernetes_monitoring_telemetry" {
 // Kubelet
 discovery.relabel "kubelet" {
   targets = discovery.kubernetes.nodes.targets
-  rule {
-    target_label = "__address__"
-    replacement  = "kubernetes.default.svc.cluster.local:443"
-  }
-  rule {
-    source_labels = ["__meta_kubernetes_node_name"]
-    regex         = "(.+)"
-    replacement   = "/api/v1/nodes/${1}/proxy/metrics"
-    target_label  = "__metrics_path__"
-  }
 }
 
 prometheus.scrape "kubelet" {
@@ -423,16 +413,6 @@ prometheus.relabel "kubelet" {
 // cAdvisor
 discovery.relabel "cadvisor" {
   targets = discovery.kubernetes.nodes.targets
-  rule {
-    target_label = "__address__"
-    replacement  = "kubernetes.default.svc.cluster.local:443"
-  }
-  rule {
-    source_labels = ["__meta_kubernetes_node_name"]
-    regex         = "(.+)"
-    replacement   = "/api/v1/nodes/${1}/proxy/metrics/cadvisor"
-    target_label  = "__metrics_path__"
-  }
 }
 
 prometheus.scrape "cadvisor" {

--- a/examples/default-values/metrics.river
+++ b/examples/default-values/metrics.river
@@ -413,6 +413,10 @@ prometheus.relabel "kubelet" {
 // cAdvisor
 discovery.relabel "cadvisor" {
   targets = discovery.kubernetes.nodes.targets
+  rule {
+    replacement   = "/metrics/cadvisor"
+    target_label  = "__metrics_path__"
+  }
 }
 
 prometheus.scrape "cadvisor" {

--- a/examples/default-values/output.yaml
+++ b/examples/default-values/output.yaml
@@ -534,6 +534,10 @@ data:
     // cAdvisor
     discovery.relabel "cadvisor" {
       targets = discovery.kubernetes.nodes.targets
+      rule {
+        replacement   = "/metrics/cadvisor"
+        target_label  = "__metrics_path__"
+      }
     }
     
     prometheus.scrape "cadvisor" {
@@ -45257,6 +45261,10 @@ data:
     // cAdvisor
     discovery.relabel "cadvisor" {
       targets = discovery.kubernetes.nodes.targets
+      rule {
+        replacement   = "/metrics/cadvisor"
+        target_label  = "__metrics_path__"
+      }
     }
     
     prometheus.scrape "cadvisor" {

--- a/examples/default-values/output.yaml
+++ b/examples/default-values/output.yaml
@@ -505,16 +505,6 @@ data:
     // Kubelet
     discovery.relabel "kubelet" {
       targets = discovery.kubernetes.nodes.targets
-      rule {
-        target_label = "__address__"
-        replacement  = "kubernetes.default.svc.cluster.local:443"
-      }
-      rule {
-        source_labels = ["__meta_kubernetes_node_name"]
-        regex         = "(.+)"
-        replacement   = "/api/v1/nodes/${1}/proxy/metrics"
-        target_label  = "__metrics_path__"
-      }
     }
     
     prometheus.scrape "kubelet" {
@@ -544,16 +534,6 @@ data:
     // cAdvisor
     discovery.relabel "cadvisor" {
       targets = discovery.kubernetes.nodes.targets
-      rule {
-        target_label = "__address__"
-        replacement  = "kubernetes.default.svc.cluster.local:443"
-      }
-      rule {
-        source_labels = ["__meta_kubernetes_node_name"]
-        regex         = "(.+)"
-        replacement   = "/api/v1/nodes/${1}/proxy/metrics/cadvisor"
-        target_label  = "__metrics_path__"
-      }
     }
     
     prometheus.scrape "cadvisor" {
@@ -45248,16 +45228,6 @@ data:
     // Kubelet
     discovery.relabel "kubelet" {
       targets = discovery.kubernetes.nodes.targets
-      rule {
-        target_label = "__address__"
-        replacement  = "kubernetes.default.svc.cluster.local:443"
-      }
-      rule {
-        source_labels = ["__meta_kubernetes_node_name"]
-        regex         = "(.+)"
-        replacement   = "/api/v1/nodes/${1}/proxy/metrics"
-        target_label  = "__metrics_path__"
-      }
     }
     
     prometheus.scrape "kubelet" {
@@ -45287,16 +45257,6 @@ data:
     // cAdvisor
     discovery.relabel "cadvisor" {
       targets = discovery.kubernetes.nodes.targets
-      rule {
-        target_label = "__address__"
-        replacement  = "kubernetes.default.svc.cluster.local:443"
-      }
-      rule {
-        source_labels = ["__meta_kubernetes_node_name"]
-        regex         = "(.+)"
-        replacement   = "/api/v1/nodes/${1}/proxy/metrics/cadvisor"
-        target_label  = "__metrics_path__"
-      }
     }
     
     prometheus.scrape "cadvisor" {

--- a/examples/eks-fargate/metrics.river
+++ b/examples/eks-fargate/metrics.river
@@ -384,16 +384,6 @@ prometheus.relabel "kubernetes_monitoring_telemetry" {
 // Kubelet
 discovery.relabel "kubelet" {
   targets = discovery.kubernetes.nodes.targets
-  rule {
-    target_label = "__address__"
-    replacement  = "kubernetes.default.svc.cluster.local:443"
-  }
-  rule {
-    source_labels = ["__meta_kubernetes_node_name"]
-    regex         = "(.+)"
-    replacement   = "/api/v1/nodes/${1}/proxy/metrics"
-    target_label  = "__metrics_path__"
-  }
 }
 
 prometheus.scrape "kubelet" {
@@ -423,16 +413,6 @@ prometheus.relabel "kubelet" {
 // cAdvisor
 discovery.relabel "cadvisor" {
   targets = discovery.kubernetes.nodes.targets
-  rule {
-    target_label = "__address__"
-    replacement  = "kubernetes.default.svc.cluster.local:443"
-  }
-  rule {
-    source_labels = ["__meta_kubernetes_node_name"]
-    regex         = "(.+)"
-    replacement   = "/api/v1/nodes/${1}/proxy/metrics/cadvisor"
-    target_label  = "__metrics_path__"
-  }
 }
 
 prometheus.scrape "cadvisor" {

--- a/examples/eks-fargate/metrics.river
+++ b/examples/eks-fargate/metrics.river
@@ -413,6 +413,10 @@ prometheus.relabel "kubelet" {
 // cAdvisor
 discovery.relabel "cadvisor" {
   targets = discovery.kubernetes.nodes.targets
+  rule {
+    replacement   = "/metrics/cadvisor"
+    target_label  = "__metrics_path__"
+  }
 }
 
 prometheus.scrape "cadvisor" {

--- a/examples/eks-fargate/output.yaml
+++ b/examples/eks-fargate/output.yaml
@@ -519,6 +519,10 @@ data:
     // cAdvisor
     discovery.relabel "cadvisor" {
       targets = discovery.kubernetes.nodes.targets
+      rule {
+        replacement   = "/metrics/cadvisor"
+        target_label  = "__metrics_path__"
+      }
     }
     
     prometheus.scrape "cadvisor" {
@@ -45030,6 +45034,10 @@ data:
     // cAdvisor
     discovery.relabel "cadvisor" {
       targets = discovery.kubernetes.nodes.targets
+      rule {
+        replacement   = "/metrics/cadvisor"
+        target_label  = "__metrics_path__"
+      }
     }
     
     prometheus.scrape "cadvisor" {

--- a/examples/eks-fargate/output.yaml
+++ b/examples/eks-fargate/output.yaml
@@ -490,16 +490,6 @@ data:
     // Kubelet
     discovery.relabel "kubelet" {
       targets = discovery.kubernetes.nodes.targets
-      rule {
-        target_label = "__address__"
-        replacement  = "kubernetes.default.svc.cluster.local:443"
-      }
-      rule {
-        source_labels = ["__meta_kubernetes_node_name"]
-        regex         = "(.+)"
-        replacement   = "/api/v1/nodes/${1}/proxy/metrics"
-        target_label  = "__metrics_path__"
-      }
     }
     
     prometheus.scrape "kubelet" {
@@ -529,16 +519,6 @@ data:
     // cAdvisor
     discovery.relabel "cadvisor" {
       targets = discovery.kubernetes.nodes.targets
-      rule {
-        target_label = "__address__"
-        replacement  = "kubernetes.default.svc.cluster.local:443"
-      }
-      rule {
-        source_labels = ["__meta_kubernetes_node_name"]
-        regex         = "(.+)"
-        replacement   = "/api/v1/nodes/${1}/proxy/metrics/cadvisor"
-        target_label  = "__metrics_path__"
-      }
     }
     
     prometheus.scrape "cadvisor" {
@@ -45021,16 +45001,6 @@ data:
     // Kubelet
     discovery.relabel "kubelet" {
       targets = discovery.kubernetes.nodes.targets
-      rule {
-        target_label = "__address__"
-        replacement  = "kubernetes.default.svc.cluster.local:443"
-      }
-      rule {
-        source_labels = ["__meta_kubernetes_node_name"]
-        regex         = "(.+)"
-        replacement   = "/api/v1/nodes/${1}/proxy/metrics"
-        target_label  = "__metrics_path__"
-      }
     }
     
     prometheus.scrape "kubelet" {
@@ -45060,16 +45030,6 @@ data:
     // cAdvisor
     discovery.relabel "cadvisor" {
       targets = discovery.kubernetes.nodes.targets
-      rule {
-        target_label = "__address__"
-        replacement  = "kubernetes.default.svc.cluster.local:443"
-      }
-      rule {
-        source_labels = ["__meta_kubernetes_node_name"]
-        regex         = "(.+)"
-        replacement   = "/api/v1/nodes/${1}/proxy/metrics/cadvisor"
-        target_label  = "__metrics_path__"
-      }
     }
     
     prometheus.scrape "cadvisor" {

--- a/examples/extra-rules/metrics.river
+++ b/examples/extra-rules/metrics.river
@@ -439,6 +439,10 @@ prometheus.relabel "kubelet" {
 discovery.relabel "cadvisor" {
   targets = discovery.kubernetes.nodes.targets
   rule {
+    replacement   = "/metrics/cadvisor"
+    target_label  = "__metrics_path__"
+  }
+  rule {
     source_labels = ["__meta_kubernetes_namespace"]
     regex = "private"
     action = "drop"

--- a/examples/extra-rules/metrics.river
+++ b/examples/extra-rules/metrics.river
@@ -400,16 +400,6 @@ prometheus.relabel "kubernetes_monitoring_telemetry" {
 discovery.relabel "kubelet" {
   targets = discovery.kubernetes.nodes.targets
   rule {
-    target_label = "__address__"
-    replacement  = "kubernetes.default.svc.cluster.local:443"
-  }
-  rule {
-    source_labels = ["__meta_kubernetes_node_name"]
-    regex         = "(.+)"
-    replacement   = "/api/v1/nodes/${1}/proxy/metrics"
-    target_label  = "__metrics_path__"
-  }
-  rule {
     source_labels = ["__meta_kubernetes_namespace"]
     regex = "private"
     action = "drop"
@@ -448,16 +438,6 @@ prometheus.relabel "kubelet" {
 // cAdvisor
 discovery.relabel "cadvisor" {
   targets = discovery.kubernetes.nodes.targets
-  rule {
-    target_label = "__address__"
-    replacement  = "kubernetes.default.svc.cluster.local:443"
-  }
-  rule {
-    source_labels = ["__meta_kubernetes_node_name"]
-    regex         = "(.+)"
-    replacement   = "/api/v1/nodes/${1}/proxy/metrics/cadvisor"
-    target_label  = "__metrics_path__"
-  }
   rule {
     source_labels = ["__meta_kubernetes_namespace"]
     regex = "private"

--- a/examples/extra-rules/output.yaml
+++ b/examples/extra-rules/output.yaml
@@ -522,16 +522,6 @@ data:
     discovery.relabel "kubelet" {
       targets = discovery.kubernetes.nodes.targets
       rule {
-        target_label = "__address__"
-        replacement  = "kubernetes.default.svc.cluster.local:443"
-      }
-      rule {
-        source_labels = ["__meta_kubernetes_node_name"]
-        regex         = "(.+)"
-        replacement   = "/api/v1/nodes/${1}/proxy/metrics"
-        target_label  = "__metrics_path__"
-      }
-      rule {
         source_labels = ["__meta_kubernetes_namespace"]
         regex = "private"
         action = "drop"
@@ -570,16 +560,6 @@ data:
     // cAdvisor
     discovery.relabel "cadvisor" {
       targets = discovery.kubernetes.nodes.targets
-      rule {
-        target_label = "__address__"
-        replacement  = "kubernetes.default.svc.cluster.local:443"
-      }
-      rule {
-        source_labels = ["__meta_kubernetes_node_name"]
-        regex         = "(.+)"
-        replacement   = "/api/v1/nodes/${1}/proxy/metrics/cadvisor"
-        target_label  = "__metrics_path__"
-      }
       rule {
         source_labels = ["__meta_kubernetes_namespace"]
         regex = "private"
@@ -45364,16 +45344,6 @@ data:
     discovery.relabel "kubelet" {
       targets = discovery.kubernetes.nodes.targets
       rule {
-        target_label = "__address__"
-        replacement  = "kubernetes.default.svc.cluster.local:443"
-      }
-      rule {
-        source_labels = ["__meta_kubernetes_node_name"]
-        regex         = "(.+)"
-        replacement   = "/api/v1/nodes/${1}/proxy/metrics"
-        target_label  = "__metrics_path__"
-      }
-      rule {
         source_labels = ["__meta_kubernetes_namespace"]
         regex = "private"
         action = "drop"
@@ -45412,16 +45382,6 @@ data:
     // cAdvisor
     discovery.relabel "cadvisor" {
       targets = discovery.kubernetes.nodes.targets
-      rule {
-        target_label = "__address__"
-        replacement  = "kubernetes.default.svc.cluster.local:443"
-      }
-      rule {
-        source_labels = ["__meta_kubernetes_node_name"]
-        regex         = "(.+)"
-        replacement   = "/api/v1/nodes/${1}/proxy/metrics/cadvisor"
-        target_label  = "__metrics_path__"
-      }
       rule {
         source_labels = ["__meta_kubernetes_namespace"]
         regex = "private"

--- a/examples/extra-rules/output.yaml
+++ b/examples/extra-rules/output.yaml
@@ -561,6 +561,10 @@ data:
     discovery.relabel "cadvisor" {
       targets = discovery.kubernetes.nodes.targets
       rule {
+        replacement   = "/metrics/cadvisor"
+        target_label  = "__metrics_path__"
+      }
+      rule {
         source_labels = ["__meta_kubernetes_namespace"]
         regex = "private"
         action = "drop"
@@ -45382,6 +45386,10 @@ data:
     // cAdvisor
     discovery.relabel "cadvisor" {
       targets = discovery.kubernetes.nodes.targets
+      rule {
+        replacement   = "/metrics/cadvisor"
+        target_label  = "__metrics_path__"
+      }
       rule {
         source_labels = ["__meta_kubernetes_namespace"]
         regex = "private"

--- a/examples/gke-autopilot/metrics.river
+++ b/examples/gke-autopilot/metrics.river
@@ -384,16 +384,6 @@ prometheus.relabel "kubernetes_monitoring_telemetry" {
 // Kubelet
 discovery.relabel "kubelet" {
   targets = discovery.kubernetes.nodes.targets
-  rule {
-    target_label = "__address__"
-    replacement  = "kubernetes.default.svc.cluster.local:443"
-  }
-  rule {
-    source_labels = ["__meta_kubernetes_node_name"]
-    regex         = "(.+)"
-    replacement   = "/api/v1/nodes/${1}/proxy/metrics"
-    target_label  = "__metrics_path__"
-  }
 }
 
 prometheus.scrape "kubelet" {
@@ -423,16 +413,6 @@ prometheus.relabel "kubelet" {
 // cAdvisor
 discovery.relabel "cadvisor" {
   targets = discovery.kubernetes.nodes.targets
-  rule {
-    target_label = "__address__"
-    replacement  = "kubernetes.default.svc.cluster.local:443"
-  }
-  rule {
-    source_labels = ["__meta_kubernetes_node_name"]
-    regex         = "(.+)"
-    replacement   = "/api/v1/nodes/${1}/proxy/metrics/cadvisor"
-    target_label  = "__metrics_path__"
-  }
 }
 
 prometheus.scrape "cadvisor" {

--- a/examples/gke-autopilot/metrics.river
+++ b/examples/gke-autopilot/metrics.river
@@ -413,6 +413,10 @@ prometheus.relabel "kubelet" {
 // cAdvisor
 discovery.relabel "cadvisor" {
   targets = discovery.kubernetes.nodes.targets
+  rule {
+    replacement   = "/metrics/cadvisor"
+    target_label  = "__metrics_path__"
+  }
 }
 
 prometheus.scrape "cadvisor" {

--- a/examples/gke-autopilot/output.yaml
+++ b/examples/gke-autopilot/output.yaml
@@ -519,6 +519,10 @@ data:
     // cAdvisor
     discovery.relabel "cadvisor" {
       targets = discovery.kubernetes.nodes.targets
+      rule {
+        replacement   = "/metrics/cadvisor"
+        target_label  = "__metrics_path__"
+      }
     }
     
     prometheus.scrape "cadvisor" {
@@ -45048,6 +45052,10 @@ data:
     // cAdvisor
     discovery.relabel "cadvisor" {
       targets = discovery.kubernetes.nodes.targets
+      rule {
+        replacement   = "/metrics/cadvisor"
+        target_label  = "__metrics_path__"
+      }
     }
     
     prometheus.scrape "cadvisor" {

--- a/examples/gke-autopilot/output.yaml
+++ b/examples/gke-autopilot/output.yaml
@@ -490,16 +490,6 @@ data:
     // Kubelet
     discovery.relabel "kubelet" {
       targets = discovery.kubernetes.nodes.targets
-      rule {
-        target_label = "__address__"
-        replacement  = "kubernetes.default.svc.cluster.local:443"
-      }
-      rule {
-        source_labels = ["__meta_kubernetes_node_name"]
-        regex         = "(.+)"
-        replacement   = "/api/v1/nodes/${1}/proxy/metrics"
-        target_label  = "__metrics_path__"
-      }
     }
     
     prometheus.scrape "kubelet" {
@@ -529,16 +519,6 @@ data:
     // cAdvisor
     discovery.relabel "cadvisor" {
       targets = discovery.kubernetes.nodes.targets
-      rule {
-        target_label = "__address__"
-        replacement  = "kubernetes.default.svc.cluster.local:443"
-      }
-      rule {
-        source_labels = ["__meta_kubernetes_node_name"]
-        regex         = "(.+)"
-        replacement   = "/api/v1/nodes/${1}/proxy/metrics/cadvisor"
-        target_label  = "__metrics_path__"
-      }
     }
     
     prometheus.scrape "cadvisor" {
@@ -45039,16 +45019,6 @@ data:
     // Kubelet
     discovery.relabel "kubelet" {
       targets = discovery.kubernetes.nodes.targets
-      rule {
-        target_label = "__address__"
-        replacement  = "kubernetes.default.svc.cluster.local:443"
-      }
-      rule {
-        source_labels = ["__meta_kubernetes_node_name"]
-        regex         = "(.+)"
-        replacement   = "/api/v1/nodes/${1}/proxy/metrics"
-        target_label  = "__metrics_path__"
-      }
     }
     
     prometheus.scrape "kubelet" {
@@ -45078,16 +45048,6 @@ data:
     // cAdvisor
     discovery.relabel "cadvisor" {
       targets = discovery.kubernetes.nodes.targets
-      rule {
-        target_label = "__address__"
-        replacement  = "kubernetes.default.svc.cluster.local:443"
-      }
-      rule {
-        source_labels = ["__meta_kubernetes_node_name"]
-        regex         = "(.+)"
-        replacement   = "/api/v1/nodes/${1}/proxy/metrics/cadvisor"
-        target_label  = "__metrics_path__"
-      }
     }
     
     prometheus.scrape "cadvisor" {

--- a/examples/ibm-cloud/metrics.river
+++ b/examples/ibm-cloud/metrics.river
@@ -384,16 +384,6 @@ prometheus.relabel "kubernetes_monitoring_telemetry" {
 // Kubelet
 discovery.relabel "kubelet" {
   targets = discovery.kubernetes.nodes.targets
-  rule {
-    target_label = "__address__"
-    replacement  = "kubernetes.default.svc.cluster.local:443"
-  }
-  rule {
-    source_labels = ["__meta_kubernetes_node_name"]
-    regex         = "(.+)"
-    replacement   = "/api/v1/nodes/${1}/proxy/metrics"
-    target_label  = "__metrics_path__"
-  }
 }
 
 prometheus.scrape "kubelet" {
@@ -423,16 +413,6 @@ prometheus.relabel "kubelet" {
 // cAdvisor
 discovery.relabel "cadvisor" {
   targets = discovery.kubernetes.nodes.targets
-  rule {
-    target_label = "__address__"
-    replacement  = "kubernetes.default.svc.cluster.local:443"
-  }
-  rule {
-    source_labels = ["__meta_kubernetes_node_name"]
-    regex         = "(.+)"
-    replacement   = "/api/v1/nodes/${1}/proxy/metrics/cadvisor"
-    target_label  = "__metrics_path__"
-  }
 }
 
 prometheus.scrape "cadvisor" {

--- a/examples/ibm-cloud/metrics.river
+++ b/examples/ibm-cloud/metrics.river
@@ -413,6 +413,10 @@ prometheus.relabel "kubelet" {
 // cAdvisor
 discovery.relabel "cadvisor" {
   targets = discovery.kubernetes.nodes.targets
+  rule {
+    replacement   = "/metrics/cadvisor"
+    target_label  = "__metrics_path__"
+  }
 }
 
 prometheus.scrape "cadvisor" {

--- a/examples/ibm-cloud/output.yaml
+++ b/examples/ibm-cloud/output.yaml
@@ -534,6 +534,10 @@ data:
     // cAdvisor
     discovery.relabel "cadvisor" {
       targets = discovery.kubernetes.nodes.targets
+      rule {
+        replacement   = "/metrics/cadvisor"
+        target_label  = "__metrics_path__"
+      }
     }
     
     prometheus.scrape "cadvisor" {
@@ -45263,6 +45267,10 @@ data:
     // cAdvisor
     discovery.relabel "cadvisor" {
       targets = discovery.kubernetes.nodes.targets
+      rule {
+        replacement   = "/metrics/cadvisor"
+        target_label  = "__metrics_path__"
+      }
     }
     
     prometheus.scrape "cadvisor" {

--- a/examples/ibm-cloud/output.yaml
+++ b/examples/ibm-cloud/output.yaml
@@ -505,16 +505,6 @@ data:
     // Kubelet
     discovery.relabel "kubelet" {
       targets = discovery.kubernetes.nodes.targets
-      rule {
-        target_label = "__address__"
-        replacement  = "kubernetes.default.svc.cluster.local:443"
-      }
-      rule {
-        source_labels = ["__meta_kubernetes_node_name"]
-        regex         = "(.+)"
-        replacement   = "/api/v1/nodes/${1}/proxy/metrics"
-        target_label  = "__metrics_path__"
-      }
     }
     
     prometheus.scrape "kubelet" {
@@ -544,16 +534,6 @@ data:
     // cAdvisor
     discovery.relabel "cadvisor" {
       targets = discovery.kubernetes.nodes.targets
-      rule {
-        target_label = "__address__"
-        replacement  = "kubernetes.default.svc.cluster.local:443"
-      }
-      rule {
-        source_labels = ["__meta_kubernetes_node_name"]
-        regex         = "(.+)"
-        replacement   = "/api/v1/nodes/${1}/proxy/metrics/cadvisor"
-        target_label  = "__metrics_path__"
-      }
     }
     
     prometheus.scrape "cadvisor" {
@@ -45254,16 +45234,6 @@ data:
     // Kubelet
     discovery.relabel "kubelet" {
       targets = discovery.kubernetes.nodes.targets
-      rule {
-        target_label = "__address__"
-        replacement  = "kubernetes.default.svc.cluster.local:443"
-      }
-      rule {
-        source_labels = ["__meta_kubernetes_node_name"]
-        regex         = "(.+)"
-        replacement   = "/api/v1/nodes/${1}/proxy/metrics"
-        target_label  = "__metrics_path__"
-      }
     }
     
     prometheus.scrape "kubelet" {
@@ -45293,16 +45263,6 @@ data:
     // cAdvisor
     discovery.relabel "cadvisor" {
       targets = discovery.kubernetes.nodes.targets
-      rule {
-        target_label = "__address__"
-        replacement  = "kubernetes.default.svc.cluster.local:443"
-      }
-      rule {
-        source_labels = ["__meta_kubernetes_node_name"]
-        regex         = "(.+)"
-        replacement   = "/api/v1/nodes/${1}/proxy/metrics/cadvisor"
-        target_label  = "__metrics_path__"
-      }
     }
     
     prometheus.scrape "cadvisor" {

--- a/examples/metrics-only/metrics.river
+++ b/examples/metrics-only/metrics.river
@@ -384,16 +384,6 @@ prometheus.relabel "kubernetes_monitoring_telemetry" {
 // Kubelet
 discovery.relabel "kubelet" {
   targets = discovery.kubernetes.nodes.targets
-  rule {
-    target_label = "__address__"
-    replacement  = "kubernetes.default.svc.cluster.local:443"
-  }
-  rule {
-    source_labels = ["__meta_kubernetes_node_name"]
-    regex         = "(.+)"
-    replacement   = "/api/v1/nodes/${1}/proxy/metrics"
-    target_label  = "__metrics_path__"
-  }
 }
 
 prometheus.scrape "kubelet" {
@@ -423,16 +413,6 @@ prometheus.relabel "kubelet" {
 // cAdvisor
 discovery.relabel "cadvisor" {
   targets = discovery.kubernetes.nodes.targets
-  rule {
-    target_label = "__address__"
-    replacement  = "kubernetes.default.svc.cluster.local:443"
-  }
-  rule {
-    source_labels = ["__meta_kubernetes_node_name"]
-    regex         = "(.+)"
-    replacement   = "/api/v1/nodes/${1}/proxy/metrics/cadvisor"
-    target_label  = "__metrics_path__"
-  }
 }
 
 prometheus.scrape "cadvisor" {

--- a/examples/metrics-only/metrics.river
+++ b/examples/metrics-only/metrics.river
@@ -413,6 +413,10 @@ prometheus.relabel "kubelet" {
 // cAdvisor
 discovery.relabel "cadvisor" {
   targets = discovery.kubernetes.nodes.targets
+  rule {
+    replacement   = "/metrics/cadvisor"
+    target_label  = "__metrics_path__"
+  }
 }
 
 prometheus.scrape "cadvisor" {

--- a/examples/metrics-only/output.yaml
+++ b/examples/metrics-only/output.yaml
@@ -494,6 +494,10 @@ data:
     // cAdvisor
     discovery.relabel "cadvisor" {
       targets = discovery.kubernetes.nodes.targets
+      rule {
+        replacement   = "/metrics/cadvisor"
+        target_label  = "__metrics_path__"
+      }
     }
     
     prometheus.scrape "cadvisor" {
@@ -44564,6 +44568,10 @@ data:
     // cAdvisor
     discovery.relabel "cadvisor" {
       targets = discovery.kubernetes.nodes.targets
+      rule {
+        replacement   = "/metrics/cadvisor"
+        target_label  = "__metrics_path__"
+      }
     }
     
     prometheus.scrape "cadvisor" {

--- a/examples/metrics-only/output.yaml
+++ b/examples/metrics-only/output.yaml
@@ -465,16 +465,6 @@ data:
     // Kubelet
     discovery.relabel "kubelet" {
       targets = discovery.kubernetes.nodes.targets
-      rule {
-        target_label = "__address__"
-        replacement  = "kubernetes.default.svc.cluster.local:443"
-      }
-      rule {
-        source_labels = ["__meta_kubernetes_node_name"]
-        regex         = "(.+)"
-        replacement   = "/api/v1/nodes/${1}/proxy/metrics"
-        target_label  = "__metrics_path__"
-      }
     }
     
     prometheus.scrape "kubelet" {
@@ -504,16 +494,6 @@ data:
     // cAdvisor
     discovery.relabel "cadvisor" {
       targets = discovery.kubernetes.nodes.targets
-      rule {
-        target_label = "__address__"
-        replacement  = "kubernetes.default.svc.cluster.local:443"
-      }
-      rule {
-        source_labels = ["__meta_kubernetes_node_name"]
-        regex         = "(.+)"
-        replacement   = "/api/v1/nodes/${1}/proxy/metrics/cadvisor"
-        target_label  = "__metrics_path__"
-      }
     }
     
     prometheus.scrape "cadvisor" {
@@ -44555,16 +44535,6 @@ data:
     // Kubelet
     discovery.relabel "kubelet" {
       targets = discovery.kubernetes.nodes.targets
-      rule {
-        target_label = "__address__"
-        replacement  = "kubernetes.default.svc.cluster.local:443"
-      }
-      rule {
-        source_labels = ["__meta_kubernetes_node_name"]
-        regex         = "(.+)"
-        replacement   = "/api/v1/nodes/${1}/proxy/metrics"
-        target_label  = "__metrics_path__"
-      }
     }
     
     prometheus.scrape "kubelet" {
@@ -44594,16 +44564,6 @@ data:
     // cAdvisor
     discovery.relabel "cadvisor" {
       targets = discovery.kubernetes.nodes.targets
-      rule {
-        target_label = "__address__"
-        replacement  = "kubernetes.default.svc.cluster.local:443"
-      }
-      rule {
-        source_labels = ["__meta_kubernetes_node_name"]
-        regex         = "(.+)"
-        replacement   = "/api/v1/nodes/${1}/proxy/metrics/cadvisor"
-        target_label  = "__metrics_path__"
-      }
     }
     
     prometheus.scrape "cadvisor" {

--- a/examples/openshift-compatible/metrics.river
+++ b/examples/openshift-compatible/metrics.river
@@ -384,16 +384,6 @@ prometheus.relabel "kubernetes_monitoring_telemetry" {
 // Kubelet
 discovery.relabel "kubelet" {
   targets = discovery.kubernetes.nodes.targets
-  rule {
-    target_label = "__address__"
-    replacement  = "kubernetes.default.svc.cluster.local:443"
-  }
-  rule {
-    source_labels = ["__meta_kubernetes_node_name"]
-    regex         = "(.+)"
-    replacement   = "/api/v1/nodes/${1}/proxy/metrics"
-    target_label  = "__metrics_path__"
-  }
 }
 
 prometheus.scrape "kubelet" {
@@ -423,16 +413,6 @@ prometheus.relabel "kubelet" {
 // cAdvisor
 discovery.relabel "cadvisor" {
   targets = discovery.kubernetes.nodes.targets
-  rule {
-    target_label = "__address__"
-    replacement  = "kubernetes.default.svc.cluster.local:443"
-  }
-  rule {
-    source_labels = ["__meta_kubernetes_node_name"]
-    regex         = "(.+)"
-    replacement   = "/api/v1/nodes/${1}/proxy/metrics/cadvisor"
-    target_label  = "__metrics_path__"
-  }
 }
 
 prometheus.scrape "cadvisor" {

--- a/examples/openshift-compatible/metrics.river
+++ b/examples/openshift-compatible/metrics.river
@@ -413,6 +413,10 @@ prometheus.relabel "kubelet" {
 // cAdvisor
 discovery.relabel "cadvisor" {
   targets = discovery.kubernetes.nodes.targets
+  rule {
+    replacement   = "/metrics/cadvisor"
+    target_label  = "__metrics_path__"
+  }
 }
 
 prometheus.scrape "cadvisor" {

--- a/examples/openshift-compatible/output.yaml
+++ b/examples/openshift-compatible/output.yaml
@@ -504,6 +504,10 @@ data:
     // cAdvisor
     discovery.relabel "cadvisor" {
       targets = discovery.kubernetes.nodes.targets
+      rule {
+        replacement   = "/metrics/cadvisor"
+        target_label  = "__metrics_path__"
+      }
     }
     
     prometheus.scrape "cadvisor" {
@@ -44902,6 +44906,10 @@ data:
     // cAdvisor
     discovery.relabel "cadvisor" {
       targets = discovery.kubernetes.nodes.targets
+      rule {
+        replacement   = "/metrics/cadvisor"
+        target_label  = "__metrics_path__"
+      }
     }
     
     prometheus.scrape "cadvisor" {

--- a/examples/openshift-compatible/output.yaml
+++ b/examples/openshift-compatible/output.yaml
@@ -475,16 +475,6 @@ data:
     // Kubelet
     discovery.relabel "kubelet" {
       targets = discovery.kubernetes.nodes.targets
-      rule {
-        target_label = "__address__"
-        replacement  = "kubernetes.default.svc.cluster.local:443"
-      }
-      rule {
-        source_labels = ["__meta_kubernetes_node_name"]
-        regex         = "(.+)"
-        replacement   = "/api/v1/nodes/${1}/proxy/metrics"
-        target_label  = "__metrics_path__"
-      }
     }
     
     prometheus.scrape "kubelet" {
@@ -514,16 +504,6 @@ data:
     // cAdvisor
     discovery.relabel "cadvisor" {
       targets = discovery.kubernetes.nodes.targets
-      rule {
-        target_label = "__address__"
-        replacement  = "kubernetes.default.svc.cluster.local:443"
-      }
-      rule {
-        source_labels = ["__meta_kubernetes_node_name"]
-        regex         = "(.+)"
-        replacement   = "/api/v1/nodes/${1}/proxy/metrics/cadvisor"
-        target_label  = "__metrics_path__"
-      }
     }
     
     prometheus.scrape "cadvisor" {
@@ -44893,16 +44873,6 @@ data:
     // Kubelet
     discovery.relabel "kubelet" {
       targets = discovery.kubernetes.nodes.targets
-      rule {
-        target_label = "__address__"
-        replacement  = "kubernetes.default.svc.cluster.local:443"
-      }
-      rule {
-        source_labels = ["__meta_kubernetes_node_name"]
-        regex         = "(.+)"
-        replacement   = "/api/v1/nodes/${1}/proxy/metrics"
-        target_label  = "__metrics_path__"
-      }
     }
     
     prometheus.scrape "kubelet" {
@@ -44932,16 +44902,6 @@ data:
     // cAdvisor
     discovery.relabel "cadvisor" {
       targets = discovery.kubernetes.nodes.targets
-      rule {
-        target_label = "__address__"
-        replacement  = "kubernetes.default.svc.cluster.local:443"
-      }
-      rule {
-        source_labels = ["__meta_kubernetes_node_name"]
-        regex         = "(.+)"
-        replacement   = "/api/v1/nodes/${1}/proxy/metrics/cadvisor"
-        target_label  = "__metrics_path__"
-      }
     }
     
     prometheus.scrape "cadvisor" {

--- a/examples/otel-metrics-service/metrics.river
+++ b/examples/otel-metrics-service/metrics.river
@@ -384,16 +384,6 @@ prometheus.relabel "kubernetes_monitoring_telemetry" {
 // Kubelet
 discovery.relabel "kubelet" {
   targets = discovery.kubernetes.nodes.targets
-  rule {
-    target_label = "__address__"
-    replacement  = "kubernetes.default.svc.cluster.local:443"
-  }
-  rule {
-    source_labels = ["__meta_kubernetes_node_name"]
-    regex         = "(.+)"
-    replacement   = "/api/v1/nodes/${1}/proxy/metrics"
-    target_label  = "__metrics_path__"
-  }
 }
 
 prometheus.scrape "kubelet" {
@@ -423,16 +413,6 @@ prometheus.relabel "kubelet" {
 // cAdvisor
 discovery.relabel "cadvisor" {
   targets = discovery.kubernetes.nodes.targets
-  rule {
-    target_label = "__address__"
-    replacement  = "kubernetes.default.svc.cluster.local:443"
-  }
-  rule {
-    source_labels = ["__meta_kubernetes_node_name"]
-    regex         = "(.+)"
-    replacement   = "/api/v1/nodes/${1}/proxy/metrics/cadvisor"
-    target_label  = "__metrics_path__"
-  }
 }
 
 prometheus.scrape "cadvisor" {

--- a/examples/otel-metrics-service/metrics.river
+++ b/examples/otel-metrics-service/metrics.river
@@ -413,6 +413,10 @@ prometheus.relabel "kubelet" {
 // cAdvisor
 discovery.relabel "cadvisor" {
   targets = discovery.kubernetes.nodes.targets
+  rule {
+    replacement   = "/metrics/cadvisor"
+    target_label  = "__metrics_path__"
+  }
 }
 
 prometheus.scrape "cadvisor" {

--- a/examples/otel-metrics-service/output.yaml
+++ b/examples/otel-metrics-service/output.yaml
@@ -534,6 +534,10 @@ data:
     // cAdvisor
     discovery.relabel "cadvisor" {
       targets = discovery.kubernetes.nodes.targets
+      rule {
+        replacement   = "/metrics/cadvisor"
+        target_label  = "__metrics_path__"
+      }
     }
     
     prometheus.scrape "cadvisor" {
@@ -45287,6 +45291,10 @@ data:
     // cAdvisor
     discovery.relabel "cadvisor" {
       targets = discovery.kubernetes.nodes.targets
+      rule {
+        replacement   = "/metrics/cadvisor"
+        target_label  = "__metrics_path__"
+      }
     }
     
     prometheus.scrape "cadvisor" {

--- a/examples/otel-metrics-service/output.yaml
+++ b/examples/otel-metrics-service/output.yaml
@@ -505,16 +505,6 @@ data:
     // Kubelet
     discovery.relabel "kubelet" {
       targets = discovery.kubernetes.nodes.targets
-      rule {
-        target_label = "__address__"
-        replacement  = "kubernetes.default.svc.cluster.local:443"
-      }
-      rule {
-        source_labels = ["__meta_kubernetes_node_name"]
-        regex         = "(.+)"
-        replacement   = "/api/v1/nodes/${1}/proxy/metrics"
-        target_label  = "__metrics_path__"
-      }
     }
     
     prometheus.scrape "kubelet" {
@@ -544,16 +534,6 @@ data:
     // cAdvisor
     discovery.relabel "cadvisor" {
       targets = discovery.kubernetes.nodes.targets
-      rule {
-        target_label = "__address__"
-        replacement  = "kubernetes.default.svc.cluster.local:443"
-      }
-      rule {
-        source_labels = ["__meta_kubernetes_node_name"]
-        regex         = "(.+)"
-        replacement   = "/api/v1/nodes/${1}/proxy/metrics/cadvisor"
-        target_label  = "__metrics_path__"
-      }
     }
     
     prometheus.scrape "cadvisor" {
@@ -45278,16 +45258,6 @@ data:
     // Kubelet
     discovery.relabel "kubelet" {
       targets = discovery.kubernetes.nodes.targets
-      rule {
-        target_label = "__address__"
-        replacement  = "kubernetes.default.svc.cluster.local:443"
-      }
-      rule {
-        source_labels = ["__meta_kubernetes_node_name"]
-        regex         = "(.+)"
-        replacement   = "/api/v1/nodes/${1}/proxy/metrics"
-        target_label  = "__metrics_path__"
-      }
     }
     
     prometheus.scrape "kubelet" {
@@ -45317,16 +45287,6 @@ data:
     // cAdvisor
     discovery.relabel "cadvisor" {
       targets = discovery.kubernetes.nodes.targets
-      rule {
-        target_label = "__address__"
-        replacement  = "kubernetes.default.svc.cluster.local:443"
-      }
-      rule {
-        source_labels = ["__meta_kubernetes_node_name"]
-        regex         = "(.+)"
-        replacement   = "/api/v1/nodes/${1}/proxy/metrics/cadvisor"
-        target_label  = "__metrics_path__"
-      }
     }
     
     prometheus.scrape "cadvisor" {

--- a/examples/private-image-registry/metrics.river
+++ b/examples/private-image-registry/metrics.river
@@ -384,16 +384,6 @@ prometheus.relabel "kubernetes_monitoring_telemetry" {
 // Kubelet
 discovery.relabel "kubelet" {
   targets = discovery.kubernetes.nodes.targets
-  rule {
-    target_label = "__address__"
-    replacement  = "kubernetes.default.svc.cluster.local:443"
-  }
-  rule {
-    source_labels = ["__meta_kubernetes_node_name"]
-    regex         = "(.+)"
-    replacement   = "/api/v1/nodes/${1}/proxy/metrics"
-    target_label  = "__metrics_path__"
-  }
 }
 
 prometheus.scrape "kubelet" {
@@ -423,16 +413,6 @@ prometheus.relabel "kubelet" {
 // cAdvisor
 discovery.relabel "cadvisor" {
   targets = discovery.kubernetes.nodes.targets
-  rule {
-    target_label = "__address__"
-    replacement  = "kubernetes.default.svc.cluster.local:443"
-  }
-  rule {
-    source_labels = ["__meta_kubernetes_node_name"]
-    regex         = "(.+)"
-    replacement   = "/api/v1/nodes/${1}/proxy/metrics/cadvisor"
-    target_label  = "__metrics_path__"
-  }
 }
 
 prometheus.scrape "cadvisor" {

--- a/examples/private-image-registry/metrics.river
+++ b/examples/private-image-registry/metrics.river
@@ -413,6 +413,10 @@ prometheus.relabel "kubelet" {
 // cAdvisor
 discovery.relabel "cadvisor" {
   targets = discovery.kubernetes.nodes.targets
+  rule {
+    replacement   = "/metrics/cadvisor"
+    target_label  = "__metrics_path__"
+  }
 }
 
 prometheus.scrape "cadvisor" {

--- a/examples/private-image-registry/output.yaml
+++ b/examples/private-image-registry/output.yaml
@@ -509,16 +509,6 @@ data:
     // Kubelet
     discovery.relabel "kubelet" {
       targets = discovery.kubernetes.nodes.targets
-      rule {
-        target_label = "__address__"
-        replacement  = "kubernetes.default.svc.cluster.local:443"
-      }
-      rule {
-        source_labels = ["__meta_kubernetes_node_name"]
-        regex         = "(.+)"
-        replacement   = "/api/v1/nodes/${1}/proxy/metrics"
-        target_label  = "__metrics_path__"
-      }
     }
     
     prometheus.scrape "kubelet" {
@@ -548,16 +538,6 @@ data:
     // cAdvisor
     discovery.relabel "cadvisor" {
       targets = discovery.kubernetes.nodes.targets
-      rule {
-        target_label = "__address__"
-        replacement  = "kubernetes.default.svc.cluster.local:443"
-      }
-      rule {
-        source_labels = ["__meta_kubernetes_node_name"]
-        regex         = "(.+)"
-        replacement   = "/api/v1/nodes/${1}/proxy/metrics/cadvisor"
-        target_label  = "__metrics_path__"
-      }
     }
     
     prometheus.scrape "cadvisor" {
@@ -45264,16 +45244,6 @@ data:
     // Kubelet
     discovery.relabel "kubelet" {
       targets = discovery.kubernetes.nodes.targets
-      rule {
-        target_label = "__address__"
-        replacement  = "kubernetes.default.svc.cluster.local:443"
-      }
-      rule {
-        source_labels = ["__meta_kubernetes_node_name"]
-        regex         = "(.+)"
-        replacement   = "/api/v1/nodes/${1}/proxy/metrics"
-        target_label  = "__metrics_path__"
-      }
     }
     
     prometheus.scrape "kubelet" {
@@ -45303,16 +45273,6 @@ data:
     // cAdvisor
     discovery.relabel "cadvisor" {
       targets = discovery.kubernetes.nodes.targets
-      rule {
-        target_label = "__address__"
-        replacement  = "kubernetes.default.svc.cluster.local:443"
-      }
-      rule {
-        source_labels = ["__meta_kubernetes_node_name"]
-        regex         = "(.+)"
-        replacement   = "/api/v1/nodes/${1}/proxy/metrics/cadvisor"
-        target_label  = "__metrics_path__"
-      }
     }
     
     prometheus.scrape "cadvisor" {

--- a/examples/private-image-registry/output.yaml
+++ b/examples/private-image-registry/output.yaml
@@ -538,6 +538,10 @@ data:
     // cAdvisor
     discovery.relabel "cadvisor" {
       targets = discovery.kubernetes.nodes.targets
+      rule {
+        replacement   = "/metrics/cadvisor"
+        target_label  = "__metrics_path__"
+      }
     }
     
     prometheus.scrape "cadvisor" {
@@ -45273,6 +45277,10 @@ data:
     // cAdvisor
     discovery.relabel "cadvisor" {
       targets = discovery.kubernetes.nodes.targets
+      rule {
+        replacement   = "/metrics/cadvisor"
+        target_label  = "__metrics_path__"
+      }
     }
     
     prometheus.scrape "cadvisor" {

--- a/examples/proxies/metrics.river
+++ b/examples/proxies/metrics.river
@@ -384,16 +384,6 @@ prometheus.relabel "kubernetes_monitoring_telemetry" {
 // Kubelet
 discovery.relabel "kubelet" {
   targets = discovery.kubernetes.nodes.targets
-  rule {
-    target_label = "__address__"
-    replacement  = "kubernetes.default.svc.cluster.local:443"
-  }
-  rule {
-    source_labels = ["__meta_kubernetes_node_name"]
-    regex         = "(.+)"
-    replacement   = "/api/v1/nodes/${1}/proxy/metrics"
-    target_label  = "__metrics_path__"
-  }
 }
 
 prometheus.scrape "kubelet" {
@@ -423,16 +413,6 @@ prometheus.relabel "kubelet" {
 // cAdvisor
 discovery.relabel "cadvisor" {
   targets = discovery.kubernetes.nodes.targets
-  rule {
-    target_label = "__address__"
-    replacement  = "kubernetes.default.svc.cluster.local:443"
-  }
-  rule {
-    source_labels = ["__meta_kubernetes_node_name"]
-    regex         = "(.+)"
-    replacement   = "/api/v1/nodes/${1}/proxy/metrics/cadvisor"
-    target_label  = "__metrics_path__"
-  }
 }
 
 prometheus.scrape "cadvisor" {

--- a/examples/proxies/metrics.river
+++ b/examples/proxies/metrics.river
@@ -413,6 +413,10 @@ prometheus.relabel "kubelet" {
 // cAdvisor
 discovery.relabel "cadvisor" {
   targets = discovery.kubernetes.nodes.targets
+  rule {
+    replacement   = "/metrics/cadvisor"
+    target_label  = "__metrics_path__"
+  }
 }
 
 prometheus.scrape "cadvisor" {

--- a/examples/proxies/output.yaml
+++ b/examples/proxies/output.yaml
@@ -505,16 +505,6 @@ data:
     // Kubelet
     discovery.relabel "kubelet" {
       targets = discovery.kubernetes.nodes.targets
-      rule {
-        target_label = "__address__"
-        replacement  = "kubernetes.default.svc.cluster.local:443"
-      }
-      rule {
-        source_labels = ["__meta_kubernetes_node_name"]
-        regex         = "(.+)"
-        replacement   = "/api/v1/nodes/${1}/proxy/metrics"
-        target_label  = "__metrics_path__"
-      }
     }
     
     prometheus.scrape "kubelet" {
@@ -544,16 +534,6 @@ data:
     // cAdvisor
     discovery.relabel "cadvisor" {
       targets = discovery.kubernetes.nodes.targets
-      rule {
-        target_label = "__address__"
-        replacement  = "kubernetes.default.svc.cluster.local:443"
-      }
-      rule {
-        source_labels = ["__meta_kubernetes_node_name"]
-        regex         = "(.+)"
-        replacement   = "/api/v1/nodes/${1}/proxy/metrics/cadvisor"
-        target_label  = "__metrics_path__"
-      }
     }
     
     prometheus.scrape "cadvisor" {
@@ -45264,16 +45244,6 @@ data:
     // Kubelet
     discovery.relabel "kubelet" {
       targets = discovery.kubernetes.nodes.targets
-      rule {
-        target_label = "__address__"
-        replacement  = "kubernetes.default.svc.cluster.local:443"
-      }
-      rule {
-        source_labels = ["__meta_kubernetes_node_name"]
-        regex         = "(.+)"
-        replacement   = "/api/v1/nodes/${1}/proxy/metrics"
-        target_label  = "__metrics_path__"
-      }
     }
     
     prometheus.scrape "kubelet" {
@@ -45303,16 +45273,6 @@ data:
     // cAdvisor
     discovery.relabel "cadvisor" {
       targets = discovery.kubernetes.nodes.targets
-      rule {
-        target_label = "__address__"
-        replacement  = "kubernetes.default.svc.cluster.local:443"
-      }
-      rule {
-        source_labels = ["__meta_kubernetes_node_name"]
-        regex         = "(.+)"
-        replacement   = "/api/v1/nodes/${1}/proxy/metrics/cadvisor"
-        target_label  = "__metrics_path__"
-      }
     }
     
     prometheus.scrape "cadvisor" {

--- a/examples/proxies/output.yaml
+++ b/examples/proxies/output.yaml
@@ -534,6 +534,10 @@ data:
     // cAdvisor
     discovery.relabel "cadvisor" {
       targets = discovery.kubernetes.nodes.targets
+      rule {
+        replacement   = "/metrics/cadvisor"
+        target_label  = "__metrics_path__"
+      }
     }
     
     prometheus.scrape "cadvisor" {
@@ -45273,6 +45277,10 @@ data:
     // cAdvisor
     discovery.relabel "cadvisor" {
       targets = discovery.kubernetes.nodes.targets
+      rule {
+        replacement   = "/metrics/cadvisor"
+        target_label  = "__metrics_path__"
+      }
     }
     
     prometheus.scrape "cadvisor" {

--- a/examples/scrape-intervals/metrics.river
+++ b/examples/scrape-intervals/metrics.river
@@ -384,16 +384,6 @@ prometheus.relabel "kubernetes_monitoring_telemetry" {
 // Kubelet
 discovery.relabel "kubelet" {
   targets = discovery.kubernetes.nodes.targets
-  rule {
-    target_label = "__address__"
-    replacement  = "kubernetes.default.svc.cluster.local:443"
-  }
-  rule {
-    source_labels = ["__meta_kubernetes_node_name"]
-    regex         = "(.+)"
-    replacement   = "/api/v1/nodes/${1}/proxy/metrics"
-    target_label  = "__metrics_path__"
-  }
 }
 
 prometheus.scrape "kubelet" {
@@ -423,16 +413,6 @@ prometheus.relabel "kubelet" {
 // cAdvisor
 discovery.relabel "cadvisor" {
   targets = discovery.kubernetes.nodes.targets
-  rule {
-    target_label = "__address__"
-    replacement  = "kubernetes.default.svc.cluster.local:443"
-  }
-  rule {
-    source_labels = ["__meta_kubernetes_node_name"]
-    regex         = "(.+)"
-    replacement   = "/api/v1/nodes/${1}/proxy/metrics/cadvisor"
-    target_label  = "__metrics_path__"
-  }
 }
 
 prometheus.scrape "cadvisor" {

--- a/examples/scrape-intervals/metrics.river
+++ b/examples/scrape-intervals/metrics.river
@@ -413,6 +413,10 @@ prometheus.relabel "kubelet" {
 // cAdvisor
 discovery.relabel "cadvisor" {
   targets = discovery.kubernetes.nodes.targets
+  rule {
+    replacement   = "/metrics/cadvisor"
+    target_label  = "__metrics_path__"
+  }
 }
 
 prometheus.scrape "cadvisor" {

--- a/examples/scrape-intervals/output.yaml
+++ b/examples/scrape-intervals/output.yaml
@@ -464,16 +464,6 @@ data:
     // Kubelet
     discovery.relabel "kubelet" {
       targets = discovery.kubernetes.nodes.targets
-      rule {
-        target_label = "__address__"
-        replacement  = "kubernetes.default.svc.cluster.local:443"
-      }
-      rule {
-        source_labels = ["__meta_kubernetes_node_name"]
-        regex         = "(.+)"
-        replacement   = "/api/v1/nodes/${1}/proxy/metrics"
-        target_label  = "__metrics_path__"
-      }
     }
     
     prometheus.scrape "kubelet" {
@@ -503,16 +493,6 @@ data:
     // cAdvisor
     discovery.relabel "cadvisor" {
       targets = discovery.kubernetes.nodes.targets
-      rule {
-        target_label = "__address__"
-        replacement  = "kubernetes.default.svc.cluster.local:443"
-      }
-      rule {
-        source_labels = ["__meta_kubernetes_node_name"]
-        regex         = "(.+)"
-        replacement   = "/api/v1/nodes/${1}/proxy/metrics/cadvisor"
-        target_label  = "__metrics_path__"
-      }
     }
     
     prometheus.scrape "cadvisor" {
@@ -44554,16 +44534,6 @@ data:
     // Kubelet
     discovery.relabel "kubelet" {
       targets = discovery.kubernetes.nodes.targets
-      rule {
-        target_label = "__address__"
-        replacement  = "kubernetes.default.svc.cluster.local:443"
-      }
-      rule {
-        source_labels = ["__meta_kubernetes_node_name"]
-        regex         = "(.+)"
-        replacement   = "/api/v1/nodes/${1}/proxy/metrics"
-        target_label  = "__metrics_path__"
-      }
     }
     
     prometheus.scrape "kubelet" {
@@ -44593,16 +44563,6 @@ data:
     // cAdvisor
     discovery.relabel "cadvisor" {
       targets = discovery.kubernetes.nodes.targets
-      rule {
-        target_label = "__address__"
-        replacement  = "kubernetes.default.svc.cluster.local:443"
-      }
-      rule {
-        source_labels = ["__meta_kubernetes_node_name"]
-        regex         = "(.+)"
-        replacement   = "/api/v1/nodes/${1}/proxy/metrics/cadvisor"
-        target_label  = "__metrics_path__"
-      }
     }
     
     prometheus.scrape "cadvisor" {

--- a/examples/scrape-intervals/output.yaml
+++ b/examples/scrape-intervals/output.yaml
@@ -493,6 +493,10 @@ data:
     // cAdvisor
     discovery.relabel "cadvisor" {
       targets = discovery.kubernetes.nodes.targets
+      rule {
+        replacement   = "/metrics/cadvisor"
+        target_label  = "__metrics_path__"
+      }
     }
     
     prometheus.scrape "cadvisor" {
@@ -44563,6 +44567,10 @@ data:
     // cAdvisor
     discovery.relabel "cadvisor" {
       targets = discovery.kubernetes.nodes.targets
+      rule {
+        replacement   = "/metrics/cadvisor"
+        target_label  = "__metrics_path__"
+      }
     }
     
     prometheus.scrape "cadvisor" {

--- a/examples/service-integrations/metrics.river
+++ b/examples/service-integrations/metrics.river
@@ -384,16 +384,6 @@ prometheus.relabel "kubernetes_monitoring_telemetry" {
 // Kubelet
 discovery.relabel "kubelet" {
   targets = discovery.kubernetes.nodes.targets
-  rule {
-    target_label = "__address__"
-    replacement  = "kubernetes.default.svc.cluster.local:443"
-  }
-  rule {
-    source_labels = ["__meta_kubernetes_node_name"]
-    regex         = "(.+)"
-    replacement   = "/api/v1/nodes/${1}/proxy/metrics"
-    target_label  = "__metrics_path__"
-  }
 }
 
 prometheus.scrape "kubelet" {
@@ -423,16 +413,6 @@ prometheus.relabel "kubelet" {
 // cAdvisor
 discovery.relabel "cadvisor" {
   targets = discovery.kubernetes.nodes.targets
-  rule {
-    target_label = "__address__"
-    replacement  = "kubernetes.default.svc.cluster.local:443"
-  }
-  rule {
-    source_labels = ["__meta_kubernetes_node_name"]
-    regex         = "(.+)"
-    replacement   = "/api/v1/nodes/${1}/proxy/metrics/cadvisor"
-    target_label  = "__metrics_path__"
-  }
 }
 
 prometheus.scrape "cadvisor" {

--- a/examples/service-integrations/metrics.river
+++ b/examples/service-integrations/metrics.river
@@ -413,6 +413,10 @@ prometheus.relabel "kubelet" {
 // cAdvisor
 discovery.relabel "cadvisor" {
   targets = discovery.kubernetes.nodes.targets
+  rule {
+    replacement   = "/metrics/cadvisor"
+    target_label  = "__metrics_path__"
+  }
 }
 
 prometheus.scrape "cadvisor" {

--- a/examples/service-integrations/output.yaml
+++ b/examples/service-integrations/output.yaml
@@ -534,6 +534,10 @@ data:
     // cAdvisor
     discovery.relabel "cadvisor" {
       targets = discovery.kubernetes.nodes.targets
+      rule {
+        replacement   = "/metrics/cadvisor"
+        target_label  = "__metrics_path__"
+      }
     }
     
     prometheus.scrape "cadvisor" {
@@ -45292,6 +45296,10 @@ data:
     // cAdvisor
     discovery.relabel "cadvisor" {
       targets = discovery.kubernetes.nodes.targets
+      rule {
+        replacement   = "/metrics/cadvisor"
+        target_label  = "__metrics_path__"
+      }
     }
     
     prometheus.scrape "cadvisor" {

--- a/examples/service-integrations/output.yaml
+++ b/examples/service-integrations/output.yaml
@@ -505,16 +505,6 @@ data:
     // Kubelet
     discovery.relabel "kubelet" {
       targets = discovery.kubernetes.nodes.targets
-      rule {
-        target_label = "__address__"
-        replacement  = "kubernetes.default.svc.cluster.local:443"
-      }
-      rule {
-        source_labels = ["__meta_kubernetes_node_name"]
-        regex         = "(.+)"
-        replacement   = "/api/v1/nodes/${1}/proxy/metrics"
-        target_label  = "__metrics_path__"
-      }
     }
     
     prometheus.scrape "kubelet" {
@@ -544,16 +534,6 @@ data:
     // cAdvisor
     discovery.relabel "cadvisor" {
       targets = discovery.kubernetes.nodes.targets
-      rule {
-        target_label = "__address__"
-        replacement  = "kubernetes.default.svc.cluster.local:443"
-      }
-      rule {
-        source_labels = ["__meta_kubernetes_node_name"]
-        regex         = "(.+)"
-        replacement   = "/api/v1/nodes/${1}/proxy/metrics/cadvisor"
-        target_label  = "__metrics_path__"
-      }
     }
     
     prometheus.scrape "cadvisor" {
@@ -45283,16 +45263,6 @@ data:
     // Kubelet
     discovery.relabel "kubelet" {
       targets = discovery.kubernetes.nodes.targets
-      rule {
-        target_label = "__address__"
-        replacement  = "kubernetes.default.svc.cluster.local:443"
-      }
-      rule {
-        source_labels = ["__meta_kubernetes_node_name"]
-        regex         = "(.+)"
-        replacement   = "/api/v1/nodes/${1}/proxy/metrics"
-        target_label  = "__metrics_path__"
-      }
     }
     
     prometheus.scrape "kubelet" {
@@ -45322,16 +45292,6 @@ data:
     // cAdvisor
     discovery.relabel "cadvisor" {
       targets = discovery.kubernetes.nodes.targets
-      rule {
-        target_label = "__address__"
-        replacement  = "kubernetes.default.svc.cluster.local:443"
-      }
-      rule {
-        source_labels = ["__meta_kubernetes_node_name"]
-        regex         = "(.+)"
-        replacement   = "/api/v1/nodes/${1}/proxy/metrics/cadvisor"
-        target_label  = "__metrics_path__"
-      }
     }
     
     prometheus.scrape "cadvisor" {

--- a/examples/specific-namespace/metrics.river
+++ b/examples/specific-namespace/metrics.river
@@ -384,16 +384,6 @@ prometheus.relabel "kubernetes_monitoring_telemetry" {
 // Kubelet
 discovery.relabel "kubelet" {
   targets = discovery.kubernetes.nodes.targets
-  rule {
-    target_label = "__address__"
-    replacement  = "kubernetes.default.svc.cluster.local:443"
-  }
-  rule {
-    source_labels = ["__meta_kubernetes_node_name"]
-    regex         = "(.+)"
-    replacement   = "/api/v1/nodes/${1}/proxy/metrics"
-    target_label  = "__metrics_path__"
-  }
 }
 
 prometheus.scrape "kubelet" {
@@ -423,16 +413,6 @@ prometheus.relabel "kubelet" {
 // cAdvisor
 discovery.relabel "cadvisor" {
   targets = discovery.kubernetes.nodes.targets
-  rule {
-    target_label = "__address__"
-    replacement  = "kubernetes.default.svc.cluster.local:443"
-  }
-  rule {
-    source_labels = ["__meta_kubernetes_node_name"]
-    regex         = "(.+)"
-    replacement   = "/api/v1/nodes/${1}/proxy/metrics/cadvisor"
-    target_label  = "__metrics_path__"
-  }
 }
 
 prometheus.scrape "cadvisor" {

--- a/examples/specific-namespace/metrics.river
+++ b/examples/specific-namespace/metrics.river
@@ -413,6 +413,10 @@ prometheus.relabel "kubelet" {
 // cAdvisor
 discovery.relabel "cadvisor" {
   targets = discovery.kubernetes.nodes.targets
+  rule {
+    replacement   = "/metrics/cadvisor"
+    target_label  = "__metrics_path__"
+  }
 }
 
 prometheus.scrape "cadvisor" {

--- a/examples/specific-namespace/output.yaml
+++ b/examples/specific-namespace/output.yaml
@@ -505,16 +505,6 @@ data:
     // Kubelet
     discovery.relabel "kubelet" {
       targets = discovery.kubernetes.nodes.targets
-      rule {
-        target_label = "__address__"
-        replacement  = "kubernetes.default.svc.cluster.local:443"
-      }
-      rule {
-        source_labels = ["__meta_kubernetes_node_name"]
-        regex         = "(.+)"
-        replacement   = "/api/v1/nodes/${1}/proxy/metrics"
-        target_label  = "__metrics_path__"
-      }
     }
     
     prometheus.scrape "kubelet" {
@@ -544,16 +534,6 @@ data:
     // cAdvisor
     discovery.relabel "cadvisor" {
       targets = discovery.kubernetes.nodes.targets
-      rule {
-        target_label = "__address__"
-        replacement  = "kubernetes.default.svc.cluster.local:443"
-      }
-      rule {
-        source_labels = ["__meta_kubernetes_node_name"]
-        regex         = "(.+)"
-        replacement   = "/api/v1/nodes/${1}/proxy/metrics/cadvisor"
-        target_label  = "__metrics_path__"
-      }
     }
     
     prometheus.scrape "cadvisor" {
@@ -45259,16 +45239,6 @@ data:
     // Kubelet
     discovery.relabel "kubelet" {
       targets = discovery.kubernetes.nodes.targets
-      rule {
-        target_label = "__address__"
-        replacement  = "kubernetes.default.svc.cluster.local:443"
-      }
-      rule {
-        source_labels = ["__meta_kubernetes_node_name"]
-        regex         = "(.+)"
-        replacement   = "/api/v1/nodes/${1}/proxy/metrics"
-        target_label  = "__metrics_path__"
-      }
     }
     
     prometheus.scrape "kubelet" {
@@ -45298,16 +45268,6 @@ data:
     // cAdvisor
     discovery.relabel "cadvisor" {
       targets = discovery.kubernetes.nodes.targets
-      rule {
-        target_label = "__address__"
-        replacement  = "kubernetes.default.svc.cluster.local:443"
-      }
-      rule {
-        source_labels = ["__meta_kubernetes_node_name"]
-        regex         = "(.+)"
-        replacement   = "/api/v1/nodes/${1}/proxy/metrics/cadvisor"
-        target_label  = "__metrics_path__"
-      }
     }
     
     prometheus.scrape "cadvisor" {

--- a/examples/specific-namespace/output.yaml
+++ b/examples/specific-namespace/output.yaml
@@ -534,6 +534,10 @@ data:
     // cAdvisor
     discovery.relabel "cadvisor" {
       targets = discovery.kubernetes.nodes.targets
+      rule {
+        replacement   = "/metrics/cadvisor"
+        target_label  = "__metrics_path__"
+      }
     }
     
     prometheus.scrape "cadvisor" {
@@ -45268,6 +45272,10 @@ data:
     // cAdvisor
     discovery.relabel "cadvisor" {
       targets = discovery.kubernetes.nodes.targets
+      rule {
+        replacement   = "/metrics/cadvisor"
+        target_label  = "__metrics_path__"
+      }
     }
     
     prometheus.scrape "cadvisor" {

--- a/examples/traces-enabled/metrics.river
+++ b/examples/traces-enabled/metrics.river
@@ -424,6 +424,10 @@ prometheus.relabel "kubelet" {
 // cAdvisor
 discovery.relabel "cadvisor" {
   targets = discovery.kubernetes.nodes.targets
+  rule {
+    replacement   = "/metrics/cadvisor"
+    target_label  = "__metrics_path__"
+  }
 }
 
 prometheus.scrape "cadvisor" {

--- a/examples/traces-enabled/metrics.river
+++ b/examples/traces-enabled/metrics.river
@@ -395,16 +395,6 @@ prometheus.relabel "kubernetes_monitoring_telemetry" {
 // Kubelet
 discovery.relabel "kubelet" {
   targets = discovery.kubernetes.nodes.targets
-  rule {
-    target_label = "__address__"
-    replacement  = "kubernetes.default.svc.cluster.local:443"
-  }
-  rule {
-    source_labels = ["__meta_kubernetes_node_name"]
-    regex         = "(.+)"
-    replacement   = "/api/v1/nodes/${1}/proxy/metrics"
-    target_label  = "__metrics_path__"
-  }
 }
 
 prometheus.scrape "kubelet" {
@@ -434,16 +424,6 @@ prometheus.relabel "kubelet" {
 // cAdvisor
 discovery.relabel "cadvisor" {
   targets = discovery.kubernetes.nodes.targets
-  rule {
-    target_label = "__address__"
-    replacement  = "kubernetes.default.svc.cluster.local:443"
-  }
-  rule {
-    source_labels = ["__meta_kubernetes_node_name"]
-    regex         = "(.+)"
-    replacement   = "/api/v1/nodes/${1}/proxy/metrics/cadvisor"
-    target_label  = "__metrics_path__"
-  }
 }
 
 prometheus.scrape "cadvisor" {

--- a/examples/traces-enabled/output.yaml
+++ b/examples/traces-enabled/output.yaml
@@ -558,6 +558,10 @@ data:
     // cAdvisor
     discovery.relabel "cadvisor" {
       targets = discovery.kubernetes.nodes.targets
+      rule {
+        replacement   = "/metrics/cadvisor"
+        target_label  = "__metrics_path__"
+      }
     }
     
     prometheus.scrape "cadvisor" {
@@ -45312,6 +45316,10 @@ data:
     // cAdvisor
     discovery.relabel "cadvisor" {
       targets = discovery.kubernetes.nodes.targets
+      rule {
+        replacement   = "/metrics/cadvisor"
+        target_label  = "__metrics_path__"
+      }
     }
     
     prometheus.scrape "cadvisor" {

--- a/examples/traces-enabled/output.yaml
+++ b/examples/traces-enabled/output.yaml
@@ -529,16 +529,6 @@ data:
     // Kubelet
     discovery.relabel "kubelet" {
       targets = discovery.kubernetes.nodes.targets
-      rule {
-        target_label = "__address__"
-        replacement  = "kubernetes.default.svc.cluster.local:443"
-      }
-      rule {
-        source_labels = ["__meta_kubernetes_node_name"]
-        regex         = "(.+)"
-        replacement   = "/api/v1/nodes/${1}/proxy/metrics"
-        target_label  = "__metrics_path__"
-      }
     }
     
     prometheus.scrape "kubelet" {
@@ -568,16 +558,6 @@ data:
     // cAdvisor
     discovery.relabel "cadvisor" {
       targets = discovery.kubernetes.nodes.targets
-      rule {
-        target_label = "__address__"
-        replacement  = "kubernetes.default.svc.cluster.local:443"
-      }
-      rule {
-        source_labels = ["__meta_kubernetes_node_name"]
-        regex         = "(.+)"
-        replacement   = "/api/v1/nodes/${1}/proxy/metrics/cadvisor"
-        target_label  = "__metrics_path__"
-      }
     }
     
     prometheus.scrape "cadvisor" {
@@ -45303,16 +45283,6 @@ data:
     // Kubelet
     discovery.relabel "kubelet" {
       targets = discovery.kubernetes.nodes.targets
-      rule {
-        target_label = "__address__"
-        replacement  = "kubernetes.default.svc.cluster.local:443"
-      }
-      rule {
-        source_labels = ["__meta_kubernetes_node_name"]
-        regex         = "(.+)"
-        replacement   = "/api/v1/nodes/${1}/proxy/metrics"
-        target_label  = "__metrics_path__"
-      }
     }
     
     prometheus.scrape "kubelet" {
@@ -45342,16 +45312,6 @@ data:
     // cAdvisor
     discovery.relabel "cadvisor" {
       targets = discovery.kubernetes.nodes.targets
-      rule {
-        target_label = "__address__"
-        replacement  = "kubernetes.default.svc.cluster.local:443"
-      }
-      rule {
-        source_labels = ["__meta_kubernetes_node_name"]
-        regex         = "(.+)"
-        replacement   = "/api/v1/nodes/${1}/proxy/metrics/cadvisor"
-        target_label  = "__metrics_path__"
-      }
     }
     
     prometheus.scrape "cadvisor" {

--- a/examples/windows-exporter/metrics.river
+++ b/examples/windows-exporter/metrics.river
@@ -384,16 +384,6 @@ prometheus.relabel "kubernetes_monitoring_telemetry" {
 // Kubelet
 discovery.relabel "kubelet" {
   targets = discovery.kubernetes.nodes.targets
-  rule {
-    target_label = "__address__"
-    replacement  = "kubernetes.default.svc.cluster.local:443"
-  }
-  rule {
-    source_labels = ["__meta_kubernetes_node_name"]
-    regex         = "(.+)"
-    replacement   = "/api/v1/nodes/${1}/proxy/metrics"
-    target_label  = "__metrics_path__"
-  }
 }
 
 prometheus.scrape "kubelet" {
@@ -423,16 +413,6 @@ prometheus.relabel "kubelet" {
 // cAdvisor
 discovery.relabel "cadvisor" {
   targets = discovery.kubernetes.nodes.targets
-  rule {
-    target_label = "__address__"
-    replacement  = "kubernetes.default.svc.cluster.local:443"
-  }
-  rule {
-    source_labels = ["__meta_kubernetes_node_name"]
-    regex         = "(.+)"
-    replacement   = "/api/v1/nodes/${1}/proxy/metrics/cadvisor"
-    target_label  = "__metrics_path__"
-  }
 }
 
 prometheus.scrape "cadvisor" {

--- a/examples/windows-exporter/metrics.river
+++ b/examples/windows-exporter/metrics.river
@@ -413,6 +413,10 @@ prometheus.relabel "kubelet" {
 // cAdvisor
 discovery.relabel "cadvisor" {
   targets = discovery.kubernetes.nodes.targets
+  rule {
+    replacement   = "/metrics/cadvisor"
+    target_label  = "__metrics_path__"
+  }
 }
 
 prometheus.scrape "cadvisor" {

--- a/examples/windows-exporter/output.yaml
+++ b/examples/windows-exporter/output.yaml
@@ -542,16 +542,6 @@ data:
     // Kubelet
     discovery.relabel "kubelet" {
       targets = discovery.kubernetes.nodes.targets
-      rule {
-        target_label = "__address__"
-        replacement  = "kubernetes.default.svc.cluster.local:443"
-      }
-      rule {
-        source_labels = ["__meta_kubernetes_node_name"]
-        regex         = "(.+)"
-        replacement   = "/api/v1/nodes/${1}/proxy/metrics"
-        target_label  = "__metrics_path__"
-      }
     }
     
     prometheus.scrape "kubelet" {
@@ -581,16 +571,6 @@ data:
     // cAdvisor
     discovery.relabel "cadvisor" {
       targets = discovery.kubernetes.nodes.targets
-      rule {
-        target_label = "__address__"
-        replacement  = "kubernetes.default.svc.cluster.local:443"
-      }
-      rule {
-        source_labels = ["__meta_kubernetes_node_name"]
-        regex         = "(.+)"
-        replacement   = "/api/v1/nodes/${1}/proxy/metrics/cadvisor"
-        target_label  = "__metrics_path__"
-      }
     }
     
     prometheus.scrape "cadvisor" {
@@ -45479,16 +45459,6 @@ data:
     // Kubelet
     discovery.relabel "kubelet" {
       targets = discovery.kubernetes.nodes.targets
-      rule {
-        target_label = "__address__"
-        replacement  = "kubernetes.default.svc.cluster.local:443"
-      }
-      rule {
-        source_labels = ["__meta_kubernetes_node_name"]
-        regex         = "(.+)"
-        replacement   = "/api/v1/nodes/${1}/proxy/metrics"
-        target_label  = "__metrics_path__"
-      }
     }
     
     prometheus.scrape "kubelet" {
@@ -45518,16 +45488,6 @@ data:
     // cAdvisor
     discovery.relabel "cadvisor" {
       targets = discovery.kubernetes.nodes.targets
-      rule {
-        target_label = "__address__"
-        replacement  = "kubernetes.default.svc.cluster.local:443"
-      }
-      rule {
-        source_labels = ["__meta_kubernetes_node_name"]
-        regex         = "(.+)"
-        replacement   = "/api/v1/nodes/${1}/proxy/metrics/cadvisor"
-        target_label  = "__metrics_path__"
-      }
     }
     
     prometheus.scrape "cadvisor" {

--- a/examples/windows-exporter/output.yaml
+++ b/examples/windows-exporter/output.yaml
@@ -571,6 +571,10 @@ data:
     // cAdvisor
     discovery.relabel "cadvisor" {
       targets = discovery.kubernetes.nodes.targets
+      rule {
+        replacement   = "/metrics/cadvisor"
+        target_label  = "__metrics_path__"
+      }
     }
     
     prometheus.scrape "cadvisor" {
@@ -45488,6 +45492,10 @@ data:
     // cAdvisor
     discovery.relabel "cadvisor" {
       targets = discovery.kubernetes.nodes.targets
+      rule {
+        replacement   = "/metrics/cadvisor"
+        target_label  = "__metrics_path__"
+      }
     }
     
     prometheus.scrape "cadvisor" {


### PR DESCRIPTION
This fixes gathering of those metrics on systems like GKE autopilot where access to nodes via proxy is blocked.

If `nodeAddressFormat` is `direct`, then we use the node service discovery to get the node IP. For cAdvisor only, we change the metrics path to `/metrics/cadvisor`. It follows this answer: https://stackoverflow.com/a/72292498

If `nodeAddressFormat` is `proxy`, we go the original route of setting the address to the `kubernetes` service, then set the path to `/api/v1/nodes/<node-name>/proxy/metrics` or `.../cadvisor`. This has been the accepted method for most prometheus scrapers, but it wasn't working on Autopilot.