### PR TITLE
Create the loki secret when logs.enabled is true

### DIFF
--- a/charts/k8s-monitoring/templates/log-service-credentials.yaml
+++ b/charts/k8s-monitoring/templates/log-service-credentials.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.logs.enabled (or .Values.logs.pod_logs.enabled .Values.logs.cluster_events.enabled) .Values.externalServices.loki.secret.create }}
+{{- if and .Values.logs.enabled .Values.externalServices.loki.secret.create }}
 ---
 apiVersion: v1
 kind: Secret

--- a/examples/custom-metrics-tuning/metrics.river
+++ b/examples/custom-metrics-tuning/metrics.river
@@ -29,7 +29,6 @@ otelcol.receiver.otlp "receiver" {
   }
   output {
     metrics = [otelcol.processor.transform.add_metric_datapoint_attributes.input]
-    logs = [otelcol.processor.k8sattributes.default.input]
   }
 }
 
@@ -78,7 +77,6 @@ otelcol.processor.k8sattributes "default" {
 
   output {
     metrics = [otelcol.processor.transform.add_resource_attributes.input]
-    logs    = [otelcol.processor.transform.add_resource_attributes.input]
   }
 }
 
@@ -91,18 +89,8 @@ otelcol.processor.transform "add_resource_attributes" {
       "set(attributes[\"k8s.cluster.name\"], \"custom-allow-lists-test\") where attributes[\"k8s.cluster.name\"] == nil",
     ]
   }
-  log_statements {
-    context = "resource"
-    statements = [
-      "set(attributes[\"pod\"], attributes[\"k8s.pod.name\"])",
-      "set(attributes[\"namespace\"], attributes[\"k8s.namespace.name\"])",
-      "set(attributes[\"loki.resource.labels\"], \"pod, namespace, cluster, job\")",
-      "set(attributes[\"k8s.cluster.name\"], \"custom-allow-lists-test\") where attributes[\"k8s.cluster.name\"] == nil",
-    ]
-  }
   output {
     metrics = [otelcol.processor.filter.default.input]
-    logs = [otelcol.processor.filter.default.input]
   }
 }
 
@@ -111,7 +99,6 @@ otelcol.processor.filter "default" {
 
   output {
     metrics = [otelcol.processor.batch.batch_processor.input]
-    logs = [otelcol.processor.batch.batch_processor.input]
   }
 }
 
@@ -121,14 +108,10 @@ otelcol.processor.batch "batch_processor" {
   timeout = "2s"
   output {
     metrics = [otelcol.exporter.prometheus.metrics_converter.input]
-    logs = [otelcol.exporter.loki.logs_converter.input]
   }
 }
 otelcol.exporter.prometheus "metrics_converter" {
   forward_to = [prometheus.relabel.metrics_service.receiver]
-}
-otelcol.exporter.loki "logs_converter" {
-  forward_to = [loki.process.pod_logs.receiver]
 }
 // Annotation Autodiscovery
 discovery.relabel "annotation_autodiscovery_pods" {
@@ -719,63 +702,5 @@ prometheus.remote_write "metrics_service" {
   }
 
   external_labels = {
-  }
-}
-
-loki.process "pod_logs" {
-  stage.match {
-    selector = "{tmp_container_runtime=\"containerd\"}"
-    // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
-    stage.cri {}
-
-    // Set the extract flags and stream values as labels
-    stage.labels {
-      values = {
-        flags  = "",
-        stream  = "",
-      }
-    }
-  }
-
-  // if the label tmp_container_runtime from above is docker parse using docker
-  stage.match {
-    selector = "{tmp_container_runtime=\"docker\"}"
-    // the docker processing stage extracts the following k/v pairs: log, stream, time
-    stage.docker {}
-
-    // Set the extract stream value as a label
-    stage.labels {
-      values = {
-        stream  = "",
-      }
-    }
-  }
-
-  // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have
-  // cluster, namespace, pod, and container labels.
-  // Also drop the temporary container runtime label as it is no longer needed.
-  stage.label_drop {
-    values = ["filename", "tmp_container_runtime"]
-  }
-  forward_to = [loki.write.grafana_cloud_loki.receiver]
-}
-
-// Loki
-remote.kubernetes.secret "logs_service" {
-  name = "loki-k8s-monitoring"
-  namespace = "default"
-}
-loki.write "grafana_cloud_loki" {
-  endpoint {
-    url = nonsensitive(remote.kubernetes.secret.logs_service.data["host"]) + "/loki/api/v1/push"
-    tenant_id = nonsensitive(remote.kubernetes.secret.logs_service.data["tenantId"])
-
-    basic_auth {
-      username = nonsensitive(remote.kubernetes.secret.logs_service.data["username"])
-      password = remote.kubernetes.secret.logs_service.data["password"]
-    }
-  }
-  external_labels = {
-    cluster = "custom-allow-lists-test",
   }
 }

--- a/examples/custom-metrics-tuning/output.yaml
+++ b/examples/custom-metrics-tuning/output.yaml
@@ -109,7 +109,6 @@ data:
       }
       output {
         metrics = [otelcol.processor.transform.add_metric_datapoint_attributes.input]
-        logs = [otelcol.processor.k8sattributes.default.input]
       }
     }
     
@@ -158,7 +157,6 @@ data:
     
       output {
         metrics = [otelcol.processor.transform.add_resource_attributes.input]
-        logs    = [otelcol.processor.transform.add_resource_attributes.input]
       }
     }
     
@@ -171,18 +169,8 @@ data:
           "set(attributes[\"k8s.cluster.name\"], \"custom-allow-lists-test\") where attributes[\"k8s.cluster.name\"] == nil",
         ]
       }
-      log_statements {
-        context = "resource"
-        statements = [
-          "set(attributes[\"pod\"], attributes[\"k8s.pod.name\"])",
-          "set(attributes[\"namespace\"], attributes[\"k8s.namespace.name\"])",
-          "set(attributes[\"loki.resource.labels\"], \"pod, namespace, cluster, job\")",
-          "set(attributes[\"k8s.cluster.name\"], \"custom-allow-lists-test\") where attributes[\"k8s.cluster.name\"] == nil",
-        ]
-      }
       output {
         metrics = [otelcol.processor.filter.default.input]
-        logs = [otelcol.processor.filter.default.input]
       }
     }
     
@@ -191,7 +179,6 @@ data:
     
       output {
         metrics = [otelcol.processor.batch.batch_processor.input]
-        logs = [otelcol.processor.batch.batch_processor.input]
       }
     }
     
@@ -201,14 +188,10 @@ data:
       timeout = "2s"
       output {
         metrics = [otelcol.exporter.prometheus.metrics_converter.input]
-        logs = [otelcol.exporter.loki.logs_converter.input]
       }
     }
     otelcol.exporter.prometheus "metrics_converter" {
       forward_to = [prometheus.relabel.metrics_service.receiver]
-    }
-    otelcol.exporter.loki "logs_converter" {
-      forward_to = [loki.process.pod_logs.receiver]
     }
     // Annotation Autodiscovery
     discovery.relabel "annotation_autodiscovery_pods" {
@@ -801,64 +784,6 @@ data:
       external_labels = {
       }
     }
-    
-    loki.process "pod_logs" {
-      stage.match {
-        selector = "{tmp_container_runtime=\"containerd\"}"
-        // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
-        stage.cri {}
-    
-        // Set the extract flags and stream values as labels
-        stage.labels {
-          values = {
-            flags  = "",
-            stream  = "",
-          }
-        }
-      }
-    
-      // if the label tmp_container_runtime from above is docker parse using docker
-      stage.match {
-        selector = "{tmp_container_runtime=\"docker\"}"
-        // the docker processing stage extracts the following k/v pairs: log, stream, time
-        stage.docker {}
-    
-        // Set the extract stream value as a label
-        stage.labels {
-          values = {
-            stream  = "",
-          }
-        }
-      }
-    
-      // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have
-      // cluster, namespace, pod, and container labels.
-      // Also drop the temporary container runtime label as it is no longer needed.
-      stage.label_drop {
-        values = ["filename", "tmp_container_runtime"]
-      }
-      forward_to = [loki.write.grafana_cloud_loki.receiver]
-    }
-    
-    // Loki
-    remote.kubernetes.secret "logs_service" {
-      name = "loki-k8s-monitoring"
-      namespace = "default"
-    }
-    loki.write "grafana_cloud_loki" {
-      endpoint {
-        url = nonsensitive(remote.kubernetes.secret.logs_service.data["host"]) + "/loki/api/v1/push"
-        tenant_id = nonsensitive(remote.kubernetes.secret.logs_service.data["tenantId"])
-    
-        basic_auth {
-          username = nonsensitive(remote.kubernetes.secret.logs_service.data["username"])
-          password = remote.kubernetes.secret.logs_service.data["password"]
-        }
-      }
-      external_labels = {
-        cluster = "custom-allow-lists-test",
-      }
-    }
 ---
 # Source: k8s-monitoring/templates/kubernetes-monitoring-telemetry.yaml
 apiVersion: v1
@@ -870,7 +795,7 @@ data:
   metrics.prom: |
     # HELP grafana_kubernetes_monitoring_build_info A metric to report the version of the Kubernetes Monitoring Helm chart as well as a summary of enabled features
     # TYPE grafana_kubernetes_monitoring_build_info gauge
-    grafana_kubernetes_monitoring_build_info{version="0.10.3", namespace="default", metrics="enabled,agent,autoDiscover,kube-state-metrics,node-exporter,kubelet,cadvisor,cost", logs="enabled", traces="disabled", deployments="kube-state-metrics,prometheus-node-exporter,prometheus-operator-crds,opencost"} 1
+    grafana_kubernetes_monitoring_build_info{version="0.10.3", namespace="default", metrics="enabled,agent,autoDiscover,kube-state-metrics,node-exporter,kubelet,cadvisor,cost", logs="disabled", traces="disabled", deployments="kube-state-metrics,prometheus-node-exporter,prometheus-operator-crds,opencost"} 1
 ---
 # Source: k8s-monitoring/charts/prometheus-operator-crds/charts/crds/templates/crd-alertmanagerconfigs.yaml
 apiVersion: apiextensions.k8s.io/v1
@@ -44230,7 +44155,6 @@ data:
       }
       output {
         metrics = [otelcol.processor.transform.add_metric_datapoint_attributes.input]
-        logs = [otelcol.processor.k8sattributes.default.input]
       }
     }
     
@@ -44279,7 +44203,6 @@ data:
     
       output {
         metrics = [otelcol.processor.transform.add_resource_attributes.input]
-        logs    = [otelcol.processor.transform.add_resource_attributes.input]
       }
     }
     
@@ -44292,18 +44215,8 @@ data:
           "set(attributes[\"k8s.cluster.name\"], \"custom-allow-lists-test\") where attributes[\"k8s.cluster.name\"] == nil",
         ]
       }
-      log_statements {
-        context = "resource"
-        statements = [
-          "set(attributes[\"pod\"], attributes[\"k8s.pod.name\"])",
-          "set(attributes[\"namespace\"], attributes[\"k8s.namespace.name\"])",
-          "set(attributes[\"loki.resource.labels\"], \"pod, namespace, cluster, job\")",
-          "set(attributes[\"k8s.cluster.name\"], \"custom-allow-lists-test\") where attributes[\"k8s.cluster.name\"] == nil",
-        ]
-      }
       output {
         metrics = [otelcol.processor.filter.default.input]
-        logs = [otelcol.processor.filter.default.input]
       }
     }
     
@@ -44312,7 +44225,6 @@ data:
     
       output {
         metrics = [otelcol.processor.batch.batch_processor.input]
-        logs = [otelcol.processor.batch.batch_processor.input]
       }
     }
     
@@ -44322,14 +44234,10 @@ data:
       timeout = "2s"
       output {
         metrics = [otelcol.exporter.prometheus.metrics_converter.input]
-        logs = [otelcol.exporter.loki.logs_converter.input]
       }
     }
     otelcol.exporter.prometheus "metrics_converter" {
       forward_to = [prometheus.relabel.metrics_service.receiver]
-    }
-    otelcol.exporter.loki "logs_converter" {
-      forward_to = [loki.process.pod_logs.receiver]
     }
     // Annotation Autodiscovery
     discovery.relabel "annotation_autodiscovery_pods" {
@@ -44920,64 +44828,6 @@ data:
       }
     
       external_labels = {
-      }
-    }
-    
-    loki.process "pod_logs" {
-      stage.match {
-        selector = "{tmp_container_runtime=\"containerd\"}"
-        // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
-        stage.cri {}
-    
-        // Set the extract flags and stream values as labels
-        stage.labels {
-          values = {
-            flags  = "",
-            stream  = "",
-          }
-        }
-      }
-    
-      // if the label tmp_container_runtime from above is docker parse using docker
-      stage.match {
-        selector = "{tmp_container_runtime=\"docker\"}"
-        // the docker processing stage extracts the following k/v pairs: log, stream, time
-        stage.docker {}
-    
-        // Set the extract stream value as a label
-        stage.labels {
-          values = {
-            stream  = "",
-          }
-        }
-      }
-    
-      // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have
-      // cluster, namespace, pod, and container labels.
-      // Also drop the temporary container runtime label as it is no longer needed.
-      stage.label_drop {
-        values = ["filename", "tmp_container_runtime"]
-      }
-      forward_to = [loki.write.grafana_cloud_loki.receiver]
-    }
-    
-    // Loki
-    remote.kubernetes.secret "logs_service" {
-      name = "loki-k8s-monitoring"
-      namespace = "default"
-    }
-    loki.write "grafana_cloud_loki" {
-      endpoint {
-        url = nonsensitive(remote.kubernetes.secret.logs_service.data["host"]) + "/loki/api/v1/push"
-        tenant_id = nonsensitive(remote.kubernetes.secret.logs_service.data["tenantId"])
-    
-        basic_auth {
-          username = nonsensitive(remote.kubernetes.secret.logs_service.data["username"])
-          password = remote.kubernetes.secret.logs_service.data["password"]
-        }
-      }
-      external_labels = {
-        cluster = "custom-allow-lists-test",
       }
     }
 ---

--- a/examples/custom-metrics-tuning/values.yaml
+++ b/examples/custom-metrics-tuning/values.yaml
@@ -36,6 +36,7 @@ metrics:
   enabled: true
 
 logs:
+  enabled: false
   pod_logs:
     enabled: false
 

--- a/examples/metrics-only/metrics.river
+++ b/examples/metrics-only/metrics.river
@@ -29,7 +29,6 @@ otelcol.receiver.otlp "receiver" {
   }
   output {
     metrics = [otelcol.processor.transform.add_metric_datapoint_attributes.input]
-    logs = [otelcol.processor.k8sattributes.default.input]
   }
 }
 
@@ -78,7 +77,6 @@ otelcol.processor.k8sattributes "default" {
 
   output {
     metrics = [otelcol.processor.transform.add_resource_attributes.input]
-    logs    = [otelcol.processor.transform.add_resource_attributes.input]
   }
 }
 
@@ -91,18 +89,8 @@ otelcol.processor.transform "add_resource_attributes" {
       "set(attributes[\"k8s.cluster.name\"], \"metrics-only-test\") where attributes[\"k8s.cluster.name\"] == nil",
     ]
   }
-  log_statements {
-    context = "resource"
-    statements = [
-      "set(attributes[\"pod\"], attributes[\"k8s.pod.name\"])",
-      "set(attributes[\"namespace\"], attributes[\"k8s.namespace.name\"])",
-      "set(attributes[\"loki.resource.labels\"], \"pod, namespace, cluster, job\")",
-      "set(attributes[\"k8s.cluster.name\"], \"metrics-only-test\") where attributes[\"k8s.cluster.name\"] == nil",
-    ]
-  }
   output {
     metrics = [otelcol.processor.filter.default.input]
-    logs = [otelcol.processor.filter.default.input]
   }
 }
 
@@ -111,7 +99,6 @@ otelcol.processor.filter "default" {
 
   output {
     metrics = [otelcol.processor.batch.batch_processor.input]
-    logs = [otelcol.processor.batch.batch_processor.input]
   }
 }
 
@@ -121,14 +108,10 @@ otelcol.processor.batch "batch_processor" {
   timeout = "2s"
   output {
     metrics = [otelcol.exporter.prometheus.metrics_converter.input]
-    logs = [otelcol.exporter.loki.logs_converter.input]
   }
 }
 otelcol.exporter.prometheus "metrics_converter" {
   forward_to = [prometheus.relabel.metrics_service.receiver]
-}
-otelcol.exporter.loki "logs_converter" {
-  forward_to = [loki.process.pod_logs.receiver]
 }
 // Annotation Autodiscovery
 discovery.relabel "annotation_autodiscovery_pods" {
@@ -724,63 +707,5 @@ prometheus.remote_write "metrics_service" {
   }
 
   external_labels = {
-  }
-}
-
-loki.process "pod_logs" {
-  stage.match {
-    selector = "{tmp_container_runtime=\"containerd\"}"
-    // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
-    stage.cri {}
-
-    // Set the extract flags and stream values as labels
-    stage.labels {
-      values = {
-        flags  = "",
-        stream  = "",
-      }
-    }
-  }
-
-  // if the label tmp_container_runtime from above is docker parse using docker
-  stage.match {
-    selector = "{tmp_container_runtime=\"docker\"}"
-    // the docker processing stage extracts the following k/v pairs: log, stream, time
-    stage.docker {}
-
-    // Set the extract stream value as a label
-    stage.labels {
-      values = {
-        stream  = "",
-      }
-    }
-  }
-
-  // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have
-  // cluster, namespace, pod, and container labels.
-  // Also drop the temporary container runtime label as it is no longer needed.
-  stage.label_drop {
-    values = ["filename", "tmp_container_runtime"]
-  }
-  forward_to = [loki.write.grafana_cloud_loki.receiver]
-}
-
-// Loki
-remote.kubernetes.secret "logs_service" {
-  name = "loki-k8s-monitoring"
-  namespace = "default"
-}
-loki.write "grafana_cloud_loki" {
-  endpoint {
-    url = nonsensitive(remote.kubernetes.secret.logs_service.data["host"]) + "/loki/api/v1/push"
-    tenant_id = nonsensitive(remote.kubernetes.secret.logs_service.data["tenantId"])
-
-    basic_auth {
-      username = nonsensitive(remote.kubernetes.secret.logs_service.data["username"])
-      password = remote.kubernetes.secret.logs_service.data["password"]
-    }
-  }
-  external_labels = {
-    cluster = "metrics-only-test",
   }
 }

--- a/examples/metrics-only/output.yaml
+++ b/examples/metrics-only/output.yaml
@@ -110,7 +110,6 @@ data:
       }
       output {
         metrics = [otelcol.processor.transform.add_metric_datapoint_attributes.input]
-        logs = [otelcol.processor.k8sattributes.default.input]
       }
     }
     
@@ -159,7 +158,6 @@ data:
     
       output {
         metrics = [otelcol.processor.transform.add_resource_attributes.input]
-        logs    = [otelcol.processor.transform.add_resource_attributes.input]
       }
     }
     
@@ -172,18 +170,8 @@ data:
           "set(attributes[\"k8s.cluster.name\"], \"metrics-only-test\") where attributes[\"k8s.cluster.name\"] == nil",
         ]
       }
-      log_statements {
-        context = "resource"
-        statements = [
-          "set(attributes[\"pod\"], attributes[\"k8s.pod.name\"])",
-          "set(attributes[\"namespace\"], attributes[\"k8s.namespace.name\"])",
-          "set(attributes[\"loki.resource.labels\"], \"pod, namespace, cluster, job\")",
-          "set(attributes[\"k8s.cluster.name\"], \"metrics-only-test\") where attributes[\"k8s.cluster.name\"] == nil",
-        ]
-      }
       output {
         metrics = [otelcol.processor.filter.default.input]
-        logs = [otelcol.processor.filter.default.input]
       }
     }
     
@@ -192,7 +180,6 @@ data:
     
       output {
         metrics = [otelcol.processor.batch.batch_processor.input]
-        logs = [otelcol.processor.batch.batch_processor.input]
       }
     }
     
@@ -202,14 +189,10 @@ data:
       timeout = "2s"
       output {
         metrics = [otelcol.exporter.prometheus.metrics_converter.input]
-        logs = [otelcol.exporter.loki.logs_converter.input]
       }
     }
     otelcol.exporter.prometheus "metrics_converter" {
       forward_to = [prometheus.relabel.metrics_service.receiver]
-    }
-    otelcol.exporter.loki "logs_converter" {
-      forward_to = [loki.process.pod_logs.receiver]
     }
     // Annotation Autodiscovery
     discovery.relabel "annotation_autodiscovery_pods" {
@@ -807,64 +790,6 @@ data:
       external_labels = {
       }
     }
-    
-    loki.process "pod_logs" {
-      stage.match {
-        selector = "{tmp_container_runtime=\"containerd\"}"
-        // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
-        stage.cri {}
-    
-        // Set the extract flags and stream values as labels
-        stage.labels {
-          values = {
-            flags  = "",
-            stream  = "",
-          }
-        }
-      }
-    
-      // if the label tmp_container_runtime from above is docker parse using docker
-      stage.match {
-        selector = "{tmp_container_runtime=\"docker\"}"
-        // the docker processing stage extracts the following k/v pairs: log, stream, time
-        stage.docker {}
-    
-        // Set the extract stream value as a label
-        stage.labels {
-          values = {
-            stream  = "",
-          }
-        }
-      }
-    
-      // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have
-      // cluster, namespace, pod, and container labels.
-      // Also drop the temporary container runtime label as it is no longer needed.
-      stage.label_drop {
-        values = ["filename", "tmp_container_runtime"]
-      }
-      forward_to = [loki.write.grafana_cloud_loki.receiver]
-    }
-    
-    // Loki
-    remote.kubernetes.secret "logs_service" {
-      name = "loki-k8s-monitoring"
-      namespace = "default"
-    }
-    loki.write "grafana_cloud_loki" {
-      endpoint {
-        url = nonsensitive(remote.kubernetes.secret.logs_service.data["host"]) + "/loki/api/v1/push"
-        tenant_id = nonsensitive(remote.kubernetes.secret.logs_service.data["tenantId"])
-    
-        basic_auth {
-          username = nonsensitive(remote.kubernetes.secret.logs_service.data["username"])
-          password = remote.kubernetes.secret.logs_service.data["password"]
-        }
-      }
-      external_labels = {
-        cluster = "metrics-only-test",
-      }
-    }
 ---
 # Source: k8s-monitoring/templates/kubernetes-monitoring-telemetry.yaml
 apiVersion: v1
@@ -876,7 +801,7 @@ data:
   metrics.prom: |
     # HELP grafana_kubernetes_monitoring_build_info A metric to report the version of the Kubernetes Monitoring Helm chart as well as a summary of enabled features
     # TYPE grafana_kubernetes_monitoring_build_info gauge
-    grafana_kubernetes_monitoring_build_info{version="0.10.3", namespace="default", metrics="enabled,agent,autoDiscover,kube-state-metrics,node-exporter,kubelet,cadvisor,cost", logs="enabled", traces="disabled", deployments="kube-state-metrics,prometheus-node-exporter,prometheus-operator-crds,opencost"} 1
+    grafana_kubernetes_monitoring_build_info{version="0.10.3", namespace="default", metrics="enabled,agent,autoDiscover,kube-state-metrics,node-exporter,kubelet,cadvisor,cost", logs="disabled", traces="disabled", deployments="kube-state-metrics,prometheus-node-exporter,prometheus-operator-crds,opencost"} 1
 ---
 # Source: k8s-monitoring/charts/prometheus-operator-crds/charts/crds/templates/crd-alertmanagerconfigs.yaml
 apiVersion: apiextensions.k8s.io/v1
@@ -44236,7 +44161,6 @@ data:
       }
       output {
         metrics = [otelcol.processor.transform.add_metric_datapoint_attributes.input]
-        logs = [otelcol.processor.k8sattributes.default.input]
       }
     }
     
@@ -44285,7 +44209,6 @@ data:
     
       output {
         metrics = [otelcol.processor.transform.add_resource_attributes.input]
-        logs    = [otelcol.processor.transform.add_resource_attributes.input]
       }
     }
     
@@ -44298,18 +44221,8 @@ data:
           "set(attributes[\"k8s.cluster.name\"], \"metrics-only-test\") where attributes[\"k8s.cluster.name\"] == nil",
         ]
       }
-      log_statements {
-        context = "resource"
-        statements = [
-          "set(attributes[\"pod\"], attributes[\"k8s.pod.name\"])",
-          "set(attributes[\"namespace\"], attributes[\"k8s.namespace.name\"])",
-          "set(attributes[\"loki.resource.labels\"], \"pod, namespace, cluster, job\")",
-          "set(attributes[\"k8s.cluster.name\"], \"metrics-only-test\") where attributes[\"k8s.cluster.name\"] == nil",
-        ]
-      }
       output {
         metrics = [otelcol.processor.filter.default.input]
-        logs = [otelcol.processor.filter.default.input]
       }
     }
     
@@ -44318,7 +44231,6 @@ data:
     
       output {
         metrics = [otelcol.processor.batch.batch_processor.input]
-        logs = [otelcol.processor.batch.batch_processor.input]
       }
     }
     
@@ -44328,14 +44240,10 @@ data:
       timeout = "2s"
       output {
         metrics = [otelcol.exporter.prometheus.metrics_converter.input]
-        logs = [otelcol.exporter.loki.logs_converter.input]
       }
     }
     otelcol.exporter.prometheus "metrics_converter" {
       forward_to = [prometheus.relabel.metrics_service.receiver]
-    }
-    otelcol.exporter.loki "logs_converter" {
-      forward_to = [loki.process.pod_logs.receiver]
     }
     // Annotation Autodiscovery
     discovery.relabel "annotation_autodiscovery_pods" {
@@ -44931,64 +44839,6 @@ data:
       }
     
       external_labels = {
-      }
-    }
-    
-    loki.process "pod_logs" {
-      stage.match {
-        selector = "{tmp_container_runtime=\"containerd\"}"
-        // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
-        stage.cri {}
-    
-        // Set the extract flags and stream values as labels
-        stage.labels {
-          values = {
-            flags  = "",
-            stream  = "",
-          }
-        }
-      }
-    
-      // if the label tmp_container_runtime from above is docker parse using docker
-      stage.match {
-        selector = "{tmp_container_runtime=\"docker\"}"
-        // the docker processing stage extracts the following k/v pairs: log, stream, time
-        stage.docker {}
-    
-        // Set the extract stream value as a label
-        stage.labels {
-          values = {
-            stream  = "",
-          }
-        }
-      }
-    
-      // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have
-      // cluster, namespace, pod, and container labels.
-      // Also drop the temporary container runtime label as it is no longer needed.
-      stage.label_drop {
-        values = ["filename", "tmp_container_runtime"]
-      }
-      forward_to = [loki.write.grafana_cloud_loki.receiver]
-    }
-    
-    // Loki
-    remote.kubernetes.secret "logs_service" {
-      name = "loki-k8s-monitoring"
-      namespace = "default"
-    }
-    loki.write "grafana_cloud_loki" {
-      endpoint {
-        url = nonsensitive(remote.kubernetes.secret.logs_service.data["host"]) + "/loki/api/v1/push"
-        tenant_id = nonsensitive(remote.kubernetes.secret.logs_service.data["tenantId"])
-    
-        basic_auth {
-          username = nonsensitive(remote.kubernetes.secret.logs_service.data["username"])
-          password = remote.kubernetes.secret.logs_service.data["password"]
-        }
-      }
-      external_labels = {
-        cluster = "metrics-only-test",
       }
     }
 ---

--- a/examples/metrics-only/values.yaml
+++ b/examples/metrics-only/values.yaml
@@ -10,6 +10,7 @@ externalServices:
       password: "It's a secret to everyone"
 
 logs:
+  enabled: false
   pod_logs:
     enabled: false
 

--- a/examples/scrape-intervals/metrics.river
+++ b/examples/scrape-intervals/metrics.river
@@ -29,7 +29,6 @@ otelcol.receiver.otlp "receiver" {
   }
   output {
     metrics = [otelcol.processor.transform.add_metric_datapoint_attributes.input]
-    logs = [otelcol.processor.k8sattributes.default.input]
   }
 }
 
@@ -78,7 +77,6 @@ otelcol.processor.k8sattributes "default" {
 
   output {
     metrics = [otelcol.processor.transform.add_resource_attributes.input]
-    logs    = [otelcol.processor.transform.add_resource_attributes.input]
   }
 }
 
@@ -91,18 +89,8 @@ otelcol.processor.transform "add_resource_attributes" {
       "set(attributes[\"k8s.cluster.name\"], \"custom-scrape-intervals-test\") where attributes[\"k8s.cluster.name\"] == nil",
     ]
   }
-  log_statements {
-    context = "resource"
-    statements = [
-      "set(attributes[\"pod\"], attributes[\"k8s.pod.name\"])",
-      "set(attributes[\"namespace\"], attributes[\"k8s.namespace.name\"])",
-      "set(attributes[\"loki.resource.labels\"], \"pod, namespace, cluster, job\")",
-      "set(attributes[\"k8s.cluster.name\"], \"custom-scrape-intervals-test\") where attributes[\"k8s.cluster.name\"] == nil",
-    ]
-  }
   output {
     metrics = [otelcol.processor.filter.default.input]
-    logs = [otelcol.processor.filter.default.input]
   }
 }
 
@@ -111,7 +99,6 @@ otelcol.processor.filter "default" {
 
   output {
     metrics = [otelcol.processor.batch.batch_processor.input]
-    logs = [otelcol.processor.batch.batch_processor.input]
   }
 }
 
@@ -121,14 +108,10 @@ otelcol.processor.batch "batch_processor" {
   timeout = "2s"
   output {
     metrics = [otelcol.exporter.prometheus.metrics_converter.input]
-    logs = [otelcol.exporter.loki.logs_converter.input]
   }
 }
 otelcol.exporter.prometheus "metrics_converter" {
   forward_to = [prometheus.relabel.metrics_service.receiver]
-}
-otelcol.exporter.loki "logs_converter" {
-  forward_to = [loki.process.pod_logs.receiver]
 }
 // Annotation Autodiscovery
 discovery.relabel "annotation_autodiscovery_pods" {
@@ -724,63 +707,5 @@ prometheus.remote_write "metrics_service" {
   }
 
   external_labels = {
-  }
-}
-
-loki.process "pod_logs" {
-  stage.match {
-    selector = "{tmp_container_runtime=\"containerd\"}"
-    // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
-    stage.cri {}
-
-    // Set the extract flags and stream values as labels
-    stage.labels {
-      values = {
-        flags  = "",
-        stream  = "",
-      }
-    }
-  }
-
-  // if the label tmp_container_runtime from above is docker parse using docker
-  stage.match {
-    selector = "{tmp_container_runtime=\"docker\"}"
-    // the docker processing stage extracts the following k/v pairs: log, stream, time
-    stage.docker {}
-
-    // Set the extract stream value as a label
-    stage.labels {
-      values = {
-        stream  = "",
-      }
-    }
-  }
-
-  // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have
-  // cluster, namespace, pod, and container labels.
-  // Also drop the temporary container runtime label as it is no longer needed.
-  stage.label_drop {
-    values = ["filename", "tmp_container_runtime"]
-  }
-  forward_to = [loki.write.grafana_cloud_loki.receiver]
-}
-
-// Loki
-remote.kubernetes.secret "logs_service" {
-  name = "loki-k8s-monitoring"
-  namespace = "default"
-}
-loki.write "grafana_cloud_loki" {
-  endpoint {
-    url = nonsensitive(remote.kubernetes.secret.logs_service.data["host"]) + "/loki/api/v1/push"
-    tenant_id = nonsensitive(remote.kubernetes.secret.logs_service.data["tenantId"])
-
-    basic_auth {
-      username = nonsensitive(remote.kubernetes.secret.logs_service.data["username"])
-      password = remote.kubernetes.secret.logs_service.data["password"]
-    }
-  }
-  external_labels = {
-    cluster = "custom-scrape-intervals-test",
   }
 }

--- a/examples/scrape-intervals/output.yaml
+++ b/examples/scrape-intervals/output.yaml
@@ -109,7 +109,6 @@ data:
       }
       output {
         metrics = [otelcol.processor.transform.add_metric_datapoint_attributes.input]
-        logs = [otelcol.processor.k8sattributes.default.input]
       }
     }
     
@@ -158,7 +157,6 @@ data:
     
       output {
         metrics = [otelcol.processor.transform.add_resource_attributes.input]
-        logs    = [otelcol.processor.transform.add_resource_attributes.input]
       }
     }
     
@@ -171,18 +169,8 @@ data:
           "set(attributes[\"k8s.cluster.name\"], \"custom-scrape-intervals-test\") where attributes[\"k8s.cluster.name\"] == nil",
         ]
       }
-      log_statements {
-        context = "resource"
-        statements = [
-          "set(attributes[\"pod\"], attributes[\"k8s.pod.name\"])",
-          "set(attributes[\"namespace\"], attributes[\"k8s.namespace.name\"])",
-          "set(attributes[\"loki.resource.labels\"], \"pod, namespace, cluster, job\")",
-          "set(attributes[\"k8s.cluster.name\"], \"custom-scrape-intervals-test\") where attributes[\"k8s.cluster.name\"] == nil",
-        ]
-      }
       output {
         metrics = [otelcol.processor.filter.default.input]
-        logs = [otelcol.processor.filter.default.input]
       }
     }
     
@@ -191,7 +179,6 @@ data:
     
       output {
         metrics = [otelcol.processor.batch.batch_processor.input]
-        logs = [otelcol.processor.batch.batch_processor.input]
       }
     }
     
@@ -201,14 +188,10 @@ data:
       timeout = "2s"
       output {
         metrics = [otelcol.exporter.prometheus.metrics_converter.input]
-        logs = [otelcol.exporter.loki.logs_converter.input]
       }
     }
     otelcol.exporter.prometheus "metrics_converter" {
       forward_to = [prometheus.relabel.metrics_service.receiver]
-    }
-    otelcol.exporter.loki "logs_converter" {
-      forward_to = [loki.process.pod_logs.receiver]
     }
     // Annotation Autodiscovery
     discovery.relabel "annotation_autodiscovery_pods" {
@@ -806,64 +789,6 @@ data:
       external_labels = {
       }
     }
-    
-    loki.process "pod_logs" {
-      stage.match {
-        selector = "{tmp_container_runtime=\"containerd\"}"
-        // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
-        stage.cri {}
-    
-        // Set the extract flags and stream values as labels
-        stage.labels {
-          values = {
-            flags  = "",
-            stream  = "",
-          }
-        }
-      }
-    
-      // if the label tmp_container_runtime from above is docker parse using docker
-      stage.match {
-        selector = "{tmp_container_runtime=\"docker\"}"
-        // the docker processing stage extracts the following k/v pairs: log, stream, time
-        stage.docker {}
-    
-        // Set the extract stream value as a label
-        stage.labels {
-          values = {
-            stream  = "",
-          }
-        }
-      }
-    
-      // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have
-      // cluster, namespace, pod, and container labels.
-      // Also drop the temporary container runtime label as it is no longer needed.
-      stage.label_drop {
-        values = ["filename", "tmp_container_runtime"]
-      }
-      forward_to = [loki.write.grafana_cloud_loki.receiver]
-    }
-    
-    // Loki
-    remote.kubernetes.secret "logs_service" {
-      name = "loki-k8s-monitoring"
-      namespace = "default"
-    }
-    loki.write "grafana_cloud_loki" {
-      endpoint {
-        url = nonsensitive(remote.kubernetes.secret.logs_service.data["host"]) + "/loki/api/v1/push"
-        tenant_id = nonsensitive(remote.kubernetes.secret.logs_service.data["tenantId"])
-    
-        basic_auth {
-          username = nonsensitive(remote.kubernetes.secret.logs_service.data["username"])
-          password = remote.kubernetes.secret.logs_service.data["password"]
-        }
-      }
-      external_labels = {
-        cluster = "custom-scrape-intervals-test",
-      }
-    }
 ---
 # Source: k8s-monitoring/templates/kubernetes-monitoring-telemetry.yaml
 apiVersion: v1
@@ -875,7 +800,7 @@ data:
   metrics.prom: |
     # HELP grafana_kubernetes_monitoring_build_info A metric to report the version of the Kubernetes Monitoring Helm chart as well as a summary of enabled features
     # TYPE grafana_kubernetes_monitoring_build_info gauge
-    grafana_kubernetes_monitoring_build_info{version="0.10.3", namespace="default", metrics="enabled,agent,autoDiscover,kube-state-metrics,node-exporter,kubelet,cadvisor,cost", logs="enabled", traces="disabled", deployments="kube-state-metrics,prometheus-node-exporter,prometheus-operator-crds,opencost"} 1
+    grafana_kubernetes_monitoring_build_info{version="0.10.3", namespace="default", metrics="enabled,agent,autoDiscover,kube-state-metrics,node-exporter,kubelet,cadvisor,cost", logs="disabled", traces="disabled", deployments="kube-state-metrics,prometheus-node-exporter,prometheus-operator-crds,opencost"} 1
 ---
 # Source: k8s-monitoring/charts/prometheus-operator-crds/charts/crds/templates/crd-alertmanagerconfigs.yaml
 apiVersion: apiextensions.k8s.io/v1
@@ -44235,7 +44160,6 @@ data:
       }
       output {
         metrics = [otelcol.processor.transform.add_metric_datapoint_attributes.input]
-        logs = [otelcol.processor.k8sattributes.default.input]
       }
     }
     
@@ -44284,7 +44208,6 @@ data:
     
       output {
         metrics = [otelcol.processor.transform.add_resource_attributes.input]
-        logs    = [otelcol.processor.transform.add_resource_attributes.input]
       }
     }
     
@@ -44297,18 +44220,8 @@ data:
           "set(attributes[\"k8s.cluster.name\"], \"custom-scrape-intervals-test\") where attributes[\"k8s.cluster.name\"] == nil",
         ]
       }
-      log_statements {
-        context = "resource"
-        statements = [
-          "set(attributes[\"pod\"], attributes[\"k8s.pod.name\"])",
-          "set(attributes[\"namespace\"], attributes[\"k8s.namespace.name\"])",
-          "set(attributes[\"loki.resource.labels\"], \"pod, namespace, cluster, job\")",
-          "set(attributes[\"k8s.cluster.name\"], \"custom-scrape-intervals-test\") where attributes[\"k8s.cluster.name\"] == nil",
-        ]
-      }
       output {
         metrics = [otelcol.processor.filter.default.input]
-        logs = [otelcol.processor.filter.default.input]
       }
     }
     
@@ -44317,7 +44230,6 @@ data:
     
       output {
         metrics = [otelcol.processor.batch.batch_processor.input]
-        logs = [otelcol.processor.batch.batch_processor.input]
       }
     }
     
@@ -44327,14 +44239,10 @@ data:
       timeout = "2s"
       output {
         metrics = [otelcol.exporter.prometheus.metrics_converter.input]
-        logs = [otelcol.exporter.loki.logs_converter.input]
       }
     }
     otelcol.exporter.prometheus "metrics_converter" {
       forward_to = [prometheus.relabel.metrics_service.receiver]
-    }
-    otelcol.exporter.loki "logs_converter" {
-      forward_to = [loki.process.pod_logs.receiver]
     }
     // Annotation Autodiscovery
     discovery.relabel "annotation_autodiscovery_pods" {
@@ -44930,64 +44838,6 @@ data:
       }
     
       external_labels = {
-      }
-    }
-    
-    loki.process "pod_logs" {
-      stage.match {
-        selector = "{tmp_container_runtime=\"containerd\"}"
-        // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
-        stage.cri {}
-    
-        // Set the extract flags and stream values as labels
-        stage.labels {
-          values = {
-            flags  = "",
-            stream  = "",
-          }
-        }
-      }
-    
-      // if the label tmp_container_runtime from above is docker parse using docker
-      stage.match {
-        selector = "{tmp_container_runtime=\"docker\"}"
-        // the docker processing stage extracts the following k/v pairs: log, stream, time
-        stage.docker {}
-    
-        // Set the extract stream value as a label
-        stage.labels {
-          values = {
-            stream  = "",
-          }
-        }
-      }
-    
-      // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have
-      // cluster, namespace, pod, and container labels.
-      // Also drop the temporary container runtime label as it is no longer needed.
-      stage.label_drop {
-        values = ["filename", "tmp_container_runtime"]
-      }
-      forward_to = [loki.write.grafana_cloud_loki.receiver]
-    }
-    
-    // Loki
-    remote.kubernetes.secret "logs_service" {
-      name = "loki-k8s-monitoring"
-      namespace = "default"
-    }
-    loki.write "grafana_cloud_loki" {
-      endpoint {
-        url = nonsensitive(remote.kubernetes.secret.logs_service.data["host"]) + "/loki/api/v1/push"
-        tenant_id = nonsensitive(remote.kubernetes.secret.logs_service.data["tenantId"])
-    
-        basic_auth {
-          username = nonsensitive(remote.kubernetes.secret.logs_service.data["username"])
-          password = remote.kubernetes.secret.logs_service.data["password"]
-        }
-      }
-      external_labels = {
-        cluster = "custom-scrape-intervals-test",
       }
     }
 ---

--- a/examples/scrape-intervals/values.yaml
+++ b/examples/scrape-intervals/values.yaml
@@ -16,6 +16,7 @@ metrics:
     scrapeInterval: 60s
 
 logs:
+  enabled: false
   pod_logs:
     enabled: false
 


### PR DESCRIPTION
This change means the loki secret is available even if we're only using the receivers for logs. This is helpful for an AppO11y-only deployment of the chart.