### PR TITLE
Do not set the namespaces list for Prom Operator objects

### DIFF
--- a/charts/k8s-monitoring/templates/agent_config/_prometheus_operator_objects.txt
+++ b/charts/k8s-monitoring/templates/agent_config/_prometheus_operator_objects.txt
@@ -1,7 +1,9 @@
 {{ define "agent.config.pod_monitors" }}
 // Prometheus Operator PodMonitor objects
 prometheus.operator.podmonitors "pod_monitors" {
+{{- if .Values.metrics.podMonitors.namespaces }}
   namespaces = {{ .Values.metrics.podMonitors.namespaces | toJson }}
+{{- end }}
   forward_to = [prometheus.relabel.podmonitors.receiver]
 {{- if .Values.metrics.podMonitors.selector }}
   selector {
@@ -29,7 +31,9 @@ prometheus.relabel "podmonitors" {
 {{ define "agent.config.probes" }}
 // Prometheus Operator Probe objects
 prometheus.operator.probes "probes" {
+{{- if .Values.metrics.probes.namespaces }}
   namespaces = {{ .Values.metrics.probes.namespaces | toJson }}
+{{- end }}
   forward_to = [prometheus.relabel.probes.receiver]
 {{- if .Values.metrics.probes.selector }}
   selector {
@@ -58,7 +62,9 @@ prometheus.relabel "probes" {
 {{ define "agent.config.service_monitors" }}
 // Prometheus Operator ServiceMonitor objects
 prometheus.operator.servicemonitors "service_monitors" {
+{{- if .Values.metrics.serviceMonitors.namespaces }}
   namespaces = {{ .Values.metrics.serviceMonitors.namespaces | toJson }}
+{{- end }}
   forward_to = [prometheus.relabel.servicemonitors.receiver]
 {{- if .Values.metrics.serviceMonitors.selector }}
   selector {

--- a/examples/cluster-with-pvc/metrics.river
+++ b/examples/cluster-with-pvc/metrics.river
@@ -643,7 +643,6 @@ prometheus.relabel "opencost" {
 
 // Prometheus Operator PodMonitor objects
 prometheus.operator.podmonitors "pod_monitors" {
-  namespaces = []
   forward_to = [prometheus.relabel.podmonitors.receiver]
   clustering {
     enabled = true
@@ -659,7 +658,6 @@ prometheus.relabel "podmonitors" {
 
 // Prometheus Operator Probe objects
 prometheus.operator.probes "probes" {
-  namespaces = []
   forward_to = [prometheus.relabel.probes.receiver]
   clustering {
     enabled = true
@@ -675,7 +673,6 @@ prometheus.relabel "probes" {
 
 // Prometheus Operator ServiceMonitor objects
 prometheus.operator.servicemonitors "service_monitors" {
-  namespaces = []
   forward_to = [prometheus.relabel.servicemonitors.receiver]
   clustering {
     enabled = true

--- a/examples/cluster-with-pvc/output.yaml
+++ b/examples/cluster-with-pvc/output.yaml
@@ -764,7 +764,6 @@ data:
     
     // Prometheus Operator PodMonitor objects
     prometheus.operator.podmonitors "pod_monitors" {
-      namespaces = []
       forward_to = [prometheus.relabel.podmonitors.receiver]
       clustering {
         enabled = true
@@ -780,7 +779,6 @@ data:
     
     // Prometheus Operator Probe objects
     prometheus.operator.probes "probes" {
-      namespaces = []
       forward_to = [prometheus.relabel.probes.receiver]
       clustering {
         enabled = true
@@ -796,7 +794,6 @@ data:
     
     // Prometheus Operator ServiceMonitor objects
     prometheus.operator.servicemonitors "service_monitors" {
-      namespaces = []
       forward_to = [prometheus.relabel.servicemonitors.receiver]
       clustering {
         enabled = true
@@ -45607,7 +45604,6 @@ data:
     
     // Prometheus Operator PodMonitor objects
     prometheus.operator.podmonitors "pod_monitors" {
-      namespaces = []
       forward_to = [prometheus.relabel.podmonitors.receiver]
       clustering {
         enabled = true
@@ -45623,7 +45619,6 @@ data:
     
     // Prometheus Operator Probe objects
     prometheus.operator.probes "probes" {
-      namespaces = []
       forward_to = [prometheus.relabel.probes.receiver]
       clustering {
         enabled = true
@@ -45639,7 +45634,6 @@ data:
     
     // Prometheus Operator ServiceMonitor objects
     prometheus.operator.servicemonitors "service_monitors" {
-      namespaces = []
       forward_to = [prometheus.relabel.servicemonitors.receiver]
       clustering {
         enabled = true

--- a/examples/control-plane-metrics/metrics.river
+++ b/examples/control-plane-metrics/metrics.river
@@ -795,7 +795,6 @@ prometheus.relabel "opencost" {
 
 // Prometheus Operator PodMonitor objects
 prometheus.operator.podmonitors "pod_monitors" {
-  namespaces = []
   forward_to = [prometheus.relabel.podmonitors.receiver]
   clustering {
     enabled = true
@@ -811,7 +810,6 @@ prometheus.relabel "podmonitors" {
 
 // Prometheus Operator Probe objects
 prometheus.operator.probes "probes" {
-  namespaces = []
   forward_to = [prometheus.relabel.probes.receiver]
   clustering {
     enabled = true
@@ -827,7 +825,6 @@ prometheus.relabel "probes" {
 
 // Prometheus Operator ServiceMonitor objects
 prometheus.operator.servicemonitors "service_monitors" {
-  namespaces = []
   forward_to = [prometheus.relabel.servicemonitors.receiver]
   clustering {
     enabled = true

--- a/examples/control-plane-metrics/output.yaml
+++ b/examples/control-plane-metrics/output.yaml
@@ -917,7 +917,6 @@ data:
     
     // Prometheus Operator PodMonitor objects
     prometheus.operator.podmonitors "pod_monitors" {
-      namespaces = []
       forward_to = [prometheus.relabel.podmonitors.receiver]
       clustering {
         enabled = true
@@ -933,7 +932,6 @@ data:
     
     // Prometheus Operator Probe objects
     prometheus.operator.probes "probes" {
-      namespaces = []
       forward_to = [prometheus.relabel.probes.receiver]
       clustering {
         enabled = true
@@ -949,7 +947,6 @@ data:
     
     // Prometheus Operator ServiceMonitor objects
     prometheus.operator.servicemonitors "service_monitors" {
-      namespaces = []
       forward_to = [prometheus.relabel.servicemonitors.receiver]
       clustering {
         enabled = true
@@ -45852,7 +45849,6 @@ data:
     
     // Prometheus Operator PodMonitor objects
     prometheus.operator.podmonitors "pod_monitors" {
-      namespaces = []
       forward_to = [prometheus.relabel.podmonitors.receiver]
       clustering {
         enabled = true
@@ -45868,7 +45864,6 @@ data:
     
     // Prometheus Operator Probe objects
     prometheus.operator.probes "probes" {
-      namespaces = []
       forward_to = [prometheus.relabel.probes.receiver]
       clustering {
         enabled = true
@@ -45884,7 +45879,6 @@ data:
     
     // Prometheus Operator ServiceMonitor objects
     prometheus.operator.servicemonitors "service_monitors" {
-      namespaces = []
       forward_to = [prometheus.relabel.servicemonitors.receiver]
       clustering {
         enabled = true

--- a/examples/custom-config/metrics.river
+++ b/examples/custom-config/metrics.river
@@ -643,7 +643,6 @@ prometheus.relabel "opencost" {
 
 // Prometheus Operator PodMonitor objects
 prometheus.operator.podmonitors "pod_monitors" {
-  namespaces = []
   forward_to = [prometheus.relabel.podmonitors.receiver]
   clustering {
     enabled = true
@@ -659,7 +658,6 @@ prometheus.relabel "podmonitors" {
 
 // Prometheus Operator Probe objects
 prometheus.operator.probes "probes" {
-  namespaces = []
   forward_to = [prometheus.relabel.probes.receiver]
   clustering {
     enabled = true
@@ -675,7 +673,6 @@ prometheus.relabel "probes" {
 
 // Prometheus Operator ServiceMonitor objects
 prometheus.operator.servicemonitors "service_monitors" {
-  namespaces = []
   forward_to = [prometheus.relabel.servicemonitors.receiver]
   clustering {
     enabled = true

--- a/examples/custom-config/output.yaml
+++ b/examples/custom-config/output.yaml
@@ -764,7 +764,6 @@ data:
     
     // Prometheus Operator PodMonitor objects
     prometheus.operator.podmonitors "pod_monitors" {
-      namespaces = []
       forward_to = [prometheus.relabel.podmonitors.receiver]
       clustering {
         enabled = true
@@ -780,7 +779,6 @@ data:
     
     // Prometheus Operator Probe objects
     prometheus.operator.probes "probes" {
-      namespaces = []
       forward_to = [prometheus.relabel.probes.receiver]
       clustering {
         enabled = true
@@ -796,7 +794,6 @@ data:
     
     // Prometheus Operator ServiceMonitor objects
     prometheus.operator.servicemonitors "service_monitors" {
-      namespaces = []
       forward_to = [prometheus.relabel.servicemonitors.receiver]
       clustering {
         enabled = true
@@ -45610,7 +45607,6 @@ data:
     
     // Prometheus Operator PodMonitor objects
     prometheus.operator.podmonitors "pod_monitors" {
-      namespaces = []
       forward_to = [prometheus.relabel.podmonitors.receiver]
       clustering {
         enabled = true
@@ -45626,7 +45622,6 @@ data:
     
     // Prometheus Operator Probe objects
     prometheus.operator.probes "probes" {
-      namespaces = []
       forward_to = [prometheus.relabel.probes.receiver]
       clustering {
         enabled = true
@@ -45642,7 +45637,6 @@ data:
     
     // Prometheus Operator ServiceMonitor objects
     prometheus.operator.servicemonitors "service_monitors" {
-      namespaces = []
       forward_to = [prometheus.relabel.servicemonitors.receiver]
       clustering {
         enabled = true

--- a/examples/custom-metrics-tuning/metrics.river
+++ b/examples/custom-metrics-tuning/metrics.river
@@ -621,7 +621,6 @@ prometheus.relabel "opencost" {
 
 // Prometheus Operator PodMonitor objects
 prometheus.operator.podmonitors "pod_monitors" {
-  namespaces = []
   forward_to = [prometheus.relabel.podmonitors.receiver]
   clustering {
     enabled = true
@@ -637,7 +636,6 @@ prometheus.relabel "podmonitors" {
 
 // Prometheus Operator Probe objects
 prometheus.operator.probes "probes" {
-  namespaces = []
   forward_to = [prometheus.relabel.probes.receiver]
   clustering {
     enabled = true
@@ -653,7 +651,6 @@ prometheus.relabel "probes" {
 
 // Prometheus Operator ServiceMonitor objects
 prometheus.operator.servicemonitors "service_monitors" {
-  namespaces = []
   forward_to = [prometheus.relabel.servicemonitors.receiver]
   clustering {
     enabled = true

--- a/examples/custom-metrics-tuning/output.yaml
+++ b/examples/custom-metrics-tuning/output.yaml
@@ -701,7 +701,6 @@ data:
     
     // Prometheus Operator PodMonitor objects
     prometheus.operator.podmonitors "pod_monitors" {
-      namespaces = []
       forward_to = [prometheus.relabel.podmonitors.receiver]
       clustering {
         enabled = true
@@ -717,7 +716,6 @@ data:
     
     // Prometheus Operator Probe objects
     prometheus.operator.probes "probes" {
-      namespaces = []
       forward_to = [prometheus.relabel.probes.receiver]
       clustering {
         enabled = true
@@ -733,7 +731,6 @@ data:
     
     // Prometheus Operator ServiceMonitor objects
     prometheus.operator.servicemonitors "service_monitors" {
-      namespaces = []
       forward_to = [prometheus.relabel.servicemonitors.receiver]
       clustering {
         enabled = true
@@ -44747,7 +44744,6 @@ data:
     
     // Prometheus Operator PodMonitor objects
     prometheus.operator.podmonitors "pod_monitors" {
-      namespaces = []
       forward_to = [prometheus.relabel.podmonitors.receiver]
       clustering {
         enabled = true
@@ -44763,7 +44759,6 @@ data:
     
     // Prometheus Operator Probe objects
     prometheus.operator.probes "probes" {
-      namespaces = []
       forward_to = [prometheus.relabel.probes.receiver]
       clustering {
         enabled = true
@@ -44779,7 +44774,6 @@ data:
     
     // Prometheus Operator ServiceMonitor objects
     prometheus.operator.servicemonitors "service_monitors" {
-      namespaces = []
       forward_to = [prometheus.relabel.servicemonitors.receiver]
       clustering {
         enabled = true

--- a/examples/default-values/metrics.river
+++ b/examples/default-values/metrics.river
@@ -643,7 +643,6 @@ prometheus.relabel "opencost" {
 
 // Prometheus Operator PodMonitor objects
 prometheus.operator.podmonitors "pod_monitors" {
-  namespaces = []
   forward_to = [prometheus.relabel.podmonitors.receiver]
   clustering {
     enabled = true
@@ -659,7 +658,6 @@ prometheus.relabel "podmonitors" {
 
 // Prometheus Operator Probe objects
 prometheus.operator.probes "probes" {
-  namespaces = []
   forward_to = [prometheus.relabel.probes.receiver]
   clustering {
     enabled = true
@@ -675,7 +673,6 @@ prometheus.relabel "probes" {
 
 // Prometheus Operator ServiceMonitor objects
 prometheus.operator.servicemonitors "service_monitors" {
-  namespaces = []
   forward_to = [prometheus.relabel.servicemonitors.receiver]
   clustering {
     enabled = true

--- a/examples/default-values/output.yaml
+++ b/examples/default-values/output.yaml
@@ -764,7 +764,6 @@ data:
     
     // Prometheus Operator PodMonitor objects
     prometheus.operator.podmonitors "pod_monitors" {
-      namespaces = []
       forward_to = [prometheus.relabel.podmonitors.receiver]
       clustering {
         enabled = true
@@ -780,7 +779,6 @@ data:
     
     // Prometheus Operator Probe objects
     prometheus.operator.probes "probes" {
-      namespaces = []
       forward_to = [prometheus.relabel.probes.receiver]
       clustering {
         enabled = true
@@ -796,7 +794,6 @@ data:
     
     // Prometheus Operator ServiceMonitor objects
     prometheus.operator.servicemonitors "service_monitors" {
-      namespaces = []
       forward_to = [prometheus.relabel.servicemonitors.receiver]
       clustering {
         enabled = true
@@ -45547,7 +45544,6 @@ data:
     
     // Prometheus Operator PodMonitor objects
     prometheus.operator.podmonitors "pod_monitors" {
-      namespaces = []
       forward_to = [prometheus.relabel.podmonitors.receiver]
       clustering {
         enabled = true
@@ -45563,7 +45559,6 @@ data:
     
     // Prometheus Operator Probe objects
     prometheus.operator.probes "probes" {
-      namespaces = []
       forward_to = [prometheus.relabel.probes.receiver]
       clustering {
         enabled = true
@@ -45579,7 +45574,6 @@ data:
     
     // Prometheus Operator ServiceMonitor objects
     prometheus.operator.servicemonitors "service_monitors" {
-      namespaces = []
       forward_to = [prometheus.relabel.servicemonitors.receiver]
       clustering {
         enabled = true

--- a/examples/eks-fargate/metrics.river
+++ b/examples/eks-fargate/metrics.river
@@ -597,7 +597,6 @@ prometheus.relabel "opencost" {
 
 // Prometheus Operator PodMonitor objects
 prometheus.operator.podmonitors "pod_monitors" {
-  namespaces = []
   forward_to = [prometheus.relabel.podmonitors.receiver]
   clustering {
     enabled = true
@@ -613,7 +612,6 @@ prometheus.relabel "podmonitors" {
 
 // Prometheus Operator Probe objects
 prometheus.operator.probes "probes" {
-  namespaces = []
   forward_to = [prometheus.relabel.probes.receiver]
   clustering {
     enabled = true
@@ -629,7 +627,6 @@ prometheus.relabel "probes" {
 
 // Prometheus Operator ServiceMonitor objects
 prometheus.operator.servicemonitors "service_monitors" {
-  namespaces = []
   forward_to = [prometheus.relabel.servicemonitors.receiver]
   clustering {
     enabled = true

--- a/examples/eks-fargate/output.yaml
+++ b/examples/eks-fargate/output.yaml
@@ -703,7 +703,6 @@ data:
     
     // Prometheus Operator PodMonitor objects
     prometheus.operator.podmonitors "pod_monitors" {
-      namespaces = []
       forward_to = [prometheus.relabel.podmonitors.receiver]
       clustering {
         enabled = true
@@ -719,7 +718,6 @@ data:
     
     // Prometheus Operator Probe objects
     prometheus.operator.probes "probes" {
-      namespaces = []
       forward_to = [prometheus.relabel.probes.receiver]
       clustering {
         enabled = true
@@ -735,7 +733,6 @@ data:
     
     // Prometheus Operator ServiceMonitor objects
     prometheus.operator.servicemonitors "service_monitors" {
-      namespaces = []
       forward_to = [prometheus.relabel.servicemonitors.receiver]
       clustering {
         enabled = true
@@ -45274,7 +45271,6 @@ data:
     
     // Prometheus Operator PodMonitor objects
     prometheus.operator.podmonitors "pod_monitors" {
-      namespaces = []
       forward_to = [prometheus.relabel.podmonitors.receiver]
       clustering {
         enabled = true
@@ -45290,7 +45286,6 @@ data:
     
     // Prometheus Operator Probe objects
     prometheus.operator.probes "probes" {
-      namespaces = []
       forward_to = [prometheus.relabel.probes.receiver]
       clustering {
         enabled = true
@@ -45306,7 +45301,6 @@ data:
     
     // Prometheus Operator ServiceMonitor objects
     prometheus.operator.servicemonitors "service_monitors" {
-      namespaces = []
       forward_to = [prometheus.relabel.servicemonitors.receiver]
       clustering {
         enabled = true

--- a/examples/extra-rules/metrics.river
+++ b/examples/extra-rules/metrics.river
@@ -693,7 +693,6 @@ prometheus.relabel "opencost" {
 
 // Prometheus Operator PodMonitor objects
 prometheus.operator.podmonitors "pod_monitors" {
-  namespaces = []
   forward_to = [prometheus.relabel.podmonitors.receiver]
   clustering {
     enabled = true
@@ -709,7 +708,6 @@ prometheus.relabel "podmonitors" {
 
 // Prometheus Operator Probe objects
 prometheus.operator.probes "probes" {
-  namespaces = []
   forward_to = [prometheus.relabel.probes.receiver]
   clustering {
     enabled = true
@@ -725,7 +723,6 @@ prometheus.relabel "probes" {
 
 // Prometheus Operator ServiceMonitor objects
 prometheus.operator.servicemonitors "service_monitors" {
-  namespaces = []
   forward_to = [prometheus.relabel.servicemonitors.receiver]
   clustering {
     enabled = true

--- a/examples/extra-rules/output.yaml
+++ b/examples/extra-rules/output.yaml
@@ -815,7 +815,6 @@ data:
     
     // Prometheus Operator PodMonitor objects
     prometheus.operator.podmonitors "pod_monitors" {
-      namespaces = []
       forward_to = [prometheus.relabel.podmonitors.receiver]
       clustering {
         enabled = true
@@ -831,7 +830,6 @@ data:
     
     // Prometheus Operator Probe objects
     prometheus.operator.probes "probes" {
-      namespaces = []
       forward_to = [prometheus.relabel.probes.receiver]
       clustering {
         enabled = true
@@ -847,7 +845,6 @@ data:
     
     // Prometheus Operator ServiceMonitor objects
     prometheus.operator.servicemonitors "service_monitors" {
-      namespaces = []
       forward_to = [prometheus.relabel.servicemonitors.receiver]
       clustering {
         enabled = true
@@ -45697,7 +45694,6 @@ data:
     
     // Prometheus Operator PodMonitor objects
     prometheus.operator.podmonitors "pod_monitors" {
-      namespaces = []
       forward_to = [prometheus.relabel.podmonitors.receiver]
       clustering {
         enabled = true
@@ -45713,7 +45709,6 @@ data:
     
     // Prometheus Operator Probe objects
     prometheus.operator.probes "probes" {
-      namespaces = []
       forward_to = [prometheus.relabel.probes.receiver]
       clustering {
         enabled = true
@@ -45729,7 +45724,6 @@ data:
     
     // Prometheus Operator ServiceMonitor objects
     prometheus.operator.servicemonitors "service_monitors" {
-      namespaces = []
       forward_to = [prometheus.relabel.servicemonitors.receiver]
       clustering {
         enabled = true

--- a/examples/gke-autopilot/metrics.river
+++ b/examples/gke-autopilot/metrics.river
@@ -597,7 +597,6 @@ prometheus.relabel "opencost" {
 
 // Prometheus Operator PodMonitor objects
 prometheus.operator.podmonitors "pod_monitors" {
-  namespaces = []
   forward_to = [prometheus.relabel.podmonitors.receiver]
   clustering {
     enabled = true
@@ -613,7 +612,6 @@ prometheus.relabel "podmonitors" {
 
 // Prometheus Operator Probe objects
 prometheus.operator.probes "probes" {
-  namespaces = []
   forward_to = [prometheus.relabel.probes.receiver]
   clustering {
     enabled = true
@@ -629,7 +627,6 @@ prometheus.relabel "probes" {
 
 // Prometheus Operator ServiceMonitor objects
 prometheus.operator.servicemonitors "service_monitors" {
-  namespaces = []
   forward_to = [prometheus.relabel.servicemonitors.receiver]
   clustering {
     enabled = true

--- a/examples/gke-autopilot/output.yaml
+++ b/examples/gke-autopilot/output.yaml
@@ -703,7 +703,6 @@ data:
     
     // Prometheus Operator PodMonitor objects
     prometheus.operator.podmonitors "pod_monitors" {
-      namespaces = []
       forward_to = [prometheus.relabel.podmonitors.receiver]
       clustering {
         enabled = true
@@ -719,7 +718,6 @@ data:
     
     // Prometheus Operator Probe objects
     prometheus.operator.probes "probes" {
-      namespaces = []
       forward_to = [prometheus.relabel.probes.receiver]
       clustering {
         enabled = true
@@ -735,7 +733,6 @@ data:
     
     // Prometheus Operator ServiceMonitor objects
     prometheus.operator.servicemonitors "service_monitors" {
-      namespaces = []
       forward_to = [prometheus.relabel.servicemonitors.receiver]
       clustering {
         enabled = true
@@ -45292,7 +45289,6 @@ data:
     
     // Prometheus Operator PodMonitor objects
     prometheus.operator.podmonitors "pod_monitors" {
-      namespaces = []
       forward_to = [prometheus.relabel.podmonitors.receiver]
       clustering {
         enabled = true
@@ -45308,7 +45304,6 @@ data:
     
     // Prometheus Operator Probe objects
     prometheus.operator.probes "probes" {
-      namespaces = []
       forward_to = [prometheus.relabel.probes.receiver]
       clustering {
         enabled = true
@@ -45324,7 +45319,6 @@ data:
     
     // Prometheus Operator ServiceMonitor objects
     prometheus.operator.servicemonitors "service_monitors" {
-      namespaces = []
       forward_to = [prometheus.relabel.servicemonitors.receiver]
       clustering {
         enabled = true

--- a/examples/ibm-cloud/metrics.river
+++ b/examples/ibm-cloud/metrics.river
@@ -643,7 +643,6 @@ prometheus.relabel "opencost" {
 
 // Prometheus Operator PodMonitor objects
 prometheus.operator.podmonitors "pod_monitors" {
-  namespaces = []
   forward_to = [prometheus.relabel.podmonitors.receiver]
   clustering {
     enabled = true
@@ -659,7 +658,6 @@ prometheus.relabel "podmonitors" {
 
 // Prometheus Operator Probe objects
 prometheus.operator.probes "probes" {
-  namespaces = []
   forward_to = [prometheus.relabel.probes.receiver]
   clustering {
     enabled = true
@@ -675,7 +673,6 @@ prometheus.relabel "probes" {
 
 // Prometheus Operator ServiceMonitor objects
 prometheus.operator.servicemonitors "service_monitors" {
-  namespaces = []
   forward_to = [prometheus.relabel.servicemonitors.receiver]
   clustering {
     enabled = true

--- a/examples/ibm-cloud/output.yaml
+++ b/examples/ibm-cloud/output.yaml
@@ -764,7 +764,6 @@ data:
     
     // Prometheus Operator PodMonitor objects
     prometheus.operator.podmonitors "pod_monitors" {
-      namespaces = []
       forward_to = [prometheus.relabel.podmonitors.receiver]
       clustering {
         enabled = true
@@ -780,7 +779,6 @@ data:
     
     // Prometheus Operator Probe objects
     prometheus.operator.probes "probes" {
-      namespaces = []
       forward_to = [prometheus.relabel.probes.receiver]
       clustering {
         enabled = true
@@ -796,7 +794,6 @@ data:
     
     // Prometheus Operator ServiceMonitor objects
     prometheus.operator.servicemonitors "service_monitors" {
-      namespaces = []
       forward_to = [prometheus.relabel.servicemonitors.receiver]
       clustering {
         enabled = true
@@ -45553,7 +45550,6 @@ data:
     
     // Prometheus Operator PodMonitor objects
     prometheus.operator.podmonitors "pod_monitors" {
-      namespaces = []
       forward_to = [prometheus.relabel.podmonitors.receiver]
       clustering {
         enabled = true
@@ -45569,7 +45565,6 @@ data:
     
     // Prometheus Operator Probe objects
     prometheus.operator.probes "probes" {
-      namespaces = []
       forward_to = [prometheus.relabel.probes.receiver]
       clustering {
         enabled = true
@@ -45585,7 +45580,6 @@ data:
     
     // Prometheus Operator ServiceMonitor objects
     prometheus.operator.servicemonitors "service_monitors" {
-      namespaces = []
       forward_to = [prometheus.relabel.servicemonitors.receiver]
       clustering {
         enabled = true

--- a/examples/kube-pod-labels/metrics.river
+++ b/examples/kube-pod-labels/metrics.river
@@ -643,7 +643,6 @@ prometheus.relabel "opencost" {
 
 // Prometheus Operator PodMonitor objects
 prometheus.operator.podmonitors "pod_monitors" {
-  namespaces = []
   forward_to = [prometheus.relabel.podmonitors.receiver]
   clustering {
     enabled = true
@@ -659,7 +658,6 @@ prometheus.relabel "podmonitors" {
 
 // Prometheus Operator Probe objects
 prometheus.operator.probes "probes" {
-  namespaces = []
   forward_to = [prometheus.relabel.probes.receiver]
   clustering {
     enabled = true
@@ -675,7 +673,6 @@ prometheus.relabel "probes" {
 
 // Prometheus Operator ServiceMonitor objects
 prometheus.operator.servicemonitors "service_monitors" {
-  namespaces = []
   forward_to = [prometheus.relabel.servicemonitors.receiver]
   clustering {
     enabled = true

--- a/examples/kube-pod-labels/output.yaml
+++ b/examples/kube-pod-labels/output.yaml
@@ -764,7 +764,6 @@ data:
     
     // Prometheus Operator PodMonitor objects
     prometheus.operator.podmonitors "pod_monitors" {
-      namespaces = []
       forward_to = [prometheus.relabel.podmonitors.receiver]
       clustering {
         enabled = true
@@ -780,7 +779,6 @@ data:
     
     // Prometheus Operator Probe objects
     prometheus.operator.probes "probes" {
-      namespaces = []
       forward_to = [prometheus.relabel.probes.receiver]
       clustering {
         enabled = true
@@ -796,7 +794,6 @@ data:
     
     // Prometheus Operator ServiceMonitor objects
     prometheus.operator.servicemonitors "service_monitors" {
-      namespaces = []
       forward_to = [prometheus.relabel.servicemonitors.receiver]
       clustering {
         enabled = true
@@ -45548,7 +45545,6 @@ data:
     
     // Prometheus Operator PodMonitor objects
     prometheus.operator.podmonitors "pod_monitors" {
-      namespaces = []
       forward_to = [prometheus.relabel.podmonitors.receiver]
       clustering {
         enabled = true
@@ -45564,7 +45560,6 @@ data:
     
     // Prometheus Operator Probe objects
     prometheus.operator.probes "probes" {
-      namespaces = []
       forward_to = [prometheus.relabel.probes.receiver]
       clustering {
         enabled = true
@@ -45580,7 +45575,6 @@ data:
     
     // Prometheus Operator ServiceMonitor objects
     prometheus.operator.servicemonitors "service_monitors" {
-      namespaces = []
       forward_to = [prometheus.relabel.servicemonitors.receiver]
       clustering {
         enabled = true

--- a/examples/metrics-only/metrics.river
+++ b/examples/metrics-only/metrics.river
@@ -626,7 +626,6 @@ prometheus.relabel "opencost" {
 
 // Prometheus Operator PodMonitor objects
 prometheus.operator.podmonitors "pod_monitors" {
-  namespaces = []
   forward_to = [prometheus.relabel.podmonitors.receiver]
   clustering {
     enabled = true
@@ -642,7 +641,6 @@ prometheus.relabel "podmonitors" {
 
 // Prometheus Operator Probe objects
 prometheus.operator.probes "probes" {
-  namespaces = []
   forward_to = [prometheus.relabel.probes.receiver]
   clustering {
     enabled = true
@@ -658,7 +656,6 @@ prometheus.relabel "probes" {
 
 // Prometheus Operator ServiceMonitor objects
 prometheus.operator.servicemonitors "service_monitors" {
-  namespaces = []
   forward_to = [prometheus.relabel.servicemonitors.receiver]
   clustering {
     enabled = true

--- a/examples/metrics-only/output.yaml
+++ b/examples/metrics-only/output.yaml
@@ -707,7 +707,6 @@ data:
     
     // Prometheus Operator PodMonitor objects
     prometheus.operator.podmonitors "pod_monitors" {
-      namespaces = []
       forward_to = [prometheus.relabel.podmonitors.receiver]
       clustering {
         enabled = true
@@ -723,7 +722,6 @@ data:
     
     // Prometheus Operator Probe objects
     prometheus.operator.probes "probes" {
-      namespaces = []
       forward_to = [prometheus.relabel.probes.receiver]
       clustering {
         enabled = true
@@ -739,7 +737,6 @@ data:
     
     // Prometheus Operator ServiceMonitor objects
     prometheus.operator.servicemonitors "service_monitors" {
-      namespaces = []
       forward_to = [prometheus.relabel.servicemonitors.receiver]
       clustering {
         enabled = true
@@ -44758,7 +44755,6 @@ data:
     
     // Prometheus Operator PodMonitor objects
     prometheus.operator.podmonitors "pod_monitors" {
-      namespaces = []
       forward_to = [prometheus.relabel.podmonitors.receiver]
       clustering {
         enabled = true
@@ -44774,7 +44770,6 @@ data:
     
     // Prometheus Operator Probe objects
     prometheus.operator.probes "probes" {
-      namespaces = []
       forward_to = [prometheus.relabel.probes.receiver]
       clustering {
         enabled = true
@@ -44790,7 +44785,6 @@ data:
     
     // Prometheus Operator ServiceMonitor objects
     prometheus.operator.servicemonitors "service_monitors" {
-      namespaces = []
       forward_to = [prometheus.relabel.servicemonitors.receiver]
       clustering {
         enabled = true

--- a/examples/openshift-compatible/metrics.river
+++ b/examples/openshift-compatible/metrics.river
@@ -644,7 +644,6 @@ prometheus.relabel "opencost" {
 
 // Prometheus Operator PodMonitor objects
 prometheus.operator.podmonitors "pod_monitors" {
-  namespaces = []
   forward_to = [prometheus.relabel.podmonitors.receiver]
   clustering {
     enabled = true
@@ -660,7 +659,6 @@ prometheus.relabel "podmonitors" {
 
 // Prometheus Operator Probe objects
 prometheus.operator.probes "probes" {
-  namespaces = []
   forward_to = [prometheus.relabel.probes.receiver]
   clustering {
     enabled = true
@@ -676,7 +674,6 @@ prometheus.relabel "probes" {
 
 // Prometheus Operator ServiceMonitor objects
 prometheus.operator.servicemonitors "service_monitors" {
-  namespaces = []
   forward_to = [prometheus.relabel.servicemonitors.receiver]
   clustering {
     enabled = true

--- a/examples/openshift-compatible/output.yaml
+++ b/examples/openshift-compatible/output.yaml
@@ -735,7 +735,6 @@ data:
     
     // Prometheus Operator PodMonitor objects
     prometheus.operator.podmonitors "pod_monitors" {
-      namespaces = []
       forward_to = [prometheus.relabel.podmonitors.receiver]
       clustering {
         enabled = true
@@ -751,7 +750,6 @@ data:
     
     // Prometheus Operator Probe objects
     prometheus.operator.probes "probes" {
-      namespaces = []
       forward_to = [prometheus.relabel.probes.receiver]
       clustering {
         enabled = true
@@ -767,7 +765,6 @@ data:
     
     // Prometheus Operator ServiceMonitor objects
     prometheus.operator.servicemonitors "service_monitors" {
-      namespaces = []
       forward_to = [prometheus.relabel.servicemonitors.receiver]
       clustering {
         enabled = true
@@ -45193,7 +45190,6 @@ data:
     
     // Prometheus Operator PodMonitor objects
     prometheus.operator.podmonitors "pod_monitors" {
-      namespaces = []
       forward_to = [prometheus.relabel.podmonitors.receiver]
       clustering {
         enabled = true
@@ -45209,7 +45205,6 @@ data:
     
     // Prometheus Operator Probe objects
     prometheus.operator.probes "probes" {
-      namespaces = []
       forward_to = [prometheus.relabel.probes.receiver]
       clustering {
         enabled = true
@@ -45225,7 +45220,6 @@ data:
     
     // Prometheus Operator ServiceMonitor objects
     prometheus.operator.servicemonitors "service_monitors" {
-      namespaces = []
       forward_to = [prometheus.relabel.servicemonitors.receiver]
       clustering {
         enabled = true

--- a/examples/otel-metrics-service/metrics.river
+++ b/examples/otel-metrics-service/metrics.river
@@ -643,7 +643,6 @@ prometheus.relabel "opencost" {
 
 // Prometheus Operator PodMonitor objects
 prometheus.operator.podmonitors "pod_monitors" {
-  namespaces = []
   forward_to = [prometheus.relabel.podmonitors.receiver]
   clustering {
     enabled = true
@@ -659,7 +658,6 @@ prometheus.relabel "podmonitors" {
 
 // Prometheus Operator Probe objects
 prometheus.operator.probes "probes" {
-  namespaces = []
   forward_to = [prometheus.relabel.probes.receiver]
   clustering {
     enabled = true
@@ -675,7 +673,6 @@ prometheus.relabel "probes" {
 
 // Prometheus Operator ServiceMonitor objects
 prometheus.operator.servicemonitors "service_monitors" {
-  namespaces = []
   forward_to = [prometheus.relabel.servicemonitors.receiver]
   clustering {
     enabled = true

--- a/examples/otel-metrics-service/output.yaml
+++ b/examples/otel-metrics-service/output.yaml
@@ -764,7 +764,6 @@ data:
     
     // Prometheus Operator PodMonitor objects
     prometheus.operator.podmonitors "pod_monitors" {
-      namespaces = []
       forward_to = [prometheus.relabel.podmonitors.receiver]
       clustering {
         enabled = true
@@ -780,7 +779,6 @@ data:
     
     // Prometheus Operator Probe objects
     prometheus.operator.probes "probes" {
-      namespaces = []
       forward_to = [prometheus.relabel.probes.receiver]
       clustering {
         enabled = true
@@ -796,7 +794,6 @@ data:
     
     // Prometheus Operator ServiceMonitor objects
     prometheus.operator.servicemonitors "service_monitors" {
-      namespaces = []
       forward_to = [prometheus.relabel.servicemonitors.receiver]
       clustering {
         enabled = true
@@ -45577,7 +45574,6 @@ data:
     
     // Prometheus Operator PodMonitor objects
     prometheus.operator.podmonitors "pod_monitors" {
-      namespaces = []
       forward_to = [prometheus.relabel.podmonitors.receiver]
       clustering {
         enabled = true
@@ -45593,7 +45589,6 @@ data:
     
     // Prometheus Operator Probe objects
     prometheus.operator.probes "probes" {
-      namespaces = []
       forward_to = [prometheus.relabel.probes.receiver]
       clustering {
         enabled = true
@@ -45609,7 +45604,6 @@ data:
     
     // Prometheus Operator ServiceMonitor objects
     prometheus.operator.servicemonitors "service_monitors" {
-      namespaces = []
       forward_to = [prometheus.relabel.servicemonitors.receiver]
       clustering {
         enabled = true

--- a/examples/private-image-registry/metrics.river
+++ b/examples/private-image-registry/metrics.river
@@ -643,7 +643,6 @@ prometheus.relabel "opencost" {
 
 // Prometheus Operator PodMonitor objects
 prometheus.operator.podmonitors "pod_monitors" {
-  namespaces = []
   forward_to = [prometheus.relabel.podmonitors.receiver]
   clustering {
     enabled = true
@@ -659,7 +658,6 @@ prometheus.relabel "podmonitors" {
 
 // Prometheus Operator Probe objects
 prometheus.operator.probes "probes" {
-  namespaces = []
   forward_to = [prometheus.relabel.probes.receiver]
   clustering {
     enabled = true
@@ -675,7 +673,6 @@ prometheus.relabel "probes" {
 
 // Prometheus Operator ServiceMonitor objects
 prometheus.operator.servicemonitors "service_monitors" {
-  namespaces = []
   forward_to = [prometheus.relabel.servicemonitors.receiver]
   clustering {
     enabled = true

--- a/examples/private-image-registry/output.yaml
+++ b/examples/private-image-registry/output.yaml
@@ -768,7 +768,6 @@ data:
     
     // Prometheus Operator PodMonitor objects
     prometheus.operator.podmonitors "pod_monitors" {
-      namespaces = []
       forward_to = [prometheus.relabel.podmonitors.receiver]
       clustering {
         enabled = true
@@ -784,7 +783,6 @@ data:
     
     // Prometheus Operator Probe objects
     prometheus.operator.probes "probes" {
-      namespaces = []
       forward_to = [prometheus.relabel.probes.receiver]
       clustering {
         enabled = true
@@ -800,7 +798,6 @@ data:
     
     // Prometheus Operator ServiceMonitor objects
     prometheus.operator.servicemonitors "service_monitors" {
-      namespaces = []
       forward_to = [prometheus.relabel.servicemonitors.receiver]
       clustering {
         enabled = true
@@ -45563,7 +45560,6 @@ data:
     
     // Prometheus Operator PodMonitor objects
     prometheus.operator.podmonitors "pod_monitors" {
-      namespaces = []
       forward_to = [prometheus.relabel.podmonitors.receiver]
       clustering {
         enabled = true
@@ -45579,7 +45575,6 @@ data:
     
     // Prometheus Operator Probe objects
     prometheus.operator.probes "probes" {
-      namespaces = []
       forward_to = [prometheus.relabel.probes.receiver]
       clustering {
         enabled = true
@@ -45595,7 +45590,6 @@ data:
     
     // Prometheus Operator ServiceMonitor objects
     prometheus.operator.servicemonitors "service_monitors" {
-      namespaces = []
       forward_to = [prometheus.relabel.servicemonitors.receiver]
       clustering {
         enabled = true

--- a/examples/proxies/metrics.river
+++ b/examples/proxies/metrics.river
@@ -643,7 +643,6 @@ prometheus.relabel "opencost" {
 
 // Prometheus Operator PodMonitor objects
 prometheus.operator.podmonitors "pod_monitors" {
-  namespaces = []
   forward_to = [prometheus.relabel.podmonitors.receiver]
   clustering {
     enabled = true
@@ -659,7 +658,6 @@ prometheus.relabel "podmonitors" {
 
 // Prometheus Operator Probe objects
 prometheus.operator.probes "probes" {
-  namespaces = []
   forward_to = [prometheus.relabel.probes.receiver]
   clustering {
     enabled = true
@@ -675,7 +673,6 @@ prometheus.relabel "probes" {
 
 // Prometheus Operator ServiceMonitor objects
 prometheus.operator.servicemonitors "service_monitors" {
-  namespaces = []
   forward_to = [prometheus.relabel.servicemonitors.receiver]
   clustering {
     enabled = true

--- a/examples/proxies/output.yaml
+++ b/examples/proxies/output.yaml
@@ -764,7 +764,6 @@ data:
     
     // Prometheus Operator PodMonitor objects
     prometheus.operator.podmonitors "pod_monitors" {
-      namespaces = []
       forward_to = [prometheus.relabel.podmonitors.receiver]
       clustering {
         enabled = true
@@ -780,7 +779,6 @@ data:
     
     // Prometheus Operator Probe objects
     prometheus.operator.probes "probes" {
-      namespaces = []
       forward_to = [prometheus.relabel.probes.receiver]
       clustering {
         enabled = true
@@ -796,7 +794,6 @@ data:
     
     // Prometheus Operator ServiceMonitor objects
     prometheus.operator.servicemonitors "service_monitors" {
-      namespaces = []
       forward_to = [prometheus.relabel.servicemonitors.receiver]
       clustering {
         enabled = true
@@ -45563,7 +45560,6 @@ data:
     
     // Prometheus Operator PodMonitor objects
     prometheus.operator.podmonitors "pod_monitors" {
-      namespaces = []
       forward_to = [prometheus.relabel.podmonitors.receiver]
       clustering {
         enabled = true
@@ -45579,7 +45575,6 @@ data:
     
     // Prometheus Operator Probe objects
     prometheus.operator.probes "probes" {
-      namespaces = []
       forward_to = [prometheus.relabel.probes.receiver]
       clustering {
         enabled = true
@@ -45595,7 +45590,6 @@ data:
     
     // Prometheus Operator ServiceMonitor objects
     prometheus.operator.servicemonitors "service_monitors" {
-      namespaces = []
       forward_to = [prometheus.relabel.servicemonitors.receiver]
       clustering {
         enabled = true

--- a/examples/scrape-intervals/metrics.river
+++ b/examples/scrape-intervals/metrics.river
@@ -626,7 +626,6 @@ prometheus.relabel "opencost" {
 
 // Prometheus Operator PodMonitor objects
 prometheus.operator.podmonitors "pod_monitors" {
-  namespaces = []
   forward_to = [prometheus.relabel.podmonitors.receiver]
   clustering {
     enabled = true
@@ -642,7 +641,6 @@ prometheus.relabel "podmonitors" {
 
 // Prometheus Operator Probe objects
 prometheus.operator.probes "probes" {
-  namespaces = []
   forward_to = [prometheus.relabel.probes.receiver]
   clustering {
     enabled = true
@@ -658,7 +656,6 @@ prometheus.relabel "probes" {
 
 // Prometheus Operator ServiceMonitor objects
 prometheus.operator.servicemonitors "service_monitors" {
-  namespaces = []
   forward_to = [prometheus.relabel.servicemonitors.receiver]
   clustering {
     enabled = true

--- a/examples/scrape-intervals/output.yaml
+++ b/examples/scrape-intervals/output.yaml
@@ -706,7 +706,6 @@ data:
     
     // Prometheus Operator PodMonitor objects
     prometheus.operator.podmonitors "pod_monitors" {
-      namespaces = []
       forward_to = [prometheus.relabel.podmonitors.receiver]
       clustering {
         enabled = true
@@ -722,7 +721,6 @@ data:
     
     // Prometheus Operator Probe objects
     prometheus.operator.probes "probes" {
-      namespaces = []
       forward_to = [prometheus.relabel.probes.receiver]
       clustering {
         enabled = true
@@ -738,7 +736,6 @@ data:
     
     // Prometheus Operator ServiceMonitor objects
     prometheus.operator.servicemonitors "service_monitors" {
-      namespaces = []
       forward_to = [prometheus.relabel.servicemonitors.receiver]
       clustering {
         enabled = true
@@ -44757,7 +44754,6 @@ data:
     
     // Prometheus Operator PodMonitor objects
     prometheus.operator.podmonitors "pod_monitors" {
-      namespaces = []
       forward_to = [prometheus.relabel.podmonitors.receiver]
       clustering {
         enabled = true
@@ -44773,7 +44769,6 @@ data:
     
     // Prometheus Operator Probe objects
     prometheus.operator.probes "probes" {
-      namespaces = []
       forward_to = [prometheus.relabel.probes.receiver]
       clustering {
         enabled = true
@@ -44789,7 +44784,6 @@ data:
     
     // Prometheus Operator ServiceMonitor objects
     prometheus.operator.servicemonitors "service_monitors" {
-      namespaces = []
       forward_to = [prometheus.relabel.servicemonitors.receiver]
       clustering {
         enabled = true

--- a/examples/service-integrations/metrics.river
+++ b/examples/service-integrations/metrics.river
@@ -643,7 +643,6 @@ prometheus.relabel "opencost" {
 
 // Prometheus Operator PodMonitor objects
 prometheus.operator.podmonitors "pod_monitors" {
-  namespaces = []
   forward_to = [prometheus.relabel.podmonitors.receiver]
   clustering {
     enabled = true
@@ -659,7 +658,6 @@ prometheus.relabel "podmonitors" {
 
 // Prometheus Operator Probe objects
 prometheus.operator.probes "probes" {
-  namespaces = []
   forward_to = [prometheus.relabel.probes.receiver]
   clustering {
     enabled = true
@@ -675,7 +673,6 @@ prometheus.relabel "probes" {
 
 // Prometheus Operator ServiceMonitor objects
 prometheus.operator.servicemonitors "service_monitors" {
-  namespaces = []
   forward_to = [prometheus.relabel.servicemonitors.receiver]
   clustering {
     enabled = true

--- a/examples/service-integrations/output.yaml
+++ b/examples/service-integrations/output.yaml
@@ -764,7 +764,6 @@ data:
     
     // Prometheus Operator PodMonitor objects
     prometheus.operator.podmonitors "pod_monitors" {
-      namespaces = []
       forward_to = [prometheus.relabel.podmonitors.receiver]
       clustering {
         enabled = true
@@ -780,7 +779,6 @@ data:
     
     // Prometheus Operator Probe objects
     prometheus.operator.probes "probes" {
-      namespaces = []
       forward_to = [prometheus.relabel.probes.receiver]
       clustering {
         enabled = true
@@ -796,7 +794,6 @@ data:
     
     // Prometheus Operator ServiceMonitor objects
     prometheus.operator.servicemonitors "service_monitors" {
-      namespaces = []
       forward_to = [prometheus.relabel.servicemonitors.receiver]
       clustering {
         enabled = true
@@ -45582,7 +45579,6 @@ data:
     
     // Prometheus Operator PodMonitor objects
     prometheus.operator.podmonitors "pod_monitors" {
-      namespaces = []
       forward_to = [prometheus.relabel.podmonitors.receiver]
       clustering {
         enabled = true
@@ -45598,7 +45594,6 @@ data:
     
     // Prometheus Operator Probe objects
     prometheus.operator.probes "probes" {
-      namespaces = []
       forward_to = [prometheus.relabel.probes.receiver]
       clustering {
         enabled = true
@@ -45614,7 +45609,6 @@ data:
     
     // Prometheus Operator ServiceMonitor objects
     prometheus.operator.servicemonitors "service_monitors" {
-      namespaces = []
       forward_to = [prometheus.relabel.servicemonitors.receiver]
       clustering {
         enabled = true

--- a/examples/traces-enabled/metrics.river
+++ b/examples/traces-enabled/metrics.river
@@ -688,7 +688,6 @@ prometheus.relabel "opencost" {
 
 // Prometheus Operator PodMonitor objects
 prometheus.operator.podmonitors "pod_monitors" {
-  namespaces = []
   forward_to = [prometheus.relabel.podmonitors.receiver]
   clustering {
     enabled = true
@@ -704,7 +703,6 @@ prometheus.relabel "podmonitors" {
 
 // Prometheus Operator Probe objects
 prometheus.operator.probes "probes" {
-  namespaces = []
   forward_to = [prometheus.relabel.probes.receiver]
   clustering {
     enabled = true
@@ -720,7 +718,6 @@ prometheus.relabel "probes" {
 
 // Prometheus Operator ServiceMonitor objects
 prometheus.operator.servicemonitors "service_monitors" {
-  namespaces = []
   forward_to = [prometheus.relabel.servicemonitors.receiver]
   clustering {
     enabled = true

--- a/examples/traces-enabled/output.yaml
+++ b/examples/traces-enabled/output.yaml
@@ -822,7 +822,6 @@ data:
     
     // Prometheus Operator PodMonitor objects
     prometheus.operator.podmonitors "pod_monitors" {
-      namespaces = []
       forward_to = [prometheus.relabel.podmonitors.receiver]
       clustering {
         enabled = true
@@ -838,7 +837,6 @@ data:
     
     // Prometheus Operator Probe objects
     prometheus.operator.probes "probes" {
-      namespaces = []
       forward_to = [prometheus.relabel.probes.receiver]
       clustering {
         enabled = true
@@ -854,7 +852,6 @@ data:
     
     // Prometheus Operator ServiceMonitor objects
     prometheus.operator.servicemonitors "service_monitors" {
-      namespaces = []
       forward_to = [prometheus.relabel.servicemonitors.receiver]
       clustering {
         enabled = true
@@ -45670,7 +45667,6 @@ data:
     
     // Prometheus Operator PodMonitor objects
     prometheus.operator.podmonitors "pod_monitors" {
-      namespaces = []
       forward_to = [prometheus.relabel.podmonitors.receiver]
       clustering {
         enabled = true
@@ -45686,7 +45682,6 @@ data:
     
     // Prometheus Operator Probe objects
     prometheus.operator.probes "probes" {
-      namespaces = []
       forward_to = [prometheus.relabel.probes.receiver]
       clustering {
         enabled = true
@@ -45702,7 +45697,6 @@ data:
     
     // Prometheus Operator ServiceMonitor objects
     prometheus.operator.servicemonitors "service_monitors" {
-      namespaces = []
       forward_to = [prometheus.relabel.servicemonitors.receiver]
       clustering {
         enabled = true

--- a/examples/windows-exporter/metrics.river
+++ b/examples/windows-exporter/metrics.river
@@ -711,7 +711,6 @@ prometheus.relabel "opencost" {
 
 // Prometheus Operator PodMonitor objects
 prometheus.operator.podmonitors "pod_monitors" {
-  namespaces = []
   forward_to = [prometheus.relabel.podmonitors.receiver]
   clustering {
     enabled = true
@@ -727,7 +726,6 @@ prometheus.relabel "podmonitors" {
 
 // Prometheus Operator Probe objects
 prometheus.operator.probes "probes" {
-  namespaces = []
   forward_to = [prometheus.relabel.probes.receiver]
   clustering {
     enabled = true
@@ -743,7 +741,6 @@ prometheus.relabel "probes" {
 
 // Prometheus Operator ServiceMonitor objects
 prometheus.operator.servicemonitors "service_monitors" {
-  namespaces = []
   forward_to = [prometheus.relabel.servicemonitors.receiver]
   clustering {
     enabled = true

--- a/examples/windows-exporter/output.yaml
+++ b/examples/windows-exporter/output.yaml
@@ -869,7 +869,6 @@ data:
     
     // Prometheus Operator PodMonitor objects
     prometheus.operator.podmonitors "pod_monitors" {
-      namespaces = []
       forward_to = [prometheus.relabel.podmonitors.receiver]
       clustering {
         enabled = true
@@ -885,7 +884,6 @@ data:
     
     // Prometheus Operator Probe objects
     prometheus.operator.probes "probes" {
-      namespaces = []
       forward_to = [prometheus.relabel.probes.receiver]
       clustering {
         enabled = true
@@ -901,7 +899,6 @@ data:
     
     // Prometheus Operator ServiceMonitor objects
     prometheus.operator.servicemonitors "service_monitors" {
-      namespaces = []
       forward_to = [prometheus.relabel.servicemonitors.receiver]
       clustering {
         enabled = true
@@ -45846,7 +45843,6 @@ data:
     
     // Prometheus Operator PodMonitor objects
     prometheus.operator.podmonitors "pod_monitors" {
-      namespaces = []
       forward_to = [prometheus.relabel.podmonitors.receiver]
       clustering {
         enabled = true
@@ -45862,7 +45858,6 @@ data:
     
     // Prometheus Operator Probe objects
     prometheus.operator.probes "probes" {
-      namespaces = []
       forward_to = [prometheus.relabel.probes.receiver]
       clustering {
         enabled = true
@@ -45878,7 +45873,6 @@ data:
     
     // Prometheus Operator ServiceMonitor objects
     prometheus.operator.servicemonitors "service_monitors" {
-      namespaces = []
       forward_to = [prometheus.relabel.servicemonitors.receiver]
       clustering {
         enabled = true


### PR DESCRIPTION
Should cause no functional difference, but it's clearer this way.

Comment to reviewers: Worth noting that the example that was not modified is the [specific namespace example](https://github.com/grafana/k8s-monitoring-helm/tree/main/examples/specific-namespace)