### PR TITLE
Convert test back to a job and break out functionality for the config analysis

### DIFF
--- a/.github/configs/mysql-config.yaml
+++ b/.github/configs/mysql-config.yaml
@@ -60,6 +60,9 @@ data:
     prometheus.scrape "mysql" {
       targets      = prometheus.exporter.mysql.mysql.targets
       job_name     = "integrations/mysql"
+      clustering {
+        enabled = true
+      }
       forward_to   = [prometheus.relabel.mysql.receiver]
     }
 

--- a/.github/workflows/helm-test.yml
+++ b/.github/workflows/helm-test.yml
@@ -201,4 +201,4 @@ jobs:
       if: steps.list-changed.outputs.changed == 'true'
       run: |
         latestRelease=$(git describe --abbrev=0 --tags)
-        ct install --config "${CT_CONFIGFILE}" --since "${latestRelease}"
+        ct install --config "${CT_CONFIGFILE}" --since "${latestRelease}" --helm-extra-args "--timeout 10m"

--- a/charts/k8s-monitoring/README.md
+++ b/charts/k8s-monitoring/README.md
@@ -111,6 +111,16 @@ The Prometheus and Loki services may be hosted on the same cluster, or remotely 
 | cluster.kubernetesAPIService | string | `"kubernetes.default.svc.cluster.local:443"` | The Kubernetes service. Change this if your cluster DNS is configured differently than the default. |
 | cluster.name | string | `""` | The name of this cluster, which will be set in all labels. Required. |
 | cluster.platform | string | `""` | The specific platform for this cluster. Will enable compatibility for some platforms. Supported options: (empty) or "openshift". |
+| configAnalysis.enabled | bool | `true` | Should `helm test` run the config analysis pod? |
+| configAnalysis.extraAnnotations | object | `{}` | Extra annotations to add to the config analysis pod. |
+| configAnalysis.extraLabels | object | `{}` | Extra labels to add to the config analysis pod. |
+| configAnalysis.image.image | string | `"grafana/k8s-monitoring-test"` | Config Analysis image repository. |
+| configAnalysis.image.pullSecrets | list | `[]` | Optional set of image pull secrets. |
+| configAnalysis.image.registry | string | `"ghcr.io"` | Config Analysis image registry. |
+| configAnalysis.image.tag | string | `""` | Config Analysis image tag. Default is the chart version. |
+| configAnalysis.nodeSelector | object | `{"kubernetes.io/os":"linux"}` | nodeSelector to apply to the config analysis pod. |
+| configAnalysis.tolerations | list | `[]` | Tolerations to apply to the config analysis pod. |
+| configValidator.enabled | bool | `true` | Should config validation be run? |
 | configValidator.extraAnnotations | object | `{}` | Extra annotations to add to the test config validator job. |
 | configValidator.extraLabels | object | `{}` | Extra labels to add to the test config validator job. |
 | configValidator.nodeSelector | object | `{"kubernetes.io/os":"linux"}` | nodeSelector to apply to the config validator job. |
@@ -354,10 +364,11 @@ The Prometheus and Loki services may be hosted on the same cluster, or remotely 
 | receivers.zipkin.enabled | bool | `false` | Receive Zipkin traces |
 | receivers.zipkin.port | int | `9411` | Which port to use for the Zipkin receiver. This port needs to be opened in the grafana-agent section below. |
 | test.attempts | int | `10` | How many times to attempt the test job. |
+| test.enabled | bool | `true` | Should `helm test` run the test job? |
 | test.envOverrides | object | `{"LOKI_URL":"","PROMETHEUS_URL":"","TEMPO_URL":""}` | Overrides the URLs for various data sources |
-| test.extraAnnotations | object | `{}` | Extra annotations to add to the test jobs. |
-| test.extraLabels | object | `{}` | Extra labels to add to the test jobs. |
-| test.extraQueries | list | `[]` | Additional queries that will be run with `helm test`. NOTE that this uses the host, username, and password in the externalServices section. The user account must have the ability to run queries. Example: extraQueries:   - query: prometheus_metric{cluster="my-cluster-name"}     type: [promql|logql] |
+| test.extraAnnotations | object | `{}` | Extra annotations to add to the test job. |
+| test.extraLabels | object | `{}` | Extra labels to add to the test job. |
+| test.extraQueries | list | `[]` | Additional queries to run during the test. NOTE that this uses the host, username, and password in the externalServices section. The user account must have the ability to run queries. Example: extraQueries:   - query: prometheus_metric{cluster="my-cluster-name"}     type: promql  Can optionally provide expectations: - query: "avg(count_over_time(scrape_samples_scraped{cluster=~\"ci-test-cluster-2|from-the-other-agent\"}[1m]))"   type: promql   expect:     value: 1     operator: == |
 | test.image.image | string | `"grafana/k8s-monitoring-test"` | Test job image repository. |
 | test.image.pullSecrets | list | `[]` | Optional set of image pull secrets. |
 | test.image.registry | string | `"ghcr.io"` | Test job image registry. |

--- a/charts/k8s-monitoring/ci/ci-2-values.yaml
+++ b/charts/k8s-monitoring/ci/ci-2-values.yaml
@@ -80,11 +80,14 @@ test:
       operator: "<="  # There's gotta be at least one pod
 
   # Check for cluster events
-  - query: "{cluster=\"ci-test-cluster-2\", job=\"integrations/kubernetes/eventhandler\"}"
+  - query: "count_over_time({cluster=\"ci-test-cluster-2\", job=\"integrations/kubernetes/eventhandler\"}[1h])"
     type: logql
+
   # Check for pod logs (gathered via API)
-  - query: "{cluster=\"ci-test-cluster-2\", job!=\"integrations/kubernetes/eventhandler\"}"
+  - query: "count_over_time({cluster=\"ci-test-cluster-2\", job!=\"integrations/kubernetes/eventhandler\"}[1h])"
     type: logql
+
+  # Check for traces
   - query: "{.k8s.cluster.name=\"ci-test-cluster-2\"}"
     type: traceql
 

--- a/charts/k8s-monitoring/ci/ci-integrations-values.yaml
+++ b/charts/k8s-monitoring/ci/ci-integrations-values.yaml
@@ -106,15 +106,15 @@ test:
     type: promql
 
   # Check for MySQL logs, discovered by the module loaded above in .logs.extraConfig
-  - query: "{cluster=\"ci-integrations-cluster\", job=\"integrations/mysql\"}"
+  - query: "count_over_time({cluster=\"ci-integrations-cluster\", job=\"integrations/mysql\"}[1h])"
     type: logql
 
   # Cluster events still work, too
-  - query: "{cluster=\"ci-integrations-cluster\", job=\"integrations/kubernetes/eventhandler\"}"
+  - query: "count_over_time({cluster=\"ci-integrations-cluster\", job=\"integrations/kubernetes/eventhandler\"}[1h])"
     type: logql
 
   # Regular pod logs still work, too (checking the Loki pod <namespace>/<pod_name>)
-  - query: "{cluster=\"ci-integrations-cluster\", job=\"loki/loki\"}"
+  - query: "count_over_time({cluster=\"ci-integrations-cluster\", job=\"loki/loki\"}[1h])"
     type: logql
 
   # DPM check

--- a/charts/k8s-monitoring/ci/ci-values.yaml
+++ b/charts/k8s-monitoring/ci/ci-values.yaml
@@ -63,10 +63,10 @@ test:
       expect:
         count: 0
     # Check for cluster events
-    - query: "{cluster=\"ci-test-cluster\", job=\"integrations/kubernetes/eventhandler\"}"
+    - query: "count_over_time({cluster=\"ci-test-cluster\", job=\"integrations/kubernetes/eventhandler\"}[1h])"
       type: logql
     # Check for pod logs
-    - query: "{cluster=\"ci-test-cluster\", job!=\"integrations/kubernetes/eventhandler\"}"
+    - query: "count_over_time({cluster=\"ci-test-cluster\", job!=\"integrations/kubernetes/eventhandler\"}[1h])"
       type: logql
 
     # DPM check

--- a/charts/k8s-monitoring/templates/hooks/validate-configuration.yaml
+++ b/charts/k8s-monitoring/templates/hooks/validate-configuration.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.configValidator.enabled }}
 ---
 apiVersion: batch/v1
 kind: Job
@@ -112,3 +113,4 @@ data:
   logs.river: |-
     {{- include "agentLogsConfig" . | trim | nindent 4 }}
 {{- end }}
+{{- end -}}

--- a/charts/k8s-monitoring/templates/tests/test.yaml
+++ b/charts/k8s-monitoring/templates/tests/test.yaml
@@ -56,6 +56,8 @@ queries:
     {{- end }}
   {{- end }}
 {{- end -}}
+
+{{- if .Values.configAnalysis.enabled }}
 ---
 apiVersion: v1
 kind: Pod
@@ -67,44 +69,46 @@ metadata:
     app.kubernetes.io/instance: {{ .Release.Name | quote }}
     app.kubernetes.io/version: {{ .Chart.AppVersion }}
     helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
-    {{- range $key, $val := .Values.test.extraLabels }}
+    {{- range $key, $val := .Values.configAnalysis.extraLabels }}
     {{ $key }}: {{ $val | quote }}
     {{- end}}
   annotations:
     "helm.sh/hook": test
     "helm.sh/hook-delete-policy": before-hook-creation
     "helm.sh/hook-weight": "0"
-    {{- range $key, $val := .Values.test.extraAnnotations }}
+    {{- range $key, $val := .Values.configAnalysis.extraAnnotations }}
     {{ $key }}: {{ $val | quote }}
     {{- end}}
 spec:
-  {{- if or .Values.global.image.pullSecrets .Values.test.image.pullSecrets }}
+  {{- if or .Values.global.image.pullSecrets .Values.configAnalysis.image.pullSecrets }}
   imagePullSecrets:
     {{- if .Values.global.image.pullSecrets }}
     {{- toYaml .Values.global.image.pullSecrets | nindent 8 }}
     {{- else }}
-    {{- toYaml .Values.test.image.pullSecrets | nindent 8 }}
+    {{- toYaml .Values.configAnalysis.image.pullSecrets | nindent 8 }}
     {{- end }}
   {{- end }}
   restartPolicy: OnFailure
-  {{- with .Values.test.nodeSelector }}
+  {{- with .Values.configAnalysis.nodeSelector }}
   nodeSelector:
     {{- toYaml . | nindent 8 }}
   {{- end }}
-  {{- with .Values.test.tolerations }}
+  {{- with .Values.configAnalysis.tolerations }}
   tolerations:
     {{- toYaml . | nindent 8 }}
   {{- end }}
   containers:
     - name: config-analysis
-      image: {{ .Values.global.image.registry | default .Values.test.image.registry }}/{{ .Values.test.image.image }}:{{ .Values.test.image.tag | default .Chart.Version }}
+      image: {{ .Values.global.image.registry | default .Values.configAnalysis.image.registry }}/{{ .Values.configAnalysis.image.image }}:{{ .Values.configAnalysis.image.tag | default .Chart.Version }}
       command: [/etc/bin/config-analysis.sh]
       env:
         - name: AGENT_HOST
           value: {{ include "grafana-agent.fullname" (index .Subcharts "grafana-agent") }}.{{ .Release.Namespace }}.svc
+{{- end -}}
+{{- if .Values.test.enabled }}
 ---
-apiVersion: v1
-kind: Pod
+apiVersion: batch/v1
+kind: Job
 metadata:
   name: {{ include "kubernetes-monitoring-test.fullname" . | quote }}
   namespace: {{ .Release.Namespace }}
@@ -124,118 +128,139 @@ metadata:
     {{ $key }}: {{ $val | quote }}
     {{- end}}
 spec:
-  {{- if or .Values.global.image.pullSecrets .Values.test.image.pullSecrets }}
-  imagePullSecrets:
-    {{- if .Values.global.image.pullSecrets }}
-    {{- toYaml .Values.global.image.pullSecrets | nindent 8 }}
+  completions: 1
+  parallelism: 1
+  backoffLimit: {{ sub .Values.test.attempts 1 }}
+  template:
+    metadata:
+      name: {{ include "kubernetes-monitoring-test.fullname" . | quote }}
+      namespace: {{ .Release.Namespace }}
+      labels:
+        app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+        app.kubernetes.io/instance: {{ .Release.Name | quote }}
+        helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+        {{- range $key, $val := .Values.test.extraLabels }}
+        {{ $key }}: {{ $val | quote }}
+        {{- end}}
+      {{- with .Values.test.extraAnnotations }}
+      annotations:
+        {{- . | toYaml | nindent 8 }}
+      {{- end }}
+    spec:
+      {{- if or .Values.global.image.pullSecrets .Values.test.image.pullSecrets }}
+      imagePullSecrets:
+        {{- if .Values.global.image.pullSecrets }}
+        {{- toYaml .Values.global.image.pullSecrets | nindent 8 }}
+        {{- else }}
+        {{- toYaml .Values.test.image.pullSecrets | nindent 8 }}
+        {{- end }}
+      {{- end }}
+      restartPolicy: Never
+      {{- with .Values.test.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.test.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: query-test
+          image: {{ .Values.global.image.registry | default .Values.test.image.registry }}/{{ .Values.test.image.image }}:{{ .Values.test.image.tag | default .Chart.Version }}
+          command: ["bash", "-c", "/etc/bin/query-test.sh /etc/test/testQueries.json"]
+          volumeMounts:
+            - name: test-files
+              mountPath: /etc/test
+          env:
+            - name: SINCE
+              value: {{ .Values.test.queryRange }}
+    {{- if .Values.test.envOverrides.PROMETHEUS_URL }}
+            - name: PROMETHEUS_URL
+              value: {{ .Values.test.envOverrides.PROMETHEUS_URL | quote }}
     {{- else }}
-    {{- toYaml .Values.test.image.pullSecrets | nindent 8 }}
+            - name: PROMETHEUS_HOST
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "kubernetes_monitoring.metrics_service.secret.name" . }}
+                  key: {{ .Values.externalServices.prometheus.hostKey }}
+                  optional: true
+            - name: PROMETHEUS_URL
+              value: $(PROMETHEUS_HOST){{ .Values.externalServices.prometheus.queryEndpoint }}
     {{- end }}
-  {{- end }}
-  restartPolicy: OnFailure
-  {{- with .Values.test.nodeSelector }}
-  nodeSelector:
-    {{- toYaml . | nindent 8 }}
-  {{- end }}
-  {{- with .Values.test.tolerations }}
-  tolerations:
-    {{- toYaml . | nindent 8 }}
-  {{- end }}
-  containers:
-    - name: query-test
-      image: {{ .Values.global.image.registry | default .Values.test.image.registry }}/{{ .Values.test.image.image }}:{{ .Values.test.image.tag | default .Chart.Version }}
-      command: ["bash", "-c", "/etc/bin/query-test.sh /etc/test/testQueries.json"]
-      volumeMounts:
+            - name: PROMETHEUS_USER
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "kubernetes_monitoring.metrics_service.secret.name" . }}
+                  key: {{ .Values.externalServices.prometheus.basicAuth.usernameKey }}
+                  optional: true
+            - name: PROMETHEUS_PASS
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "kubernetes_monitoring.metrics_service.secret.name" . }}
+                  key: {{ .Values.externalServices.prometheus.basicAuth.passwordKey }}
+                  optional: true
+
+    {{- if .Values.test.envOverrides.LOKI_URL }}
+            - name: LOKI_URL
+              value: {{ .Values.test.envOverrides.LOKI_URL | quote }}
+    {{- else }}
+            - name: LOKI_HOST
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "kubernetes_monitoring.logs_service.secret.name" . }}
+                  key: {{ .Values.externalServices.loki.hostKey }}
+            - name: LOKI_URL
+              value: $(LOKI_HOST){{ .Values.externalServices.loki.queryEndpoint }}
+    {{- end }}
+            - name: LOKI_USER
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "kubernetes_monitoring.logs_service.secret.name" . }}
+                  key: {{ .Values.externalServices.loki.basicAuth.usernameKey }}
+                  optional: true
+            - name: LOKI_PASS
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "kubernetes_monitoring.logs_service.secret.name" . }}
+                  key: {{ .Values.externalServices.loki.basicAuth.passwordKey }}
+                  optional: true
+            - name: LOKI_TENANTID
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "kubernetes_monitoring.logs_service.secret.name" . }}
+                  key: {{ .Values.externalServices.loki.tenantIdKey }}
+                  optional: true
+
+    {{- if .Values.test.envOverrides.TEMPO_URL }}
+            - name: TEMPO_URL
+              value: {{ .Values.test.envOverrides.TEMPO_URL | quote }}
+    {{- else }}
+            - name: TEMPO_HOST
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "kubernetes_monitoring.traces_service.secret.name" . }}
+                  key: {{ .Values.externalServices.tempo.hostKey }}
+                  optional: true
+            - name: TEMPO_URL
+              value: $(TEMPO_HOST){{ .Values.externalServices.tempo.searchEndpoint }}
+    {{- end }}
+            - name: TEMPO_USER
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "kubernetes_monitoring.traces_service.secret.name" . }}
+                  key: {{ .Values.externalServices.tempo.basicAuth.usernameKey }}
+                  optional: true
+            - name: TEMPO_PASS
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "kubernetes_monitoring.traces_service.secret.name" . }}
+                  key: {{ .Values.externalServices.tempo.basicAuth.passwordKey }}
+                  optional: true
+
+      volumes:
         - name: test-files
-          mountPath: /etc/test
-      env:
-{{- if .Values.test.envOverrides.PROMETHEUS_URL }}
-        - name: PROMETHEUS_URL
-          value: {{ .Values.test.envOverrides.PROMETHEUS_URL | quote }}
-{{- else }}
-        - name: PROMETHEUS_HOST
-          valueFrom:
-            secretKeyRef:
-              name: {{ include "kubernetes_monitoring.metrics_service.secret.name" . }}
-              key: {{ .Values.externalServices.prometheus.hostKey }}
-              optional: true
-        - name: PROMETHEUS_URL
-          value: $(PROMETHEUS_HOST){{ .Values.externalServices.prometheus.queryEndpoint }}
-{{- end }}
-        - name: PROMETHEUS_USER
-          valueFrom:
-            secretKeyRef:
-              name: {{ include "kubernetes_monitoring.metrics_service.secret.name" . }}
-              key: {{ .Values.externalServices.prometheus.basicAuth.usernameKey }}
-              optional: true
-        - name: PROMETHEUS_PASS
-          valueFrom:
-            secretKeyRef:
-              name: {{ include "kubernetes_monitoring.metrics_service.secret.name" . }}
-              key: {{ .Values.externalServices.prometheus.basicAuth.passwordKey }}
-              optional: true
-
-{{- if .Values.test.envOverrides.LOKI_URL }}
-        - name: LOKI_URL
-          value: {{ .Values.test.envOverrides.LOKI_URL | quote }}
-{{- else }}
-        - name: LOKI_HOST
-          valueFrom:
-            secretKeyRef:
-              name: {{ include "kubernetes_monitoring.logs_service.secret.name" . }}
-              key: {{ .Values.externalServices.loki.hostKey }}
-        - name: LOKI_URL
-          value: $(LOKI_HOST){{ .Values.externalServices.loki.queryEndpoint }}
-{{- end }}
-        - name: LOKI_USER
-          valueFrom:
-            secretKeyRef:
-              name: {{ include "kubernetes_monitoring.logs_service.secret.name" . }}
-              key: {{ .Values.externalServices.loki.basicAuth.usernameKey }}
-              optional: true
-        - name: LOKI_PASS
-          valueFrom:
-            secretKeyRef:
-              name: {{ include "kubernetes_monitoring.logs_service.secret.name" . }}
-              key: {{ .Values.externalServices.loki.basicAuth.passwordKey }}
-              optional: true
-        - name: LOKI_TENANTID
-          valueFrom:
-            secretKeyRef:
-              name: {{ include "kubernetes_monitoring.logs_service.secret.name" . }}
-              key: {{ .Values.externalServices.loki.tenantIdKey }}
-              optional: true
-
-{{- if .Values.test.envOverrides.TEMPO_URL }}
-        - name: TEMPO_URL
-          value: {{ .Values.test.envOverrides.TEMPO_URL | quote }}
-{{- else }}
-        - name: TEMPO_HOST
-          valueFrom:
-            secretKeyRef:
-              name: {{ include "kubernetes_monitoring.traces_service.secret.name" . }}
-              key: {{ .Values.externalServices.tempo.hostKey }}
-              optional: true
-        - name: TEMPO_URL
-          value: $(TEMPO_HOST){{ .Values.externalServices.tempo.searchEndpoint }}
-{{- end }}
-        - name: TEMPO_USER
-          valueFrom:
-            secretKeyRef:
-              name: {{ include "kubernetes_monitoring.traces_service.secret.name" . }}
-              key: {{ .Values.externalServices.tempo.basicAuth.usernameKey }}
-              optional: true
-        - name: TEMPO_PASS
-          valueFrom:
-            secretKeyRef:
-              name: {{ include "kubernetes_monitoring.traces_service.secret.name" . }}
-              key: {{ .Values.externalServices.tempo.basicAuth.passwordKey }}
-              optional: true
-
-  volumes:
-    - name: test-files
-      configMap:
-        name: {{ include "kubernetes-monitoring-test.fullname" . | quote }}
+          configMap:
+            name: {{ include "kubernetes-monitoring-test.fullname" . | quote }}
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -254,3 +279,4 @@ metadata:
 data:
   testQueries.json: |-
 {{- include "test.queryList" . | fromYaml | toPrettyJson | nindent 4 }}
+{{- end -}}

--- a/charts/k8s-monitoring/values.yaml
+++ b/charts/k8s-monitoring/values.yaml
@@ -799,9 +799,12 @@ receivers:
 # See [Adding custom Flow configuration](#adding-custom-flow-configuration) for an example.
 extraConfig: ""
 
-# Setting for the config validator job, run as a post-install and post-upgrade hook to validate that the generated
+# Setting for the config validator job, run as a pre-install and pre-upgrade hook to validate that the generated
 # configuration, including extraConfig settings are valid.
 configValidator:
+  # -- Should config validation be run?
+  enabled: true
+
   # -- nodeSelector to apply to the config validator job.
   nodeSelector:
     kubernetes.io/os: linux
@@ -815,15 +818,26 @@ configValidator:
   # -- Tolerations to apply to the config validator job.
   tolerations: []
 
-# Settings for the test job, runnable by "helm test"
+# Settings for the test job, which runs queries against Prometheus, Loki, and/or Tempo to check for data that should be
+# available based on the current configuration. Runnable by "helm test"
 test:
-  # -- Additional queries that will be run with `helm test`.
+  # -- Should `helm test` run the test job?
+  enabled: true
+
+  # -- Additional queries to run during the test.
   # NOTE that this uses the host, username, and password in the externalServices section.
   # The user account must have the ability to run queries.
   # Example:
   # extraQueries:
   #   - query: prometheus_metric{cluster="my-cluster-name"}
-  #     type: [promql|logql]
+  #     type: promql
+  #
+  # Can optionally provide expectations:
+  # - query: "avg(count_over_time(scrape_samples_scraped{cluster=~\"ci-test-cluster-2|from-the-other-agent\"}[1m]))"
+  #   type: promql
+  #   expect:
+  #     value: 1
+  #     operator: ==
   extraQueries: []
 
   # -- How many times to attempt the test job.
@@ -833,10 +847,10 @@ test:
   nodeSelector:
     kubernetes.io/os: linux
 
-  # -- Extra annotations to add to the test jobs.
+  # -- Extra annotations to add to the test job.
   extraAnnotations: {}
 
-  # -- Extra labels to add to the test jobs.
+  # -- Extra labels to add to the test job.
   extraLabels: {}
 
   # -- Tolerations to apply to the test job.
@@ -857,6 +871,36 @@ test:
     tag: ""
     # -- Optional set of image pull secrets.
     pullSecrets: []
+
+# Settings for the config analysis pod, which asks the Grafana Agent for an analysis of expected metric discoveries and
+# scrapes. Runnable by "helm test"
+configAnalysis:
+  # -- Should `helm test` run the config analysis pod?
+  enabled: true
+
+  # -- nodeSelector to apply to the config analysis pod.
+  nodeSelector:
+    kubernetes.io/os: linux
+
+  # -- Extra annotations to add to the config analysis pod.
+  extraAnnotations: {}
+
+  # -- Extra labels to add to the config analysis pod.
+  extraLabels: {}
+
+  # -- Tolerations to apply to the config analysis pod.
+  tolerations: []
+
+  image:
+    # -- Config Analysis image registry.
+    registry: ghcr.io
+    # -- Config Analysis image repository.
+    image: grafana/k8s-monitoring-test
+    # -- Config Analysis image tag. Default is the chart version.
+    tag: ""
+    # -- Optional set of image pull secrets.
+    pullSecrets: []
+
 
 ## Global properties for image pulling override the values defined under `image.registry` and `configReloader.image.registry`.
 ## If you want to override only one image registry, use the specific fields but if you want to override them all, use `global.image.registry`

--- a/examples/cluster-with-pvc/output.yaml
+++ b/examples/cluster-with-pvc/output.yaml
@@ -45993,104 +45993,6 @@ spec:
         - name: AGENT_HOST
           value: k8smon-grafana-agent.default.svc
 ---
-# Source: k8s-monitoring/templates/tests/test.yaml
-apiVersion: v1
-kind: Pod
-metadata:
-  name: "test-k8smon-k8s-monitoring"
-  namespace: default
-  labels:
-    app.kubernetes.io/managed-by: "Helm"
-    app.kubernetes.io/instance: "k8smon"
-    app.kubernetes.io/version: 2.0.2
-    helm.sh/chart: "k8s-monitoring-0.10.3"
-  annotations:
-    "helm.sh/hook": test
-    "helm.sh/hook-delete-policy": before-hook-creation
-    "helm.sh/hook-weight": "0"
-spec:
-  restartPolicy: OnFailure
-  nodeSelector:
-        kubernetes.io/os: linux
-  containers:
-    - name: query-test
-      image: ghcr.io/grafana/k8s-monitoring-test:0.10.3
-      command: ["bash", "-c", "/etc/bin/query-test.sh /etc/test/testQueries.json"]
-      volumeMounts:
-        - name: test-files
-          mountPath: /etc/test
-      env:
-        - name: PROMETHEUS_HOST
-          valueFrom:
-            secretKeyRef:
-              name: prometheus-k8s-monitoring
-              key: host
-              optional: true
-        - name: PROMETHEUS_URL
-          value: $(PROMETHEUS_HOST)/api/prom/api/v1/query
-        - name: PROMETHEUS_USER
-          valueFrom:
-            secretKeyRef:
-              name: prometheus-k8s-monitoring
-              key: username
-              optional: true
-        - name: PROMETHEUS_PASS
-          valueFrom:
-            secretKeyRef:
-              name: prometheus-k8s-monitoring
-              key: password
-              optional: true
-        - name: LOKI_HOST
-          valueFrom:
-            secretKeyRef:
-              name: loki-k8s-monitoring
-              key: host
-        - name: LOKI_URL
-          value: $(LOKI_HOST)/loki/api/v1/query
-        - name: LOKI_USER
-          valueFrom:
-            secretKeyRef:
-              name: loki-k8s-monitoring
-              key: username
-              optional: true
-        - name: LOKI_PASS
-          valueFrom:
-            secretKeyRef:
-              name: loki-k8s-monitoring
-              key: password
-              optional: true
-        - name: LOKI_TENANTID
-          valueFrom:
-            secretKeyRef:
-              name: loki-k8s-monitoring
-              key: tenantId
-              optional: true
-        - name: TEMPO_HOST
-          valueFrom:
-            secretKeyRef:
-              name: tempo-k8s-monitoring
-              key: host
-              optional: true
-        - name: TEMPO_URL
-          value: $(TEMPO_HOST)/api/search
-        - name: TEMPO_USER
-          valueFrom:
-            secretKeyRef:
-              name: tempo-k8s-monitoring
-              key: username
-              optional: true
-        - name: TEMPO_PASS
-          valueFrom:
-            secretKeyRef:
-              name: tempo-k8s-monitoring
-              key: password
-              optional: true
-
-  volumes:
-    - name: test-files
-      configMap:
-        name: "test-k8smon-k8s-monitoring"
----
 # Source: k8s-monitoring/templates/hooks/validate-configuration.yaml
 apiVersion: batch/v1
 kind: Job
@@ -46148,3 +46050,115 @@ spec:
         - name: config
           configMap:
             name: "validate-k8smon-k8s-monitoring"
+---
+# Source: k8s-monitoring/templates/tests/test.yaml
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: "test-k8smon-k8s-monitoring"
+  namespace: default
+  labels:
+    app.kubernetes.io/managed-by: "Helm"
+    app.kubernetes.io/instance: "k8smon"
+    app.kubernetes.io/version: 2.0.2
+    helm.sh/chart: "k8s-monitoring-0.10.3"
+  annotations:
+    "helm.sh/hook": test
+    "helm.sh/hook-delete-policy": before-hook-creation
+    "helm.sh/hook-weight": "0"
+spec:
+  completions: 1
+  parallelism: 1
+  backoffLimit: 9
+  template:
+    metadata:
+      name: "test-k8smon-k8s-monitoring"
+      namespace: default
+      labels:
+        app.kubernetes.io/managed-by: "Helm"
+        app.kubernetes.io/instance: "k8smon"
+        helm.sh/chart: "k8s-monitoring-0.10.3"
+    spec:
+      restartPolicy: Never
+      nodeSelector:
+        kubernetes.io/os: linux
+      containers:
+        - name: query-test
+          image: ghcr.io/grafana/k8s-monitoring-test:0.10.3
+          command: ["bash", "-c", "/etc/bin/query-test.sh /etc/test/testQueries.json"]
+          volumeMounts:
+            - name: test-files
+              mountPath: /etc/test
+          env:
+            - name: SINCE
+              value: 
+            - name: PROMETHEUS_HOST
+              valueFrom:
+                secretKeyRef:
+                  name: prometheus-k8s-monitoring
+                  key: host
+                  optional: true
+            - name: PROMETHEUS_URL
+              value: $(PROMETHEUS_HOST)/api/prom/api/v1/query
+            - name: PROMETHEUS_USER
+              valueFrom:
+                secretKeyRef:
+                  name: prometheus-k8s-monitoring
+                  key: username
+                  optional: true
+            - name: PROMETHEUS_PASS
+              valueFrom:
+                secretKeyRef:
+                  name: prometheus-k8s-monitoring
+                  key: password
+                  optional: true
+            - name: LOKI_HOST
+              valueFrom:
+                secretKeyRef:
+                  name: loki-k8s-monitoring
+                  key: host
+            - name: LOKI_URL
+              value: $(LOKI_HOST)/loki/api/v1/query
+            - name: LOKI_USER
+              valueFrom:
+                secretKeyRef:
+                  name: loki-k8s-monitoring
+                  key: username
+                  optional: true
+            - name: LOKI_PASS
+              valueFrom:
+                secretKeyRef:
+                  name: loki-k8s-monitoring
+                  key: password
+                  optional: true
+            - name: LOKI_TENANTID
+              valueFrom:
+                secretKeyRef:
+                  name: loki-k8s-monitoring
+                  key: tenantId
+                  optional: true
+            - name: TEMPO_HOST
+              valueFrom:
+                secretKeyRef:
+                  name: tempo-k8s-monitoring
+                  key: host
+                  optional: true
+            - name: TEMPO_URL
+              value: $(TEMPO_HOST)/api/search
+            - name: TEMPO_USER
+              valueFrom:
+                secretKeyRef:
+                  name: tempo-k8s-monitoring
+                  key: username
+                  optional: true
+            - name: TEMPO_PASS
+              valueFrom:
+                secretKeyRef:
+                  name: tempo-k8s-monitoring
+                  key: password
+                  optional: true
+
+      volumes:
+        - name: test-files
+          configMap:
+            name: "test-k8smon-k8s-monitoring"

--- a/examples/control-plane-metrics/output.yaml
+++ b/examples/control-plane-metrics/output.yaml
@@ -46246,104 +46246,6 @@ spec:
         - name: AGENT_HOST
           value: k8smon-grafana-agent.default.svc
 ---
-# Source: k8s-monitoring/templates/tests/test.yaml
-apiVersion: v1
-kind: Pod
-metadata:
-  name: "test-k8smon-k8s-monitoring"
-  namespace: default
-  labels:
-    app.kubernetes.io/managed-by: "Helm"
-    app.kubernetes.io/instance: "k8smon"
-    app.kubernetes.io/version: 2.0.2
-    helm.sh/chart: "k8s-monitoring-0.10.3"
-  annotations:
-    "helm.sh/hook": test
-    "helm.sh/hook-delete-policy": before-hook-creation
-    "helm.sh/hook-weight": "0"
-spec:
-  restartPolicy: OnFailure
-  nodeSelector:
-        kubernetes.io/os: linux
-  containers:
-    - name: query-test
-      image: ghcr.io/grafana/k8s-monitoring-test:0.10.3
-      command: ["bash", "-c", "/etc/bin/query-test.sh /etc/test/testQueries.json"]
-      volumeMounts:
-        - name: test-files
-          mountPath: /etc/test
-      env:
-        - name: PROMETHEUS_HOST
-          valueFrom:
-            secretKeyRef:
-              name: prometheus-k8s-monitoring
-              key: host
-              optional: true
-        - name: PROMETHEUS_URL
-          value: $(PROMETHEUS_HOST)/api/prom/api/v1/query
-        - name: PROMETHEUS_USER
-          valueFrom:
-            secretKeyRef:
-              name: prometheus-k8s-monitoring
-              key: username
-              optional: true
-        - name: PROMETHEUS_PASS
-          valueFrom:
-            secretKeyRef:
-              name: prometheus-k8s-monitoring
-              key: password
-              optional: true
-        - name: LOKI_HOST
-          valueFrom:
-            secretKeyRef:
-              name: loki-k8s-monitoring
-              key: host
-        - name: LOKI_URL
-          value: $(LOKI_HOST)/loki/api/v1/query
-        - name: LOKI_USER
-          valueFrom:
-            secretKeyRef:
-              name: loki-k8s-monitoring
-              key: username
-              optional: true
-        - name: LOKI_PASS
-          valueFrom:
-            secretKeyRef:
-              name: loki-k8s-monitoring
-              key: password
-              optional: true
-        - name: LOKI_TENANTID
-          valueFrom:
-            secretKeyRef:
-              name: loki-k8s-monitoring
-              key: tenantId
-              optional: true
-        - name: TEMPO_HOST
-          valueFrom:
-            secretKeyRef:
-              name: tempo-k8s-monitoring
-              key: host
-              optional: true
-        - name: TEMPO_URL
-          value: $(TEMPO_HOST)/api/search
-        - name: TEMPO_USER
-          valueFrom:
-            secretKeyRef:
-              name: tempo-k8s-monitoring
-              key: username
-              optional: true
-        - name: TEMPO_PASS
-          valueFrom:
-            secretKeyRef:
-              name: tempo-k8s-monitoring
-              key: password
-              optional: true
-
-  volumes:
-    - name: test-files
-      configMap:
-        name: "test-k8smon-k8s-monitoring"
----
 # Source: k8s-monitoring/templates/hooks/validate-configuration.yaml
 apiVersion: batch/v1
 kind: Job
@@ -46401,3 +46303,115 @@ spec:
         - name: config
           configMap:
             name: "validate-k8smon-k8s-monitoring"
+---
+# Source: k8s-monitoring/templates/tests/test.yaml
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: "test-k8smon-k8s-monitoring"
+  namespace: default
+  labels:
+    app.kubernetes.io/managed-by: "Helm"
+    app.kubernetes.io/instance: "k8smon"
+    app.kubernetes.io/version: 2.0.2
+    helm.sh/chart: "k8s-monitoring-0.10.3"
+  annotations:
+    "helm.sh/hook": test
+    "helm.sh/hook-delete-policy": before-hook-creation
+    "helm.sh/hook-weight": "0"
+spec:
+  completions: 1
+  parallelism: 1
+  backoffLimit: 9
+  template:
+    metadata:
+      name: "test-k8smon-k8s-monitoring"
+      namespace: default
+      labels:
+        app.kubernetes.io/managed-by: "Helm"
+        app.kubernetes.io/instance: "k8smon"
+        helm.sh/chart: "k8s-monitoring-0.10.3"
+    spec:
+      restartPolicy: Never
+      nodeSelector:
+        kubernetes.io/os: linux
+      containers:
+        - name: query-test
+          image: ghcr.io/grafana/k8s-monitoring-test:0.10.3
+          command: ["bash", "-c", "/etc/bin/query-test.sh /etc/test/testQueries.json"]
+          volumeMounts:
+            - name: test-files
+              mountPath: /etc/test
+          env:
+            - name: SINCE
+              value: 
+            - name: PROMETHEUS_HOST
+              valueFrom:
+                secretKeyRef:
+                  name: prometheus-k8s-monitoring
+                  key: host
+                  optional: true
+            - name: PROMETHEUS_URL
+              value: $(PROMETHEUS_HOST)/api/prom/api/v1/query
+            - name: PROMETHEUS_USER
+              valueFrom:
+                secretKeyRef:
+                  name: prometheus-k8s-monitoring
+                  key: username
+                  optional: true
+            - name: PROMETHEUS_PASS
+              valueFrom:
+                secretKeyRef:
+                  name: prometheus-k8s-monitoring
+                  key: password
+                  optional: true
+            - name: LOKI_HOST
+              valueFrom:
+                secretKeyRef:
+                  name: loki-k8s-monitoring
+                  key: host
+            - name: LOKI_URL
+              value: $(LOKI_HOST)/loki/api/v1/query
+            - name: LOKI_USER
+              valueFrom:
+                secretKeyRef:
+                  name: loki-k8s-monitoring
+                  key: username
+                  optional: true
+            - name: LOKI_PASS
+              valueFrom:
+                secretKeyRef:
+                  name: loki-k8s-monitoring
+                  key: password
+                  optional: true
+            - name: LOKI_TENANTID
+              valueFrom:
+                secretKeyRef:
+                  name: loki-k8s-monitoring
+                  key: tenantId
+                  optional: true
+            - name: TEMPO_HOST
+              valueFrom:
+                secretKeyRef:
+                  name: tempo-k8s-monitoring
+                  key: host
+                  optional: true
+            - name: TEMPO_URL
+              value: $(TEMPO_HOST)/api/search
+            - name: TEMPO_USER
+              valueFrom:
+                secretKeyRef:
+                  name: tempo-k8s-monitoring
+                  key: username
+                  optional: true
+            - name: TEMPO_PASS
+              valueFrom:
+                secretKeyRef:
+                  name: tempo-k8s-monitoring
+                  key: password
+                  optional: true
+
+      volumes:
+        - name: test-files
+          configMap:
+            name: "test-k8smon-k8s-monitoring"

--- a/examples/custom-config/output.yaml
+++ b/examples/custom-config/output.yaml
@@ -46051,104 +46051,6 @@ spec:
         - name: AGENT_HOST
           value: k8smon-grafana-agent.default.svc
 ---
-# Source: k8s-monitoring/templates/tests/test.yaml
-apiVersion: v1
-kind: Pod
-metadata:
-  name: "test-k8smon-k8s-monitoring"
-  namespace: default
-  labels:
-    app.kubernetes.io/managed-by: "Helm"
-    app.kubernetes.io/instance: "k8smon"
-    app.kubernetes.io/version: 2.0.2
-    helm.sh/chart: "k8s-monitoring-0.10.3"
-  annotations:
-    "helm.sh/hook": test
-    "helm.sh/hook-delete-policy": before-hook-creation
-    "helm.sh/hook-weight": "0"
-spec:
-  restartPolicy: OnFailure
-  nodeSelector:
-        kubernetes.io/os: linux
-  containers:
-    - name: query-test
-      image: ghcr.io/grafana/k8s-monitoring-test:0.10.3
-      command: ["bash", "-c", "/etc/bin/query-test.sh /etc/test/testQueries.json"]
-      volumeMounts:
-        - name: test-files
-          mountPath: /etc/test
-      env:
-        - name: PROMETHEUS_HOST
-          valueFrom:
-            secretKeyRef:
-              name: prometheus-k8s-monitoring
-              key: host
-              optional: true
-        - name: PROMETHEUS_URL
-          value: $(PROMETHEUS_HOST)/api/prom/api/v1/query
-        - name: PROMETHEUS_USER
-          valueFrom:
-            secretKeyRef:
-              name: prometheus-k8s-monitoring
-              key: username
-              optional: true
-        - name: PROMETHEUS_PASS
-          valueFrom:
-            secretKeyRef:
-              name: prometheus-k8s-monitoring
-              key: password
-              optional: true
-        - name: LOKI_HOST
-          valueFrom:
-            secretKeyRef:
-              name: loki-k8s-monitoring
-              key: host
-        - name: LOKI_URL
-          value: $(LOKI_HOST)/loki/api/v1/query
-        - name: LOKI_USER
-          valueFrom:
-            secretKeyRef:
-              name: loki-k8s-monitoring
-              key: username
-              optional: true
-        - name: LOKI_PASS
-          valueFrom:
-            secretKeyRef:
-              name: loki-k8s-monitoring
-              key: password
-              optional: true
-        - name: LOKI_TENANTID
-          valueFrom:
-            secretKeyRef:
-              name: loki-k8s-monitoring
-              key: tenantId
-              optional: true
-        - name: TEMPO_HOST
-          valueFrom:
-            secretKeyRef:
-              name: tempo-k8s-monitoring
-              key: host
-              optional: true
-        - name: TEMPO_URL
-          value: $(TEMPO_HOST)/api/search
-        - name: TEMPO_USER
-          valueFrom:
-            secretKeyRef:
-              name: tempo-k8s-monitoring
-              key: username
-              optional: true
-        - name: TEMPO_PASS
-          valueFrom:
-            secretKeyRef:
-              name: tempo-k8s-monitoring
-              key: password
-              optional: true
-
-  volumes:
-    - name: test-files
-      configMap:
-        name: "test-k8smon-k8s-monitoring"
----
 # Source: k8s-monitoring/templates/hooks/validate-configuration.yaml
 apiVersion: batch/v1
 kind: Job
@@ -46206,3 +46108,115 @@ spec:
         - name: config
           configMap:
             name: "validate-k8smon-k8s-monitoring"
+---
+# Source: k8s-monitoring/templates/tests/test.yaml
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: "test-k8smon-k8s-monitoring"
+  namespace: default
+  labels:
+    app.kubernetes.io/managed-by: "Helm"
+    app.kubernetes.io/instance: "k8smon"
+    app.kubernetes.io/version: 2.0.2
+    helm.sh/chart: "k8s-monitoring-0.10.3"
+  annotations:
+    "helm.sh/hook": test
+    "helm.sh/hook-delete-policy": before-hook-creation
+    "helm.sh/hook-weight": "0"
+spec:
+  completions: 1
+  parallelism: 1
+  backoffLimit: 9
+  template:
+    metadata:
+      name: "test-k8smon-k8s-monitoring"
+      namespace: default
+      labels:
+        app.kubernetes.io/managed-by: "Helm"
+        app.kubernetes.io/instance: "k8smon"
+        helm.sh/chart: "k8s-monitoring-0.10.3"
+    spec:
+      restartPolicy: Never
+      nodeSelector:
+        kubernetes.io/os: linux
+      containers:
+        - name: query-test
+          image: ghcr.io/grafana/k8s-monitoring-test:0.10.3
+          command: ["bash", "-c", "/etc/bin/query-test.sh /etc/test/testQueries.json"]
+          volumeMounts:
+            - name: test-files
+              mountPath: /etc/test
+          env:
+            - name: SINCE
+              value: 
+            - name: PROMETHEUS_HOST
+              valueFrom:
+                secretKeyRef:
+                  name: prometheus-k8s-monitoring
+                  key: host
+                  optional: true
+            - name: PROMETHEUS_URL
+              value: $(PROMETHEUS_HOST)/api/prom/api/v1/query
+            - name: PROMETHEUS_USER
+              valueFrom:
+                secretKeyRef:
+                  name: prometheus-k8s-monitoring
+                  key: username
+                  optional: true
+            - name: PROMETHEUS_PASS
+              valueFrom:
+                secretKeyRef:
+                  name: prometheus-k8s-monitoring
+                  key: password
+                  optional: true
+            - name: LOKI_HOST
+              valueFrom:
+                secretKeyRef:
+                  name: loki-k8s-monitoring
+                  key: host
+            - name: LOKI_URL
+              value: $(LOKI_HOST)/loki/api/v1/query
+            - name: LOKI_USER
+              valueFrom:
+                secretKeyRef:
+                  name: loki-k8s-monitoring
+                  key: username
+                  optional: true
+            - name: LOKI_PASS
+              valueFrom:
+                secretKeyRef:
+                  name: loki-k8s-monitoring
+                  key: password
+                  optional: true
+            - name: LOKI_TENANTID
+              valueFrom:
+                secretKeyRef:
+                  name: loki-k8s-monitoring
+                  key: tenantId
+                  optional: true
+            - name: TEMPO_HOST
+              valueFrom:
+                secretKeyRef:
+                  name: tempo-k8s-monitoring
+                  key: host
+                  optional: true
+            - name: TEMPO_URL
+              value: $(TEMPO_HOST)/api/search
+            - name: TEMPO_USER
+              valueFrom:
+                secretKeyRef:
+                  name: tempo-k8s-monitoring
+                  key: username
+                  optional: true
+            - name: TEMPO_PASS
+              valueFrom:
+                secretKeyRef:
+                  name: tempo-k8s-monitoring
+                  key: password
+                  optional: true
+
+      volumes:
+        - name: test-files
+          configMap:
+            name: "test-k8smon-k8s-monitoring"

--- a/examples/custom-metrics-tuning/output.yaml
+++ b/examples/custom-metrics-tuning/output.yaml
@@ -44912,104 +44912,6 @@ spec:
         - name: AGENT_HOST
           value: k8smon-grafana-agent.default.svc
 ---
-# Source: k8s-monitoring/templates/tests/test.yaml
-apiVersion: v1
-kind: Pod
-metadata:
-  name: "test-k8smon-k8s-monitoring"
-  namespace: default
-  labels:
-    app.kubernetes.io/managed-by: "Helm"
-    app.kubernetes.io/instance: "k8smon"
-    app.kubernetes.io/version: 2.0.2
-    helm.sh/chart: "k8s-monitoring-0.10.3"
-  annotations:
-    "helm.sh/hook": test
-    "helm.sh/hook-delete-policy": before-hook-creation
-    "helm.sh/hook-weight": "0"
-spec:
-  restartPolicy: OnFailure
-  nodeSelector:
-        kubernetes.io/os: linux
-  containers:
-    - name: query-test
-      image: ghcr.io/grafana/k8s-monitoring-test:0.10.3
-      command: ["bash", "-c", "/etc/bin/query-test.sh /etc/test/testQueries.json"]
-      volumeMounts:
-        - name: test-files
-          mountPath: /etc/test
-      env:
-        - name: PROMETHEUS_HOST
-          valueFrom:
-            secretKeyRef:
-              name: prometheus-k8s-monitoring
-              key: host
-              optional: true
-        - name: PROMETHEUS_URL
-          value: $(PROMETHEUS_HOST)/api/prom/api/v1/query
-        - name: PROMETHEUS_USER
-          valueFrom:
-            secretKeyRef:
-              name: prometheus-k8s-monitoring
-              key: username
-              optional: true
-        - name: PROMETHEUS_PASS
-          valueFrom:
-            secretKeyRef:
-              name: prometheus-k8s-monitoring
-              key: password
-              optional: true
-        - name: LOKI_HOST
-          valueFrom:
-            secretKeyRef:
-              name: loki-k8s-monitoring
-              key: host
-        - name: LOKI_URL
-          value: $(LOKI_HOST)/loki/api/v1/query
-        - name: LOKI_USER
-          valueFrom:
-            secretKeyRef:
-              name: loki-k8s-monitoring
-              key: username
-              optional: true
-        - name: LOKI_PASS
-          valueFrom:
-            secretKeyRef:
-              name: loki-k8s-monitoring
-              key: password
-              optional: true
-        - name: LOKI_TENANTID
-          valueFrom:
-            secretKeyRef:
-              name: loki-k8s-monitoring
-              key: tenantId
-              optional: true
-        - name: TEMPO_HOST
-          valueFrom:
-            secretKeyRef:
-              name: tempo-k8s-monitoring
-              key: host
-              optional: true
-        - name: TEMPO_URL
-          value: $(TEMPO_HOST)/api/search
-        - name: TEMPO_USER
-          valueFrom:
-            secretKeyRef:
-              name: tempo-k8s-monitoring
-              key: username
-              optional: true
-        - name: TEMPO_PASS
-          valueFrom:
-            secretKeyRef:
-              name: tempo-k8s-monitoring
-              key: password
-              optional: true
-
-  volumes:
-    - name: test-files
-      configMap:
-        name: "test-k8smon-k8s-monitoring"
----
 # Source: k8s-monitoring/templates/hooks/validate-configuration.yaml
 apiVersion: batch/v1
 kind: Job
@@ -45059,3 +44961,115 @@ spec:
         - name: config
           configMap:
             name: "validate-k8smon-k8s-monitoring"
+---
+# Source: k8s-monitoring/templates/tests/test.yaml
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: "test-k8smon-k8s-monitoring"
+  namespace: default
+  labels:
+    app.kubernetes.io/managed-by: "Helm"
+    app.kubernetes.io/instance: "k8smon"
+    app.kubernetes.io/version: 2.0.2
+    helm.sh/chart: "k8s-monitoring-0.10.3"
+  annotations:
+    "helm.sh/hook": test
+    "helm.sh/hook-delete-policy": before-hook-creation
+    "helm.sh/hook-weight": "0"
+spec:
+  completions: 1
+  parallelism: 1
+  backoffLimit: 9
+  template:
+    metadata:
+      name: "test-k8smon-k8s-monitoring"
+      namespace: default
+      labels:
+        app.kubernetes.io/managed-by: "Helm"
+        app.kubernetes.io/instance: "k8smon"
+        helm.sh/chart: "k8s-monitoring-0.10.3"
+    spec:
+      restartPolicy: Never
+      nodeSelector:
+        kubernetes.io/os: linux
+      containers:
+        - name: query-test
+          image: ghcr.io/grafana/k8s-monitoring-test:0.10.3
+          command: ["bash", "-c", "/etc/bin/query-test.sh /etc/test/testQueries.json"]
+          volumeMounts:
+            - name: test-files
+              mountPath: /etc/test
+          env:
+            - name: SINCE
+              value: 
+            - name: PROMETHEUS_HOST
+              valueFrom:
+                secretKeyRef:
+                  name: prometheus-k8s-monitoring
+                  key: host
+                  optional: true
+            - name: PROMETHEUS_URL
+              value: $(PROMETHEUS_HOST)/api/prom/api/v1/query
+            - name: PROMETHEUS_USER
+              valueFrom:
+                secretKeyRef:
+                  name: prometheus-k8s-monitoring
+                  key: username
+                  optional: true
+            - name: PROMETHEUS_PASS
+              valueFrom:
+                secretKeyRef:
+                  name: prometheus-k8s-monitoring
+                  key: password
+                  optional: true
+            - name: LOKI_HOST
+              valueFrom:
+                secretKeyRef:
+                  name: loki-k8s-monitoring
+                  key: host
+            - name: LOKI_URL
+              value: $(LOKI_HOST)/loki/api/v1/query
+            - name: LOKI_USER
+              valueFrom:
+                secretKeyRef:
+                  name: loki-k8s-monitoring
+                  key: username
+                  optional: true
+            - name: LOKI_PASS
+              valueFrom:
+                secretKeyRef:
+                  name: loki-k8s-monitoring
+                  key: password
+                  optional: true
+            - name: LOKI_TENANTID
+              valueFrom:
+                secretKeyRef:
+                  name: loki-k8s-monitoring
+                  key: tenantId
+                  optional: true
+            - name: TEMPO_HOST
+              valueFrom:
+                secretKeyRef:
+                  name: tempo-k8s-monitoring
+                  key: host
+                  optional: true
+            - name: TEMPO_URL
+              value: $(TEMPO_HOST)/api/search
+            - name: TEMPO_USER
+              valueFrom:
+                secretKeyRef:
+                  name: tempo-k8s-monitoring
+                  key: username
+                  optional: true
+            - name: TEMPO_PASS
+              valueFrom:
+                secretKeyRef:
+                  name: tempo-k8s-monitoring
+                  key: password
+                  optional: true
+
+      volumes:
+        - name: test-files
+          configMap:
+            name: "test-k8smon-k8s-monitoring"

--- a/examples/default-values/output.yaml
+++ b/examples/default-values/output.yaml
@@ -45925,104 +45925,6 @@ spec:
         - name: AGENT_HOST
           value: k8smon-grafana-agent.default.svc
 ---
-# Source: k8s-monitoring/templates/tests/test.yaml
-apiVersion: v1
-kind: Pod
-metadata:
-  name: "test-k8smon-k8s-monitoring"
-  namespace: default
-  labels:
-    app.kubernetes.io/managed-by: "Helm"
-    app.kubernetes.io/instance: "k8smon"
-    app.kubernetes.io/version: 2.0.2
-    helm.sh/chart: "k8s-monitoring-0.10.3"
-  annotations:
-    "helm.sh/hook": test
-    "helm.sh/hook-delete-policy": before-hook-creation
-    "helm.sh/hook-weight": "0"
-spec:
-  restartPolicy: OnFailure
-  nodeSelector:
-        kubernetes.io/os: linux
-  containers:
-    - name: query-test
-      image: ghcr.io/grafana/k8s-monitoring-test:0.10.3
-      command: ["bash", "-c", "/etc/bin/query-test.sh /etc/test/testQueries.json"]
-      volumeMounts:
-        - name: test-files
-          mountPath: /etc/test
-      env:
-        - name: PROMETHEUS_HOST
-          valueFrom:
-            secretKeyRef:
-              name: prometheus-k8s-monitoring
-              key: host
-              optional: true
-        - name: PROMETHEUS_URL
-          value: $(PROMETHEUS_HOST)/api/prom/api/v1/query
-        - name: PROMETHEUS_USER
-          valueFrom:
-            secretKeyRef:
-              name: prometheus-k8s-monitoring
-              key: username
-              optional: true
-        - name: PROMETHEUS_PASS
-          valueFrom:
-            secretKeyRef:
-              name: prometheus-k8s-monitoring
-              key: password
-              optional: true
-        - name: LOKI_HOST
-          valueFrom:
-            secretKeyRef:
-              name: loki-k8s-monitoring
-              key: host
-        - name: LOKI_URL
-          value: $(LOKI_HOST)/loki/api/v1/query
-        - name: LOKI_USER
-          valueFrom:
-            secretKeyRef:
-              name: loki-k8s-monitoring
-              key: username
-              optional: true
-        - name: LOKI_PASS
-          valueFrom:
-            secretKeyRef:
-              name: loki-k8s-monitoring
-              key: password
-              optional: true
-        - name: LOKI_TENANTID
-          valueFrom:
-            secretKeyRef:
-              name: loki-k8s-monitoring
-              key: tenantId
-              optional: true
-        - name: TEMPO_HOST
-          valueFrom:
-            secretKeyRef:
-              name: tempo-k8s-monitoring
-              key: host
-              optional: true
-        - name: TEMPO_URL
-          value: $(TEMPO_HOST)/api/search
-        - name: TEMPO_USER
-          valueFrom:
-            secretKeyRef:
-              name: tempo-k8s-monitoring
-              key: username
-              optional: true
-        - name: TEMPO_PASS
-          valueFrom:
-            secretKeyRef:
-              name: tempo-k8s-monitoring
-              key: password
-              optional: true
-
-  volumes:
-    - name: test-files
-      configMap:
-        name: "test-k8smon-k8s-monitoring"
----
 # Source: k8s-monitoring/templates/hooks/validate-configuration.yaml
 apiVersion: batch/v1
 kind: Job
@@ -46080,3 +45982,115 @@ spec:
         - name: config
           configMap:
             name: "validate-k8smon-k8s-monitoring"
+---
+# Source: k8s-monitoring/templates/tests/test.yaml
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: "test-k8smon-k8s-monitoring"
+  namespace: default
+  labels:
+    app.kubernetes.io/managed-by: "Helm"
+    app.kubernetes.io/instance: "k8smon"
+    app.kubernetes.io/version: 2.0.2
+    helm.sh/chart: "k8s-monitoring-0.10.3"
+  annotations:
+    "helm.sh/hook": test
+    "helm.sh/hook-delete-policy": before-hook-creation
+    "helm.sh/hook-weight": "0"
+spec:
+  completions: 1
+  parallelism: 1
+  backoffLimit: 9
+  template:
+    metadata:
+      name: "test-k8smon-k8s-monitoring"
+      namespace: default
+      labels:
+        app.kubernetes.io/managed-by: "Helm"
+        app.kubernetes.io/instance: "k8smon"
+        helm.sh/chart: "k8s-monitoring-0.10.3"
+    spec:
+      restartPolicy: Never
+      nodeSelector:
+        kubernetes.io/os: linux
+      containers:
+        - name: query-test
+          image: ghcr.io/grafana/k8s-monitoring-test:0.10.3
+          command: ["bash", "-c", "/etc/bin/query-test.sh /etc/test/testQueries.json"]
+          volumeMounts:
+            - name: test-files
+              mountPath: /etc/test
+          env:
+            - name: SINCE
+              value: 
+            - name: PROMETHEUS_HOST
+              valueFrom:
+                secretKeyRef:
+                  name: prometheus-k8s-monitoring
+                  key: host
+                  optional: true
+            - name: PROMETHEUS_URL
+              value: $(PROMETHEUS_HOST)/api/prom/api/v1/query
+            - name: PROMETHEUS_USER
+              valueFrom:
+                secretKeyRef:
+                  name: prometheus-k8s-monitoring
+                  key: username
+                  optional: true
+            - name: PROMETHEUS_PASS
+              valueFrom:
+                secretKeyRef:
+                  name: prometheus-k8s-monitoring
+                  key: password
+                  optional: true
+            - name: LOKI_HOST
+              valueFrom:
+                secretKeyRef:
+                  name: loki-k8s-monitoring
+                  key: host
+            - name: LOKI_URL
+              value: $(LOKI_HOST)/loki/api/v1/query
+            - name: LOKI_USER
+              valueFrom:
+                secretKeyRef:
+                  name: loki-k8s-monitoring
+                  key: username
+                  optional: true
+            - name: LOKI_PASS
+              valueFrom:
+                secretKeyRef:
+                  name: loki-k8s-monitoring
+                  key: password
+                  optional: true
+            - name: LOKI_TENANTID
+              valueFrom:
+                secretKeyRef:
+                  name: loki-k8s-monitoring
+                  key: tenantId
+                  optional: true
+            - name: TEMPO_HOST
+              valueFrom:
+                secretKeyRef:
+                  name: tempo-k8s-monitoring
+                  key: host
+                  optional: true
+            - name: TEMPO_URL
+              value: $(TEMPO_HOST)/api/search
+            - name: TEMPO_USER
+              valueFrom:
+                secretKeyRef:
+                  name: tempo-k8s-monitoring
+                  key: username
+                  optional: true
+            - name: TEMPO_PASS
+              valueFrom:
+                secretKeyRef:
+                  name: tempo-k8s-monitoring
+                  key: password
+                  optional: true
+
+      volumes:
+        - name: test-files
+          configMap:
+            name: "test-k8smon-k8s-monitoring"

--- a/examples/eks-fargate/output.yaml
+++ b/examples/eks-fargate/output.yaml
@@ -45635,104 +45635,6 @@ spec:
         - name: AGENT_HOST
           value: k8smon-grafana-agent.default.svc
 ---
-# Source: k8s-monitoring/templates/tests/test.yaml
-apiVersion: v1
-kind: Pod
-metadata:
-  name: "test-k8smon-k8s-monitoring"
-  namespace: default
-  labels:
-    app.kubernetes.io/managed-by: "Helm"
-    app.kubernetes.io/instance: "k8smon"
-    app.kubernetes.io/version: 2.0.2
-    helm.sh/chart: "k8s-monitoring-0.10.3"
-  annotations:
-    "helm.sh/hook": test
-    "helm.sh/hook-delete-policy": before-hook-creation
-    "helm.sh/hook-weight": "0"
-spec:
-  restartPolicy: OnFailure
-  nodeSelector:
-        kubernetes.io/os: linux
-  containers:
-    - name: query-test
-      image: ghcr.io/grafana/k8s-monitoring-test:0.10.3
-      command: ["bash", "-c", "/etc/bin/query-test.sh /etc/test/testQueries.json"]
-      volumeMounts:
-        - name: test-files
-          mountPath: /etc/test
-      env:
-        - name: PROMETHEUS_HOST
-          valueFrom:
-            secretKeyRef:
-              name: prometheus-k8s-monitoring
-              key: host
-              optional: true
-        - name: PROMETHEUS_URL
-          value: $(PROMETHEUS_HOST)/api/prom/api/v1/query
-        - name: PROMETHEUS_USER
-          valueFrom:
-            secretKeyRef:
-              name: prometheus-k8s-monitoring
-              key: username
-              optional: true
-        - name: PROMETHEUS_PASS
-          valueFrom:
-            secretKeyRef:
-              name: prometheus-k8s-monitoring
-              key: password
-              optional: true
-        - name: LOKI_HOST
-          valueFrom:
-            secretKeyRef:
-              name: loki-k8s-monitoring
-              key: host
-        - name: LOKI_URL
-          value: $(LOKI_HOST)/loki/api/v1/query
-        - name: LOKI_USER
-          valueFrom:
-            secretKeyRef:
-              name: loki-k8s-monitoring
-              key: username
-              optional: true
-        - name: LOKI_PASS
-          valueFrom:
-            secretKeyRef:
-              name: loki-k8s-monitoring
-              key: password
-              optional: true
-        - name: LOKI_TENANTID
-          valueFrom:
-            secretKeyRef:
-              name: loki-k8s-monitoring
-              key: tenantId
-              optional: true
-        - name: TEMPO_HOST
-          valueFrom:
-            secretKeyRef:
-              name: tempo-k8s-monitoring
-              key: host
-              optional: true
-        - name: TEMPO_URL
-          value: $(TEMPO_HOST)/api/search
-        - name: TEMPO_USER
-          valueFrom:
-            secretKeyRef:
-              name: tempo-k8s-monitoring
-              key: username
-              optional: true
-        - name: TEMPO_PASS
-          valueFrom:
-            secretKeyRef:
-              name: tempo-k8s-monitoring
-              key: password
-              optional: true
-
-  volumes:
-    - name: test-files
-      configMap:
-        name: "test-k8smon-k8s-monitoring"
----
 # Source: k8s-monitoring/templates/hooks/validate-configuration.yaml
 apiVersion: batch/v1
 kind: Job
@@ -45790,3 +45692,115 @@ spec:
         - name: config
           configMap:
             name: "validate-k8smon-k8s-monitoring"
+---
+# Source: k8s-monitoring/templates/tests/test.yaml
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: "test-k8smon-k8s-monitoring"
+  namespace: default
+  labels:
+    app.kubernetes.io/managed-by: "Helm"
+    app.kubernetes.io/instance: "k8smon"
+    app.kubernetes.io/version: 2.0.2
+    helm.sh/chart: "k8s-monitoring-0.10.3"
+  annotations:
+    "helm.sh/hook": test
+    "helm.sh/hook-delete-policy": before-hook-creation
+    "helm.sh/hook-weight": "0"
+spec:
+  completions: 1
+  parallelism: 1
+  backoffLimit: 9
+  template:
+    metadata:
+      name: "test-k8smon-k8s-monitoring"
+      namespace: default
+      labels:
+        app.kubernetes.io/managed-by: "Helm"
+        app.kubernetes.io/instance: "k8smon"
+        helm.sh/chart: "k8s-monitoring-0.10.3"
+    spec:
+      restartPolicy: Never
+      nodeSelector:
+        kubernetes.io/os: linux
+      containers:
+        - name: query-test
+          image: ghcr.io/grafana/k8s-monitoring-test:0.10.3
+          command: ["bash", "-c", "/etc/bin/query-test.sh /etc/test/testQueries.json"]
+          volumeMounts:
+            - name: test-files
+              mountPath: /etc/test
+          env:
+            - name: SINCE
+              value: 
+            - name: PROMETHEUS_HOST
+              valueFrom:
+                secretKeyRef:
+                  name: prometheus-k8s-monitoring
+                  key: host
+                  optional: true
+            - name: PROMETHEUS_URL
+              value: $(PROMETHEUS_HOST)/api/prom/api/v1/query
+            - name: PROMETHEUS_USER
+              valueFrom:
+                secretKeyRef:
+                  name: prometheus-k8s-monitoring
+                  key: username
+                  optional: true
+            - name: PROMETHEUS_PASS
+              valueFrom:
+                secretKeyRef:
+                  name: prometheus-k8s-monitoring
+                  key: password
+                  optional: true
+            - name: LOKI_HOST
+              valueFrom:
+                secretKeyRef:
+                  name: loki-k8s-monitoring
+                  key: host
+            - name: LOKI_URL
+              value: $(LOKI_HOST)/loki/api/v1/query
+            - name: LOKI_USER
+              valueFrom:
+                secretKeyRef:
+                  name: loki-k8s-monitoring
+                  key: username
+                  optional: true
+            - name: LOKI_PASS
+              valueFrom:
+                secretKeyRef:
+                  name: loki-k8s-monitoring
+                  key: password
+                  optional: true
+            - name: LOKI_TENANTID
+              valueFrom:
+                secretKeyRef:
+                  name: loki-k8s-monitoring
+                  key: tenantId
+                  optional: true
+            - name: TEMPO_HOST
+              valueFrom:
+                secretKeyRef:
+                  name: tempo-k8s-monitoring
+                  key: host
+                  optional: true
+            - name: TEMPO_URL
+              value: $(TEMPO_HOST)/api/search
+            - name: TEMPO_USER
+              valueFrom:
+                secretKeyRef:
+                  name: tempo-k8s-monitoring
+                  key: username
+                  optional: true
+            - name: TEMPO_PASS
+              valueFrom:
+                secretKeyRef:
+                  name: tempo-k8s-monitoring
+                  key: password
+                  optional: true
+
+      volumes:
+        - name: test-files
+          configMap:
+            name: "test-k8smon-k8s-monitoring"

--- a/examples/extra-rules/output.yaml
+++ b/examples/extra-rules/output.yaml
@@ -46124,104 +46124,6 @@ spec:
         - name: AGENT_HOST
           value: k8smon-grafana-agent.default.svc
 ---
-# Source: k8s-monitoring/templates/tests/test.yaml
-apiVersion: v1
-kind: Pod
-metadata:
-  name: "test-k8smon-k8s-monitoring"
-  namespace: default
-  labels:
-    app.kubernetes.io/managed-by: "Helm"
-    app.kubernetes.io/instance: "k8smon"
-    app.kubernetes.io/version: 2.0.2
-    helm.sh/chart: "k8s-monitoring-0.10.3"
-  annotations:
-    "helm.sh/hook": test
-    "helm.sh/hook-delete-policy": before-hook-creation
-    "helm.sh/hook-weight": "0"
-spec:
-  restartPolicy: OnFailure
-  nodeSelector:
-        kubernetes.io/os: linux
-  containers:
-    - name: query-test
-      image: ghcr.io/grafana/k8s-monitoring-test:0.10.3
-      command: ["bash", "-c", "/etc/bin/query-test.sh /etc/test/testQueries.json"]
-      volumeMounts:
-        - name: test-files
-          mountPath: /etc/test
-      env:
-        - name: PROMETHEUS_HOST
-          valueFrom:
-            secretKeyRef:
-              name: prometheus-k8s-monitoring
-              key: host
-              optional: true
-        - name: PROMETHEUS_URL
-          value: $(PROMETHEUS_HOST)/api/prom/api/v1/query
-        - name: PROMETHEUS_USER
-          valueFrom:
-            secretKeyRef:
-              name: prometheus-k8s-monitoring
-              key: username
-              optional: true
-        - name: PROMETHEUS_PASS
-          valueFrom:
-            secretKeyRef:
-              name: prometheus-k8s-monitoring
-              key: password
-              optional: true
-        - name: LOKI_HOST
-          valueFrom:
-            secretKeyRef:
-              name: loki-k8s-monitoring
-              key: host
-        - name: LOKI_URL
-          value: $(LOKI_HOST)/loki/api/v1/query
-        - name: LOKI_USER
-          valueFrom:
-            secretKeyRef:
-              name: loki-k8s-monitoring
-              key: username
-              optional: true
-        - name: LOKI_PASS
-          valueFrom:
-            secretKeyRef:
-              name: loki-k8s-monitoring
-              key: password
-              optional: true
-        - name: LOKI_TENANTID
-          valueFrom:
-            secretKeyRef:
-              name: loki-k8s-monitoring
-              key: tenantId
-              optional: true
-        - name: TEMPO_HOST
-          valueFrom:
-            secretKeyRef:
-              name: tempo-k8s-monitoring
-              key: host
-              optional: true
-        - name: TEMPO_URL
-          value: $(TEMPO_HOST)/api/search
-        - name: TEMPO_USER
-          valueFrom:
-            secretKeyRef:
-              name: tempo-k8s-monitoring
-              key: username
-              optional: true
-        - name: TEMPO_PASS
-          valueFrom:
-            secretKeyRef:
-              name: tempo-k8s-monitoring
-              key: password
-              optional: true
-
-  volumes:
-    - name: test-files
-      configMap:
-        name: "test-k8smon-k8s-monitoring"
----
 # Source: k8s-monitoring/templates/hooks/validate-configuration.yaml
 apiVersion: batch/v1
 kind: Job
@@ -46279,3 +46181,115 @@ spec:
         - name: config
           configMap:
             name: "validate-k8smon-k8s-monitoring"
+---
+# Source: k8s-monitoring/templates/tests/test.yaml
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: "test-k8smon-k8s-monitoring"
+  namespace: default
+  labels:
+    app.kubernetes.io/managed-by: "Helm"
+    app.kubernetes.io/instance: "k8smon"
+    app.kubernetes.io/version: 2.0.2
+    helm.sh/chart: "k8s-monitoring-0.10.3"
+  annotations:
+    "helm.sh/hook": test
+    "helm.sh/hook-delete-policy": before-hook-creation
+    "helm.sh/hook-weight": "0"
+spec:
+  completions: 1
+  parallelism: 1
+  backoffLimit: 9
+  template:
+    metadata:
+      name: "test-k8smon-k8s-monitoring"
+      namespace: default
+      labels:
+        app.kubernetes.io/managed-by: "Helm"
+        app.kubernetes.io/instance: "k8smon"
+        helm.sh/chart: "k8s-monitoring-0.10.3"
+    spec:
+      restartPolicy: Never
+      nodeSelector:
+        kubernetes.io/os: linux
+      containers:
+        - name: query-test
+          image: ghcr.io/grafana/k8s-monitoring-test:0.10.3
+          command: ["bash", "-c", "/etc/bin/query-test.sh /etc/test/testQueries.json"]
+          volumeMounts:
+            - name: test-files
+              mountPath: /etc/test
+          env:
+            - name: SINCE
+              value: 
+            - name: PROMETHEUS_HOST
+              valueFrom:
+                secretKeyRef:
+                  name: prometheus-k8s-monitoring
+                  key: host
+                  optional: true
+            - name: PROMETHEUS_URL
+              value: $(PROMETHEUS_HOST)/api/prom/api/v1/query
+            - name: PROMETHEUS_USER
+              valueFrom:
+                secretKeyRef:
+                  name: prometheus-k8s-monitoring
+                  key: username
+                  optional: true
+            - name: PROMETHEUS_PASS
+              valueFrom:
+                secretKeyRef:
+                  name: prometheus-k8s-monitoring
+                  key: password
+                  optional: true
+            - name: LOKI_HOST
+              valueFrom:
+                secretKeyRef:
+                  name: loki-k8s-monitoring
+                  key: host
+            - name: LOKI_URL
+              value: $(LOKI_HOST)/loki/api/v1/query
+            - name: LOKI_USER
+              valueFrom:
+                secretKeyRef:
+                  name: loki-k8s-monitoring
+                  key: username
+                  optional: true
+            - name: LOKI_PASS
+              valueFrom:
+                secretKeyRef:
+                  name: loki-k8s-monitoring
+                  key: password
+                  optional: true
+            - name: LOKI_TENANTID
+              valueFrom:
+                secretKeyRef:
+                  name: loki-k8s-monitoring
+                  key: tenantId
+                  optional: true
+            - name: TEMPO_HOST
+              valueFrom:
+                secretKeyRef:
+                  name: tempo-k8s-monitoring
+                  key: host
+                  optional: true
+            - name: TEMPO_URL
+              value: $(TEMPO_HOST)/api/search
+            - name: TEMPO_USER
+              valueFrom:
+                secretKeyRef:
+                  name: tempo-k8s-monitoring
+                  key: username
+                  optional: true
+            - name: TEMPO_PASS
+              valueFrom:
+                secretKeyRef:
+                  name: tempo-k8s-monitoring
+                  key: password
+                  optional: true
+
+      volumes:
+        - name: test-files
+          configMap:
+            name: "test-k8smon-k8s-monitoring"

--- a/examples/gke-autopilot/output.yaml
+++ b/examples/gke-autopilot/output.yaml
@@ -45666,104 +45666,6 @@ spec:
         - name: AGENT_HOST
           value: k8smon-grafana-agent.default.svc
 ---
-# Source: k8s-monitoring/templates/tests/test.yaml
-apiVersion: v1
-kind: Pod
-metadata:
-  name: "test-k8smon-k8s-monitoring"
-  namespace: default
-  labels:
-    app.kubernetes.io/managed-by: "Helm"
-    app.kubernetes.io/instance: "k8smon"
-    app.kubernetes.io/version: 2.0.2
-    helm.sh/chart: "k8s-monitoring-0.10.3"
-  annotations:
-    "helm.sh/hook": test
-    "helm.sh/hook-delete-policy": before-hook-creation
-    "helm.sh/hook-weight": "0"
-spec:
-  restartPolicy: OnFailure
-  nodeSelector:
-        kubernetes.io/os: linux
-  containers:
-    - name: query-test
-      image: ghcr.io/grafana/k8s-monitoring-test:0.10.3
-      command: ["bash", "-c", "/etc/bin/query-test.sh /etc/test/testQueries.json"]
-      volumeMounts:
-        - name: test-files
-          mountPath: /etc/test
-      env:
-        - name: PROMETHEUS_HOST
-          valueFrom:
-            secretKeyRef:
-              name: prometheus-k8s-monitoring
-              key: host
-              optional: true
-        - name: PROMETHEUS_URL
-          value: $(PROMETHEUS_HOST)/api/prom/api/v1/query
-        - name: PROMETHEUS_USER
-          valueFrom:
-            secretKeyRef:
-              name: prometheus-k8s-monitoring
-              key: username
-              optional: true
-        - name: PROMETHEUS_PASS
-          valueFrom:
-            secretKeyRef:
-              name: prometheus-k8s-monitoring
-              key: password
-              optional: true
-        - name: LOKI_HOST
-          valueFrom:
-            secretKeyRef:
-              name: loki-k8s-monitoring
-              key: host
-        - name: LOKI_URL
-          value: $(LOKI_HOST)/loki/api/v1/query
-        - name: LOKI_USER
-          valueFrom:
-            secretKeyRef:
-              name: loki-k8s-monitoring
-              key: username
-              optional: true
-        - name: LOKI_PASS
-          valueFrom:
-            secretKeyRef:
-              name: loki-k8s-monitoring
-              key: password
-              optional: true
-        - name: LOKI_TENANTID
-          valueFrom:
-            secretKeyRef:
-              name: loki-k8s-monitoring
-              key: tenantId
-              optional: true
-        - name: TEMPO_HOST
-          valueFrom:
-            secretKeyRef:
-              name: tempo-k8s-monitoring
-              key: host
-              optional: true
-        - name: TEMPO_URL
-          value: $(TEMPO_HOST)/api/search
-        - name: TEMPO_USER
-          valueFrom:
-            secretKeyRef:
-              name: tempo-k8s-monitoring
-              key: username
-              optional: true
-        - name: TEMPO_PASS
-          valueFrom:
-            secretKeyRef:
-              name: tempo-k8s-monitoring
-              key: password
-              optional: true
-
-  volumes:
-    - name: test-files
-      configMap:
-        name: "test-k8smon-k8s-monitoring"
----
 # Source: k8s-monitoring/templates/hooks/validate-configuration.yaml
 apiVersion: batch/v1
 kind: Job
@@ -45821,3 +45723,115 @@ spec:
         - name: config
           configMap:
             name: "validate-k8smon-k8s-monitoring"
+---
+# Source: k8s-monitoring/templates/tests/test.yaml
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: "test-k8smon-k8s-monitoring"
+  namespace: default
+  labels:
+    app.kubernetes.io/managed-by: "Helm"
+    app.kubernetes.io/instance: "k8smon"
+    app.kubernetes.io/version: 2.0.2
+    helm.sh/chart: "k8s-monitoring-0.10.3"
+  annotations:
+    "helm.sh/hook": test
+    "helm.sh/hook-delete-policy": before-hook-creation
+    "helm.sh/hook-weight": "0"
+spec:
+  completions: 1
+  parallelism: 1
+  backoffLimit: 9
+  template:
+    metadata:
+      name: "test-k8smon-k8s-monitoring"
+      namespace: default
+      labels:
+        app.kubernetes.io/managed-by: "Helm"
+        app.kubernetes.io/instance: "k8smon"
+        helm.sh/chart: "k8s-monitoring-0.10.3"
+    spec:
+      restartPolicy: Never
+      nodeSelector:
+        kubernetes.io/os: linux
+      containers:
+        - name: query-test
+          image: ghcr.io/grafana/k8s-monitoring-test:0.10.3
+          command: ["bash", "-c", "/etc/bin/query-test.sh /etc/test/testQueries.json"]
+          volumeMounts:
+            - name: test-files
+              mountPath: /etc/test
+          env:
+            - name: SINCE
+              value: 
+            - name: PROMETHEUS_HOST
+              valueFrom:
+                secretKeyRef:
+                  name: prometheus-k8s-monitoring
+                  key: host
+                  optional: true
+            - name: PROMETHEUS_URL
+              value: $(PROMETHEUS_HOST)/api/prom/api/v1/query
+            - name: PROMETHEUS_USER
+              valueFrom:
+                secretKeyRef:
+                  name: prometheus-k8s-monitoring
+                  key: username
+                  optional: true
+            - name: PROMETHEUS_PASS
+              valueFrom:
+                secretKeyRef:
+                  name: prometheus-k8s-monitoring
+                  key: password
+                  optional: true
+            - name: LOKI_HOST
+              valueFrom:
+                secretKeyRef:
+                  name: loki-k8s-monitoring
+                  key: host
+            - name: LOKI_URL
+              value: $(LOKI_HOST)/loki/api/v1/query
+            - name: LOKI_USER
+              valueFrom:
+                secretKeyRef:
+                  name: loki-k8s-monitoring
+                  key: username
+                  optional: true
+            - name: LOKI_PASS
+              valueFrom:
+                secretKeyRef:
+                  name: loki-k8s-monitoring
+                  key: password
+                  optional: true
+            - name: LOKI_TENANTID
+              valueFrom:
+                secretKeyRef:
+                  name: loki-k8s-monitoring
+                  key: tenantId
+                  optional: true
+            - name: TEMPO_HOST
+              valueFrom:
+                secretKeyRef:
+                  name: tempo-k8s-monitoring
+                  key: host
+                  optional: true
+            - name: TEMPO_URL
+              value: $(TEMPO_HOST)/api/search
+            - name: TEMPO_USER
+              valueFrom:
+                secretKeyRef:
+                  name: tempo-k8s-monitoring
+                  key: username
+                  optional: true
+            - name: TEMPO_PASS
+              valueFrom:
+                secretKeyRef:
+                  name: tempo-k8s-monitoring
+                  key: password
+                  optional: true
+
+      volumes:
+        - name: test-files
+          configMap:
+            name: "test-k8smon-k8s-monitoring"

--- a/examples/ibm-cloud/output.yaml
+++ b/examples/ibm-cloud/output.yaml
@@ -45931,104 +45931,6 @@ spec:
         - name: AGENT_HOST
           value: k8smon-grafana-agent.default.svc
 ---
-# Source: k8s-monitoring/templates/tests/test.yaml
-apiVersion: v1
-kind: Pod
-metadata:
-  name: "test-k8smon-k8s-monitoring"
-  namespace: default
-  labels:
-    app.kubernetes.io/managed-by: "Helm"
-    app.kubernetes.io/instance: "k8smon"
-    app.kubernetes.io/version: 2.0.2
-    helm.sh/chart: "k8s-monitoring-0.10.3"
-  annotations:
-    "helm.sh/hook": test
-    "helm.sh/hook-delete-policy": before-hook-creation
-    "helm.sh/hook-weight": "0"
-spec:
-  restartPolicy: OnFailure
-  nodeSelector:
-        kubernetes.io/os: linux
-  containers:
-    - name: query-test
-      image: ghcr.io/grafana/k8s-monitoring-test:0.10.3
-      command: ["bash", "-c", "/etc/bin/query-test.sh /etc/test/testQueries.json"]
-      volumeMounts:
-        - name: test-files
-          mountPath: /etc/test
-      env:
-        - name: PROMETHEUS_HOST
-          valueFrom:
-            secretKeyRef:
-              name: prometheus-k8s-monitoring
-              key: host
-              optional: true
-        - name: PROMETHEUS_URL
-          value: $(PROMETHEUS_HOST)/api/prom/api/v1/query
-        - name: PROMETHEUS_USER
-          valueFrom:
-            secretKeyRef:
-              name: prometheus-k8s-monitoring
-              key: username
-              optional: true
-        - name: PROMETHEUS_PASS
-          valueFrom:
-            secretKeyRef:
-              name: prometheus-k8s-monitoring
-              key: password
-              optional: true
-        - name: LOKI_HOST
-          valueFrom:
-            secretKeyRef:
-              name: loki-k8s-monitoring
-              key: host
-        - name: LOKI_URL
-          value: $(LOKI_HOST)/loki/api/v1/query
-        - name: LOKI_USER
-          valueFrom:
-            secretKeyRef:
-              name: loki-k8s-monitoring
-              key: username
-              optional: true
-        - name: LOKI_PASS
-          valueFrom:
-            secretKeyRef:
-              name: loki-k8s-monitoring
-              key: password
-              optional: true
-        - name: LOKI_TENANTID
-          valueFrom:
-            secretKeyRef:
-              name: loki-k8s-monitoring
-              key: tenantId
-              optional: true
-        - name: TEMPO_HOST
-          valueFrom:
-            secretKeyRef:
-              name: tempo-k8s-monitoring
-              key: host
-              optional: true
-        - name: TEMPO_URL
-          value: $(TEMPO_HOST)/api/search
-        - name: TEMPO_USER
-          valueFrom:
-            secretKeyRef:
-              name: tempo-k8s-monitoring
-              key: username
-              optional: true
-        - name: TEMPO_PASS
-          valueFrom:
-            secretKeyRef:
-              name: tempo-k8s-monitoring
-              key: password
-              optional: true
-
-  volumes:
-    - name: test-files
-      configMap:
-        name: "test-k8smon-k8s-monitoring"
----
 # Source: k8s-monitoring/templates/hooks/validate-configuration.yaml
 apiVersion: batch/v1
 kind: Job
@@ -46086,3 +45988,115 @@ spec:
         - name: config
           configMap:
             name: "validate-k8smon-k8s-monitoring"
+---
+# Source: k8s-monitoring/templates/tests/test.yaml
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: "test-k8smon-k8s-monitoring"
+  namespace: default
+  labels:
+    app.kubernetes.io/managed-by: "Helm"
+    app.kubernetes.io/instance: "k8smon"
+    app.kubernetes.io/version: 2.0.2
+    helm.sh/chart: "k8s-monitoring-0.10.3"
+  annotations:
+    "helm.sh/hook": test
+    "helm.sh/hook-delete-policy": before-hook-creation
+    "helm.sh/hook-weight": "0"
+spec:
+  completions: 1
+  parallelism: 1
+  backoffLimit: 9
+  template:
+    metadata:
+      name: "test-k8smon-k8s-monitoring"
+      namespace: default
+      labels:
+        app.kubernetes.io/managed-by: "Helm"
+        app.kubernetes.io/instance: "k8smon"
+        helm.sh/chart: "k8s-monitoring-0.10.3"
+    spec:
+      restartPolicy: Never
+      nodeSelector:
+        kubernetes.io/os: linux
+      containers:
+        - name: query-test
+          image: ghcr.io/grafana/k8s-monitoring-test:0.10.3
+          command: ["bash", "-c", "/etc/bin/query-test.sh /etc/test/testQueries.json"]
+          volumeMounts:
+            - name: test-files
+              mountPath: /etc/test
+          env:
+            - name: SINCE
+              value: 
+            - name: PROMETHEUS_HOST
+              valueFrom:
+                secretKeyRef:
+                  name: prometheus-k8s-monitoring
+                  key: host
+                  optional: true
+            - name: PROMETHEUS_URL
+              value: $(PROMETHEUS_HOST)/api/prom/api/v1/query
+            - name: PROMETHEUS_USER
+              valueFrom:
+                secretKeyRef:
+                  name: prometheus-k8s-monitoring
+                  key: username
+                  optional: true
+            - name: PROMETHEUS_PASS
+              valueFrom:
+                secretKeyRef:
+                  name: prometheus-k8s-monitoring
+                  key: password
+                  optional: true
+            - name: LOKI_HOST
+              valueFrom:
+                secretKeyRef:
+                  name: loki-k8s-monitoring
+                  key: host
+            - name: LOKI_URL
+              value: $(LOKI_HOST)/loki/api/v1/query
+            - name: LOKI_USER
+              valueFrom:
+                secretKeyRef:
+                  name: loki-k8s-monitoring
+                  key: username
+                  optional: true
+            - name: LOKI_PASS
+              valueFrom:
+                secretKeyRef:
+                  name: loki-k8s-monitoring
+                  key: password
+                  optional: true
+            - name: LOKI_TENANTID
+              valueFrom:
+                secretKeyRef:
+                  name: loki-k8s-monitoring
+                  key: tenantId
+                  optional: true
+            - name: TEMPO_HOST
+              valueFrom:
+                secretKeyRef:
+                  name: tempo-k8s-monitoring
+                  key: host
+                  optional: true
+            - name: TEMPO_URL
+              value: $(TEMPO_HOST)/api/search
+            - name: TEMPO_USER
+              valueFrom:
+                secretKeyRef:
+                  name: tempo-k8s-monitoring
+                  key: username
+                  optional: true
+            - name: TEMPO_PASS
+              valueFrom:
+                secretKeyRef:
+                  name: tempo-k8s-monitoring
+                  key: password
+                  optional: true
+
+      volumes:
+        - name: test-files
+          configMap:
+            name: "test-k8smon-k8s-monitoring"

--- a/examples/kube-pod-labels/output.yaml
+++ b/examples/kube-pod-labels/output.yaml
@@ -45930,104 +45930,6 @@ spec:
         - name: AGENT_HOST
           value: k8smon-grafana-agent.default.svc
 ---
-# Source: k8s-monitoring/templates/tests/test.yaml
-apiVersion: v1
-kind: Pod
-metadata:
-  name: "test-k8smon-k8s-monitoring"
-  namespace: default
-  labels:
-    app.kubernetes.io/managed-by: "Helm"
-    app.kubernetes.io/instance: "k8smon"
-    app.kubernetes.io/version: 2.0.2
-    helm.sh/chart: "k8s-monitoring-0.10.3"
-  annotations:
-    "helm.sh/hook": test
-    "helm.sh/hook-delete-policy": before-hook-creation
-    "helm.sh/hook-weight": "0"
-spec:
-  restartPolicy: OnFailure
-  nodeSelector:
-        kubernetes.io/os: linux
-  containers:
-    - name: query-test
-      image: ghcr.io/grafana/k8s-monitoring-test:0.10.3
-      command: ["bash", "-c", "/etc/bin/query-test.sh /etc/test/testQueries.json"]
-      volumeMounts:
-        - name: test-files
-          mountPath: /etc/test
-      env:
-        - name: PROMETHEUS_HOST
-          valueFrom:
-            secretKeyRef:
-              name: prometheus-k8s-monitoring
-              key: host
-              optional: true
-        - name: PROMETHEUS_URL
-          value: $(PROMETHEUS_HOST)/api/prom/api/v1/query
-        - name: PROMETHEUS_USER
-          valueFrom:
-            secretKeyRef:
-              name: prometheus-k8s-monitoring
-              key: username
-              optional: true
-        - name: PROMETHEUS_PASS
-          valueFrom:
-            secretKeyRef:
-              name: prometheus-k8s-monitoring
-              key: password
-              optional: true
-        - name: LOKI_HOST
-          valueFrom:
-            secretKeyRef:
-              name: loki-k8s-monitoring
-              key: host
-        - name: LOKI_URL
-          value: $(LOKI_HOST)/loki/api/v1/query
-        - name: LOKI_USER
-          valueFrom:
-            secretKeyRef:
-              name: loki-k8s-monitoring
-              key: username
-              optional: true
-        - name: LOKI_PASS
-          valueFrom:
-            secretKeyRef:
-              name: loki-k8s-monitoring
-              key: password
-              optional: true
-        - name: LOKI_TENANTID
-          valueFrom:
-            secretKeyRef:
-              name: loki-k8s-monitoring
-              key: tenantId
-              optional: true
-        - name: TEMPO_HOST
-          valueFrom:
-            secretKeyRef:
-              name: tempo-k8s-monitoring
-              key: host
-              optional: true
-        - name: TEMPO_URL
-          value: $(TEMPO_HOST)/api/search
-        - name: TEMPO_USER
-          valueFrom:
-            secretKeyRef:
-              name: tempo-k8s-monitoring
-              key: username
-              optional: true
-        - name: TEMPO_PASS
-          valueFrom:
-            secretKeyRef:
-              name: tempo-k8s-monitoring
-              key: password
-              optional: true
-
-  volumes:
-    - name: test-files
-      configMap:
-        name: "test-k8smon-k8s-monitoring"
----
 # Source: k8s-monitoring/templates/hooks/validate-configuration.yaml
 apiVersion: batch/v1
 kind: Job
@@ -46085,3 +45987,115 @@ spec:
         - name: config
           configMap:
             name: "validate-k8smon-k8s-monitoring"
+---
+# Source: k8s-monitoring/templates/tests/test.yaml
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: "test-k8smon-k8s-monitoring"
+  namespace: default
+  labels:
+    app.kubernetes.io/managed-by: "Helm"
+    app.kubernetes.io/instance: "k8smon"
+    app.kubernetes.io/version: 2.0.2
+    helm.sh/chart: "k8s-monitoring-0.10.3"
+  annotations:
+    "helm.sh/hook": test
+    "helm.sh/hook-delete-policy": before-hook-creation
+    "helm.sh/hook-weight": "0"
+spec:
+  completions: 1
+  parallelism: 1
+  backoffLimit: 9
+  template:
+    metadata:
+      name: "test-k8smon-k8s-monitoring"
+      namespace: default
+      labels:
+        app.kubernetes.io/managed-by: "Helm"
+        app.kubernetes.io/instance: "k8smon"
+        helm.sh/chart: "k8s-monitoring-0.10.3"
+    spec:
+      restartPolicy: Never
+      nodeSelector:
+        kubernetes.io/os: linux
+      containers:
+        - name: query-test
+          image: ghcr.io/grafana/k8s-monitoring-test:0.10.3
+          command: ["bash", "-c", "/etc/bin/query-test.sh /etc/test/testQueries.json"]
+          volumeMounts:
+            - name: test-files
+              mountPath: /etc/test
+          env:
+            - name: SINCE
+              value: 
+            - name: PROMETHEUS_HOST
+              valueFrom:
+                secretKeyRef:
+                  name: prometheus-k8s-monitoring
+                  key: host
+                  optional: true
+            - name: PROMETHEUS_URL
+              value: $(PROMETHEUS_HOST)/api/prom/api/v1/query
+            - name: PROMETHEUS_USER
+              valueFrom:
+                secretKeyRef:
+                  name: prometheus-k8s-monitoring
+                  key: username
+                  optional: true
+            - name: PROMETHEUS_PASS
+              valueFrom:
+                secretKeyRef:
+                  name: prometheus-k8s-monitoring
+                  key: password
+                  optional: true
+            - name: LOKI_HOST
+              valueFrom:
+                secretKeyRef:
+                  name: loki-k8s-monitoring
+                  key: host
+            - name: LOKI_URL
+              value: $(LOKI_HOST)/loki/api/v1/query
+            - name: LOKI_USER
+              valueFrom:
+                secretKeyRef:
+                  name: loki-k8s-monitoring
+                  key: username
+                  optional: true
+            - name: LOKI_PASS
+              valueFrom:
+                secretKeyRef:
+                  name: loki-k8s-monitoring
+                  key: password
+                  optional: true
+            - name: LOKI_TENANTID
+              valueFrom:
+                secretKeyRef:
+                  name: loki-k8s-monitoring
+                  key: tenantId
+                  optional: true
+            - name: TEMPO_HOST
+              valueFrom:
+                secretKeyRef:
+                  name: tempo-k8s-monitoring
+                  key: host
+                  optional: true
+            - name: TEMPO_URL
+              value: $(TEMPO_HOST)/api/search
+            - name: TEMPO_USER
+              valueFrom:
+                secretKeyRef:
+                  name: tempo-k8s-monitoring
+                  key: username
+                  optional: true
+            - name: TEMPO_PASS
+              valueFrom:
+                secretKeyRef:
+                  name: tempo-k8s-monitoring
+                  key: password
+                  optional: true
+
+      volumes:
+        - name: test-files
+          configMap:
+            name: "test-k8smon-k8s-monitoring"

--- a/examples/logs-only/output.yaml
+++ b/examples/logs-only/output.yaml
@@ -1627,104 +1627,6 @@ spec:
         - name: AGENT_HOST
           value: k8smon-grafana-agent.default.svc
 ---
-# Source: k8s-monitoring/templates/tests/test.yaml
-apiVersion: v1
-kind: Pod
-metadata:
-  name: "test-k8smon-k8s-monitoring"
-  namespace: default
-  labels:
-    app.kubernetes.io/managed-by: "Helm"
-    app.kubernetes.io/instance: "k8smon"
-    app.kubernetes.io/version: 2.0.2
-    helm.sh/chart: "k8s-monitoring-0.10.3"
-  annotations:
-    "helm.sh/hook": test
-    "helm.sh/hook-delete-policy": before-hook-creation
-    "helm.sh/hook-weight": "0"
-spec:
-  restartPolicy: OnFailure
-  nodeSelector:
-        kubernetes.io/os: linux
-  containers:
-    - name: query-test
-      image: ghcr.io/grafana/k8s-monitoring-test:0.10.3
-      command: ["bash", "-c", "/etc/bin/query-test.sh /etc/test/testQueries.json"]
-      volumeMounts:
-        - name: test-files
-          mountPath: /etc/test
-      env:
-        - name: PROMETHEUS_HOST
-          valueFrom:
-            secretKeyRef:
-              name: prometheus-k8s-monitoring
-              key: host
-              optional: true
-        - name: PROMETHEUS_URL
-          value: $(PROMETHEUS_HOST)/api/prom/api/v1/query
-        - name: PROMETHEUS_USER
-          valueFrom:
-            secretKeyRef:
-              name: prometheus-k8s-monitoring
-              key: username
-              optional: true
-        - name: PROMETHEUS_PASS
-          valueFrom:
-            secretKeyRef:
-              name: prometheus-k8s-monitoring
-              key: password
-              optional: true
-        - name: LOKI_HOST
-          valueFrom:
-            secretKeyRef:
-              name: loki-k8s-monitoring
-              key: host
-        - name: LOKI_URL
-          value: $(LOKI_HOST)/loki/api/v1/query
-        - name: LOKI_USER
-          valueFrom:
-            secretKeyRef:
-              name: loki-k8s-monitoring
-              key: username
-              optional: true
-        - name: LOKI_PASS
-          valueFrom:
-            secretKeyRef:
-              name: loki-k8s-monitoring
-              key: password
-              optional: true
-        - name: LOKI_TENANTID
-          valueFrom:
-            secretKeyRef:
-              name: loki-k8s-monitoring
-              key: tenantId
-              optional: true
-        - name: TEMPO_HOST
-          valueFrom:
-            secretKeyRef:
-              name: tempo-k8s-monitoring
-              key: host
-              optional: true
-        - name: TEMPO_URL
-          value: $(TEMPO_HOST)/api/search
-        - name: TEMPO_USER
-          valueFrom:
-            secretKeyRef:
-              name: tempo-k8s-monitoring
-              key: username
-              optional: true
-        - name: TEMPO_PASS
-          valueFrom:
-            secretKeyRef:
-              name: tempo-k8s-monitoring
-              key: password
-              optional: true
-
-  volumes:
-    - name: test-files
-      configMap:
-        name: "test-k8smon-k8s-monitoring"
----
 # Source: k8s-monitoring/templates/hooks/validate-configuration.yaml
 apiVersion: batch/v1
 kind: Job
@@ -1782,3 +1684,115 @@ spec:
         - name: config
           configMap:
             name: "validate-k8smon-k8s-monitoring"
+---
+# Source: k8s-monitoring/templates/tests/test.yaml
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: "test-k8smon-k8s-monitoring"
+  namespace: default
+  labels:
+    app.kubernetes.io/managed-by: "Helm"
+    app.kubernetes.io/instance: "k8smon"
+    app.kubernetes.io/version: 2.0.2
+    helm.sh/chart: "k8s-monitoring-0.10.3"
+  annotations:
+    "helm.sh/hook": test
+    "helm.sh/hook-delete-policy": before-hook-creation
+    "helm.sh/hook-weight": "0"
+spec:
+  completions: 1
+  parallelism: 1
+  backoffLimit: 9
+  template:
+    metadata:
+      name: "test-k8smon-k8s-monitoring"
+      namespace: default
+      labels:
+        app.kubernetes.io/managed-by: "Helm"
+        app.kubernetes.io/instance: "k8smon"
+        helm.sh/chart: "k8s-monitoring-0.10.3"
+    spec:
+      restartPolicy: Never
+      nodeSelector:
+        kubernetes.io/os: linux
+      containers:
+        - name: query-test
+          image: ghcr.io/grafana/k8s-monitoring-test:0.10.3
+          command: ["bash", "-c", "/etc/bin/query-test.sh /etc/test/testQueries.json"]
+          volumeMounts:
+            - name: test-files
+              mountPath: /etc/test
+          env:
+            - name: SINCE
+              value: 
+            - name: PROMETHEUS_HOST
+              valueFrom:
+                secretKeyRef:
+                  name: prometheus-k8s-monitoring
+                  key: host
+                  optional: true
+            - name: PROMETHEUS_URL
+              value: $(PROMETHEUS_HOST)/api/prom/api/v1/query
+            - name: PROMETHEUS_USER
+              valueFrom:
+                secretKeyRef:
+                  name: prometheus-k8s-monitoring
+                  key: username
+                  optional: true
+            - name: PROMETHEUS_PASS
+              valueFrom:
+                secretKeyRef:
+                  name: prometheus-k8s-monitoring
+                  key: password
+                  optional: true
+            - name: LOKI_HOST
+              valueFrom:
+                secretKeyRef:
+                  name: loki-k8s-monitoring
+                  key: host
+            - name: LOKI_URL
+              value: $(LOKI_HOST)/loki/api/v1/query
+            - name: LOKI_USER
+              valueFrom:
+                secretKeyRef:
+                  name: loki-k8s-monitoring
+                  key: username
+                  optional: true
+            - name: LOKI_PASS
+              valueFrom:
+                secretKeyRef:
+                  name: loki-k8s-monitoring
+                  key: password
+                  optional: true
+            - name: LOKI_TENANTID
+              valueFrom:
+                secretKeyRef:
+                  name: loki-k8s-monitoring
+                  key: tenantId
+                  optional: true
+            - name: TEMPO_HOST
+              valueFrom:
+                secretKeyRef:
+                  name: tempo-k8s-monitoring
+                  key: host
+                  optional: true
+            - name: TEMPO_URL
+              value: $(TEMPO_HOST)/api/search
+            - name: TEMPO_USER
+              valueFrom:
+                secretKeyRef:
+                  name: tempo-k8s-monitoring
+                  key: username
+                  optional: true
+            - name: TEMPO_PASS
+              valueFrom:
+                secretKeyRef:
+                  name: tempo-k8s-monitoring
+                  key: password
+                  optional: true
+
+      volumes:
+        - name: test-files
+          configMap:
+            name: "test-k8smon-k8s-monitoring"

--- a/examples/metrics-only/output.yaml
+++ b/examples/metrics-only/output.yaml
@@ -44923,104 +44923,6 @@ spec:
         - name: AGENT_HOST
           value: k8smon-grafana-agent.default.svc
 ---
-# Source: k8s-monitoring/templates/tests/test.yaml
-apiVersion: v1
-kind: Pod
-metadata:
-  name: "test-k8smon-k8s-monitoring"
-  namespace: default
-  labels:
-    app.kubernetes.io/managed-by: "Helm"
-    app.kubernetes.io/instance: "k8smon"
-    app.kubernetes.io/version: 2.0.2
-    helm.sh/chart: "k8s-monitoring-0.10.3"
-  annotations:
-    "helm.sh/hook": test
-    "helm.sh/hook-delete-policy": before-hook-creation
-    "helm.sh/hook-weight": "0"
-spec:
-  restartPolicy: OnFailure
-  nodeSelector:
-        kubernetes.io/os: linux
-  containers:
-    - name: query-test
-      image: ghcr.io/grafana/k8s-monitoring-test:0.10.3
-      command: ["bash", "-c", "/etc/bin/query-test.sh /etc/test/testQueries.json"]
-      volumeMounts:
-        - name: test-files
-          mountPath: /etc/test
-      env:
-        - name: PROMETHEUS_HOST
-          valueFrom:
-            secretKeyRef:
-              name: prometheus-k8s-monitoring
-              key: host
-              optional: true
-        - name: PROMETHEUS_URL
-          value: $(PROMETHEUS_HOST)/api/prom/api/v1/query
-        - name: PROMETHEUS_USER
-          valueFrom:
-            secretKeyRef:
-              name: prometheus-k8s-monitoring
-              key: username
-              optional: true
-        - name: PROMETHEUS_PASS
-          valueFrom:
-            secretKeyRef:
-              name: prometheus-k8s-monitoring
-              key: password
-              optional: true
-        - name: LOKI_HOST
-          valueFrom:
-            secretKeyRef:
-              name: loki-k8s-monitoring
-              key: host
-        - name: LOKI_URL
-          value: $(LOKI_HOST)/loki/api/v1/query
-        - name: LOKI_USER
-          valueFrom:
-            secretKeyRef:
-              name: loki-k8s-monitoring
-              key: username
-              optional: true
-        - name: LOKI_PASS
-          valueFrom:
-            secretKeyRef:
-              name: loki-k8s-monitoring
-              key: password
-              optional: true
-        - name: LOKI_TENANTID
-          valueFrom:
-            secretKeyRef:
-              name: loki-k8s-monitoring
-              key: tenantId
-              optional: true
-        - name: TEMPO_HOST
-          valueFrom:
-            secretKeyRef:
-              name: tempo-k8s-monitoring
-              key: host
-              optional: true
-        - name: TEMPO_URL
-          value: $(TEMPO_HOST)/api/search
-        - name: TEMPO_USER
-          valueFrom:
-            secretKeyRef:
-              name: tempo-k8s-monitoring
-              key: username
-              optional: true
-        - name: TEMPO_PASS
-          valueFrom:
-            secretKeyRef:
-              name: tempo-k8s-monitoring
-              key: password
-              optional: true
-
-  volumes:
-    - name: test-files
-      configMap:
-        name: "test-k8smon-k8s-monitoring"
----
 # Source: k8s-monitoring/templates/hooks/validate-configuration.yaml
 apiVersion: batch/v1
 kind: Job
@@ -45070,3 +44972,115 @@ spec:
         - name: config
           configMap:
             name: "validate-k8smon-k8s-monitoring"
+---
+# Source: k8s-monitoring/templates/tests/test.yaml
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: "test-k8smon-k8s-monitoring"
+  namespace: default
+  labels:
+    app.kubernetes.io/managed-by: "Helm"
+    app.kubernetes.io/instance: "k8smon"
+    app.kubernetes.io/version: 2.0.2
+    helm.sh/chart: "k8s-monitoring-0.10.3"
+  annotations:
+    "helm.sh/hook": test
+    "helm.sh/hook-delete-policy": before-hook-creation
+    "helm.sh/hook-weight": "0"
+spec:
+  completions: 1
+  parallelism: 1
+  backoffLimit: 9
+  template:
+    metadata:
+      name: "test-k8smon-k8s-monitoring"
+      namespace: default
+      labels:
+        app.kubernetes.io/managed-by: "Helm"
+        app.kubernetes.io/instance: "k8smon"
+        helm.sh/chart: "k8s-monitoring-0.10.3"
+    spec:
+      restartPolicy: Never
+      nodeSelector:
+        kubernetes.io/os: linux
+      containers:
+        - name: query-test
+          image: ghcr.io/grafana/k8s-monitoring-test:0.10.3
+          command: ["bash", "-c", "/etc/bin/query-test.sh /etc/test/testQueries.json"]
+          volumeMounts:
+            - name: test-files
+              mountPath: /etc/test
+          env:
+            - name: SINCE
+              value: 
+            - name: PROMETHEUS_HOST
+              valueFrom:
+                secretKeyRef:
+                  name: prometheus-k8s-monitoring
+                  key: host
+                  optional: true
+            - name: PROMETHEUS_URL
+              value: $(PROMETHEUS_HOST)/api/prom/api/v1/query
+            - name: PROMETHEUS_USER
+              valueFrom:
+                secretKeyRef:
+                  name: prometheus-k8s-monitoring
+                  key: username
+                  optional: true
+            - name: PROMETHEUS_PASS
+              valueFrom:
+                secretKeyRef:
+                  name: prometheus-k8s-monitoring
+                  key: password
+                  optional: true
+            - name: LOKI_HOST
+              valueFrom:
+                secretKeyRef:
+                  name: loki-k8s-monitoring
+                  key: host
+            - name: LOKI_URL
+              value: $(LOKI_HOST)/loki/api/v1/query
+            - name: LOKI_USER
+              valueFrom:
+                secretKeyRef:
+                  name: loki-k8s-monitoring
+                  key: username
+                  optional: true
+            - name: LOKI_PASS
+              valueFrom:
+                secretKeyRef:
+                  name: loki-k8s-monitoring
+                  key: password
+                  optional: true
+            - name: LOKI_TENANTID
+              valueFrom:
+                secretKeyRef:
+                  name: loki-k8s-monitoring
+                  key: tenantId
+                  optional: true
+            - name: TEMPO_HOST
+              valueFrom:
+                secretKeyRef:
+                  name: tempo-k8s-monitoring
+                  key: host
+                  optional: true
+            - name: TEMPO_URL
+              value: $(TEMPO_HOST)/api/search
+            - name: TEMPO_USER
+              valueFrom:
+                secretKeyRef:
+                  name: tempo-k8s-monitoring
+                  key: username
+                  optional: true
+            - name: TEMPO_PASS
+              valueFrom:
+                secretKeyRef:
+                  name: tempo-k8s-monitoring
+                  key: password
+                  optional: true
+
+      volumes:
+        - name: test-files
+          configMap:
+            name: "test-k8smon-k8s-monitoring"

--- a/examples/openshift-compatible/output.yaml
+++ b/examples/openshift-compatible/output.yaml
@@ -45575,104 +45575,6 @@ spec:
         - name: AGENT_HOST
           value: k8smon-grafana-agent.default.svc
 ---
-# Source: k8s-monitoring/templates/tests/test.yaml
-apiVersion: v1
-kind: Pod
-metadata:
-  name: "test-k8smon-k8s-monitoring"
-  namespace: default
-  labels:
-    app.kubernetes.io/managed-by: "Helm"
-    app.kubernetes.io/instance: "k8smon"
-    app.kubernetes.io/version: 2.0.2
-    helm.sh/chart: "k8s-monitoring-0.10.3"
-  annotations:
-    "helm.sh/hook": test
-    "helm.sh/hook-delete-policy": before-hook-creation
-    "helm.sh/hook-weight": "0"
-spec:
-  restartPolicy: OnFailure
-  nodeSelector:
-        kubernetes.io/os: linux
-  containers:
-    - name: query-test
-      image: ghcr.io/grafana/k8s-monitoring-test:0.10.3
-      command: ["bash", "-c", "/etc/bin/query-test.sh /etc/test/testQueries.json"]
-      volumeMounts:
-        - name: test-files
-          mountPath: /etc/test
-      env:
-        - name: PROMETHEUS_HOST
-          valueFrom:
-            secretKeyRef:
-              name: prometheus-k8s-monitoring
-              key: host
-              optional: true
-        - name: PROMETHEUS_URL
-          value: $(PROMETHEUS_HOST)/api/prom/api/v1/query
-        - name: PROMETHEUS_USER
-          valueFrom:
-            secretKeyRef:
-              name: prometheus-k8s-monitoring
-              key: username
-              optional: true
-        - name: PROMETHEUS_PASS
-          valueFrom:
-            secretKeyRef:
-              name: prometheus-k8s-monitoring
-              key: password
-              optional: true
-        - name: LOKI_HOST
-          valueFrom:
-            secretKeyRef:
-              name: loki-k8s-monitoring
-              key: host
-        - name: LOKI_URL
-          value: $(LOKI_HOST)/loki/api/v1/query
-        - name: LOKI_USER
-          valueFrom:
-            secretKeyRef:
-              name: loki-k8s-monitoring
-              key: username
-              optional: true
-        - name: LOKI_PASS
-          valueFrom:
-            secretKeyRef:
-              name: loki-k8s-monitoring
-              key: password
-              optional: true
-        - name: LOKI_TENANTID
-          valueFrom:
-            secretKeyRef:
-              name: loki-k8s-monitoring
-              key: tenantId
-              optional: true
-        - name: TEMPO_HOST
-          valueFrom:
-            secretKeyRef:
-              name: tempo-k8s-monitoring
-              key: host
-              optional: true
-        - name: TEMPO_URL
-          value: $(TEMPO_HOST)/api/search
-        - name: TEMPO_USER
-          valueFrom:
-            secretKeyRef:
-              name: tempo-k8s-monitoring
-              key: username
-              optional: true
-        - name: TEMPO_PASS
-          valueFrom:
-            secretKeyRef:
-              name: tempo-k8s-monitoring
-              key: password
-              optional: true
-
-  volumes:
-    - name: test-files
-      configMap:
-        name: "test-k8smon-k8s-monitoring"
----
 # Source: k8s-monitoring/templates/hooks/validate-configuration.yaml
 apiVersion: batch/v1
 kind: Job
@@ -45730,3 +45632,115 @@ spec:
         - name: config
           configMap:
             name: "validate-k8smon-k8s-monitoring"
+---
+# Source: k8s-monitoring/templates/tests/test.yaml
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: "test-k8smon-k8s-monitoring"
+  namespace: default
+  labels:
+    app.kubernetes.io/managed-by: "Helm"
+    app.kubernetes.io/instance: "k8smon"
+    app.kubernetes.io/version: 2.0.2
+    helm.sh/chart: "k8s-monitoring-0.10.3"
+  annotations:
+    "helm.sh/hook": test
+    "helm.sh/hook-delete-policy": before-hook-creation
+    "helm.sh/hook-weight": "0"
+spec:
+  completions: 1
+  parallelism: 1
+  backoffLimit: 9
+  template:
+    metadata:
+      name: "test-k8smon-k8s-monitoring"
+      namespace: default
+      labels:
+        app.kubernetes.io/managed-by: "Helm"
+        app.kubernetes.io/instance: "k8smon"
+        helm.sh/chart: "k8s-monitoring-0.10.3"
+    spec:
+      restartPolicy: Never
+      nodeSelector:
+        kubernetes.io/os: linux
+      containers:
+        - name: query-test
+          image: ghcr.io/grafana/k8s-monitoring-test:0.10.3
+          command: ["bash", "-c", "/etc/bin/query-test.sh /etc/test/testQueries.json"]
+          volumeMounts:
+            - name: test-files
+              mountPath: /etc/test
+          env:
+            - name: SINCE
+              value: 
+            - name: PROMETHEUS_HOST
+              valueFrom:
+                secretKeyRef:
+                  name: prometheus-k8s-monitoring
+                  key: host
+                  optional: true
+            - name: PROMETHEUS_URL
+              value: $(PROMETHEUS_HOST)/api/prom/api/v1/query
+            - name: PROMETHEUS_USER
+              valueFrom:
+                secretKeyRef:
+                  name: prometheus-k8s-monitoring
+                  key: username
+                  optional: true
+            - name: PROMETHEUS_PASS
+              valueFrom:
+                secretKeyRef:
+                  name: prometheus-k8s-monitoring
+                  key: password
+                  optional: true
+            - name: LOKI_HOST
+              valueFrom:
+                secretKeyRef:
+                  name: loki-k8s-monitoring
+                  key: host
+            - name: LOKI_URL
+              value: $(LOKI_HOST)/loki/api/v1/query
+            - name: LOKI_USER
+              valueFrom:
+                secretKeyRef:
+                  name: loki-k8s-monitoring
+                  key: username
+                  optional: true
+            - name: LOKI_PASS
+              valueFrom:
+                secretKeyRef:
+                  name: loki-k8s-monitoring
+                  key: password
+                  optional: true
+            - name: LOKI_TENANTID
+              valueFrom:
+                secretKeyRef:
+                  name: loki-k8s-monitoring
+                  key: tenantId
+                  optional: true
+            - name: TEMPO_HOST
+              valueFrom:
+                secretKeyRef:
+                  name: tempo-k8s-monitoring
+                  key: host
+                  optional: true
+            - name: TEMPO_URL
+              value: $(TEMPO_HOST)/api/search
+            - name: TEMPO_USER
+              valueFrom:
+                secretKeyRef:
+                  name: tempo-k8s-monitoring
+                  key: username
+                  optional: true
+            - name: TEMPO_PASS
+              valueFrom:
+                secretKeyRef:
+                  name: tempo-k8s-monitoring
+                  key: password
+                  optional: true
+
+      volumes:
+        - name: test-files
+          configMap:
+            name: "test-k8smon-k8s-monitoring"

--- a/examples/otel-metrics-service/output.yaml
+++ b/examples/otel-metrics-service/output.yaml
@@ -45985,104 +45985,6 @@ spec:
         - name: AGENT_HOST
           value: k8smon-grafana-agent.default.svc
 ---
-# Source: k8s-monitoring/templates/tests/test.yaml
-apiVersion: v1
-kind: Pod
-metadata:
-  name: "test-k8smon-k8s-monitoring"
-  namespace: default
-  labels:
-    app.kubernetes.io/managed-by: "Helm"
-    app.kubernetes.io/instance: "k8smon"
-    app.kubernetes.io/version: 2.0.2
-    helm.sh/chart: "k8s-monitoring-0.10.3"
-  annotations:
-    "helm.sh/hook": test
-    "helm.sh/hook-delete-policy": before-hook-creation
-    "helm.sh/hook-weight": "0"
-spec:
-  restartPolicy: OnFailure
-  nodeSelector:
-        kubernetes.io/os: linux
-  containers:
-    - name: query-test
-      image: ghcr.io/grafana/k8s-monitoring-test:0.10.3
-      command: ["bash", "-c", "/etc/bin/query-test.sh /etc/test/testQueries.json"]
-      volumeMounts:
-        - name: test-files
-          mountPath: /etc/test
-      env:
-        - name: PROMETHEUS_HOST
-          valueFrom:
-            secretKeyRef:
-              name: prometheus-k8s-monitoring
-              key: host
-              optional: true
-        - name: PROMETHEUS_URL
-          value: $(PROMETHEUS_HOST)/api/v1/query
-        - name: PROMETHEUS_USER
-          valueFrom:
-            secretKeyRef:
-              name: prometheus-k8s-monitoring
-              key: username
-              optional: true
-        - name: PROMETHEUS_PASS
-          valueFrom:
-            secretKeyRef:
-              name: prometheus-k8s-monitoring
-              key: password
-              optional: true
-        - name: LOKI_HOST
-          valueFrom:
-            secretKeyRef:
-              name: loki-k8s-monitoring
-              key: host
-        - name: LOKI_URL
-          value: $(LOKI_HOST)/loki/api/v1/query
-        - name: LOKI_USER
-          valueFrom:
-            secretKeyRef:
-              name: loki-k8s-monitoring
-              key: username
-              optional: true
-        - name: LOKI_PASS
-          valueFrom:
-            secretKeyRef:
-              name: loki-k8s-monitoring
-              key: password
-              optional: true
-        - name: LOKI_TENANTID
-          valueFrom:
-            secretKeyRef:
-              name: loki-k8s-monitoring
-              key: tenantId
-              optional: true
-        - name: TEMPO_HOST
-          valueFrom:
-            secretKeyRef:
-              name: tempo-k8s-monitoring
-              key: host
-              optional: true
-        - name: TEMPO_URL
-          value: $(TEMPO_HOST)/api/search
-        - name: TEMPO_USER
-          valueFrom:
-            secretKeyRef:
-              name: tempo-k8s-monitoring
-              key: username
-              optional: true
-        - name: TEMPO_PASS
-          valueFrom:
-            secretKeyRef:
-              name: tempo-k8s-monitoring
-              key: password
-              optional: true
-
-  volumes:
-    - name: test-files
-      configMap:
-        name: "test-k8smon-k8s-monitoring"
----
 # Source: k8s-monitoring/templates/hooks/validate-configuration.yaml
 apiVersion: batch/v1
 kind: Job
@@ -46140,3 +46042,115 @@ spec:
         - name: config
           configMap:
             name: "validate-k8smon-k8s-monitoring"
+---
+# Source: k8s-monitoring/templates/tests/test.yaml
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: "test-k8smon-k8s-monitoring"
+  namespace: default
+  labels:
+    app.kubernetes.io/managed-by: "Helm"
+    app.kubernetes.io/instance: "k8smon"
+    app.kubernetes.io/version: 2.0.2
+    helm.sh/chart: "k8s-monitoring-0.10.3"
+  annotations:
+    "helm.sh/hook": test
+    "helm.sh/hook-delete-policy": before-hook-creation
+    "helm.sh/hook-weight": "0"
+spec:
+  completions: 1
+  parallelism: 1
+  backoffLimit: 9
+  template:
+    metadata:
+      name: "test-k8smon-k8s-monitoring"
+      namespace: default
+      labels:
+        app.kubernetes.io/managed-by: "Helm"
+        app.kubernetes.io/instance: "k8smon"
+        helm.sh/chart: "k8s-monitoring-0.10.3"
+    spec:
+      restartPolicy: Never
+      nodeSelector:
+        kubernetes.io/os: linux
+      containers:
+        - name: query-test
+          image: ghcr.io/grafana/k8s-monitoring-test:0.10.3
+          command: ["bash", "-c", "/etc/bin/query-test.sh /etc/test/testQueries.json"]
+          volumeMounts:
+            - name: test-files
+              mountPath: /etc/test
+          env:
+            - name: SINCE
+              value: 
+            - name: PROMETHEUS_HOST
+              valueFrom:
+                secretKeyRef:
+                  name: prometheus-k8s-monitoring
+                  key: host
+                  optional: true
+            - name: PROMETHEUS_URL
+              value: $(PROMETHEUS_HOST)/api/v1/query
+            - name: PROMETHEUS_USER
+              valueFrom:
+                secretKeyRef:
+                  name: prometheus-k8s-monitoring
+                  key: username
+                  optional: true
+            - name: PROMETHEUS_PASS
+              valueFrom:
+                secretKeyRef:
+                  name: prometheus-k8s-monitoring
+                  key: password
+                  optional: true
+            - name: LOKI_HOST
+              valueFrom:
+                secretKeyRef:
+                  name: loki-k8s-monitoring
+                  key: host
+            - name: LOKI_URL
+              value: $(LOKI_HOST)/loki/api/v1/query
+            - name: LOKI_USER
+              valueFrom:
+                secretKeyRef:
+                  name: loki-k8s-monitoring
+                  key: username
+                  optional: true
+            - name: LOKI_PASS
+              valueFrom:
+                secretKeyRef:
+                  name: loki-k8s-monitoring
+                  key: password
+                  optional: true
+            - name: LOKI_TENANTID
+              valueFrom:
+                secretKeyRef:
+                  name: loki-k8s-monitoring
+                  key: tenantId
+                  optional: true
+            - name: TEMPO_HOST
+              valueFrom:
+                secretKeyRef:
+                  name: tempo-k8s-monitoring
+                  key: host
+                  optional: true
+            - name: TEMPO_URL
+              value: $(TEMPO_HOST)/api/search
+            - name: TEMPO_USER
+              valueFrom:
+                secretKeyRef:
+                  name: tempo-k8s-monitoring
+                  key: username
+                  optional: true
+            - name: TEMPO_PASS
+              valueFrom:
+                secretKeyRef:
+                  name: tempo-k8s-monitoring
+                  key: password
+                  optional: true
+
+      volumes:
+        - name: test-files
+          configMap:
+            name: "test-k8smon-k8s-monitoring"

--- a/examples/private-image-registry/output.yaml
+++ b/examples/private-image-registry/output.yaml
@@ -45943,106 +45943,6 @@ spec:
         - name: AGENT_HOST
           value: k8smon-grafana-agent.default.svc
 ---
-# Source: k8s-monitoring/templates/tests/test.yaml
-apiVersion: v1
-kind: Pod
-metadata:
-  name: "test-k8smon-k8s-monitoring"
-  namespace: default
-  labels:
-    app.kubernetes.io/managed-by: "Helm"
-    app.kubernetes.io/instance: "k8smon"
-    app.kubernetes.io/version: 2.0.2
-    helm.sh/chart: "k8s-monitoring-0.10.3"
-  annotations:
-    "helm.sh/hook": test
-    "helm.sh/hook-delete-policy": before-hook-creation
-    "helm.sh/hook-weight": "0"
-spec:
-  imagePullSecrets:
-        - name: my-registry-creds
-  restartPolicy: OnFailure
-  nodeSelector:
-        kubernetes.io/os: linux
-  containers:
-    - name: query-test
-      image: my.registry.com/grafana/k8s-monitoring-test:0.10.3
-      command: ["bash", "-c", "/etc/bin/query-test.sh /etc/test/testQueries.json"]
-      volumeMounts:
-        - name: test-files
-          mountPath: /etc/test
-      env:
-        - name: PROMETHEUS_HOST
-          valueFrom:
-            secretKeyRef:
-              name: prometheus-k8s-monitoring
-              key: host
-              optional: true
-        - name: PROMETHEUS_URL
-          value: $(PROMETHEUS_HOST)/api/prom/api/v1/query
-        - name: PROMETHEUS_USER
-          valueFrom:
-            secretKeyRef:
-              name: prometheus-k8s-monitoring
-              key: username
-              optional: true
-        - name: PROMETHEUS_PASS
-          valueFrom:
-            secretKeyRef:
-              name: prometheus-k8s-monitoring
-              key: password
-              optional: true
-        - name: LOKI_HOST
-          valueFrom:
-            secretKeyRef:
-              name: loki-k8s-monitoring
-              key: host
-        - name: LOKI_URL
-          value: $(LOKI_HOST)/loki/api/v1/query
-        - name: LOKI_USER
-          valueFrom:
-            secretKeyRef:
-              name: loki-k8s-monitoring
-              key: username
-              optional: true
-        - name: LOKI_PASS
-          valueFrom:
-            secretKeyRef:
-              name: loki-k8s-monitoring
-              key: password
-              optional: true
-        - name: LOKI_TENANTID
-          valueFrom:
-            secretKeyRef:
-              name: loki-k8s-monitoring
-              key: tenantId
-              optional: true
-        - name: TEMPO_HOST
-          valueFrom:
-            secretKeyRef:
-              name: tempo-k8s-monitoring
-              key: host
-              optional: true
-        - name: TEMPO_URL
-          value: $(TEMPO_HOST)/api/search
-        - name: TEMPO_USER
-          valueFrom:
-            secretKeyRef:
-              name: tempo-k8s-monitoring
-              key: username
-              optional: true
-        - name: TEMPO_PASS
-          valueFrom:
-            secretKeyRef:
-              name: tempo-k8s-monitoring
-              key: password
-              optional: true
-
-  volumes:
-    - name: test-files
-      configMap:
-        name: "test-k8smon-k8s-monitoring"
----
 # Source: k8s-monitoring/templates/hooks/validate-configuration.yaml
 apiVersion: batch/v1
 kind: Job
@@ -46102,3 +46002,117 @@ spec:
         - name: config
           configMap:
             name: "validate-k8smon-k8s-monitoring"
+---
+# Source: k8s-monitoring/templates/tests/test.yaml
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: "test-k8smon-k8s-monitoring"
+  namespace: default
+  labels:
+    app.kubernetes.io/managed-by: "Helm"
+    app.kubernetes.io/instance: "k8smon"
+    app.kubernetes.io/version: 2.0.2
+    helm.sh/chart: "k8s-monitoring-0.10.3"
+  annotations:
+    "helm.sh/hook": test
+    "helm.sh/hook-delete-policy": before-hook-creation
+    "helm.sh/hook-weight": "0"
+spec:
+  completions: 1
+  parallelism: 1
+  backoffLimit: 9
+  template:
+    metadata:
+      name: "test-k8smon-k8s-monitoring"
+      namespace: default
+      labels:
+        app.kubernetes.io/managed-by: "Helm"
+        app.kubernetes.io/instance: "k8smon"
+        helm.sh/chart: "k8s-monitoring-0.10.3"
+    spec:
+      imagePullSecrets:
+        - name: my-registry-creds
+      restartPolicy: Never
+      nodeSelector:
+        kubernetes.io/os: linux
+      containers:
+        - name: query-test
+          image: my.registry.com/grafana/k8s-monitoring-test:0.10.3
+          command: ["bash", "-c", "/etc/bin/query-test.sh /etc/test/testQueries.json"]
+          volumeMounts:
+            - name: test-files
+              mountPath: /etc/test
+          env:
+            - name: SINCE
+              value: 
+            - name: PROMETHEUS_HOST
+              valueFrom:
+                secretKeyRef:
+                  name: prometheus-k8s-monitoring
+                  key: host
+                  optional: true
+            - name: PROMETHEUS_URL
+              value: $(PROMETHEUS_HOST)/api/prom/api/v1/query
+            - name: PROMETHEUS_USER
+              valueFrom:
+                secretKeyRef:
+                  name: prometheus-k8s-monitoring
+                  key: username
+                  optional: true
+            - name: PROMETHEUS_PASS
+              valueFrom:
+                secretKeyRef:
+                  name: prometheus-k8s-monitoring
+                  key: password
+                  optional: true
+            - name: LOKI_HOST
+              valueFrom:
+                secretKeyRef:
+                  name: loki-k8s-monitoring
+                  key: host
+            - name: LOKI_URL
+              value: $(LOKI_HOST)/loki/api/v1/query
+            - name: LOKI_USER
+              valueFrom:
+                secretKeyRef:
+                  name: loki-k8s-monitoring
+                  key: username
+                  optional: true
+            - name: LOKI_PASS
+              valueFrom:
+                secretKeyRef:
+                  name: loki-k8s-monitoring
+                  key: password
+                  optional: true
+            - name: LOKI_TENANTID
+              valueFrom:
+                secretKeyRef:
+                  name: loki-k8s-monitoring
+                  key: tenantId
+                  optional: true
+            - name: TEMPO_HOST
+              valueFrom:
+                secretKeyRef:
+                  name: tempo-k8s-monitoring
+                  key: host
+                  optional: true
+            - name: TEMPO_URL
+              value: $(TEMPO_HOST)/api/search
+            - name: TEMPO_USER
+              valueFrom:
+                secretKeyRef:
+                  name: tempo-k8s-monitoring
+                  key: username
+                  optional: true
+            - name: TEMPO_PASS
+              valueFrom:
+                secretKeyRef:
+                  name: tempo-k8s-monitoring
+                  key: password
+                  optional: true
+
+      volumes:
+        - name: test-files
+          configMap:
+            name: "test-k8smon-k8s-monitoring"

--- a/examples/proxies/output.yaml
+++ b/examples/proxies/output.yaml
@@ -45957,104 +45957,6 @@ spec:
         - name: AGENT_HOST
           value: k8smon-grafana-agent.default.svc
 ---
-# Source: k8s-monitoring/templates/tests/test.yaml
-apiVersion: v1
-kind: Pod
-metadata:
-  name: "test-k8smon-k8s-monitoring"
-  namespace: default
-  labels:
-    app.kubernetes.io/managed-by: "Helm"
-    app.kubernetes.io/instance: "k8smon"
-    app.kubernetes.io/version: 2.0.2
-    helm.sh/chart: "k8s-monitoring-0.10.3"
-  annotations:
-    "helm.sh/hook": test
-    "helm.sh/hook-delete-policy": before-hook-creation
-    "helm.sh/hook-weight": "0"
-spec:
-  restartPolicy: OnFailure
-  nodeSelector:
-        kubernetes.io/os: linux
-  containers:
-    - name: query-test
-      image: ghcr.io/grafana/k8s-monitoring-test:0.10.3
-      command: ["bash", "-c", "/etc/bin/query-test.sh /etc/test/testQueries.json"]
-      volumeMounts:
-        - name: test-files
-          mountPath: /etc/test
-      env:
-        - name: PROMETHEUS_HOST
-          valueFrom:
-            secretKeyRef:
-              name: prometheus-k8s-monitoring
-              key: host
-              optional: true
-        - name: PROMETHEUS_URL
-          value: $(PROMETHEUS_HOST)/api/prom/api/v1/query
-        - name: PROMETHEUS_USER
-          valueFrom:
-            secretKeyRef:
-              name: prometheus-k8s-monitoring
-              key: username
-              optional: true
-        - name: PROMETHEUS_PASS
-          valueFrom:
-            secretKeyRef:
-              name: prometheus-k8s-monitoring
-              key: password
-              optional: true
-        - name: LOKI_HOST
-          valueFrom:
-            secretKeyRef:
-              name: loki-k8s-monitoring
-              key: host
-        - name: LOKI_URL
-          value: $(LOKI_HOST)/loki/api/v1/query
-        - name: LOKI_USER
-          valueFrom:
-            secretKeyRef:
-              name: loki-k8s-monitoring
-              key: username
-              optional: true
-        - name: LOKI_PASS
-          valueFrom:
-            secretKeyRef:
-              name: loki-k8s-monitoring
-              key: password
-              optional: true
-        - name: LOKI_TENANTID
-          valueFrom:
-            secretKeyRef:
-              name: loki-k8s-monitoring
-              key: tenantId
-              optional: true
-        - name: TEMPO_HOST
-          valueFrom:
-            secretKeyRef:
-              name: tempo-k8s-monitoring
-              key: host
-              optional: true
-        - name: TEMPO_URL
-          value: $(TEMPO_HOST)/api/search
-        - name: TEMPO_USER
-          valueFrom:
-            secretKeyRef:
-              name: tempo-k8s-monitoring
-              key: username
-              optional: true
-        - name: TEMPO_PASS
-          valueFrom:
-            secretKeyRef:
-              name: tempo-k8s-monitoring
-              key: password
-              optional: true
-
-  volumes:
-    - name: test-files
-      configMap:
-        name: "test-k8smon-k8s-monitoring"
----
 # Source: k8s-monitoring/templates/hooks/validate-configuration.yaml
 apiVersion: batch/v1
 kind: Job
@@ -46112,3 +46014,115 @@ spec:
         - name: config
           configMap:
             name: "validate-k8smon-k8s-monitoring"
+---
+# Source: k8s-monitoring/templates/tests/test.yaml
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: "test-k8smon-k8s-monitoring"
+  namespace: default
+  labels:
+    app.kubernetes.io/managed-by: "Helm"
+    app.kubernetes.io/instance: "k8smon"
+    app.kubernetes.io/version: 2.0.2
+    helm.sh/chart: "k8s-monitoring-0.10.3"
+  annotations:
+    "helm.sh/hook": test
+    "helm.sh/hook-delete-policy": before-hook-creation
+    "helm.sh/hook-weight": "0"
+spec:
+  completions: 1
+  parallelism: 1
+  backoffLimit: 9
+  template:
+    metadata:
+      name: "test-k8smon-k8s-monitoring"
+      namespace: default
+      labels:
+        app.kubernetes.io/managed-by: "Helm"
+        app.kubernetes.io/instance: "k8smon"
+        helm.sh/chart: "k8s-monitoring-0.10.3"
+    spec:
+      restartPolicy: Never
+      nodeSelector:
+        kubernetes.io/os: linux
+      containers:
+        - name: query-test
+          image: ghcr.io/grafana/k8s-monitoring-test:0.10.3
+          command: ["bash", "-c", "/etc/bin/query-test.sh /etc/test/testQueries.json"]
+          volumeMounts:
+            - name: test-files
+              mountPath: /etc/test
+          env:
+            - name: SINCE
+              value: 
+            - name: PROMETHEUS_HOST
+              valueFrom:
+                secretKeyRef:
+                  name: prometheus-k8s-monitoring
+                  key: host
+                  optional: true
+            - name: PROMETHEUS_URL
+              value: $(PROMETHEUS_HOST)/api/prom/api/v1/query
+            - name: PROMETHEUS_USER
+              valueFrom:
+                secretKeyRef:
+                  name: prometheus-k8s-monitoring
+                  key: username
+                  optional: true
+            - name: PROMETHEUS_PASS
+              valueFrom:
+                secretKeyRef:
+                  name: prometheus-k8s-monitoring
+                  key: password
+                  optional: true
+            - name: LOKI_HOST
+              valueFrom:
+                secretKeyRef:
+                  name: loki-k8s-monitoring
+                  key: host
+            - name: LOKI_URL
+              value: $(LOKI_HOST)/loki/api/v1/query
+            - name: LOKI_USER
+              valueFrom:
+                secretKeyRef:
+                  name: loki-k8s-monitoring
+                  key: username
+                  optional: true
+            - name: LOKI_PASS
+              valueFrom:
+                secretKeyRef:
+                  name: loki-k8s-monitoring
+                  key: password
+                  optional: true
+            - name: LOKI_TENANTID
+              valueFrom:
+                secretKeyRef:
+                  name: loki-k8s-monitoring
+                  key: tenantId
+                  optional: true
+            - name: TEMPO_HOST
+              valueFrom:
+                secretKeyRef:
+                  name: tempo-k8s-monitoring
+                  key: host
+                  optional: true
+            - name: TEMPO_URL
+              value: $(TEMPO_HOST)/api/search
+            - name: TEMPO_USER
+              valueFrom:
+                secretKeyRef:
+                  name: tempo-k8s-monitoring
+                  key: username
+                  optional: true
+            - name: TEMPO_PASS
+              valueFrom:
+                secretKeyRef:
+                  name: tempo-k8s-monitoring
+                  key: password
+                  optional: true
+
+      volumes:
+        - name: test-files
+          configMap:
+            name: "test-k8smon-k8s-monitoring"

--- a/examples/scrape-intervals/output.yaml
+++ b/examples/scrape-intervals/output.yaml
@@ -44922,104 +44922,6 @@ spec:
         - name: AGENT_HOST
           value: k8smon-grafana-agent.default.svc
 ---
-# Source: k8s-monitoring/templates/tests/test.yaml
-apiVersion: v1
-kind: Pod
-metadata:
-  name: "test-k8smon-k8s-monitoring"
-  namespace: default
-  labels:
-    app.kubernetes.io/managed-by: "Helm"
-    app.kubernetes.io/instance: "k8smon"
-    app.kubernetes.io/version: 2.0.2
-    helm.sh/chart: "k8s-monitoring-0.10.3"
-  annotations:
-    "helm.sh/hook": test
-    "helm.sh/hook-delete-policy": before-hook-creation
-    "helm.sh/hook-weight": "0"
-spec:
-  restartPolicy: OnFailure
-  nodeSelector:
-        kubernetes.io/os: linux
-  containers:
-    - name: query-test
-      image: ghcr.io/grafana/k8s-monitoring-test:0.10.3
-      command: ["bash", "-c", "/etc/bin/query-test.sh /etc/test/testQueries.json"]
-      volumeMounts:
-        - name: test-files
-          mountPath: /etc/test
-      env:
-        - name: PROMETHEUS_HOST
-          valueFrom:
-            secretKeyRef:
-              name: prometheus-k8s-monitoring
-              key: host
-              optional: true
-        - name: PROMETHEUS_URL
-          value: $(PROMETHEUS_HOST)/api/prom/api/v1/query
-        - name: PROMETHEUS_USER
-          valueFrom:
-            secretKeyRef:
-              name: prometheus-k8s-monitoring
-              key: username
-              optional: true
-        - name: PROMETHEUS_PASS
-          valueFrom:
-            secretKeyRef:
-              name: prometheus-k8s-monitoring
-              key: password
-              optional: true
-        - name: LOKI_HOST
-          valueFrom:
-            secretKeyRef:
-              name: loki-k8s-monitoring
-              key: host
-        - name: LOKI_URL
-          value: $(LOKI_HOST)/loki/api/v1/query
-        - name: LOKI_USER
-          valueFrom:
-            secretKeyRef:
-              name: loki-k8s-monitoring
-              key: username
-              optional: true
-        - name: LOKI_PASS
-          valueFrom:
-            secretKeyRef:
-              name: loki-k8s-monitoring
-              key: password
-              optional: true
-        - name: LOKI_TENANTID
-          valueFrom:
-            secretKeyRef:
-              name: loki-k8s-monitoring
-              key: tenantId
-              optional: true
-        - name: TEMPO_HOST
-          valueFrom:
-            secretKeyRef:
-              name: tempo-k8s-monitoring
-              key: host
-              optional: true
-        - name: TEMPO_URL
-          value: $(TEMPO_HOST)/api/search
-        - name: TEMPO_USER
-          valueFrom:
-            secretKeyRef:
-              name: tempo-k8s-monitoring
-              key: username
-              optional: true
-        - name: TEMPO_PASS
-          valueFrom:
-            secretKeyRef:
-              name: tempo-k8s-monitoring
-              key: password
-              optional: true
-
-  volumes:
-    - name: test-files
-      configMap:
-        name: "test-k8smon-k8s-monitoring"
----
 # Source: k8s-monitoring/templates/hooks/validate-configuration.yaml
 apiVersion: batch/v1
 kind: Job
@@ -45069,3 +44971,115 @@ spec:
         - name: config
           configMap:
             name: "validate-k8smon-k8s-monitoring"
+---
+# Source: k8s-monitoring/templates/tests/test.yaml
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: "test-k8smon-k8s-monitoring"
+  namespace: default
+  labels:
+    app.kubernetes.io/managed-by: "Helm"
+    app.kubernetes.io/instance: "k8smon"
+    app.kubernetes.io/version: 2.0.2
+    helm.sh/chart: "k8s-monitoring-0.10.3"
+  annotations:
+    "helm.sh/hook": test
+    "helm.sh/hook-delete-policy": before-hook-creation
+    "helm.sh/hook-weight": "0"
+spec:
+  completions: 1
+  parallelism: 1
+  backoffLimit: 9
+  template:
+    metadata:
+      name: "test-k8smon-k8s-monitoring"
+      namespace: default
+      labels:
+        app.kubernetes.io/managed-by: "Helm"
+        app.kubernetes.io/instance: "k8smon"
+        helm.sh/chart: "k8s-monitoring-0.10.3"
+    spec:
+      restartPolicy: Never
+      nodeSelector:
+        kubernetes.io/os: linux
+      containers:
+        - name: query-test
+          image: ghcr.io/grafana/k8s-monitoring-test:0.10.3
+          command: ["bash", "-c", "/etc/bin/query-test.sh /etc/test/testQueries.json"]
+          volumeMounts:
+            - name: test-files
+              mountPath: /etc/test
+          env:
+            - name: SINCE
+              value: 
+            - name: PROMETHEUS_HOST
+              valueFrom:
+                secretKeyRef:
+                  name: prometheus-k8s-monitoring
+                  key: host
+                  optional: true
+            - name: PROMETHEUS_URL
+              value: $(PROMETHEUS_HOST)/api/prom/api/v1/query
+            - name: PROMETHEUS_USER
+              valueFrom:
+                secretKeyRef:
+                  name: prometheus-k8s-monitoring
+                  key: username
+                  optional: true
+            - name: PROMETHEUS_PASS
+              valueFrom:
+                secretKeyRef:
+                  name: prometheus-k8s-monitoring
+                  key: password
+                  optional: true
+            - name: LOKI_HOST
+              valueFrom:
+                secretKeyRef:
+                  name: loki-k8s-monitoring
+                  key: host
+            - name: LOKI_URL
+              value: $(LOKI_HOST)/loki/api/v1/query
+            - name: LOKI_USER
+              valueFrom:
+                secretKeyRef:
+                  name: loki-k8s-monitoring
+                  key: username
+                  optional: true
+            - name: LOKI_PASS
+              valueFrom:
+                secretKeyRef:
+                  name: loki-k8s-monitoring
+                  key: password
+                  optional: true
+            - name: LOKI_TENANTID
+              valueFrom:
+                secretKeyRef:
+                  name: loki-k8s-monitoring
+                  key: tenantId
+                  optional: true
+            - name: TEMPO_HOST
+              valueFrom:
+                secretKeyRef:
+                  name: tempo-k8s-monitoring
+                  key: host
+                  optional: true
+            - name: TEMPO_URL
+              value: $(TEMPO_HOST)/api/search
+            - name: TEMPO_USER
+              valueFrom:
+                secretKeyRef:
+                  name: tempo-k8s-monitoring
+                  key: username
+                  optional: true
+            - name: TEMPO_PASS
+              valueFrom:
+                secretKeyRef:
+                  name: tempo-k8s-monitoring
+                  key: password
+                  optional: true
+
+      volumes:
+        - name: test-files
+          configMap:
+            name: "test-k8smon-k8s-monitoring"

--- a/examples/service-integrations/output.yaml
+++ b/examples/service-integrations/output.yaml
@@ -46007,104 +46007,6 @@ spec:
         - name: AGENT_HOST
           value: k8smon-grafana-agent.default.svc
 ---
-# Source: k8s-monitoring/templates/tests/test.yaml
-apiVersion: v1
-kind: Pod
-metadata:
-  name: "test-k8smon-k8s-monitoring"
-  namespace: default
-  labels:
-    app.kubernetes.io/managed-by: "Helm"
-    app.kubernetes.io/instance: "k8smon"
-    app.kubernetes.io/version: 2.0.2
-    helm.sh/chart: "k8s-monitoring-0.10.3"
-  annotations:
-    "helm.sh/hook": test
-    "helm.sh/hook-delete-policy": before-hook-creation
-    "helm.sh/hook-weight": "0"
-spec:
-  restartPolicy: OnFailure
-  nodeSelector:
-        kubernetes.io/os: linux
-  containers:
-    - name: query-test
-      image: ghcr.io/grafana/k8s-monitoring-test:0.10.3
-      command: ["bash", "-c", "/etc/bin/query-test.sh /etc/test/testQueries.json"]
-      volumeMounts:
-        - name: test-files
-          mountPath: /etc/test
-      env:
-        - name: PROMETHEUS_HOST
-          valueFrom:
-            secretKeyRef:
-              name: prometheus-k8s-monitoring
-              key: host
-              optional: true
-        - name: PROMETHEUS_URL
-          value: $(PROMETHEUS_HOST)/api/prom/api/v1/query
-        - name: PROMETHEUS_USER
-          valueFrom:
-            secretKeyRef:
-              name: prometheus-k8s-monitoring
-              key: username
-              optional: true
-        - name: PROMETHEUS_PASS
-          valueFrom:
-            secretKeyRef:
-              name: prometheus-k8s-monitoring
-              key: password
-              optional: true
-        - name: LOKI_HOST
-          valueFrom:
-            secretKeyRef:
-              name: loki-k8s-monitoring
-              key: host
-        - name: LOKI_URL
-          value: $(LOKI_HOST)/loki/api/v1/query
-        - name: LOKI_USER
-          valueFrom:
-            secretKeyRef:
-              name: loki-k8s-monitoring
-              key: username
-              optional: true
-        - name: LOKI_PASS
-          valueFrom:
-            secretKeyRef:
-              name: loki-k8s-monitoring
-              key: password
-              optional: true
-        - name: LOKI_TENANTID
-          valueFrom:
-            secretKeyRef:
-              name: loki-k8s-monitoring
-              key: tenantId
-              optional: true
-        - name: TEMPO_HOST
-          valueFrom:
-            secretKeyRef:
-              name: tempo-k8s-monitoring
-              key: host
-              optional: true
-        - name: TEMPO_URL
-          value: $(TEMPO_HOST)/api/search
-        - name: TEMPO_USER
-          valueFrom:
-            secretKeyRef:
-              name: tempo-k8s-monitoring
-              key: username
-              optional: true
-        - name: TEMPO_PASS
-          valueFrom:
-            secretKeyRef:
-              name: tempo-k8s-monitoring
-              key: password
-              optional: true
-
-  volumes:
-    - name: test-files
-      configMap:
-        name: "test-k8smon-k8s-monitoring"
----
 # Source: k8s-monitoring/templates/hooks/validate-configuration.yaml
 apiVersion: batch/v1
 kind: Job
@@ -46162,3 +46064,115 @@ spec:
         - name: config
           configMap:
             name: "validate-k8smon-k8s-monitoring"
+---
+# Source: k8s-monitoring/templates/tests/test.yaml
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: "test-k8smon-k8s-monitoring"
+  namespace: default
+  labels:
+    app.kubernetes.io/managed-by: "Helm"
+    app.kubernetes.io/instance: "k8smon"
+    app.kubernetes.io/version: 2.0.2
+    helm.sh/chart: "k8s-monitoring-0.10.3"
+  annotations:
+    "helm.sh/hook": test
+    "helm.sh/hook-delete-policy": before-hook-creation
+    "helm.sh/hook-weight": "0"
+spec:
+  completions: 1
+  parallelism: 1
+  backoffLimit: 9
+  template:
+    metadata:
+      name: "test-k8smon-k8s-monitoring"
+      namespace: default
+      labels:
+        app.kubernetes.io/managed-by: "Helm"
+        app.kubernetes.io/instance: "k8smon"
+        helm.sh/chart: "k8s-monitoring-0.10.3"
+    spec:
+      restartPolicy: Never
+      nodeSelector:
+        kubernetes.io/os: linux
+      containers:
+        - name: query-test
+          image: ghcr.io/grafana/k8s-monitoring-test:0.10.3
+          command: ["bash", "-c", "/etc/bin/query-test.sh /etc/test/testQueries.json"]
+          volumeMounts:
+            - name: test-files
+              mountPath: /etc/test
+          env:
+            - name: SINCE
+              value: 
+            - name: PROMETHEUS_HOST
+              valueFrom:
+                secretKeyRef:
+                  name: prometheus-k8s-monitoring
+                  key: host
+                  optional: true
+            - name: PROMETHEUS_URL
+              value: $(PROMETHEUS_HOST)/api/prom/api/v1/query
+            - name: PROMETHEUS_USER
+              valueFrom:
+                secretKeyRef:
+                  name: prometheus-k8s-monitoring
+                  key: username
+                  optional: true
+            - name: PROMETHEUS_PASS
+              valueFrom:
+                secretKeyRef:
+                  name: prometheus-k8s-monitoring
+                  key: password
+                  optional: true
+            - name: LOKI_HOST
+              valueFrom:
+                secretKeyRef:
+                  name: loki-k8s-monitoring
+                  key: host
+            - name: LOKI_URL
+              value: $(LOKI_HOST)/loki/api/v1/query
+            - name: LOKI_USER
+              valueFrom:
+                secretKeyRef:
+                  name: loki-k8s-monitoring
+                  key: username
+                  optional: true
+            - name: LOKI_PASS
+              valueFrom:
+                secretKeyRef:
+                  name: loki-k8s-monitoring
+                  key: password
+                  optional: true
+            - name: LOKI_TENANTID
+              valueFrom:
+                secretKeyRef:
+                  name: loki-k8s-monitoring
+                  key: tenantId
+                  optional: true
+            - name: TEMPO_HOST
+              valueFrom:
+                secretKeyRef:
+                  name: tempo-k8s-monitoring
+                  key: host
+                  optional: true
+            - name: TEMPO_URL
+              value: $(TEMPO_HOST)/api/search
+            - name: TEMPO_USER
+              valueFrom:
+                secretKeyRef:
+                  name: tempo-k8s-monitoring
+                  key: username
+                  optional: true
+            - name: TEMPO_PASS
+              valueFrom:
+                secretKeyRef:
+                  name: tempo-k8s-monitoring
+                  key: password
+                  optional: true
+
+      volumes:
+        - name: test-files
+          configMap:
+            name: "test-k8smon-k8s-monitoring"

--- a/examples/specific-namespace/output.yaml
+++ b/examples/specific-namespace/output.yaml
@@ -45947,104 +45947,6 @@ spec:
         - name: AGENT_HOST
           value: k8smon-grafana-agent.default.svc
 ---
-# Source: k8s-monitoring/templates/tests/test.yaml
-apiVersion: v1
-kind: Pod
-metadata:
-  name: "test-k8smon-k8s-monitoring"
-  namespace: default
-  labels:
-    app.kubernetes.io/managed-by: "Helm"
-    app.kubernetes.io/instance: "k8smon"
-    app.kubernetes.io/version: 2.0.2
-    helm.sh/chart: "k8s-monitoring-0.10.3"
-  annotations:
-    "helm.sh/hook": test
-    "helm.sh/hook-delete-policy": before-hook-creation
-    "helm.sh/hook-weight": "0"
-spec:
-  restartPolicy: OnFailure
-  nodeSelector:
-        kubernetes.io/os: linux
-  containers:
-    - name: query-test
-      image: ghcr.io/grafana/k8s-monitoring-test:0.10.3
-      command: ["bash", "-c", "/etc/bin/query-test.sh /etc/test/testQueries.json"]
-      volumeMounts:
-        - name: test-files
-          mountPath: /etc/test
-      env:
-        - name: PROMETHEUS_HOST
-          valueFrom:
-            secretKeyRef:
-              name: prometheus-k8s-monitoring
-              key: host
-              optional: true
-        - name: PROMETHEUS_URL
-          value: $(PROMETHEUS_HOST)/api/prom/api/v1/query
-        - name: PROMETHEUS_USER
-          valueFrom:
-            secretKeyRef:
-              name: prometheus-k8s-monitoring
-              key: username
-              optional: true
-        - name: PROMETHEUS_PASS
-          valueFrom:
-            secretKeyRef:
-              name: prometheus-k8s-monitoring
-              key: password
-              optional: true
-        - name: LOKI_HOST
-          valueFrom:
-            secretKeyRef:
-              name: loki-k8s-monitoring
-              key: host
-        - name: LOKI_URL
-          value: $(LOKI_HOST)/loki/api/v1/query
-        - name: LOKI_USER
-          valueFrom:
-            secretKeyRef:
-              name: loki-k8s-monitoring
-              key: username
-              optional: true
-        - name: LOKI_PASS
-          valueFrom:
-            secretKeyRef:
-              name: loki-k8s-monitoring
-              key: password
-              optional: true
-        - name: LOKI_TENANTID
-          valueFrom:
-            secretKeyRef:
-              name: loki-k8s-monitoring
-              key: tenantId
-              optional: true
-        - name: TEMPO_HOST
-          valueFrom:
-            secretKeyRef:
-              name: tempo-k8s-monitoring
-              key: host
-              optional: true
-        - name: TEMPO_URL
-          value: $(TEMPO_HOST)/api/search
-        - name: TEMPO_USER
-          valueFrom:
-            secretKeyRef:
-              name: tempo-k8s-monitoring
-              key: username
-              optional: true
-        - name: TEMPO_PASS
-          valueFrom:
-            secretKeyRef:
-              name: tempo-k8s-monitoring
-              key: password
-              optional: true
-
-  volumes:
-    - name: test-files
-      configMap:
-        name: "test-k8smon-k8s-monitoring"
----
 # Source: k8s-monitoring/templates/hooks/validate-configuration.yaml
 apiVersion: batch/v1
 kind: Job
@@ -46102,3 +46004,115 @@ spec:
         - name: config
           configMap:
             name: "validate-k8smon-k8s-monitoring"
+---
+# Source: k8s-monitoring/templates/tests/test.yaml
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: "test-k8smon-k8s-monitoring"
+  namespace: default
+  labels:
+    app.kubernetes.io/managed-by: "Helm"
+    app.kubernetes.io/instance: "k8smon"
+    app.kubernetes.io/version: 2.0.2
+    helm.sh/chart: "k8s-monitoring-0.10.3"
+  annotations:
+    "helm.sh/hook": test
+    "helm.sh/hook-delete-policy": before-hook-creation
+    "helm.sh/hook-weight": "0"
+spec:
+  completions: 1
+  parallelism: 1
+  backoffLimit: 9
+  template:
+    metadata:
+      name: "test-k8smon-k8s-monitoring"
+      namespace: default
+      labels:
+        app.kubernetes.io/managed-by: "Helm"
+        app.kubernetes.io/instance: "k8smon"
+        helm.sh/chart: "k8s-monitoring-0.10.3"
+    spec:
+      restartPolicy: Never
+      nodeSelector:
+        kubernetes.io/os: linux
+      containers:
+        - name: query-test
+          image: ghcr.io/grafana/k8s-monitoring-test:0.10.3
+          command: ["bash", "-c", "/etc/bin/query-test.sh /etc/test/testQueries.json"]
+          volumeMounts:
+            - name: test-files
+              mountPath: /etc/test
+          env:
+            - name: SINCE
+              value: 
+            - name: PROMETHEUS_HOST
+              valueFrom:
+                secretKeyRef:
+                  name: prometheus-k8s-monitoring
+                  key: host
+                  optional: true
+            - name: PROMETHEUS_URL
+              value: $(PROMETHEUS_HOST)/api/prom/api/v1/query
+            - name: PROMETHEUS_USER
+              valueFrom:
+                secretKeyRef:
+                  name: prometheus-k8s-monitoring
+                  key: username
+                  optional: true
+            - name: PROMETHEUS_PASS
+              valueFrom:
+                secretKeyRef:
+                  name: prometheus-k8s-monitoring
+                  key: password
+                  optional: true
+            - name: LOKI_HOST
+              valueFrom:
+                secretKeyRef:
+                  name: loki-k8s-monitoring
+                  key: host
+            - name: LOKI_URL
+              value: $(LOKI_HOST)/loki/api/v1/query
+            - name: LOKI_USER
+              valueFrom:
+                secretKeyRef:
+                  name: loki-k8s-monitoring
+                  key: username
+                  optional: true
+            - name: LOKI_PASS
+              valueFrom:
+                secretKeyRef:
+                  name: loki-k8s-monitoring
+                  key: password
+                  optional: true
+            - name: LOKI_TENANTID
+              valueFrom:
+                secretKeyRef:
+                  name: loki-k8s-monitoring
+                  key: tenantId
+                  optional: true
+            - name: TEMPO_HOST
+              valueFrom:
+                secretKeyRef:
+                  name: tempo-k8s-monitoring
+                  key: host
+                  optional: true
+            - name: TEMPO_URL
+              value: $(TEMPO_HOST)/api/search
+            - name: TEMPO_USER
+              valueFrom:
+                secretKeyRef:
+                  name: tempo-k8s-monitoring
+                  key: username
+                  optional: true
+            - name: TEMPO_PASS
+              valueFrom:
+                secretKeyRef:
+                  name: tempo-k8s-monitoring
+                  key: password
+                  optional: true
+
+      volumes:
+        - name: test-files
+          configMap:
+            name: "test-k8smon-k8s-monitoring"

--- a/examples/traces-enabled/output.yaml
+++ b/examples/traces-enabled/output.yaml
@@ -46068,104 +46068,6 @@ spec:
         - name: AGENT_HOST
           value: k8smon-grafana-agent.default.svc
 ---
-# Source: k8s-monitoring/templates/tests/test.yaml
-apiVersion: v1
-kind: Pod
-metadata:
-  name: "test-k8smon-k8s-monitoring"
-  namespace: default
-  labels:
-    app.kubernetes.io/managed-by: "Helm"
-    app.kubernetes.io/instance: "k8smon"
-    app.kubernetes.io/version: 2.0.2
-    helm.sh/chart: "k8s-monitoring-0.10.3"
-  annotations:
-    "helm.sh/hook": test
-    "helm.sh/hook-delete-policy": before-hook-creation
-    "helm.sh/hook-weight": "0"
-spec:
-  restartPolicy: OnFailure
-  nodeSelector:
-        kubernetes.io/os: linux
-  containers:
-    - name: query-test
-      image: ghcr.io/grafana/k8s-monitoring-test:0.10.3
-      command: ["bash", "-c", "/etc/bin/query-test.sh /etc/test/testQueries.json"]
-      volumeMounts:
-        - name: test-files
-          mountPath: /etc/test
-      env:
-        - name: PROMETHEUS_HOST
-          valueFrom:
-            secretKeyRef:
-              name: prometheus-k8s-monitoring
-              key: host
-              optional: true
-        - name: PROMETHEUS_URL
-          value: $(PROMETHEUS_HOST)/api/prom/api/v1/query
-        - name: PROMETHEUS_USER
-          valueFrom:
-            secretKeyRef:
-              name: prometheus-k8s-monitoring
-              key: username
-              optional: true
-        - name: PROMETHEUS_PASS
-          valueFrom:
-            secretKeyRef:
-              name: prometheus-k8s-monitoring
-              key: password
-              optional: true
-        - name: LOKI_HOST
-          valueFrom:
-            secretKeyRef:
-              name: loki-k8s-monitoring
-              key: host
-        - name: LOKI_URL
-          value: $(LOKI_HOST)/loki/api/v1/query
-        - name: LOKI_USER
-          valueFrom:
-            secretKeyRef:
-              name: loki-k8s-monitoring
-              key: username
-              optional: true
-        - name: LOKI_PASS
-          valueFrom:
-            secretKeyRef:
-              name: loki-k8s-monitoring
-              key: password
-              optional: true
-        - name: LOKI_TENANTID
-          valueFrom:
-            secretKeyRef:
-              name: loki-k8s-monitoring
-              key: tenantId
-              optional: true
-        - name: TEMPO_HOST
-          valueFrom:
-            secretKeyRef:
-              name: tempo-k8s-monitoring
-              key: host
-              optional: true
-        - name: TEMPO_URL
-          value: $(TEMPO_HOST)/api/search
-        - name: TEMPO_USER
-          valueFrom:
-            secretKeyRef:
-              name: tempo-k8s-monitoring
-              key: username
-              optional: true
-        - name: TEMPO_PASS
-          valueFrom:
-            secretKeyRef:
-              name: tempo-k8s-monitoring
-              key: password
-              optional: true
-
-  volumes:
-    - name: test-files
-      configMap:
-        name: "test-k8smon-k8s-monitoring"
----
 # Source: k8s-monitoring/templates/hooks/validate-configuration.yaml
 apiVersion: batch/v1
 kind: Job
@@ -46223,3 +46125,115 @@ spec:
         - name: config
           configMap:
             name: "validate-k8smon-k8s-monitoring"
+---
+# Source: k8s-monitoring/templates/tests/test.yaml
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: "test-k8smon-k8s-monitoring"
+  namespace: default
+  labels:
+    app.kubernetes.io/managed-by: "Helm"
+    app.kubernetes.io/instance: "k8smon"
+    app.kubernetes.io/version: 2.0.2
+    helm.sh/chart: "k8s-monitoring-0.10.3"
+  annotations:
+    "helm.sh/hook": test
+    "helm.sh/hook-delete-policy": before-hook-creation
+    "helm.sh/hook-weight": "0"
+spec:
+  completions: 1
+  parallelism: 1
+  backoffLimit: 9
+  template:
+    metadata:
+      name: "test-k8smon-k8s-monitoring"
+      namespace: default
+      labels:
+        app.kubernetes.io/managed-by: "Helm"
+        app.kubernetes.io/instance: "k8smon"
+        helm.sh/chart: "k8s-monitoring-0.10.3"
+    spec:
+      restartPolicy: Never
+      nodeSelector:
+        kubernetes.io/os: linux
+      containers:
+        - name: query-test
+          image: ghcr.io/grafana/k8s-monitoring-test:0.10.3
+          command: ["bash", "-c", "/etc/bin/query-test.sh /etc/test/testQueries.json"]
+          volumeMounts:
+            - name: test-files
+              mountPath: /etc/test
+          env:
+            - name: SINCE
+              value: 
+            - name: PROMETHEUS_HOST
+              valueFrom:
+                secretKeyRef:
+                  name: prometheus-k8s-monitoring
+                  key: host
+                  optional: true
+            - name: PROMETHEUS_URL
+              value: $(PROMETHEUS_HOST)/api/prom/api/v1/query
+            - name: PROMETHEUS_USER
+              valueFrom:
+                secretKeyRef:
+                  name: prometheus-k8s-monitoring
+                  key: username
+                  optional: true
+            - name: PROMETHEUS_PASS
+              valueFrom:
+                secretKeyRef:
+                  name: prometheus-k8s-monitoring
+                  key: password
+                  optional: true
+            - name: LOKI_HOST
+              valueFrom:
+                secretKeyRef:
+                  name: loki-k8s-monitoring
+                  key: host
+            - name: LOKI_URL
+              value: $(LOKI_HOST)/loki/api/v1/query
+            - name: LOKI_USER
+              valueFrom:
+                secretKeyRef:
+                  name: loki-k8s-monitoring
+                  key: username
+                  optional: true
+            - name: LOKI_PASS
+              valueFrom:
+                secretKeyRef:
+                  name: loki-k8s-monitoring
+                  key: password
+                  optional: true
+            - name: LOKI_TENANTID
+              valueFrom:
+                secretKeyRef:
+                  name: loki-k8s-monitoring
+                  key: tenantId
+                  optional: true
+            - name: TEMPO_HOST
+              valueFrom:
+                secretKeyRef:
+                  name: tempo-k8s-monitoring
+                  key: host
+                  optional: true
+            - name: TEMPO_URL
+              value: $(TEMPO_HOST)/api/search
+            - name: TEMPO_USER
+              valueFrom:
+                secretKeyRef:
+                  name: tempo-k8s-monitoring
+                  key: username
+                  optional: true
+            - name: TEMPO_PASS
+              valueFrom:
+                secretKeyRef:
+                  name: tempo-k8s-monitoring
+                  key: password
+                  optional: true
+
+      volumes:
+        - name: test-files
+          configMap:
+            name: "test-k8smon-k8s-monitoring"

--- a/examples/windows-exporter/output.yaml
+++ b/examples/windows-exporter/output.yaml
@@ -46228,104 +46228,6 @@ spec:
         - name: AGENT_HOST
           value: k8smon-grafana-agent.default.svc
 ---
-# Source: k8s-monitoring/templates/tests/test.yaml
-apiVersion: v1
-kind: Pod
-metadata:
-  name: "test-k8smon-k8s-monitoring"
-  namespace: default
-  labels:
-    app.kubernetes.io/managed-by: "Helm"
-    app.kubernetes.io/instance: "k8smon"
-    app.kubernetes.io/version: 2.0.2
-    helm.sh/chart: "k8s-monitoring-0.10.3"
-  annotations:
-    "helm.sh/hook": test
-    "helm.sh/hook-delete-policy": before-hook-creation
-    "helm.sh/hook-weight": "0"
-spec:
-  restartPolicy: OnFailure
-  nodeSelector:
-        kubernetes.io/os: linux
-  containers:
-    - name: query-test
-      image: ghcr.io/grafana/k8s-monitoring-test:0.10.3
-      command: ["bash", "-c", "/etc/bin/query-test.sh /etc/test/testQueries.json"]
-      volumeMounts:
-        - name: test-files
-          mountPath: /etc/test
-      env:
-        - name: PROMETHEUS_HOST
-          valueFrom:
-            secretKeyRef:
-              name: prometheus-k8s-monitoring
-              key: host
-              optional: true
-        - name: PROMETHEUS_URL
-          value: $(PROMETHEUS_HOST)/api/prom/api/v1/query
-        - name: PROMETHEUS_USER
-          valueFrom:
-            secretKeyRef:
-              name: prometheus-k8s-monitoring
-              key: username
-              optional: true
-        - name: PROMETHEUS_PASS
-          valueFrom:
-            secretKeyRef:
-              name: prometheus-k8s-monitoring
-              key: password
-              optional: true
-        - name: LOKI_HOST
-          valueFrom:
-            secretKeyRef:
-              name: loki-k8s-monitoring
-              key: host
-        - name: LOKI_URL
-          value: $(LOKI_HOST)/loki/api/v1/query
-        - name: LOKI_USER
-          valueFrom:
-            secretKeyRef:
-              name: loki-k8s-monitoring
-              key: username
-              optional: true
-        - name: LOKI_PASS
-          valueFrom:
-            secretKeyRef:
-              name: loki-k8s-monitoring
-              key: password
-              optional: true
-        - name: LOKI_TENANTID
-          valueFrom:
-            secretKeyRef:
-              name: loki-k8s-monitoring
-              key: tenantId
-              optional: true
-        - name: TEMPO_HOST
-          valueFrom:
-            secretKeyRef:
-              name: tempo-k8s-monitoring
-              key: host
-              optional: true
-        - name: TEMPO_URL
-          value: $(TEMPO_HOST)/api/search
-        - name: TEMPO_USER
-          valueFrom:
-            secretKeyRef:
-              name: tempo-k8s-monitoring
-              key: username
-              optional: true
-        - name: TEMPO_PASS
-          valueFrom:
-            secretKeyRef:
-              name: tempo-k8s-monitoring
-              key: password
-              optional: true
-
-  volumes:
-    - name: test-files
-      configMap:
-        name: "test-k8smon-k8s-monitoring"
----
 # Source: k8s-monitoring/templates/hooks/validate-configuration.yaml
 apiVersion: batch/v1
 kind: Job
@@ -46383,3 +46285,115 @@ spec:
         - name: config
           configMap:
             name: "validate-k8smon-k8s-monitoring"
+---
+# Source: k8s-monitoring/templates/tests/test.yaml
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: "test-k8smon-k8s-monitoring"
+  namespace: default
+  labels:
+    app.kubernetes.io/managed-by: "Helm"
+    app.kubernetes.io/instance: "k8smon"
+    app.kubernetes.io/version: 2.0.2
+    helm.sh/chart: "k8s-monitoring-0.10.3"
+  annotations:
+    "helm.sh/hook": test
+    "helm.sh/hook-delete-policy": before-hook-creation
+    "helm.sh/hook-weight": "0"
+spec:
+  completions: 1
+  parallelism: 1
+  backoffLimit: 9
+  template:
+    metadata:
+      name: "test-k8smon-k8s-monitoring"
+      namespace: default
+      labels:
+        app.kubernetes.io/managed-by: "Helm"
+        app.kubernetes.io/instance: "k8smon"
+        helm.sh/chart: "k8s-monitoring-0.10.3"
+    spec:
+      restartPolicy: Never
+      nodeSelector:
+        kubernetes.io/os: linux
+      containers:
+        - name: query-test
+          image: ghcr.io/grafana/k8s-monitoring-test:0.10.3
+          command: ["bash", "-c", "/etc/bin/query-test.sh /etc/test/testQueries.json"]
+          volumeMounts:
+            - name: test-files
+              mountPath: /etc/test
+          env:
+            - name: SINCE
+              value: 
+            - name: PROMETHEUS_HOST
+              valueFrom:
+                secretKeyRef:
+                  name: prometheus-k8s-monitoring
+                  key: host
+                  optional: true
+            - name: PROMETHEUS_URL
+              value: $(PROMETHEUS_HOST)/api/prom/api/v1/query
+            - name: PROMETHEUS_USER
+              valueFrom:
+                secretKeyRef:
+                  name: prometheus-k8s-monitoring
+                  key: username
+                  optional: true
+            - name: PROMETHEUS_PASS
+              valueFrom:
+                secretKeyRef:
+                  name: prometheus-k8s-monitoring
+                  key: password
+                  optional: true
+            - name: LOKI_HOST
+              valueFrom:
+                secretKeyRef:
+                  name: loki-k8s-monitoring
+                  key: host
+            - name: LOKI_URL
+              value: $(LOKI_HOST)/loki/api/v1/query
+            - name: LOKI_USER
+              valueFrom:
+                secretKeyRef:
+                  name: loki-k8s-monitoring
+                  key: username
+                  optional: true
+            - name: LOKI_PASS
+              valueFrom:
+                secretKeyRef:
+                  name: loki-k8s-monitoring
+                  key: password
+                  optional: true
+            - name: LOKI_TENANTID
+              valueFrom:
+                secretKeyRef:
+                  name: loki-k8s-monitoring
+                  key: tenantId
+                  optional: true
+            - name: TEMPO_HOST
+              valueFrom:
+                secretKeyRef:
+                  name: tempo-k8s-monitoring
+                  key: host
+                  optional: true
+            - name: TEMPO_URL
+              value: $(TEMPO_HOST)/api/search
+            - name: TEMPO_USER
+              valueFrom:
+                secretKeyRef:
+                  name: tempo-k8s-monitoring
+                  key: username
+                  optional: true
+            - name: TEMPO_PASS
+              valueFrom:
+                secretKeyRef:
+                  name: tempo-k8s-monitoring
+                  key: password
+                  optional: true
+
+      volumes:
+        - name: test-files
+          configMap:
+            name: "test-k8smon-k8s-monitoring"


### PR DESCRIPTION
Seems to be improving the test reliability

* MySQL clustering enabled to ensure the DPM stays at 1
* Increased test timeout to 10m to ensure that all metrics, logs, and traces are delivered to their data sources.
* Added some values for the different test and validation tasks. This makes them much more configurable
* Wrapped LogQL queries in count_over_time to make sure it goes back in time to when those logs or events occurred.