### PR TITLE
Improve the config validation hook so that it actually runs the agent and finds invalid configurations

### DIFF
--- a/charts/k8s-monitoring/templates/hooks/validate-configuration.yaml
+++ b/charts/k8s-monitoring/templates/hooks/validate-configuration.yaml
@@ -1,7 +1,7 @@
 {{- if .Values.configValidator.enabled }}
 ---
-apiVersion: batch/v1
-kind: Job
+apiVersion: v1
+kind: Pod
 metadata:
   name: {{ include "config-validator.fullname" . | quote }}
   namespace: {{ .Release.Namespace }}
@@ -21,72 +21,78 @@ metadata:
     {{ $key }}: {{ $val | quote }}
     {{- end}}
 spec:
-  backoffLimit: 0
-  template:
-    metadata:
-      name: {{ include "config-validator.fullname" . | quote }}
-      labels:
-        app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
-        app.kubernetes.io/instance: {{ .Release.Name | quote }}
-        helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
-        {{- range $key, $val := .Values.configValidator.extraLabels }}
-        {{ $key }}: {{ $val | quote }}
-        {{- end}}
-      {{- with .Values.configValidator.extraAnnotations }}
-      annotations:
-        {{- . | toYaml | nindent 8 }}
-      {{- end }}
-    spec:
-      {{- if or .Values.global.image.pullSecrets (index .Values "grafana-agent").image.pullSecrets }}
-      imagePullSecrets:
-        {{- if .Values.global.image.pullSecrets }}
-        {{- toYaml .Values.global.image.pullSecrets | nindent 8 }}
-        {{- else }}
-        {{- toYaml (index .Values "grafana-agent").image.pullSecrets | nindent 8 }}
-        {{- end }}
-      {{- end }}
-      restartPolicy: Never
-      {{- with .Values.configValidator.nodeSelector }}
-      nodeSelector:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
-      {{- with .Values.configValidator.tolerations }}
-      tolerations:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
-      containers:
-        - name: grafana-agent
-          image: "{{ .Values.global.image.registry | default (index .Values "grafana-agent").image.registry }}/{{ (index .Values "grafana-agent").image.repository }}{{ include "grafana-agent.imageId" (index .Subcharts "grafana-agent") }}"
-          command:
-          - bash
-          - -ec
-          - |
-            echo Validating Grafana Agent config file
-            if grafana-agent fmt /etc/agent/config.river > /dev/null; then
-              echo "Grafana Agent config file is valid"
-            fi
+  {{- if or .Values.global.image.pullSecrets (index .Values "grafana-agent").image.pullSecrets }}
+  imagePullSecrets:
+    {{- if .Values.global.image.pullSecrets }}
+    {{- toYaml .Values.global.image.pullSecrets | nindent 8 }}
+    {{- else }}
+    {{- toYaml (index .Values "grafana-agent").image.pullSecrets | nindent 8 }}
+    {{- end }}
+  {{- end }}
+  restartPolicy: Never
+  {{- with .Values.configValidator.nodeSelector }}
+  nodeSelector:
+    {{- toYaml . | nindent 8 }}
+  {{- end }}
+  {{- with .Values.configValidator.tolerations }}
+  tolerations:
+    {{- toYaml . | nindent 8 }}
+  {{- end }}
+  containers:
+    - name: grafana-agent
+      image: "{{ .Values.global.image.registry | default (index .Values "grafana-agent").image.registry }}/{{ (index .Values "grafana-agent").image.repository }}{{ include "grafana-agent.imageId" (index .Subcharts "grafana-agent") }}"
+      command:
+      - bash
+      - -c
+      - |
+        echo Validating Grafana Agent config file
+        if ! grafana-agent fmt /etc/agent/config.river > /dev/null; then
+          exit 1
+        fi
+        output=$(grafana-agent run "/etc/agent/config.river" 2>&1)
+        if ! echo "${output}" | grep "KUBERNETES_SERVICE_HOST and KUBERNETES_SERVICE_PORT must be defined" >/dev/null; then
+          echo "${output}"
+          exit 1
+        fi
+        echo "Grafana Agent config file is valid"
 {{- if and .Values.logs.enabled .Values.logs.cluster_events.enabled }}
-            echo Validating Grafana Agent for Events config file
-            if grafana-agent fmt /etc/agent/events.river > /dev/null; then
-              echo "Grafana Agent for Events config file is valid"
-            fi
+        echo Validating Grafana Agent for Events config file
+        if ! grafana-agent fmt /etc/agent/events.river > /dev/null; then
+          exit 1
+        fi
+        output=$(grafana-agent run "/etc/agent/events.river" 2>&1)
+        if ! echo "${output}" | grep "KUBERNETES_SERVICE_HOST and KUBERNETES_SERVICE_PORT must be defined" >/dev/null; then
+          echo "${output}"
+          exit 1
+        fi
+        echo "Grafana Agent for Events config file is valid"
 {{- end }}
 {{- if and .Values.logs.enabled .Values.logs.pod_logs.enabled }}
-            echo Validating Grafana Agent for Logs config file
-            if grafana-agent fmt /etc/agent/logs.river > /dev/null; then
-              echo "Grafana Agent for Logs config file is valid"
-            fi
+        echo Validating Grafana Agent for Logs config file
+        if ! grafana-agent fmt /etc/agent/logs.river > /dev/null; then
+          exit 1
+        fi
+        output=$(grafana-agent run "/etc/agent/logs.river" 2>&1)
+        if ! echo "${output}" | grep "KUBERNETES_SERVICE_HOST and KUBERNETES_SERVICE_PORT must be defined" >/dev/null; then
+          echo "${output}"
+          exit 1
+        fi
+        echo "Grafana Agent for Logs config file is valid"
 {{- end }}
-          env:
-            - name: AGENT_MODE
-              value: flow
-          volumeMounts:
-            - name: config
-              mountPath: /etc/agent
-      volumes:
+      env:
+        - name: AGENT_MODE
+          value: flow
+        - name: KUBERNETES_SERVICE_HOST  # Intentionally disable its connection to Kubernetes to make it fail in a known way
+          value: ""
+        - name: KUBERNETES_SERVICE_PORT  # Intentionally disable its connection to Kubernetes to make it fail in a known way
+          value: ""
+      volumeMounts:
         - name: config
-          configMap:
-            name: {{ include "config-validator.fullname" . | quote }}
+          mountPath: /etc/agent
+  volumes:
+    - name: config
+      configMap:
+        name: {{ include "config-validator.fullname" . | quote }}
 ---
 apiVersion: v1
 kind: ConfigMap

--- a/examples/agent-autoscaling-and-storage/output.yaml
+++ b/examples/agent-autoscaling-and-storage/output.yaml
@@ -46012,6 +46012,77 @@ data:
       ]
     }
 ---
+# Source: k8s-monitoring/templates/hooks/validate-configuration.yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "validate-k8smon-k8s-monitoring"
+  namespace: default
+  labels:
+    app.kubernetes.io/managed-by: "Helm"
+    app.kubernetes.io/instance: "k8smon"
+    app.kubernetes.io/version: 2.0.2
+    helm.sh/chart: "k8s-monitoring-0.12.0"
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "-5"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+spec:
+  restartPolicy: Never
+  nodeSelector:
+        kubernetes.io/os: linux
+  containers:
+    - name: grafana-agent
+      image: "docker.io/grafana/agent:v0.40.3"
+      command:
+      - bash
+      - -c
+      - |
+        echo Validating Grafana Agent config file
+        if ! grafana-agent fmt /etc/agent/config.river > /dev/null; then
+          exit 1
+        fi
+        output=$(grafana-agent run "/etc/agent/config.river" 2>&1)
+        if ! echo "${output}" | grep "KUBERNETES_SERVICE_HOST and KUBERNETES_SERVICE_PORT must be defined" >/dev/null; then
+          echo "${output}"
+          exit 1
+        fi
+        echo "Grafana Agent config file is valid"
+        echo Validating Grafana Agent for Events config file
+        if ! grafana-agent fmt /etc/agent/events.river > /dev/null; then
+          exit 1
+        fi
+        output=$(grafana-agent run "/etc/agent/events.river" 2>&1)
+        if ! echo "${output}" | grep "KUBERNETES_SERVICE_HOST and KUBERNETES_SERVICE_PORT must be defined" >/dev/null; then
+          echo "${output}"
+          exit 1
+        fi
+        echo "Grafana Agent for Events config file is valid"
+        echo Validating Grafana Agent for Logs config file
+        if ! grafana-agent fmt /etc/agent/logs.river > /dev/null; then
+          exit 1
+        fi
+        output=$(grafana-agent run "/etc/agent/logs.river" 2>&1)
+        if ! echo "${output}" | grep "KUBERNETES_SERVICE_HOST and KUBERNETES_SERVICE_PORT must be defined" >/dev/null; then
+          echo "${output}"
+          exit 1
+        fi
+        echo "Grafana Agent for Logs config file is valid"
+      env:
+        - name: AGENT_MODE
+          value: flow
+        - name: KUBERNETES_SERVICE_HOST  # Intentionally disable its connection to Kubernetes to make it fail in a known way
+          value: ""
+        - name: KUBERNETES_SERVICE_PORT  # Intentionally disable its connection to Kubernetes to make it fail in a known way
+          value: ""
+      volumeMounts:
+        - name: config
+          mountPath: /etc/agent
+  volumes:
+    - name: config
+      configMap:
+        name: "validate-k8smon-k8s-monitoring"
+---
 # Source: k8s-monitoring/templates/tests/test.yaml
 apiVersion: v1
 kind: Pod
@@ -46038,64 +46109,6 @@ spec:
       env:
         - name: AGENT_HOST
           value: k8smon-grafana-agent.default.svc
----
-# Source: k8s-monitoring/templates/hooks/validate-configuration.yaml
-apiVersion: batch/v1
-kind: Job
-metadata:
-  name: "validate-k8smon-k8s-monitoring"
-  namespace: default
-  labels:
-    app.kubernetes.io/managed-by: "Helm"
-    app.kubernetes.io/instance: "k8smon"
-    app.kubernetes.io/version: 2.0.2
-    helm.sh/chart: "k8s-monitoring-0.12.0"
-  annotations:
-    "helm.sh/hook": pre-install,pre-upgrade
-    "helm.sh/hook-weight": "-5"
-    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
-spec:
-  backoffLimit: 0
-  template:
-    metadata:
-      name: "validate-k8smon-k8s-monitoring"
-      labels:
-        app.kubernetes.io/managed-by: "Helm"
-        app.kubernetes.io/instance: "k8smon"
-        helm.sh/chart: "k8s-monitoring-0.12.0"
-    spec:
-      restartPolicy: Never
-      nodeSelector:
-        kubernetes.io/os: linux
-      containers:
-        - name: grafana-agent
-          image: "docker.io/grafana/agent:v0.40.3"
-          command:
-          - bash
-          - -ec
-          - |
-            echo Validating Grafana Agent config file
-            if grafana-agent fmt /etc/agent/config.river > /dev/null; then
-              echo "Grafana Agent config file is valid"
-            fi
-            echo Validating Grafana Agent for Events config file
-            if grafana-agent fmt /etc/agent/events.river > /dev/null; then
-              echo "Grafana Agent for Events config file is valid"
-            fi
-            echo Validating Grafana Agent for Logs config file
-            if grafana-agent fmt /etc/agent/logs.river > /dev/null; then
-              echo "Grafana Agent for Logs config file is valid"
-            fi
-          env:
-            - name: AGENT_MODE
-              value: flow
-          volumeMounts:
-            - name: config
-              mountPath: /etc/agent
-      volumes:
-        - name: config
-          configMap:
-            name: "validate-k8smon-k8s-monitoring"
 ---
 # Source: k8s-monitoring/templates/tests/test.yaml
 apiVersion: batch/v1

--- a/examples/control-plane-metrics/output.yaml
+++ b/examples/control-plane-metrics/output.yaml
@@ -46281,6 +46281,77 @@ data:
       ]
     }
 ---
+# Source: k8s-monitoring/templates/hooks/validate-configuration.yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "validate-k8smon-k8s-monitoring"
+  namespace: default
+  labels:
+    app.kubernetes.io/managed-by: "Helm"
+    app.kubernetes.io/instance: "k8smon"
+    app.kubernetes.io/version: 2.0.2
+    helm.sh/chart: "k8s-monitoring-0.12.0"
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "-5"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+spec:
+  restartPolicy: Never
+  nodeSelector:
+        kubernetes.io/os: linux
+  containers:
+    - name: grafana-agent
+      image: "docker.io/grafana/agent:v0.40.3"
+      command:
+      - bash
+      - -c
+      - |
+        echo Validating Grafana Agent config file
+        if ! grafana-agent fmt /etc/agent/config.river > /dev/null; then
+          exit 1
+        fi
+        output=$(grafana-agent run "/etc/agent/config.river" 2>&1)
+        if ! echo "${output}" | grep "KUBERNETES_SERVICE_HOST and KUBERNETES_SERVICE_PORT must be defined" >/dev/null; then
+          echo "${output}"
+          exit 1
+        fi
+        echo "Grafana Agent config file is valid"
+        echo Validating Grafana Agent for Events config file
+        if ! grafana-agent fmt /etc/agent/events.river > /dev/null; then
+          exit 1
+        fi
+        output=$(grafana-agent run "/etc/agent/events.river" 2>&1)
+        if ! echo "${output}" | grep "KUBERNETES_SERVICE_HOST and KUBERNETES_SERVICE_PORT must be defined" >/dev/null; then
+          echo "${output}"
+          exit 1
+        fi
+        echo "Grafana Agent for Events config file is valid"
+        echo Validating Grafana Agent for Logs config file
+        if ! grafana-agent fmt /etc/agent/logs.river > /dev/null; then
+          exit 1
+        fi
+        output=$(grafana-agent run "/etc/agent/logs.river" 2>&1)
+        if ! echo "${output}" | grep "KUBERNETES_SERVICE_HOST and KUBERNETES_SERVICE_PORT must be defined" >/dev/null; then
+          echo "${output}"
+          exit 1
+        fi
+        echo "Grafana Agent for Logs config file is valid"
+      env:
+        - name: AGENT_MODE
+          value: flow
+        - name: KUBERNETES_SERVICE_HOST  # Intentionally disable its connection to Kubernetes to make it fail in a known way
+          value: ""
+        - name: KUBERNETES_SERVICE_PORT  # Intentionally disable its connection to Kubernetes to make it fail in a known way
+          value: ""
+      volumeMounts:
+        - name: config
+          mountPath: /etc/agent
+  volumes:
+    - name: config
+      configMap:
+        name: "validate-k8smon-k8s-monitoring"
+---
 # Source: k8s-monitoring/templates/tests/test.yaml
 apiVersion: v1
 kind: Pod
@@ -46307,64 +46378,6 @@ spec:
       env:
         - name: AGENT_HOST
           value: k8smon-grafana-agent.default.svc
----
-# Source: k8s-monitoring/templates/hooks/validate-configuration.yaml
-apiVersion: batch/v1
-kind: Job
-metadata:
-  name: "validate-k8smon-k8s-monitoring"
-  namespace: default
-  labels:
-    app.kubernetes.io/managed-by: "Helm"
-    app.kubernetes.io/instance: "k8smon"
-    app.kubernetes.io/version: 2.0.2
-    helm.sh/chart: "k8s-monitoring-0.12.0"
-  annotations:
-    "helm.sh/hook": pre-install,pre-upgrade
-    "helm.sh/hook-weight": "-5"
-    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
-spec:
-  backoffLimit: 0
-  template:
-    metadata:
-      name: "validate-k8smon-k8s-monitoring"
-      labels:
-        app.kubernetes.io/managed-by: "Helm"
-        app.kubernetes.io/instance: "k8smon"
-        helm.sh/chart: "k8s-monitoring-0.12.0"
-    spec:
-      restartPolicy: Never
-      nodeSelector:
-        kubernetes.io/os: linux
-      containers:
-        - name: grafana-agent
-          image: "docker.io/grafana/agent:v0.40.3"
-          command:
-          - bash
-          - -ec
-          - |
-            echo Validating Grafana Agent config file
-            if grafana-agent fmt /etc/agent/config.river > /dev/null; then
-              echo "Grafana Agent config file is valid"
-            fi
-            echo Validating Grafana Agent for Events config file
-            if grafana-agent fmt /etc/agent/events.river > /dev/null; then
-              echo "Grafana Agent for Events config file is valid"
-            fi
-            echo Validating Grafana Agent for Logs config file
-            if grafana-agent fmt /etc/agent/logs.river > /dev/null; then
-              echo "Grafana Agent for Logs config file is valid"
-            fi
-          env:
-            - name: AGENT_MODE
-              value: flow
-          volumeMounts:
-            - name: config
-              mountPath: /etc/agent
-      volumes:
-        - name: config
-          configMap:
-            name: "validate-k8smon-k8s-monitoring"
 ---
 # Source: k8s-monitoring/templates/tests/test.yaml
 apiVersion: batch/v1

--- a/examples/custom-config/output.yaml
+++ b/examples/custom-config/output.yaml
@@ -46104,6 +46104,77 @@ data:
       ]
     }
 ---
+# Source: k8s-monitoring/templates/hooks/validate-configuration.yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "validate-k8smon-k8s-monitoring"
+  namespace: default
+  labels:
+    app.kubernetes.io/managed-by: "Helm"
+    app.kubernetes.io/instance: "k8smon"
+    app.kubernetes.io/version: 2.0.2
+    helm.sh/chart: "k8s-monitoring-0.12.0"
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "-5"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+spec:
+  restartPolicy: Never
+  nodeSelector:
+        kubernetes.io/os: linux
+  containers:
+    - name: grafana-agent
+      image: "docker.io/grafana/agent:v0.40.3"
+      command:
+      - bash
+      - -c
+      - |
+        echo Validating Grafana Agent config file
+        if ! grafana-agent fmt /etc/agent/config.river > /dev/null; then
+          exit 1
+        fi
+        output=$(grafana-agent run "/etc/agent/config.river" 2>&1)
+        if ! echo "${output}" | grep "KUBERNETES_SERVICE_HOST and KUBERNETES_SERVICE_PORT must be defined" >/dev/null; then
+          echo "${output}"
+          exit 1
+        fi
+        echo "Grafana Agent config file is valid"
+        echo Validating Grafana Agent for Events config file
+        if ! grafana-agent fmt /etc/agent/events.river > /dev/null; then
+          exit 1
+        fi
+        output=$(grafana-agent run "/etc/agent/events.river" 2>&1)
+        if ! echo "${output}" | grep "KUBERNETES_SERVICE_HOST and KUBERNETES_SERVICE_PORT must be defined" >/dev/null; then
+          echo "${output}"
+          exit 1
+        fi
+        echo "Grafana Agent for Events config file is valid"
+        echo Validating Grafana Agent for Logs config file
+        if ! grafana-agent fmt /etc/agent/logs.river > /dev/null; then
+          exit 1
+        fi
+        output=$(grafana-agent run "/etc/agent/logs.river" 2>&1)
+        if ! echo "${output}" | grep "KUBERNETES_SERVICE_HOST and KUBERNETES_SERVICE_PORT must be defined" >/dev/null; then
+          echo "${output}"
+          exit 1
+        fi
+        echo "Grafana Agent for Logs config file is valid"
+      env:
+        - name: AGENT_MODE
+          value: flow
+        - name: KUBERNETES_SERVICE_HOST  # Intentionally disable its connection to Kubernetes to make it fail in a known way
+          value: ""
+        - name: KUBERNETES_SERVICE_PORT  # Intentionally disable its connection to Kubernetes to make it fail in a known way
+          value: ""
+      volumeMounts:
+        - name: config
+          mountPath: /etc/agent
+  volumes:
+    - name: config
+      configMap:
+        name: "validate-k8smon-k8s-monitoring"
+---
 # Source: k8s-monitoring/templates/tests/test.yaml
 apiVersion: v1
 kind: Pod
@@ -46130,64 +46201,6 @@ spec:
       env:
         - name: AGENT_HOST
           value: k8smon-grafana-agent.default.svc
----
-# Source: k8s-monitoring/templates/hooks/validate-configuration.yaml
-apiVersion: batch/v1
-kind: Job
-metadata:
-  name: "validate-k8smon-k8s-monitoring"
-  namespace: default
-  labels:
-    app.kubernetes.io/managed-by: "Helm"
-    app.kubernetes.io/instance: "k8smon"
-    app.kubernetes.io/version: 2.0.2
-    helm.sh/chart: "k8s-monitoring-0.12.0"
-  annotations:
-    "helm.sh/hook": pre-install,pre-upgrade
-    "helm.sh/hook-weight": "-5"
-    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
-spec:
-  backoffLimit: 0
-  template:
-    metadata:
-      name: "validate-k8smon-k8s-monitoring"
-      labels:
-        app.kubernetes.io/managed-by: "Helm"
-        app.kubernetes.io/instance: "k8smon"
-        helm.sh/chart: "k8s-monitoring-0.12.0"
-    spec:
-      restartPolicy: Never
-      nodeSelector:
-        kubernetes.io/os: linux
-      containers:
-        - name: grafana-agent
-          image: "docker.io/grafana/agent:v0.40.3"
-          command:
-          - bash
-          - -ec
-          - |
-            echo Validating Grafana Agent config file
-            if grafana-agent fmt /etc/agent/config.river > /dev/null; then
-              echo "Grafana Agent config file is valid"
-            fi
-            echo Validating Grafana Agent for Events config file
-            if grafana-agent fmt /etc/agent/events.river > /dev/null; then
-              echo "Grafana Agent for Events config file is valid"
-            fi
-            echo Validating Grafana Agent for Logs config file
-            if grafana-agent fmt /etc/agent/logs.river > /dev/null; then
-              echo "Grafana Agent for Logs config file is valid"
-            fi
-          env:
-            - name: AGENT_MODE
-              value: flow
-          volumeMounts:
-            - name: config
-              mountPath: /etc/agent
-      volumes:
-        - name: config
-          configMap:
-            name: "validate-k8smon-k8s-monitoring"
 ---
 # Source: k8s-monitoring/templates/tests/test.yaml
 apiVersion: batch/v1

--- a/examples/custom-metrics-tuning/output.yaml
+++ b/examples/custom-metrics-tuning/output.yaml
@@ -44897,6 +44897,57 @@ data:
       ]
     }
 ---
+# Source: k8s-monitoring/templates/hooks/validate-configuration.yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "validate-k8smon-k8s-monitoring"
+  namespace: default
+  labels:
+    app.kubernetes.io/managed-by: "Helm"
+    app.kubernetes.io/instance: "k8smon"
+    app.kubernetes.io/version: 2.0.2
+    helm.sh/chart: "k8s-monitoring-0.12.0"
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "-5"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+spec:
+  restartPolicy: Never
+  nodeSelector:
+        kubernetes.io/os: linux
+  containers:
+    - name: grafana-agent
+      image: "docker.io/grafana/agent:v0.40.3"
+      command:
+      - bash
+      - -c
+      - |
+        echo Validating Grafana Agent config file
+        if ! grafana-agent fmt /etc/agent/config.river > /dev/null; then
+          exit 1
+        fi
+        output=$(grafana-agent run "/etc/agent/config.river" 2>&1)
+        if ! echo "${output}" | grep "KUBERNETES_SERVICE_HOST and KUBERNETES_SERVICE_PORT must be defined" >/dev/null; then
+          echo "${output}"
+          exit 1
+        fi
+        echo "Grafana Agent config file is valid"
+      env:
+        - name: AGENT_MODE
+          value: flow
+        - name: KUBERNETES_SERVICE_HOST  # Intentionally disable its connection to Kubernetes to make it fail in a known way
+          value: ""
+        - name: KUBERNETES_SERVICE_PORT  # Intentionally disable its connection to Kubernetes to make it fail in a known way
+          value: ""
+      volumeMounts:
+        - name: config
+          mountPath: /etc/agent
+  volumes:
+    - name: config
+      configMap:
+        name: "validate-k8smon-k8s-monitoring"
+---
 # Source: k8s-monitoring/templates/tests/test.yaml
 apiVersion: v1
 kind: Pod
@@ -44923,56 +44974,6 @@ spec:
       env:
         - name: AGENT_HOST
           value: k8smon-grafana-agent.default.svc
----
-# Source: k8s-monitoring/templates/hooks/validate-configuration.yaml
-apiVersion: batch/v1
-kind: Job
-metadata:
-  name: "validate-k8smon-k8s-monitoring"
-  namespace: default
-  labels:
-    app.kubernetes.io/managed-by: "Helm"
-    app.kubernetes.io/instance: "k8smon"
-    app.kubernetes.io/version: 2.0.2
-    helm.sh/chart: "k8s-monitoring-0.12.0"
-  annotations:
-    "helm.sh/hook": pre-install,pre-upgrade
-    "helm.sh/hook-weight": "-5"
-    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
-spec:
-  backoffLimit: 0
-  template:
-    metadata:
-      name: "validate-k8smon-k8s-monitoring"
-      labels:
-        app.kubernetes.io/managed-by: "Helm"
-        app.kubernetes.io/instance: "k8smon"
-        helm.sh/chart: "k8s-monitoring-0.12.0"
-    spec:
-      restartPolicy: Never
-      nodeSelector:
-        kubernetes.io/os: linux
-      containers:
-        - name: grafana-agent
-          image: "docker.io/grafana/agent:v0.40.3"
-          command:
-          - bash
-          - -ec
-          - |
-            echo Validating Grafana Agent config file
-            if grafana-agent fmt /etc/agent/config.river > /dev/null; then
-              echo "Grafana Agent config file is valid"
-            fi
-          env:
-            - name: AGENT_MODE
-              value: flow
-          volumeMounts:
-            - name: config
-              mountPath: /etc/agent
-      volumes:
-        - name: config
-          configMap:
-            name: "validate-k8smon-k8s-monitoring"
 ---
 # Source: k8s-monitoring/templates/tests/test.yaml
 apiVersion: batch/v1

--- a/examples/custom-pricing/output.yaml
+++ b/examples/custom-pricing/output.yaml
@@ -45991,6 +45991,77 @@ data:
       ]
     }
 ---
+# Source: k8s-monitoring/templates/hooks/validate-configuration.yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "validate-k8smon-k8s-monitoring"
+  namespace: default
+  labels:
+    app.kubernetes.io/managed-by: "Helm"
+    app.kubernetes.io/instance: "k8smon"
+    app.kubernetes.io/version: 2.0.2
+    helm.sh/chart: "k8s-monitoring-0.12.0"
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "-5"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+spec:
+  restartPolicy: Never
+  nodeSelector:
+        kubernetes.io/os: linux
+  containers:
+    - name: grafana-agent
+      image: "docker.io/grafana/agent:v0.40.3"
+      command:
+      - bash
+      - -c
+      - |
+        echo Validating Grafana Agent config file
+        if ! grafana-agent fmt /etc/agent/config.river > /dev/null; then
+          exit 1
+        fi
+        output=$(grafana-agent run "/etc/agent/config.river" 2>&1)
+        if ! echo "${output}" | grep "KUBERNETES_SERVICE_HOST and KUBERNETES_SERVICE_PORT must be defined" >/dev/null; then
+          echo "${output}"
+          exit 1
+        fi
+        echo "Grafana Agent config file is valid"
+        echo Validating Grafana Agent for Events config file
+        if ! grafana-agent fmt /etc/agent/events.river > /dev/null; then
+          exit 1
+        fi
+        output=$(grafana-agent run "/etc/agent/events.river" 2>&1)
+        if ! echo "${output}" | grep "KUBERNETES_SERVICE_HOST and KUBERNETES_SERVICE_PORT must be defined" >/dev/null; then
+          echo "${output}"
+          exit 1
+        fi
+        echo "Grafana Agent for Events config file is valid"
+        echo Validating Grafana Agent for Logs config file
+        if ! grafana-agent fmt /etc/agent/logs.river > /dev/null; then
+          exit 1
+        fi
+        output=$(grafana-agent run "/etc/agent/logs.river" 2>&1)
+        if ! echo "${output}" | grep "KUBERNETES_SERVICE_HOST and KUBERNETES_SERVICE_PORT must be defined" >/dev/null; then
+          echo "${output}"
+          exit 1
+        fi
+        echo "Grafana Agent for Logs config file is valid"
+      env:
+        - name: AGENT_MODE
+          value: flow
+        - name: KUBERNETES_SERVICE_HOST  # Intentionally disable its connection to Kubernetes to make it fail in a known way
+          value: ""
+        - name: KUBERNETES_SERVICE_PORT  # Intentionally disable its connection to Kubernetes to make it fail in a known way
+          value: ""
+      volumeMounts:
+        - name: config
+          mountPath: /etc/agent
+  volumes:
+    - name: config
+      configMap:
+        name: "validate-k8smon-k8s-monitoring"
+---
 # Source: k8s-monitoring/templates/tests/test.yaml
 apiVersion: v1
 kind: Pod
@@ -46017,64 +46088,6 @@ spec:
       env:
         - name: AGENT_HOST
           value: k8smon-grafana-agent.default.svc
----
-# Source: k8s-monitoring/templates/hooks/validate-configuration.yaml
-apiVersion: batch/v1
-kind: Job
-metadata:
-  name: "validate-k8smon-k8s-monitoring"
-  namespace: default
-  labels:
-    app.kubernetes.io/managed-by: "Helm"
-    app.kubernetes.io/instance: "k8smon"
-    app.kubernetes.io/version: 2.0.2
-    helm.sh/chart: "k8s-monitoring-0.12.0"
-  annotations:
-    "helm.sh/hook": pre-install,pre-upgrade
-    "helm.sh/hook-weight": "-5"
-    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
-spec:
-  backoffLimit: 0
-  template:
-    metadata:
-      name: "validate-k8smon-k8s-monitoring"
-      labels:
-        app.kubernetes.io/managed-by: "Helm"
-        app.kubernetes.io/instance: "k8smon"
-        helm.sh/chart: "k8s-monitoring-0.12.0"
-    spec:
-      restartPolicy: Never
-      nodeSelector:
-        kubernetes.io/os: linux
-      containers:
-        - name: grafana-agent
-          image: "docker.io/grafana/agent:v0.40.3"
-          command:
-          - bash
-          - -ec
-          - |
-            echo Validating Grafana Agent config file
-            if grafana-agent fmt /etc/agent/config.river > /dev/null; then
-              echo "Grafana Agent config file is valid"
-            fi
-            echo Validating Grafana Agent for Events config file
-            if grafana-agent fmt /etc/agent/events.river > /dev/null; then
-              echo "Grafana Agent for Events config file is valid"
-            fi
-            echo Validating Grafana Agent for Logs config file
-            if grafana-agent fmt /etc/agent/logs.river > /dev/null; then
-              echo "Grafana Agent for Logs config file is valid"
-            fi
-          env:
-            - name: AGENT_MODE
-              value: flow
-          volumeMounts:
-            - name: config
-              mountPath: /etc/agent
-      volumes:
-        - name: config
-          configMap:
-            name: "validate-k8smon-k8s-monitoring"
 ---
 # Source: k8s-monitoring/templates/tests/test.yaml
 apiVersion: batch/v1

--- a/examples/default-values/output.yaml
+++ b/examples/default-values/output.yaml
@@ -45960,6 +45960,77 @@ data:
       ]
     }
 ---
+# Source: k8s-monitoring/templates/hooks/validate-configuration.yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "validate-k8smon-k8s-monitoring"
+  namespace: default
+  labels:
+    app.kubernetes.io/managed-by: "Helm"
+    app.kubernetes.io/instance: "k8smon"
+    app.kubernetes.io/version: 2.0.2
+    helm.sh/chart: "k8s-monitoring-0.12.0"
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "-5"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+spec:
+  restartPolicy: Never
+  nodeSelector:
+        kubernetes.io/os: linux
+  containers:
+    - name: grafana-agent
+      image: "docker.io/grafana/agent:v0.40.3"
+      command:
+      - bash
+      - -c
+      - |
+        echo Validating Grafana Agent config file
+        if ! grafana-agent fmt /etc/agent/config.river > /dev/null; then
+          exit 1
+        fi
+        output=$(grafana-agent run "/etc/agent/config.river" 2>&1)
+        if ! echo "${output}" | grep "KUBERNETES_SERVICE_HOST and KUBERNETES_SERVICE_PORT must be defined" >/dev/null; then
+          echo "${output}"
+          exit 1
+        fi
+        echo "Grafana Agent config file is valid"
+        echo Validating Grafana Agent for Events config file
+        if ! grafana-agent fmt /etc/agent/events.river > /dev/null; then
+          exit 1
+        fi
+        output=$(grafana-agent run "/etc/agent/events.river" 2>&1)
+        if ! echo "${output}" | grep "KUBERNETES_SERVICE_HOST and KUBERNETES_SERVICE_PORT must be defined" >/dev/null; then
+          echo "${output}"
+          exit 1
+        fi
+        echo "Grafana Agent for Events config file is valid"
+        echo Validating Grafana Agent for Logs config file
+        if ! grafana-agent fmt /etc/agent/logs.river > /dev/null; then
+          exit 1
+        fi
+        output=$(grafana-agent run "/etc/agent/logs.river" 2>&1)
+        if ! echo "${output}" | grep "KUBERNETES_SERVICE_HOST and KUBERNETES_SERVICE_PORT must be defined" >/dev/null; then
+          echo "${output}"
+          exit 1
+        fi
+        echo "Grafana Agent for Logs config file is valid"
+      env:
+        - name: AGENT_MODE
+          value: flow
+        - name: KUBERNETES_SERVICE_HOST  # Intentionally disable its connection to Kubernetes to make it fail in a known way
+          value: ""
+        - name: KUBERNETES_SERVICE_PORT  # Intentionally disable its connection to Kubernetes to make it fail in a known way
+          value: ""
+      volumeMounts:
+        - name: config
+          mountPath: /etc/agent
+  volumes:
+    - name: config
+      configMap:
+        name: "validate-k8smon-k8s-monitoring"
+---
 # Source: k8s-monitoring/templates/tests/test.yaml
 apiVersion: v1
 kind: Pod
@@ -45986,64 +46057,6 @@ spec:
       env:
         - name: AGENT_HOST
           value: k8smon-grafana-agent.default.svc
----
-# Source: k8s-monitoring/templates/hooks/validate-configuration.yaml
-apiVersion: batch/v1
-kind: Job
-metadata:
-  name: "validate-k8smon-k8s-monitoring"
-  namespace: default
-  labels:
-    app.kubernetes.io/managed-by: "Helm"
-    app.kubernetes.io/instance: "k8smon"
-    app.kubernetes.io/version: 2.0.2
-    helm.sh/chart: "k8s-monitoring-0.12.0"
-  annotations:
-    "helm.sh/hook": pre-install,pre-upgrade
-    "helm.sh/hook-weight": "-5"
-    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
-spec:
-  backoffLimit: 0
-  template:
-    metadata:
-      name: "validate-k8smon-k8s-monitoring"
-      labels:
-        app.kubernetes.io/managed-by: "Helm"
-        app.kubernetes.io/instance: "k8smon"
-        helm.sh/chart: "k8s-monitoring-0.12.0"
-    spec:
-      restartPolicy: Never
-      nodeSelector:
-        kubernetes.io/os: linux
-      containers:
-        - name: grafana-agent
-          image: "docker.io/grafana/agent:v0.40.3"
-          command:
-          - bash
-          - -ec
-          - |
-            echo Validating Grafana Agent config file
-            if grafana-agent fmt /etc/agent/config.river > /dev/null; then
-              echo "Grafana Agent config file is valid"
-            fi
-            echo Validating Grafana Agent for Events config file
-            if grafana-agent fmt /etc/agent/events.river > /dev/null; then
-              echo "Grafana Agent for Events config file is valid"
-            fi
-            echo Validating Grafana Agent for Logs config file
-            if grafana-agent fmt /etc/agent/logs.river > /dev/null; then
-              echo "Grafana Agent for Logs config file is valid"
-            fi
-          env:
-            - name: AGENT_MODE
-              value: flow
-          volumeMounts:
-            - name: config
-              mountPath: /etc/agent
-      volumes:
-        - name: config
-          configMap:
-            name: "validate-k8smon-k8s-monitoring"
 ---
 # Source: k8s-monitoring/templates/tests/test.yaml
 apiVersion: batch/v1

--- a/examples/eks-fargate/output.yaml
+++ b/examples/eks-fargate/output.yaml
@@ -45670,6 +45670,77 @@ data:
       ]
     }
 ---
+# Source: k8s-monitoring/templates/hooks/validate-configuration.yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "validate-k8smon-k8s-monitoring"
+  namespace: default
+  labels:
+    app.kubernetes.io/managed-by: "Helm"
+    app.kubernetes.io/instance: "k8smon"
+    app.kubernetes.io/version: 2.0.2
+    helm.sh/chart: "k8s-monitoring-0.12.0"
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "-5"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+spec:
+  restartPolicy: Never
+  nodeSelector:
+        kubernetes.io/os: linux
+  containers:
+    - name: grafana-agent
+      image: "docker.io/grafana/agent:v0.40.3"
+      command:
+      - bash
+      - -c
+      - |
+        echo Validating Grafana Agent config file
+        if ! grafana-agent fmt /etc/agent/config.river > /dev/null; then
+          exit 1
+        fi
+        output=$(grafana-agent run "/etc/agent/config.river" 2>&1)
+        if ! echo "${output}" | grep "KUBERNETES_SERVICE_HOST and KUBERNETES_SERVICE_PORT must be defined" >/dev/null; then
+          echo "${output}"
+          exit 1
+        fi
+        echo "Grafana Agent config file is valid"
+        echo Validating Grafana Agent for Events config file
+        if ! grafana-agent fmt /etc/agent/events.river > /dev/null; then
+          exit 1
+        fi
+        output=$(grafana-agent run "/etc/agent/events.river" 2>&1)
+        if ! echo "${output}" | grep "KUBERNETES_SERVICE_HOST and KUBERNETES_SERVICE_PORT must be defined" >/dev/null; then
+          echo "${output}"
+          exit 1
+        fi
+        echo "Grafana Agent for Events config file is valid"
+        echo Validating Grafana Agent for Logs config file
+        if ! grafana-agent fmt /etc/agent/logs.river > /dev/null; then
+          exit 1
+        fi
+        output=$(grafana-agent run "/etc/agent/logs.river" 2>&1)
+        if ! echo "${output}" | grep "KUBERNETES_SERVICE_HOST and KUBERNETES_SERVICE_PORT must be defined" >/dev/null; then
+          echo "${output}"
+          exit 1
+        fi
+        echo "Grafana Agent for Logs config file is valid"
+      env:
+        - name: AGENT_MODE
+          value: flow
+        - name: KUBERNETES_SERVICE_HOST  # Intentionally disable its connection to Kubernetes to make it fail in a known way
+          value: ""
+        - name: KUBERNETES_SERVICE_PORT  # Intentionally disable its connection to Kubernetes to make it fail in a known way
+          value: ""
+      volumeMounts:
+        - name: config
+          mountPath: /etc/agent
+  volumes:
+    - name: config
+      configMap:
+        name: "validate-k8smon-k8s-monitoring"
+---
 # Source: k8s-monitoring/templates/tests/test.yaml
 apiVersion: v1
 kind: Pod
@@ -45696,64 +45767,6 @@ spec:
       env:
         - name: AGENT_HOST
           value: k8smon-grafana-agent.default.svc
----
-# Source: k8s-monitoring/templates/hooks/validate-configuration.yaml
-apiVersion: batch/v1
-kind: Job
-metadata:
-  name: "validate-k8smon-k8s-monitoring"
-  namespace: default
-  labels:
-    app.kubernetes.io/managed-by: "Helm"
-    app.kubernetes.io/instance: "k8smon"
-    app.kubernetes.io/version: 2.0.2
-    helm.sh/chart: "k8s-monitoring-0.12.0"
-  annotations:
-    "helm.sh/hook": pre-install,pre-upgrade
-    "helm.sh/hook-weight": "-5"
-    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
-spec:
-  backoffLimit: 0
-  template:
-    metadata:
-      name: "validate-k8smon-k8s-monitoring"
-      labels:
-        app.kubernetes.io/managed-by: "Helm"
-        app.kubernetes.io/instance: "k8smon"
-        helm.sh/chart: "k8s-monitoring-0.12.0"
-    spec:
-      restartPolicy: Never
-      nodeSelector:
-        kubernetes.io/os: linux
-      containers:
-        - name: grafana-agent
-          image: "docker.io/grafana/agent:v0.40.3"
-          command:
-          - bash
-          - -ec
-          - |
-            echo Validating Grafana Agent config file
-            if grafana-agent fmt /etc/agent/config.river > /dev/null; then
-              echo "Grafana Agent config file is valid"
-            fi
-            echo Validating Grafana Agent for Events config file
-            if grafana-agent fmt /etc/agent/events.river > /dev/null; then
-              echo "Grafana Agent for Events config file is valid"
-            fi
-            echo Validating Grafana Agent for Logs config file
-            if grafana-agent fmt /etc/agent/logs.river > /dev/null; then
-              echo "Grafana Agent for Logs config file is valid"
-            fi
-          env:
-            - name: AGENT_MODE
-              value: flow
-          volumeMounts:
-            - name: config
-              mountPath: /etc/agent
-      volumes:
-        - name: config
-          configMap:
-            name: "validate-k8smon-k8s-monitoring"
 ---
 # Source: k8s-monitoring/templates/tests/test.yaml
 apiVersion: batch/v1

--- a/examples/extra-rules/output.yaml
+++ b/examples/extra-rules/output.yaml
@@ -46149,6 +46149,77 @@ data:
       ]
     }
 ---
+# Source: k8s-monitoring/templates/hooks/validate-configuration.yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "validate-k8smon-k8s-monitoring"
+  namespace: default
+  labels:
+    app.kubernetes.io/managed-by: "Helm"
+    app.kubernetes.io/instance: "k8smon"
+    app.kubernetes.io/version: 2.0.2
+    helm.sh/chart: "k8s-monitoring-0.12.0"
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "-5"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+spec:
+  restartPolicy: Never
+  nodeSelector:
+        kubernetes.io/os: linux
+  containers:
+    - name: grafana-agent
+      image: "docker.io/grafana/agent:v0.40.3"
+      command:
+      - bash
+      - -c
+      - |
+        echo Validating Grafana Agent config file
+        if ! grafana-agent fmt /etc/agent/config.river > /dev/null; then
+          exit 1
+        fi
+        output=$(grafana-agent run "/etc/agent/config.river" 2>&1)
+        if ! echo "${output}" | grep "KUBERNETES_SERVICE_HOST and KUBERNETES_SERVICE_PORT must be defined" >/dev/null; then
+          echo "${output}"
+          exit 1
+        fi
+        echo "Grafana Agent config file is valid"
+        echo Validating Grafana Agent for Events config file
+        if ! grafana-agent fmt /etc/agent/events.river > /dev/null; then
+          exit 1
+        fi
+        output=$(grafana-agent run "/etc/agent/events.river" 2>&1)
+        if ! echo "${output}" | grep "KUBERNETES_SERVICE_HOST and KUBERNETES_SERVICE_PORT must be defined" >/dev/null; then
+          echo "${output}"
+          exit 1
+        fi
+        echo "Grafana Agent for Events config file is valid"
+        echo Validating Grafana Agent for Logs config file
+        if ! grafana-agent fmt /etc/agent/logs.river > /dev/null; then
+          exit 1
+        fi
+        output=$(grafana-agent run "/etc/agent/logs.river" 2>&1)
+        if ! echo "${output}" | grep "KUBERNETES_SERVICE_HOST and KUBERNETES_SERVICE_PORT must be defined" >/dev/null; then
+          echo "${output}"
+          exit 1
+        fi
+        echo "Grafana Agent for Logs config file is valid"
+      env:
+        - name: AGENT_MODE
+          value: flow
+        - name: KUBERNETES_SERVICE_HOST  # Intentionally disable its connection to Kubernetes to make it fail in a known way
+          value: ""
+        - name: KUBERNETES_SERVICE_PORT  # Intentionally disable its connection to Kubernetes to make it fail in a known way
+          value: ""
+      volumeMounts:
+        - name: config
+          mountPath: /etc/agent
+  volumes:
+    - name: config
+      configMap:
+        name: "validate-k8smon-k8s-monitoring"
+---
 # Source: k8s-monitoring/templates/tests/test.yaml
 apiVersion: v1
 kind: Pod
@@ -46175,64 +46246,6 @@ spec:
       env:
         - name: AGENT_HOST
           value: k8smon-grafana-agent.default.svc
----
-# Source: k8s-monitoring/templates/hooks/validate-configuration.yaml
-apiVersion: batch/v1
-kind: Job
-metadata:
-  name: "validate-k8smon-k8s-monitoring"
-  namespace: default
-  labels:
-    app.kubernetes.io/managed-by: "Helm"
-    app.kubernetes.io/instance: "k8smon"
-    app.kubernetes.io/version: 2.0.2
-    helm.sh/chart: "k8s-monitoring-0.12.0"
-  annotations:
-    "helm.sh/hook": pre-install,pre-upgrade
-    "helm.sh/hook-weight": "-5"
-    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
-spec:
-  backoffLimit: 0
-  template:
-    metadata:
-      name: "validate-k8smon-k8s-monitoring"
-      labels:
-        app.kubernetes.io/managed-by: "Helm"
-        app.kubernetes.io/instance: "k8smon"
-        helm.sh/chart: "k8s-monitoring-0.12.0"
-    spec:
-      restartPolicy: Never
-      nodeSelector:
-        kubernetes.io/os: linux
-      containers:
-        - name: grafana-agent
-          image: "docker.io/grafana/agent:v0.40.3"
-          command:
-          - bash
-          - -ec
-          - |
-            echo Validating Grafana Agent config file
-            if grafana-agent fmt /etc/agent/config.river > /dev/null; then
-              echo "Grafana Agent config file is valid"
-            fi
-            echo Validating Grafana Agent for Events config file
-            if grafana-agent fmt /etc/agent/events.river > /dev/null; then
-              echo "Grafana Agent for Events config file is valid"
-            fi
-            echo Validating Grafana Agent for Logs config file
-            if grafana-agent fmt /etc/agent/logs.river > /dev/null; then
-              echo "Grafana Agent for Logs config file is valid"
-            fi
-          env:
-            - name: AGENT_MODE
-              value: flow
-          volumeMounts:
-            - name: config
-              mountPath: /etc/agent
-      volumes:
-        - name: config
-          configMap:
-            name: "validate-k8smon-k8s-monitoring"
 ---
 # Source: k8s-monitoring/templates/tests/test.yaml
 apiVersion: batch/v1

--- a/examples/gke-autopilot/output.yaml
+++ b/examples/gke-autopilot/output.yaml
@@ -45701,6 +45701,77 @@ data:
       ]
     }
 ---
+# Source: k8s-monitoring/templates/hooks/validate-configuration.yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "validate-k8smon-k8s-monitoring"
+  namespace: default
+  labels:
+    app.kubernetes.io/managed-by: "Helm"
+    app.kubernetes.io/instance: "k8smon"
+    app.kubernetes.io/version: 2.0.2
+    helm.sh/chart: "k8s-monitoring-0.12.0"
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "-5"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+spec:
+  restartPolicy: Never
+  nodeSelector:
+        kubernetes.io/os: linux
+  containers:
+    - name: grafana-agent
+      image: "docker.io/grafana/agent:v0.40.3"
+      command:
+      - bash
+      - -c
+      - |
+        echo Validating Grafana Agent config file
+        if ! grafana-agent fmt /etc/agent/config.river > /dev/null; then
+          exit 1
+        fi
+        output=$(grafana-agent run "/etc/agent/config.river" 2>&1)
+        if ! echo "${output}" | grep "KUBERNETES_SERVICE_HOST and KUBERNETES_SERVICE_PORT must be defined" >/dev/null; then
+          echo "${output}"
+          exit 1
+        fi
+        echo "Grafana Agent config file is valid"
+        echo Validating Grafana Agent for Events config file
+        if ! grafana-agent fmt /etc/agent/events.river > /dev/null; then
+          exit 1
+        fi
+        output=$(grafana-agent run "/etc/agent/events.river" 2>&1)
+        if ! echo "${output}" | grep "KUBERNETES_SERVICE_HOST and KUBERNETES_SERVICE_PORT must be defined" >/dev/null; then
+          echo "${output}"
+          exit 1
+        fi
+        echo "Grafana Agent for Events config file is valid"
+        echo Validating Grafana Agent for Logs config file
+        if ! grafana-agent fmt /etc/agent/logs.river > /dev/null; then
+          exit 1
+        fi
+        output=$(grafana-agent run "/etc/agent/logs.river" 2>&1)
+        if ! echo "${output}" | grep "KUBERNETES_SERVICE_HOST and KUBERNETES_SERVICE_PORT must be defined" >/dev/null; then
+          echo "${output}"
+          exit 1
+        fi
+        echo "Grafana Agent for Logs config file is valid"
+      env:
+        - name: AGENT_MODE
+          value: flow
+        - name: KUBERNETES_SERVICE_HOST  # Intentionally disable its connection to Kubernetes to make it fail in a known way
+          value: ""
+        - name: KUBERNETES_SERVICE_PORT  # Intentionally disable its connection to Kubernetes to make it fail in a known way
+          value: ""
+      volumeMounts:
+        - name: config
+          mountPath: /etc/agent
+  volumes:
+    - name: config
+      configMap:
+        name: "validate-k8smon-k8s-monitoring"
+---
 # Source: k8s-monitoring/templates/tests/test.yaml
 apiVersion: v1
 kind: Pod
@@ -45727,64 +45798,6 @@ spec:
       env:
         - name: AGENT_HOST
           value: k8smon-grafana-agent.default.svc
----
-# Source: k8s-monitoring/templates/hooks/validate-configuration.yaml
-apiVersion: batch/v1
-kind: Job
-metadata:
-  name: "validate-k8smon-k8s-monitoring"
-  namespace: default
-  labels:
-    app.kubernetes.io/managed-by: "Helm"
-    app.kubernetes.io/instance: "k8smon"
-    app.kubernetes.io/version: 2.0.2
-    helm.sh/chart: "k8s-monitoring-0.12.0"
-  annotations:
-    "helm.sh/hook": pre-install,pre-upgrade
-    "helm.sh/hook-weight": "-5"
-    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
-spec:
-  backoffLimit: 0
-  template:
-    metadata:
-      name: "validate-k8smon-k8s-monitoring"
-      labels:
-        app.kubernetes.io/managed-by: "Helm"
-        app.kubernetes.io/instance: "k8smon"
-        helm.sh/chart: "k8s-monitoring-0.12.0"
-    spec:
-      restartPolicy: Never
-      nodeSelector:
-        kubernetes.io/os: linux
-      containers:
-        - name: grafana-agent
-          image: "docker.io/grafana/agent:v0.40.3"
-          command:
-          - bash
-          - -ec
-          - |
-            echo Validating Grafana Agent config file
-            if grafana-agent fmt /etc/agent/config.river > /dev/null; then
-              echo "Grafana Agent config file is valid"
-            fi
-            echo Validating Grafana Agent for Events config file
-            if grafana-agent fmt /etc/agent/events.river > /dev/null; then
-              echo "Grafana Agent for Events config file is valid"
-            fi
-            echo Validating Grafana Agent for Logs config file
-            if grafana-agent fmt /etc/agent/logs.river > /dev/null; then
-              echo "Grafana Agent for Logs config file is valid"
-            fi
-          env:
-            - name: AGENT_MODE
-              value: flow
-          volumeMounts:
-            - name: config
-              mountPath: /etc/agent
-      volumes:
-        - name: config
-          configMap:
-            name: "validate-k8smon-k8s-monitoring"
 ---
 # Source: k8s-monitoring/templates/tests/test.yaml
 apiVersion: batch/v1

--- a/examples/ibm-cloud/output.yaml
+++ b/examples/ibm-cloud/output.yaml
@@ -45966,6 +45966,77 @@ data:
       ]
     }
 ---
+# Source: k8s-monitoring/templates/hooks/validate-configuration.yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "validate-k8smon-k8s-monitoring"
+  namespace: default
+  labels:
+    app.kubernetes.io/managed-by: "Helm"
+    app.kubernetes.io/instance: "k8smon"
+    app.kubernetes.io/version: 2.0.2
+    helm.sh/chart: "k8s-monitoring-0.12.0"
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "-5"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+spec:
+  restartPolicy: Never
+  nodeSelector:
+        kubernetes.io/os: linux
+  containers:
+    - name: grafana-agent
+      image: "docker.io/grafana/agent:v0.40.3"
+      command:
+      - bash
+      - -c
+      - |
+        echo Validating Grafana Agent config file
+        if ! grafana-agent fmt /etc/agent/config.river > /dev/null; then
+          exit 1
+        fi
+        output=$(grafana-agent run "/etc/agent/config.river" 2>&1)
+        if ! echo "${output}" | grep "KUBERNETES_SERVICE_HOST and KUBERNETES_SERVICE_PORT must be defined" >/dev/null; then
+          echo "${output}"
+          exit 1
+        fi
+        echo "Grafana Agent config file is valid"
+        echo Validating Grafana Agent for Events config file
+        if ! grafana-agent fmt /etc/agent/events.river > /dev/null; then
+          exit 1
+        fi
+        output=$(grafana-agent run "/etc/agent/events.river" 2>&1)
+        if ! echo "${output}" | grep "KUBERNETES_SERVICE_HOST and KUBERNETES_SERVICE_PORT must be defined" >/dev/null; then
+          echo "${output}"
+          exit 1
+        fi
+        echo "Grafana Agent for Events config file is valid"
+        echo Validating Grafana Agent for Logs config file
+        if ! grafana-agent fmt /etc/agent/logs.river > /dev/null; then
+          exit 1
+        fi
+        output=$(grafana-agent run "/etc/agent/logs.river" 2>&1)
+        if ! echo "${output}" | grep "KUBERNETES_SERVICE_HOST and KUBERNETES_SERVICE_PORT must be defined" >/dev/null; then
+          echo "${output}"
+          exit 1
+        fi
+        echo "Grafana Agent for Logs config file is valid"
+      env:
+        - name: AGENT_MODE
+          value: flow
+        - name: KUBERNETES_SERVICE_HOST  # Intentionally disable its connection to Kubernetes to make it fail in a known way
+          value: ""
+        - name: KUBERNETES_SERVICE_PORT  # Intentionally disable its connection to Kubernetes to make it fail in a known way
+          value: ""
+      volumeMounts:
+        - name: config
+          mountPath: /etc/agent
+  volumes:
+    - name: config
+      configMap:
+        name: "validate-k8smon-k8s-monitoring"
+---
 # Source: k8s-monitoring/templates/tests/test.yaml
 apiVersion: v1
 kind: Pod
@@ -45992,64 +46063,6 @@ spec:
       env:
         - name: AGENT_HOST
           value: k8smon-grafana-agent.default.svc
----
-# Source: k8s-monitoring/templates/hooks/validate-configuration.yaml
-apiVersion: batch/v1
-kind: Job
-metadata:
-  name: "validate-k8smon-k8s-monitoring"
-  namespace: default
-  labels:
-    app.kubernetes.io/managed-by: "Helm"
-    app.kubernetes.io/instance: "k8smon"
-    app.kubernetes.io/version: 2.0.2
-    helm.sh/chart: "k8s-monitoring-0.12.0"
-  annotations:
-    "helm.sh/hook": pre-install,pre-upgrade
-    "helm.sh/hook-weight": "-5"
-    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
-spec:
-  backoffLimit: 0
-  template:
-    metadata:
-      name: "validate-k8smon-k8s-monitoring"
-      labels:
-        app.kubernetes.io/managed-by: "Helm"
-        app.kubernetes.io/instance: "k8smon"
-        helm.sh/chart: "k8s-monitoring-0.12.0"
-    spec:
-      restartPolicy: Never
-      nodeSelector:
-        kubernetes.io/os: linux
-      containers:
-        - name: grafana-agent
-          image: "docker.io/grafana/agent:v0.40.3"
-          command:
-          - bash
-          - -ec
-          - |
-            echo Validating Grafana Agent config file
-            if grafana-agent fmt /etc/agent/config.river > /dev/null; then
-              echo "Grafana Agent config file is valid"
-            fi
-            echo Validating Grafana Agent for Events config file
-            if grafana-agent fmt /etc/agent/events.river > /dev/null; then
-              echo "Grafana Agent for Events config file is valid"
-            fi
-            echo Validating Grafana Agent for Logs config file
-            if grafana-agent fmt /etc/agent/logs.river > /dev/null; then
-              echo "Grafana Agent for Logs config file is valid"
-            fi
-          env:
-            - name: AGENT_MODE
-              value: flow
-          volumeMounts:
-            - name: config
-              mountPath: /etc/agent
-      volumes:
-        - name: config
-          configMap:
-            name: "validate-k8smon-k8s-monitoring"
 ---
 # Source: k8s-monitoring/templates/tests/test.yaml
 apiVersion: batch/v1

--- a/examples/kube-pod-labels/output.yaml
+++ b/examples/kube-pod-labels/output.yaml
@@ -45965,6 +45965,77 @@ data:
       ]
     }
 ---
+# Source: k8s-monitoring/templates/hooks/validate-configuration.yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "validate-k8smon-k8s-monitoring"
+  namespace: default
+  labels:
+    app.kubernetes.io/managed-by: "Helm"
+    app.kubernetes.io/instance: "k8smon"
+    app.kubernetes.io/version: 2.0.2
+    helm.sh/chart: "k8s-monitoring-0.12.0"
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "-5"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+spec:
+  restartPolicy: Never
+  nodeSelector:
+        kubernetes.io/os: linux
+  containers:
+    - name: grafana-agent
+      image: "docker.io/grafana/agent:v0.40.3"
+      command:
+      - bash
+      - -c
+      - |
+        echo Validating Grafana Agent config file
+        if ! grafana-agent fmt /etc/agent/config.river > /dev/null; then
+          exit 1
+        fi
+        output=$(grafana-agent run "/etc/agent/config.river" 2>&1)
+        if ! echo "${output}" | grep "KUBERNETES_SERVICE_HOST and KUBERNETES_SERVICE_PORT must be defined" >/dev/null; then
+          echo "${output}"
+          exit 1
+        fi
+        echo "Grafana Agent config file is valid"
+        echo Validating Grafana Agent for Events config file
+        if ! grafana-agent fmt /etc/agent/events.river > /dev/null; then
+          exit 1
+        fi
+        output=$(grafana-agent run "/etc/agent/events.river" 2>&1)
+        if ! echo "${output}" | grep "KUBERNETES_SERVICE_HOST and KUBERNETES_SERVICE_PORT must be defined" >/dev/null; then
+          echo "${output}"
+          exit 1
+        fi
+        echo "Grafana Agent for Events config file is valid"
+        echo Validating Grafana Agent for Logs config file
+        if ! grafana-agent fmt /etc/agent/logs.river > /dev/null; then
+          exit 1
+        fi
+        output=$(grafana-agent run "/etc/agent/logs.river" 2>&1)
+        if ! echo "${output}" | grep "KUBERNETES_SERVICE_HOST and KUBERNETES_SERVICE_PORT must be defined" >/dev/null; then
+          echo "${output}"
+          exit 1
+        fi
+        echo "Grafana Agent for Logs config file is valid"
+      env:
+        - name: AGENT_MODE
+          value: flow
+        - name: KUBERNETES_SERVICE_HOST  # Intentionally disable its connection to Kubernetes to make it fail in a known way
+          value: ""
+        - name: KUBERNETES_SERVICE_PORT  # Intentionally disable its connection to Kubernetes to make it fail in a known way
+          value: ""
+      volumeMounts:
+        - name: config
+          mountPath: /etc/agent
+  volumes:
+    - name: config
+      configMap:
+        name: "validate-k8smon-k8s-monitoring"
+---
 # Source: k8s-monitoring/templates/tests/test.yaml
 apiVersion: v1
 kind: Pod
@@ -45991,64 +46062,6 @@ spec:
       env:
         - name: AGENT_HOST
           value: k8smon-grafana-agent.default.svc
----
-# Source: k8s-monitoring/templates/hooks/validate-configuration.yaml
-apiVersion: batch/v1
-kind: Job
-metadata:
-  name: "validate-k8smon-k8s-monitoring"
-  namespace: default
-  labels:
-    app.kubernetes.io/managed-by: "Helm"
-    app.kubernetes.io/instance: "k8smon"
-    app.kubernetes.io/version: 2.0.2
-    helm.sh/chart: "k8s-monitoring-0.12.0"
-  annotations:
-    "helm.sh/hook": pre-install,pre-upgrade
-    "helm.sh/hook-weight": "-5"
-    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
-spec:
-  backoffLimit: 0
-  template:
-    metadata:
-      name: "validate-k8smon-k8s-monitoring"
-      labels:
-        app.kubernetes.io/managed-by: "Helm"
-        app.kubernetes.io/instance: "k8smon"
-        helm.sh/chart: "k8s-monitoring-0.12.0"
-    spec:
-      restartPolicy: Never
-      nodeSelector:
-        kubernetes.io/os: linux
-      containers:
-        - name: grafana-agent
-          image: "docker.io/grafana/agent:v0.40.3"
-          command:
-          - bash
-          - -ec
-          - |
-            echo Validating Grafana Agent config file
-            if grafana-agent fmt /etc/agent/config.river > /dev/null; then
-              echo "Grafana Agent config file is valid"
-            fi
-            echo Validating Grafana Agent for Events config file
-            if grafana-agent fmt /etc/agent/events.river > /dev/null; then
-              echo "Grafana Agent for Events config file is valid"
-            fi
-            echo Validating Grafana Agent for Logs config file
-            if grafana-agent fmt /etc/agent/logs.river > /dev/null; then
-              echo "Grafana Agent for Logs config file is valid"
-            fi
-          env:
-            - name: AGENT_MODE
-              value: flow
-          volumeMounts:
-            - name: config
-              mountPath: /etc/agent
-      volumes:
-        - name: config
-          configMap:
-            name: "validate-k8smon-k8s-monitoring"
 ---
 # Source: k8s-monitoring/templates/tests/test.yaml
 apiVersion: batch/v1

--- a/examples/logs-only/output.yaml
+++ b/examples/logs-only/output.yaml
@@ -1666,6 +1666,77 @@ data:
       "queries": null
     }
 ---
+# Source: k8s-monitoring/templates/hooks/validate-configuration.yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "validate-k8smon-k8s-monitoring"
+  namespace: default
+  labels:
+    app.kubernetes.io/managed-by: "Helm"
+    app.kubernetes.io/instance: "k8smon"
+    app.kubernetes.io/version: 2.0.2
+    helm.sh/chart: "k8s-monitoring-0.12.0"
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "-5"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+spec:
+  restartPolicy: Never
+  nodeSelector:
+        kubernetes.io/os: linux
+  containers:
+    - name: grafana-agent
+      image: "docker.io/grafana/agent:v0.40.3"
+      command:
+      - bash
+      - -c
+      - |
+        echo Validating Grafana Agent config file
+        if ! grafana-agent fmt /etc/agent/config.river > /dev/null; then
+          exit 1
+        fi
+        output=$(grafana-agent run "/etc/agent/config.river" 2>&1)
+        if ! echo "${output}" | grep "KUBERNETES_SERVICE_HOST and KUBERNETES_SERVICE_PORT must be defined" >/dev/null; then
+          echo "${output}"
+          exit 1
+        fi
+        echo "Grafana Agent config file is valid"
+        echo Validating Grafana Agent for Events config file
+        if ! grafana-agent fmt /etc/agent/events.river > /dev/null; then
+          exit 1
+        fi
+        output=$(grafana-agent run "/etc/agent/events.river" 2>&1)
+        if ! echo "${output}" | grep "KUBERNETES_SERVICE_HOST and KUBERNETES_SERVICE_PORT must be defined" >/dev/null; then
+          echo "${output}"
+          exit 1
+        fi
+        echo "Grafana Agent for Events config file is valid"
+        echo Validating Grafana Agent for Logs config file
+        if ! grafana-agent fmt /etc/agent/logs.river > /dev/null; then
+          exit 1
+        fi
+        output=$(grafana-agent run "/etc/agent/logs.river" 2>&1)
+        if ! echo "${output}" | grep "KUBERNETES_SERVICE_HOST and KUBERNETES_SERVICE_PORT must be defined" >/dev/null; then
+          echo "${output}"
+          exit 1
+        fi
+        echo "Grafana Agent for Logs config file is valid"
+      env:
+        - name: AGENT_MODE
+          value: flow
+        - name: KUBERNETES_SERVICE_HOST  # Intentionally disable its connection to Kubernetes to make it fail in a known way
+          value: ""
+        - name: KUBERNETES_SERVICE_PORT  # Intentionally disable its connection to Kubernetes to make it fail in a known way
+          value: ""
+      volumeMounts:
+        - name: config
+          mountPath: /etc/agent
+  volumes:
+    - name: config
+      configMap:
+        name: "validate-k8smon-k8s-monitoring"
+---
 # Source: k8s-monitoring/templates/tests/test.yaml
 apiVersion: v1
 kind: Pod
@@ -1692,64 +1763,6 @@ spec:
       env:
         - name: AGENT_HOST
           value: k8smon-grafana-agent.default.svc
----
-# Source: k8s-monitoring/templates/hooks/validate-configuration.yaml
-apiVersion: batch/v1
-kind: Job
-metadata:
-  name: "validate-k8smon-k8s-monitoring"
-  namespace: default
-  labels:
-    app.kubernetes.io/managed-by: "Helm"
-    app.kubernetes.io/instance: "k8smon"
-    app.kubernetes.io/version: 2.0.2
-    helm.sh/chart: "k8s-monitoring-0.12.0"
-  annotations:
-    "helm.sh/hook": pre-install,pre-upgrade
-    "helm.sh/hook-weight": "-5"
-    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
-spec:
-  backoffLimit: 0
-  template:
-    metadata:
-      name: "validate-k8smon-k8s-monitoring"
-      labels:
-        app.kubernetes.io/managed-by: "Helm"
-        app.kubernetes.io/instance: "k8smon"
-        helm.sh/chart: "k8s-monitoring-0.12.0"
-    spec:
-      restartPolicy: Never
-      nodeSelector:
-        kubernetes.io/os: linux
-      containers:
-        - name: grafana-agent
-          image: "docker.io/grafana/agent:v0.40.3"
-          command:
-          - bash
-          - -ec
-          - |
-            echo Validating Grafana Agent config file
-            if grafana-agent fmt /etc/agent/config.river > /dev/null; then
-              echo "Grafana Agent config file is valid"
-            fi
-            echo Validating Grafana Agent for Events config file
-            if grafana-agent fmt /etc/agent/events.river > /dev/null; then
-              echo "Grafana Agent for Events config file is valid"
-            fi
-            echo Validating Grafana Agent for Logs config file
-            if grafana-agent fmt /etc/agent/logs.river > /dev/null; then
-              echo "Grafana Agent for Logs config file is valid"
-            fi
-          env:
-            - name: AGENT_MODE
-              value: flow
-          volumeMounts:
-            - name: config
-              mountPath: /etc/agent
-      volumes:
-        - name: config
-          configMap:
-            name: "validate-k8smon-k8s-monitoring"
 ---
 # Source: k8s-monitoring/templates/tests/test.yaml
 apiVersion: batch/v1

--- a/examples/metrics-only/output.yaml
+++ b/examples/metrics-only/output.yaml
@@ -44908,6 +44908,57 @@ data:
       ]
     }
 ---
+# Source: k8s-monitoring/templates/hooks/validate-configuration.yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "validate-k8smon-k8s-monitoring"
+  namespace: default
+  labels:
+    app.kubernetes.io/managed-by: "Helm"
+    app.kubernetes.io/instance: "k8smon"
+    app.kubernetes.io/version: 2.0.2
+    helm.sh/chart: "k8s-monitoring-0.12.0"
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "-5"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+spec:
+  restartPolicy: Never
+  nodeSelector:
+        kubernetes.io/os: linux
+  containers:
+    - name: grafana-agent
+      image: "docker.io/grafana/agent:v0.40.3"
+      command:
+      - bash
+      - -c
+      - |
+        echo Validating Grafana Agent config file
+        if ! grafana-agent fmt /etc/agent/config.river > /dev/null; then
+          exit 1
+        fi
+        output=$(grafana-agent run "/etc/agent/config.river" 2>&1)
+        if ! echo "${output}" | grep "KUBERNETES_SERVICE_HOST and KUBERNETES_SERVICE_PORT must be defined" >/dev/null; then
+          echo "${output}"
+          exit 1
+        fi
+        echo "Grafana Agent config file is valid"
+      env:
+        - name: AGENT_MODE
+          value: flow
+        - name: KUBERNETES_SERVICE_HOST  # Intentionally disable its connection to Kubernetes to make it fail in a known way
+          value: ""
+        - name: KUBERNETES_SERVICE_PORT  # Intentionally disable its connection to Kubernetes to make it fail in a known way
+          value: ""
+      volumeMounts:
+        - name: config
+          mountPath: /etc/agent
+  volumes:
+    - name: config
+      configMap:
+        name: "validate-k8smon-k8s-monitoring"
+---
 # Source: k8s-monitoring/templates/tests/test.yaml
 apiVersion: v1
 kind: Pod
@@ -44934,56 +44985,6 @@ spec:
       env:
         - name: AGENT_HOST
           value: k8smon-grafana-agent.default.svc
----
-# Source: k8s-monitoring/templates/hooks/validate-configuration.yaml
-apiVersion: batch/v1
-kind: Job
-metadata:
-  name: "validate-k8smon-k8s-monitoring"
-  namespace: default
-  labels:
-    app.kubernetes.io/managed-by: "Helm"
-    app.kubernetes.io/instance: "k8smon"
-    app.kubernetes.io/version: 2.0.2
-    helm.sh/chart: "k8s-monitoring-0.12.0"
-  annotations:
-    "helm.sh/hook": pre-install,pre-upgrade
-    "helm.sh/hook-weight": "-5"
-    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
-spec:
-  backoffLimit: 0
-  template:
-    metadata:
-      name: "validate-k8smon-k8s-monitoring"
-      labels:
-        app.kubernetes.io/managed-by: "Helm"
-        app.kubernetes.io/instance: "k8smon"
-        helm.sh/chart: "k8s-monitoring-0.12.0"
-    spec:
-      restartPolicy: Never
-      nodeSelector:
-        kubernetes.io/os: linux
-      containers:
-        - name: grafana-agent
-          image: "docker.io/grafana/agent:v0.40.3"
-          command:
-          - bash
-          - -ec
-          - |
-            echo Validating Grafana Agent config file
-            if grafana-agent fmt /etc/agent/config.river > /dev/null; then
-              echo "Grafana Agent config file is valid"
-            fi
-          env:
-            - name: AGENT_MODE
-              value: flow
-          volumeMounts:
-            - name: config
-              mountPath: /etc/agent
-      volumes:
-        - name: config
-          configMap:
-            name: "validate-k8smon-k8s-monitoring"
 ---
 # Source: k8s-monitoring/templates/tests/test.yaml
 apiVersion: batch/v1

--- a/examples/openshift-compatible/output.yaml
+++ b/examples/openshift-compatible/output.yaml
@@ -45618,6 +45618,77 @@ data:
       ]
     }
 ---
+# Source: k8s-monitoring/templates/hooks/validate-configuration.yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "validate-k8smon-k8s-monitoring"
+  namespace: default
+  labels:
+    app.kubernetes.io/managed-by: "Helm"
+    app.kubernetes.io/instance: "k8smon"
+    app.kubernetes.io/version: 2.0.2
+    helm.sh/chart: "k8s-monitoring-0.12.0"
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "-5"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+spec:
+  restartPolicy: Never
+  nodeSelector:
+        kubernetes.io/os: linux
+  containers:
+    - name: grafana-agent
+      image: "docker.io/grafana/agent:v0.40.3"
+      command:
+      - bash
+      - -c
+      - |
+        echo Validating Grafana Agent config file
+        if ! grafana-agent fmt /etc/agent/config.river > /dev/null; then
+          exit 1
+        fi
+        output=$(grafana-agent run "/etc/agent/config.river" 2>&1)
+        if ! echo "${output}" | grep "KUBERNETES_SERVICE_HOST and KUBERNETES_SERVICE_PORT must be defined" >/dev/null; then
+          echo "${output}"
+          exit 1
+        fi
+        echo "Grafana Agent config file is valid"
+        echo Validating Grafana Agent for Events config file
+        if ! grafana-agent fmt /etc/agent/events.river > /dev/null; then
+          exit 1
+        fi
+        output=$(grafana-agent run "/etc/agent/events.river" 2>&1)
+        if ! echo "${output}" | grep "KUBERNETES_SERVICE_HOST and KUBERNETES_SERVICE_PORT must be defined" >/dev/null; then
+          echo "${output}"
+          exit 1
+        fi
+        echo "Grafana Agent for Events config file is valid"
+        echo Validating Grafana Agent for Logs config file
+        if ! grafana-agent fmt /etc/agent/logs.river > /dev/null; then
+          exit 1
+        fi
+        output=$(grafana-agent run "/etc/agent/logs.river" 2>&1)
+        if ! echo "${output}" | grep "KUBERNETES_SERVICE_HOST and KUBERNETES_SERVICE_PORT must be defined" >/dev/null; then
+          echo "${output}"
+          exit 1
+        fi
+        echo "Grafana Agent for Logs config file is valid"
+      env:
+        - name: AGENT_MODE
+          value: flow
+        - name: KUBERNETES_SERVICE_HOST  # Intentionally disable its connection to Kubernetes to make it fail in a known way
+          value: ""
+        - name: KUBERNETES_SERVICE_PORT  # Intentionally disable its connection to Kubernetes to make it fail in a known way
+          value: ""
+      volumeMounts:
+        - name: config
+          mountPath: /etc/agent
+  volumes:
+    - name: config
+      configMap:
+        name: "validate-k8smon-k8s-monitoring"
+---
 # Source: k8s-monitoring/templates/tests/test.yaml
 apiVersion: v1
 kind: Pod
@@ -45644,64 +45715,6 @@ spec:
       env:
         - name: AGENT_HOST
           value: k8smon-grafana-agent.default.svc
----
-# Source: k8s-monitoring/templates/hooks/validate-configuration.yaml
-apiVersion: batch/v1
-kind: Job
-metadata:
-  name: "validate-k8smon-k8s-monitoring"
-  namespace: default
-  labels:
-    app.kubernetes.io/managed-by: "Helm"
-    app.kubernetes.io/instance: "k8smon"
-    app.kubernetes.io/version: 2.0.2
-    helm.sh/chart: "k8s-monitoring-0.12.0"
-  annotations:
-    "helm.sh/hook": pre-install,pre-upgrade
-    "helm.sh/hook-weight": "-5"
-    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
-spec:
-  backoffLimit: 0
-  template:
-    metadata:
-      name: "validate-k8smon-k8s-monitoring"
-      labels:
-        app.kubernetes.io/managed-by: "Helm"
-        app.kubernetes.io/instance: "k8smon"
-        helm.sh/chart: "k8s-monitoring-0.12.0"
-    spec:
-      restartPolicy: Never
-      nodeSelector:
-        kubernetes.io/os: linux
-      containers:
-        - name: grafana-agent
-          image: "docker.io/grafana/agent:v0.40.3"
-          command:
-          - bash
-          - -ec
-          - |
-            echo Validating Grafana Agent config file
-            if grafana-agent fmt /etc/agent/config.river > /dev/null; then
-              echo "Grafana Agent config file is valid"
-            fi
-            echo Validating Grafana Agent for Events config file
-            if grafana-agent fmt /etc/agent/events.river > /dev/null; then
-              echo "Grafana Agent for Events config file is valid"
-            fi
-            echo Validating Grafana Agent for Logs config file
-            if grafana-agent fmt /etc/agent/logs.river > /dev/null; then
-              echo "Grafana Agent for Logs config file is valid"
-            fi
-          env:
-            - name: AGENT_MODE
-              value: flow
-          volumeMounts:
-            - name: config
-              mountPath: /etc/agent
-      volumes:
-        - name: config
-          configMap:
-            name: "validate-k8smon-k8s-monitoring"
 ---
 # Source: k8s-monitoring/templates/tests/test.yaml
 apiVersion: batch/v1

--- a/examples/otel-metrics-service/output.yaml
+++ b/examples/otel-metrics-service/output.yaml
@@ -46020,6 +46020,77 @@ data:
       ]
     }
 ---
+# Source: k8s-monitoring/templates/hooks/validate-configuration.yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "validate-k8smon-k8s-monitoring"
+  namespace: default
+  labels:
+    app.kubernetes.io/managed-by: "Helm"
+    app.kubernetes.io/instance: "k8smon"
+    app.kubernetes.io/version: 2.0.2
+    helm.sh/chart: "k8s-monitoring-0.12.0"
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "-5"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+spec:
+  restartPolicy: Never
+  nodeSelector:
+        kubernetes.io/os: linux
+  containers:
+    - name: grafana-agent
+      image: "docker.io/grafana/agent:v0.40.3"
+      command:
+      - bash
+      - -c
+      - |
+        echo Validating Grafana Agent config file
+        if ! grafana-agent fmt /etc/agent/config.river > /dev/null; then
+          exit 1
+        fi
+        output=$(grafana-agent run "/etc/agent/config.river" 2>&1)
+        if ! echo "${output}" | grep "KUBERNETES_SERVICE_HOST and KUBERNETES_SERVICE_PORT must be defined" >/dev/null; then
+          echo "${output}"
+          exit 1
+        fi
+        echo "Grafana Agent config file is valid"
+        echo Validating Grafana Agent for Events config file
+        if ! grafana-agent fmt /etc/agent/events.river > /dev/null; then
+          exit 1
+        fi
+        output=$(grafana-agent run "/etc/agent/events.river" 2>&1)
+        if ! echo "${output}" | grep "KUBERNETES_SERVICE_HOST and KUBERNETES_SERVICE_PORT must be defined" >/dev/null; then
+          echo "${output}"
+          exit 1
+        fi
+        echo "Grafana Agent for Events config file is valid"
+        echo Validating Grafana Agent for Logs config file
+        if ! grafana-agent fmt /etc/agent/logs.river > /dev/null; then
+          exit 1
+        fi
+        output=$(grafana-agent run "/etc/agent/logs.river" 2>&1)
+        if ! echo "${output}" | grep "KUBERNETES_SERVICE_HOST and KUBERNETES_SERVICE_PORT must be defined" >/dev/null; then
+          echo "${output}"
+          exit 1
+        fi
+        echo "Grafana Agent for Logs config file is valid"
+      env:
+        - name: AGENT_MODE
+          value: flow
+        - name: KUBERNETES_SERVICE_HOST  # Intentionally disable its connection to Kubernetes to make it fail in a known way
+          value: ""
+        - name: KUBERNETES_SERVICE_PORT  # Intentionally disable its connection to Kubernetes to make it fail in a known way
+          value: ""
+      volumeMounts:
+        - name: config
+          mountPath: /etc/agent
+  volumes:
+    - name: config
+      configMap:
+        name: "validate-k8smon-k8s-monitoring"
+---
 # Source: k8s-monitoring/templates/tests/test.yaml
 apiVersion: v1
 kind: Pod
@@ -46046,64 +46117,6 @@ spec:
       env:
         - name: AGENT_HOST
           value: k8smon-grafana-agent.default.svc
----
-# Source: k8s-monitoring/templates/hooks/validate-configuration.yaml
-apiVersion: batch/v1
-kind: Job
-metadata:
-  name: "validate-k8smon-k8s-monitoring"
-  namespace: default
-  labels:
-    app.kubernetes.io/managed-by: "Helm"
-    app.kubernetes.io/instance: "k8smon"
-    app.kubernetes.io/version: 2.0.2
-    helm.sh/chart: "k8s-monitoring-0.12.0"
-  annotations:
-    "helm.sh/hook": pre-install,pre-upgrade
-    "helm.sh/hook-weight": "-5"
-    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
-spec:
-  backoffLimit: 0
-  template:
-    metadata:
-      name: "validate-k8smon-k8s-monitoring"
-      labels:
-        app.kubernetes.io/managed-by: "Helm"
-        app.kubernetes.io/instance: "k8smon"
-        helm.sh/chart: "k8s-monitoring-0.12.0"
-    spec:
-      restartPolicy: Never
-      nodeSelector:
-        kubernetes.io/os: linux
-      containers:
-        - name: grafana-agent
-          image: "docker.io/grafana/agent:v0.40.3"
-          command:
-          - bash
-          - -ec
-          - |
-            echo Validating Grafana Agent config file
-            if grafana-agent fmt /etc/agent/config.river > /dev/null; then
-              echo "Grafana Agent config file is valid"
-            fi
-            echo Validating Grafana Agent for Events config file
-            if grafana-agent fmt /etc/agent/events.river > /dev/null; then
-              echo "Grafana Agent for Events config file is valid"
-            fi
-            echo Validating Grafana Agent for Logs config file
-            if grafana-agent fmt /etc/agent/logs.river > /dev/null; then
-              echo "Grafana Agent for Logs config file is valid"
-            fi
-          env:
-            - name: AGENT_MODE
-              value: flow
-          volumeMounts:
-            - name: config
-              mountPath: /etc/agent
-      volumes:
-        - name: config
-          configMap:
-            name: "validate-k8smon-k8s-monitoring"
 ---
 # Source: k8s-monitoring/templates/tests/test.yaml
 apiVersion: batch/v1

--- a/examples/private-image-registry/output.yaml
+++ b/examples/private-image-registry/output.yaml
@@ -45976,6 +45976,79 @@ data:
       ]
     }
 ---
+# Source: k8s-monitoring/templates/hooks/validate-configuration.yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "validate-k8smon-k8s-monitoring"
+  namespace: default
+  labels:
+    app.kubernetes.io/managed-by: "Helm"
+    app.kubernetes.io/instance: "k8smon"
+    app.kubernetes.io/version: 2.0.2
+    helm.sh/chart: "k8s-monitoring-0.12.0"
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "-5"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+spec:
+  imagePullSecrets:
+        - name: my-registry-creds
+  restartPolicy: Never
+  nodeSelector:
+        kubernetes.io/os: linux
+  containers:
+    - name: grafana-agent
+      image: "my.registry.com/grafana/agent:v0.40.3"
+      command:
+      - bash
+      - -c
+      - |
+        echo Validating Grafana Agent config file
+        if ! grafana-agent fmt /etc/agent/config.river > /dev/null; then
+          exit 1
+        fi
+        output=$(grafana-agent run "/etc/agent/config.river" 2>&1)
+        if ! echo "${output}" | grep "KUBERNETES_SERVICE_HOST and KUBERNETES_SERVICE_PORT must be defined" >/dev/null; then
+          echo "${output}"
+          exit 1
+        fi
+        echo "Grafana Agent config file is valid"
+        echo Validating Grafana Agent for Events config file
+        if ! grafana-agent fmt /etc/agent/events.river > /dev/null; then
+          exit 1
+        fi
+        output=$(grafana-agent run "/etc/agent/events.river" 2>&1)
+        if ! echo "${output}" | grep "KUBERNETES_SERVICE_HOST and KUBERNETES_SERVICE_PORT must be defined" >/dev/null; then
+          echo "${output}"
+          exit 1
+        fi
+        echo "Grafana Agent for Events config file is valid"
+        echo Validating Grafana Agent for Logs config file
+        if ! grafana-agent fmt /etc/agent/logs.river > /dev/null; then
+          exit 1
+        fi
+        output=$(grafana-agent run "/etc/agent/logs.river" 2>&1)
+        if ! echo "${output}" | grep "KUBERNETES_SERVICE_HOST and KUBERNETES_SERVICE_PORT must be defined" >/dev/null; then
+          echo "${output}"
+          exit 1
+        fi
+        echo "Grafana Agent for Logs config file is valid"
+      env:
+        - name: AGENT_MODE
+          value: flow
+        - name: KUBERNETES_SERVICE_HOST  # Intentionally disable its connection to Kubernetes to make it fail in a known way
+          value: ""
+        - name: KUBERNETES_SERVICE_PORT  # Intentionally disable its connection to Kubernetes to make it fail in a known way
+          value: ""
+      volumeMounts:
+        - name: config
+          mountPath: /etc/agent
+  volumes:
+    - name: config
+      configMap:
+        name: "validate-k8smon-k8s-monitoring"
+---
 # Source: k8s-monitoring/templates/tests/test.yaml
 apiVersion: v1
 kind: Pod
@@ -46004,66 +46077,6 @@ spec:
       env:
         - name: AGENT_HOST
           value: k8smon-grafana-agent.default.svc
----
-# Source: k8s-monitoring/templates/hooks/validate-configuration.yaml
-apiVersion: batch/v1
-kind: Job
-metadata:
-  name: "validate-k8smon-k8s-monitoring"
-  namespace: default
-  labels:
-    app.kubernetes.io/managed-by: "Helm"
-    app.kubernetes.io/instance: "k8smon"
-    app.kubernetes.io/version: 2.0.2
-    helm.sh/chart: "k8s-monitoring-0.12.0"
-  annotations:
-    "helm.sh/hook": pre-install,pre-upgrade
-    "helm.sh/hook-weight": "-5"
-    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
-spec:
-  backoffLimit: 0
-  template:
-    metadata:
-      name: "validate-k8smon-k8s-monitoring"
-      labels:
-        app.kubernetes.io/managed-by: "Helm"
-        app.kubernetes.io/instance: "k8smon"
-        helm.sh/chart: "k8s-monitoring-0.12.0"
-    spec:
-      imagePullSecrets:
-        - name: my-registry-creds
-      restartPolicy: Never
-      nodeSelector:
-        kubernetes.io/os: linux
-      containers:
-        - name: grafana-agent
-          image: "my.registry.com/grafana/agent:v0.40.3"
-          command:
-          - bash
-          - -ec
-          - |
-            echo Validating Grafana Agent config file
-            if grafana-agent fmt /etc/agent/config.river > /dev/null; then
-              echo "Grafana Agent config file is valid"
-            fi
-            echo Validating Grafana Agent for Events config file
-            if grafana-agent fmt /etc/agent/events.river > /dev/null; then
-              echo "Grafana Agent for Events config file is valid"
-            fi
-            echo Validating Grafana Agent for Logs config file
-            if grafana-agent fmt /etc/agent/logs.river > /dev/null; then
-              echo "Grafana Agent for Logs config file is valid"
-            fi
-          env:
-            - name: AGENT_MODE
-              value: flow
-          volumeMounts:
-            - name: config
-              mountPath: /etc/agent
-      volumes:
-        - name: config
-          configMap:
-            name: "validate-k8smon-k8s-monitoring"
 ---
 # Source: k8s-monitoring/templates/tests/test.yaml
 apiVersion: batch/v1

--- a/examples/proxies/output.yaml
+++ b/examples/proxies/output.yaml
@@ -45992,6 +45992,77 @@ data:
       ]
     }
 ---
+# Source: k8s-monitoring/templates/hooks/validate-configuration.yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "validate-k8smon-k8s-monitoring"
+  namespace: default
+  labels:
+    app.kubernetes.io/managed-by: "Helm"
+    app.kubernetes.io/instance: "k8smon"
+    app.kubernetes.io/version: 2.0.2
+    helm.sh/chart: "k8s-monitoring-0.12.0"
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "-5"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+spec:
+  restartPolicy: Never
+  nodeSelector:
+        kubernetes.io/os: linux
+  containers:
+    - name: grafana-agent
+      image: "docker.io/grafana/agent:v0.40.3"
+      command:
+      - bash
+      - -c
+      - |
+        echo Validating Grafana Agent config file
+        if ! grafana-agent fmt /etc/agent/config.river > /dev/null; then
+          exit 1
+        fi
+        output=$(grafana-agent run "/etc/agent/config.river" 2>&1)
+        if ! echo "${output}" | grep "KUBERNETES_SERVICE_HOST and KUBERNETES_SERVICE_PORT must be defined" >/dev/null; then
+          echo "${output}"
+          exit 1
+        fi
+        echo "Grafana Agent config file is valid"
+        echo Validating Grafana Agent for Events config file
+        if ! grafana-agent fmt /etc/agent/events.river > /dev/null; then
+          exit 1
+        fi
+        output=$(grafana-agent run "/etc/agent/events.river" 2>&1)
+        if ! echo "${output}" | grep "KUBERNETES_SERVICE_HOST and KUBERNETES_SERVICE_PORT must be defined" >/dev/null; then
+          echo "${output}"
+          exit 1
+        fi
+        echo "Grafana Agent for Events config file is valid"
+        echo Validating Grafana Agent for Logs config file
+        if ! grafana-agent fmt /etc/agent/logs.river > /dev/null; then
+          exit 1
+        fi
+        output=$(grafana-agent run "/etc/agent/logs.river" 2>&1)
+        if ! echo "${output}" | grep "KUBERNETES_SERVICE_HOST and KUBERNETES_SERVICE_PORT must be defined" >/dev/null; then
+          echo "${output}"
+          exit 1
+        fi
+        echo "Grafana Agent for Logs config file is valid"
+      env:
+        - name: AGENT_MODE
+          value: flow
+        - name: KUBERNETES_SERVICE_HOST  # Intentionally disable its connection to Kubernetes to make it fail in a known way
+          value: ""
+        - name: KUBERNETES_SERVICE_PORT  # Intentionally disable its connection to Kubernetes to make it fail in a known way
+          value: ""
+      volumeMounts:
+        - name: config
+          mountPath: /etc/agent
+  volumes:
+    - name: config
+      configMap:
+        name: "validate-k8smon-k8s-monitoring"
+---
 # Source: k8s-monitoring/templates/tests/test.yaml
 apiVersion: v1
 kind: Pod
@@ -46018,64 +46089,6 @@ spec:
       env:
         - name: AGENT_HOST
           value: k8smon-grafana-agent.default.svc
----
-# Source: k8s-monitoring/templates/hooks/validate-configuration.yaml
-apiVersion: batch/v1
-kind: Job
-metadata:
-  name: "validate-k8smon-k8s-monitoring"
-  namespace: default
-  labels:
-    app.kubernetes.io/managed-by: "Helm"
-    app.kubernetes.io/instance: "k8smon"
-    app.kubernetes.io/version: 2.0.2
-    helm.sh/chart: "k8s-monitoring-0.12.0"
-  annotations:
-    "helm.sh/hook": pre-install,pre-upgrade
-    "helm.sh/hook-weight": "-5"
-    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
-spec:
-  backoffLimit: 0
-  template:
-    metadata:
-      name: "validate-k8smon-k8s-monitoring"
-      labels:
-        app.kubernetes.io/managed-by: "Helm"
-        app.kubernetes.io/instance: "k8smon"
-        helm.sh/chart: "k8s-monitoring-0.12.0"
-    spec:
-      restartPolicy: Never
-      nodeSelector:
-        kubernetes.io/os: linux
-      containers:
-        - name: grafana-agent
-          image: "docker.io/grafana/agent:v0.40.3"
-          command:
-          - bash
-          - -ec
-          - |
-            echo Validating Grafana Agent config file
-            if grafana-agent fmt /etc/agent/config.river > /dev/null; then
-              echo "Grafana Agent config file is valid"
-            fi
-            echo Validating Grafana Agent for Events config file
-            if grafana-agent fmt /etc/agent/events.river > /dev/null; then
-              echo "Grafana Agent for Events config file is valid"
-            fi
-            echo Validating Grafana Agent for Logs config file
-            if grafana-agent fmt /etc/agent/logs.river > /dev/null; then
-              echo "Grafana Agent for Logs config file is valid"
-            fi
-          env:
-            - name: AGENT_MODE
-              value: flow
-          volumeMounts:
-            - name: config
-              mountPath: /etc/agent
-      volumes:
-        - name: config
-          configMap:
-            name: "validate-k8smon-k8s-monitoring"
 ---
 # Source: k8s-monitoring/templates/tests/test.yaml
 apiVersion: batch/v1

--- a/examples/scrape-intervals/output.yaml
+++ b/examples/scrape-intervals/output.yaml
@@ -44907,6 +44907,57 @@ data:
       ]
     }
 ---
+# Source: k8s-monitoring/templates/hooks/validate-configuration.yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "validate-k8smon-k8s-monitoring"
+  namespace: default
+  labels:
+    app.kubernetes.io/managed-by: "Helm"
+    app.kubernetes.io/instance: "k8smon"
+    app.kubernetes.io/version: 2.0.2
+    helm.sh/chart: "k8s-monitoring-0.12.0"
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "-5"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+spec:
+  restartPolicy: Never
+  nodeSelector:
+        kubernetes.io/os: linux
+  containers:
+    - name: grafana-agent
+      image: "docker.io/grafana/agent:v0.40.3"
+      command:
+      - bash
+      - -c
+      - |
+        echo Validating Grafana Agent config file
+        if ! grafana-agent fmt /etc/agent/config.river > /dev/null; then
+          exit 1
+        fi
+        output=$(grafana-agent run "/etc/agent/config.river" 2>&1)
+        if ! echo "${output}" | grep "KUBERNETES_SERVICE_HOST and KUBERNETES_SERVICE_PORT must be defined" >/dev/null; then
+          echo "${output}"
+          exit 1
+        fi
+        echo "Grafana Agent config file is valid"
+      env:
+        - name: AGENT_MODE
+          value: flow
+        - name: KUBERNETES_SERVICE_HOST  # Intentionally disable its connection to Kubernetes to make it fail in a known way
+          value: ""
+        - name: KUBERNETES_SERVICE_PORT  # Intentionally disable its connection to Kubernetes to make it fail in a known way
+          value: ""
+      volumeMounts:
+        - name: config
+          mountPath: /etc/agent
+  volumes:
+    - name: config
+      configMap:
+        name: "validate-k8smon-k8s-monitoring"
+---
 # Source: k8s-monitoring/templates/tests/test.yaml
 apiVersion: v1
 kind: Pod
@@ -44933,56 +44984,6 @@ spec:
       env:
         - name: AGENT_HOST
           value: k8smon-grafana-agent.default.svc
----
-# Source: k8s-monitoring/templates/hooks/validate-configuration.yaml
-apiVersion: batch/v1
-kind: Job
-metadata:
-  name: "validate-k8smon-k8s-monitoring"
-  namespace: default
-  labels:
-    app.kubernetes.io/managed-by: "Helm"
-    app.kubernetes.io/instance: "k8smon"
-    app.kubernetes.io/version: 2.0.2
-    helm.sh/chart: "k8s-monitoring-0.12.0"
-  annotations:
-    "helm.sh/hook": pre-install,pre-upgrade
-    "helm.sh/hook-weight": "-5"
-    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
-spec:
-  backoffLimit: 0
-  template:
-    metadata:
-      name: "validate-k8smon-k8s-monitoring"
-      labels:
-        app.kubernetes.io/managed-by: "Helm"
-        app.kubernetes.io/instance: "k8smon"
-        helm.sh/chart: "k8s-monitoring-0.12.0"
-    spec:
-      restartPolicy: Never
-      nodeSelector:
-        kubernetes.io/os: linux
-      containers:
-        - name: grafana-agent
-          image: "docker.io/grafana/agent:v0.40.3"
-          command:
-          - bash
-          - -ec
-          - |
-            echo Validating Grafana Agent config file
-            if grafana-agent fmt /etc/agent/config.river > /dev/null; then
-              echo "Grafana Agent config file is valid"
-            fi
-          env:
-            - name: AGENT_MODE
-              value: flow
-          volumeMounts:
-            - name: config
-              mountPath: /etc/agent
-      volumes:
-        - name: config
-          configMap:
-            name: "validate-k8smon-k8s-monitoring"
 ---
 # Source: k8s-monitoring/templates/tests/test.yaml
 apiVersion: batch/v1

--- a/examples/service-integrations/output.yaml
+++ b/examples/service-integrations/output.yaml
@@ -46046,6 +46046,77 @@ data:
       ]
     }
 ---
+# Source: k8s-monitoring/templates/hooks/validate-configuration.yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "validate-k8smon-k8s-monitoring"
+  namespace: default
+  labels:
+    app.kubernetes.io/managed-by: "Helm"
+    app.kubernetes.io/instance: "k8smon"
+    app.kubernetes.io/version: 2.0.2
+    helm.sh/chart: "k8s-monitoring-0.12.0"
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "-5"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+spec:
+  restartPolicy: Never
+  nodeSelector:
+        kubernetes.io/os: linux
+  containers:
+    - name: grafana-agent
+      image: "docker.io/grafana/agent:v0.40.3"
+      command:
+      - bash
+      - -c
+      - |
+        echo Validating Grafana Agent config file
+        if ! grafana-agent fmt /etc/agent/config.river > /dev/null; then
+          exit 1
+        fi
+        output=$(grafana-agent run "/etc/agent/config.river" 2>&1)
+        if ! echo "${output}" | grep "KUBERNETES_SERVICE_HOST and KUBERNETES_SERVICE_PORT must be defined" >/dev/null; then
+          echo "${output}"
+          exit 1
+        fi
+        echo "Grafana Agent config file is valid"
+        echo Validating Grafana Agent for Events config file
+        if ! grafana-agent fmt /etc/agent/events.river > /dev/null; then
+          exit 1
+        fi
+        output=$(grafana-agent run "/etc/agent/events.river" 2>&1)
+        if ! echo "${output}" | grep "KUBERNETES_SERVICE_HOST and KUBERNETES_SERVICE_PORT must be defined" >/dev/null; then
+          echo "${output}"
+          exit 1
+        fi
+        echo "Grafana Agent for Events config file is valid"
+        echo Validating Grafana Agent for Logs config file
+        if ! grafana-agent fmt /etc/agent/logs.river > /dev/null; then
+          exit 1
+        fi
+        output=$(grafana-agent run "/etc/agent/logs.river" 2>&1)
+        if ! echo "${output}" | grep "KUBERNETES_SERVICE_HOST and KUBERNETES_SERVICE_PORT must be defined" >/dev/null; then
+          echo "${output}"
+          exit 1
+        fi
+        echo "Grafana Agent for Logs config file is valid"
+      env:
+        - name: AGENT_MODE
+          value: flow
+        - name: KUBERNETES_SERVICE_HOST  # Intentionally disable its connection to Kubernetes to make it fail in a known way
+          value: ""
+        - name: KUBERNETES_SERVICE_PORT  # Intentionally disable its connection to Kubernetes to make it fail in a known way
+          value: ""
+      volumeMounts:
+        - name: config
+          mountPath: /etc/agent
+  volumes:
+    - name: config
+      configMap:
+        name: "validate-k8smon-k8s-monitoring"
+---
 # Source: k8s-monitoring/templates/tests/test.yaml
 apiVersion: v1
 kind: Pod
@@ -46072,64 +46143,6 @@ spec:
       env:
         - name: AGENT_HOST
           value: k8smon-grafana-agent.default.svc
----
-# Source: k8s-monitoring/templates/hooks/validate-configuration.yaml
-apiVersion: batch/v1
-kind: Job
-metadata:
-  name: "validate-k8smon-k8s-monitoring"
-  namespace: default
-  labels:
-    app.kubernetes.io/managed-by: "Helm"
-    app.kubernetes.io/instance: "k8smon"
-    app.kubernetes.io/version: 2.0.2
-    helm.sh/chart: "k8s-monitoring-0.12.0"
-  annotations:
-    "helm.sh/hook": pre-install,pre-upgrade
-    "helm.sh/hook-weight": "-5"
-    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
-spec:
-  backoffLimit: 0
-  template:
-    metadata:
-      name: "validate-k8smon-k8s-monitoring"
-      labels:
-        app.kubernetes.io/managed-by: "Helm"
-        app.kubernetes.io/instance: "k8smon"
-        helm.sh/chart: "k8s-monitoring-0.12.0"
-    spec:
-      restartPolicy: Never
-      nodeSelector:
-        kubernetes.io/os: linux
-      containers:
-        - name: grafana-agent
-          image: "docker.io/grafana/agent:v0.40.3"
-          command:
-          - bash
-          - -ec
-          - |
-            echo Validating Grafana Agent config file
-            if grafana-agent fmt /etc/agent/config.river > /dev/null; then
-              echo "Grafana Agent config file is valid"
-            fi
-            echo Validating Grafana Agent for Events config file
-            if grafana-agent fmt /etc/agent/events.river > /dev/null; then
-              echo "Grafana Agent for Events config file is valid"
-            fi
-            echo Validating Grafana Agent for Logs config file
-            if grafana-agent fmt /etc/agent/logs.river > /dev/null; then
-              echo "Grafana Agent for Logs config file is valid"
-            fi
-          env:
-            - name: AGENT_MODE
-              value: flow
-          volumeMounts:
-            - name: config
-              mountPath: /etc/agent
-      volumes:
-        - name: config
-          configMap:
-            name: "validate-k8smon-k8s-monitoring"
 ---
 # Source: k8s-monitoring/templates/tests/test.yaml
 apiVersion: batch/v1

--- a/examples/specific-namespace/output.yaml
+++ b/examples/specific-namespace/output.yaml
@@ -46088,6 +46088,77 @@ data:
       ]
     }
 ---
+# Source: k8s-monitoring/templates/hooks/validate-configuration.yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "validate-k8smon-k8s-monitoring"
+  namespace: default
+  labels:
+    app.kubernetes.io/managed-by: "Helm"
+    app.kubernetes.io/instance: "k8smon"
+    app.kubernetes.io/version: 2.0.2
+    helm.sh/chart: "k8s-monitoring-0.12.0"
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "-5"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+spec:
+  restartPolicy: Never
+  nodeSelector:
+        kubernetes.io/os: linux
+  containers:
+    - name: grafana-agent
+      image: "docker.io/grafana/agent:v0.40.3"
+      command:
+      - bash
+      - -c
+      - |
+        echo Validating Grafana Agent config file
+        if ! grafana-agent fmt /etc/agent/config.river > /dev/null; then
+          exit 1
+        fi
+        output=$(grafana-agent run "/etc/agent/config.river" 2>&1)
+        if ! echo "${output}" | grep "KUBERNETES_SERVICE_HOST and KUBERNETES_SERVICE_PORT must be defined" >/dev/null; then
+          echo "${output}"
+          exit 1
+        fi
+        echo "Grafana Agent config file is valid"
+        echo Validating Grafana Agent for Events config file
+        if ! grafana-agent fmt /etc/agent/events.river > /dev/null; then
+          exit 1
+        fi
+        output=$(grafana-agent run "/etc/agent/events.river" 2>&1)
+        if ! echo "${output}" | grep "KUBERNETES_SERVICE_HOST and KUBERNETES_SERVICE_PORT must be defined" >/dev/null; then
+          echo "${output}"
+          exit 1
+        fi
+        echo "Grafana Agent for Events config file is valid"
+        echo Validating Grafana Agent for Logs config file
+        if ! grafana-agent fmt /etc/agent/logs.river > /dev/null; then
+          exit 1
+        fi
+        output=$(grafana-agent run "/etc/agent/logs.river" 2>&1)
+        if ! echo "${output}" | grep "KUBERNETES_SERVICE_HOST and KUBERNETES_SERVICE_PORT must be defined" >/dev/null; then
+          echo "${output}"
+          exit 1
+        fi
+        echo "Grafana Agent for Logs config file is valid"
+      env:
+        - name: AGENT_MODE
+          value: flow
+        - name: KUBERNETES_SERVICE_HOST  # Intentionally disable its connection to Kubernetes to make it fail in a known way
+          value: ""
+        - name: KUBERNETES_SERVICE_PORT  # Intentionally disable its connection to Kubernetes to make it fail in a known way
+          value: ""
+      volumeMounts:
+        - name: config
+          mountPath: /etc/agent
+  volumes:
+    - name: config
+      configMap:
+        name: "validate-k8smon-k8s-monitoring"
+---
 # Source: k8s-monitoring/templates/tests/test.yaml
 apiVersion: v1
 kind: Pod
@@ -46114,64 +46185,6 @@ spec:
       env:
         - name: AGENT_HOST
           value: k8smon-grafana-agent.default.svc
----
-# Source: k8s-monitoring/templates/hooks/validate-configuration.yaml
-apiVersion: batch/v1
-kind: Job
-metadata:
-  name: "validate-k8smon-k8s-monitoring"
-  namespace: default
-  labels:
-    app.kubernetes.io/managed-by: "Helm"
-    app.kubernetes.io/instance: "k8smon"
-    app.kubernetes.io/version: 2.0.2
-    helm.sh/chart: "k8s-monitoring-0.12.0"
-  annotations:
-    "helm.sh/hook": pre-install,pre-upgrade
-    "helm.sh/hook-weight": "-5"
-    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
-spec:
-  backoffLimit: 0
-  template:
-    metadata:
-      name: "validate-k8smon-k8s-monitoring"
-      labels:
-        app.kubernetes.io/managed-by: "Helm"
-        app.kubernetes.io/instance: "k8smon"
-        helm.sh/chart: "k8s-monitoring-0.12.0"
-    spec:
-      restartPolicy: Never
-      nodeSelector:
-        kubernetes.io/os: linux
-      containers:
-        - name: grafana-agent
-          image: "docker.io/grafana/agent:v0.40.3"
-          command:
-          - bash
-          - -ec
-          - |
-            echo Validating Grafana Agent config file
-            if grafana-agent fmt /etc/agent/config.river > /dev/null; then
-              echo "Grafana Agent config file is valid"
-            fi
-            echo Validating Grafana Agent for Events config file
-            if grafana-agent fmt /etc/agent/events.river > /dev/null; then
-              echo "Grafana Agent for Events config file is valid"
-            fi
-            echo Validating Grafana Agent for Logs config file
-            if grafana-agent fmt /etc/agent/logs.river > /dev/null; then
-              echo "Grafana Agent for Logs config file is valid"
-            fi
-          env:
-            - name: AGENT_MODE
-              value: flow
-          volumeMounts:
-            - name: config
-              mountPath: /etc/agent
-      volumes:
-        - name: config
-          configMap:
-            name: "validate-k8smon-k8s-monitoring"
 ---
 # Source: k8s-monitoring/templates/tests/test.yaml
 apiVersion: batch/v1

--- a/examples/traces-enabled/output.yaml
+++ b/examples/traces-enabled/output.yaml
@@ -46151,6 +46151,77 @@ data:
       ]
     }
 ---
+# Source: k8s-monitoring/templates/hooks/validate-configuration.yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "validate-k8smon-k8s-monitoring"
+  namespace: default
+  labels:
+    app.kubernetes.io/managed-by: "Helm"
+    app.kubernetes.io/instance: "k8smon"
+    app.kubernetes.io/version: 2.0.2
+    helm.sh/chart: "k8s-monitoring-0.12.0"
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "-5"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+spec:
+  restartPolicy: Never
+  nodeSelector:
+        kubernetes.io/os: linux
+  containers:
+    - name: grafana-agent
+      image: "docker.io/grafana/agent:v0.40.3"
+      command:
+      - bash
+      - -c
+      - |
+        echo Validating Grafana Agent config file
+        if ! grafana-agent fmt /etc/agent/config.river > /dev/null; then
+          exit 1
+        fi
+        output=$(grafana-agent run "/etc/agent/config.river" 2>&1)
+        if ! echo "${output}" | grep "KUBERNETES_SERVICE_HOST and KUBERNETES_SERVICE_PORT must be defined" >/dev/null; then
+          echo "${output}"
+          exit 1
+        fi
+        echo "Grafana Agent config file is valid"
+        echo Validating Grafana Agent for Events config file
+        if ! grafana-agent fmt /etc/agent/events.river > /dev/null; then
+          exit 1
+        fi
+        output=$(grafana-agent run "/etc/agent/events.river" 2>&1)
+        if ! echo "${output}" | grep "KUBERNETES_SERVICE_HOST and KUBERNETES_SERVICE_PORT must be defined" >/dev/null; then
+          echo "${output}"
+          exit 1
+        fi
+        echo "Grafana Agent for Events config file is valid"
+        echo Validating Grafana Agent for Logs config file
+        if ! grafana-agent fmt /etc/agent/logs.river > /dev/null; then
+          exit 1
+        fi
+        output=$(grafana-agent run "/etc/agent/logs.river" 2>&1)
+        if ! echo "${output}" | grep "KUBERNETES_SERVICE_HOST and KUBERNETES_SERVICE_PORT must be defined" >/dev/null; then
+          echo "${output}"
+          exit 1
+        fi
+        echo "Grafana Agent for Logs config file is valid"
+      env:
+        - name: AGENT_MODE
+          value: flow
+        - name: KUBERNETES_SERVICE_HOST  # Intentionally disable its connection to Kubernetes to make it fail in a known way
+          value: ""
+        - name: KUBERNETES_SERVICE_PORT  # Intentionally disable its connection to Kubernetes to make it fail in a known way
+          value: ""
+      volumeMounts:
+        - name: config
+          mountPath: /etc/agent
+  volumes:
+    - name: config
+      configMap:
+        name: "validate-k8smon-k8s-monitoring"
+---
 # Source: k8s-monitoring/templates/tests/test.yaml
 apiVersion: v1
 kind: Pod
@@ -46177,64 +46248,6 @@ spec:
       env:
         - name: AGENT_HOST
           value: k8smon-grafana-agent.default.svc
----
-# Source: k8s-monitoring/templates/hooks/validate-configuration.yaml
-apiVersion: batch/v1
-kind: Job
-metadata:
-  name: "validate-k8smon-k8s-monitoring"
-  namespace: default
-  labels:
-    app.kubernetes.io/managed-by: "Helm"
-    app.kubernetes.io/instance: "k8smon"
-    app.kubernetes.io/version: 2.0.2
-    helm.sh/chart: "k8s-monitoring-0.12.0"
-  annotations:
-    "helm.sh/hook": pre-install,pre-upgrade
-    "helm.sh/hook-weight": "-5"
-    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
-spec:
-  backoffLimit: 0
-  template:
-    metadata:
-      name: "validate-k8smon-k8s-monitoring"
-      labels:
-        app.kubernetes.io/managed-by: "Helm"
-        app.kubernetes.io/instance: "k8smon"
-        helm.sh/chart: "k8s-monitoring-0.12.0"
-    spec:
-      restartPolicy: Never
-      nodeSelector:
-        kubernetes.io/os: linux
-      containers:
-        - name: grafana-agent
-          image: "docker.io/grafana/agent:v0.40.3"
-          command:
-          - bash
-          - -ec
-          - |
-            echo Validating Grafana Agent config file
-            if grafana-agent fmt /etc/agent/config.river > /dev/null; then
-              echo "Grafana Agent config file is valid"
-            fi
-            echo Validating Grafana Agent for Events config file
-            if grafana-agent fmt /etc/agent/events.river > /dev/null; then
-              echo "Grafana Agent for Events config file is valid"
-            fi
-            echo Validating Grafana Agent for Logs config file
-            if grafana-agent fmt /etc/agent/logs.river > /dev/null; then
-              echo "Grafana Agent for Logs config file is valid"
-            fi
-          env:
-            - name: AGENT_MODE
-              value: flow
-          volumeMounts:
-            - name: config
-              mountPath: /etc/agent
-      volumes:
-        - name: config
-          configMap:
-            name: "validate-k8smon-k8s-monitoring"
 ---
 # Source: k8s-monitoring/templates/tests/test.yaml
 apiVersion: batch/v1

--- a/examples/windows-exporter/output.yaml
+++ b/examples/windows-exporter/output.yaml
@@ -46263,6 +46263,77 @@ data:
       ]
     }
 ---
+# Source: k8s-monitoring/templates/hooks/validate-configuration.yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "validate-k8smon-k8s-monitoring"
+  namespace: default
+  labels:
+    app.kubernetes.io/managed-by: "Helm"
+    app.kubernetes.io/instance: "k8smon"
+    app.kubernetes.io/version: 2.0.2
+    helm.sh/chart: "k8s-monitoring-0.12.0"
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "-5"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+spec:
+  restartPolicy: Never
+  nodeSelector:
+        kubernetes.io/os: linux
+  containers:
+    - name: grafana-agent
+      image: "docker.io/grafana/agent:v0.40.3"
+      command:
+      - bash
+      - -c
+      - |
+        echo Validating Grafana Agent config file
+        if ! grafana-agent fmt /etc/agent/config.river > /dev/null; then
+          exit 1
+        fi
+        output=$(grafana-agent run "/etc/agent/config.river" 2>&1)
+        if ! echo "${output}" | grep "KUBERNETES_SERVICE_HOST and KUBERNETES_SERVICE_PORT must be defined" >/dev/null; then
+          echo "${output}"
+          exit 1
+        fi
+        echo "Grafana Agent config file is valid"
+        echo Validating Grafana Agent for Events config file
+        if ! grafana-agent fmt /etc/agent/events.river > /dev/null; then
+          exit 1
+        fi
+        output=$(grafana-agent run "/etc/agent/events.river" 2>&1)
+        if ! echo "${output}" | grep "KUBERNETES_SERVICE_HOST and KUBERNETES_SERVICE_PORT must be defined" >/dev/null; then
+          echo "${output}"
+          exit 1
+        fi
+        echo "Grafana Agent for Events config file is valid"
+        echo Validating Grafana Agent for Logs config file
+        if ! grafana-agent fmt /etc/agent/logs.river > /dev/null; then
+          exit 1
+        fi
+        output=$(grafana-agent run "/etc/agent/logs.river" 2>&1)
+        if ! echo "${output}" | grep "KUBERNETES_SERVICE_HOST and KUBERNETES_SERVICE_PORT must be defined" >/dev/null; then
+          echo "${output}"
+          exit 1
+        fi
+        echo "Grafana Agent for Logs config file is valid"
+      env:
+        - name: AGENT_MODE
+          value: flow
+        - name: KUBERNETES_SERVICE_HOST  # Intentionally disable its connection to Kubernetes to make it fail in a known way
+          value: ""
+        - name: KUBERNETES_SERVICE_PORT  # Intentionally disable its connection to Kubernetes to make it fail in a known way
+          value: ""
+      volumeMounts:
+        - name: config
+          mountPath: /etc/agent
+  volumes:
+    - name: config
+      configMap:
+        name: "validate-k8smon-k8s-monitoring"
+---
 # Source: k8s-monitoring/templates/tests/test.yaml
 apiVersion: v1
 kind: Pod
@@ -46289,64 +46360,6 @@ spec:
       env:
         - name: AGENT_HOST
           value: k8smon-grafana-agent.default.svc
----
-# Source: k8s-monitoring/templates/hooks/validate-configuration.yaml
-apiVersion: batch/v1
-kind: Job
-metadata:
-  name: "validate-k8smon-k8s-monitoring"
-  namespace: default
-  labels:
-    app.kubernetes.io/managed-by: "Helm"
-    app.kubernetes.io/instance: "k8smon"
-    app.kubernetes.io/version: 2.0.2
-    helm.sh/chart: "k8s-monitoring-0.12.0"
-  annotations:
-    "helm.sh/hook": pre-install,pre-upgrade
-    "helm.sh/hook-weight": "-5"
-    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
-spec:
-  backoffLimit: 0
-  template:
-    metadata:
-      name: "validate-k8smon-k8s-monitoring"
-      labels:
-        app.kubernetes.io/managed-by: "Helm"
-        app.kubernetes.io/instance: "k8smon"
-        helm.sh/chart: "k8s-monitoring-0.12.0"
-    spec:
-      restartPolicy: Never
-      nodeSelector:
-        kubernetes.io/os: linux
-      containers:
-        - name: grafana-agent
-          image: "docker.io/grafana/agent:v0.40.3"
-          command:
-          - bash
-          - -ec
-          - |
-            echo Validating Grafana Agent config file
-            if grafana-agent fmt /etc/agent/config.river > /dev/null; then
-              echo "Grafana Agent config file is valid"
-            fi
-            echo Validating Grafana Agent for Events config file
-            if grafana-agent fmt /etc/agent/events.river > /dev/null; then
-              echo "Grafana Agent for Events config file is valid"
-            fi
-            echo Validating Grafana Agent for Logs config file
-            if grafana-agent fmt /etc/agent/logs.river > /dev/null; then
-              echo "Grafana Agent for Logs config file is valid"
-            fi
-          env:
-            - name: AGENT_MODE
-              value: flow
-          volumeMounts:
-            - name: config
-              mountPath: /etc/agent
-      volumes:
-        - name: config
-          configMap:
-            name: "validate-k8smon-k8s-monitoring"
 ---
 # Source: k8s-monitoring/templates/tests/test.yaml
 apiVersion: batch/v1


### PR DESCRIPTION
The hook runs `grafana-agent fmt` which only checks for syntax errors, but it will not catch issues if a component references a component that doesn't exist.

Running `grafana-agent run` will find those... but it actually runs the agent.

By setting `KUBERNETES_SERVICE_HOST` and `KUBERNETES_SERVICE_PORT` to empty values, we can force the agent to fail in a known way. If it fails in that way, we can assume the configuration is "valid" enough to proceed.