### PR TITLE
Support sending native histograms with remote_write

### DIFF
--- a/charts/k8s-monitoring/README.md
+++ b/charts/k8s-monitoring/README.md
@@ -175,6 +175,7 @@ The Prometheus and Loki services may be hosted on the same cluster, or remotely 
 | externalServices.prometheus.secret.create | bool | `true` | Should this Helm chart create the secret. If false, you must define the name and namespace values. |
 | externalServices.prometheus.secret.name | string | `""` | The name of the secret. |
 | externalServices.prometheus.secret.namespace | string | `""` | The namespace of the secret. Only used if secret.create = "false" |
+| externalServices.prometheus.sendNativeHistograms | bool | `false` | Whether native histograms should be sent. Only applies when protocol is "remote_write". |
 | externalServices.prometheus.tenantId | string | `""` | Sets the `X-Scope-OrgID` header when sending metrics |
 | externalServices.prometheus.tenantIdKey | string | `"tenantId"` | The key for the tenant ID property in the secret |
 | externalServices.prometheus.tls | object | `{}` | TLS settings to configure for the metrics service, compatible with [remoteWrite protocol](https://grafana.com/docs/agent/latest/flow/reference/components/prometheus.remote_write/#tls_config-block), [otlp](https://grafana.com/docs/agent/latest/flow/reference/components/otelcol.exporter.otlp/#tls-block), or [otlphttp](https://grafana.com/docs/agent/latest/flow/reference/components/otelcol.exporter.otlphttp/#tls-block) protocols |

--- a/charts/k8s-monitoring/templates/agent_config/_metrics_service_remote_write.river.txt
+++ b/charts/k8s-monitoring/templates/agent_config/_metrics_service_remote_write.river.txt
@@ -23,6 +23,7 @@ prometheus.remote_write "metrics_service" {
     {{- end }}
     }
 {{- end }}
+    send_native_histograms = {{ .sendNativeHistograms }}
   }
 
   wal {

--- a/charts/k8s-monitoring/values.schema.json
+++ b/charts/k8s-monitoring/values.schema.json
@@ -302,6 +302,9 @@
                                 }
                             }
                         },
+                        "sendNativeHistograms": {
+                            "type": "boolean"
+                        },
                         "tenantId": {
                             "type": [
                                 "string",

--- a/charts/k8s-monitoring/values.yaml
+++ b/charts/k8s-monitoring/values.yaml
@@ -95,6 +95,9 @@ externalServices:
       # -- Maximum time to keep data in the WAL before removing it.
       maxKeepaliveTime: 8h
 
+    # -- Whether native histograms should be sent. Only applies when protocol is "remote_write".
+    sendNativeHistograms: false
+
   # Connection information for Grafana Loki
   loki:
     # -- Loki host where logs and events will be sent

--- a/examples/agent-autoscaling-and-storage/metrics.river
+++ b/examples/agent-autoscaling-and-storage/metrics.river
@@ -722,6 +722,7 @@ prometheus.remote_write "metrics_service" {
       password = remote.kubernetes.secret.metrics_service.data["password"]
     }
 
+    send_native_histograms = false
   }
 
   wal {

--- a/examples/agent-autoscaling-and-storage/output.yaml
+++ b/examples/agent-autoscaling-and-storage/output.yaml
@@ -44293,8 +44293,6 @@ metadata:
     app.kubernetes.io/name: prometheus-node-exporter
     app.kubernetes.io/instance: k8smon
     app.kubernetes.io/version: "1.7.0"
-  annotations:
-    prometheus.io/scrape: "true"
 spec:
   type: ClusterIP
   ports:

--- a/examples/agent-autoscaling-and-storage/output.yaml
+++ b/examples/agent-autoscaling-and-storage/output.yaml
@@ -843,6 +843,7 @@ data:
           password = remote.kubernetes.secret.metrics_service.data["password"]
         }
     
+        send_native_histograms = false
       }
     
       wal {
@@ -44292,6 +44293,8 @@ metadata:
     app.kubernetes.io/name: prometheus-node-exporter
     app.kubernetes.io/instance: k8smon
     app.kubernetes.io/version: "1.7.0"
+  annotations:
+    prometheus.io/scrape: "true"
 spec:
   type: ClusterIP
   ports:
@@ -45709,6 +45712,7 @@ data:
           password = remote.kubernetes.secret.metrics_service.data["password"]
         }
     
+        send_native_histograms = false
       }
     
       wal {

--- a/examples/control-plane-metrics/metrics.river
+++ b/examples/control-plane-metrics/metrics.river
@@ -874,6 +874,7 @@ prometheus.remote_write "metrics_service" {
       password = remote.kubernetes.secret.metrics_service.data["password"]
     }
 
+    send_native_histograms = false
   }
 
   wal {

--- a/examples/control-plane-metrics/output.yaml
+++ b/examples/control-plane-metrics/output.yaml
@@ -996,6 +996,7 @@ data:
           password = remote.kubernetes.secret.metrics_service.data["password"]
         }
     
+        send_native_histograms = false
       }
     
       wal {
@@ -44445,6 +44446,8 @@ metadata:
     app.kubernetes.io/name: prometheus-node-exporter
     app.kubernetes.io/instance: k8smon
     app.kubernetes.io/version: "1.7.0"
+  annotations:
+    prometheus.io/scrape: "true"
 spec:
   type: ClusterIP
   ports:
@@ -45962,6 +45965,7 @@ data:
           password = remote.kubernetes.secret.metrics_service.data["password"]
         }
     
+        send_native_histograms = false
       }
     
       wal {

--- a/examples/control-plane-metrics/output.yaml
+++ b/examples/control-plane-metrics/output.yaml
@@ -44446,8 +44446,6 @@ metadata:
     app.kubernetes.io/name: prometheus-node-exporter
     app.kubernetes.io/instance: k8smon
     app.kubernetes.io/version: "1.7.0"
-  annotations:
-    prometheus.io/scrape: "true"
 spec:
   type: ClusterIP
   ports:

--- a/examples/custom-config/metrics.river
+++ b/examples/custom-config/metrics.river
@@ -722,6 +722,7 @@ prometheus.remote_write "metrics_service" {
       password = remote.kubernetes.secret.metrics_service.data["password"]
     }
 
+    send_native_histograms = false
   }
 
   wal {

--- a/examples/custom-config/output.yaml
+++ b/examples/custom-config/output.yaml
@@ -843,6 +843,7 @@ data:
           password = remote.kubernetes.secret.metrics_service.data["password"]
         }
     
+        send_native_histograms = false
       }
     
       wal {
@@ -44362,6 +44363,8 @@ metadata:
     app.kubernetes.io/name: prometheus-node-exporter
     app.kubernetes.io/instance: k8smon
     app.kubernetes.io/version: "1.7.0"
+  annotations:
+    prometheus.io/scrape: "true"
 spec:
   type: ClusterIP
   ports:
@@ -45727,6 +45730,7 @@ data:
           password = remote.kubernetes.secret.metrics_service.data["password"]
         }
     
+        send_native_histograms = false
       }
     
       wal {

--- a/examples/custom-config/output.yaml
+++ b/examples/custom-config/output.yaml
@@ -44363,8 +44363,6 @@ metadata:
     app.kubernetes.io/name: prometheus-node-exporter
     app.kubernetes.io/instance: k8smon
     app.kubernetes.io/version: "1.7.0"
-  annotations:
-    prometheus.io/scrape: "true"
 spec:
   type: ClusterIP
   ports:

--- a/examples/custom-metrics-tuning/metrics.river
+++ b/examples/custom-metrics-tuning/metrics.river
@@ -699,6 +699,7 @@ prometheus.remote_write "metrics_service" {
       password = remote.kubernetes.secret.metrics_service.data["password"]
     }
 
+    send_native_histograms = false
   }
 
   wal {

--- a/examples/custom-metrics-tuning/output.yaml
+++ b/examples/custom-metrics-tuning/output.yaml
@@ -779,6 +779,7 @@ data:
           password = remote.kubernetes.secret.metrics_service.data["password"]
         }
     
+        send_native_histograms = false
       }
     
       wal {
@@ -43659,6 +43660,8 @@ metadata:
     app.kubernetes.io/name: prometheus-node-exporter
     app.kubernetes.io/instance: k8smon
     app.kubernetes.io/version: "1.7.0"
+  annotations:
+    prometheus.io/scrape: "true"
 spec:
   type: ClusterIP
   ports:
@@ -44831,6 +44834,7 @@ data:
           password = remote.kubernetes.secret.metrics_service.data["password"]
         }
     
+        send_native_histograms = false
       }
     
       wal {

--- a/examples/custom-metrics-tuning/output.yaml
+++ b/examples/custom-metrics-tuning/output.yaml
@@ -43660,8 +43660,6 @@ metadata:
     app.kubernetes.io/name: prometheus-node-exporter
     app.kubernetes.io/instance: k8smon
     app.kubernetes.io/version: "1.7.0"
-  annotations:
-    prometheus.io/scrape: "true"
 spec:
   type: ClusterIP
   ports:

--- a/examples/custom-pricing/metrics.river
+++ b/examples/custom-pricing/metrics.river
@@ -722,6 +722,7 @@ prometheus.remote_write "metrics_service" {
       password = remote.kubernetes.secret.metrics_service.data["password"]
     }
 
+    send_native_histograms = false
   }
 
   wal {

--- a/examples/custom-pricing/output.yaml
+++ b/examples/custom-pricing/output.yaml
@@ -44314,8 +44314,6 @@ metadata:
     app.kubernetes.io/name: prometheus-node-exporter
     app.kubernetes.io/instance: k8smon
     app.kubernetes.io/version: "1.7.0"
-  annotations:
-    prometheus.io/scrape: "true"
 spec:
   type: ClusterIP
   ports:

--- a/examples/custom-pricing/output.yaml
+++ b/examples/custom-pricing/output.yaml
@@ -864,6 +864,7 @@ data:
           password = remote.kubernetes.secret.metrics_service.data["password"]
         }
     
+        send_native_histograms = false
       }
     
       wal {
@@ -44313,6 +44314,8 @@ metadata:
     app.kubernetes.io/name: prometheus-node-exporter
     app.kubernetes.io/instance: k8smon
     app.kubernetes.io/version: "1.7.0"
+  annotations:
+    prometheus.io/scrape: "true"
 spec:
   type: ClusterIP
   ports:
@@ -45688,6 +45691,7 @@ data:
           password = remote.kubernetes.secret.metrics_service.data["password"]
         }
     
+        send_native_histograms = false
       }
     
       wal {

--- a/examples/default-values/metrics.river
+++ b/examples/default-values/metrics.river
@@ -722,6 +722,7 @@ prometheus.remote_write "metrics_service" {
       password = remote.kubernetes.secret.metrics_service.data["password"]
     }
 
+    send_native_histograms = false
   }
 
   wal {

--- a/examples/default-values/output.yaml
+++ b/examples/default-values/output.yaml
@@ -44293,8 +44293,6 @@ metadata:
     app.kubernetes.io/name: prometheus-node-exporter
     app.kubernetes.io/instance: k8smon
     app.kubernetes.io/version: "1.7.0"
-  annotations:
-    prometheus.io/scrape: "true"
 spec:
   type: ClusterIP
   ports:

--- a/examples/default-values/output.yaml
+++ b/examples/default-values/output.yaml
@@ -843,6 +843,7 @@ data:
           password = remote.kubernetes.secret.metrics_service.data["password"]
         }
     
+        send_native_histograms = false
       }
     
       wal {
@@ -44292,6 +44293,8 @@ metadata:
     app.kubernetes.io/name: prometheus-node-exporter
     app.kubernetes.io/instance: k8smon
     app.kubernetes.io/version: "1.7.0"
+  annotations:
+    prometheus.io/scrape: "true"
 spec:
   type: ClusterIP
   ports:
@@ -45657,6 +45660,7 @@ data:
           password = remote.kubernetes.secret.metrics_service.data["password"]
         }
     
+        send_native_histograms = false
       }
     
       wal {

--- a/examples/eks-fargate/metrics.river
+++ b/examples/eks-fargate/metrics.river
@@ -676,6 +676,7 @@ prometheus.remote_write "metrics_service" {
       password = remote.kubernetes.secret.metrics_service.data["password"]
     }
 
+    send_native_histograms = false
   }
 
   wal {

--- a/examples/eks-fargate/output.yaml
+++ b/examples/eks-fargate/output.yaml
@@ -782,6 +782,7 @@ data:
           password = remote.kubernetes.secret.metrics_service.data["password"]
         }
     
+        send_native_histograms = false
       }
     
       wal {
@@ -45384,6 +45385,7 @@ data:
           password = remote.kubernetes.secret.metrics_service.data["password"]
         }
     
+        send_native_histograms = false
       }
     
       wal {

--- a/examples/extra-rules/metrics.river
+++ b/examples/extra-rules/metrics.river
@@ -772,6 +772,7 @@ prometheus.remote_write "metrics_service" {
       regex = "metric_to_drop|another_metric_to_drop"
       action = "drop"
     }
+    send_native_histograms = false
   }
 
   wal {

--- a/examples/extra-rules/output.yaml
+++ b/examples/extra-rules/output.yaml
@@ -44400,8 +44400,6 @@ metadata:
     app.kubernetes.io/name: prometheus-node-exporter
     app.kubernetes.io/instance: k8smon
     app.kubernetes.io/version: "1.7.0"
-  annotations:
-    prometheus.io/scrape: "true"
 spec:
   type: ClusterIP
   ports:

--- a/examples/extra-rules/output.yaml
+++ b/examples/extra-rules/output.yaml
@@ -894,6 +894,7 @@ data:
           regex = "metric_to_drop|another_metric_to_drop"
           action = "drop"
         }
+        send_native_histograms = false
       }
     
       wal {
@@ -44399,6 +44400,8 @@ metadata:
     app.kubernetes.io/name: prometheus-node-exporter
     app.kubernetes.io/instance: k8smon
     app.kubernetes.io/version: "1.7.0"
+  annotations:
+    prometheus.io/scrape: "true"
 spec:
   type: ClusterIP
   ports:
@@ -45814,6 +45817,7 @@ data:
           regex = "metric_to_drop|another_metric_to_drop"
           action = "drop"
         }
+        send_native_histograms = false
       }
     
       wal {

--- a/examples/gke-autopilot/metrics.river
+++ b/examples/gke-autopilot/metrics.river
@@ -676,6 +676,7 @@ prometheus.remote_write "metrics_service" {
       password = remote.kubernetes.secret.metrics_service.data["password"]
     }
 
+    send_native_histograms = false
   }
 
   wal {

--- a/examples/gke-autopilot/output.yaml
+++ b/examples/gke-autopilot/output.yaml
@@ -782,6 +782,7 @@ data:
           password = remote.kubernetes.secret.metrics_service.data["password"]
         }
     
+        send_native_histograms = false
       }
     
       wal {
@@ -45402,6 +45403,7 @@ data:
           password = remote.kubernetes.secret.metrics_service.data["password"]
         }
     
+        send_native_histograms = false
       }
     
       wal {

--- a/examples/ibm-cloud/metrics.river
+++ b/examples/ibm-cloud/metrics.river
@@ -722,6 +722,7 @@ prometheus.remote_write "metrics_service" {
       password = remote.kubernetes.secret.metrics_service.data["password"]
     }
 
+    send_native_histograms = false
   }
 
   wal {

--- a/examples/ibm-cloud/output.yaml
+++ b/examples/ibm-cloud/output.yaml
@@ -843,6 +843,7 @@ data:
           password = remote.kubernetes.secret.metrics_service.data["password"]
         }
     
+        send_native_histograms = false
       }
     
       wal {
@@ -44292,6 +44293,8 @@ metadata:
     app.kubernetes.io/name: prometheus-node-exporter
     app.kubernetes.io/instance: k8smon
     app.kubernetes.io/version: "1.7.0"
+  annotations:
+    prometheus.io/scrape: "true"
 spec:
   type: ClusterIP
   ports:
@@ -45663,6 +45666,7 @@ data:
           password = remote.kubernetes.secret.metrics_service.data["password"]
         }
     
+        send_native_histograms = false
       }
     
       wal {

--- a/examples/ibm-cloud/output.yaml
+++ b/examples/ibm-cloud/output.yaml
@@ -44293,8 +44293,6 @@ metadata:
     app.kubernetes.io/name: prometheus-node-exporter
     app.kubernetes.io/instance: k8smon
     app.kubernetes.io/version: "1.7.0"
-  annotations:
-    prometheus.io/scrape: "true"
 spec:
   type: ClusterIP
   ports:

--- a/examples/kube-pod-labels/metrics.river
+++ b/examples/kube-pod-labels/metrics.river
@@ -722,6 +722,7 @@ prometheus.remote_write "metrics_service" {
       password = remote.kubernetes.secret.metrics_service.data["password"]
     }
 
+    send_native_histograms = false
   }
 
   wal {

--- a/examples/kube-pod-labels/output.yaml
+++ b/examples/kube-pod-labels/output.yaml
@@ -44293,8 +44293,6 @@ metadata:
     app.kubernetes.io/name: prometheus-node-exporter
     app.kubernetes.io/instance: k8smon
     app.kubernetes.io/version: "1.7.0"
-  annotations:
-    prometheus.io/scrape: "true"
 spec:
   type: ClusterIP
   ports:

--- a/examples/kube-pod-labels/output.yaml
+++ b/examples/kube-pod-labels/output.yaml
@@ -843,6 +843,7 @@ data:
           password = remote.kubernetes.secret.metrics_service.data["password"]
         }
     
+        send_native_histograms = false
       }
     
       wal {
@@ -44292,6 +44293,8 @@ metadata:
     app.kubernetes.io/name: prometheus-node-exporter
     app.kubernetes.io/instance: k8smon
     app.kubernetes.io/version: "1.7.0"
+  annotations:
+    prometheus.io/scrape: "true"
 spec:
   type: ClusterIP
   ports:
@@ -45658,6 +45661,7 @@ data:
           password = remote.kubernetes.secret.metrics_service.data["password"]
         }
     
+        send_native_histograms = false
       }
     
       wal {

--- a/examples/metrics-only/metrics.river
+++ b/examples/metrics-only/metrics.river
@@ -704,6 +704,7 @@ prometheus.remote_write "metrics_service" {
       password = remote.kubernetes.secret.metrics_service.data["password"]
     }
 
+    send_native_histograms = false
   }
 
   wal {

--- a/examples/metrics-only/output.yaml
+++ b/examples/metrics-only/output.yaml
@@ -43666,8 +43666,6 @@ metadata:
     app.kubernetes.io/name: prometheus-node-exporter
     app.kubernetes.io/instance: k8smon
     app.kubernetes.io/version: "1.7.0"
-  annotations:
-    prometheus.io/scrape: "true"
 spec:
   type: ClusterIP
   ports:

--- a/examples/metrics-only/output.yaml
+++ b/examples/metrics-only/output.yaml
@@ -785,6 +785,7 @@ data:
           password = remote.kubernetes.secret.metrics_service.data["password"]
         }
     
+        send_native_histograms = false
       }
     
       wal {
@@ -43665,6 +43666,8 @@ metadata:
     app.kubernetes.io/name: prometheus-node-exporter
     app.kubernetes.io/instance: k8smon
     app.kubernetes.io/version: "1.7.0"
+  annotations:
+    prometheus.io/scrape: "true"
 spec:
   type: ClusterIP
   ports:
@@ -44842,6 +44845,7 @@ data:
           password = remote.kubernetes.secret.metrics_service.data["password"]
         }
     
+        send_native_histograms = false
       }
     
       wal {

--- a/examples/openshift-compatible/metrics.river
+++ b/examples/openshift-compatible/metrics.river
@@ -724,6 +724,7 @@ prometheus.remote_write "metrics_service" {
       password = remote.kubernetes.secret.metrics_service.data["password"]
     }
 
+    send_native_histograms = false
   }
 
   wal {

--- a/examples/openshift-compatible/output.yaml
+++ b/examples/openshift-compatible/output.yaml
@@ -815,6 +815,7 @@ data:
           password = remote.kubernetes.secret.metrics_service.data["password"]
         }
     
+        send_native_histograms = false
       }
     
       wal {
@@ -45312,6 +45313,7 @@ data:
           password = remote.kubernetes.secret.metrics_service.data["password"]
         }
     
+        send_native_histograms = false
       }
     
       wal {

--- a/examples/otel-metrics-service/output.yaml
+++ b/examples/otel-metrics-service/output.yaml
@@ -44322,6 +44322,8 @@ metadata:
     app.kubernetes.io/name: prometheus-node-exporter
     app.kubernetes.io/instance: k8smon
     app.kubernetes.io/version: "1.7.0"
+  annotations:
+    prometheus.io/scrape: "true"
 spec:
   type: ClusterIP
   ports:

--- a/examples/otel-metrics-service/output.yaml
+++ b/examples/otel-metrics-service/output.yaml
@@ -44322,8 +44322,6 @@ metadata:
     app.kubernetes.io/name: prometheus-node-exporter
     app.kubernetes.io/instance: k8smon
     app.kubernetes.io/version: "1.7.0"
-  annotations:
-    prometheus.io/scrape: "true"
 spec:
   type: ClusterIP
   ports:

--- a/examples/private-image-registry/metrics.river
+++ b/examples/private-image-registry/metrics.river
@@ -722,6 +722,7 @@ prometheus.remote_write "metrics_service" {
       password = remote.kubernetes.secret.metrics_service.data["password"]
     }
 
+    send_native_histograms = false
   }
 
   wal {

--- a/examples/private-image-registry/output.yaml
+++ b/examples/private-image-registry/output.yaml
@@ -44297,8 +44297,6 @@ metadata:
     app.kubernetes.io/name: prometheus-node-exporter
     app.kubernetes.io/instance: k8smon
     app.kubernetes.io/version: "1.7.0"
-  annotations:
-    prometheus.io/scrape: "true"
 spec:
   type: ClusterIP
   ports:

--- a/examples/private-image-registry/output.yaml
+++ b/examples/private-image-registry/output.yaml
@@ -847,6 +847,7 @@ data:
           password = remote.kubernetes.secret.metrics_service.data["password"]
         }
     
+        send_native_histograms = false
       }
     
       wal {
@@ -44296,6 +44297,8 @@ metadata:
     app.kubernetes.io/name: prometheus-node-exporter
     app.kubernetes.io/instance: k8smon
     app.kubernetes.io/version: "1.7.0"
+  annotations:
+    prometheus.io/scrape: "true"
 spec:
   type: ClusterIP
   ports:
@@ -45673,6 +45676,7 @@ data:
           password = remote.kubernetes.secret.metrics_service.data["password"]
         }
     
+        send_native_histograms = false
       }
     
       wal {

--- a/examples/proxies/metrics.river
+++ b/examples/proxies/metrics.river
@@ -726,6 +726,7 @@ prometheus.remote_write "metrics_service" {
     tls_config {
       insecure_skip_verify = true
     }
+    send_native_histograms = false
   }
 
   wal {

--- a/examples/proxies/output.yaml
+++ b/examples/proxies/output.yaml
@@ -847,6 +847,7 @@ data:
         tls_config {
           insecure_skip_verify = true
         }
+        send_native_histograms = false
       }
     
       wal {
@@ -44308,6 +44309,8 @@ metadata:
     app.kubernetes.io/name: prometheus-node-exporter
     app.kubernetes.io/instance: k8smon
     app.kubernetes.io/version: "1.7.0"
+  annotations:
+    prometheus.io/scrape: "true"
 spec:
   type: ClusterIP
   ports:
@@ -45677,6 +45680,7 @@ data:
         tls_config {
           insecure_skip_verify = true
         }
+        send_native_histograms = false
       }
     
       wal {

--- a/examples/proxies/output.yaml
+++ b/examples/proxies/output.yaml
@@ -44309,8 +44309,6 @@ metadata:
     app.kubernetes.io/name: prometheus-node-exporter
     app.kubernetes.io/instance: k8smon
     app.kubernetes.io/version: "1.7.0"
-  annotations:
-    prometheus.io/scrape: "true"
 spec:
   type: ClusterIP
   ports:

--- a/examples/scrape-intervals/metrics.river
+++ b/examples/scrape-intervals/metrics.river
@@ -704,6 +704,7 @@ prometheus.remote_write "metrics_service" {
       password = remote.kubernetes.secret.metrics_service.data["password"]
     }
 
+    send_native_histograms = false
   }
 
   wal {

--- a/examples/scrape-intervals/output.yaml
+++ b/examples/scrape-intervals/output.yaml
@@ -784,6 +784,7 @@ data:
           password = remote.kubernetes.secret.metrics_service.data["password"]
         }
     
+        send_native_histograms = false
       }
     
       wal {
@@ -43664,6 +43665,8 @@ metadata:
     app.kubernetes.io/name: prometheus-node-exporter
     app.kubernetes.io/instance: k8smon
     app.kubernetes.io/version: "1.7.0"
+  annotations:
+    prometheus.io/scrape: "true"
 spec:
   type: ClusterIP
   ports:
@@ -44841,6 +44844,7 @@ data:
           password = remote.kubernetes.secret.metrics_service.data["password"]
         }
     
+        send_native_histograms = false
       }
     
       wal {

--- a/examples/scrape-intervals/output.yaml
+++ b/examples/scrape-intervals/output.yaml
@@ -43665,8 +43665,6 @@ metadata:
     app.kubernetes.io/name: prometheus-node-exporter
     app.kubernetes.io/instance: k8smon
     app.kubernetes.io/version: "1.7.0"
-  annotations:
-    prometheus.io/scrape: "true"
 spec:
   type: ClusterIP
   ports:

--- a/examples/service-integrations/metrics.river
+++ b/examples/service-integrations/metrics.river
@@ -722,6 +722,7 @@ prometheus.remote_write "metrics_service" {
       password = remote.kubernetes.secret.metrics_service.data["password"]
     }
 
+    send_native_histograms = false
   }
 
   wal {

--- a/examples/service-integrations/output.yaml
+++ b/examples/service-integrations/output.yaml
@@ -843,6 +843,7 @@ data:
           password = remote.kubernetes.secret.metrics_service.data["password"]
         }
     
+        send_native_histograms = false
       }
     
       wal {
@@ -44327,6 +44328,8 @@ metadata:
     app.kubernetes.io/name: prometheus-node-exporter
     app.kubernetes.io/instance: k8smon
     app.kubernetes.io/version: "1.7.0"
+  annotations:
+    prometheus.io/scrape: "true"
 spec:
   type: ClusterIP
   ports:
@@ -45692,6 +45695,7 @@ data:
           password = remote.kubernetes.secret.metrics_service.data["password"]
         }
     
+        send_native_histograms = false
       }
     
       wal {

--- a/examples/service-integrations/output.yaml
+++ b/examples/service-integrations/output.yaml
@@ -44328,8 +44328,6 @@ metadata:
     app.kubernetes.io/name: prometheus-node-exporter
     app.kubernetes.io/instance: k8smon
     app.kubernetes.io/version: "1.7.0"
-  annotations:
-    prometheus.io/scrape: "true"
 spec:
   type: ClusterIP
   ports:

--- a/examples/specific-namespace/metrics.river
+++ b/examples/specific-namespace/metrics.river
@@ -780,6 +780,7 @@ prometheus.remote_write "metrics_service" {
       password = remote.kubernetes.secret.metrics_service.data["password"]
     }
 
+    send_native_histograms = false
   }
 
   wal {

--- a/examples/specific-namespace/output.yaml
+++ b/examples/specific-namespace/output.yaml
@@ -44357,8 +44357,6 @@ metadata:
     app.kubernetes.io/name: prometheus-node-exporter
     app.kubernetes.io/instance: k8smon
     app.kubernetes.io/version: "1.7.0"
-  annotations:
-    prometheus.io/scrape: "true"
 spec:
   type: ClusterIP
   ports:

--- a/examples/specific-namespace/output.yaml
+++ b/examples/specific-namespace/output.yaml
@@ -901,6 +901,7 @@ data:
           password = remote.kubernetes.secret.metrics_service.data["password"]
         }
     
+        send_native_histograms = false
       }
     
       wal {
@@ -44356,6 +44357,8 @@ metadata:
     app.kubernetes.io/name: prometheus-node-exporter
     app.kubernetes.io/instance: k8smon
     app.kubernetes.io/version: "1.7.0"
+  annotations:
+    prometheus.io/scrape: "true"
 spec:
   type: ClusterIP
   ports:
@@ -45779,6 +45782,7 @@ data:
           password = remote.kubernetes.secret.metrics_service.data["password"]
         }
     
+        send_native_histograms = false
       }
     
       wal {

--- a/examples/traces-enabled/metrics.river
+++ b/examples/traces-enabled/metrics.river
@@ -790,6 +790,7 @@ prometheus.remote_write "metrics_service" {
       password = remote.kubernetes.secret.metrics_service.data["password"]
     }
 
+    send_native_histograms = false
   }
 
   wal {

--- a/examples/traces-enabled/output.yaml
+++ b/examples/traces-enabled/output.yaml
@@ -924,6 +924,7 @@ data:
           password = remote.kubernetes.secret.metrics_service.data["password"]
         }
     
+        send_native_histograms = false
       }
     
       wal {
@@ -44394,6 +44395,8 @@ metadata:
     app.kubernetes.io/name: prometheus-node-exporter
     app.kubernetes.io/instance: k8smon
     app.kubernetes.io/version: "1.7.0"
+  annotations:
+    prometheus.io/scrape: "true"
 spec:
   type: ClusterIP
   ports:
@@ -45827,6 +45830,7 @@ data:
           password = remote.kubernetes.secret.metrics_service.data["password"]
         }
     
+        send_native_histograms = false
       }
     
       wal {

--- a/examples/traces-enabled/output.yaml
+++ b/examples/traces-enabled/output.yaml
@@ -44395,8 +44395,6 @@ metadata:
     app.kubernetes.io/name: prometheus-node-exporter
     app.kubernetes.io/instance: k8smon
     app.kubernetes.io/version: "1.7.0"
-  annotations:
-    prometheus.io/scrape: "true"
 spec:
   type: ClusterIP
   ports:

--- a/examples/windows-exporter/metrics.river
+++ b/examples/windows-exporter/metrics.river
@@ -790,6 +790,7 @@ prometheus.remote_write "metrics_service" {
       password = remote.kubernetes.secret.metrics_service.data["password"]
     }
 
+    send_native_histograms = false
   }
 
   wal {

--- a/examples/windows-exporter/output.yaml
+++ b/examples/windows-exporter/output.yaml
@@ -948,6 +948,7 @@ data:
           password = remote.kubernetes.secret.metrics_service.data["password"]
         }
     
+        send_native_histograms = false
       }
     
       wal {
@@ -44397,6 +44398,8 @@ metadata:
     app.kubernetes.io/name: prometheus-node-exporter
     app.kubernetes.io/instance: k8smon
     app.kubernetes.io/version: "1.7.0"
+  annotations:
+    prometheus.io/scrape: "true"
 spec:
   type: ClusterIP
   ports:
@@ -45956,6 +45959,7 @@ data:
           password = remote.kubernetes.secret.metrics_service.data["password"]
         }
     
+        send_native_histograms = false
       }
     
       wal {

--- a/examples/windows-exporter/output.yaml
+++ b/examples/windows-exporter/output.yaml
@@ -44398,8 +44398,6 @@ metadata:
     app.kubernetes.io/name: prometheus-node-exporter
     app.kubernetes.io/instance: k8smon
     app.kubernetes.io/version: "1.7.0"
-  annotations:
-    prometheus.io/scrape: "true"
 spec:
   type: ClusterIP
   ports:


### PR DESCRIPTION
Expose this setting under `externalServices.prometheus`, for backends that support it.