### PR TITLE
Fix Helm chart dependency checking

### DIFF
--- a/.github/configs/updatecli.d/kube-state-metrics.yaml
+++ b/.github/configs/updatecli.d/kube-state-metrics.yaml
@@ -15,7 +15,7 @@ conditions:
         kind: yaml
         spec:
             file: charts/k8s-monitoring/Chart.yaml
-            key: $.dependencies[2].name
+            key: $.dependencies[3].name
             value: kube-state-metrics
         disablesourceinput: true
 targets:
@@ -24,7 +24,7 @@ targets:
         kind: helmchart
         spec:
             file: Chart.yaml
-            key: $.dependencies[2].version
+            key: $.dependencies[3].version
             name: charts/k8s-monitoring
             versionincrement: none
         sourceid: kube-state-metrics

--- a/.github/configs/updatecli.d/node-exporter.yaml
+++ b/.github/configs/updatecli.d/node-exporter.yaml
@@ -16,7 +16,7 @@ conditions:
         kind: yaml
         spec:
             file: charts/k8s-monitoring/Chart.yaml
-            key: $.dependencies[3].name
+            key: $.dependencies[4].name
             value: prometheus-node-exporter
         disablesourceinput: true
 
@@ -26,7 +26,7 @@ targets:
         kind: helmchart
         spec:
             file: Chart.yaml
-            key: $.dependencies[3].version
+            key: $.dependencies[4].version
             name: charts/k8s-monitoring
             versionincrement: none
         sourceid: prometheus-node-exporter

--- a/.github/configs/updatecli.d/opencost.yaml
+++ b/.github/configs/updatecli.d/opencost.yaml
@@ -15,7 +15,7 @@ conditions:
         kind: yaml
         spec:
             file: charts/k8s-monitoring/Chart.yaml
-            key: $.dependencies[6].name
+            key: $.dependencies[7].name
             value: opencost
         disablesourceinput: true
 targets:
@@ -24,7 +24,7 @@ targets:
         kind: helmchart
         spec:
             file: Chart.yaml
-            key: $.dependencies[6].version
+            key: $.dependencies[7].version
             name: charts/k8s-monitoring
             versionincrement: none
         sourceid: opencost

--- a/.github/configs/updatecli.d/prometheus-operator-crds.yaml
+++ b/.github/configs/updatecli.d/prometheus-operator-crds.yaml
@@ -15,7 +15,7 @@ conditions:
         kind: yaml
         spec:
             file: charts/k8s-monitoring/Chart.yaml
-            key: $.dependencies[4].name
+            key: $.dependencies[5].name
             value: prometheus-operator-crds
         disablesourceinput: true
 targets:
@@ -24,7 +24,7 @@ targets:
         kind: helmchart
         spec:
             file: Chart.yaml
-            key: $.dependencies[4].version
+            key: $.dependencies[5].version
             name: charts/k8s-monitoring
             versionincrement: none
         sourceid: prometheus-operator-crds

--- a/.github/configs/updatecli.d/windows-exporter.yaml
+++ b/.github/configs/updatecli.d/windows-exporter.yaml
@@ -15,7 +15,7 @@ conditions:
         kind: yaml
         spec:
             file: charts/k8s-monitoring/Chart.yaml
-            key: $.dependencies[5].name
+            key: $.dependencies[6].name
             value: prometheus-windows-exporter
         disablesourceinput: true
 targets:
@@ -24,7 +24,7 @@ targets:
         kind: helmchart
         spec:
             file: Chart.yaml
-            key: $.dependencies[5].version
+            key: $.dependencies[6].version
             name: charts/k8s-monitoring
             versionincrement: none
         sourceid: prometheus-windows-exporter


### PR DESCRIPTION
Never adjusted the indices after adding Grafana Agent for Events.

Note to reviewer:
Indices 0, 1, and 2 are used by Grafana Agent, agent for events, and agent for logs.
It should match the lines in this file: https://github.com/grafana/k8s-monitoring-helm/blob/main/charts/k8s-monitoring/Chart.yaml