### PR TITLE
Add extension points for otelcol.processor.transform

### DIFF
--- a/charts/k8s-monitoring/README.md
+++ b/charts/k8s-monitoring/README.md
@@ -222,6 +222,7 @@ The Prometheus and Loki services may be hosted on the same cluster, or remotely 
 | logs.pod_logs.gatherMethod | string | `"volumes"` | Controls the behavior of gathering pod logs. When set to "volumes", the Grafana Agent will use HostPath volume mounts on the cluster nodes to access the pod log files directly. When set to "api", the Grafana Agent will access pod logs via the API server. This method may be preferable if your cluster prevents DaemonSets, HostPath volume mounts, or for other reasons. |
 | logs.pod_logs.namespaces | list | `[]` | Only capture logs from pods in these namespaces (`[]` means all namespaces) |
 | logs.receiver.filters | object | `{"log_record":[]}` | Apply a filter to logs received via the OTLP or OTLP HTTP receivers. ([docs](https://grafana.com/docs/agent/latest/flow/reference/components/otelcol.processor.filter/)) |
+| logs.receiver.transforms | object | `{"log":[],"resource":[]}` | Apply a transformation to logs received via the OTLP or OTLP HTTP receivers. ([docs](https://grafana.com/docs/agent/latest/flow/reference/components/otelcol.processor.transform/)) |
 | metrics.agent.enabled | bool | `true` | Scrape metrics from Grafana Agent |
 | metrics.agent.extraMetricRelabelingRules | string | `""` | Rule blocks to be added to the prometheus.relabel component for Grafana Agent. ([docs](https://grafana.com/docs/agent/latest/flow/reference/components/prometheus.relabel/#rule-block)) |
 | metrics.agent.extraRelabelingRules | string | `""` | Rule blocks to be added to the discovery.relabel component for Grafana Agent. ([docs](https://grafana.com/docs/agent/latest/flow/reference/components/discovery.relabel/#rule-block)) |
@@ -335,6 +336,7 @@ The Prometheus and Loki services may be hosted on the same cluster, or remotely 
 | metrics.probes.scrapeInterval | string | 60s | How frequently to scrape metrics from Probe objects. Only used if the Probe does not specify the scrape interval. Overrides metrics.scrapeInterval |
 | metrics.probes.selector | string | `""` | Selector to filter which Probes objects to use. |
 | metrics.receiver.filters | object | `{"datapoint":[],"metric":[]}` | Apply a filter to metrics received via the OTLP or OTLP HTTP receivers. ([docs](https://grafana.com/docs/agent/latest/flow/reference/components/otelcol.processor.filter/)) |
+| metrics.receiver.transforms | object | `{"datapoint":[],"metric":[],"resource":[]}` | Apply a transformation to metrics received via the OTLP or OTLP HTTP receivers. ([docs](https://grafana.com/docs/agent/latest/flow/reference/components/otelcol.processor.transform/)) |
 | metrics.scrapeInterval | string | `"60s"` | How frequently to scrape metrics |
 | metrics.serviceMonitors.enabled | bool | `true` | Enable discovery of Prometheus Operator ServiceMonitor objects. |
 | metrics.serviceMonitors.extraMetricRelabelingRules | string | `""` | Rule blocks to be added to the prometheus.relabel component for ServiceMonitor objects. ([docs](https://grafana.com/docs/agent/latest/flow/reference/components/prometheus.relabel/#rule-block)) |
@@ -395,6 +397,7 @@ The Prometheus and Loki services may be hosted on the same cluster, or remotely 
 | test.tolerations | list | `[]` | Tolerations to apply to the test job. |
 | traces.enabled | bool | `false` | Receive and forward traces. |
 | traces.receiver.filters | object | `{"span":[],"spanevent":[]}` | Apply a filter to traces received via the OTLP or OTLP HTTP receivers. ([docs](https://grafana.com/docs/agent/latest/flow/reference/components/otelcol.processor.filter/)) |
+| traces.receiver.transforms | object | `{"resource":[],"span":[],"spanevent":[]}` | Apply a transformation to traces received via the OTLP or OTLP HTTP receivers. ([docs](https://grafana.com/docs/agent/latest/flow/reference/components/otelcol.processor.transform/)) |
 
 ## Customizing the configuration
 

--- a/charts/k8s-monitoring/templates/agent_config/_processors.river.txt
+++ b/charts/k8s-monitoring/templates/agent_config/_processors.river.txt
@@ -61,14 +61,14 @@ otelcol.processor.k8sattributes "default" {
 
   output {
 {{- if .Values.metrics.enabled }}
-    metrics = [otelcol.processor.transform.add_resource_attributes.input]
+    metrics = [otelcol.processor.transform.default.input]
 {{- end }}
 {{- if .Values.logs.enabled }}
-    logs    = [otelcol.processor.transform.add_resource_attributes.input]
+    logs    = [otelcol.processor.transform.default.input]
 {{- end }}
 {{- if .Values.traces.enabled }}
     traces  = [
-      otelcol.processor.transform.add_resource_attributes.input, 
+      otelcol.processor.transform.default.input, 
     {{- if .Values.metrics.enabled }}
       otelcol.connector.host_info.default.input,
     {{- end }}
@@ -104,35 +104,100 @@ otelcol.exporter.prometheus "host_info_metrics" {
   {{- end }}
 {{- end }}
 
-otelcol.processor.transform "add_resource_attributes" {
+otelcol.processor.transform "default" {
   // Grafana Cloud Kubernetes monitoring expects Loki labels `cluster`, `pod`, and `namespace`
   error_mode = "ignore"
 {{- if .Values.metrics.enabled }}
   metric_statements {
     context = "resource"
     statements = [
+{{- if .Values.metrics.receiver.transforms.resource }}
+{{- range $transform := .Values.metrics.receiver.transforms.resource }}
+{{ $transform | quote | indent 6 }},
+{{- end }}
+{{- end }}
       "set(attributes[\"k8s.cluster.name\"], \"{{ required ".Values.cluster.name is a required value. Please set it and try again." .Values.cluster.name }}\") where attributes[\"k8s.cluster.name\"] == nil",
     ]
   }
+{{- if .Values.metrics.receiver.transforms.metric }}
+  metric_statements {
+    context = "metric"
+    statements = [
+{{- range $transform := .Values.metrics.receiver.transforms.metric }}
+{{ $transform | quote | indent 6 }},
+{{- end }}
+    ]
+  }
+{{- end }}
+{{- if .Values.metrics.receiver.transforms.datapoint }}
+  metric_statements {
+    context = "datapoint"
+    statements = [
+{{- range $transform := .Values.metrics.receiver.transforms.datapoint }}
+{{ $transform | quote | indent 6 }},
+{{- end }}
+    ]
+  }
+{{- end }}
 {{- end }}
 {{- if .Values.logs.enabled }}
   log_statements {
     context = "resource"
     statements = [
+{{- if .Values.logs.receiver.transforms.resource }}
+{{- range $transform := .Values.logs.receiver.transforms.resource }}
+{{ $transform | quote | indent 6 }},
+{{- end }}
+{{- end }}
       "set(attributes[\"pod\"], attributes[\"k8s.pod.name\"])",
       "set(attributes[\"namespace\"], attributes[\"k8s.namespace.name\"])",
       "set(attributes[\"loki.resource.labels\"], \"pod, namespace, cluster, job\")",
       "set(attributes[\"k8s.cluster.name\"], \"{{ required ".Values.cluster.name is a required value. Please set it and try again." .Values.cluster.name }}\") where attributes[\"k8s.cluster.name\"] == nil",
     ]
   }
+{{- if .Values.logs.receiver.transforms.log }}
+  log_statements {
+    context = "log"
+    statements = [
+{{- range $transform := .Values.logs.receiver.transforms.log }}
+{{ $transform | quote | indent 6 }},
+{{- end }}
+    ]
+  }
+{{- end }}
 {{- end }}
 {{- if .Values.traces.enabled }}
   trace_statements {
     context = "resource"
     statements = [
+{{- if .Values.traces.receiver.transforms.resource }}
+{{- range $transform := .Values.traces.receiver.transforms.resource }}
+{{ $transform | quote | indent 6 }},
+{{- end }}
+{{- end }}
       "set(attributes[\"k8s.cluster.name\"], \"{{ required ".Values.cluster.name is a required value. Please set it and try again." .Values.cluster.name }}\") where attributes[\"k8s.cluster.name\"] == nil",
     ]
   }
+{{- if .Values.traces.receiver.transforms.span }}
+  trace_statements {
+    context = "span"
+    statements = [
+{{- range $transform := .Values.traces.receiver.transforms.span }}
+{{ $transform | quote | indent 6 }},
+{{- end }}
+    ]
+  }
+{{- end }}
+{{- if .Values.traces.receiver.transforms.spanevent }}
+  trace_statements {
+    context = "spanevent"
+    statements = [
+{{- range $transform := .Values.traces.receiver.transforms.spanevent }}
+{{ $transform | quote | indent 6 }},
+{{- end }}
+    ]
+  }
+{{- end }}
 {{- end }}
   output {
 {{- if .Values.metrics.enabled }}

--- a/charts/k8s-monitoring/values.schema.json
+++ b/charts/k8s-monitoring/values.schema.json
@@ -528,6 +528,17 @@
                                     "type": "array"
                                 }
                             }
+                        },
+                        "transforms": {
+                            "type": "object",
+                            "properties": {
+                                "log": {
+                                    "type": "array"
+                                },
+                                "resource": {
+                                    "type": "array"
+                                }
+                            }
                         }
                     }
                 }
@@ -1142,6 +1153,20 @@
                                     "type": "array"
                                 }
                             }
+                        },
+                        "transforms": {
+                            "type": "object",
+                            "properties": {
+                                "datapoint": {
+                                    "type": "array"
+                                },
+                                "metric": {
+                                    "type": "array"
+                                },
+                                "resource": {
+                                    "type": "array"
+                                }
+                            }
                         }
                     }
                 },
@@ -1493,6 +1518,20 @@
                         "filters": {
                             "type": "object",
                             "properties": {
+                                "span": {
+                                    "type": "array"
+                                },
+                                "spanevent": {
+                                    "type": "array"
+                                }
+                            }
+                        },
+                        "transforms": {
+                            "type": "object",
+                            "properties": {
+                                "resource": {
+                                    "type": "array"
+                                },
                                 "span": {
                                     "type": "array"
                                 },

--- a/charts/k8s-monitoring/values.yaml
+++ b/charts/k8s-monitoring/values.yaml
@@ -676,6 +676,11 @@ metrics:
     filters:
       metric: []
       datapoint: []
+    # -- Apply a transformation to metrics received via the OTLP or OTLP HTTP receivers. ([docs](https://grafana.com/docs/agent/latest/flow/reference/components/otelcol.processor.transform/))
+    transforms:
+      resource: []
+      metric: []
+      datapoint: []
 
 # Settings related to capturing and forwarding logs
 logs:
@@ -751,6 +756,10 @@ logs:
     # -- Apply a filter to logs received via the OTLP or OTLP HTTP receivers. ([docs](https://grafana.com/docs/agent/latest/flow/reference/components/otelcol.processor.filter/))
     filters:
       log_record: []
+    # -- Apply a transformation to logs received via the OTLP or OTLP HTTP receivers. ([docs](https://grafana.com/docs/agent/latest/flow/reference/components/otelcol.processor.transform/))
+    transforms:
+      resource: []
+      log: []
 
   # -- Extra configuration that will be added to Grafana Agent Logs configuration file.
   # This value is templated so that you can refer to other values from this file.
@@ -767,6 +776,11 @@ traces:
   receiver:
     # -- Apply a filter to traces received via the OTLP or OTLP HTTP receivers. ([docs](https://grafana.com/docs/agent/latest/flow/reference/components/otelcol.processor.filter/))
     filters:
+      span: []
+      spanevent: []
+    # -- Apply a transformation to traces received via the OTLP or OTLP HTTP receivers. ([docs](https://grafana.com/docs/agent/latest/flow/reference/components/otelcol.processor.transform/))
+    transforms:
+      resource: []
       span: []
       spanevent: []
 

--- a/examples/agent-autoscaling-and-storage/metrics.river
+++ b/examples/agent-autoscaling-and-storage/metrics.river
@@ -87,12 +87,12 @@ otelcol.processor.k8sattributes "default" {
   }
 
   output {
-    metrics = [otelcol.processor.transform.add_resource_attributes.input]
-    logs    = [otelcol.processor.transform.add_resource_attributes.input]
+    metrics = [otelcol.processor.transform.default.input]
+    logs    = [otelcol.processor.transform.default.input]
   }
 }
 
-otelcol.processor.transform "add_resource_attributes" {
+otelcol.processor.transform "default" {
   // Grafana Cloud Kubernetes monitoring expects Loki labels `cluster`, `pod`, and `namespace`
   error_mode = "ignore"
   metric_statements {

--- a/examples/agent-autoscaling-and-storage/output.yaml
+++ b/examples/agent-autoscaling-and-storage/output.yaml
@@ -209,12 +209,12 @@ data:
       }
     
       output {
-        metrics = [otelcol.processor.transform.add_resource_attributes.input]
-        logs    = [otelcol.processor.transform.add_resource_attributes.input]
+        metrics = [otelcol.processor.transform.default.input]
+        logs    = [otelcol.processor.transform.default.input]
       }
     }
     
-    otelcol.processor.transform "add_resource_attributes" {
+    otelcol.processor.transform "default" {
       // Grafana Cloud Kubernetes monitoring expects Loki labels `cluster`, `pod`, and `namespace`
       error_mode = "ignore"
       metric_statements {
@@ -47908,12 +47908,12 @@ data:
       }
     
       output {
-        metrics = [otelcol.processor.transform.add_resource_attributes.input]
-        logs    = [otelcol.processor.transform.add_resource_attributes.input]
+        metrics = [otelcol.processor.transform.default.input]
+        logs    = [otelcol.processor.transform.default.input]
       }
     }
     
-    otelcol.processor.transform "add_resource_attributes" {
+    otelcol.processor.transform "default" {
       // Grafana Cloud Kubernetes monitoring expects Loki labels `cluster`, `pod`, and `namespace`
       error_mode = "ignore"
       metric_statements {

--- a/examples/control-plane-metrics/metrics.river
+++ b/examples/control-plane-metrics/metrics.river
@@ -87,12 +87,12 @@ otelcol.processor.k8sattributes "default" {
   }
 
   output {
-    metrics = [otelcol.processor.transform.add_resource_attributes.input]
-    logs    = [otelcol.processor.transform.add_resource_attributes.input]
+    metrics = [otelcol.processor.transform.default.input]
+    logs    = [otelcol.processor.transform.default.input]
   }
 }
 
-otelcol.processor.transform "add_resource_attributes" {
+otelcol.processor.transform "default" {
   // Grafana Cloud Kubernetes monitoring expects Loki labels `cluster`, `pod`, and `namespace`
   error_mode = "ignore"
   metric_statements {

--- a/examples/control-plane-metrics/output.yaml
+++ b/examples/control-plane-metrics/output.yaml
@@ -210,12 +210,12 @@ data:
       }
     
       output {
-        metrics = [otelcol.processor.transform.add_resource_attributes.input]
-        logs    = [otelcol.processor.transform.add_resource_attributes.input]
+        metrics = [otelcol.processor.transform.default.input]
+        logs    = [otelcol.processor.transform.default.input]
       }
     }
     
-    otelcol.processor.transform "add_resource_attributes" {
+    otelcol.processor.transform "default" {
       // Grafana Cloud Kubernetes monitoring expects Loki labels `cluster`, `pod`, and `namespace`
       error_mode = "ignore"
       metric_statements {
@@ -48009,12 +48009,12 @@ data:
       }
     
       output {
-        metrics = [otelcol.processor.transform.add_resource_attributes.input]
-        logs    = [otelcol.processor.transform.add_resource_attributes.input]
+        metrics = [otelcol.processor.transform.default.input]
+        logs    = [otelcol.processor.transform.default.input]
       }
     }
     
-    otelcol.processor.transform "add_resource_attributes" {
+    otelcol.processor.transform "default" {
       // Grafana Cloud Kubernetes monitoring expects Loki labels `cluster`, `pod`, and `namespace`
       error_mode = "ignore"
       metric_statements {

--- a/examples/custom-config/metrics.river
+++ b/examples/custom-config/metrics.river
@@ -87,12 +87,12 @@ otelcol.processor.k8sattributes "default" {
   }
 
   output {
-    metrics = [otelcol.processor.transform.add_resource_attributes.input]
-    logs    = [otelcol.processor.transform.add_resource_attributes.input]
+    metrics = [otelcol.processor.transform.default.input]
+    logs    = [otelcol.processor.transform.default.input]
   }
 }
 
-otelcol.processor.transform "add_resource_attributes" {
+otelcol.processor.transform "default" {
   // Grafana Cloud Kubernetes monitoring expects Loki labels `cluster`, `pod`, and `namespace`
   error_mode = "ignore"
   metric_statements {

--- a/examples/custom-config/output.yaml
+++ b/examples/custom-config/output.yaml
@@ -209,12 +209,12 @@ data:
       }
     
       output {
-        metrics = [otelcol.processor.transform.add_resource_attributes.input]
-        logs    = [otelcol.processor.transform.add_resource_attributes.input]
+        metrics = [otelcol.processor.transform.default.input]
+        logs    = [otelcol.processor.transform.default.input]
       }
     }
     
-    otelcol.processor.transform "add_resource_attributes" {
+    otelcol.processor.transform "default" {
       // Grafana Cloud Kubernetes monitoring expects Loki labels `cluster`, `pod`, and `namespace`
       error_mode = "ignore"
       metric_statements {
@@ -47926,12 +47926,12 @@ data:
       }
     
       output {
-        metrics = [otelcol.processor.transform.add_resource_attributes.input]
-        logs    = [otelcol.processor.transform.add_resource_attributes.input]
+        metrics = [otelcol.processor.transform.default.input]
+        logs    = [otelcol.processor.transform.default.input]
       }
     }
     
-    otelcol.processor.transform "add_resource_attributes" {
+    otelcol.processor.transform "default" {
       // Grafana Cloud Kubernetes monitoring expects Loki labels `cluster`, `pod`, and `namespace`
       error_mode = "ignore"
       metric_statements {

--- a/examples/custom-metrics-tuning/metrics.river
+++ b/examples/custom-metrics-tuning/metrics.river
@@ -85,11 +85,11 @@ otelcol.processor.k8sattributes "default" {
   }
 
   output {
-    metrics = [otelcol.processor.transform.add_resource_attributes.input]
+    metrics = [otelcol.processor.transform.default.input]
   }
 }
 
-otelcol.processor.transform "add_resource_attributes" {
+otelcol.processor.transform "default" {
   // Grafana Cloud Kubernetes monitoring expects Loki labels `cluster`, `pod`, and `namespace`
   error_mode = "ignore"
   metric_statements {

--- a/examples/custom-metrics-tuning/output.yaml
+++ b/examples/custom-metrics-tuning/output.yaml
@@ -166,11 +166,11 @@ data:
       }
     
       output {
-        metrics = [otelcol.processor.transform.add_resource_attributes.input]
+        metrics = [otelcol.processor.transform.default.input]
       }
     }
     
-    otelcol.processor.transform "add_resource_attributes" {
+    otelcol.processor.transform "default" {
       // Grafana Cloud Kubernetes monitoring expects Loki labels `cluster`, `pod`, and `namespace`
       error_mode = "ignore"
       metric_statements {
@@ -47051,11 +47051,11 @@ data:
       }
     
       output {
-        metrics = [otelcol.processor.transform.add_resource_attributes.input]
+        metrics = [otelcol.processor.transform.default.input]
       }
     }
     
-    otelcol.processor.transform "add_resource_attributes" {
+    otelcol.processor.transform "default" {
       // Grafana Cloud Kubernetes monitoring expects Loki labels `cluster`, `pod`, and `namespace`
       error_mode = "ignore"
       metric_statements {

--- a/examples/custom-pricing/metrics.river
+++ b/examples/custom-pricing/metrics.river
@@ -87,12 +87,12 @@ otelcol.processor.k8sattributes "default" {
   }
 
   output {
-    metrics = [otelcol.processor.transform.add_resource_attributes.input]
-    logs    = [otelcol.processor.transform.add_resource_attributes.input]
+    metrics = [otelcol.processor.transform.default.input]
+    logs    = [otelcol.processor.transform.default.input]
   }
 }
 
-otelcol.processor.transform "add_resource_attributes" {
+otelcol.processor.transform "default" {
   // Grafana Cloud Kubernetes monitoring expects Loki labels `cluster`, `pod`, and `namespace`
   error_mode = "ignore"
   metric_statements {

--- a/examples/custom-pricing/output.yaml
+++ b/examples/custom-pricing/output.yaml
@@ -231,12 +231,12 @@ data:
       }
     
       output {
-        metrics = [otelcol.processor.transform.add_resource_attributes.input]
-        logs    = [otelcol.processor.transform.add_resource_attributes.input]
+        metrics = [otelcol.processor.transform.default.input]
+        logs    = [otelcol.processor.transform.default.input]
       }
     }
     
-    otelcol.processor.transform "add_resource_attributes" {
+    otelcol.processor.transform "default" {
       // Grafana Cloud Kubernetes monitoring expects Loki labels `cluster`, `pod`, and `namespace`
       error_mode = "ignore"
       metric_statements {
@@ -47888,12 +47888,12 @@ data:
       }
     
       output {
-        metrics = [otelcol.processor.transform.add_resource_attributes.input]
-        logs    = [otelcol.processor.transform.add_resource_attributes.input]
+        metrics = [otelcol.processor.transform.default.input]
+        logs    = [otelcol.processor.transform.default.input]
       }
     }
     
-    otelcol.processor.transform "add_resource_attributes" {
+    otelcol.processor.transform "default" {
       // Grafana Cloud Kubernetes monitoring expects Loki labels `cluster`, `pod`, and `namespace`
       error_mode = "ignore"
       metric_statements {

--- a/examples/default-values/metrics.river
+++ b/examples/default-values/metrics.river
@@ -87,12 +87,12 @@ otelcol.processor.k8sattributes "default" {
   }
 
   output {
-    metrics = [otelcol.processor.transform.add_resource_attributes.input]
-    logs    = [otelcol.processor.transform.add_resource_attributes.input]
+    metrics = [otelcol.processor.transform.default.input]
+    logs    = [otelcol.processor.transform.default.input]
   }
 }
 
-otelcol.processor.transform "add_resource_attributes" {
+otelcol.processor.transform "default" {
   // Grafana Cloud Kubernetes monitoring expects Loki labels `cluster`, `pod`, and `namespace`
   error_mode = "ignore"
   metric_statements {

--- a/examples/default-values/output.yaml
+++ b/examples/default-values/output.yaml
@@ -209,12 +209,12 @@ data:
       }
     
       output {
-        metrics = [otelcol.processor.transform.add_resource_attributes.input]
-        logs    = [otelcol.processor.transform.add_resource_attributes.input]
+        metrics = [otelcol.processor.transform.default.input]
+        logs    = [otelcol.processor.transform.default.input]
       }
     }
     
-    otelcol.processor.transform "add_resource_attributes" {
+    otelcol.processor.transform "default" {
       // Grafana Cloud Kubernetes monitoring expects Loki labels `cluster`, `pod`, and `namespace`
       error_mode = "ignore"
       metric_statements {
@@ -47856,12 +47856,12 @@ data:
       }
     
       output {
-        metrics = [otelcol.processor.transform.add_resource_attributes.input]
-        logs    = [otelcol.processor.transform.add_resource_attributes.input]
+        metrics = [otelcol.processor.transform.default.input]
+        logs    = [otelcol.processor.transform.default.input]
       }
     }
     
-    otelcol.processor.transform "add_resource_attributes" {
+    otelcol.processor.transform "default" {
       // Grafana Cloud Kubernetes monitoring expects Loki labels `cluster`, `pod`, and `namespace`
       error_mode = "ignore"
       metric_statements {

--- a/examples/eks-fargate/metrics.river
+++ b/examples/eks-fargate/metrics.river
@@ -87,12 +87,12 @@ otelcol.processor.k8sattributes "default" {
   }
 
   output {
-    metrics = [otelcol.processor.transform.add_resource_attributes.input]
-    logs    = [otelcol.processor.transform.add_resource_attributes.input]
+    metrics = [otelcol.processor.transform.default.input]
+    logs    = [otelcol.processor.transform.default.input]
   }
 }
 
-otelcol.processor.transform "add_resource_attributes" {
+otelcol.processor.transform "default" {
   // Grafana Cloud Kubernetes monitoring expects Loki labels `cluster`, `pod`, and `namespace`
   error_mode = "ignore"
   metric_statements {

--- a/examples/eks-fargate/output.yaml
+++ b/examples/eks-fargate/output.yaml
@@ -194,12 +194,12 @@ data:
       }
     
       output {
-        metrics = [otelcol.processor.transform.add_resource_attributes.input]
-        logs    = [otelcol.processor.transform.add_resource_attributes.input]
+        metrics = [otelcol.processor.transform.default.input]
+        logs    = [otelcol.processor.transform.default.input]
       }
     }
     
-    otelcol.processor.transform "add_resource_attributes" {
+    otelcol.processor.transform "default" {
       // Grafana Cloud Kubernetes monitoring expects Loki labels `cluster`, `pod`, and `namespace`
       error_mode = "ignore"
       metric_statements {
@@ -47629,12 +47629,12 @@ data:
       }
     
       output {
-        metrics = [otelcol.processor.transform.add_resource_attributes.input]
-        logs    = [otelcol.processor.transform.add_resource_attributes.input]
+        metrics = [otelcol.processor.transform.default.input]
+        logs    = [otelcol.processor.transform.default.input]
       }
     }
     
-    otelcol.processor.transform "add_resource_attributes" {
+    otelcol.processor.transform "default" {
       // Grafana Cloud Kubernetes monitoring expects Loki labels `cluster`, `pod`, and `namespace`
       error_mode = "ignore"
       metric_statements {

--- a/examples/extra-rules/metrics.river
+++ b/examples/extra-rules/metrics.river
@@ -87,12 +87,12 @@ otelcol.processor.k8sattributes "default" {
   }
 
   output {
-    metrics = [otelcol.processor.transform.add_resource_attributes.input]
-    logs    = [otelcol.processor.transform.add_resource_attributes.input]
+    metrics = [otelcol.processor.transform.default.input]
+    logs    = [otelcol.processor.transform.default.input]
   }
 }
 
-otelcol.processor.transform "add_resource_attributes" {
+otelcol.processor.transform "default" {
   // Grafana Cloud Kubernetes monitoring expects Loki labels `cluster`, `pod`, and `namespace`
   error_mode = "ignore"
   metric_statements {

--- a/examples/extra-rules/output.yaml
+++ b/examples/extra-rules/output.yaml
@@ -210,12 +210,12 @@ data:
       }
     
       output {
-        metrics = [otelcol.processor.transform.add_resource_attributes.input]
-        logs    = [otelcol.processor.transform.add_resource_attributes.input]
+        metrics = [otelcol.processor.transform.default.input]
+        logs    = [otelcol.processor.transform.default.input]
       }
     }
     
-    otelcol.processor.transform "add_resource_attributes" {
+    otelcol.processor.transform "default" {
       // Grafana Cloud Kubernetes monitoring expects Loki labels `cluster`, `pod`, and `namespace`
       error_mode = "ignore"
       metric_statements {
@@ -47963,12 +47963,12 @@ data:
       }
     
       output {
-        metrics = [otelcol.processor.transform.add_resource_attributes.input]
-        logs    = [otelcol.processor.transform.add_resource_attributes.input]
+        metrics = [otelcol.processor.transform.default.input]
+        logs    = [otelcol.processor.transform.default.input]
       }
     }
     
-    otelcol.processor.transform "add_resource_attributes" {
+    otelcol.processor.transform "default" {
       // Grafana Cloud Kubernetes monitoring expects Loki labels `cluster`, `pod`, and `namespace`
       error_mode = "ignore"
       metric_statements {

--- a/examples/gke-autopilot/metrics.river
+++ b/examples/gke-autopilot/metrics.river
@@ -87,12 +87,12 @@ otelcol.processor.k8sattributes "default" {
   }
 
   output {
-    metrics = [otelcol.processor.transform.add_resource_attributes.input]
-    logs    = [otelcol.processor.transform.add_resource_attributes.input]
+    metrics = [otelcol.processor.transform.default.input]
+    logs    = [otelcol.processor.transform.default.input]
   }
 }
 
-otelcol.processor.transform "add_resource_attributes" {
+otelcol.processor.transform "default" {
   // Grafana Cloud Kubernetes monitoring expects Loki labels `cluster`, `pod`, and `namespace`
   error_mode = "ignore"
   metric_statements {

--- a/examples/gke-autopilot/output.yaml
+++ b/examples/gke-autopilot/output.yaml
@@ -194,12 +194,12 @@ data:
       }
     
       output {
-        metrics = [otelcol.processor.transform.add_resource_attributes.input]
-        logs    = [otelcol.processor.transform.add_resource_attributes.input]
+        metrics = [otelcol.processor.transform.default.input]
+        logs    = [otelcol.processor.transform.default.input]
       }
     }
     
-    otelcol.processor.transform "add_resource_attributes" {
+    otelcol.processor.transform "default" {
       // Grafana Cloud Kubernetes monitoring expects Loki labels `cluster`, `pod`, and `namespace`
       error_mode = "ignore"
       metric_statements {
@@ -47647,12 +47647,12 @@ data:
       }
     
       output {
-        metrics = [otelcol.processor.transform.add_resource_attributes.input]
-        logs    = [otelcol.processor.transform.add_resource_attributes.input]
+        metrics = [otelcol.processor.transform.default.input]
+        logs    = [otelcol.processor.transform.default.input]
       }
     }
     
-    otelcol.processor.transform "add_resource_attributes" {
+    otelcol.processor.transform "default" {
       // Grafana Cloud Kubernetes monitoring expects Loki labels `cluster`, `pod`, and `namespace`
       error_mode = "ignore"
       metric_statements {

--- a/examples/ibm-cloud/metrics.river
+++ b/examples/ibm-cloud/metrics.river
@@ -87,12 +87,12 @@ otelcol.processor.k8sattributes "default" {
   }
 
   output {
-    metrics = [otelcol.processor.transform.add_resource_attributes.input]
-    logs    = [otelcol.processor.transform.add_resource_attributes.input]
+    metrics = [otelcol.processor.transform.default.input]
+    logs    = [otelcol.processor.transform.default.input]
   }
 }
 
-otelcol.processor.transform "add_resource_attributes" {
+otelcol.processor.transform "default" {
   // Grafana Cloud Kubernetes monitoring expects Loki labels `cluster`, `pod`, and `namespace`
   error_mode = "ignore"
   metric_statements {

--- a/examples/ibm-cloud/output.yaml
+++ b/examples/ibm-cloud/output.yaml
@@ -209,12 +209,12 @@ data:
       }
     
       output {
-        metrics = [otelcol.processor.transform.add_resource_attributes.input]
-        logs    = [otelcol.processor.transform.add_resource_attributes.input]
+        metrics = [otelcol.processor.transform.default.input]
+        logs    = [otelcol.processor.transform.default.input]
       }
     }
     
-    otelcol.processor.transform "add_resource_attributes" {
+    otelcol.processor.transform "default" {
       // Grafana Cloud Kubernetes monitoring expects Loki labels `cluster`, `pod`, and `namespace`
       error_mode = "ignore"
       metric_statements {
@@ -47862,12 +47862,12 @@ data:
       }
     
       output {
-        metrics = [otelcol.processor.transform.add_resource_attributes.input]
-        logs    = [otelcol.processor.transform.add_resource_attributes.input]
+        metrics = [otelcol.processor.transform.default.input]
+        logs    = [otelcol.processor.transform.default.input]
       }
     }
     
-    otelcol.processor.transform "add_resource_attributes" {
+    otelcol.processor.transform "default" {
       // Grafana Cloud Kubernetes monitoring expects Loki labels `cluster`, `pod`, and `namespace`
       error_mode = "ignore"
       metric_statements {

--- a/examples/kube-pod-labels/metrics.river
+++ b/examples/kube-pod-labels/metrics.river
@@ -87,12 +87,12 @@ otelcol.processor.k8sattributes "default" {
   }
 
   output {
-    metrics = [otelcol.processor.transform.add_resource_attributes.input]
-    logs    = [otelcol.processor.transform.add_resource_attributes.input]
+    metrics = [otelcol.processor.transform.default.input]
+    logs    = [otelcol.processor.transform.default.input]
   }
 }
 
-otelcol.processor.transform "add_resource_attributes" {
+otelcol.processor.transform "default" {
   // Grafana Cloud Kubernetes monitoring expects Loki labels `cluster`, `pod`, and `namespace`
   error_mode = "ignore"
   metric_statements {

--- a/examples/kube-pod-labels/output.yaml
+++ b/examples/kube-pod-labels/output.yaml
@@ -209,12 +209,12 @@ data:
       }
     
       output {
-        metrics = [otelcol.processor.transform.add_resource_attributes.input]
-        logs    = [otelcol.processor.transform.add_resource_attributes.input]
+        metrics = [otelcol.processor.transform.default.input]
+        logs    = [otelcol.processor.transform.default.input]
       }
     }
     
-    otelcol.processor.transform "add_resource_attributes" {
+    otelcol.processor.transform "default" {
       // Grafana Cloud Kubernetes monitoring expects Loki labels `cluster`, `pod`, and `namespace`
       error_mode = "ignore"
       metric_statements {
@@ -47857,12 +47857,12 @@ data:
       }
     
       output {
-        metrics = [otelcol.processor.transform.add_resource_attributes.input]
-        logs    = [otelcol.processor.transform.add_resource_attributes.input]
+        metrics = [otelcol.processor.transform.default.input]
+        logs    = [otelcol.processor.transform.default.input]
       }
     }
     
-    otelcol.processor.transform "add_resource_attributes" {
+    otelcol.processor.transform "default" {
       // Grafana Cloud Kubernetes monitoring expects Loki labels `cluster`, `pod`, and `namespace`
       error_mode = "ignore"
       metric_statements {

--- a/examples/logs-only/metrics.river
+++ b/examples/logs-only/metrics.river
@@ -71,11 +71,11 @@ otelcol.processor.k8sattributes "default" {
   }
 
   output {
-    logs    = [otelcol.processor.transform.add_resource_attributes.input]
+    logs    = [otelcol.processor.transform.default.input]
   }
 }
 
-otelcol.processor.transform "add_resource_attributes" {
+otelcol.processor.transform "default" {
   // Grafana Cloud Kubernetes monitoring expects Loki labels `cluster`, `pod`, and `namespace`
   error_mode = "ignore"
   log_statements {

--- a/examples/logs-only/output.yaml
+++ b/examples/logs-only/output.yaml
@@ -136,11 +136,11 @@ data:
       }
     
       output {
-        logs    = [otelcol.processor.transform.add_resource_attributes.input]
+        logs    = [otelcol.processor.transform.default.input]
       }
     }
     
-    otelcol.processor.transform "add_resource_attributes" {
+    otelcol.processor.transform "default" {
       // Grafana Cloud Kubernetes monitoring expects Loki labels `cluster`, `pod`, and `namespace`
       error_mode = "ignore"
       log_statements {
@@ -1368,11 +1368,11 @@ data:
       }
     
       output {
-        logs    = [otelcol.processor.transform.add_resource_attributes.input]
+        logs    = [otelcol.processor.transform.default.input]
       }
     }
     
-    otelcol.processor.transform "add_resource_attributes" {
+    otelcol.processor.transform "default" {
       // Grafana Cloud Kubernetes monitoring expects Loki labels `cluster`, `pod`, and `namespace`
       error_mode = "ignore"
       log_statements {

--- a/examples/metrics-only/metrics.river
+++ b/examples/metrics-only/metrics.river
@@ -85,11 +85,11 @@ otelcol.processor.k8sattributes "default" {
   }
 
   output {
-    metrics = [otelcol.processor.transform.add_resource_attributes.input]
+    metrics = [otelcol.processor.transform.default.input]
   }
 }
 
-otelcol.processor.transform "add_resource_attributes" {
+otelcol.processor.transform "default" {
   // Grafana Cloud Kubernetes monitoring expects Loki labels `cluster`, `pod`, and `namespace`
   error_mode = "ignore"
   metric_statements {

--- a/examples/metrics-only/output.yaml
+++ b/examples/metrics-only/output.yaml
@@ -167,11 +167,11 @@ data:
       }
     
       output {
-        metrics = [otelcol.processor.transform.add_resource_attributes.input]
+        metrics = [otelcol.processor.transform.default.input]
       }
     }
     
-    otelcol.processor.transform "add_resource_attributes" {
+    otelcol.processor.transform "default" {
       // Grafana Cloud Kubernetes monitoring expects Loki labels `cluster`, `pod`, and `namespace`
       error_mode = "ignore"
       metric_statements {
@@ -47057,11 +47057,11 @@ data:
       }
     
       output {
-        metrics = [otelcol.processor.transform.add_resource_attributes.input]
+        metrics = [otelcol.processor.transform.default.input]
       }
     }
     
-    otelcol.processor.transform "add_resource_attributes" {
+    otelcol.processor.transform "default" {
       // Grafana Cloud Kubernetes monitoring expects Loki labels `cluster`, `pod`, and `namespace`
       error_mode = "ignore"
       metric_statements {

--- a/examples/openshift-compatible/metrics.river
+++ b/examples/openshift-compatible/metrics.river
@@ -87,12 +87,12 @@ otelcol.processor.k8sattributes "default" {
   }
 
   output {
-    metrics = [otelcol.processor.transform.add_resource_attributes.input]
-    logs    = [otelcol.processor.transform.add_resource_attributes.input]
+    metrics = [otelcol.processor.transform.default.input]
+    logs    = [otelcol.processor.transform.default.input]
   }
 }
 
-otelcol.processor.transform "add_resource_attributes" {
+otelcol.processor.transform "default" {
   // Grafana Cloud Kubernetes monitoring expects Loki labels `cluster`, `pod`, and `namespace`
   error_mode = "ignore"
   metric_statements {

--- a/examples/openshift-compatible/output.yaml
+++ b/examples/openshift-compatible/output.yaml
@@ -179,12 +179,12 @@ data:
       }
     
       output {
-        metrics = [otelcol.processor.transform.add_resource_attributes.input]
-        logs    = [otelcol.processor.transform.add_resource_attributes.input]
+        metrics = [otelcol.processor.transform.default.input]
+        logs    = [otelcol.processor.transform.default.input]
       }
     }
     
-    otelcol.processor.transform "add_resource_attributes" {
+    otelcol.processor.transform "default" {
       // Grafana Cloud Kubernetes monitoring expects Loki labels `cluster`, `pod`, and `namespace`
       error_mode = "ignore"
       metric_statements {
@@ -47498,12 +47498,12 @@ data:
       }
     
       output {
-        metrics = [otelcol.processor.transform.add_resource_attributes.input]
-        logs    = [otelcol.processor.transform.add_resource_attributes.input]
+        metrics = [otelcol.processor.transform.default.input]
+        logs    = [otelcol.processor.transform.default.input]
       }
     }
     
-    otelcol.processor.transform "add_resource_attributes" {
+    otelcol.processor.transform "default" {
       // Grafana Cloud Kubernetes monitoring expects Loki labels `cluster`, `pod`, and `namespace`
       error_mode = "ignore"
       metric_statements {

--- a/examples/otel-metrics-service/metrics.river
+++ b/examples/otel-metrics-service/metrics.river
@@ -87,12 +87,12 @@ otelcol.processor.k8sattributes "default" {
   }
 
   output {
-    metrics = [otelcol.processor.transform.add_resource_attributes.input]
-    logs    = [otelcol.processor.transform.add_resource_attributes.input]
+    metrics = [otelcol.processor.transform.default.input]
+    logs    = [otelcol.processor.transform.default.input]
   }
 }
 
-otelcol.processor.transform "add_resource_attributes" {
+otelcol.processor.transform "default" {
   // Grafana Cloud Kubernetes monitoring expects Loki labels `cluster`, `pod`, and `namespace`
   error_mode = "ignore"
   metric_statements {

--- a/examples/otel-metrics-service/output.yaml
+++ b/examples/otel-metrics-service/output.yaml
@@ -209,12 +209,12 @@ data:
       }
     
       output {
-        metrics = [otelcol.processor.transform.add_resource_attributes.input]
-        logs    = [otelcol.processor.transform.add_resource_attributes.input]
+        metrics = [otelcol.processor.transform.default.input]
+        logs    = [otelcol.processor.transform.default.input]
       }
     }
     
-    otelcol.processor.transform "add_resource_attributes" {
+    otelcol.processor.transform "default" {
       // Grafana Cloud Kubernetes monitoring expects Loki labels `cluster`, `pod`, and `namespace`
       error_mode = "ignore"
       metric_statements {
@@ -47885,12 +47885,12 @@ data:
       }
     
       output {
-        metrics = [otelcol.processor.transform.add_resource_attributes.input]
-        logs    = [otelcol.processor.transform.add_resource_attributes.input]
+        metrics = [otelcol.processor.transform.default.input]
+        logs    = [otelcol.processor.transform.default.input]
       }
     }
     
-    otelcol.processor.transform "add_resource_attributes" {
+    otelcol.processor.transform "default" {
       // Grafana Cloud Kubernetes monitoring expects Loki labels `cluster`, `pod`, and `namespace`
       error_mode = "ignore"
       metric_statements {

--- a/examples/private-image-registry/metrics.river
+++ b/examples/private-image-registry/metrics.river
@@ -87,12 +87,12 @@ otelcol.processor.k8sattributes "default" {
   }
 
   output {
-    metrics = [otelcol.processor.transform.add_resource_attributes.input]
-    logs    = [otelcol.processor.transform.add_resource_attributes.input]
+    metrics = [otelcol.processor.transform.default.input]
+    logs    = [otelcol.processor.transform.default.input]
   }
 }
 
-otelcol.processor.transform "add_resource_attributes" {
+otelcol.processor.transform "default" {
   // Grafana Cloud Kubernetes monitoring expects Loki labels `cluster`, `pod`, and `namespace`
   error_mode = "ignore"
   metric_statements {

--- a/examples/private-image-registry/output.yaml
+++ b/examples/private-image-registry/output.yaml
@@ -213,12 +213,12 @@ data:
       }
     
       output {
-        metrics = [otelcol.processor.transform.add_resource_attributes.input]
-        logs    = [otelcol.processor.transform.add_resource_attributes.input]
+        metrics = [otelcol.processor.transform.default.input]
+        logs    = [otelcol.processor.transform.default.input]
       }
     }
     
-    otelcol.processor.transform "add_resource_attributes" {
+    otelcol.processor.transform "default" {
       // Grafana Cloud Kubernetes monitoring expects Loki labels `cluster`, `pod`, and `namespace`
       error_mode = "ignore"
       metric_statements {
@@ -47872,12 +47872,12 @@ data:
       }
     
       output {
-        metrics = [otelcol.processor.transform.add_resource_attributes.input]
-        logs    = [otelcol.processor.transform.add_resource_attributes.input]
+        metrics = [otelcol.processor.transform.default.input]
+        logs    = [otelcol.processor.transform.default.input]
       }
     }
     
-    otelcol.processor.transform "add_resource_attributes" {
+    otelcol.processor.transform "default" {
       // Grafana Cloud Kubernetes monitoring expects Loki labels `cluster`, `pod`, and `namespace`
       error_mode = "ignore"
       metric_statements {

--- a/examples/proxies/metrics.river
+++ b/examples/proxies/metrics.river
@@ -87,12 +87,12 @@ otelcol.processor.k8sattributes "default" {
   }
 
   output {
-    metrics = [otelcol.processor.transform.add_resource_attributes.input]
-    logs    = [otelcol.processor.transform.add_resource_attributes.input]
+    metrics = [otelcol.processor.transform.default.input]
+    logs    = [otelcol.processor.transform.default.input]
   }
 }
 
-otelcol.processor.transform "add_resource_attributes" {
+otelcol.processor.transform "default" {
   // Grafana Cloud Kubernetes monitoring expects Loki labels `cluster`, `pod`, and `namespace`
   error_mode = "ignore"
   metric_statements {

--- a/examples/proxies/output.yaml
+++ b/examples/proxies/output.yaml
@@ -209,12 +209,12 @@ data:
       }
     
       output {
-        metrics = [otelcol.processor.transform.add_resource_attributes.input]
-        logs    = [otelcol.processor.transform.add_resource_attributes.input]
+        metrics = [otelcol.processor.transform.default.input]
+        logs    = [otelcol.processor.transform.default.input]
       }
     }
     
-    otelcol.processor.transform "add_resource_attributes" {
+    otelcol.processor.transform "default" {
       // Grafana Cloud Kubernetes monitoring expects Loki labels `cluster`, `pod`, and `namespace`
       error_mode = "ignore"
       metric_statements {
@@ -47872,12 +47872,12 @@ data:
       }
     
       output {
-        metrics = [otelcol.processor.transform.add_resource_attributes.input]
-        logs    = [otelcol.processor.transform.add_resource_attributes.input]
+        metrics = [otelcol.processor.transform.default.input]
+        logs    = [otelcol.processor.transform.default.input]
       }
     }
     
-    otelcol.processor.transform "add_resource_attributes" {
+    otelcol.processor.transform "default" {
       // Grafana Cloud Kubernetes monitoring expects Loki labels `cluster`, `pod`, and `namespace`
       error_mode = "ignore"
       metric_statements {

--- a/examples/scrape-intervals/metrics.river
+++ b/examples/scrape-intervals/metrics.river
@@ -85,11 +85,11 @@ otelcol.processor.k8sattributes "default" {
   }
 
   output {
-    metrics = [otelcol.processor.transform.add_resource_attributes.input]
+    metrics = [otelcol.processor.transform.default.input]
   }
 }
 
-otelcol.processor.transform "add_resource_attributes" {
+otelcol.processor.transform "default" {
   // Grafana Cloud Kubernetes monitoring expects Loki labels `cluster`, `pod`, and `namespace`
   error_mode = "ignore"
   metric_statements {

--- a/examples/scrape-intervals/output.yaml
+++ b/examples/scrape-intervals/output.yaml
@@ -166,11 +166,11 @@ data:
       }
     
       output {
-        metrics = [otelcol.processor.transform.add_resource_attributes.input]
+        metrics = [otelcol.processor.transform.default.input]
       }
     }
     
-    otelcol.processor.transform "add_resource_attributes" {
+    otelcol.processor.transform "default" {
       // Grafana Cloud Kubernetes monitoring expects Loki labels `cluster`, `pod`, and `namespace`
       error_mode = "ignore"
       metric_statements {
@@ -47056,11 +47056,11 @@ data:
       }
     
       output {
-        metrics = [otelcol.processor.transform.add_resource_attributes.input]
+        metrics = [otelcol.processor.transform.default.input]
       }
     }
     
-    otelcol.processor.transform "add_resource_attributes" {
+    otelcol.processor.transform "default" {
       // Grafana Cloud Kubernetes monitoring expects Loki labels `cluster`, `pod`, and `namespace`
       error_mode = "ignore"
       metric_statements {

--- a/examples/service-integrations/metrics.river
+++ b/examples/service-integrations/metrics.river
@@ -87,12 +87,12 @@ otelcol.processor.k8sattributes "default" {
   }
 
   output {
-    metrics = [otelcol.processor.transform.add_resource_attributes.input]
-    logs    = [otelcol.processor.transform.add_resource_attributes.input]
+    metrics = [otelcol.processor.transform.default.input]
+    logs    = [otelcol.processor.transform.default.input]
   }
 }
 
-otelcol.processor.transform "add_resource_attributes" {
+otelcol.processor.transform "default" {
   // Grafana Cloud Kubernetes monitoring expects Loki labels `cluster`, `pod`, and `namespace`
   error_mode = "ignore"
   metric_statements {

--- a/examples/service-integrations/output.yaml
+++ b/examples/service-integrations/output.yaml
@@ -209,12 +209,12 @@ data:
       }
     
       output {
-        metrics = [otelcol.processor.transform.add_resource_attributes.input]
-        logs    = [otelcol.processor.transform.add_resource_attributes.input]
+        metrics = [otelcol.processor.transform.default.input]
+        logs    = [otelcol.processor.transform.default.input]
       }
     }
     
-    otelcol.processor.transform "add_resource_attributes" {
+    otelcol.processor.transform "default" {
       // Grafana Cloud Kubernetes monitoring expects Loki labels `cluster`, `pod`, and `namespace`
       error_mode = "ignore"
       metric_statements {
@@ -47891,12 +47891,12 @@ data:
       }
     
       output {
-        metrics = [otelcol.processor.transform.add_resource_attributes.input]
-        logs    = [otelcol.processor.transform.add_resource_attributes.input]
+        metrics = [otelcol.processor.transform.default.input]
+        logs    = [otelcol.processor.transform.default.input]
       }
     }
     
-    otelcol.processor.transform "add_resource_attributes" {
+    otelcol.processor.transform "default" {
       // Grafana Cloud Kubernetes monitoring expects Loki labels `cluster`, `pod`, and `namespace`
       error_mode = "ignore"
       metric_statements {

--- a/examples/specific-namespace/metrics.river
+++ b/examples/specific-namespace/metrics.river
@@ -87,12 +87,12 @@ otelcol.processor.k8sattributes "default" {
   }
 
   output {
-    metrics = [otelcol.processor.transform.add_resource_attributes.input]
-    logs    = [otelcol.processor.transform.add_resource_attributes.input]
+    metrics = [otelcol.processor.transform.default.input]
+    logs    = [otelcol.processor.transform.default.input]
   }
 }
 
-otelcol.processor.transform "add_resource_attributes" {
+otelcol.processor.transform "default" {
   // Grafana Cloud Kubernetes monitoring expects Loki labels `cluster`, `pod`, and `namespace`
   error_mode = "ignore"
   metric_statements {

--- a/examples/specific-namespace/output.yaml
+++ b/examples/specific-namespace/output.yaml
@@ -209,12 +209,12 @@ data:
       }
     
       output {
-        metrics = [otelcol.processor.transform.add_resource_attributes.input]
-        logs    = [otelcol.processor.transform.add_resource_attributes.input]
+        metrics = [otelcol.processor.transform.default.input]
+        logs    = [otelcol.processor.transform.default.input]
       }
     }
     
-    otelcol.processor.transform "add_resource_attributes" {
+    otelcol.processor.transform "default" {
       // Grafana Cloud Kubernetes monitoring expects Loki labels `cluster`, `pod`, and `namespace`
       error_mode = "ignore"
       metric_statements {
@@ -47920,12 +47920,12 @@ data:
       }
     
       output {
-        metrics = [otelcol.processor.transform.add_resource_attributes.input]
-        logs    = [otelcol.processor.transform.add_resource_attributes.input]
+        metrics = [otelcol.processor.transform.default.input]
+        logs    = [otelcol.processor.transform.default.input]
       }
     }
     
-    otelcol.processor.transform "add_resource_attributes" {
+    otelcol.processor.transform "default" {
       // Grafana Cloud Kubernetes monitoring expects Loki labels `cluster`, `pod`, and `namespace`
       error_mode = "ignore"
       metric_statements {

--- a/examples/traces-enabled/metrics.river
+++ b/examples/traces-enabled/metrics.river
@@ -125,10 +125,10 @@ otelcol.processor.k8sattributes "default" {
   }
 
   output {
-    metrics = [otelcol.processor.transform.add_resource_attributes.input]
-    logs    = [otelcol.processor.transform.add_resource_attributes.input]
+    metrics = [otelcol.processor.transform.default.input]
+    logs    = [otelcol.processor.transform.default.input]
     traces  = [
-      otelcol.processor.transform.add_resource_attributes.input,
+      otelcol.processor.transform.default.input,
       otelcol.connector.host_info.default.input,
     ]
   }
@@ -151,7 +151,7 @@ otelcol.exporter.prometheus "host_info_metrics" {
   forward_to = [prometheus.remote_write.metrics_service.receiver]
 }
 
-otelcol.processor.transform "add_resource_attributes" {
+otelcol.processor.transform "default" {
   // Grafana Cloud Kubernetes monitoring expects Loki labels `cluster`, `pod`, and `namespace`
   error_mode = "ignore"
   metric_statements {
@@ -172,7 +172,16 @@ otelcol.processor.transform "add_resource_attributes" {
   trace_statements {
     context = "resource"
     statements = [
+      "limit(attributes, 100, [])",
+      "truncate_all(attributes, 4096)",
       "set(attributes[\"k8s.cluster.name\"], \"traces-enabled-test\") where attributes[\"k8s.cluster.name\"] == nil",
+    ]
+  }
+  trace_statements {
+    context = "span"
+    statements = [
+      "limit(attributes, 100, [])",
+      "truncate_all(attributes, 4096)",
     ]
   }
   output {

--- a/examples/traces-enabled/output.yaml
+++ b/examples/traces-enabled/output.yaml
@@ -260,10 +260,10 @@ data:
       }
     
       output {
-        metrics = [otelcol.processor.transform.add_resource_attributes.input]
-        logs    = [otelcol.processor.transform.add_resource_attributes.input]
+        metrics = [otelcol.processor.transform.default.input]
+        logs    = [otelcol.processor.transform.default.input]
         traces  = [
-          otelcol.processor.transform.add_resource_attributes.input,
+          otelcol.processor.transform.default.input,
           otelcol.connector.host_info.default.input,
         ]
       }
@@ -286,7 +286,7 @@ data:
       forward_to = [prometheus.remote_write.metrics_service.receiver]
     }
     
-    otelcol.processor.transform "add_resource_attributes" {
+    otelcol.processor.transform "default" {
       // Grafana Cloud Kubernetes monitoring expects Loki labels `cluster`, `pod`, and `namespace`
       error_mode = "ignore"
       metric_statements {
@@ -307,7 +307,16 @@ data:
       trace_statements {
         context = "resource"
         statements = [
+          "limit(attributes, 100, [])",
+          "truncate_all(attributes, 4096)",
           "set(attributes[\"k8s.cluster.name\"], \"traces-enabled-test\") where attributes[\"k8s.cluster.name\"] == nil",
+        ]
+      }
+      trace_statements {
+        context = "span"
+        statements = [
+          "limit(attributes, 100, [])",
+          "truncate_all(attributes, 4096)",
         ]
       }
       output {
@@ -48003,10 +48012,10 @@ data:
       }
     
       output {
-        metrics = [otelcol.processor.transform.add_resource_attributes.input]
-        logs    = [otelcol.processor.transform.add_resource_attributes.input]
+        metrics = [otelcol.processor.transform.default.input]
+        logs    = [otelcol.processor.transform.default.input]
         traces  = [
-          otelcol.processor.transform.add_resource_attributes.input,
+          otelcol.processor.transform.default.input,
           otelcol.connector.host_info.default.input,
         ]
       }
@@ -48029,7 +48038,7 @@ data:
       forward_to = [prometheus.remote_write.metrics_service.receiver]
     }
     
-    otelcol.processor.transform "add_resource_attributes" {
+    otelcol.processor.transform "default" {
       // Grafana Cloud Kubernetes monitoring expects Loki labels `cluster`, `pod`, and `namespace`
       error_mode = "ignore"
       metric_statements {
@@ -48050,7 +48059,16 @@ data:
       trace_statements {
         context = "resource"
         statements = [
+          "limit(attributes, 100, [])",
+          "truncate_all(attributes, 4096)",
           "set(attributes[\"k8s.cluster.name\"], \"traces-enabled-test\") where attributes[\"k8s.cluster.name\"] == nil",
+        ]
+      }
+      trace_statements {
+        context = "span"
+        statements = [
+          "limit(attributes, 100, [])",
+          "truncate_all(attributes, 4096)",
         ]
       }
       output {

--- a/examples/traces-enabled/values.yaml
+++ b/examples/traces-enabled/values.yaml
@@ -26,6 +26,13 @@ traces:
         -  attributes["http.route"] == "/live"
         -  attributes["http.route"] == "/healthy"
         -  attributes["http.route"] == "/ready"
+    transforms:
+      resource:
+        - limit(attributes, 100, [])
+        - truncate_all(attributes, 4096)
+      span:
+        - limit(attributes, 100, [])
+        - truncate_all(attributes, 4096)
 
 receivers:
   jaeger:

--- a/examples/windows-exporter/metrics.river
+++ b/examples/windows-exporter/metrics.river
@@ -87,12 +87,12 @@ otelcol.processor.k8sattributes "default" {
   }
 
   output {
-    metrics = [otelcol.processor.transform.add_resource_attributes.input]
-    logs    = [otelcol.processor.transform.add_resource_attributes.input]
+    metrics = [otelcol.processor.transform.default.input]
+    logs    = [otelcol.processor.transform.default.input]
   }
 }
 
-otelcol.processor.transform "add_resource_attributes" {
+otelcol.processor.transform "default" {
   // Grafana Cloud Kubernetes monitoring expects Loki labels `cluster`, `pod`, and `namespace`
   error_mode = "ignore"
   metric_statements {

--- a/examples/windows-exporter/output.yaml
+++ b/examples/windows-exporter/output.yaml
@@ -246,12 +246,12 @@ data:
       }
     
       output {
-        metrics = [otelcol.processor.transform.add_resource_attributes.input]
-        logs    = [otelcol.processor.transform.add_resource_attributes.input]
+        metrics = [otelcol.processor.transform.default.input]
+        logs    = [otelcol.processor.transform.default.input]
       }
     }
     
-    otelcol.processor.transform "add_resource_attributes" {
+    otelcol.processor.transform "default" {
       // Grafana Cloud Kubernetes monitoring expects Loki labels `cluster`, `pod`, and `namespace`
       error_mode = "ignore"
       metric_statements {
@@ -48087,12 +48087,12 @@ data:
       }
     
       output {
-        metrics = [otelcol.processor.transform.add_resource_attributes.input]
-        logs    = [otelcol.processor.transform.add_resource_attributes.input]
+        metrics = [otelcol.processor.transform.default.input]
+        logs    = [otelcol.processor.transform.default.input]
       }
     }
     
-    otelcol.processor.transform "add_resource_attributes" {
+    otelcol.processor.transform "default" {
       // Grafana Cloud Kubernetes monitoring expects Loki labels `cluster`, `pod`, and `namespace`
       error_mode = "ignore"
       metric_statements {


### PR DESCRIPTION
This PR adds extension points for `otelcol.processor.transform`, in the same manner as what already exists for `otelcol.processor.filter`.

For example, my current setup does some truncation of trace data to protect Tempo against bad configuration in clients. There's no extension point to add these additional OTTL-statements currently. With this PR, you could do something like this:

```yaml
traces:
  receiver:
    filters: {}
    transforms:
      resource:
        - limit(attributes, 100, [])
        - truncate_all(attributes, 4096)
      span:
        - limit(attributes, 100, [])
        - truncate_all(attributes, 4096)
```

We also typically set the `service.name` automatically from the k8s deployment name if the app hasn't set it itself, i.e.:

```yaml
traces:
  receiver:
    transforms:
      resource:
        - set(attributes["service.name"], attributes["k8s.deployment.name"]) where attributes["service.name"] == nil
```

These are just some examples. Being able to set additional OTTL-statements in the transform processor would be very useful for us in a lot of situtations.

I think I've done the README/schema update correctly, but let me know if something needs to be changed.

I'm not sure how precedence works with this processor, but I assume that later statements override earlier ones. Since there are already some default statements for the resource-context in all signal types, I've templated in the extra statements first in those lists.

I renamed the transform processor to `default`, since I didn't feel the current name made sense anymore. Let me know if you'd like me to revert that. I don't think it should be a breaking change.

I have tested this branch on some of my own clusters.