### PR TITLE
Correct Title for Profiles Enabled Example

### DIFF
--- a/examples/profiles-enabled/README.md
+++ b/examples/profiles-enabled/README.md
@@ -1,4 +1,4 @@
-# Traces Enabled
+# Profiles Enabled
 
 This example contains the values required to enable gathering profile data, and sending them
 to [Grafana Pyroscope](https://grafana.com/oss/pyroscope/).


### PR DESCRIPTION
Correct Title for Profiles Enabled Example, replaces `Traces Enabled` with `Profiles Enabled`