### PR TITLE
Correct templating for pprof Profiling Enabled

### DIFF
--- a/charts/k8s-monitoring/templates/agent_config/_profiles_pprof.river.txt
+++ b/charts/k8s-monitoring/templates/agent_config/_profiles_pprof.river.txt
@@ -1,6 +1,6 @@
 {{ define "agent.config.profilesPprof" }}
 // Profiles
-{{- if .Values.profiles.ebpf.enabled }}
+{{- if .Values.profiles.pprof.enabled }}
 discovery.kubernetes "pprof_pods" {
   selectors {
     role = "pod"


### PR DESCRIPTION
Correct templating for pprof Profiling Enabled, currently its disabled if ebpf is disabled, but it should use `.Values.profiles.pprof.enabled` instead.