### PR TITLE
Pin loki chart to the version < Loki 3.0

### DIFF
--- a/.github/workflows/helm-test.yml
+++ b/.github/workflows/helm-test.yml
@@ -188,7 +188,7 @@ jobs:
     - name: Deploy Loki
       if: steps.list-changed.outputs.changed == 'true'
       run: |
-        helm install loki grafana/loki -f "${LOKI_VALUES}" -n loki --create-namespace --wait
+        helm install loki grafana/loki -f "${LOKI_VALUES}" --version ^5.0.0 -n loki --create-namespace --wait
         helm install loki-otlp grafana/grafana-agent -f "${GRAFANA_AGENT_LOKI_OTLP_VALUES}" -n loki --wait
 
     - name: Deploy Tempo

--- a/scripts/setup-local-test-cluster.sh
+++ b/scripts/setup-local-test-cluster.sh
@@ -57,7 +57,7 @@ echo "Deploying Prometheus..."
 helm upgrade --install prometheus prometheus-community/prometheus -f "${PROMETHEUS_VALUES}" -n prometheus --create-namespace --wait
 
 echo "Deploying Loki..."
-helm upgrade --install loki grafana/loki -f "${LOKI_VALUES}" -n loki --create-namespace --wait
+helm upgrade --install loki grafana/loki -f "${LOKI_VALUES}" --version ^5.0.0 -n loki --create-namespace --wait
 helm upgrade --install loki-otlp grafana/grafana-agent -f "${GRAFANA_AGENT_LOKI_OTLP_VALUES}" -n loki --wait
 
 echo "Deploying Tempo..."


### PR DESCRIPTION
The Loki Helm chart version 6.0 and greater installs Loki 3.0. The current values file does not work with the new Loki, and I don't want to hold up work to figure out why.

Eventually, we should make the loki config work with 3.0 and remove this constraint.