### PR TITLE
Turn off clustering for log gathering alloy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+data-alloy

--- a/charts/k8s-monitoring/templates/_config_validations.tpl
+++ b/charts/k8s-monitoring/templates/_config_validations.tpl
@@ -2,15 +2,54 @@
 {{- if and .Values.logs.enabled .Values.logs.pod_logs.enabled }}
   {{- if eq .Values.logs.pod_logs.gatherMethod "volumes" }}
     {{- if ne (index .Values "alloy-logs").controller.type "daemonset" }}
+{{/*
+Invalid configuration for gathering pod logs! When using logs.pod_logs.gatherMethod: "volumes", Grafana Alloy for Logs must be a Daemonset. Otherwise, logs will be missing!
+Please set:
+logs:
+  pod_logs:
+    gatherMethod: api
+or
+alloy-logs:
+  controller:
+    type: daemonset
+*/}}
       {{ fail "Invalid configuration for gathering pod logs! When using logs.pod_logs.gatherMethod: \"volumes\", Grafana Alloy for Logs must be a Daemonset. Otherwise, logs will be missing!\nPlease set:\nlogs:\n  pod_logs:\n    gatherMethod: api\n  or\nalloy-logs:\n  controller:\n    type: daemonset"}}
     {{- end }}
+    {{- if (index .Values "alloy-logs").alloy.clustering.enabled }}
+{{/*
+Invalid configuration for gathering pod logs! When using logs.pod_logs.gatherMethod: "volumes", Grafana Alloy for Logs should not utilize clustering. Otherwise, performance will suffer!
+Please set:
+alloy-logs:
+  alloy:
+    clustering:
+      enabled: false
+*/}}
+      {{ fail "Invalid configuration for gathering pod logs! When using logs.pod_logs.gatherMethod: \"volumes\", Grafana Alloy for Logs should not utilize clustering. Otherwise, performance will suffer!\nPlease set:\nalloy-logs:\n  alloy:\n    clustering:\n      enabled: false"}}
+    {{- end }}
+
   {{- else if eq .Values.logs.pod_logs.gatherMethod "api" }}
     {{- if not (index .Values "alloy-logs").alloy.clustering.enabled }}
       {{- if eq (index .Values "alloy-logs").controller.type "daemonset" }}
+{{/*
+Invalid configuration for gathering pod logs! When using logs.pod_logs.gatherMethod: "api" and the Grafana Alloy for Logs is a Daemonset, you must enable clustering. Otherwise, log files may be duplicated!
+Please set:
+alloy-logs:
+  alloy:
+    clustering:
+      enabled: true
+*/}}
         {{ fail "Invalid configuration for gathering pod logs! When using logs.pod_logs.gatherMethod: \"api\" and the Grafana Alloy for Logs is a Daemonset, you must enable clustering. Otherwise, log files may be duplicated!\nPlease set:\nalloy-logs:\n  alloy:\n    clustering:\n      enabled: true"}}
       {{- end }}
 
       {{- if gt (int (index .Values "alloy-logs").controller.replicas) 1 }}
+{{/*
+Invalid configuration for gathering pod logs! When using logs.pod_logs.gatherMethod: "api" and the Grafana Alloy for Logs has multiple replicas, you must enable clustering. Otherwise, log files will be duplicated!
+Please set:
+alloy-logs:
+  alloy:
+    clustering:
+      enabled: true
+*/}}
         {{ fail "Invalid configuration for gathering pod logs! When using logs.pod_logs.gatherMethod: \"api\" and the Grafana Alloy for Logs has multiple replicas, you must enable clustering. Otherwise, log files will be duplicated!\nPlease set:\nalloy-logs:\n  alloy:\n    clustering:\n      enabled: true"}}
       {{- end }}
 

--- a/charts/k8s-monitoring/templates/_configs.tpl
+++ b/charts/k8s-monitoring/templates/_configs.tpl
@@ -80,7 +80,11 @@
     {{- include "alloy.config.metricsService" . }}
   {{- end }}
 
-  {{- if and .Values.logs.enabled (or .Values.receivers.grpc.enabled .Values.receivers.http.enabled .Values.receivers.zipkin.enabled) }}
+  {{- if and .Values.logs.enabled (or .Values.logs.podLogsObjects.enabled .Values.receivers.grpc.enabled .Values.receivers.http.enabled) }}
+    {{- if .Values.logs.podLogsObjects.enabled }}
+      {{- include "alloy.config.pod_log_objects" . }}
+    {{- end }}
+
     {{- include "alloy.config.logs.pod_logs_processor" . }}
     {{- include "alloy.config.logsService" . }}
   {{- end }}
@@ -100,14 +104,10 @@
   {{- include "alloy.config.logsService" . }}
 {{- end -}}
 
-{{/* Grafana Allyo for Logs config */}}
+{{/* Grafana Alloy for Logs config */}}
 {{- define "alloyLogsConfig" -}}
   {{- include "alloy.config.logs.pod_logs_discovery" . }}
   {{- include "alloy.config.logs.pod_logs_processor" . }}
-  {{- if .Values.logs.podLogsObjects.enabled }}
-    {{- include "alloy.config.pod_log_objects" . }}
-  {{- end }}
-
   {{- include "alloy.config.logsService" . }}
 
   {{- if .Values.logs.extraConfig }}

--- a/charts/k8s-monitoring/values.yaml
+++ b/charts/k8s-monitoring/values.yaml
@@ -1272,8 +1272,8 @@ alloy-logs:
     # This chart is creating the configuration, so the alloy chart does not need to.
     configMap: {create: false}
 
-    # Enable clustering by default to make it simpler when using API-based log gathering.
-    clustering: {enabled: true}
+    # Disabling clustering by default, because the default log gathering format does not require clusters.
+    clustering: {enabled: false}
 
     mounts:
       # Mount /var/log from the host into the container for log collection.

--- a/examples/alloy-autoscaling-and-storage/README.md
+++ b/examples/alloy-autoscaling-and-storage/README.md
@@ -54,4 +54,24 @@ alloy:
           resources:
             requests:
               storage: 5Gi
+
+alloy-logs:
+  alloy:
+    storagePath: /var/lib/alloy
+    mounts:
+      extra:
+        - mountPath: /var/lib/alloy
+          name: alloy-log-positions
+
+  controller:
+    enableStatefulSetAutoDeletePVC: true
+    volumeClaimTemplates:
+      - metadata:
+          name: alloy-log-positions
+        spec:
+          accessModes: ["ReadWriteOnce"]
+          storageClassName: "standard"
+          resources:
+            requests:
+              storage: 100Mi
 ```

--- a/examples/alloy-autoscaling-and-storage/output.yaml
+++ b/examples/alloy-autoscaling-and-storage/output.yaml
@@ -48736,36 +48736,6 @@ spec:
       targetPort: 12345
       protocol: "TCP"
 ---
-# Source: k8s-monitoring/charts/alloy-logs/templates/cluster_service.yaml
-apiVersion: v1
-kind: Service
-metadata:
-  name: k8smon-alloy-logs-cluster
-  labels:
-    helm.sh/chart: alloy-logs-0.1.1
-    app.kubernetes.io/name: alloy-logs
-    app.kubernetes.io/instance: k8smon
-    
-    app.kubernetes.io/version: "v1.0.0"
-    app.kubernetes.io/managed-by: Helm
-spec:
-  type: ClusterIP
-  clusterIP: 'None'
-  selector:
-    app.kubernetes.io/name: alloy-logs
-    app.kubernetes.io/instance: k8smon
-  ports:
-    # Do not include the -metrics suffix in the port name, otherwise metrics
-    # can be double-collected with the non-headless Service if it's also
-    # enabled.
-    #
-    # This service should only be used for clustering, and not metric
-    # collection.
-    - name: http
-      port: 12345
-      targetPort: 12345
-      protocol: "TCP"
----
 # Source: k8s-monitoring/charts/alloy-logs/templates/service.yaml
 apiVersion: v1
 kind: Service
@@ -49073,11 +49043,9 @@ spec:
           args:
             - run
             - /etc/alloy/config.alloy
-            - --storage.path=/tmp/alloy
+            - --storage.path=/var/lib/alloy
             - --server.http.listen-addr=0.0.0.0:12345
             - --server.http.ui-path-prefix=/
-            - --cluster.enabled=true
-            - --cluster.join-addresses=k8smon-alloy-logs-cluster
             - --stability.level=generally-available
           env:
             - name: ALLOY_DEPLOY_MODE
@@ -49102,6 +49070,9 @@ spec:
             - name: varlog
               mountPath: /var/log
               readOnly: true
+            -
+              mountPath: /var/lib/alloy
+              name: alloy-log-positions
         - name: config-reloader
           image: ghcr.io/jimmidyson/configmap-reload:v0.12.0
           args:

--- a/examples/alloy-autoscaling-and-storage/values.yaml
+++ b/examples/alloy-autoscaling-and-storage/values.yaml
@@ -43,3 +43,23 @@ alloy:
           resources:
             requests:
               storage: 5Gi
+
+alloy-logs:
+  alloy:
+    storagePath: /var/lib/alloy
+    mounts:
+      extra:
+        - mountPath: /var/lib/alloy
+          name: alloy-log-positions
+
+  controller:
+    enableStatefulSetAutoDeletePVC: true
+    volumeClaimTemplates:
+      - metadata:
+          name: alloy-log-positions
+        spec:
+          accessModes: ["ReadWriteOnce"]
+          storageClassName: "standard"
+          resources:
+            requests:
+              storage: 100Mi

--- a/examples/control-plane-metrics/output.yaml
+++ b/examples/control-plane-metrics/output.yaml
@@ -48889,36 +48889,6 @@ spec:
       targetPort: 12345
       protocol: "TCP"
 ---
-# Source: k8s-monitoring/charts/alloy-logs/templates/cluster_service.yaml
-apiVersion: v1
-kind: Service
-metadata:
-  name: k8smon-alloy-logs-cluster
-  labels:
-    helm.sh/chart: alloy-logs-0.1.1
-    app.kubernetes.io/name: alloy-logs
-    app.kubernetes.io/instance: k8smon
-    
-    app.kubernetes.io/version: "v1.0.0"
-    app.kubernetes.io/managed-by: Helm
-spec:
-  type: ClusterIP
-  clusterIP: 'None'
-  selector:
-    app.kubernetes.io/name: alloy-logs
-    app.kubernetes.io/instance: k8smon
-  ports:
-    # Do not include the -metrics suffix in the port name, otherwise metrics
-    # can be double-collected with the non-headless Service if it's also
-    # enabled.
-    #
-    # This service should only be used for clustering, and not metric
-    # collection.
-    - name: http
-      port: 12345
-      targetPort: 12345
-      protocol: "TCP"
----
 # Source: k8s-monitoring/charts/alloy-logs/templates/service.yaml
 apiVersion: v1
 kind: Service
@@ -49229,8 +49199,6 @@ spec:
             - --storage.path=/tmp/alloy
             - --server.http.listen-addr=0.0.0.0:12345
             - --server.http.ui-path-prefix=/
-            - --cluster.enabled=true
-            - --cluster.join-addresses=k8smon-alloy-logs-cluster
             - --stability.level=generally-available
           env:
             - name: ALLOY_DEPLOY_MODE

--- a/examples/custom-config/output.yaml
+++ b/examples/custom-config/output.yaml
@@ -48806,36 +48806,6 @@ spec:
       targetPort: 12345
       protocol: "TCP"
 ---
-# Source: k8s-monitoring/charts/alloy-logs/templates/cluster_service.yaml
-apiVersion: v1
-kind: Service
-metadata:
-  name: k8smon-alloy-logs-cluster
-  labels:
-    helm.sh/chart: alloy-logs-0.1.1
-    app.kubernetes.io/name: alloy-logs
-    app.kubernetes.io/instance: k8smon
-    
-    app.kubernetes.io/version: "v1.0.0"
-    app.kubernetes.io/managed-by: Helm
-spec:
-  type: ClusterIP
-  clusterIP: 'None'
-  selector:
-    app.kubernetes.io/name: alloy-logs
-    app.kubernetes.io/instance: k8smon
-  ports:
-    # Do not include the -metrics suffix in the port name, otherwise metrics
-    # can be double-collected with the non-headless Service if it's also
-    # enabled.
-    #
-    # This service should only be used for clustering, and not metric
-    # collection.
-    - name: http
-      port: 12345
-      targetPort: 12345
-      protocol: "TCP"
----
 # Source: k8s-monitoring/charts/alloy-logs/templates/service.yaml
 apiVersion: v1
 kind: Service
@@ -49146,8 +49116,6 @@ spec:
             - --storage.path=/tmp/alloy
             - --server.http.listen-addr=0.0.0.0:12345
             - --server.http.ui-path-prefix=/
-            - --cluster.enabled=true
-            - --cluster.join-addresses=k8smon-alloy-logs-cluster
             - --stability.level=generally-available
           env:
             - name: ALLOY_DEPLOY_MODE

--- a/examples/custom-pricing/output.yaml
+++ b/examples/custom-pricing/output.yaml
@@ -48758,36 +48758,6 @@ spec:
       targetPort: 12345
       protocol: "TCP"
 ---
-# Source: k8s-monitoring/charts/alloy-logs/templates/cluster_service.yaml
-apiVersion: v1
-kind: Service
-metadata:
-  name: k8smon-alloy-logs-cluster
-  labels:
-    helm.sh/chart: alloy-logs-0.1.1
-    app.kubernetes.io/name: alloy-logs
-    app.kubernetes.io/instance: k8smon
-    
-    app.kubernetes.io/version: "v1.0.0"
-    app.kubernetes.io/managed-by: Helm
-spec:
-  type: ClusterIP
-  clusterIP: 'None'
-  selector:
-    app.kubernetes.io/name: alloy-logs
-    app.kubernetes.io/instance: k8smon
-  ports:
-    # Do not include the -metrics suffix in the port name, otherwise metrics
-    # can be double-collected with the non-headless Service if it's also
-    # enabled.
-    #
-    # This service should only be used for clustering, and not metric
-    # collection.
-    - name: http
-      port: 12345
-      targetPort: 12345
-      protocol: "TCP"
----
 # Source: k8s-monitoring/charts/alloy-logs/templates/service.yaml
 apiVersion: v1
 kind: Service
@@ -49098,8 +49068,6 @@ spec:
             - --storage.path=/tmp/alloy
             - --server.http.listen-addr=0.0.0.0:12345
             - --server.http.ui-path-prefix=/
-            - --cluster.enabled=true
-            - --cluster.join-addresses=k8smon-alloy-logs-cluster
             - --stability.level=generally-available
           env:
             - name: ALLOY_DEPLOY_MODE

--- a/examples/default-values/output.yaml
+++ b/examples/default-values/output.yaml
@@ -48736,36 +48736,6 @@ spec:
       targetPort: 12345
       protocol: "TCP"
 ---
-# Source: k8s-monitoring/charts/alloy-logs/templates/cluster_service.yaml
-apiVersion: v1
-kind: Service
-metadata:
-  name: k8smon-alloy-logs-cluster
-  labels:
-    helm.sh/chart: alloy-logs-0.1.1
-    app.kubernetes.io/name: alloy-logs
-    app.kubernetes.io/instance: k8smon
-    
-    app.kubernetes.io/version: "v1.0.0"
-    app.kubernetes.io/managed-by: Helm
-spec:
-  type: ClusterIP
-  clusterIP: 'None'
-  selector:
-    app.kubernetes.io/name: alloy-logs
-    app.kubernetes.io/instance: k8smon
-  ports:
-    # Do not include the -metrics suffix in the port name, otherwise metrics
-    # can be double-collected with the non-headless Service if it's also
-    # enabled.
-    #
-    # This service should only be used for clustering, and not metric
-    # collection.
-    - name: http
-      port: 12345
-      targetPort: 12345
-      protocol: "TCP"
----
 # Source: k8s-monitoring/charts/alloy-logs/templates/service.yaml
 apiVersion: v1
 kind: Service
@@ -49076,8 +49046,6 @@ spec:
             - --storage.path=/tmp/alloy
             - --server.http.listen-addr=0.0.0.0:12345
             - --server.http.ui-path-prefix=/
-            - --cluster.enabled=true
-            - --cluster.join-addresses=k8smon-alloy-logs-cluster
             - --stability.level=generally-available
           env:
             - name: ALLOY_DEPLOY_MODE

--- a/examples/extra-rules/output.yaml
+++ b/examples/extra-rules/output.yaml
@@ -48843,36 +48843,6 @@ spec:
       targetPort: 12345
       protocol: "TCP"
 ---
-# Source: k8s-monitoring/charts/alloy-logs/templates/cluster_service.yaml
-apiVersion: v1
-kind: Service
-metadata:
-  name: k8smon-alloy-logs-cluster
-  labels:
-    helm.sh/chart: alloy-logs-0.1.1
-    app.kubernetes.io/name: alloy-logs
-    app.kubernetes.io/instance: k8smon
-    
-    app.kubernetes.io/version: "v1.0.0"
-    app.kubernetes.io/managed-by: Helm
-spec:
-  type: ClusterIP
-  clusterIP: 'None'
-  selector:
-    app.kubernetes.io/name: alloy-logs
-    app.kubernetes.io/instance: k8smon
-  ports:
-    # Do not include the -metrics suffix in the port name, otherwise metrics
-    # can be double-collected with the non-headless Service if it's also
-    # enabled.
-    #
-    # This service should only be used for clustering, and not metric
-    # collection.
-    - name: http
-      port: 12345
-      targetPort: 12345
-      protocol: "TCP"
----
 # Source: k8s-monitoring/charts/alloy-logs/templates/service.yaml
 apiVersion: v1
 kind: Service
@@ -49183,8 +49153,6 @@ spec:
             - --storage.path=/tmp/alloy
             - --server.http.listen-addr=0.0.0.0:12345
             - --server.http.ui-path-prefix=/
-            - --cluster.enabled=true
-            - --cluster.join-addresses=k8smon-alloy-logs-cluster
             - --stability.level=generally-available
           env:
             - name: ALLOY_DEPLOY_MODE

--- a/examples/gke-autopilot/output.yaml
+++ b/examples/gke-autopilot/output.yaml
@@ -48675,36 +48675,6 @@ spec:
       targetPort: 12345
       protocol: "TCP"
 ---
-# Source: k8s-monitoring/charts/alloy-logs/templates/cluster_service.yaml
-apiVersion: v1
-kind: Service
-metadata:
-  name: k8smon-alloy-logs-cluster
-  labels:
-    helm.sh/chart: alloy-logs-0.1.1
-    app.kubernetes.io/name: alloy-logs
-    app.kubernetes.io/instance: k8smon
-    
-    app.kubernetes.io/version: "v1.0.0"
-    app.kubernetes.io/managed-by: Helm
-spec:
-  type: ClusterIP
-  clusterIP: 'None'
-  selector:
-    app.kubernetes.io/name: alloy-logs
-    app.kubernetes.io/instance: k8smon
-  ports:
-    # Do not include the -metrics suffix in the port name, otherwise metrics
-    # can be double-collected with the non-headless Service if it's also
-    # enabled.
-    #
-    # This service should only be used for clustering, and not metric
-    # collection.
-    - name: http
-      port: 12345
-      targetPort: 12345
-      protocol: "TCP"
----
 # Source: k8s-monitoring/charts/alloy-logs/templates/service.yaml
 apiVersion: v1
 kind: Service
@@ -48990,8 +48960,6 @@ spec:
             - --storage.path=/tmp/alloy
             - --server.http.listen-addr=0.0.0.0:12345
             - --server.http.ui-path-prefix=/
-            - --cluster.enabled=true
-            - --cluster.join-addresses=k8smon-alloy-logs-cluster
             - --stability.level=generally-available
           env:
             - name: ALLOY_DEPLOY_MODE

--- a/examples/ibm-cloud/output.yaml
+++ b/examples/ibm-cloud/output.yaml
@@ -48736,36 +48736,6 @@ spec:
       targetPort: 12345
       protocol: "TCP"
 ---
-# Source: k8s-monitoring/charts/alloy-logs/templates/cluster_service.yaml
-apiVersion: v1
-kind: Service
-metadata:
-  name: k8smon-alloy-logs-cluster
-  labels:
-    helm.sh/chart: alloy-logs-0.1.1
-    app.kubernetes.io/name: alloy-logs
-    app.kubernetes.io/instance: k8smon
-    
-    app.kubernetes.io/version: "v1.0.0"
-    app.kubernetes.io/managed-by: Helm
-spec:
-  type: ClusterIP
-  clusterIP: 'None'
-  selector:
-    app.kubernetes.io/name: alloy-logs
-    app.kubernetes.io/instance: k8smon
-  ports:
-    # Do not include the -metrics suffix in the port name, otherwise metrics
-    # can be double-collected with the non-headless Service if it's also
-    # enabled.
-    #
-    # This service should only be used for clustering, and not metric
-    # collection.
-    - name: http
-      port: 12345
-      targetPort: 12345
-      protocol: "TCP"
----
 # Source: k8s-monitoring/charts/alloy-logs/templates/service.yaml
 apiVersion: v1
 kind: Service
@@ -49076,8 +49046,6 @@ spec:
             - --storage.path=/tmp/alloy
             - --server.http.listen-addr=0.0.0.0:12345
             - --server.http.ui-path-prefix=/
-            - --cluster.enabled=true
-            - --cluster.join-addresses=k8smon-alloy-logs-cluster
             - --stability.level=generally-available
           env:
             - name: ALLOY_DEPLOY_MODE

--- a/examples/kube-pod-labels/output.yaml
+++ b/examples/kube-pod-labels/output.yaml
@@ -48736,36 +48736,6 @@ spec:
       targetPort: 12345
       protocol: "TCP"
 ---
-# Source: k8s-monitoring/charts/alloy-logs/templates/cluster_service.yaml
-apiVersion: v1
-kind: Service
-metadata:
-  name: k8smon-alloy-logs-cluster
-  labels:
-    helm.sh/chart: alloy-logs-0.1.1
-    app.kubernetes.io/name: alloy-logs
-    app.kubernetes.io/instance: k8smon
-    
-    app.kubernetes.io/version: "v1.0.0"
-    app.kubernetes.io/managed-by: Helm
-spec:
-  type: ClusterIP
-  clusterIP: 'None'
-  selector:
-    app.kubernetes.io/name: alloy-logs
-    app.kubernetes.io/instance: k8smon
-  ports:
-    # Do not include the -metrics suffix in the port name, otherwise metrics
-    # can be double-collected with the non-headless Service if it's also
-    # enabled.
-    #
-    # This service should only be used for clustering, and not metric
-    # collection.
-    - name: http
-      port: 12345
-      targetPort: 12345
-      protocol: "TCP"
----
 # Source: k8s-monitoring/charts/alloy-logs/templates/service.yaml
 apiVersion: v1
 kind: Service
@@ -49076,8 +49046,6 @@ spec:
             - --storage.path=/tmp/alloy
             - --server.http.listen-addr=0.0.0.0:12345
             - --server.http.ui-path-prefix=/
-            - --cluster.enabled=true
-            - --cluster.join-addresses=k8smon-alloy-logs-cluster
             - --stability.level=generally-available
           env:
             - name: ALLOY_DEPLOY_MODE

--- a/examples/logs-only/output.yaml
+++ b/examples/logs-only/output.yaml
@@ -822,36 +822,6 @@ spec:
       targetPort: 12345
       protocol: "TCP"
 ---
-# Source: k8s-monitoring/charts/alloy-logs/templates/cluster_service.yaml
-apiVersion: v1
-kind: Service
-metadata:
-  name: k8smon-alloy-logs-cluster
-  labels:
-    helm.sh/chart: alloy-logs-0.1.1
-    app.kubernetes.io/name: alloy-logs
-    app.kubernetes.io/instance: k8smon
-    
-    app.kubernetes.io/version: "v1.0.0"
-    app.kubernetes.io/managed-by: Helm
-spec:
-  type: ClusterIP
-  clusterIP: 'None'
-  selector:
-    app.kubernetes.io/name: alloy-logs
-    app.kubernetes.io/instance: k8smon
-  ports:
-    # Do not include the -metrics suffix in the port name, otherwise metrics
-    # can be double-collected with the non-headless Service if it's also
-    # enabled.
-    #
-    # This service should only be used for clustering, and not metric
-    # collection.
-    - name: http
-      port: 12345
-      targetPort: 12345
-      protocol: "TCP"
----
 # Source: k8s-monitoring/charts/alloy-logs/templates/service.yaml
 apiVersion: v1
 kind: Service
@@ -1087,8 +1057,6 @@ spec:
             - --storage.path=/tmp/alloy
             - --server.http.listen-addr=0.0.0.0:12345
             - --server.http.ui-path-prefix=/
-            - --cluster.enabled=true
-            - --cluster.join-addresses=k8smon-alloy-logs-cluster
             - --stability.level=generally-available
           env:
             - name: ALLOY_DEPLOY_MODE

--- a/examples/openshift-compatible/output.yaml
+++ b/examples/openshift-compatible/output.yaml
@@ -48563,36 +48563,6 @@ spec:
       targetPort: 8080
       protocol: "TCP"
 ---
-# Source: k8s-monitoring/charts/alloy-logs/templates/cluster_service.yaml
-apiVersion: v1
-kind: Service
-metadata:
-  name: k8smon-alloy-logs-cluster
-  labels:
-    helm.sh/chart: alloy-logs-0.1.1
-    app.kubernetes.io/name: alloy-logs
-    app.kubernetes.io/instance: k8smon
-    
-    app.kubernetes.io/version: "v1.0.0"
-    app.kubernetes.io/managed-by: Helm
-spec:
-  type: ClusterIP
-  clusterIP: 'None'
-  selector:
-    app.kubernetes.io/name: alloy-logs
-    app.kubernetes.io/instance: k8smon
-  ports:
-    # Do not include the -metrics suffix in the port name, otherwise metrics
-    # can be double-collected with the non-headless Service if it's also
-    # enabled.
-    #
-    # This service should only be used for clustering, and not metric
-    # collection.
-    - name: http
-      port: 8080
-      targetPort: 8080
-      protocol: "TCP"
----
 # Source: k8s-monitoring/charts/alloy-logs/templates/service.yaml
 apiVersion: v1
 kind: Service
@@ -48854,8 +48824,6 @@ spec:
             - --storage.path=/tmp/alloy
             - --server.http.listen-addr=0.0.0.0:8080
             - --server.http.ui-path-prefix=/
-            - --cluster.enabled=true
-            - --cluster.join-addresses=k8smon-alloy-logs-cluster
             - --stability.level=generally-available
           env:
             - name: ALLOY_DEPLOY_MODE

--- a/examples/otel-metrics-service/output.yaml
+++ b/examples/otel-metrics-service/output.yaml
@@ -48765,36 +48765,6 @@ spec:
       targetPort: 12345
       protocol: "TCP"
 ---
-# Source: k8s-monitoring/charts/alloy-logs/templates/cluster_service.yaml
-apiVersion: v1
-kind: Service
-metadata:
-  name: k8smon-alloy-logs-cluster
-  labels:
-    helm.sh/chart: alloy-logs-0.1.1
-    app.kubernetes.io/name: alloy-logs
-    app.kubernetes.io/instance: k8smon
-    
-    app.kubernetes.io/version: "v1.0.0"
-    app.kubernetes.io/managed-by: Helm
-spec:
-  type: ClusterIP
-  clusterIP: 'None'
-  selector:
-    app.kubernetes.io/name: alloy-logs
-    app.kubernetes.io/instance: k8smon
-  ports:
-    # Do not include the -metrics suffix in the port name, otherwise metrics
-    # can be double-collected with the non-headless Service if it's also
-    # enabled.
-    #
-    # This service should only be used for clustering, and not metric
-    # collection.
-    - name: http
-      port: 12345
-      targetPort: 12345
-      protocol: "TCP"
----
 # Source: k8s-monitoring/charts/alloy-logs/templates/service.yaml
 apiVersion: v1
 kind: Service
@@ -49105,8 +49075,6 @@ spec:
             - --storage.path=/tmp/alloy
             - --server.http.listen-addr=0.0.0.0:12345
             - --server.http.ui-path-prefix=/
-            - --cluster.enabled=true
-            - --cluster.join-addresses=k8smon-alloy-logs-cluster
             - --stability.level=generally-available
           env:
             - name: ALLOY_DEPLOY_MODE

--- a/examples/private-image-registry/output.yaml
+++ b/examples/private-image-registry/output.yaml
@@ -48740,36 +48740,6 @@ spec:
       targetPort: 12345
       protocol: "TCP"
 ---
-# Source: k8s-monitoring/charts/alloy-logs/templates/cluster_service.yaml
-apiVersion: v1
-kind: Service
-metadata:
-  name: k8smon-alloy-logs-cluster
-  labels:
-    helm.sh/chart: alloy-logs-0.1.1
-    app.kubernetes.io/name: alloy-logs
-    app.kubernetes.io/instance: k8smon
-    
-    app.kubernetes.io/version: "v1.0.0"
-    app.kubernetes.io/managed-by: Helm
-spec:
-  type: ClusterIP
-  clusterIP: 'None'
-  selector:
-    app.kubernetes.io/name: alloy-logs
-    app.kubernetes.io/instance: k8smon
-  ports:
-    # Do not include the -metrics suffix in the port name, otherwise metrics
-    # can be double-collected with the non-headless Service if it's also
-    # enabled.
-    #
-    # This service should only be used for clustering, and not metric
-    # collection.
-    - name: http
-      port: 12345
-      targetPort: 12345
-      protocol: "TCP"
----
 # Source: k8s-monitoring/charts/alloy-logs/templates/service.yaml
 apiVersion: v1
 kind: Service
@@ -49082,8 +49052,6 @@ spec:
             - --storage.path=/tmp/alloy
             - --server.http.listen-addr=0.0.0.0:12345
             - --server.http.ui-path-prefix=/
-            - --cluster.enabled=true
-            - --cluster.join-addresses=k8smon-alloy-logs-cluster
             - --stability.level=generally-available
           env:
             - name: ALLOY_DEPLOY_MODE

--- a/examples/profiles-enabled/output.yaml
+++ b/examples/profiles-enabled/output.yaml
@@ -49678,36 +49678,6 @@ spec:
       targetPort: 12345
       protocol: "TCP"
 ---
-# Source: k8s-monitoring/charts/alloy-logs/templates/cluster_service.yaml
-apiVersion: v1
-kind: Service
-metadata:
-  name: k8smon-alloy-logs-cluster
-  labels:
-    helm.sh/chart: alloy-logs-0.1.1
-    app.kubernetes.io/name: alloy-logs
-    app.kubernetes.io/instance: k8smon
-    
-    app.kubernetes.io/version: "v1.0.0"
-    app.kubernetes.io/managed-by: Helm
-spec:
-  type: ClusterIP
-  clusterIP: 'None'
-  selector:
-    app.kubernetes.io/name: alloy-logs
-    app.kubernetes.io/instance: k8smon
-  ports:
-    # Do not include the -metrics suffix in the port name, otherwise metrics
-    # can be double-collected with the non-headless Service if it's also
-    # enabled.
-    #
-    # This service should only be used for clustering, and not metric
-    # collection.
-    - name: http
-      port: 12345
-      targetPort: 12345
-      protocol: "TCP"
----
 # Source: k8s-monitoring/charts/alloy-logs/templates/service.yaml
 apiVersion: v1
 kind: Service
@@ -50042,8 +50012,6 @@ spec:
             - --storage.path=/tmp/alloy
             - --server.http.listen-addr=0.0.0.0:12345
             - --server.http.ui-path-prefix=/
-            - --cluster.enabled=true
-            - --cluster.join-addresses=k8smon-alloy-logs-cluster
             - --stability.level=generally-available
           env:
             - name: ALLOY_DEPLOY_MODE

--- a/examples/proxies/output.yaml
+++ b/examples/proxies/output.yaml
@@ -48752,36 +48752,6 @@ spec:
       targetPort: 12345
       protocol: "TCP"
 ---
-# Source: k8s-monitoring/charts/alloy-logs/templates/cluster_service.yaml
-apiVersion: v1
-kind: Service
-metadata:
-  name: k8smon-alloy-logs-cluster
-  labels:
-    helm.sh/chart: alloy-logs-0.1.1
-    app.kubernetes.io/name: alloy-logs
-    app.kubernetes.io/instance: k8smon
-    
-    app.kubernetes.io/version: "v1.0.0"
-    app.kubernetes.io/managed-by: Helm
-spec:
-  type: ClusterIP
-  clusterIP: 'None'
-  selector:
-    app.kubernetes.io/name: alloy-logs
-    app.kubernetes.io/instance: k8smon
-  ports:
-    # Do not include the -metrics suffix in the port name, otherwise metrics
-    # can be double-collected with the non-headless Service if it's also
-    # enabled.
-    #
-    # This service should only be used for clustering, and not metric
-    # collection.
-    - name: http
-      port: 12345
-      targetPort: 12345
-      protocol: "TCP"
----
 # Source: k8s-monitoring/charts/alloy-logs/templates/service.yaml
 apiVersion: v1
 kind: Service
@@ -49092,8 +49062,6 @@ spec:
             - --storage.path=/tmp/alloy
             - --server.http.listen-addr=0.0.0.0:12345
             - --server.http.ui-path-prefix=/
-            - --cluster.enabled=true
-            - --cluster.join-addresses=k8smon-alloy-logs-cluster
             - --stability.level=generally-available
           env:
             - name: ALLOY_DEPLOY_MODE

--- a/examples/service-integrations/output.yaml
+++ b/examples/service-integrations/output.yaml
@@ -48771,36 +48771,6 @@ spec:
       targetPort: 12345
       protocol: "TCP"
 ---
-# Source: k8s-monitoring/charts/alloy-logs/templates/cluster_service.yaml
-apiVersion: v1
-kind: Service
-metadata:
-  name: k8smon-alloy-logs-cluster
-  labels:
-    helm.sh/chart: alloy-logs-0.1.1
-    app.kubernetes.io/name: alloy-logs
-    app.kubernetes.io/instance: k8smon
-    
-    app.kubernetes.io/version: "v1.0.0"
-    app.kubernetes.io/managed-by: Helm
-spec:
-  type: ClusterIP
-  clusterIP: 'None'
-  selector:
-    app.kubernetes.io/name: alloy-logs
-    app.kubernetes.io/instance: k8smon
-  ports:
-    # Do not include the -metrics suffix in the port name, otherwise metrics
-    # can be double-collected with the non-headless Service if it's also
-    # enabled.
-    #
-    # This service should only be used for clustering, and not metric
-    # collection.
-    - name: http
-      port: 12345
-      targetPort: 12345
-      protocol: "TCP"
----
 # Source: k8s-monitoring/charts/alloy-logs/templates/service.yaml
 apiVersion: v1
 kind: Service
@@ -49111,8 +49081,6 @@ spec:
             - --storage.path=/tmp/alloy
             - --server.http.listen-addr=0.0.0.0:12345
             - --server.http.ui-path-prefix=/
-            - --cluster.enabled=true
-            - --cluster.join-addresses=k8smon-alloy-logs-cluster
             - --stability.level=generally-available
           env:
             - name: ALLOY_DEPLOY_MODE

--- a/examples/specific-namespace/output.yaml
+++ b/examples/specific-namespace/output.yaml
@@ -48800,36 +48800,6 @@ spec:
       targetPort: 12345
       protocol: "TCP"
 ---
-# Source: k8s-monitoring/charts/alloy-logs/templates/cluster_service.yaml
-apiVersion: v1
-kind: Service
-metadata:
-  name: k8smon-alloy-logs-cluster
-  labels:
-    helm.sh/chart: alloy-logs-0.1.1
-    app.kubernetes.io/name: alloy-logs
-    app.kubernetes.io/instance: k8smon
-    
-    app.kubernetes.io/version: "v1.0.0"
-    app.kubernetes.io/managed-by: Helm
-spec:
-  type: ClusterIP
-  clusterIP: 'None'
-  selector:
-    app.kubernetes.io/name: alloy-logs
-    app.kubernetes.io/instance: k8smon
-  ports:
-    # Do not include the -metrics suffix in the port name, otherwise metrics
-    # can be double-collected with the non-headless Service if it's also
-    # enabled.
-    #
-    # This service should only be used for clustering, and not metric
-    # collection.
-    - name: http
-      port: 12345
-      targetPort: 12345
-      protocol: "TCP"
----
 # Source: k8s-monitoring/charts/alloy-logs/templates/service.yaml
 apiVersion: v1
 kind: Service
@@ -49140,8 +49110,6 @@ spec:
             - --storage.path=/tmp/alloy
             - --server.http.listen-addr=0.0.0.0:12345
             - --server.http.ui-path-prefix=/
-            - --cluster.enabled=true
-            - --cluster.join-addresses=k8smon-alloy-logs-cluster
             - --stability.level=generally-available
           env:
             - name: ALLOY_DEPLOY_MODE

--- a/examples/traces-enabled/output.yaml
+++ b/examples/traces-enabled/output.yaml
@@ -48854,36 +48854,6 @@ spec:
       targetPort: 12345
       protocol: "TCP"
 ---
-# Source: k8s-monitoring/charts/alloy-logs/templates/cluster_service.yaml
-apiVersion: v1
-kind: Service
-metadata:
-  name: k8smon-alloy-logs-cluster
-  labels:
-    helm.sh/chart: alloy-logs-0.1.1
-    app.kubernetes.io/name: alloy-logs
-    app.kubernetes.io/instance: k8smon
-    
-    app.kubernetes.io/version: "v1.0.0"
-    app.kubernetes.io/managed-by: Helm
-spec:
-  type: ClusterIP
-  clusterIP: 'None'
-  selector:
-    app.kubernetes.io/name: alloy-logs
-    app.kubernetes.io/instance: k8smon
-  ports:
-    # Do not include the -metrics suffix in the port name, otherwise metrics
-    # can be double-collected with the non-headless Service if it's also
-    # enabled.
-    #
-    # This service should only be used for clustering, and not metric
-    # collection.
-    - name: http
-      port: 12345
-      targetPort: 12345
-      protocol: "TCP"
----
 # Source: k8s-monitoring/charts/alloy-logs/templates/service.yaml
 apiVersion: v1
 kind: Service
@@ -49194,8 +49164,6 @@ spec:
             - --storage.path=/tmp/alloy
             - --server.http.listen-addr=0.0.0.0:12345
             - --server.http.ui-path-prefix=/
-            - --cluster.enabled=true
-            - --cluster.join-addresses=k8smon-alloy-logs-cluster
             - --stability.level=generally-available
           env:
             - name: ALLOY_DEPLOY_MODE

--- a/examples/windows-exporter/output.yaml
+++ b/examples/windows-exporter/output.yaml
@@ -48841,36 +48841,6 @@ spec:
       targetPort: 12345
       protocol: "TCP"
 ---
-# Source: k8s-monitoring/charts/alloy-logs/templates/cluster_service.yaml
-apiVersion: v1
-kind: Service
-metadata:
-  name: k8smon-alloy-logs-cluster
-  labels:
-    helm.sh/chart: alloy-logs-0.1.1
-    app.kubernetes.io/name: alloy-logs
-    app.kubernetes.io/instance: k8smon
-    
-    app.kubernetes.io/version: "v1.0.0"
-    app.kubernetes.io/managed-by: Helm
-spec:
-  type: ClusterIP
-  clusterIP: 'None'
-  selector:
-    app.kubernetes.io/name: alloy-logs
-    app.kubernetes.io/instance: k8smon
-  ports:
-    # Do not include the -metrics suffix in the port name, otherwise metrics
-    # can be double-collected with the non-headless Service if it's also
-    # enabled.
-    #
-    # This service should only be used for clustering, and not metric
-    # collection.
-    - name: http
-      port: 12345
-      targetPort: 12345
-      protocol: "TCP"
----
 # Source: k8s-monitoring/charts/alloy-logs/templates/service.yaml
 apiVersion: v1
 kind: Service
@@ -49209,8 +49179,6 @@ spec:
             - --storage.path=/tmp/alloy
             - --server.http.listen-addr=0.0.0.0:12345
             - --server.http.ui-path-prefix=/
-            - --cluster.enabled=true
-            - --cluster.join-addresses=k8smon-alloy-logs-cluster
             - --stability.level=generally-available
           env:
             - name: ALLOY_DEPLOY_MODE

--- a/tests/spec/fixtures/invalid-logs-config-volumes-and-clustering-values.yaml
+++ b/tests/spec/fixtures/invalid-logs-config-volumes-and-clustering-values.yaml
@@ -1,0 +1,23 @@
+cluster:
+  name: invalid-logs-config-volumes-and-clustering
+
+externalServices:
+  prometheus:
+    host: https://prometheus.example.com
+    basicAuth:
+      username: 12345
+      password: "It's a secret to everyone"
+  loki:
+    host: https://loki.example.com
+    basicAuth:
+      username: 12345
+      password: "It's a secret to everyone"
+
+logs:
+  pod_logs:
+    gatherMethod: volumes
+
+alloy-logs:
+  alloy:
+    clustering:
+      enabled: true

--- a/tests/spec/invalid-logs-configurations_spec.sh
+++ b/tests/spec/invalid-logs-configurations_spec.sh
@@ -12,6 +12,19 @@ alloy-logs:
     End
   End
 
+  Describe 'Using volume log gathering and clustering'
+    It 'prints a friendly error message'
+      When call helm template k8smon ../charts/k8s-monitoring -f "spec/fixtures/invalid-logs-config-volumes-and-clustering-values.yaml"
+      The status should be failure
+      The error should include 'Invalid configuration for gathering pod logs! When using logs.pod_logs.gatherMethod: "volumes", Grafana Alloy for Logs should not utilize clustering. Otherwise, performance will suffer!
+Please set:
+alloy-logs:
+  alloy:
+    clustering:
+      enabled: false'
+    End
+  End
+
   Describe 'Using multiple replicas with API log gathering and no clustering'
     It 'prints a friendly error message'
       When call helm template k8smon ../charts/k8s-monitoring -f "spec/fixtures/invalid-logs-config-multiple-replicas-and-api_values.yaml"


### PR DESCRIPTION
Move PodLogs control to the primary alloy, which does use clustering.

Also add some instructions for setting the storage path for logs instance.
