### PR TITLE
Update OpenShift platform and examples

### DIFF
--- a/charts/k8s-monitoring/templates/platform_specific/openshift/security-context-constraint.yaml
+++ b/charts/k8s-monitoring/templates/platform_specific/openshift/security-context-constraint.yaml
@@ -13,18 +13,18 @@ allowPrivilegeEscalation: false
 allowPrivilegedContainer: false
 allowedCapabilities:
 - CHOWN
-# - DAC_OVERRIDE
+- DAC_OVERRIDE
 - FOWNER
 - FSETID
-# - KILL
+- KILL
 - SETGID
 - SETUID
 - SETPCAP
 - NET_BIND_SERVICE
 - NET_RAW
 - SYS_CHROOT
-# - MKNOD
-# - AUDIT_WRITE
+- MKNOD
+- AUDIT_WRITE
 - SETFCAP
 defaultAddCapabilities: null
 defaultAllowPrivilegeEscalation: false
@@ -83,15 +83,17 @@ subjects:
 {{- end -}}
 
 {{- if eq .Values.cluster.platform "openshift" }}
-
+{{/* Create the SecurityContextConstraints for the main Alloy instance */}}
 {{$data := dict "name" (include "alloy.fullname" (index .Subcharts "alloy")) "namespace" .Release.Namespace "hostpath" false }}
 {{- include "alloySecurityContextConstraintTemplate" $data }}
 
+{{/* Create the SecurityContextConstraints for the Alloy for Cluster Events instance */}}
 {{- if and .Values.logs.enabled .Values.logs.cluster_events.enabled }}
 {{$data := dict "name" (include "alloy.fullname" (index .Subcharts "alloy-events")) "namespace" .Release.Namespace "hostpath" false }}
 {{- include "alloySecurityContextConstraintTemplate" $data }}
 {{- end }}
 
+{{/* Create the SecurityContextConstraints for the Alloy for Logs instance */}}
 {{- if and .Values.logs.enabled .Values.logs.pod_logs.enabled }}
 {{$data := dict "name" (include "alloy.fullname" (index .Subcharts "alloy-logs")) "namespace" .Release.Namespace "hostpath" (eq .Values.logs.pod_logs.gatherMethod "volumes") }}
 {{- include "alloySecurityContextConstraintTemplate" $data }}

--- a/charts/k8s-monitoring/templates/platform_specific/openshift/security-context-constraint.yaml
+++ b/charts/k8s-monitoring/templates/platform_specific/openshift/security-context-constraint.yaml
@@ -1,17 +1,31 @@
-{{- if and (eq .Values.cluster.platform "openshift") .Values.logs.enabled .Values.logs.pod_logs.enabled }}
+{{- define "alloySecurityContextConstraintTemplate" -}}
 ---
 apiVersion: security.openshift.io/v1
 kind: SecurityContextConstraints
 metadata:
-  name: {{ include "alloy.fullname" (index .Subcharts "alloy-logs") }}
-allowHostDirVolumePlugin: true
+  name: {{ .name }}
+allowHostDirVolumePlugin: {{ .hostpath }}
 allowHostIPC: false
 allowHostNetwork: false
 allowHostPID: false
 allowHostPorts: false
 allowPrivilegeEscalation: false
 allowPrivilegedContainer: false
-allowedCapabilities: null
+allowedCapabilities:
+- CHOWN
+# - DAC_OVERRIDE
+- FOWNER
+- FSETID
+# - KILL
+- SETGID
+- SETUID
+- SETPCAP
+- NET_BIND_SERVICE
+- NET_RAW
+- SYS_CHROOT
+# - MKNOD
+# - AUDIT_WRITE
+- SETFCAP
 defaultAddCapabilities: null
 defaultAllowPrivilegeEscalation: false
 forbiddenSysctls:
@@ -21,16 +35,7 @@ fsGroup:
 groups: []
 priority: null
 readOnlyRootFilesystem: false  # Set because Grafana Alloy needs to write to /tmp/alloy
-requiredDropCapabilities:
-- CHOWN
-- DAC_OVERRIDE
-- FSETID
-- FOWNER
-- SETGID
-- SETUID
-- SETPCAP
-- NET_BIND_SERVICE
-- KILL
+requiredDropCapabilities: null
 runAsUser:
   type: RunAsAny
 seLinuxContext:
@@ -43,34 +48,52 @@ users: []
 volumes:
 - configMap
 - emptyDir
+{{- if .hostpath }}
 - hostPath
+{{- end }}
 - projected
 - secret
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: {{ include "alloy.fullname" (index .Subcharts "alloy-logs") }}-scc
+  name: {{ .name }}-scc
 rules:
 - verbs:
-  - use
+    - use
   apiGroups:
-  - security.openshift.io
+    - security.openshift.io
   resources:
-  - securitycontextconstraints
+    - securitycontextconstraints
   resourceNames:
-  - {{ include "alloy.fullname" (index .Subcharts "alloy-logs") }}
+    - {{ .name }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: {{ include "alloy.fullname" (index .Subcharts "alloy-logs") }}-scc
+  name: {{ .name }}-scc
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: {{ include "alloy.fullname" (index .Subcharts "alloy-logs") }}-scc
+  name: {{ .name }}-scc
 subjects:
 - kind: ServiceAccount
-  name: {{ include "alloy.serviceAccountName" (index .Subcharts "alloy-logs") }}
-  namespace: {{ .Release.Namespace }}
+  name: {{ .name }}
+  namespace: {{ .namespace }}
+{{- end -}}
+
+{{- if eq .Values.cluster.platform "openshift" }}
+
+{{$data := dict "name" (include "alloy.fullname" (index .Subcharts "alloy")) "namespace" .Release.Namespace "hostpath" false }}
+{{- include "alloySecurityContextConstraintTemplate" $data }}
+
+{{- if and .Values.logs.enabled .Values.logs.cluster_events.enabled }}
+{{$data := dict "name" (include "alloy.fullname" (index .Subcharts "alloy-events")) "namespace" .Release.Namespace "hostpath" false }}
+{{- include "alloySecurityContextConstraintTemplate" $data }}
+{{- end }}
+
+{{- if and .Values.logs.enabled .Values.logs.pod_logs.enabled }}
+{{$data := dict "name" (include "alloy.fullname" (index .Subcharts "alloy-logs")) "namespace" .Release.Namespace "hostpath" (eq .Values.logs.pod_logs.gatherMethod "volumes") }}
+{{- include "alloySecurityContextConstraintTemplate" $data }}
+{{- end }}
 {{- end }}

--- a/examples/openshift-compatible/README.md
+++ b/examples/openshift-compatible/README.md
@@ -1,5 +1,7 @@
 # OpenShift Compatible
 
+TODO THESE PARAGRAPHS NEED UPDATING
+
 This example shows the modifications from the [default](../default-values) to deploy Kubernetes Monitoring on an OpenShift cluster.
 
 These modifications prevent deploying Kube State Metrics and Node Exporter, since they will already be present on the
@@ -52,22 +54,52 @@ prometheus-node-exporter:
 
 alloy:
   alloy:
-    listenPort: 8080
     securityContext:
+      runAsUser: 473
+      runAsGroup: 473
       allowPrivilegeEscalation: false
       capabilities:
-        drop: [ "ALL" ]
+        drop: ["ALL"]
+        add:
+          - CHOWN
+          # - DAC_OVERRIDE
+          - FOWNER
+          - FSETID
+          # - KILL
+          - SETGID
+          - SETUID
+          - SETPCAP
+          - NET_BIND_SERVICE
+          - NET_RAW
+          - SYS_CHROOT
+          # - MKNOD
+          # - AUDIT_WRITE
+          - SETFCAP
       runAsNonRoot: true
       seccompProfile:
         type: "RuntimeDefault"
 
 alloy-logs:
   alloy:
-    listenPort: 8080
     securityContext:
       allowPrivilegeEscalation: false
       capabilities:
-        drop: [ "ALL" ]
+        drop: ["ALL"]
+        add:
+          - CHOWN
+          # - DAC_OVERRIDE
+          - FOWNER
+          - FSETID
+          # - KILL
+          - SETGID
+          - SETUID
+          - SETPCAP
+          - NET_BIND_SERVICE
+          - NET_RAW
+          - SYS_CHROOT
+          # - MKNOD
+          # - AUDIT_WRITE
+          - SETFCAP
       privileged: false
       runAsUser: 0
   global:
@@ -77,11 +109,27 @@ alloy-logs:
 
 alloy-events:
   alloy:
-    listenPort: 8080
     securityContext:
+      runAsUser: 473
+      runAsGroup: 473
       allowPrivilegeEscalation: false
       capabilities:
-        drop: [ "ALL" ]
+        drop: ["ALL"]
+        add:
+          - CHOWN
+          # - DAC_OVERRIDE
+          - FOWNER
+          - FSETID
+          # - KILL
+          - SETGID
+          - SETUID
+          - SETPCAP
+          - NET_BIND_SERVICE
+          - NET_RAW
+          - SYS_CHROOT
+          # - MKNOD
+          # - AUDIT_WRITE
+          - SETFCAP
       runAsNonRoot: true
       seccompProfile:
         type: "RuntimeDefault"

--- a/examples/openshift-compatible/README.md
+++ b/examples/openshift-compatible/README.md
@@ -1,7 +1,5 @@
 # OpenShift Compatible
 
-TODO THESE PARAGRAPHS NEED UPDATING
-
 This example shows the modifications from the [default](../default-values) to deploy Kubernetes Monitoring on an OpenShift cluster.
 
 These modifications skip the deployment of kube-state-metrics and Node Exporter, since they will already be present on

--- a/examples/openshift-compatible/README.md
+++ b/examples/openshift-compatible/README.md
@@ -4,12 +4,12 @@ TODO THESE PARAGRAPHS NEED UPDATING
 
 This example shows the modifications from the [default](../default-values) to deploy Kubernetes Monitoring on an OpenShift cluster.
 
-These modifications prevent deploying Kube State Metrics and Node Exporter, since they will already be present on the
-cluster, and adjust the configuration to Grafana Alloy to find those existing components.
-It also modifies Grafana Alloy to lock down security and permissions, and assigns a high-number port. 
+These modifications skip the deployment of kube-state-metrics and Node Exporter, since they will already be present on
+the cluster, and adjust the configuration to Grafana Alloy to find those existing components.
+It also modifies Grafana Alloy to lock down security and permissions. 
 
-The `platform: openshift` switch also creates a SecurityContextConstraints object that modifies the permissions for the
-Grafana Alloy for logs. This is required because of its use of hostPath volume mounts to detect and capture pod logs.
+The `platform: openshift` switch also creates SecurityContextConstraints objects that modifies the permissions for the
+Grafana Alloy.
 
 Note that these alloy pods cannot enable `readOnlyRootFilesystem` because they require being able to write to their
 storage path, which defaults to `/tmp/alloy`.
@@ -55,27 +55,10 @@ prometheus-node-exporter:
 alloy:
   alloy:
     securityContext:
-      runAsUser: 473
-      runAsGroup: 473
       allowPrivilegeEscalation: false
       capabilities:
         drop: ["ALL"]
-        add:
-          - CHOWN
-          # - DAC_OVERRIDE
-          - FOWNER
-          - FSETID
-          # - KILL
-          - SETGID
-          - SETUID
-          - SETPCAP
-          - NET_BIND_SERVICE
-          - NET_RAW
-          - SYS_CHROOT
-          # - MKNOD
-          # - AUDIT_WRITE
-          - SETFCAP
-      runAsNonRoot: true
+        add: ["CHOWN", "DAC_OVERRIDE", "FOWNER", "FSETID", "KILL", "SETGID", "SETUID", "SETPCAP", "NET_BIND_SERVICE", "NET_RAW", "SYS_CHROOT", "MKNOD", "AUDIT_WRITE", "SETFCAP"]
       seccompProfile:
         type: "RuntimeDefault"
 
@@ -85,21 +68,7 @@ alloy-logs:
       allowPrivilegeEscalation: false
       capabilities:
         drop: ["ALL"]
-        add:
-          - CHOWN
-          # - DAC_OVERRIDE
-          - FOWNER
-          - FSETID
-          # - KILL
-          - SETGID
-          - SETUID
-          - SETPCAP
-          - NET_BIND_SERVICE
-          - NET_RAW
-          - SYS_CHROOT
-          # - MKNOD
-          # - AUDIT_WRITE
-          - SETFCAP
+        add: ["CHOWN", "DAC_OVERRIDE", "FOWNER", "FSETID", "KILL", "SETGID", "SETUID", "SETPCAP", "NET_BIND_SERVICE", "NET_RAW", "SYS_CHROOT", "MKNOD", "AUDIT_WRITE", "SETFCAP"]
       privileged: false
       runAsUser: 0
   global:
@@ -110,27 +79,10 @@ alloy-logs:
 alloy-events:
   alloy:
     securityContext:
-      runAsUser: 473
-      runAsGroup: 473
       allowPrivilegeEscalation: false
       capabilities:
         drop: ["ALL"]
-        add:
-          - CHOWN
-          # - DAC_OVERRIDE
-          - FOWNER
-          - FSETID
-          # - KILL
-          - SETGID
-          - SETUID
-          - SETPCAP
-          - NET_BIND_SERVICE
-          - NET_RAW
-          - SYS_CHROOT
-          # - MKNOD
-          # - AUDIT_WRITE
-          - SETFCAP
-      runAsNonRoot: true
+        add: ["CHOWN", "DAC_OVERRIDE", "FOWNER", "FSETID", "KILL", "SETGID", "SETUID", "SETPCAP", "NET_BIND_SERVICE", "NET_RAW", "SYS_CHROOT", "MKNOD", "AUDIT_WRITE", "SETFCAP"]
       seccompProfile:
         type: "RuntimeDefault"
 ```

--- a/examples/openshift-compatible/output.yaml
+++ b/examples/openshift-compatible/output.yaml
@@ -48923,14 +48923,18 @@ spec:
             capabilities:
               add:
               - CHOWN
+              - DAC_OVERRIDE
               - FOWNER
               - FSETID
+              - KILL
               - SETGID
               - SETUID
               - SETPCAP
               - NET_BIND_SERVICE
               - NET_RAW
               - SYS_CHROOT
+              - MKNOD
+              - AUDIT_WRITE
               - SETFCAP
               drop:
               - ALL
@@ -49029,14 +49033,18 @@ spec:
             capabilities:
               add:
               - CHOWN
+              - DAC_OVERRIDE
               - FOWNER
               - FSETID
+              - KILL
               - SETGID
               - SETUID
               - SETPCAP
               - NET_BIND_SERVICE
               - NET_RAW
               - SYS_CHROOT
+              - MKNOD
+              - AUDIT_WRITE
               - SETFCAP
               drop:
               - ALL
@@ -49260,14 +49268,18 @@ spec:
             capabilities:
               add:
               - CHOWN
+              - DAC_OVERRIDE
               - FOWNER
               - FSETID
+              - KILL
               - SETGID
               - SETUID
               - SETPCAP
               - NET_BIND_SERVICE
               - NET_RAW
               - SYS_CHROOT
+              - MKNOD
+              - AUDIT_WRITE
               - SETFCAP
               drop:
               - ALL
@@ -49346,18 +49358,18 @@ allowPrivilegeEscalation: false
 allowPrivilegedContainer: false
 allowedCapabilities:
 - CHOWN
-# - DAC_OVERRIDE
+- DAC_OVERRIDE
 - FOWNER
 - FSETID
-# - KILL
+- KILL
 - SETGID
 - SETUID
 - SETPCAP
 - NET_BIND_SERVICE
 - NET_RAW
 - SYS_CHROOT
-# - MKNOD
-# - AUDIT_WRITE
+- MKNOD
+- AUDIT_WRITE
 - SETFCAP
 defaultAddCapabilities: null
 defaultAllowPrivilegeEscalation: false
@@ -49398,18 +49410,18 @@ allowPrivilegeEscalation: false
 allowPrivilegedContainer: false
 allowedCapabilities:
 - CHOWN
-# - DAC_OVERRIDE
+- DAC_OVERRIDE
 - FOWNER
 - FSETID
-# - KILL
+- KILL
 - SETGID
 - SETUID
 - SETPCAP
 - NET_BIND_SERVICE
 - NET_RAW
 - SYS_CHROOT
-# - MKNOD
-# - AUDIT_WRITE
+- MKNOD
+- AUDIT_WRITE
 - SETFCAP
 defaultAddCapabilities: null
 defaultAllowPrivilegeEscalation: false
@@ -49450,18 +49462,18 @@ allowPrivilegeEscalation: false
 allowPrivilegedContainer: false
 allowedCapabilities:
 - CHOWN
-# - DAC_OVERRIDE
+- DAC_OVERRIDE
 - FOWNER
 - FSETID
-# - KILL
+- KILL
 - SETGID
 - SETUID
 - SETPCAP
 - NET_BIND_SERVICE
 - NET_RAW
 - SYS_CHROOT
-# - MKNOD
-# - AUDIT_WRITE
+- MKNOD
+- AUDIT_WRITE
 - SETFCAP
 defaultAddCapabilities: null
 defaultAllowPrivilegeEscalation: false

--- a/examples/openshift-compatible/output.yaml
+++ b/examples/openshift-compatible/output.yaml
@@ -48448,16 +48448,46 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
+  name: k8smon-alloy-scc
+rules:
+- verbs:
+    - use
+  apiGroups:
+    - security.openshift.io
+  resources:
+    - securitycontextconstraints
+  resourceNames:
+    - k8smon-alloy
+---
+# Source: k8s-monitoring/templates/platform_specific/openshift/security-context-constraint.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: k8smon-alloy-events-scc
+rules:
+- verbs:
+    - use
+  apiGroups:
+    - security.openshift.io
+  resources:
+    - securitycontextconstraints
+  resourceNames:
+    - k8smon-alloy-events
+---
+# Source: k8s-monitoring/templates/platform_specific/openshift/security-context-constraint.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
   name: k8smon-alloy-logs-scc
 rules:
 - verbs:
-  - use
+    - use
   apiGroups:
-  - security.openshift.io
+    - security.openshift.io
   resources:
-  - securitycontextconstraints
+    - securitycontextconstraints
   resourceNames:
-  - k8smon-alloy-logs
+    - k8smon-alloy-logs
 ---
 # Source: k8s-monitoring/charts/alloy-events/templates/rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1
@@ -48547,6 +48577,34 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
+  name: k8smon-alloy-scc
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: k8smon-alloy-scc
+subjects:
+- kind: ServiceAccount
+  name: k8smon-alloy
+  namespace: default
+---
+# Source: k8s-monitoring/templates/platform_specific/openshift/security-context-constraint.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: k8smon-alloy-events-scc
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: k8smon-alloy-events-scc
+subjects:
+- kind: ServiceAccount
+  name: k8smon-alloy-events
+  namespace: default
+---
+# Source: k8s-monitoring/templates/platform_specific/openshift/security-context-constraint.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
   name: k8smon-alloy-logs-scc
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -48577,8 +48635,8 @@ spec:
   internalTrafficPolicy: Cluster
   ports:
     - name: http-metrics
-      port: 8080
-      targetPort: 8080
+      port: 12345
+      targetPort: 12345
       protocol: "TCP"
 ---
 # Source: k8s-monitoring/charts/alloy-logs/templates/service.yaml
@@ -48601,8 +48659,8 @@ spec:
   internalTrafficPolicy: Cluster
   ports:
     - name: http-metrics
-      port: 8080
-      targetPort: 8080
+      port: 12345
+      targetPort: 12345
       protocol: "TCP"
 ---
 # Source: k8s-monitoring/charts/alloy/templates/cluster_service.yaml
@@ -48631,8 +48689,8 @@ spec:
     # This service should only be used for clustering, and not metric
     # collection.
     - name: http
-      port: 8080
-      targetPort: 8080
+      port: 12345
+      targetPort: 12345
       protocol: "TCP"
     - name: otlp-grpc
       port: 4317
@@ -48687,8 +48745,8 @@ spec:
   internalTrafficPolicy: Cluster
   ports:
     - name: http-metrics
-      port: 8080
-      targetPort: 8080
+      port: 12345
+      targetPort: 12345
       protocol: "TCP"
     - name: otlp-grpc
       port: 4317
@@ -48766,8 +48824,8 @@ spec:
   internalTrafficPolicy: Cluster
   ports:
     - name: http-metrics
-      port: 8080
-      targetPort: 8080
+      port: 12345
+      targetPort: 12345
       protocol: "TCP"
     - name: otlp-grpc
       port: 4317
@@ -48840,7 +48898,7 @@ spec:
             - run
             - /etc/alloy/config.alloy
             - --storage.path=/tmp/alloy
-            - --server.http.listen-addr=0.0.0.0:8080
+            - --server.http.listen-addr=0.0.0.0:12345
             - --server.http.ui-path-prefix=/
             - --stability.level=generally-available
           env:
@@ -48851,18 +48909,29 @@ spec:
                 fieldRef:
                   fieldPath: spec.nodeName
           ports:
-            - containerPort: 8080
+            - containerPort: 12345
               name: http-metrics
           readinessProbe:
             httpGet:
               path: /-/ready
-              port: 8080
+              port: 12345
               scheme: HTTP
             initialDelaySeconds: 10
             timeoutSeconds: 1
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:
+              add:
+              - CHOWN
+              - FOWNER
+              - FSETID
+              - SETGID
+              - SETUID
+              - SETPCAP
+              - NET_BIND_SERVICE
+              - NET_RAW
+              - SYS_CHROOT
+              - SETFCAP
               drop:
               - ALL
             privileged: false
@@ -48877,7 +48946,7 @@ spec:
           image: ghcr.io/jimmidyson/configmap-reload:v0.12.0
           args:
             - --volume-dir=/etc/alloy
-            - --webhook-url=http://localhost:8080/-/reload
+            - --webhook-url=http://localhost:12345/-/reload
           volumeMounts:
             - name: config
               mountPath: /etc/alloy
@@ -48935,7 +49004,7 @@ spec:
             - run
             - /etc/alloy/config.alloy
             - --storage.path=/tmp/alloy
-            - --server.http.listen-addr=0.0.0.0:8080
+            - --server.http.listen-addr=0.0.0.0:12345
             - --server.http.ui-path-prefix=/
             - --stability.level=generally-available
           env:
@@ -48946,21 +49015,31 @@ spec:
                 fieldRef:
                   fieldPath: spec.nodeName
           ports:
-            - containerPort: 8080
+            - containerPort: 12345
               name: http-metrics
           readinessProbe:
             httpGet:
               path: /-/ready
-              port: 8080
+              port: 12345
               scheme: HTTP
             initialDelaySeconds: 10
             timeoutSeconds: 1
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:
+              add:
+              - CHOWN
+              - FOWNER
+              - FSETID
+              - SETGID
+              - SETUID
+              - SETPCAP
+              - NET_BIND_SERVICE
+              - NET_RAW
+              - SYS_CHROOT
+              - SETFCAP
               drop:
               - ALL
-            runAsNonRoot: true
             seccompProfile:
               type: RuntimeDefault
           volumeMounts:
@@ -48970,7 +49049,7 @@ spec:
           image: ghcr.io/jimmidyson/configmap-reload:v0.12.0
           args:
             - --volume-dir=/etc/alloy
-            - --webhook-url=http://localhost:8080/-/reload
+            - --webhook-url=http://localhost:12345/-/reload
           volumeMounts:
             - name: config
               mountPath: /etc/alloy
@@ -49130,7 +49209,7 @@ spec:
             - run
             - /etc/alloy/config.alloy
             - --storage.path=/tmp/alloy
-            - --server.http.listen-addr=0.0.0.0:8080
+            - --server.http.listen-addr=0.0.0.0:12345
             - --server.http.ui-path-prefix=/
             - --cluster.enabled=true
             - --cluster.join-addresses=k8smon-alloy-cluster
@@ -49143,7 +49222,7 @@ spec:
                 fieldRef:
                   fieldPath: spec.nodeName
           ports:
-            - containerPort: 8080
+            - containerPort: 12345
               name: http-metrics
             - containerPort: 4317
               name: otlp-grpc
@@ -49172,16 +49251,26 @@ spec:
           readinessProbe:
             httpGet:
               path: /-/ready
-              port: 8080
+              port: 12345
               scheme: HTTP
             initialDelaySeconds: 10
             timeoutSeconds: 1
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:
+              add:
+              - CHOWN
+              - FOWNER
+              - FSETID
+              - SETGID
+              - SETUID
+              - SETPCAP
+              - NET_BIND_SERVICE
+              - NET_RAW
+              - SYS_CHROOT
+              - SETFCAP
               drop:
               - ALL
-            runAsNonRoot: true
             seccompProfile:
               type: RuntimeDefault
           volumeMounts:
@@ -49194,7 +49283,7 @@ spec:
           image: ghcr.io/jimmidyson/configmap-reload:v0.12.0
           args:
             - --volume-dir=/etc/alloy
-            - --webhook-url=http://localhost:8080/-/reload
+            - --webhook-url=http://localhost:12345/-/reload
           volumeMounts:
             - name: config
               mountPath: /etc/alloy
@@ -49247,15 +49336,29 @@ spec:
 apiVersion: security.openshift.io/v1
 kind: SecurityContextConstraints
 metadata:
-  name: k8smon-alloy-logs
-allowHostDirVolumePlugin: true
+  name: k8smon-alloy
+allowHostDirVolumePlugin: false
 allowHostIPC: false
 allowHostNetwork: false
 allowHostPID: false
 allowHostPorts: false
 allowPrivilegeEscalation: false
 allowPrivilegedContainer: false
-allowedCapabilities: null
+allowedCapabilities:
+- CHOWN
+# - DAC_OVERRIDE
+- FOWNER
+- FSETID
+# - KILL
+- SETGID
+- SETUID
+- SETPCAP
+- NET_BIND_SERVICE
+- NET_RAW
+- SYS_CHROOT
+# - MKNOD
+# - AUDIT_WRITE
+- SETFCAP
 defaultAddCapabilities: null
 defaultAllowPrivilegeEscalation: false
 forbiddenSysctls:
@@ -49265,16 +49368,111 @@ fsGroup:
 groups: []
 priority: null
 readOnlyRootFilesystem: false  # Set because Grafana Alloy needs to write to /tmp/alloy
-requiredDropCapabilities:
+requiredDropCapabilities: null
+runAsUser:
+  type: RunAsAny
+seLinuxContext:
+  type: RunAsAny
+seccompProfiles:
+  - runtime/default
+supplementalGroups:
+  type: RunAsAny
+users: []
+volumes:
+- configMap
+- emptyDir
+- projected
+- secret
+---
+# Source: k8s-monitoring/templates/platform_specific/openshift/security-context-constraint.yaml
+apiVersion: security.openshift.io/v1
+kind: SecurityContextConstraints
+metadata:
+  name: k8smon-alloy-events
+allowHostDirVolumePlugin: false
+allowHostIPC: false
+allowHostNetwork: false
+allowHostPID: false
+allowHostPorts: false
+allowPrivilegeEscalation: false
+allowPrivilegedContainer: false
+allowedCapabilities:
 - CHOWN
-- DAC_OVERRIDE
-- FSETID
+# - DAC_OVERRIDE
 - FOWNER
+- FSETID
+# - KILL
 - SETGID
 - SETUID
 - SETPCAP
 - NET_BIND_SERVICE
-- KILL
+- NET_RAW
+- SYS_CHROOT
+# - MKNOD
+# - AUDIT_WRITE
+- SETFCAP
+defaultAddCapabilities: null
+defaultAllowPrivilegeEscalation: false
+forbiddenSysctls:
+- '*'
+fsGroup:
+  type: RunAsAny
+groups: []
+priority: null
+readOnlyRootFilesystem: false  # Set because Grafana Alloy needs to write to /tmp/alloy
+requiredDropCapabilities: null
+runAsUser:
+  type: RunAsAny
+seLinuxContext:
+  type: RunAsAny
+seccompProfiles:
+  - runtime/default
+supplementalGroups:
+  type: RunAsAny
+users: []
+volumes:
+- configMap
+- emptyDir
+- projected
+- secret
+---
+# Source: k8s-monitoring/templates/platform_specific/openshift/security-context-constraint.yaml
+apiVersion: security.openshift.io/v1
+kind: SecurityContextConstraints
+metadata:
+  name: k8smon-alloy-logs
+allowHostDirVolumePlugin: true
+allowHostIPC: false
+allowHostNetwork: false
+allowHostPID: false
+allowHostPorts: false
+allowPrivilegeEscalation: false
+allowPrivilegedContainer: false
+allowedCapabilities:
+- CHOWN
+# - DAC_OVERRIDE
+- FOWNER
+- FSETID
+# - KILL
+- SETGID
+- SETUID
+- SETPCAP
+- NET_BIND_SERVICE
+- NET_RAW
+- SYS_CHROOT
+# - MKNOD
+# - AUDIT_WRITE
+- SETFCAP
+defaultAddCapabilities: null
+defaultAllowPrivilegeEscalation: false
+forbiddenSysctls:
+- '*'
+fsGroup:
+  type: RunAsAny
+groups: []
+priority: null
+readOnlyRootFilesystem: false  # Set because Grafana Alloy needs to write to /tmp/alloy
+requiredDropCapabilities: null
 runAsUser:
   type: RunAsAny
 seLinuxContext:
@@ -50453,7 +50651,7 @@ spec:
       command: [/etc/bin/config-analysis.sh]
       env:
         - name: ALLOY_HOST
-          value: k8smon-alloy.default.svc:8080
+          value: k8smon-alloy.default.svc:12345
 ---
 # Source: k8s-monitoring/templates/tests/test.yaml
 apiVersion: batch/v1

--- a/examples/openshift-compatible/values.yaml
+++ b/examples/openshift-compatible/values.yaml
@@ -41,21 +41,7 @@ alloy:
       allowPrivilegeEscalation: false
       capabilities:
         drop: ["ALL"]
-        add:
-          - CHOWN
-          # - DAC_OVERRIDE
-          - FOWNER
-          - FSETID
-          # - KILL
-          - SETGID
-          - SETUID
-          - SETPCAP
-          - NET_BIND_SERVICE
-          - NET_RAW
-          - SYS_CHROOT
-          # - MKNOD
-          # - AUDIT_WRITE
-          - SETFCAP
+        add: ["CHOWN", "DAC_OVERRIDE", "FOWNER", "FSETID", "KILL", "SETGID", "SETUID", "SETPCAP", "NET_BIND_SERVICE", "NET_RAW", "SYS_CHROOT", "MKNOD", "AUDIT_WRITE", "SETFCAP"]
       seccompProfile:
         type: "RuntimeDefault"
 
@@ -65,21 +51,7 @@ alloy-logs:
       allowPrivilegeEscalation: false
       capabilities:
         drop: ["ALL"]
-        add:
-          - CHOWN
-          # - DAC_OVERRIDE
-          - FOWNER
-          - FSETID
-          # - KILL
-          - SETGID
-          - SETUID
-          - SETPCAP
-          - NET_BIND_SERVICE
-          - NET_RAW
-          - SYS_CHROOT
-          # - MKNOD
-          # - AUDIT_WRITE
-          - SETFCAP
+        add: ["CHOWN", "DAC_OVERRIDE", "FOWNER", "FSETID", "KILL", "SETGID", "SETUID", "SETPCAP", "NET_BIND_SERVICE", "NET_RAW", "SYS_CHROOT", "MKNOD", "AUDIT_WRITE", "SETFCAP"]
       privileged: false
       runAsUser: 0
   global:
@@ -93,20 +65,6 @@ alloy-events:
       allowPrivilegeEscalation: false
       capabilities:
         drop: ["ALL"]
-        add:
-          - CHOWN
-          # - DAC_OVERRIDE
-          - FOWNER
-          - FSETID
-          # - KILL
-          - SETGID
-          - SETUID
-          - SETPCAP
-          - NET_BIND_SERVICE
-          - NET_RAW
-          - SYS_CHROOT
-          # - MKNOD
-          # - AUDIT_WRITE
-          - SETFCAP
+        add: ["CHOWN", "DAC_OVERRIDE", "FOWNER", "FSETID", "KILL", "SETGID", "SETUID", "SETPCAP", "NET_BIND_SERVICE", "NET_RAW", "SYS_CHROOT", "MKNOD", "AUDIT_WRITE", "SETFCAP"]
       seccompProfile:
         type: "RuntimeDefault"

--- a/examples/openshift-compatible/values.yaml
+++ b/examples/openshift-compatible/values.yaml
@@ -37,22 +37,49 @@ prometheus-node-exporter:
 
 alloy:
   alloy:
-    listenPort: 8080
     securityContext:
       allowPrivilegeEscalation: false
       capabilities:
-        drop: [ "ALL" ]
-      runAsNonRoot: true
+        drop: ["ALL"]
+        add:
+          - CHOWN
+          # - DAC_OVERRIDE
+          - FOWNER
+          - FSETID
+          # - KILL
+          - SETGID
+          - SETUID
+          - SETPCAP
+          - NET_BIND_SERVICE
+          - NET_RAW
+          - SYS_CHROOT
+          # - MKNOD
+          # - AUDIT_WRITE
+          - SETFCAP
       seccompProfile:
         type: "RuntimeDefault"
 
 alloy-logs:
   alloy:
-    listenPort: 8080
     securityContext:
       allowPrivilegeEscalation: false
       capabilities:
-        drop: [ "ALL" ]
+        drop: ["ALL"]
+        add:
+          - CHOWN
+          # - DAC_OVERRIDE
+          - FOWNER
+          - FSETID
+          # - KILL
+          - SETGID
+          - SETUID
+          - SETPCAP
+          - NET_BIND_SERVICE
+          - NET_RAW
+          - SYS_CHROOT
+          # - MKNOD
+          # - AUDIT_WRITE
+          - SETFCAP
       privileged: false
       runAsUser: 0
   global:
@@ -62,11 +89,24 @@ alloy-logs:
 
 alloy-events:
   alloy:
-    listenPort: 8080
     securityContext:
       allowPrivilegeEscalation: false
       capabilities:
-        drop: [ "ALL" ]
-      runAsNonRoot: true
+        drop: ["ALL"]
+        add:
+          - CHOWN
+          # - DAC_OVERRIDE
+          - FOWNER
+          - FSETID
+          # - KILL
+          - SETGID
+          - SETUID
+          - SETPCAP
+          - NET_BIND_SERVICE
+          - NET_RAW
+          - SYS_CHROOT
+          # - MKNOD
+          # - AUDIT_WRITE
+          - SETFCAP
       seccompProfile:
         type: "RuntimeDefault"


### PR DESCRIPTION
This creates three security context constraints objects now, one for each Alloy instance. The code does template once and invokes that template three times (the logs template will enable hostpath permissions if it's using volume based log gathering)

It does not set the user id to non-root.

It does add a set of capabilities that was listed in another issue. At some point, I'll need to sync with the alloy team for the minimal set required here.