### PR TITLE
[examples] Corrects COMPONENT_NAME in mysql's k8s ConfigMap

### DIFF
--- a/examples/service-integrations/mysql-config.yaml
+++ b/examples/service-integrations/mysql-config.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: mysql
 data:
   metrics.alloy: |-
-    declare "mysql" {
+    declare "metrics" {
       argument "host" {
           default = "mysql"
           optional = true
@@ -76,7 +76,7 @@ data:
       }
     }
   logs.alloy: |-
-    declare "mysql" {
+    declare "logs" {
       argument "instance" {
           default = "primary"
           optional = true


### PR DESCRIPTION

Corrects `declare "mysql"` to `declare "metrics"` in mysql's k8s ConfigMap

See:
https://github.com/grafana/k8s-monitoring-helm/blob/98bc370a8bf7b340d3e71d535e5301579f3b226d/examples/service-integrations/metrics.alloy#L814-L818

https://github.com/grafana/k8s-monitoring-helm/blob/98bc370a8bf7b340d3e71d535e5301579f3b226d/examples/service-integrations/logs.alloy#L151
