### PR TITLE
Fix OpenCost Prometheus existing secret fetching

### DIFF
--- a/charts/k8s-monitoring/Chart.yaml
+++ b/charts/k8s-monitoring/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: k8s-monitoring
 description: A Helm chart for gathering, scraping, and forwarding Kubernetes telemetry data to a Grafana Stack.
 type: application
-version: 1.0.3
+version: 1.0.4
 appVersion: 2.2.4
 icon: https://raw.githubusercontent.com/grafana/grafana/main/public/img/grafana_icon.svg
 sources:

--- a/charts/k8s-monitoring/README.md
+++ b/charts/k8s-monitoring/README.md
@@ -401,7 +401,7 @@ The Prometheus and Loki services may be hosted on the same cluster, or remotely 
 | opencost.enabled | bool | `true` | Should this Helm chart deploy OpenCost to the cluster. Set this to false if your cluster already has OpenCost, or if you do not want to scrape metrics from OpenCost. |
 | opencost.opencost.prometheus.external.url | string | `"https://prom.example.com/api/prom"` | The URL for Prometheus queries. It should match externalService.prometheus.host + "/api/prom" |
 | opencost.opencost.prometheus.password_key | string | `"password"` | The key for the password property in the secret. |
-| opencost.opencost.prometheus.secret_name | string | `"prometheus-k8s-monitoring"` | The name of the secret containing the username and password for the metrics service. This must be in the same namespace as the OpenCost deployment. |
+| opencost.opencost.prometheus.existingSecretName | string | `"prometheus-k8s-monitoring"` | The name of the secret containing the username and password for the metrics service. This must be in the same namespace as the OpenCost deployment. |
 | opencost.opencost.prometheus.username_key | string | `"username"` | The key for the username property in the secret. |
 | profiles.ebpf.demangle | string | `"none"` | C++ demangle mode. Available options are: none, simplified, templates, full |
 | profiles.ebpf.enabled | bool | `true` | Gather profiles using eBPF |

--- a/charts/k8s-monitoring/README.md
+++ b/charts/k8s-monitoring/README.md
@@ -3,7 +3,7 @@
 
 # k8s-monitoring
 
-![Version: 1.0.3](https://img.shields.io/badge/Version-1.0.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.2.4](https://img.shields.io/badge/AppVersion-2.2.4-informational?style=flat-square)
+![Version: 1.0.4](https://img.shields.io/badge/Version-1.0.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.2.4](https://img.shields.io/badge/AppVersion-2.2.4-informational?style=flat-square)
 
 A Helm chart for gathering, scraping, and forwarding Kubernetes telemetry data to a Grafana Stack.
 

--- a/charts/k8s-monitoring/values.yaml
+++ b/charts/k8s-monitoring/values.yaml
@@ -1159,7 +1159,7 @@ opencost:
 
     prometheus:
       # -- The name of the secret containing the username and password for the metrics service. This must be in the same namespace as the OpenCost deployment.
-      secret_name: prometheus-k8s-monitoring
+      existingSecretName: prometheus-k8s-monitoring
       # -- The key for the username property in the secret.
       username_key: username
       # -- The key for the password property in the secret.


### PR DESCRIPTION
I've noticed Grafana Cloud Kubernetes monitoring OpenCost pod started to silently fail with following error:
```
ERR Failed to query prometheus at https://prometheus-prod-01-eu-west-0.grafana.net/api/prom. Error: Prometheus communication error: 401 (Unauthorized)
...
Body: '{"status":"error","error":"authentication error: no credentials provided"}
```

Pods starts just fine, but OpenCost can't connect to Grafana Cloud Prometheus endpoint. And then pods will produce more error logs:

```
0) Errors:
  Request Error: Prometheus communication error: 401 (Unauthorized) URL: 'https://prometheus-prod-01-eu-west-0.grafana.net/api/prom/api/v1/query ...
  Parse Error: Prometheus communication error: ...
```

After digging into this I've found out that OpenCost chart which this repo uses [introduced](https://github.com/opencost/opencost-helm-chart/pull/196
) new property `prometheus.existingSecretName`, so by changing `secret_name` to `existingSecretName`, OpenCost pod starts calling Grafana Prometheus endpoint just fine.

So far the workaround is to add `existingSecretName` to final value file:

```
k8s-monitoring:
  opencost:
    opencost:
      prometheus:
        existingSecretName: prometheus-k8s-monitoring
        external:
          url: "https://prometheus-prod-01-eu-west-0.grafana.net/api/prom"
```

In this PR, I've simply decided to replace `secret_name` -> `existingSecretName` property name in default value file.

Relevant OpenCost PR: https://github.com/opencost/opencost-helm-chart/pull/196