### PR TITLE
Dump the generated alloy config when the helm validate hook fails.

### DIFF
--- a/charts/k8s-monitoring/templates/hooks/validate-configuration.yaml
+++ b/charts/k8s-monitoring/templates/hooks/validate-configuration.yaml
@@ -47,6 +47,8 @@ spec:
       - |
         echo Validating Grafana Alloy config file
         if ! alloy fmt /etc/alloy/config.alloy > /dev/null; then
+          echo Generated Config with Errors
+          cat /etc/alloy/config.alloy
           exit 1
         fi
         output=$(alloy run "/etc/alloy/config.alloy" 2>&1)
@@ -58,6 +60,8 @@ spec:
 {{- if and .Values.logs.enabled .Values.logs.cluster_events.enabled }}
         echo Validating Grafana Alloy for Events config file
         if ! alloy fmt /etc/alloy/events.alloy > /dev/null; then
+          echo Generated Config with Errors
+          cat /etc/alloy/events.alloy
           exit 1
         fi
         output=$(alloy run "/etc/alloy/events.alloy" 2>&1)
@@ -70,6 +74,8 @@ spec:
 {{- if and .Values.logs.enabled .Values.logs.pod_logs.enabled }}
         echo Validating Grafana Alloy for Logs config file
         if ! alloy fmt /etc/alloy/logs.alloy > /dev/null; then
+          echo Generated Config with Errors
+          cat /etc/alloy/logs.alloy
           exit 1
         fi
         output=$(alloy run "/etc/alloy/logs.alloy" 2>&1)
@@ -82,6 +88,8 @@ spec:
 {{- if .Values.profiles.enabled }}
         echo Validating Grafana Alloy for Profiles config file
         if ! alloy fmt /etc/alloy/profiles.alloy > /dev/null; then
+          echo Generated Config with Errors
+          cat /etc/alloy/profiles.alloy
           exit 1
         fi
         output=$(alloy run --stability.level public-preview "/etc/alloy/profiles.alloy" 2>&1)

--- a/examples/alloy-autoscaling-and-storage/output.yaml
+++ b/examples/alloy-autoscaling-and-storage/output.yaml
@@ -50805,6 +50805,8 @@ spec:
       - |
         echo Validating Grafana Alloy config file
         if ! alloy fmt /etc/alloy/config.alloy > /dev/null; then
+          echo Generated Config with Errors
+          cat /etc/alloy/config.alloy
           exit 1
         fi
         output=$(alloy run "/etc/alloy/config.alloy" 2>&1)
@@ -50815,6 +50817,8 @@ spec:
         echo "Grafana Alloy config file is valid"
         echo Validating Grafana Alloy for Events config file
         if ! alloy fmt /etc/alloy/events.alloy > /dev/null; then
+          echo Generated Config with Errors
+          cat /etc/alloy/events.alloy
           exit 1
         fi
         output=$(alloy run "/etc/alloy/events.alloy" 2>&1)
@@ -50825,6 +50829,8 @@ spec:
         echo "Grafana Alloy for Events config file is valid"
         echo Validating Grafana Alloy for Logs config file
         if ! alloy fmt /etc/alloy/logs.alloy > /dev/null; then
+          echo Generated Config with Errors
+          cat /etc/alloy/logs.alloy
           exit 1
         fi
         output=$(alloy run "/etc/alloy/logs.alloy" 2>&1)

--- a/examples/control-plane-metrics/output.yaml
+++ b/examples/control-plane-metrics/output.yaml
@@ -51071,6 +51071,8 @@ spec:
       - |
         echo Validating Grafana Alloy config file
         if ! alloy fmt /etc/alloy/config.alloy > /dev/null; then
+          echo Generated Config with Errors
+          cat /etc/alloy/config.alloy
           exit 1
         fi
         output=$(alloy run "/etc/alloy/config.alloy" 2>&1)
@@ -51081,6 +51083,8 @@ spec:
         echo "Grafana Alloy config file is valid"
         echo Validating Grafana Alloy for Events config file
         if ! alloy fmt /etc/alloy/events.alloy > /dev/null; then
+          echo Generated Config with Errors
+          cat /etc/alloy/events.alloy
           exit 1
         fi
         output=$(alloy run "/etc/alloy/events.alloy" 2>&1)
@@ -51091,6 +51095,8 @@ spec:
         echo "Grafana Alloy for Events config file is valid"
         echo Validating Grafana Alloy for Logs config file
         if ! alloy fmt /etc/alloy/logs.alloy > /dev/null; then
+          echo Generated Config with Errors
+          cat /etc/alloy/logs.alloy
           exit 1
         fi
         output=$(alloy run "/etc/alloy/logs.alloy" 2>&1)

--- a/examples/custom-config/output.yaml
+++ b/examples/custom-config/output.yaml
@@ -50886,6 +50886,8 @@ spec:
       - |
         echo Validating Grafana Alloy config file
         if ! alloy fmt /etc/alloy/config.alloy > /dev/null; then
+          echo Generated Config with Errors
+          cat /etc/alloy/config.alloy
           exit 1
         fi
         output=$(alloy run "/etc/alloy/config.alloy" 2>&1)
@@ -50896,6 +50898,8 @@ spec:
         echo "Grafana Alloy config file is valid"
         echo Validating Grafana Alloy for Events config file
         if ! alloy fmt /etc/alloy/events.alloy > /dev/null; then
+          echo Generated Config with Errors
+          cat /etc/alloy/events.alloy
           exit 1
         fi
         output=$(alloy run "/etc/alloy/events.alloy" 2>&1)
@@ -50906,6 +50910,8 @@ spec:
         echo "Grafana Alloy for Events config file is valid"
         echo Validating Grafana Alloy for Logs config file
         if ! alloy fmt /etc/alloy/logs.alloy > /dev/null; then
+          echo Generated Config with Errors
+          cat /etc/alloy/logs.alloy
           exit 1
         fi
         output=$(alloy run "/etc/alloy/logs.alloy" 2>&1)

--- a/examples/custom-metrics-tuning/output.yaml
+++ b/examples/custom-metrics-tuning/output.yaml
@@ -49695,6 +49695,8 @@ spec:
       - |
         echo Validating Grafana Alloy config file
         if ! alloy fmt /etc/alloy/config.alloy > /dev/null; then
+          echo Generated Config with Errors
+          cat /etc/alloy/config.alloy
           exit 1
         fi
         output=$(alloy run "/etc/alloy/config.alloy" 2>&1)

--- a/examples/custom-pricing/output.yaml
+++ b/examples/custom-pricing/output.yaml
@@ -50782,6 +50782,8 @@ spec:
       - |
         echo Validating Grafana Alloy config file
         if ! alloy fmt /etc/alloy/config.alloy > /dev/null; then
+          echo Generated Config with Errors
+          cat /etc/alloy/config.alloy
           exit 1
         fi
         output=$(alloy run "/etc/alloy/config.alloy" 2>&1)
@@ -50792,6 +50794,8 @@ spec:
         echo "Grafana Alloy config file is valid"
         echo Validating Grafana Alloy for Events config file
         if ! alloy fmt /etc/alloy/events.alloy > /dev/null; then
+          echo Generated Config with Errors
+          cat /etc/alloy/events.alloy
           exit 1
         fi
         output=$(alloy run "/etc/alloy/events.alloy" 2>&1)
@@ -50802,6 +50806,8 @@ spec:
         echo "Grafana Alloy for Events config file is valid"
         echo Validating Grafana Alloy for Logs config file
         if ! alloy fmt /etc/alloy/logs.alloy > /dev/null; then
+          echo Generated Config with Errors
+          cat /etc/alloy/logs.alloy
           exit 1
         fi
         output=$(alloy run "/etc/alloy/logs.alloy" 2>&1)

--- a/examples/default-values/output.yaml
+++ b/examples/default-values/output.yaml
@@ -50750,6 +50750,8 @@ spec:
       - |
         echo Validating Grafana Alloy config file
         if ! alloy fmt /etc/alloy/config.alloy > /dev/null; then
+          echo Generated Config with Errors
+          cat /etc/alloy/config.alloy
           exit 1
         fi
         output=$(alloy run "/etc/alloy/config.alloy" 2>&1)
@@ -50760,6 +50762,8 @@ spec:
         echo "Grafana Alloy config file is valid"
         echo Validating Grafana Alloy for Events config file
         if ! alloy fmt /etc/alloy/events.alloy > /dev/null; then
+          echo Generated Config with Errors
+          cat /etc/alloy/events.alloy
           exit 1
         fi
         output=$(alloy run "/etc/alloy/events.alloy" 2>&1)
@@ -50770,6 +50774,8 @@ spec:
         echo "Grafana Alloy for Events config file is valid"
         echo Validating Grafana Alloy for Logs config file
         if ! alloy fmt /etc/alloy/logs.alloy > /dev/null; then
+          echo Generated Config with Errors
+          cat /etc/alloy/logs.alloy
           exit 1
         fi
         output=$(alloy run "/etc/alloy/logs.alloy" 2>&1)

--- a/examples/eks-fargate/output.yaml
+++ b/examples/eks-fargate/output.yaml
@@ -50492,6 +50492,8 @@ spec:
       - |
         echo Validating Grafana Alloy config file
         if ! alloy fmt /etc/alloy/config.alloy > /dev/null; then
+          echo Generated Config with Errors
+          cat /etc/alloy/config.alloy
           exit 1
         fi
         output=$(alloy run "/etc/alloy/config.alloy" 2>&1)
@@ -50502,6 +50504,8 @@ spec:
         echo "Grafana Alloy config file is valid"
         echo Validating Grafana Alloy for Events config file
         if ! alloy fmt /etc/alloy/events.alloy > /dev/null; then
+          echo Generated Config with Errors
+          cat /etc/alloy/events.alloy
           exit 1
         fi
         output=$(alloy run "/etc/alloy/events.alloy" 2>&1)
@@ -50512,6 +50516,8 @@ spec:
         echo "Grafana Alloy for Events config file is valid"
         echo Validating Grafana Alloy for Logs config file
         if ! alloy fmt /etc/alloy/logs.alloy > /dev/null; then
+          echo Generated Config with Errors
+          cat /etc/alloy/logs.alloy
           exit 1
         fi
         output=$(alloy run "/etc/alloy/logs.alloy" 2>&1)

--- a/examples/extra-rules/output.yaml
+++ b/examples/extra-rules/output.yaml
@@ -50963,6 +50963,8 @@ spec:
       - |
         echo Validating Grafana Alloy config file
         if ! alloy fmt /etc/alloy/config.alloy > /dev/null; then
+          echo Generated Config with Errors
+          cat /etc/alloy/config.alloy
           exit 1
         fi
         output=$(alloy run "/etc/alloy/config.alloy" 2>&1)
@@ -50973,6 +50975,8 @@ spec:
         echo "Grafana Alloy config file is valid"
         echo Validating Grafana Alloy for Events config file
         if ! alloy fmt /etc/alloy/events.alloy > /dev/null; then
+          echo Generated Config with Errors
+          cat /etc/alloy/events.alloy
           exit 1
         fi
         output=$(alloy run "/etc/alloy/events.alloy" 2>&1)
@@ -50983,6 +50987,8 @@ spec:
         echo "Grafana Alloy for Events config file is valid"
         echo Validating Grafana Alloy for Logs config file
         if ! alloy fmt /etc/alloy/logs.alloy > /dev/null; then
+          echo Generated Config with Errors
+          cat /etc/alloy/logs.alloy
           exit 1
         fi
         output=$(alloy run "/etc/alloy/logs.alloy" 2>&1)

--- a/examples/gke-autopilot/output.yaml
+++ b/examples/gke-autopilot/output.yaml
@@ -50491,6 +50491,8 @@ spec:
       - |
         echo Validating Grafana Alloy config file
         if ! alloy fmt /etc/alloy/config.alloy > /dev/null; then
+          echo Generated Config with Errors
+          cat /etc/alloy/config.alloy
           exit 1
         fi
         output=$(alloy run "/etc/alloy/config.alloy" 2>&1)
@@ -50501,6 +50503,8 @@ spec:
         echo "Grafana Alloy config file is valid"
         echo Validating Grafana Alloy for Events config file
         if ! alloy fmt /etc/alloy/events.alloy > /dev/null; then
+          echo Generated Config with Errors
+          cat /etc/alloy/events.alloy
           exit 1
         fi
         output=$(alloy run "/etc/alloy/events.alloy" 2>&1)
@@ -50511,6 +50515,8 @@ spec:
         echo "Grafana Alloy for Events config file is valid"
         echo Validating Grafana Alloy for Logs config file
         if ! alloy fmt /etc/alloy/logs.alloy > /dev/null; then
+          echo Generated Config with Errors
+          cat /etc/alloy/logs.alloy
           exit 1
         fi
         output=$(alloy run "/etc/alloy/logs.alloy" 2>&1)

--- a/examples/ibm-cloud/output.yaml
+++ b/examples/ibm-cloud/output.yaml
@@ -50756,6 +50756,8 @@ spec:
       - |
         echo Validating Grafana Alloy config file
         if ! alloy fmt /etc/alloy/config.alloy > /dev/null; then
+          echo Generated Config with Errors
+          cat /etc/alloy/config.alloy
           exit 1
         fi
         output=$(alloy run "/etc/alloy/config.alloy" 2>&1)
@@ -50766,6 +50768,8 @@ spec:
         echo "Grafana Alloy config file is valid"
         echo Validating Grafana Alloy for Events config file
         if ! alloy fmt /etc/alloy/events.alloy > /dev/null; then
+          echo Generated Config with Errors
+          cat /etc/alloy/events.alloy
           exit 1
         fi
         output=$(alloy run "/etc/alloy/events.alloy" 2>&1)
@@ -50776,6 +50780,8 @@ spec:
         echo "Grafana Alloy for Events config file is valid"
         echo Validating Grafana Alloy for Logs config file
         if ! alloy fmt /etc/alloy/logs.alloy > /dev/null; then
+          echo Generated Config with Errors
+          cat /etc/alloy/logs.alloy
           exit 1
         fi
         output=$(alloy run "/etc/alloy/logs.alloy" 2>&1)

--- a/examples/kube-pod-labels/output.yaml
+++ b/examples/kube-pod-labels/output.yaml
@@ -50755,6 +50755,8 @@ spec:
       - |
         echo Validating Grafana Alloy config file
         if ! alloy fmt /etc/alloy/config.alloy > /dev/null; then
+          echo Generated Config with Errors
+          cat /etc/alloy/config.alloy
           exit 1
         fi
         output=$(alloy run "/etc/alloy/config.alloy" 2>&1)
@@ -50765,6 +50767,8 @@ spec:
         echo "Grafana Alloy config file is valid"
         echo Validating Grafana Alloy for Events config file
         if ! alloy fmt /etc/alloy/events.alloy > /dev/null; then
+          echo Generated Config with Errors
+          cat /etc/alloy/events.alloy
           exit 1
         fi
         output=$(alloy run "/etc/alloy/events.alloy" 2>&1)
@@ -50775,6 +50779,8 @@ spec:
         echo "Grafana Alloy for Events config file is valid"
         echo Validating Grafana Alloy for Logs config file
         if ! alloy fmt /etc/alloy/logs.alloy > /dev/null; then
+          echo Generated Config with Errors
+          cat /etc/alloy/logs.alloy
           exit 1
         fi
         output=$(alloy run "/etc/alloy/logs.alloy" 2>&1)

--- a/examples/logs-only/output.yaml
+++ b/examples/logs-only/output.yaml
@@ -1751,6 +1751,8 @@ spec:
       - |
         echo Validating Grafana Alloy config file
         if ! alloy fmt /etc/alloy/config.alloy > /dev/null; then
+          echo Generated Config with Errors
+          cat /etc/alloy/config.alloy
           exit 1
         fi
         output=$(alloy run "/etc/alloy/config.alloy" 2>&1)
@@ -1761,6 +1763,8 @@ spec:
         echo "Grafana Alloy config file is valid"
         echo Validating Grafana Alloy for Events config file
         if ! alloy fmt /etc/alloy/events.alloy > /dev/null; then
+          echo Generated Config with Errors
+          cat /etc/alloy/events.alloy
           exit 1
         fi
         output=$(alloy run "/etc/alloy/events.alloy" 2>&1)
@@ -1771,6 +1775,8 @@ spec:
         echo "Grafana Alloy for Events config file is valid"
         echo Validating Grafana Alloy for Logs config file
         if ! alloy fmt /etc/alloy/logs.alloy > /dev/null; then
+          echo Generated Config with Errors
+          cat /etc/alloy/logs.alloy
           exit 1
         fi
         output=$(alloy run "/etc/alloy/logs.alloy" 2>&1)

--- a/examples/metrics-only/output.yaml
+++ b/examples/metrics-only/output.yaml
@@ -49706,6 +49706,8 @@ spec:
       - |
         echo Validating Grafana Alloy config file
         if ! alloy fmt /etc/alloy/config.alloy > /dev/null; then
+          echo Generated Config with Errors
+          cat /etc/alloy/config.alloy
           exit 1
         fi
         output=$(alloy run "/etc/alloy/config.alloy" 2>&1)

--- a/examples/openshift-compatible/output.yaml
+++ b/examples/openshift-compatible/output.yaml
@@ -50607,6 +50607,8 @@ spec:
       - |
         echo Validating Grafana Alloy config file
         if ! alloy fmt /etc/alloy/config.alloy > /dev/null; then
+          echo Generated Config with Errors
+          cat /etc/alloy/config.alloy
           exit 1
         fi
         output=$(alloy run "/etc/alloy/config.alloy" 2>&1)
@@ -50617,6 +50619,8 @@ spec:
         echo "Grafana Alloy config file is valid"
         echo Validating Grafana Alloy for Events config file
         if ! alloy fmt /etc/alloy/events.alloy > /dev/null; then
+          echo Generated Config with Errors
+          cat /etc/alloy/events.alloy
           exit 1
         fi
         output=$(alloy run "/etc/alloy/events.alloy" 2>&1)
@@ -50627,6 +50631,8 @@ spec:
         echo "Grafana Alloy for Events config file is valid"
         echo Validating Grafana Alloy for Logs config file
         if ! alloy fmt /etc/alloy/logs.alloy > /dev/null; then
+          echo Generated Config with Errors
+          cat /etc/alloy/logs.alloy
           exit 1
         fi
         output=$(alloy run "/etc/alloy/logs.alloy" 2>&1)

--- a/examples/otel-metrics-service/output.yaml
+++ b/examples/otel-metrics-service/output.yaml
@@ -50808,6 +50808,8 @@ spec:
       - |
         echo Validating Grafana Alloy config file
         if ! alloy fmt /etc/alloy/config.alloy > /dev/null; then
+          echo Generated Config with Errors
+          cat /etc/alloy/config.alloy
           exit 1
         fi
         output=$(alloy run "/etc/alloy/config.alloy" 2>&1)
@@ -50818,6 +50820,8 @@ spec:
         echo "Grafana Alloy config file is valid"
         echo Validating Grafana Alloy for Events config file
         if ! alloy fmt /etc/alloy/events.alloy > /dev/null; then
+          echo Generated Config with Errors
+          cat /etc/alloy/events.alloy
           exit 1
         fi
         output=$(alloy run "/etc/alloy/events.alloy" 2>&1)
@@ -50828,6 +50832,8 @@ spec:
         echo "Grafana Alloy for Events config file is valid"
         echo Validating Grafana Alloy for Logs config file
         if ! alloy fmt /etc/alloy/logs.alloy > /dev/null; then
+          echo Generated Config with Errors
+          cat /etc/alloy/logs.alloy
           exit 1
         fi
         output=$(alloy run "/etc/alloy/logs.alloy" 2>&1)

--- a/examples/private-image-registry/output.yaml
+++ b/examples/private-image-registry/output.yaml
@@ -50768,6 +50768,8 @@ spec:
       - |
         echo Validating Grafana Alloy config file
         if ! alloy fmt /etc/alloy/config.alloy > /dev/null; then
+          echo Generated Config with Errors
+          cat /etc/alloy/config.alloy
           exit 1
         fi
         output=$(alloy run "/etc/alloy/config.alloy" 2>&1)
@@ -50778,6 +50780,8 @@ spec:
         echo "Grafana Alloy config file is valid"
         echo Validating Grafana Alloy for Events config file
         if ! alloy fmt /etc/alloy/events.alloy > /dev/null; then
+          echo Generated Config with Errors
+          cat /etc/alloy/events.alloy
           exit 1
         fi
         output=$(alloy run "/etc/alloy/events.alloy" 2>&1)
@@ -50788,6 +50792,8 @@ spec:
         echo "Grafana Alloy for Events config file is valid"
         echo Validating Grafana Alloy for Logs config file
         if ! alloy fmt /etc/alloy/logs.alloy > /dev/null; then
+          echo Generated Config with Errors
+          cat /etc/alloy/logs.alloy
           exit 1
         fi
         output=$(alloy run "/etc/alloy/logs.alloy" 2>&1)

--- a/examples/profiles-enabled/output.yaml
+++ b/examples/profiles-enabled/output.yaml
@@ -52600,6 +52600,8 @@ spec:
       - |
         echo Validating Grafana Alloy config file
         if ! alloy fmt /etc/alloy/config.alloy > /dev/null; then
+          echo Generated Config with Errors
+          cat /etc/alloy/config.alloy
           exit 1
         fi
         output=$(alloy run "/etc/alloy/config.alloy" 2>&1)
@@ -52610,6 +52612,8 @@ spec:
         echo "Grafana Alloy config file is valid"
         echo Validating Grafana Alloy for Events config file
         if ! alloy fmt /etc/alloy/events.alloy > /dev/null; then
+          echo Generated Config with Errors
+          cat /etc/alloy/events.alloy
           exit 1
         fi
         output=$(alloy run "/etc/alloy/events.alloy" 2>&1)
@@ -52620,6 +52624,8 @@ spec:
         echo "Grafana Alloy for Events config file is valid"
         echo Validating Grafana Alloy for Logs config file
         if ! alloy fmt /etc/alloy/logs.alloy > /dev/null; then
+          echo Generated Config with Errors
+          cat /etc/alloy/logs.alloy
           exit 1
         fi
         output=$(alloy run "/etc/alloy/logs.alloy" 2>&1)
@@ -52630,6 +52636,8 @@ spec:
         echo "Grafana Alloy for Logs config file is valid"
         echo Validating Grafana Alloy for Profiles config file
         if ! alloy fmt /etc/alloy/profiles.alloy > /dev/null; then
+          echo Generated Config with Errors
+          cat /etc/alloy/profiles.alloy
           exit 1
         fi
         output=$(alloy run --stability.level public-preview "/etc/alloy/profiles.alloy" 2>&1)

--- a/examples/proxies/output.yaml
+++ b/examples/proxies/output.yaml
@@ -50782,6 +50782,8 @@ spec:
       - |
         echo Validating Grafana Alloy config file
         if ! alloy fmt /etc/alloy/config.alloy > /dev/null; then
+          echo Generated Config with Errors
+          cat /etc/alloy/config.alloy
           exit 1
         fi
         output=$(alloy run "/etc/alloy/config.alloy" 2>&1)
@@ -50792,6 +50794,8 @@ spec:
         echo "Grafana Alloy config file is valid"
         echo Validating Grafana Alloy for Events config file
         if ! alloy fmt /etc/alloy/events.alloy > /dev/null; then
+          echo Generated Config with Errors
+          cat /etc/alloy/events.alloy
           exit 1
         fi
         output=$(alloy run "/etc/alloy/events.alloy" 2>&1)
@@ -50802,6 +50806,8 @@ spec:
         echo "Grafana Alloy for Events config file is valid"
         echo Validating Grafana Alloy for Logs config file
         if ! alloy fmt /etc/alloy/logs.alloy > /dev/null; then
+          echo Generated Config with Errors
+          cat /etc/alloy/logs.alloy
           exit 1
         fi
         output=$(alloy run "/etc/alloy/logs.alloy" 2>&1)

--- a/examples/scrape-intervals/output.yaml
+++ b/examples/scrape-intervals/output.yaml
@@ -49705,6 +49705,8 @@ spec:
       - |
         echo Validating Grafana Alloy config file
         if ! alloy fmt /etc/alloy/config.alloy > /dev/null; then
+          echo Generated Config with Errors
+          cat /etc/alloy/config.alloy
           exit 1
         fi
         output=$(alloy run "/etc/alloy/config.alloy" 2>&1)

--- a/examples/service-integrations/output.yaml
+++ b/examples/service-integrations/output.yaml
@@ -50828,6 +50828,8 @@ spec:
       - |
         echo Validating Grafana Alloy config file
         if ! alloy fmt /etc/alloy/config.alloy > /dev/null; then
+          echo Generated Config with Errors
+          cat /etc/alloy/config.alloy
           exit 1
         fi
         output=$(alloy run "/etc/alloy/config.alloy" 2>&1)
@@ -50838,6 +50840,8 @@ spec:
         echo "Grafana Alloy config file is valid"
         echo Validating Grafana Alloy for Events config file
         if ! alloy fmt /etc/alloy/events.alloy > /dev/null; then
+          echo Generated Config with Errors
+          cat /etc/alloy/events.alloy
           exit 1
         fi
         output=$(alloy run "/etc/alloy/events.alloy" 2>&1)
@@ -50848,6 +50852,8 @@ spec:
         echo "Grafana Alloy for Events config file is valid"
         echo Validating Grafana Alloy for Logs config file
         if ! alloy fmt /etc/alloy/logs.alloy > /dev/null; then
+          echo Generated Config with Errors
+          cat /etc/alloy/logs.alloy
           exit 1
         fi
         output=$(alloy run "/etc/alloy/logs.alloy" 2>&1)

--- a/examples/specific-namespace/output.yaml
+++ b/examples/specific-namespace/output.yaml
@@ -50878,6 +50878,8 @@ spec:
       - |
         echo Validating Grafana Alloy config file
         if ! alloy fmt /etc/alloy/config.alloy > /dev/null; then
+          echo Generated Config with Errors
+          cat /etc/alloy/config.alloy
           exit 1
         fi
         output=$(alloy run "/etc/alloy/config.alloy" 2>&1)
@@ -50888,6 +50890,8 @@ spec:
         echo "Grafana Alloy config file is valid"
         echo Validating Grafana Alloy for Events config file
         if ! alloy fmt /etc/alloy/events.alloy > /dev/null; then
+          echo Generated Config with Errors
+          cat /etc/alloy/events.alloy
           exit 1
         fi
         output=$(alloy run "/etc/alloy/events.alloy" 2>&1)
@@ -50898,6 +50902,8 @@ spec:
         echo "Grafana Alloy for Events config file is valid"
         echo Validating Grafana Alloy for Logs config file
         if ! alloy fmt /etc/alloy/logs.alloy > /dev/null; then
+          echo Generated Config with Errors
+          cat /etc/alloy/logs.alloy
           exit 1
         fi
         output=$(alloy run "/etc/alloy/logs.alloy" 2>&1)

--- a/examples/traces-enabled/output.yaml
+++ b/examples/traces-enabled/output.yaml
@@ -50977,6 +50977,8 @@ spec:
       - |
         echo Validating Grafana Alloy config file
         if ! alloy fmt /etc/alloy/config.alloy > /dev/null; then
+          echo Generated Config with Errors
+          cat /etc/alloy/config.alloy
           exit 1
         fi
         output=$(alloy run "/etc/alloy/config.alloy" 2>&1)
@@ -50987,6 +50989,8 @@ spec:
         echo "Grafana Alloy config file is valid"
         echo Validating Grafana Alloy for Events config file
         if ! alloy fmt /etc/alloy/events.alloy > /dev/null; then
+          echo Generated Config with Errors
+          cat /etc/alloy/events.alloy
           exit 1
         fi
         output=$(alloy run "/etc/alloy/events.alloy" 2>&1)
@@ -50997,6 +51001,8 @@ spec:
         echo "Grafana Alloy for Events config file is valid"
         echo Validating Grafana Alloy for Logs config file
         if ! alloy fmt /etc/alloy/logs.alloy > /dev/null; then
+          echo Generated Config with Errors
+          cat /etc/alloy/logs.alloy
           exit 1
         fi
         output=$(alloy run "/etc/alloy/logs.alloy" 2>&1)

--- a/examples/windows-exporter/output.yaml
+++ b/examples/windows-exporter/output.yaml
@@ -51053,6 +51053,8 @@ spec:
       - |
         echo Validating Grafana Alloy config file
         if ! alloy fmt /etc/alloy/config.alloy > /dev/null; then
+          echo Generated Config with Errors
+          cat /etc/alloy/config.alloy
           exit 1
         fi
         output=$(alloy run "/etc/alloy/config.alloy" 2>&1)
@@ -51063,6 +51065,8 @@ spec:
         echo "Grafana Alloy config file is valid"
         echo Validating Grafana Alloy for Events config file
         if ! alloy fmt /etc/alloy/events.alloy > /dev/null; then
+          echo Generated Config with Errors
+          cat /etc/alloy/events.alloy
           exit 1
         fi
         output=$(alloy run "/etc/alloy/events.alloy" 2>&1)
@@ -51073,6 +51077,8 @@ spec:
         echo "Grafana Alloy for Events config file is valid"
         echo Validating Grafana Alloy for Logs config file
         if ! alloy fmt /etc/alloy/logs.alloy > /dev/null; then
+          echo Generated Config with Errors
+          cat /etc/alloy/logs.alloy
           exit 1
         fi
         output=$(alloy run "/etc/alloy/logs.alloy" 2>&1)


### PR DESCRIPTION
Quality of life improvement, it's hard to dig out the file from the configmap otherwise. 