### PR TITLE
Always call tpl outside of with blocks to preserve backwards compatibility

### DIFF
--- a/charts/k8s-monitoring/templates/_configs.tpl
+++ b/charts/k8s-monitoring/templates/_configs.tpl
@@ -96,7 +96,7 @@
   {{- include "alloy.config.logging" .Values.alloy.logging}}
 
   {{- if .Values.extraConfig }}
-    {{- tpl .Values.extraConfig . | indent 0 }}
+    {{- tpl .Values.extraConfig $ | indent 0 }}
   {{- end }}
 {{- end -}}
 
@@ -107,7 +107,7 @@
   {{- include "alloy.config.logging" (index .Values "alloy-events").logging }}
 
   {{- if .Values.logs.cluster_events.extraConfig }}
-    {{- tpl .Values.logs.cluster_events.extraConfig . | indent 0 }}
+    {{- tpl .Values.logs.cluster_events.extraConfig $ | indent 0 }}
   {{- end }}
 {{- end -}}
 
@@ -120,7 +120,7 @@
   {{- include "alloy.config.logging" (index .Values "alloy-logs").logging }}
 
   {{- if .Values.logs.extraConfig }}
-    {{- tpl .Values.logs.extraConfig . | indent 0 }}
+    {{- tpl .Values.logs.extraConfig $ | indent 0 }}
   {{- end }}
 {{- end -}}
 

--- a/charts/k8s-monitoring/templates/alloy_config/_cluster_events.alloy.txt
+++ b/charts/k8s-monitoring/templates/alloy_config/_cluster_events.alloy.txt
@@ -13,11 +13,13 @@ loki.source.kubernetes_events "cluster_events" {
 }
 
 loki.process "cluster_events" {
-{{- if .extraStageBlocks }}
-{{ tpl .extraStageBlocks . | indent 2 }}
+{{- end }}{{/* Avoid calling tpl inside of a with block, makes for better backwards compatibility */}}
+{{- if .Values.logs.cluster_events.extraStageBlocks }}
+{{ tpl .Values.logs.cluster_events.extraStageBlocks $ | indent 2 }}
 {{- end }}
   forward_to = [
     loki.process.logs_service.receiver,
+{{- with .Values.logs.cluster_events }}
 {{- if .logToStdout }}
     loki.echo.cluster_events.receiver,
 {{- end }}

--- a/charts/k8s-monitoring/templates/alloy_config/_operator_objects.txt
+++ b/charts/k8s-monitoring/templates/alloy_config/_operator_objects.txt
@@ -149,7 +149,7 @@ loki.source.podlogs "podlogs_objects" {
 
 loki.process "podlogs_objects" {
 {{- if .Values.logs.podLogsObjects.extraStageBlocks }}
-{{ tpl .Values.logs.podLogsObjects.extraStageBlocks . | indent 2 }}
+{{ tpl .Values.logs.podLogsObjects.extraStageBlocks $ | indent 2 }}
 {{- end }}
   forward_to = [loki.process.logs_service.receiver]
 }

--- a/charts/k8s-monitoring/templates/alloy_config/_pod_logs_processor.alloy.txt
+++ b/charts/k8s-monitoring/templates/alloy_config/_pod_logs_processor.alloy.txt
@@ -50,7 +50,7 @@ loki.process "pod_logs" {
   }
 
 {{- if .Values.logs.pod_logs.extraStageBlocks }}
-{{ tpl .Values.logs.pod_logs.extraStageBlocks . | indent 2 }}
+{{ tpl .Values.logs.pod_logs.extraStageBlocks $ | indent 2 }}
 {{ end }}
   forward_to = [loki.process.logs_service.receiver]
 }


### PR DESCRIPTION
Even though this functionality was [fixed in 3.14](https://github.com/helm/helm/issues/5979#issuecomment-2108701112), some systems (like ArgoCD) might not be able to upgrade so quickly or easily.

Notes for reviewers: `.` is the current context, which gets modified by `with` or with `range`, `$` is always the top context. It's just good practice to use `$`, which is why this one didn't need to change: `charts/k8s-monitoring/templates/extra-manifests.yaml`