### PR TITLE
Add log components if logs are enabled

### DIFF
--- a/charts/k8s-monitoring/templates/_configs.tpl
+++ b/charts/k8s-monitoring/templates/_configs.tpl
@@ -84,7 +84,7 @@
     {{- include "alloy.config.metricsService" . }}
   {{- end }}
 
-  {{- if and .Values.logs.enabled (or .Values.logs.podLogsObjects.enabled .Values.receivers.grpc.enabled .Values.receivers.http.enabled) }}
+  {{- if .Values.logs.enabled }}
     {{- if .Values.logs.podLogsObjects.enabled }}
       {{- include "alloy.config.pod_log_objects" . }}
     {{- end }}

--- a/examples/logs-journal/metrics.alloy
+++ b/examples/logs-journal/metrics.alloy
@@ -19,6 +19,87 @@ discovery.kubernetes "pods" {
 
 
 // Processors
+loki.process "pod_logs" {
+  stage.match {
+    selector = "{tmp_container_runtime=\"containerd\"}"
+    // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
+    stage.cri {}
+
+    // Set the extract flags and stream values as labels
+    stage.labels {
+      values = {
+        flags  = "",
+        stream  = "",
+      }
+    }
+  }
+
+  stage.match {
+    selector = "{tmp_container_runtime=\"cri-o\"}"
+    // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
+    stage.cri {}
+
+    // Set the extract flags and stream values as labels
+    stage.labels {
+      values = {
+        flags  = "",
+        stream  = "",
+      }
+    }
+  }
+
+  // if the label tmp_container_runtime from above is docker parse using docker
+  stage.match {
+    selector = "{tmp_container_runtime=\"docker\"}"
+    // the docker processing stage extracts the following k/v pairs: log, stream, time
+    stage.docker {}
+
+    // Set the extract stream value as a label
+    stage.labels {
+      values = {
+        stream  = "",
+      }
+    }
+  }
+
+  // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have
+  // cluster, namespace, pod, and container labels.
+  // Also drop the temporary container runtime label as it is no longer needed.
+  stage.label_drop {
+    values = ["filename", "tmp_container_runtime"]
+  }
+  forward_to = [loki.process.logs_service.receiver]
+}
+
+// Logs Service
+remote.kubernetes.secret "logs_service" {
+  name = "loki-k8s-monitoring"
+  namespace = "default"
+}
+
+loki.process "logs_service" {
+  stage.static_labels {
+      values = {
+        cluster = "logs-journal",
+      }
+  }
+  forward_to = [loki.write.logs_service.receiver]
+}
+
+// Loki
+loki.write "logs_service" {
+  endpoint {
+    url = nonsensitive(remote.kubernetes.secret.logs_service.data["host"]) + "/loki/api/v1/push"
+    tenant_id = nonsensitive(remote.kubernetes.secret.logs_service.data["tenantId"])
+
+    basic_auth {
+      username = nonsensitive(remote.kubernetes.secret.logs_service.data["username"])
+      password = remote.kubernetes.secret.logs_service.data["password"]
+    }
+  }
+}
+
+
 logging {
   level  = "info"
   format = "logfmt"

--- a/examples/logs-journal/output.yaml
+++ b/examples/logs-journal/output.yaml
@@ -89,6 +89,87 @@ data:
     
     
     // Processors
+    loki.process "pod_logs" {
+      stage.match {
+        selector = "{tmp_container_runtime=\"containerd\"}"
+        // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
+        stage.cri {}
+    
+        // Set the extract flags and stream values as labels
+        stage.labels {
+          values = {
+            flags  = "",
+            stream  = "",
+          }
+        }
+      }
+    
+      stage.match {
+        selector = "{tmp_container_runtime=\"cri-o\"}"
+        // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
+        stage.cri {}
+    
+        // Set the extract flags and stream values as labels
+        stage.labels {
+          values = {
+            flags  = "",
+            stream  = "",
+          }
+        }
+      }
+    
+      // if the label tmp_container_runtime from above is docker parse using docker
+      stage.match {
+        selector = "{tmp_container_runtime=\"docker\"}"
+        // the docker processing stage extracts the following k/v pairs: log, stream, time
+        stage.docker {}
+    
+        // Set the extract stream value as a label
+        stage.labels {
+          values = {
+            stream  = "",
+          }
+        }
+      }
+    
+      // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have
+      // cluster, namespace, pod, and container labels.
+      // Also drop the temporary container runtime label as it is no longer needed.
+      stage.label_drop {
+        values = ["filename", "tmp_container_runtime"]
+      }
+      forward_to = [loki.process.logs_service.receiver]
+    }
+    
+    // Logs Service
+    remote.kubernetes.secret "logs_service" {
+      name = "loki-k8s-monitoring"
+      namespace = "default"
+    }
+    
+    loki.process "logs_service" {
+      stage.static_labels {
+          values = {
+            cluster = "logs-journal",
+          }
+      }
+      forward_to = [loki.write.logs_service.receiver]
+    }
+    
+    // Loki
+    loki.write "logs_service" {
+      endpoint {
+        url = nonsensitive(remote.kubernetes.secret.logs_service.data["host"]) + "/loki/api/v1/push"
+        tenant_id = nonsensitive(remote.kubernetes.secret.logs_service.data["tenantId"])
+    
+        basic_auth {
+          username = nonsensitive(remote.kubernetes.secret.logs_service.data["username"])
+          password = remote.kubernetes.secret.logs_service.data["password"]
+        }
+      }
+    }
+    
+    
     logging {
       level  = "info"
       format = "logfmt"
@@ -1274,6 +1355,87 @@ data:
     
     
     // Processors
+    loki.process "pod_logs" {
+      stage.match {
+        selector = "{tmp_container_runtime=\"containerd\"}"
+        // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
+        stage.cri {}
+    
+        // Set the extract flags and stream values as labels
+        stage.labels {
+          values = {
+            flags  = "",
+            stream  = "",
+          }
+        }
+      }
+    
+      stage.match {
+        selector = "{tmp_container_runtime=\"cri-o\"}"
+        // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
+        stage.cri {}
+    
+        // Set the extract flags and stream values as labels
+        stage.labels {
+          values = {
+            flags  = "",
+            stream  = "",
+          }
+        }
+      }
+    
+      // if the label tmp_container_runtime from above is docker parse using docker
+      stage.match {
+        selector = "{tmp_container_runtime=\"docker\"}"
+        // the docker processing stage extracts the following k/v pairs: log, stream, time
+        stage.docker {}
+    
+        // Set the extract stream value as a label
+        stage.labels {
+          values = {
+            stream  = "",
+          }
+        }
+      }
+    
+      // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have
+      // cluster, namespace, pod, and container labels.
+      // Also drop the temporary container runtime label as it is no longer needed.
+      stage.label_drop {
+        values = ["filename", "tmp_container_runtime"]
+      }
+      forward_to = [loki.process.logs_service.receiver]
+    }
+    
+    // Logs Service
+    remote.kubernetes.secret "logs_service" {
+      name = "loki-k8s-monitoring"
+      namespace = "default"
+    }
+    
+    loki.process "logs_service" {
+      stage.static_labels {
+          values = {
+            cluster = "logs-journal",
+          }
+      }
+      forward_to = [loki.write.logs_service.receiver]
+    }
+    
+    // Loki
+    loki.write "logs_service" {
+      endpoint {
+        url = nonsensitive(remote.kubernetes.secret.logs_service.data["host"]) + "/loki/api/v1/push"
+        tenant_id = nonsensitive(remote.kubernetes.secret.logs_service.data["tenantId"])
+    
+        basic_auth {
+          username = nonsensitive(remote.kubernetes.secret.logs_service.data["username"])
+          password = remote.kubernetes.secret.logs_service.data["password"]
+        }
+      }
+    }
+    
+    
     logging {
       level  = "info"
       format = "logfmt"


### PR DESCRIPTION
Without this, if the user enables the zipkin receiver, but not otlp receivers, the receiver pipelines will handle and pass log components, but will have no log destination at the end of the pipeline.

It doesn't really hurt much to enable these components if they're doing no work. But I wanted to avoid adding more and more complicated logic to determine if they needed to be included.