### PR TITLE
Added support to modify the scrape_interval for Auto-Discovery jobs

### DIFF
--- a/charts/k8s-monitoring/README.md
+++ b/charts/k8s-monitoring/README.md
@@ -435,6 +435,7 @@ The Prometheus and Loki services may be hosted on the same cluster, or remotely 
 | metrics.autoDiscover.maxCacheSize | string | `nil` | Sets the max_cache_size for cadvisor prometheus.relabel component. This should be at least 2x-5x your largest scrape target or samples appended rate. ([docs](https://grafana.com/docs/alloy/latest/reference/components/prometheus.relabel/#arguments)) Overrides metrics.maxCacheSize |
 | metrics.autoDiscover.metricsTuning.excludeMetrics | list | `[]` | Metrics to drop. Can use regex. |
 | metrics.autoDiscover.metricsTuning.includeMetrics | list | `[]` | Metrics to keep. Can use regex. An empty list means keep all. |
+| metrics.autoDiscover.scrapeInterval | string | 60s | How frequently to scrape metrics from auto-discovered entities. Overrides metrics.scrapeInterval |
 
 ### Metrics Job: cAdvisor
 

--- a/charts/k8s-monitoring/templates/alloy_config/_annotation_autodiscovery.alloy.txt
+++ b/charts/k8s-monitoring/templates/alloy_config/_annotation_autodiscovery.alloy.txt
@@ -156,6 +156,7 @@ discovery.relabel "annotation_autodiscovery_https" {
 
 prometheus.scrape "annotation_autodiscovery_http" {
   targets = discovery.relabel.annotation_autodiscovery_http.output
+  scrape_interval = {{ .Values.metrics.autoDiscover.scrapeInterval | default .Values.metrics.scrapeInterval | quote }}
   honor_labels = true
 {{- if .Values.alloy.alloy.clustering.enabled }}
   clustering {
@@ -167,6 +168,7 @@ prometheus.scrape "annotation_autodiscovery_http" {
 
 prometheus.scrape "annotation_autodiscovery_https" {
   targets = discovery.relabel.annotation_autodiscovery_https.output
+  scrape_interval = {{ .Values.metrics.autoDiscover.scrapeInterval | default .Values.metrics.scrapeInterval | quote }}
   honor_labels = true
   bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
   tls_config {

--- a/charts/k8s-monitoring/values.schema.json
+++ b/charts/k8s-monitoring/values.schema.json
@@ -1097,6 +1097,9 @@
                                     }
                                 }
                             }
+                        },
+                        "scrapeInterval": {
+                            "type": "string"
                         }
                     }
                 },

--- a/charts/k8s-monitoring/values.yaml
+++ b/charts/k8s-monitoring/values.yaml
@@ -437,6 +437,12 @@ metrics:
     # -- Enable annotation-based auto-discovery
     # @section -- Metrics Job: Auto-Discovery
     enabled: true
+    
+    # -- How frequently to scrape metrics from auto-discovered entities.
+    # Overrides metrics.scrapeInterval
+    # @default -- 60s
+    # @section -- Metrics Job: Auto-Discovery
+    scrapeInterval: ""
 
     # -- Rule blocks to be added to the discovery.relabel component for auto-discovered entities.
     # These relabeling rules are applied pre-scrape against the targets from service discovery.

--- a/charts/k8s-monitoring/values.yaml
+++ b/charts/k8s-monitoring/values.yaml
@@ -437,7 +437,7 @@ metrics:
     # -- Enable annotation-based auto-discovery
     # @section -- Metrics Job: Auto-Discovery
     enabled: true
-    
+
     # -- How frequently to scrape metrics from auto-discovered entities.
     # Overrides metrics.scrapeInterval
     # @default -- 60s

--- a/examples/alloy-autoscaling-and-storage/metrics.alloy
+++ b/examples/alloy-autoscaling-and-storage/metrics.alloy
@@ -272,6 +272,7 @@ discovery.relabel "annotation_autodiscovery_https" {
 
 prometheus.scrape "annotation_autodiscovery_http" {
   targets = discovery.relabel.annotation_autodiscovery_http.output
+  scrape_interval = "60s"
   honor_labels = true
   clustering {
     enabled = true
@@ -281,6 +282,7 @@ prometheus.scrape "annotation_autodiscovery_http" {
 
 prometheus.scrape "annotation_autodiscovery_https" {
   targets = discovery.relabel.annotation_autodiscovery_https.output
+  scrape_interval = "60s"
   honor_labels = true
   bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
   tls_config {

--- a/examples/alloy-autoscaling-and-storage/output.yaml
+++ b/examples/alloy-autoscaling-and-storage/output.yaml
@@ -400,6 +400,7 @@ data:
     
     prometheus.scrape "annotation_autodiscovery_http" {
       targets = discovery.relabel.annotation_autodiscovery_http.output
+      scrape_interval = "60s"
       honor_labels = true
       clustering {
         enabled = true
@@ -409,6 +410,7 @@ data:
     
     prometheus.scrape "annotation_autodiscovery_https" {
       targets = discovery.relabel.annotation_autodiscovery_https.output
+      scrape_interval = "60s"
       honor_labels = true
       bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
       tls_config {
@@ -52903,6 +52905,7 @@ data:
     
     prometheus.scrape "annotation_autodiscovery_http" {
       targets = discovery.relabel.annotation_autodiscovery_http.output
+      scrape_interval = "60s"
       honor_labels = true
       clustering {
         enabled = true
@@ -52912,6 +52915,7 @@ data:
     
     prometheus.scrape "annotation_autodiscovery_https" {
       targets = discovery.relabel.annotation_autodiscovery_https.output
+      scrape_interval = "60s"
       honor_labels = true
       bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
       tls_config {

--- a/examples/application-observability/metrics.alloy
+++ b/examples/application-observability/metrics.alloy
@@ -304,6 +304,7 @@ discovery.relabel "annotation_autodiscovery_https" {
 
 prometheus.scrape "annotation_autodiscovery_http" {
   targets = discovery.relabel.annotation_autodiscovery_http.output
+  scrape_interval = "60s"
   honor_labels = true
   clustering {
     enabled = true
@@ -313,6 +314,7 @@ prometheus.scrape "annotation_autodiscovery_http" {
 
 prometheus.scrape "annotation_autodiscovery_https" {
   targets = discovery.relabel.annotation_autodiscovery_https.output
+  scrape_interval = "60s"
   honor_labels = true
   bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
   tls_config {

--- a/examples/application-observability/output.yaml
+++ b/examples/application-observability/output.yaml
@@ -474,6 +474,7 @@ data:
     
     prometheus.scrape "annotation_autodiscovery_http" {
       targets = discovery.relabel.annotation_autodiscovery_http.output
+      scrape_interval = "60s"
       honor_labels = true
       clustering {
         enabled = true
@@ -483,6 +484,7 @@ data:
     
     prometheus.scrape "annotation_autodiscovery_https" {
       targets = discovery.relabel.annotation_autodiscovery_https.output
+      scrape_interval = "60s"
       honor_labels = true
       bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
       tls_config {
@@ -54005,6 +54007,7 @@ data:
     
     prometheus.scrape "annotation_autodiscovery_http" {
       targets = discovery.relabel.annotation_autodiscovery_http.output
+      scrape_interval = "60s"
       honor_labels = true
       clustering {
         enabled = true
@@ -54014,6 +54017,7 @@ data:
     
     prometheus.scrape "annotation_autodiscovery_https" {
       targets = discovery.relabel.annotation_autodiscovery_https.output
+      scrape_interval = "60s"
       honor_labels = true
       bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
       tls_config {

--- a/examples/control-plane-metrics/metrics.alloy
+++ b/examples/control-plane-metrics/metrics.alloy
@@ -272,6 +272,7 @@ discovery.relabel "annotation_autodiscovery_https" {
 
 prometheus.scrape "annotation_autodiscovery_http" {
   targets = discovery.relabel.annotation_autodiscovery_http.output
+  scrape_interval = "60s"
   honor_labels = true
   clustering {
     enabled = true
@@ -281,6 +282,7 @@ prometheus.scrape "annotation_autodiscovery_http" {
 
 prometheus.scrape "annotation_autodiscovery_https" {
   targets = discovery.relabel.annotation_autodiscovery_https.output
+  scrape_interval = "60s"
   honor_labels = true
   bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
   tls_config {

--- a/examples/control-plane-metrics/output.yaml
+++ b/examples/control-plane-metrics/output.yaml
@@ -401,6 +401,7 @@ data:
     
     prometheus.scrape "annotation_autodiscovery_http" {
       targets = discovery.relabel.annotation_autodiscovery_http.output
+      scrape_interval = "60s"
       honor_labels = true
       clustering {
         enabled = true
@@ -410,6 +411,7 @@ data:
     
     prometheus.scrape "annotation_autodiscovery_https" {
       targets = discovery.relabel.annotation_autodiscovery_https.output
+      scrape_interval = "60s"
       honor_labels = true
       bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
       tls_config {
@@ -52999,6 +53001,7 @@ data:
     
     prometheus.scrape "annotation_autodiscovery_http" {
       targets = discovery.relabel.annotation_autodiscovery_http.output
+      scrape_interval = "60s"
       honor_labels = true
       clustering {
         enabled = true
@@ -53008,6 +53011,7 @@ data:
     
     prometheus.scrape "annotation_autodiscovery_https" {
       targets = discovery.relabel.annotation_autodiscovery_https.output
+      scrape_interval = "60s"
       honor_labels = true
       bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
       tls_config {

--- a/examples/custom-config/metrics.alloy
+++ b/examples/custom-config/metrics.alloy
@@ -272,6 +272,7 @@ discovery.relabel "annotation_autodiscovery_https" {
 
 prometheus.scrape "annotation_autodiscovery_http" {
   targets = discovery.relabel.annotation_autodiscovery_http.output
+  scrape_interval = "60s"
   honor_labels = true
   clustering {
     enabled = true
@@ -281,6 +282,7 @@ prometheus.scrape "annotation_autodiscovery_http" {
 
 prometheus.scrape "annotation_autodiscovery_https" {
   targets = discovery.relabel.annotation_autodiscovery_https.output
+  scrape_interval = "60s"
   honor_labels = true
   bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
   tls_config {

--- a/examples/custom-config/output.yaml
+++ b/examples/custom-config/output.yaml
@@ -400,6 +400,7 @@ data:
     
     prometheus.scrape "annotation_autodiscovery_http" {
       targets = discovery.relabel.annotation_autodiscovery_http.output
+      scrape_interval = "60s"
       honor_labels = true
       clustering {
         enabled = true
@@ -409,6 +410,7 @@ data:
     
     prometheus.scrape "annotation_autodiscovery_https" {
       targets = discovery.relabel.annotation_autodiscovery_https.output
+      scrape_interval = "60s"
       honor_labels = true
       bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
       tls_config {
@@ -52932,6 +52934,7 @@ data:
     
     prometheus.scrape "annotation_autodiscovery_http" {
       targets = discovery.relabel.annotation_autodiscovery_http.output
+      scrape_interval = "60s"
       honor_labels = true
       clustering {
         enabled = true
@@ -52941,6 +52944,7 @@ data:
     
     prometheus.scrape "annotation_autodiscovery_https" {
       targets = discovery.relabel.annotation_autodiscovery_https.output
+      scrape_interval = "60s"
       honor_labels = true
       bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
       tls_config {

--- a/examples/custom-metrics-tuning/metrics.alloy
+++ b/examples/custom-metrics-tuning/metrics.alloy
@@ -254,6 +254,7 @@ discovery.relabel "annotation_autodiscovery_https" {
 
 prometheus.scrape "annotation_autodiscovery_http" {
   targets = discovery.relabel.annotation_autodiscovery_http.output
+  scrape_interval = "60s"
   honor_labels = true
   clustering {
     enabled = true
@@ -263,6 +264,7 @@ prometheus.scrape "annotation_autodiscovery_http" {
 
 prometheus.scrape "annotation_autodiscovery_https" {
   targets = discovery.relabel.annotation_autodiscovery_https.output
+  scrape_interval = "60s"
   honor_labels = true
   bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
   tls_config {

--- a/examples/custom-metrics-tuning/output.yaml
+++ b/examples/custom-metrics-tuning/output.yaml
@@ -337,6 +337,7 @@ data:
     
     prometheus.scrape "annotation_autodiscovery_http" {
       targets = discovery.relabel.annotation_autodiscovery_http.output
+      scrape_interval = "60s"
       honor_labels = true
       clustering {
         enabled = true
@@ -346,6 +347,7 @@ data:
     
     prometheus.scrape "annotation_autodiscovery_https" {
       targets = discovery.relabel.annotation_autodiscovery_https.output
+      scrape_interval = "60s"
       honor_labels = true
       bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
       tls_config {
@@ -51988,6 +51990,7 @@ data:
     
     prometheus.scrape "annotation_autodiscovery_http" {
       targets = discovery.relabel.annotation_autodiscovery_http.output
+      scrape_interval = "60s"
       honor_labels = true
       clustering {
         enabled = true
@@ -51997,6 +52000,7 @@ data:
     
     prometheus.scrape "annotation_autodiscovery_https" {
       targets = discovery.relabel.annotation_autodiscovery_https.output
+      scrape_interval = "60s"
       honor_labels = true
       bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
       tls_config {

--- a/examples/custom-pricing/metrics.alloy
+++ b/examples/custom-pricing/metrics.alloy
@@ -272,6 +272,7 @@ discovery.relabel "annotation_autodiscovery_https" {
 
 prometheus.scrape "annotation_autodiscovery_http" {
   targets = discovery.relabel.annotation_autodiscovery_http.output
+  scrape_interval = "60s"
   honor_labels = true
   clustering {
     enabled = true
@@ -281,6 +282,7 @@ prometheus.scrape "annotation_autodiscovery_http" {
 
 prometheus.scrape "annotation_autodiscovery_https" {
   targets = discovery.relabel.annotation_autodiscovery_https.output
+  scrape_interval = "60s"
   honor_labels = true
   bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
   tls_config {

--- a/examples/custom-pricing/output.yaml
+++ b/examples/custom-pricing/output.yaml
@@ -422,6 +422,7 @@ data:
     
     prometheus.scrape "annotation_autodiscovery_http" {
       targets = discovery.relabel.annotation_autodiscovery_http.output
+      scrape_interval = "60s"
       honor_labels = true
       clustering {
         enabled = true
@@ -431,6 +432,7 @@ data:
     
     prometheus.scrape "annotation_autodiscovery_https" {
       targets = discovery.relabel.annotation_autodiscovery_https.output
+      scrape_interval = "60s"
       honor_labels = true
       bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
       tls_config {
@@ -52875,6 +52877,7 @@ data:
     
     prometheus.scrape "annotation_autodiscovery_http" {
       targets = discovery.relabel.annotation_autodiscovery_http.output
+      scrape_interval = "60s"
       honor_labels = true
       clustering {
         enabled = true
@@ -52884,6 +52887,7 @@ data:
     
     prometheus.scrape "annotation_autodiscovery_https" {
       targets = discovery.relabel.annotation_autodiscovery_https.output
+      scrape_interval = "60s"
       honor_labels = true
       bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
       tls_config {

--- a/examples/custom-prometheus-operator-rules/metrics.alloy
+++ b/examples/custom-prometheus-operator-rules/metrics.alloy
@@ -264,6 +264,7 @@ discovery.relabel "annotation_autodiscovery_https" {
 
 prometheus.scrape "annotation_autodiscovery_http" {
   targets = discovery.relabel.annotation_autodiscovery_http.output
+  scrape_interval = "60s"
   honor_labels = true
   clustering {
     enabled = true
@@ -273,6 +274,7 @@ prometheus.scrape "annotation_autodiscovery_http" {
 
 prometheus.scrape "annotation_autodiscovery_https" {
   targets = discovery.relabel.annotation_autodiscovery_https.output
+  scrape_interval = "60s"
   honor_labels = true
   bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
   tls_config {

--- a/examples/custom-prometheus-operator-rules/output.yaml
+++ b/examples/custom-prometheus-operator-rules/output.yaml
@@ -347,6 +347,7 @@ data:
     
     prometheus.scrape "annotation_autodiscovery_http" {
       targets = discovery.relabel.annotation_autodiscovery_http.output
+      scrape_interval = "60s"
       honor_labels = true
       clustering {
         enabled = true
@@ -356,6 +357,7 @@ data:
     
     prometheus.scrape "annotation_autodiscovery_https" {
       targets = discovery.relabel.annotation_autodiscovery_https.output
+      scrape_interval = "60s"
       honor_labels = true
       bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
       tls_config {
@@ -52080,6 +52082,7 @@ data:
     
     prometheus.scrape "annotation_autodiscovery_http" {
       targets = discovery.relabel.annotation_autodiscovery_http.output
+      scrape_interval = "60s"
       honor_labels = true
       clustering {
         enabled = true
@@ -52089,6 +52092,7 @@ data:
     
     prometheus.scrape "annotation_autodiscovery_https" {
       targets = discovery.relabel.annotation_autodiscovery_https.output
+      scrape_interval = "60s"
       honor_labels = true
       bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
       tls_config {

--- a/examples/default-values/metrics.alloy
+++ b/examples/default-values/metrics.alloy
@@ -272,6 +272,7 @@ discovery.relabel "annotation_autodiscovery_https" {
 
 prometheus.scrape "annotation_autodiscovery_http" {
   targets = discovery.relabel.annotation_autodiscovery_http.output
+  scrape_interval = "60s"
   honor_labels = true
   clustering {
     enabled = true
@@ -281,6 +282,7 @@ prometheus.scrape "annotation_autodiscovery_http" {
 
 prometheus.scrape "annotation_autodiscovery_https" {
   targets = discovery.relabel.annotation_autodiscovery_https.output
+  scrape_interval = "60s"
   honor_labels = true
   bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
   tls_config {

--- a/examples/default-values/output.yaml
+++ b/examples/default-values/output.yaml
@@ -400,6 +400,7 @@ data:
     
     prometheus.scrape "annotation_autodiscovery_http" {
       targets = discovery.relabel.annotation_autodiscovery_http.output
+      scrape_interval = "60s"
       honor_labels = true
       clustering {
         enabled = true
@@ -409,6 +410,7 @@ data:
     
     prometheus.scrape "annotation_autodiscovery_https" {
       targets = discovery.relabel.annotation_autodiscovery_https.output
+      scrape_interval = "60s"
       honor_labels = true
       bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
       tls_config {
@@ -52842,6 +52844,7 @@ data:
     
     prometheus.scrape "annotation_autodiscovery_http" {
       targets = discovery.relabel.annotation_autodiscovery_http.output
+      scrape_interval = "60s"
       honor_labels = true
       clustering {
         enabled = true
@@ -52851,6 +52854,7 @@ data:
     
     prometheus.scrape "annotation_autodiscovery_https" {
       targets = discovery.relabel.annotation_autodiscovery_https.output
+      scrape_interval = "60s"
       honor_labels = true
       bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
       tls_config {

--- a/examples/eks-fargate/metrics.alloy
+++ b/examples/eks-fargate/metrics.alloy
@@ -272,6 +272,7 @@ discovery.relabel "annotation_autodiscovery_https" {
 
 prometheus.scrape "annotation_autodiscovery_http" {
   targets = discovery.relabel.annotation_autodiscovery_http.output
+  scrape_interval = "60s"
   honor_labels = true
   clustering {
     enabled = true
@@ -281,6 +282,7 @@ prometheus.scrape "annotation_autodiscovery_http" {
 
 prometheus.scrape "annotation_autodiscovery_https" {
   targets = discovery.relabel.annotation_autodiscovery_https.output
+  scrape_interval = "60s"
   honor_labels = true
   bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
   tls_config {

--- a/examples/eks-fargate/output.yaml
+++ b/examples/eks-fargate/output.yaml
@@ -385,6 +385,7 @@ data:
     
     prometheus.scrape "annotation_autodiscovery_http" {
       targets = discovery.relabel.annotation_autodiscovery_http.output
+      scrape_interval = "60s"
       honor_labels = true
       clustering {
         enabled = true
@@ -394,6 +395,7 @@ data:
     
     prometheus.scrape "annotation_autodiscovery_https" {
       targets = discovery.relabel.annotation_autodiscovery_https.output
+      scrape_interval = "60s"
       honor_labels = true
       bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
       tls_config {
@@ -52648,6 +52650,7 @@ data:
     
     prometheus.scrape "annotation_autodiscovery_http" {
       targets = discovery.relabel.annotation_autodiscovery_http.output
+      scrape_interval = "60s"
       honor_labels = true
       clustering {
         enabled = true
@@ -52657,6 +52660,7 @@ data:
     
     prometheus.scrape "annotation_autodiscovery_https" {
       targets = discovery.relabel.annotation_autodiscovery_https.output
+      scrape_interval = "60s"
       honor_labels = true
       bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
       tls_config {

--- a/examples/extra-rules/metrics.alloy
+++ b/examples/extra-rules/metrics.alloy
@@ -282,6 +282,7 @@ discovery.relabel "annotation_autodiscovery_https" {
 
 prometheus.scrape "annotation_autodiscovery_http" {
   targets = discovery.relabel.annotation_autodiscovery_http.output
+  scrape_interval = "60s"
   honor_labels = true
   clustering {
     enabled = true
@@ -291,6 +292,7 @@ prometheus.scrape "annotation_autodiscovery_http" {
 
 prometheus.scrape "annotation_autodiscovery_https" {
   targets = discovery.relabel.annotation_autodiscovery_https.output
+  scrape_interval = "60s"
   honor_labels = true
   bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
   tls_config {

--- a/examples/extra-rules/output.yaml
+++ b/examples/extra-rules/output.yaml
@@ -411,6 +411,7 @@ data:
     
     prometheus.scrape "annotation_autodiscovery_http" {
       targets = discovery.relabel.annotation_autodiscovery_http.output
+      scrape_interval = "60s"
       honor_labels = true
       clustering {
         enabled = true
@@ -420,6 +421,7 @@ data:
     
     prometheus.scrape "annotation_autodiscovery_https" {
       targets = discovery.relabel.annotation_autodiscovery_https.output
+      scrape_interval = "60s"
       honor_labels = true
       bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
       tls_config {
@@ -52974,6 +52976,7 @@ data:
     
     prometheus.scrape "annotation_autodiscovery_http" {
       targets = discovery.relabel.annotation_autodiscovery_http.output
+      scrape_interval = "60s"
       honor_labels = true
       clustering {
         enabled = true
@@ -52983,6 +52986,7 @@ data:
     
     prometheus.scrape "annotation_autodiscovery_https" {
       targets = discovery.relabel.annotation_autodiscovery_https.output
+      scrape_interval = "60s"
       honor_labels = true
       bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
       tls_config {

--- a/examples/gke-autopilot/metrics.alloy
+++ b/examples/gke-autopilot/metrics.alloy
@@ -272,6 +272,7 @@ discovery.relabel "annotation_autodiscovery_https" {
 
 prometheus.scrape "annotation_autodiscovery_http" {
   targets = discovery.relabel.annotation_autodiscovery_http.output
+  scrape_interval = "60s"
   honor_labels = true
   clustering {
     enabled = true
@@ -281,6 +282,7 @@ prometheus.scrape "annotation_autodiscovery_http" {
 
 prometheus.scrape "annotation_autodiscovery_https" {
   targets = discovery.relabel.annotation_autodiscovery_https.output
+  scrape_interval = "60s"
   honor_labels = true
   bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
   tls_config {

--- a/examples/gke-autopilot/output.yaml
+++ b/examples/gke-autopilot/output.yaml
@@ -385,6 +385,7 @@ data:
     
     prometheus.scrape "annotation_autodiscovery_http" {
       targets = discovery.relabel.annotation_autodiscovery_http.output
+      scrape_interval = "60s"
       honor_labels = true
       clustering {
         enabled = true
@@ -394,6 +395,7 @@ data:
     
     prometheus.scrape "annotation_autodiscovery_https" {
       targets = discovery.relabel.annotation_autodiscovery_https.output
+      scrape_interval = "60s"
       honor_labels = true
       bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
       tls_config {
@@ -52632,6 +52634,7 @@ data:
     
     prometheus.scrape "annotation_autodiscovery_http" {
       targets = discovery.relabel.annotation_autodiscovery_http.output
+      scrape_interval = "60s"
       honor_labels = true
       clustering {
         enabled = true
@@ -52641,6 +52644,7 @@ data:
     
     prometheus.scrape "annotation_autodiscovery_https" {
       targets = discovery.relabel.annotation_autodiscovery_https.output
+      scrape_interval = "60s"
       honor_labels = true
       bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
       tls_config {

--- a/examples/ibm-cloud/metrics.alloy
+++ b/examples/ibm-cloud/metrics.alloy
@@ -272,6 +272,7 @@ discovery.relabel "annotation_autodiscovery_https" {
 
 prometheus.scrape "annotation_autodiscovery_http" {
   targets = discovery.relabel.annotation_autodiscovery_http.output
+  scrape_interval = "60s"
   honor_labels = true
   clustering {
     enabled = true
@@ -281,6 +282,7 @@ prometheus.scrape "annotation_autodiscovery_http" {
 
 prometheus.scrape "annotation_autodiscovery_https" {
   targets = discovery.relabel.annotation_autodiscovery_https.output
+  scrape_interval = "60s"
   honor_labels = true
   bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
   tls_config {

--- a/examples/ibm-cloud/output.yaml
+++ b/examples/ibm-cloud/output.yaml
@@ -400,6 +400,7 @@ data:
     
     prometheus.scrape "annotation_autodiscovery_http" {
       targets = discovery.relabel.annotation_autodiscovery_http.output
+      scrape_interval = "60s"
       honor_labels = true
       clustering {
         enabled = true
@@ -409,6 +410,7 @@ data:
     
     prometheus.scrape "annotation_autodiscovery_https" {
       targets = discovery.relabel.annotation_autodiscovery_https.output
+      scrape_interval = "60s"
       honor_labels = true
       bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
       tls_config {
@@ -52848,6 +52850,7 @@ data:
     
     prometheus.scrape "annotation_autodiscovery_http" {
       targets = discovery.relabel.annotation_autodiscovery_http.output
+      scrape_interval = "60s"
       honor_labels = true
       clustering {
         enabled = true
@@ -52857,6 +52860,7 @@ data:
     
     prometheus.scrape "annotation_autodiscovery_https" {
       targets = discovery.relabel.annotation_autodiscovery_https.output
+      scrape_interval = "60s"
       honor_labels = true
       bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
       tls_config {

--- a/examples/metric-module-imports-extra-config/metrics.alloy
+++ b/examples/metric-module-imports-extra-config/metrics.alloy
@@ -272,6 +272,7 @@ discovery.relabel "annotation_autodiscovery_https" {
 
 prometheus.scrape "annotation_autodiscovery_http" {
   targets = discovery.relabel.annotation_autodiscovery_http.output
+  scrape_interval = "60s"
   honor_labels = true
   clustering {
     enabled = true
@@ -281,6 +282,7 @@ prometheus.scrape "annotation_autodiscovery_http" {
 
 prometheus.scrape "annotation_autodiscovery_https" {
   targets = discovery.relabel.annotation_autodiscovery_https.output
+  scrape_interval = "60s"
   honor_labels = true
   bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
   tls_config {

--- a/examples/metric-module-imports-extra-config/output.yaml
+++ b/examples/metric-module-imports-extra-config/output.yaml
@@ -400,6 +400,7 @@ data:
     
     prometheus.scrape "annotation_autodiscovery_http" {
       targets = discovery.relabel.annotation_autodiscovery_http.output
+      scrape_interval = "60s"
       honor_labels = true
       clustering {
         enabled = true
@@ -409,6 +410,7 @@ data:
     
     prometheus.scrape "annotation_autodiscovery_https" {
       targets = discovery.relabel.annotation_autodiscovery_https.output
+      scrape_interval = "60s"
       honor_labels = true
       bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
       tls_config {
@@ -52857,6 +52859,7 @@ data:
     
     prometheus.scrape "annotation_autodiscovery_http" {
       targets = discovery.relabel.annotation_autodiscovery_http.output
+      scrape_interval = "60s"
       honor_labels = true
       clustering {
         enabled = true
@@ -52866,6 +52869,7 @@ data:
     
     prometheus.scrape "annotation_autodiscovery_https" {
       targets = discovery.relabel.annotation_autodiscovery_https.output
+      scrape_interval = "60s"
       honor_labels = true
       bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
       tls_config {

--- a/examples/metric-module-imports/metrics.alloy
+++ b/examples/metric-module-imports/metrics.alloy
@@ -272,6 +272,7 @@ discovery.relabel "annotation_autodiscovery_https" {
 
 prometheus.scrape "annotation_autodiscovery_http" {
   targets = discovery.relabel.annotation_autodiscovery_http.output
+  scrape_interval = "60s"
   honor_labels = true
   clustering {
     enabled = true
@@ -281,6 +282,7 @@ prometheus.scrape "annotation_autodiscovery_http" {
 
 prometheus.scrape "annotation_autodiscovery_https" {
   targets = discovery.relabel.annotation_autodiscovery_https.output
+  scrape_interval = "60s"
   honor_labels = true
   bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
   tls_config {

--- a/examples/metric-module-imports/output.yaml
+++ b/examples/metric-module-imports/output.yaml
@@ -400,6 +400,7 @@ data:
     
     prometheus.scrape "annotation_autodiscovery_http" {
       targets = discovery.relabel.annotation_autodiscovery_http.output
+      scrape_interval = "60s"
       honor_labels = true
       clustering {
         enabled = true
@@ -409,6 +410,7 @@ data:
     
     prometheus.scrape "annotation_autodiscovery_https" {
       targets = discovery.relabel.annotation_autodiscovery_https.output
+      scrape_interval = "60s"
       honor_labels = true
       bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
       tls_config {
@@ -53019,6 +53021,7 @@ data:
     
     prometheus.scrape "annotation_autodiscovery_http" {
       targets = discovery.relabel.annotation_autodiscovery_http.output
+      scrape_interval = "60s"
       honor_labels = true
       clustering {
         enabled = true
@@ -53028,6 +53031,7 @@ data:
     
     prometheus.scrape "annotation_autodiscovery_https" {
       targets = discovery.relabel.annotation_autodiscovery_https.output
+      scrape_interval = "60s"
       honor_labels = true
       bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
       tls_config {

--- a/examples/metrics-only/metrics.alloy
+++ b/examples/metrics-only/metrics.alloy
@@ -254,6 +254,7 @@ discovery.relabel "annotation_autodiscovery_https" {
 
 prometheus.scrape "annotation_autodiscovery_http" {
   targets = discovery.relabel.annotation_autodiscovery_http.output
+  scrape_interval = "60s"
   honor_labels = true
   clustering {
     enabled = true
@@ -263,6 +264,7 @@ prometheus.scrape "annotation_autodiscovery_http" {
 
 prometheus.scrape "annotation_autodiscovery_https" {
   targets = discovery.relabel.annotation_autodiscovery_https.output
+  scrape_interval = "60s"
   honor_labels = true
   bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
   tls_config {

--- a/examples/metrics-only/output.yaml
+++ b/examples/metrics-only/output.yaml
@@ -338,6 +338,7 @@ data:
     
     prometheus.scrape "annotation_autodiscovery_http" {
       targets = discovery.relabel.annotation_autodiscovery_http.output
+      scrape_interval = "60s"
       honor_labels = true
       clustering {
         enabled = true
@@ -347,6 +348,7 @@ data:
     
     prometheus.scrape "annotation_autodiscovery_https" {
       targets = discovery.relabel.annotation_autodiscovery_https.output
+      scrape_interval = "60s"
       honor_labels = true
       bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
       tls_config {
@@ -51994,6 +51996,7 @@ data:
     
     prometheus.scrape "annotation_autodiscovery_http" {
       targets = discovery.relabel.annotation_autodiscovery_http.output
+      scrape_interval = "60s"
       honor_labels = true
       clustering {
         enabled = true
@@ -52003,6 +52006,7 @@ data:
     
     prometheus.scrape "annotation_autodiscovery_https" {
       targets = discovery.relabel.annotation_autodiscovery_https.output
+      scrape_interval = "60s"
       honor_labels = true
       bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
       tls_config {

--- a/examples/openshift-compatible/metrics.alloy
+++ b/examples/openshift-compatible/metrics.alloy
@@ -272,6 +272,7 @@ discovery.relabel "annotation_autodiscovery_https" {
 
 prometheus.scrape "annotation_autodiscovery_http" {
   targets = discovery.relabel.annotation_autodiscovery_http.output
+  scrape_interval = "60s"
   honor_labels = true
   clustering {
     enabled = true
@@ -281,6 +282,7 @@ prometheus.scrape "annotation_autodiscovery_http" {
 
 prometheus.scrape "annotation_autodiscovery_https" {
   targets = discovery.relabel.annotation_autodiscovery_https.output
+  scrape_interval = "60s"
   honor_labels = true
   bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
   tls_config {

--- a/examples/openshift-compatible/output.yaml
+++ b/examples/openshift-compatible/output.yaml
@@ -370,6 +370,7 @@ data:
     
     prometheus.scrape "annotation_autodiscovery_http" {
       targets = discovery.relabel.annotation_autodiscovery_http.output
+      scrape_interval = "60s"
       honor_labels = true
       clustering {
         enabled = true
@@ -379,6 +380,7 @@ data:
     
     prometheus.scrape "annotation_autodiscovery_https" {
       targets = discovery.relabel.annotation_autodiscovery_https.output
+      scrape_interval = "60s"
       honor_labels = true
       bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
       tls_config {
@@ -52694,6 +52696,7 @@ data:
     
     prometheus.scrape "annotation_autodiscovery_http" {
       targets = discovery.relabel.annotation_autodiscovery_http.output
+      scrape_interval = "60s"
       honor_labels = true
       clustering {
         enabled = true
@@ -52703,6 +52706,7 @@ data:
     
     prometheus.scrape "annotation_autodiscovery_https" {
       targets = discovery.relabel.annotation_autodiscovery_https.output
+      scrape_interval = "60s"
       honor_labels = true
       bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
       tls_config {

--- a/examples/otel-metrics-service/metrics.alloy
+++ b/examples/otel-metrics-service/metrics.alloy
@@ -272,6 +272,7 @@ discovery.relabel "annotation_autodiscovery_https" {
 
 prometheus.scrape "annotation_autodiscovery_http" {
   targets = discovery.relabel.annotation_autodiscovery_http.output
+  scrape_interval = "60s"
   honor_labels = true
   clustering {
     enabled = true
@@ -281,6 +282,7 @@ prometheus.scrape "annotation_autodiscovery_http" {
 
 prometheus.scrape "annotation_autodiscovery_https" {
   targets = discovery.relabel.annotation_autodiscovery_https.output
+  scrape_interval = "60s"
   honor_labels = true
   bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
   tls_config {

--- a/examples/otel-metrics-service/output.yaml
+++ b/examples/otel-metrics-service/output.yaml
@@ -400,6 +400,7 @@ data:
     
     prometheus.scrape "annotation_autodiscovery_http" {
       targets = discovery.relabel.annotation_autodiscovery_http.output
+      scrape_interval = "60s"
       honor_labels = true
       clustering {
         enabled = true
@@ -409,6 +410,7 @@ data:
     
     prometheus.scrape "annotation_autodiscovery_https" {
       targets = discovery.relabel.annotation_autodiscovery_https.output
+      scrape_interval = "60s"
       honor_labels = true
       bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
       tls_config {
@@ -52859,6 +52861,7 @@ data:
     
     prometheus.scrape "annotation_autodiscovery_http" {
       targets = discovery.relabel.annotation_autodiscovery_http.output
+      scrape_interval = "60s"
       honor_labels = true
       clustering {
         enabled = true
@@ -52868,6 +52871,7 @@ data:
     
     prometheus.scrape "annotation_autodiscovery_https" {
       targets = discovery.relabel.annotation_autodiscovery_https.output
+      scrape_interval = "60s"
       honor_labels = true
       bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
       tls_config {

--- a/examples/pod-labels/metrics.alloy
+++ b/examples/pod-labels/metrics.alloy
@@ -309,6 +309,7 @@ discovery.relabel "annotation_autodiscovery_https" {
 
 prometheus.scrape "annotation_autodiscovery_http" {
   targets = discovery.relabel.annotation_autodiscovery_http.output
+  scrape_interval = "60s"
   honor_labels = true
   clustering {
     enabled = true
@@ -318,6 +319,7 @@ prometheus.scrape "annotation_autodiscovery_http" {
 
 prometheus.scrape "annotation_autodiscovery_https" {
   targets = discovery.relabel.annotation_autodiscovery_https.output
+  scrape_interval = "60s"
   honor_labels = true
   bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
   tls_config {

--- a/examples/pod-labels/output.yaml
+++ b/examples/pod-labels/output.yaml
@@ -450,6 +450,7 @@ data:
     
     prometheus.scrape "annotation_autodiscovery_http" {
       targets = discovery.relabel.annotation_autodiscovery_http.output
+      scrape_interval = "60s"
       honor_labels = true
       clustering {
         enabled = true
@@ -459,6 +460,7 @@ data:
     
     prometheus.scrape "annotation_autodiscovery_https" {
       targets = discovery.relabel.annotation_autodiscovery_https.output
+      scrape_interval = "60s"
       honor_labels = true
       bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
       tls_config {
@@ -52956,6 +52958,7 @@ data:
     
     prometheus.scrape "annotation_autodiscovery_http" {
       targets = discovery.relabel.annotation_autodiscovery_http.output
+      scrape_interval = "60s"
       honor_labels = true
       clustering {
         enabled = true
@@ -52965,6 +52968,7 @@ data:
     
     prometheus.scrape "annotation_autodiscovery_https" {
       targets = discovery.relabel.annotation_autodiscovery_https.output
+      scrape_interval = "60s"
       honor_labels = true
       bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
       tls_config {

--- a/examples/private-image-registry/metrics.alloy
+++ b/examples/private-image-registry/metrics.alloy
@@ -272,6 +272,7 @@ discovery.relabel "annotation_autodiscovery_https" {
 
 prometheus.scrape "annotation_autodiscovery_http" {
   targets = discovery.relabel.annotation_autodiscovery_http.output
+  scrape_interval = "60s"
   honor_labels = true
   clustering {
     enabled = true
@@ -281,6 +282,7 @@ prometheus.scrape "annotation_autodiscovery_http" {
 
 prometheus.scrape "annotation_autodiscovery_https" {
   targets = discovery.relabel.annotation_autodiscovery_https.output
+  scrape_interval = "60s"
   honor_labels = true
   bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
   tls_config {

--- a/examples/private-image-registry/output.yaml
+++ b/examples/private-image-registry/output.yaml
@@ -404,6 +404,7 @@ data:
     
     prometheus.scrape "annotation_autodiscovery_http" {
       targets = discovery.relabel.annotation_autodiscovery_http.output
+      scrape_interval = "60s"
       honor_labels = true
       clustering {
         enabled = true
@@ -413,6 +414,7 @@ data:
     
     prometheus.scrape "annotation_autodiscovery_https" {
       targets = discovery.relabel.annotation_autodiscovery_https.output
+      scrape_interval = "60s"
       honor_labels = true
       bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
       tls_config {
@@ -52858,6 +52860,7 @@ data:
     
     prometheus.scrape "annotation_autodiscovery_http" {
       targets = discovery.relabel.annotation_autodiscovery_http.output
+      scrape_interval = "60s"
       honor_labels = true
       clustering {
         enabled = true
@@ -52867,6 +52870,7 @@ data:
     
     prometheus.scrape "annotation_autodiscovery_https" {
       targets = discovery.relabel.annotation_autodiscovery_https.output
+      scrape_interval = "60s"
       honor_labels = true
       bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
       tls_config {

--- a/examples/profiles-enabled/metrics.alloy
+++ b/examples/profiles-enabled/metrics.alloy
@@ -272,6 +272,7 @@ discovery.relabel "annotation_autodiscovery_https" {
 
 prometheus.scrape "annotation_autodiscovery_http" {
   targets = discovery.relabel.annotation_autodiscovery_http.output
+  scrape_interval = "60s"
   honor_labels = true
   clustering {
     enabled = true
@@ -281,6 +282,7 @@ prometheus.scrape "annotation_autodiscovery_http" {
 
 prometheus.scrape "annotation_autodiscovery_https" {
   targets = discovery.relabel.annotation_autodiscovery_https.output
+  scrape_interval = "60s"
   honor_labels = true
   bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
   tls_config {

--- a/examples/profiles-enabled/output.yaml
+++ b/examples/profiles-enabled/output.yaml
@@ -429,6 +429,7 @@ data:
     
     prometheus.scrape "annotation_autodiscovery_http" {
       targets = discovery.relabel.annotation_autodiscovery_http.output
+      scrape_interval = "60s"
       honor_labels = true
       clustering {
         enabled = true
@@ -438,6 +439,7 @@ data:
     
     prometheus.scrape "annotation_autodiscovery_https" {
       targets = discovery.relabel.annotation_autodiscovery_https.output
+      scrape_interval = "60s"
       honor_labels = true
       bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
       tls_config {
@@ -53908,6 +53910,7 @@ data:
     
     prometheus.scrape "annotation_autodiscovery_http" {
       targets = discovery.relabel.annotation_autodiscovery_http.output
+      scrape_interval = "60s"
       honor_labels = true
       clustering {
         enabled = true
@@ -53917,6 +53920,7 @@ data:
     
     prometheus.scrape "annotation_autodiscovery_https" {
       targets = discovery.relabel.annotation_autodiscovery_https.output
+      scrape_interval = "60s"
       honor_labels = true
       bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
       tls_config {

--- a/examples/proxies/metrics.alloy
+++ b/examples/proxies/metrics.alloy
@@ -272,6 +272,7 @@ discovery.relabel "annotation_autodiscovery_https" {
 
 prometheus.scrape "annotation_autodiscovery_http" {
   targets = discovery.relabel.annotation_autodiscovery_http.output
+  scrape_interval = "60s"
   honor_labels = true
   clustering {
     enabled = true
@@ -281,6 +282,7 @@ prometheus.scrape "annotation_autodiscovery_http" {
 
 prometheus.scrape "annotation_autodiscovery_https" {
   targets = discovery.relabel.annotation_autodiscovery_https.output
+  scrape_interval = "60s"
   honor_labels = true
   bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
   tls_config {

--- a/examples/proxies/output.yaml
+++ b/examples/proxies/output.yaml
@@ -400,6 +400,7 @@ data:
     
     prometheus.scrape "annotation_autodiscovery_http" {
       targets = discovery.relabel.annotation_autodiscovery_http.output
+      scrape_interval = "60s"
       honor_labels = true
       clustering {
         enabled = true
@@ -409,6 +410,7 @@ data:
     
     prometheus.scrape "annotation_autodiscovery_https" {
       targets = discovery.relabel.annotation_autodiscovery_https.output
+      scrape_interval = "60s"
       honor_labels = true
       bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
       tls_config {
@@ -52858,6 +52860,7 @@ data:
     
     prometheus.scrape "annotation_autodiscovery_http" {
       targets = discovery.relabel.annotation_autodiscovery_http.output
+      scrape_interval = "60s"
       honor_labels = true
       clustering {
         enabled = true
@@ -52867,6 +52870,7 @@ data:
     
     prometheus.scrape "annotation_autodiscovery_https" {
       targets = discovery.relabel.annotation_autodiscovery_https.output
+      scrape_interval = "60s"
       honor_labels = true
       bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
       tls_config {

--- a/examples/scrape-intervals/metrics.alloy
+++ b/examples/scrape-intervals/metrics.alloy
@@ -254,6 +254,7 @@ discovery.relabel "annotation_autodiscovery_https" {
 
 prometheus.scrape "annotation_autodiscovery_http" {
   targets = discovery.relabel.annotation_autodiscovery_http.output
+  scrape_interval = "2m"
   honor_labels = true
   clustering {
     enabled = true
@@ -263,6 +264,7 @@ prometheus.scrape "annotation_autodiscovery_http" {
 
 prometheus.scrape "annotation_autodiscovery_https" {
   targets = discovery.relabel.annotation_autodiscovery_https.output
+  scrape_interval = "2m"
   honor_labels = true
   bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
   tls_config {

--- a/examples/scrape-intervals/output.yaml
+++ b/examples/scrape-intervals/output.yaml
@@ -337,6 +337,7 @@ data:
     
     prometheus.scrape "annotation_autodiscovery_http" {
       targets = discovery.relabel.annotation_autodiscovery_http.output
+      scrape_interval = "2m"
       honor_labels = true
       clustering {
         enabled = true
@@ -346,6 +347,7 @@ data:
     
     prometheus.scrape "annotation_autodiscovery_https" {
       targets = discovery.relabel.annotation_autodiscovery_https.output
+      scrape_interval = "2m"
       honor_labels = true
       bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
       tls_config {
@@ -51993,6 +51995,7 @@ data:
     
     prometheus.scrape "annotation_autodiscovery_http" {
       targets = discovery.relabel.annotation_autodiscovery_http.output
+      scrape_interval = "2m"
       honor_labels = true
       clustering {
         enabled = true
@@ -52002,6 +52005,7 @@ data:
     
     prometheus.scrape "annotation_autodiscovery_https" {
       targets = discovery.relabel.annotation_autodiscovery_https.output
+      scrape_interval = "2m"
       honor_labels = true
       bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
       tls_config {

--- a/examples/service-integrations/metrics.alloy
+++ b/examples/service-integrations/metrics.alloy
@@ -272,6 +272,7 @@ discovery.relabel "annotation_autodiscovery_https" {
 
 prometheus.scrape "annotation_autodiscovery_http" {
   targets = discovery.relabel.annotation_autodiscovery_http.output
+  scrape_interval = "60s"
   honor_labels = true
   clustering {
     enabled = true
@@ -281,6 +282,7 @@ prometheus.scrape "annotation_autodiscovery_http" {
 
 prometheus.scrape "annotation_autodiscovery_https" {
   targets = discovery.relabel.annotation_autodiscovery_https.output
+  scrape_interval = "60s"
   honor_labels = true
   bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
   tls_config {

--- a/examples/service-integrations/output.yaml
+++ b/examples/service-integrations/output.yaml
@@ -400,6 +400,7 @@ data:
     
     prometheus.scrape "annotation_autodiscovery_http" {
       targets = discovery.relabel.annotation_autodiscovery_http.output
+      scrape_interval = "60s"
       honor_labels = true
       clustering {
         enabled = true
@@ -409,6 +410,7 @@ data:
     
     prometheus.scrape "annotation_autodiscovery_https" {
       targets = discovery.relabel.annotation_autodiscovery_https.output
+      scrape_interval = "60s"
       honor_labels = true
       bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
       tls_config {
@@ -52875,6 +52877,7 @@ data:
     
     prometheus.scrape "annotation_autodiscovery_http" {
       targets = discovery.relabel.annotation_autodiscovery_http.output
+      scrape_interval = "60s"
       honor_labels = true
       clustering {
         enabled = true
@@ -52884,6 +52887,7 @@ data:
     
     prometheus.scrape "annotation_autodiscovery_https" {
       targets = discovery.relabel.annotation_autodiscovery_https.output
+      scrape_interval = "60s"
       honor_labels = true
       bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
       tls_config {

--- a/examples/specific-namespace/metrics.alloy
+++ b/examples/specific-namespace/metrics.alloy
@@ -272,6 +272,7 @@ discovery.relabel "annotation_autodiscovery_https" {
 
 prometheus.scrape "annotation_autodiscovery_http" {
   targets = discovery.relabel.annotation_autodiscovery_http.output
+  scrape_interval = "60s"
   honor_labels = true
   clustering {
     enabled = true
@@ -281,6 +282,7 @@ prometheus.scrape "annotation_autodiscovery_http" {
 
 prometheus.scrape "annotation_autodiscovery_https" {
   targets = discovery.relabel.annotation_autodiscovery_https.output
+  scrape_interval = "60s"
   honor_labels = true
   bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
   tls_config {

--- a/examples/specific-namespace/output.yaml
+++ b/examples/specific-namespace/output.yaml
@@ -400,6 +400,7 @@ data:
     
     prometheus.scrape "annotation_autodiscovery_http" {
       targets = discovery.relabel.annotation_autodiscovery_http.output
+      scrape_interval = "60s"
       honor_labels = true
       clustering {
         enabled = true
@@ -409,6 +410,7 @@ data:
     
     prometheus.scrape "annotation_autodiscovery_https" {
       targets = discovery.relabel.annotation_autodiscovery_https.output
+      scrape_interval = "60s"
       honor_labels = true
       bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
       tls_config {
@@ -52906,6 +52908,7 @@ data:
     
     prometheus.scrape "annotation_autodiscovery_http" {
       targets = discovery.relabel.annotation_autodiscovery_http.output
+      scrape_interval = "60s"
       honor_labels = true
       clustering {
         enabled = true
@@ -52915,6 +52918,7 @@ data:
     
     prometheus.scrape "annotation_autodiscovery_https" {
       targets = discovery.relabel.annotation_autodiscovery_https.output
+      scrape_interval = "60s"
       honor_labels = true
       bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
       tls_config {

--- a/examples/traces-enabled/metrics.alloy
+++ b/examples/traces-enabled/metrics.alloy
@@ -358,6 +358,7 @@ discovery.relabel "annotation_autodiscovery_https" {
 
 prometheus.scrape "annotation_autodiscovery_http" {
   targets = discovery.relabel.annotation_autodiscovery_http.output
+  scrape_interval = "60s"
   honor_labels = true
   clustering {
     enabled = true
@@ -367,6 +368,7 @@ prometheus.scrape "annotation_autodiscovery_http" {
 
 prometheus.scrape "annotation_autodiscovery_https" {
   targets = discovery.relabel.annotation_autodiscovery_https.output
+  scrape_interval = "60s"
   honor_labels = true
   bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
   tls_config {

--- a/examples/traces-enabled/output.yaml
+++ b/examples/traces-enabled/output.yaml
@@ -499,6 +499,7 @@ data:
     
     prometheus.scrape "annotation_autodiscovery_http" {
       targets = discovery.relabel.annotation_autodiscovery_http.output
+      scrape_interval = "60s"
       honor_labels = true
       clustering {
         enabled = true
@@ -508,6 +509,7 @@ data:
     
     prometheus.scrape "annotation_autodiscovery_https" {
       targets = discovery.relabel.annotation_autodiscovery_https.output
+      scrape_interval = "60s"
       honor_labels = true
       bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
       tls_config {
@@ -53047,6 +53049,7 @@ data:
     
     prometheus.scrape "annotation_autodiscovery_http" {
       targets = discovery.relabel.annotation_autodiscovery_http.output
+      scrape_interval = "60s"
       honor_labels = true
       clustering {
         enabled = true
@@ -53056,6 +53059,7 @@ data:
     
     prometheus.scrape "annotation_autodiscovery_https" {
       targets = discovery.relabel.annotation_autodiscovery_https.output
+      scrape_interval = "60s"
       honor_labels = true
       bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
       tls_config {

--- a/examples/windows-exporter/metrics.alloy
+++ b/examples/windows-exporter/metrics.alloy
@@ -272,6 +272,7 @@ discovery.relabel "annotation_autodiscovery_https" {
 
 prometheus.scrape "annotation_autodiscovery_http" {
   targets = discovery.relabel.annotation_autodiscovery_http.output
+  scrape_interval = "60s"
   honor_labels = true
   clustering {
     enabled = true
@@ -281,6 +282,7 @@ prometheus.scrape "annotation_autodiscovery_http" {
 
 prometheus.scrape "annotation_autodiscovery_https" {
   targets = discovery.relabel.annotation_autodiscovery_https.output
+  scrape_interval = "60s"
   honor_labels = true
   bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
   tls_config {

--- a/examples/windows-exporter/output.yaml
+++ b/examples/windows-exporter/output.yaml
@@ -437,6 +437,7 @@ data:
     
     prometheus.scrape "annotation_autodiscovery_http" {
       targets = discovery.relabel.annotation_autodiscovery_http.output
+      scrape_interval = "60s"
       honor_labels = true
       clustering {
         enabled = true
@@ -446,6 +447,7 @@ data:
     
     prometheus.scrape "annotation_autodiscovery_https" {
       targets = discovery.relabel.annotation_autodiscovery_https.output
+      scrape_interval = "60s"
       honor_labels = true
       bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
       tls_config {
@@ -53074,6 +53076,7 @@ data:
     
     prometheus.scrape "annotation_autodiscovery_http" {
       targets = discovery.relabel.annotation_autodiscovery_http.output
+      scrape_interval = "60s"
       honor_labels = true
       clustering {
         enabled = true
@@ -53083,6 +53086,7 @@ data:
     
     prometheus.scrape "annotation_autodiscovery_https" {
       targets = discovery.relabel.annotation_autodiscovery_https.output
+      scrape_interval = "60s"
       honor_labels = true
       bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
       tls_config {


### PR DESCRIPTION
This adds support for configuring the scrapeInterval for the Auto-Discovery jobs (http & https) in the same way it can be modified for all other scrape jobs.