### PR TITLE
feat: Add network metrics to node exporter allow list

### DIFF
--- a/charts/k8s-monitoring/default_allow_lists/node_exporter.yaml
+++ b/charts/k8s-monitoring/default_allow_lists/node_exporter.yaml
@@ -4,5 +4,9 @@
 - node_exporter_build_info
 - node_filesystem.*
 - node_memory.*
+- node_network_receive_bytes_total
+- node_network_receive_drop_total
+- node_network_transmit_bytes_total
+- node_network_transmit_drop_total
 - process_cpu_seconds_total
 - process_resident_memory_bytes


### PR DESCRIPTION
Adds network metrics to node exporter default allow list.