### PR TITLE
Add the ability to set the Service Account names

### DIFF
--- a/charts/k8s-monitoring/README.md
+++ b/charts/k8s-monitoring/README.md
@@ -169,6 +169,7 @@ The Prometheus and Loki services may be hosted on the same cluster, or remotely 
 | configAnalysis.image.registry | string | `"ghcr.io"` | Config Analysis image registry. |
 | configAnalysis.image.tag | string | `""` | Config Analysis image tag. Default is the chart version. |
 | configAnalysis.nodeSelector | object | `{"kubernetes.io/os":"linux"}` | nodeSelector to apply to the config analysis pod. |
+| configAnalysis.serviceAccount | object | `{"name":""}` | Service Account to use for the config analysis pod. |
 | configAnalysis.tolerations | list | `[]` | Tolerations to apply to the config analysis pod. |
 
 ### Config Validator Job
@@ -179,6 +180,7 @@ The Prometheus and Loki services may be hosted on the same cluster, or remotely 
 | configValidator.extraAnnotations | object | `{}` | Extra annotations to add to the test config validator job. |
 | configValidator.extraLabels | object | `{}` | Extra labels to add to the test config validator job. |
 | configValidator.nodeSelector | object | `{"kubernetes.io/os":"linux"}` | nodeSelector to apply to the config validator job. |
+| configValidator.serviceAccount | object | `{"name":""}` | Service Account to use for the config validator job. |
 | configValidator.tolerations | list | `[]` | Tolerations to apply to the config validator job. |
 
 ### External Services (Loki)
@@ -734,6 +736,7 @@ The Prometheus and Loki services may be hosted on the same cluster, or remotely 
 | test.image.registry | string | `"ghcr.io"` | Test job image registry. |
 | test.image.tag | string | `""` | Test job image tag. Default is the chart version. |
 | test.nodeSelector | object | `{"kubernetes.io/os":"linux"}` | nodeSelector to apply to the test job. |
+| test.serviceAccount | object | `{"name":""}` | Service Account to use for the test job. |
 | test.tolerations | list | `[]` | Tolerations to apply to the test job. |
 
 ### Traces

--- a/charts/k8s-monitoring/templates/hooks/validate-configuration.yaml
+++ b/charts/k8s-monitoring/templates/hooks/validate-configuration.yaml
@@ -21,6 +21,9 @@ metadata:
     {{ $key }}: {{ $val | quote }}
     {{- end}}
 spec:
+  {{- if .Values.configValidator.serviceAccount.name }}
+  serviceAccountName: {{ .Values.configValidator.serviceAccount.name }}
+  {{- end }}
   {{- if or .Values.global.image.pullSecrets .Values.alloy.image.pullSecrets }}
   imagePullSecrets:
     {{- if .Values.global.image.pullSecrets }}

--- a/charts/k8s-monitoring/templates/tests/test.yaml
+++ b/charts/k8s-monitoring/templates/tests/test.yaml
@@ -80,6 +80,9 @@ metadata:
     {{ $key }}: {{ $val | quote }}
     {{- end}}
 spec:
+  {{- if .Values.configAnalysis.serviceAccount.name }}
+  serviceAccountName: {{ .Values.configAnalysis.serviceAccount.name }}
+  {{- end }}
   {{- if or .Values.global.image.pullSecrets .Values.configAnalysis.image.pullSecrets }}
   imagePullSecrets:
     {{- if .Values.global.image.pullSecrets }}
@@ -147,6 +150,9 @@ spec:
         {{- . | toYaml | nindent 8 }}
       {{- end }}
     spec:
+      {{- if .Values.test.serviceAccount.name }}
+      serviceAccountName: {{ .Values.test.serviceAccount.name }}
+      {{- end }}
       {{- if or .Values.global.image.pullSecrets .Values.test.image.pullSecrets }}
       imagePullSecrets:
         {{- if .Values.global.image.pullSecrets }}

--- a/charts/k8s-monitoring/values.schema.json
+++ b/charts/k8s-monitoring/values.schema.json
@@ -164,6 +164,14 @@
                         }
                     }
                 },
+                "serviceAccount": {
+                    "type": "object",
+                    "properties": {
+                        "name": {
+                            "type": "string"
+                        }
+                    }
+                },
                 "tolerations": {
                     "type": "array"
                 }
@@ -185,6 +193,14 @@
                     "type": "object",
                     "properties": {
                         "kubernetes.io/os": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "serviceAccount": {
+                    "type": "object",
+                    "properties": {
+                        "name": {
                             "type": "string"
                         }
                     }
@@ -1884,6 +1900,9 @@
                         },
                         "port": {
                             "type": "integer"
+                        },
+                        "tls": {
+                            "type": "object"
                         }
                     }
                 },
@@ -1898,6 +1917,9 @@
                         },
                         "port": {
                             "type": "integer"
+                        },
+                        "tls": {
+                            "type": "object"
                         }
                     }
                 },
@@ -1950,6 +1972,9 @@
                                     "type": "integer"
                                 }
                             }
+                        },
+                        "tls": {
+                            "type": "object"
                         }
                     }
                 },
@@ -2011,6 +2036,9 @@
                         },
                         "port": {
                             "type": "integer"
+                        },
+                        "tls": {
+                            "type": "object"
                         }
                     }
                 }
@@ -2072,6 +2100,14 @@
                     "type": "object",
                     "properties": {
                         "kubernetes.io/os": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "serviceAccount": {
+                    "type": "object",
+                    "properties": {
+                        "name": {
                             "type": "string"
                         }
                     }

--- a/charts/k8s-monitoring/values.yaml
+++ b/charts/k8s-monitoring/values.yaml
@@ -1721,6 +1721,11 @@ configValidator:
   # @section -- Config Validator Job
   tolerations: []
 
+  # -- Service Account to use for the config validator job.
+  # @section -- Config Validator Job
+  serviceAccount:
+    name: ""
+
 # Settings for the test job, which runs queries against Prometheus, Loki, and/or Tempo to check for data that should be
 # available based on the current configuration. Runnable by "helm test"
 test:
@@ -1765,6 +1770,11 @@ test:
   # -- Tolerations to apply to the test job.
   # @section -- Test Job
   tolerations: []
+
+  # -- Service Account to use for the test job.
+  # @section -- Test Job
+  serviceAccount:
+    name: ""
 
   # -- Overrides the URLs for various data sources
   # @section -- Test Job
@@ -1811,6 +1821,11 @@ configAnalysis:
   # -- Tolerations to apply to the config analysis pod.
   # @section -- Config Analysis Job
   tolerations: []
+
+  # -- Service Account to use for the config analysis pod.
+  # @section -- Config Analysis Job
+  serviceAccount:
+    name: ""
 
   image:
     # -- Config Analysis image registry.


### PR DESCRIPTION
Solves an issue when installing to a cluster where the default service account is not usable or prohibited.