### PR TITLE
Added support to modify the scrape_interval for Auto-Discovery jobs

### DIFF
--- a/charts/k8s-monitoring/README.md
+++ b/charts/k8s-monitoring/README.md
@@ -437,6 +437,7 @@ The Prometheus and Loki services may be hosted on the same cluster, or remotely 
 | metrics.autoDiscover.maxCacheSize | string | `nil` | Sets the max_cache_size for cadvisor prometheus.relabel component. This should be at least 2x-5x your largest scrape target or samples appended rate. ([docs](https://grafana.com/docs/alloy/latest/reference/components/prometheus.relabel/#arguments)) Overrides metrics.maxCacheSize |
 | metrics.autoDiscover.metricsTuning.excludeMetrics | list | `[]` | Metrics to drop. Can use regex. |
 | metrics.autoDiscover.metricsTuning.includeMetrics | list | `[]` | Metrics to keep. Can use regex. An empty list means keep all. |
+| metrics.autoDiscover.scrapeInterval | string | 60s | How frequently to scrape metrics from auto-discovered entities. Overrides metrics.scrapeInterval |
 
 ### Metrics Job: cAdvisor
 

--- a/charts/k8s-monitoring/README.md
+++ b/charts/k8s-monitoring/README.md
@@ -430,6 +430,7 @@ The Prometheus and Loki services may be hosted on the same cluster, or remotely 
 | metrics.autoDiscover.annotations.metricsPortName | string | `"k8s.grafana.com/metrics.portName"` | Annotation for setting the metrics port by name. |
 | metrics.autoDiscover.annotations.metricsPortNumber | string | `"k8s.grafana.com/metrics.portNumber"` | Annotation for setting the metrics port by number. |
 | metrics.autoDiscover.annotations.metricsScheme | string | `"k8s.grafana.com/metrics.scheme"` | Annotation for setting the metrics scheme, default: http. |
+| metrics.autoDiscover.annotations.metricsScrapeInterval | string | `"k8s.grafana.com/metrics.scrapeInterval"` | Annotation for overriding the scrape interval for this service or pod. Value should be a duration like "15s, 1m", Overrides metrics.autoDiscover.scrapeInterval |
 | metrics.autoDiscover.annotations.scrape | string | `"k8s.grafana.com/scrape"` | Annotation for enabling scraping for this service or pod. Value should be either "true" or "false" |
 | metrics.autoDiscover.enabled | bool | `true` | Enable annotation-based auto-discovery |
 | metrics.autoDiscover.extraMetricRelabelingRules | string | `""` | Rule blocks to be added to the prometheus.relabel component for auto-discovered entities. These relabeling rules are applied post-scrape against the metrics returned from the scraped target, no `__meta*` labels are present. ([docs](https://grafana.com/docs/alloy/latest/reference/components/prometheus.relabel/#rule-block)) |

--- a/charts/k8s-monitoring/README.md
+++ b/charts/k8s-monitoring/README.md
@@ -430,7 +430,7 @@ The Prometheus and Loki services may be hosted on the same cluster, or remotely 
 | metrics.autoDiscover.annotations.metricsPortName | string | `"k8s.grafana.com/metrics.portName"` | Annotation for setting the metrics port by name. |
 | metrics.autoDiscover.annotations.metricsPortNumber | string | `"k8s.grafana.com/metrics.portNumber"` | Annotation for setting the metrics port by number. |
 | metrics.autoDiscover.annotations.metricsScheme | string | `"k8s.grafana.com/metrics.scheme"` | Annotation for setting the metrics scheme, default: http. |
-| metrics.autoDiscover.annotations.metricsScrapeInterval | string | `"k8s.grafana.com/metrics.scrapeInterval"` | Annotation for overriding the scrape interval for this service or pod. Value should be a duration like "15s, 1m", Overrides metrics.autoDiscover.scrapeInterval |
+| metrics.autoDiscover.annotations.metricsScrapeInterval | string | `"k8s.grafana.com/metrics.scrapeInterval"` | Annotation for overriding the scrape interval for this service or pod. Value should be a duration like "15s, 1m". Overrides metrics.autoDiscover.scrapeInterval |
 | metrics.autoDiscover.annotations.scrape | string | `"k8s.grafana.com/scrape"` | Annotation for enabling scraping for this service or pod. Value should be either "true" or "false" |
 | metrics.autoDiscover.enabled | bool | `true` | Enable annotation-based auto-discovery |
 | metrics.autoDiscover.extraMetricRelabelingRules | string | `""` | Rule blocks to be added to the prometheus.relabel component for auto-discovered entities. These relabeling rules are applied post-scrape against the metrics returned from the scraped target, no `__meta*` labels are present. ([docs](https://grafana.com/docs/alloy/latest/reference/components/prometheus.relabel/#rule-block)) |

--- a/charts/k8s-monitoring/templates/alloy_config/_annotation_autodiscovery.alloy.txt
+++ b/charts/k8s-monitoring/templates/alloy_config/_annotation_autodiscovery.alloy.txt
@@ -156,6 +156,7 @@ discovery.relabel "annotation_autodiscovery_https" {
 
 prometheus.scrape "annotation_autodiscovery_http" {
   targets = discovery.relabel.annotation_autodiscovery_http.output
+  scrape_interval = {{ .Values.metrics.autoDiscover.scrapeInterval | default .Values.metrics.scrapeInterval | quote }}
   honor_labels = true
 {{- if .Values.alloy.alloy.clustering.enabled }}
   clustering {
@@ -167,6 +168,7 @@ prometheus.scrape "annotation_autodiscovery_http" {
 
 prometheus.scrape "annotation_autodiscovery_https" {
   targets = discovery.relabel.annotation_autodiscovery_https.output
+  scrape_interval = {{ .Values.metrics.autoDiscover.scrapeInterval | default .Values.metrics.scrapeInterval | quote }}
   honor_labels = true
   bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
   tls_config {

--- a/charts/k8s-monitoring/templates/alloy_config/_annotation_autodiscovery.alloy.txt
+++ b/charts/k8s-monitoring/templates/alloy_config/_annotation_autodiscovery.alloy.txt
@@ -61,6 +61,12 @@ discovery.relabel "annotation_autodiscovery_pods" {
     action = "replace"
     target_label = "__scheme__"
   }
+
+  rule {
+    source_labels = ["__meta_kubernetes_pod_annotation_{{ include "escape_label" .Values.metrics.autoDiscover.annotations.metricsScrapeInterval }}"]
+    action = "replace"
+    target_label = "__scrape_interval__"
+  }
 {{- if .Values.metrics.extraRelabelingRules }}
 {{ .Values.metrics.extraRelabelingRules | indent 2 }}
 {{- end }}
@@ -127,6 +133,12 @@ discovery.relabel "annotation_autodiscovery_services" {
     source_labels = ["__meta_kubernetes_service_annotation_{{ include "escape_label" .Values.metrics.autoDiscover.annotations.metricsScheme }}"]
     action = "replace"
     target_label = "__scheme__"
+  }
+
+  rule {
+    source_labels = ["__meta_kubernetes_service_annotation_{{ include "escape_label" .Values.metrics.autoDiscover.annotations.metricsScrapeInterval }}"]
+    action = "replace"
+    target_label = "__scrape_interval__"
   }
 {{- if .Values.metrics.extraRelabelingRules }}
 {{ .Values.metrics.extraRelabelingRules | indent 2 }}

--- a/charts/k8s-monitoring/values.schema.json
+++ b/charts/k8s-monitoring/values.schema.json
@@ -1076,6 +1076,9 @@
                                 "metricsScheme": {
                                     "type": "string"
                                 },
+                                "metricsScrapeInterval": {
+                                    "type": "string"
+                                },
                                 "scrape": {
                                     "type": "string"
                                 }

--- a/charts/k8s-monitoring/values.schema.json
+++ b/charts/k8s-monitoring/values.schema.json
@@ -1113,6 +1113,9 @@
                                     }
                                 }
                             }
+                        },
+                        "scrapeInterval": {
+                            "type": "string"
                         }
                     }
                 },

--- a/charts/k8s-monitoring/values.yaml
+++ b/charts/k8s-monitoring/values.yaml
@@ -438,6 +438,12 @@ metrics:
     # @section -- Metrics Job: Auto-Discovery
     enabled: true
 
+    # -- How frequently to scrape metrics from auto-discovered entities.
+    # Overrides metrics.scrapeInterval
+    # @default -- 60s
+    # @section -- Metrics Job: Auto-Discovery
+    scrapeInterval: ""
+
     # -- Rule blocks to be added to the discovery.relabel component for auto-discovered entities.
     # These relabeling rules are applied pre-scrape against the targets from service discovery.
     # Before the scrape, any remaining target labels that start with `__` (i.e. `__meta_kubernetes*`) are dropped.

--- a/charts/k8s-monitoring/values.yaml
+++ b/charts/k8s-monitoring/values.yaml
@@ -490,6 +490,9 @@ metrics:
       # -- Annotation for setting the metrics scheme, default: http.
       # @section -- Metrics Job: Auto-Discovery
       metricsScheme: "k8s.grafana.com/metrics.scheme"
+      # -- Annotation for overriding the scrape interval for this service or pod. Value should be a duration like "15s, 1m"
+      # @section -- Metrics Job: Auto-Discovery
+      metricsScrapeInterval: "k8s.grafana.com/metrics.scrapeInterval"
 
     # -- Sets the max_cache_size for cadvisor prometheus.relabel component.
     # This should be at least 2x-5x your largest scrape target or samples appended rate.

--- a/charts/k8s-monitoring/values.yaml
+++ b/charts/k8s-monitoring/values.yaml
@@ -490,7 +490,8 @@ metrics:
       # -- Annotation for setting the metrics scheme, default: http.
       # @section -- Metrics Job: Auto-Discovery
       metricsScheme: "k8s.grafana.com/metrics.scheme"
-      # -- Annotation for overriding the scrape interval for this service or pod. Value should be a duration like "15s, 1m"
+      # -- Annotation for overriding the scrape interval for this service or pod. Value should be a duration like "15s, 1m".
+      # Overrides metrics.autoDiscover.scrapeInterval
       # @section -- Metrics Job: Auto-Discovery
       metricsScrapeInterval: "k8s.grafana.com/metrics.scrapeInterval"
 

--- a/examples/alloy-autoscaling-and-storage/metrics.alloy
+++ b/examples/alloy-autoscaling-and-storage/metrics.alloy
@@ -272,6 +272,7 @@ discovery.relabel "annotation_autodiscovery_https" {
 
 prometheus.scrape "annotation_autodiscovery_http" {
   targets = discovery.relabel.annotation_autodiscovery_http.output
+  scrape_interval = "60s"
   honor_labels = true
   clustering {
     enabled = true
@@ -281,6 +282,7 @@ prometheus.scrape "annotation_autodiscovery_http" {
 
 prometheus.scrape "annotation_autodiscovery_https" {
   targets = discovery.relabel.annotation_autodiscovery_https.output
+  scrape_interval = "60s"
   honor_labels = true
   bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
   tls_config {

--- a/examples/alloy-autoscaling-and-storage/metrics.alloy
+++ b/examples/alloy-autoscaling-and-storage/metrics.alloy
@@ -189,6 +189,12 @@ discovery.relabel "annotation_autodiscovery_pods" {
     action = "replace"
     target_label = "__scheme__"
   }
+
+  rule {
+    source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_scrapeInterval"]
+    action = "replace"
+    target_label = "__scrape_interval__"
+  }
 }
 
 discovery.relabel "annotation_autodiscovery_services" {
@@ -249,6 +255,12 @@ discovery.relabel "annotation_autodiscovery_services" {
     source_labels = ["__meta_kubernetes_service_annotation_k8s_grafana_com_metrics_scheme"]
     action = "replace"
     target_label = "__scheme__"
+  }
+
+  rule {
+    source_labels = ["__meta_kubernetes_service_annotation_k8s_grafana_com_metrics_scrapeInterval"]
+    action = "replace"
+    target_label = "__scrape_interval__"
   }
 }
 

--- a/examples/alloy-autoscaling-and-storage/output.yaml
+++ b/examples/alloy-autoscaling-and-storage/output.yaml
@@ -317,6 +317,12 @@ data:
         action = "replace"
         target_label = "__scheme__"
       }
+    
+      rule {
+        source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_scrapeInterval"]
+        action = "replace"
+        target_label = "__scrape_interval__"
+      }
     }
     
     discovery.relabel "annotation_autodiscovery_services" {
@@ -377,6 +383,12 @@ data:
         source_labels = ["__meta_kubernetes_service_annotation_k8s_grafana_com_metrics_scheme"]
         action = "replace"
         target_label = "__scheme__"
+      }
+    
+      rule {
+        source_labels = ["__meta_kubernetes_service_annotation_k8s_grafana_com_metrics_scrapeInterval"]
+        action = "replace"
+        target_label = "__scrape_interval__"
       }
     }
     
@@ -52822,6 +52834,12 @@ data:
         action = "replace"
         target_label = "__scheme__"
       }
+    
+      rule {
+        source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_scrapeInterval"]
+        action = "replace"
+        target_label = "__scrape_interval__"
+      }
     }
     
     discovery.relabel "annotation_autodiscovery_services" {
@@ -52882,6 +52900,12 @@ data:
         source_labels = ["__meta_kubernetes_service_annotation_k8s_grafana_com_metrics_scheme"]
         action = "replace"
         target_label = "__scheme__"
+      }
+    
+      rule {
+        source_labels = ["__meta_kubernetes_service_annotation_k8s_grafana_com_metrics_scrapeInterval"]
+        action = "replace"
+        target_label = "__scrape_interval__"
       }
     }
     

--- a/examples/alloy-autoscaling-and-storage/output.yaml
+++ b/examples/alloy-autoscaling-and-storage/output.yaml
@@ -400,6 +400,7 @@ data:
     
     prometheus.scrape "annotation_autodiscovery_http" {
       targets = discovery.relabel.annotation_autodiscovery_http.output
+      scrape_interval = "60s"
       honor_labels = true
       clustering {
         enabled = true
@@ -409,6 +410,7 @@ data:
     
     prometheus.scrape "annotation_autodiscovery_https" {
       targets = discovery.relabel.annotation_autodiscovery_https.output
+      scrape_interval = "60s"
       honor_labels = true
       bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
       tls_config {
@@ -52903,6 +52905,7 @@ data:
     
     prometheus.scrape "annotation_autodiscovery_http" {
       targets = discovery.relabel.annotation_autodiscovery_http.output
+      scrape_interval = "60s"
       honor_labels = true
       clustering {
         enabled = true
@@ -52912,6 +52915,7 @@ data:
     
     prometheus.scrape "annotation_autodiscovery_https" {
       targets = discovery.relabel.annotation_autodiscovery_https.output
+      scrape_interval = "60s"
       honor_labels = true
       bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
       tls_config {

--- a/examples/application-observability/metrics.alloy
+++ b/examples/application-observability/metrics.alloy
@@ -304,6 +304,7 @@ discovery.relabel "annotation_autodiscovery_https" {
 
 prometheus.scrape "annotation_autodiscovery_http" {
   targets = discovery.relabel.annotation_autodiscovery_http.output
+  scrape_interval = "60s"
   honor_labels = true
   clustering {
     enabled = true
@@ -313,6 +314,7 @@ prometheus.scrape "annotation_autodiscovery_http" {
 
 prometheus.scrape "annotation_autodiscovery_https" {
   targets = discovery.relabel.annotation_autodiscovery_https.output
+  scrape_interval = "60s"
   honor_labels = true
   bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
   tls_config {

--- a/examples/application-observability/metrics.alloy
+++ b/examples/application-observability/metrics.alloy
@@ -221,6 +221,12 @@ discovery.relabel "annotation_autodiscovery_pods" {
     action = "replace"
     target_label = "__scheme__"
   }
+
+  rule {
+    source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_scrapeInterval"]
+    action = "replace"
+    target_label = "__scrape_interval__"
+  }
 }
 
 discovery.relabel "annotation_autodiscovery_services" {
@@ -281,6 +287,12 @@ discovery.relabel "annotation_autodiscovery_services" {
     source_labels = ["__meta_kubernetes_service_annotation_k8s_grafana_com_metrics_scheme"]
     action = "replace"
     target_label = "__scheme__"
+  }
+
+  rule {
+    source_labels = ["__meta_kubernetes_service_annotation_k8s_grafana_com_metrics_scrapeInterval"]
+    action = "replace"
+    target_label = "__scrape_interval__"
   }
 }
 

--- a/examples/application-observability/output.yaml
+++ b/examples/application-observability/output.yaml
@@ -391,6 +391,12 @@ data:
         action = "replace"
         target_label = "__scheme__"
       }
+    
+      rule {
+        source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_scrapeInterval"]
+        action = "replace"
+        target_label = "__scrape_interval__"
+      }
     }
     
     discovery.relabel "annotation_autodiscovery_services" {
@@ -451,6 +457,12 @@ data:
         source_labels = ["__meta_kubernetes_service_annotation_k8s_grafana_com_metrics_scheme"]
         action = "replace"
         target_label = "__scheme__"
+      }
+    
+      rule {
+        source_labels = ["__meta_kubernetes_service_annotation_k8s_grafana_com_metrics_scrapeInterval"]
+        action = "replace"
+        target_label = "__scrape_interval__"
       }
     }
     
@@ -53924,6 +53936,12 @@ data:
         action = "replace"
         target_label = "__scheme__"
       }
+    
+      rule {
+        source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_scrapeInterval"]
+        action = "replace"
+        target_label = "__scrape_interval__"
+      }
     }
     
     discovery.relabel "annotation_autodiscovery_services" {
@@ -53984,6 +54002,12 @@ data:
         source_labels = ["__meta_kubernetes_service_annotation_k8s_grafana_com_metrics_scheme"]
         action = "replace"
         target_label = "__scheme__"
+      }
+    
+      rule {
+        source_labels = ["__meta_kubernetes_service_annotation_k8s_grafana_com_metrics_scrapeInterval"]
+        action = "replace"
+        target_label = "__scrape_interval__"
       }
     }
     

--- a/examples/application-observability/output.yaml
+++ b/examples/application-observability/output.yaml
@@ -474,6 +474,7 @@ data:
     
     prometheus.scrape "annotation_autodiscovery_http" {
       targets = discovery.relabel.annotation_autodiscovery_http.output
+      scrape_interval = "60s"
       honor_labels = true
       clustering {
         enabled = true
@@ -483,6 +484,7 @@ data:
     
     prometheus.scrape "annotation_autodiscovery_https" {
       targets = discovery.relabel.annotation_autodiscovery_https.output
+      scrape_interval = "60s"
       honor_labels = true
       bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
       tls_config {
@@ -54005,6 +54007,7 @@ data:
     
     prometheus.scrape "annotation_autodiscovery_http" {
       targets = discovery.relabel.annotation_autodiscovery_http.output
+      scrape_interval = "60s"
       honor_labels = true
       clustering {
         enabled = true
@@ -54014,6 +54017,7 @@ data:
     
     prometheus.scrape "annotation_autodiscovery_https" {
       targets = discovery.relabel.annotation_autodiscovery_https.output
+      scrape_interval = "60s"
       honor_labels = true
       bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
       tls_config {

--- a/examples/control-plane-metrics/metrics.alloy
+++ b/examples/control-plane-metrics/metrics.alloy
@@ -272,6 +272,7 @@ discovery.relabel "annotation_autodiscovery_https" {
 
 prometheus.scrape "annotation_autodiscovery_http" {
   targets = discovery.relabel.annotation_autodiscovery_http.output
+  scrape_interval = "60s"
   honor_labels = true
   clustering {
     enabled = true
@@ -281,6 +282,7 @@ prometheus.scrape "annotation_autodiscovery_http" {
 
 prometheus.scrape "annotation_autodiscovery_https" {
   targets = discovery.relabel.annotation_autodiscovery_https.output
+  scrape_interval = "60s"
   honor_labels = true
   bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
   tls_config {

--- a/examples/control-plane-metrics/metrics.alloy
+++ b/examples/control-plane-metrics/metrics.alloy
@@ -189,6 +189,12 @@ discovery.relabel "annotation_autodiscovery_pods" {
     action = "replace"
     target_label = "__scheme__"
   }
+
+  rule {
+    source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_scrapeInterval"]
+    action = "replace"
+    target_label = "__scrape_interval__"
+  }
 }
 
 discovery.relabel "annotation_autodiscovery_services" {
@@ -249,6 +255,12 @@ discovery.relabel "annotation_autodiscovery_services" {
     source_labels = ["__meta_kubernetes_service_annotation_k8s_grafana_com_metrics_scheme"]
     action = "replace"
     target_label = "__scheme__"
+  }
+
+  rule {
+    source_labels = ["__meta_kubernetes_service_annotation_k8s_grafana_com_metrics_scrapeInterval"]
+    action = "replace"
+    target_label = "__scrape_interval__"
   }
 }
 

--- a/examples/control-plane-metrics/output.yaml
+++ b/examples/control-plane-metrics/output.yaml
@@ -318,6 +318,12 @@ data:
         action = "replace"
         target_label = "__scheme__"
       }
+    
+      rule {
+        source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_scrapeInterval"]
+        action = "replace"
+        target_label = "__scrape_interval__"
+      }
     }
     
     discovery.relabel "annotation_autodiscovery_services" {
@@ -378,6 +384,12 @@ data:
         source_labels = ["__meta_kubernetes_service_annotation_k8s_grafana_com_metrics_scheme"]
         action = "replace"
         target_label = "__scheme__"
+      }
+    
+      rule {
+        source_labels = ["__meta_kubernetes_service_annotation_k8s_grafana_com_metrics_scrapeInterval"]
+        action = "replace"
+        target_label = "__scrape_interval__"
       }
     }
     
@@ -52918,6 +52930,12 @@ data:
         action = "replace"
         target_label = "__scheme__"
       }
+    
+      rule {
+        source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_scrapeInterval"]
+        action = "replace"
+        target_label = "__scrape_interval__"
+      }
     }
     
     discovery.relabel "annotation_autodiscovery_services" {
@@ -52978,6 +52996,12 @@ data:
         source_labels = ["__meta_kubernetes_service_annotation_k8s_grafana_com_metrics_scheme"]
         action = "replace"
         target_label = "__scheme__"
+      }
+    
+      rule {
+        source_labels = ["__meta_kubernetes_service_annotation_k8s_grafana_com_metrics_scrapeInterval"]
+        action = "replace"
+        target_label = "__scrape_interval__"
       }
     }
     

--- a/examples/control-plane-metrics/output.yaml
+++ b/examples/control-plane-metrics/output.yaml
@@ -401,6 +401,7 @@ data:
     
     prometheus.scrape "annotation_autodiscovery_http" {
       targets = discovery.relabel.annotation_autodiscovery_http.output
+      scrape_interval = "60s"
       honor_labels = true
       clustering {
         enabled = true
@@ -410,6 +411,7 @@ data:
     
     prometheus.scrape "annotation_autodiscovery_https" {
       targets = discovery.relabel.annotation_autodiscovery_https.output
+      scrape_interval = "60s"
       honor_labels = true
       bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
       tls_config {
@@ -52999,6 +53001,7 @@ data:
     
     prometheus.scrape "annotation_autodiscovery_http" {
       targets = discovery.relabel.annotation_autodiscovery_http.output
+      scrape_interval = "60s"
       honor_labels = true
       clustering {
         enabled = true
@@ -53008,6 +53011,7 @@ data:
     
     prometheus.scrape "annotation_autodiscovery_https" {
       targets = discovery.relabel.annotation_autodiscovery_https.output
+      scrape_interval = "60s"
       honor_labels = true
       bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
       tls_config {

--- a/examples/custom-config/metrics.alloy
+++ b/examples/custom-config/metrics.alloy
@@ -272,6 +272,7 @@ discovery.relabel "annotation_autodiscovery_https" {
 
 prometheus.scrape "annotation_autodiscovery_http" {
   targets = discovery.relabel.annotation_autodiscovery_http.output
+  scrape_interval = "60s"
   honor_labels = true
   clustering {
     enabled = true
@@ -281,6 +282,7 @@ prometheus.scrape "annotation_autodiscovery_http" {
 
 prometheus.scrape "annotation_autodiscovery_https" {
   targets = discovery.relabel.annotation_autodiscovery_https.output
+  scrape_interval = "60s"
   honor_labels = true
   bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
   tls_config {

--- a/examples/custom-config/metrics.alloy
+++ b/examples/custom-config/metrics.alloy
@@ -189,6 +189,12 @@ discovery.relabel "annotation_autodiscovery_pods" {
     action = "replace"
     target_label = "__scheme__"
   }
+
+  rule {
+    source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_scrapeInterval"]
+    action = "replace"
+    target_label = "__scrape_interval__"
+  }
 }
 
 discovery.relabel "annotation_autodiscovery_services" {
@@ -249,6 +255,12 @@ discovery.relabel "annotation_autodiscovery_services" {
     source_labels = ["__meta_kubernetes_service_annotation_k8s_grafana_com_metrics_scheme"]
     action = "replace"
     target_label = "__scheme__"
+  }
+
+  rule {
+    source_labels = ["__meta_kubernetes_service_annotation_k8s_grafana_com_metrics_scrapeInterval"]
+    action = "replace"
+    target_label = "__scrape_interval__"
   }
 }
 

--- a/examples/custom-config/output.yaml
+++ b/examples/custom-config/output.yaml
@@ -317,6 +317,12 @@ data:
         action = "replace"
         target_label = "__scheme__"
       }
+    
+      rule {
+        source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_scrapeInterval"]
+        action = "replace"
+        target_label = "__scrape_interval__"
+      }
     }
     
     discovery.relabel "annotation_autodiscovery_services" {
@@ -377,6 +383,12 @@ data:
         source_labels = ["__meta_kubernetes_service_annotation_k8s_grafana_com_metrics_scheme"]
         action = "replace"
         target_label = "__scheme__"
+      }
+    
+      rule {
+        source_labels = ["__meta_kubernetes_service_annotation_k8s_grafana_com_metrics_scrapeInterval"]
+        action = "replace"
+        target_label = "__scrape_interval__"
       }
     }
     
@@ -52851,6 +52863,12 @@ data:
         action = "replace"
         target_label = "__scheme__"
       }
+    
+      rule {
+        source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_scrapeInterval"]
+        action = "replace"
+        target_label = "__scrape_interval__"
+      }
     }
     
     discovery.relabel "annotation_autodiscovery_services" {
@@ -52911,6 +52929,12 @@ data:
         source_labels = ["__meta_kubernetes_service_annotation_k8s_grafana_com_metrics_scheme"]
         action = "replace"
         target_label = "__scheme__"
+      }
+    
+      rule {
+        source_labels = ["__meta_kubernetes_service_annotation_k8s_grafana_com_metrics_scrapeInterval"]
+        action = "replace"
+        target_label = "__scrape_interval__"
       }
     }
     

--- a/examples/custom-config/output.yaml
+++ b/examples/custom-config/output.yaml
@@ -400,6 +400,7 @@ data:
     
     prometheus.scrape "annotation_autodiscovery_http" {
       targets = discovery.relabel.annotation_autodiscovery_http.output
+      scrape_interval = "60s"
       honor_labels = true
       clustering {
         enabled = true
@@ -409,6 +410,7 @@ data:
     
     prometheus.scrape "annotation_autodiscovery_https" {
       targets = discovery.relabel.annotation_autodiscovery_https.output
+      scrape_interval = "60s"
       honor_labels = true
       bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
       tls_config {
@@ -52932,6 +52934,7 @@ data:
     
     prometheus.scrape "annotation_autodiscovery_http" {
       targets = discovery.relabel.annotation_autodiscovery_http.output
+      scrape_interval = "60s"
       honor_labels = true
       clustering {
         enabled = true
@@ -52941,6 +52944,7 @@ data:
     
     prometheus.scrape "annotation_autodiscovery_https" {
       targets = discovery.relabel.annotation_autodiscovery_https.output
+      scrape_interval = "60s"
       honor_labels = true
       bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
       tls_config {

--- a/examples/custom-metrics-tuning/metrics.alloy
+++ b/examples/custom-metrics-tuning/metrics.alloy
@@ -254,6 +254,7 @@ discovery.relabel "annotation_autodiscovery_https" {
 
 prometheus.scrape "annotation_autodiscovery_http" {
   targets = discovery.relabel.annotation_autodiscovery_http.output
+  scrape_interval = "60s"
   honor_labels = true
   clustering {
     enabled = true
@@ -263,6 +264,7 @@ prometheus.scrape "annotation_autodiscovery_http" {
 
 prometheus.scrape "annotation_autodiscovery_https" {
   targets = discovery.relabel.annotation_autodiscovery_https.output
+  scrape_interval = "60s"
   honor_labels = true
   bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
   tls_config {

--- a/examples/custom-metrics-tuning/metrics.alloy
+++ b/examples/custom-metrics-tuning/metrics.alloy
@@ -171,6 +171,12 @@ discovery.relabel "annotation_autodiscovery_pods" {
     action = "replace"
     target_label = "__scheme__"
   }
+
+  rule {
+    source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_scrapeInterval"]
+    action = "replace"
+    target_label = "__scrape_interval__"
+  }
 }
 
 discovery.relabel "annotation_autodiscovery_services" {
@@ -231,6 +237,12 @@ discovery.relabel "annotation_autodiscovery_services" {
     source_labels = ["__meta_kubernetes_service_annotation_k8s_grafana_com_metrics_scheme"]
     action = "replace"
     target_label = "__scheme__"
+  }
+
+  rule {
+    source_labels = ["__meta_kubernetes_service_annotation_k8s_grafana_com_metrics_scrapeInterval"]
+    action = "replace"
+    target_label = "__scrape_interval__"
   }
 }
 

--- a/examples/custom-metrics-tuning/output.yaml
+++ b/examples/custom-metrics-tuning/output.yaml
@@ -337,6 +337,7 @@ data:
     
     prometheus.scrape "annotation_autodiscovery_http" {
       targets = discovery.relabel.annotation_autodiscovery_http.output
+      scrape_interval = "60s"
       honor_labels = true
       clustering {
         enabled = true
@@ -346,6 +347,7 @@ data:
     
     prometheus.scrape "annotation_autodiscovery_https" {
       targets = discovery.relabel.annotation_autodiscovery_https.output
+      scrape_interval = "60s"
       honor_labels = true
       bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
       tls_config {
@@ -51988,6 +51990,7 @@ data:
     
     prometheus.scrape "annotation_autodiscovery_http" {
       targets = discovery.relabel.annotation_autodiscovery_http.output
+      scrape_interval = "60s"
       honor_labels = true
       clustering {
         enabled = true
@@ -51997,6 +52000,7 @@ data:
     
     prometheus.scrape "annotation_autodiscovery_https" {
       targets = discovery.relabel.annotation_autodiscovery_https.output
+      scrape_interval = "60s"
       honor_labels = true
       bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
       tls_config {

--- a/examples/custom-metrics-tuning/output.yaml
+++ b/examples/custom-metrics-tuning/output.yaml
@@ -254,6 +254,12 @@ data:
         action = "replace"
         target_label = "__scheme__"
       }
+    
+      rule {
+        source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_scrapeInterval"]
+        action = "replace"
+        target_label = "__scrape_interval__"
+      }
     }
     
     discovery.relabel "annotation_autodiscovery_services" {
@@ -314,6 +320,12 @@ data:
         source_labels = ["__meta_kubernetes_service_annotation_k8s_grafana_com_metrics_scheme"]
         action = "replace"
         target_label = "__scheme__"
+      }
+    
+      rule {
+        source_labels = ["__meta_kubernetes_service_annotation_k8s_grafana_com_metrics_scrapeInterval"]
+        action = "replace"
+        target_label = "__scrape_interval__"
       }
     }
     
@@ -51907,6 +51919,12 @@ data:
         action = "replace"
         target_label = "__scheme__"
       }
+    
+      rule {
+        source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_scrapeInterval"]
+        action = "replace"
+        target_label = "__scrape_interval__"
+      }
     }
     
     discovery.relabel "annotation_autodiscovery_services" {
@@ -51967,6 +51985,12 @@ data:
         source_labels = ["__meta_kubernetes_service_annotation_k8s_grafana_com_metrics_scheme"]
         action = "replace"
         target_label = "__scheme__"
+      }
+    
+      rule {
+        source_labels = ["__meta_kubernetes_service_annotation_k8s_grafana_com_metrics_scrapeInterval"]
+        action = "replace"
+        target_label = "__scrape_interval__"
       }
     }
     

--- a/examples/custom-pricing/metrics.alloy
+++ b/examples/custom-pricing/metrics.alloy
@@ -272,6 +272,7 @@ discovery.relabel "annotation_autodiscovery_https" {
 
 prometheus.scrape "annotation_autodiscovery_http" {
   targets = discovery.relabel.annotation_autodiscovery_http.output
+  scrape_interval = "60s"
   honor_labels = true
   clustering {
     enabled = true
@@ -281,6 +282,7 @@ prometheus.scrape "annotation_autodiscovery_http" {
 
 prometheus.scrape "annotation_autodiscovery_https" {
   targets = discovery.relabel.annotation_autodiscovery_https.output
+  scrape_interval = "60s"
   honor_labels = true
   bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
   tls_config {

--- a/examples/custom-pricing/metrics.alloy
+++ b/examples/custom-pricing/metrics.alloy
@@ -189,6 +189,12 @@ discovery.relabel "annotation_autodiscovery_pods" {
     action = "replace"
     target_label = "__scheme__"
   }
+
+  rule {
+    source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_scrapeInterval"]
+    action = "replace"
+    target_label = "__scrape_interval__"
+  }
 }
 
 discovery.relabel "annotation_autodiscovery_services" {
@@ -249,6 +255,12 @@ discovery.relabel "annotation_autodiscovery_services" {
     source_labels = ["__meta_kubernetes_service_annotation_k8s_grafana_com_metrics_scheme"]
     action = "replace"
     target_label = "__scheme__"
+  }
+
+  rule {
+    source_labels = ["__meta_kubernetes_service_annotation_k8s_grafana_com_metrics_scrapeInterval"]
+    action = "replace"
+    target_label = "__scrape_interval__"
   }
 }
 

--- a/examples/custom-pricing/output.yaml
+++ b/examples/custom-pricing/output.yaml
@@ -422,6 +422,7 @@ data:
     
     prometheus.scrape "annotation_autodiscovery_http" {
       targets = discovery.relabel.annotation_autodiscovery_http.output
+      scrape_interval = "60s"
       honor_labels = true
       clustering {
         enabled = true
@@ -431,6 +432,7 @@ data:
     
     prometheus.scrape "annotation_autodiscovery_https" {
       targets = discovery.relabel.annotation_autodiscovery_https.output
+      scrape_interval = "60s"
       honor_labels = true
       bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
       tls_config {
@@ -52875,6 +52877,7 @@ data:
     
     prometheus.scrape "annotation_autodiscovery_http" {
       targets = discovery.relabel.annotation_autodiscovery_http.output
+      scrape_interval = "60s"
       honor_labels = true
       clustering {
         enabled = true
@@ -52884,6 +52887,7 @@ data:
     
     prometheus.scrape "annotation_autodiscovery_https" {
       targets = discovery.relabel.annotation_autodiscovery_https.output
+      scrape_interval = "60s"
       honor_labels = true
       bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
       tls_config {

--- a/examples/custom-pricing/output.yaml
+++ b/examples/custom-pricing/output.yaml
@@ -339,6 +339,12 @@ data:
         action = "replace"
         target_label = "__scheme__"
       }
+    
+      rule {
+        source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_scrapeInterval"]
+        action = "replace"
+        target_label = "__scrape_interval__"
+      }
     }
     
     discovery.relabel "annotation_autodiscovery_services" {
@@ -399,6 +405,12 @@ data:
         source_labels = ["__meta_kubernetes_service_annotation_k8s_grafana_com_metrics_scheme"]
         action = "replace"
         target_label = "__scheme__"
+      }
+    
+      rule {
+        source_labels = ["__meta_kubernetes_service_annotation_k8s_grafana_com_metrics_scrapeInterval"]
+        action = "replace"
+        target_label = "__scrape_interval__"
       }
     }
     
@@ -52794,6 +52806,12 @@ data:
         action = "replace"
         target_label = "__scheme__"
       }
+    
+      rule {
+        source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_scrapeInterval"]
+        action = "replace"
+        target_label = "__scrape_interval__"
+      }
     }
     
     discovery.relabel "annotation_autodiscovery_services" {
@@ -52854,6 +52872,12 @@ data:
         source_labels = ["__meta_kubernetes_service_annotation_k8s_grafana_com_metrics_scheme"]
         action = "replace"
         target_label = "__scheme__"
+      }
+    
+      rule {
+        source_labels = ["__meta_kubernetes_service_annotation_k8s_grafana_com_metrics_scrapeInterval"]
+        action = "replace"
+        target_label = "__scrape_interval__"
       }
     }
     

--- a/examples/custom-prometheus-operator-rules/metrics.alloy
+++ b/examples/custom-prometheus-operator-rules/metrics.alloy
@@ -171,6 +171,12 @@ discovery.relabel "annotation_autodiscovery_pods" {
     action = "replace"
     target_label = "__scheme__"
   }
+
+  rule {
+    source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_scrapeInterval"]
+    action = "replace"
+    target_label = "__scrape_interval__"
+  }
   rule {
     source_labels = ["__meta_kubernetes_namespace"]
     regex = "private"
@@ -236,6 +242,12 @@ discovery.relabel "annotation_autodiscovery_services" {
     source_labels = ["__meta_kubernetes_service_annotation_k8s_grafana_com_metrics_scheme"]
     action = "replace"
     target_label = "__scheme__"
+  }
+
+  rule {
+    source_labels = ["__meta_kubernetes_service_annotation_k8s_grafana_com_metrics_scrapeInterval"]
+    action = "replace"
+    target_label = "__scrape_interval__"
   }
   rule {
     source_labels = ["__meta_kubernetes_namespace"]

--- a/examples/custom-prometheus-operator-rules/metrics.alloy
+++ b/examples/custom-prometheus-operator-rules/metrics.alloy
@@ -264,6 +264,7 @@ discovery.relabel "annotation_autodiscovery_https" {
 
 prometheus.scrape "annotation_autodiscovery_http" {
   targets = discovery.relabel.annotation_autodiscovery_http.output
+  scrape_interval = "60s"
   honor_labels = true
   clustering {
     enabled = true
@@ -273,6 +274,7 @@ prometheus.scrape "annotation_autodiscovery_http" {
 
 prometheus.scrape "annotation_autodiscovery_https" {
   targets = discovery.relabel.annotation_autodiscovery_https.output
+  scrape_interval = "60s"
   honor_labels = true
   bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
   tls_config {

--- a/examples/custom-prometheus-operator-rules/output.yaml
+++ b/examples/custom-prometheus-operator-rules/output.yaml
@@ -347,6 +347,7 @@ data:
     
     prometheus.scrape "annotation_autodiscovery_http" {
       targets = discovery.relabel.annotation_autodiscovery_http.output
+      scrape_interval = "60s"
       honor_labels = true
       clustering {
         enabled = true
@@ -356,6 +357,7 @@ data:
     
     prometheus.scrape "annotation_autodiscovery_https" {
       targets = discovery.relabel.annotation_autodiscovery_https.output
+      scrape_interval = "60s"
       honor_labels = true
       bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
       tls_config {
@@ -52080,6 +52082,7 @@ data:
     
     prometheus.scrape "annotation_autodiscovery_http" {
       targets = discovery.relabel.annotation_autodiscovery_http.output
+      scrape_interval = "60s"
       honor_labels = true
       clustering {
         enabled = true
@@ -52089,6 +52092,7 @@ data:
     
     prometheus.scrape "annotation_autodiscovery_https" {
       targets = discovery.relabel.annotation_autodiscovery_https.output
+      scrape_interval = "60s"
       honor_labels = true
       bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
       tls_config {

--- a/examples/custom-prometheus-operator-rules/output.yaml
+++ b/examples/custom-prometheus-operator-rules/output.yaml
@@ -254,6 +254,12 @@ data:
         action = "replace"
         target_label = "__scheme__"
       }
+    
+      rule {
+        source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_scrapeInterval"]
+        action = "replace"
+        target_label = "__scrape_interval__"
+      }
       rule {
         source_labels = ["__meta_kubernetes_namespace"]
         regex = "private"
@@ -319,6 +325,12 @@ data:
         source_labels = ["__meta_kubernetes_service_annotation_k8s_grafana_com_metrics_scheme"]
         action = "replace"
         target_label = "__scheme__"
+      }
+    
+      rule {
+        source_labels = ["__meta_kubernetes_service_annotation_k8s_grafana_com_metrics_scrapeInterval"]
+        action = "replace"
+        target_label = "__scrape_interval__"
       }
       rule {
         source_labels = ["__meta_kubernetes_namespace"]
@@ -51989,6 +52001,12 @@ data:
         action = "replace"
         target_label = "__scheme__"
       }
+    
+      rule {
+        source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_scrapeInterval"]
+        action = "replace"
+        target_label = "__scrape_interval__"
+      }
       rule {
         source_labels = ["__meta_kubernetes_namespace"]
         regex = "private"
@@ -52054,6 +52072,12 @@ data:
         source_labels = ["__meta_kubernetes_service_annotation_k8s_grafana_com_metrics_scheme"]
         action = "replace"
         target_label = "__scheme__"
+      }
+    
+      rule {
+        source_labels = ["__meta_kubernetes_service_annotation_k8s_grafana_com_metrics_scrapeInterval"]
+        action = "replace"
+        target_label = "__scrape_interval__"
       }
       rule {
         source_labels = ["__meta_kubernetes_namespace"]

--- a/examples/default-values/metrics.alloy
+++ b/examples/default-values/metrics.alloy
@@ -272,6 +272,7 @@ discovery.relabel "annotation_autodiscovery_https" {
 
 prometheus.scrape "annotation_autodiscovery_http" {
   targets = discovery.relabel.annotation_autodiscovery_http.output
+  scrape_interval = "60s"
   honor_labels = true
   clustering {
     enabled = true
@@ -281,6 +282,7 @@ prometheus.scrape "annotation_autodiscovery_http" {
 
 prometheus.scrape "annotation_autodiscovery_https" {
   targets = discovery.relabel.annotation_autodiscovery_https.output
+  scrape_interval = "60s"
   honor_labels = true
   bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
   tls_config {

--- a/examples/default-values/metrics.alloy
+++ b/examples/default-values/metrics.alloy
@@ -189,6 +189,12 @@ discovery.relabel "annotation_autodiscovery_pods" {
     action = "replace"
     target_label = "__scheme__"
   }
+
+  rule {
+    source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_scrapeInterval"]
+    action = "replace"
+    target_label = "__scrape_interval__"
+  }
 }
 
 discovery.relabel "annotation_autodiscovery_services" {
@@ -249,6 +255,12 @@ discovery.relabel "annotation_autodiscovery_services" {
     source_labels = ["__meta_kubernetes_service_annotation_k8s_grafana_com_metrics_scheme"]
     action = "replace"
     target_label = "__scheme__"
+  }
+
+  rule {
+    source_labels = ["__meta_kubernetes_service_annotation_k8s_grafana_com_metrics_scrapeInterval"]
+    action = "replace"
+    target_label = "__scrape_interval__"
   }
 }
 

--- a/examples/default-values/output.yaml
+++ b/examples/default-values/output.yaml
@@ -317,6 +317,12 @@ data:
         action = "replace"
         target_label = "__scheme__"
       }
+    
+      rule {
+        source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_scrapeInterval"]
+        action = "replace"
+        target_label = "__scrape_interval__"
+      }
     }
     
     discovery.relabel "annotation_autodiscovery_services" {
@@ -377,6 +383,12 @@ data:
         source_labels = ["__meta_kubernetes_service_annotation_k8s_grafana_com_metrics_scheme"]
         action = "replace"
         target_label = "__scheme__"
+      }
+    
+      rule {
+        source_labels = ["__meta_kubernetes_service_annotation_k8s_grafana_com_metrics_scrapeInterval"]
+        action = "replace"
+        target_label = "__scrape_interval__"
       }
     }
     
@@ -52761,6 +52773,12 @@ data:
         action = "replace"
         target_label = "__scheme__"
       }
+    
+      rule {
+        source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_scrapeInterval"]
+        action = "replace"
+        target_label = "__scrape_interval__"
+      }
     }
     
     discovery.relabel "annotation_autodiscovery_services" {
@@ -52821,6 +52839,12 @@ data:
         source_labels = ["__meta_kubernetes_service_annotation_k8s_grafana_com_metrics_scheme"]
         action = "replace"
         target_label = "__scheme__"
+      }
+    
+      rule {
+        source_labels = ["__meta_kubernetes_service_annotation_k8s_grafana_com_metrics_scrapeInterval"]
+        action = "replace"
+        target_label = "__scrape_interval__"
       }
     }
     

--- a/examples/default-values/output.yaml
+++ b/examples/default-values/output.yaml
@@ -400,6 +400,7 @@ data:
     
     prometheus.scrape "annotation_autodiscovery_http" {
       targets = discovery.relabel.annotation_autodiscovery_http.output
+      scrape_interval = "60s"
       honor_labels = true
       clustering {
         enabled = true
@@ -409,6 +410,7 @@ data:
     
     prometheus.scrape "annotation_autodiscovery_https" {
       targets = discovery.relabel.annotation_autodiscovery_https.output
+      scrape_interval = "60s"
       honor_labels = true
       bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
       tls_config {
@@ -52842,6 +52844,7 @@ data:
     
     prometheus.scrape "annotation_autodiscovery_http" {
       targets = discovery.relabel.annotation_autodiscovery_http.output
+      scrape_interval = "60s"
       honor_labels = true
       clustering {
         enabled = true
@@ -52851,6 +52854,7 @@ data:
     
     prometheus.scrape "annotation_autodiscovery_https" {
       targets = discovery.relabel.annotation_autodiscovery_https.output
+      scrape_interval = "60s"
       honor_labels = true
       bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
       tls_config {

--- a/examples/eks-fargate/metrics.alloy
+++ b/examples/eks-fargate/metrics.alloy
@@ -272,6 +272,7 @@ discovery.relabel "annotation_autodiscovery_https" {
 
 prometheus.scrape "annotation_autodiscovery_http" {
   targets = discovery.relabel.annotation_autodiscovery_http.output
+  scrape_interval = "60s"
   honor_labels = true
   clustering {
     enabled = true
@@ -281,6 +282,7 @@ prometheus.scrape "annotation_autodiscovery_http" {
 
 prometheus.scrape "annotation_autodiscovery_https" {
   targets = discovery.relabel.annotation_autodiscovery_https.output
+  scrape_interval = "60s"
   honor_labels = true
   bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
   tls_config {

--- a/examples/eks-fargate/metrics.alloy
+++ b/examples/eks-fargate/metrics.alloy
@@ -189,6 +189,12 @@ discovery.relabel "annotation_autodiscovery_pods" {
     action = "replace"
     target_label = "__scheme__"
   }
+
+  rule {
+    source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_scrapeInterval"]
+    action = "replace"
+    target_label = "__scrape_interval__"
+  }
 }
 
 discovery.relabel "annotation_autodiscovery_services" {
@@ -249,6 +255,12 @@ discovery.relabel "annotation_autodiscovery_services" {
     source_labels = ["__meta_kubernetes_service_annotation_k8s_grafana_com_metrics_scheme"]
     action = "replace"
     target_label = "__scheme__"
+  }
+
+  rule {
+    source_labels = ["__meta_kubernetes_service_annotation_k8s_grafana_com_metrics_scrapeInterval"]
+    action = "replace"
+    target_label = "__scrape_interval__"
   }
 }
 

--- a/examples/eks-fargate/output.yaml
+++ b/examples/eks-fargate/output.yaml
@@ -385,6 +385,7 @@ data:
     
     prometheus.scrape "annotation_autodiscovery_http" {
       targets = discovery.relabel.annotation_autodiscovery_http.output
+      scrape_interval = "60s"
       honor_labels = true
       clustering {
         enabled = true
@@ -394,6 +395,7 @@ data:
     
     prometheus.scrape "annotation_autodiscovery_https" {
       targets = discovery.relabel.annotation_autodiscovery_https.output
+      scrape_interval = "60s"
       honor_labels = true
       bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
       tls_config {
@@ -52648,6 +52650,7 @@ data:
     
     prometheus.scrape "annotation_autodiscovery_http" {
       targets = discovery.relabel.annotation_autodiscovery_http.output
+      scrape_interval = "60s"
       honor_labels = true
       clustering {
         enabled = true
@@ -52657,6 +52660,7 @@ data:
     
     prometheus.scrape "annotation_autodiscovery_https" {
       targets = discovery.relabel.annotation_autodiscovery_https.output
+      scrape_interval = "60s"
       honor_labels = true
       bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
       tls_config {

--- a/examples/eks-fargate/output.yaml
+++ b/examples/eks-fargate/output.yaml
@@ -302,6 +302,12 @@ data:
         action = "replace"
         target_label = "__scheme__"
       }
+    
+      rule {
+        source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_scrapeInterval"]
+        action = "replace"
+        target_label = "__scrape_interval__"
+      }
     }
     
     discovery.relabel "annotation_autodiscovery_services" {
@@ -362,6 +368,12 @@ data:
         source_labels = ["__meta_kubernetes_service_annotation_k8s_grafana_com_metrics_scheme"]
         action = "replace"
         target_label = "__scheme__"
+      }
+    
+      rule {
+        source_labels = ["__meta_kubernetes_service_annotation_k8s_grafana_com_metrics_scrapeInterval"]
+        action = "replace"
+        target_label = "__scrape_interval__"
       }
     }
     
@@ -52567,6 +52579,12 @@ data:
         action = "replace"
         target_label = "__scheme__"
       }
+    
+      rule {
+        source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_scrapeInterval"]
+        action = "replace"
+        target_label = "__scrape_interval__"
+      }
     }
     
     discovery.relabel "annotation_autodiscovery_services" {
@@ -52627,6 +52645,12 @@ data:
         source_labels = ["__meta_kubernetes_service_annotation_k8s_grafana_com_metrics_scheme"]
         action = "replace"
         target_label = "__scheme__"
+      }
+    
+      rule {
+        source_labels = ["__meta_kubernetes_service_annotation_k8s_grafana_com_metrics_scrapeInterval"]
+        action = "replace"
+        target_label = "__scrape_interval__"
       }
     }
     

--- a/examples/extra-rules/metrics.alloy
+++ b/examples/extra-rules/metrics.alloy
@@ -189,6 +189,12 @@ discovery.relabel "annotation_autodiscovery_pods" {
     action = "replace"
     target_label = "__scheme__"
   }
+
+  rule {
+    source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_scrapeInterval"]
+    action = "replace"
+    target_label = "__scrape_interval__"
+  }
   rule {
     source_labels = ["__meta_kubernetes_namespace"]
     regex = "private"
@@ -254,6 +260,12 @@ discovery.relabel "annotation_autodiscovery_services" {
     source_labels = ["__meta_kubernetes_service_annotation_k8s_grafana_com_metrics_scheme"]
     action = "replace"
     target_label = "__scheme__"
+  }
+
+  rule {
+    source_labels = ["__meta_kubernetes_service_annotation_k8s_grafana_com_metrics_scrapeInterval"]
+    action = "replace"
+    target_label = "__scrape_interval__"
   }
   rule {
     source_labels = ["__meta_kubernetes_namespace"]

--- a/examples/extra-rules/metrics.alloy
+++ b/examples/extra-rules/metrics.alloy
@@ -282,6 +282,7 @@ discovery.relabel "annotation_autodiscovery_https" {
 
 prometheus.scrape "annotation_autodiscovery_http" {
   targets = discovery.relabel.annotation_autodiscovery_http.output
+  scrape_interval = "60s"
   honor_labels = true
   clustering {
     enabled = true
@@ -291,6 +292,7 @@ prometheus.scrape "annotation_autodiscovery_http" {
 
 prometheus.scrape "annotation_autodiscovery_https" {
   targets = discovery.relabel.annotation_autodiscovery_https.output
+  scrape_interval = "60s"
   honor_labels = true
   bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
   tls_config {

--- a/examples/extra-rules/output.yaml
+++ b/examples/extra-rules/output.yaml
@@ -318,6 +318,12 @@ data:
         action = "replace"
         target_label = "__scheme__"
       }
+    
+      rule {
+        source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_scrapeInterval"]
+        action = "replace"
+        target_label = "__scrape_interval__"
+      }
       rule {
         source_labels = ["__meta_kubernetes_namespace"]
         regex = "private"
@@ -383,6 +389,12 @@ data:
         source_labels = ["__meta_kubernetes_service_annotation_k8s_grafana_com_metrics_scheme"]
         action = "replace"
         target_label = "__scheme__"
+      }
+    
+      rule {
+        source_labels = ["__meta_kubernetes_service_annotation_k8s_grafana_com_metrics_scrapeInterval"]
+        action = "replace"
+        target_label = "__scrape_interval__"
       }
       rule {
         source_labels = ["__meta_kubernetes_namespace"]
@@ -52883,6 +52895,12 @@ data:
         action = "replace"
         target_label = "__scheme__"
       }
+    
+      rule {
+        source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_scrapeInterval"]
+        action = "replace"
+        target_label = "__scrape_interval__"
+      }
       rule {
         source_labels = ["__meta_kubernetes_namespace"]
         regex = "private"
@@ -52948,6 +52966,12 @@ data:
         source_labels = ["__meta_kubernetes_service_annotation_k8s_grafana_com_metrics_scheme"]
         action = "replace"
         target_label = "__scheme__"
+      }
+    
+      rule {
+        source_labels = ["__meta_kubernetes_service_annotation_k8s_grafana_com_metrics_scrapeInterval"]
+        action = "replace"
+        target_label = "__scrape_interval__"
       }
       rule {
         source_labels = ["__meta_kubernetes_namespace"]

--- a/examples/extra-rules/output.yaml
+++ b/examples/extra-rules/output.yaml
@@ -411,6 +411,7 @@ data:
     
     prometheus.scrape "annotation_autodiscovery_http" {
       targets = discovery.relabel.annotation_autodiscovery_http.output
+      scrape_interval = "60s"
       honor_labels = true
       clustering {
         enabled = true
@@ -420,6 +421,7 @@ data:
     
     prometheus.scrape "annotation_autodiscovery_https" {
       targets = discovery.relabel.annotation_autodiscovery_https.output
+      scrape_interval = "60s"
       honor_labels = true
       bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
       tls_config {
@@ -52974,6 +52976,7 @@ data:
     
     prometheus.scrape "annotation_autodiscovery_http" {
       targets = discovery.relabel.annotation_autodiscovery_http.output
+      scrape_interval = "60s"
       honor_labels = true
       clustering {
         enabled = true
@@ -52983,6 +52986,7 @@ data:
     
     prometheus.scrape "annotation_autodiscovery_https" {
       targets = discovery.relabel.annotation_autodiscovery_https.output
+      scrape_interval = "60s"
       honor_labels = true
       bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
       tls_config {

--- a/examples/gke-autopilot/metrics.alloy
+++ b/examples/gke-autopilot/metrics.alloy
@@ -272,6 +272,7 @@ discovery.relabel "annotation_autodiscovery_https" {
 
 prometheus.scrape "annotation_autodiscovery_http" {
   targets = discovery.relabel.annotation_autodiscovery_http.output
+  scrape_interval = "60s"
   honor_labels = true
   clustering {
     enabled = true
@@ -281,6 +282,7 @@ prometheus.scrape "annotation_autodiscovery_http" {
 
 prometheus.scrape "annotation_autodiscovery_https" {
   targets = discovery.relabel.annotation_autodiscovery_https.output
+  scrape_interval = "60s"
   honor_labels = true
   bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
   tls_config {

--- a/examples/gke-autopilot/metrics.alloy
+++ b/examples/gke-autopilot/metrics.alloy
@@ -189,6 +189,12 @@ discovery.relabel "annotation_autodiscovery_pods" {
     action = "replace"
     target_label = "__scheme__"
   }
+
+  rule {
+    source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_scrapeInterval"]
+    action = "replace"
+    target_label = "__scrape_interval__"
+  }
 }
 
 discovery.relabel "annotation_autodiscovery_services" {
@@ -249,6 +255,12 @@ discovery.relabel "annotation_autodiscovery_services" {
     source_labels = ["__meta_kubernetes_service_annotation_k8s_grafana_com_metrics_scheme"]
     action = "replace"
     target_label = "__scheme__"
+  }
+
+  rule {
+    source_labels = ["__meta_kubernetes_service_annotation_k8s_grafana_com_metrics_scrapeInterval"]
+    action = "replace"
+    target_label = "__scrape_interval__"
   }
 }
 

--- a/examples/gke-autopilot/output.yaml
+++ b/examples/gke-autopilot/output.yaml
@@ -302,6 +302,12 @@ data:
         action = "replace"
         target_label = "__scheme__"
       }
+    
+      rule {
+        source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_scrapeInterval"]
+        action = "replace"
+        target_label = "__scrape_interval__"
+      }
     }
     
     discovery.relabel "annotation_autodiscovery_services" {
@@ -362,6 +368,12 @@ data:
         source_labels = ["__meta_kubernetes_service_annotation_k8s_grafana_com_metrics_scheme"]
         action = "replace"
         target_label = "__scheme__"
+      }
+    
+      rule {
+        source_labels = ["__meta_kubernetes_service_annotation_k8s_grafana_com_metrics_scrapeInterval"]
+        action = "replace"
+        target_label = "__scrape_interval__"
       }
     }
     
@@ -52551,6 +52563,12 @@ data:
         action = "replace"
         target_label = "__scheme__"
       }
+    
+      rule {
+        source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_scrapeInterval"]
+        action = "replace"
+        target_label = "__scrape_interval__"
+      }
     }
     
     discovery.relabel "annotation_autodiscovery_services" {
@@ -52611,6 +52629,12 @@ data:
         source_labels = ["__meta_kubernetes_service_annotation_k8s_grafana_com_metrics_scheme"]
         action = "replace"
         target_label = "__scheme__"
+      }
+    
+      rule {
+        source_labels = ["__meta_kubernetes_service_annotation_k8s_grafana_com_metrics_scrapeInterval"]
+        action = "replace"
+        target_label = "__scrape_interval__"
       }
     }
     

--- a/examples/gke-autopilot/output.yaml
+++ b/examples/gke-autopilot/output.yaml
@@ -385,6 +385,7 @@ data:
     
     prometheus.scrape "annotation_autodiscovery_http" {
       targets = discovery.relabel.annotation_autodiscovery_http.output
+      scrape_interval = "60s"
       honor_labels = true
       clustering {
         enabled = true
@@ -394,6 +395,7 @@ data:
     
     prometheus.scrape "annotation_autodiscovery_https" {
       targets = discovery.relabel.annotation_autodiscovery_https.output
+      scrape_interval = "60s"
       honor_labels = true
       bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
       tls_config {
@@ -52632,6 +52634,7 @@ data:
     
     prometheus.scrape "annotation_autodiscovery_http" {
       targets = discovery.relabel.annotation_autodiscovery_http.output
+      scrape_interval = "60s"
       honor_labels = true
       clustering {
         enabled = true
@@ -52641,6 +52644,7 @@ data:
     
     prometheus.scrape "annotation_autodiscovery_https" {
       targets = discovery.relabel.annotation_autodiscovery_https.output
+      scrape_interval = "60s"
       honor_labels = true
       bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
       tls_config {

--- a/examples/ibm-cloud/metrics.alloy
+++ b/examples/ibm-cloud/metrics.alloy
@@ -272,6 +272,7 @@ discovery.relabel "annotation_autodiscovery_https" {
 
 prometheus.scrape "annotation_autodiscovery_http" {
   targets = discovery.relabel.annotation_autodiscovery_http.output
+  scrape_interval = "60s"
   honor_labels = true
   clustering {
     enabled = true
@@ -281,6 +282,7 @@ prometheus.scrape "annotation_autodiscovery_http" {
 
 prometheus.scrape "annotation_autodiscovery_https" {
   targets = discovery.relabel.annotation_autodiscovery_https.output
+  scrape_interval = "60s"
   honor_labels = true
   bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
   tls_config {

--- a/examples/ibm-cloud/metrics.alloy
+++ b/examples/ibm-cloud/metrics.alloy
@@ -189,6 +189,12 @@ discovery.relabel "annotation_autodiscovery_pods" {
     action = "replace"
     target_label = "__scheme__"
   }
+
+  rule {
+    source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_scrapeInterval"]
+    action = "replace"
+    target_label = "__scrape_interval__"
+  }
 }
 
 discovery.relabel "annotation_autodiscovery_services" {
@@ -249,6 +255,12 @@ discovery.relabel "annotation_autodiscovery_services" {
     source_labels = ["__meta_kubernetes_service_annotation_k8s_grafana_com_metrics_scheme"]
     action = "replace"
     target_label = "__scheme__"
+  }
+
+  rule {
+    source_labels = ["__meta_kubernetes_service_annotation_k8s_grafana_com_metrics_scrapeInterval"]
+    action = "replace"
+    target_label = "__scrape_interval__"
   }
 }
 

--- a/examples/ibm-cloud/output.yaml
+++ b/examples/ibm-cloud/output.yaml
@@ -317,6 +317,12 @@ data:
         action = "replace"
         target_label = "__scheme__"
       }
+    
+      rule {
+        source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_scrapeInterval"]
+        action = "replace"
+        target_label = "__scrape_interval__"
+      }
     }
     
     discovery.relabel "annotation_autodiscovery_services" {
@@ -377,6 +383,12 @@ data:
         source_labels = ["__meta_kubernetes_service_annotation_k8s_grafana_com_metrics_scheme"]
         action = "replace"
         target_label = "__scheme__"
+      }
+    
+      rule {
+        source_labels = ["__meta_kubernetes_service_annotation_k8s_grafana_com_metrics_scrapeInterval"]
+        action = "replace"
+        target_label = "__scrape_interval__"
       }
     }
     
@@ -52767,6 +52779,12 @@ data:
         action = "replace"
         target_label = "__scheme__"
       }
+    
+      rule {
+        source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_scrapeInterval"]
+        action = "replace"
+        target_label = "__scrape_interval__"
+      }
     }
     
     discovery.relabel "annotation_autodiscovery_services" {
@@ -52827,6 +52845,12 @@ data:
         source_labels = ["__meta_kubernetes_service_annotation_k8s_grafana_com_metrics_scheme"]
         action = "replace"
         target_label = "__scheme__"
+      }
+    
+      rule {
+        source_labels = ["__meta_kubernetes_service_annotation_k8s_grafana_com_metrics_scrapeInterval"]
+        action = "replace"
+        target_label = "__scrape_interval__"
       }
     }
     

--- a/examples/ibm-cloud/output.yaml
+++ b/examples/ibm-cloud/output.yaml
@@ -400,6 +400,7 @@ data:
     
     prometheus.scrape "annotation_autodiscovery_http" {
       targets = discovery.relabel.annotation_autodiscovery_http.output
+      scrape_interval = "60s"
       honor_labels = true
       clustering {
         enabled = true
@@ -409,6 +410,7 @@ data:
     
     prometheus.scrape "annotation_autodiscovery_https" {
       targets = discovery.relabel.annotation_autodiscovery_https.output
+      scrape_interval = "60s"
       honor_labels = true
       bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
       tls_config {
@@ -52848,6 +52850,7 @@ data:
     
     prometheus.scrape "annotation_autodiscovery_http" {
       targets = discovery.relabel.annotation_autodiscovery_http.output
+      scrape_interval = "60s"
       honor_labels = true
       clustering {
         enabled = true
@@ -52857,6 +52860,7 @@ data:
     
     prometheus.scrape "annotation_autodiscovery_https" {
       targets = discovery.relabel.annotation_autodiscovery_https.output
+      scrape_interval = "60s"
       honor_labels = true
       bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
       tls_config {

--- a/examples/metric-module-imports-extra-config/metrics.alloy
+++ b/examples/metric-module-imports-extra-config/metrics.alloy
@@ -272,6 +272,7 @@ discovery.relabel "annotation_autodiscovery_https" {
 
 prometheus.scrape "annotation_autodiscovery_http" {
   targets = discovery.relabel.annotation_autodiscovery_http.output
+  scrape_interval = "60s"
   honor_labels = true
   clustering {
     enabled = true
@@ -281,6 +282,7 @@ prometheus.scrape "annotation_autodiscovery_http" {
 
 prometheus.scrape "annotation_autodiscovery_https" {
   targets = discovery.relabel.annotation_autodiscovery_https.output
+  scrape_interval = "60s"
   honor_labels = true
   bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
   tls_config {

--- a/examples/metric-module-imports-extra-config/metrics.alloy
+++ b/examples/metric-module-imports-extra-config/metrics.alloy
@@ -189,6 +189,12 @@ discovery.relabel "annotation_autodiscovery_pods" {
     action = "replace"
     target_label = "__scheme__"
   }
+
+  rule {
+    source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_scrapeInterval"]
+    action = "replace"
+    target_label = "__scrape_interval__"
+  }
 }
 
 discovery.relabel "annotation_autodiscovery_services" {
@@ -249,6 +255,12 @@ discovery.relabel "annotation_autodiscovery_services" {
     source_labels = ["__meta_kubernetes_service_annotation_k8s_grafana_com_metrics_scheme"]
     action = "replace"
     target_label = "__scheme__"
+  }
+
+  rule {
+    source_labels = ["__meta_kubernetes_service_annotation_k8s_grafana_com_metrics_scrapeInterval"]
+    action = "replace"
+    target_label = "__scrape_interval__"
   }
 }
 

--- a/examples/metric-module-imports-extra-config/output.yaml
+++ b/examples/metric-module-imports-extra-config/output.yaml
@@ -317,6 +317,12 @@ data:
         action = "replace"
         target_label = "__scheme__"
       }
+    
+      rule {
+        source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_scrapeInterval"]
+        action = "replace"
+        target_label = "__scrape_interval__"
+      }
     }
     
     discovery.relabel "annotation_autodiscovery_services" {
@@ -377,6 +383,12 @@ data:
         source_labels = ["__meta_kubernetes_service_annotation_k8s_grafana_com_metrics_scheme"]
         action = "replace"
         target_label = "__scheme__"
+      }
+    
+      rule {
+        source_labels = ["__meta_kubernetes_service_annotation_k8s_grafana_com_metrics_scrapeInterval"]
+        action = "replace"
+        target_label = "__scrape_interval__"
       }
     }
     
@@ -52776,6 +52788,12 @@ data:
         action = "replace"
         target_label = "__scheme__"
       }
+    
+      rule {
+        source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_scrapeInterval"]
+        action = "replace"
+        target_label = "__scrape_interval__"
+      }
     }
     
     discovery.relabel "annotation_autodiscovery_services" {
@@ -52836,6 +52854,12 @@ data:
         source_labels = ["__meta_kubernetes_service_annotation_k8s_grafana_com_metrics_scheme"]
         action = "replace"
         target_label = "__scheme__"
+      }
+    
+      rule {
+        source_labels = ["__meta_kubernetes_service_annotation_k8s_grafana_com_metrics_scrapeInterval"]
+        action = "replace"
+        target_label = "__scrape_interval__"
       }
     }
     

--- a/examples/metric-module-imports-extra-config/output.yaml
+++ b/examples/metric-module-imports-extra-config/output.yaml
@@ -400,6 +400,7 @@ data:
     
     prometheus.scrape "annotation_autodiscovery_http" {
       targets = discovery.relabel.annotation_autodiscovery_http.output
+      scrape_interval = "60s"
       honor_labels = true
       clustering {
         enabled = true
@@ -409,6 +410,7 @@ data:
     
     prometheus.scrape "annotation_autodiscovery_https" {
       targets = discovery.relabel.annotation_autodiscovery_https.output
+      scrape_interval = "60s"
       honor_labels = true
       bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
       tls_config {
@@ -52857,6 +52859,7 @@ data:
     
     prometheus.scrape "annotation_autodiscovery_http" {
       targets = discovery.relabel.annotation_autodiscovery_http.output
+      scrape_interval = "60s"
       honor_labels = true
       clustering {
         enabled = true
@@ -52866,6 +52869,7 @@ data:
     
     prometheus.scrape "annotation_autodiscovery_https" {
       targets = discovery.relabel.annotation_autodiscovery_https.output
+      scrape_interval = "60s"
       honor_labels = true
       bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
       tls_config {

--- a/examples/metric-module-imports/metrics.alloy
+++ b/examples/metric-module-imports/metrics.alloy
@@ -272,6 +272,7 @@ discovery.relabel "annotation_autodiscovery_https" {
 
 prometheus.scrape "annotation_autodiscovery_http" {
   targets = discovery.relabel.annotation_autodiscovery_http.output
+  scrape_interval = "60s"
   honor_labels = true
   clustering {
     enabled = true
@@ -281,6 +282,7 @@ prometheus.scrape "annotation_autodiscovery_http" {
 
 prometheus.scrape "annotation_autodiscovery_https" {
   targets = discovery.relabel.annotation_autodiscovery_https.output
+  scrape_interval = "60s"
   honor_labels = true
   bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
   tls_config {

--- a/examples/metric-module-imports/metrics.alloy
+++ b/examples/metric-module-imports/metrics.alloy
@@ -189,6 +189,12 @@ discovery.relabel "annotation_autodiscovery_pods" {
     action = "replace"
     target_label = "__scheme__"
   }
+
+  rule {
+    source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_scrapeInterval"]
+    action = "replace"
+    target_label = "__scrape_interval__"
+  }
 }
 
 discovery.relabel "annotation_autodiscovery_services" {
@@ -249,6 +255,12 @@ discovery.relabel "annotation_autodiscovery_services" {
     source_labels = ["__meta_kubernetes_service_annotation_k8s_grafana_com_metrics_scheme"]
     action = "replace"
     target_label = "__scheme__"
+  }
+
+  rule {
+    source_labels = ["__meta_kubernetes_service_annotation_k8s_grafana_com_metrics_scrapeInterval"]
+    action = "replace"
+    target_label = "__scrape_interval__"
   }
 }
 

--- a/examples/metric-module-imports/output.yaml
+++ b/examples/metric-module-imports/output.yaml
@@ -400,6 +400,7 @@ data:
     
     prometheus.scrape "annotation_autodiscovery_http" {
       targets = discovery.relabel.annotation_autodiscovery_http.output
+      scrape_interval = "60s"
       honor_labels = true
       clustering {
         enabled = true
@@ -409,6 +410,7 @@ data:
     
     prometheus.scrape "annotation_autodiscovery_https" {
       targets = discovery.relabel.annotation_autodiscovery_https.output
+      scrape_interval = "60s"
       honor_labels = true
       bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
       tls_config {
@@ -53019,6 +53021,7 @@ data:
     
     prometheus.scrape "annotation_autodiscovery_http" {
       targets = discovery.relabel.annotation_autodiscovery_http.output
+      scrape_interval = "60s"
       honor_labels = true
       clustering {
         enabled = true
@@ -53028,6 +53031,7 @@ data:
     
     prometheus.scrape "annotation_autodiscovery_https" {
       targets = discovery.relabel.annotation_autodiscovery_https.output
+      scrape_interval = "60s"
       honor_labels = true
       bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
       tls_config {

--- a/examples/metric-module-imports/output.yaml
+++ b/examples/metric-module-imports/output.yaml
@@ -317,6 +317,12 @@ data:
         action = "replace"
         target_label = "__scheme__"
       }
+    
+      rule {
+        source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_scrapeInterval"]
+        action = "replace"
+        target_label = "__scrape_interval__"
+      }
     }
     
     discovery.relabel "annotation_autodiscovery_services" {
@@ -377,6 +383,12 @@ data:
         source_labels = ["__meta_kubernetes_service_annotation_k8s_grafana_com_metrics_scheme"]
         action = "replace"
         target_label = "__scheme__"
+      }
+    
+      rule {
+        source_labels = ["__meta_kubernetes_service_annotation_k8s_grafana_com_metrics_scrapeInterval"]
+        action = "replace"
+        target_label = "__scrape_interval__"
       }
     }
     
@@ -52938,6 +52950,12 @@ data:
         action = "replace"
         target_label = "__scheme__"
       }
+    
+      rule {
+        source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_scrapeInterval"]
+        action = "replace"
+        target_label = "__scrape_interval__"
+      }
     }
     
     discovery.relabel "annotation_autodiscovery_services" {
@@ -52998,6 +53016,12 @@ data:
         source_labels = ["__meta_kubernetes_service_annotation_k8s_grafana_com_metrics_scheme"]
         action = "replace"
         target_label = "__scheme__"
+      }
+    
+      rule {
+        source_labels = ["__meta_kubernetes_service_annotation_k8s_grafana_com_metrics_scrapeInterval"]
+        action = "replace"
+        target_label = "__scrape_interval__"
       }
     }
     

--- a/examples/metrics-only/metrics.alloy
+++ b/examples/metrics-only/metrics.alloy
@@ -254,6 +254,7 @@ discovery.relabel "annotation_autodiscovery_https" {
 
 prometheus.scrape "annotation_autodiscovery_http" {
   targets = discovery.relabel.annotation_autodiscovery_http.output
+  scrape_interval = "60s"
   honor_labels = true
   clustering {
     enabled = true
@@ -263,6 +264,7 @@ prometheus.scrape "annotation_autodiscovery_http" {
 
 prometheus.scrape "annotation_autodiscovery_https" {
   targets = discovery.relabel.annotation_autodiscovery_https.output
+  scrape_interval = "60s"
   honor_labels = true
   bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
   tls_config {

--- a/examples/metrics-only/metrics.alloy
+++ b/examples/metrics-only/metrics.alloy
@@ -171,6 +171,12 @@ discovery.relabel "annotation_autodiscovery_pods" {
     action = "replace"
     target_label = "__scheme__"
   }
+
+  rule {
+    source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_scrapeInterval"]
+    action = "replace"
+    target_label = "__scrape_interval__"
+  }
 }
 
 discovery.relabel "annotation_autodiscovery_services" {
@@ -231,6 +237,12 @@ discovery.relabel "annotation_autodiscovery_services" {
     source_labels = ["__meta_kubernetes_service_annotation_k8s_grafana_com_metrics_scheme"]
     action = "replace"
     target_label = "__scheme__"
+  }
+
+  rule {
+    source_labels = ["__meta_kubernetes_service_annotation_k8s_grafana_com_metrics_scrapeInterval"]
+    action = "replace"
+    target_label = "__scrape_interval__"
   }
 }
 

--- a/examples/metrics-only/output.yaml
+++ b/examples/metrics-only/output.yaml
@@ -255,6 +255,12 @@ data:
         action = "replace"
         target_label = "__scheme__"
       }
+    
+      rule {
+        source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_scrapeInterval"]
+        action = "replace"
+        target_label = "__scrape_interval__"
+      }
     }
     
     discovery.relabel "annotation_autodiscovery_services" {
@@ -315,6 +321,12 @@ data:
         source_labels = ["__meta_kubernetes_service_annotation_k8s_grafana_com_metrics_scheme"]
         action = "replace"
         target_label = "__scheme__"
+      }
+    
+      rule {
+        source_labels = ["__meta_kubernetes_service_annotation_k8s_grafana_com_metrics_scrapeInterval"]
+        action = "replace"
+        target_label = "__scrape_interval__"
       }
     }
     
@@ -51913,6 +51925,12 @@ data:
         action = "replace"
         target_label = "__scheme__"
       }
+    
+      rule {
+        source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_scrapeInterval"]
+        action = "replace"
+        target_label = "__scrape_interval__"
+      }
     }
     
     discovery.relabel "annotation_autodiscovery_services" {
@@ -51973,6 +51991,12 @@ data:
         source_labels = ["__meta_kubernetes_service_annotation_k8s_grafana_com_metrics_scheme"]
         action = "replace"
         target_label = "__scheme__"
+      }
+    
+      rule {
+        source_labels = ["__meta_kubernetes_service_annotation_k8s_grafana_com_metrics_scrapeInterval"]
+        action = "replace"
+        target_label = "__scrape_interval__"
       }
     }
     

--- a/examples/metrics-only/output.yaml
+++ b/examples/metrics-only/output.yaml
@@ -338,6 +338,7 @@ data:
     
     prometheus.scrape "annotation_autodiscovery_http" {
       targets = discovery.relabel.annotation_autodiscovery_http.output
+      scrape_interval = "60s"
       honor_labels = true
       clustering {
         enabled = true
@@ -347,6 +348,7 @@ data:
     
     prometheus.scrape "annotation_autodiscovery_https" {
       targets = discovery.relabel.annotation_autodiscovery_https.output
+      scrape_interval = "60s"
       honor_labels = true
       bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
       tls_config {
@@ -51994,6 +51996,7 @@ data:
     
     prometheus.scrape "annotation_autodiscovery_http" {
       targets = discovery.relabel.annotation_autodiscovery_http.output
+      scrape_interval = "60s"
       honor_labels = true
       clustering {
         enabled = true
@@ -52003,6 +52006,7 @@ data:
     
     prometheus.scrape "annotation_autodiscovery_https" {
       targets = discovery.relabel.annotation_autodiscovery_https.output
+      scrape_interval = "60s"
       honor_labels = true
       bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
       tls_config {

--- a/examples/openshift-compatible/metrics.alloy
+++ b/examples/openshift-compatible/metrics.alloy
@@ -272,6 +272,7 @@ discovery.relabel "annotation_autodiscovery_https" {
 
 prometheus.scrape "annotation_autodiscovery_http" {
   targets = discovery.relabel.annotation_autodiscovery_http.output
+  scrape_interval = "60s"
   honor_labels = true
   clustering {
     enabled = true
@@ -281,6 +282,7 @@ prometheus.scrape "annotation_autodiscovery_http" {
 
 prometheus.scrape "annotation_autodiscovery_https" {
   targets = discovery.relabel.annotation_autodiscovery_https.output
+  scrape_interval = "60s"
   honor_labels = true
   bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
   tls_config {

--- a/examples/openshift-compatible/metrics.alloy
+++ b/examples/openshift-compatible/metrics.alloy
@@ -189,6 +189,12 @@ discovery.relabel "annotation_autodiscovery_pods" {
     action = "replace"
     target_label = "__scheme__"
   }
+
+  rule {
+    source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_scrapeInterval"]
+    action = "replace"
+    target_label = "__scrape_interval__"
+  }
 }
 
 discovery.relabel "annotation_autodiscovery_services" {
@@ -249,6 +255,12 @@ discovery.relabel "annotation_autodiscovery_services" {
     source_labels = ["__meta_kubernetes_service_annotation_k8s_grafana_com_metrics_scheme"]
     action = "replace"
     target_label = "__scheme__"
+  }
+
+  rule {
+    source_labels = ["__meta_kubernetes_service_annotation_k8s_grafana_com_metrics_scrapeInterval"]
+    action = "replace"
+    target_label = "__scrape_interval__"
   }
 }
 

--- a/examples/openshift-compatible/output.yaml
+++ b/examples/openshift-compatible/output.yaml
@@ -370,6 +370,7 @@ data:
     
     prometheus.scrape "annotation_autodiscovery_http" {
       targets = discovery.relabel.annotation_autodiscovery_http.output
+      scrape_interval = "60s"
       honor_labels = true
       clustering {
         enabled = true
@@ -379,6 +380,7 @@ data:
     
     prometheus.scrape "annotation_autodiscovery_https" {
       targets = discovery.relabel.annotation_autodiscovery_https.output
+      scrape_interval = "60s"
       honor_labels = true
       bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
       tls_config {
@@ -52694,6 +52696,7 @@ data:
     
     prometheus.scrape "annotation_autodiscovery_http" {
       targets = discovery.relabel.annotation_autodiscovery_http.output
+      scrape_interval = "60s"
       honor_labels = true
       clustering {
         enabled = true
@@ -52703,6 +52706,7 @@ data:
     
     prometheus.scrape "annotation_autodiscovery_https" {
       targets = discovery.relabel.annotation_autodiscovery_https.output
+      scrape_interval = "60s"
       honor_labels = true
       bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
       tls_config {

--- a/examples/openshift-compatible/output.yaml
+++ b/examples/openshift-compatible/output.yaml
@@ -287,6 +287,12 @@ data:
         action = "replace"
         target_label = "__scheme__"
       }
+    
+      rule {
+        source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_scrapeInterval"]
+        action = "replace"
+        target_label = "__scrape_interval__"
+      }
     }
     
     discovery.relabel "annotation_autodiscovery_services" {
@@ -347,6 +353,12 @@ data:
         source_labels = ["__meta_kubernetes_service_annotation_k8s_grafana_com_metrics_scheme"]
         action = "replace"
         target_label = "__scheme__"
+      }
+    
+      rule {
+        source_labels = ["__meta_kubernetes_service_annotation_k8s_grafana_com_metrics_scrapeInterval"]
+        action = "replace"
+        target_label = "__scrape_interval__"
       }
     }
     
@@ -52613,6 +52625,12 @@ data:
         action = "replace"
         target_label = "__scheme__"
       }
+    
+      rule {
+        source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_scrapeInterval"]
+        action = "replace"
+        target_label = "__scrape_interval__"
+      }
     }
     
     discovery.relabel "annotation_autodiscovery_services" {
@@ -52673,6 +52691,12 @@ data:
         source_labels = ["__meta_kubernetes_service_annotation_k8s_grafana_com_metrics_scheme"]
         action = "replace"
         target_label = "__scheme__"
+      }
+    
+      rule {
+        source_labels = ["__meta_kubernetes_service_annotation_k8s_grafana_com_metrics_scrapeInterval"]
+        action = "replace"
+        target_label = "__scrape_interval__"
       }
     }
     

--- a/examples/otel-metrics-service/metrics.alloy
+++ b/examples/otel-metrics-service/metrics.alloy
@@ -272,6 +272,7 @@ discovery.relabel "annotation_autodiscovery_https" {
 
 prometheus.scrape "annotation_autodiscovery_http" {
   targets = discovery.relabel.annotation_autodiscovery_http.output
+  scrape_interval = "60s"
   honor_labels = true
   clustering {
     enabled = true
@@ -281,6 +282,7 @@ prometheus.scrape "annotation_autodiscovery_http" {
 
 prometheus.scrape "annotation_autodiscovery_https" {
   targets = discovery.relabel.annotation_autodiscovery_https.output
+  scrape_interval = "60s"
   honor_labels = true
   bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
   tls_config {

--- a/examples/otel-metrics-service/metrics.alloy
+++ b/examples/otel-metrics-service/metrics.alloy
@@ -189,6 +189,12 @@ discovery.relabel "annotation_autodiscovery_pods" {
     action = "replace"
     target_label = "__scheme__"
   }
+
+  rule {
+    source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_scrapeInterval"]
+    action = "replace"
+    target_label = "__scrape_interval__"
+  }
 }
 
 discovery.relabel "annotation_autodiscovery_services" {
@@ -249,6 +255,12 @@ discovery.relabel "annotation_autodiscovery_services" {
     source_labels = ["__meta_kubernetes_service_annotation_k8s_grafana_com_metrics_scheme"]
     action = "replace"
     target_label = "__scheme__"
+  }
+
+  rule {
+    source_labels = ["__meta_kubernetes_service_annotation_k8s_grafana_com_metrics_scrapeInterval"]
+    action = "replace"
+    target_label = "__scrape_interval__"
   }
 }
 

--- a/examples/otel-metrics-service/output.yaml
+++ b/examples/otel-metrics-service/output.yaml
@@ -400,6 +400,7 @@ data:
     
     prometheus.scrape "annotation_autodiscovery_http" {
       targets = discovery.relabel.annotation_autodiscovery_http.output
+      scrape_interval = "60s"
       honor_labels = true
       clustering {
         enabled = true
@@ -409,6 +410,7 @@ data:
     
     prometheus.scrape "annotation_autodiscovery_https" {
       targets = discovery.relabel.annotation_autodiscovery_https.output
+      scrape_interval = "60s"
       honor_labels = true
       bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
       tls_config {
@@ -52859,6 +52861,7 @@ data:
     
     prometheus.scrape "annotation_autodiscovery_http" {
       targets = discovery.relabel.annotation_autodiscovery_http.output
+      scrape_interval = "60s"
       honor_labels = true
       clustering {
         enabled = true
@@ -52868,6 +52871,7 @@ data:
     
     prometheus.scrape "annotation_autodiscovery_https" {
       targets = discovery.relabel.annotation_autodiscovery_https.output
+      scrape_interval = "60s"
       honor_labels = true
       bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
       tls_config {

--- a/examples/otel-metrics-service/output.yaml
+++ b/examples/otel-metrics-service/output.yaml
@@ -317,6 +317,12 @@ data:
         action = "replace"
         target_label = "__scheme__"
       }
+    
+      rule {
+        source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_scrapeInterval"]
+        action = "replace"
+        target_label = "__scrape_interval__"
+      }
     }
     
     discovery.relabel "annotation_autodiscovery_services" {
@@ -377,6 +383,12 @@ data:
         source_labels = ["__meta_kubernetes_service_annotation_k8s_grafana_com_metrics_scheme"]
         action = "replace"
         target_label = "__scheme__"
+      }
+    
+      rule {
+        source_labels = ["__meta_kubernetes_service_annotation_k8s_grafana_com_metrics_scrapeInterval"]
+        action = "replace"
+        target_label = "__scrape_interval__"
       }
     }
     
@@ -52778,6 +52790,12 @@ data:
         action = "replace"
         target_label = "__scheme__"
       }
+    
+      rule {
+        source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_scrapeInterval"]
+        action = "replace"
+        target_label = "__scrape_interval__"
+      }
     }
     
     discovery.relabel "annotation_autodiscovery_services" {
@@ -52838,6 +52856,12 @@ data:
         source_labels = ["__meta_kubernetes_service_annotation_k8s_grafana_com_metrics_scheme"]
         action = "replace"
         target_label = "__scheme__"
+      }
+    
+      rule {
+        source_labels = ["__meta_kubernetes_service_annotation_k8s_grafana_com_metrics_scrapeInterval"]
+        action = "replace"
+        target_label = "__scrape_interval__"
       }
     }
     

--- a/examples/pod-labels/metrics.alloy
+++ b/examples/pod-labels/metrics.alloy
@@ -226,6 +226,12 @@ discovery.relabel "annotation_autodiscovery_pods" {
     action = "replace"
     target_label = "__scheme__"
   }
+
+  rule {
+    source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_scrapeInterval"]
+    action = "replace"
+    target_label = "__scrape_interval__"
+  }
 }
 
 discovery.relabel "annotation_autodiscovery_services" {
@@ -286,6 +292,12 @@ discovery.relabel "annotation_autodiscovery_services" {
     source_labels = ["__meta_kubernetes_service_annotation_k8s_grafana_com_metrics_scheme"]
     action = "replace"
     target_label = "__scheme__"
+  }
+
+  rule {
+    source_labels = ["__meta_kubernetes_service_annotation_k8s_grafana_com_metrics_scrapeInterval"]
+    action = "replace"
+    target_label = "__scrape_interval__"
   }
 }
 

--- a/examples/pod-labels/metrics.alloy
+++ b/examples/pod-labels/metrics.alloy
@@ -309,6 +309,7 @@ discovery.relabel "annotation_autodiscovery_https" {
 
 prometheus.scrape "annotation_autodiscovery_http" {
   targets = discovery.relabel.annotation_autodiscovery_http.output
+  scrape_interval = "60s"
   honor_labels = true
   clustering {
     enabled = true
@@ -318,6 +319,7 @@ prometheus.scrape "annotation_autodiscovery_http" {
 
 prometheus.scrape "annotation_autodiscovery_https" {
   targets = discovery.relabel.annotation_autodiscovery_https.output
+  scrape_interval = "60s"
   honor_labels = true
   bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
   tls_config {

--- a/examples/pod-labels/output.yaml
+++ b/examples/pod-labels/output.yaml
@@ -367,6 +367,12 @@ data:
         action = "replace"
         target_label = "__scheme__"
       }
+    
+      rule {
+        source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_scrapeInterval"]
+        action = "replace"
+        target_label = "__scrape_interval__"
+      }
     }
     
     discovery.relabel "annotation_autodiscovery_services" {
@@ -427,6 +433,12 @@ data:
         source_labels = ["__meta_kubernetes_service_annotation_k8s_grafana_com_metrics_scheme"]
         action = "replace"
         target_label = "__scheme__"
+      }
+    
+      rule {
+        source_labels = ["__meta_kubernetes_service_annotation_k8s_grafana_com_metrics_scrapeInterval"]
+        action = "replace"
+        target_label = "__scrape_interval__"
       }
     }
     
@@ -52875,6 +52887,12 @@ data:
         action = "replace"
         target_label = "__scheme__"
       }
+    
+      rule {
+        source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_scrapeInterval"]
+        action = "replace"
+        target_label = "__scrape_interval__"
+      }
     }
     
     discovery.relabel "annotation_autodiscovery_services" {
@@ -52935,6 +52953,12 @@ data:
         source_labels = ["__meta_kubernetes_service_annotation_k8s_grafana_com_metrics_scheme"]
         action = "replace"
         target_label = "__scheme__"
+      }
+    
+      rule {
+        source_labels = ["__meta_kubernetes_service_annotation_k8s_grafana_com_metrics_scrapeInterval"]
+        action = "replace"
+        target_label = "__scrape_interval__"
       }
     }
     

--- a/examples/pod-labels/output.yaml
+++ b/examples/pod-labels/output.yaml
@@ -450,6 +450,7 @@ data:
     
     prometheus.scrape "annotation_autodiscovery_http" {
       targets = discovery.relabel.annotation_autodiscovery_http.output
+      scrape_interval = "60s"
       honor_labels = true
       clustering {
         enabled = true
@@ -459,6 +460,7 @@ data:
     
     prometheus.scrape "annotation_autodiscovery_https" {
       targets = discovery.relabel.annotation_autodiscovery_https.output
+      scrape_interval = "60s"
       honor_labels = true
       bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
       tls_config {
@@ -52956,6 +52958,7 @@ data:
     
     prometheus.scrape "annotation_autodiscovery_http" {
       targets = discovery.relabel.annotation_autodiscovery_http.output
+      scrape_interval = "60s"
       honor_labels = true
       clustering {
         enabled = true
@@ -52965,6 +52968,7 @@ data:
     
     prometheus.scrape "annotation_autodiscovery_https" {
       targets = discovery.relabel.annotation_autodiscovery_https.output
+      scrape_interval = "60s"
       honor_labels = true
       bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
       tls_config {

--- a/examples/private-image-registry/metrics.alloy
+++ b/examples/private-image-registry/metrics.alloy
@@ -272,6 +272,7 @@ discovery.relabel "annotation_autodiscovery_https" {
 
 prometheus.scrape "annotation_autodiscovery_http" {
   targets = discovery.relabel.annotation_autodiscovery_http.output
+  scrape_interval = "60s"
   honor_labels = true
   clustering {
     enabled = true
@@ -281,6 +282,7 @@ prometheus.scrape "annotation_autodiscovery_http" {
 
 prometheus.scrape "annotation_autodiscovery_https" {
   targets = discovery.relabel.annotation_autodiscovery_https.output
+  scrape_interval = "60s"
   honor_labels = true
   bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
   tls_config {

--- a/examples/private-image-registry/metrics.alloy
+++ b/examples/private-image-registry/metrics.alloy
@@ -189,6 +189,12 @@ discovery.relabel "annotation_autodiscovery_pods" {
     action = "replace"
     target_label = "__scheme__"
   }
+
+  rule {
+    source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_scrapeInterval"]
+    action = "replace"
+    target_label = "__scrape_interval__"
+  }
 }
 
 discovery.relabel "annotation_autodiscovery_services" {
@@ -249,6 +255,12 @@ discovery.relabel "annotation_autodiscovery_services" {
     source_labels = ["__meta_kubernetes_service_annotation_k8s_grafana_com_metrics_scheme"]
     action = "replace"
     target_label = "__scheme__"
+  }
+
+  rule {
+    source_labels = ["__meta_kubernetes_service_annotation_k8s_grafana_com_metrics_scrapeInterval"]
+    action = "replace"
+    target_label = "__scrape_interval__"
   }
 }
 

--- a/examples/private-image-registry/output.yaml
+++ b/examples/private-image-registry/output.yaml
@@ -404,6 +404,7 @@ data:
     
     prometheus.scrape "annotation_autodiscovery_http" {
       targets = discovery.relabel.annotation_autodiscovery_http.output
+      scrape_interval = "60s"
       honor_labels = true
       clustering {
         enabled = true
@@ -413,6 +414,7 @@ data:
     
     prometheus.scrape "annotation_autodiscovery_https" {
       targets = discovery.relabel.annotation_autodiscovery_https.output
+      scrape_interval = "60s"
       honor_labels = true
       bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
       tls_config {
@@ -52858,6 +52860,7 @@ data:
     
     prometheus.scrape "annotation_autodiscovery_http" {
       targets = discovery.relabel.annotation_autodiscovery_http.output
+      scrape_interval = "60s"
       honor_labels = true
       clustering {
         enabled = true
@@ -52867,6 +52870,7 @@ data:
     
     prometheus.scrape "annotation_autodiscovery_https" {
       targets = discovery.relabel.annotation_autodiscovery_https.output
+      scrape_interval = "60s"
       honor_labels = true
       bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
       tls_config {

--- a/examples/private-image-registry/output.yaml
+++ b/examples/private-image-registry/output.yaml
@@ -321,6 +321,12 @@ data:
         action = "replace"
         target_label = "__scheme__"
       }
+    
+      rule {
+        source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_scrapeInterval"]
+        action = "replace"
+        target_label = "__scrape_interval__"
+      }
     }
     
     discovery.relabel "annotation_autodiscovery_services" {
@@ -381,6 +387,12 @@ data:
         source_labels = ["__meta_kubernetes_service_annotation_k8s_grafana_com_metrics_scheme"]
         action = "replace"
         target_label = "__scheme__"
+      }
+    
+      rule {
+        source_labels = ["__meta_kubernetes_service_annotation_k8s_grafana_com_metrics_scrapeInterval"]
+        action = "replace"
+        target_label = "__scrape_interval__"
       }
     }
     
@@ -52777,6 +52789,12 @@ data:
         action = "replace"
         target_label = "__scheme__"
       }
+    
+      rule {
+        source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_scrapeInterval"]
+        action = "replace"
+        target_label = "__scrape_interval__"
+      }
     }
     
     discovery.relabel "annotation_autodiscovery_services" {
@@ -52837,6 +52855,12 @@ data:
         source_labels = ["__meta_kubernetes_service_annotation_k8s_grafana_com_metrics_scheme"]
         action = "replace"
         target_label = "__scheme__"
+      }
+    
+      rule {
+        source_labels = ["__meta_kubernetes_service_annotation_k8s_grafana_com_metrics_scrapeInterval"]
+        action = "replace"
+        target_label = "__scrape_interval__"
       }
     }
     

--- a/examples/profiles-enabled/metrics.alloy
+++ b/examples/profiles-enabled/metrics.alloy
@@ -272,6 +272,7 @@ discovery.relabel "annotation_autodiscovery_https" {
 
 prometheus.scrape "annotation_autodiscovery_http" {
   targets = discovery.relabel.annotation_autodiscovery_http.output
+  scrape_interval = "60s"
   honor_labels = true
   clustering {
     enabled = true
@@ -281,6 +282,7 @@ prometheus.scrape "annotation_autodiscovery_http" {
 
 prometheus.scrape "annotation_autodiscovery_https" {
   targets = discovery.relabel.annotation_autodiscovery_https.output
+  scrape_interval = "60s"
   honor_labels = true
   bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
   tls_config {

--- a/examples/profiles-enabled/metrics.alloy
+++ b/examples/profiles-enabled/metrics.alloy
@@ -189,6 +189,12 @@ discovery.relabel "annotation_autodiscovery_pods" {
     action = "replace"
     target_label = "__scheme__"
   }
+
+  rule {
+    source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_scrapeInterval"]
+    action = "replace"
+    target_label = "__scrape_interval__"
+  }
 }
 
 discovery.relabel "annotation_autodiscovery_services" {
@@ -249,6 +255,12 @@ discovery.relabel "annotation_autodiscovery_services" {
     source_labels = ["__meta_kubernetes_service_annotation_k8s_grafana_com_metrics_scheme"]
     action = "replace"
     target_label = "__scheme__"
+  }
+
+  rule {
+    source_labels = ["__meta_kubernetes_service_annotation_k8s_grafana_com_metrics_scrapeInterval"]
+    action = "replace"
+    target_label = "__scrape_interval__"
   }
 }
 

--- a/examples/profiles-enabled/output.yaml
+++ b/examples/profiles-enabled/output.yaml
@@ -346,6 +346,12 @@ data:
         action = "replace"
         target_label = "__scheme__"
       }
+    
+      rule {
+        source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_scrapeInterval"]
+        action = "replace"
+        target_label = "__scrape_interval__"
+      }
     }
     
     discovery.relabel "annotation_autodiscovery_services" {
@@ -406,6 +412,12 @@ data:
         source_labels = ["__meta_kubernetes_service_annotation_k8s_grafana_com_metrics_scheme"]
         action = "replace"
         target_label = "__scheme__"
+      }
+    
+      rule {
+        source_labels = ["__meta_kubernetes_service_annotation_k8s_grafana_com_metrics_scrapeInterval"]
+        action = "replace"
+        target_label = "__scrape_interval__"
       }
     }
     
@@ -53827,6 +53839,12 @@ data:
         action = "replace"
         target_label = "__scheme__"
       }
+    
+      rule {
+        source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_scrapeInterval"]
+        action = "replace"
+        target_label = "__scrape_interval__"
+      }
     }
     
     discovery.relabel "annotation_autodiscovery_services" {
@@ -53887,6 +53905,12 @@ data:
         source_labels = ["__meta_kubernetes_service_annotation_k8s_grafana_com_metrics_scheme"]
         action = "replace"
         target_label = "__scheme__"
+      }
+    
+      rule {
+        source_labels = ["__meta_kubernetes_service_annotation_k8s_grafana_com_metrics_scrapeInterval"]
+        action = "replace"
+        target_label = "__scrape_interval__"
       }
     }
     

--- a/examples/profiles-enabled/output.yaml
+++ b/examples/profiles-enabled/output.yaml
@@ -429,6 +429,7 @@ data:
     
     prometheus.scrape "annotation_autodiscovery_http" {
       targets = discovery.relabel.annotation_autodiscovery_http.output
+      scrape_interval = "60s"
       honor_labels = true
       clustering {
         enabled = true
@@ -438,6 +439,7 @@ data:
     
     prometheus.scrape "annotation_autodiscovery_https" {
       targets = discovery.relabel.annotation_autodiscovery_https.output
+      scrape_interval = "60s"
       honor_labels = true
       bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
       tls_config {
@@ -53908,6 +53910,7 @@ data:
     
     prometheus.scrape "annotation_autodiscovery_http" {
       targets = discovery.relabel.annotation_autodiscovery_http.output
+      scrape_interval = "60s"
       honor_labels = true
       clustering {
         enabled = true
@@ -53917,6 +53920,7 @@ data:
     
     prometheus.scrape "annotation_autodiscovery_https" {
       targets = discovery.relabel.annotation_autodiscovery_https.output
+      scrape_interval = "60s"
       honor_labels = true
       bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
       tls_config {

--- a/examples/proxies/metrics.alloy
+++ b/examples/proxies/metrics.alloy
@@ -272,6 +272,7 @@ discovery.relabel "annotation_autodiscovery_https" {
 
 prometheus.scrape "annotation_autodiscovery_http" {
   targets = discovery.relabel.annotation_autodiscovery_http.output
+  scrape_interval = "60s"
   honor_labels = true
   clustering {
     enabled = true
@@ -281,6 +282,7 @@ prometheus.scrape "annotation_autodiscovery_http" {
 
 prometheus.scrape "annotation_autodiscovery_https" {
   targets = discovery.relabel.annotation_autodiscovery_https.output
+  scrape_interval = "60s"
   honor_labels = true
   bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
   tls_config {

--- a/examples/proxies/metrics.alloy
+++ b/examples/proxies/metrics.alloy
@@ -189,6 +189,12 @@ discovery.relabel "annotation_autodiscovery_pods" {
     action = "replace"
     target_label = "__scheme__"
   }
+
+  rule {
+    source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_scrapeInterval"]
+    action = "replace"
+    target_label = "__scrape_interval__"
+  }
 }
 
 discovery.relabel "annotation_autodiscovery_services" {
@@ -249,6 +255,12 @@ discovery.relabel "annotation_autodiscovery_services" {
     source_labels = ["__meta_kubernetes_service_annotation_k8s_grafana_com_metrics_scheme"]
     action = "replace"
     target_label = "__scheme__"
+  }
+
+  rule {
+    source_labels = ["__meta_kubernetes_service_annotation_k8s_grafana_com_metrics_scrapeInterval"]
+    action = "replace"
+    target_label = "__scrape_interval__"
   }
 }
 

--- a/examples/proxies/output.yaml
+++ b/examples/proxies/output.yaml
@@ -400,6 +400,7 @@ data:
     
     prometheus.scrape "annotation_autodiscovery_http" {
       targets = discovery.relabel.annotation_autodiscovery_http.output
+      scrape_interval = "60s"
       honor_labels = true
       clustering {
         enabled = true
@@ -409,6 +410,7 @@ data:
     
     prometheus.scrape "annotation_autodiscovery_https" {
       targets = discovery.relabel.annotation_autodiscovery_https.output
+      scrape_interval = "60s"
       honor_labels = true
       bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
       tls_config {
@@ -52858,6 +52860,7 @@ data:
     
     prometheus.scrape "annotation_autodiscovery_http" {
       targets = discovery.relabel.annotation_autodiscovery_http.output
+      scrape_interval = "60s"
       honor_labels = true
       clustering {
         enabled = true
@@ -52867,6 +52870,7 @@ data:
     
     prometheus.scrape "annotation_autodiscovery_https" {
       targets = discovery.relabel.annotation_autodiscovery_https.output
+      scrape_interval = "60s"
       honor_labels = true
       bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
       tls_config {

--- a/examples/proxies/output.yaml
+++ b/examples/proxies/output.yaml
@@ -317,6 +317,12 @@ data:
         action = "replace"
         target_label = "__scheme__"
       }
+    
+      rule {
+        source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_scrapeInterval"]
+        action = "replace"
+        target_label = "__scrape_interval__"
+      }
     }
     
     discovery.relabel "annotation_autodiscovery_services" {
@@ -377,6 +383,12 @@ data:
         source_labels = ["__meta_kubernetes_service_annotation_k8s_grafana_com_metrics_scheme"]
         action = "replace"
         target_label = "__scheme__"
+      }
+    
+      rule {
+        source_labels = ["__meta_kubernetes_service_annotation_k8s_grafana_com_metrics_scrapeInterval"]
+        action = "replace"
+        target_label = "__scrape_interval__"
       }
     }
     
@@ -52777,6 +52789,12 @@ data:
         action = "replace"
         target_label = "__scheme__"
       }
+    
+      rule {
+        source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_scrapeInterval"]
+        action = "replace"
+        target_label = "__scrape_interval__"
+      }
     }
     
     discovery.relabel "annotation_autodiscovery_services" {
@@ -52837,6 +52855,12 @@ data:
         source_labels = ["__meta_kubernetes_service_annotation_k8s_grafana_com_metrics_scheme"]
         action = "replace"
         target_label = "__scheme__"
+      }
+    
+      rule {
+        source_labels = ["__meta_kubernetes_service_annotation_k8s_grafana_com_metrics_scrapeInterval"]
+        action = "replace"
+        target_label = "__scrape_interval__"
       }
     }
     

--- a/examples/scrape-intervals/metrics.alloy
+++ b/examples/scrape-intervals/metrics.alloy
@@ -254,6 +254,7 @@ discovery.relabel "annotation_autodiscovery_https" {
 
 prometheus.scrape "annotation_autodiscovery_http" {
   targets = discovery.relabel.annotation_autodiscovery_http.output
+  scrape_interval = "2m"
   honor_labels = true
   clustering {
     enabled = true
@@ -263,6 +264,7 @@ prometheus.scrape "annotation_autodiscovery_http" {
 
 prometheus.scrape "annotation_autodiscovery_https" {
   targets = discovery.relabel.annotation_autodiscovery_https.output
+  scrape_interval = "2m"
   honor_labels = true
   bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
   tls_config {

--- a/examples/scrape-intervals/metrics.alloy
+++ b/examples/scrape-intervals/metrics.alloy
@@ -171,6 +171,12 @@ discovery.relabel "annotation_autodiscovery_pods" {
     action = "replace"
     target_label = "__scheme__"
   }
+
+  rule {
+    source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_scrapeInterval"]
+    action = "replace"
+    target_label = "__scrape_interval__"
+  }
 }
 
 discovery.relabel "annotation_autodiscovery_services" {
@@ -231,6 +237,12 @@ discovery.relabel "annotation_autodiscovery_services" {
     source_labels = ["__meta_kubernetes_service_annotation_k8s_grafana_com_metrics_scheme"]
     action = "replace"
     target_label = "__scheme__"
+  }
+
+  rule {
+    source_labels = ["__meta_kubernetes_service_annotation_k8s_grafana_com_metrics_scrapeInterval"]
+    action = "replace"
+    target_label = "__scrape_interval__"
   }
 }
 

--- a/examples/scrape-intervals/output.yaml
+++ b/examples/scrape-intervals/output.yaml
@@ -254,6 +254,12 @@ data:
         action = "replace"
         target_label = "__scheme__"
       }
+    
+      rule {
+        source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_scrapeInterval"]
+        action = "replace"
+        target_label = "__scrape_interval__"
+      }
     }
     
     discovery.relabel "annotation_autodiscovery_services" {
@@ -314,6 +320,12 @@ data:
         source_labels = ["__meta_kubernetes_service_annotation_k8s_grafana_com_metrics_scheme"]
         action = "replace"
         target_label = "__scheme__"
+      }
+    
+      rule {
+        source_labels = ["__meta_kubernetes_service_annotation_k8s_grafana_com_metrics_scrapeInterval"]
+        action = "replace"
+        target_label = "__scrape_interval__"
       }
     }
     
@@ -51912,6 +51924,12 @@ data:
         action = "replace"
         target_label = "__scheme__"
       }
+    
+      rule {
+        source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_scrapeInterval"]
+        action = "replace"
+        target_label = "__scrape_interval__"
+      }
     }
     
     discovery.relabel "annotation_autodiscovery_services" {
@@ -51972,6 +51990,12 @@ data:
         source_labels = ["__meta_kubernetes_service_annotation_k8s_grafana_com_metrics_scheme"]
         action = "replace"
         target_label = "__scheme__"
+      }
+    
+      rule {
+        source_labels = ["__meta_kubernetes_service_annotation_k8s_grafana_com_metrics_scrapeInterval"]
+        action = "replace"
+        target_label = "__scrape_interval__"
       }
     }
     

--- a/examples/scrape-intervals/output.yaml
+++ b/examples/scrape-intervals/output.yaml
@@ -337,6 +337,7 @@ data:
     
     prometheus.scrape "annotation_autodiscovery_http" {
       targets = discovery.relabel.annotation_autodiscovery_http.output
+      scrape_interval = "2m"
       honor_labels = true
       clustering {
         enabled = true
@@ -346,6 +347,7 @@ data:
     
     prometheus.scrape "annotation_autodiscovery_https" {
       targets = discovery.relabel.annotation_autodiscovery_https.output
+      scrape_interval = "2m"
       honor_labels = true
       bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
       tls_config {
@@ -51993,6 +51995,7 @@ data:
     
     prometheus.scrape "annotation_autodiscovery_http" {
       targets = discovery.relabel.annotation_autodiscovery_http.output
+      scrape_interval = "2m"
       honor_labels = true
       clustering {
         enabled = true
@@ -52002,6 +52005,7 @@ data:
     
     prometheus.scrape "annotation_autodiscovery_https" {
       targets = discovery.relabel.annotation_autodiscovery_https.output
+      scrape_interval = "2m"
       honor_labels = true
       bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
       tls_config {

--- a/examples/service-integrations/metrics.alloy
+++ b/examples/service-integrations/metrics.alloy
@@ -272,6 +272,7 @@ discovery.relabel "annotation_autodiscovery_https" {
 
 prometheus.scrape "annotation_autodiscovery_http" {
   targets = discovery.relabel.annotation_autodiscovery_http.output
+  scrape_interval = "60s"
   honor_labels = true
   clustering {
     enabled = true
@@ -281,6 +282,7 @@ prometheus.scrape "annotation_autodiscovery_http" {
 
 prometheus.scrape "annotation_autodiscovery_https" {
   targets = discovery.relabel.annotation_autodiscovery_https.output
+  scrape_interval = "60s"
   honor_labels = true
   bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
   tls_config {

--- a/examples/service-integrations/metrics.alloy
+++ b/examples/service-integrations/metrics.alloy
@@ -189,6 +189,12 @@ discovery.relabel "annotation_autodiscovery_pods" {
     action = "replace"
     target_label = "__scheme__"
   }
+
+  rule {
+    source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_scrapeInterval"]
+    action = "replace"
+    target_label = "__scrape_interval__"
+  }
 }
 
 discovery.relabel "annotation_autodiscovery_services" {
@@ -249,6 +255,12 @@ discovery.relabel "annotation_autodiscovery_services" {
     source_labels = ["__meta_kubernetes_service_annotation_k8s_grafana_com_metrics_scheme"]
     action = "replace"
     target_label = "__scheme__"
+  }
+
+  rule {
+    source_labels = ["__meta_kubernetes_service_annotation_k8s_grafana_com_metrics_scrapeInterval"]
+    action = "replace"
+    target_label = "__scrape_interval__"
   }
 }
 

--- a/examples/service-integrations/output.yaml
+++ b/examples/service-integrations/output.yaml
@@ -400,6 +400,7 @@ data:
     
     prometheus.scrape "annotation_autodiscovery_http" {
       targets = discovery.relabel.annotation_autodiscovery_http.output
+      scrape_interval = "60s"
       honor_labels = true
       clustering {
         enabled = true
@@ -409,6 +410,7 @@ data:
     
     prometheus.scrape "annotation_autodiscovery_https" {
       targets = discovery.relabel.annotation_autodiscovery_https.output
+      scrape_interval = "60s"
       honor_labels = true
       bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
       tls_config {
@@ -52875,6 +52877,7 @@ data:
     
     prometheus.scrape "annotation_autodiscovery_http" {
       targets = discovery.relabel.annotation_autodiscovery_http.output
+      scrape_interval = "60s"
       honor_labels = true
       clustering {
         enabled = true
@@ -52884,6 +52887,7 @@ data:
     
     prometheus.scrape "annotation_autodiscovery_https" {
       targets = discovery.relabel.annotation_autodiscovery_https.output
+      scrape_interval = "60s"
       honor_labels = true
       bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
       tls_config {

--- a/examples/service-integrations/output.yaml
+++ b/examples/service-integrations/output.yaml
@@ -317,6 +317,12 @@ data:
         action = "replace"
         target_label = "__scheme__"
       }
+    
+      rule {
+        source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_scrapeInterval"]
+        action = "replace"
+        target_label = "__scrape_interval__"
+      }
     }
     
     discovery.relabel "annotation_autodiscovery_services" {
@@ -377,6 +383,12 @@ data:
         source_labels = ["__meta_kubernetes_service_annotation_k8s_grafana_com_metrics_scheme"]
         action = "replace"
         target_label = "__scheme__"
+      }
+    
+      rule {
+        source_labels = ["__meta_kubernetes_service_annotation_k8s_grafana_com_metrics_scrapeInterval"]
+        action = "replace"
+        target_label = "__scrape_interval__"
       }
     }
     
@@ -52794,6 +52806,12 @@ data:
         action = "replace"
         target_label = "__scheme__"
       }
+    
+      rule {
+        source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_scrapeInterval"]
+        action = "replace"
+        target_label = "__scrape_interval__"
+      }
     }
     
     discovery.relabel "annotation_autodiscovery_services" {
@@ -52854,6 +52872,12 @@ data:
         source_labels = ["__meta_kubernetes_service_annotation_k8s_grafana_com_metrics_scheme"]
         action = "replace"
         target_label = "__scheme__"
+      }
+    
+      rule {
+        source_labels = ["__meta_kubernetes_service_annotation_k8s_grafana_com_metrics_scrapeInterval"]
+        action = "replace"
+        target_label = "__scrape_interval__"
       }
     }
     

--- a/examples/specific-namespace/metrics.alloy
+++ b/examples/specific-namespace/metrics.alloy
@@ -272,6 +272,7 @@ discovery.relabel "annotation_autodiscovery_https" {
 
 prometheus.scrape "annotation_autodiscovery_http" {
   targets = discovery.relabel.annotation_autodiscovery_http.output
+  scrape_interval = "60s"
   honor_labels = true
   clustering {
     enabled = true
@@ -281,6 +282,7 @@ prometheus.scrape "annotation_autodiscovery_http" {
 
 prometheus.scrape "annotation_autodiscovery_https" {
   targets = discovery.relabel.annotation_autodiscovery_https.output
+  scrape_interval = "60s"
   honor_labels = true
   bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
   tls_config {

--- a/examples/specific-namespace/metrics.alloy
+++ b/examples/specific-namespace/metrics.alloy
@@ -189,6 +189,12 @@ discovery.relabel "annotation_autodiscovery_pods" {
     action = "replace"
     target_label = "__scheme__"
   }
+
+  rule {
+    source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_scrapeInterval"]
+    action = "replace"
+    target_label = "__scrape_interval__"
+  }
 }
 
 discovery.relabel "annotation_autodiscovery_services" {
@@ -249,6 +255,12 @@ discovery.relabel "annotation_autodiscovery_services" {
     source_labels = ["__meta_kubernetes_service_annotation_k8s_grafana_com_metrics_scheme"]
     action = "replace"
     target_label = "__scheme__"
+  }
+
+  rule {
+    source_labels = ["__meta_kubernetes_service_annotation_k8s_grafana_com_metrics_scrapeInterval"]
+    action = "replace"
+    target_label = "__scrape_interval__"
   }
 }
 

--- a/examples/specific-namespace/output.yaml
+++ b/examples/specific-namespace/output.yaml
@@ -317,6 +317,12 @@ data:
         action = "replace"
         target_label = "__scheme__"
       }
+    
+      rule {
+        source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_scrapeInterval"]
+        action = "replace"
+        target_label = "__scrape_interval__"
+      }
     }
     
     discovery.relabel "annotation_autodiscovery_services" {
@@ -377,6 +383,12 @@ data:
         source_labels = ["__meta_kubernetes_service_annotation_k8s_grafana_com_metrics_scheme"]
         action = "replace"
         target_label = "__scheme__"
+      }
+    
+      rule {
+        source_labels = ["__meta_kubernetes_service_annotation_k8s_grafana_com_metrics_scrapeInterval"]
+        action = "replace"
+        target_label = "__scrape_interval__"
       }
     }
     
@@ -52825,6 +52837,12 @@ data:
         action = "replace"
         target_label = "__scheme__"
       }
+    
+      rule {
+        source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_scrapeInterval"]
+        action = "replace"
+        target_label = "__scrape_interval__"
+      }
     }
     
     discovery.relabel "annotation_autodiscovery_services" {
@@ -52885,6 +52903,12 @@ data:
         source_labels = ["__meta_kubernetes_service_annotation_k8s_grafana_com_metrics_scheme"]
         action = "replace"
         target_label = "__scheme__"
+      }
+    
+      rule {
+        source_labels = ["__meta_kubernetes_service_annotation_k8s_grafana_com_metrics_scrapeInterval"]
+        action = "replace"
+        target_label = "__scrape_interval__"
       }
     }
     

--- a/examples/specific-namespace/output.yaml
+++ b/examples/specific-namespace/output.yaml
@@ -400,6 +400,7 @@ data:
     
     prometheus.scrape "annotation_autodiscovery_http" {
       targets = discovery.relabel.annotation_autodiscovery_http.output
+      scrape_interval = "60s"
       honor_labels = true
       clustering {
         enabled = true
@@ -409,6 +410,7 @@ data:
     
     prometheus.scrape "annotation_autodiscovery_https" {
       targets = discovery.relabel.annotation_autodiscovery_https.output
+      scrape_interval = "60s"
       honor_labels = true
       bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
       tls_config {
@@ -52906,6 +52908,7 @@ data:
     
     prometheus.scrape "annotation_autodiscovery_http" {
       targets = discovery.relabel.annotation_autodiscovery_http.output
+      scrape_interval = "60s"
       honor_labels = true
       clustering {
         enabled = true
@@ -52915,6 +52918,7 @@ data:
     
     prometheus.scrape "annotation_autodiscovery_https" {
       targets = discovery.relabel.annotation_autodiscovery_https.output
+      scrape_interval = "60s"
       honor_labels = true
       bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
       tls_config {

--- a/examples/traces-enabled/metrics.alloy
+++ b/examples/traces-enabled/metrics.alloy
@@ -275,6 +275,12 @@ discovery.relabel "annotation_autodiscovery_pods" {
     action = "replace"
     target_label = "__scheme__"
   }
+
+  rule {
+    source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_scrapeInterval"]
+    action = "replace"
+    target_label = "__scrape_interval__"
+  }
 }
 
 discovery.relabel "annotation_autodiscovery_services" {
@@ -335,6 +341,12 @@ discovery.relabel "annotation_autodiscovery_services" {
     source_labels = ["__meta_kubernetes_service_annotation_k8s_grafana_com_metrics_scheme"]
     action = "replace"
     target_label = "__scheme__"
+  }
+
+  rule {
+    source_labels = ["__meta_kubernetes_service_annotation_k8s_grafana_com_metrics_scrapeInterval"]
+    action = "replace"
+    target_label = "__scrape_interval__"
   }
 }
 

--- a/examples/traces-enabled/metrics.alloy
+++ b/examples/traces-enabled/metrics.alloy
@@ -358,6 +358,7 @@ discovery.relabel "annotation_autodiscovery_https" {
 
 prometheus.scrape "annotation_autodiscovery_http" {
   targets = discovery.relabel.annotation_autodiscovery_http.output
+  scrape_interval = "60s"
   honor_labels = true
   clustering {
     enabled = true
@@ -367,6 +368,7 @@ prometheus.scrape "annotation_autodiscovery_http" {
 
 prometheus.scrape "annotation_autodiscovery_https" {
   targets = discovery.relabel.annotation_autodiscovery_https.output
+  scrape_interval = "60s"
   honor_labels = true
   bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
   tls_config {

--- a/examples/traces-enabled/output.yaml
+++ b/examples/traces-enabled/output.yaml
@@ -499,6 +499,7 @@ data:
     
     prometheus.scrape "annotation_autodiscovery_http" {
       targets = discovery.relabel.annotation_autodiscovery_http.output
+      scrape_interval = "60s"
       honor_labels = true
       clustering {
         enabled = true
@@ -508,6 +509,7 @@ data:
     
     prometheus.scrape "annotation_autodiscovery_https" {
       targets = discovery.relabel.annotation_autodiscovery_https.output
+      scrape_interval = "60s"
       honor_labels = true
       bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
       tls_config {
@@ -53047,6 +53049,7 @@ data:
     
     prometheus.scrape "annotation_autodiscovery_http" {
       targets = discovery.relabel.annotation_autodiscovery_http.output
+      scrape_interval = "60s"
       honor_labels = true
       clustering {
         enabled = true
@@ -53056,6 +53059,7 @@ data:
     
     prometheus.scrape "annotation_autodiscovery_https" {
       targets = discovery.relabel.annotation_autodiscovery_https.output
+      scrape_interval = "60s"
       honor_labels = true
       bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
       tls_config {

--- a/examples/traces-enabled/output.yaml
+++ b/examples/traces-enabled/output.yaml
@@ -416,6 +416,12 @@ data:
         action = "replace"
         target_label = "__scheme__"
       }
+    
+      rule {
+        source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_scrapeInterval"]
+        action = "replace"
+        target_label = "__scrape_interval__"
+      }
     }
     
     discovery.relabel "annotation_autodiscovery_services" {
@@ -476,6 +482,12 @@ data:
         source_labels = ["__meta_kubernetes_service_annotation_k8s_grafana_com_metrics_scheme"]
         action = "replace"
         target_label = "__scheme__"
+      }
+    
+      rule {
+        source_labels = ["__meta_kubernetes_service_annotation_k8s_grafana_com_metrics_scrapeInterval"]
+        action = "replace"
+        target_label = "__scrape_interval__"
       }
     }
     
@@ -52966,6 +52978,12 @@ data:
         action = "replace"
         target_label = "__scheme__"
       }
+    
+      rule {
+        source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_scrapeInterval"]
+        action = "replace"
+        target_label = "__scrape_interval__"
+      }
     }
     
     discovery.relabel "annotation_autodiscovery_services" {
@@ -53026,6 +53044,12 @@ data:
         source_labels = ["__meta_kubernetes_service_annotation_k8s_grafana_com_metrics_scheme"]
         action = "replace"
         target_label = "__scheme__"
+      }
+    
+      rule {
+        source_labels = ["__meta_kubernetes_service_annotation_k8s_grafana_com_metrics_scrapeInterval"]
+        action = "replace"
+        target_label = "__scrape_interval__"
       }
     }
     

--- a/examples/windows-exporter/metrics.alloy
+++ b/examples/windows-exporter/metrics.alloy
@@ -272,6 +272,7 @@ discovery.relabel "annotation_autodiscovery_https" {
 
 prometheus.scrape "annotation_autodiscovery_http" {
   targets = discovery.relabel.annotation_autodiscovery_http.output
+  scrape_interval = "60s"
   honor_labels = true
   clustering {
     enabled = true
@@ -281,6 +282,7 @@ prometheus.scrape "annotation_autodiscovery_http" {
 
 prometheus.scrape "annotation_autodiscovery_https" {
   targets = discovery.relabel.annotation_autodiscovery_https.output
+  scrape_interval = "60s"
   honor_labels = true
   bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
   tls_config {

--- a/examples/windows-exporter/metrics.alloy
+++ b/examples/windows-exporter/metrics.alloy
@@ -189,6 +189,12 @@ discovery.relabel "annotation_autodiscovery_pods" {
     action = "replace"
     target_label = "__scheme__"
   }
+
+  rule {
+    source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_scrapeInterval"]
+    action = "replace"
+    target_label = "__scrape_interval__"
+  }
 }
 
 discovery.relabel "annotation_autodiscovery_services" {
@@ -249,6 +255,12 @@ discovery.relabel "annotation_autodiscovery_services" {
     source_labels = ["__meta_kubernetes_service_annotation_k8s_grafana_com_metrics_scheme"]
     action = "replace"
     target_label = "__scheme__"
+  }
+
+  rule {
+    source_labels = ["__meta_kubernetes_service_annotation_k8s_grafana_com_metrics_scrapeInterval"]
+    action = "replace"
+    target_label = "__scrape_interval__"
   }
 }
 

--- a/examples/windows-exporter/output.yaml
+++ b/examples/windows-exporter/output.yaml
@@ -354,6 +354,12 @@ data:
         action = "replace"
         target_label = "__scheme__"
       }
+    
+      rule {
+        source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_scrapeInterval"]
+        action = "replace"
+        target_label = "__scrape_interval__"
+      }
     }
     
     discovery.relabel "annotation_autodiscovery_services" {
@@ -414,6 +420,12 @@ data:
         source_labels = ["__meta_kubernetes_service_annotation_k8s_grafana_com_metrics_scheme"]
         action = "replace"
         target_label = "__scheme__"
+      }
+    
+      rule {
+        source_labels = ["__meta_kubernetes_service_annotation_k8s_grafana_com_metrics_scrapeInterval"]
+        action = "replace"
+        target_label = "__scrape_interval__"
       }
     }
     
@@ -52993,6 +53005,12 @@ data:
         action = "replace"
         target_label = "__scheme__"
       }
+    
+      rule {
+        source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_scrapeInterval"]
+        action = "replace"
+        target_label = "__scrape_interval__"
+      }
     }
     
     discovery.relabel "annotation_autodiscovery_services" {
@@ -53053,6 +53071,12 @@ data:
         source_labels = ["__meta_kubernetes_service_annotation_k8s_grafana_com_metrics_scheme"]
         action = "replace"
         target_label = "__scheme__"
+      }
+    
+      rule {
+        source_labels = ["__meta_kubernetes_service_annotation_k8s_grafana_com_metrics_scrapeInterval"]
+        action = "replace"
+        target_label = "__scrape_interval__"
       }
     }
     

--- a/examples/windows-exporter/output.yaml
+++ b/examples/windows-exporter/output.yaml
@@ -437,6 +437,7 @@ data:
     
     prometheus.scrape "annotation_autodiscovery_http" {
       targets = discovery.relabel.annotation_autodiscovery_http.output
+      scrape_interval = "60s"
       honor_labels = true
       clustering {
         enabled = true
@@ -446,6 +447,7 @@ data:
     
     prometheus.scrape "annotation_autodiscovery_https" {
       targets = discovery.relabel.annotation_autodiscovery_https.output
+      scrape_interval = "60s"
       honor_labels = true
       bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
       tls_config {
@@ -53074,6 +53076,7 @@ data:
     
     prometheus.scrape "annotation_autodiscovery_http" {
       targets = discovery.relabel.annotation_autodiscovery_http.output
+      scrape_interval = "60s"
       honor_labels = true
       clustering {
         enabled = true
@@ -53083,6 +53086,7 @@ data:
     
     prometheus.scrape "annotation_autodiscovery_https" {
       targets = discovery.relabel.annotation_autodiscovery_https.output
+      scrape_interval = "60s"
       honor_labels = true
       bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
       tls_config {


### PR DESCRIPTION
This adds support for configuring the scrapeInterval for the Auto-Discovery jobs (http & https) in the same way it can be modified for all other scrape jobs.