### PR TITLE
fix: allow for receiver service name override

### DIFF
--- a/charts/k8s-monitoring/templates/_helpers.tpl
+++ b/charts/k8s-monitoring/templates/_helpers.tpl
@@ -96,11 +96,11 @@
 {{ . | replace "-" "_" | replace "." "_" | replace "/" "_" }}
 {{- end }}
 
-{{- define "grafana-agent.fullname" -}}
-{{- if (index .Values "grafana-agent").fullnameOverride }}
-{{- (index .Values "grafana-agent").fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- define "alloy.fullname" -}}
+{{- if (index .Values "alloy").fullnameOverride }}
+{{- (index .Values "alloy").fullnameOverride | trunc 63 | trimSuffix "-" }}
 {{- else }}
-{{- $name := default "grafana-agent" (index .Values "grafana-agent").nameOverride }}
+{{- $name := default "alloy" (index .Values "alloy").nameOverride }}
 {{- if contains $name .Release.Name }}
 {{- .Release.Name | trunc 63 | trimSuffix "-" }}
 {{- else }}

--- a/charts/k8s-monitoring/templates/grafana-agent-receiver-service.yaml
+++ b/charts/k8s-monitoring/templates/grafana-agent-receiver-service.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "grafana-agent.fullname" . }}
+  name: {{ include "alloy.fullname" . }}
   labels:
     {{- include "alloy.labels" .Subcharts.alloy | nindent 4 }}
   {{- with .Values.alloy.service.annotations }}


### PR DESCRIPTION
## Description
We want to be able to pick the name of the receiver service, but after the migration to alloy whenever we pass in
`.Values.grafana-agent.fullnameOverride` we get the following error

```bash
Error: execution error at (grafana-chart/charts/k8s-monitoring/templates/kubernetes-monitoring-telemetry.yaml:1:3): 

As of k8s-monitoring Chart version 1.0, Grafana Agent has been replaced with Grafana Alloy.
These sections in your values file will need to be renamed:
  grafana-agent          --> alloy
  grafana-agent-events   --> alloy-events
  grafana-agent-logs     --> alloy-logs
  grafana-agent-profiles --> alloy-profiles
  metrics.agent          --> metrics.alloy

For more information, see https://github.com/grafana/k8s-monitoring-helm/tree/main/charts/k8s-monitoring#breaking-change-announcements

Use --debug flag to render out invalid YAML
```