### PR TITLE
allow specifying additional outputs for otlp batch processor

### DIFF
--- a/charts/k8s-monitoring/templates/alloy_config/_processors.alloy.txt
+++ b/charts/k8s-monitoring/templates/alloy_config/_processors.alloy.txt
@@ -287,14 +287,14 @@ otelcol.processor.batch "batch_processor" {
 {{- end }}
   output {
 {{- if .Values.metrics.enabled }}
-    metrics = [otelcol.exporter.prometheus.metrics_converter.input]
+    metrics = [{{ append ((.Values.receivers.processors.batch.output).metrics | default (list)) "otelcol.exporter.prometheus.metrics_converter.input" | join "," }}]
 {{- end }}
 {{- if .Values.logs.enabled }}
-    logs = [otelcol.exporter.loki.logs_converter.input]
+    logs = [{{ append ((.Values.receivers.processors.batch.output).logs | default (list)) "otelcol.exporter.loki.logs_converter.input" | join "," }}]
 {{- end }}
 {{- if .Values.traces.enabled }}
 {{- if eq .Values.externalServices.tempo.protocol "otlp" }}
-    traces = [otelcol.exporter.otlp.traces_service.input]
+    traces = [{{ append ((.Values.receivers.processors.batch.output).traces | default (list)) "otelcol.exporter.otlp.traces_service.input" | join "," }}]
 {{- else if eq .Values.externalServices.tempo.protocol "otlphttp" }}
     traces = [otelcol.exporter.otlphttp.traces_service.input]
 {{- end }}


### PR DESCRIPTION
motivation: hook into existing otlp receiver and avoid running another one just for exporting data to kafka

e.g.
```yaml
# values.yaml
receivers:
  processors:
    batch:
      output:
        metrics: [otelcol.exporter.kafka.kafka.input]
        logs: [otelcol.exporter.kafka.kafka.input]
        traces: [otelcol.exporter.kafka.kafka.input]
```