### PR TITLE
Only use internalTrafficPolicy: if on Kubernetes vesrion 1.26 or later

### DIFF
--- a/charts/k8s-monitoring/templates/grafana-agent-receiver-service.yaml
+++ b/charts/k8s-monitoring/templates/grafana-agent-receiver-service.yaml
@@ -16,7 +16,9 @@ spec:
   {{- end }}
   selector:
     {{- include "alloy.selectorLabels" .Subcharts.alloy | nindent 4 }}
+  {{- if semverCompare ">=1.26-0" .Capabilities.KubeVersion.Version }}
   internalTrafficPolicy: {{.Values.alloy.service.internalTrafficPolicy}}
+  {{- end }}
   ports:
     - name: http-metrics
       {{- if eq .Values.alloy.service.type "NodePort" }}


### PR DESCRIPTION

As far as I can tell, this is the only thing that prevents deploying on 1.19

