### PR TITLE
Add ability to set Loki labels from Pod labels

### DIFF
--- a/charts/k8s-monitoring/README.md
+++ b/charts/k8s-monitoring/README.md
@@ -400,6 +400,7 @@ The Prometheus and Loki services may be hosted on the same cluster, or remotely 
 | logs.pod_logs.extraRelabelingRules | string | `""` | Rule blocks to be added to the discovery.relabel component for pod logs. These relabeling rules are applied pre-scrape against the targets from service discovery. Before the scrape, any remaining target labels that start with `__` (i.e. `__meta_kubernetes*`) are dropped. ([docs](https://grafana.com/docs/alloy/latest/reference/components/discovery.relabel/#rule-block)) |
 | logs.pod_logs.extraStageBlocks | string | `""` | Stage blocks to be added to the loki.process component for pod logs. ([docs](https://grafana.com/docs/alloy/latest/reference/components/loki.process/#blocks)) This value is templated so that you can refer to other values from this file. |
 | logs.pod_logs.gatherMethod | string | `"volumes"` | Controls the behavior of gathering pod logs. When set to `volumes`, Grafana Alloy will use HostPath volume mounts on the cluster nodes to access the pod log files directly. When set to `api`, Grafana Alloy will access pod logs via the API server. This method may be preferable if your cluster prevents DaemonSets, HostPath volume mounts, or for other reasons. |
+| logs.pod_logs.labels | object | `{"app_kubernetes_io_name":"app.kubernetes.io/name"}` | Loki labels that will be set from the Kubernetes Pod labels. |
 | logs.pod_logs.namespaces | list | `[]` | Only capture logs from pods in these namespaces (`[]` means all namespaces). |
 
 ### Logs Scrape: PodLog Objects

--- a/charts/k8s-monitoring/README.md
+++ b/charts/k8s-monitoring/README.md
@@ -400,7 +400,7 @@ The Prometheus and Loki services may be hosted on the same cluster, or remotely 
 | logs.pod_logs.extraRelabelingRules | string | `""` | Rule blocks to be added to the discovery.relabel component for pod logs. These relabeling rules are applied pre-scrape against the targets from service discovery. Before the scrape, any remaining target labels that start with `__` (i.e. `__meta_kubernetes*`) are dropped. ([docs](https://grafana.com/docs/alloy/latest/reference/components/discovery.relabel/#rule-block)) |
 | logs.pod_logs.extraStageBlocks | string | `""` | Stage blocks to be added to the loki.process component for pod logs. ([docs](https://grafana.com/docs/alloy/latest/reference/components/loki.process/#blocks)) This value is templated so that you can refer to other values from this file. |
 | logs.pod_logs.gatherMethod | string | `"volumes"` | Controls the behavior of gathering pod logs. When set to `volumes`, Grafana Alloy will use HostPath volume mounts on the cluster nodes to access the pod log files directly. When set to `api`, Grafana Alloy will access pod logs via the API server. This method may be preferable if your cluster prevents DaemonSets, HostPath volume mounts, or for other reasons. |
-| logs.pod_logs.labels | object | `{"app_kubernetes_io_name":"app.kubernetes.io/name"}` | Loki labels that will be set from the Kubernetes Pod labels. |
+| logs.pod_logs.labels | object | `{"app_kubernetes_io_name":"app.kubernetes.io/name"}` | Loki labels to set with values copied fro the Kubernetes Pod labels. Format: `<loki_label>: <kubernetes_label>`. |
 | logs.pod_logs.namespaces | list | `[]` | Only capture logs from pods in these namespaces (`[]` means all namespaces). |
 
 ### Logs Scrape: PodLog Objects

--- a/charts/k8s-monitoring/templates/alloy_config/_pod_logs_discovery.alloy.txt
+++ b/charts/k8s-monitoring/templates/alloy_config/_pod_logs_discovery.alloy.txt
@@ -49,14 +49,12 @@ discovery.relabel "pod_logs" {
     target_label = "job"
   }
 
+{{- range $lokiLabel, $podLabel := .Values.logs.pod_logs.labels }}
   rule {
-    source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
-    target_label  = "name"
+    source_labels = ["__meta_kubernetes_pod_label_{{ include "escape_label" $podLabel }}"]
+    target_label  = {{ $lokiLabel | quote }}
   }
-  rule {
-    source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_component"]
-    target_label  = "component"
-  }
+{{ end }}
 
   {{- if eq .Values.logs.pod_logs.gatherMethod "volumes" }}
   rule {

--- a/charts/k8s-monitoring/templates/alloy_config/_pod_logs_discovery.alloy.txt
+++ b/charts/k8s-monitoring/templates/alloy_config/_pod_logs_discovery.alloy.txt
@@ -48,6 +48,16 @@ discovery.relabel "pod_logs" {
     replacement = "$1"
     target_label = "job"
   }
+
+  rule {
+    source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+    target_label  = "name"
+  }
+  rule {
+    source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_component"]
+    target_label  = "component"
+  }
+
   {{- if eq .Values.logs.pod_logs.gatherMethod "volumes" }}
   rule {
     source_labels = ["__meta_kubernetes_pod_uid", "__meta_kubernetes_pod_container_name"]

--- a/charts/k8s-monitoring/values.yaml
+++ b/charts/k8s-monitoring/values.yaml
@@ -1382,6 +1382,11 @@ logs:
     # @section -- Logs Scrape: Pod Logs
     extraStageBlocks: ""
 
+    # -- Loki labels that will be set from the Kubernetes Pod labels.
+    # @section -- Logs Scrape: Pod Logs
+    labels:
+      app_kubernetes_io_name: app.kubernetes.io/name
+
   # PodLog Objects
   podLogsObjects:
     # -- Enable discovery of Grafana Alloy PodLogs objects.

--- a/charts/k8s-monitoring/values.yaml
+++ b/charts/k8s-monitoring/values.yaml
@@ -1382,7 +1382,8 @@ logs:
     # @section -- Logs Scrape: Pod Logs
     extraStageBlocks: ""
 
-    # -- Loki labels that will be set from the Kubernetes Pod labels.
+    # -- Loki labels to set with values copied from the Kubernetes Pod labels.
+    # Format: `<loki_label>: <kubernetes_label>`.
     # @section -- Logs Scrape: Pod Logs
     labels:
       app_kubernetes_io_name: app.kubernetes.io/name

--- a/examples/alloy-autoscaling-and-storage/logs.alloy
+++ b/examples/alloy-autoscaling-and-storage/logs.alloy
@@ -33,6 +33,11 @@ discovery.relabel "pod_logs" {
     target_label = "job"
   }
   rule {
+    source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+    target_label  = "app_kubernetes_io_name"
+  }
+
+  rule {
     source_labels = ["__meta_kubernetes_pod_uid", "__meta_kubernetes_pod_container_name"]
     separator = "/"
     action = "replace"

--- a/examples/alloy-autoscaling-and-storage/output.yaml
+++ b/examples/alloy-autoscaling-and-storage/output.yaml
@@ -1078,6 +1078,11 @@ data:
         target_label = "job"
       }
       rule {
+        source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+        target_label  = "app_kubernetes_io_name"
+      }
+    
+      rule {
         source_labels = ["__meta_kubernetes_pod_uid", "__meta_kubernetes_pod_container_name"]
         separator = "/"
         action = "replace"
@@ -60003,6 +60008,11 @@ data:
         replacement = "$1"
         target_label = "job"
       }
+      rule {
+        source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+        target_label  = "app_kubernetes_io_name"
+      }
+    
       rule {
         source_labels = ["__meta_kubernetes_pod_uid", "__meta_kubernetes_pod_container_name"]
         separator = "/"

--- a/examples/application-observability/logs.alloy
+++ b/examples/application-observability/logs.alloy
@@ -33,6 +33,11 @@ discovery.relabel "pod_logs" {
     target_label = "job"
   }
   rule {
+    source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+    target_label  = "app_kubernetes_io_name"
+  }
+
+  rule {
     source_labels = ["__meta_kubernetes_pod_uid", "__meta_kubernetes_pod_container_name"]
     separator = "/"
     action = "replace"

--- a/examples/application-observability/output.yaml
+++ b/examples/application-observability/output.yaml
@@ -1172,6 +1172,11 @@ data:
         target_label = "job"
       }
       rule {
+        source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+        target_label  = "app_kubernetes_io_name"
+      }
+    
+      rule {
         source_labels = ["__meta_kubernetes_pod_uid", "__meta_kubernetes_pod_container_name"]
         separator = "/"
         action = "replace"
@@ -61191,6 +61196,11 @@ data:
         replacement = "$1"
         target_label = "job"
       }
+      rule {
+        source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+        target_label  = "app_kubernetes_io_name"
+      }
+    
       rule {
         source_labels = ["__meta_kubernetes_pod_uid", "__meta_kubernetes_pod_container_name"]
         separator = "/"

--- a/examples/control-plane-metrics/logs.alloy
+++ b/examples/control-plane-metrics/logs.alloy
@@ -33,6 +33,11 @@ discovery.relabel "pod_logs" {
     target_label = "job"
   }
   rule {
+    source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+    target_label  = "app_kubernetes_io_name"
+  }
+
+  rule {
     source_labels = ["__meta_kubernetes_pod_uid", "__meta_kubernetes_pod_container_name"]
     separator = "/"
     action = "replace"

--- a/examples/control-plane-metrics/output.yaml
+++ b/examples/control-plane-metrics/output.yaml
@@ -1235,6 +1235,11 @@ data:
         target_label = "job"
       }
       rule {
+        source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+        target_label  = "app_kubernetes_io_name"
+      }
+    
+      rule {
         source_labels = ["__meta_kubernetes_pod_uid", "__meta_kubernetes_pod_container_name"]
         separator = "/"
         action = "replace"
@@ -60255,6 +60260,11 @@ data:
         replacement = "$1"
         target_label = "job"
       }
+      rule {
+        source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+        target_label  = "app_kubernetes_io_name"
+      }
+    
       rule {
         source_labels = ["__meta_kubernetes_pod_uid", "__meta_kubernetes_pod_container_name"]
         separator = "/"

--- a/examples/custom-config/logs.alloy
+++ b/examples/custom-config/logs.alloy
@@ -33,6 +33,11 @@ discovery.relabel "pod_logs" {
     target_label = "job"
   }
   rule {
+    source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+    target_label  = "app_kubernetes_io_name"
+  }
+
+  rule {
     source_labels = ["__meta_kubernetes_pod_uid", "__meta_kubernetes_pod_container_name"]
     separator = "/"
     action = "replace"

--- a/examples/custom-config/output.yaml
+++ b/examples/custom-config/output.yaml
@@ -1124,6 +1124,11 @@ data:
         target_label = "job"
       }
       rule {
+        source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+        target_label  = "app_kubernetes_io_name"
+      }
+    
+      rule {
         source_labels = ["__meta_kubernetes_pod_uid", "__meta_kubernetes_pod_container_name"]
         separator = "/"
         action = "replace"
@@ -60081,6 +60086,11 @@ data:
         replacement = "$1"
         target_label = "job"
       }
+      rule {
+        source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+        target_label  = "app_kubernetes_io_name"
+      }
+    
       rule {
         source_labels = ["__meta_kubernetes_pod_uid", "__meta_kubernetes_pod_container_name"]
         separator = "/"

--- a/examples/custom-pricing/logs.alloy
+++ b/examples/custom-pricing/logs.alloy
@@ -33,6 +33,11 @@ discovery.relabel "pod_logs" {
     target_label = "job"
   }
   rule {
+    source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+    target_label  = "app_kubernetes_io_name"
+  }
+
+  rule {
     source_labels = ["__meta_kubernetes_pod_uid", "__meta_kubernetes_pod_container_name"]
     separator = "/"
     action = "replace"

--- a/examples/custom-pricing/output.yaml
+++ b/examples/custom-pricing/output.yaml
@@ -1100,6 +1100,11 @@ data:
         target_label = "job"
       }
       rule {
+        source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+        target_label  = "app_kubernetes_io_name"
+      }
+    
+      rule {
         source_labels = ["__meta_kubernetes_pod_uid", "__meta_kubernetes_pod_container_name"]
         separator = "/"
         action = "replace"
@@ -59975,6 +59980,11 @@ data:
         replacement = "$1"
         target_label = "job"
       }
+      rule {
+        source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+        target_label  = "app_kubernetes_io_name"
+      }
+    
       rule {
         source_labels = ["__meta_kubernetes_pod_uid", "__meta_kubernetes_pod_container_name"]
         separator = "/"

--- a/examples/default-values/logs.alloy
+++ b/examples/default-values/logs.alloy
@@ -33,6 +33,11 @@ discovery.relabel "pod_logs" {
     target_label = "job"
   }
   rule {
+    source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+    target_label  = "app_kubernetes_io_name"
+  }
+
+  rule {
     source_labels = ["__meta_kubernetes_pod_uid", "__meta_kubernetes_pod_container_name"]
     separator = "/"
     action = "replace"

--- a/examples/default-values/output.yaml
+++ b/examples/default-values/output.yaml
@@ -1078,6 +1078,11 @@ data:
         target_label = "job"
       }
       rule {
+        source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+        target_label  = "app_kubernetes_io_name"
+      }
+    
+      rule {
         source_labels = ["__meta_kubernetes_pod_uid", "__meta_kubernetes_pod_container_name"]
         separator = "/"
         action = "replace"
@@ -59942,6 +59947,11 @@ data:
         replacement = "$1"
         target_label = "job"
       }
+      rule {
+        source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+        target_label  = "app_kubernetes_io_name"
+      }
+    
       rule {
         source_labels = ["__meta_kubernetes_pod_uid", "__meta_kubernetes_pod_container_name"]
         separator = "/"

--- a/examples/eks-fargate/logs.alloy
+++ b/examples/eks-fargate/logs.alloy
@@ -28,6 +28,11 @@ discovery.relabel "pod_logs" {
     replacement = "$1"
     target_label = "job"
   }
+  rule {
+    source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+    target_label  = "app_kubernetes_io_name"
+  }
+
 
   // set the container runtime as a label
   rule {

--- a/examples/eks-fargate/output.yaml
+++ b/examples/eks-fargate/output.yaml
@@ -1010,6 +1010,11 @@ data:
         replacement = "$1"
         target_label = "job"
       }
+      rule {
+        source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+        target_label  = "app_kubernetes_io_name"
+      }
+    
     
       // set the container runtime as a label
       rule {
@@ -59696,6 +59701,11 @@ data:
         replacement = "$1"
         target_label = "job"
       }
+      rule {
+        source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+        target_label  = "app_kubernetes_io_name"
+      }
+    
     
       // set the container runtime as a label
       rule {

--- a/examples/extra-rules/logs.alloy
+++ b/examples/extra-rules/logs.alloy
@@ -33,6 +33,11 @@ discovery.relabel "pod_logs" {
     target_label = "job"
   }
   rule {
+    source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+    target_label  = "app_kubernetes_io_name"
+  }
+
+  rule {
     source_labels = ["__meta_kubernetes_pod_uid", "__meta_kubernetes_pod_container_name"]
     separator = "/"
     action = "replace"

--- a/examples/extra-rules/output.yaml
+++ b/examples/extra-rules/output.yaml
@@ -1170,6 +1170,11 @@ data:
         target_label = "job"
       }
       rule {
+        source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+        target_label  = "app_kubernetes_io_name"
+      }
+    
+      rule {
         source_labels = ["__meta_kubernetes_pod_uid", "__meta_kubernetes_pod_container_name"]
         separator = "/"
         action = "replace"
@@ -60155,6 +60160,11 @@ data:
         replacement = "$1"
         target_label = "job"
       }
+      rule {
+        source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+        target_label  = "app_kubernetes_io_name"
+      }
+    
       rule {
         source_labels = ["__meta_kubernetes_pod_uid", "__meta_kubernetes_pod_container_name"]
         separator = "/"

--- a/examples/gke-autopilot/logs.alloy
+++ b/examples/gke-autopilot/logs.alloy
@@ -33,6 +33,11 @@ discovery.relabel "pod_logs" {
     target_label = "job"
   }
   rule {
+    source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+    target_label  = "app_kubernetes_io_name"
+  }
+
+  rule {
     source_labels = ["__meta_kubernetes_pod_uid", "__meta_kubernetes_pod_container_name"]
     separator = "/"
     action = "replace"

--- a/examples/gke-autopilot/output.yaml
+++ b/examples/gke-autopilot/output.yaml
@@ -1015,6 +1015,11 @@ data:
         target_label = "job"
       }
       rule {
+        source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+        target_label  = "app_kubernetes_io_name"
+      }
+    
+      rule {
         source_labels = ["__meta_kubernetes_pod_uid", "__meta_kubernetes_pod_container_name"]
         separator = "/"
         action = "replace"
@@ -59684,6 +59689,11 @@ data:
         replacement = "$1"
         target_label = "job"
       }
+      rule {
+        source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+        target_label  = "app_kubernetes_io_name"
+      }
+    
       rule {
         source_labels = ["__meta_kubernetes_pod_uid", "__meta_kubernetes_pod_container_name"]
         separator = "/"

--- a/examples/ibm-cloud/logs.alloy
+++ b/examples/ibm-cloud/logs.alloy
@@ -33,6 +33,11 @@ discovery.relabel "pod_logs" {
     target_label = "job"
   }
   rule {
+    source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+    target_label  = "app_kubernetes_io_name"
+  }
+
+  rule {
     source_labels = ["__meta_kubernetes_pod_uid", "__meta_kubernetes_pod_container_name"]
     separator = "/"
     action = "replace"

--- a/examples/ibm-cloud/output.yaml
+++ b/examples/ibm-cloud/output.yaml
@@ -1078,6 +1078,11 @@ data:
         target_label = "job"
       }
       rule {
+        source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+        target_label  = "app_kubernetes_io_name"
+      }
+    
+      rule {
         source_labels = ["__meta_kubernetes_pod_uid", "__meta_kubernetes_pod_container_name"]
         separator = "/"
         action = "replace"
@@ -59948,6 +59953,11 @@ data:
         replacement = "$1"
         target_label = "job"
       }
+      rule {
+        source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+        target_label  = "app_kubernetes_io_name"
+      }
+    
       rule {
         source_labels = ["__meta_kubernetes_pod_uid", "__meta_kubernetes_pod_container_name"]
         separator = "/"

--- a/examples/logs-journal/logs.alloy
+++ b/examples/logs-journal/logs.alloy
@@ -33,6 +33,11 @@ discovery.relabel "pod_logs" {
     target_label = "job"
   }
   rule {
+    source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+    target_label  = "app_kubernetes_io_name"
+  }
+
+  rule {
     source_labels = ["__meta_kubernetes_pod_uid", "__meta_kubernetes_pod_container_name"]
     separator = "/"
     action = "replace"

--- a/examples/logs-journal/output.yaml
+++ b/examples/logs-journal/output.yaml
@@ -275,6 +275,11 @@ data:
         target_label = "job"
       }
       rule {
+        source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+        target_label  = "app_kubernetes_io_name"
+      }
+    
+      rule {
         source_labels = ["__meta_kubernetes_pod_uid", "__meta_kubernetes_pod_container_name"]
         separator = "/"
         action = "replace"
@@ -1524,6 +1529,11 @@ data:
         replacement = "$1"
         target_label = "job"
       }
+      rule {
+        source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+        target_label  = "app_kubernetes_io_name"
+      }
+    
       rule {
         source_labels = ["__meta_kubernetes_pod_uid", "__meta_kubernetes_pod_container_name"]
         separator = "/"

--- a/examples/logs-only/logs.alloy
+++ b/examples/logs-only/logs.alloy
@@ -33,6 +33,11 @@ discovery.relabel "pod_logs" {
     target_label = "job"
   }
   rule {
+    source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+    target_label  = "app_kubernetes_io_name"
+  }
+
+  rule {
     source_labels = ["__meta_kubernetes_pod_uid", "__meta_kubernetes_pod_container_name"]
     separator = "/"
     action = "replace"

--- a/examples/logs-only/output.yaml
+++ b/examples/logs-only/output.yaml
@@ -355,6 +355,11 @@ data:
         target_label = "job"
       }
       rule {
+        source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+        target_label  = "app_kubernetes_io_name"
+      }
+    
+      rule {
         source_labels = ["__meta_kubernetes_pod_uid", "__meta_kubernetes_pod_container_name"]
         separator = "/"
         action = "replace"
@@ -1656,6 +1661,11 @@ data:
         replacement = "$1"
         target_label = "job"
       }
+      rule {
+        source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+        target_label  = "app_kubernetes_io_name"
+      }
+    
       rule {
         source_labels = ["__meta_kubernetes_pod_uid", "__meta_kubernetes_pod_container_name"]
         separator = "/"

--- a/examples/metric-module-imports-extra-config/logs.alloy
+++ b/examples/metric-module-imports-extra-config/logs.alloy
@@ -33,6 +33,11 @@ discovery.relabel "pod_logs" {
     target_label = "job"
   }
   rule {
+    source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+    target_label  = "app_kubernetes_io_name"
+  }
+
+  rule {
     source_labels = ["__meta_kubernetes_pod_uid", "__meta_kubernetes_pod_container_name"]
     separator = "/"
     action = "replace"

--- a/examples/metric-module-imports-extra-config/output.yaml
+++ b/examples/metric-module-imports-extra-config/output.yaml
@@ -1094,6 +1094,11 @@ data:
         target_label = "job"
       }
       rule {
+        source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+        target_label  = "app_kubernetes_io_name"
+      }
+    
+      rule {
         source_labels = ["__meta_kubernetes_pod_uid", "__meta_kubernetes_pod_container_name"]
         separator = "/"
         action = "replace"
@@ -59974,6 +59979,11 @@ data:
         replacement = "$1"
         target_label = "job"
       }
+      rule {
+        source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+        target_label  = "app_kubernetes_io_name"
+      }
+    
       rule {
         source_labels = ["__meta_kubernetes_pod_uid", "__meta_kubernetes_pod_container_name"]
         separator = "/"

--- a/examples/metric-module-imports/logs.alloy
+++ b/examples/metric-module-imports/logs.alloy
@@ -33,6 +33,11 @@ discovery.relabel "pod_logs" {
     target_label = "job"
   }
   rule {
+    source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+    target_label  = "app_kubernetes_io_name"
+  }
+
+  rule {
     source_labels = ["__meta_kubernetes_pod_uid", "__meta_kubernetes_pod_container_name"]
     separator = "/"
     action = "replace"

--- a/examples/metric-module-imports/output.yaml
+++ b/examples/metric-module-imports/output.yaml
@@ -1255,6 +1255,11 @@ data:
         target_label = "job"
       }
       rule {
+        source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+        target_label  = "app_kubernetes_io_name"
+      }
+    
+      rule {
         source_labels = ["__meta_kubernetes_pod_uid", "__meta_kubernetes_pod_container_name"]
         separator = "/"
         action = "replace"
@@ -60296,6 +60301,11 @@ data:
         replacement = "$1"
         target_label = "job"
       }
+      rule {
+        source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+        target_label  = "app_kubernetes_io_name"
+      }
+    
       rule {
         source_labels = ["__meta_kubernetes_pod_uid", "__meta_kubernetes_pod_container_name"]
         separator = "/"

--- a/examples/openshift-compatible/logs.alloy
+++ b/examples/openshift-compatible/logs.alloy
@@ -33,6 +33,11 @@ discovery.relabel "pod_logs" {
     target_label = "job"
   }
   rule {
+    source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+    target_label  = "app_kubernetes_io_name"
+  }
+
+  rule {
     source_labels = ["__meta_kubernetes_pod_uid", "__meta_kubernetes_pod_container_name"]
     separator = "/"
     action = "replace"

--- a/examples/openshift-compatible/output.yaml
+++ b/examples/openshift-compatible/output.yaml
@@ -1050,6 +1050,11 @@ data:
         target_label = "job"
       }
       rule {
+        source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+        target_label  = "app_kubernetes_io_name"
+      }
+    
+      rule {
         source_labels = ["__meta_kubernetes_pod_uid", "__meta_kubernetes_pod_container_name"]
         separator = "/"
         action = "replace"
@@ -59793,6 +59798,11 @@ data:
         replacement = "$1"
         target_label = "job"
       }
+      rule {
+        source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+        target_label  = "app_kubernetes_io_name"
+      }
+    
       rule {
         source_labels = ["__meta_kubernetes_pod_uid", "__meta_kubernetes_pod_container_name"]
         separator = "/"

--- a/examples/otel-metrics-service/logs.alloy
+++ b/examples/otel-metrics-service/logs.alloy
@@ -33,6 +33,11 @@ discovery.relabel "pod_logs" {
     target_label = "job"
   }
   rule {
+    source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+    target_label  = "app_kubernetes_io_name"
+  }
+
+  rule {
     source_labels = ["__meta_kubernetes_pod_uid", "__meta_kubernetes_pod_container_name"]
     separator = "/"
     action = "replace"

--- a/examples/otel-metrics-service/output.yaml
+++ b/examples/otel-metrics-service/output.yaml
@@ -1095,6 +1095,11 @@ data:
         target_label = "job"
       }
       rule {
+        source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+        target_label  = "app_kubernetes_io_name"
+      }
+    
+      rule {
         source_labels = ["__meta_kubernetes_pod_uid", "__meta_kubernetes_pod_container_name"]
         separator = "/"
         action = "replace"
@@ -59976,6 +59981,11 @@ data:
         replacement = "$1"
         target_label = "job"
       }
+      rule {
+        source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+        target_label  = "app_kubernetes_io_name"
+      }
+    
       rule {
         source_labels = ["__meta_kubernetes_pod_uid", "__meta_kubernetes_pod_container_name"]
         separator = "/"

--- a/examples/pod-labels/logs.alloy
+++ b/examples/pod-labels/logs.alloy
@@ -33,6 +33,11 @@ discovery.relabel "pod_logs" {
     target_label = "job"
   }
   rule {
+    source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+    target_label  = "app_kubernetes_io_name"
+  }
+
+  rule {
     source_labels = ["__meta_kubernetes_pod_uid", "__meta_kubernetes_pod_container_name"]
     separator = "/"
     action = "replace"

--- a/examples/pod-labels/output.yaml
+++ b/examples/pod-labels/output.yaml
@@ -1148,6 +1148,11 @@ data:
         target_label = "job"
       }
       rule {
+        source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+        target_label  = "app_kubernetes_io_name"
+      }
+    
+      rule {
         source_labels = ["__meta_kubernetes_pod_uid", "__meta_kubernetes_pod_container_name"]
         separator = "/"
         action = "replace"
@@ -60076,6 +60081,11 @@ data:
         replacement = "$1"
         target_label = "job"
       }
+      rule {
+        source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+        target_label  = "app_kubernetes_io_name"
+      }
+    
       rule {
         source_labels = ["__meta_kubernetes_pod_uid", "__meta_kubernetes_pod_container_name"]
         separator = "/"

--- a/examples/private-image-registry/logs.alloy
+++ b/examples/private-image-registry/logs.alloy
@@ -33,6 +33,11 @@ discovery.relabel "pod_logs" {
     target_label = "job"
   }
   rule {
+    source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+    target_label  = "app_kubernetes_io_name"
+  }
+
+  rule {
     source_labels = ["__meta_kubernetes_pod_uid", "__meta_kubernetes_pod_container_name"]
     separator = "/"
     action = "replace"

--- a/examples/private-image-registry/output.yaml
+++ b/examples/private-image-registry/output.yaml
@@ -1082,6 +1082,11 @@ data:
         target_label = "job"
       }
       rule {
+        source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+        target_label  = "app_kubernetes_io_name"
+      }
+    
+      rule {
         source_labels = ["__meta_kubernetes_pod_uid", "__meta_kubernetes_pod_container_name"]
         separator = "/"
         action = "replace"
@@ -59958,6 +59963,11 @@ data:
         replacement = "$1"
         target_label = "job"
       }
+      rule {
+        source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+        target_label  = "app_kubernetes_io_name"
+      }
+    
       rule {
         source_labels = ["__meta_kubernetes_pod_uid", "__meta_kubernetes_pod_container_name"]
         separator = "/"

--- a/examples/profiles-enabled/logs.alloy
+++ b/examples/profiles-enabled/logs.alloy
@@ -33,6 +33,11 @@ discovery.relabel "pod_logs" {
     target_label = "job"
   }
   rule {
+    source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+    target_label  = "app_kubernetes_io_name"
+  }
+
+  rule {
     source_labels = ["__meta_kubernetes_pod_uid", "__meta_kubernetes_pod_container_name"]
     separator = "/"
     action = "replace"

--- a/examples/profiles-enabled/output.yaml
+++ b/examples/profiles-enabled/output.yaml
@@ -1107,6 +1107,11 @@ data:
         target_label = "job"
       }
       rule {
+        source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+        target_label  = "app_kubernetes_io_name"
+      }
+    
+      rule {
         source_labels = ["__meta_kubernetes_pod_uid", "__meta_kubernetes_pod_container_name"]
         separator = "/"
         action = "replace"
@@ -61074,6 +61079,11 @@ data:
         replacement = "$1"
         target_label = "job"
       }
+      rule {
+        source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+        target_label  = "app_kubernetes_io_name"
+      }
+    
       rule {
         source_labels = ["__meta_kubernetes_pod_uid", "__meta_kubernetes_pod_container_name"]
         separator = "/"

--- a/examples/proxies/logs.alloy
+++ b/examples/proxies/logs.alloy
@@ -33,6 +33,11 @@ discovery.relabel "pod_logs" {
     target_label = "job"
   }
   rule {
+    source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+    target_label  = "app_kubernetes_io_name"
+  }
+
+  rule {
     source_labels = ["__meta_kubernetes_pod_uid", "__meta_kubernetes_pod_container_name"]
     separator = "/"
     action = "replace"

--- a/examples/proxies/output.yaml
+++ b/examples/proxies/output.yaml
@@ -1090,6 +1090,11 @@ data:
         target_label = "job"
       }
       rule {
+        source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+        target_label  = "app_kubernetes_io_name"
+      }
+    
+      rule {
         source_labels = ["__meta_kubernetes_pod_uid", "__meta_kubernetes_pod_container_name"]
         separator = "/"
         action = "replace"
@@ -59970,6 +59975,11 @@ data:
         replacement = "$1"
         target_label = "job"
       }
+      rule {
+        source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+        target_label  = "app_kubernetes_io_name"
+      }
+    
       rule {
         source_labels = ["__meta_kubernetes_pod_uid", "__meta_kubernetes_pod_container_name"]
         separator = "/"

--- a/examples/service-integrations/logs.alloy
+++ b/examples/service-integrations/logs.alloy
@@ -33,6 +33,11 @@ discovery.relabel "pod_logs" {
     target_label = "job"
   }
   rule {
+    source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+    target_label  = "app_kubernetes_io_name"
+  }
+
+  rule {
     source_labels = ["__meta_kubernetes_pod_uid", "__meta_kubernetes_pod_container_name"]
     separator = "/"
     action = "replace"

--- a/examples/service-integrations/output.yaml
+++ b/examples/service-integrations/output.yaml
@@ -1098,6 +1098,11 @@ data:
         target_label = "job"
       }
       rule {
+        source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+        target_label  = "app_kubernetes_io_name"
+      }
+    
+      rule {
         source_labels = ["__meta_kubernetes_pod_uid", "__meta_kubernetes_pod_container_name"]
         separator = "/"
         action = "replace"
@@ -59997,6 +60002,11 @@ data:
         replacement = "$1"
         target_label = "job"
       }
+      rule {
+        source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+        target_label  = "app_kubernetes_io_name"
+      }
+    
       rule {
         source_labels = ["__meta_kubernetes_pod_uid", "__meta_kubernetes_pod_container_name"]
         separator = "/"

--- a/examples/specific-namespace/logs.alloy
+++ b/examples/specific-namespace/logs.alloy
@@ -38,6 +38,11 @@ discovery.relabel "pod_logs" {
     target_label = "job"
   }
   rule {
+    source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+    target_label  = "app_kubernetes_io_name"
+  }
+
+  rule {
     source_labels = ["__meta_kubernetes_pod_uid", "__meta_kubernetes_pod_container_name"]
     separator = "/"
     action = "replace"

--- a/examples/specific-namespace/output.yaml
+++ b/examples/specific-namespace/output.yaml
@@ -1142,6 +1142,11 @@ data:
         target_label = "job"
       }
       rule {
+        source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+        target_label  = "app_kubernetes_io_name"
+      }
+    
+      rule {
         source_labels = ["__meta_kubernetes_pod_uid", "__meta_kubernetes_pod_container_name"]
         separator = "/"
         action = "replace"
@@ -60070,6 +60075,11 @@ data:
         replacement = "$1"
         target_label = "job"
       }
+      rule {
+        source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+        target_label  = "app_kubernetes_io_name"
+      }
+    
       rule {
         source_labels = ["__meta_kubernetes_pod_uid", "__meta_kubernetes_pod_container_name"]
         separator = "/"

--- a/examples/traces-enabled/logs.alloy
+++ b/examples/traces-enabled/logs.alloy
@@ -33,6 +33,11 @@ discovery.relabel "pod_logs" {
     target_label = "job"
   }
   rule {
+    source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+    target_label  = "app_kubernetes_io_name"
+  }
+
+  rule {
     source_labels = ["__meta_kubernetes_pod_uid", "__meta_kubernetes_pod_container_name"]
     separator = "/"
     action = "replace"

--- a/examples/traces-enabled/output.yaml
+++ b/examples/traces-enabled/output.yaml
@@ -1197,6 +1197,11 @@ data:
         target_label = "job"
       }
       rule {
+        source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+        target_label  = "app_kubernetes_io_name"
+      }
+    
+      rule {
         source_labels = ["__meta_kubernetes_pod_uid", "__meta_kubernetes_pod_container_name"]
         separator = "/"
         action = "replace"
@@ -60167,6 +60172,11 @@ data:
         replacement = "$1"
         target_label = "job"
       }
+      rule {
+        source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+        target_label  = "app_kubernetes_io_name"
+      }
+    
       rule {
         source_labels = ["__meta_kubernetes_pod_uid", "__meta_kubernetes_pod_container_name"]
         separator = "/"

--- a/examples/windows-exporter/logs.alloy
+++ b/examples/windows-exporter/logs.alloy
@@ -33,6 +33,11 @@ discovery.relabel "pod_logs" {
     target_label = "job"
   }
   rule {
+    source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+    target_label  = "app_kubernetes_io_name"
+  }
+
+  rule {
     source_labels = ["__meta_kubernetes_pod_uid", "__meta_kubernetes_pod_container_name"]
     separator = "/"
     action = "replace"

--- a/examples/windows-exporter/output.yaml
+++ b/examples/windows-exporter/output.yaml
@@ -1184,6 +1184,11 @@ data:
         target_label = "job"
       }
       rule {
+        source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+        target_label  = "app_kubernetes_io_name"
+      }
+    
+      rule {
         source_labels = ["__meta_kubernetes_pod_uid", "__meta_kubernetes_pod_container_name"]
         separator = "/"
         action = "replace"
@@ -60243,6 +60248,11 @@ data:
         replacement = "$1"
         target_label = "job"
       }
+      rule {
+        source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+        target_label  = "app_kubernetes_io_name"
+      }
+    
       rule {
         source_labels = ["__meta_kubernetes_pod_uid", "__meta_kubernetes_pod_container_name"]
         separator = "/"


### PR DESCRIPTION
Chose to set `app_kubernetes_io_name` from the Pod label `app.kubernetes.io/name`, because it's the most clear what is happening.