### PR TITLE
feat: allow adding extra outputs

### DIFF
--- a/charts/k8s-monitoring/README.md
+++ b/charts/k8s-monitoring/README.md
@@ -227,6 +227,7 @@ The Prometheus and Loki services may be hosted on the same cluster, or remotely 
 | externalServices.loki.basicAuth.usernameKey | string | `"username"` | The key for the username property in the secret |
 | externalServices.loki.externalLabels | object | `{}` | Custom labels to be added to all logs and events, all values are treated as strings and automatically quoted. |
 | externalServices.loki.externalLabelsFrom | object | `{}` | Custom labels to be added to all logs and events through a dynamic reference, all values are treated as raw strings and not quoted. |
+| externalServices.loki.extraOutputs | list | `[]` | Extra outputs configured in Alloy to send logs to at the end on the pipeline. When the protocol is "loki" the output is in the Loki format, while if the protocol is "otlp" or "otlphttp" it is the OTel format. |
 | externalServices.loki.host | string | `""` | Loki host where logs and events will be sent |
 | externalServices.loki.hostKey | string | `"host"` | The key for the host property in the secret |
 | externalServices.loki.processors.batch.maxSize | int | `0` | Upper limit of a batch size. When set to 0, there is no upper limit. |
@@ -257,6 +258,7 @@ The Prometheus and Loki services may be hosted on the same cluster, or remotely 
 | externalServices.prometheus.basicAuth.usernameKey | string | `"username"` | The key for the username property in the secret |
 | externalServices.prometheus.externalLabels | object | `{}` | Custom labels to be added to all time series, all values are treated as strings and automatically quoted. |
 | externalServices.prometheus.externalLabelsFrom | object | `{}` | Custom labels to be added to all time series through a dynamic reference, all values are treated as raw strings and not quoted. |
+| externalServices.prometheus.extraOutputs | list | `[]` | Extra outputs configured in Alloy to send metics to at the end on the pipeline. When the protocol is "remote_write" the output is in the Prometheus format, while if the protocol is "otlp" or "otlphttp" it is the OTel format. |
 | externalServices.prometheus.host | string | `""` | Prometheus host where metrics will be sent |
 | externalServices.prometheus.hostKey | string | `"host"` | The key for the host property in the secret |
 | externalServices.prometheus.processors.batch.maxSize | int | `0` | Upper limit of a batch size. When set to 0, there is no upper limit. |
@@ -759,6 +761,9 @@ The Prometheus and Loki services may be hosted on the same cluster, or remotely 
 |-----|------|---------|-------------|
 | receivers.grafanaCloudMetrics.enabled | bool | `true` | Generate host info metrics from telemetry data, used in Application Observability in Grafana Cloud. |
 | receivers.processors.batch.maxSize | int | `0` | The upper limit of the amount of data contained in a single batch, in bytes. When set to 0, batches can be any size. |
+| receivers.processors.batch.output.logs | list | `[]` | Extra outputs to send the batched logs to. |
+| receivers.processors.batch.output.metrics | list | `[]` | Extra outputs to send the batched metrics to. |
+| receivers.processors.batch.output.traces | list | `[]` | Extra outputs to send the batched traces to. |
 | receivers.processors.batch.size | int | `16384` | What batch size to use, in bytes |
 | receivers.processors.batch.timeout | string | `"2s"` | How long before sending (Processors) |
 | receivers.processors.k8sattributes.annotations | list | `[]` | Kubernetes annotations to extract and add to the attributes of the received telemetry data. |

--- a/charts/k8s-monitoring/templates/alloy_config/_logs_service.alloy.txt
+++ b/charts/k8s-monitoring/templates/alloy_config/_logs_service.alloy.txt
@@ -13,7 +13,7 @@ loki.process "logs_service" {
   }
 
 {{- if eq .Values.externalServices.loki.protocol "loki" }}
-  forward_to = [loki.write.logs_service.receiver]
+  forward_to = [{{ append (.Values.externalServices.loki.extraOutputs | default (list)) "loki.write.logs_service.receiver" | join "," }}]
 }
 {{ include "alloy.config.logsServiceLoki" . }}
 {{- end }}

--- a/charts/k8s-monitoring/templates/alloy_config/_logs_service_otlp.alloy.txt
+++ b/charts/k8s-monitoring/templates/alloy_config/_logs_service_otlp.alloy.txt
@@ -47,10 +47,10 @@ otelcol.processor.memory_limiter "logs_service" {
   output {
 {{- end }}
 {{- if eq .protocol "otlp" }}
-    logs = [{{ append (.Values.externalServices.loki.extraOutputs | default (list)) "otelcol.exporter.otlp.logs_service.input" | join "," }}]
+    logs = [{{ append (.extraOutputs | default (list)) "otelcol.exporter.otlp.logs_service.input" | join "," }}]
 {{- end }}
 {{- if eq .protocol "otlphttp" }}
-    logs = [{{ append (.Values.externalServices.loki.extraOutputs | default (list)) "otelcol.exporter.otlphttp.logs_service.input" | join "," }}]
+    logs = [{{ append (.extraOutputs | default (list)) "otelcol.exporter.otlphttp.logs_service.input" | join "," }}]
 {{- end }}
   }
 }

--- a/charts/k8s-monitoring/templates/alloy_config/_logs_service_otlp.alloy.txt
+++ b/charts/k8s-monitoring/templates/alloy_config/_logs_service_otlp.alloy.txt
@@ -47,10 +47,10 @@ otelcol.processor.memory_limiter "logs_service" {
   output {
 {{- end }}
 {{- if eq .protocol "otlp" }}
-    logs = [otelcol.exporter.otlp.logs_service.input]
+    logs = [{{ append (.Values.externalServices.loki.extraOutputs | default (list)) "otelcol.exporter.otlp.logs_service.input" | join "," }}]
 {{- end }}
 {{- if eq .protocol "otlphttp" }}
-    logs = [otelcol.exporter.otlphttp.logs_service.input]
+    logs = [{{ append (.Values.externalServices.loki.extraOutputs | default (list)) "otelcol.exporter.otlphttp.logs_service.input" | join "," }}]
 {{- end }}
   }
 }

--- a/charts/k8s-monitoring/templates/alloy_config/_metrics_service.alloy.txt
+++ b/charts/k8s-monitoring/templates/alloy_config/_metrics_service.alloy.txt
@@ -19,7 +19,7 @@ prometheus.relabel "metrics_service" {
 {{- end }}
 
 {{- if eq .Values.externalServices.prometheus.protocol "remote_write" }}
-  forward_to = [prometheus.remote_write.metrics_service.receiver]
+  forward_to = [{{ append (.Values.externalServices.prometheus.extraOutputs | default (list)) "prometheus.remote_write.metrics_service.receiver" | join "," }}]
 }
 {{ include "alloy.config.metricsServiceRemoteWrite" . }}
 {{- end }}

--- a/charts/k8s-monitoring/templates/alloy_config/_metrics_service_otlp.alloy.txt
+++ b/charts/k8s-monitoring/templates/alloy_config/_metrics_service_otlp.alloy.txt
@@ -47,10 +47,10 @@ otelcol.processor.memory_limiter "metrics_service" {
   output {
 {{- end }}
 {{- if eq .protocol "otlp" }}
-    metrics = [otelcol.exporter.otlp.metrics_service.input]
+    metrics = [{{ append (.Values.externalServices.prometheus.extraOutputs | default (list)) "otelcol.exporter.otlp.metrics_service.input" | join "," }}]
 {{- end }}
 {{- if eq .protocol "otlphttp" }}
-    metrics = [otelcol.exporter.otlphttp.metrics_service.input]
+    metrics = [{{ append (.Values.externalServices.prometheus.extraOutputs | default (list)) "otelcol.exporter.otlphttp.metrics_service.input" | join "," }}]
 {{- end }}
   }
 }

--- a/charts/k8s-monitoring/templates/alloy_config/_metrics_service_otlp.alloy.txt
+++ b/charts/k8s-monitoring/templates/alloy_config/_metrics_service_otlp.alloy.txt
@@ -47,10 +47,10 @@ otelcol.processor.memory_limiter "metrics_service" {
   output {
 {{- end }}
 {{- if eq .protocol "otlp" }}
-    metrics = [{{ append (.Values.externalServices.prometheus.extraOutputs | default (list)) "otelcol.exporter.otlp.metrics_service.input" | join "," }}]
+    metrics = [{{ append (.extraOutputs | default (list)) "otelcol.exporter.otlp.metrics_service.input" | join "," }}]
 {{- end }}
 {{- if eq .protocol "otlphttp" }}
-    metrics = [{{ append (.Values.externalServices.prometheus.extraOutputs | default (list)) "otelcol.exporter.otlphttp.metrics_service.input" | join "," }}]
+    metrics = [{{ append (.extraOutputs | default (list)) "otelcol.exporter.otlphttp.metrics_service.input" | join "," }}]
 {{- end }}
   }
 }

--- a/charts/k8s-monitoring/templates/alloy_config/_processors.alloy.txt
+++ b/charts/k8s-monitoring/templates/alloy_config/_processors.alloy.txt
@@ -73,7 +73,7 @@ otelcol.processor.k8sattributes "default" {
 {{- end }}
 {{- if .Values.traces.enabled }}
     traces  = [
-      otelcol.processor.transform.default.input, 
+      otelcol.processor.transform.default.input,
     {{- if and .Values.metrics.enabled .Values.receivers.grafanaCloudMetrics.enabled }}
       otelcol.connector.host_info.default.input,
     {{- end }}
@@ -287,16 +287,16 @@ otelcol.processor.batch "batch_processor" {
 {{- end }}
   output {
 {{- if .Values.metrics.enabled }}
-    metrics = [otelcol.exporter.prometheus.metrics_converter.input]
+    metrics = [{{ append ((.Values.receivers.processors.batch.output).metrics | default (list)) "otelcol.exporter.prometheus.metrics_converter.input" | join "," }}]
 {{- end }}
 {{- if .Values.logs.enabled }}
-    logs = [otelcol.exporter.loki.logs_converter.input]
+    logs = [{{ append ((.Values.receivers.processors.batch.output).logs | default (list)) "otelcol.exporter.loki.logs_converter.input" | join "," }}]
 {{- end }}
 {{- if .Values.traces.enabled }}
 {{- if eq .Values.externalServices.tempo.protocol "otlp" }}
-    traces = [otelcol.exporter.otlp.traces_service.input]
+    traces = [{{ append ((.Values.receivers.processors.batch.output).traces | default (list)) "otelcol.exporter.otlp.traces_service.input" | join "," }}]
 {{- else if eq .Values.externalServices.tempo.protocol "otlphttp" }}
-    traces = [otelcol.exporter.otlphttp.traces_service.input]
+    traces = [{{ append ((.Values.receivers.processors.batch.output).traces | default (list)) "otelcol.exporter.otlphttp.traces_service.input" | join "," }}]
 {{- end }}
 {{- end }}
   }

--- a/charts/k8s-monitoring/values.schema.json
+++ b/charts/k8s-monitoring/values.schema.json
@@ -277,6 +277,9 @@
                         "externalLabelsFrom": {
                             "type": "object"
                         },
+                        "extraOutputs": {
+                            "type": "array"
+                        },
                         "host": {
                             "type": "string"
                         },
@@ -392,6 +395,9 @@
                         },
                         "externalLabelsFrom": {
                             "type": "object"
+                        },
+                        "extraOutputs": {
+                            "type": "array"
                         },
                         "host": {
                             "type": "string"
@@ -756,9 +762,6 @@
                     "properties": {
                         "enabled": {
                             "type": "boolean"
-                        },
-                        "extraConfig": {
-                            "type": "string"
                         },
                         "extraRelabelingRules": {
                             "type": "string"
@@ -2119,6 +2122,20 @@
                             "properties": {
                                 "maxSize": {
                                     "type": "integer"
+                                },
+                                "output": {
+                                    "type": "object",
+                                    "properties": {
+                                        "logs": {
+                                            "type": "array"
+                                        },
+                                        "metrics": {
+                                            "type": "array"
+                                        },
+                                        "traces": {
+                                            "type": "array"
+                                        }
+                                    }
                                 },
                                 "size": {
                                     "type": "integer"

--- a/charts/k8s-monitoring/values.yaml
+++ b/charts/k8s-monitoring/values.yaml
@@ -177,6 +177,10 @@ externalServices:
     # @section -- External Services (Prometheus)
     sendNativeHistograms: false
 
+    # -- Extra outputs configured in Alloy to send metics to at the end on the pipeline. When the protocol is "remote_write" the output is in the Prometheus format, while if the protocol is "otlp" or "otlphttp" it is the OTel format.
+    # @section -- External Services (Prometheus)
+    extraOutputs: []
+
   # Connection information for Grafana Loki
   loki:
     # -- Loki host where logs and events will be sent
@@ -271,6 +275,10 @@ externalServices:
         # -- Maximum amount of memory targeted to be allocated by the process heap.
         # @section -- External Services (Loki)
         limit: 0MiB
+
+    # -- Extra outputs configured in Alloy to send logs to at the end on the pipeline. When the protocol is "loki" the output is in the Loki format, while if the protocol is "otlp" or "otlphttp" it is the OTel format.
+    # @section -- External Services (Loki)
+    extraOutputs: []
 
   # Connection information for Grafana Tempo
   tempo:
@@ -1732,6 +1740,19 @@ receivers:
       # -- How long before sending (Processors)
       # @section -- OTEL Receivers (Processors)
       timeout: 2s
+
+      # Extra outputs to send the batched data to.
+      # @section -- OTEL Receivers (Processors)
+      output:
+        # -- Extra outputs to send the batched metrics to.
+        # @section -- OTEL Receivers (Processors)
+        metrics: []
+        # -- Extra outputs to send the batched logs to.
+        # @section -- OTEL Receivers (Processors)
+        logs: []
+        # -- Extra outputs to send the batched traces to.
+        # @section -- OTEL Receivers (Processors)
+        traces: []
 
     # Attribute processor for OTLP/gRPC, OTLP/HTTP, Jaeger, or Zipkin receivers
     # @section -- OTEL Receivers (Processors)


### PR DESCRIPTION
Inspired by https://github.com/grafana/k8s-monitoring-helm/pull/608, this PR adds the ability to specify extra outputs both for the batch processor receiver, as well as at the last stage for metrics and logs after all processing has been done. The use case for this is for a simple way to duplicate metrics, logs and traces across multiple backends. A more complex implementation could be to have the `externalServices.*` values be an array, but that would make the chart much more complicated. Instead, users can use the `extraConfig` value to configure any additional outputs that are then referenced in these new settings.

Example:

```yaml
# values.yaml
receivers:
  processors:
    batch:
      output:
        metrics: [otelcol.exporter.kafka.kafka.input]
        logs: [otelcol.exporter.kafka.kafka.input]
        traces: [otelcol.exporter.kafka.kafka.input]
externalServices:
  prometheus:
    extraOutputs: [otelcol.exporter.otlp.duplicate.input]
  loki:
    extraOutputs: [otelcol.exporter.otlp.duplicate.input]
```
