### PR TITLE
Use annotations to set the pod logs job label

### DIFF
--- a/charts/k8s-monitoring/Makefile
+++ b/charts/k8s-monitoring/Makefile
@@ -25,8 +25,10 @@ values.schema.json: values.yaml schema-mods/enums-and-types.json schema-mods/req
 			| del(.properties["kube-state-metrics"].properties.prometheusScrape) \
 			| del(.properties["kube-state-metrics"].properties.updateStrategy) \
 			| del(.properties["prometheus-node-exporter"].properties.nodeSelector) \
+			| del(.properties["prometheus-node-exporter"].properties.podAnnotations) \
 			| del(.properties["prometheus-node-exporter"].properties.service) \
 			| del(.properties["prometheus-windows-exporter"].properties.config) \
+			| del(.properties["prometheus-windows-exporter"].properties.podAnnotations) \
 			| del(.properties.logs.properties.pod_logs.properties.labels.properties) \
 			| del(.properties.opencost.properties.opencost)' values.schema.generated.json) \
 		schema-mods/enums-and-types.json \

--- a/charts/k8s-monitoring/README.md
+++ b/charts/k8s-monitoring/README.md
@@ -393,6 +393,7 @@ The Prometheus and Loki services may be hosted on the same cluster, or remotely 
 |-----|------|---------|-------------|
 | logs.journal.extraRelabelingRules | string | `""` | Rule blocks to be added used with the loki.source.journal component for journal logs. These relabeling rules are applied pre-scrape against the targets from service discovery. Before the scrape, any remaining target labels that start with `__` (i.e. `__meta_kubernetes*`) are dropped. ([docs](https://grafana.com/docs/alloy/latest/reference/components/discovery.relabel/#rule-block)) **Note:** Many field names from journald start with an `_`, such as `_systemd_unit`. The final internal label name would be `__journal__systemd_unit`, with two underscores between `__journal` and `systemd_unit`. |
 | logs.pod_logs.annotation | string | `"k8s.grafana.com/logs.autogather"` | Pod annotation to use for controlling log discovery. |
+| logs.pod_logs.annotations | object | `{"job":"k8s.grafana.com/logs.job"}` | Loki labels to set with values copied from the Kubernetes Pod annotations. Format: `<loki_label>: <kubernetes_annotation>`. |
 | logs.pod_logs.discovery | string | `"all"` | Controls the behavior of discovering pods for logs. |
 | logs.pod_logs.enabled | bool | `true` | Capture and forward logs from Kubernetes pods |
 | logs.pod_logs.excludeNamespaces | list | `[]` | Do not capture logs from any pods in these namespaces. |

--- a/charts/k8s-monitoring/templates/alloy_config/_pod_logs_discovery.alloy.txt
+++ b/charts/k8s-monitoring/templates/alloy_config/_pod_logs_discovery.alloy.txt
@@ -55,6 +55,12 @@ discovery.relabel "pod_logs" {
     target_label  = {{ $lokiLabel | quote }}
   }
 {{ end }}
+{{- range $lokiLabel, $podAnnotation := .Values.logs.pod_logs.annotations }}
+  rule {
+    source_labels = ["__meta_kubernetes_pod_annotation_{{ include "escape_label" $podAnnotation }}"]
+    target_label  = {{ $lokiLabel | quote }}
+  }
+{{ end }}
 
   {{- if eq .Values.logs.pod_logs.gatherMethod "volumes" }}
   rule {

--- a/charts/k8s-monitoring/templates/alloy_config/_pod_logs_discovery.alloy.txt
+++ b/charts/k8s-monitoring/templates/alloy_config/_pod_logs_discovery.alloy.txt
@@ -52,12 +52,14 @@ discovery.relabel "pod_logs" {
 {{- range $lokiLabel, $podLabel := .Values.logs.pod_logs.labels }}
   rule {
     source_labels = ["__meta_kubernetes_pod_label_{{ include "escape_label" $podLabel }}"]
+    regex         = "(.+)"
     target_label  = {{ $lokiLabel | quote }}
   }
 {{ end }}
 {{- range $lokiLabel, $podAnnotation := .Values.logs.pod_logs.annotations }}
   rule {
     source_labels = ["__meta_kubernetes_pod_annotation_{{ include "escape_label" $podAnnotation }}"]
+    regex         = "(.+)"
     target_label  = {{ $lokiLabel | quote }}
   }
 {{ end }}

--- a/charts/k8s-monitoring/templates/alloy_config/_windows_exporter.alloy.txt
+++ b/charts/k8s-monitoring/templates/alloy_config/_windows_exporter.alloy.txt
@@ -44,7 +44,7 @@ discovery.relabel "windows_exporter" {
 }
 
 prometheus.scrape "windows_exporter" {
-  job_name   = "integrations/kubernetes/windows-exporter"
+  job_name   = "integrations/windows-exporter"
   targets  = discovery.relabel.windows_exporter.output
   scrape_interval = {{ (index .Values.metrics "windows-exporter").scrapeInterval | default .Values.metrics.scrapeInterval | quote }}
 {{- if .Values.alloy.alloy.clustering.enabled }}

--- a/charts/k8s-monitoring/values.schema.json
+++ b/charts/k8s-monitoring/values.schema.json
@@ -757,9 +757,6 @@
                         "enabled": {
                             "type": "boolean"
                         },
-                        "extraConfig": {
-                            "type": "string"
-                        },
                         "extraRelabelingRules": {
                             "type": "string"
                         },
@@ -805,6 +802,14 @@
                     "properties": {
                         "annotation": {
                             "type": "string"
+                        },
+                        "annotations": {
+                            "type": "object",
+                            "properties": {
+                                "job": {
+                                    "type": "string"
+                                }
+                            }
                         },
                         "discovery": {
                             "type": "string",

--- a/charts/k8s-monitoring/values.yaml
+++ b/charts/k8s-monitoring/values.yaml
@@ -1388,6 +1388,12 @@ logs:
     labels:
       app_kubernetes_io_name: app.kubernetes.io/name
 
+    # -- Loki labels to set with values copied from the Kubernetes Pod annotations.
+    # Format: `<loki_label>: <kubernetes_annotation>`.
+    # @section -- Logs Scrape: Pod Logs
+    annotations:
+      job: k8s.grafana.com/logs.job
+
   # PodLog Objects
   podLogsObjects:
     # -- Enable discovery of Grafana Alloy PodLogs objects.
@@ -1963,6 +1969,10 @@ prometheus-node-exporter:
                 operator: NotIn
                 values: [fargate]
 
+  # @ignored - Set annotation to override the job label
+  podAnnotations:
+    k8s.grafana.com/logs.job: integrations/node_exporter
+
   # @ignored - Disable prometheus.io/scrape annotation
   service:
     annotations:
@@ -1986,6 +1996,10 @@ prometheus-windows-exporter:
     collector:
       service:
         services-where: "Name='containerd' or Name='kubelet'"
+
+  # @ignored - Set annotation to override the job label
+  podAnnotations:
+    k8s.grafana.com/logs.job: integrations/windows_exporter
 
 # Settings for the Prometheus Operator CRD deployment
 # You can use this sections to make modifications to the Prometheus Operator CRD deployment.
@@ -2151,6 +2165,9 @@ alloy:
     nodeSelector:
       kubernetes.io/os: linux
 
+    podAnnotations:
+      k8s.grafana.com/logs.job: integrations/alloy
+
     # This chart creates the credentials for Prometheus and Loki. This section
     # connects those credentials into the Grafana Alloy pod.
     # @ignored
@@ -2191,6 +2208,9 @@ alloy-events:
     replicas: 1  # Only one replica should be used, otherwise multiple copies of cluster events might get sent to Loki.
     nodeSelector:
       kubernetes.io/os: linux
+
+    podAnnotations:
+      k8s.grafana.com/logs.job: integrations/alloy
 
   # Skip installation of the Grafana Alloy CRDs, since we don't use them in this chart
   # @ignored
@@ -2238,6 +2258,9 @@ alloy-logs:
       - effect: NoSchedule
         operator: Exists
 
+    podAnnotations:
+      k8s.grafana.com/logs.job: integrations/alloy
+
   # Skip installation of the Grafana Alloy CRDs, since we don't use them in this chart
   # @ignored
   crds: {create: false}
@@ -2284,6 +2307,9 @@ alloy-profiles:
     tolerations:
       - effect: NoSchedule
         operator: Exists
+
+    podAnnotations:
+      k8s.grafana.com/logs.job: integrations/alloy
 
   # Skip installation of the Grafana Alloy CRDs, since we don't use them in this chart
   # @ignored

--- a/examples/alloy-autoscaling-and-storage/logs.alloy
+++ b/examples/alloy-autoscaling-and-storage/logs.alloy
@@ -34,11 +34,13 @@ discovery.relabel "pod_logs" {
   }
   rule {
     source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+    regex         = "(.+)"
     target_label  = "app_kubernetes_io_name"
   }
 
   rule {
     source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_job"]
+    regex         = "(.+)"
     target_label  = "job"
   }
 

--- a/examples/alloy-autoscaling-and-storage/logs.alloy
+++ b/examples/alloy-autoscaling-and-storage/logs.alloy
@@ -38,6 +38,11 @@ discovery.relabel "pod_logs" {
   }
 
   rule {
+    source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_job"]
+    target_label  = "job"
+  }
+
+  rule {
     source_labels = ["__meta_kubernetes_pod_uid", "__meta_kubernetes_pod_container_name"]
     separator = "/"
     action = "replace"

--- a/examples/alloy-autoscaling-and-storage/output.yaml
+++ b/examples/alloy-autoscaling-and-storage/output.yaml
@@ -1083,6 +1083,11 @@ data:
       }
     
       rule {
+        source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_job"]
+        target_label  = "job"
+      }
+    
+      rule {
         source_labels = ["__meta_kubernetes_pod_uid", "__meta_kubernetes_pod_container_name"]
         separator = "/"
         action = "replace"
@@ -58382,6 +58387,7 @@ spec:
     metadata:
       annotations:
         kubectl.kubernetes.io/default-container: alloy
+        k8s.grafana.com/logs.job: integrations/alloy
       labels:
         app.kubernetes.io/name: alloy-logs
         app.kubernetes.io/instance: k8smon
@@ -58482,6 +58488,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
+        k8s.grafana.com/logs.job: integrations/node_exporter
       labels:
         helm.sh/chart: prometheus-node-exporter-4.37.0
         app.kubernetes.io/managed-by: Helm
@@ -58601,6 +58608,7 @@ spec:
     metadata:
       annotations:
         kubectl.kubernetes.io/default-container: alloy
+        k8s.grafana.com/logs.job: integrations/alloy
       labels:
         app.kubernetes.io/name: alloy-events
         app.kubernetes.io/instance: k8smon
@@ -58922,6 +58930,7 @@ spec:
     metadata:
       annotations:
         kubectl.kubernetes.io/default-container: alloy
+        k8s.grafana.com/logs.job: integrations/alloy
       labels:
         app.kubernetes.io/name: alloy
         app.kubernetes.io/instance: k8smon
@@ -60011,6 +60020,11 @@ data:
       rule {
         source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
         target_label  = "app_kubernetes_io_name"
+      }
+    
+      rule {
+        source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_job"]
+        target_label  = "job"
       }
     
       rule {

--- a/examples/alloy-autoscaling-and-storage/output.yaml
+++ b/examples/alloy-autoscaling-and-storage/output.yaml
@@ -1079,11 +1079,13 @@ data:
       }
       rule {
         source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+        regex         = "(.+)"
         target_label  = "app_kubernetes_io_name"
       }
     
       rule {
         source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_job"]
+        regex         = "(.+)"
         target_label  = "job"
       }
     
@@ -60019,11 +60021,13 @@ data:
       }
       rule {
         source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+        regex         = "(.+)"
         target_label  = "app_kubernetes_io_name"
       }
     
       rule {
         source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_job"]
+        regex         = "(.+)"
         target_label  = "job"
       }
     

--- a/examples/application-observability/logs.alloy
+++ b/examples/application-observability/logs.alloy
@@ -34,11 +34,13 @@ discovery.relabel "pod_logs" {
   }
   rule {
     source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+    regex         = "(.+)"
     target_label  = "app_kubernetes_io_name"
   }
 
   rule {
     source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_job"]
+    regex         = "(.+)"
     target_label  = "job"
   }
 

--- a/examples/application-observability/logs.alloy
+++ b/examples/application-observability/logs.alloy
@@ -38,6 +38,11 @@ discovery.relabel "pod_logs" {
   }
 
   rule {
+    source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_job"]
+    target_label  = "job"
+  }
+
+  rule {
     source_labels = ["__meta_kubernetes_pod_uid", "__meta_kubernetes_pod_container_name"]
     separator = "/"
     action = "replace"

--- a/examples/application-observability/output.yaml
+++ b/examples/application-observability/output.yaml
@@ -1173,11 +1173,13 @@ data:
       }
       rule {
         source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+        regex         = "(.+)"
         target_label  = "app_kubernetes_io_name"
       }
     
       rule {
         source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_job"]
+        regex         = "(.+)"
         target_label  = "job"
       }
     
@@ -61266,11 +61268,13 @@ data:
       }
       rule {
         source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+        regex         = "(.+)"
         target_label  = "app_kubernetes_io_name"
       }
     
       rule {
         source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_job"]
+        regex         = "(.+)"
         target_label  = "job"
       }
     

--- a/examples/application-observability/output.yaml
+++ b/examples/application-observability/output.yaml
@@ -1177,6 +1177,11 @@ data:
       }
     
       rule {
+        source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_job"]
+        target_label  = "job"
+      }
+    
+      rule {
         source_labels = ["__meta_kubernetes_pod_uid", "__meta_kubernetes_pod_container_name"]
         separator = "/"
         action = "replace"
@@ -59550,6 +59555,7 @@ spec:
     metadata:
       annotations:
         kubectl.kubernetes.io/default-container: alloy
+        k8s.grafana.com/logs.job: integrations/alloy
       labels:
         app.kubernetes.io/name: alloy-logs
         app.kubernetes.io/instance: k8smon
@@ -59638,6 +59644,7 @@ spec:
     metadata:
       annotations:
         kubectl.kubernetes.io/default-container: alloy
+        k8s.grafana.com/logs.job: integrations/alloy
       labels:
         app.kubernetes.io/name: alloy-profiles
         app.kubernetes.io/instance: k8smon
@@ -59730,6 +59737,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
+        k8s.grafana.com/logs.job: integrations/node_exporter
       labels:
         helm.sh/chart: prometheus-node-exporter-4.37.0
         app.kubernetes.io/managed-by: Helm
@@ -59849,6 +59857,7 @@ spec:
     metadata:
       annotations:
         kubectl.kubernetes.io/default-container: alloy
+        k8s.grafana.com/logs.job: integrations/alloy
       labels:
         app.kubernetes.io/name: alloy-events
         app.kubernetes.io/instance: k8smon
@@ -60134,6 +60143,7 @@ spec:
     metadata:
       annotations:
         kubectl.kubernetes.io/default-container: alloy
+        k8s.grafana.com/logs.job: integrations/alloy
       labels:
         app.kubernetes.io/name: alloy
         app.kubernetes.io/instance: k8smon
@@ -61257,6 +61267,11 @@ data:
       rule {
         source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
         target_label  = "app_kubernetes_io_name"
+      }
+    
+      rule {
+        source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_job"]
+        target_label  = "job"
       }
     
       rule {

--- a/examples/control-plane-metrics/logs.alloy
+++ b/examples/control-plane-metrics/logs.alloy
@@ -34,11 +34,13 @@ discovery.relabel "pod_logs" {
   }
   rule {
     source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+    regex         = "(.+)"
     target_label  = "app_kubernetes_io_name"
   }
 
   rule {
     source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_job"]
+    regex         = "(.+)"
     target_label  = "job"
   }
 

--- a/examples/control-plane-metrics/logs.alloy
+++ b/examples/control-plane-metrics/logs.alloy
@@ -38,6 +38,11 @@ discovery.relabel "pod_logs" {
   }
 
   rule {
+    source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_job"]
+    target_label  = "job"
+  }
+
+  rule {
     source_labels = ["__meta_kubernetes_pod_uid", "__meta_kubernetes_pod_container_name"]
     separator = "/"
     action = "replace"

--- a/examples/control-plane-metrics/output.yaml
+++ b/examples/control-plane-metrics/output.yaml
@@ -1240,6 +1240,11 @@ data:
       }
     
       rule {
+        source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_job"]
+        target_label  = "job"
+      }
+    
+      rule {
         source_labels = ["__meta_kubernetes_pod_uid", "__meta_kubernetes_pod_container_name"]
         separator = "/"
         action = "replace"
@@ -58539,6 +58544,7 @@ spec:
     metadata:
       annotations:
         kubectl.kubernetes.io/default-container: alloy
+        k8s.grafana.com/logs.job: integrations/alloy
       labels:
         app.kubernetes.io/name: alloy-logs
         app.kubernetes.io/instance: k8smon
@@ -58632,6 +58638,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
+        k8s.grafana.com/logs.job: integrations/node_exporter
       labels:
         helm.sh/chart: prometheus-node-exporter-4.37.0
         app.kubernetes.io/managed-by: Helm
@@ -58751,6 +58758,7 @@ spec:
     metadata:
       annotations:
         kubectl.kubernetes.io/default-container: alloy
+        k8s.grafana.com/logs.job: integrations/alloy
       labels:
         app.kubernetes.io/name: alloy-events
         app.kubernetes.io/instance: k8smon
@@ -59036,6 +59044,7 @@ spec:
     metadata:
       annotations:
         kubectl.kubernetes.io/default-container: alloy
+        k8s.grafana.com/logs.job: integrations/alloy
       labels:
         app.kubernetes.io/name: alloy
         app.kubernetes.io/instance: k8smon
@@ -60263,6 +60272,11 @@ data:
       rule {
         source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
         target_label  = "app_kubernetes_io_name"
+      }
+    
+      rule {
+        source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_job"]
+        target_label  = "job"
       }
     
       rule {

--- a/examples/control-plane-metrics/output.yaml
+++ b/examples/control-plane-metrics/output.yaml
@@ -1236,11 +1236,13 @@ data:
       }
       rule {
         source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+        regex         = "(.+)"
         target_label  = "app_kubernetes_io_name"
       }
     
       rule {
         source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_job"]
+        regex         = "(.+)"
         target_label  = "job"
       }
     
@@ -60271,11 +60273,13 @@ data:
       }
       rule {
         source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+        regex         = "(.+)"
         target_label  = "app_kubernetes_io_name"
       }
     
       rule {
         source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_job"]
+        regex         = "(.+)"
         target_label  = "job"
       }
     

--- a/examples/custom-config/logs.alloy
+++ b/examples/custom-config/logs.alloy
@@ -34,11 +34,13 @@ discovery.relabel "pod_logs" {
   }
   rule {
     source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+    regex         = "(.+)"
     target_label  = "app_kubernetes_io_name"
   }
 
   rule {
     source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_job"]
+    regex         = "(.+)"
     target_label  = "job"
   }
 

--- a/examples/custom-config/logs.alloy
+++ b/examples/custom-config/logs.alloy
@@ -38,6 +38,11 @@ discovery.relabel "pod_logs" {
   }
 
   rule {
+    source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_job"]
+    target_label  = "job"
+  }
+
+  rule {
     source_labels = ["__meta_kubernetes_pod_uid", "__meta_kubernetes_pod_container_name"]
     separator = "/"
     action = "replace"

--- a/examples/custom-config/output.yaml
+++ b/examples/custom-config/output.yaml
@@ -1129,6 +1129,11 @@ data:
       }
     
       rule {
+        source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_job"]
+        target_label  = "job"
+      }
+    
+      rule {
         source_labels = ["__meta_kubernetes_pod_uid", "__meta_kubernetes_pod_container_name"]
         separator = "/"
         action = "replace"
@@ -58475,6 +58480,7 @@ spec:
     metadata:
       annotations:
         kubectl.kubernetes.io/default-container: alloy
+        k8s.grafana.com/logs.job: integrations/alloy
       labels:
         app.kubernetes.io/name: alloy-logs
         app.kubernetes.io/instance: k8smon
@@ -58568,6 +58574,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
+        k8s.grafana.com/logs.job: integrations/node_exporter
       labels:
         helm.sh/chart: prometheus-node-exporter-4.37.0
         app.kubernetes.io/managed-by: Helm
@@ -58687,6 +58694,7 @@ spec:
     metadata:
       annotations:
         kubectl.kubernetes.io/default-container: alloy
+        k8s.grafana.com/logs.job: integrations/alloy
       labels:
         app.kubernetes.io/name: alloy-events
         app.kubernetes.io/instance: k8smon
@@ -58972,6 +58980,7 @@ spec:
     metadata:
       annotations:
         kubectl.kubernetes.io/default-container: alloy
+        k8s.grafana.com/logs.job: integrations/alloy
       labels:
         app.kubernetes.io/name: alloy
         app.kubernetes.io/instance: k8smon
@@ -60089,6 +60098,11 @@ data:
       rule {
         source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
         target_label  = "app_kubernetes_io_name"
+      }
+    
+      rule {
+        source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_job"]
+        target_label  = "job"
       }
     
       rule {

--- a/examples/custom-config/output.yaml
+++ b/examples/custom-config/output.yaml
@@ -1125,11 +1125,13 @@ data:
       }
       rule {
         source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+        regex         = "(.+)"
         target_label  = "app_kubernetes_io_name"
       }
     
       rule {
         source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_job"]
+        regex         = "(.+)"
         target_label  = "job"
       }
     
@@ -60097,11 +60099,13 @@ data:
       }
       rule {
         source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+        regex         = "(.+)"
         target_label  = "app_kubernetes_io_name"
       }
     
       rule {
         source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_job"]
+        regex         = "(.+)"
         target_label  = "job"
       }
     

--- a/examples/custom-metrics-tuning/output.yaml
+++ b/examples/custom-metrics-tuning/output.yaml
@@ -57714,6 +57714,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
+        k8s.grafana.com/logs.job: integrations/node_exporter
       labels:
         helm.sh/chart: prometheus-node-exporter-4.37.0
         app.kubernetes.io/managed-by: Helm
@@ -58038,6 +58039,7 @@ spec:
     metadata:
       annotations:
         kubectl.kubernetes.io/default-container: alloy
+        k8s.grafana.com/logs.job: integrations/alloy
       labels:
         app.kubernetes.io/name: alloy
         app.kubernetes.io/instance: k8smon

--- a/examples/custom-pricing/logs.alloy
+++ b/examples/custom-pricing/logs.alloy
@@ -34,11 +34,13 @@ discovery.relabel "pod_logs" {
   }
   rule {
     source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+    regex         = "(.+)"
     target_label  = "app_kubernetes_io_name"
   }
 
   rule {
     source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_job"]
+    regex         = "(.+)"
     target_label  = "job"
   }
 

--- a/examples/custom-pricing/logs.alloy
+++ b/examples/custom-pricing/logs.alloy
@@ -38,6 +38,11 @@ discovery.relabel "pod_logs" {
   }
 
   rule {
+    source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_job"]
+    target_label  = "job"
+  }
+
+  rule {
     source_labels = ["__meta_kubernetes_pod_uid", "__meta_kubernetes_pod_container_name"]
     separator = "/"
     action = "replace"

--- a/examples/custom-pricing/output.yaml
+++ b/examples/custom-pricing/output.yaml
@@ -1105,6 +1105,11 @@ data:
       }
     
       rule {
+        source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_job"]
+        target_label  = "job"
+      }
+    
+      rule {
         source_labels = ["__meta_kubernetes_pod_uid", "__meta_kubernetes_pod_container_name"]
         separator = "/"
         action = "replace"
@@ -58404,6 +58409,7 @@ spec:
     metadata:
       annotations:
         kubectl.kubernetes.io/default-container: alloy
+        k8s.grafana.com/logs.job: integrations/alloy
       labels:
         app.kubernetes.io/name: alloy-logs
         app.kubernetes.io/instance: k8smon
@@ -58497,6 +58503,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
+        k8s.grafana.com/logs.job: integrations/node_exporter
       labels:
         helm.sh/chart: prometheus-node-exporter-4.37.0
         app.kubernetes.io/managed-by: Helm
@@ -58616,6 +58623,7 @@ spec:
     metadata:
       annotations:
         kubectl.kubernetes.io/default-container: alloy
+        k8s.grafana.com/logs.job: integrations/alloy
       labels:
         app.kubernetes.io/name: alloy-events
         app.kubernetes.io/instance: k8smon
@@ -58912,6 +58920,7 @@ spec:
     metadata:
       annotations:
         kubectl.kubernetes.io/default-container: alloy
+        k8s.grafana.com/logs.job: integrations/alloy
       labels:
         app.kubernetes.io/name: alloy
         app.kubernetes.io/instance: k8smon
@@ -59983,6 +59992,11 @@ data:
       rule {
         source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
         target_label  = "app_kubernetes_io_name"
+      }
+    
+      rule {
+        source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_job"]
+        target_label  = "job"
       }
     
       rule {

--- a/examples/custom-pricing/output.yaml
+++ b/examples/custom-pricing/output.yaml
@@ -1101,11 +1101,13 @@ data:
       }
       rule {
         source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+        regex         = "(.+)"
         target_label  = "app_kubernetes_io_name"
       }
     
       rule {
         source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_job"]
+        regex         = "(.+)"
         target_label  = "job"
       }
     
@@ -59991,11 +59993,13 @@ data:
       }
       rule {
         source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+        regex         = "(.+)"
         target_label  = "app_kubernetes_io_name"
       }
     
       rule {
         source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_job"]
+        regex         = "(.+)"
         target_label  = "job"
       }
     

--- a/examples/custom-prometheus-operator-rules/output.yaml
+++ b/examples/custom-prometheus-operator-rules/output.yaml
@@ -57796,6 +57796,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
+        k8s.grafana.com/logs.job: integrations/node_exporter
       labels:
         helm.sh/chart: prometheus-node-exporter-4.37.0
         app.kubernetes.io/managed-by: Helm
@@ -58120,6 +58121,7 @@ spec:
     metadata:
       annotations:
         kubectl.kubernetes.io/default-container: alloy
+        k8s.grafana.com/logs.job: integrations/alloy
       labels:
         app.kubernetes.io/name: alloy
         app.kubernetes.io/instance: k8smon

--- a/examples/default-values/logs.alloy
+++ b/examples/default-values/logs.alloy
@@ -34,11 +34,13 @@ discovery.relabel "pod_logs" {
   }
   rule {
     source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+    regex         = "(.+)"
     target_label  = "app_kubernetes_io_name"
   }
 
   rule {
     source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_job"]
+    regex         = "(.+)"
     target_label  = "job"
   }
 

--- a/examples/default-values/logs.alloy
+++ b/examples/default-values/logs.alloy
@@ -38,6 +38,11 @@ discovery.relabel "pod_logs" {
   }
 
   rule {
+    source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_job"]
+    target_label  = "job"
+  }
+
+  rule {
     source_labels = ["__meta_kubernetes_pod_uid", "__meta_kubernetes_pod_container_name"]
     separator = "/"
     action = "replace"

--- a/examples/default-values/output.yaml
+++ b/examples/default-values/output.yaml
@@ -1083,6 +1083,11 @@ data:
       }
     
       rule {
+        source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_job"]
+        target_label  = "job"
+      }
+    
+      rule {
         source_labels = ["__meta_kubernetes_pod_uid", "__meta_kubernetes_pod_container_name"]
         separator = "/"
         action = "replace"
@@ -58382,6 +58387,7 @@ spec:
     metadata:
       annotations:
         kubectl.kubernetes.io/default-container: alloy
+        k8s.grafana.com/logs.job: integrations/alloy
       labels:
         app.kubernetes.io/name: alloy-logs
         app.kubernetes.io/instance: k8smon
@@ -58475,6 +58481,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
+        k8s.grafana.com/logs.job: integrations/node_exporter
       labels:
         helm.sh/chart: prometheus-node-exporter-4.37.0
         app.kubernetes.io/managed-by: Helm
@@ -58594,6 +58601,7 @@ spec:
     metadata:
       annotations:
         kubectl.kubernetes.io/default-container: alloy
+        k8s.grafana.com/logs.job: integrations/alloy
       labels:
         app.kubernetes.io/name: alloy-events
         app.kubernetes.io/instance: k8smon
@@ -58879,6 +58887,7 @@ spec:
     metadata:
       annotations:
         kubectl.kubernetes.io/default-container: alloy
+        k8s.grafana.com/logs.job: integrations/alloy
       labels:
         app.kubernetes.io/name: alloy
         app.kubernetes.io/instance: k8smon
@@ -59950,6 +59959,11 @@ data:
       rule {
         source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
         target_label  = "app_kubernetes_io_name"
+      }
+    
+      rule {
+        source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_job"]
+        target_label  = "job"
       }
     
       rule {

--- a/examples/default-values/output.yaml
+++ b/examples/default-values/output.yaml
@@ -1079,11 +1079,13 @@ data:
       }
       rule {
         source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+        regex         = "(.+)"
         target_label  = "app_kubernetes_io_name"
       }
     
       rule {
         source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_job"]
+        regex         = "(.+)"
         target_label  = "job"
       }
     
@@ -59958,11 +59960,13 @@ data:
       }
       rule {
         source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+        regex         = "(.+)"
         target_label  = "app_kubernetes_io_name"
       }
     
       rule {
         source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_job"]
+        regex         = "(.+)"
         target_label  = "job"
       }
     

--- a/examples/eks-fargate/logs.alloy
+++ b/examples/eks-fargate/logs.alloy
@@ -33,6 +33,11 @@ discovery.relabel "pod_logs" {
     target_label  = "app_kubernetes_io_name"
   }
 
+  rule {
+    source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_job"]
+    target_label  = "job"
+  }
+
 
   // set the container runtime as a label
   rule {

--- a/examples/eks-fargate/logs.alloy
+++ b/examples/eks-fargate/logs.alloy
@@ -30,11 +30,13 @@ discovery.relabel "pod_logs" {
   }
   rule {
     source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+    regex         = "(.+)"
     target_label  = "app_kubernetes_io_name"
   }
 
   rule {
     source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_job"]
+    regex         = "(.+)"
     target_label  = "job"
   }
 

--- a/examples/eks-fargate/output.yaml
+++ b/examples/eks-fargate/output.yaml
@@ -1012,11 +1012,13 @@ data:
       }
       rule {
         source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+        regex         = "(.+)"
         target_label  = "app_kubernetes_io_name"
       }
     
       rule {
         source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_job"]
+        regex         = "(.+)"
         target_label  = "job"
       }
     
@@ -59711,11 +59713,13 @@ data:
       }
       rule {
         source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+        regex         = "(.+)"
         target_label  = "app_kubernetes_io_name"
       }
     
       rule {
         source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_job"]
+        regex         = "(.+)"
         target_label  = "job"
       }
     

--- a/examples/eks-fargate/output.yaml
+++ b/examples/eks-fargate/output.yaml
@@ -1015,6 +1015,11 @@ data:
         target_label  = "app_kubernetes_io_name"
       }
     
+      rule {
+        source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_job"]
+        target_label  = "job"
+      }
+    
     
       // set the container runtime as a label
       rule {
@@ -58314,6 +58319,7 @@ spec:
     metadata:
       annotations:
         kubectl.kubernetes.io/default-container: alloy
+        k8s.grafana.com/logs.job: integrations/alloy
       labels:
         app.kubernetes.io/name: alloy-events
         app.kubernetes.io/instance: k8smon
@@ -58394,6 +58400,7 @@ spec:
     metadata:
       annotations:
         kubectl.kubernetes.io/default-container: alloy
+        k8s.grafana.com/logs.job: integrations/alloy
       labels:
         app.kubernetes.io/name: alloy-logs
         app.kubernetes.io/instance: k8smon
@@ -58684,6 +58691,7 @@ spec:
     metadata:
       annotations:
         kubectl.kubernetes.io/default-container: alloy
+        k8s.grafana.com/logs.job: integrations/alloy
       labels:
         app.kubernetes.io/name: alloy
         app.kubernetes.io/instance: k8smon
@@ -59704,6 +59712,11 @@ data:
       rule {
         source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
         target_label  = "app_kubernetes_io_name"
+      }
+    
+      rule {
+        source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_job"]
+        target_label  = "job"
       }
     
     

--- a/examples/extra-rules/logs.alloy
+++ b/examples/extra-rules/logs.alloy
@@ -34,11 +34,13 @@ discovery.relabel "pod_logs" {
   }
   rule {
     source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+    regex         = "(.+)"
     target_label  = "app_kubernetes_io_name"
   }
 
   rule {
     source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_job"]
+    regex         = "(.+)"
     target_label  = "job"
   }
 

--- a/examples/extra-rules/logs.alloy
+++ b/examples/extra-rules/logs.alloy
@@ -38,6 +38,11 @@ discovery.relabel "pod_logs" {
   }
 
   rule {
+    source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_job"]
+    target_label  = "job"
+  }
+
+  rule {
     source_labels = ["__meta_kubernetes_pod_uid", "__meta_kubernetes_pod_container_name"]
     separator = "/"
     action = "replace"

--- a/examples/extra-rules/output.yaml
+++ b/examples/extra-rules/output.yaml
@@ -1171,11 +1171,13 @@ data:
       }
       rule {
         source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+        regex         = "(.+)"
         target_label  = "app_kubernetes_io_name"
       }
     
       rule {
         source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_job"]
+        regex         = "(.+)"
         target_label  = "job"
       }
     
@@ -60171,11 +60173,13 @@ data:
       }
       rule {
         source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+        regex         = "(.+)"
         target_label  = "app_kubernetes_io_name"
       }
     
       rule {
         source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_job"]
+        regex         = "(.+)"
         target_label  = "job"
       }
     

--- a/examples/extra-rules/output.yaml
+++ b/examples/extra-rules/output.yaml
@@ -1175,6 +1175,11 @@ data:
       }
     
       rule {
+        source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_job"]
+        target_label  = "job"
+      }
+    
+      rule {
         source_labels = ["__meta_kubernetes_pod_uid", "__meta_kubernetes_pod_container_name"]
         separator = "/"
         action = "replace"
@@ -58504,6 +58509,7 @@ spec:
     metadata:
       annotations:
         kubectl.kubernetes.io/default-container: alloy
+        k8s.grafana.com/logs.job: integrations/alloy
       labels:
         app.kubernetes.io/name: alloy-logs
         app.kubernetes.io/instance: k8smon
@@ -58597,6 +58603,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
+        k8s.grafana.com/logs.job: integrations/node_exporter
       labels:
         helm.sh/chart: prometheus-node-exporter-4.37.0
         app.kubernetes.io/managed-by: Helm
@@ -58716,6 +58723,7 @@ spec:
     metadata:
       annotations:
         kubectl.kubernetes.io/default-container: alloy
+        k8s.grafana.com/logs.job: integrations/alloy
       labels:
         app.kubernetes.io/name: alloy-events
         app.kubernetes.io/instance: k8smon
@@ -59001,6 +59009,7 @@ spec:
     metadata:
       annotations:
         kubectl.kubernetes.io/default-container: alloy
+        k8s.grafana.com/logs.job: integrations/alloy
       labels:
         app.kubernetes.io/name: alloy
         app.kubernetes.io/instance: k8smon
@@ -60163,6 +60172,11 @@ data:
       rule {
         source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
         target_label  = "app_kubernetes_io_name"
+      }
+    
+      rule {
+        source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_job"]
+        target_label  = "job"
       }
     
       rule {

--- a/examples/gke-autopilot/logs.alloy
+++ b/examples/gke-autopilot/logs.alloy
@@ -34,11 +34,13 @@ discovery.relabel "pod_logs" {
   }
   rule {
     source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+    regex         = "(.+)"
     target_label  = "app_kubernetes_io_name"
   }
 
   rule {
     source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_job"]
+    regex         = "(.+)"
     target_label  = "job"
   }
 

--- a/examples/gke-autopilot/logs.alloy
+++ b/examples/gke-autopilot/logs.alloy
@@ -38,6 +38,11 @@ discovery.relabel "pod_logs" {
   }
 
   rule {
+    source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_job"]
+    target_label  = "job"
+  }
+
+  rule {
     source_labels = ["__meta_kubernetes_pod_uid", "__meta_kubernetes_pod_container_name"]
     separator = "/"
     action = "replace"

--- a/examples/gke-autopilot/output.yaml
+++ b/examples/gke-autopilot/output.yaml
@@ -1016,11 +1016,13 @@ data:
       }
       rule {
         source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+        regex         = "(.+)"
         target_label  = "app_kubernetes_io_name"
       }
     
       rule {
         source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_job"]
+        regex         = "(.+)"
         target_label  = "job"
       }
     
@@ -59699,11 +59701,13 @@ data:
       }
       rule {
         source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+        regex         = "(.+)"
         target_label  = "app_kubernetes_io_name"
       }
     
       rule {
         source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_job"]
+        regex         = "(.+)"
         target_label  = "job"
       }
     

--- a/examples/gke-autopilot/output.yaml
+++ b/examples/gke-autopilot/output.yaml
@@ -1020,6 +1020,11 @@ data:
       }
     
       rule {
+        source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_job"]
+        target_label  = "job"
+      }
+    
+      rule {
         source_labels = ["__meta_kubernetes_pod_uid", "__meta_kubernetes_pod_container_name"]
         separator = "/"
         action = "replace"
@@ -58294,6 +58299,7 @@ spec:
     metadata:
       annotations:
         kubectl.kubernetes.io/default-container: alloy
+        k8s.grafana.com/logs.job: integrations/alloy
       labels:
         app.kubernetes.io/name: alloy-logs
         app.kubernetes.io/instance: k8smon
@@ -58383,6 +58389,7 @@ spec:
     metadata:
       annotations:
         kubectl.kubernetes.io/default-container: alloy
+        k8s.grafana.com/logs.job: integrations/alloy
       labels:
         app.kubernetes.io/name: alloy-events
         app.kubernetes.io/instance: k8smon
@@ -58668,6 +58675,7 @@ spec:
     metadata:
       annotations:
         kubectl.kubernetes.io/default-container: alloy
+        k8s.grafana.com/logs.job: integrations/alloy
       labels:
         app.kubernetes.io/name: alloy
         app.kubernetes.io/instance: k8smon
@@ -59692,6 +59700,11 @@ data:
       rule {
         source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
         target_label  = "app_kubernetes_io_name"
+      }
+    
+      rule {
+        source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_job"]
+        target_label  = "job"
       }
     
       rule {

--- a/examples/ibm-cloud/logs.alloy
+++ b/examples/ibm-cloud/logs.alloy
@@ -34,11 +34,13 @@ discovery.relabel "pod_logs" {
   }
   rule {
     source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+    regex         = "(.+)"
     target_label  = "app_kubernetes_io_name"
   }
 
   rule {
     source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_job"]
+    regex         = "(.+)"
     target_label  = "job"
   }
 

--- a/examples/ibm-cloud/logs.alloy
+++ b/examples/ibm-cloud/logs.alloy
@@ -38,6 +38,11 @@ discovery.relabel "pod_logs" {
   }
 
   rule {
+    source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_job"]
+    target_label  = "job"
+  }
+
+  rule {
     source_labels = ["__meta_kubernetes_pod_uid", "__meta_kubernetes_pod_container_name"]
     separator = "/"
     action = "replace"

--- a/examples/ibm-cloud/output.yaml
+++ b/examples/ibm-cloud/output.yaml
@@ -1083,6 +1083,11 @@ data:
       }
     
       rule {
+        source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_job"]
+        target_label  = "job"
+      }
+    
+      rule {
         source_labels = ["__meta_kubernetes_pod_uid", "__meta_kubernetes_pod_container_name"]
         separator = "/"
         action = "replace"
@@ -58382,6 +58387,7 @@ spec:
     metadata:
       annotations:
         kubectl.kubernetes.io/default-container: alloy
+        k8s.grafana.com/logs.job: integrations/alloy
       labels:
         app.kubernetes.io/name: alloy-logs
         app.kubernetes.io/instance: k8smon
@@ -58481,6 +58487,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
+        k8s.grafana.com/logs.job: integrations/node_exporter
       labels:
         helm.sh/chart: prometheus-node-exporter-4.37.0
         app.kubernetes.io/managed-by: Helm
@@ -58600,6 +58607,7 @@ spec:
     metadata:
       annotations:
         kubectl.kubernetes.io/default-container: alloy
+        k8s.grafana.com/logs.job: integrations/alloy
       labels:
         app.kubernetes.io/name: alloy-events
         app.kubernetes.io/instance: k8smon
@@ -58885,6 +58893,7 @@ spec:
     metadata:
       annotations:
         kubectl.kubernetes.io/default-container: alloy
+        k8s.grafana.com/logs.job: integrations/alloy
       labels:
         app.kubernetes.io/name: alloy
         app.kubernetes.io/instance: k8smon
@@ -59956,6 +59965,11 @@ data:
       rule {
         source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
         target_label  = "app_kubernetes_io_name"
+      }
+    
+      rule {
+        source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_job"]
+        target_label  = "job"
       }
     
       rule {

--- a/examples/ibm-cloud/output.yaml
+++ b/examples/ibm-cloud/output.yaml
@@ -1079,11 +1079,13 @@ data:
       }
       rule {
         source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+        regex         = "(.+)"
         target_label  = "app_kubernetes_io_name"
       }
     
       rule {
         source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_job"]
+        regex         = "(.+)"
         target_label  = "job"
       }
     
@@ -59964,11 +59966,13 @@ data:
       }
       rule {
         source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+        regex         = "(.+)"
         target_label  = "app_kubernetes_io_name"
       }
     
       rule {
         source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_job"]
+        regex         = "(.+)"
         target_label  = "job"
       }
     

--- a/examples/logs-journal/logs.alloy
+++ b/examples/logs-journal/logs.alloy
@@ -34,11 +34,13 @@ discovery.relabel "pod_logs" {
   }
   rule {
     source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+    regex         = "(.+)"
     target_label  = "app_kubernetes_io_name"
   }
 
   rule {
     source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_job"]
+    regex         = "(.+)"
     target_label  = "job"
   }
 

--- a/examples/logs-journal/logs.alloy
+++ b/examples/logs-journal/logs.alloy
@@ -38,6 +38,11 @@ discovery.relabel "pod_logs" {
   }
 
   rule {
+    source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_job"]
+    target_label  = "job"
+  }
+
+  rule {
     source_labels = ["__meta_kubernetes_pod_uid", "__meta_kubernetes_pod_container_name"]
     separator = "/"
     action = "replace"

--- a/examples/logs-journal/output.yaml
+++ b/examples/logs-journal/output.yaml
@@ -276,11 +276,13 @@ data:
       }
       rule {
         source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+        regex         = "(.+)"
         target_label  = "app_kubernetes_io_name"
       }
     
       rule {
         source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_job"]
+        regex         = "(.+)"
         target_label  = "job"
       }
     
@@ -1540,11 +1542,13 @@ data:
       }
       rule {
         source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+        regex         = "(.+)"
         target_label  = "app_kubernetes_io_name"
       }
     
       rule {
         source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_job"]
+        regex         = "(.+)"
         target_label  = "job"
       }
     

--- a/examples/logs-journal/output.yaml
+++ b/examples/logs-journal/output.yaml
@@ -280,6 +280,11 @@ data:
       }
     
       rule {
+        source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_job"]
+        target_label  = "job"
+      }
+    
+      rule {
         source_labels = ["__meta_kubernetes_pod_uid", "__meta_kubernetes_pod_container_name"]
         separator = "/"
         action = "replace"
@@ -1064,6 +1069,7 @@ spec:
     metadata:
       annotations:
         kubectl.kubernetes.io/default-container: alloy
+        k8s.grafana.com/logs.job: integrations/alloy
       labels:
         app.kubernetes.io/name: alloy-logs
         app.kubernetes.io/instance: k8smon
@@ -1153,6 +1159,7 @@ spec:
     metadata:
       annotations:
         kubectl.kubernetes.io/default-container: alloy
+        k8s.grafana.com/logs.job: integrations/alloy
       labels:
         app.kubernetes.io/name: alloy-events
         app.kubernetes.io/instance: k8smon
@@ -1235,6 +1242,7 @@ spec:
     metadata:
       annotations:
         kubectl.kubernetes.io/default-container: alloy
+        k8s.grafana.com/logs.job: integrations/alloy
       labels:
         app.kubernetes.io/name: alloy
         app.kubernetes.io/instance: k8smon
@@ -1533,6 +1541,11 @@ data:
       rule {
         source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
         target_label  = "app_kubernetes_io_name"
+      }
+    
+      rule {
+        source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_job"]
+        target_label  = "job"
       }
     
       rule {

--- a/examples/logs-only/logs.alloy
+++ b/examples/logs-only/logs.alloy
@@ -34,11 +34,13 @@ discovery.relabel "pod_logs" {
   }
   rule {
     source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+    regex         = "(.+)"
     target_label  = "app_kubernetes_io_name"
   }
 
   rule {
     source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_job"]
+    regex         = "(.+)"
     target_label  = "job"
   }
 

--- a/examples/logs-only/logs.alloy
+++ b/examples/logs-only/logs.alloy
@@ -38,6 +38,11 @@ discovery.relabel "pod_logs" {
   }
 
   rule {
+    source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_job"]
+    target_label  = "job"
+  }
+
+  rule {
     source_labels = ["__meta_kubernetes_pod_uid", "__meta_kubernetes_pod_container_name"]
     separator = "/"
     action = "replace"

--- a/examples/logs-only/output.yaml
+++ b/examples/logs-only/output.yaml
@@ -356,11 +356,13 @@ data:
       }
       rule {
         source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+        regex         = "(.+)"
         target_label  = "app_kubernetes_io_name"
       }
     
       rule {
         source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_job"]
+        regex         = "(.+)"
         target_label  = "job"
       }
     
@@ -1671,11 +1673,13 @@ data:
       }
       rule {
         source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+        regex         = "(.+)"
         target_label  = "app_kubernetes_io_name"
       }
     
       rule {
         source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_job"]
+        regex         = "(.+)"
         target_label  = "job"
       }
     

--- a/examples/logs-only/output.yaml
+++ b/examples/logs-only/output.yaml
@@ -360,6 +360,11 @@ data:
       }
     
       rule {
+        source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_job"]
+        target_label  = "job"
+      }
+    
+      rule {
         source_labels = ["__meta_kubernetes_pod_uid", "__meta_kubernetes_pod_container_name"]
         separator = "/"
         action = "replace"
@@ -1116,6 +1121,7 @@ spec:
     metadata:
       annotations:
         kubectl.kubernetes.io/default-container: alloy
+        k8s.grafana.com/logs.job: integrations/alloy
       labels:
         app.kubernetes.io/name: alloy-logs
         app.kubernetes.io/instance: k8smon
@@ -1205,6 +1211,7 @@ spec:
     metadata:
       annotations:
         kubectl.kubernetes.io/default-container: alloy
+        k8s.grafana.com/logs.job: integrations/alloy
       labels:
         app.kubernetes.io/name: alloy-events
         app.kubernetes.io/instance: k8smon
@@ -1287,6 +1294,7 @@ spec:
     metadata:
       annotations:
         kubectl.kubernetes.io/default-container: alloy
+        k8s.grafana.com/logs.job: integrations/alloy
       labels:
         app.kubernetes.io/name: alloy
         app.kubernetes.io/instance: k8smon
@@ -1664,6 +1672,11 @@ data:
       rule {
         source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
         target_label  = "app_kubernetes_io_name"
+      }
+    
+      rule {
+        source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_job"]
+        target_label  = "job"
       }
     
       rule {

--- a/examples/metric-module-imports-extra-config/logs.alloy
+++ b/examples/metric-module-imports-extra-config/logs.alloy
@@ -34,11 +34,13 @@ discovery.relabel "pod_logs" {
   }
   rule {
     source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+    regex         = "(.+)"
     target_label  = "app_kubernetes_io_name"
   }
 
   rule {
     source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_job"]
+    regex         = "(.+)"
     target_label  = "job"
   }
 

--- a/examples/metric-module-imports-extra-config/logs.alloy
+++ b/examples/metric-module-imports-extra-config/logs.alloy
@@ -38,6 +38,11 @@ discovery.relabel "pod_logs" {
   }
 
   rule {
+    source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_job"]
+    target_label  = "job"
+  }
+
+  rule {
     source_labels = ["__meta_kubernetes_pod_uid", "__meta_kubernetes_pod_container_name"]
     separator = "/"
     action = "replace"

--- a/examples/metric-module-imports-extra-config/output.yaml
+++ b/examples/metric-module-imports-extra-config/output.yaml
@@ -1095,11 +1095,13 @@ data:
       }
       rule {
         source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+        regex         = "(.+)"
         target_label  = "app_kubernetes_io_name"
       }
     
       rule {
         source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_job"]
+        regex         = "(.+)"
         target_label  = "job"
       }
     
@@ -59990,11 +59992,13 @@ data:
       }
       rule {
         source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+        regex         = "(.+)"
         target_label  = "app_kubernetes_io_name"
       }
     
       rule {
         source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_job"]
+        regex         = "(.+)"
         target_label  = "job"
       }
     

--- a/examples/metric-module-imports-extra-config/output.yaml
+++ b/examples/metric-module-imports-extra-config/output.yaml
@@ -1099,6 +1099,11 @@ data:
       }
     
       rule {
+        source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_job"]
+        target_label  = "job"
+      }
+    
+      rule {
         source_labels = ["__meta_kubernetes_pod_uid", "__meta_kubernetes_pod_container_name"]
         separator = "/"
         action = "replace"
@@ -58398,6 +58403,7 @@ spec:
     metadata:
       annotations:
         kubectl.kubernetes.io/default-container: alloy
+        k8s.grafana.com/logs.job: integrations/alloy
       labels:
         app.kubernetes.io/name: alloy-logs
         app.kubernetes.io/instance: k8smon
@@ -58491,6 +58497,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
+        k8s.grafana.com/logs.job: integrations/node_exporter
       labels:
         helm.sh/chart: prometheus-node-exporter-4.37.0
         app.kubernetes.io/managed-by: Helm
@@ -58610,6 +58617,7 @@ spec:
     metadata:
       annotations:
         kubectl.kubernetes.io/default-container: alloy
+        k8s.grafana.com/logs.job: integrations/alloy
       labels:
         app.kubernetes.io/name: alloy-events
         app.kubernetes.io/instance: k8smon
@@ -58895,6 +58903,7 @@ spec:
     metadata:
       annotations:
         kubectl.kubernetes.io/default-container: alloy
+        k8s.grafana.com/logs.job: integrations/alloy
       labels:
         app.kubernetes.io/name: alloy
         app.kubernetes.io/instance: k8smon
@@ -59982,6 +59991,11 @@ data:
       rule {
         source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
         target_label  = "app_kubernetes_io_name"
+      }
+    
+      rule {
+        source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_job"]
+        target_label  = "job"
       }
     
       rule {

--- a/examples/metric-module-imports/logs.alloy
+++ b/examples/metric-module-imports/logs.alloy
@@ -34,11 +34,13 @@ discovery.relabel "pod_logs" {
   }
   rule {
     source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+    regex         = "(.+)"
     target_label  = "app_kubernetes_io_name"
   }
 
   rule {
     source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_job"]
+    regex         = "(.+)"
     target_label  = "job"
   }
 

--- a/examples/metric-module-imports/logs.alloy
+++ b/examples/metric-module-imports/logs.alloy
@@ -38,6 +38,11 @@ discovery.relabel "pod_logs" {
   }
 
   rule {
+    source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_job"]
+    target_label  = "job"
+  }
+
+  rule {
     source_labels = ["__meta_kubernetes_pod_uid", "__meta_kubernetes_pod_container_name"]
     separator = "/"
     action = "replace"

--- a/examples/metric-module-imports/output.yaml
+++ b/examples/metric-module-imports/output.yaml
@@ -1260,6 +1260,11 @@ data:
       }
     
       rule {
+        source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_job"]
+        target_label  = "job"
+      }
+    
+      rule {
         source_labels = ["__meta_kubernetes_pod_uid", "__meta_kubernetes_pod_container_name"]
         separator = "/"
         action = "replace"
@@ -58559,6 +58564,7 @@ spec:
     metadata:
       annotations:
         kubectl.kubernetes.io/default-container: alloy
+        k8s.grafana.com/logs.job: integrations/alloy
       labels:
         app.kubernetes.io/name: alloy-logs
         app.kubernetes.io/instance: k8smon
@@ -58652,6 +58658,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
+        k8s.grafana.com/logs.job: integrations/node_exporter
       labels:
         helm.sh/chart: prometheus-node-exporter-4.37.0
         app.kubernetes.io/managed-by: Helm
@@ -58771,6 +58778,7 @@ spec:
     metadata:
       annotations:
         kubectl.kubernetes.io/default-container: alloy
+        k8s.grafana.com/logs.job: integrations/alloy
       labels:
         app.kubernetes.io/name: alloy-events
         app.kubernetes.io/instance: k8smon
@@ -59056,6 +59064,7 @@ spec:
     metadata:
       annotations:
         kubectl.kubernetes.io/default-container: alloy
+        k8s.grafana.com/logs.job: integrations/alloy
       labels:
         app.kubernetes.io/name: alloy
         app.kubernetes.io/instance: k8smon
@@ -60304,6 +60313,11 @@ data:
       rule {
         source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
         target_label  = "app_kubernetes_io_name"
+      }
+    
+      rule {
+        source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_job"]
+        target_label  = "job"
       }
     
       rule {

--- a/examples/metric-module-imports/output.yaml
+++ b/examples/metric-module-imports/output.yaml
@@ -1256,11 +1256,13 @@ data:
       }
       rule {
         source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+        regex         = "(.+)"
         target_label  = "app_kubernetes_io_name"
       }
     
       rule {
         source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_job"]
+        regex         = "(.+)"
         target_label  = "job"
       }
     
@@ -60312,11 +60314,13 @@ data:
       }
       rule {
         source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+        regex         = "(.+)"
         target_label  = "app_kubernetes_io_name"
       }
     
       rule {
         source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_job"]
+        regex         = "(.+)"
         target_label  = "job"
       }
     

--- a/examples/metrics-only/output.yaml
+++ b/examples/metrics-only/output.yaml
@@ -57720,6 +57720,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
+        k8s.grafana.com/logs.job: integrations/node_exporter
       labels:
         helm.sh/chart: prometheus-node-exporter-4.37.0
         app.kubernetes.io/managed-by: Helm
@@ -58044,6 +58045,7 @@ spec:
     metadata:
       annotations:
         kubectl.kubernetes.io/default-container: alloy
+        k8s.grafana.com/logs.job: integrations/alloy
       labels:
         app.kubernetes.io/name: alloy
         app.kubernetes.io/instance: k8smon

--- a/examples/openshift-compatible/logs.alloy
+++ b/examples/openshift-compatible/logs.alloy
@@ -34,11 +34,13 @@ discovery.relabel "pod_logs" {
   }
   rule {
     source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+    regex         = "(.+)"
     target_label  = "app_kubernetes_io_name"
   }
 
   rule {
     source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_job"]
+    regex         = "(.+)"
     target_label  = "job"
   }
 

--- a/examples/openshift-compatible/logs.alloy
+++ b/examples/openshift-compatible/logs.alloy
@@ -38,6 +38,11 @@ discovery.relabel "pod_logs" {
   }
 
   rule {
+    source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_job"]
+    target_label  = "job"
+  }
+
+  rule {
     source_labels = ["__meta_kubernetes_pod_uid", "__meta_kubernetes_pod_container_name"]
     separator = "/"
     action = "replace"

--- a/examples/openshift-compatible/output.yaml
+++ b/examples/openshift-compatible/output.yaml
@@ -1055,6 +1055,11 @@ data:
       }
     
       rule {
+        source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_job"]
+        target_label  = "job"
+      }
+    
+      rule {
         source_labels = ["__meta_kubernetes_pod_uid", "__meta_kubernetes_pod_container_name"]
         separator = "/"
         action = "replace"
@@ -58213,6 +58218,7 @@ spec:
     metadata:
       annotations:
         kubectl.kubernetes.io/default-container: alloy
+        k8s.grafana.com/logs.job: integrations/alloy
       labels:
         app.kubernetes.io/name: alloy-logs
         app.kubernetes.io/instance: k8smon
@@ -58327,6 +58333,7 @@ spec:
     metadata:
       annotations:
         kubectl.kubernetes.io/default-container: alloy
+        k8s.grafana.com/logs.job: integrations/alloy
       labels:
         app.kubernetes.io/name: alloy-events
         app.kubernetes.io/instance: k8smon
@@ -58547,6 +58554,7 @@ spec:
     metadata:
       annotations:
         kubectl.kubernetes.io/default-container: alloy
+        k8s.grafana.com/logs.job: integrations/alloy
       labels:
         app.kubernetes.io/name: alloy
         app.kubernetes.io/instance: k8smon
@@ -59801,6 +59809,11 @@ data:
       rule {
         source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
         target_label  = "app_kubernetes_io_name"
+      }
+    
+      rule {
+        source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_job"]
+        target_label  = "job"
       }
     
       rule {

--- a/examples/openshift-compatible/output.yaml
+++ b/examples/openshift-compatible/output.yaml
@@ -1051,11 +1051,13 @@ data:
       }
       rule {
         source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+        regex         = "(.+)"
         target_label  = "app_kubernetes_io_name"
       }
     
       rule {
         source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_job"]
+        regex         = "(.+)"
         target_label  = "job"
       }
     
@@ -59808,11 +59810,13 @@ data:
       }
       rule {
         source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+        regex         = "(.+)"
         target_label  = "app_kubernetes_io_name"
       }
     
       rule {
         source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_job"]
+        regex         = "(.+)"
         target_label  = "job"
       }
     

--- a/examples/otel-metrics-service/logs.alloy
+++ b/examples/otel-metrics-service/logs.alloy
@@ -34,11 +34,13 @@ discovery.relabel "pod_logs" {
   }
   rule {
     source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+    regex         = "(.+)"
     target_label  = "app_kubernetes_io_name"
   }
 
   rule {
     source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_job"]
+    regex         = "(.+)"
     target_label  = "job"
   }
 

--- a/examples/otel-metrics-service/logs.alloy
+++ b/examples/otel-metrics-service/logs.alloy
@@ -38,6 +38,11 @@ discovery.relabel "pod_logs" {
   }
 
   rule {
+    source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_job"]
+    target_label  = "job"
+  }
+
+  rule {
     source_labels = ["__meta_kubernetes_pod_uid", "__meta_kubernetes_pod_container_name"]
     separator = "/"
     action = "replace"

--- a/examples/otel-metrics-service/output.yaml
+++ b/examples/otel-metrics-service/output.yaml
@@ -1096,11 +1096,13 @@ data:
       }
       rule {
         source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+        regex         = "(.+)"
         target_label  = "app_kubernetes_io_name"
       }
     
       rule {
         source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_job"]
+        regex         = "(.+)"
         target_label  = "job"
       }
     
@@ -59992,11 +59994,13 @@ data:
       }
       rule {
         source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+        regex         = "(.+)"
         target_label  = "app_kubernetes_io_name"
       }
     
       rule {
         source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_job"]
+        regex         = "(.+)"
         target_label  = "job"
       }
     

--- a/examples/otel-metrics-service/output.yaml
+++ b/examples/otel-metrics-service/output.yaml
@@ -1100,6 +1100,11 @@ data:
       }
     
       rule {
+        source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_job"]
+        target_label  = "job"
+      }
+    
+      rule {
         source_labels = ["__meta_kubernetes_pod_uid", "__meta_kubernetes_pod_container_name"]
         separator = "/"
         action = "replace"
@@ -58399,6 +58404,7 @@ spec:
     metadata:
       annotations:
         kubectl.kubernetes.io/default-container: alloy
+        k8s.grafana.com/logs.job: integrations/alloy
       labels:
         app.kubernetes.io/name: alloy-logs
         app.kubernetes.io/instance: k8smon
@@ -58492,6 +58498,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
+        k8s.grafana.com/logs.job: integrations/node_exporter
       labels:
         helm.sh/chart: prometheus-node-exporter-4.37.0
         app.kubernetes.io/managed-by: Helm
@@ -58611,6 +58618,7 @@ spec:
     metadata:
       annotations:
         kubectl.kubernetes.io/default-container: alloy
+        k8s.grafana.com/logs.job: integrations/alloy
       labels:
         app.kubernetes.io/name: alloy-events
         app.kubernetes.io/instance: k8smon
@@ -58896,6 +58904,7 @@ spec:
     metadata:
       annotations:
         kubectl.kubernetes.io/default-container: alloy
+        k8s.grafana.com/logs.job: integrations/alloy
       labels:
         app.kubernetes.io/name: alloy
         app.kubernetes.io/instance: k8smon
@@ -59984,6 +59993,11 @@ data:
       rule {
         source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
         target_label  = "app_kubernetes_io_name"
+      }
+    
+      rule {
+        source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_job"]
+        target_label  = "job"
       }
     
       rule {

--- a/examples/pod-labels/logs.alloy
+++ b/examples/pod-labels/logs.alloy
@@ -34,11 +34,13 @@ discovery.relabel "pod_logs" {
   }
   rule {
     source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+    regex         = "(.+)"
     target_label  = "app_kubernetes_io_name"
   }
 
   rule {
     source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_job"]
+    regex         = "(.+)"
     target_label  = "job"
   }
 

--- a/examples/pod-labels/logs.alloy
+++ b/examples/pod-labels/logs.alloy
@@ -38,6 +38,11 @@ discovery.relabel "pod_logs" {
   }
 
   rule {
+    source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_job"]
+    target_label  = "job"
+  }
+
+  rule {
     source_labels = ["__meta_kubernetes_pod_uid", "__meta_kubernetes_pod_container_name"]
     separator = "/"
     action = "replace"

--- a/examples/pod-labels/output.yaml
+++ b/examples/pod-labels/output.yaml
@@ -1149,11 +1149,13 @@ data:
       }
       rule {
         source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+        regex         = "(.+)"
         target_label  = "app_kubernetes_io_name"
       }
     
       rule {
         source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_job"]
+        regex         = "(.+)"
         target_label  = "job"
       }
     
@@ -60092,11 +60094,13 @@ data:
       }
       rule {
         source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+        regex         = "(.+)"
         target_label  = "app_kubernetes_io_name"
       }
     
       rule {
         source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_job"]
+        regex         = "(.+)"
         target_label  = "job"
       }
     

--- a/examples/pod-labels/output.yaml
+++ b/examples/pod-labels/output.yaml
@@ -1153,6 +1153,11 @@ data:
       }
     
       rule {
+        source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_job"]
+        target_label  = "job"
+      }
+    
+      rule {
         source_labels = ["__meta_kubernetes_pod_uid", "__meta_kubernetes_pod_container_name"]
         separator = "/"
         action = "replace"
@@ -58458,6 +58463,7 @@ spec:
     metadata:
       annotations:
         kubectl.kubernetes.io/default-container: alloy
+        k8s.grafana.com/logs.job: integrations/alloy
       labels:
         app.kubernetes.io/name: alloy-logs
         app.kubernetes.io/instance: k8smon
@@ -58551,6 +58557,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
+        k8s.grafana.com/logs.job: integrations/node_exporter
       labels:
         helm.sh/chart: prometheus-node-exporter-4.37.0
         app.kubernetes.io/managed-by: Helm
@@ -58670,6 +58677,7 @@ spec:
     metadata:
       annotations:
         kubectl.kubernetes.io/default-container: alloy
+        k8s.grafana.com/logs.job: integrations/alloy
       labels:
         app.kubernetes.io/name: alloy-events
         app.kubernetes.io/instance: k8smon
@@ -58956,6 +58964,7 @@ spec:
     metadata:
       annotations:
         kubectl.kubernetes.io/default-container: alloy
+        k8s.grafana.com/logs.job: integrations/alloy
       labels:
         app.kubernetes.io/name: alloy
         app.kubernetes.io/instance: k8smon
@@ -60084,6 +60093,11 @@ data:
       rule {
         source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
         target_label  = "app_kubernetes_io_name"
+      }
+    
+      rule {
+        source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_job"]
+        target_label  = "job"
       }
     
       rule {

--- a/examples/private-image-registry/logs.alloy
+++ b/examples/private-image-registry/logs.alloy
@@ -34,11 +34,13 @@ discovery.relabel "pod_logs" {
   }
   rule {
     source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+    regex         = "(.+)"
     target_label  = "app_kubernetes_io_name"
   }
 
   rule {
     source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_job"]
+    regex         = "(.+)"
     target_label  = "job"
   }
 

--- a/examples/private-image-registry/logs.alloy
+++ b/examples/private-image-registry/logs.alloy
@@ -38,6 +38,11 @@ discovery.relabel "pod_logs" {
   }
 
   rule {
+    source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_job"]
+    target_label  = "job"
+  }
+
+  rule {
     source_labels = ["__meta_kubernetes_pod_uid", "__meta_kubernetes_pod_container_name"]
     separator = "/"
     action = "replace"

--- a/examples/private-image-registry/output.yaml
+++ b/examples/private-image-registry/output.yaml
@@ -1083,11 +1083,13 @@ data:
       }
       rule {
         source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+        regex         = "(.+)"
         target_label  = "app_kubernetes_io_name"
       }
     
       rule {
         source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_job"]
+        regex         = "(.+)"
         target_label  = "job"
       }
     
@@ -59974,11 +59976,13 @@ data:
       }
       rule {
         source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+        regex         = "(.+)"
         target_label  = "app_kubernetes_io_name"
       }
     
       rule {
         source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_job"]
+        regex         = "(.+)"
         target_label  = "job"
       }
     

--- a/examples/private-image-registry/output.yaml
+++ b/examples/private-image-registry/output.yaml
@@ -1087,6 +1087,11 @@ data:
       }
     
       rule {
+        source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_job"]
+        target_label  = "job"
+      }
+    
+      rule {
         source_labels = ["__meta_kubernetes_pod_uid", "__meta_kubernetes_pod_container_name"]
         separator = "/"
         action = "replace"
@@ -58386,6 +58391,7 @@ spec:
     metadata:
       annotations:
         kubectl.kubernetes.io/default-container: alloy
+        k8s.grafana.com/logs.job: integrations/alloy
       labels:
         app.kubernetes.io/name: alloy-logs
         app.kubernetes.io/instance: k8smon
@@ -58481,6 +58487,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
+        k8s.grafana.com/logs.job: integrations/node_exporter
       labels:
         helm.sh/chart: prometheus-node-exporter-4.37.0
         app.kubernetes.io/managed-by: Helm
@@ -58602,6 +58609,7 @@ spec:
     metadata:
       annotations:
         kubectl.kubernetes.io/default-container: alloy
+        k8s.grafana.com/logs.job: integrations/alloy
       labels:
         app.kubernetes.io/name: alloy-events
         app.kubernetes.io/instance: k8smon
@@ -58893,6 +58901,7 @@ spec:
     metadata:
       annotations:
         kubectl.kubernetes.io/default-container: alloy
+        k8s.grafana.com/logs.job: integrations/alloy
       labels:
         app.kubernetes.io/name: alloy
         app.kubernetes.io/instance: k8smon
@@ -59966,6 +59975,11 @@ data:
       rule {
         source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
         target_label  = "app_kubernetes_io_name"
+      }
+    
+      rule {
+        source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_job"]
+        target_label  = "job"
       }
     
       rule {

--- a/examples/profiles-enabled/logs.alloy
+++ b/examples/profiles-enabled/logs.alloy
@@ -34,11 +34,13 @@ discovery.relabel "pod_logs" {
   }
   rule {
     source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+    regex         = "(.+)"
     target_label  = "app_kubernetes_io_name"
   }
 
   rule {
     source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_job"]
+    regex         = "(.+)"
     target_label  = "job"
   }
 

--- a/examples/profiles-enabled/logs.alloy
+++ b/examples/profiles-enabled/logs.alloy
@@ -38,6 +38,11 @@ discovery.relabel "pod_logs" {
   }
 
   rule {
+    source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_job"]
+    target_label  = "job"
+  }
+
+  rule {
     source_labels = ["__meta_kubernetes_pod_uid", "__meta_kubernetes_pod_container_name"]
     separator = "/"
     action = "replace"

--- a/examples/profiles-enabled/output.yaml
+++ b/examples/profiles-enabled/output.yaml
@@ -1108,11 +1108,13 @@ data:
       }
       rule {
         source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+        regex         = "(.+)"
         target_label  = "app_kubernetes_io_name"
       }
     
       rule {
         source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_job"]
+        regex         = "(.+)"
         target_label  = "job"
       }
     
@@ -61149,11 +61151,13 @@ data:
       }
       rule {
         source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+        regex         = "(.+)"
         target_label  = "app_kubernetes_io_name"
       }
     
       rule {
         source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_job"]
+        regex         = "(.+)"
         target_label  = "job"
       }
     

--- a/examples/profiles-enabled/output.yaml
+++ b/examples/profiles-enabled/output.yaml
@@ -1112,6 +1112,11 @@ data:
       }
     
       rule {
+        source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_job"]
+        target_label  = "job"
+      }
+    
+      rule {
         source_labels = ["__meta_kubernetes_pod_uid", "__meta_kubernetes_pod_container_name"]
         separator = "/"
         action = "replace"
@@ -59485,6 +59490,7 @@ spec:
     metadata:
       annotations:
         kubectl.kubernetes.io/default-container: alloy
+        k8s.grafana.com/logs.job: integrations/alloy
       labels:
         app.kubernetes.io/name: alloy-logs
         app.kubernetes.io/instance: k8smon
@@ -59573,6 +59579,7 @@ spec:
     metadata:
       annotations:
         kubectl.kubernetes.io/default-container: alloy
+        k8s.grafana.com/logs.job: integrations/alloy
       labels:
         app.kubernetes.io/name: alloy-profiles
         app.kubernetes.io/instance: k8smon
@@ -59665,6 +59672,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
+        k8s.grafana.com/logs.job: integrations/node_exporter
       labels:
         helm.sh/chart: prometheus-node-exporter-4.37.0
         app.kubernetes.io/managed-by: Helm
@@ -59784,6 +59792,7 @@ spec:
     metadata:
       annotations:
         kubectl.kubernetes.io/default-container: alloy
+        k8s.grafana.com/logs.job: integrations/alloy
       labels:
         app.kubernetes.io/name: alloy-events
         app.kubernetes.io/instance: k8smon
@@ -60069,6 +60078,7 @@ spec:
     metadata:
       annotations:
         kubectl.kubernetes.io/default-container: alloy
+        k8s.grafana.com/logs.job: integrations/alloy
       labels:
         app.kubernetes.io/name: alloy
         app.kubernetes.io/instance: k8smon
@@ -61140,6 +61150,11 @@ data:
       rule {
         source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
         target_label  = "app_kubernetes_io_name"
+      }
+    
+      rule {
+        source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_job"]
+        target_label  = "job"
       }
     
       rule {

--- a/examples/proxies/logs.alloy
+++ b/examples/proxies/logs.alloy
@@ -34,11 +34,13 @@ discovery.relabel "pod_logs" {
   }
   rule {
     source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+    regex         = "(.+)"
     target_label  = "app_kubernetes_io_name"
   }
 
   rule {
     source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_job"]
+    regex         = "(.+)"
     target_label  = "job"
   }
 

--- a/examples/proxies/logs.alloy
+++ b/examples/proxies/logs.alloy
@@ -38,6 +38,11 @@ discovery.relabel "pod_logs" {
   }
 
   rule {
+    source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_job"]
+    target_label  = "job"
+  }
+
+  rule {
     source_labels = ["__meta_kubernetes_pod_uid", "__meta_kubernetes_pod_container_name"]
     separator = "/"
     action = "replace"

--- a/examples/proxies/output.yaml
+++ b/examples/proxies/output.yaml
@@ -1091,11 +1091,13 @@ data:
       }
       rule {
         source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+        regex         = "(.+)"
         target_label  = "app_kubernetes_io_name"
       }
     
       rule {
         source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_job"]
+        regex         = "(.+)"
         target_label  = "job"
       }
     
@@ -59986,11 +59988,13 @@ data:
       }
       rule {
         source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+        regex         = "(.+)"
         target_label  = "app_kubernetes_io_name"
       }
     
       rule {
         source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_job"]
+        regex         = "(.+)"
         target_label  = "job"
       }
     

--- a/examples/proxies/output.yaml
+++ b/examples/proxies/output.yaml
@@ -1095,6 +1095,11 @@ data:
       }
     
       rule {
+        source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_job"]
+        target_label  = "job"
+      }
+    
+      rule {
         source_labels = ["__meta_kubernetes_pod_uid", "__meta_kubernetes_pod_container_name"]
         separator = "/"
         action = "replace"
@@ -58398,6 +58403,7 @@ spec:
     metadata:
       annotations:
         kubectl.kubernetes.io/default-container: alloy
+        k8s.grafana.com/logs.job: integrations/alloy
       labels:
         app.kubernetes.io/name: alloy-logs
         app.kubernetes.io/instance: k8smon
@@ -58491,6 +58497,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
+        k8s.grafana.com/logs.job: integrations/node_exporter
       labels:
         helm.sh/chart: prometheus-node-exporter-4.37.0
         app.kubernetes.io/managed-by: Helm
@@ -58610,6 +58617,7 @@ spec:
     metadata:
       annotations:
         kubectl.kubernetes.io/default-container: alloy
+        k8s.grafana.com/logs.job: integrations/alloy
       labels:
         app.kubernetes.io/name: alloy-events
         app.kubernetes.io/instance: k8smon
@@ -58895,6 +58903,7 @@ spec:
     metadata:
       annotations:
         kubectl.kubernetes.io/default-container: alloy
+        k8s.grafana.com/logs.job: integrations/alloy
       labels:
         app.kubernetes.io/name: alloy
         app.kubernetes.io/instance: k8smon
@@ -59978,6 +59987,11 @@ data:
       rule {
         source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
         target_label  = "app_kubernetes_io_name"
+      }
+    
+      rule {
+        source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_job"]
+        target_label  = "job"
       }
     
       rule {

--- a/examples/scrape-intervals/output.yaml
+++ b/examples/scrape-intervals/output.yaml
@@ -57719,6 +57719,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
+        k8s.grafana.com/logs.job: integrations/node_exporter
       labels:
         helm.sh/chart: prometheus-node-exporter-4.37.0
         app.kubernetes.io/managed-by: Helm
@@ -58043,6 +58044,7 @@ spec:
     metadata:
       annotations:
         kubectl.kubernetes.io/default-container: alloy
+        k8s.grafana.com/logs.job: integrations/alloy
       labels:
         app.kubernetes.io/name: alloy
         app.kubernetes.io/instance: k8smon

--- a/examples/service-integrations/logs.alloy
+++ b/examples/service-integrations/logs.alloy
@@ -34,11 +34,13 @@ discovery.relabel "pod_logs" {
   }
   rule {
     source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+    regex         = "(.+)"
     target_label  = "app_kubernetes_io_name"
   }
 
   rule {
     source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_job"]
+    regex         = "(.+)"
     target_label  = "job"
   }
 

--- a/examples/service-integrations/logs.alloy
+++ b/examples/service-integrations/logs.alloy
@@ -38,6 +38,11 @@ discovery.relabel "pod_logs" {
   }
 
   rule {
+    source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_job"]
+    target_label  = "job"
+  }
+
+  rule {
     source_labels = ["__meta_kubernetes_pod_uid", "__meta_kubernetes_pod_container_name"]
     separator = "/"
     action = "replace"

--- a/examples/service-integrations/output.yaml
+++ b/examples/service-integrations/output.yaml
@@ -60220,6 +60220,14 @@ data:
         {
           "query": "{cluster=\"ci-integrations-cluster\", job=\"integrations/mysql\"}",
           "type": "logql"
+        },
+        {
+          "query": "{cluster=\"ci-integrations-cluster\", job=\"integrations/alloy\"}",
+          "type": "logql"
+        },
+        {
+          "query": "{cluster=\"ci-integrations-cluster\", job=\"integrations/node_exporter\"}",
+          "type": "logql"
         }
       ]
     }

--- a/examples/service-integrations/output.yaml
+++ b/examples/service-integrations/output.yaml
@@ -1103,6 +1103,11 @@ data:
       }
     
       rule {
+        source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_job"]
+        target_label  = "job"
+      }
+    
+      rule {
         source_labels = ["__meta_kubernetes_pod_uid", "__meta_kubernetes_pod_container_name"]
         separator = "/"
         action = "replace"
@@ -58417,6 +58422,7 @@ spec:
     metadata:
       annotations:
         kubectl.kubernetes.io/default-container: alloy
+        k8s.grafana.com/logs.job: integrations/alloy
       labels:
         app.kubernetes.io/name: alloy-logs
         app.kubernetes.io/instance: k8smon
@@ -58510,6 +58516,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
+        k8s.grafana.com/logs.job: integrations/node_exporter
       labels:
         helm.sh/chart: prometheus-node-exporter-4.37.0
         app.kubernetes.io/managed-by: Helm
@@ -58629,6 +58636,7 @@ spec:
     metadata:
       annotations:
         kubectl.kubernetes.io/default-container: alloy
+        k8s.grafana.com/logs.job: integrations/alloy
       labels:
         app.kubernetes.io/name: alloy-events
         app.kubernetes.io/instance: k8smon
@@ -58914,6 +58922,7 @@ spec:
     metadata:
       annotations:
         kubectl.kubernetes.io/default-container: alloy
+        k8s.grafana.com/logs.job: integrations/alloy
       labels:
         app.kubernetes.io/name: alloy
         app.kubernetes.io/instance: k8smon
@@ -60005,6 +60014,11 @@ data:
       rule {
         source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
         target_label  = "app_kubernetes_io_name"
+      }
+    
+      rule {
+        source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_job"]
+        target_label  = "job"
       }
     
       rule {

--- a/examples/service-integrations/output.yaml
+++ b/examples/service-integrations/output.yaml
@@ -1099,11 +1099,13 @@ data:
       }
       rule {
         source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+        regex         = "(.+)"
         target_label  = "app_kubernetes_io_name"
       }
     
       rule {
         source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_job"]
+        regex         = "(.+)"
         target_label  = "job"
       }
     
@@ -60013,11 +60015,13 @@ data:
       }
       rule {
         source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+        regex         = "(.+)"
         target_label  = "app_kubernetes_io_name"
       }
     
       rule {
         source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_job"]
+        regex         = "(.+)"
         target_label  = "job"
       }
     

--- a/examples/service-integrations/values.yaml
+++ b/examples/service-integrations/values.yaml
@@ -63,3 +63,9 @@ test:
     # Check for MySQL logs
     - query: "{cluster=\"ci-integrations-cluster\", job=\"integrations/mysql\"}"
       type: logql
+    # Check for Alloy logs
+    - query: "{cluster=\"ci-integrations-cluster\", job=\"integrations/alloy\"}"
+      type: logql
+    # Check for Node Exporter logs
+    - query: "{cluster=\"ci-integrations-cluster\", job=\"integrations/node_exporter\"}"
+      type: logql

--- a/examples/specific-namespace/logs.alloy
+++ b/examples/specific-namespace/logs.alloy
@@ -39,11 +39,13 @@ discovery.relabel "pod_logs" {
   }
   rule {
     source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+    regex         = "(.+)"
     target_label  = "app_kubernetes_io_name"
   }
 
   rule {
     source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_job"]
+    regex         = "(.+)"
     target_label  = "job"
   }
 

--- a/examples/specific-namespace/logs.alloy
+++ b/examples/specific-namespace/logs.alloy
@@ -43,6 +43,11 @@ discovery.relabel "pod_logs" {
   }
 
   rule {
+    source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_job"]
+    target_label  = "job"
+  }
+
+  rule {
     source_labels = ["__meta_kubernetes_pod_uid", "__meta_kubernetes_pod_container_name"]
     separator = "/"
     action = "replace"

--- a/examples/specific-namespace/output.yaml
+++ b/examples/specific-namespace/output.yaml
@@ -1147,6 +1147,11 @@ data:
       }
     
       rule {
+        source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_job"]
+        target_label  = "job"
+      }
+    
+      rule {
         source_labels = ["__meta_kubernetes_pod_uid", "__meta_kubernetes_pod_container_name"]
         separator = "/"
         action = "replace"
@@ -58446,6 +58451,7 @@ spec:
     metadata:
       annotations:
         kubectl.kubernetes.io/default-container: alloy
+        k8s.grafana.com/logs.job: integrations/alloy
       labels:
         app.kubernetes.io/name: alloy-logs
         app.kubernetes.io/instance: k8smon
@@ -58539,6 +58545,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
+        k8s.grafana.com/logs.job: integrations/node_exporter
       labels:
         helm.sh/chart: prometheus-node-exporter-4.37.0
         app.kubernetes.io/managed-by: Helm
@@ -58658,6 +58665,7 @@ spec:
     metadata:
       annotations:
         kubectl.kubernetes.io/default-container: alloy
+        k8s.grafana.com/logs.job: integrations/alloy
       labels:
         app.kubernetes.io/name: alloy-events
         app.kubernetes.io/instance: k8smon
@@ -58943,6 +58951,7 @@ spec:
     metadata:
       annotations:
         kubectl.kubernetes.io/default-container: alloy
+        k8s.grafana.com/logs.job: integrations/alloy
       labels:
         app.kubernetes.io/name: alloy
         app.kubernetes.io/instance: k8smon
@@ -60078,6 +60087,11 @@ data:
       rule {
         source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
         target_label  = "app_kubernetes_io_name"
+      }
+    
+      rule {
+        source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_job"]
+        target_label  = "job"
       }
     
       rule {

--- a/examples/specific-namespace/output.yaml
+++ b/examples/specific-namespace/output.yaml
@@ -1143,11 +1143,13 @@ data:
       }
       rule {
         source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+        regex         = "(.+)"
         target_label  = "app_kubernetes_io_name"
       }
     
       rule {
         source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_job"]
+        regex         = "(.+)"
         target_label  = "job"
       }
     
@@ -60086,11 +60088,13 @@ data:
       }
       rule {
         source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+        regex         = "(.+)"
         target_label  = "app_kubernetes_io_name"
       }
     
       rule {
         source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_job"]
+        regex         = "(.+)"
         target_label  = "job"
       }
     

--- a/examples/traces-enabled/logs.alloy
+++ b/examples/traces-enabled/logs.alloy
@@ -34,11 +34,13 @@ discovery.relabel "pod_logs" {
   }
   rule {
     source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+    regex         = "(.+)"
     target_label  = "app_kubernetes_io_name"
   }
 
   rule {
     source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_job"]
+    regex         = "(.+)"
     target_label  = "job"
   }
 

--- a/examples/traces-enabled/logs.alloy
+++ b/examples/traces-enabled/logs.alloy
@@ -38,6 +38,11 @@ discovery.relabel "pod_logs" {
   }
 
   rule {
+    source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_job"]
+    target_label  = "job"
+  }
+
+  rule {
     source_labels = ["__meta_kubernetes_pod_uid", "__meta_kubernetes_pod_container_name"]
     separator = "/"
     action = "replace"

--- a/examples/traces-enabled/output.yaml
+++ b/examples/traces-enabled/output.yaml
@@ -1198,11 +1198,13 @@ data:
       }
       rule {
         source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+        regex         = "(.+)"
         target_label  = "app_kubernetes_io_name"
       }
     
       rule {
         source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_job"]
+        regex         = "(.+)"
         target_label  = "job"
       }
     
@@ -60183,11 +60185,13 @@ data:
       }
       rule {
         source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+        regex         = "(.+)"
         target_label  = "app_kubernetes_io_name"
       }
     
       rule {
         source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_job"]
+        regex         = "(.+)"
         target_label  = "job"
       }
     

--- a/examples/traces-enabled/output.yaml
+++ b/examples/traces-enabled/output.yaml
@@ -1202,6 +1202,11 @@ data:
       }
     
       rule {
+        source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_job"]
+        target_label  = "job"
+      }
+    
+      rule {
         source_labels = ["__meta_kubernetes_pod_uid", "__meta_kubernetes_pod_container_name"]
         separator = "/"
         action = "replace"
@@ -58501,6 +58506,7 @@ spec:
     metadata:
       annotations:
         kubectl.kubernetes.io/default-container: alloy
+        k8s.grafana.com/logs.job: integrations/alloy
       labels:
         app.kubernetes.io/name: alloy-logs
         app.kubernetes.io/instance: k8smon
@@ -58594,6 +58600,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
+        k8s.grafana.com/logs.job: integrations/node_exporter
       labels:
         helm.sh/chart: prometheus-node-exporter-4.37.0
         app.kubernetes.io/managed-by: Helm
@@ -58713,6 +58720,7 @@ spec:
     metadata:
       annotations:
         kubectl.kubernetes.io/default-container: alloy
+        k8s.grafana.com/logs.job: integrations/alloy
       labels:
         app.kubernetes.io/name: alloy-events
         app.kubernetes.io/instance: k8smon
@@ -58998,6 +59006,7 @@ spec:
     metadata:
       annotations:
         kubectl.kubernetes.io/default-container: alloy
+        k8s.grafana.com/logs.job: integrations/alloy
       labels:
         app.kubernetes.io/name: alloy
         app.kubernetes.io/instance: k8smon
@@ -60175,6 +60184,11 @@ data:
       rule {
         source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
         target_label  = "app_kubernetes_io_name"
+      }
+    
+      rule {
+        source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_job"]
+        target_label  = "job"
       }
     
       rule {

--- a/examples/windows-exporter/logs.alloy
+++ b/examples/windows-exporter/logs.alloy
@@ -34,11 +34,13 @@ discovery.relabel "pod_logs" {
   }
   rule {
     source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+    regex         = "(.+)"
     target_label  = "app_kubernetes_io_name"
   }
 
   rule {
     source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_job"]
+    regex         = "(.+)"
     target_label  = "job"
   }
 

--- a/examples/windows-exporter/logs.alloy
+++ b/examples/windows-exporter/logs.alloy
@@ -38,6 +38,11 @@ discovery.relabel "pod_logs" {
   }
 
   rule {
+    source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_job"]
+    target_label  = "job"
+  }
+
+  rule {
     source_labels = ["__meta_kubernetes_pod_uid", "__meta_kubernetes_pod_container_name"]
     separator = "/"
     action = "replace"

--- a/examples/windows-exporter/metrics.alloy
+++ b/examples/windows-exporter/metrics.alloy
@@ -647,7 +647,7 @@ discovery.relabel "windows_exporter" {
 }
 
 prometheus.scrape "windows_exporter" {
-  job_name   = "integrations/kubernetes/windows-exporter"
+  job_name   = "integrations/windows-exporter"
   targets  = discovery.relabel.windows_exporter.output
   scrape_interval = "60s"
   clustering {

--- a/examples/windows-exporter/output.yaml
+++ b/examples/windows-exporter/output.yaml
@@ -1185,11 +1185,13 @@ data:
       }
       rule {
         source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+        regex         = "(.+)"
         target_label  = "app_kubernetes_io_name"
       }
     
       rule {
         source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_job"]
+        regex         = "(.+)"
         target_label  = "job"
       }
     
@@ -60260,11 +60262,13 @@ data:
       }
       rule {
         source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+        regex         = "(.+)"
         target_label  = "app_kubernetes_io_name"
       }
     
       rule {
         source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_job"]
+        regex         = "(.+)"
         target_label  = "job"
       }
     

--- a/examples/windows-exporter/output.yaml
+++ b/examples/windows-exporter/output.yaml
@@ -814,7 +814,7 @@ data:
     }
     
     prometheus.scrape "windows_exporter" {
-      job_name   = "integrations/kubernetes/windows-exporter"
+      job_name   = "integrations/windows-exporter"
       targets  = discovery.relabel.windows_exporter.output
       scrape_interval = "60s"
       clustering {
@@ -1186,6 +1186,11 @@ data:
       rule {
         source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
         target_label  = "app_kubernetes_io_name"
+      }
+    
+      rule {
+        source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_job"]
+        target_label  = "job"
       }
     
       rule {
@@ -58516,6 +58521,7 @@ spec:
     metadata:
       annotations:
         kubectl.kubernetes.io/default-container: alloy
+        k8s.grafana.com/logs.job: integrations/alloy
       labels:
         app.kubernetes.io/name: alloy-logs
         app.kubernetes.io/instance: k8smon
@@ -58609,6 +58615,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
+        k8s.grafana.com/logs.job: integrations/node_exporter
       labels:
         helm.sh/chart: prometheus-node-exporter-4.37.0
         app.kubernetes.io/managed-by: Helm
@@ -58731,6 +58738,7 @@ spec:
     metadata:
       annotations:
         cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
+        k8s.grafana.com/logs.job: integrations/windows_exporter
       labels:
         helm.sh/chart: prometheus-windows-exporter-0.3.1
         app.kubernetes.io/managed-by: Helm
@@ -58826,6 +58834,7 @@ spec:
     metadata:
       annotations:
         kubectl.kubernetes.io/default-container: alloy
+        k8s.grafana.com/logs.job: integrations/alloy
       labels:
         app.kubernetes.io/name: alloy-events
         app.kubernetes.io/instance: k8smon
@@ -59111,6 +59120,7 @@ spec:
     metadata:
       annotations:
         kubectl.kubernetes.io/default-container: alloy
+        k8s.grafana.com/logs.job: integrations/alloy
       labels:
         app.kubernetes.io/name: alloy
         app.kubernetes.io/instance: k8smon
@@ -59895,7 +59905,7 @@ data:
     }
     
     prometheus.scrape "windows_exporter" {
-      job_name   = "integrations/kubernetes/windows-exporter"
+      job_name   = "integrations/windows-exporter"
       targets  = discovery.relabel.windows_exporter.output
       scrape_interval = "60s"
       clustering {
@@ -60251,6 +60261,11 @@ data:
       rule {
         source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
         target_label  = "app_kubernetes_io_name"
+      }
+    
+      rule {
+        source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_job"]
+        target_label  = "job"
       }
     
       rule {


### PR DESCRIPTION
And set that annotation in our deployments of Alloy, Node Exporter, and Windows Exporter.