### PR TITLE
Move pod to structured metadata and remove duplicate code.

### DIFF
--- a/charts/k8s-monitoring/templates/alloy_config/_pod_logs_processor.alloy.txt
+++ b/charts/k8s-monitoring/templates/alloy_config/_pod_logs_processor.alloy.txt
@@ -1,7 +1,7 @@
 {{ define "alloy.config.logs.pod_logs_processor" }}
 loki.process "pod_logs" {
   stage.match {
-    selector = "{tmp_container_runtime=\"containerd\"}"
+    selector = "{tmp_container_runtime=~\"containerd|cri-o\"}"
     // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
     stage.cri {}
 
@@ -14,21 +14,6 @@ loki.process "pod_logs" {
     }
   }
 
-  stage.match {
-    selector = "{tmp_container_runtime=\"cri-o\"}"
-    // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
-    stage.cri {}
-
-    // Set the extract flags and stream values as labels
-    stage.labels {
-      values = {
-        flags  = "",
-        stream  = "",
-      }
-    }
-  }
-
-  // if the label tmp_container_runtime from above is docker parse using docker
   stage.match {
     selector = "{tmp_container_runtime=\"docker\"}"
     // the docker processing stage extracts the following k/v pairs: log, stream, time
@@ -42,11 +27,18 @@ loki.process "pod_logs" {
     }
   }
 
-  // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have
-  // cluster, namespace, pod, and container labels.
-  // Also drop the temporary container runtime label as it is no longer needed.
+  // Move high-cardinality labels to structured metadata
+  stage.structured_metadata {
+    values = {
+      pod  = "",
+    }
+  }
+
+  // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
+  // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+  // container runtime label as it is no longer needed.
   stage.label_drop {
-    values = ["filename", "tmp_container_runtime"]
+    values = ["filename", "pod", "tmp_container_runtime"]
   }
 
 {{- if .Values.logs.pod_logs.extraStageBlocks }}

--- a/examples/alloy-autoscaling-and-storage/logs.alloy
+++ b/examples/alloy-autoscaling-and-storage/logs.alloy
@@ -82,7 +82,7 @@ loki.source.file "pod_logs" {
 
 loki.process "pod_logs" {
   stage.match {
-    selector = "{tmp_container_runtime=\"containerd\"}"
+    selector = "{tmp_container_runtime=~\"containerd|cri-o\"}"
     // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
     stage.cri {}
 
@@ -95,21 +95,6 @@ loki.process "pod_logs" {
     }
   }
 
-  stage.match {
-    selector = "{tmp_container_runtime=\"cri-o\"}"
-    // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
-    stage.cri {}
-
-    // Set the extract flags and stream values as labels
-    stage.labels {
-      values = {
-        flags  = "",
-        stream  = "",
-      }
-    }
-  }
-
-  // if the label tmp_container_runtime from above is docker parse using docker
   stage.match {
     selector = "{tmp_container_runtime=\"docker\"}"
     // the docker processing stage extracts the following k/v pairs: log, stream, time
@@ -123,11 +108,18 @@ loki.process "pod_logs" {
     }
   }
 
-  // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have
-  // cluster, namespace, pod, and container labels.
-  // Also drop the temporary container runtime label as it is no longer needed.
+  // Move high-cardinality labels to structured metadata
+  stage.structured_metadata {
+    values = {
+      pod  = "",
+    }
+  }
+
+  // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
+  // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+  // container runtime label as it is no longer needed.
   stage.label_drop {
-    values = ["filename", "tmp_container_runtime"]
+    values = ["filename", "pod", "tmp_container_runtime"]
   }
   forward_to = [loki.process.logs_service.receiver]
 }

--- a/examples/alloy-autoscaling-and-storage/metrics.alloy
+++ b/examples/alloy-autoscaling-and-storage/metrics.alloy
@@ -764,7 +764,7 @@ prometheus.remote_write "metrics_service" {
 
 loki.process "pod_logs" {
   stage.match {
-    selector = "{tmp_container_runtime=\"containerd\"}"
+    selector = "{tmp_container_runtime=~\"containerd|cri-o\"}"
     // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
     stage.cri {}
 
@@ -777,21 +777,6 @@ loki.process "pod_logs" {
     }
   }
 
-  stage.match {
-    selector = "{tmp_container_runtime=\"cri-o\"}"
-    // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
-    stage.cri {}
-
-    // Set the extract flags and stream values as labels
-    stage.labels {
-      values = {
-        flags  = "",
-        stream  = "",
-      }
-    }
-  }
-
-  // if the label tmp_container_runtime from above is docker parse using docker
   stage.match {
     selector = "{tmp_container_runtime=\"docker\"}"
     // the docker processing stage extracts the following k/v pairs: log, stream, time
@@ -805,11 +790,18 @@ loki.process "pod_logs" {
     }
   }
 
-  // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have
-  // cluster, namespace, pod, and container labels.
-  // Also drop the temporary container runtime label as it is no longer needed.
+  // Move high-cardinality labels to structured metadata
+  stage.structured_metadata {
+    values = {
+      pod  = "",
+    }
+  }
+
+  // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
+  // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+  // container runtime label as it is no longer needed.
   stage.label_drop {
-    values = ["filename", "tmp_container_runtime"]
+    values = ["filename", "pod", "tmp_container_runtime"]
   }
   forward_to = [loki.process.logs_service.receiver]
 }

--- a/examples/alloy-autoscaling-and-storage/output.yaml
+++ b/examples/alloy-autoscaling-and-storage/output.yaml
@@ -894,7 +894,7 @@ data:
     
     loki.process "pod_logs" {
       stage.match {
-        selector = "{tmp_container_runtime=\"containerd\"}"
+        selector = "{tmp_container_runtime=~\"containerd|cri-o\"}"
         // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
         stage.cri {}
     
@@ -907,21 +907,6 @@ data:
         }
       }
     
-      stage.match {
-        selector = "{tmp_container_runtime=\"cri-o\"}"
-        // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
-        stage.cri {}
-    
-        // Set the extract flags and stream values as labels
-        stage.labels {
-          values = {
-            flags  = "",
-            stream  = "",
-          }
-        }
-      }
-    
-      // if the label tmp_container_runtime from above is docker parse using docker
       stage.match {
         selector = "{tmp_container_runtime=\"docker\"}"
         // the docker processing stage extracts the following k/v pairs: log, stream, time
@@ -935,11 +920,18 @@ data:
         }
       }
     
-      // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have
-      // cluster, namespace, pod, and container labels.
-      // Also drop the temporary container runtime label as it is no longer needed.
+      // Move high-cardinality labels to structured metadata
+      stage.structured_metadata {
+        values = {
+          pod  = "",
+        }
+      }
+    
+      // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
+      // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+      // container runtime label as it is no longer needed.
       stage.label_drop {
-        values = ["filename", "tmp_container_runtime"]
+        values = ["filename", "pod", "tmp_container_runtime"]
       }
       forward_to = [loki.process.logs_service.receiver]
     }
@@ -1127,7 +1119,7 @@ data:
     
     loki.process "pod_logs" {
       stage.match {
-        selector = "{tmp_container_runtime=\"containerd\"}"
+        selector = "{tmp_container_runtime=~\"containerd|cri-o\"}"
         // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
         stage.cri {}
     
@@ -1140,21 +1132,6 @@ data:
         }
       }
     
-      stage.match {
-        selector = "{tmp_container_runtime=\"cri-o\"}"
-        // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
-        stage.cri {}
-    
-        // Set the extract flags and stream values as labels
-        stage.labels {
-          values = {
-            flags  = "",
-            stream  = "",
-          }
-        }
-      }
-    
-      // if the label tmp_container_runtime from above is docker parse using docker
       stage.match {
         selector = "{tmp_container_runtime=\"docker\"}"
         // the docker processing stage extracts the following k/v pairs: log, stream, time
@@ -1168,11 +1145,18 @@ data:
         }
       }
     
-      // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have
-      // cluster, namespace, pod, and container labels.
-      // Also drop the temporary container runtime label as it is no longer needed.
+      // Move high-cardinality labels to structured metadata
+      stage.structured_metadata {
+        values = {
+          pod  = "",
+        }
+      }
+    
+      // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
+      // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+      // container runtime label as it is no longer needed.
       stage.label_drop {
-        values = ["filename", "tmp_container_runtime"]
+        values = ["filename", "pod", "tmp_container_runtime"]
       }
       forward_to = [loki.process.logs_service.receiver]
     }
@@ -59852,7 +59836,7 @@ data:
     
     loki.process "pod_logs" {
       stage.match {
-        selector = "{tmp_container_runtime=\"containerd\"}"
+        selector = "{tmp_container_runtime=~\"containerd|cri-o\"}"
         // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
         stage.cri {}
     
@@ -59865,21 +59849,6 @@ data:
         }
       }
     
-      stage.match {
-        selector = "{tmp_container_runtime=\"cri-o\"}"
-        // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
-        stage.cri {}
-    
-        // Set the extract flags and stream values as labels
-        stage.labels {
-          values = {
-            flags  = "",
-            stream  = "",
-          }
-        }
-      }
-    
-      // if the label tmp_container_runtime from above is docker parse using docker
       stage.match {
         selector = "{tmp_container_runtime=\"docker\"}"
         // the docker processing stage extracts the following k/v pairs: log, stream, time
@@ -59893,11 +59862,18 @@ data:
         }
       }
     
-      // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have
-      // cluster, namespace, pod, and container labels.
-      // Also drop the temporary container runtime label as it is no longer needed.
+      // Move high-cardinality labels to structured metadata
+      stage.structured_metadata {
+        values = {
+          pod  = "",
+        }
+      }
+    
+      // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
+      // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+      // container runtime label as it is no longer needed.
       stage.label_drop {
-        values = ["filename", "tmp_container_runtime"]
+        values = ["filename", "pod", "tmp_container_runtime"]
       }
       forward_to = [loki.process.logs_service.receiver]
     }
@@ -60069,7 +60045,7 @@ data:
     
     loki.process "pod_logs" {
       stage.match {
-        selector = "{tmp_container_runtime=\"containerd\"}"
+        selector = "{tmp_container_runtime=~\"containerd|cri-o\"}"
         // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
         stage.cri {}
     
@@ -60082,21 +60058,6 @@ data:
         }
       }
     
-      stage.match {
-        selector = "{tmp_container_runtime=\"cri-o\"}"
-        // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
-        stage.cri {}
-    
-        // Set the extract flags and stream values as labels
-        stage.labels {
-          values = {
-            flags  = "",
-            stream  = "",
-          }
-        }
-      }
-    
-      // if the label tmp_container_runtime from above is docker parse using docker
       stage.match {
         selector = "{tmp_container_runtime=\"docker\"}"
         // the docker processing stage extracts the following k/v pairs: log, stream, time
@@ -60110,11 +60071,18 @@ data:
         }
       }
     
-      // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have
-      // cluster, namespace, pod, and container labels.
-      // Also drop the temporary container runtime label as it is no longer needed.
+      // Move high-cardinality labels to structured metadata
+      stage.structured_metadata {
+        values = {
+          pod  = "",
+        }
+      }
+    
+      // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
+      // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+      // container runtime label as it is no longer needed.
       stage.label_drop {
-        values = ["filename", "tmp_container_runtime"]
+        values = ["filename", "pod", "tmp_container_runtime"]
       }
       forward_to = [loki.process.logs_service.receiver]
     }

--- a/examples/application-observability/logs.alloy
+++ b/examples/application-observability/logs.alloy
@@ -82,7 +82,7 @@ loki.source.file "pod_logs" {
 
 loki.process "pod_logs" {
   stage.match {
-    selector = "{tmp_container_runtime=\"containerd\"}"
+    selector = "{tmp_container_runtime=~\"containerd|cri-o\"}"
     // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
     stage.cri {}
 
@@ -95,21 +95,6 @@ loki.process "pod_logs" {
     }
   }
 
-  stage.match {
-    selector = "{tmp_container_runtime=\"cri-o\"}"
-    // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
-    stage.cri {}
-
-    // Set the extract flags and stream values as labels
-    stage.labels {
-      values = {
-        flags  = "",
-        stream  = "",
-      }
-    }
-  }
-
-  // if the label tmp_container_runtime from above is docker parse using docker
   stage.match {
     selector = "{tmp_container_runtime=\"docker\"}"
     // the docker processing stage extracts the following k/v pairs: log, stream, time
@@ -123,11 +108,18 @@ loki.process "pod_logs" {
     }
   }
 
-  // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have
-  // cluster, namespace, pod, and container labels.
-  // Also drop the temporary container runtime label as it is no longer needed.
+  // Move high-cardinality labels to structured metadata
+  stage.structured_metadata {
+    values = {
+      pod  = "",
+    }
+  }
+
+  // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
+  // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+  // container runtime label as it is no longer needed.
   stage.label_drop {
-    values = ["filename", "tmp_container_runtime"]
+    values = ["filename", "pod", "tmp_container_runtime"]
   }
   forward_to = [loki.process.logs_service.receiver]
 }

--- a/examples/application-observability/metrics.alloy
+++ b/examples/application-observability/metrics.alloy
@@ -796,7 +796,7 @@ prometheus.remote_write "metrics_service" {
 
 loki.process "pod_logs" {
   stage.match {
-    selector = "{tmp_container_runtime=\"containerd\"}"
+    selector = "{tmp_container_runtime=~\"containerd|cri-o\"}"
     // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
     stage.cri {}
 
@@ -809,21 +809,6 @@ loki.process "pod_logs" {
     }
   }
 
-  stage.match {
-    selector = "{tmp_container_runtime=\"cri-o\"}"
-    // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
-    stage.cri {}
-
-    // Set the extract flags and stream values as labels
-    stage.labels {
-      values = {
-        flags  = "",
-        stream  = "",
-      }
-    }
-  }
-
-  // if the label tmp_container_runtime from above is docker parse using docker
   stage.match {
     selector = "{tmp_container_runtime=\"docker\"}"
     // the docker processing stage extracts the following k/v pairs: log, stream, time
@@ -837,11 +822,18 @@ loki.process "pod_logs" {
     }
   }
 
-  // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have
-  // cluster, namespace, pod, and container labels.
-  // Also drop the temporary container runtime label as it is no longer needed.
+  // Move high-cardinality labels to structured metadata
+  stage.structured_metadata {
+    values = {
+      pod  = "",
+    }
+  }
+
+  // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
+  // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+  // container runtime label as it is no longer needed.
   stage.label_drop {
-    values = ["filename", "tmp_container_runtime"]
+    values = ["filename", "pod", "tmp_container_runtime"]
   }
   forward_to = [loki.process.logs_service.receiver]
 }

--- a/examples/application-observability/output.yaml
+++ b/examples/application-observability/output.yaml
@@ -968,7 +968,7 @@ data:
     
     loki.process "pod_logs" {
       stage.match {
-        selector = "{tmp_container_runtime=\"containerd\"}"
+        selector = "{tmp_container_runtime=~\"containerd|cri-o\"}"
         // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
         stage.cri {}
     
@@ -981,21 +981,6 @@ data:
         }
       }
     
-      stage.match {
-        selector = "{tmp_container_runtime=\"cri-o\"}"
-        // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
-        stage.cri {}
-    
-        // Set the extract flags and stream values as labels
-        stage.labels {
-          values = {
-            flags  = "",
-            stream  = "",
-          }
-        }
-      }
-    
-      // if the label tmp_container_runtime from above is docker parse using docker
       stage.match {
         selector = "{tmp_container_runtime=\"docker\"}"
         // the docker processing stage extracts the following k/v pairs: log, stream, time
@@ -1009,11 +994,18 @@ data:
         }
       }
     
-      // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have
-      // cluster, namespace, pod, and container labels.
-      // Also drop the temporary container runtime label as it is no longer needed.
+      // Move high-cardinality labels to structured metadata
+      stage.structured_metadata {
+        values = {
+          pod  = "",
+        }
+      }
+    
+      // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
+      // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+      // container runtime label as it is no longer needed.
       stage.label_drop {
-        values = ["filename", "tmp_container_runtime"]
+        values = ["filename", "pod", "tmp_container_runtime"]
       }
       forward_to = [loki.process.logs_service.receiver]
     }
@@ -1221,7 +1213,7 @@ data:
     
     loki.process "pod_logs" {
       stage.match {
-        selector = "{tmp_container_runtime=\"containerd\"}"
+        selector = "{tmp_container_runtime=~\"containerd|cri-o\"}"
         // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
         stage.cri {}
     
@@ -1234,21 +1226,6 @@ data:
         }
       }
     
-      stage.match {
-        selector = "{tmp_container_runtime=\"cri-o\"}"
-        // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
-        stage.cri {}
-    
-        // Set the extract flags and stream values as labels
-        stage.labels {
-          values = {
-            flags  = "",
-            stream  = "",
-          }
-        }
-      }
-    
-      // if the label tmp_container_runtime from above is docker parse using docker
       stage.match {
         selector = "{tmp_container_runtime=\"docker\"}"
         // the docker processing stage extracts the following k/v pairs: log, stream, time
@@ -1262,11 +1239,18 @@ data:
         }
       }
     
-      // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have
-      // cluster, namespace, pod, and container labels.
-      // Also drop the temporary container runtime label as it is no longer needed.
+      // Move high-cardinality labels to structured metadata
+      stage.structured_metadata {
+        values = {
+          pod  = "",
+        }
+      }
+    
+      // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
+      // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+      // container runtime label as it is no longer needed.
       stage.label_drop {
-        values = ["filename", "tmp_container_runtime"]
+        values = ["filename", "pod", "tmp_container_runtime"]
       }
       forward_to = [loki.process.logs_service.receiver]
     }
@@ -61079,7 +61063,7 @@ data:
     
     loki.process "pod_logs" {
       stage.match {
-        selector = "{tmp_container_runtime=\"containerd\"}"
+        selector = "{tmp_container_runtime=~\"containerd|cri-o\"}"
         // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
         stage.cri {}
     
@@ -61092,21 +61076,6 @@ data:
         }
       }
     
-      stage.match {
-        selector = "{tmp_container_runtime=\"cri-o\"}"
-        // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
-        stage.cri {}
-    
-        // Set the extract flags and stream values as labels
-        stage.labels {
-          values = {
-            flags  = "",
-            stream  = "",
-          }
-        }
-      }
-    
-      // if the label tmp_container_runtime from above is docker parse using docker
       stage.match {
         selector = "{tmp_container_runtime=\"docker\"}"
         // the docker processing stage extracts the following k/v pairs: log, stream, time
@@ -61120,11 +61089,18 @@ data:
         }
       }
     
-      // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have
-      // cluster, namespace, pod, and container labels.
-      // Also drop the temporary container runtime label as it is no longer needed.
+      // Move high-cardinality labels to structured metadata
+      stage.structured_metadata {
+        values = {
+          pod  = "",
+        }
+      }
+    
+      // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
+      // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+      // container runtime label as it is no longer needed.
       stage.label_drop {
-        values = ["filename", "tmp_container_runtime"]
+        values = ["filename", "pod", "tmp_container_runtime"]
       }
       forward_to = [loki.process.logs_service.receiver]
     }
@@ -61316,7 +61292,7 @@ data:
     
     loki.process "pod_logs" {
       stage.match {
-        selector = "{tmp_container_runtime=\"containerd\"}"
+        selector = "{tmp_container_runtime=~\"containerd|cri-o\"}"
         // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
         stage.cri {}
     
@@ -61329,21 +61305,6 @@ data:
         }
       }
     
-      stage.match {
-        selector = "{tmp_container_runtime=\"cri-o\"}"
-        // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
-        stage.cri {}
-    
-        // Set the extract flags and stream values as labels
-        stage.labels {
-          values = {
-            flags  = "",
-            stream  = "",
-          }
-        }
-      }
-    
-      // if the label tmp_container_runtime from above is docker parse using docker
       stage.match {
         selector = "{tmp_container_runtime=\"docker\"}"
         // the docker processing stage extracts the following k/v pairs: log, stream, time
@@ -61357,11 +61318,18 @@ data:
         }
       }
     
-      // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have
-      // cluster, namespace, pod, and container labels.
-      // Also drop the temporary container runtime label as it is no longer needed.
+      // Move high-cardinality labels to structured metadata
+      stage.structured_metadata {
+        values = {
+          pod  = "",
+        }
+      }
+    
+      // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
+      // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+      // container runtime label as it is no longer needed.
       stage.label_drop {
-        values = ["filename", "tmp_container_runtime"]
+        values = ["filename", "pod", "tmp_container_runtime"]
       }
       forward_to = [loki.process.logs_service.receiver]
     }

--- a/examples/control-plane-metrics/logs.alloy
+++ b/examples/control-plane-metrics/logs.alloy
@@ -82,7 +82,7 @@ loki.source.file "pod_logs" {
 
 loki.process "pod_logs" {
   stage.match {
-    selector = "{tmp_container_runtime=\"containerd\"}"
+    selector = "{tmp_container_runtime=~\"containerd|cri-o\"}"
     // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
     stage.cri {}
 
@@ -95,21 +95,6 @@ loki.process "pod_logs" {
     }
   }
 
-  stage.match {
-    selector = "{tmp_container_runtime=\"cri-o\"}"
-    // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
-    stage.cri {}
-
-    // Set the extract flags and stream values as labels
-    stage.labels {
-      values = {
-        flags  = "",
-        stream  = "",
-      }
-    }
-  }
-
-  // if the label tmp_container_runtime from above is docker parse using docker
   stage.match {
     selector = "{tmp_container_runtime=\"docker\"}"
     // the docker processing stage extracts the following k/v pairs: log, stream, time
@@ -123,11 +108,18 @@ loki.process "pod_logs" {
     }
   }
 
-  // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have
-  // cluster, namespace, pod, and container labels.
-  // Also drop the temporary container runtime label as it is no longer needed.
+  // Move high-cardinality labels to structured metadata
+  stage.structured_metadata {
+    values = {
+      pod  = "",
+    }
+  }
+
+  // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
+  // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+  // container runtime label as it is no longer needed.
   stage.label_drop {
-    values = ["filename", "tmp_container_runtime"]
+    values = ["filename", "pod", "tmp_container_runtime"]
   }
   forward_to = [loki.process.logs_service.receiver]
 }

--- a/examples/control-plane-metrics/metrics.alloy
+++ b/examples/control-plane-metrics/metrics.alloy
@@ -920,7 +920,7 @@ prometheus.remote_write "metrics_service" {
 
 loki.process "pod_logs" {
   stage.match {
-    selector = "{tmp_container_runtime=\"containerd\"}"
+    selector = "{tmp_container_runtime=~\"containerd|cri-o\"}"
     // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
     stage.cri {}
 
@@ -933,21 +933,6 @@ loki.process "pod_logs" {
     }
   }
 
-  stage.match {
-    selector = "{tmp_container_runtime=\"cri-o\"}"
-    // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
-    stage.cri {}
-
-    // Set the extract flags and stream values as labels
-    stage.labels {
-      values = {
-        flags  = "",
-        stream  = "",
-      }
-    }
-  }
-
-  // if the label tmp_container_runtime from above is docker parse using docker
   stage.match {
     selector = "{tmp_container_runtime=\"docker\"}"
     // the docker processing stage extracts the following k/v pairs: log, stream, time
@@ -961,11 +946,18 @@ loki.process "pod_logs" {
     }
   }
 
-  // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have
-  // cluster, namespace, pod, and container labels.
-  // Also drop the temporary container runtime label as it is no longer needed.
+  // Move high-cardinality labels to structured metadata
+  stage.structured_metadata {
+    values = {
+      pod  = "",
+    }
+  }
+
+  // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
+  // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+  // container runtime label as it is no longer needed.
   stage.label_drop {
-    values = ["filename", "tmp_container_runtime"]
+    values = ["filename", "pod", "tmp_container_runtime"]
   }
   forward_to = [loki.process.logs_service.receiver]
 }

--- a/examples/control-plane-metrics/output.yaml
+++ b/examples/control-plane-metrics/output.yaml
@@ -1051,7 +1051,7 @@ data:
     
     loki.process "pod_logs" {
       stage.match {
-        selector = "{tmp_container_runtime=\"containerd\"}"
+        selector = "{tmp_container_runtime=~\"containerd|cri-o\"}"
         // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
         stage.cri {}
     
@@ -1064,21 +1064,6 @@ data:
         }
       }
     
-      stage.match {
-        selector = "{tmp_container_runtime=\"cri-o\"}"
-        // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
-        stage.cri {}
-    
-        // Set the extract flags and stream values as labels
-        stage.labels {
-          values = {
-            flags  = "",
-            stream  = "",
-          }
-        }
-      }
-    
-      // if the label tmp_container_runtime from above is docker parse using docker
       stage.match {
         selector = "{tmp_container_runtime=\"docker\"}"
         // the docker processing stage extracts the following k/v pairs: log, stream, time
@@ -1092,11 +1077,18 @@ data:
         }
       }
     
-      // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have
-      // cluster, namespace, pod, and container labels.
-      // Also drop the temporary container runtime label as it is no longer needed.
+      // Move high-cardinality labels to structured metadata
+      stage.structured_metadata {
+        values = {
+          pod  = "",
+        }
+      }
+    
+      // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
+      // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+      // container runtime label as it is no longer needed.
       stage.label_drop {
-        values = ["filename", "tmp_container_runtime"]
+        values = ["filename", "pod", "tmp_container_runtime"]
       }
       forward_to = [loki.process.logs_service.receiver]
     }
@@ -1284,7 +1276,7 @@ data:
     
     loki.process "pod_logs" {
       stage.match {
-        selector = "{tmp_container_runtime=\"containerd\"}"
+        selector = "{tmp_container_runtime=~\"containerd|cri-o\"}"
         // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
         stage.cri {}
     
@@ -1297,21 +1289,6 @@ data:
         }
       }
     
-      stage.match {
-        selector = "{tmp_container_runtime=\"cri-o\"}"
-        // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
-        stage.cri {}
-    
-        // Set the extract flags and stream values as labels
-        stage.labels {
-          values = {
-            flags  = "",
-            stream  = "",
-          }
-        }
-      }
-    
-      // if the label tmp_container_runtime from above is docker parse using docker
       stage.match {
         selector = "{tmp_container_runtime=\"docker\"}"
         // the docker processing stage extracts the following k/v pairs: log, stream, time
@@ -1325,11 +1302,18 @@ data:
         }
       }
     
-      // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have
-      // cluster, namespace, pod, and container labels.
-      // Also drop the temporary container runtime label as it is no longer needed.
+      // Move high-cardinality labels to structured metadata
+      stage.structured_metadata {
+        values = {
+          pod  = "",
+        }
+      }
+    
+      // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
+      // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+      // container runtime label as it is no longer needed.
       stage.label_drop {
-        values = ["filename", "tmp_container_runtime"]
+        values = ["filename", "pod", "tmp_container_runtime"]
       }
       forward_to = [loki.process.logs_service.receiver]
     }
@@ -60104,7 +60088,7 @@ data:
     
     loki.process "pod_logs" {
       stage.match {
-        selector = "{tmp_container_runtime=\"containerd\"}"
+        selector = "{tmp_container_runtime=~\"containerd|cri-o\"}"
         // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
         stage.cri {}
     
@@ -60117,21 +60101,6 @@ data:
         }
       }
     
-      stage.match {
-        selector = "{tmp_container_runtime=\"cri-o\"}"
-        // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
-        stage.cri {}
-    
-        // Set the extract flags and stream values as labels
-        stage.labels {
-          values = {
-            flags  = "",
-            stream  = "",
-          }
-        }
-      }
-    
-      // if the label tmp_container_runtime from above is docker parse using docker
       stage.match {
         selector = "{tmp_container_runtime=\"docker\"}"
         // the docker processing stage extracts the following k/v pairs: log, stream, time
@@ -60145,11 +60114,18 @@ data:
         }
       }
     
-      // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have
-      // cluster, namespace, pod, and container labels.
-      // Also drop the temporary container runtime label as it is no longer needed.
+      // Move high-cardinality labels to structured metadata
+      stage.structured_metadata {
+        values = {
+          pod  = "",
+        }
+      }
+    
+      // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
+      // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+      // container runtime label as it is no longer needed.
       stage.label_drop {
-        values = ["filename", "tmp_container_runtime"]
+        values = ["filename", "pod", "tmp_container_runtime"]
       }
       forward_to = [loki.process.logs_service.receiver]
     }
@@ -60321,7 +60297,7 @@ data:
     
     loki.process "pod_logs" {
       stage.match {
-        selector = "{tmp_container_runtime=\"containerd\"}"
+        selector = "{tmp_container_runtime=~\"containerd|cri-o\"}"
         // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
         stage.cri {}
     
@@ -60334,21 +60310,6 @@ data:
         }
       }
     
-      stage.match {
-        selector = "{tmp_container_runtime=\"cri-o\"}"
-        // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
-        stage.cri {}
-    
-        // Set the extract flags and stream values as labels
-        stage.labels {
-          values = {
-            flags  = "",
-            stream  = "",
-          }
-        }
-      }
-    
-      // if the label tmp_container_runtime from above is docker parse using docker
       stage.match {
         selector = "{tmp_container_runtime=\"docker\"}"
         // the docker processing stage extracts the following k/v pairs: log, stream, time
@@ -60362,11 +60323,18 @@ data:
         }
       }
     
-      // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have
-      // cluster, namespace, pod, and container labels.
-      // Also drop the temporary container runtime label as it is no longer needed.
+      // Move high-cardinality labels to structured metadata
+      stage.structured_metadata {
+        values = {
+          pod  = "",
+        }
+      }
+    
+      // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
+      // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+      // container runtime label as it is no longer needed.
       stage.label_drop {
-        values = ["filename", "tmp_container_runtime"]
+        values = ["filename", "pod", "tmp_container_runtime"]
       }
       forward_to = [loki.process.logs_service.receiver]
     }

--- a/examples/custom-config/logs.alloy
+++ b/examples/custom-config/logs.alloy
@@ -82,7 +82,7 @@ loki.source.file "pod_logs" {
 
 loki.process "pod_logs" {
   stage.match {
-    selector = "{tmp_container_runtime=\"containerd\"}"
+    selector = "{tmp_container_runtime=~\"containerd|cri-o\"}"
     // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
     stage.cri {}
 
@@ -95,21 +95,6 @@ loki.process "pod_logs" {
     }
   }
 
-  stage.match {
-    selector = "{tmp_container_runtime=\"cri-o\"}"
-    // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
-    stage.cri {}
-
-    // Set the extract flags and stream values as labels
-    stage.labels {
-      values = {
-        flags  = "",
-        stream  = "",
-      }
-    }
-  }
-
-  // if the label tmp_container_runtime from above is docker parse using docker
   stage.match {
     selector = "{tmp_container_runtime=\"docker\"}"
     // the docker processing stage extracts the following k/v pairs: log, stream, time
@@ -123,11 +108,18 @@ loki.process "pod_logs" {
     }
   }
 
-  // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have
-  // cluster, namespace, pod, and container labels.
-  // Also drop the temporary container runtime label as it is no longer needed.
+  // Move high-cardinality labels to structured metadata
+  stage.structured_metadata {
+    values = {
+      pod  = "",
+    }
+  }
+
+  // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
+  // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+  // container runtime label as it is no longer needed.
   stage.label_drop {
-    values = ["filename", "tmp_container_runtime"]
+    values = ["filename", "pod", "tmp_container_runtime"]
   }
   forward_to = [loki.process.logs_service.receiver]
 }

--- a/examples/custom-config/metrics.alloy
+++ b/examples/custom-config/metrics.alloy
@@ -768,7 +768,7 @@ prometheus.remote_write "metrics_service" {
 
 loki.process "pod_logs" {
   stage.match {
-    selector = "{tmp_container_runtime=\"containerd\"}"
+    selector = "{tmp_container_runtime=~\"containerd|cri-o\"}"
     // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
     stage.cri {}
 
@@ -781,21 +781,6 @@ loki.process "pod_logs" {
     }
   }
 
-  stage.match {
-    selector = "{tmp_container_runtime=\"cri-o\"}"
-    // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
-    stage.cri {}
-
-    // Set the extract flags and stream values as labels
-    stage.labels {
-      values = {
-        flags  = "",
-        stream  = "",
-      }
-    }
-  }
-
-  // if the label tmp_container_runtime from above is docker parse using docker
   stage.match {
     selector = "{tmp_container_runtime=\"docker\"}"
     // the docker processing stage extracts the following k/v pairs: log, stream, time
@@ -809,11 +794,18 @@ loki.process "pod_logs" {
     }
   }
 
-  // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have
-  // cluster, namespace, pod, and container labels.
-  // Also drop the temporary container runtime label as it is no longer needed.
+  // Move high-cardinality labels to structured metadata
+  stage.structured_metadata {
+    values = {
+      pod  = "",
+    }
+  }
+
+  // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
+  // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+  // container runtime label as it is no longer needed.
   stage.label_drop {
-    values = ["filename", "tmp_container_runtime"]
+    values = ["filename", "pod", "tmp_container_runtime"]
   }
   forward_to = [loki.process.logs_service.receiver]
 }

--- a/examples/custom-config/output.yaml
+++ b/examples/custom-config/output.yaml
@@ -898,7 +898,7 @@ data:
     
     loki.process "pod_logs" {
       stage.match {
-        selector = "{tmp_container_runtime=\"containerd\"}"
+        selector = "{tmp_container_runtime=~\"containerd|cri-o\"}"
         // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
         stage.cri {}
     
@@ -911,21 +911,6 @@ data:
         }
       }
     
-      stage.match {
-        selector = "{tmp_container_runtime=\"cri-o\"}"
-        // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
-        stage.cri {}
-    
-        // Set the extract flags and stream values as labels
-        stage.labels {
-          values = {
-            flags  = "",
-            stream  = "",
-          }
-        }
-      }
-    
-      // if the label tmp_container_runtime from above is docker parse using docker
       stage.match {
         selector = "{tmp_container_runtime=\"docker\"}"
         // the docker processing stage extracts the following k/v pairs: log, stream, time
@@ -939,11 +924,18 @@ data:
         }
       }
     
-      // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have
-      // cluster, namespace, pod, and container labels.
-      // Also drop the temporary container runtime label as it is no longer needed.
+      // Move high-cardinality labels to structured metadata
+      stage.structured_metadata {
+        values = {
+          pod  = "",
+        }
+      }
+    
+      // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
+      // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+      // container runtime label as it is no longer needed.
       stage.label_drop {
-        values = ["filename", "tmp_container_runtime"]
+        values = ["filename", "pod", "tmp_container_runtime"]
       }
       forward_to = [loki.process.logs_service.receiver]
     }
@@ -1173,7 +1165,7 @@ data:
     
     loki.process "pod_logs" {
       stage.match {
-        selector = "{tmp_container_runtime=\"containerd\"}"
+        selector = "{tmp_container_runtime=~\"containerd|cri-o\"}"
         // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
         stage.cri {}
     
@@ -1186,21 +1178,6 @@ data:
         }
       }
     
-      stage.match {
-        selector = "{tmp_container_runtime=\"cri-o\"}"
-        // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
-        stage.cri {}
-    
-        // Set the extract flags and stream values as labels
-        stage.labels {
-          values = {
-            flags  = "",
-            stream  = "",
-          }
-        }
-      }
-    
-      // if the label tmp_container_runtime from above is docker parse using docker
       stage.match {
         selector = "{tmp_container_runtime=\"docker\"}"
         // the docker processing stage extracts the following k/v pairs: log, stream, time
@@ -1214,11 +1191,18 @@ data:
         }
       }
     
-      // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have
-      // cluster, namespace, pod, and container labels.
-      // Also drop the temporary container runtime label as it is no longer needed.
+      // Move high-cardinality labels to structured metadata
+      stage.structured_metadata {
+        values = {
+          pod  = "",
+        }
+      }
+    
+      // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
+      // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+      // container runtime label as it is no longer needed.
       stage.label_drop {
-        values = ["filename", "tmp_container_runtime"]
+        values = ["filename", "pod", "tmp_container_runtime"]
       }
       forward_to = [loki.process.logs_service.receiver]
     }
@@ -59888,7 +59872,7 @@ data:
     
     loki.process "pod_logs" {
       stage.match {
-        selector = "{tmp_container_runtime=\"containerd\"}"
+        selector = "{tmp_container_runtime=~\"containerd|cri-o\"}"
         // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
         stage.cri {}
     
@@ -59901,21 +59885,6 @@ data:
         }
       }
     
-      stage.match {
-        selector = "{tmp_container_runtime=\"cri-o\"}"
-        // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
-        stage.cri {}
-    
-        // Set the extract flags and stream values as labels
-        stage.labels {
-          values = {
-            flags  = "",
-            stream  = "",
-          }
-        }
-      }
-    
-      // if the label tmp_container_runtime from above is docker parse using docker
       stage.match {
         selector = "{tmp_container_runtime=\"docker\"}"
         // the docker processing stage extracts the following k/v pairs: log, stream, time
@@ -59929,11 +59898,18 @@ data:
         }
       }
     
-      // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have
-      // cluster, namespace, pod, and container labels.
-      // Also drop the temporary container runtime label as it is no longer needed.
+      // Move high-cardinality labels to structured metadata
+      stage.structured_metadata {
+        values = {
+          pod  = "",
+        }
+      }
+    
+      // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
+      // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+      // container runtime label as it is no longer needed.
       stage.label_drop {
-        values = ["filename", "tmp_container_runtime"]
+        values = ["filename", "pod", "tmp_container_runtime"]
       }
       forward_to = [loki.process.logs_service.receiver]
     }
@@ -60147,7 +60123,7 @@ data:
     
     loki.process "pod_logs" {
       stage.match {
-        selector = "{tmp_container_runtime=\"containerd\"}"
+        selector = "{tmp_container_runtime=~\"containerd|cri-o\"}"
         // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
         stage.cri {}
     
@@ -60160,21 +60136,6 @@ data:
         }
       }
     
-      stage.match {
-        selector = "{tmp_container_runtime=\"cri-o\"}"
-        // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
-        stage.cri {}
-    
-        // Set the extract flags and stream values as labels
-        stage.labels {
-          values = {
-            flags  = "",
-            stream  = "",
-          }
-        }
-      }
-    
-      // if the label tmp_container_runtime from above is docker parse using docker
       stage.match {
         selector = "{tmp_container_runtime=\"docker\"}"
         // the docker processing stage extracts the following k/v pairs: log, stream, time
@@ -60188,11 +60149,18 @@ data:
         }
       }
     
-      // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have
-      // cluster, namespace, pod, and container labels.
-      // Also drop the temporary container runtime label as it is no longer needed.
+      // Move high-cardinality labels to structured metadata
+      stage.structured_metadata {
+        values = {
+          pod  = "",
+        }
+      }
+    
+      // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
+      // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+      // container runtime label as it is no longer needed.
       stage.label_drop {
-        values = ["filename", "tmp_container_runtime"]
+        values = ["filename", "pod", "tmp_container_runtime"]
       }
       forward_to = [loki.process.logs_service.receiver]
     }

--- a/examples/custom-pricing/logs.alloy
+++ b/examples/custom-pricing/logs.alloy
@@ -82,7 +82,7 @@ loki.source.file "pod_logs" {
 
 loki.process "pod_logs" {
   stage.match {
-    selector = "{tmp_container_runtime=\"containerd\"}"
+    selector = "{tmp_container_runtime=~\"containerd|cri-o\"}"
     // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
     stage.cri {}
 
@@ -95,21 +95,6 @@ loki.process "pod_logs" {
     }
   }
 
-  stage.match {
-    selector = "{tmp_container_runtime=\"cri-o\"}"
-    // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
-    stage.cri {}
-
-    // Set the extract flags and stream values as labels
-    stage.labels {
-      values = {
-        flags  = "",
-        stream  = "",
-      }
-    }
-  }
-
-  // if the label tmp_container_runtime from above is docker parse using docker
   stage.match {
     selector = "{tmp_container_runtime=\"docker\"}"
     // the docker processing stage extracts the following k/v pairs: log, stream, time
@@ -123,11 +108,18 @@ loki.process "pod_logs" {
     }
   }
 
-  // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have
-  // cluster, namespace, pod, and container labels.
-  // Also drop the temporary container runtime label as it is no longer needed.
+  // Move high-cardinality labels to structured metadata
+  stage.structured_metadata {
+    values = {
+      pod  = "",
+    }
+  }
+
+  // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
+  // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+  // container runtime label as it is no longer needed.
   stage.label_drop {
-    values = ["filename", "tmp_container_runtime"]
+    values = ["filename", "pod", "tmp_container_runtime"]
   }
   forward_to = [loki.process.logs_service.receiver]
 }

--- a/examples/custom-pricing/metrics.alloy
+++ b/examples/custom-pricing/metrics.alloy
@@ -764,7 +764,7 @@ prometheus.remote_write "metrics_service" {
 
 loki.process "pod_logs" {
   stage.match {
-    selector = "{tmp_container_runtime=\"containerd\"}"
+    selector = "{tmp_container_runtime=~\"containerd|cri-o\"}"
     // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
     stage.cri {}
 
@@ -777,21 +777,6 @@ loki.process "pod_logs" {
     }
   }
 
-  stage.match {
-    selector = "{tmp_container_runtime=\"cri-o\"}"
-    // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
-    stage.cri {}
-
-    // Set the extract flags and stream values as labels
-    stage.labels {
-      values = {
-        flags  = "",
-        stream  = "",
-      }
-    }
-  }
-
-  // if the label tmp_container_runtime from above is docker parse using docker
   stage.match {
     selector = "{tmp_container_runtime=\"docker\"}"
     // the docker processing stage extracts the following k/v pairs: log, stream, time
@@ -805,11 +790,18 @@ loki.process "pod_logs" {
     }
   }
 
-  // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have
-  // cluster, namespace, pod, and container labels.
-  // Also drop the temporary container runtime label as it is no longer needed.
+  // Move high-cardinality labels to structured metadata
+  stage.structured_metadata {
+    values = {
+      pod  = "",
+    }
+  }
+
+  // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
+  // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+  // container runtime label as it is no longer needed.
   stage.label_drop {
-    values = ["filename", "tmp_container_runtime"]
+    values = ["filename", "pod", "tmp_container_runtime"]
   }
   forward_to = [loki.process.logs_service.receiver]
 }

--- a/examples/custom-pricing/output.yaml
+++ b/examples/custom-pricing/output.yaml
@@ -916,7 +916,7 @@ data:
     
     loki.process "pod_logs" {
       stage.match {
-        selector = "{tmp_container_runtime=\"containerd\"}"
+        selector = "{tmp_container_runtime=~\"containerd|cri-o\"}"
         // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
         stage.cri {}
     
@@ -929,21 +929,6 @@ data:
         }
       }
     
-      stage.match {
-        selector = "{tmp_container_runtime=\"cri-o\"}"
-        // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
-        stage.cri {}
-    
-        // Set the extract flags and stream values as labels
-        stage.labels {
-          values = {
-            flags  = "",
-            stream  = "",
-          }
-        }
-      }
-    
-      // if the label tmp_container_runtime from above is docker parse using docker
       stage.match {
         selector = "{tmp_container_runtime=\"docker\"}"
         // the docker processing stage extracts the following k/v pairs: log, stream, time
@@ -957,11 +942,18 @@ data:
         }
       }
     
-      // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have
-      // cluster, namespace, pod, and container labels.
-      // Also drop the temporary container runtime label as it is no longer needed.
+      // Move high-cardinality labels to structured metadata
+      stage.structured_metadata {
+        values = {
+          pod  = "",
+        }
+      }
+    
+      // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
+      // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+      // container runtime label as it is no longer needed.
       stage.label_drop {
-        values = ["filename", "tmp_container_runtime"]
+        values = ["filename", "pod", "tmp_container_runtime"]
       }
       forward_to = [loki.process.logs_service.receiver]
     }
@@ -1149,7 +1141,7 @@ data:
     
     loki.process "pod_logs" {
       stage.match {
-        selector = "{tmp_container_runtime=\"containerd\"}"
+        selector = "{tmp_container_runtime=~\"containerd|cri-o\"}"
         // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
         stage.cri {}
     
@@ -1162,21 +1154,6 @@ data:
         }
       }
     
-      stage.match {
-        selector = "{tmp_container_runtime=\"cri-o\"}"
-        // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
-        stage.cri {}
-    
-        // Set the extract flags and stream values as labels
-        stage.labels {
-          values = {
-            flags  = "",
-            stream  = "",
-          }
-        }
-      }
-    
-      // if the label tmp_container_runtime from above is docker parse using docker
       stage.match {
         selector = "{tmp_container_runtime=\"docker\"}"
         // the docker processing stage extracts the following k/v pairs: log, stream, time
@@ -1190,11 +1167,18 @@ data:
         }
       }
     
-      // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have
-      // cluster, namespace, pod, and container labels.
-      // Also drop the temporary container runtime label as it is no longer needed.
+      // Move high-cardinality labels to structured metadata
+      stage.structured_metadata {
+        values = {
+          pod  = "",
+        }
+      }
+    
+      // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
+      // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+      // container runtime label as it is no longer needed.
       stage.label_drop {
-        values = ["filename", "tmp_container_runtime"]
+        values = ["filename", "pod", "tmp_container_runtime"]
       }
       forward_to = [loki.process.logs_service.receiver]
     }
@@ -59824,7 +59808,7 @@ data:
     
     loki.process "pod_logs" {
       stage.match {
-        selector = "{tmp_container_runtime=\"containerd\"}"
+        selector = "{tmp_container_runtime=~\"containerd|cri-o\"}"
         // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
         stage.cri {}
     
@@ -59837,21 +59821,6 @@ data:
         }
       }
     
-      stage.match {
-        selector = "{tmp_container_runtime=\"cri-o\"}"
-        // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
-        stage.cri {}
-    
-        // Set the extract flags and stream values as labels
-        stage.labels {
-          values = {
-            flags  = "",
-            stream  = "",
-          }
-        }
-      }
-    
-      // if the label tmp_container_runtime from above is docker parse using docker
       stage.match {
         selector = "{tmp_container_runtime=\"docker\"}"
         // the docker processing stage extracts the following k/v pairs: log, stream, time
@@ -59865,11 +59834,18 @@ data:
         }
       }
     
-      // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have
-      // cluster, namespace, pod, and container labels.
-      // Also drop the temporary container runtime label as it is no longer needed.
+      // Move high-cardinality labels to structured metadata
+      stage.structured_metadata {
+        values = {
+          pod  = "",
+        }
+      }
+    
+      // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
+      // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+      // container runtime label as it is no longer needed.
       stage.label_drop {
-        values = ["filename", "tmp_container_runtime"]
+        values = ["filename", "pod", "tmp_container_runtime"]
       }
       forward_to = [loki.process.logs_service.receiver]
     }
@@ -60041,7 +60017,7 @@ data:
     
     loki.process "pod_logs" {
       stage.match {
-        selector = "{tmp_container_runtime=\"containerd\"}"
+        selector = "{tmp_container_runtime=~\"containerd|cri-o\"}"
         // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
         stage.cri {}
     
@@ -60054,21 +60030,6 @@ data:
         }
       }
     
-      stage.match {
-        selector = "{tmp_container_runtime=\"cri-o\"}"
-        // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
-        stage.cri {}
-    
-        // Set the extract flags and stream values as labels
-        stage.labels {
-          values = {
-            flags  = "",
-            stream  = "",
-          }
-        }
-      }
-    
-      // if the label tmp_container_runtime from above is docker parse using docker
       stage.match {
         selector = "{tmp_container_runtime=\"docker\"}"
         // the docker processing stage extracts the following k/v pairs: log, stream, time
@@ -60082,11 +60043,18 @@ data:
         }
       }
     
-      // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have
-      // cluster, namespace, pod, and container labels.
-      // Also drop the temporary container runtime label as it is no longer needed.
+      // Move high-cardinality labels to structured metadata
+      stage.structured_metadata {
+        values = {
+          pod  = "",
+        }
+      }
+    
+      // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
+      // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+      // container runtime label as it is no longer needed.
       stage.label_drop {
-        values = ["filename", "tmp_container_runtime"]
+        values = ["filename", "pod", "tmp_container_runtime"]
       }
       forward_to = [loki.process.logs_service.receiver]
     }

--- a/examples/default-values/logs.alloy
+++ b/examples/default-values/logs.alloy
@@ -82,7 +82,7 @@ loki.source.file "pod_logs" {
 
 loki.process "pod_logs" {
   stage.match {
-    selector = "{tmp_container_runtime=\"containerd\"}"
+    selector = "{tmp_container_runtime=~\"containerd|cri-o\"}"
     // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
     stage.cri {}
 
@@ -95,21 +95,6 @@ loki.process "pod_logs" {
     }
   }
 
-  stage.match {
-    selector = "{tmp_container_runtime=\"cri-o\"}"
-    // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
-    stage.cri {}
-
-    // Set the extract flags and stream values as labels
-    stage.labels {
-      values = {
-        flags  = "",
-        stream  = "",
-      }
-    }
-  }
-
-  // if the label tmp_container_runtime from above is docker parse using docker
   stage.match {
     selector = "{tmp_container_runtime=\"docker\"}"
     // the docker processing stage extracts the following k/v pairs: log, stream, time
@@ -123,11 +108,18 @@ loki.process "pod_logs" {
     }
   }
 
-  // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have
-  // cluster, namespace, pod, and container labels.
-  // Also drop the temporary container runtime label as it is no longer needed.
+  // Move high-cardinality labels to structured metadata
+  stage.structured_metadata {
+    values = {
+      pod  = "",
+    }
+  }
+
+  // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
+  // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+  // container runtime label as it is no longer needed.
   stage.label_drop {
-    values = ["filename", "tmp_container_runtime"]
+    values = ["filename", "pod", "tmp_container_runtime"]
   }
   forward_to = [loki.process.logs_service.receiver]
 }

--- a/examples/default-values/metrics.alloy
+++ b/examples/default-values/metrics.alloy
@@ -764,7 +764,7 @@ prometheus.remote_write "metrics_service" {
 
 loki.process "pod_logs" {
   stage.match {
-    selector = "{tmp_container_runtime=\"containerd\"}"
+    selector = "{tmp_container_runtime=~\"containerd|cri-o\"}"
     // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
     stage.cri {}
 
@@ -777,21 +777,6 @@ loki.process "pod_logs" {
     }
   }
 
-  stage.match {
-    selector = "{tmp_container_runtime=\"cri-o\"}"
-    // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
-    stage.cri {}
-
-    // Set the extract flags and stream values as labels
-    stage.labels {
-      values = {
-        flags  = "",
-        stream  = "",
-      }
-    }
-  }
-
-  // if the label tmp_container_runtime from above is docker parse using docker
   stage.match {
     selector = "{tmp_container_runtime=\"docker\"}"
     // the docker processing stage extracts the following k/v pairs: log, stream, time
@@ -805,11 +790,18 @@ loki.process "pod_logs" {
     }
   }
 
-  // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have
-  // cluster, namespace, pod, and container labels.
-  // Also drop the temporary container runtime label as it is no longer needed.
+  // Move high-cardinality labels to structured metadata
+  stage.structured_metadata {
+    values = {
+      pod  = "",
+    }
+  }
+
+  // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
+  // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+  // container runtime label as it is no longer needed.
   stage.label_drop {
-    values = ["filename", "tmp_container_runtime"]
+    values = ["filename", "pod", "tmp_container_runtime"]
   }
   forward_to = [loki.process.logs_service.receiver]
 }

--- a/examples/default-values/output.yaml
+++ b/examples/default-values/output.yaml
@@ -894,7 +894,7 @@ data:
     
     loki.process "pod_logs" {
       stage.match {
-        selector = "{tmp_container_runtime=\"containerd\"}"
+        selector = "{tmp_container_runtime=~\"containerd|cri-o\"}"
         // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
         stage.cri {}
     
@@ -907,21 +907,6 @@ data:
         }
       }
     
-      stage.match {
-        selector = "{tmp_container_runtime=\"cri-o\"}"
-        // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
-        stage.cri {}
-    
-        // Set the extract flags and stream values as labels
-        stage.labels {
-          values = {
-            flags  = "",
-            stream  = "",
-          }
-        }
-      }
-    
-      // if the label tmp_container_runtime from above is docker parse using docker
       stage.match {
         selector = "{tmp_container_runtime=\"docker\"}"
         // the docker processing stage extracts the following k/v pairs: log, stream, time
@@ -935,11 +920,18 @@ data:
         }
       }
     
-      // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have
-      // cluster, namespace, pod, and container labels.
-      // Also drop the temporary container runtime label as it is no longer needed.
+      // Move high-cardinality labels to structured metadata
+      stage.structured_metadata {
+        values = {
+          pod  = "",
+        }
+      }
+    
+      // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
+      // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+      // container runtime label as it is no longer needed.
       stage.label_drop {
-        values = ["filename", "tmp_container_runtime"]
+        values = ["filename", "pod", "tmp_container_runtime"]
       }
       forward_to = [loki.process.logs_service.receiver]
     }
@@ -1127,7 +1119,7 @@ data:
     
     loki.process "pod_logs" {
       stage.match {
-        selector = "{tmp_container_runtime=\"containerd\"}"
+        selector = "{tmp_container_runtime=~\"containerd|cri-o\"}"
         // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
         stage.cri {}
     
@@ -1140,21 +1132,6 @@ data:
         }
       }
     
-      stage.match {
-        selector = "{tmp_container_runtime=\"cri-o\"}"
-        // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
-        stage.cri {}
-    
-        // Set the extract flags and stream values as labels
-        stage.labels {
-          values = {
-            flags  = "",
-            stream  = "",
-          }
-        }
-      }
-    
-      // if the label tmp_container_runtime from above is docker parse using docker
       stage.match {
         selector = "{tmp_container_runtime=\"docker\"}"
         // the docker processing stage extracts the following k/v pairs: log, stream, time
@@ -1168,11 +1145,18 @@ data:
         }
       }
     
-      // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have
-      // cluster, namespace, pod, and container labels.
-      // Also drop the temporary container runtime label as it is no longer needed.
+      // Move high-cardinality labels to structured metadata
+      stage.structured_metadata {
+        values = {
+          pod  = "",
+        }
+      }
+    
+      // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
+      // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+      // container runtime label as it is no longer needed.
       stage.label_drop {
-        values = ["filename", "tmp_container_runtime"]
+        values = ["filename", "pod", "tmp_container_runtime"]
       }
       forward_to = [loki.process.logs_service.receiver]
     }
@@ -59791,7 +59775,7 @@ data:
     
     loki.process "pod_logs" {
       stage.match {
-        selector = "{tmp_container_runtime=\"containerd\"}"
+        selector = "{tmp_container_runtime=~\"containerd|cri-o\"}"
         // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
         stage.cri {}
     
@@ -59804,21 +59788,6 @@ data:
         }
       }
     
-      stage.match {
-        selector = "{tmp_container_runtime=\"cri-o\"}"
-        // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
-        stage.cri {}
-    
-        // Set the extract flags and stream values as labels
-        stage.labels {
-          values = {
-            flags  = "",
-            stream  = "",
-          }
-        }
-      }
-    
-      // if the label tmp_container_runtime from above is docker parse using docker
       stage.match {
         selector = "{tmp_container_runtime=\"docker\"}"
         // the docker processing stage extracts the following k/v pairs: log, stream, time
@@ -59832,11 +59801,18 @@ data:
         }
       }
     
-      // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have
-      // cluster, namespace, pod, and container labels.
-      // Also drop the temporary container runtime label as it is no longer needed.
+      // Move high-cardinality labels to structured metadata
+      stage.structured_metadata {
+        values = {
+          pod  = "",
+        }
+      }
+    
+      // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
+      // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+      // container runtime label as it is no longer needed.
       stage.label_drop {
-        values = ["filename", "tmp_container_runtime"]
+        values = ["filename", "pod", "tmp_container_runtime"]
       }
       forward_to = [loki.process.logs_service.receiver]
     }
@@ -60008,7 +59984,7 @@ data:
     
     loki.process "pod_logs" {
       stage.match {
-        selector = "{tmp_container_runtime=\"containerd\"}"
+        selector = "{tmp_container_runtime=~\"containerd|cri-o\"}"
         // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
         stage.cri {}
     
@@ -60021,21 +59997,6 @@ data:
         }
       }
     
-      stage.match {
-        selector = "{tmp_container_runtime=\"cri-o\"}"
-        // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
-        stage.cri {}
-    
-        // Set the extract flags and stream values as labels
-        stage.labels {
-          values = {
-            flags  = "",
-            stream  = "",
-          }
-        }
-      }
-    
-      // if the label tmp_container_runtime from above is docker parse using docker
       stage.match {
         selector = "{tmp_container_runtime=\"docker\"}"
         // the docker processing stage extracts the following k/v pairs: log, stream, time
@@ -60049,11 +60010,18 @@ data:
         }
       }
     
-      // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have
-      // cluster, namespace, pod, and container labels.
-      // Also drop the temporary container runtime label as it is no longer needed.
+      // Move high-cardinality labels to structured metadata
+      stage.structured_metadata {
+        values = {
+          pod  = "",
+        }
+      }
+    
+      // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
+      // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+      // container runtime label as it is no longer needed.
       stage.label_drop {
-        values = ["filename", "tmp_container_runtime"]
+        values = ["filename", "pod", "tmp_container_runtime"]
       }
       forward_to = [loki.process.logs_service.receiver]
     }

--- a/examples/eks-fargate/logs.alloy
+++ b/examples/eks-fargate/logs.alloy
@@ -69,7 +69,7 @@ loki.source.kubernetes "pod_logs" {
 }
 loki.process "pod_logs" {
   stage.match {
-    selector = "{tmp_container_runtime=\"containerd\"}"
+    selector = "{tmp_container_runtime=~\"containerd|cri-o\"}"
     // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
     stage.cri {}
 
@@ -82,21 +82,6 @@ loki.process "pod_logs" {
     }
   }
 
-  stage.match {
-    selector = "{tmp_container_runtime=\"cri-o\"}"
-    // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
-    stage.cri {}
-
-    // Set the extract flags and stream values as labels
-    stage.labels {
-      values = {
-        flags  = "",
-        stream  = "",
-      }
-    }
-  }
-
-  // if the label tmp_container_runtime from above is docker parse using docker
   stage.match {
     selector = "{tmp_container_runtime=\"docker\"}"
     // the docker processing stage extracts the following k/v pairs: log, stream, time
@@ -110,11 +95,18 @@ loki.process "pod_logs" {
     }
   }
 
-  // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have
-  // cluster, namespace, pod, and container labels.
-  // Also drop the temporary container runtime label as it is no longer needed.
+  // Move high-cardinality labels to structured metadata
+  stage.structured_metadata {
+    values = {
+      pod  = "",
+    }
+  }
+
+  // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
+  // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+  // container runtime label as it is no longer needed.
   stage.label_drop {
-    values = ["filename", "tmp_container_runtime"]
+    values = ["filename", "pod", "tmp_container_runtime"]
   }
   forward_to = [loki.process.logs_service.receiver]
 }

--- a/examples/eks-fargate/metrics.alloy
+++ b/examples/eks-fargate/metrics.alloy
@@ -717,7 +717,7 @@ prometheus.remote_write "metrics_service" {
 
 loki.process "pod_logs" {
   stage.match {
-    selector = "{tmp_container_runtime=\"containerd\"}"
+    selector = "{tmp_container_runtime=~\"containerd|cri-o\"}"
     // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
     stage.cri {}
 
@@ -730,21 +730,6 @@ loki.process "pod_logs" {
     }
   }
 
-  stage.match {
-    selector = "{tmp_container_runtime=\"cri-o\"}"
-    // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
-    stage.cri {}
-
-    // Set the extract flags and stream values as labels
-    stage.labels {
-      values = {
-        flags  = "",
-        stream  = "",
-      }
-    }
-  }
-
-  // if the label tmp_container_runtime from above is docker parse using docker
   stage.match {
     selector = "{tmp_container_runtime=\"docker\"}"
     // the docker processing stage extracts the following k/v pairs: log, stream, time
@@ -758,11 +743,18 @@ loki.process "pod_logs" {
     }
   }
 
-  // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have
-  // cluster, namespace, pod, and container labels.
-  // Also drop the temporary container runtime label as it is no longer needed.
+  // Move high-cardinality labels to structured metadata
+  stage.structured_metadata {
+    values = {
+      pod  = "",
+    }
+  }
+
+  // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
+  // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+  // container runtime label as it is no longer needed.
   stage.label_drop {
-    values = ["filename", "tmp_container_runtime"]
+    values = ["filename", "pod", "tmp_container_runtime"]
   }
   forward_to = [loki.process.logs_service.receiver]
 }

--- a/examples/eks-fargate/output.yaml
+++ b/examples/eks-fargate/output.yaml
@@ -831,7 +831,7 @@ data:
     
     loki.process "pod_logs" {
       stage.match {
-        selector = "{tmp_container_runtime=\"containerd\"}"
+        selector = "{tmp_container_runtime=~\"containerd|cri-o\"}"
         // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
         stage.cri {}
     
@@ -844,21 +844,6 @@ data:
         }
       }
     
-      stage.match {
-        selector = "{tmp_container_runtime=\"cri-o\"}"
-        // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
-        stage.cri {}
-    
-        // Set the extract flags and stream values as labels
-        stage.labels {
-          values = {
-            flags  = "",
-            stream  = "",
-          }
-        }
-      }
-    
-      // if the label tmp_container_runtime from above is docker parse using docker
       stage.match {
         selector = "{tmp_container_runtime=\"docker\"}"
         // the docker processing stage extracts the following k/v pairs: log, stream, time
@@ -872,11 +857,18 @@ data:
         }
       }
     
-      // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have
-      // cluster, namespace, pod, and container labels.
-      // Also drop the temporary container runtime label as it is no longer needed.
+      // Move high-cardinality labels to structured metadata
+      stage.structured_metadata {
+        values = {
+          pod  = "",
+        }
+      }
+    
+      // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
+      // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+      // container runtime label as it is no longer needed.
       stage.label_drop {
-        values = ["filename", "tmp_container_runtime"]
+        values = ["filename", "pod", "tmp_container_runtime"]
       }
       forward_to = [loki.process.logs_service.receiver]
     }
@@ -1051,7 +1043,7 @@ data:
     }
     loki.process "pod_logs" {
       stage.match {
-        selector = "{tmp_container_runtime=\"containerd\"}"
+        selector = "{tmp_container_runtime=~\"containerd|cri-o\"}"
         // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
         stage.cri {}
     
@@ -1064,21 +1056,6 @@ data:
         }
       }
     
-      stage.match {
-        selector = "{tmp_container_runtime=\"cri-o\"}"
-        // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
-        stage.cri {}
-    
-        // Set the extract flags and stream values as labels
-        stage.labels {
-          values = {
-            flags  = "",
-            stream  = "",
-          }
-        }
-      }
-    
-      // if the label tmp_container_runtime from above is docker parse using docker
       stage.match {
         selector = "{tmp_container_runtime=\"docker\"}"
         // the docker processing stage extracts the following k/v pairs: log, stream, time
@@ -1092,11 +1069,18 @@ data:
         }
       }
     
-      // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have
-      // cluster, namespace, pod, and container labels.
-      // Also drop the temporary container runtime label as it is no longer needed.
+      // Move high-cardinality labels to structured metadata
+      stage.structured_metadata {
+        values = {
+          pod  = "",
+        }
+      }
+    
+      // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
+      // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+      // container runtime label as it is no longer needed.
       stage.label_drop {
-        values = ["filename", "tmp_container_runtime"]
+        values = ["filename", "pod", "tmp_container_runtime"]
       }
       forward_to = [loki.process.logs_service.receiver]
     }
@@ -59548,7 +59532,7 @@ data:
     
     loki.process "pod_logs" {
       stage.match {
-        selector = "{tmp_container_runtime=\"containerd\"}"
+        selector = "{tmp_container_runtime=~\"containerd|cri-o\"}"
         // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
         stage.cri {}
     
@@ -59561,21 +59545,6 @@ data:
         }
       }
     
-      stage.match {
-        selector = "{tmp_container_runtime=\"cri-o\"}"
-        // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
-        stage.cri {}
-    
-        // Set the extract flags and stream values as labels
-        stage.labels {
-          values = {
-            flags  = "",
-            stream  = "",
-          }
-        }
-      }
-    
-      // if the label tmp_container_runtime from above is docker parse using docker
       stage.match {
         selector = "{tmp_container_runtime=\"docker\"}"
         // the docker processing stage extracts the following k/v pairs: log, stream, time
@@ -59589,11 +59558,18 @@ data:
         }
       }
     
-      // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have
-      // cluster, namespace, pod, and container labels.
-      // Also drop the temporary container runtime label as it is no longer needed.
+      // Move high-cardinality labels to structured metadata
+      stage.structured_metadata {
+        values = {
+          pod  = "",
+        }
+      }
+    
+      // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
+      // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+      // container runtime label as it is no longer needed.
       stage.label_drop {
-        values = ["filename", "tmp_container_runtime"]
+        values = ["filename", "pod", "tmp_container_runtime"]
       }
       forward_to = [loki.process.logs_service.receiver]
     }
@@ -59752,7 +59728,7 @@ data:
     }
     loki.process "pod_logs" {
       stage.match {
-        selector = "{tmp_container_runtime=\"containerd\"}"
+        selector = "{tmp_container_runtime=~\"containerd|cri-o\"}"
         // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
         stage.cri {}
     
@@ -59765,21 +59741,6 @@ data:
         }
       }
     
-      stage.match {
-        selector = "{tmp_container_runtime=\"cri-o\"}"
-        // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
-        stage.cri {}
-    
-        // Set the extract flags and stream values as labels
-        stage.labels {
-          values = {
-            flags  = "",
-            stream  = "",
-          }
-        }
-      }
-    
-      // if the label tmp_container_runtime from above is docker parse using docker
       stage.match {
         selector = "{tmp_container_runtime=\"docker\"}"
         // the docker processing stage extracts the following k/v pairs: log, stream, time
@@ -59793,11 +59754,18 @@ data:
         }
       }
     
-      // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have
-      // cluster, namespace, pod, and container labels.
-      // Also drop the temporary container runtime label as it is no longer needed.
+      // Move high-cardinality labels to structured metadata
+      stage.structured_metadata {
+        values = {
+          pod  = "",
+        }
+      }
+    
+      // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
+      // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+      // container runtime label as it is no longer needed.
       stage.label_drop {
-        values = ["filename", "tmp_container_runtime"]
+        values = ["filename", "pod", "tmp_container_runtime"]
       }
       forward_to = [loki.process.logs_service.receiver]
     }

--- a/examples/extra-rules/logs.alloy
+++ b/examples/extra-rules/logs.alloy
@@ -87,7 +87,7 @@ loki.source.file "pod_logs" {
 
 loki.process "pod_logs" {
   stage.match {
-    selector = "{tmp_container_runtime=\"containerd\"}"
+    selector = "{tmp_container_runtime=~\"containerd|cri-o\"}"
     // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
     stage.cri {}
 
@@ -100,21 +100,6 @@ loki.process "pod_logs" {
     }
   }
 
-  stage.match {
-    selector = "{tmp_container_runtime=\"cri-o\"}"
-    // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
-    stage.cri {}
-
-    // Set the extract flags and stream values as labels
-    stage.labels {
-      values = {
-        flags  = "",
-        stream  = "",
-      }
-    }
-  }
-
-  // if the label tmp_container_runtime from above is docker parse using docker
   stage.match {
     selector = "{tmp_container_runtime=\"docker\"}"
     // the docker processing stage extracts the following k/v pairs: log, stream, time
@@ -128,11 +113,18 @@ loki.process "pod_logs" {
     }
   }
 
-  // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have
-  // cluster, namespace, pod, and container labels.
-  // Also drop the temporary container runtime label as it is no longer needed.
+  // Move high-cardinality labels to structured metadata
+  stage.structured_metadata {
+    values = {
+      pod  = "",
+    }
+  }
+
+  // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
+  // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+  // container runtime label as it is no longer needed.
   stage.label_drop {
-    values = ["filename", "tmp_container_runtime"]
+    values = ["filename", "pod", "tmp_container_runtime"]
   }
   stage.logfmt {
     payload = ""

--- a/examples/extra-rules/metrics.alloy
+++ b/examples/extra-rules/metrics.alloy
@@ -830,7 +830,7 @@ prometheus.remote_write "metrics_service" {
 
 loki.process "pod_logs" {
   stage.match {
-    selector = "{tmp_container_runtime=\"containerd\"}"
+    selector = "{tmp_container_runtime=~\"containerd|cri-o\"}"
     // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
     stage.cri {}
 
@@ -843,21 +843,6 @@ loki.process "pod_logs" {
     }
   }
 
-  stage.match {
-    selector = "{tmp_container_runtime=\"cri-o\"}"
-    // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
-    stage.cri {}
-
-    // Set the extract flags and stream values as labels
-    stage.labels {
-      values = {
-        flags  = "",
-        stream  = "",
-      }
-    }
-  }
-
-  // if the label tmp_container_runtime from above is docker parse using docker
   stage.match {
     selector = "{tmp_container_runtime=\"docker\"}"
     // the docker processing stage extracts the following k/v pairs: log, stream, time
@@ -871,11 +856,18 @@ loki.process "pod_logs" {
     }
   }
 
-  // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have
-  // cluster, namespace, pod, and container labels.
-  // Also drop the temporary container runtime label as it is no longer needed.
+  // Move high-cardinality labels to structured metadata
+  stage.structured_metadata {
+    values = {
+      pod  = "",
+    }
+  }
+
+  // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
+  // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+  // container runtime label as it is no longer needed.
   stage.label_drop {
-    values = ["filename", "tmp_container_runtime"]
+    values = ["filename", "pod", "tmp_container_runtime"]
   }
   stage.logfmt {
     payload = ""

--- a/examples/extra-rules/output.yaml
+++ b/examples/extra-rules/output.yaml
@@ -961,7 +961,7 @@ data:
     
     loki.process "pod_logs" {
       stage.match {
-        selector = "{tmp_container_runtime=\"containerd\"}"
+        selector = "{tmp_container_runtime=~\"containerd|cri-o\"}"
         // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
         stage.cri {}
     
@@ -974,21 +974,6 @@ data:
         }
       }
     
-      stage.match {
-        selector = "{tmp_container_runtime=\"cri-o\"}"
-        // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
-        stage.cri {}
-    
-        // Set the extract flags and stream values as labels
-        stage.labels {
-          values = {
-            flags  = "",
-            stream  = "",
-          }
-        }
-      }
-    
-      // if the label tmp_container_runtime from above is docker parse using docker
       stage.match {
         selector = "{tmp_container_runtime=\"docker\"}"
         // the docker processing stage extracts the following k/v pairs: log, stream, time
@@ -1002,11 +987,18 @@ data:
         }
       }
     
-      // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have
-      // cluster, namespace, pod, and container labels.
-      // Also drop the temporary container runtime label as it is no longer needed.
+      // Move high-cardinality labels to structured metadata
+      stage.structured_metadata {
+        values = {
+          pod  = "",
+        }
+      }
+    
+      // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
+      // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+      // container runtime label as it is no longer needed.
       stage.label_drop {
-        values = ["filename", "tmp_container_runtime"]
+        values = ["filename", "pod", "tmp_container_runtime"]
       }
       stage.logfmt {
         payload = ""
@@ -1224,7 +1216,7 @@ data:
     
     loki.process "pod_logs" {
       stage.match {
-        selector = "{tmp_container_runtime=\"containerd\"}"
+        selector = "{tmp_container_runtime=~\"containerd|cri-o\"}"
         // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
         stage.cri {}
     
@@ -1237,21 +1229,6 @@ data:
         }
       }
     
-      stage.match {
-        selector = "{tmp_container_runtime=\"cri-o\"}"
-        // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
-        stage.cri {}
-    
-        // Set the extract flags and stream values as labels
-        stage.labels {
-          values = {
-            flags  = "",
-            stream  = "",
-          }
-        }
-      }
-    
-      // if the label tmp_container_runtime from above is docker parse using docker
       stage.match {
         selector = "{tmp_container_runtime=\"docker\"}"
         // the docker processing stage extracts the following k/v pairs: log, stream, time
@@ -1265,11 +1242,18 @@ data:
         }
       }
     
-      // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have
-      // cluster, namespace, pod, and container labels.
-      // Also drop the temporary container runtime label as it is no longer needed.
+      // Move high-cardinality labels to structured metadata
+      stage.structured_metadata {
+        values = {
+          pod  = "",
+        }
+      }
+    
+      // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
+      // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+      // container runtime label as it is no longer needed.
       stage.label_drop {
-        values = ["filename", "tmp_container_runtime"]
+        values = ["filename", "pod", "tmp_container_runtime"]
       }
       stage.logfmt {
         payload = ""
@@ -59979,7 +59963,7 @@ data:
     
     loki.process "pod_logs" {
       stage.match {
-        selector = "{tmp_container_runtime=\"containerd\"}"
+        selector = "{tmp_container_runtime=~\"containerd|cri-o\"}"
         // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
         stage.cri {}
     
@@ -59992,21 +59976,6 @@ data:
         }
       }
     
-      stage.match {
-        selector = "{tmp_container_runtime=\"cri-o\"}"
-        // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
-        stage.cri {}
-    
-        // Set the extract flags and stream values as labels
-        stage.labels {
-          values = {
-            flags  = "",
-            stream  = "",
-          }
-        }
-      }
-    
-      // if the label tmp_container_runtime from above is docker parse using docker
       stage.match {
         selector = "{tmp_container_runtime=\"docker\"}"
         // the docker processing stage extracts the following k/v pairs: log, stream, time
@@ -60020,11 +59989,18 @@ data:
         }
       }
     
-      // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have
-      // cluster, namespace, pod, and container labels.
-      // Also drop the temporary container runtime label as it is no longer needed.
+      // Move high-cardinality labels to structured metadata
+      stage.structured_metadata {
+        values = {
+          pod  = "",
+        }
+      }
+    
+      // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
+      // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+      // container runtime label as it is no longer needed.
       stage.label_drop {
-        values = ["filename", "tmp_container_runtime"]
+        values = ["filename", "pod", "tmp_container_runtime"]
       }
       stage.logfmt {
         payload = ""
@@ -60226,7 +60202,7 @@ data:
     
     loki.process "pod_logs" {
       stage.match {
-        selector = "{tmp_container_runtime=\"containerd\"}"
+        selector = "{tmp_container_runtime=~\"containerd|cri-o\"}"
         // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
         stage.cri {}
     
@@ -60239,21 +60215,6 @@ data:
         }
       }
     
-      stage.match {
-        selector = "{tmp_container_runtime=\"cri-o\"}"
-        // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
-        stage.cri {}
-    
-        // Set the extract flags and stream values as labels
-        stage.labels {
-          values = {
-            flags  = "",
-            stream  = "",
-          }
-        }
-      }
-    
-      // if the label tmp_container_runtime from above is docker parse using docker
       stage.match {
         selector = "{tmp_container_runtime=\"docker\"}"
         // the docker processing stage extracts the following k/v pairs: log, stream, time
@@ -60267,11 +60228,18 @@ data:
         }
       }
     
-      // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have
-      // cluster, namespace, pod, and container labels.
-      // Also drop the temporary container runtime label as it is no longer needed.
+      // Move high-cardinality labels to structured metadata
+      stage.structured_metadata {
+        values = {
+          pod  = "",
+        }
+      }
+    
+      // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
+      // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+      // container runtime label as it is no longer needed.
       stage.label_drop {
-        values = ["filename", "tmp_container_runtime"]
+        values = ["filename", "pod", "tmp_container_runtime"]
       }
       stage.logfmt {
         payload = ""

--- a/examples/gke-autopilot/logs.alloy
+++ b/examples/gke-autopilot/logs.alloy
@@ -82,7 +82,7 @@ loki.source.file "pod_logs" {
 
 loki.process "pod_logs" {
   stage.match {
-    selector = "{tmp_container_runtime=\"containerd\"}"
+    selector = "{tmp_container_runtime=~\"containerd|cri-o\"}"
     // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
     stage.cri {}
 
@@ -95,21 +95,6 @@ loki.process "pod_logs" {
     }
   }
 
-  stage.match {
-    selector = "{tmp_container_runtime=\"cri-o\"}"
-    // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
-    stage.cri {}
-
-    // Set the extract flags and stream values as labels
-    stage.labels {
-      values = {
-        flags  = "",
-        stream  = "",
-      }
-    }
-  }
-
-  // if the label tmp_container_runtime from above is docker parse using docker
   stage.match {
     selector = "{tmp_container_runtime=\"docker\"}"
     // the docker processing stage extracts the following k/v pairs: log, stream, time
@@ -123,11 +108,18 @@ loki.process "pod_logs" {
     }
   }
 
-  // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have
-  // cluster, namespace, pod, and container labels.
-  // Also drop the temporary container runtime label as it is no longer needed.
+  // Move high-cardinality labels to structured metadata
+  stage.structured_metadata {
+    values = {
+      pod  = "",
+    }
+  }
+
+  // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
+  // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+  // container runtime label as it is no longer needed.
   stage.label_drop {
-    values = ["filename", "tmp_container_runtime"]
+    values = ["filename", "pod", "tmp_container_runtime"]
   }
   forward_to = [loki.process.logs_service.receiver]
 }

--- a/examples/gke-autopilot/metrics.alloy
+++ b/examples/gke-autopilot/metrics.alloy
@@ -717,7 +717,7 @@ prometheus.remote_write "metrics_service" {
 
 loki.process "pod_logs" {
   stage.match {
-    selector = "{tmp_container_runtime=\"containerd\"}"
+    selector = "{tmp_container_runtime=~\"containerd|cri-o\"}"
     // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
     stage.cri {}
 
@@ -730,21 +730,6 @@ loki.process "pod_logs" {
     }
   }
 
-  stage.match {
-    selector = "{tmp_container_runtime=\"cri-o\"}"
-    // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
-    stage.cri {}
-
-    // Set the extract flags and stream values as labels
-    stage.labels {
-      values = {
-        flags  = "",
-        stream  = "",
-      }
-    }
-  }
-
-  // if the label tmp_container_runtime from above is docker parse using docker
   stage.match {
     selector = "{tmp_container_runtime=\"docker\"}"
     // the docker processing stage extracts the following k/v pairs: log, stream, time
@@ -758,11 +743,18 @@ loki.process "pod_logs" {
     }
   }
 
-  // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have
-  // cluster, namespace, pod, and container labels.
-  // Also drop the temporary container runtime label as it is no longer needed.
+  // Move high-cardinality labels to structured metadata
+  stage.structured_metadata {
+    values = {
+      pod  = "",
+    }
+  }
+
+  // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
+  // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+  // container runtime label as it is no longer needed.
   stage.label_drop {
-    values = ["filename", "tmp_container_runtime"]
+    values = ["filename", "pod", "tmp_container_runtime"]
   }
   forward_to = [loki.process.logs_service.receiver]
 }

--- a/examples/gke-autopilot/output.yaml
+++ b/examples/gke-autopilot/output.yaml
@@ -831,7 +831,7 @@ data:
     
     loki.process "pod_logs" {
       stage.match {
-        selector = "{tmp_container_runtime=\"containerd\"}"
+        selector = "{tmp_container_runtime=~\"containerd|cri-o\"}"
         // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
         stage.cri {}
     
@@ -844,21 +844,6 @@ data:
         }
       }
     
-      stage.match {
-        selector = "{tmp_container_runtime=\"cri-o\"}"
-        // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
-        stage.cri {}
-    
-        // Set the extract flags and stream values as labels
-        stage.labels {
-          values = {
-            flags  = "",
-            stream  = "",
-          }
-        }
-      }
-    
-      // if the label tmp_container_runtime from above is docker parse using docker
       stage.match {
         selector = "{tmp_container_runtime=\"docker\"}"
         // the docker processing stage extracts the following k/v pairs: log, stream, time
@@ -872,11 +857,18 @@ data:
         }
       }
     
-      // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have
-      // cluster, namespace, pod, and container labels.
-      // Also drop the temporary container runtime label as it is no longer needed.
+      // Move high-cardinality labels to structured metadata
+      stage.structured_metadata {
+        values = {
+          pod  = "",
+        }
+      }
+    
+      // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
+      // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+      // container runtime label as it is no longer needed.
       stage.label_drop {
-        values = ["filename", "tmp_container_runtime"]
+        values = ["filename", "pod", "tmp_container_runtime"]
       }
       forward_to = [loki.process.logs_service.receiver]
     }
@@ -1064,7 +1056,7 @@ data:
     
     loki.process "pod_logs" {
       stage.match {
-        selector = "{tmp_container_runtime=\"containerd\"}"
+        selector = "{tmp_container_runtime=~\"containerd|cri-o\"}"
         // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
         stage.cri {}
     
@@ -1077,21 +1069,6 @@ data:
         }
       }
     
-      stage.match {
-        selector = "{tmp_container_runtime=\"cri-o\"}"
-        // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
-        stage.cri {}
-    
-        // Set the extract flags and stream values as labels
-        stage.labels {
-          values = {
-            flags  = "",
-            stream  = "",
-          }
-        }
-      }
-    
-      // if the label tmp_container_runtime from above is docker parse using docker
       stage.match {
         selector = "{tmp_container_runtime=\"docker\"}"
         // the docker processing stage extracts the following k/v pairs: log, stream, time
@@ -1105,11 +1082,18 @@ data:
         }
       }
     
-      // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have
-      // cluster, namespace, pod, and container labels.
-      // Also drop the temporary container runtime label as it is no longer needed.
+      // Move high-cardinality labels to structured metadata
+      stage.structured_metadata {
+        values = {
+          pod  = "",
+        }
+      }
+    
+      // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
+      // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+      // container runtime label as it is no longer needed.
       stage.label_drop {
-        values = ["filename", "tmp_container_runtime"]
+        values = ["filename", "pod", "tmp_container_runtime"]
       }
       forward_to = [loki.process.logs_service.receiver]
     }
@@ -59532,7 +59516,7 @@ data:
     
     loki.process "pod_logs" {
       stage.match {
-        selector = "{tmp_container_runtime=\"containerd\"}"
+        selector = "{tmp_container_runtime=~\"containerd|cri-o\"}"
         // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
         stage.cri {}
     
@@ -59545,21 +59529,6 @@ data:
         }
       }
     
-      stage.match {
-        selector = "{tmp_container_runtime=\"cri-o\"}"
-        // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
-        stage.cri {}
-    
-        // Set the extract flags and stream values as labels
-        stage.labels {
-          values = {
-            flags  = "",
-            stream  = "",
-          }
-        }
-      }
-    
-      // if the label tmp_container_runtime from above is docker parse using docker
       stage.match {
         selector = "{tmp_container_runtime=\"docker\"}"
         // the docker processing stage extracts the following k/v pairs: log, stream, time
@@ -59573,11 +59542,18 @@ data:
         }
       }
     
-      // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have
-      // cluster, namespace, pod, and container labels.
-      // Also drop the temporary container runtime label as it is no longer needed.
+      // Move high-cardinality labels to structured metadata
+      stage.structured_metadata {
+        values = {
+          pod  = "",
+        }
+      }
+    
+      // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
+      // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+      // container runtime label as it is no longer needed.
       stage.label_drop {
-        values = ["filename", "tmp_container_runtime"]
+        values = ["filename", "pod", "tmp_container_runtime"]
       }
       forward_to = [loki.process.logs_service.receiver]
     }
@@ -59749,7 +59725,7 @@ data:
     
     loki.process "pod_logs" {
       stage.match {
-        selector = "{tmp_container_runtime=\"containerd\"}"
+        selector = "{tmp_container_runtime=~\"containerd|cri-o\"}"
         // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
         stage.cri {}
     
@@ -59762,21 +59738,6 @@ data:
         }
       }
     
-      stage.match {
-        selector = "{tmp_container_runtime=\"cri-o\"}"
-        // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
-        stage.cri {}
-    
-        // Set the extract flags and stream values as labels
-        stage.labels {
-          values = {
-            flags  = "",
-            stream  = "",
-          }
-        }
-      }
-    
-      // if the label tmp_container_runtime from above is docker parse using docker
       stage.match {
         selector = "{tmp_container_runtime=\"docker\"}"
         // the docker processing stage extracts the following k/v pairs: log, stream, time
@@ -59790,11 +59751,18 @@ data:
         }
       }
     
-      // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have
-      // cluster, namespace, pod, and container labels.
-      // Also drop the temporary container runtime label as it is no longer needed.
+      // Move high-cardinality labels to structured metadata
+      stage.structured_metadata {
+        values = {
+          pod  = "",
+        }
+      }
+    
+      // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
+      // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+      // container runtime label as it is no longer needed.
       stage.label_drop {
-        values = ["filename", "tmp_container_runtime"]
+        values = ["filename", "pod", "tmp_container_runtime"]
       }
       forward_to = [loki.process.logs_service.receiver]
     }

--- a/examples/ibm-cloud/logs.alloy
+++ b/examples/ibm-cloud/logs.alloy
@@ -82,7 +82,7 @@ loki.source.file "pod_logs" {
 
 loki.process "pod_logs" {
   stage.match {
-    selector = "{tmp_container_runtime=\"containerd\"}"
+    selector = "{tmp_container_runtime=~\"containerd|cri-o\"}"
     // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
     stage.cri {}
 
@@ -95,21 +95,6 @@ loki.process "pod_logs" {
     }
   }
 
-  stage.match {
-    selector = "{tmp_container_runtime=\"cri-o\"}"
-    // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
-    stage.cri {}
-
-    // Set the extract flags and stream values as labels
-    stage.labels {
-      values = {
-        flags  = "",
-        stream  = "",
-      }
-    }
-  }
-
-  // if the label tmp_container_runtime from above is docker parse using docker
   stage.match {
     selector = "{tmp_container_runtime=\"docker\"}"
     // the docker processing stage extracts the following k/v pairs: log, stream, time
@@ -123,11 +108,18 @@ loki.process "pod_logs" {
     }
   }
 
-  // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have
-  // cluster, namespace, pod, and container labels.
-  // Also drop the temporary container runtime label as it is no longer needed.
+  // Move high-cardinality labels to structured metadata
+  stage.structured_metadata {
+    values = {
+      pod  = "",
+    }
+  }
+
+  // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
+  // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+  // container runtime label as it is no longer needed.
   stage.label_drop {
-    values = ["filename", "tmp_container_runtime"]
+    values = ["filename", "pod", "tmp_container_runtime"]
   }
   forward_to = [loki.process.logs_service.receiver]
 }

--- a/examples/ibm-cloud/metrics.alloy
+++ b/examples/ibm-cloud/metrics.alloy
@@ -764,7 +764,7 @@ prometheus.remote_write "metrics_service" {
 
 loki.process "pod_logs" {
   stage.match {
-    selector = "{tmp_container_runtime=\"containerd\"}"
+    selector = "{tmp_container_runtime=~\"containerd|cri-o\"}"
     // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
     stage.cri {}
 
@@ -777,21 +777,6 @@ loki.process "pod_logs" {
     }
   }
 
-  stage.match {
-    selector = "{tmp_container_runtime=\"cri-o\"}"
-    // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
-    stage.cri {}
-
-    // Set the extract flags and stream values as labels
-    stage.labels {
-      values = {
-        flags  = "",
-        stream  = "",
-      }
-    }
-  }
-
-  // if the label tmp_container_runtime from above is docker parse using docker
   stage.match {
     selector = "{tmp_container_runtime=\"docker\"}"
     // the docker processing stage extracts the following k/v pairs: log, stream, time
@@ -805,11 +790,18 @@ loki.process "pod_logs" {
     }
   }
 
-  // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have
-  // cluster, namespace, pod, and container labels.
-  // Also drop the temporary container runtime label as it is no longer needed.
+  // Move high-cardinality labels to structured metadata
+  stage.structured_metadata {
+    values = {
+      pod  = "",
+    }
+  }
+
+  // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
+  // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+  // container runtime label as it is no longer needed.
   stage.label_drop {
-    values = ["filename", "tmp_container_runtime"]
+    values = ["filename", "pod", "tmp_container_runtime"]
   }
   forward_to = [loki.process.logs_service.receiver]
 }

--- a/examples/ibm-cloud/output.yaml
+++ b/examples/ibm-cloud/output.yaml
@@ -894,7 +894,7 @@ data:
     
     loki.process "pod_logs" {
       stage.match {
-        selector = "{tmp_container_runtime=\"containerd\"}"
+        selector = "{tmp_container_runtime=~\"containerd|cri-o\"}"
         // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
         stage.cri {}
     
@@ -907,21 +907,6 @@ data:
         }
       }
     
-      stage.match {
-        selector = "{tmp_container_runtime=\"cri-o\"}"
-        // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
-        stage.cri {}
-    
-        // Set the extract flags and stream values as labels
-        stage.labels {
-          values = {
-            flags  = "",
-            stream  = "",
-          }
-        }
-      }
-    
-      // if the label tmp_container_runtime from above is docker parse using docker
       stage.match {
         selector = "{tmp_container_runtime=\"docker\"}"
         // the docker processing stage extracts the following k/v pairs: log, stream, time
@@ -935,11 +920,18 @@ data:
         }
       }
     
-      // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have
-      // cluster, namespace, pod, and container labels.
-      // Also drop the temporary container runtime label as it is no longer needed.
+      // Move high-cardinality labels to structured metadata
+      stage.structured_metadata {
+        values = {
+          pod  = "",
+        }
+      }
+    
+      // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
+      // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+      // container runtime label as it is no longer needed.
       stage.label_drop {
-        values = ["filename", "tmp_container_runtime"]
+        values = ["filename", "pod", "tmp_container_runtime"]
       }
       forward_to = [loki.process.logs_service.receiver]
     }
@@ -1127,7 +1119,7 @@ data:
     
     loki.process "pod_logs" {
       stage.match {
-        selector = "{tmp_container_runtime=\"containerd\"}"
+        selector = "{tmp_container_runtime=~\"containerd|cri-o\"}"
         // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
         stage.cri {}
     
@@ -1140,21 +1132,6 @@ data:
         }
       }
     
-      stage.match {
-        selector = "{tmp_container_runtime=\"cri-o\"}"
-        // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
-        stage.cri {}
-    
-        // Set the extract flags and stream values as labels
-        stage.labels {
-          values = {
-            flags  = "",
-            stream  = "",
-          }
-        }
-      }
-    
-      // if the label tmp_container_runtime from above is docker parse using docker
       stage.match {
         selector = "{tmp_container_runtime=\"docker\"}"
         // the docker processing stage extracts the following k/v pairs: log, stream, time
@@ -1168,11 +1145,18 @@ data:
         }
       }
     
-      // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have
-      // cluster, namespace, pod, and container labels.
-      // Also drop the temporary container runtime label as it is no longer needed.
+      // Move high-cardinality labels to structured metadata
+      stage.structured_metadata {
+        values = {
+          pod  = "",
+        }
+      }
+    
+      // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
+      // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+      // container runtime label as it is no longer needed.
       stage.label_drop {
-        values = ["filename", "tmp_container_runtime"]
+        values = ["filename", "pod", "tmp_container_runtime"]
       }
       forward_to = [loki.process.logs_service.receiver]
     }
@@ -59797,7 +59781,7 @@ data:
     
     loki.process "pod_logs" {
       stage.match {
-        selector = "{tmp_container_runtime=\"containerd\"}"
+        selector = "{tmp_container_runtime=~\"containerd|cri-o\"}"
         // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
         stage.cri {}
     
@@ -59810,21 +59794,6 @@ data:
         }
       }
     
-      stage.match {
-        selector = "{tmp_container_runtime=\"cri-o\"}"
-        // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
-        stage.cri {}
-    
-        // Set the extract flags and stream values as labels
-        stage.labels {
-          values = {
-            flags  = "",
-            stream  = "",
-          }
-        }
-      }
-    
-      // if the label tmp_container_runtime from above is docker parse using docker
       stage.match {
         selector = "{tmp_container_runtime=\"docker\"}"
         // the docker processing stage extracts the following k/v pairs: log, stream, time
@@ -59838,11 +59807,18 @@ data:
         }
       }
     
-      // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have
-      // cluster, namespace, pod, and container labels.
-      // Also drop the temporary container runtime label as it is no longer needed.
+      // Move high-cardinality labels to structured metadata
+      stage.structured_metadata {
+        values = {
+          pod  = "",
+        }
+      }
+    
+      // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
+      // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+      // container runtime label as it is no longer needed.
       stage.label_drop {
-        values = ["filename", "tmp_container_runtime"]
+        values = ["filename", "pod", "tmp_container_runtime"]
       }
       forward_to = [loki.process.logs_service.receiver]
     }
@@ -60014,7 +59990,7 @@ data:
     
     loki.process "pod_logs" {
       stage.match {
-        selector = "{tmp_container_runtime=\"containerd\"}"
+        selector = "{tmp_container_runtime=~\"containerd|cri-o\"}"
         // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
         stage.cri {}
     
@@ -60027,21 +60003,6 @@ data:
         }
       }
     
-      stage.match {
-        selector = "{tmp_container_runtime=\"cri-o\"}"
-        // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
-        stage.cri {}
-    
-        // Set the extract flags and stream values as labels
-        stage.labels {
-          values = {
-            flags  = "",
-            stream  = "",
-          }
-        }
-      }
-    
-      // if the label tmp_container_runtime from above is docker parse using docker
       stage.match {
         selector = "{tmp_container_runtime=\"docker\"}"
         // the docker processing stage extracts the following k/v pairs: log, stream, time
@@ -60055,11 +60016,18 @@ data:
         }
       }
     
-      // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have
-      // cluster, namespace, pod, and container labels.
-      // Also drop the temporary container runtime label as it is no longer needed.
+      // Move high-cardinality labels to structured metadata
+      stage.structured_metadata {
+        values = {
+          pod  = "",
+        }
+      }
+    
+      // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
+      // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+      // container runtime label as it is no longer needed.
       stage.label_drop {
-        values = ["filename", "tmp_container_runtime"]
+        values = ["filename", "pod", "tmp_container_runtime"]
       }
       forward_to = [loki.process.logs_service.receiver]
     }

--- a/examples/logs-journal/logs.alloy
+++ b/examples/logs-journal/logs.alloy
@@ -82,7 +82,7 @@ loki.source.file "pod_logs" {
 
 loki.process "pod_logs" {
   stage.match {
-    selector = "{tmp_container_runtime=\"containerd\"}"
+    selector = "{tmp_container_runtime=~\"containerd|cri-o\"}"
     // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
     stage.cri {}
 
@@ -95,21 +95,6 @@ loki.process "pod_logs" {
     }
   }
 
-  stage.match {
-    selector = "{tmp_container_runtime=\"cri-o\"}"
-    // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
-    stage.cri {}
-
-    // Set the extract flags and stream values as labels
-    stage.labels {
-      values = {
-        flags  = "",
-        stream  = "",
-      }
-    }
-  }
-
-  // if the label tmp_container_runtime from above is docker parse using docker
   stage.match {
     selector = "{tmp_container_runtime=\"docker\"}"
     // the docker processing stage extracts the following k/v pairs: log, stream, time
@@ -123,11 +108,18 @@ loki.process "pod_logs" {
     }
   }
 
-  // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have
-  // cluster, namespace, pod, and container labels.
-  // Also drop the temporary container runtime label as it is no longer needed.
+  // Move high-cardinality labels to structured metadata
+  stage.structured_metadata {
+    values = {
+      pod  = "",
+    }
+  }
+
+  // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
+  // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+  // container runtime label as it is no longer needed.
   stage.label_drop {
-    values = ["filename", "tmp_container_runtime"]
+    values = ["filename", "pod", "tmp_container_runtime"]
   }
   forward_to = [loki.process.logs_service.receiver]
 }

--- a/examples/logs-journal/metrics.alloy
+++ b/examples/logs-journal/metrics.alloy
@@ -21,7 +21,7 @@ discovery.kubernetes "pods" {
 // Processors
 loki.process "pod_logs" {
   stage.match {
-    selector = "{tmp_container_runtime=\"containerd\"}"
+    selector = "{tmp_container_runtime=~\"containerd|cri-o\"}"
     // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
     stage.cri {}
 
@@ -34,21 +34,6 @@ loki.process "pod_logs" {
     }
   }
 
-  stage.match {
-    selector = "{tmp_container_runtime=\"cri-o\"}"
-    // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
-    stage.cri {}
-
-    // Set the extract flags and stream values as labels
-    stage.labels {
-      values = {
-        flags  = "",
-        stream  = "",
-      }
-    }
-  }
-
-  // if the label tmp_container_runtime from above is docker parse using docker
   stage.match {
     selector = "{tmp_container_runtime=\"docker\"}"
     // the docker processing stage extracts the following k/v pairs: log, stream, time
@@ -62,11 +47,18 @@ loki.process "pod_logs" {
     }
   }
 
-  // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have
-  // cluster, namespace, pod, and container labels.
-  // Also drop the temporary container runtime label as it is no longer needed.
+  // Move high-cardinality labels to structured metadata
+  stage.structured_metadata {
+    values = {
+      pod  = "",
+    }
+  }
+
+  // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
+  // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+  // container runtime label as it is no longer needed.
   stage.label_drop {
-    values = ["filename", "tmp_container_runtime"]
+    values = ["filename", "pod", "tmp_container_runtime"]
   }
   forward_to = [loki.process.logs_service.receiver]
 }

--- a/examples/logs-journal/output.yaml
+++ b/examples/logs-journal/output.yaml
@@ -91,7 +91,7 @@ data:
     // Processors
     loki.process "pod_logs" {
       stage.match {
-        selector = "{tmp_container_runtime=\"containerd\"}"
+        selector = "{tmp_container_runtime=~\"containerd|cri-o\"}"
         // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
         stage.cri {}
     
@@ -104,21 +104,6 @@ data:
         }
       }
     
-      stage.match {
-        selector = "{tmp_container_runtime=\"cri-o\"}"
-        // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
-        stage.cri {}
-    
-        // Set the extract flags and stream values as labels
-        stage.labels {
-          values = {
-            flags  = "",
-            stream  = "",
-          }
-        }
-      }
-    
-      // if the label tmp_container_runtime from above is docker parse using docker
       stage.match {
         selector = "{tmp_container_runtime=\"docker\"}"
         // the docker processing stage extracts the following k/v pairs: log, stream, time
@@ -132,11 +117,18 @@ data:
         }
       }
     
-      // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have
-      // cluster, namespace, pod, and container labels.
-      // Also drop the temporary container runtime label as it is no longer needed.
+      // Move high-cardinality labels to structured metadata
+      stage.structured_metadata {
+        values = {
+          pod  = "",
+        }
+      }
+    
+      // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
+      // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+      // container runtime label as it is no longer needed.
       stage.label_drop {
-        values = ["filename", "tmp_container_runtime"]
+        values = ["filename", "pod", "tmp_container_runtime"]
       }
       forward_to = [loki.process.logs_service.receiver]
     }
@@ -324,7 +316,7 @@ data:
     
     loki.process "pod_logs" {
       stage.match {
-        selector = "{tmp_container_runtime=\"containerd\"}"
+        selector = "{tmp_container_runtime=~\"containerd|cri-o\"}"
         // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
         stage.cri {}
     
@@ -337,21 +329,6 @@ data:
         }
       }
     
-      stage.match {
-        selector = "{tmp_container_runtime=\"cri-o\"}"
-        // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
-        stage.cri {}
-    
-        // Set the extract flags and stream values as labels
-        stage.labels {
-          values = {
-            flags  = "",
-            stream  = "",
-          }
-        }
-      }
-    
-      // if the label tmp_container_runtime from above is docker parse using docker
       stage.match {
         selector = "{tmp_container_runtime=\"docker\"}"
         // the docker processing stage extracts the following k/v pairs: log, stream, time
@@ -365,11 +342,18 @@ data:
         }
       }
     
-      // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have
-      // cluster, namespace, pod, and container labels.
-      // Also drop the temporary container runtime label as it is no longer needed.
+      // Move high-cardinality labels to structured metadata
+      stage.structured_metadata {
+        values = {
+          pod  = "",
+        }
+      }
+    
+      // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
+      // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+      // container runtime label as it is no longer needed.
       stage.label_drop {
-        values = ["filename", "tmp_container_runtime"]
+        values = ["filename", "pod", "tmp_container_runtime"]
       }
       forward_to = [loki.process.logs_service.receiver]
     }
@@ -1373,7 +1357,7 @@ data:
     // Processors
     loki.process "pod_logs" {
       stage.match {
-        selector = "{tmp_container_runtime=\"containerd\"}"
+        selector = "{tmp_container_runtime=~\"containerd|cri-o\"}"
         // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
         stage.cri {}
     
@@ -1386,21 +1370,6 @@ data:
         }
       }
     
-      stage.match {
-        selector = "{tmp_container_runtime=\"cri-o\"}"
-        // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
-        stage.cri {}
-    
-        // Set the extract flags and stream values as labels
-        stage.labels {
-          values = {
-            flags  = "",
-            stream  = "",
-          }
-        }
-      }
-    
-      // if the label tmp_container_runtime from above is docker parse using docker
       stage.match {
         selector = "{tmp_container_runtime=\"docker\"}"
         // the docker processing stage extracts the following k/v pairs: log, stream, time
@@ -1414,11 +1383,18 @@ data:
         }
       }
     
-      // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have
-      // cluster, namespace, pod, and container labels.
-      // Also drop the temporary container runtime label as it is no longer needed.
+      // Move high-cardinality labels to structured metadata
+      stage.structured_metadata {
+        values = {
+          pod  = "",
+        }
+      }
+    
+      // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
+      // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+      // container runtime label as it is no longer needed.
       stage.label_drop {
-        values = ["filename", "tmp_container_runtime"]
+        values = ["filename", "pod", "tmp_container_runtime"]
       }
       forward_to = [loki.process.logs_service.receiver]
     }
@@ -1590,7 +1566,7 @@ data:
     
     loki.process "pod_logs" {
       stage.match {
-        selector = "{tmp_container_runtime=\"containerd\"}"
+        selector = "{tmp_container_runtime=~\"containerd|cri-o\"}"
         // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
         stage.cri {}
     
@@ -1603,21 +1579,6 @@ data:
         }
       }
     
-      stage.match {
-        selector = "{tmp_container_runtime=\"cri-o\"}"
-        // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
-        stage.cri {}
-    
-        // Set the extract flags and stream values as labels
-        stage.labels {
-          values = {
-            flags  = "",
-            stream  = "",
-          }
-        }
-      }
-    
-      // if the label tmp_container_runtime from above is docker parse using docker
       stage.match {
         selector = "{tmp_container_runtime=\"docker\"}"
         // the docker processing stage extracts the following k/v pairs: log, stream, time
@@ -1631,11 +1592,18 @@ data:
         }
       }
     
-      // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have
-      // cluster, namespace, pod, and container labels.
-      // Also drop the temporary container runtime label as it is no longer needed.
+      // Move high-cardinality labels to structured metadata
+      stage.structured_metadata {
+        values = {
+          pod  = "",
+        }
+      }
+    
+      // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
+      // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+      // container runtime label as it is no longer needed.
       stage.label_drop {
-        values = ["filename", "tmp_container_runtime"]
+        values = ["filename", "pod", "tmp_container_runtime"]
       }
       forward_to = [loki.process.logs_service.receiver]
     }

--- a/examples/logs-only/logs.alloy
+++ b/examples/logs-only/logs.alloy
@@ -82,7 +82,7 @@ loki.source.file "pod_logs" {
 
 loki.process "pod_logs" {
   stage.match {
-    selector = "{tmp_container_runtime=\"containerd\"}"
+    selector = "{tmp_container_runtime=~\"containerd|cri-o\"}"
     // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
     stage.cri {}
 
@@ -95,21 +95,6 @@ loki.process "pod_logs" {
     }
   }
 
-  stage.match {
-    selector = "{tmp_container_runtime=\"cri-o\"}"
-    // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
-    stage.cri {}
-
-    // Set the extract flags and stream values as labels
-    stage.labels {
-      values = {
-        flags  = "",
-        stream  = "",
-      }
-    }
-  }
-
-  // if the label tmp_container_runtime from above is docker parse using docker
   stage.match {
     selector = "{tmp_container_runtime=\"docker\"}"
     // the docker processing stage extracts the following k/v pairs: log, stream, time
@@ -123,11 +108,18 @@ loki.process "pod_logs" {
     }
   }
 
-  // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have
-  // cluster, namespace, pod, and container labels.
-  // Also drop the temporary container runtime label as it is no longer needed.
+  // Move high-cardinality labels to structured metadata
+  stage.structured_metadata {
+    values = {
+      pod  = "",
+    }
+  }
+
+  // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
+  // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+  // container runtime label as it is no longer needed.
   stage.label_drop {
-    values = ["filename", "tmp_container_runtime"]
+    values = ["filename", "pod", "tmp_container_runtime"]
   }
   forward_to = [loki.process.logs_service.receiver]
 }

--- a/examples/logs-only/metrics.alloy
+++ b/examples/logs-only/metrics.alloy
@@ -100,7 +100,7 @@ otelcol.exporter.loki "logs_converter" {
 }
 loki.process "pod_logs" {
   stage.match {
-    selector = "{tmp_container_runtime=\"containerd\"}"
+    selector = "{tmp_container_runtime=~\"containerd|cri-o\"}"
     // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
     stage.cri {}
 
@@ -113,21 +113,6 @@ loki.process "pod_logs" {
     }
   }
 
-  stage.match {
-    selector = "{tmp_container_runtime=\"cri-o\"}"
-    // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
-    stage.cri {}
-
-    // Set the extract flags and stream values as labels
-    stage.labels {
-      values = {
-        flags  = "",
-        stream  = "",
-      }
-    }
-  }
-
-  // if the label tmp_container_runtime from above is docker parse using docker
   stage.match {
     selector = "{tmp_container_runtime=\"docker\"}"
     // the docker processing stage extracts the following k/v pairs: log, stream, time
@@ -141,11 +126,18 @@ loki.process "pod_logs" {
     }
   }
 
-  // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have
-  // cluster, namespace, pod, and container labels.
-  // Also drop the temporary container runtime label as it is no longer needed.
+  // Move high-cardinality labels to structured metadata
+  stage.structured_metadata {
+    values = {
+      pod  = "",
+    }
+  }
+
+  // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
+  // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+  // container runtime label as it is no longer needed.
   stage.label_drop {
-    values = ["filename", "tmp_container_runtime"]
+    values = ["filename", "pod", "tmp_container_runtime"]
   }
   forward_to = [loki.process.logs_service.receiver]
 }

--- a/examples/logs-only/output.yaml
+++ b/examples/logs-only/output.yaml
@@ -171,7 +171,7 @@ data:
     }
     loki.process "pod_logs" {
       stage.match {
-        selector = "{tmp_container_runtime=\"containerd\"}"
+        selector = "{tmp_container_runtime=~\"containerd|cri-o\"}"
         // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
         stage.cri {}
     
@@ -184,21 +184,6 @@ data:
         }
       }
     
-      stage.match {
-        selector = "{tmp_container_runtime=\"cri-o\"}"
-        // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
-        stage.cri {}
-    
-        // Set the extract flags and stream values as labels
-        stage.labels {
-          values = {
-            flags  = "",
-            stream  = "",
-          }
-        }
-      }
-    
-      // if the label tmp_container_runtime from above is docker parse using docker
       stage.match {
         selector = "{tmp_container_runtime=\"docker\"}"
         // the docker processing stage extracts the following k/v pairs: log, stream, time
@@ -212,11 +197,18 @@ data:
         }
       }
     
-      // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have
-      // cluster, namespace, pod, and container labels.
-      // Also drop the temporary container runtime label as it is no longer needed.
+      // Move high-cardinality labels to structured metadata
+      stage.structured_metadata {
+        values = {
+          pod  = "",
+        }
+      }
+    
+      // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
+      // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+      // container runtime label as it is no longer needed.
       stage.label_drop {
-        values = ["filename", "tmp_container_runtime"]
+        values = ["filename", "pod", "tmp_container_runtime"]
       }
       forward_to = [loki.process.logs_service.receiver]
     }
@@ -404,7 +396,7 @@ data:
     
     loki.process "pod_logs" {
       stage.match {
-        selector = "{tmp_container_runtime=\"containerd\"}"
+        selector = "{tmp_container_runtime=~\"containerd|cri-o\"}"
         // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
         stage.cri {}
     
@@ -417,21 +409,6 @@ data:
         }
       }
     
-      stage.match {
-        selector = "{tmp_container_runtime=\"cri-o\"}"
-        // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
-        stage.cri {}
-    
-        // Set the extract flags and stream values as labels
-        stage.labels {
-          values = {
-            flags  = "",
-            stream  = "",
-          }
-        }
-      }
-    
-      // if the label tmp_container_runtime from above is docker parse using docker
       stage.match {
         selector = "{tmp_container_runtime=\"docker\"}"
         // the docker processing stage extracts the following k/v pairs: log, stream, time
@@ -445,11 +422,18 @@ data:
         }
       }
     
-      // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have
-      // cluster, namespace, pod, and container labels.
-      // Also drop the temporary container runtime label as it is no longer needed.
+      // Move high-cardinality labels to structured metadata
+      stage.structured_metadata {
+        values = {
+          pod  = "",
+        }
+      }
+    
+      // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
+      // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+      // container runtime label as it is no longer needed.
       stage.label_drop {
-        values = ["filename", "tmp_container_runtime"]
+        values = ["filename", "pod", "tmp_container_runtime"]
       }
       forward_to = [loki.process.logs_service.receiver]
     }
@@ -1504,7 +1488,7 @@ data:
     }
     loki.process "pod_logs" {
       stage.match {
-        selector = "{tmp_container_runtime=\"containerd\"}"
+        selector = "{tmp_container_runtime=~\"containerd|cri-o\"}"
         // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
         stage.cri {}
     
@@ -1517,21 +1501,6 @@ data:
         }
       }
     
-      stage.match {
-        selector = "{tmp_container_runtime=\"cri-o\"}"
-        // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
-        stage.cri {}
-    
-        // Set the extract flags and stream values as labels
-        stage.labels {
-          values = {
-            flags  = "",
-            stream  = "",
-          }
-        }
-      }
-    
-      // if the label tmp_container_runtime from above is docker parse using docker
       stage.match {
         selector = "{tmp_container_runtime=\"docker\"}"
         // the docker processing stage extracts the following k/v pairs: log, stream, time
@@ -1545,11 +1514,18 @@ data:
         }
       }
     
-      // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have
-      // cluster, namespace, pod, and container labels.
-      // Also drop the temporary container runtime label as it is no longer needed.
+      // Move high-cardinality labels to structured metadata
+      stage.structured_metadata {
+        values = {
+          pod  = "",
+        }
+      }
+    
+      // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
+      // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+      // container runtime label as it is no longer needed.
       stage.label_drop {
-        values = ["filename", "tmp_container_runtime"]
+        values = ["filename", "pod", "tmp_container_runtime"]
       }
       forward_to = [loki.process.logs_service.receiver]
     }
@@ -1721,7 +1697,7 @@ data:
     
     loki.process "pod_logs" {
       stage.match {
-        selector = "{tmp_container_runtime=\"containerd\"}"
+        selector = "{tmp_container_runtime=~\"containerd|cri-o\"}"
         // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
         stage.cri {}
     
@@ -1734,21 +1710,6 @@ data:
         }
       }
     
-      stage.match {
-        selector = "{tmp_container_runtime=\"cri-o\"}"
-        // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
-        stage.cri {}
-    
-        // Set the extract flags and stream values as labels
-        stage.labels {
-          values = {
-            flags  = "",
-            stream  = "",
-          }
-        }
-      }
-    
-      // if the label tmp_container_runtime from above is docker parse using docker
       stage.match {
         selector = "{tmp_container_runtime=\"docker\"}"
         // the docker processing stage extracts the following k/v pairs: log, stream, time
@@ -1762,11 +1723,18 @@ data:
         }
       }
     
-      // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have
-      // cluster, namespace, pod, and container labels.
-      // Also drop the temporary container runtime label as it is no longer needed.
+      // Move high-cardinality labels to structured metadata
+      stage.structured_metadata {
+        values = {
+          pod  = "",
+        }
+      }
+    
+      // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
+      // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+      // container runtime label as it is no longer needed.
       stage.label_drop {
-        values = ["filename", "tmp_container_runtime"]
+        values = ["filename", "pod", "tmp_container_runtime"]
       }
       forward_to = [loki.process.logs_service.receiver]
     }

--- a/examples/metric-module-imports-extra-config/logs.alloy
+++ b/examples/metric-module-imports-extra-config/logs.alloy
@@ -82,7 +82,7 @@ loki.source.file "pod_logs" {
 
 loki.process "pod_logs" {
   stage.match {
-    selector = "{tmp_container_runtime=\"containerd\"}"
+    selector = "{tmp_container_runtime=~\"containerd|cri-o\"}"
     // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
     stage.cri {}
 
@@ -95,21 +95,6 @@ loki.process "pod_logs" {
     }
   }
 
-  stage.match {
-    selector = "{tmp_container_runtime=\"cri-o\"}"
-    // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
-    stage.cri {}
-
-    // Set the extract flags and stream values as labels
-    stage.labels {
-      values = {
-        flags  = "",
-        stream  = "",
-      }
-    }
-  }
-
-  // if the label tmp_container_runtime from above is docker parse using docker
   stage.match {
     selector = "{tmp_container_runtime=\"docker\"}"
     // the docker processing stage extracts the following k/v pairs: log, stream, time
@@ -123,11 +108,18 @@ loki.process "pod_logs" {
     }
   }
 
-  // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have
-  // cluster, namespace, pod, and container labels.
-  // Also drop the temporary container runtime label as it is no longer needed.
+  // Move high-cardinality labels to structured metadata
+  stage.structured_metadata {
+    values = {
+      pod  = "",
+    }
+  }
+
+  // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
+  // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+  // container runtime label as it is no longer needed.
   stage.label_drop {
-    values = ["filename", "tmp_container_runtime"]
+    values = ["filename", "pod", "tmp_container_runtime"]
   }
   forward_to = [loki.process.logs_service.receiver]
 }

--- a/examples/metric-module-imports-extra-config/metrics.alloy
+++ b/examples/metric-module-imports-extra-config/metrics.alloy
@@ -764,7 +764,7 @@ prometheus.remote_write "metrics_service" {
 
 loki.process "pod_logs" {
   stage.match {
-    selector = "{tmp_container_runtime=\"containerd\"}"
+    selector = "{tmp_container_runtime=~\"containerd|cri-o\"}"
     // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
     stage.cri {}
 
@@ -777,21 +777,6 @@ loki.process "pod_logs" {
     }
   }
 
-  stage.match {
-    selector = "{tmp_container_runtime=\"cri-o\"}"
-    // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
-    stage.cri {}
-
-    // Set the extract flags and stream values as labels
-    stage.labels {
-      values = {
-        flags  = "",
-        stream  = "",
-      }
-    }
-  }
-
-  // if the label tmp_container_runtime from above is docker parse using docker
   stage.match {
     selector = "{tmp_container_runtime=\"docker\"}"
     // the docker processing stage extracts the following k/v pairs: log, stream, time
@@ -805,11 +790,18 @@ loki.process "pod_logs" {
     }
   }
 
-  // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have
-  // cluster, namespace, pod, and container labels.
-  // Also drop the temporary container runtime label as it is no longer needed.
+  // Move high-cardinality labels to structured metadata
+  stage.structured_metadata {
+    values = {
+      pod  = "",
+    }
+  }
+
+  // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
+  // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+  // container runtime label as it is no longer needed.
   stage.label_drop {
-    values = ["filename", "tmp_container_runtime"]
+    values = ["filename", "pod", "tmp_container_runtime"]
   }
   forward_to = [loki.process.logs_service.receiver]
 }

--- a/examples/metric-module-imports-extra-config/output.yaml
+++ b/examples/metric-module-imports-extra-config/output.yaml
@@ -894,7 +894,7 @@ data:
     
     loki.process "pod_logs" {
       stage.match {
-        selector = "{tmp_container_runtime=\"containerd\"}"
+        selector = "{tmp_container_runtime=~\"containerd|cri-o\"}"
         // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
         stage.cri {}
     
@@ -907,21 +907,6 @@ data:
         }
       }
     
-      stage.match {
-        selector = "{tmp_container_runtime=\"cri-o\"}"
-        // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
-        stage.cri {}
-    
-        // Set the extract flags and stream values as labels
-        stage.labels {
-          values = {
-            flags  = "",
-            stream  = "",
-          }
-        }
-      }
-    
-      // if the label tmp_container_runtime from above is docker parse using docker
       stage.match {
         selector = "{tmp_container_runtime=\"docker\"}"
         // the docker processing stage extracts the following k/v pairs: log, stream, time
@@ -935,11 +920,18 @@ data:
         }
       }
     
-      // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have
-      // cluster, namespace, pod, and container labels.
-      // Also drop the temporary container runtime label as it is no longer needed.
+      // Move high-cardinality labels to structured metadata
+      stage.structured_metadata {
+        values = {
+          pod  = "",
+        }
+      }
+    
+      // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
+      // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+      // container runtime label as it is no longer needed.
       stage.label_drop {
-        values = ["filename", "tmp_container_runtime"]
+        values = ["filename", "pod", "tmp_container_runtime"]
       }
       forward_to = [loki.process.logs_service.receiver]
     }
@@ -1143,7 +1135,7 @@ data:
     
     loki.process "pod_logs" {
       stage.match {
-        selector = "{tmp_container_runtime=\"containerd\"}"
+        selector = "{tmp_container_runtime=~\"containerd|cri-o\"}"
         // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
         stage.cri {}
     
@@ -1156,21 +1148,6 @@ data:
         }
       }
     
-      stage.match {
-        selector = "{tmp_container_runtime=\"cri-o\"}"
-        // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
-        stage.cri {}
-    
-        // Set the extract flags and stream values as labels
-        stage.labels {
-          values = {
-            flags  = "",
-            stream  = "",
-          }
-        }
-      }
-    
-      // if the label tmp_container_runtime from above is docker parse using docker
       stage.match {
         selector = "{tmp_container_runtime=\"docker\"}"
         // the docker processing stage extracts the following k/v pairs: log, stream, time
@@ -1184,11 +1161,18 @@ data:
         }
       }
     
-      // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have
-      // cluster, namespace, pod, and container labels.
-      // Also drop the temporary container runtime label as it is no longer needed.
+      // Move high-cardinality labels to structured metadata
+      stage.structured_metadata {
+        values = {
+          pod  = "",
+        }
+      }
+    
+      // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
+      // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+      // container runtime label as it is no longer needed.
       stage.label_drop {
-        values = ["filename", "tmp_container_runtime"]
+        values = ["filename", "pod", "tmp_container_runtime"]
       }
       forward_to = [loki.process.logs_service.receiver]
     }
@@ -59807,7 +59791,7 @@ data:
     
     loki.process "pod_logs" {
       stage.match {
-        selector = "{tmp_container_runtime=\"containerd\"}"
+        selector = "{tmp_container_runtime=~\"containerd|cri-o\"}"
         // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
         stage.cri {}
     
@@ -59820,21 +59804,6 @@ data:
         }
       }
     
-      stage.match {
-        selector = "{tmp_container_runtime=\"cri-o\"}"
-        // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
-        stage.cri {}
-    
-        // Set the extract flags and stream values as labels
-        stage.labels {
-          values = {
-            flags  = "",
-            stream  = "",
-          }
-        }
-      }
-    
-      // if the label tmp_container_runtime from above is docker parse using docker
       stage.match {
         selector = "{tmp_container_runtime=\"docker\"}"
         // the docker processing stage extracts the following k/v pairs: log, stream, time
@@ -59848,11 +59817,18 @@ data:
         }
       }
     
-      // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have
-      // cluster, namespace, pod, and container labels.
-      // Also drop the temporary container runtime label as it is no longer needed.
+      // Move high-cardinality labels to structured metadata
+      stage.structured_metadata {
+        values = {
+          pod  = "",
+        }
+      }
+    
+      // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
+      // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+      // container runtime label as it is no longer needed.
       stage.label_drop {
-        values = ["filename", "tmp_container_runtime"]
+        values = ["filename", "pod", "tmp_container_runtime"]
       }
       forward_to = [loki.process.logs_service.receiver]
     }
@@ -60040,7 +60016,7 @@ data:
     
     loki.process "pod_logs" {
       stage.match {
-        selector = "{tmp_container_runtime=\"containerd\"}"
+        selector = "{tmp_container_runtime=~\"containerd|cri-o\"}"
         // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
         stage.cri {}
     
@@ -60053,21 +60029,6 @@ data:
         }
       }
     
-      stage.match {
-        selector = "{tmp_container_runtime=\"cri-o\"}"
-        // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
-        stage.cri {}
-    
-        // Set the extract flags and stream values as labels
-        stage.labels {
-          values = {
-            flags  = "",
-            stream  = "",
-          }
-        }
-      }
-    
-      // if the label tmp_container_runtime from above is docker parse using docker
       stage.match {
         selector = "{tmp_container_runtime=\"docker\"}"
         // the docker processing stage extracts the following k/v pairs: log, stream, time
@@ -60081,11 +60042,18 @@ data:
         }
       }
     
-      // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have
-      // cluster, namespace, pod, and container labels.
-      // Also drop the temporary container runtime label as it is no longer needed.
+      // Move high-cardinality labels to structured metadata
+      stage.structured_metadata {
+        values = {
+          pod  = "",
+        }
+      }
+    
+      // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
+      // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+      // container runtime label as it is no longer needed.
       stage.label_drop {
-        values = ["filename", "tmp_container_runtime"]
+        values = ["filename", "pod", "tmp_container_runtime"]
       }
       forward_to = [loki.process.logs_service.receiver]
     }

--- a/examples/metric-module-imports/logs.alloy
+++ b/examples/metric-module-imports/logs.alloy
@@ -82,7 +82,7 @@ loki.source.file "pod_logs" {
 
 loki.process "pod_logs" {
   stage.match {
-    selector = "{tmp_container_runtime=\"containerd\"}"
+    selector = "{tmp_container_runtime=~\"containerd|cri-o\"}"
     // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
     stage.cri {}
 
@@ -95,21 +95,6 @@ loki.process "pod_logs" {
     }
   }
 
-  stage.match {
-    selector = "{tmp_container_runtime=\"cri-o\"}"
-    // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
-    stage.cri {}
-
-    // Set the extract flags and stream values as labels
-    stage.labels {
-      values = {
-        flags  = "",
-        stream  = "",
-      }
-    }
-  }
-
-  // if the label tmp_container_runtime from above is docker parse using docker
   stage.match {
     selector = "{tmp_container_runtime=\"docker\"}"
     // the docker processing stage extracts the following k/v pairs: log, stream, time
@@ -123,11 +108,18 @@ loki.process "pod_logs" {
     }
   }
 
-  // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have
-  // cluster, namespace, pod, and container labels.
-  // Also drop the temporary container runtime label as it is no longer needed.
+  // Move high-cardinality labels to structured metadata
+  stage.structured_metadata {
+    values = {
+      pod  = "",
+    }
+  }
+
+  // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
+  // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+  // container runtime label as it is no longer needed.
   stage.label_drop {
-    values = ["filename", "tmp_container_runtime"]
+    values = ["filename", "pod", "tmp_container_runtime"]
   }
   forward_to = [loki.process.logs_service.receiver]
 }

--- a/examples/metric-module-imports/metrics.alloy
+++ b/examples/metric-module-imports/metrics.alloy
@@ -941,7 +941,7 @@ prometheus.remote_write "metrics_service" {
 
 loki.process "pod_logs" {
   stage.match {
-    selector = "{tmp_container_runtime=\"containerd\"}"
+    selector = "{tmp_container_runtime=~\"containerd|cri-o\"}"
     // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
     stage.cri {}
 
@@ -954,21 +954,6 @@ loki.process "pod_logs" {
     }
   }
 
-  stage.match {
-    selector = "{tmp_container_runtime=\"cri-o\"}"
-    // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
-    stage.cri {}
-
-    // Set the extract flags and stream values as labels
-    stage.labels {
-      values = {
-        flags  = "",
-        stream  = "",
-      }
-    }
-  }
-
-  // if the label tmp_container_runtime from above is docker parse using docker
   stage.match {
     selector = "{tmp_container_runtime=\"docker\"}"
     // the docker processing stage extracts the following k/v pairs: log, stream, time
@@ -982,11 +967,18 @@ loki.process "pod_logs" {
     }
   }
 
-  // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have
-  // cluster, namespace, pod, and container labels.
-  // Also drop the temporary container runtime label as it is no longer needed.
+  // Move high-cardinality labels to structured metadata
+  stage.structured_metadata {
+    values = {
+      pod  = "",
+    }
+  }
+
+  // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
+  // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+  // container runtime label as it is no longer needed.
   stage.label_drop {
-    values = ["filename", "tmp_container_runtime"]
+    values = ["filename", "pod", "tmp_container_runtime"]
   }
   forward_to = [loki.process.logs_service.receiver]
 }

--- a/examples/metric-module-imports/output.yaml
+++ b/examples/metric-module-imports/output.yaml
@@ -1071,7 +1071,7 @@ data:
     
     loki.process "pod_logs" {
       stage.match {
-        selector = "{tmp_container_runtime=\"containerd\"}"
+        selector = "{tmp_container_runtime=~\"containerd|cri-o\"}"
         // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
         stage.cri {}
     
@@ -1084,21 +1084,6 @@ data:
         }
       }
     
-      stage.match {
-        selector = "{tmp_container_runtime=\"cri-o\"}"
-        // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
-        stage.cri {}
-    
-        // Set the extract flags and stream values as labels
-        stage.labels {
-          values = {
-            flags  = "",
-            stream  = "",
-          }
-        }
-      }
-    
-      // if the label tmp_container_runtime from above is docker parse using docker
       stage.match {
         selector = "{tmp_container_runtime=\"docker\"}"
         // the docker processing stage extracts the following k/v pairs: log, stream, time
@@ -1112,11 +1097,18 @@ data:
         }
       }
     
-      // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have
-      // cluster, namespace, pod, and container labels.
-      // Also drop the temporary container runtime label as it is no longer needed.
+      // Move high-cardinality labels to structured metadata
+      stage.structured_metadata {
+        values = {
+          pod  = "",
+        }
+      }
+    
+      // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
+      // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+      // container runtime label as it is no longer needed.
       stage.label_drop {
-        values = ["filename", "tmp_container_runtime"]
+        values = ["filename", "pod", "tmp_container_runtime"]
       }
       forward_to = [loki.process.logs_service.receiver]
     }
@@ -1304,7 +1296,7 @@ data:
     
     loki.process "pod_logs" {
       stage.match {
-        selector = "{tmp_container_runtime=\"containerd\"}"
+        selector = "{tmp_container_runtime=~\"containerd|cri-o\"}"
         // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
         stage.cri {}
     
@@ -1317,21 +1309,6 @@ data:
         }
       }
     
-      stage.match {
-        selector = "{tmp_container_runtime=\"cri-o\"}"
-        // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
-        stage.cri {}
-    
-        // Set the extract flags and stream values as labels
-        stage.labels {
-          values = {
-            flags  = "",
-            stream  = "",
-          }
-        }
-      }
-    
-      // if the label tmp_container_runtime from above is docker parse using docker
       stage.match {
         selector = "{tmp_container_runtime=\"docker\"}"
         // the docker processing stage extracts the following k/v pairs: log, stream, time
@@ -1345,11 +1322,18 @@ data:
         }
       }
     
-      // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have
-      // cluster, namespace, pod, and container labels.
-      // Also drop the temporary container runtime label as it is no longer needed.
+      // Move high-cardinality labels to structured metadata
+      stage.structured_metadata {
+        values = {
+          pod  = "",
+        }
+      }
+    
+      // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
+      // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+      // container runtime label as it is no longer needed.
       stage.label_drop {
-        values = ["filename", "tmp_container_runtime"]
+        values = ["filename", "pod", "tmp_container_runtime"]
       }
       forward_to = [loki.process.logs_service.receiver]
     }
@@ -60145,7 +60129,7 @@ data:
     
     loki.process "pod_logs" {
       stage.match {
-        selector = "{tmp_container_runtime=\"containerd\"}"
+        selector = "{tmp_container_runtime=~\"containerd|cri-o\"}"
         // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
         stage.cri {}
     
@@ -60158,21 +60142,6 @@ data:
         }
       }
     
-      stage.match {
-        selector = "{tmp_container_runtime=\"cri-o\"}"
-        // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
-        stage.cri {}
-    
-        // Set the extract flags and stream values as labels
-        stage.labels {
-          values = {
-            flags  = "",
-            stream  = "",
-          }
-        }
-      }
-    
-      // if the label tmp_container_runtime from above is docker parse using docker
       stage.match {
         selector = "{tmp_container_runtime=\"docker\"}"
         // the docker processing stage extracts the following k/v pairs: log, stream, time
@@ -60186,11 +60155,18 @@ data:
         }
       }
     
-      // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have
-      // cluster, namespace, pod, and container labels.
-      // Also drop the temporary container runtime label as it is no longer needed.
+      // Move high-cardinality labels to structured metadata
+      stage.structured_metadata {
+        values = {
+          pod  = "",
+        }
+      }
+    
+      // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
+      // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+      // container runtime label as it is no longer needed.
       stage.label_drop {
-        values = ["filename", "tmp_container_runtime"]
+        values = ["filename", "pod", "tmp_container_runtime"]
       }
       forward_to = [loki.process.logs_service.receiver]
     }
@@ -60362,7 +60338,7 @@ data:
     
     loki.process "pod_logs" {
       stage.match {
-        selector = "{tmp_container_runtime=\"containerd\"}"
+        selector = "{tmp_container_runtime=~\"containerd|cri-o\"}"
         // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
         stage.cri {}
     
@@ -60375,21 +60351,6 @@ data:
         }
       }
     
-      stage.match {
-        selector = "{tmp_container_runtime=\"cri-o\"}"
-        // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
-        stage.cri {}
-    
-        // Set the extract flags and stream values as labels
-        stage.labels {
-          values = {
-            flags  = "",
-            stream  = "",
-          }
-        }
-      }
-    
-      // if the label tmp_container_runtime from above is docker parse using docker
       stage.match {
         selector = "{tmp_container_runtime=\"docker\"}"
         // the docker processing stage extracts the following k/v pairs: log, stream, time
@@ -60403,11 +60364,18 @@ data:
         }
       }
     
-      // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have
-      // cluster, namespace, pod, and container labels.
-      // Also drop the temporary container runtime label as it is no longer needed.
+      // Move high-cardinality labels to structured metadata
+      stage.structured_metadata {
+        values = {
+          pod  = "",
+        }
+      }
+    
+      // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
+      // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+      // container runtime label as it is no longer needed.
       stage.label_drop {
-        values = ["filename", "tmp_container_runtime"]
+        values = ["filename", "pod", "tmp_container_runtime"]
       }
       forward_to = [loki.process.logs_service.receiver]
     }

--- a/examples/openshift-compatible/logs.alloy
+++ b/examples/openshift-compatible/logs.alloy
@@ -82,7 +82,7 @@ loki.source.file "pod_logs" {
 
 loki.process "pod_logs" {
   stage.match {
-    selector = "{tmp_container_runtime=\"containerd\"}"
+    selector = "{tmp_container_runtime=~\"containerd|cri-o\"}"
     // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
     stage.cri {}
 
@@ -95,21 +95,6 @@ loki.process "pod_logs" {
     }
   }
 
-  stage.match {
-    selector = "{tmp_container_runtime=\"cri-o\"}"
-    // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
-    stage.cri {}
-
-    // Set the extract flags and stream values as labels
-    stage.labels {
-      values = {
-        flags  = "",
-        stream  = "",
-      }
-    }
-  }
-
-  // if the label tmp_container_runtime from above is docker parse using docker
   stage.match {
     selector = "{tmp_container_runtime=\"docker\"}"
     // the docker processing stage extracts the following k/v pairs: log, stream, time
@@ -123,11 +108,18 @@ loki.process "pod_logs" {
     }
   }
 
-  // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have
-  // cluster, namespace, pod, and container labels.
-  // Also drop the temporary container runtime label as it is no longer needed.
+  // Move high-cardinality labels to structured metadata
+  stage.structured_metadata {
+    values = {
+      pod  = "",
+    }
+  }
+
+  // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
+  // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+  // container runtime label as it is no longer needed.
   stage.label_drop {
-    values = ["filename", "tmp_container_runtime"]
+    values = ["filename", "pod", "tmp_container_runtime"]
   }
   forward_to = [loki.process.logs_service.receiver]
 }

--- a/examples/openshift-compatible/metrics.alloy
+++ b/examples/openshift-compatible/metrics.alloy
@@ -766,7 +766,7 @@ prometheus.remote_write "metrics_service" {
 
 loki.process "pod_logs" {
   stage.match {
-    selector = "{tmp_container_runtime=\"containerd\"}"
+    selector = "{tmp_container_runtime=~\"containerd|cri-o\"}"
     // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
     stage.cri {}
 
@@ -779,21 +779,6 @@ loki.process "pod_logs" {
     }
   }
 
-  stage.match {
-    selector = "{tmp_container_runtime=\"cri-o\"}"
-    // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
-    stage.cri {}
-
-    // Set the extract flags and stream values as labels
-    stage.labels {
-      values = {
-        flags  = "",
-        stream  = "",
-      }
-    }
-  }
-
-  // if the label tmp_container_runtime from above is docker parse using docker
   stage.match {
     selector = "{tmp_container_runtime=\"docker\"}"
     // the docker processing stage extracts the following k/v pairs: log, stream, time
@@ -807,11 +792,18 @@ loki.process "pod_logs" {
     }
   }
 
-  // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have
-  // cluster, namespace, pod, and container labels.
-  // Also drop the temporary container runtime label as it is no longer needed.
+  // Move high-cardinality labels to structured metadata
+  stage.structured_metadata {
+    values = {
+      pod  = "",
+    }
+  }
+
+  // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
+  // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+  // container runtime label as it is no longer needed.
   stage.label_drop {
-    values = ["filename", "tmp_container_runtime"]
+    values = ["filename", "pod", "tmp_container_runtime"]
   }
   forward_to = [loki.process.logs_service.receiver]
 }

--- a/examples/openshift-compatible/output.yaml
+++ b/examples/openshift-compatible/output.yaml
@@ -864,7 +864,7 @@ data:
     
     loki.process "pod_logs" {
       stage.match {
-        selector = "{tmp_container_runtime=\"containerd\"}"
+        selector = "{tmp_container_runtime=~\"containerd|cri-o\"}"
         // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
         stage.cri {}
     
@@ -877,21 +877,6 @@ data:
         }
       }
     
-      stage.match {
-        selector = "{tmp_container_runtime=\"cri-o\"}"
-        // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
-        stage.cri {}
-    
-        // Set the extract flags and stream values as labels
-        stage.labels {
-          values = {
-            flags  = "",
-            stream  = "",
-          }
-        }
-      }
-    
-      // if the label tmp_container_runtime from above is docker parse using docker
       stage.match {
         selector = "{tmp_container_runtime=\"docker\"}"
         // the docker processing stage extracts the following k/v pairs: log, stream, time
@@ -905,11 +890,18 @@ data:
         }
       }
     
-      // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have
-      // cluster, namespace, pod, and container labels.
-      // Also drop the temporary container runtime label as it is no longer needed.
+      // Move high-cardinality labels to structured metadata
+      stage.structured_metadata {
+        values = {
+          pod  = "",
+        }
+      }
+    
+      // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
+      // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+      // container runtime label as it is no longer needed.
       stage.label_drop {
-        values = ["filename", "tmp_container_runtime"]
+        values = ["filename", "pod", "tmp_container_runtime"]
       }
       forward_to = [loki.process.logs_service.receiver]
     }
@@ -1099,7 +1091,7 @@ data:
     
     loki.process "pod_logs" {
       stage.match {
-        selector = "{tmp_container_runtime=\"containerd\"}"
+        selector = "{tmp_container_runtime=~\"containerd|cri-o\"}"
         // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
         stage.cri {}
     
@@ -1112,21 +1104,6 @@ data:
         }
       }
     
-      stage.match {
-        selector = "{tmp_container_runtime=\"cri-o\"}"
-        // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
-        stage.cri {}
-    
-        // Set the extract flags and stream values as labels
-        stage.labels {
-          values = {
-            flags  = "",
-            stream  = "",
-          }
-        }
-      }
-    
-      // if the label tmp_container_runtime from above is docker parse using docker
       stage.match {
         selector = "{tmp_container_runtime=\"docker\"}"
         // the docker processing stage extracts the following k/v pairs: log, stream, time
@@ -1140,11 +1117,18 @@ data:
         }
       }
     
-      // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have
-      // cluster, namespace, pod, and container labels.
-      // Also drop the temporary container runtime label as it is no longer needed.
+      // Move high-cardinality labels to structured metadata
+      stage.structured_metadata {
+        values = {
+          pod  = "",
+        }
+      }
+    
+      // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
+      // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+      // container runtime label as it is no longer needed.
       stage.label_drop {
-        values = ["filename", "tmp_container_runtime"]
+        values = ["filename", "pod", "tmp_container_runtime"]
       }
       forward_to = [loki.process.logs_service.receiver]
     }
@@ -59639,7 +59623,7 @@ data:
     
     loki.process "pod_logs" {
       stage.match {
-        selector = "{tmp_container_runtime=\"containerd\"}"
+        selector = "{tmp_container_runtime=~\"containerd|cri-o\"}"
         // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
         stage.cri {}
     
@@ -59652,21 +59636,6 @@ data:
         }
       }
     
-      stage.match {
-        selector = "{tmp_container_runtime=\"cri-o\"}"
-        // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
-        stage.cri {}
-    
-        // Set the extract flags and stream values as labels
-        stage.labels {
-          values = {
-            flags  = "",
-            stream  = "",
-          }
-        }
-      }
-    
-      // if the label tmp_container_runtime from above is docker parse using docker
       stage.match {
         selector = "{tmp_container_runtime=\"docker\"}"
         // the docker processing stage extracts the following k/v pairs: log, stream, time
@@ -59680,11 +59649,18 @@ data:
         }
       }
     
-      // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have
-      // cluster, namespace, pod, and container labels.
-      // Also drop the temporary container runtime label as it is no longer needed.
+      // Move high-cardinality labels to structured metadata
+      stage.structured_metadata {
+        values = {
+          pod  = "",
+        }
+      }
+    
+      // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
+      // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+      // container runtime label as it is no longer needed.
       stage.label_drop {
-        values = ["filename", "tmp_container_runtime"]
+        values = ["filename", "pod", "tmp_container_runtime"]
       }
       forward_to = [loki.process.logs_service.receiver]
     }
@@ -59858,7 +59834,7 @@ data:
     
     loki.process "pod_logs" {
       stage.match {
-        selector = "{tmp_container_runtime=\"containerd\"}"
+        selector = "{tmp_container_runtime=~\"containerd|cri-o\"}"
         // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
         stage.cri {}
     
@@ -59871,21 +59847,6 @@ data:
         }
       }
     
-      stage.match {
-        selector = "{tmp_container_runtime=\"cri-o\"}"
-        // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
-        stage.cri {}
-    
-        // Set the extract flags and stream values as labels
-        stage.labels {
-          values = {
-            flags  = "",
-            stream  = "",
-          }
-        }
-      }
-    
-      // if the label tmp_container_runtime from above is docker parse using docker
       stage.match {
         selector = "{tmp_container_runtime=\"docker\"}"
         // the docker processing stage extracts the following k/v pairs: log, stream, time
@@ -59899,11 +59860,18 @@ data:
         }
       }
     
-      // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have
-      // cluster, namespace, pod, and container labels.
-      // Also drop the temporary container runtime label as it is no longer needed.
+      // Move high-cardinality labels to structured metadata
+      stage.structured_metadata {
+        values = {
+          pod  = "",
+        }
+      }
+    
+      // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
+      // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+      // container runtime label as it is no longer needed.
       stage.label_drop {
-        values = ["filename", "tmp_container_runtime"]
+        values = ["filename", "pod", "tmp_container_runtime"]
       }
       forward_to = [loki.process.logs_service.receiver]
     }

--- a/examples/otel-metrics-service/logs.alloy
+++ b/examples/otel-metrics-service/logs.alloy
@@ -82,7 +82,7 @@ loki.source.file "pod_logs" {
 
 loki.process "pod_logs" {
   stage.match {
-    selector = "{tmp_container_runtime=\"containerd\"}"
+    selector = "{tmp_container_runtime=~\"containerd|cri-o\"}"
     // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
     stage.cri {}
 
@@ -95,21 +95,6 @@ loki.process "pod_logs" {
     }
   }
 
-  stage.match {
-    selector = "{tmp_container_runtime=\"cri-o\"}"
-    // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
-    stage.cri {}
-
-    // Set the extract flags and stream values as labels
-    stage.labels {
-      values = {
-        flags  = "",
-        stream  = "",
-      }
-    }
-  }
-
-  // if the label tmp_container_runtime from above is docker parse using docker
   stage.match {
     selector = "{tmp_container_runtime=\"docker\"}"
     // the docker processing stage extracts the following k/v pairs: log, stream, time
@@ -123,11 +108,18 @@ loki.process "pod_logs" {
     }
   }
 
-  // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have
-  // cluster, namespace, pod, and container labels.
-  // Also drop the temporary container runtime label as it is no longer needed.
+  // Move high-cardinality labels to structured metadata
+  stage.structured_metadata {
+    values = {
+      pod  = "",
+    }
+  }
+
+  // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
+  // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+  // container runtime label as it is no longer needed.
   stage.label_drop {
-    values = ["filename", "tmp_container_runtime"]
+    values = ["filename", "pod", "tmp_container_runtime"]
   }
   forward_to = [loki.process.logs_service.receiver]
 }

--- a/examples/otel-metrics-service/metrics.alloy
+++ b/examples/otel-metrics-service/metrics.alloy
@@ -781,7 +781,7 @@ otelcol.exporter.otlphttp "metrics_service" {
 
 loki.process "pod_logs" {
   stage.match {
-    selector = "{tmp_container_runtime=\"containerd\"}"
+    selector = "{tmp_container_runtime=~\"containerd|cri-o\"}"
     // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
     stage.cri {}
 
@@ -794,21 +794,6 @@ loki.process "pod_logs" {
     }
   }
 
-  stage.match {
-    selector = "{tmp_container_runtime=\"cri-o\"}"
-    // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
-    stage.cri {}
-
-    // Set the extract flags and stream values as labels
-    stage.labels {
-      values = {
-        flags  = "",
-        stream  = "",
-      }
-    }
-  }
-
-  // if the label tmp_container_runtime from above is docker parse using docker
   stage.match {
     selector = "{tmp_container_runtime=\"docker\"}"
     // the docker processing stage extracts the following k/v pairs: log, stream, time
@@ -822,11 +807,18 @@ loki.process "pod_logs" {
     }
   }
 
-  // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have
-  // cluster, namespace, pod, and container labels.
-  // Also drop the temporary container runtime label as it is no longer needed.
+  // Move high-cardinality labels to structured metadata
+  stage.structured_metadata {
+    values = {
+      pod  = "",
+    }
+  }
+
+  // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
+  // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+  // container runtime label as it is no longer needed.
   stage.label_drop {
-    values = ["filename", "tmp_container_runtime"]
+    values = ["filename", "pod", "tmp_container_runtime"]
   }
   forward_to = [loki.process.logs_service.receiver]
 }

--- a/examples/otel-metrics-service/output.yaml
+++ b/examples/otel-metrics-service/output.yaml
@@ -911,7 +911,7 @@ data:
     
     loki.process "pod_logs" {
       stage.match {
-        selector = "{tmp_container_runtime=\"containerd\"}"
+        selector = "{tmp_container_runtime=~\"containerd|cri-o\"}"
         // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
         stage.cri {}
     
@@ -924,21 +924,6 @@ data:
         }
       }
     
-      stage.match {
-        selector = "{tmp_container_runtime=\"cri-o\"}"
-        // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
-        stage.cri {}
-    
-        // Set the extract flags and stream values as labels
-        stage.labels {
-          values = {
-            flags  = "",
-            stream  = "",
-          }
-        }
-      }
-    
-      // if the label tmp_container_runtime from above is docker parse using docker
       stage.match {
         selector = "{tmp_container_runtime=\"docker\"}"
         // the docker processing stage extracts the following k/v pairs: log, stream, time
@@ -952,11 +937,18 @@ data:
         }
       }
     
-      // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have
-      // cluster, namespace, pod, and container labels.
-      // Also drop the temporary container runtime label as it is no longer needed.
+      // Move high-cardinality labels to structured metadata
+      stage.structured_metadata {
+        values = {
+          pod  = "",
+        }
+      }
+    
+      // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
+      // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+      // container runtime label as it is no longer needed.
       stage.label_drop {
-        values = ["filename", "tmp_container_runtime"]
+        values = ["filename", "pod", "tmp_container_runtime"]
       }
       forward_to = [loki.process.logs_service.receiver]
     }
@@ -1144,7 +1136,7 @@ data:
     
     loki.process "pod_logs" {
       stage.match {
-        selector = "{tmp_container_runtime=\"containerd\"}"
+        selector = "{tmp_container_runtime=~\"containerd|cri-o\"}"
         // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
         stage.cri {}
     
@@ -1157,21 +1149,6 @@ data:
         }
       }
     
-      stage.match {
-        selector = "{tmp_container_runtime=\"cri-o\"}"
-        // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
-        stage.cri {}
-    
-        // Set the extract flags and stream values as labels
-        stage.labels {
-          values = {
-            flags  = "",
-            stream  = "",
-          }
-        }
-      }
-    
-      // if the label tmp_container_runtime from above is docker parse using docker
       stage.match {
         selector = "{tmp_container_runtime=\"docker\"}"
         // the docker processing stage extracts the following k/v pairs: log, stream, time
@@ -1185,11 +1162,18 @@ data:
         }
       }
     
-      // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have
-      // cluster, namespace, pod, and container labels.
-      // Also drop the temporary container runtime label as it is no longer needed.
+      // Move high-cardinality labels to structured metadata
+      stage.structured_metadata {
+        values = {
+          pod  = "",
+        }
+      }
+    
+      // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
+      // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+      // container runtime label as it is no longer needed.
       stage.label_drop {
-        values = ["filename", "tmp_container_runtime"]
+        values = ["filename", "pod", "tmp_container_runtime"]
       }
       forward_to = [loki.process.logs_service.receiver]
     }
@@ -59825,7 +59809,7 @@ data:
     
     loki.process "pod_logs" {
       stage.match {
-        selector = "{tmp_container_runtime=\"containerd\"}"
+        selector = "{tmp_container_runtime=~\"containerd|cri-o\"}"
         // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
         stage.cri {}
     
@@ -59838,21 +59822,6 @@ data:
         }
       }
     
-      stage.match {
-        selector = "{tmp_container_runtime=\"cri-o\"}"
-        // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
-        stage.cri {}
-    
-        // Set the extract flags and stream values as labels
-        stage.labels {
-          values = {
-            flags  = "",
-            stream  = "",
-          }
-        }
-      }
-    
-      // if the label tmp_container_runtime from above is docker parse using docker
       stage.match {
         selector = "{tmp_container_runtime=\"docker\"}"
         // the docker processing stage extracts the following k/v pairs: log, stream, time
@@ -59866,11 +59835,18 @@ data:
         }
       }
     
-      // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have
-      // cluster, namespace, pod, and container labels.
-      // Also drop the temporary container runtime label as it is no longer needed.
+      // Move high-cardinality labels to structured metadata
+      stage.structured_metadata {
+        values = {
+          pod  = "",
+        }
+      }
+    
+      // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
+      // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+      // container runtime label as it is no longer needed.
       stage.label_drop {
-        values = ["filename", "tmp_container_runtime"]
+        values = ["filename", "pod", "tmp_container_runtime"]
       }
       forward_to = [loki.process.logs_service.receiver]
     }
@@ -60042,7 +60018,7 @@ data:
     
     loki.process "pod_logs" {
       stage.match {
-        selector = "{tmp_container_runtime=\"containerd\"}"
+        selector = "{tmp_container_runtime=~\"containerd|cri-o\"}"
         // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
         stage.cri {}
     
@@ -60055,21 +60031,6 @@ data:
         }
       }
     
-      stage.match {
-        selector = "{tmp_container_runtime=\"cri-o\"}"
-        // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
-        stage.cri {}
-    
-        // Set the extract flags and stream values as labels
-        stage.labels {
-          values = {
-            flags  = "",
-            stream  = "",
-          }
-        }
-      }
-    
-      // if the label tmp_container_runtime from above is docker parse using docker
       stage.match {
         selector = "{tmp_container_runtime=\"docker\"}"
         // the docker processing stage extracts the following k/v pairs: log, stream, time
@@ -60083,11 +60044,18 @@ data:
         }
       }
     
-      // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have
-      // cluster, namespace, pod, and container labels.
-      // Also drop the temporary container runtime label as it is no longer needed.
+      // Move high-cardinality labels to structured metadata
+      stage.structured_metadata {
+        values = {
+          pod  = "",
+        }
+      }
+    
+      // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
+      // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+      // container runtime label as it is no longer needed.
       stage.label_drop {
-        values = ["filename", "tmp_container_runtime"]
+        values = ["filename", "pod", "tmp_container_runtime"]
       }
       forward_to = [loki.process.logs_service.receiver]
     }

--- a/examples/pod-labels/logs.alloy
+++ b/examples/pod-labels/logs.alloy
@@ -88,7 +88,7 @@ loki.source.file "pod_logs" {
 
 loki.process "pod_logs" {
   stage.match {
-    selector = "{tmp_container_runtime=\"containerd\"}"
+    selector = "{tmp_container_runtime=~\"containerd|cri-o\"}"
     // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
     stage.cri {}
 
@@ -101,21 +101,6 @@ loki.process "pod_logs" {
     }
   }
 
-  stage.match {
-    selector = "{tmp_container_runtime=\"cri-o\"}"
-    // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
-    stage.cri {}
-
-    // Set the extract flags and stream values as labels
-    stage.labels {
-      values = {
-        flags  = "",
-        stream  = "",
-      }
-    }
-  }
-
-  // if the label tmp_container_runtime from above is docker parse using docker
   stage.match {
     selector = "{tmp_container_runtime=\"docker\"}"
     // the docker processing stage extracts the following k/v pairs: log, stream, time
@@ -129,11 +114,18 @@ loki.process "pod_logs" {
     }
   }
 
-  // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have
-  // cluster, namespace, pod, and container labels.
-  // Also drop the temporary container runtime label as it is no longer needed.
+  // Move high-cardinality labels to structured metadata
+  stage.structured_metadata {
+    values = {
+      pod  = "",
+    }
+  }
+
+  // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
+  // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+  // container runtime label as it is no longer needed.
   stage.label_drop {
-    values = ["filename", "tmp_container_runtime"]
+    values = ["filename", "pod", "tmp_container_runtime"]
   }
   forward_to = [loki.process.logs_service.receiver]
 }

--- a/examples/pod-labels/metrics.alloy
+++ b/examples/pod-labels/metrics.alloy
@@ -801,7 +801,7 @@ prometheus.remote_write "metrics_service" {
 
 loki.process "pod_logs" {
   stage.match {
-    selector = "{tmp_container_runtime=\"containerd\"}"
+    selector = "{tmp_container_runtime=~\"containerd|cri-o\"}"
     // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
     stage.cri {}
 
@@ -814,21 +814,6 @@ loki.process "pod_logs" {
     }
   }
 
-  stage.match {
-    selector = "{tmp_container_runtime=\"cri-o\"}"
-    // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
-    stage.cri {}
-
-    // Set the extract flags and stream values as labels
-    stage.labels {
-      values = {
-        flags  = "",
-        stream  = "",
-      }
-    }
-  }
-
-  // if the label tmp_container_runtime from above is docker parse using docker
   stage.match {
     selector = "{tmp_container_runtime=\"docker\"}"
     // the docker processing stage extracts the following k/v pairs: log, stream, time
@@ -842,11 +827,18 @@ loki.process "pod_logs" {
     }
   }
 
-  // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have
-  // cluster, namespace, pod, and container labels.
-  // Also drop the temporary container runtime label as it is no longer needed.
+  // Move high-cardinality labels to structured metadata
+  stage.structured_metadata {
+    values = {
+      pod  = "",
+    }
+  }
+
+  // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
+  // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+  // container runtime label as it is no longer needed.
   stage.label_drop {
-    values = ["filename", "tmp_container_runtime"]
+    values = ["filename", "pod", "tmp_container_runtime"]
   }
   forward_to = [loki.process.logs_service.receiver]
 }

--- a/examples/pod-labels/output.yaml
+++ b/examples/pod-labels/output.yaml
@@ -944,7 +944,7 @@ data:
     
     loki.process "pod_logs" {
       stage.match {
-        selector = "{tmp_container_runtime=\"containerd\"}"
+        selector = "{tmp_container_runtime=~\"containerd|cri-o\"}"
         // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
         stage.cri {}
     
@@ -957,21 +957,6 @@ data:
         }
       }
     
-      stage.match {
-        selector = "{tmp_container_runtime=\"cri-o\"}"
-        // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
-        stage.cri {}
-    
-        // Set the extract flags and stream values as labels
-        stage.labels {
-          values = {
-            flags  = "",
-            stream  = "",
-          }
-        }
-      }
-    
-      // if the label tmp_container_runtime from above is docker parse using docker
       stage.match {
         selector = "{tmp_container_runtime=\"docker\"}"
         // the docker processing stage extracts the following k/v pairs: log, stream, time
@@ -985,11 +970,18 @@ data:
         }
       }
     
-      // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have
-      // cluster, namespace, pod, and container labels.
-      // Also drop the temporary container runtime label as it is no longer needed.
+      // Move high-cardinality labels to structured metadata
+      stage.structured_metadata {
+        values = {
+          pod  = "",
+        }
+      }
+    
+      // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
+      // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+      // container runtime label as it is no longer needed.
       stage.label_drop {
-        values = ["filename", "tmp_container_runtime"]
+        values = ["filename", "pod", "tmp_container_runtime"]
       }
       forward_to = [loki.process.logs_service.receiver]
     }
@@ -1203,7 +1195,7 @@ data:
     
     loki.process "pod_logs" {
       stage.match {
-        selector = "{tmp_container_runtime=\"containerd\"}"
+        selector = "{tmp_container_runtime=~\"containerd|cri-o\"}"
         // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
         stage.cri {}
     
@@ -1216,21 +1208,6 @@ data:
         }
       }
     
-      stage.match {
-        selector = "{tmp_container_runtime=\"cri-o\"}"
-        // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
-        stage.cri {}
-    
-        // Set the extract flags and stream values as labels
-        stage.labels {
-          values = {
-            flags  = "",
-            stream  = "",
-          }
-        }
-      }
-    
-      // if the label tmp_container_runtime from above is docker parse using docker
       stage.match {
         selector = "{tmp_container_runtime=\"docker\"}"
         // the docker processing stage extracts the following k/v pairs: log, stream, time
@@ -1244,11 +1221,18 @@ data:
         }
       }
     
-      // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have
-      // cluster, namespace, pod, and container labels.
-      // Also drop the temporary container runtime label as it is no longer needed.
+      // Move high-cardinality labels to structured metadata
+      stage.structured_metadata {
+        values = {
+          pod  = "",
+        }
+      }
+    
+      // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
+      // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+      // container runtime label as it is no longer needed.
       stage.label_drop {
-        values = ["filename", "tmp_container_runtime"]
+        values = ["filename", "pod", "tmp_container_runtime"]
       }
       forward_to = [loki.process.logs_service.receiver]
     }
@@ -59905,7 +59889,7 @@ data:
     
     loki.process "pod_logs" {
       stage.match {
-        selector = "{tmp_container_runtime=\"containerd\"}"
+        selector = "{tmp_container_runtime=~\"containerd|cri-o\"}"
         // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
         stage.cri {}
     
@@ -59918,21 +59902,6 @@ data:
         }
       }
     
-      stage.match {
-        selector = "{tmp_container_runtime=\"cri-o\"}"
-        // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
-        stage.cri {}
-    
-        // Set the extract flags and stream values as labels
-        stage.labels {
-          values = {
-            flags  = "",
-            stream  = "",
-          }
-        }
-      }
-    
-      // if the label tmp_container_runtime from above is docker parse using docker
       stage.match {
         selector = "{tmp_container_runtime=\"docker\"}"
         // the docker processing stage extracts the following k/v pairs: log, stream, time
@@ -59946,11 +59915,18 @@ data:
         }
       }
     
-      // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have
-      // cluster, namespace, pod, and container labels.
-      // Also drop the temporary container runtime label as it is no longer needed.
+      // Move high-cardinality labels to structured metadata
+      stage.structured_metadata {
+        values = {
+          pod  = "",
+        }
+      }
+    
+      // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
+      // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+      // container runtime label as it is no longer needed.
       stage.label_drop {
-        values = ["filename", "tmp_container_runtime"]
+        values = ["filename", "pod", "tmp_container_runtime"]
       }
       forward_to = [loki.process.logs_service.receiver]
     }
@@ -60148,7 +60124,7 @@ data:
     
     loki.process "pod_logs" {
       stage.match {
-        selector = "{tmp_container_runtime=\"containerd\"}"
+        selector = "{tmp_container_runtime=~\"containerd|cri-o\"}"
         // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
         stage.cri {}
     
@@ -60161,21 +60137,6 @@ data:
         }
       }
     
-      stage.match {
-        selector = "{tmp_container_runtime=\"cri-o\"}"
-        // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
-        stage.cri {}
-    
-        // Set the extract flags and stream values as labels
-        stage.labels {
-          values = {
-            flags  = "",
-            stream  = "",
-          }
-        }
-      }
-    
-      // if the label tmp_container_runtime from above is docker parse using docker
       stage.match {
         selector = "{tmp_container_runtime=\"docker\"}"
         // the docker processing stage extracts the following k/v pairs: log, stream, time
@@ -60189,11 +60150,18 @@ data:
         }
       }
     
-      // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have
-      // cluster, namespace, pod, and container labels.
-      // Also drop the temporary container runtime label as it is no longer needed.
+      // Move high-cardinality labels to structured metadata
+      stage.structured_metadata {
+        values = {
+          pod  = "",
+        }
+      }
+    
+      // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
+      // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+      // container runtime label as it is no longer needed.
       stage.label_drop {
-        values = ["filename", "tmp_container_runtime"]
+        values = ["filename", "pod", "tmp_container_runtime"]
       }
       forward_to = [loki.process.logs_service.receiver]
     }

--- a/examples/private-image-registry/logs.alloy
+++ b/examples/private-image-registry/logs.alloy
@@ -82,7 +82,7 @@ loki.source.file "pod_logs" {
 
 loki.process "pod_logs" {
   stage.match {
-    selector = "{tmp_container_runtime=\"containerd\"}"
+    selector = "{tmp_container_runtime=~\"containerd|cri-o\"}"
     // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
     stage.cri {}
 
@@ -95,21 +95,6 @@ loki.process "pod_logs" {
     }
   }
 
-  stage.match {
-    selector = "{tmp_container_runtime=\"cri-o\"}"
-    // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
-    stage.cri {}
-
-    // Set the extract flags and stream values as labels
-    stage.labels {
-      values = {
-        flags  = "",
-        stream  = "",
-      }
-    }
-  }
-
-  // if the label tmp_container_runtime from above is docker parse using docker
   stage.match {
     selector = "{tmp_container_runtime=\"docker\"}"
     // the docker processing stage extracts the following k/v pairs: log, stream, time
@@ -123,11 +108,18 @@ loki.process "pod_logs" {
     }
   }
 
-  // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have
-  // cluster, namespace, pod, and container labels.
-  // Also drop the temporary container runtime label as it is no longer needed.
+  // Move high-cardinality labels to structured metadata
+  stage.structured_metadata {
+    values = {
+      pod  = "",
+    }
+  }
+
+  // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
+  // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+  // container runtime label as it is no longer needed.
   stage.label_drop {
-    values = ["filename", "tmp_container_runtime"]
+    values = ["filename", "pod", "tmp_container_runtime"]
   }
   forward_to = [loki.process.logs_service.receiver]
 }

--- a/examples/private-image-registry/metrics.alloy
+++ b/examples/private-image-registry/metrics.alloy
@@ -764,7 +764,7 @@ prometheus.remote_write "metrics_service" {
 
 loki.process "pod_logs" {
   stage.match {
-    selector = "{tmp_container_runtime=\"containerd\"}"
+    selector = "{tmp_container_runtime=~\"containerd|cri-o\"}"
     // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
     stage.cri {}
 
@@ -777,21 +777,6 @@ loki.process "pod_logs" {
     }
   }
 
-  stage.match {
-    selector = "{tmp_container_runtime=\"cri-o\"}"
-    // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
-    stage.cri {}
-
-    // Set the extract flags and stream values as labels
-    stage.labels {
-      values = {
-        flags  = "",
-        stream  = "",
-      }
-    }
-  }
-
-  // if the label tmp_container_runtime from above is docker parse using docker
   stage.match {
     selector = "{tmp_container_runtime=\"docker\"}"
     // the docker processing stage extracts the following k/v pairs: log, stream, time
@@ -805,11 +790,18 @@ loki.process "pod_logs" {
     }
   }
 
-  // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have
-  // cluster, namespace, pod, and container labels.
-  // Also drop the temporary container runtime label as it is no longer needed.
+  // Move high-cardinality labels to structured metadata
+  stage.structured_metadata {
+    values = {
+      pod  = "",
+    }
+  }
+
+  // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
+  // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+  // container runtime label as it is no longer needed.
   stage.label_drop {
-    values = ["filename", "tmp_container_runtime"]
+    values = ["filename", "pod", "tmp_container_runtime"]
   }
   forward_to = [loki.process.logs_service.receiver]
 }

--- a/examples/private-image-registry/output.yaml
+++ b/examples/private-image-registry/output.yaml
@@ -898,7 +898,7 @@ data:
     
     loki.process "pod_logs" {
       stage.match {
-        selector = "{tmp_container_runtime=\"containerd\"}"
+        selector = "{tmp_container_runtime=~\"containerd|cri-o\"}"
         // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
         stage.cri {}
     
@@ -911,21 +911,6 @@ data:
         }
       }
     
-      stage.match {
-        selector = "{tmp_container_runtime=\"cri-o\"}"
-        // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
-        stage.cri {}
-    
-        // Set the extract flags and stream values as labels
-        stage.labels {
-          values = {
-            flags  = "",
-            stream  = "",
-          }
-        }
-      }
-    
-      // if the label tmp_container_runtime from above is docker parse using docker
       stage.match {
         selector = "{tmp_container_runtime=\"docker\"}"
         // the docker processing stage extracts the following k/v pairs: log, stream, time
@@ -939,11 +924,18 @@ data:
         }
       }
     
-      // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have
-      // cluster, namespace, pod, and container labels.
-      // Also drop the temporary container runtime label as it is no longer needed.
+      // Move high-cardinality labels to structured metadata
+      stage.structured_metadata {
+        values = {
+          pod  = "",
+        }
+      }
+    
+      // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
+      // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+      // container runtime label as it is no longer needed.
       stage.label_drop {
-        values = ["filename", "tmp_container_runtime"]
+        values = ["filename", "pod", "tmp_container_runtime"]
       }
       forward_to = [loki.process.logs_service.receiver]
     }
@@ -1131,7 +1123,7 @@ data:
     
     loki.process "pod_logs" {
       stage.match {
-        selector = "{tmp_container_runtime=\"containerd\"}"
+        selector = "{tmp_container_runtime=~\"containerd|cri-o\"}"
         // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
         stage.cri {}
     
@@ -1144,21 +1136,6 @@ data:
         }
       }
     
-      stage.match {
-        selector = "{tmp_container_runtime=\"cri-o\"}"
-        // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
-        stage.cri {}
-    
-        // Set the extract flags and stream values as labels
-        stage.labels {
-          values = {
-            flags  = "",
-            stream  = "",
-          }
-        }
-      }
-    
-      // if the label tmp_container_runtime from above is docker parse using docker
       stage.match {
         selector = "{tmp_container_runtime=\"docker\"}"
         // the docker processing stage extracts the following k/v pairs: log, stream, time
@@ -1172,11 +1149,18 @@ data:
         }
       }
     
-      // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have
-      // cluster, namespace, pod, and container labels.
-      // Also drop the temporary container runtime label as it is no longer needed.
+      // Move high-cardinality labels to structured metadata
+      stage.structured_metadata {
+        values = {
+          pod  = "",
+        }
+      }
+    
+      // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
+      // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+      // container runtime label as it is no longer needed.
       stage.label_drop {
-        values = ["filename", "tmp_container_runtime"]
+        values = ["filename", "pod", "tmp_container_runtime"]
       }
       forward_to = [loki.process.logs_service.receiver]
     }
@@ -59807,7 +59791,7 @@ data:
     
     loki.process "pod_logs" {
       stage.match {
-        selector = "{tmp_container_runtime=\"containerd\"}"
+        selector = "{tmp_container_runtime=~\"containerd|cri-o\"}"
         // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
         stage.cri {}
     
@@ -59820,21 +59804,6 @@ data:
         }
       }
     
-      stage.match {
-        selector = "{tmp_container_runtime=\"cri-o\"}"
-        // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
-        stage.cri {}
-    
-        // Set the extract flags and stream values as labels
-        stage.labels {
-          values = {
-            flags  = "",
-            stream  = "",
-          }
-        }
-      }
-    
-      // if the label tmp_container_runtime from above is docker parse using docker
       stage.match {
         selector = "{tmp_container_runtime=\"docker\"}"
         // the docker processing stage extracts the following k/v pairs: log, stream, time
@@ -59848,11 +59817,18 @@ data:
         }
       }
     
-      // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have
-      // cluster, namespace, pod, and container labels.
-      // Also drop the temporary container runtime label as it is no longer needed.
+      // Move high-cardinality labels to structured metadata
+      stage.structured_metadata {
+        values = {
+          pod  = "",
+        }
+      }
+    
+      // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
+      // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+      // container runtime label as it is no longer needed.
       stage.label_drop {
-        values = ["filename", "tmp_container_runtime"]
+        values = ["filename", "pod", "tmp_container_runtime"]
       }
       forward_to = [loki.process.logs_service.receiver]
     }
@@ -60024,7 +60000,7 @@ data:
     
     loki.process "pod_logs" {
       stage.match {
-        selector = "{tmp_container_runtime=\"containerd\"}"
+        selector = "{tmp_container_runtime=~\"containerd|cri-o\"}"
         // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
         stage.cri {}
     
@@ -60037,21 +60013,6 @@ data:
         }
       }
     
-      stage.match {
-        selector = "{tmp_container_runtime=\"cri-o\"}"
-        // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
-        stage.cri {}
-    
-        // Set the extract flags and stream values as labels
-        stage.labels {
-          values = {
-            flags  = "",
-            stream  = "",
-          }
-        }
-      }
-    
-      // if the label tmp_container_runtime from above is docker parse using docker
       stage.match {
         selector = "{tmp_container_runtime=\"docker\"}"
         // the docker processing stage extracts the following k/v pairs: log, stream, time
@@ -60065,11 +60026,18 @@ data:
         }
       }
     
-      // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have
-      // cluster, namespace, pod, and container labels.
-      // Also drop the temporary container runtime label as it is no longer needed.
+      // Move high-cardinality labels to structured metadata
+      stage.structured_metadata {
+        values = {
+          pod  = "",
+        }
+      }
+    
+      // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
+      // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+      // container runtime label as it is no longer needed.
       stage.label_drop {
-        values = ["filename", "tmp_container_runtime"]
+        values = ["filename", "pod", "tmp_container_runtime"]
       }
       forward_to = [loki.process.logs_service.receiver]
     }

--- a/examples/profiles-enabled/logs.alloy
+++ b/examples/profiles-enabled/logs.alloy
@@ -82,7 +82,7 @@ loki.source.file "pod_logs" {
 
 loki.process "pod_logs" {
   stage.match {
-    selector = "{tmp_container_runtime=\"containerd\"}"
+    selector = "{tmp_container_runtime=~\"containerd|cri-o\"}"
     // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
     stage.cri {}
 
@@ -95,21 +95,6 @@ loki.process "pod_logs" {
     }
   }
 
-  stage.match {
-    selector = "{tmp_container_runtime=\"cri-o\"}"
-    // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
-    stage.cri {}
-
-    // Set the extract flags and stream values as labels
-    stage.labels {
-      values = {
-        flags  = "",
-        stream  = "",
-      }
-    }
-  }
-
-  // if the label tmp_container_runtime from above is docker parse using docker
   stage.match {
     selector = "{tmp_container_runtime=\"docker\"}"
     // the docker processing stage extracts the following k/v pairs: log, stream, time
@@ -123,11 +108,18 @@ loki.process "pod_logs" {
     }
   }
 
-  // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have
-  // cluster, namespace, pod, and container labels.
-  // Also drop the temporary container runtime label as it is no longer needed.
+  // Move high-cardinality labels to structured metadata
+  stage.structured_metadata {
+    values = {
+      pod  = "",
+    }
+  }
+
+  // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
+  // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+  // container runtime label as it is no longer needed.
   stage.label_drop {
-    values = ["filename", "tmp_container_runtime"]
+    values = ["filename", "pod", "tmp_container_runtime"]
   }
   forward_to = [loki.process.logs_service.receiver]
 }

--- a/examples/profiles-enabled/metrics.alloy
+++ b/examples/profiles-enabled/metrics.alloy
@@ -764,7 +764,7 @@ prometheus.remote_write "metrics_service" {
 
 loki.process "pod_logs" {
   stage.match {
-    selector = "{tmp_container_runtime=\"containerd\"}"
+    selector = "{tmp_container_runtime=~\"containerd|cri-o\"}"
     // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
     stage.cri {}
 
@@ -777,21 +777,6 @@ loki.process "pod_logs" {
     }
   }
 
-  stage.match {
-    selector = "{tmp_container_runtime=\"cri-o\"}"
-    // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
-    stage.cri {}
-
-    // Set the extract flags and stream values as labels
-    stage.labels {
-      values = {
-        flags  = "",
-        stream  = "",
-      }
-    }
-  }
-
-  // if the label tmp_container_runtime from above is docker parse using docker
   stage.match {
     selector = "{tmp_container_runtime=\"docker\"}"
     // the docker processing stage extracts the following k/v pairs: log, stream, time
@@ -805,11 +790,18 @@ loki.process "pod_logs" {
     }
   }
 
-  // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have
-  // cluster, namespace, pod, and container labels.
-  // Also drop the temporary container runtime label as it is no longer needed.
+  // Move high-cardinality labels to structured metadata
+  stage.structured_metadata {
+    values = {
+      pod  = "",
+    }
+  }
+
+  // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
+  // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+  // container runtime label as it is no longer needed.
   stage.label_drop {
-    values = ["filename", "tmp_container_runtime"]
+    values = ["filename", "pod", "tmp_container_runtime"]
   }
   forward_to = [loki.process.logs_service.receiver]
 }

--- a/examples/profiles-enabled/output.yaml
+++ b/examples/profiles-enabled/output.yaml
@@ -923,7 +923,7 @@ data:
     
     loki.process "pod_logs" {
       stage.match {
-        selector = "{tmp_container_runtime=\"containerd\"}"
+        selector = "{tmp_container_runtime=~\"containerd|cri-o\"}"
         // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
         stage.cri {}
     
@@ -936,21 +936,6 @@ data:
         }
       }
     
-      stage.match {
-        selector = "{tmp_container_runtime=\"cri-o\"}"
-        // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
-        stage.cri {}
-    
-        // Set the extract flags and stream values as labels
-        stage.labels {
-          values = {
-            flags  = "",
-            stream  = "",
-          }
-        }
-      }
-    
-      // if the label tmp_container_runtime from above is docker parse using docker
       stage.match {
         selector = "{tmp_container_runtime=\"docker\"}"
         // the docker processing stage extracts the following k/v pairs: log, stream, time
@@ -964,11 +949,18 @@ data:
         }
       }
     
-      // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have
-      // cluster, namespace, pod, and container labels.
-      // Also drop the temporary container runtime label as it is no longer needed.
+      // Move high-cardinality labels to structured metadata
+      stage.structured_metadata {
+        values = {
+          pod  = "",
+        }
+      }
+    
+      // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
+      // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+      // container runtime label as it is no longer needed.
       stage.label_drop {
-        values = ["filename", "tmp_container_runtime"]
+        values = ["filename", "pod", "tmp_container_runtime"]
       }
       forward_to = [loki.process.logs_service.receiver]
     }
@@ -1156,7 +1148,7 @@ data:
     
     loki.process "pod_logs" {
       stage.match {
-        selector = "{tmp_container_runtime=\"containerd\"}"
+        selector = "{tmp_container_runtime=~\"containerd|cri-o\"}"
         // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
         stage.cri {}
     
@@ -1169,21 +1161,6 @@ data:
         }
       }
     
-      stage.match {
-        selector = "{tmp_container_runtime=\"cri-o\"}"
-        // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
-        stage.cri {}
-    
-        // Set the extract flags and stream values as labels
-        stage.labels {
-          values = {
-            flags  = "",
-            stream  = "",
-          }
-        }
-      }
-    
-      // if the label tmp_container_runtime from above is docker parse using docker
       stage.match {
         selector = "{tmp_container_runtime=\"docker\"}"
         // the docker processing stage extracts the following k/v pairs: log, stream, time
@@ -1197,11 +1174,18 @@ data:
         }
       }
     
-      // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have
-      // cluster, namespace, pod, and container labels.
-      // Also drop the temporary container runtime label as it is no longer needed.
+      // Move high-cardinality labels to structured metadata
+      stage.structured_metadata {
+        values = {
+          pod  = "",
+        }
+      }
+    
+      // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
+      // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+      // container runtime label as it is no longer needed.
       stage.label_drop {
-        values = ["filename", "tmp_container_runtime"]
+        values = ["filename", "pod", "tmp_container_runtime"]
       }
       forward_to = [loki.process.logs_service.receiver]
     }
@@ -60982,7 +60966,7 @@ data:
     
     loki.process "pod_logs" {
       stage.match {
-        selector = "{tmp_container_runtime=\"containerd\"}"
+        selector = "{tmp_container_runtime=~\"containerd|cri-o\"}"
         // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
         stage.cri {}
     
@@ -60995,21 +60979,6 @@ data:
         }
       }
     
-      stage.match {
-        selector = "{tmp_container_runtime=\"cri-o\"}"
-        // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
-        stage.cri {}
-    
-        // Set the extract flags and stream values as labels
-        stage.labels {
-          values = {
-            flags  = "",
-            stream  = "",
-          }
-        }
-      }
-    
-      // if the label tmp_container_runtime from above is docker parse using docker
       stage.match {
         selector = "{tmp_container_runtime=\"docker\"}"
         // the docker processing stage extracts the following k/v pairs: log, stream, time
@@ -61023,11 +60992,18 @@ data:
         }
       }
     
-      // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have
-      // cluster, namespace, pod, and container labels.
-      // Also drop the temporary container runtime label as it is no longer needed.
+      // Move high-cardinality labels to structured metadata
+      stage.structured_metadata {
+        values = {
+          pod  = "",
+        }
+      }
+    
+      // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
+      // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+      // container runtime label as it is no longer needed.
       stage.label_drop {
-        values = ["filename", "tmp_container_runtime"]
+        values = ["filename", "pod", "tmp_container_runtime"]
       }
       forward_to = [loki.process.logs_service.receiver]
     }
@@ -61199,7 +61175,7 @@ data:
     
     loki.process "pod_logs" {
       stage.match {
-        selector = "{tmp_container_runtime=\"containerd\"}"
+        selector = "{tmp_container_runtime=~\"containerd|cri-o\"}"
         // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
         stage.cri {}
     
@@ -61212,21 +61188,6 @@ data:
         }
       }
     
-      stage.match {
-        selector = "{tmp_container_runtime=\"cri-o\"}"
-        // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
-        stage.cri {}
-    
-        // Set the extract flags and stream values as labels
-        stage.labels {
-          values = {
-            flags  = "",
-            stream  = "",
-          }
-        }
-      }
-    
-      // if the label tmp_container_runtime from above is docker parse using docker
       stage.match {
         selector = "{tmp_container_runtime=\"docker\"}"
         // the docker processing stage extracts the following k/v pairs: log, stream, time
@@ -61240,11 +61201,18 @@ data:
         }
       }
     
-      // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have
-      // cluster, namespace, pod, and container labels.
-      // Also drop the temporary container runtime label as it is no longer needed.
+      // Move high-cardinality labels to structured metadata
+      stage.structured_metadata {
+        values = {
+          pod  = "",
+        }
+      }
+    
+      // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
+      // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+      // container runtime label as it is no longer needed.
       stage.label_drop {
-        values = ["filename", "tmp_container_runtime"]
+        values = ["filename", "pod", "tmp_container_runtime"]
       }
       forward_to = [loki.process.logs_service.receiver]
     }

--- a/examples/proxies/logs.alloy
+++ b/examples/proxies/logs.alloy
@@ -82,7 +82,7 @@ loki.source.file "pod_logs" {
 
 loki.process "pod_logs" {
   stage.match {
-    selector = "{tmp_container_runtime=\"containerd\"}"
+    selector = "{tmp_container_runtime=~\"containerd|cri-o\"}"
     // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
     stage.cri {}
 
@@ -95,21 +95,6 @@ loki.process "pod_logs" {
     }
   }
 
-  stage.match {
-    selector = "{tmp_container_runtime=\"cri-o\"}"
-    // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
-    stage.cri {}
-
-    // Set the extract flags and stream values as labels
-    stage.labels {
-      values = {
-        flags  = "",
-        stream  = "",
-      }
-    }
-  }
-
-  // if the label tmp_container_runtime from above is docker parse using docker
   stage.match {
     selector = "{tmp_container_runtime=\"docker\"}"
     // the docker processing stage extracts the following k/v pairs: log, stream, time
@@ -123,11 +108,18 @@ loki.process "pod_logs" {
     }
   }
 
-  // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have
-  // cluster, namespace, pod, and container labels.
-  // Also drop the temporary container runtime label as it is no longer needed.
+  // Move high-cardinality labels to structured metadata
+  stage.structured_metadata {
+    values = {
+      pod  = "",
+    }
+  }
+
+  // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
+  // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+  // container runtime label as it is no longer needed.
   stage.label_drop {
-    values = ["filename", "tmp_container_runtime"]
+    values = ["filename", "pod", "tmp_container_runtime"]
   }
   forward_to = [loki.process.logs_service.receiver]
 }

--- a/examples/proxies/metrics.alloy
+++ b/examples/proxies/metrics.alloy
@@ -768,7 +768,7 @@ prometheus.remote_write "metrics_service" {
 
 loki.process "pod_logs" {
   stage.match {
-    selector = "{tmp_container_runtime=\"containerd\"}"
+    selector = "{tmp_container_runtime=~\"containerd|cri-o\"}"
     // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
     stage.cri {}
 
@@ -781,21 +781,6 @@ loki.process "pod_logs" {
     }
   }
 
-  stage.match {
-    selector = "{tmp_container_runtime=\"cri-o\"}"
-    // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
-    stage.cri {}
-
-    // Set the extract flags and stream values as labels
-    stage.labels {
-      values = {
-        flags  = "",
-        stream  = "",
-      }
-    }
-  }
-
-  // if the label tmp_container_runtime from above is docker parse using docker
   stage.match {
     selector = "{tmp_container_runtime=\"docker\"}"
     // the docker processing stage extracts the following k/v pairs: log, stream, time
@@ -809,11 +794,18 @@ loki.process "pod_logs" {
     }
   }
 
-  // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have
-  // cluster, namespace, pod, and container labels.
-  // Also drop the temporary container runtime label as it is no longer needed.
+  // Move high-cardinality labels to structured metadata
+  stage.structured_metadata {
+    values = {
+      pod  = "",
+    }
+  }
+
+  // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
+  // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+  // container runtime label as it is no longer needed.
   stage.label_drop {
-    values = ["filename", "tmp_container_runtime"]
+    values = ["filename", "pod", "tmp_container_runtime"]
   }
   forward_to = [loki.process.logs_service.receiver]
 }

--- a/examples/proxies/output.yaml
+++ b/examples/proxies/output.yaml
@@ -898,7 +898,7 @@ data:
     
     loki.process "pod_logs" {
       stage.match {
-        selector = "{tmp_container_runtime=\"containerd\"}"
+        selector = "{tmp_container_runtime=~\"containerd|cri-o\"}"
         // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
         stage.cri {}
     
@@ -911,21 +911,6 @@ data:
         }
       }
     
-      stage.match {
-        selector = "{tmp_container_runtime=\"cri-o\"}"
-        // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
-        stage.cri {}
-    
-        // Set the extract flags and stream values as labels
-        stage.labels {
-          values = {
-            flags  = "",
-            stream  = "",
-          }
-        }
-      }
-    
-      // if the label tmp_container_runtime from above is docker parse using docker
       stage.match {
         selector = "{tmp_container_runtime=\"docker\"}"
         // the docker processing stage extracts the following k/v pairs: log, stream, time
@@ -939,11 +924,18 @@ data:
         }
       }
     
-      // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have
-      // cluster, namespace, pod, and container labels.
-      // Also drop the temporary container runtime label as it is no longer needed.
+      // Move high-cardinality labels to structured metadata
+      stage.structured_metadata {
+        values = {
+          pod  = "",
+        }
+      }
+    
+      // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
+      // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+      // container runtime label as it is no longer needed.
       stage.label_drop {
-        values = ["filename", "tmp_container_runtime"]
+        values = ["filename", "pod", "tmp_container_runtime"]
       }
       forward_to = [loki.process.logs_service.receiver]
     }
@@ -1139,7 +1131,7 @@ data:
     
     loki.process "pod_logs" {
       stage.match {
-        selector = "{tmp_container_runtime=\"containerd\"}"
+        selector = "{tmp_container_runtime=~\"containerd|cri-o\"}"
         // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
         stage.cri {}
     
@@ -1152,21 +1144,6 @@ data:
         }
       }
     
-      stage.match {
-        selector = "{tmp_container_runtime=\"cri-o\"}"
-        // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
-        stage.cri {}
-    
-        // Set the extract flags and stream values as labels
-        stage.labels {
-          values = {
-            flags  = "",
-            stream  = "",
-          }
-        }
-      }
-    
-      // if the label tmp_container_runtime from above is docker parse using docker
       stage.match {
         selector = "{tmp_container_runtime=\"docker\"}"
         // the docker processing stage extracts the following k/v pairs: log, stream, time
@@ -1180,11 +1157,18 @@ data:
         }
       }
     
-      // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have
-      // cluster, namespace, pod, and container labels.
-      // Also drop the temporary container runtime label as it is no longer needed.
+      // Move high-cardinality labels to structured metadata
+      stage.structured_metadata {
+        values = {
+          pod  = "",
+        }
+      }
+    
+      // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
+      // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+      // container runtime label as it is no longer needed.
       stage.label_drop {
-        values = ["filename", "tmp_container_runtime"]
+        values = ["filename", "pod", "tmp_container_runtime"]
       }
       forward_to = [loki.process.logs_service.receiver]
     }
@@ -59811,7 +59795,7 @@ data:
     
     loki.process "pod_logs" {
       stage.match {
-        selector = "{tmp_container_runtime=\"containerd\"}"
+        selector = "{tmp_container_runtime=~\"containerd|cri-o\"}"
         // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
         stage.cri {}
     
@@ -59824,21 +59808,6 @@ data:
         }
       }
     
-      stage.match {
-        selector = "{tmp_container_runtime=\"cri-o\"}"
-        // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
-        stage.cri {}
-    
-        // Set the extract flags and stream values as labels
-        stage.labels {
-          values = {
-            flags  = "",
-            stream  = "",
-          }
-        }
-      }
-    
-      // if the label tmp_container_runtime from above is docker parse using docker
       stage.match {
         selector = "{tmp_container_runtime=\"docker\"}"
         // the docker processing stage extracts the following k/v pairs: log, stream, time
@@ -59852,11 +59821,18 @@ data:
         }
       }
     
-      // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have
-      // cluster, namespace, pod, and container labels.
-      // Also drop the temporary container runtime label as it is no longer needed.
+      // Move high-cardinality labels to structured metadata
+      stage.structured_metadata {
+        values = {
+          pod  = "",
+        }
+      }
+    
+      // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
+      // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+      // container runtime label as it is no longer needed.
       stage.label_drop {
-        values = ["filename", "tmp_container_runtime"]
+        values = ["filename", "pod", "tmp_container_runtime"]
       }
       forward_to = [loki.process.logs_service.receiver]
     }
@@ -60036,7 +60012,7 @@ data:
     
     loki.process "pod_logs" {
       stage.match {
-        selector = "{tmp_container_runtime=\"containerd\"}"
+        selector = "{tmp_container_runtime=~\"containerd|cri-o\"}"
         // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
         stage.cri {}
     
@@ -60049,21 +60025,6 @@ data:
         }
       }
     
-      stage.match {
-        selector = "{tmp_container_runtime=\"cri-o\"}"
-        // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
-        stage.cri {}
-    
-        // Set the extract flags and stream values as labels
-        stage.labels {
-          values = {
-            flags  = "",
-            stream  = "",
-          }
-        }
-      }
-    
-      // if the label tmp_container_runtime from above is docker parse using docker
       stage.match {
         selector = "{tmp_container_runtime=\"docker\"}"
         // the docker processing stage extracts the following k/v pairs: log, stream, time
@@ -60077,11 +60038,18 @@ data:
         }
       }
     
-      // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have
-      // cluster, namespace, pod, and container labels.
-      // Also drop the temporary container runtime label as it is no longer needed.
+      // Move high-cardinality labels to structured metadata
+      stage.structured_metadata {
+        values = {
+          pod  = "",
+        }
+      }
+    
+      // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
+      // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+      // container runtime label as it is no longer needed.
       stage.label_drop {
-        values = ["filename", "tmp_container_runtime"]
+        values = ["filename", "pod", "tmp_container_runtime"]
       }
       forward_to = [loki.process.logs_service.receiver]
     }

--- a/examples/service-integrations/logs.alloy
+++ b/examples/service-integrations/logs.alloy
@@ -82,7 +82,7 @@ loki.source.file "pod_logs" {
 
 loki.process "pod_logs" {
   stage.match {
-    selector = "{tmp_container_runtime=\"containerd\"}"
+    selector = "{tmp_container_runtime=~\"containerd|cri-o\"}"
     // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
     stage.cri {}
 
@@ -95,21 +95,6 @@ loki.process "pod_logs" {
     }
   }
 
-  stage.match {
-    selector = "{tmp_container_runtime=\"cri-o\"}"
-    // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
-    stage.cri {}
-
-    // Set the extract flags and stream values as labels
-    stage.labels {
-      values = {
-        flags  = "",
-        stream  = "",
-      }
-    }
-  }
-
-  // if the label tmp_container_runtime from above is docker parse using docker
   stage.match {
     selector = "{tmp_container_runtime=\"docker\"}"
     // the docker processing stage extracts the following k/v pairs: log, stream, time
@@ -123,11 +108,18 @@ loki.process "pod_logs" {
     }
   }
 
-  // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have
-  // cluster, namespace, pod, and container labels.
-  // Also drop the temporary container runtime label as it is no longer needed.
+  // Move high-cardinality labels to structured metadata
+  stage.structured_metadata {
+    values = {
+      pod  = "",
+    }
+  }
+
+  // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
+  // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+  // container runtime label as it is no longer needed.
   stage.label_drop {
-    values = ["filename", "tmp_container_runtime"]
+    values = ["filename", "pod", "tmp_container_runtime"]
   }
   forward_to = [loki.process.logs_service.receiver]
 }

--- a/examples/service-integrations/metrics.alloy
+++ b/examples/service-integrations/metrics.alloy
@@ -764,7 +764,7 @@ prometheus.remote_write "metrics_service" {
 
 loki.process "pod_logs" {
   stage.match {
-    selector = "{tmp_container_runtime=\"containerd\"}"
+    selector = "{tmp_container_runtime=~\"containerd|cri-o\"}"
     // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
     stage.cri {}
 
@@ -777,21 +777,6 @@ loki.process "pod_logs" {
     }
   }
 
-  stage.match {
-    selector = "{tmp_container_runtime=\"cri-o\"}"
-    // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
-    stage.cri {}
-
-    // Set the extract flags and stream values as labels
-    stage.labels {
-      values = {
-        flags  = "",
-        stream  = "",
-      }
-    }
-  }
-
-  // if the label tmp_container_runtime from above is docker parse using docker
   stage.match {
     selector = "{tmp_container_runtime=\"docker\"}"
     // the docker processing stage extracts the following k/v pairs: log, stream, time
@@ -805,11 +790,18 @@ loki.process "pod_logs" {
     }
   }
 
-  // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have
-  // cluster, namespace, pod, and container labels.
-  // Also drop the temporary container runtime label as it is no longer needed.
+  // Move high-cardinality labels to structured metadata
+  stage.structured_metadata {
+    values = {
+      pod  = "",
+    }
+  }
+
+  // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
+  // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+  // container runtime label as it is no longer needed.
   stage.label_drop {
-    values = ["filename", "tmp_container_runtime"]
+    values = ["filename", "pod", "tmp_container_runtime"]
   }
   forward_to = [loki.process.logs_service.receiver]
 }

--- a/examples/service-integrations/output.yaml
+++ b/examples/service-integrations/output.yaml
@@ -894,7 +894,7 @@ data:
     
     loki.process "pod_logs" {
       stage.match {
-        selector = "{tmp_container_runtime=\"containerd\"}"
+        selector = "{tmp_container_runtime=~\"containerd|cri-o\"}"
         // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
         stage.cri {}
     
@@ -907,21 +907,6 @@ data:
         }
       }
     
-      stage.match {
-        selector = "{tmp_container_runtime=\"cri-o\"}"
-        // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
-        stage.cri {}
-    
-        // Set the extract flags and stream values as labels
-        stage.labels {
-          values = {
-            flags  = "",
-            stream  = "",
-          }
-        }
-      }
-    
-      // if the label tmp_container_runtime from above is docker parse using docker
       stage.match {
         selector = "{tmp_container_runtime=\"docker\"}"
         // the docker processing stage extracts the following k/v pairs: log, stream, time
@@ -935,11 +920,18 @@ data:
         }
       }
     
-      // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have
-      // cluster, namespace, pod, and container labels.
-      // Also drop the temporary container runtime label as it is no longer needed.
+      // Move high-cardinality labels to structured metadata
+      stage.structured_metadata {
+        values = {
+          pod  = "",
+        }
+      }
+    
+      // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
+      // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+      // container runtime label as it is no longer needed.
       stage.label_drop {
-        values = ["filename", "tmp_container_runtime"]
+        values = ["filename", "pod", "tmp_container_runtime"]
       }
       forward_to = [loki.process.logs_service.receiver]
     }
@@ -1147,7 +1139,7 @@ data:
     
     loki.process "pod_logs" {
       stage.match {
-        selector = "{tmp_container_runtime=\"containerd\"}"
+        selector = "{tmp_container_runtime=~\"containerd|cri-o\"}"
         // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
         stage.cri {}
     
@@ -1160,21 +1152,6 @@ data:
         }
       }
     
-      stage.match {
-        selector = "{tmp_container_runtime=\"cri-o\"}"
-        // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
-        stage.cri {}
-    
-        // Set the extract flags and stream values as labels
-        stage.labels {
-          values = {
-            flags  = "",
-            stream  = "",
-          }
-        }
-      }
-    
-      // if the label tmp_container_runtime from above is docker parse using docker
       stage.match {
         selector = "{tmp_container_runtime=\"docker\"}"
         // the docker processing stage extracts the following k/v pairs: log, stream, time
@@ -1188,11 +1165,18 @@ data:
         }
       }
     
-      // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have
-      // cluster, namespace, pod, and container labels.
-      // Also drop the temporary container runtime label as it is no longer needed.
+      // Move high-cardinality labels to structured metadata
+      stage.structured_metadata {
+        values = {
+          pod  = "",
+        }
+      }
+    
+      // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
+      // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+      // container runtime label as it is no longer needed.
       stage.label_drop {
-        values = ["filename", "tmp_container_runtime"]
+        values = ["filename", "pod", "tmp_container_runtime"]
       }
       forward_to = [loki.process.logs_service.receiver]
     }
@@ -59826,7 +59810,7 @@ data:
     
     loki.process "pod_logs" {
       stage.match {
-        selector = "{tmp_container_runtime=\"containerd\"}"
+        selector = "{tmp_container_runtime=~\"containerd|cri-o\"}"
         // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
         stage.cri {}
     
@@ -59839,21 +59823,6 @@ data:
         }
       }
     
-      stage.match {
-        selector = "{tmp_container_runtime=\"cri-o\"}"
-        // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
-        stage.cri {}
-    
-        // Set the extract flags and stream values as labels
-        stage.labels {
-          values = {
-            flags  = "",
-            stream  = "",
-          }
-        }
-      }
-    
-      // if the label tmp_container_runtime from above is docker parse using docker
       stage.match {
         selector = "{tmp_container_runtime=\"docker\"}"
         // the docker processing stage extracts the following k/v pairs: log, stream, time
@@ -59867,11 +59836,18 @@ data:
         }
       }
     
-      // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have
-      // cluster, namespace, pod, and container labels.
-      // Also drop the temporary container runtime label as it is no longer needed.
+      // Move high-cardinality labels to structured metadata
+      stage.structured_metadata {
+        values = {
+          pod  = "",
+        }
+      }
+    
+      // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
+      // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+      // container runtime label as it is no longer needed.
       stage.label_drop {
-        values = ["filename", "tmp_container_runtime"]
+        values = ["filename", "pod", "tmp_container_runtime"]
       }
       forward_to = [loki.process.logs_service.receiver]
     }
@@ -60063,7 +60039,7 @@ data:
     
     loki.process "pod_logs" {
       stage.match {
-        selector = "{tmp_container_runtime=\"containerd\"}"
+        selector = "{tmp_container_runtime=~\"containerd|cri-o\"}"
         // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
         stage.cri {}
     
@@ -60076,21 +60052,6 @@ data:
         }
       }
     
-      stage.match {
-        selector = "{tmp_container_runtime=\"cri-o\"}"
-        // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
-        stage.cri {}
-    
-        // Set the extract flags and stream values as labels
-        stage.labels {
-          values = {
-            flags  = "",
-            stream  = "",
-          }
-        }
-      }
-    
-      // if the label tmp_container_runtime from above is docker parse using docker
       stage.match {
         selector = "{tmp_container_runtime=\"docker\"}"
         // the docker processing stage extracts the following k/v pairs: log, stream, time
@@ -60104,11 +60065,18 @@ data:
         }
       }
     
-      // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have
-      // cluster, namespace, pod, and container labels.
-      // Also drop the temporary container runtime label as it is no longer needed.
+      // Move high-cardinality labels to structured metadata
+      stage.structured_metadata {
+        values = {
+          pod  = "",
+        }
+      }
+    
+      // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
+      // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+      // container runtime label as it is no longer needed.
       stage.label_drop {
-        values = ["filename", "tmp_container_runtime"]
+        values = ["filename", "pod", "tmp_container_runtime"]
       }
       forward_to = [loki.process.logs_service.receiver]
     }

--- a/examples/specific-namespace/logs.alloy
+++ b/examples/specific-namespace/logs.alloy
@@ -87,7 +87,7 @@ loki.source.file "pod_logs" {
 
 loki.process "pod_logs" {
   stage.match {
-    selector = "{tmp_container_runtime=\"containerd\"}"
+    selector = "{tmp_container_runtime=~\"containerd|cri-o\"}"
     // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
     stage.cri {}
 
@@ -100,21 +100,6 @@ loki.process "pod_logs" {
     }
   }
 
-  stage.match {
-    selector = "{tmp_container_runtime=\"cri-o\"}"
-    // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
-    stage.cri {}
-
-    // Set the extract flags and stream values as labels
-    stage.labels {
-      values = {
-        flags  = "",
-        stream  = "",
-      }
-    }
-  }
-
-  // if the label tmp_container_runtime from above is docker parse using docker
   stage.match {
     selector = "{tmp_container_runtime=\"docker\"}"
     // the docker processing stage extracts the following k/v pairs: log, stream, time
@@ -128,11 +113,18 @@ loki.process "pod_logs" {
     }
   }
 
-  // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have
-  // cluster, namespace, pod, and container labels.
-  // Also drop the temporary container runtime label as it is no longer needed.
+  // Move high-cardinality labels to structured metadata
+  stage.structured_metadata {
+    values = {
+      pod  = "",
+    }
+  }
+
+  // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
+  // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+  // container runtime label as it is no longer needed.
   stage.label_drop {
-    values = ["filename", "tmp_container_runtime"]
+    values = ["filename", "pod", "tmp_container_runtime"]
   }
   forward_to = [loki.process.logs_service.receiver]
 }

--- a/examples/specific-namespace/metrics.alloy
+++ b/examples/specific-namespace/metrics.alloy
@@ -822,7 +822,7 @@ prometheus.remote_write "metrics_service" {
 
 loki.process "pod_logs" {
   stage.match {
-    selector = "{tmp_container_runtime=\"containerd\"}"
+    selector = "{tmp_container_runtime=~\"containerd|cri-o\"}"
     // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
     stage.cri {}
 
@@ -835,21 +835,6 @@ loki.process "pod_logs" {
     }
   }
 
-  stage.match {
-    selector = "{tmp_container_runtime=\"cri-o\"}"
-    // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
-    stage.cri {}
-
-    // Set the extract flags and stream values as labels
-    stage.labels {
-      values = {
-        flags  = "",
-        stream  = "",
-      }
-    }
-  }
-
-  // if the label tmp_container_runtime from above is docker parse using docker
   stage.match {
     selector = "{tmp_container_runtime=\"docker\"}"
     // the docker processing stage extracts the following k/v pairs: log, stream, time
@@ -863,11 +848,18 @@ loki.process "pod_logs" {
     }
   }
 
-  // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have
-  // cluster, namespace, pod, and container labels.
-  // Also drop the temporary container runtime label as it is no longer needed.
+  // Move high-cardinality labels to structured metadata
+  stage.structured_metadata {
+    values = {
+      pod  = "",
+    }
+  }
+
+  // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
+  // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+  // container runtime label as it is no longer needed.
   stage.label_drop {
-    values = ["filename", "tmp_container_runtime"]
+    values = ["filename", "pod", "tmp_container_runtime"]
   }
   forward_to = [loki.process.logs_service.receiver]
 }

--- a/examples/specific-namespace/output.yaml
+++ b/examples/specific-namespace/output.yaml
@@ -952,7 +952,7 @@ data:
     
     loki.process "pod_logs" {
       stage.match {
-        selector = "{tmp_container_runtime=\"containerd\"}"
+        selector = "{tmp_container_runtime=~\"containerd|cri-o\"}"
         // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
         stage.cri {}
     
@@ -965,21 +965,6 @@ data:
         }
       }
     
-      stage.match {
-        selector = "{tmp_container_runtime=\"cri-o\"}"
-        // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
-        stage.cri {}
-    
-        // Set the extract flags and stream values as labels
-        stage.labels {
-          values = {
-            flags  = "",
-            stream  = "",
-          }
-        }
-      }
-    
-      // if the label tmp_container_runtime from above is docker parse using docker
       stage.match {
         selector = "{tmp_container_runtime=\"docker\"}"
         // the docker processing stage extracts the following k/v pairs: log, stream, time
@@ -993,11 +978,18 @@ data:
         }
       }
     
-      // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have
-      // cluster, namespace, pod, and container labels.
-      // Also drop the temporary container runtime label as it is no longer needed.
+      // Move high-cardinality labels to structured metadata
+      stage.structured_metadata {
+        values = {
+          pod  = "",
+        }
+      }
+    
+      // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
+      // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+      // container runtime label as it is no longer needed.
       stage.label_drop {
-        values = ["filename", "tmp_container_runtime"]
+        values = ["filename", "pod", "tmp_container_runtime"]
       }
       forward_to = [loki.process.logs_service.receiver]
     }
@@ -1191,7 +1183,7 @@ data:
     
     loki.process "pod_logs" {
       stage.match {
-        selector = "{tmp_container_runtime=\"containerd\"}"
+        selector = "{tmp_container_runtime=~\"containerd|cri-o\"}"
         // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
         stage.cri {}
     
@@ -1204,21 +1196,6 @@ data:
         }
       }
     
-      stage.match {
-        selector = "{tmp_container_runtime=\"cri-o\"}"
-        // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
-        stage.cri {}
-    
-        // Set the extract flags and stream values as labels
-        stage.labels {
-          values = {
-            flags  = "",
-            stream  = "",
-          }
-        }
-      }
-    
-      // if the label tmp_container_runtime from above is docker parse using docker
       stage.match {
         selector = "{tmp_container_runtime=\"docker\"}"
         // the docker processing stage extracts the following k/v pairs: log, stream, time
@@ -1232,11 +1209,18 @@ data:
         }
       }
     
-      // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have
-      // cluster, namespace, pod, and container labels.
-      // Also drop the temporary container runtime label as it is no longer needed.
+      // Move high-cardinality labels to structured metadata
+      stage.structured_metadata {
+        values = {
+          pod  = "",
+        }
+      }
+    
+      // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
+      // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+      // container runtime label as it is no longer needed.
       stage.label_drop {
-        values = ["filename", "tmp_container_runtime"]
+        values = ["filename", "pod", "tmp_container_runtime"]
       }
       forward_to = [loki.process.logs_service.receiver]
     }
@@ -59913,7 +59897,7 @@ data:
     
     loki.process "pod_logs" {
       stage.match {
-        selector = "{tmp_container_runtime=\"containerd\"}"
+        selector = "{tmp_container_runtime=~\"containerd|cri-o\"}"
         // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
         stage.cri {}
     
@@ -59926,21 +59910,6 @@ data:
         }
       }
     
-      stage.match {
-        selector = "{tmp_container_runtime=\"cri-o\"}"
-        // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
-        stage.cri {}
-    
-        // Set the extract flags and stream values as labels
-        stage.labels {
-          values = {
-            flags  = "",
-            stream  = "",
-          }
-        }
-      }
-    
-      // if the label tmp_container_runtime from above is docker parse using docker
       stage.match {
         selector = "{tmp_container_runtime=\"docker\"}"
         // the docker processing stage extracts the following k/v pairs: log, stream, time
@@ -59954,11 +59923,18 @@ data:
         }
       }
     
-      // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have
-      // cluster, namespace, pod, and container labels.
-      // Also drop the temporary container runtime label as it is no longer needed.
+      // Move high-cardinality labels to structured metadata
+      stage.structured_metadata {
+        values = {
+          pod  = "",
+        }
+      }
+    
+      // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
+      // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+      // container runtime label as it is no longer needed.
       stage.label_drop {
-        values = ["filename", "tmp_container_runtime"]
+        values = ["filename", "pod", "tmp_container_runtime"]
       }
       forward_to = [loki.process.logs_service.receiver]
     }
@@ -60136,7 +60112,7 @@ data:
     
     loki.process "pod_logs" {
       stage.match {
-        selector = "{tmp_container_runtime=\"containerd\"}"
+        selector = "{tmp_container_runtime=~\"containerd|cri-o\"}"
         // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
         stage.cri {}
     
@@ -60149,21 +60125,6 @@ data:
         }
       }
     
-      stage.match {
-        selector = "{tmp_container_runtime=\"cri-o\"}"
-        // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
-        stage.cri {}
-    
-        // Set the extract flags and stream values as labels
-        stage.labels {
-          values = {
-            flags  = "",
-            stream  = "",
-          }
-        }
-      }
-    
-      // if the label tmp_container_runtime from above is docker parse using docker
       stage.match {
         selector = "{tmp_container_runtime=\"docker\"}"
         // the docker processing stage extracts the following k/v pairs: log, stream, time
@@ -60177,11 +60138,18 @@ data:
         }
       }
     
-      // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have
-      // cluster, namespace, pod, and container labels.
-      // Also drop the temporary container runtime label as it is no longer needed.
+      // Move high-cardinality labels to structured metadata
+      stage.structured_metadata {
+        values = {
+          pod  = "",
+        }
+      }
+    
+      // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
+      // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+      // container runtime label as it is no longer needed.
       stage.label_drop {
-        values = ["filename", "tmp_container_runtime"]
+        values = ["filename", "pod", "tmp_container_runtime"]
       }
       forward_to = [loki.process.logs_service.receiver]
     }

--- a/examples/traces-enabled/logs.alloy
+++ b/examples/traces-enabled/logs.alloy
@@ -82,7 +82,7 @@ loki.source.file "pod_logs" {
 
 loki.process "pod_logs" {
   stage.match {
-    selector = "{tmp_container_runtime=\"containerd\"}"
+    selector = "{tmp_container_runtime=~\"containerd|cri-o\"}"
     // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
     stage.cri {}
 
@@ -95,21 +95,6 @@ loki.process "pod_logs" {
     }
   }
 
-  stage.match {
-    selector = "{tmp_container_runtime=\"cri-o\"}"
-    // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
-    stage.cri {}
-
-    // Set the extract flags and stream values as labels
-    stage.labels {
-      values = {
-        flags  = "",
-        stream  = "",
-      }
-    }
-  }
-
-  // if the label tmp_container_runtime from above is docker parse using docker
   stage.match {
     selector = "{tmp_container_runtime=\"docker\"}"
     // the docker processing stage extracts the following k/v pairs: log, stream, time
@@ -123,11 +108,18 @@ loki.process "pod_logs" {
     }
   }
 
-  // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have
-  // cluster, namespace, pod, and container labels.
-  // Also drop the temporary container runtime label as it is no longer needed.
+  // Move high-cardinality labels to structured metadata
+  stage.structured_metadata {
+    values = {
+      pod  = "",
+    }
+  }
+
+  // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
+  // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+  // container runtime label as it is no longer needed.
   stage.label_drop {
-    values = ["filename", "tmp_container_runtime"]
+    values = ["filename", "pod", "tmp_container_runtime"]
   }
   forward_to = [loki.process.logs_service.receiver]
 }

--- a/examples/traces-enabled/metrics.alloy
+++ b/examples/traces-enabled/metrics.alloy
@@ -850,7 +850,7 @@ prometheus.remote_write "metrics_service" {
 
 loki.process "pod_logs" {
   stage.match {
-    selector = "{tmp_container_runtime=\"containerd\"}"
+    selector = "{tmp_container_runtime=~\"containerd|cri-o\"}"
     // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
     stage.cri {}
 
@@ -863,21 +863,6 @@ loki.process "pod_logs" {
     }
   }
 
-  stage.match {
-    selector = "{tmp_container_runtime=\"cri-o\"}"
-    // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
-    stage.cri {}
-
-    // Set the extract flags and stream values as labels
-    stage.labels {
-      values = {
-        flags  = "",
-        stream  = "",
-      }
-    }
-  }
-
-  // if the label tmp_container_runtime from above is docker parse using docker
   stage.match {
     selector = "{tmp_container_runtime=\"docker\"}"
     // the docker processing stage extracts the following k/v pairs: log, stream, time
@@ -891,11 +876,18 @@ loki.process "pod_logs" {
     }
   }
 
-  // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have
-  // cluster, namespace, pod, and container labels.
-  // Also drop the temporary container runtime label as it is no longer needed.
+  // Move high-cardinality labels to structured metadata
+  stage.structured_metadata {
+    values = {
+      pod  = "",
+    }
+  }
+
+  // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
+  // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+  // container runtime label as it is no longer needed.
   stage.label_drop {
-    values = ["filename", "tmp_container_runtime"]
+    values = ["filename", "pod", "tmp_container_runtime"]
   }
   forward_to = [loki.process.logs_service.receiver]
 }

--- a/examples/traces-enabled/output.yaml
+++ b/examples/traces-enabled/output.yaml
@@ -993,7 +993,7 @@ data:
     
     loki.process "pod_logs" {
       stage.match {
-        selector = "{tmp_container_runtime=\"containerd\"}"
+        selector = "{tmp_container_runtime=~\"containerd|cri-o\"}"
         // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
         stage.cri {}
     
@@ -1006,21 +1006,6 @@ data:
         }
       }
     
-      stage.match {
-        selector = "{tmp_container_runtime=\"cri-o\"}"
-        // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
-        stage.cri {}
-    
-        // Set the extract flags and stream values as labels
-        stage.labels {
-          values = {
-            flags  = "",
-            stream  = "",
-          }
-        }
-      }
-    
-      // if the label tmp_container_runtime from above is docker parse using docker
       stage.match {
         selector = "{tmp_container_runtime=\"docker\"}"
         // the docker processing stage extracts the following k/v pairs: log, stream, time
@@ -1034,11 +1019,18 @@ data:
         }
       }
     
-      // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have
-      // cluster, namespace, pod, and container labels.
-      // Also drop the temporary container runtime label as it is no longer needed.
+      // Move high-cardinality labels to structured metadata
+      stage.structured_metadata {
+        values = {
+          pod  = "",
+        }
+      }
+    
+      // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
+      // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+      // container runtime label as it is no longer needed.
       stage.label_drop {
-        values = ["filename", "tmp_container_runtime"]
+        values = ["filename", "pod", "tmp_container_runtime"]
       }
       forward_to = [loki.process.logs_service.receiver]
     }
@@ -1246,7 +1238,7 @@ data:
     
     loki.process "pod_logs" {
       stage.match {
-        selector = "{tmp_container_runtime=\"containerd\"}"
+        selector = "{tmp_container_runtime=~\"containerd|cri-o\"}"
         // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
         stage.cri {}
     
@@ -1259,21 +1251,6 @@ data:
         }
       }
     
-      stage.match {
-        selector = "{tmp_container_runtime=\"cri-o\"}"
-        // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
-        stage.cri {}
-    
-        // Set the extract flags and stream values as labels
-        stage.labels {
-          values = {
-            flags  = "",
-            stream  = "",
-          }
-        }
-      }
-    
-      // if the label tmp_container_runtime from above is docker parse using docker
       stage.match {
         selector = "{tmp_container_runtime=\"docker\"}"
         // the docker processing stage extracts the following k/v pairs: log, stream, time
@@ -1287,11 +1264,18 @@ data:
         }
       }
     
-      // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have
-      // cluster, namespace, pod, and container labels.
-      // Also drop the temporary container runtime label as it is no longer needed.
+      // Move high-cardinality labels to structured metadata
+      stage.structured_metadata {
+        values = {
+          pod  = "",
+        }
+      }
+    
+      // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
+      // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+      // container runtime label as it is no longer needed.
       stage.label_drop {
-        values = ["filename", "tmp_container_runtime"]
+        values = ["filename", "pod", "tmp_container_runtime"]
       }
       forward_to = [loki.process.logs_service.receiver]
     }
@@ -59996,7 +59980,7 @@ data:
     
     loki.process "pod_logs" {
       stage.match {
-        selector = "{tmp_container_runtime=\"containerd\"}"
+        selector = "{tmp_container_runtime=~\"containerd|cri-o\"}"
         // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
         stage.cri {}
     
@@ -60009,21 +59993,6 @@ data:
         }
       }
     
-      stage.match {
-        selector = "{tmp_container_runtime=\"cri-o\"}"
-        // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
-        stage.cri {}
-    
-        // Set the extract flags and stream values as labels
-        stage.labels {
-          values = {
-            flags  = "",
-            stream  = "",
-          }
-        }
-      }
-    
-      // if the label tmp_container_runtime from above is docker parse using docker
       stage.match {
         selector = "{tmp_container_runtime=\"docker\"}"
         // the docker processing stage extracts the following k/v pairs: log, stream, time
@@ -60037,11 +60006,18 @@ data:
         }
       }
     
-      // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have
-      // cluster, namespace, pod, and container labels.
-      // Also drop the temporary container runtime label as it is no longer needed.
+      // Move high-cardinality labels to structured metadata
+      stage.structured_metadata {
+        values = {
+          pod  = "",
+        }
+      }
+    
+      // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
+      // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+      // container runtime label as it is no longer needed.
       stage.label_drop {
-        values = ["filename", "tmp_container_runtime"]
+        values = ["filename", "pod", "tmp_container_runtime"]
       }
       forward_to = [loki.process.logs_service.receiver]
     }
@@ -60233,7 +60209,7 @@ data:
     
     loki.process "pod_logs" {
       stage.match {
-        selector = "{tmp_container_runtime=\"containerd\"}"
+        selector = "{tmp_container_runtime=~\"containerd|cri-o\"}"
         // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
         stage.cri {}
     
@@ -60246,21 +60222,6 @@ data:
         }
       }
     
-      stage.match {
-        selector = "{tmp_container_runtime=\"cri-o\"}"
-        // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
-        stage.cri {}
-    
-        // Set the extract flags and stream values as labels
-        stage.labels {
-          values = {
-            flags  = "",
-            stream  = "",
-          }
-        }
-      }
-    
-      // if the label tmp_container_runtime from above is docker parse using docker
       stage.match {
         selector = "{tmp_container_runtime=\"docker\"}"
         // the docker processing stage extracts the following k/v pairs: log, stream, time
@@ -60274,11 +60235,18 @@ data:
         }
       }
     
-      // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have
-      // cluster, namespace, pod, and container labels.
-      // Also drop the temporary container runtime label as it is no longer needed.
+      // Move high-cardinality labels to structured metadata
+      stage.structured_metadata {
+        values = {
+          pod  = "",
+        }
+      }
+    
+      // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
+      // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+      // container runtime label as it is no longer needed.
       stage.label_drop {
-        values = ["filename", "tmp_container_runtime"]
+        values = ["filename", "pod", "tmp_container_runtime"]
       }
       forward_to = [loki.process.logs_service.receiver]
     }

--- a/examples/windows-exporter/logs.alloy
+++ b/examples/windows-exporter/logs.alloy
@@ -82,7 +82,7 @@ loki.source.file "pod_logs" {
 
 loki.process "pod_logs" {
   stage.match {
-    selector = "{tmp_container_runtime=\"containerd\"}"
+    selector = "{tmp_container_runtime=~\"containerd|cri-o\"}"
     // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
     stage.cri {}
 
@@ -95,21 +95,6 @@ loki.process "pod_logs" {
     }
   }
 
-  stage.match {
-    selector = "{tmp_container_runtime=\"cri-o\"}"
-    // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
-    stage.cri {}
-
-    // Set the extract flags and stream values as labels
-    stage.labels {
-      values = {
-        flags  = "",
-        stream  = "",
-      }
-    }
-  }
-
-  // if the label tmp_container_runtime from above is docker parse using docker
   stage.match {
     selector = "{tmp_container_runtime=\"docker\"}"
     // the docker processing stage extracts the following k/v pairs: log, stream, time
@@ -123,11 +108,18 @@ loki.process "pod_logs" {
     }
   }
 
-  // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have
-  // cluster, namespace, pod, and container labels.
-  // Also drop the temporary container runtime label as it is no longer needed.
+  // Move high-cardinality labels to structured metadata
+  stage.structured_metadata {
+    values = {
+      pod  = "",
+    }
+  }
+
+  // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
+  // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+  // container runtime label as it is no longer needed.
   stage.label_drop {
-    values = ["filename", "tmp_container_runtime"]
+    values = ["filename", "pod", "tmp_container_runtime"]
   }
   forward_to = [loki.process.logs_service.receiver]
 }

--- a/examples/windows-exporter/metrics.alloy
+++ b/examples/windows-exporter/metrics.alloy
@@ -833,7 +833,7 @@ prometheus.remote_write "metrics_service" {
 
 loki.process "pod_logs" {
   stage.match {
-    selector = "{tmp_container_runtime=\"containerd\"}"
+    selector = "{tmp_container_runtime=~\"containerd|cri-o\"}"
     // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
     stage.cri {}
 
@@ -846,21 +846,6 @@ loki.process "pod_logs" {
     }
   }
 
-  stage.match {
-    selector = "{tmp_container_runtime=\"cri-o\"}"
-    // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
-    stage.cri {}
-
-    // Set the extract flags and stream values as labels
-    stage.labels {
-      values = {
-        flags  = "",
-        stream  = "",
-      }
-    }
-  }
-
-  // if the label tmp_container_runtime from above is docker parse using docker
   stage.match {
     selector = "{tmp_container_runtime=\"docker\"}"
     // the docker processing stage extracts the following k/v pairs: log, stream, time
@@ -874,11 +859,18 @@ loki.process "pod_logs" {
     }
   }
 
-  // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have
-  // cluster, namespace, pod, and container labels.
-  // Also drop the temporary container runtime label as it is no longer needed.
+  // Move high-cardinality labels to structured metadata
+  stage.structured_metadata {
+    values = {
+      pod  = "",
+    }
+  }
+
+  // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
+  // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+  // container runtime label as it is no longer needed.
   stage.label_drop {
-    values = ["filename", "tmp_container_runtime"]
+    values = ["filename", "pod", "tmp_container_runtime"]
   }
   forward_to = [loki.process.logs_service.receiver]
 }

--- a/examples/windows-exporter/output.yaml
+++ b/examples/windows-exporter/output.yaml
@@ -1000,7 +1000,7 @@ data:
     
     loki.process "pod_logs" {
       stage.match {
-        selector = "{tmp_container_runtime=\"containerd\"}"
+        selector = "{tmp_container_runtime=~\"containerd|cri-o\"}"
         // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
         stage.cri {}
     
@@ -1013,21 +1013,6 @@ data:
         }
       }
     
-      stage.match {
-        selector = "{tmp_container_runtime=\"cri-o\"}"
-        // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
-        stage.cri {}
-    
-        // Set the extract flags and stream values as labels
-        stage.labels {
-          values = {
-            flags  = "",
-            stream  = "",
-          }
-        }
-      }
-    
-      // if the label tmp_container_runtime from above is docker parse using docker
       stage.match {
         selector = "{tmp_container_runtime=\"docker\"}"
         // the docker processing stage extracts the following k/v pairs: log, stream, time
@@ -1041,11 +1026,18 @@ data:
         }
       }
     
-      // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have
-      // cluster, namespace, pod, and container labels.
-      // Also drop the temporary container runtime label as it is no longer needed.
+      // Move high-cardinality labels to structured metadata
+      stage.structured_metadata {
+        values = {
+          pod  = "",
+        }
+      }
+    
+      // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
+      // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+      // container runtime label as it is no longer needed.
       stage.label_drop {
-        values = ["filename", "tmp_container_runtime"]
+        values = ["filename", "pod", "tmp_container_runtime"]
       }
       forward_to = [loki.process.logs_service.receiver]
     }
@@ -1233,7 +1225,7 @@ data:
     
     loki.process "pod_logs" {
       stage.match {
-        selector = "{tmp_container_runtime=\"containerd\"}"
+        selector = "{tmp_container_runtime=~\"containerd|cri-o\"}"
         // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
         stage.cri {}
     
@@ -1246,21 +1238,6 @@ data:
         }
       }
     
-      stage.match {
-        selector = "{tmp_container_runtime=\"cri-o\"}"
-        // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
-        stage.cri {}
-    
-        // Set the extract flags and stream values as labels
-        stage.labels {
-          values = {
-            flags  = "",
-            stream  = "",
-          }
-        }
-      }
-    
-      // if the label tmp_container_runtime from above is docker parse using docker
       stage.match {
         selector = "{tmp_container_runtime=\"docker\"}"
         // the docker processing stage extracts the following k/v pairs: log, stream, time
@@ -1274,11 +1251,18 @@ data:
         }
       }
     
-      // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have
-      // cluster, namespace, pod, and container labels.
-      // Also drop the temporary container runtime label as it is no longer needed.
+      // Move high-cardinality labels to structured metadata
+      stage.structured_metadata {
+        values = {
+          pod  = "",
+        }
+      }
+    
+      // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
+      // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+      // container runtime label as it is no longer needed.
       stage.label_drop {
-        values = ["filename", "tmp_container_runtime"]
+        values = ["filename", "pod", "tmp_container_runtime"]
       }
       forward_to = [loki.process.logs_service.receiver]
     }
@@ -60093,7 +60077,7 @@ data:
     
     loki.process "pod_logs" {
       stage.match {
-        selector = "{tmp_container_runtime=\"containerd\"}"
+        selector = "{tmp_container_runtime=~\"containerd|cri-o\"}"
         // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
         stage.cri {}
     
@@ -60106,21 +60090,6 @@ data:
         }
       }
     
-      stage.match {
-        selector = "{tmp_container_runtime=\"cri-o\"}"
-        // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
-        stage.cri {}
-    
-        // Set the extract flags and stream values as labels
-        stage.labels {
-          values = {
-            flags  = "",
-            stream  = "",
-          }
-        }
-      }
-    
-      // if the label tmp_container_runtime from above is docker parse using docker
       stage.match {
         selector = "{tmp_container_runtime=\"docker\"}"
         // the docker processing stage extracts the following k/v pairs: log, stream, time
@@ -60134,11 +60103,18 @@ data:
         }
       }
     
-      // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have
-      // cluster, namespace, pod, and container labels.
-      // Also drop the temporary container runtime label as it is no longer needed.
+      // Move high-cardinality labels to structured metadata
+      stage.structured_metadata {
+        values = {
+          pod  = "",
+        }
+      }
+    
+      // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
+      // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+      // container runtime label as it is no longer needed.
       stage.label_drop {
-        values = ["filename", "tmp_container_runtime"]
+        values = ["filename", "pod", "tmp_container_runtime"]
       }
       forward_to = [loki.process.logs_service.receiver]
     }
@@ -60310,7 +60286,7 @@ data:
     
     loki.process "pod_logs" {
       stage.match {
-        selector = "{tmp_container_runtime=\"containerd\"}"
+        selector = "{tmp_container_runtime=~\"containerd|cri-o\"}"
         // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
         stage.cri {}
     
@@ -60323,21 +60299,6 @@ data:
         }
       }
     
-      stage.match {
-        selector = "{tmp_container_runtime=\"cri-o\"}"
-        // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
-        stage.cri {}
-    
-        // Set the extract flags and stream values as labels
-        stage.labels {
-          values = {
-            flags  = "",
-            stream  = "",
-          }
-        }
-      }
-    
-      // if the label tmp_container_runtime from above is docker parse using docker
       stage.match {
         selector = "{tmp_container_runtime=\"docker\"}"
         // the docker processing stage extracts the following k/v pairs: log, stream, time
@@ -60351,11 +60312,18 @@ data:
         }
       }
     
-      // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have
-      // cluster, namespace, pod, and container labels.
-      // Also drop the temporary container runtime label as it is no longer needed.
+      // Move high-cardinality labels to structured metadata
+      stage.structured_metadata {
+        values = {
+          pod  = "",
+        }
+      }
+    
+      // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
+      // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+      // container runtime label as it is no longer needed.
       stage.label_drop {
-        values = ["filename", "tmp_container_runtime"]
+        values = ["filename", "pod", "tmp_container_runtime"]
       }
       forward_to = [loki.process.logs_service.receiver]
     }


### PR DESCRIPTION
The Pod label has high cardinality, so move that to structured metadata.
The CRI-O and containerd processors are the same, so combine.