### PR TITLE
Re-filter after discovery.process to remove any non-kubernetes java processes

### DIFF
--- a/charts/k8s-monitoring/templates/alloy_config/_profiles_java.alloy.txt
+++ b/charts/k8s-monitoring/templates/alloy_config/_profiles_java.alloy.txt
@@ -21,9 +21,14 @@ discovery.process "java_pods" {
 discovery.relabel "java_pods" {
   targets = discovery.process.java_pods.targets
   rule {
-    action = "drop"
-    regex = "Succeeded|Failed|Completed"
     source_labels = ["__meta_kubernetes_pod_phase"]
+    regex = "Succeeded|Failed|Completed"
+    action = "drop"
+  }
+  rule {
+    source_labels = ["__meta_kubernetes_pod_name"]
+    regex = "^$"
+    action = "drop"
   }
   rule {
     source_labels = ["__meta_process_exe"]
@@ -31,28 +36,23 @@ discovery.relabel "java_pods" {
     regex = ".*/java$"
   }
   rule {
-    source_labels = ["__meta_kubernetes_pod_name"]
-    regex = ".+"
-    action = "keep"
-  }
-  rule {
-    action = "replace"
     source_labels = ["__meta_kubernetes_namespace"]
+    action = "replace"
     target_label = "namespace"
   }
   rule {
-    action = "replace"
     source_labels = ["__meta_kubernetes_pod_name"]
+    action = "replace"
     target_label = "pod"
   }
   rule {
-    action = "replace"
     source_labels = ["__meta_kubernetes_pod_node_name"]
+    action = "replace"
     target_label = "node"
   }
   rule {
-    action = "replace"
     source_labels = ["__meta_kubernetes_pod_container_name"]
+    action = "replace"
     target_label = "container"
   }
 {{- if .Values.profiles.java.extraRelabelingRules }}

--- a/charts/k8s-monitoring/templates/alloy_config/_profiles_java.alloy.txt
+++ b/charts/k8s-monitoring/templates/alloy_config/_profiles_java.alloy.txt
@@ -35,13 +35,6 @@ discovery.relabel "java_pods" {
     regex = ".+"
     action = "keep"
   }
-{{- if .Values.profiles.java.namespaces }}
-  rule {
-    source_labels = ["__meta_kubernetes_namespace"]
-    regex = "({{ join "|" .Values.profiles.java.namespaces }})"
-    action = "keep"
-  }
-{{- end }}
   rule {
     action = "replace"
     source_labels = ["__meta_kubernetes_namespace"]

--- a/charts/k8s-monitoring/templates/alloy_config/_profiles_java.alloy.txt
+++ b/charts/k8s-monitoring/templates/alloy_config/_profiles_java.alloy.txt
@@ -31,6 +31,18 @@ discovery.relabel "java_pods" {
     regex = ".*/java$"
   }
   rule {
+    source_labels = ["__meta_kubernetes_pod_name"]
+    regex = ".+"
+    action = "keep"
+  }
+{{- if .Values.profiles.java.namespaces }}
+  rule {
+    source_labels = ["__meta_kubernetes_namespace"]
+    regex = "({{ join "|" .Values.profiles.java.namespaces }})"
+    action = "keep"
+  }
+{{- end }}
+  rule {
     action = "replace"
     source_labels = ["__meta_kubernetes_namespace"]
     target_label = "namespace"

--- a/examples/application-observability/output.yaml
+++ b/examples/application-observability/output.yaml
@@ -1377,6 +1377,11 @@ data:
         regex = ".*/java$"
       }
       rule {
+        source_labels = ["__meta_kubernetes_pod_name"]
+        regex = ".+"
+        action = "keep"
+      }
+      rule {
         action = "replace"
         source_labels = ["__meta_kubernetes_namespace"]
         target_label = "namespace"
@@ -61446,6 +61451,11 @@ data:
         source_labels = ["__meta_process_exe"]
         action = "keep"
         regex = ".*/java$"
+      }
+      rule {
+        source_labels = ["__meta_kubernetes_pod_name"]
+        regex = ".+"
+        action = "keep"
       }
       rule {
         action = "replace"

--- a/examples/application-observability/output.yaml
+++ b/examples/application-observability/output.yaml
@@ -1367,9 +1367,14 @@ data:
     discovery.relabel "java_pods" {
       targets = discovery.process.java_pods.targets
       rule {
-        action = "drop"
-        regex = "Succeeded|Failed|Completed"
         source_labels = ["__meta_kubernetes_pod_phase"]
+        regex = "Succeeded|Failed|Completed"
+        action = "drop"
+      }
+      rule {
+        source_labels = ["__meta_kubernetes_pod_name"]
+        regex = "^$"
+        action = "drop"
       }
       rule {
         source_labels = ["__meta_process_exe"]
@@ -1377,28 +1382,23 @@ data:
         regex = ".*/java$"
       }
       rule {
-        source_labels = ["__meta_kubernetes_pod_name"]
-        regex = ".+"
-        action = "keep"
-      }
-      rule {
-        action = "replace"
         source_labels = ["__meta_kubernetes_namespace"]
+        action = "replace"
         target_label = "namespace"
       }
       rule {
-        action = "replace"
         source_labels = ["__meta_kubernetes_pod_name"]
+        action = "replace"
         target_label = "pod"
       }
       rule {
-        action = "replace"
         source_labels = ["__meta_kubernetes_pod_node_name"]
+        action = "replace"
         target_label = "node"
       }
       rule {
-        action = "replace"
         source_labels = ["__meta_kubernetes_pod_container_name"]
+        action = "replace"
         target_label = "container"
       }
     }
@@ -61443,9 +61443,14 @@ data:
     discovery.relabel "java_pods" {
       targets = discovery.process.java_pods.targets
       rule {
-        action = "drop"
-        regex = "Succeeded|Failed|Completed"
         source_labels = ["__meta_kubernetes_pod_phase"]
+        regex = "Succeeded|Failed|Completed"
+        action = "drop"
+      }
+      rule {
+        source_labels = ["__meta_kubernetes_pod_name"]
+        regex = "^$"
+        action = "drop"
       }
       rule {
         source_labels = ["__meta_process_exe"]
@@ -61453,28 +61458,23 @@ data:
         regex = ".*/java$"
       }
       rule {
-        source_labels = ["__meta_kubernetes_pod_name"]
-        regex = ".+"
-        action = "keep"
-      }
-      rule {
-        action = "replace"
         source_labels = ["__meta_kubernetes_namespace"]
+        action = "replace"
         target_label = "namespace"
       }
       rule {
-        action = "replace"
         source_labels = ["__meta_kubernetes_pod_name"]
+        action = "replace"
         target_label = "pod"
       }
       rule {
-        action = "replace"
         source_labels = ["__meta_kubernetes_pod_node_name"]
+        action = "replace"
         target_label = "node"
       }
       rule {
-        action = "replace"
         source_labels = ["__meta_kubernetes_pod_container_name"]
+        action = "replace"
         target_label = "container"
       }
     }

--- a/examples/application-observability/profiles.alloy
+++ b/examples/application-observability/profiles.alloy
@@ -78,6 +78,11 @@ discovery.relabel "java_pods" {
     regex = ".*/java$"
   }
   rule {
+    source_labels = ["__meta_kubernetes_pod_name"]
+    regex = ".+"
+    action = "keep"
+  }
+  rule {
     action = "replace"
     source_labels = ["__meta_kubernetes_namespace"]
     target_label = "namespace"

--- a/examples/application-observability/profiles.alloy
+++ b/examples/application-observability/profiles.alloy
@@ -68,9 +68,14 @@ discovery.process "java_pods" {
 discovery.relabel "java_pods" {
   targets = discovery.process.java_pods.targets
   rule {
-    action = "drop"
-    regex = "Succeeded|Failed|Completed"
     source_labels = ["__meta_kubernetes_pod_phase"]
+    regex = "Succeeded|Failed|Completed"
+    action = "drop"
+  }
+  rule {
+    source_labels = ["__meta_kubernetes_pod_name"]
+    regex = "^$"
+    action = "drop"
   }
   rule {
     source_labels = ["__meta_process_exe"]
@@ -78,28 +83,23 @@ discovery.relabel "java_pods" {
     regex = ".*/java$"
   }
   rule {
-    source_labels = ["__meta_kubernetes_pod_name"]
-    regex = ".+"
-    action = "keep"
-  }
-  rule {
-    action = "replace"
     source_labels = ["__meta_kubernetes_namespace"]
+    action = "replace"
     target_label = "namespace"
   }
   rule {
-    action = "replace"
     source_labels = ["__meta_kubernetes_pod_name"]
+    action = "replace"
     target_label = "pod"
   }
   rule {
-    action = "replace"
     source_labels = ["__meta_kubernetes_pod_node_name"]
+    action = "replace"
     target_label = "node"
   }
   rule {
-    action = "replace"
     source_labels = ["__meta_kubernetes_pod_container_name"]
+    action = "replace"
     target_label = "container"
   }
 }

--- a/examples/profiles-enabled/output.yaml
+++ b/examples/profiles-enabled/output.yaml
@@ -1312,6 +1312,11 @@ data:
         regex = ".*/java$"
       }
       rule {
+        source_labels = ["__meta_kubernetes_pod_name"]
+        regex = ".+"
+        action = "keep"
+      }
+      rule {
         action = "replace"
         source_labels = ["__meta_kubernetes_namespace"]
         target_label = "namespace"
@@ -61329,6 +61334,11 @@ data:
         source_labels = ["__meta_process_exe"]
         action = "keep"
         regex = ".*/java$"
+      }
+      rule {
+        source_labels = ["__meta_kubernetes_pod_name"]
+        regex = ".+"
+        action = "keep"
       }
       rule {
         action = "replace"

--- a/examples/profiles-enabled/output.yaml
+++ b/examples/profiles-enabled/output.yaml
@@ -1302,9 +1302,14 @@ data:
     discovery.relabel "java_pods" {
       targets = discovery.process.java_pods.targets
       rule {
-        action = "drop"
-        regex = "Succeeded|Failed|Completed"
         source_labels = ["__meta_kubernetes_pod_phase"]
+        regex = "Succeeded|Failed|Completed"
+        action = "drop"
+      }
+      rule {
+        source_labels = ["__meta_kubernetes_pod_name"]
+        regex = "^$"
+        action = "drop"
       }
       rule {
         source_labels = ["__meta_process_exe"]
@@ -1312,28 +1317,23 @@ data:
         regex = ".*/java$"
       }
       rule {
-        source_labels = ["__meta_kubernetes_pod_name"]
-        regex = ".+"
-        action = "keep"
-      }
-      rule {
-        action = "replace"
         source_labels = ["__meta_kubernetes_namespace"]
+        action = "replace"
         target_label = "namespace"
       }
       rule {
-        action = "replace"
         source_labels = ["__meta_kubernetes_pod_name"]
+        action = "replace"
         target_label = "pod"
       }
       rule {
-        action = "replace"
         source_labels = ["__meta_kubernetes_pod_node_name"]
+        action = "replace"
         target_label = "node"
       }
       rule {
-        action = "replace"
         source_labels = ["__meta_kubernetes_pod_container_name"]
+        action = "replace"
         target_label = "container"
       }
     }
@@ -61326,9 +61326,14 @@ data:
     discovery.relabel "java_pods" {
       targets = discovery.process.java_pods.targets
       rule {
-        action = "drop"
-        regex = "Succeeded|Failed|Completed"
         source_labels = ["__meta_kubernetes_pod_phase"]
+        regex = "Succeeded|Failed|Completed"
+        action = "drop"
+      }
+      rule {
+        source_labels = ["__meta_kubernetes_pod_name"]
+        regex = "^$"
+        action = "drop"
       }
       rule {
         source_labels = ["__meta_process_exe"]
@@ -61336,28 +61341,23 @@ data:
         regex = ".*/java$"
       }
       rule {
-        source_labels = ["__meta_kubernetes_pod_name"]
-        regex = ".+"
-        action = "keep"
-      }
-      rule {
-        action = "replace"
         source_labels = ["__meta_kubernetes_namespace"]
+        action = "replace"
         target_label = "namespace"
       }
       rule {
-        action = "replace"
         source_labels = ["__meta_kubernetes_pod_name"]
+        action = "replace"
         target_label = "pod"
       }
       rule {
-        action = "replace"
         source_labels = ["__meta_kubernetes_pod_node_name"]
+        action = "replace"
         target_label = "node"
       }
       rule {
-        action = "replace"
         source_labels = ["__meta_kubernetes_pod_container_name"]
+        action = "replace"
         target_label = "container"
       }
     }

--- a/examples/profiles-enabled/profiles.alloy
+++ b/examples/profiles-enabled/profiles.alloy
@@ -78,6 +78,11 @@ discovery.relabel "java_pods" {
     regex = ".*/java$"
   }
   rule {
+    source_labels = ["__meta_kubernetes_pod_name"]
+    regex = ".+"
+    action = "keep"
+  }
+  rule {
     action = "replace"
     source_labels = ["__meta_kubernetes_namespace"]
     target_label = "namespace"

--- a/examples/profiles-enabled/profiles.alloy
+++ b/examples/profiles-enabled/profiles.alloy
@@ -68,9 +68,14 @@ discovery.process "java_pods" {
 discovery.relabel "java_pods" {
   targets = discovery.process.java_pods.targets
   rule {
-    action = "drop"
-    regex = "Succeeded|Failed|Completed"
     source_labels = ["__meta_kubernetes_pod_phase"]
+    regex = "Succeeded|Failed|Completed"
+    action = "drop"
+  }
+  rule {
+    source_labels = ["__meta_kubernetes_pod_name"]
+    regex = "^$"
+    action = "drop"
   }
   rule {
     source_labels = ["__meta_process_exe"]
@@ -78,28 +83,23 @@ discovery.relabel "java_pods" {
     regex = ".*/java$"
   }
   rule {
-    source_labels = ["__meta_kubernetes_pod_name"]
-    regex = ".+"
-    action = "keep"
-  }
-  rule {
-    action = "replace"
     source_labels = ["__meta_kubernetes_namespace"]
+    action = "replace"
     target_label = "namespace"
   }
   rule {
-    action = "replace"
     source_labels = ["__meta_kubernetes_pod_name"]
+    action = "replace"
     target_label = "pod"
   }
   rule {
-    action = "replace"
     source_labels = ["__meta_kubernetes_pod_node_name"]
+    action = "replace"
     target_label = "node"
   }
   rule {
-    action = "replace"
     source_labels = ["__meta_kubernetes_pod_container_name"]
+    action = "replace"
     target_label = "container"
   }
 }


### PR DESCRIPTION
Before, we were finding java processes by:
1. discovery.kubernetes to get the pods on the same node, and filter by namespace
2. discovery.process to merge those pods with process data
3. discovery.relabel to filter to java processes and set labels

The problem is that `discovery.process` does not just get process info for the pods found in step 1, it returns a list joined with both prods and processes ([docs](https://grafana.com/docs/alloy/latest/reference/components/discovery/discovery.process/#targets-joining)).

This change re-filters in the `discovery.relabel` component to only things that are pods (so, only get kubernetes processes) and the namespace filter again.