### PR TITLE
Add config validation to check for liveDebugging without the experimental stability level

### DIFF
--- a/charts/k8s-monitoring/README.md
+++ b/charts/k8s-monitoring/README.md
@@ -154,7 +154,7 @@ The Prometheus and Loki services may be hosted on the same cluster, or remotely 
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| alloy-events.liveDebugging.enabled | bool | `false` | Enable live debugging for the Alloy instance. Requires stability level to be set to "public-preview". |
+| alloy-events.liveDebugging.enabled | bool | `false` | Enable live debugging for the Alloy instance. Requires stability level to be set to "experimental". |
 | alloy-events.logging.format | string | `"logfmt"` | Format to use for writing Alloy log lines. |
 | alloy-events.logging.level | string | `"info"` | Level at which Alloy log lines should be written. |
 
@@ -162,7 +162,7 @@ The Prometheus and Loki services may be hosted on the same cluster, or remotely 
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| alloy-logs.liveDebugging.enabled | bool | `false` | Enable live debugging for the Alloy instance. Requires stability level to be set to "public-preview". |
+| alloy-logs.liveDebugging.enabled | bool | `false` | Enable live debugging for the Alloy instance. Requires stability level to be set to "experimental". |
 | alloy-logs.logging.format | string | `"logfmt"` | Format to use for writing Alloy log lines. |
 | alloy-logs.logging.level | string | `"info"` | Level at which Alloy log lines should be written. |
 
@@ -170,7 +170,7 @@ The Prometheus and Loki services may be hosted on the same cluster, or remotely 
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| alloy-profiles.liveDebugging.enabled | bool | `false` | Enable live debugging for the Alloy instance. Requires stability level to be set to "public-preview". |
+| alloy-profiles.liveDebugging.enabled | bool | `false` | Enable live debugging for the Alloy instance. Requires stability level to be set to "experimental". |
 | alloy-profiles.logging.format | string | `"logfmt"` | Format to use for writing Alloy log lines. |
 | alloy-profiles.logging.level | string | `"info"` | Level at which Alloy log lines should be written. |
 
@@ -178,7 +178,7 @@ The Prometheus and Loki services may be hosted on the same cluster, or remotely 
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| alloy.liveDebugging.enabled | bool | `false` | Enable live debugging for the Alloy instance. Requires stability level to be set to "public-preview". |
+| alloy.liveDebugging.enabled | bool | `false` | Enable live debugging for the Alloy instance. Requires stability level to be set to "experimental". |
 | alloy.logging.format | string | `"logfmt"` | Format to use for writing Alloy log lines. |
 | alloy.logging.level | string | `"info"` | Level at which Alloy log lines should be written. |
 

--- a/charts/k8s-monitoring/README.md
+++ b/charts/k8s-monitoring/README.md
@@ -154,7 +154,7 @@ The Prometheus and Loki services may be hosted on the same cluster, or remotely 
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| alloy-events.liveDebugging.enabled | bool | `false` | Enable live debugging for the Alloy instance. |
+| alloy-events.liveDebugging.enabled | bool | `false` | Enable live debugging for the Alloy instance. Requires stability level to be set to "public-preview". |
 | alloy-events.logging.format | string | `"logfmt"` | Format to use for writing Alloy log lines. |
 | alloy-events.logging.level | string | `"info"` | Level at which Alloy log lines should be written. |
 
@@ -162,7 +162,7 @@ The Prometheus and Loki services may be hosted on the same cluster, or remotely 
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| alloy-logs.liveDebugging.enabled | bool | `false` | Enable live debugging for the Alloy instance. |
+| alloy-logs.liveDebugging.enabled | bool | `false` | Enable live debugging for the Alloy instance. Requires stability level to be set to "public-preview". |
 | alloy-logs.logging.format | string | `"logfmt"` | Format to use for writing Alloy log lines. |
 | alloy-logs.logging.level | string | `"info"` | Level at which Alloy log lines should be written. |
 
@@ -170,7 +170,7 @@ The Prometheus and Loki services may be hosted on the same cluster, or remotely 
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| alloy-profiles.liveDebugging.enabled | bool | `false` | Enable live debugging for the Alloy instance. |
+| alloy-profiles.liveDebugging.enabled | bool | `false` | Enable live debugging for the Alloy instance. Requires stability level to be set to "public-preview". |
 | alloy-profiles.logging.format | string | `"logfmt"` | Format to use for writing Alloy log lines. |
 | alloy-profiles.logging.level | string | `"info"` | Level at which Alloy log lines should be written. |
 
@@ -178,7 +178,7 @@ The Prometheus and Loki services may be hosted on the same cluster, or remotely 
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| alloy.liveDebugging.enabled | bool | `false` | Enable live debugging for the Alloy instance. |
+| alloy.liveDebugging.enabled | bool | `false` | Enable live debugging for the Alloy instance. Requires stability level to be set to "public-preview". |
 | alloy.logging.format | string | `"logfmt"` | Format to use for writing Alloy log lines. |
 | alloy.logging.level | string | `"info"` | Level at which Alloy log lines should be written. |
 

--- a/charts/k8s-monitoring/templates/_config_validations.tpl
+++ b/charts/k8s-monitoring/templates/_config_validations.tpl
@@ -73,14 +73,14 @@ alloy-logs:
 {{- $Values := .Values }}
 {{- range $alloy := tuple "alloy" "alloy-events" "alloy-logs" "alloy-profiles"}}
   {{- with (index $Values $alloy) }}
-    {{- if and .liveDebugging.enabled (not (or (eq .alloy.stabilityLevel "public-preview") (eq .alloy.stabilityLevel "experimental"))) }}
+    {{- if and .liveDebugging.enabled (not (eq .alloy.stabilityLevel "experimental")) }}
 {{/*
-To enable Alloy live debugging, you must set the stabilityLevel to "public-preview":
+To enable Alloy live debugging, you must set the stabilityLevel to "experimental":
 alloy-logs:
   alloy:
-    stabilityLevel: public-preview
+    stabilityLevel: experimental
 */}}
-      {{ fail (printf "To enable Alloy live debugging, you must set the stabilityLevel to \"public-preview\":\n%s:\n  alloy:\n    stabilityLevel: public-preview" $alloy) }}
+      {{ fail (printf "To enable Alloy live debugging, you must set the stabilityLevel to \"experimental\":\n%s:\n  alloy:\n    stabilityLevel: experimental" $alloy) }}
     {{- end -}}
   {{- end -}}
 {{- end -}}

--- a/charts/k8s-monitoring/templates/_config_validations.tpl
+++ b/charts/k8s-monitoring/templates/_config_validations.tpl
@@ -69,4 +69,19 @@ alloy-logs:
       {{ fail "Invalid configuration for gathering journal logs! Grafana Alloy for Logs must be a Daemonset. Otherwise, journal logs will be missing!\nPlease set:\nalloy-logs:\n  controller:\n    type: daemonset"}}
   {{- end }}
 {{- end -}}
+
+{{- $Values := .Values }}
+{{- range $alloy := tuple "alloy" "alloy-events" "alloy-logs" "alloy-profiles"}}
+  {{- with (index $Values $alloy) }}
+    {{- if and .liveDebugging.enabled (not (or (eq .alloy.stabilityLevel "public-preview") (eq .alloy.stabilityLevel "experimental"))) }}
+{{/*
+To enable Alloy live debugging, you must set the stabilityLevel to "public-preview":
+alloy-logs:
+  alloy:
+    stabilityLevel: public-preview
+*/}}
+      {{ fail (printf "To enable Alloy live debugging, you must set the stabilityLevel to \"public-preview\":\n%s:\n  alloy:\n    stabilityLevel: public-preview" $alloy) }}
+    {{- end -}}
+  {{- end -}}
+{{- end -}}
 {{- end -}}

--- a/charts/k8s-monitoring/values.yaml
+++ b/charts/k8s-monitoring/values.yaml
@@ -2106,6 +2106,7 @@ alloy:
 
   liveDebugging:
     # -- Enable live debugging for the Alloy instance.
+    # Requires stability level to be set to "public-preview".
     # @section -- Deployment: [Alloy](https://github.com/grafana/alloy/tree/main/operations/helm/charts/alloy)
     enabled: false
 
@@ -2194,6 +2195,7 @@ alloy-events:
 
   liveDebugging:
     # -- Enable live debugging for the Alloy instance.
+    # Requires stability level to be set to "public-preview".
     # @section -- Deployment: [Alloy](https://github.com/grafana/alloy/tree/main/operations/helm/charts/alloy) for Cluster Events Deployment
     enabled: false
 
@@ -2229,6 +2231,7 @@ alloy-logs:
 
   liveDebugging:
     # -- Enable live debugging for the Alloy instance.
+    # Requires stability level to be set to "public-preview".
     # @section -- Deployment: [Alloy](https://github.com/grafana/alloy/tree/main/operations/helm/charts/alloy) for Logs Deployment
     enabled: false
 
@@ -2278,6 +2281,7 @@ alloy-profiles:
 
   liveDebugging:
     # -- Enable live debugging for the Alloy instance.
+    # Requires stability level to be set to "public-preview".
     # @section -- Deployment: [Alloy](https://github.com/grafana/alloy/tree/main/operations/helm/charts/alloy) for Profiles Deployment
     enabled: false
 

--- a/charts/k8s-monitoring/values.yaml
+++ b/charts/k8s-monitoring/values.yaml
@@ -2106,7 +2106,7 @@ alloy:
 
   liveDebugging:
     # -- Enable live debugging for the Alloy instance.
-    # Requires stability level to be set to "public-preview".
+    # Requires stability level to be set to "experimental".
     # @section -- Deployment: [Alloy](https://github.com/grafana/alloy/tree/main/operations/helm/charts/alloy)
     enabled: false
 
@@ -2195,7 +2195,7 @@ alloy-events:
 
   liveDebugging:
     # -- Enable live debugging for the Alloy instance.
-    # Requires stability level to be set to "public-preview".
+    # Requires stability level to be set to "experimental".
     # @section -- Deployment: [Alloy](https://github.com/grafana/alloy/tree/main/operations/helm/charts/alloy) for Cluster Events Deployment
     enabled: false
 
@@ -2231,7 +2231,7 @@ alloy-logs:
 
   liveDebugging:
     # -- Enable live debugging for the Alloy instance.
-    # Requires stability level to be set to "public-preview".
+    # Requires stability level to be set to "experimental".
     # @section -- Deployment: [Alloy](https://github.com/grafana/alloy/tree/main/operations/helm/charts/alloy) for Logs Deployment
     enabled: false
 
@@ -2281,7 +2281,7 @@ alloy-profiles:
 
   liveDebugging:
     # -- Enable live debugging for the Alloy instance.
-    # Requires stability level to be set to "public-preview".
+    # Requires stability level to be set to "experimental".
     # @section -- Deployment: [Alloy](https://github.com/grafana/alloy/tree/main/operations/helm/charts/alloy) for Profiles Deployment
     enabled: false
 


### PR DESCRIPTION
We cannot force Alloy to change its stability level, but we can warn the user to enable it.