### PR TITLE
Journal logging's format_as_json needs to be a boolean, not a string

### DIFF
--- a/charts/k8s-monitoring/templates/alloy_config/_journal_logs_discovery.alloy.txt
+++ b/charts/k8s-monitoring/templates/alloy_config/_journal_logs_discovery.alloy.txt
@@ -27,7 +27,7 @@ loki.relabel "journal" {
 
 loki.source.journal "worker" {
   path = {{ .Values.logs.journal.path | default "/var/logs/journal" | quote }}
-  format_as_json = {{ .Values.logs.journal.formatAsJson | quote }}
+  format_as_json = {{ .Values.logs.journal.formatAsJson }}
   max_age = {{ .Values.logs.journal.maxAge | default "8h" | quote }}
   relabel_rules = loki.relabel.journal.rules
   labels = {

--- a/examples/logs-journal/logs.alloy
+++ b/examples/logs-journal/logs.alloy
@@ -173,7 +173,7 @@ loki.relabel "journal" {
 
 loki.source.journal "worker" {
   path = "/var/log/journal"
-  format_as_json = "false"
+  format_as_json = false
   max_age = "8h"
   relabel_rules = loki.relabel.journal.rules
   labels = {

--- a/examples/logs-journal/output.yaml
+++ b/examples/logs-journal/output.yaml
@@ -407,7 +407,7 @@ data:
     
     loki.source.journal "worker" {
       path = "/var/log/journal"
-      format_as_json = "false"
+      format_as_json = false
       max_age = "8h"
       relabel_rules = loki.relabel.journal.rules
       labels = {


### PR DESCRIPTION
Fixes this bug:
```
Error: /etc/alloy/config.alloy:181:20: "false" should be bool, got string

180 |   path = "/var/log/journal"
181 |   format_as_json = "false"
    |                    ^^^^^^^
182 |   max_age = "8h"
```