### PR TITLE
Make structured metadata optional, and default to off

### DIFF
--- a/charts/k8s-monitoring/README.md
+++ b/charts/k8s-monitoring/README.md
@@ -402,6 +402,7 @@ The Prometheus and Loki services may be hosted on the same cluster, or remotely 
 | logs.pod_logs.gatherMethod | string | `"volumes"` | Controls the behavior of gathering pod logs. When set to `volumes`, Grafana Alloy will use HostPath volume mounts on the cluster nodes to access the pod log files directly. When set to `api`, Grafana Alloy will access pod logs via the API server. This method may be preferable if your cluster prevents DaemonSets, HostPath volume mounts, or for other reasons. |
 | logs.pod_logs.labels | object | `{"app_kubernetes_io_name":"app.kubernetes.io/name"}` | Loki labels to set with values copied from the Kubernetes Pod labels. Format: `<loki_label>: <kubernetes_label>`. |
 | logs.pod_logs.namespaces | list | `[]` | Only capture logs from pods in these namespaces (`[]` means all namespaces). |
+| logs.pod_logs.structuredMetadata | object | `{}` | List of labels to turn into structured metadata. If your Loki instance does not support structured metadata, leave this empty. Format: `<structured metadata>: <Loki label>`. |
 
 ### Logs Scrape: PodLog Objects
 

--- a/charts/k8s-monitoring/ci/ci-values.yaml
+++ b/charts/k8s-monitoring/ci/ci-values.yaml
@@ -55,6 +55,7 @@ logs:
   pod_logs:
     structuredMetadata:
       pod: ""
+      name: app_kubernetes_io_name
   cluster_events:
     logToStdout: true
 

--- a/charts/k8s-monitoring/ci/ci-values.yaml
+++ b/charts/k8s-monitoring/ci/ci-values.yaml
@@ -52,6 +52,9 @@ metrics:
         - kube_pod_info
 
 logs:
+  pod_logs:
+    structuredMetadata:
+      pod: ""
   cluster_events:
     logToStdout: true
 
@@ -112,6 +115,10 @@ opencost:
         url: https://prometheus-server.prometheus.svc.cluster.local:9090
 
 alloy:
+  liveDebugging:
+    enabled: true
+  alloy:
+    stabilityLevel: experimental
   controller:
     replicas: 2
 

--- a/charts/k8s-monitoring/templates/alloy_config/_pod_logs_processor.alloy.txt
+++ b/charts/k8s-monitoring/templates/alloy_config/_pod_logs_processor.alloy.txt
@@ -26,14 +26,16 @@ loki.process "pod_logs" {
       }
     }
   }
-
+{{ if .Values.logs.pod_logs.structuredMetadata }}
   // Move high-cardinality labels to structured metadata
   stage.structured_metadata {
     values = {
-      pod  = "",
+      {{- range $label, $lokiLabel := .Values.logs.pod_logs.structuredMetadata }}
+      {{ $label }} = {{ $lokiLabel | quote }},
+      {{- end -}}
     }
   }
-
+{{- end }}
   // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
   // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
   // container runtime label as it is no longer needed.

--- a/charts/k8s-monitoring/templates/alloy_config/_pod_logs_processor.alloy.txt
+++ b/charts/k8s-monitoring/templates/alloy_config/_pod_logs_processor.alloy.txt
@@ -32,15 +32,23 @@ loki.process "pod_logs" {
     values = {
       {{- range $label, $lokiLabel := .Values.logs.pod_logs.structuredMetadata }}
       {{ $label }} = {{ $lokiLabel | quote }},
-      {{- end -}}
+      {{- end }}
     }
   }
 {{- end }}
   // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
-  // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+  // namespace, pod, and container labels. Drop any structured metadata. Also drop the temporary
   // container runtime label as it is no longer needed.
   stage.label_drop {
-    values = ["filename", "pod", "tmp_container_runtime"]
+    values = [
+      "filename",
+      "tmp_container_runtime",
+{{- if .Values.logs.pod_logs.structuredMetadata }}
+  {{- range $label, $lokiLabel := .Values.logs.pod_logs.structuredMetadata }}
+      {{ $lokiLabel | default $label | quote }},
+  {{- end }}
+{{- end }}
+    ]
   }
 
 {{- if .Values.logs.pod_logs.extraStageBlocks }}

--- a/charts/k8s-monitoring/values.schema.json
+++ b/charts/k8s-monitoring/values.schema.json
@@ -848,6 +848,9 @@
                             "items": {
                                 "type": "string"
                             }
+                        },
+                        "structuredMetadata": {
+                            "type": "object"
                         }
                     }
                 },

--- a/charts/k8s-monitoring/values.yaml
+++ b/charts/k8s-monitoring/values.yaml
@@ -1394,6 +1394,12 @@ logs:
     annotations:
       job: k8s.grafana.com/logs.job
 
+    # -- List of labels to turn into structured metadata.
+    # If your Loki instance does not support structured metadata, leave this empty.
+    # Format: `<structured metadata>: <Loki label>`.
+    # @section -- Logs Scrape: Pod Logs
+    structuredMetadata: {}
+
   # PodLog Objects
   podLogsObjects:
     # -- Enable discovery of Grafana Alloy PodLogs objects.

--- a/examples/alloy-autoscaling-and-storage/logs.alloy
+++ b/examples/alloy-autoscaling-and-storage/logs.alloy
@@ -109,10 +109,13 @@ loki.process "pod_logs" {
   }
 
   // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
-  // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+  // namespace, pod, and container labels. Drop any structured metadata. Also drop the temporary
   // container runtime label as it is no longer needed.
   stage.label_drop {
-    values = ["filename", "pod", "tmp_container_runtime"]
+    values = [
+      "filename",
+      "tmp_container_runtime",
+    ]
   }
   forward_to = [loki.process.logs_service.receiver]
 }

--- a/examples/alloy-autoscaling-and-storage/logs.alloy
+++ b/examples/alloy-autoscaling-and-storage/logs.alloy
@@ -108,13 +108,6 @@ loki.process "pod_logs" {
     }
   }
 
-  // Move high-cardinality labels to structured metadata
-  stage.structured_metadata {
-    values = {
-      pod  = "",
-    }
-  }
-
   // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
   // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
   // container runtime label as it is no longer needed.

--- a/examples/alloy-autoscaling-and-storage/metrics.alloy
+++ b/examples/alloy-autoscaling-and-storage/metrics.alloy
@@ -791,10 +791,13 @@ loki.process "pod_logs" {
   }
 
   // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
-  // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+  // namespace, pod, and container labels. Drop any structured metadata. Also drop the temporary
   // container runtime label as it is no longer needed.
   stage.label_drop {
-    values = ["filename", "pod", "tmp_container_runtime"]
+    values = [
+      "filename",
+      "tmp_container_runtime",
+    ]
   }
   forward_to = [loki.process.logs_service.receiver]
 }

--- a/examples/alloy-autoscaling-and-storage/metrics.alloy
+++ b/examples/alloy-autoscaling-and-storage/metrics.alloy
@@ -790,13 +790,6 @@ loki.process "pod_logs" {
     }
   }
 
-  // Move high-cardinality labels to structured metadata
-  stage.structured_metadata {
-    values = {
-      pod  = "",
-    }
-  }
-
   // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
   // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
   // container runtime label as it is no longer needed.

--- a/examples/alloy-autoscaling-and-storage/output.yaml
+++ b/examples/alloy-autoscaling-and-storage/output.yaml
@@ -920,13 +920,6 @@ data:
         }
       }
     
-      // Move high-cardinality labels to structured metadata
-      stage.structured_metadata {
-        values = {
-          pod  = "",
-        }
-      }
-    
       // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
       // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
       // container runtime label as it is no longer needed.
@@ -1142,13 +1135,6 @@ data:
           values = {
             stream  = "",
           }
-        }
-      }
-    
-      // Move high-cardinality labels to structured metadata
-      stage.structured_metadata {
-        values = {
-          pod  = "",
         }
       }
     
@@ -59863,13 +59849,6 @@ data:
         }
       }
     
-      // Move high-cardinality labels to structured metadata
-      stage.structured_metadata {
-        values = {
-          pod  = "",
-        }
-      }
-    
       // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
       // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
       // container runtime label as it is no longer needed.
@@ -60069,13 +60048,6 @@ data:
           values = {
             stream  = "",
           }
-        }
-      }
-    
-      // Move high-cardinality labels to structured metadata
-      stage.structured_metadata {
-        values = {
-          pod  = "",
         }
       }
     

--- a/examples/alloy-autoscaling-and-storage/output.yaml
+++ b/examples/alloy-autoscaling-and-storage/output.yaml
@@ -921,10 +921,13 @@ data:
       }
     
       // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
-      // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+      // namespace, pod, and container labels. Drop any structured metadata. Also drop the temporary
       // container runtime label as it is no longer needed.
       stage.label_drop {
-        values = ["filename", "pod", "tmp_container_runtime"]
+        values = [
+          "filename",
+          "tmp_container_runtime",
+        ]
       }
       forward_to = [loki.process.logs_service.receiver]
     }
@@ -1139,10 +1142,13 @@ data:
       }
     
       // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
-      // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+      // namespace, pod, and container labels. Drop any structured metadata. Also drop the temporary
       // container runtime label as it is no longer needed.
       stage.label_drop {
-        values = ["filename", "pod", "tmp_container_runtime"]
+        values = [
+          "filename",
+          "tmp_container_runtime",
+        ]
       }
       forward_to = [loki.process.logs_service.receiver]
     }
@@ -59850,10 +59856,13 @@ data:
       }
     
       // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
-      // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+      // namespace, pod, and container labels. Drop any structured metadata. Also drop the temporary
       // container runtime label as it is no longer needed.
       stage.label_drop {
-        values = ["filename", "pod", "tmp_container_runtime"]
+        values = [
+          "filename",
+          "tmp_container_runtime",
+        ]
       }
       forward_to = [loki.process.logs_service.receiver]
     }
@@ -60052,10 +60061,13 @@ data:
       }
     
       // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
-      // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+      // namespace, pod, and container labels. Drop any structured metadata. Also drop the temporary
       // container runtime label as it is no longer needed.
       stage.label_drop {
-        values = ["filename", "pod", "tmp_container_runtime"]
+        values = [
+          "filename",
+          "tmp_container_runtime",
+        ]
       }
       forward_to = [loki.process.logs_service.receiver]
     }

--- a/examples/application-observability/logs.alloy
+++ b/examples/application-observability/logs.alloy
@@ -109,10 +109,13 @@ loki.process "pod_logs" {
   }
 
   // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
-  // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+  // namespace, pod, and container labels. Drop any structured metadata. Also drop the temporary
   // container runtime label as it is no longer needed.
   stage.label_drop {
-    values = ["filename", "pod", "tmp_container_runtime"]
+    values = [
+      "filename",
+      "tmp_container_runtime",
+    ]
   }
   forward_to = [loki.process.logs_service.receiver]
 }

--- a/examples/application-observability/logs.alloy
+++ b/examples/application-observability/logs.alloy
@@ -108,13 +108,6 @@ loki.process "pod_logs" {
     }
   }
 
-  // Move high-cardinality labels to structured metadata
-  stage.structured_metadata {
-    values = {
-      pod  = "",
-    }
-  }
-
   // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
   // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
   // container runtime label as it is no longer needed.

--- a/examples/application-observability/metrics.alloy
+++ b/examples/application-observability/metrics.alloy
@@ -823,10 +823,13 @@ loki.process "pod_logs" {
   }
 
   // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
-  // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+  // namespace, pod, and container labels. Drop any structured metadata. Also drop the temporary
   // container runtime label as it is no longer needed.
   stage.label_drop {
-    values = ["filename", "pod", "tmp_container_runtime"]
+    values = [
+      "filename",
+      "tmp_container_runtime",
+    ]
   }
   forward_to = [loki.process.logs_service.receiver]
 }

--- a/examples/application-observability/metrics.alloy
+++ b/examples/application-observability/metrics.alloy
@@ -822,13 +822,6 @@ loki.process "pod_logs" {
     }
   }
 
-  // Move high-cardinality labels to structured metadata
-  stage.structured_metadata {
-    values = {
-      pod  = "",
-    }
-  }
-
   // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
   // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
   // container runtime label as it is no longer needed.

--- a/examples/application-observability/output.yaml
+++ b/examples/application-observability/output.yaml
@@ -994,13 +994,6 @@ data:
         }
       }
     
-      // Move high-cardinality labels to structured metadata
-      stage.structured_metadata {
-        values = {
-          pod  = "",
-        }
-      }
-    
       // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
       // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
       // container runtime label as it is no longer needed.
@@ -1236,13 +1229,6 @@ data:
           values = {
             stream  = "",
           }
-        }
-      }
-    
-      // Move high-cardinality labels to structured metadata
-      stage.structured_metadata {
-        values = {
-          pod  = "",
         }
       }
     
@@ -61095,13 +61081,6 @@ data:
         }
       }
     
-      // Move high-cardinality labels to structured metadata
-      stage.structured_metadata {
-        values = {
-          pod  = "",
-        }
-      }
-    
       // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
       // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
       // container runtime label as it is no longer needed.
@@ -61321,13 +61300,6 @@ data:
           values = {
             stream  = "",
           }
-        }
-      }
-    
-      // Move high-cardinality labels to structured metadata
-      stage.structured_metadata {
-        values = {
-          pod  = "",
         }
       }
     

--- a/examples/application-observability/output.yaml
+++ b/examples/application-observability/output.yaml
@@ -995,10 +995,13 @@ data:
       }
     
       // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
-      // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+      // namespace, pod, and container labels. Drop any structured metadata. Also drop the temporary
       // container runtime label as it is no longer needed.
       stage.label_drop {
-        values = ["filename", "pod", "tmp_container_runtime"]
+        values = [
+          "filename",
+          "tmp_container_runtime",
+        ]
       }
       forward_to = [loki.process.logs_service.receiver]
     }
@@ -1233,10 +1236,13 @@ data:
       }
     
       // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
-      // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+      // namespace, pod, and container labels. Drop any structured metadata. Also drop the temporary
       // container runtime label as it is no longer needed.
       stage.label_drop {
-        values = ["filename", "pod", "tmp_container_runtime"]
+        values = [
+          "filename",
+          "tmp_container_runtime",
+        ]
       }
       forward_to = [loki.process.logs_service.receiver]
     }
@@ -61082,10 +61088,13 @@ data:
       }
     
       // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
-      // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+      // namespace, pod, and container labels. Drop any structured metadata. Also drop the temporary
       // container runtime label as it is no longer needed.
       stage.label_drop {
-        values = ["filename", "pod", "tmp_container_runtime"]
+        values = [
+          "filename",
+          "tmp_container_runtime",
+        ]
       }
       forward_to = [loki.process.logs_service.receiver]
     }
@@ -61304,10 +61313,13 @@ data:
       }
     
       // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
-      // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+      // namespace, pod, and container labels. Drop any structured metadata. Also drop the temporary
       // container runtime label as it is no longer needed.
       stage.label_drop {
-        values = ["filename", "pod", "tmp_container_runtime"]
+        values = [
+          "filename",
+          "tmp_container_runtime",
+        ]
       }
       forward_to = [loki.process.logs_service.receiver]
     }

--- a/examples/control-plane-metrics/logs.alloy
+++ b/examples/control-plane-metrics/logs.alloy
@@ -109,10 +109,13 @@ loki.process "pod_logs" {
   }
 
   // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
-  // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+  // namespace, pod, and container labels. Drop any structured metadata. Also drop the temporary
   // container runtime label as it is no longer needed.
   stage.label_drop {
-    values = ["filename", "pod", "tmp_container_runtime"]
+    values = [
+      "filename",
+      "tmp_container_runtime",
+    ]
   }
   forward_to = [loki.process.logs_service.receiver]
 }

--- a/examples/control-plane-metrics/logs.alloy
+++ b/examples/control-plane-metrics/logs.alloy
@@ -108,13 +108,6 @@ loki.process "pod_logs" {
     }
   }
 
-  // Move high-cardinality labels to structured metadata
-  stage.structured_metadata {
-    values = {
-      pod  = "",
-    }
-  }
-
   // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
   // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
   // container runtime label as it is no longer needed.

--- a/examples/control-plane-metrics/metrics.alloy
+++ b/examples/control-plane-metrics/metrics.alloy
@@ -947,10 +947,13 @@ loki.process "pod_logs" {
   }
 
   // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
-  // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+  // namespace, pod, and container labels. Drop any structured metadata. Also drop the temporary
   // container runtime label as it is no longer needed.
   stage.label_drop {
-    values = ["filename", "pod", "tmp_container_runtime"]
+    values = [
+      "filename",
+      "tmp_container_runtime",
+    ]
   }
   forward_to = [loki.process.logs_service.receiver]
 }

--- a/examples/control-plane-metrics/metrics.alloy
+++ b/examples/control-plane-metrics/metrics.alloy
@@ -946,13 +946,6 @@ loki.process "pod_logs" {
     }
   }
 
-  // Move high-cardinality labels to structured metadata
-  stage.structured_metadata {
-    values = {
-      pod  = "",
-    }
-  }
-
   // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
   // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
   // container runtime label as it is no longer needed.

--- a/examples/control-plane-metrics/output.yaml
+++ b/examples/control-plane-metrics/output.yaml
@@ -1078,10 +1078,13 @@ data:
       }
     
       // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
-      // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+      // namespace, pod, and container labels. Drop any structured metadata. Also drop the temporary
       // container runtime label as it is no longer needed.
       stage.label_drop {
-        values = ["filename", "pod", "tmp_container_runtime"]
+        values = [
+          "filename",
+          "tmp_container_runtime",
+        ]
       }
       forward_to = [loki.process.logs_service.receiver]
     }
@@ -1296,10 +1299,13 @@ data:
       }
     
       // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
-      // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+      // namespace, pod, and container labels. Drop any structured metadata. Also drop the temporary
       // container runtime label as it is no longer needed.
       stage.label_drop {
-        values = ["filename", "pod", "tmp_container_runtime"]
+        values = [
+          "filename",
+          "tmp_container_runtime",
+        ]
       }
       forward_to = [loki.process.logs_service.receiver]
     }
@@ -60102,10 +60108,13 @@ data:
       }
     
       // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
-      // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+      // namespace, pod, and container labels. Drop any structured metadata. Also drop the temporary
       // container runtime label as it is no longer needed.
       stage.label_drop {
-        values = ["filename", "pod", "tmp_container_runtime"]
+        values = [
+          "filename",
+          "tmp_container_runtime",
+        ]
       }
       forward_to = [loki.process.logs_service.receiver]
     }
@@ -60304,10 +60313,13 @@ data:
       }
     
       // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
-      // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+      // namespace, pod, and container labels. Drop any structured metadata. Also drop the temporary
       // container runtime label as it is no longer needed.
       stage.label_drop {
-        values = ["filename", "pod", "tmp_container_runtime"]
+        values = [
+          "filename",
+          "tmp_container_runtime",
+        ]
       }
       forward_to = [loki.process.logs_service.receiver]
     }

--- a/examples/control-plane-metrics/output.yaml
+++ b/examples/control-plane-metrics/output.yaml
@@ -1077,13 +1077,6 @@ data:
         }
       }
     
-      // Move high-cardinality labels to structured metadata
-      stage.structured_metadata {
-        values = {
-          pod  = "",
-        }
-      }
-    
       // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
       // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
       // container runtime label as it is no longer needed.
@@ -1299,13 +1292,6 @@ data:
           values = {
             stream  = "",
           }
-        }
-      }
-    
-      // Move high-cardinality labels to structured metadata
-      stage.structured_metadata {
-        values = {
-          pod  = "",
         }
       }
     
@@ -60115,13 +60101,6 @@ data:
         }
       }
     
-      // Move high-cardinality labels to structured metadata
-      stage.structured_metadata {
-        values = {
-          pod  = "",
-        }
-      }
-    
       // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
       // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
       // container runtime label as it is no longer needed.
@@ -60321,13 +60300,6 @@ data:
           values = {
             stream  = "",
           }
-        }
-      }
-    
-      // Move high-cardinality labels to structured metadata
-      stage.structured_metadata {
-        values = {
-          pod  = "",
         }
       }
     

--- a/examples/custom-config/logs.alloy
+++ b/examples/custom-config/logs.alloy
@@ -109,10 +109,13 @@ loki.process "pod_logs" {
   }
 
   // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
-  // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+  // namespace, pod, and container labels. Drop any structured metadata. Also drop the temporary
   // container runtime label as it is no longer needed.
   stage.label_drop {
-    values = ["filename", "pod", "tmp_container_runtime"]
+    values = [
+      "filename",
+      "tmp_container_runtime",
+    ]
   }
   forward_to = [loki.process.logs_service.receiver]
 }

--- a/examples/custom-config/logs.alloy
+++ b/examples/custom-config/logs.alloy
@@ -108,13 +108,6 @@ loki.process "pod_logs" {
     }
   }
 
-  // Move high-cardinality labels to structured metadata
-  stage.structured_metadata {
-    values = {
-      pod  = "",
-    }
-  }
-
   // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
   // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
   // container runtime label as it is no longer needed.

--- a/examples/custom-config/metrics.alloy
+++ b/examples/custom-config/metrics.alloy
@@ -794,13 +794,6 @@ loki.process "pod_logs" {
     }
   }
 
-  // Move high-cardinality labels to structured metadata
-  stage.structured_metadata {
-    values = {
-      pod  = "",
-    }
-  }
-
   // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
   // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
   // container runtime label as it is no longer needed.

--- a/examples/custom-config/metrics.alloy
+++ b/examples/custom-config/metrics.alloy
@@ -795,10 +795,13 @@ loki.process "pod_logs" {
   }
 
   // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
-  // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+  // namespace, pod, and container labels. Drop any structured metadata. Also drop the temporary
   // container runtime label as it is no longer needed.
   stage.label_drop {
-    values = ["filename", "pod", "tmp_container_runtime"]
+    values = [
+      "filename",
+      "tmp_container_runtime",
+    ]
   }
   forward_to = [loki.process.logs_service.receiver]
 }

--- a/examples/custom-config/output.yaml
+++ b/examples/custom-config/output.yaml
@@ -925,10 +925,13 @@ data:
       }
     
       // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
-      // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+      // namespace, pod, and container labels. Drop any structured metadata. Also drop the temporary
       // container runtime label as it is no longer needed.
       stage.label_drop {
-        values = ["filename", "pod", "tmp_container_runtime"]
+        values = [
+          "filename",
+          "tmp_container_runtime",
+        ]
       }
       forward_to = [loki.process.logs_service.receiver]
     }
@@ -1185,10 +1188,13 @@ data:
       }
     
       // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
-      // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+      // namespace, pod, and container labels. Drop any structured metadata. Also drop the temporary
       // container runtime label as it is no longer needed.
       stage.label_drop {
-        values = ["filename", "pod", "tmp_container_runtime"]
+        values = [
+          "filename",
+          "tmp_container_runtime",
+        ]
       }
       forward_to = [loki.process.logs_service.receiver]
     }
@@ -59886,10 +59892,13 @@ data:
       }
     
       // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
-      // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+      // namespace, pod, and container labels. Drop any structured metadata. Also drop the temporary
       // container runtime label as it is no longer needed.
       stage.label_drop {
-        values = ["filename", "pod", "tmp_container_runtime"]
+        values = [
+          "filename",
+          "tmp_container_runtime",
+        ]
       }
       forward_to = [loki.process.logs_service.receiver]
     }
@@ -60130,10 +60139,13 @@ data:
       }
     
       // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
-      // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+      // namespace, pod, and container labels. Drop any structured metadata. Also drop the temporary
       // container runtime label as it is no longer needed.
       stage.label_drop {
-        values = ["filename", "pod", "tmp_container_runtime"]
+        values = [
+          "filename",
+          "tmp_container_runtime",
+        ]
       }
       forward_to = [loki.process.logs_service.receiver]
     }

--- a/examples/custom-config/output.yaml
+++ b/examples/custom-config/output.yaml
@@ -924,13 +924,6 @@ data:
         }
       }
     
-      // Move high-cardinality labels to structured metadata
-      stage.structured_metadata {
-        values = {
-          pod  = "",
-        }
-      }
-    
       // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
       // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
       // container runtime label as it is no longer needed.
@@ -1188,13 +1181,6 @@ data:
           values = {
             stream  = "",
           }
-        }
-      }
-    
-      // Move high-cardinality labels to structured metadata
-      stage.structured_metadata {
-        values = {
-          pod  = "",
         }
       }
     
@@ -59899,13 +59885,6 @@ data:
         }
       }
     
-      // Move high-cardinality labels to structured metadata
-      stage.structured_metadata {
-        values = {
-          pod  = "",
-        }
-      }
-    
       // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
       // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
       // container runtime label as it is no longer needed.
@@ -60147,13 +60126,6 @@ data:
           values = {
             stream  = "",
           }
-        }
-      }
-    
-      // Move high-cardinality labels to structured metadata
-      stage.structured_metadata {
-        values = {
-          pod  = "",
         }
       }
     

--- a/examples/custom-pricing/logs.alloy
+++ b/examples/custom-pricing/logs.alloy
@@ -109,10 +109,13 @@ loki.process "pod_logs" {
   }
 
   // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
-  // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+  // namespace, pod, and container labels. Drop any structured metadata. Also drop the temporary
   // container runtime label as it is no longer needed.
   stage.label_drop {
-    values = ["filename", "pod", "tmp_container_runtime"]
+    values = [
+      "filename",
+      "tmp_container_runtime",
+    ]
   }
   forward_to = [loki.process.logs_service.receiver]
 }

--- a/examples/custom-pricing/logs.alloy
+++ b/examples/custom-pricing/logs.alloy
@@ -108,13 +108,6 @@ loki.process "pod_logs" {
     }
   }
 
-  // Move high-cardinality labels to structured metadata
-  stage.structured_metadata {
-    values = {
-      pod  = "",
-    }
-  }
-
   // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
   // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
   // container runtime label as it is no longer needed.

--- a/examples/custom-pricing/metrics.alloy
+++ b/examples/custom-pricing/metrics.alloy
@@ -791,10 +791,13 @@ loki.process "pod_logs" {
   }
 
   // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
-  // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+  // namespace, pod, and container labels. Drop any structured metadata. Also drop the temporary
   // container runtime label as it is no longer needed.
   stage.label_drop {
-    values = ["filename", "pod", "tmp_container_runtime"]
+    values = [
+      "filename",
+      "tmp_container_runtime",
+    ]
   }
   forward_to = [loki.process.logs_service.receiver]
 }

--- a/examples/custom-pricing/metrics.alloy
+++ b/examples/custom-pricing/metrics.alloy
@@ -790,13 +790,6 @@ loki.process "pod_logs" {
     }
   }
 
-  // Move high-cardinality labels to structured metadata
-  stage.structured_metadata {
-    values = {
-      pod  = "",
-    }
-  }
-
   // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
   // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
   // container runtime label as it is no longer needed.

--- a/examples/custom-pricing/output.yaml
+++ b/examples/custom-pricing/output.yaml
@@ -943,10 +943,13 @@ data:
       }
     
       // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
-      // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+      // namespace, pod, and container labels. Drop any structured metadata. Also drop the temporary
       // container runtime label as it is no longer needed.
       stage.label_drop {
-        values = ["filename", "pod", "tmp_container_runtime"]
+        values = [
+          "filename",
+          "tmp_container_runtime",
+        ]
       }
       forward_to = [loki.process.logs_service.receiver]
     }
@@ -1161,10 +1164,13 @@ data:
       }
     
       // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
-      // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+      // namespace, pod, and container labels. Drop any structured metadata. Also drop the temporary
       // container runtime label as it is no longer needed.
       stage.label_drop {
-        values = ["filename", "pod", "tmp_container_runtime"]
+        values = [
+          "filename",
+          "tmp_container_runtime",
+        ]
       }
       forward_to = [loki.process.logs_service.receiver]
     }
@@ -59822,10 +59828,13 @@ data:
       }
     
       // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
-      // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+      // namespace, pod, and container labels. Drop any structured metadata. Also drop the temporary
       // container runtime label as it is no longer needed.
       stage.label_drop {
-        values = ["filename", "pod", "tmp_container_runtime"]
+        values = [
+          "filename",
+          "tmp_container_runtime",
+        ]
       }
       forward_to = [loki.process.logs_service.receiver]
     }
@@ -60024,10 +60033,13 @@ data:
       }
     
       // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
-      // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+      // namespace, pod, and container labels. Drop any structured metadata. Also drop the temporary
       // container runtime label as it is no longer needed.
       stage.label_drop {
-        values = ["filename", "pod", "tmp_container_runtime"]
+        values = [
+          "filename",
+          "tmp_container_runtime",
+        ]
       }
       forward_to = [loki.process.logs_service.receiver]
     }

--- a/examples/custom-pricing/output.yaml
+++ b/examples/custom-pricing/output.yaml
@@ -942,13 +942,6 @@ data:
         }
       }
     
-      // Move high-cardinality labels to structured metadata
-      stage.structured_metadata {
-        values = {
-          pod  = "",
-        }
-      }
-    
       // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
       // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
       // container runtime label as it is no longer needed.
@@ -1164,13 +1157,6 @@ data:
           values = {
             stream  = "",
           }
-        }
-      }
-    
-      // Move high-cardinality labels to structured metadata
-      stage.structured_metadata {
-        values = {
-          pod  = "",
         }
       }
     
@@ -59835,13 +59821,6 @@ data:
         }
       }
     
-      // Move high-cardinality labels to structured metadata
-      stage.structured_metadata {
-        values = {
-          pod  = "",
-        }
-      }
-    
       // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
       // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
       // container runtime label as it is no longer needed.
@@ -60041,13 +60020,6 @@ data:
           values = {
             stream  = "",
           }
-        }
-      }
-    
-      // Move high-cardinality labels to structured metadata
-      stage.structured_metadata {
-        values = {
-          pod  = "",
         }
       }
     

--- a/examples/default-values/logs.alloy
+++ b/examples/default-values/logs.alloy
@@ -109,10 +109,13 @@ loki.process "pod_logs" {
   }
 
   // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
-  // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+  // namespace, pod, and container labels. Drop any structured metadata. Also drop the temporary
   // container runtime label as it is no longer needed.
   stage.label_drop {
-    values = ["filename", "pod", "tmp_container_runtime"]
+    values = [
+      "filename",
+      "tmp_container_runtime",
+    ]
   }
   forward_to = [loki.process.logs_service.receiver]
 }

--- a/examples/default-values/logs.alloy
+++ b/examples/default-values/logs.alloy
@@ -108,13 +108,6 @@ loki.process "pod_logs" {
     }
   }
 
-  // Move high-cardinality labels to structured metadata
-  stage.structured_metadata {
-    values = {
-      pod  = "",
-    }
-  }
-
   // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
   // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
   // container runtime label as it is no longer needed.

--- a/examples/default-values/metrics.alloy
+++ b/examples/default-values/metrics.alloy
@@ -791,10 +791,13 @@ loki.process "pod_logs" {
   }
 
   // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
-  // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+  // namespace, pod, and container labels. Drop any structured metadata. Also drop the temporary
   // container runtime label as it is no longer needed.
   stage.label_drop {
-    values = ["filename", "pod", "tmp_container_runtime"]
+    values = [
+      "filename",
+      "tmp_container_runtime",
+    ]
   }
   forward_to = [loki.process.logs_service.receiver]
 }

--- a/examples/default-values/metrics.alloy
+++ b/examples/default-values/metrics.alloy
@@ -790,13 +790,6 @@ loki.process "pod_logs" {
     }
   }
 
-  // Move high-cardinality labels to structured metadata
-  stage.structured_metadata {
-    values = {
-      pod  = "",
-    }
-  }
-
   // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
   // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
   // container runtime label as it is no longer needed.

--- a/examples/default-values/output.yaml
+++ b/examples/default-values/output.yaml
@@ -920,13 +920,6 @@ data:
         }
       }
     
-      // Move high-cardinality labels to structured metadata
-      stage.structured_metadata {
-        values = {
-          pod  = "",
-        }
-      }
-    
       // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
       // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
       // container runtime label as it is no longer needed.
@@ -1142,13 +1135,6 @@ data:
           values = {
             stream  = "",
           }
-        }
-      }
-    
-      // Move high-cardinality labels to structured metadata
-      stage.structured_metadata {
-        values = {
-          pod  = "",
         }
       }
     
@@ -59802,13 +59788,6 @@ data:
         }
       }
     
-      // Move high-cardinality labels to structured metadata
-      stage.structured_metadata {
-        values = {
-          pod  = "",
-        }
-      }
-    
       // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
       // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
       // container runtime label as it is no longer needed.
@@ -60008,13 +59987,6 @@ data:
           values = {
             stream  = "",
           }
-        }
-      }
-    
-      // Move high-cardinality labels to structured metadata
-      stage.structured_metadata {
-        values = {
-          pod  = "",
         }
       }
     

--- a/examples/default-values/output.yaml
+++ b/examples/default-values/output.yaml
@@ -921,10 +921,13 @@ data:
       }
     
       // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
-      // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+      // namespace, pod, and container labels. Drop any structured metadata. Also drop the temporary
       // container runtime label as it is no longer needed.
       stage.label_drop {
-        values = ["filename", "pod", "tmp_container_runtime"]
+        values = [
+          "filename",
+          "tmp_container_runtime",
+        ]
       }
       forward_to = [loki.process.logs_service.receiver]
     }
@@ -1139,10 +1142,13 @@ data:
       }
     
       // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
-      // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+      // namespace, pod, and container labels. Drop any structured metadata. Also drop the temporary
       // container runtime label as it is no longer needed.
       stage.label_drop {
-        values = ["filename", "pod", "tmp_container_runtime"]
+        values = [
+          "filename",
+          "tmp_container_runtime",
+        ]
       }
       forward_to = [loki.process.logs_service.receiver]
     }
@@ -59789,10 +59795,13 @@ data:
       }
     
       // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
-      // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+      // namespace, pod, and container labels. Drop any structured metadata. Also drop the temporary
       // container runtime label as it is no longer needed.
       stage.label_drop {
-        values = ["filename", "pod", "tmp_container_runtime"]
+        values = [
+          "filename",
+          "tmp_container_runtime",
+        ]
       }
       forward_to = [loki.process.logs_service.receiver]
     }
@@ -59991,10 +60000,13 @@ data:
       }
     
       // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
-      // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+      // namespace, pod, and container labels. Drop any structured metadata. Also drop the temporary
       // container runtime label as it is no longer needed.
       stage.label_drop {
-        values = ["filename", "pod", "tmp_container_runtime"]
+        values = [
+          "filename",
+          "tmp_container_runtime",
+        ]
       }
       forward_to = [loki.process.logs_service.receiver]
     }

--- a/examples/eks-fargate/logs.alloy
+++ b/examples/eks-fargate/logs.alloy
@@ -96,10 +96,13 @@ loki.process "pod_logs" {
   }
 
   // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
-  // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+  // namespace, pod, and container labels. Drop any structured metadata. Also drop the temporary
   // container runtime label as it is no longer needed.
   stage.label_drop {
-    values = ["filename", "pod", "tmp_container_runtime"]
+    values = [
+      "filename",
+      "tmp_container_runtime",
+    ]
   }
   forward_to = [loki.process.logs_service.receiver]
 }

--- a/examples/eks-fargate/logs.alloy
+++ b/examples/eks-fargate/logs.alloy
@@ -95,13 +95,6 @@ loki.process "pod_logs" {
     }
   }
 
-  // Move high-cardinality labels to structured metadata
-  stage.structured_metadata {
-    values = {
-      pod  = "",
-    }
-  }
-
   // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
   // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
   // container runtime label as it is no longer needed.

--- a/examples/eks-fargate/metrics.alloy
+++ b/examples/eks-fargate/metrics.alloy
@@ -743,13 +743,6 @@ loki.process "pod_logs" {
     }
   }
 
-  // Move high-cardinality labels to structured metadata
-  stage.structured_metadata {
-    values = {
-      pod  = "",
-    }
-  }
-
   // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
   // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
   // container runtime label as it is no longer needed.

--- a/examples/eks-fargate/metrics.alloy
+++ b/examples/eks-fargate/metrics.alloy
@@ -744,10 +744,13 @@ loki.process "pod_logs" {
   }
 
   // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
-  // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+  // namespace, pod, and container labels. Drop any structured metadata. Also drop the temporary
   // container runtime label as it is no longer needed.
   stage.label_drop {
-    values = ["filename", "pod", "tmp_container_runtime"]
+    values = [
+      "filename",
+      "tmp_container_runtime",
+    ]
   }
   forward_to = [loki.process.logs_service.receiver]
 }

--- a/examples/eks-fargate/output.yaml
+++ b/examples/eks-fargate/output.yaml
@@ -858,10 +858,13 @@ data:
       }
     
       // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
-      // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+      // namespace, pod, and container labels. Drop any structured metadata. Also drop the temporary
       // container runtime label as it is no longer needed.
       stage.label_drop {
-        values = ["filename", "pod", "tmp_container_runtime"]
+        values = [
+          "filename",
+          "tmp_container_runtime",
+        ]
       }
       forward_to = [loki.process.logs_service.receiver]
     }
@@ -1063,10 +1066,13 @@ data:
       }
     
       // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
-      // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+      // namespace, pod, and container labels. Drop any structured metadata. Also drop the temporary
       // container runtime label as it is no longer needed.
       stage.label_drop {
-        values = ["filename", "pod", "tmp_container_runtime"]
+        values = [
+          "filename",
+          "tmp_container_runtime",
+        ]
       }
       forward_to = [loki.process.logs_service.receiver]
     }
@@ -59547,10 +59553,13 @@ data:
       }
     
       // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
-      // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+      // namespace, pod, and container labels. Drop any structured metadata. Also drop the temporary
       // container runtime label as it is no longer needed.
       stage.label_drop {
-        values = ["filename", "pod", "tmp_container_runtime"]
+        values = [
+          "filename",
+          "tmp_container_runtime",
+        ]
       }
       forward_to = [loki.process.logs_service.receiver]
     }
@@ -59736,10 +59745,13 @@ data:
       }
     
       // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
-      // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+      // namespace, pod, and container labels. Drop any structured metadata. Also drop the temporary
       // container runtime label as it is no longer needed.
       stage.label_drop {
-        values = ["filename", "pod", "tmp_container_runtime"]
+        values = [
+          "filename",
+          "tmp_container_runtime",
+        ]
       }
       forward_to = [loki.process.logs_service.receiver]
     }

--- a/examples/eks-fargate/output.yaml
+++ b/examples/eks-fargate/output.yaml
@@ -857,13 +857,6 @@ data:
         }
       }
     
-      // Move high-cardinality labels to structured metadata
-      stage.structured_metadata {
-        values = {
-          pod  = "",
-        }
-      }
-    
       // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
       // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
       // container runtime label as it is no longer needed.
@@ -1066,13 +1059,6 @@ data:
           values = {
             stream  = "",
           }
-        }
-      }
-    
-      // Move high-cardinality labels to structured metadata
-      stage.structured_metadata {
-        values = {
-          pod  = "",
         }
       }
     
@@ -59560,13 +59546,6 @@ data:
         }
       }
     
-      // Move high-cardinality labels to structured metadata
-      stage.structured_metadata {
-        values = {
-          pod  = "",
-        }
-      }
-    
       // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
       // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
       // container runtime label as it is no longer needed.
@@ -59753,13 +59732,6 @@ data:
           values = {
             stream  = "",
           }
-        }
-      }
-    
-      // Move high-cardinality labels to structured metadata
-      stage.structured_metadata {
-        values = {
-          pod  = "",
         }
       }
     

--- a/examples/extra-rules/logs.alloy
+++ b/examples/extra-rules/logs.alloy
@@ -114,10 +114,13 @@ loki.process "pod_logs" {
   }
 
   // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
-  // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+  // namespace, pod, and container labels. Drop any structured metadata. Also drop the temporary
   // container runtime label as it is no longer needed.
   stage.label_drop {
-    values = ["filename", "pod", "tmp_container_runtime"]
+    values = [
+      "filename",
+      "tmp_container_runtime",
+    ]
   }
   stage.logfmt {
     payload = ""

--- a/examples/extra-rules/logs.alloy
+++ b/examples/extra-rules/logs.alloy
@@ -113,13 +113,6 @@ loki.process "pod_logs" {
     }
   }
 
-  // Move high-cardinality labels to structured metadata
-  stage.structured_metadata {
-    values = {
-      pod  = "",
-    }
-  }
-
   // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
   // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
   // container runtime label as it is no longer needed.

--- a/examples/extra-rules/metrics.alloy
+++ b/examples/extra-rules/metrics.alloy
@@ -856,13 +856,6 @@ loki.process "pod_logs" {
     }
   }
 
-  // Move high-cardinality labels to structured metadata
-  stage.structured_metadata {
-    values = {
-      pod  = "",
-    }
-  }
-
   // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
   // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
   // container runtime label as it is no longer needed.

--- a/examples/extra-rules/metrics.alloy
+++ b/examples/extra-rules/metrics.alloy
@@ -857,10 +857,13 @@ loki.process "pod_logs" {
   }
 
   // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
-  // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+  // namespace, pod, and container labels. Drop any structured metadata. Also drop the temporary
   // container runtime label as it is no longer needed.
   stage.label_drop {
-    values = ["filename", "pod", "tmp_container_runtime"]
+    values = [
+      "filename",
+      "tmp_container_runtime",
+    ]
   }
   stage.logfmt {
     payload = ""

--- a/examples/extra-rules/output.yaml
+++ b/examples/extra-rules/output.yaml
@@ -987,13 +987,6 @@ data:
         }
       }
     
-      // Move high-cardinality labels to structured metadata
-      stage.structured_metadata {
-        values = {
-          pod  = "",
-        }
-      }
-    
       // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
       // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
       // container runtime label as it is no longer needed.
@@ -1239,13 +1232,6 @@ data:
           values = {
             stream  = "",
           }
-        }
-      }
-    
-      // Move high-cardinality labels to structured metadata
-      stage.structured_metadata {
-        values = {
-          pod  = "",
         }
       }
     
@@ -59990,13 +59976,6 @@ data:
         }
       }
     
-      // Move high-cardinality labels to structured metadata
-      stage.structured_metadata {
-        values = {
-          pod  = "",
-        }
-      }
-    
       // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
       // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
       // container runtime label as it is no longer needed.
@@ -60226,13 +60205,6 @@ data:
           values = {
             stream  = "",
           }
-        }
-      }
-    
-      // Move high-cardinality labels to structured metadata
-      stage.structured_metadata {
-        values = {
-          pod  = "",
         }
       }
     

--- a/examples/extra-rules/output.yaml
+++ b/examples/extra-rules/output.yaml
@@ -988,10 +988,13 @@ data:
       }
     
       // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
-      // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+      // namespace, pod, and container labels. Drop any structured metadata. Also drop the temporary
       // container runtime label as it is no longer needed.
       stage.label_drop {
-        values = ["filename", "pod", "tmp_container_runtime"]
+        values = [
+          "filename",
+          "tmp_container_runtime",
+        ]
       }
       stage.logfmt {
         payload = ""
@@ -1236,10 +1239,13 @@ data:
       }
     
       // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
-      // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+      // namespace, pod, and container labels. Drop any structured metadata. Also drop the temporary
       // container runtime label as it is no longer needed.
       stage.label_drop {
-        values = ["filename", "pod", "tmp_container_runtime"]
+        values = [
+          "filename",
+          "tmp_container_runtime",
+        ]
       }
       stage.logfmt {
         payload = ""
@@ -59977,10 +59983,13 @@ data:
       }
     
       // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
-      // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+      // namespace, pod, and container labels. Drop any structured metadata. Also drop the temporary
       // container runtime label as it is no longer needed.
       stage.label_drop {
-        values = ["filename", "pod", "tmp_container_runtime"]
+        values = [
+          "filename",
+          "tmp_container_runtime",
+        ]
       }
       stage.logfmt {
         payload = ""
@@ -60209,10 +60218,13 @@ data:
       }
     
       // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
-      // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+      // namespace, pod, and container labels. Drop any structured metadata. Also drop the temporary
       // container runtime label as it is no longer needed.
       stage.label_drop {
-        values = ["filename", "pod", "tmp_container_runtime"]
+        values = [
+          "filename",
+          "tmp_container_runtime",
+        ]
       }
       stage.logfmt {
         payload = ""

--- a/examples/gke-autopilot/logs.alloy
+++ b/examples/gke-autopilot/logs.alloy
@@ -109,10 +109,13 @@ loki.process "pod_logs" {
   }
 
   // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
-  // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+  // namespace, pod, and container labels. Drop any structured metadata. Also drop the temporary
   // container runtime label as it is no longer needed.
   stage.label_drop {
-    values = ["filename", "pod", "tmp_container_runtime"]
+    values = [
+      "filename",
+      "tmp_container_runtime",
+    ]
   }
   forward_to = [loki.process.logs_service.receiver]
 }

--- a/examples/gke-autopilot/logs.alloy
+++ b/examples/gke-autopilot/logs.alloy
@@ -108,13 +108,6 @@ loki.process "pod_logs" {
     }
   }
 
-  // Move high-cardinality labels to structured metadata
-  stage.structured_metadata {
-    values = {
-      pod  = "",
-    }
-  }
-
   // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
   // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
   // container runtime label as it is no longer needed.

--- a/examples/gke-autopilot/metrics.alloy
+++ b/examples/gke-autopilot/metrics.alloy
@@ -743,13 +743,6 @@ loki.process "pod_logs" {
     }
   }
 
-  // Move high-cardinality labels to structured metadata
-  stage.structured_metadata {
-    values = {
-      pod  = "",
-    }
-  }
-
   // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
   // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
   // container runtime label as it is no longer needed.

--- a/examples/gke-autopilot/metrics.alloy
+++ b/examples/gke-autopilot/metrics.alloy
@@ -744,10 +744,13 @@ loki.process "pod_logs" {
   }
 
   // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
-  // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+  // namespace, pod, and container labels. Drop any structured metadata. Also drop the temporary
   // container runtime label as it is no longer needed.
   stage.label_drop {
-    values = ["filename", "pod", "tmp_container_runtime"]
+    values = [
+      "filename",
+      "tmp_container_runtime",
+    ]
   }
   forward_to = [loki.process.logs_service.receiver]
 }

--- a/examples/gke-autopilot/output.yaml
+++ b/examples/gke-autopilot/output.yaml
@@ -858,10 +858,13 @@ data:
       }
     
       // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
-      // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+      // namespace, pod, and container labels. Drop any structured metadata. Also drop the temporary
       // container runtime label as it is no longer needed.
       stage.label_drop {
-        values = ["filename", "pod", "tmp_container_runtime"]
+        values = [
+          "filename",
+          "tmp_container_runtime",
+        ]
       }
       forward_to = [loki.process.logs_service.receiver]
     }
@@ -1076,10 +1079,13 @@ data:
       }
     
       // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
-      // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+      // namespace, pod, and container labels. Drop any structured metadata. Also drop the temporary
       // container runtime label as it is no longer needed.
       stage.label_drop {
-        values = ["filename", "pod", "tmp_container_runtime"]
+        values = [
+          "filename",
+          "tmp_container_runtime",
+        ]
       }
       forward_to = [loki.process.logs_service.receiver]
     }
@@ -59530,10 +59536,13 @@ data:
       }
     
       // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
-      // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+      // namespace, pod, and container labels. Drop any structured metadata. Also drop the temporary
       // container runtime label as it is no longer needed.
       stage.label_drop {
-        values = ["filename", "pod", "tmp_container_runtime"]
+        values = [
+          "filename",
+          "tmp_container_runtime",
+        ]
       }
       forward_to = [loki.process.logs_service.receiver]
     }
@@ -59732,10 +59741,13 @@ data:
       }
     
       // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
-      // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+      // namespace, pod, and container labels. Drop any structured metadata. Also drop the temporary
       // container runtime label as it is no longer needed.
       stage.label_drop {
-        values = ["filename", "pod", "tmp_container_runtime"]
+        values = [
+          "filename",
+          "tmp_container_runtime",
+        ]
       }
       forward_to = [loki.process.logs_service.receiver]
     }

--- a/examples/gke-autopilot/output.yaml
+++ b/examples/gke-autopilot/output.yaml
@@ -857,13 +857,6 @@ data:
         }
       }
     
-      // Move high-cardinality labels to structured metadata
-      stage.structured_metadata {
-        values = {
-          pod  = "",
-        }
-      }
-    
       // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
       // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
       // container runtime label as it is no longer needed.
@@ -1079,13 +1072,6 @@ data:
           values = {
             stream  = "",
           }
-        }
-      }
-    
-      // Move high-cardinality labels to structured metadata
-      stage.structured_metadata {
-        values = {
-          pod  = "",
         }
       }
     
@@ -59543,13 +59529,6 @@ data:
         }
       }
     
-      // Move high-cardinality labels to structured metadata
-      stage.structured_metadata {
-        values = {
-          pod  = "",
-        }
-      }
-    
       // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
       // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
       // container runtime label as it is no longer needed.
@@ -59749,13 +59728,6 @@ data:
           values = {
             stream  = "",
           }
-        }
-      }
-    
-      // Move high-cardinality labels to structured metadata
-      stage.structured_metadata {
-        values = {
-          pod  = "",
         }
       }
     

--- a/examples/ibm-cloud/logs.alloy
+++ b/examples/ibm-cloud/logs.alloy
@@ -109,10 +109,13 @@ loki.process "pod_logs" {
   }
 
   // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
-  // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+  // namespace, pod, and container labels. Drop any structured metadata. Also drop the temporary
   // container runtime label as it is no longer needed.
   stage.label_drop {
-    values = ["filename", "pod", "tmp_container_runtime"]
+    values = [
+      "filename",
+      "tmp_container_runtime",
+    ]
   }
   forward_to = [loki.process.logs_service.receiver]
 }

--- a/examples/ibm-cloud/logs.alloy
+++ b/examples/ibm-cloud/logs.alloy
@@ -108,13 +108,6 @@ loki.process "pod_logs" {
     }
   }
 
-  // Move high-cardinality labels to structured metadata
-  stage.structured_metadata {
-    values = {
-      pod  = "",
-    }
-  }
-
   // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
   // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
   // container runtime label as it is no longer needed.

--- a/examples/ibm-cloud/metrics.alloy
+++ b/examples/ibm-cloud/metrics.alloy
@@ -791,10 +791,13 @@ loki.process "pod_logs" {
   }
 
   // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
-  // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+  // namespace, pod, and container labels. Drop any structured metadata. Also drop the temporary
   // container runtime label as it is no longer needed.
   stage.label_drop {
-    values = ["filename", "pod", "tmp_container_runtime"]
+    values = [
+      "filename",
+      "tmp_container_runtime",
+    ]
   }
   forward_to = [loki.process.logs_service.receiver]
 }

--- a/examples/ibm-cloud/metrics.alloy
+++ b/examples/ibm-cloud/metrics.alloy
@@ -790,13 +790,6 @@ loki.process "pod_logs" {
     }
   }
 
-  // Move high-cardinality labels to structured metadata
-  stage.structured_metadata {
-    values = {
-      pod  = "",
-    }
-  }
-
   // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
   // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
   // container runtime label as it is no longer needed.

--- a/examples/ibm-cloud/output.yaml
+++ b/examples/ibm-cloud/output.yaml
@@ -920,13 +920,6 @@ data:
         }
       }
     
-      // Move high-cardinality labels to structured metadata
-      stage.structured_metadata {
-        values = {
-          pod  = "",
-        }
-      }
-    
       // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
       // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
       // container runtime label as it is no longer needed.
@@ -1142,13 +1135,6 @@ data:
           values = {
             stream  = "",
           }
-        }
-      }
-    
-      // Move high-cardinality labels to structured metadata
-      stage.structured_metadata {
-        values = {
-          pod  = "",
         }
       }
     
@@ -59808,13 +59794,6 @@ data:
         }
       }
     
-      // Move high-cardinality labels to structured metadata
-      stage.structured_metadata {
-        values = {
-          pod  = "",
-        }
-      }
-    
       // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
       // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
       // container runtime label as it is no longer needed.
@@ -60014,13 +59993,6 @@ data:
           values = {
             stream  = "",
           }
-        }
-      }
-    
-      // Move high-cardinality labels to structured metadata
-      stage.structured_metadata {
-        values = {
-          pod  = "",
         }
       }
     

--- a/examples/ibm-cloud/output.yaml
+++ b/examples/ibm-cloud/output.yaml
@@ -921,10 +921,13 @@ data:
       }
     
       // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
-      // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+      // namespace, pod, and container labels. Drop any structured metadata. Also drop the temporary
       // container runtime label as it is no longer needed.
       stage.label_drop {
-        values = ["filename", "pod", "tmp_container_runtime"]
+        values = [
+          "filename",
+          "tmp_container_runtime",
+        ]
       }
       forward_to = [loki.process.logs_service.receiver]
     }
@@ -1139,10 +1142,13 @@ data:
       }
     
       // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
-      // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+      // namespace, pod, and container labels. Drop any structured metadata. Also drop the temporary
       // container runtime label as it is no longer needed.
       stage.label_drop {
-        values = ["filename", "pod", "tmp_container_runtime"]
+        values = [
+          "filename",
+          "tmp_container_runtime",
+        ]
       }
       forward_to = [loki.process.logs_service.receiver]
     }
@@ -59795,10 +59801,13 @@ data:
       }
     
       // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
-      // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+      // namespace, pod, and container labels. Drop any structured metadata. Also drop the temporary
       // container runtime label as it is no longer needed.
       stage.label_drop {
-        values = ["filename", "pod", "tmp_container_runtime"]
+        values = [
+          "filename",
+          "tmp_container_runtime",
+        ]
       }
       forward_to = [loki.process.logs_service.receiver]
     }
@@ -59997,10 +60006,13 @@ data:
       }
     
       // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
-      // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+      // namespace, pod, and container labels. Drop any structured metadata. Also drop the temporary
       // container runtime label as it is no longer needed.
       stage.label_drop {
-        values = ["filename", "pod", "tmp_container_runtime"]
+        values = [
+          "filename",
+          "tmp_container_runtime",
+        ]
       }
       forward_to = [loki.process.logs_service.receiver]
     }

--- a/examples/logs-journal/logs.alloy
+++ b/examples/logs-journal/logs.alloy
@@ -109,10 +109,13 @@ loki.process "pod_logs" {
   }
 
   // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
-  // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+  // namespace, pod, and container labels. Drop any structured metadata. Also drop the temporary
   // container runtime label as it is no longer needed.
   stage.label_drop {
-    values = ["filename", "pod", "tmp_container_runtime"]
+    values = [
+      "filename",
+      "tmp_container_runtime",
+    ]
   }
   forward_to = [loki.process.logs_service.receiver]
 }

--- a/examples/logs-journal/logs.alloy
+++ b/examples/logs-journal/logs.alloy
@@ -108,13 +108,6 @@ loki.process "pod_logs" {
     }
   }
 
-  // Move high-cardinality labels to structured metadata
-  stage.structured_metadata {
-    values = {
-      pod  = "",
-    }
-  }
-
   // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
   // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
   // container runtime label as it is no longer needed.

--- a/examples/logs-journal/metrics.alloy
+++ b/examples/logs-journal/metrics.alloy
@@ -48,10 +48,13 @@ loki.process "pod_logs" {
   }
 
   // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
-  // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+  // namespace, pod, and container labels. Drop any structured metadata. Also drop the temporary
   // container runtime label as it is no longer needed.
   stage.label_drop {
-    values = ["filename", "pod", "tmp_container_runtime"]
+    values = [
+      "filename",
+      "tmp_container_runtime",
+    ]
   }
   forward_to = [loki.process.logs_service.receiver]
 }

--- a/examples/logs-journal/metrics.alloy
+++ b/examples/logs-journal/metrics.alloy
@@ -47,13 +47,6 @@ loki.process "pod_logs" {
     }
   }
 
-  // Move high-cardinality labels to structured metadata
-  stage.structured_metadata {
-    values = {
-      pod  = "",
-    }
-  }
-
   // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
   // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
   // container runtime label as it is no longer needed.

--- a/examples/logs-journal/output.yaml
+++ b/examples/logs-journal/output.yaml
@@ -118,10 +118,13 @@ data:
       }
     
       // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
-      // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+      // namespace, pod, and container labels. Drop any structured metadata. Also drop the temporary
       // container runtime label as it is no longer needed.
       stage.label_drop {
-        values = ["filename", "pod", "tmp_container_runtime"]
+        values = [
+          "filename",
+          "tmp_container_runtime",
+        ]
       }
       forward_to = [loki.process.logs_service.receiver]
     }
@@ -336,10 +339,13 @@ data:
       }
     
       // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
-      // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+      // namespace, pod, and container labels. Drop any structured metadata. Also drop the temporary
       // container runtime label as it is no longer needed.
       stage.label_drop {
-        values = ["filename", "pod", "tmp_container_runtime"]
+        values = [
+          "filename",
+          "tmp_container_runtime",
+        ]
       }
       forward_to = [loki.process.logs_service.receiver]
     }
@@ -1371,10 +1377,13 @@ data:
       }
     
       // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
-      // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+      // namespace, pod, and container labels. Drop any structured metadata. Also drop the temporary
       // container runtime label as it is no longer needed.
       stage.label_drop {
-        values = ["filename", "pod", "tmp_container_runtime"]
+        values = [
+          "filename",
+          "tmp_container_runtime",
+        ]
       }
       forward_to = [loki.process.logs_service.receiver]
     }
@@ -1573,10 +1582,13 @@ data:
       }
     
       // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
-      // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+      // namespace, pod, and container labels. Drop any structured metadata. Also drop the temporary
       // container runtime label as it is no longer needed.
       stage.label_drop {
-        values = ["filename", "pod", "tmp_container_runtime"]
+        values = [
+          "filename",
+          "tmp_container_runtime",
+        ]
       }
       forward_to = [loki.process.logs_service.receiver]
     }

--- a/examples/logs-journal/output.yaml
+++ b/examples/logs-journal/output.yaml
@@ -117,13 +117,6 @@ data:
         }
       }
     
-      // Move high-cardinality labels to structured metadata
-      stage.structured_metadata {
-        values = {
-          pod  = "",
-        }
-      }
-    
       // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
       // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
       // container runtime label as it is no longer needed.
@@ -339,13 +332,6 @@ data:
           values = {
             stream  = "",
           }
-        }
-      }
-    
-      // Move high-cardinality labels to structured metadata
-      stage.structured_metadata {
-        values = {
-          pod  = "",
         }
       }
     
@@ -1384,13 +1370,6 @@ data:
         }
       }
     
-      // Move high-cardinality labels to structured metadata
-      stage.structured_metadata {
-        values = {
-          pod  = "",
-        }
-      }
-    
       // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
       // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
       // container runtime label as it is no longer needed.
@@ -1590,13 +1569,6 @@ data:
           values = {
             stream  = "",
           }
-        }
-      }
-    
-      // Move high-cardinality labels to structured metadata
-      stage.structured_metadata {
-        values = {
-          pod  = "",
         }
       }
     

--- a/examples/logs-only/logs.alloy
+++ b/examples/logs-only/logs.alloy
@@ -109,10 +109,13 @@ loki.process "pod_logs" {
   }
 
   // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
-  // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+  // namespace, pod, and container labels. Drop any structured metadata. Also drop the temporary
   // container runtime label as it is no longer needed.
   stage.label_drop {
-    values = ["filename", "pod", "tmp_container_runtime"]
+    values = [
+      "filename",
+      "tmp_container_runtime",
+    ]
   }
   forward_to = [loki.process.logs_service.receiver]
 }

--- a/examples/logs-only/logs.alloy
+++ b/examples/logs-only/logs.alloy
@@ -108,13 +108,6 @@ loki.process "pod_logs" {
     }
   }
 
-  // Move high-cardinality labels to structured metadata
-  stage.structured_metadata {
-    values = {
-      pod  = "",
-    }
-  }
-
   // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
   // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
   // container runtime label as it is no longer needed.

--- a/examples/logs-only/metrics.alloy
+++ b/examples/logs-only/metrics.alloy
@@ -126,13 +126,6 @@ loki.process "pod_logs" {
     }
   }
 
-  // Move high-cardinality labels to structured metadata
-  stage.structured_metadata {
-    values = {
-      pod  = "",
-    }
-  }
-
   // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
   // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
   // container runtime label as it is no longer needed.

--- a/examples/logs-only/metrics.alloy
+++ b/examples/logs-only/metrics.alloy
@@ -127,10 +127,13 @@ loki.process "pod_logs" {
   }
 
   // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
-  // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+  // namespace, pod, and container labels. Drop any structured metadata. Also drop the temporary
   // container runtime label as it is no longer needed.
   stage.label_drop {
-    values = ["filename", "pod", "tmp_container_runtime"]
+    values = [
+      "filename",
+      "tmp_container_runtime",
+    ]
   }
   forward_to = [loki.process.logs_service.receiver]
 }

--- a/examples/logs-only/output.yaml
+++ b/examples/logs-only/output.yaml
@@ -197,13 +197,6 @@ data:
         }
       }
     
-      // Move high-cardinality labels to structured metadata
-      stage.structured_metadata {
-        values = {
-          pod  = "",
-        }
-      }
-    
       // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
       // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
       // container runtime label as it is no longer needed.
@@ -419,13 +412,6 @@ data:
           values = {
             stream  = "",
           }
-        }
-      }
-    
-      // Move high-cardinality labels to structured metadata
-      stage.structured_metadata {
-        values = {
-          pod  = "",
         }
       }
     
@@ -1515,13 +1501,6 @@ data:
         }
       }
     
-      // Move high-cardinality labels to structured metadata
-      stage.structured_metadata {
-        values = {
-          pod  = "",
-        }
-      }
-    
       // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
       // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
       // container runtime label as it is no longer needed.
@@ -1721,13 +1700,6 @@ data:
           values = {
             stream  = "",
           }
-        }
-      }
-    
-      // Move high-cardinality labels to structured metadata
-      stage.structured_metadata {
-        values = {
-          pod  = "",
         }
       }
     

--- a/examples/logs-only/output.yaml
+++ b/examples/logs-only/output.yaml
@@ -198,10 +198,13 @@ data:
       }
     
       // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
-      // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+      // namespace, pod, and container labels. Drop any structured metadata. Also drop the temporary
       // container runtime label as it is no longer needed.
       stage.label_drop {
-        values = ["filename", "pod", "tmp_container_runtime"]
+        values = [
+          "filename",
+          "tmp_container_runtime",
+        ]
       }
       forward_to = [loki.process.logs_service.receiver]
     }
@@ -416,10 +419,13 @@ data:
       }
     
       // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
-      // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+      // namespace, pod, and container labels. Drop any structured metadata. Also drop the temporary
       // container runtime label as it is no longer needed.
       stage.label_drop {
-        values = ["filename", "pod", "tmp_container_runtime"]
+        values = [
+          "filename",
+          "tmp_container_runtime",
+        ]
       }
       forward_to = [loki.process.logs_service.receiver]
     }
@@ -1502,10 +1508,13 @@ data:
       }
     
       // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
-      // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+      // namespace, pod, and container labels. Drop any structured metadata. Also drop the temporary
       // container runtime label as it is no longer needed.
       stage.label_drop {
-        values = ["filename", "pod", "tmp_container_runtime"]
+        values = [
+          "filename",
+          "tmp_container_runtime",
+        ]
       }
       forward_to = [loki.process.logs_service.receiver]
     }
@@ -1704,10 +1713,13 @@ data:
       }
     
       // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
-      // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+      // namespace, pod, and container labels. Drop any structured metadata. Also drop the temporary
       // container runtime label as it is no longer needed.
       stage.label_drop {
-        values = ["filename", "pod", "tmp_container_runtime"]
+        values = [
+          "filename",
+          "tmp_container_runtime",
+        ]
       }
       forward_to = [loki.process.logs_service.receiver]
     }

--- a/examples/metric-module-imports-extra-config/logs.alloy
+++ b/examples/metric-module-imports-extra-config/logs.alloy
@@ -109,10 +109,13 @@ loki.process "pod_logs" {
   }
 
   // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
-  // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+  // namespace, pod, and container labels. Drop any structured metadata. Also drop the temporary
   // container runtime label as it is no longer needed.
   stage.label_drop {
-    values = ["filename", "pod", "tmp_container_runtime"]
+    values = [
+      "filename",
+      "tmp_container_runtime",
+    ]
   }
   forward_to = [loki.process.logs_service.receiver]
 }

--- a/examples/metric-module-imports-extra-config/logs.alloy
+++ b/examples/metric-module-imports-extra-config/logs.alloy
@@ -108,13 +108,6 @@ loki.process "pod_logs" {
     }
   }
 
-  // Move high-cardinality labels to structured metadata
-  stage.structured_metadata {
-    values = {
-      pod  = "",
-    }
-  }
-
   // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
   // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
   // container runtime label as it is no longer needed.

--- a/examples/metric-module-imports-extra-config/metrics.alloy
+++ b/examples/metric-module-imports-extra-config/metrics.alloy
@@ -791,10 +791,13 @@ loki.process "pod_logs" {
   }
 
   // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
-  // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+  // namespace, pod, and container labels. Drop any structured metadata. Also drop the temporary
   // container runtime label as it is no longer needed.
   stage.label_drop {
-    values = ["filename", "pod", "tmp_container_runtime"]
+    values = [
+      "filename",
+      "tmp_container_runtime",
+    ]
   }
   forward_to = [loki.process.logs_service.receiver]
 }

--- a/examples/metric-module-imports-extra-config/metrics.alloy
+++ b/examples/metric-module-imports-extra-config/metrics.alloy
@@ -790,13 +790,6 @@ loki.process "pod_logs" {
     }
   }
 
-  // Move high-cardinality labels to structured metadata
-  stage.structured_metadata {
-    values = {
-      pod  = "",
-    }
-  }
-
   // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
   // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
   // container runtime label as it is no longer needed.

--- a/examples/metric-module-imports-extra-config/output.yaml
+++ b/examples/metric-module-imports-extra-config/output.yaml
@@ -920,13 +920,6 @@ data:
         }
       }
     
-      // Move high-cardinality labels to structured metadata
-      stage.structured_metadata {
-        values = {
-          pod  = "",
-        }
-      }
-    
       // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
       // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
       // container runtime label as it is no longer needed.
@@ -1158,13 +1151,6 @@ data:
           values = {
             stream  = "",
           }
-        }
-      }
-    
-      // Move high-cardinality labels to structured metadata
-      stage.structured_metadata {
-        values = {
-          pod  = "",
         }
       }
     
@@ -59818,13 +59804,6 @@ data:
         }
       }
     
-      // Move high-cardinality labels to structured metadata
-      stage.structured_metadata {
-        values = {
-          pod  = "",
-        }
-      }
-    
       // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
       // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
       // container runtime label as it is no longer needed.
@@ -60040,13 +60019,6 @@ data:
           values = {
             stream  = "",
           }
-        }
-      }
-    
-      // Move high-cardinality labels to structured metadata
-      stage.structured_metadata {
-        values = {
-          pod  = "",
         }
       }
     

--- a/examples/metric-module-imports-extra-config/output.yaml
+++ b/examples/metric-module-imports-extra-config/output.yaml
@@ -921,10 +921,13 @@ data:
       }
     
       // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
-      // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+      // namespace, pod, and container labels. Drop any structured metadata. Also drop the temporary
       // container runtime label as it is no longer needed.
       stage.label_drop {
-        values = ["filename", "pod", "tmp_container_runtime"]
+        values = [
+          "filename",
+          "tmp_container_runtime",
+        ]
       }
       forward_to = [loki.process.logs_service.receiver]
     }
@@ -1155,10 +1158,13 @@ data:
       }
     
       // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
-      // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+      // namespace, pod, and container labels. Drop any structured metadata. Also drop the temporary
       // container runtime label as it is no longer needed.
       stage.label_drop {
-        values = ["filename", "pod", "tmp_container_runtime"]
+        values = [
+          "filename",
+          "tmp_container_runtime",
+        ]
       }
       forward_to = [loki.process.logs_service.receiver]
     }
@@ -59805,10 +59811,13 @@ data:
       }
     
       // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
-      // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+      // namespace, pod, and container labels. Drop any structured metadata. Also drop the temporary
       // container runtime label as it is no longer needed.
       stage.label_drop {
-        values = ["filename", "pod", "tmp_container_runtime"]
+        values = [
+          "filename",
+          "tmp_container_runtime",
+        ]
       }
       forward_to = [loki.process.logs_service.receiver]
     }
@@ -60023,10 +60032,13 @@ data:
       }
     
       // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
-      // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+      // namespace, pod, and container labels. Drop any structured metadata. Also drop the temporary
       // container runtime label as it is no longer needed.
       stage.label_drop {
-        values = ["filename", "pod", "tmp_container_runtime"]
+        values = [
+          "filename",
+          "tmp_container_runtime",
+        ]
       }
       forward_to = [loki.process.logs_service.receiver]
     }

--- a/examples/metric-module-imports/logs.alloy
+++ b/examples/metric-module-imports/logs.alloy
@@ -109,10 +109,13 @@ loki.process "pod_logs" {
   }
 
   // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
-  // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+  // namespace, pod, and container labels. Drop any structured metadata. Also drop the temporary
   // container runtime label as it is no longer needed.
   stage.label_drop {
-    values = ["filename", "pod", "tmp_container_runtime"]
+    values = [
+      "filename",
+      "tmp_container_runtime",
+    ]
   }
   forward_to = [loki.process.logs_service.receiver]
 }

--- a/examples/metric-module-imports/logs.alloy
+++ b/examples/metric-module-imports/logs.alloy
@@ -108,13 +108,6 @@ loki.process "pod_logs" {
     }
   }
 
-  // Move high-cardinality labels to structured metadata
-  stage.structured_metadata {
-    values = {
-      pod  = "",
-    }
-  }
-
   // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
   // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
   // container runtime label as it is no longer needed.

--- a/examples/metric-module-imports/metrics.alloy
+++ b/examples/metric-module-imports/metrics.alloy
@@ -967,13 +967,6 @@ loki.process "pod_logs" {
     }
   }
 
-  // Move high-cardinality labels to structured metadata
-  stage.structured_metadata {
-    values = {
-      pod  = "",
-    }
-  }
-
   // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
   // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
   // container runtime label as it is no longer needed.

--- a/examples/metric-module-imports/metrics.alloy
+++ b/examples/metric-module-imports/metrics.alloy
@@ -968,10 +968,13 @@ loki.process "pod_logs" {
   }
 
   // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
-  // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+  // namespace, pod, and container labels. Drop any structured metadata. Also drop the temporary
   // container runtime label as it is no longer needed.
   stage.label_drop {
-    values = ["filename", "pod", "tmp_container_runtime"]
+    values = [
+      "filename",
+      "tmp_container_runtime",
+    ]
   }
   forward_to = [loki.process.logs_service.receiver]
 }

--- a/examples/metric-module-imports/output.yaml
+++ b/examples/metric-module-imports/output.yaml
@@ -1097,13 +1097,6 @@ data:
         }
       }
     
-      // Move high-cardinality labels to structured metadata
-      stage.structured_metadata {
-        values = {
-          pod  = "",
-        }
-      }
-    
       // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
       // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
       // container runtime label as it is no longer needed.
@@ -1319,13 +1312,6 @@ data:
           values = {
             stream  = "",
           }
-        }
-      }
-    
-      // Move high-cardinality labels to structured metadata
-      stage.structured_metadata {
-        values = {
-          pod  = "",
         }
       }
     
@@ -60156,13 +60142,6 @@ data:
         }
       }
     
-      // Move high-cardinality labels to structured metadata
-      stage.structured_metadata {
-        values = {
-          pod  = "",
-        }
-      }
-    
       // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
       // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
       // container runtime label as it is no longer needed.
@@ -60362,13 +60341,6 @@ data:
           values = {
             stream  = "",
           }
-        }
-      }
-    
-      // Move high-cardinality labels to structured metadata
-      stage.structured_metadata {
-        values = {
-          pod  = "",
         }
       }
     

--- a/examples/metric-module-imports/output.yaml
+++ b/examples/metric-module-imports/output.yaml
@@ -1098,10 +1098,13 @@ data:
       }
     
       // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
-      // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+      // namespace, pod, and container labels. Drop any structured metadata. Also drop the temporary
       // container runtime label as it is no longer needed.
       stage.label_drop {
-        values = ["filename", "pod", "tmp_container_runtime"]
+        values = [
+          "filename",
+          "tmp_container_runtime",
+        ]
       }
       forward_to = [loki.process.logs_service.receiver]
     }
@@ -1316,10 +1319,13 @@ data:
       }
     
       // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
-      // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+      // namespace, pod, and container labels. Drop any structured metadata. Also drop the temporary
       // container runtime label as it is no longer needed.
       stage.label_drop {
-        values = ["filename", "pod", "tmp_container_runtime"]
+        values = [
+          "filename",
+          "tmp_container_runtime",
+        ]
       }
       forward_to = [loki.process.logs_service.receiver]
     }
@@ -60143,10 +60149,13 @@ data:
       }
     
       // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
-      // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+      // namespace, pod, and container labels. Drop any structured metadata. Also drop the temporary
       // container runtime label as it is no longer needed.
       stage.label_drop {
-        values = ["filename", "pod", "tmp_container_runtime"]
+        values = [
+          "filename",
+          "tmp_container_runtime",
+        ]
       }
       forward_to = [loki.process.logs_service.receiver]
     }
@@ -60345,10 +60354,13 @@ data:
       }
     
       // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
-      // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+      // namespace, pod, and container labels. Drop any structured metadata. Also drop the temporary
       // container runtime label as it is no longer needed.
       stage.label_drop {
-        values = ["filename", "pod", "tmp_container_runtime"]
+        values = [
+          "filename",
+          "tmp_container_runtime",
+        ]
       }
       forward_to = [loki.process.logs_service.receiver]
     }

--- a/examples/openshift-compatible/logs.alloy
+++ b/examples/openshift-compatible/logs.alloy
@@ -109,10 +109,13 @@ loki.process "pod_logs" {
   }
 
   // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
-  // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+  // namespace, pod, and container labels. Drop any structured metadata. Also drop the temporary
   // container runtime label as it is no longer needed.
   stage.label_drop {
-    values = ["filename", "pod", "tmp_container_runtime"]
+    values = [
+      "filename",
+      "tmp_container_runtime",
+    ]
   }
   forward_to = [loki.process.logs_service.receiver]
 }

--- a/examples/openshift-compatible/logs.alloy
+++ b/examples/openshift-compatible/logs.alloy
@@ -108,13 +108,6 @@ loki.process "pod_logs" {
     }
   }
 
-  // Move high-cardinality labels to structured metadata
-  stage.structured_metadata {
-    values = {
-      pod  = "",
-    }
-  }
-
   // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
   // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
   // container runtime label as it is no longer needed.

--- a/examples/openshift-compatible/metrics.alloy
+++ b/examples/openshift-compatible/metrics.alloy
@@ -792,13 +792,6 @@ loki.process "pod_logs" {
     }
   }
 
-  // Move high-cardinality labels to structured metadata
-  stage.structured_metadata {
-    values = {
-      pod  = "",
-    }
-  }
-
   // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
   // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
   // container runtime label as it is no longer needed.

--- a/examples/openshift-compatible/metrics.alloy
+++ b/examples/openshift-compatible/metrics.alloy
@@ -793,10 +793,13 @@ loki.process "pod_logs" {
   }
 
   // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
-  // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+  // namespace, pod, and container labels. Drop any structured metadata. Also drop the temporary
   // container runtime label as it is no longer needed.
   stage.label_drop {
-    values = ["filename", "pod", "tmp_container_runtime"]
+    values = [
+      "filename",
+      "tmp_container_runtime",
+    ]
   }
   forward_to = [loki.process.logs_service.receiver]
 }

--- a/examples/openshift-compatible/output.yaml
+++ b/examples/openshift-compatible/output.yaml
@@ -891,10 +891,13 @@ data:
       }
     
       // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
-      // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+      // namespace, pod, and container labels. Drop any structured metadata. Also drop the temporary
       // container runtime label as it is no longer needed.
       stage.label_drop {
-        values = ["filename", "pod", "tmp_container_runtime"]
+        values = [
+          "filename",
+          "tmp_container_runtime",
+        ]
       }
       forward_to = [loki.process.logs_service.receiver]
     }
@@ -1111,10 +1114,13 @@ data:
       }
     
       // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
-      // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+      // namespace, pod, and container labels. Drop any structured metadata. Also drop the temporary
       // container runtime label as it is no longer needed.
       stage.label_drop {
-        values = ["filename", "pod", "tmp_container_runtime"]
+        values = [
+          "filename",
+          "tmp_container_runtime",
+        ]
       }
       forward_to = [loki.process.logs_service.receiver]
     }
@@ -59637,10 +59643,13 @@ data:
       }
     
       // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
-      // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+      // namespace, pod, and container labels. Drop any structured metadata. Also drop the temporary
       // container runtime label as it is no longer needed.
       stage.label_drop {
-        values = ["filename", "pod", "tmp_container_runtime"]
+        values = [
+          "filename",
+          "tmp_container_runtime",
+        ]
       }
       forward_to = [loki.process.logs_service.receiver]
     }
@@ -59841,10 +59850,13 @@ data:
       }
     
       // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
-      // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+      // namespace, pod, and container labels. Drop any structured metadata. Also drop the temporary
       // container runtime label as it is no longer needed.
       stage.label_drop {
-        values = ["filename", "pod", "tmp_container_runtime"]
+        values = [
+          "filename",
+          "tmp_container_runtime",
+        ]
       }
       forward_to = [loki.process.logs_service.receiver]
     }

--- a/examples/openshift-compatible/output.yaml
+++ b/examples/openshift-compatible/output.yaml
@@ -890,13 +890,6 @@ data:
         }
       }
     
-      // Move high-cardinality labels to structured metadata
-      stage.structured_metadata {
-        values = {
-          pod  = "",
-        }
-      }
-    
       // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
       // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
       // container runtime label as it is no longer needed.
@@ -1114,13 +1107,6 @@ data:
           values = {
             stream  = "",
           }
-        }
-      }
-    
-      // Move high-cardinality labels to structured metadata
-      stage.structured_metadata {
-        values = {
-          pod  = "",
         }
       }
     
@@ -59650,13 +59636,6 @@ data:
         }
       }
     
-      // Move high-cardinality labels to structured metadata
-      stage.structured_metadata {
-        values = {
-          pod  = "",
-        }
-      }
-    
       // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
       // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
       // container runtime label as it is no longer needed.
@@ -59858,13 +59837,6 @@ data:
           values = {
             stream  = "",
           }
-        }
-      }
-    
-      // Move high-cardinality labels to structured metadata
-      stage.structured_metadata {
-        values = {
-          pod  = "",
         }
       }
     

--- a/examples/otel-metrics-service/logs.alloy
+++ b/examples/otel-metrics-service/logs.alloy
@@ -109,10 +109,13 @@ loki.process "pod_logs" {
   }
 
   // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
-  // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+  // namespace, pod, and container labels. Drop any structured metadata. Also drop the temporary
   // container runtime label as it is no longer needed.
   stage.label_drop {
-    values = ["filename", "pod", "tmp_container_runtime"]
+    values = [
+      "filename",
+      "tmp_container_runtime",
+    ]
   }
   forward_to = [loki.process.logs_service.receiver]
 }

--- a/examples/otel-metrics-service/logs.alloy
+++ b/examples/otel-metrics-service/logs.alloy
@@ -108,13 +108,6 @@ loki.process "pod_logs" {
     }
   }
 
-  // Move high-cardinality labels to structured metadata
-  stage.structured_metadata {
-    values = {
-      pod  = "",
-    }
-  }
-
   // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
   // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
   // container runtime label as it is no longer needed.

--- a/examples/otel-metrics-service/metrics.alloy
+++ b/examples/otel-metrics-service/metrics.alloy
@@ -808,10 +808,13 @@ loki.process "pod_logs" {
   }
 
   // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
-  // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+  // namespace, pod, and container labels. Drop any structured metadata. Also drop the temporary
   // container runtime label as it is no longer needed.
   stage.label_drop {
-    values = ["filename", "pod", "tmp_container_runtime"]
+    values = [
+      "filename",
+      "tmp_container_runtime",
+    ]
   }
   forward_to = [loki.process.logs_service.receiver]
 }

--- a/examples/otel-metrics-service/metrics.alloy
+++ b/examples/otel-metrics-service/metrics.alloy
@@ -807,13 +807,6 @@ loki.process "pod_logs" {
     }
   }
 
-  // Move high-cardinality labels to structured metadata
-  stage.structured_metadata {
-    values = {
-      pod  = "",
-    }
-  }
-
   // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
   // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
   // container runtime label as it is no longer needed.

--- a/examples/otel-metrics-service/output.yaml
+++ b/examples/otel-metrics-service/output.yaml
@@ -938,10 +938,13 @@ data:
       }
     
       // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
-      // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+      // namespace, pod, and container labels. Drop any structured metadata. Also drop the temporary
       // container runtime label as it is no longer needed.
       stage.label_drop {
-        values = ["filename", "pod", "tmp_container_runtime"]
+        values = [
+          "filename",
+          "tmp_container_runtime",
+        ]
       }
       forward_to = [loki.process.logs_service.receiver]
     }
@@ -1156,10 +1159,13 @@ data:
       }
     
       // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
-      // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+      // namespace, pod, and container labels. Drop any structured metadata. Also drop the temporary
       // container runtime label as it is no longer needed.
       stage.label_drop {
-        values = ["filename", "pod", "tmp_container_runtime"]
+        values = [
+          "filename",
+          "tmp_container_runtime",
+        ]
       }
       forward_to = [loki.process.logs_service.receiver]
     }
@@ -59823,10 +59829,13 @@ data:
       }
     
       // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
-      // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+      // namespace, pod, and container labels. Drop any structured metadata. Also drop the temporary
       // container runtime label as it is no longer needed.
       stage.label_drop {
-        values = ["filename", "pod", "tmp_container_runtime"]
+        values = [
+          "filename",
+          "tmp_container_runtime",
+        ]
       }
       forward_to = [loki.process.logs_service.receiver]
     }
@@ -60025,10 +60034,13 @@ data:
       }
     
       // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
-      // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+      // namespace, pod, and container labels. Drop any structured metadata. Also drop the temporary
       // container runtime label as it is no longer needed.
       stage.label_drop {
-        values = ["filename", "pod", "tmp_container_runtime"]
+        values = [
+          "filename",
+          "tmp_container_runtime",
+        ]
       }
       forward_to = [loki.process.logs_service.receiver]
     }

--- a/examples/otel-metrics-service/output.yaml
+++ b/examples/otel-metrics-service/output.yaml
@@ -937,13 +937,6 @@ data:
         }
       }
     
-      // Move high-cardinality labels to structured metadata
-      stage.structured_metadata {
-        values = {
-          pod  = "",
-        }
-      }
-    
       // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
       // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
       // container runtime label as it is no longer needed.
@@ -1159,13 +1152,6 @@ data:
           values = {
             stream  = "",
           }
-        }
-      }
-    
-      // Move high-cardinality labels to structured metadata
-      stage.structured_metadata {
-        values = {
-          pod  = "",
         }
       }
     
@@ -59836,13 +59822,6 @@ data:
         }
       }
     
-      // Move high-cardinality labels to structured metadata
-      stage.structured_metadata {
-        values = {
-          pod  = "",
-        }
-      }
-    
       // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
       // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
       // container runtime label as it is no longer needed.
@@ -60042,13 +60021,6 @@ data:
           values = {
             stream  = "",
           }
-        }
-      }
-    
-      // Move high-cardinality labels to structured metadata
-      stage.structured_metadata {
-        values = {
-          pod  = "",
         }
       }
     

--- a/examples/pod-labels/logs.alloy
+++ b/examples/pod-labels/logs.alloy
@@ -115,10 +115,13 @@ loki.process "pod_logs" {
   }
 
   // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
-  // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+  // namespace, pod, and container labels. Drop any structured metadata. Also drop the temporary
   // container runtime label as it is no longer needed.
   stage.label_drop {
-    values = ["filename", "pod", "tmp_container_runtime"]
+    values = [
+      "filename",
+      "tmp_container_runtime",
+    ]
   }
   forward_to = [loki.process.logs_service.receiver]
 }

--- a/examples/pod-labels/logs.alloy
+++ b/examples/pod-labels/logs.alloy
@@ -114,13 +114,6 @@ loki.process "pod_logs" {
     }
   }
 
-  // Move high-cardinality labels to structured metadata
-  stage.structured_metadata {
-    values = {
-      pod  = "",
-    }
-  }
-
   // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
   // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
   // container runtime label as it is no longer needed.

--- a/examples/pod-labels/metrics.alloy
+++ b/examples/pod-labels/metrics.alloy
@@ -828,10 +828,13 @@ loki.process "pod_logs" {
   }
 
   // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
-  // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+  // namespace, pod, and container labels. Drop any structured metadata. Also drop the temporary
   // container runtime label as it is no longer needed.
   stage.label_drop {
-    values = ["filename", "pod", "tmp_container_runtime"]
+    values = [
+      "filename",
+      "tmp_container_runtime",
+    ]
   }
   forward_to = [loki.process.logs_service.receiver]
 }

--- a/examples/pod-labels/metrics.alloy
+++ b/examples/pod-labels/metrics.alloy
@@ -827,13 +827,6 @@ loki.process "pod_logs" {
     }
   }
 
-  // Move high-cardinality labels to structured metadata
-  stage.structured_metadata {
-    values = {
-      pod  = "",
-    }
-  }
-
   // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
   // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
   // container runtime label as it is no longer needed.

--- a/examples/pod-labels/output.yaml
+++ b/examples/pod-labels/output.yaml
@@ -970,13 +970,6 @@ data:
         }
       }
     
-      // Move high-cardinality labels to structured metadata
-      stage.structured_metadata {
-        values = {
-          pod  = "",
-        }
-      }
-    
       // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
       // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
       // container runtime label as it is no longer needed.
@@ -1218,13 +1211,6 @@ data:
           values = {
             stream  = "",
           }
-        }
-      }
-    
-      // Move high-cardinality labels to structured metadata
-      stage.structured_metadata {
-        values = {
-          pod  = "",
         }
       }
     
@@ -59916,13 +59902,6 @@ data:
         }
       }
     
-      // Move high-cardinality labels to structured metadata
-      stage.structured_metadata {
-        values = {
-          pod  = "",
-        }
-      }
-    
       // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
       // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
       // container runtime label as it is no longer needed.
@@ -60148,13 +60127,6 @@ data:
           values = {
             stream  = "",
           }
-        }
-      }
-    
-      // Move high-cardinality labels to structured metadata
-      stage.structured_metadata {
-        values = {
-          pod  = "",
         }
       }
     

--- a/examples/pod-labels/output.yaml
+++ b/examples/pod-labels/output.yaml
@@ -971,10 +971,13 @@ data:
       }
     
       // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
-      // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+      // namespace, pod, and container labels. Drop any structured metadata. Also drop the temporary
       // container runtime label as it is no longer needed.
       stage.label_drop {
-        values = ["filename", "pod", "tmp_container_runtime"]
+        values = [
+          "filename",
+          "tmp_container_runtime",
+        ]
       }
       forward_to = [loki.process.logs_service.receiver]
     }
@@ -1215,10 +1218,13 @@ data:
       }
     
       // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
-      // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+      // namespace, pod, and container labels. Drop any structured metadata. Also drop the temporary
       // container runtime label as it is no longer needed.
       stage.label_drop {
-        values = ["filename", "pod", "tmp_container_runtime"]
+        values = [
+          "filename",
+          "tmp_container_runtime",
+        ]
       }
       forward_to = [loki.process.logs_service.receiver]
     }
@@ -59903,10 +59909,13 @@ data:
       }
     
       // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
-      // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+      // namespace, pod, and container labels. Drop any structured metadata. Also drop the temporary
       // container runtime label as it is no longer needed.
       stage.label_drop {
-        values = ["filename", "pod", "tmp_container_runtime"]
+        values = [
+          "filename",
+          "tmp_container_runtime",
+        ]
       }
       forward_to = [loki.process.logs_service.receiver]
     }
@@ -60131,10 +60140,13 @@ data:
       }
     
       // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
-      // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+      // namespace, pod, and container labels. Drop any structured metadata. Also drop the temporary
       // container runtime label as it is no longer needed.
       stage.label_drop {
-        values = ["filename", "pod", "tmp_container_runtime"]
+        values = [
+          "filename",
+          "tmp_container_runtime",
+        ]
       }
       forward_to = [loki.process.logs_service.receiver]
     }

--- a/examples/private-image-registry/logs.alloy
+++ b/examples/private-image-registry/logs.alloy
@@ -109,10 +109,13 @@ loki.process "pod_logs" {
   }
 
   // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
-  // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+  // namespace, pod, and container labels. Drop any structured metadata. Also drop the temporary
   // container runtime label as it is no longer needed.
   stage.label_drop {
-    values = ["filename", "pod", "tmp_container_runtime"]
+    values = [
+      "filename",
+      "tmp_container_runtime",
+    ]
   }
   forward_to = [loki.process.logs_service.receiver]
 }

--- a/examples/private-image-registry/logs.alloy
+++ b/examples/private-image-registry/logs.alloy
@@ -108,13 +108,6 @@ loki.process "pod_logs" {
     }
   }
 
-  // Move high-cardinality labels to structured metadata
-  stage.structured_metadata {
-    values = {
-      pod  = "",
-    }
-  }
-
   // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
   // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
   // container runtime label as it is no longer needed.

--- a/examples/private-image-registry/metrics.alloy
+++ b/examples/private-image-registry/metrics.alloy
@@ -791,10 +791,13 @@ loki.process "pod_logs" {
   }
 
   // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
-  // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+  // namespace, pod, and container labels. Drop any structured metadata. Also drop the temporary
   // container runtime label as it is no longer needed.
   stage.label_drop {
-    values = ["filename", "pod", "tmp_container_runtime"]
+    values = [
+      "filename",
+      "tmp_container_runtime",
+    ]
   }
   forward_to = [loki.process.logs_service.receiver]
 }

--- a/examples/private-image-registry/metrics.alloy
+++ b/examples/private-image-registry/metrics.alloy
@@ -790,13 +790,6 @@ loki.process "pod_logs" {
     }
   }
 
-  // Move high-cardinality labels to structured metadata
-  stage.structured_metadata {
-    values = {
-      pod  = "",
-    }
-  }
-
   // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
   // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
   // container runtime label as it is no longer needed.

--- a/examples/private-image-registry/output.yaml
+++ b/examples/private-image-registry/output.yaml
@@ -924,13 +924,6 @@ data:
         }
       }
     
-      // Move high-cardinality labels to structured metadata
-      stage.structured_metadata {
-        values = {
-          pod  = "",
-        }
-      }
-    
       // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
       // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
       // container runtime label as it is no longer needed.
@@ -1146,13 +1139,6 @@ data:
           values = {
             stream  = "",
           }
-        }
-      }
-    
-      // Move high-cardinality labels to structured metadata
-      stage.structured_metadata {
-        values = {
-          pod  = "",
         }
       }
     
@@ -59818,13 +59804,6 @@ data:
         }
       }
     
-      // Move high-cardinality labels to structured metadata
-      stage.structured_metadata {
-        values = {
-          pod  = "",
-        }
-      }
-    
       // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
       // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
       // container runtime label as it is no longer needed.
@@ -60024,13 +60003,6 @@ data:
           values = {
             stream  = "",
           }
-        }
-      }
-    
-      // Move high-cardinality labels to structured metadata
-      stage.structured_metadata {
-        values = {
-          pod  = "",
         }
       }
     

--- a/examples/private-image-registry/output.yaml
+++ b/examples/private-image-registry/output.yaml
@@ -925,10 +925,13 @@ data:
       }
     
       // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
-      // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+      // namespace, pod, and container labels. Drop any structured metadata. Also drop the temporary
       // container runtime label as it is no longer needed.
       stage.label_drop {
-        values = ["filename", "pod", "tmp_container_runtime"]
+        values = [
+          "filename",
+          "tmp_container_runtime",
+        ]
       }
       forward_to = [loki.process.logs_service.receiver]
     }
@@ -1143,10 +1146,13 @@ data:
       }
     
       // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
-      // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+      // namespace, pod, and container labels. Drop any structured metadata. Also drop the temporary
       // container runtime label as it is no longer needed.
       stage.label_drop {
-        values = ["filename", "pod", "tmp_container_runtime"]
+        values = [
+          "filename",
+          "tmp_container_runtime",
+        ]
       }
       forward_to = [loki.process.logs_service.receiver]
     }
@@ -59805,10 +59811,13 @@ data:
       }
     
       // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
-      // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+      // namespace, pod, and container labels. Drop any structured metadata. Also drop the temporary
       // container runtime label as it is no longer needed.
       stage.label_drop {
-        values = ["filename", "pod", "tmp_container_runtime"]
+        values = [
+          "filename",
+          "tmp_container_runtime",
+        ]
       }
       forward_to = [loki.process.logs_service.receiver]
     }
@@ -60007,10 +60016,13 @@ data:
       }
     
       // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
-      // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+      // namespace, pod, and container labels. Drop any structured metadata. Also drop the temporary
       // container runtime label as it is no longer needed.
       stage.label_drop {
-        values = ["filename", "pod", "tmp_container_runtime"]
+        values = [
+          "filename",
+          "tmp_container_runtime",
+        ]
       }
       forward_to = [loki.process.logs_service.receiver]
     }

--- a/examples/profiles-enabled/logs.alloy
+++ b/examples/profiles-enabled/logs.alloy
@@ -109,10 +109,13 @@ loki.process "pod_logs" {
   }
 
   // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
-  // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+  // namespace, pod, and container labels. Drop any structured metadata. Also drop the temporary
   // container runtime label as it is no longer needed.
   stage.label_drop {
-    values = ["filename", "pod", "tmp_container_runtime"]
+    values = [
+      "filename",
+      "tmp_container_runtime",
+    ]
   }
   forward_to = [loki.process.logs_service.receiver]
 }

--- a/examples/profiles-enabled/logs.alloy
+++ b/examples/profiles-enabled/logs.alloy
@@ -108,13 +108,6 @@ loki.process "pod_logs" {
     }
   }
 
-  // Move high-cardinality labels to structured metadata
-  stage.structured_metadata {
-    values = {
-      pod  = "",
-    }
-  }
-
   // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
   // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
   // container runtime label as it is no longer needed.

--- a/examples/profiles-enabled/metrics.alloy
+++ b/examples/profiles-enabled/metrics.alloy
@@ -791,10 +791,13 @@ loki.process "pod_logs" {
   }
 
   // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
-  // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+  // namespace, pod, and container labels. Drop any structured metadata. Also drop the temporary
   // container runtime label as it is no longer needed.
   stage.label_drop {
-    values = ["filename", "pod", "tmp_container_runtime"]
+    values = [
+      "filename",
+      "tmp_container_runtime",
+    ]
   }
   forward_to = [loki.process.logs_service.receiver]
 }

--- a/examples/profiles-enabled/metrics.alloy
+++ b/examples/profiles-enabled/metrics.alloy
@@ -790,13 +790,6 @@ loki.process "pod_logs" {
     }
   }
 
-  // Move high-cardinality labels to structured metadata
-  stage.structured_metadata {
-    values = {
-      pod  = "",
-    }
-  }
-
   // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
   // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
   // container runtime label as it is no longer needed.

--- a/examples/profiles-enabled/output.yaml
+++ b/examples/profiles-enabled/output.yaml
@@ -950,10 +950,13 @@ data:
       }
     
       // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
-      // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+      // namespace, pod, and container labels. Drop any structured metadata. Also drop the temporary
       // container runtime label as it is no longer needed.
       stage.label_drop {
-        values = ["filename", "pod", "tmp_container_runtime"]
+        values = [
+          "filename",
+          "tmp_container_runtime",
+        ]
       }
       forward_to = [loki.process.logs_service.receiver]
     }
@@ -1168,10 +1171,13 @@ data:
       }
     
       // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
-      // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+      // namespace, pod, and container labels. Drop any structured metadata. Also drop the temporary
       // container runtime label as it is no longer needed.
       stage.label_drop {
-        values = ["filename", "pod", "tmp_container_runtime"]
+        values = [
+          "filename",
+          "tmp_container_runtime",
+        ]
       }
       forward_to = [loki.process.logs_service.receiver]
     }
@@ -60985,10 +60991,13 @@ data:
       }
     
       // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
-      // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+      // namespace, pod, and container labels. Drop any structured metadata. Also drop the temporary
       // container runtime label as it is no longer needed.
       stage.label_drop {
-        values = ["filename", "pod", "tmp_container_runtime"]
+        values = [
+          "filename",
+          "tmp_container_runtime",
+        ]
       }
       forward_to = [loki.process.logs_service.receiver]
     }
@@ -61187,10 +61196,13 @@ data:
       }
     
       // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
-      // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+      // namespace, pod, and container labels. Drop any structured metadata. Also drop the temporary
       // container runtime label as it is no longer needed.
       stage.label_drop {
-        values = ["filename", "pod", "tmp_container_runtime"]
+        values = [
+          "filename",
+          "tmp_container_runtime",
+        ]
       }
       forward_to = [loki.process.logs_service.receiver]
     }

--- a/examples/profiles-enabled/output.yaml
+++ b/examples/profiles-enabled/output.yaml
@@ -949,13 +949,6 @@ data:
         }
       }
     
-      // Move high-cardinality labels to structured metadata
-      stage.structured_metadata {
-        values = {
-          pod  = "",
-        }
-      }
-    
       // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
       // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
       // container runtime label as it is no longer needed.
@@ -1171,13 +1164,6 @@ data:
           values = {
             stream  = "",
           }
-        }
-      }
-    
-      // Move high-cardinality labels to structured metadata
-      stage.structured_metadata {
-        values = {
-          pod  = "",
         }
       }
     
@@ -60998,13 +60984,6 @@ data:
         }
       }
     
-      // Move high-cardinality labels to structured metadata
-      stage.structured_metadata {
-        values = {
-          pod  = "",
-        }
-      }
-    
       // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
       // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
       // container runtime label as it is no longer needed.
@@ -61204,13 +61183,6 @@ data:
           values = {
             stream  = "",
           }
-        }
-      }
-    
-      // Move high-cardinality labels to structured metadata
-      stage.structured_metadata {
-        values = {
-          pod  = "",
         }
       }
     

--- a/examples/proxies/logs.alloy
+++ b/examples/proxies/logs.alloy
@@ -109,10 +109,13 @@ loki.process "pod_logs" {
   }
 
   // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
-  // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+  // namespace, pod, and container labels. Drop any structured metadata. Also drop the temporary
   // container runtime label as it is no longer needed.
   stage.label_drop {
-    values = ["filename", "pod", "tmp_container_runtime"]
+    values = [
+      "filename",
+      "tmp_container_runtime",
+    ]
   }
   forward_to = [loki.process.logs_service.receiver]
 }

--- a/examples/proxies/logs.alloy
+++ b/examples/proxies/logs.alloy
@@ -108,13 +108,6 @@ loki.process "pod_logs" {
     }
   }
 
-  // Move high-cardinality labels to structured metadata
-  stage.structured_metadata {
-    values = {
-      pod  = "",
-    }
-  }
-
   // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
   // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
   // container runtime label as it is no longer needed.

--- a/examples/proxies/metrics.alloy
+++ b/examples/proxies/metrics.alloy
@@ -794,13 +794,6 @@ loki.process "pod_logs" {
     }
   }
 
-  // Move high-cardinality labels to structured metadata
-  stage.structured_metadata {
-    values = {
-      pod  = "",
-    }
-  }
-
   // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
   // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
   // container runtime label as it is no longer needed.

--- a/examples/proxies/metrics.alloy
+++ b/examples/proxies/metrics.alloy
@@ -795,10 +795,13 @@ loki.process "pod_logs" {
   }
 
   // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
-  // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+  // namespace, pod, and container labels. Drop any structured metadata. Also drop the temporary
   // container runtime label as it is no longer needed.
   stage.label_drop {
-    values = ["filename", "pod", "tmp_container_runtime"]
+    values = [
+      "filename",
+      "tmp_container_runtime",
+    ]
   }
   forward_to = [loki.process.logs_service.receiver]
 }

--- a/examples/proxies/output.yaml
+++ b/examples/proxies/output.yaml
@@ -924,13 +924,6 @@ data:
         }
       }
     
-      // Move high-cardinality labels to structured metadata
-      stage.structured_metadata {
-        values = {
-          pod  = "",
-        }
-      }
-    
       // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
       // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
       // container runtime label as it is no longer needed.
@@ -1154,13 +1147,6 @@ data:
           values = {
             stream  = "",
           }
-        }
-      }
-    
-      // Move high-cardinality labels to structured metadata
-      stage.structured_metadata {
-        values = {
-          pod  = "",
         }
       }
     
@@ -59822,13 +59808,6 @@ data:
         }
       }
     
-      // Move high-cardinality labels to structured metadata
-      stage.structured_metadata {
-        values = {
-          pod  = "",
-        }
-      }
-    
       // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
       // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
       // container runtime label as it is no longer needed.
@@ -60036,13 +60015,6 @@ data:
           values = {
             stream  = "",
           }
-        }
-      }
-    
-      // Move high-cardinality labels to structured metadata
-      stage.structured_metadata {
-        values = {
-          pod  = "",
         }
       }
     

--- a/examples/proxies/output.yaml
+++ b/examples/proxies/output.yaml
@@ -925,10 +925,13 @@ data:
       }
     
       // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
-      // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+      // namespace, pod, and container labels. Drop any structured metadata. Also drop the temporary
       // container runtime label as it is no longer needed.
       stage.label_drop {
-        values = ["filename", "pod", "tmp_container_runtime"]
+        values = [
+          "filename",
+          "tmp_container_runtime",
+        ]
       }
       forward_to = [loki.process.logs_service.receiver]
     }
@@ -1151,10 +1154,13 @@ data:
       }
     
       // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
-      // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+      // namespace, pod, and container labels. Drop any structured metadata. Also drop the temporary
       // container runtime label as it is no longer needed.
       stage.label_drop {
-        values = ["filename", "pod", "tmp_container_runtime"]
+        values = [
+          "filename",
+          "tmp_container_runtime",
+        ]
       }
       forward_to = [loki.process.logs_service.receiver]
     }
@@ -59809,10 +59815,13 @@ data:
       }
     
       // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
-      // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+      // namespace, pod, and container labels. Drop any structured metadata. Also drop the temporary
       // container runtime label as it is no longer needed.
       stage.label_drop {
-        values = ["filename", "pod", "tmp_container_runtime"]
+        values = [
+          "filename",
+          "tmp_container_runtime",
+        ]
       }
       forward_to = [loki.process.logs_service.receiver]
     }
@@ -60019,10 +60028,13 @@ data:
       }
     
       // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
-      // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+      // namespace, pod, and container labels. Drop any structured metadata. Also drop the temporary
       // container runtime label as it is no longer needed.
       stage.label_drop {
-        values = ["filename", "pod", "tmp_container_runtime"]
+        values = [
+          "filename",
+          "tmp_container_runtime",
+        ]
       }
       forward_to = [loki.process.logs_service.receiver]
     }

--- a/examples/service-integrations/logs.alloy
+++ b/examples/service-integrations/logs.alloy
@@ -109,10 +109,13 @@ loki.process "pod_logs" {
   }
 
   // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
-  // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+  // namespace, pod, and container labels. Drop any structured metadata. Also drop the temporary
   // container runtime label as it is no longer needed.
   stage.label_drop {
-    values = ["filename", "pod", "tmp_container_runtime"]
+    values = [
+      "filename",
+      "tmp_container_runtime",
+    ]
   }
   forward_to = [loki.process.logs_service.receiver]
 }

--- a/examples/service-integrations/logs.alloy
+++ b/examples/service-integrations/logs.alloy
@@ -108,13 +108,6 @@ loki.process "pod_logs" {
     }
   }
 
-  // Move high-cardinality labels to structured metadata
-  stage.structured_metadata {
-    values = {
-      pod  = "",
-    }
-  }
-
   // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
   // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
   // container runtime label as it is no longer needed.

--- a/examples/service-integrations/metrics.alloy
+++ b/examples/service-integrations/metrics.alloy
@@ -791,10 +791,13 @@ loki.process "pod_logs" {
   }
 
   // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
-  // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+  // namespace, pod, and container labels. Drop any structured metadata. Also drop the temporary
   // container runtime label as it is no longer needed.
   stage.label_drop {
-    values = ["filename", "pod", "tmp_container_runtime"]
+    values = [
+      "filename",
+      "tmp_container_runtime",
+    ]
   }
   forward_to = [loki.process.logs_service.receiver]
 }

--- a/examples/service-integrations/metrics.alloy
+++ b/examples/service-integrations/metrics.alloy
@@ -790,13 +790,6 @@ loki.process "pod_logs" {
     }
   }
 
-  // Move high-cardinality labels to structured metadata
-  stage.structured_metadata {
-    values = {
-      pod  = "",
-    }
-  }
-
   // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
   // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
   // container runtime label as it is no longer needed.

--- a/examples/service-integrations/output.yaml
+++ b/examples/service-integrations/output.yaml
@@ -921,10 +921,13 @@ data:
       }
     
       // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
-      // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+      // namespace, pod, and container labels. Drop any structured metadata. Also drop the temporary
       // container runtime label as it is no longer needed.
       stage.label_drop {
-        values = ["filename", "pod", "tmp_container_runtime"]
+        values = [
+          "filename",
+          "tmp_container_runtime",
+        ]
       }
       forward_to = [loki.process.logs_service.receiver]
     }
@@ -1159,10 +1162,13 @@ data:
       }
     
       // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
-      // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+      // namespace, pod, and container labels. Drop any structured metadata. Also drop the temporary
       // container runtime label as it is no longer needed.
       stage.label_drop {
-        values = ["filename", "pod", "tmp_container_runtime"]
+        values = [
+          "filename",
+          "tmp_container_runtime",
+        ]
       }
       forward_to = [loki.process.logs_service.receiver]
     }
@@ -59824,10 +59830,13 @@ data:
       }
     
       // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
-      // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+      // namespace, pod, and container labels. Drop any structured metadata. Also drop the temporary
       // container runtime label as it is no longer needed.
       stage.label_drop {
-        values = ["filename", "pod", "tmp_container_runtime"]
+        values = [
+          "filename",
+          "tmp_container_runtime",
+        ]
       }
       forward_to = [loki.process.logs_service.receiver]
     }
@@ -60046,10 +60055,13 @@ data:
       }
     
       // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
-      // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+      // namespace, pod, and container labels. Drop any structured metadata. Also drop the temporary
       // container runtime label as it is no longer needed.
       stage.label_drop {
-        values = ["filename", "pod", "tmp_container_runtime"]
+        values = [
+          "filename",
+          "tmp_container_runtime",
+        ]
       }
       forward_to = [loki.process.logs_service.receiver]
     }

--- a/examples/service-integrations/output.yaml
+++ b/examples/service-integrations/output.yaml
@@ -920,13 +920,6 @@ data:
         }
       }
     
-      // Move high-cardinality labels to structured metadata
-      stage.structured_metadata {
-        values = {
-          pod  = "",
-        }
-      }
-    
       // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
       // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
       // container runtime label as it is no longer needed.
@@ -1162,13 +1155,6 @@ data:
           values = {
             stream  = "",
           }
-        }
-      }
-    
-      // Move high-cardinality labels to structured metadata
-      stage.structured_metadata {
-        values = {
-          pod  = "",
         }
       }
     
@@ -59837,13 +59823,6 @@ data:
         }
       }
     
-      // Move high-cardinality labels to structured metadata
-      stage.structured_metadata {
-        values = {
-          pod  = "",
-        }
-      }
-    
       // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
       // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
       // container runtime label as it is no longer needed.
@@ -60063,13 +60042,6 @@ data:
           values = {
             stream  = "",
           }
-        }
-      }
-    
-      // Move high-cardinality labels to structured metadata
-      stage.structured_metadata {
-        values = {
-          pod  = "",
         }
       }
     

--- a/examples/specific-namespace/logs.alloy
+++ b/examples/specific-namespace/logs.alloy
@@ -113,13 +113,6 @@ loki.process "pod_logs" {
     }
   }
 
-  // Move high-cardinality labels to structured metadata
-  stage.structured_metadata {
-    values = {
-      pod  = "",
-    }
-  }
-
   // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
   // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
   // container runtime label as it is no longer needed.

--- a/examples/specific-namespace/logs.alloy
+++ b/examples/specific-namespace/logs.alloy
@@ -114,10 +114,13 @@ loki.process "pod_logs" {
   }
 
   // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
-  // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+  // namespace, pod, and container labels. Drop any structured metadata. Also drop the temporary
   // container runtime label as it is no longer needed.
   stage.label_drop {
-    values = ["filename", "pod", "tmp_container_runtime"]
+    values = [
+      "filename",
+      "tmp_container_runtime",
+    ]
   }
   forward_to = [loki.process.logs_service.receiver]
 }

--- a/examples/specific-namespace/metrics.alloy
+++ b/examples/specific-namespace/metrics.alloy
@@ -849,10 +849,13 @@ loki.process "pod_logs" {
   }
 
   // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
-  // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+  // namespace, pod, and container labels. Drop any structured metadata. Also drop the temporary
   // container runtime label as it is no longer needed.
   stage.label_drop {
-    values = ["filename", "pod", "tmp_container_runtime"]
+    values = [
+      "filename",
+      "tmp_container_runtime",
+    ]
   }
   forward_to = [loki.process.logs_service.receiver]
 }

--- a/examples/specific-namespace/metrics.alloy
+++ b/examples/specific-namespace/metrics.alloy
@@ -848,13 +848,6 @@ loki.process "pod_logs" {
     }
   }
 
-  // Move high-cardinality labels to structured metadata
-  stage.structured_metadata {
-    values = {
-      pod  = "",
-    }
-  }
-
   // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
   // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
   // container runtime label as it is no longer needed.

--- a/examples/specific-namespace/output.yaml
+++ b/examples/specific-namespace/output.yaml
@@ -979,10 +979,13 @@ data:
       }
     
       // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
-      // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+      // namespace, pod, and container labels. Drop any structured metadata. Also drop the temporary
       // container runtime label as it is no longer needed.
       stage.label_drop {
-        values = ["filename", "pod", "tmp_container_runtime"]
+        values = [
+          "filename",
+          "tmp_container_runtime",
+        ]
       }
       forward_to = [loki.process.logs_service.receiver]
     }
@@ -1203,10 +1206,13 @@ data:
       }
     
       // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
-      // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+      // namespace, pod, and container labels. Drop any structured metadata. Also drop the temporary
       // container runtime label as it is no longer needed.
       stage.label_drop {
-        values = ["filename", "pod", "tmp_container_runtime"]
+        values = [
+          "filename",
+          "tmp_container_runtime",
+        ]
       }
       forward_to = [loki.process.logs_service.receiver]
     }
@@ -59911,10 +59917,13 @@ data:
       }
     
       // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
-      // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+      // namespace, pod, and container labels. Drop any structured metadata. Also drop the temporary
       // container runtime label as it is no longer needed.
       stage.label_drop {
-        values = ["filename", "pod", "tmp_container_runtime"]
+        values = [
+          "filename",
+          "tmp_container_runtime",
+        ]
       }
       forward_to = [loki.process.logs_service.receiver]
     }
@@ -60119,10 +60128,13 @@ data:
       }
     
       // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
-      // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+      // namespace, pod, and container labels. Drop any structured metadata. Also drop the temporary
       // container runtime label as it is no longer needed.
       stage.label_drop {
-        values = ["filename", "pod", "tmp_container_runtime"]
+        values = [
+          "filename",
+          "tmp_container_runtime",
+        ]
       }
       forward_to = [loki.process.logs_service.receiver]
     }

--- a/examples/specific-namespace/output.yaml
+++ b/examples/specific-namespace/output.yaml
@@ -978,13 +978,6 @@ data:
         }
       }
     
-      // Move high-cardinality labels to structured metadata
-      stage.structured_metadata {
-        values = {
-          pod  = "",
-        }
-      }
-    
       // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
       // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
       // container runtime label as it is no longer needed.
@@ -1206,13 +1199,6 @@ data:
           values = {
             stream  = "",
           }
-        }
-      }
-    
-      // Move high-cardinality labels to structured metadata
-      stage.structured_metadata {
-        values = {
-          pod  = "",
         }
       }
     
@@ -59924,13 +59910,6 @@ data:
         }
       }
     
-      // Move high-cardinality labels to structured metadata
-      stage.structured_metadata {
-        values = {
-          pod  = "",
-        }
-      }
-    
       // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
       // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
       // container runtime label as it is no longer needed.
@@ -60136,13 +60115,6 @@ data:
           values = {
             stream  = "",
           }
-        }
-      }
-    
-      // Move high-cardinality labels to structured metadata
-      stage.structured_metadata {
-        values = {
-          pod  = "",
         }
       }
     

--- a/examples/traces-enabled/logs.alloy
+++ b/examples/traces-enabled/logs.alloy
@@ -109,10 +109,13 @@ loki.process "pod_logs" {
   }
 
   // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
-  // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+  // namespace, pod, and container labels. Drop any structured metadata. Also drop the temporary
   // container runtime label as it is no longer needed.
   stage.label_drop {
-    values = ["filename", "pod", "tmp_container_runtime"]
+    values = [
+      "filename",
+      "tmp_container_runtime",
+    ]
   }
   forward_to = [loki.process.logs_service.receiver]
 }

--- a/examples/traces-enabled/logs.alloy
+++ b/examples/traces-enabled/logs.alloy
@@ -108,13 +108,6 @@ loki.process "pod_logs" {
     }
   }
 
-  // Move high-cardinality labels to structured metadata
-  stage.structured_metadata {
-    values = {
-      pod  = "",
-    }
-  }
-
   // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
   // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
   // container runtime label as it is no longer needed.

--- a/examples/traces-enabled/metrics.alloy
+++ b/examples/traces-enabled/metrics.alloy
@@ -876,13 +876,6 @@ loki.process "pod_logs" {
     }
   }
 
-  // Move high-cardinality labels to structured metadata
-  stage.structured_metadata {
-    values = {
-      pod  = "",
-    }
-  }
-
   // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
   // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
   // container runtime label as it is no longer needed.

--- a/examples/traces-enabled/metrics.alloy
+++ b/examples/traces-enabled/metrics.alloy
@@ -877,10 +877,13 @@ loki.process "pod_logs" {
   }
 
   // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
-  // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+  // namespace, pod, and container labels. Drop any structured metadata. Also drop the temporary
   // container runtime label as it is no longer needed.
   stage.label_drop {
-    values = ["filename", "pod", "tmp_container_runtime"]
+    values = [
+      "filename",
+      "tmp_container_runtime",
+    ]
   }
   forward_to = [loki.process.logs_service.receiver]
 }

--- a/examples/traces-enabled/output.yaml
+++ b/examples/traces-enabled/output.yaml
@@ -1019,13 +1019,6 @@ data:
         }
       }
     
-      // Move high-cardinality labels to structured metadata
-      stage.structured_metadata {
-        values = {
-          pod  = "",
-        }
-      }
-    
       // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
       // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
       // container runtime label as it is no longer needed.
@@ -1261,13 +1254,6 @@ data:
           values = {
             stream  = "",
           }
-        }
-      }
-    
-      // Move high-cardinality labels to structured metadata
-      stage.structured_metadata {
-        values = {
-          pod  = "",
         }
       }
     
@@ -60007,13 +59993,6 @@ data:
         }
       }
     
-      // Move high-cardinality labels to structured metadata
-      stage.structured_metadata {
-        values = {
-          pod  = "",
-        }
-      }
-    
       // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
       // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
       // container runtime label as it is no longer needed.
@@ -60233,13 +60212,6 @@ data:
           values = {
             stream  = "",
           }
-        }
-      }
-    
-      // Move high-cardinality labels to structured metadata
-      stage.structured_metadata {
-        values = {
-          pod  = "",
         }
       }
     

--- a/examples/traces-enabled/output.yaml
+++ b/examples/traces-enabled/output.yaml
@@ -1020,10 +1020,13 @@ data:
       }
     
       // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
-      // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+      // namespace, pod, and container labels. Drop any structured metadata. Also drop the temporary
       // container runtime label as it is no longer needed.
       stage.label_drop {
-        values = ["filename", "pod", "tmp_container_runtime"]
+        values = [
+          "filename",
+          "tmp_container_runtime",
+        ]
       }
       forward_to = [loki.process.logs_service.receiver]
     }
@@ -1258,10 +1261,13 @@ data:
       }
     
       // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
-      // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+      // namespace, pod, and container labels. Drop any structured metadata. Also drop the temporary
       // container runtime label as it is no longer needed.
       stage.label_drop {
-        values = ["filename", "pod", "tmp_container_runtime"]
+        values = [
+          "filename",
+          "tmp_container_runtime",
+        ]
       }
       forward_to = [loki.process.logs_service.receiver]
     }
@@ -59994,10 +60000,13 @@ data:
       }
     
       // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
-      // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+      // namespace, pod, and container labels. Drop any structured metadata. Also drop the temporary
       // container runtime label as it is no longer needed.
       stage.label_drop {
-        values = ["filename", "pod", "tmp_container_runtime"]
+        values = [
+          "filename",
+          "tmp_container_runtime",
+        ]
       }
       forward_to = [loki.process.logs_service.receiver]
     }
@@ -60216,10 +60225,13 @@ data:
       }
     
       // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
-      // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+      // namespace, pod, and container labels. Drop any structured metadata. Also drop the temporary
       // container runtime label as it is no longer needed.
       stage.label_drop {
-        values = ["filename", "pod", "tmp_container_runtime"]
+        values = [
+          "filename",
+          "tmp_container_runtime",
+        ]
       }
       forward_to = [loki.process.logs_service.receiver]
     }

--- a/examples/windows-exporter/logs.alloy
+++ b/examples/windows-exporter/logs.alloy
@@ -109,10 +109,13 @@ loki.process "pod_logs" {
   }
 
   // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
-  // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+  // namespace, pod, and container labels. Drop any structured metadata. Also drop the temporary
   // container runtime label as it is no longer needed.
   stage.label_drop {
-    values = ["filename", "pod", "tmp_container_runtime"]
+    values = [
+      "filename",
+      "tmp_container_runtime",
+    ]
   }
   forward_to = [loki.process.logs_service.receiver]
 }

--- a/examples/windows-exporter/logs.alloy
+++ b/examples/windows-exporter/logs.alloy
@@ -108,13 +108,6 @@ loki.process "pod_logs" {
     }
   }
 
-  // Move high-cardinality labels to structured metadata
-  stage.structured_metadata {
-    values = {
-      pod  = "",
-    }
-  }
-
   // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
   // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
   // container runtime label as it is no longer needed.

--- a/examples/windows-exporter/metrics.alloy
+++ b/examples/windows-exporter/metrics.alloy
@@ -860,10 +860,13 @@ loki.process "pod_logs" {
   }
 
   // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
-  // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+  // namespace, pod, and container labels. Drop any structured metadata. Also drop the temporary
   // container runtime label as it is no longer needed.
   stage.label_drop {
-    values = ["filename", "pod", "tmp_container_runtime"]
+    values = [
+      "filename",
+      "tmp_container_runtime",
+    ]
   }
   forward_to = [loki.process.logs_service.receiver]
 }

--- a/examples/windows-exporter/metrics.alloy
+++ b/examples/windows-exporter/metrics.alloy
@@ -859,13 +859,6 @@ loki.process "pod_logs" {
     }
   }
 
-  // Move high-cardinality labels to structured metadata
-  stage.structured_metadata {
-    values = {
-      pod  = "",
-    }
-  }
-
   // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
   // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
   // container runtime label as it is no longer needed.

--- a/examples/windows-exporter/output.yaml
+++ b/examples/windows-exporter/output.yaml
@@ -1027,10 +1027,13 @@ data:
       }
     
       // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
-      // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+      // namespace, pod, and container labels. Drop any structured metadata. Also drop the temporary
       // container runtime label as it is no longer needed.
       stage.label_drop {
-        values = ["filename", "pod", "tmp_container_runtime"]
+        values = [
+          "filename",
+          "tmp_container_runtime",
+        ]
       }
       forward_to = [loki.process.logs_service.receiver]
     }
@@ -1245,10 +1248,13 @@ data:
       }
     
       // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
-      // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+      // namespace, pod, and container labels. Drop any structured metadata. Also drop the temporary
       // container runtime label as it is no longer needed.
       stage.label_drop {
-        values = ["filename", "pod", "tmp_container_runtime"]
+        values = [
+          "filename",
+          "tmp_container_runtime",
+        ]
       }
       forward_to = [loki.process.logs_service.receiver]
     }
@@ -60091,10 +60097,13 @@ data:
       }
     
       // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
-      // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+      // namespace, pod, and container labels. Drop any structured metadata. Also drop the temporary
       // container runtime label as it is no longer needed.
       stage.label_drop {
-        values = ["filename", "pod", "tmp_container_runtime"]
+        values = [
+          "filename",
+          "tmp_container_runtime",
+        ]
       }
       forward_to = [loki.process.logs_service.receiver]
     }
@@ -60293,10 +60302,13 @@ data:
       }
     
       // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
-      // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
+      // namespace, pod, and container labels. Drop any structured metadata. Also drop the temporary
       // container runtime label as it is no longer needed.
       stage.label_drop {
-        values = ["filename", "pod", "tmp_container_runtime"]
+        values = [
+          "filename",
+          "tmp_container_runtime",
+        ]
       }
       forward_to = [loki.process.logs_service.receiver]
     }

--- a/examples/windows-exporter/output.yaml
+++ b/examples/windows-exporter/output.yaml
@@ -1026,13 +1026,6 @@ data:
         }
       }
     
-      // Move high-cardinality labels to structured metadata
-      stage.structured_metadata {
-        values = {
-          pod  = "",
-        }
-      }
-    
       // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
       // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
       // container runtime label as it is no longer needed.
@@ -1248,13 +1241,6 @@ data:
           values = {
             stream  = "",
           }
-        }
-      }
-    
-      // Move high-cardinality labels to structured metadata
-      stage.structured_metadata {
-        values = {
-          pod  = "",
         }
       }
     
@@ -60104,13 +60090,6 @@ data:
         }
       }
     
-      // Move high-cardinality labels to structured metadata
-      stage.structured_metadata {
-        values = {
-          pod  = "",
-        }
-      }
-    
       // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
       // namespace, pod, and container labels. Drop the pod label, which is in structured metadata. Also drop the temporary
       // container runtime label as it is no longer needed.
@@ -60310,13 +60289,6 @@ data:
           values = {
             stream  = "",
           }
-        }
-      }
-    
-      // Move high-cardinality labels to structured metadata
-      stage.structured_metadata {
-        values = {
-          pod  = "",
         }
       }
     


### PR DESCRIPTION
Including structured metadata is a breaking change for anyone not running a Loki that supports it.
We'll re-add `pod` to the default list in version 2.0.