### PR TITLE
feat: initial oauth2 support

### DIFF
--- a/charts/k8s-monitoring/README.md
+++ b/charts/k8s-monitoring/README.md
@@ -220,7 +220,7 @@ The Prometheus and Loki services may be hosted on the same cluster, or remotely 
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| externalServices.loki.authMode | string | `"basic"` | one of "none", "basic" |
+| externalServices.loki.authMode | string | `"basic"` | one of "none", "basic", "oauth2" |
 | externalServices.loki.basicAuth.password | string | `""` | Loki basic auth password |
 | externalServices.loki.basicAuth.passwordKey | string | `"password"` | The key for the password property in the secret |
 | externalServices.loki.basicAuth.username | string | `""` | Loki basic auth username |
@@ -229,6 +229,18 @@ The Prometheus and Loki services may be hosted on the same cluster, or remotely 
 | externalServices.loki.externalLabelsFrom | object | `{}` | Custom labels to be added to all logs and events through a dynamic reference, all values are treated as raw strings and not quoted. |
 | externalServices.loki.host | string | `""` | Loki host where logs and events will be sent |
 | externalServices.loki.hostKey | string | `"host"` | The key for the host property in the secret |
+| externalServices.loki.oauth2.clientId | string | `""` | Loki OAuth2 client ID |
+| externalServices.loki.oauth2.clientIdKey | string | `"id"` | The key for the client ID property in the secret |
+| externalServices.loki.oauth2.clientSecret | string | `""` | Loki OAuth2 client secret |
+| externalServices.loki.oauth2.clientSecretFile | string | `""` | File containing the OAuth2 client secret. |
+| externalServices.loki.oauth2.clientSecretKey | string | `"secret"` | The key for the client secret property in the secret |
+| externalServices.loki.oauth2.endpointParams | object | `{}` | Loki OAuth2 endpoint parameters |
+| externalServices.loki.oauth2.noProxy | string | `""` | Comma-separated list of IP addresses, CIDR notations, and domain names to exclude from proxying. |
+| externalServices.loki.oauth2.proxyConnectHeader | object | `{}` | Specifies headers to send to proxies during CONNECT requests. |
+| externalServices.loki.oauth2.proxyFromEnvironment | bool | `false` | Use the proxy URL indicated by environment variables. |
+| externalServices.loki.oauth2.proxyURL | string | `""` | HTTP proxy to send requests through. |
+| externalServices.loki.oauth2.scopes | list | `[]` | List of scopes to authenticate with. |
+| externalServices.loki.oauth2.tokenURL | string | `""` | URL to fetch the token from. |
 | externalServices.loki.processors.batch.maxSize | int | `0` | Upper limit of a batch size. When set to 0, there is no upper limit. |
 | externalServices.loki.processors.batch.size | int | `8192` | Amount of data to buffer before flushing the batch. |
 | externalServices.loki.processors.batch.timeout | string | `"2s"` | How long to wait before flushing the batch. |
@@ -250,7 +262,7 @@ The Prometheus and Loki services may be hosted on the same cluster, or remotely 
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| externalServices.prometheus.authMode | string | `"basic"` | one of "none", "basic" |
+| externalServices.prometheus.authMode | string | `"basic"` | one of "none", "basic", "oauth2" |
 | externalServices.prometheus.basicAuth.password | string | `""` | Prometheus basic auth password |
 | externalServices.prometheus.basicAuth.passwordKey | string | `"password"` | The key for the password property in the secret |
 | externalServices.prometheus.basicAuth.username | string | `""` | Prometheus basic auth username |
@@ -259,6 +271,18 @@ The Prometheus and Loki services may be hosted on the same cluster, or remotely 
 | externalServices.prometheus.externalLabelsFrom | object | `{}` | Custom labels to be added to all time series through a dynamic reference, all values are treated as raw strings and not quoted. |
 | externalServices.prometheus.host | string | `""` | Prometheus host where metrics will be sent |
 | externalServices.prometheus.hostKey | string | `"host"` | The key for the host property in the secret |
+| externalServices.prometheus.oauth2.clientId | string | `""` | Prometheus OAuth2 client ID |
+| externalServices.prometheus.oauth2.clientIdKey | string | `"id"` | The key for the client ID property in the secret |
+| externalServices.prometheus.oauth2.clientSecret | string | `""` | Prometheus OAuth2 client secret |
+| externalServices.prometheus.oauth2.clientSecretFile | string | `""` | File containing the OAuth2 client secret. |
+| externalServices.prometheus.oauth2.clientSecretKey | string | `"secret"` | The key for the client secret property in the secret |
+| externalServices.prometheus.oauth2.endpointParams | object | `{}` | Prometheus OAuth2 endpoint parameters |
+| externalServices.prometheus.oauth2.noProxy | string | `""` | Comma-separated list of IP addresses, CIDR notations, and domain names to exclude from proxying. |
+| externalServices.prometheus.oauth2.proxyConnectHeader | object | `{}` | Specifies headers to send to proxies during CONNECT requests. |
+| externalServices.prometheus.oauth2.proxyFromEnvironment | bool | `false` | Use the proxy URL indicated by environment variables. |
+| externalServices.prometheus.oauth2.proxyURL | string | `""` | HTTP proxy to send requests through. |
+| externalServices.prometheus.oauth2.scopes | list | `[]` | List of scopes to authenticate with. |
+| externalServices.prometheus.oauth2.tokenURL | string | `""` | URL to fetch the token from. |
 | externalServices.prometheus.processors.batch.maxSize | int | `0` | Upper limit of a batch size. When set to 0, there is no upper limit. |
 | externalServices.prometheus.processors.batch.size | int | `8192` | Amount of data to buffer before flushing the batch. |
 | externalServices.prometheus.processors.batch.timeout | string | `"2s"` | How long to wait before flushing the batch. |

--- a/charts/k8s-monitoring/templates/alloy_config/_logs_service_loki.alloy.txt
+++ b/charts/k8s-monitoring/templates/alloy_config/_logs_service_loki.alloy.txt
@@ -13,6 +13,36 @@ loki.write "logs_service" {
       username = nonsensitive(remote.kubernetes.secret.logs_service.data[{{ .basicAuth.usernameKey | quote }}])
       password = remote.kubernetes.secret.logs_service.data[{{ .basicAuth.passwordKey | quote }}]
     }
+{{ else if eq .authMode "oauth2" }}
+    oauth2 {
+      client_id = nonsensitive(remote.kubernetes.secret.logs_service.data[{{ .oauth2.clientIdKey | quote }}])
+      {{- if eq .oauth2.clientSecretFile "" }}
+      client_secret = remote.kubernetes.secret.logs_service.data[{{ .oauth2.clientSecretKey | quote }}]
+      {{- else }}
+      client_secret_file = {{ .oauth2.clientSecretFile | quote }}
+      {{- end }}
+      {{- if .oauth2.endpointParams }}
+      endpoint_params = {{ .oauth2.endpointParams | toJson }}
+      {{- end }}
+      {{- if .oauth2.proxyURL }}
+      proxy_url = {{ .oauth2.proxyURL | quote }}
+      {{- end }}
+      {{- if .oauth2.noProxy }}
+      no_proxy = {{ .oauth2.noProxy | quote }}
+      {{- end }}
+      {{- if .oauth2.proxyFromEnvironment }}
+      proxyFromEnvironment = {{ .oauth2.proxyFromEnvironment }}
+      {{- end }}
+      {{- if .oauth2.proxyConnectHeader }}
+      proxy_connect_header = {{ .oauth2.proxyConnectHeader | toJson }}
+      {{- end }}
+      {{- if .oauth2.scopes }}
+      scopes = {{ .oauth2.scopes | toJson }}
+      {{- end }}
+      {{- if .oauth2.tokenURL }}
+      token_url = {{ .oauth2.tokenURL | quote }}
+      {{- end }}
+    }
 {{- end }}
 {{- if .tls }}
     tls_config {

--- a/charts/k8s-monitoring/templates/alloy_config/_logs_service_loki.alloy.txt
+++ b/charts/k8s-monitoring/templates/alloy_config/_logs_service_loki.alloy.txt
@@ -13,7 +13,7 @@ loki.write "logs_service" {
       username = nonsensitive(remote.kubernetes.secret.logs_service.data[{{ .basicAuth.usernameKey | quote }}])
       password = remote.kubernetes.secret.logs_service.data[{{ .basicAuth.passwordKey | quote }}]
     }
-{{ else if eq .authMode "oauth2" }}
+{{- else if eq .authMode "oauth2" }}
     oauth2 {
       client_id = nonsensitive(remote.kubernetes.secret.logs_service.data[{{ .oauth2.clientIdKey | quote }}])
       {{- if eq .oauth2.clientSecretFile "" }}

--- a/charts/k8s-monitoring/templates/alloy_config/_metrics_service_remote_write.alloy.txt
+++ b/charts/k8s-monitoring/templates/alloy_config/_metrics_service_remote_write.alloy.txt
@@ -12,6 +12,36 @@ prometheus.remote_write "metrics_service" {
       username = nonsensitive(remote.kubernetes.secret.metrics_service.data[{{ .basicAuth.usernameKey | quote }}])
       password = remote.kubernetes.secret.metrics_service.data[{{ .basicAuth.passwordKey | quote }}]
     }
+{{ else if eq .authMode "oauth2" }}
+    oauth2 {
+      client_id = nonsensitive(remote.kubernetes.secret.metrics_service.data[{{ .oauth2.clientIdKey | quote }}])
+      {{- if eq .oauth2.clientSecretFile "" }}
+      client_secret = remote.kubernetes.secret.metrics_service.data[{{ .oauth2.clientSecretKey | quote }}]
+      {{- else }}
+      client_secret_file = {{ .oauth2.clientSecretFile | quote }}
+      {{- end }}
+      {{- if .oauth2.endpointParams }}
+      endpoint_params = {{ .oauth2.endpointParams | toJson }}
+      {{- end }}
+      {{- if .oauth2.proxyURL }}
+      proxy_url = {{ .oauth2.proxyURL | quote }}
+      {{- end }}
+      {{- if .oauth2.noProxy }}
+      no_proxy = {{ .oauth2.noProxy | quote }}
+      {{- end }}
+      {{- if .oauth2.proxyFromEnvironment }}
+      proxyFromEnvironment = {{ .oauth2.proxyFromEnvironment }}
+      {{- end }}
+      {{- if .oauth2.proxyConnectHeader }}
+      proxy_connect_header = {{ .oauth2.proxyConnectHeader | toJson }}
+      {{- end }}
+      {{- if .oauth2.scopes }}
+      scopes = {{ .oauth2.scopes | toJson }}
+      {{- end }}
+      {{- if .oauth2.tokenURL }}
+      token_url = {{ .oauth2.tokenURL | quote }}
+      {{- end }}
+    }
 {{- end }}
 {{ if .writeRelabelConfigRules }}
 {{ .writeRelabelConfigRules | indent 4 }}

--- a/charts/k8s-monitoring/templates/alloy_config/_metrics_service_remote_write.alloy.txt
+++ b/charts/k8s-monitoring/templates/alloy_config/_metrics_service_remote_write.alloy.txt
@@ -12,7 +12,7 @@ prometheus.remote_write "metrics_service" {
       username = nonsensitive(remote.kubernetes.secret.metrics_service.data[{{ .basicAuth.usernameKey | quote }}])
       password = remote.kubernetes.secret.metrics_service.data[{{ .basicAuth.passwordKey | quote }}]
     }
-{{ else if eq .authMode "oauth2" }}
+{{- else if eq .authMode "oauth2" }}
     oauth2 {
       client_id = nonsensitive(remote.kubernetes.secret.metrics_service.data[{{ .oauth2.clientIdKey | quote }}])
       {{- if eq .oauth2.clientSecretFile "" }}

--- a/charts/k8s-monitoring/templates/log-service-credentials.yaml
+++ b/charts/k8s-monitoring/templates/log-service-credentials.yaml
@@ -18,5 +18,11 @@ data:
 {{- if .tenantId }}
   {{ .tenantIdKey }}: {{ .tenantId | toString | b64enc | quote }}
 {{- end }}
+{{- if .oauth2.clientID }}
+  {{ .oauth2.clientIDKey }}: {{ .oauth2.clientID | toString | b64enc | quote }}
+{{- end }}
+{{- if .oauth2.clientSecret }}
+  {{ .oauth2.clientSecretKey }}: {{ .oauth2.clientSecret | toString | b64enc | quote }}
+{{- end }}
 {{- end }}
 {{- end }}

--- a/charts/k8s-monitoring/templates/metrics-service-credentials.yaml
+++ b/charts/k8s-monitoring/templates/metrics-service-credentials.yaml
@@ -18,5 +18,11 @@ data:
 {{- if .tenantId }}
   {{ .tenantIdKey }}: {{ .tenantId | toString | b64enc | quote }}
 {{- end }}
+{{- if .oauth2.clientID }}
+  {{ .oauth2.clientIDKey }}: {{ .oauth2.clientID | toString | b64enc | quote }}
+{{- end }}
+{{- if .oauth2.clientSecret }}
+  {{ .oauth2.clientSecretKey }}: {{ .oauth2.clientSecret | toString | b64enc | quote }}
+{{- end }}
 {{- end }}
 {{- end }}

--- a/charts/k8s-monitoring/values.schema.json
+++ b/charts/k8s-monitoring/values.schema.json
@@ -249,7 +249,12 @@
                     "type": "object",
                     "properties": {
                         "authMode": {
-                            "type": "string"
+                            "type": "string",
+                            "enum": [
+                                "none",
+                                "basic",
+                                "oauth2"
+                            ]
                         },
                         "basicAuth": {
                             "type": "object",
@@ -267,6 +272,53 @@
                                     ]
                                 },
                                 "usernameKey": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "oauth2": {
+                            "type": "object",
+                            "properties": {
+                                "clientId": {
+                                    "type": "string"
+                                },
+                                "clientIdKey": {
+                                    "type": "string"
+                                },
+                                "clientSecret": {
+                                    "type": "string"
+                                },
+                                "clientSecretKey": {
+                                    "type": "string"
+                                },
+                                "clientSecretFile": {
+                                    "type": "string"
+                                },
+                                "endpointParams": {
+                                    "type": "object",
+                                    "additionalProperties": {
+                                        "type": "string"
+                                    }
+                                },
+                                "proxyURL": {
+                                    "type": "string"
+                                },
+                                "noProxy": {
+                                    "type": "string"
+                                },
+                                "proxyFromEnv": {
+                                    "type": "boolean"
+                                },
+                                "proxyConnectHeader": {
+                                    "type": "object"
+                                },
+                                "scopes": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "string"
+                                    }
+                                },
+                                "tokenURL": {
                                     "type": "string"
                                 }
                             }
@@ -365,7 +417,12 @@
                     "type": "object",
                     "properties": {
                         "authMode": {
-                            "type": "string"
+                            "type": "string",
+                            "enum": [
+                                "none",
+                                "basic",
+                                "oauth2"
+                            ]
                         },
                         "basicAuth": {
                             "type": "object",
@@ -383,6 +440,53 @@
                                     ]
                                 },
                                 "usernameKey": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "oauth2": {
+                            "type": "object",
+                            "properties": {
+                                "clientId": {
+                                    "type": "string"
+                                },
+                                "clientIdKey": {
+                                    "type": "string"
+                                },
+                                "clientSecret": {
+                                    "type": "string"
+                                },
+                                "clientSecretKey": {
+                                    "type": "string"
+                                },
+                                "clientSecretFile": {
+                                    "type": "string"
+                                },
+                                "endpointParams": {
+                                    "type": "object",
+                                    "additionalProperties": {
+                                        "type": "string"
+                                    }
+                                },
+                                "proxyURL": {
+                                    "type": "string"
+                                },
+                                "noProxy": {
+                                    "type": "string"
+                                },
+                                "proxyFromEnv": {
+                                    "type": "boolean"
+                                },
+                                "proxyConnectHeader": {
+                                    "type": "object"
+                                },
+                                "scopes": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "string"
+                                    }
+                                },
+                                "tokenURL": {
                                     "type": "string"
                                 }
                             }

--- a/charts/k8s-monitoring/values.yaml
+++ b/charts/k8s-monitoring/values.yaml
@@ -57,7 +57,7 @@ externalServices:
     # @section -- External Services (Prometheus)
     tenantIdKey: tenantId
 
-    # -- one of "none", "basic"
+    # -- one of "none", "basic", "oauth2"
     # @section -- External Services (Prometheus)
     authMode: basic
 
@@ -76,6 +76,46 @@ externalServices:
       # -- The key for the password property in the secret
       # @section -- External Services (Prometheus)
       passwordKey: password
+
+    # Authenticate to Prometheus using OAuth2
+    # @section -- External Services (Prometheus)
+    oauth2:
+      # -- Prometheus OAuth2 client ID
+      # @section -- External Services (Prometheus)
+      clientId: ""
+      # -- The key for the client ID property in the secret
+      # @section -- External Services (Prometheus)
+      clientIdKey: id
+      # -- Prometheus OAuth2 client secret
+      # @section -- External Services (Prometheus)
+      clientSecret: ""
+      # -- The key for the client secret property in the secret
+      # @section -- External Services (Prometheus)
+      clientSecretKey: secret
+      # -- File containing the OAuth2 client secret.
+      # @section -- External Services (Prometheus)
+      clientSecretFile: ""
+      # -- Prometheus OAuth2 endpoint parameters
+      # @section -- External Services (Prometheus)
+      endpointParams: {}
+      # -- HTTP proxy to send requests through.
+      # @section -- External Services (Prometheus)
+      proxyURL: ""
+      # -- Comma-separated list of IP addresses, CIDR notations, and domain names to exclude from proxying.
+      # @section -- External Services (Prometheus)
+      noProxy: ""
+      # -- Use the proxy URL indicated by environment variables.
+      # @section -- External Services (Prometheus)
+      proxyFromEnvironment: false
+      # -- Specifies headers to send to proxies during CONNECT requests.
+      # @section -- External Services (Prometheus)
+      proxyConnectHeader: {}
+      # -- List of scopes to authenticate with.
+      # @section -- External Services (Prometheus)
+      scopes: []
+      # -- URL to fetch the token from.
+      # @section -- External Services (Prometheus)
+      tokenURL: ""
 
     # Configure the Prometheus Remote Write Queue
     # [docs](https://grafana.com/docs/alloy/latest/reference/components/prometheus.remote_write/#queue_config-block)
@@ -214,7 +254,7 @@ externalServices:
     # @section -- External Services (Loki)
     tenantIdKey: tenantId
 
-    # -- one of "none", "basic"
+    # -- one of "none", "basic", "oauth2"
     # @section -- External Services (Loki)
     authMode: basic
 
@@ -232,6 +272,46 @@ externalServices:
       # -- The key for the password property in the secret
       # @section -- External Services (Loki)
       passwordKey: password
+
+    # Authenticate to Loki using OAuth2
+    # @section -- External Services (Loki)
+    oauth2:
+      # -- Loki OAuth2 client ID
+      # @section -- External Services (Loki)
+      clientId: ""
+      # -- The key for the client ID property in the secret
+      # @section -- External Services (Loki)
+      clientIdKey: id
+      # -- Loki OAuth2 client secret
+      # @section -- External Services (Loki)
+      clientSecret: ""
+      # -- The key for the client secret property in the secret
+      # @section -- External Services (Loki)
+      clientSecretKey: secret
+      # -- File containing the OAuth2 client secret.
+      # @section -- External Services (Loki)
+      clientSecretFile: ""
+      # -- Loki OAuth2 endpoint parameters
+      # @section -- External Services (Loki)
+      endpointParams: {}
+      # -- HTTP proxy to send requests through.
+      # @section -- External Services (Loki)
+      proxyURL: ""
+      # -- Comma-separated list of IP addresses, CIDR notations, and domain names to exclude from proxying.
+      # @section -- External Services (Loki)
+      noProxy: ""
+      # -- Use the proxy URL indicated by environment variables.
+      # @section -- External Services (Loki)
+      proxyFromEnvironment: false
+      # -- Specifies headers to send to proxies during CONNECT requests.
+      # @section -- External Services (Loki)
+      proxyConnectHeader: {}
+      # -- List of scopes to authenticate with.
+      # @section -- External Services (Loki)
+      scopes: []
+      # -- URL to fetch the token from.
+      # @section -- External Services (Loki)
+      tokenURL: ""
 
     # Credential management
     secret:


### PR DESCRIPTION
Fixes https://github.com/grafana/k8s-monitoring-helm/issues/658

#### References:
 - [prometheus.remote_write](https://grafana.com/docs/alloy/latest/reference/components/prometheus/prometheus.remote_write/?pg=oss-alloy&plcmt=hero-btn-3#oauth2-block)
 - [loki.write](https://grafana.com/docs/alloy/latest/reference/components/loki/loki.write/?pg=oss-alloy&plcmt=hero-btn-3#oauth2-block) 

#### Changes:
 - Prometheus remote write OAuth2 support.
 - Loki write OAuth2 support.