### PR TITLE
fix(oauth2): correct object format, Id instead of ID

### DIFF
--- a/charts/k8s-monitoring/templates/alloy_config/_logs_service_loki.alloy.txt
+++ b/charts/k8s-monitoring/templates/alloy_config/_logs_service_loki.alloy.txt
@@ -22,7 +22,11 @@ loki.write "logs_service" {
       client_secret_file = {{ .oauth2.clientSecretFile | quote }}
       {{- end }}
       {{- if .oauth2.endpointParams }}
-      endpoint_params = {{ .oauth2.endpointParams | toJson }}
+      endpoint_params = {
+      {{- range $k, $v := .oauth2.endpointParams }}
+        {{ $k }} = {{ $v | quote }},
+      {{- end }}
+      }
       {{- end }}
       {{- if .oauth2.proxyURL }}
       proxy_url = {{ .oauth2.proxyURL | quote }}

--- a/charts/k8s-monitoring/templates/alloy_config/_metrics_service_remote_write.alloy.txt
+++ b/charts/k8s-monitoring/templates/alloy_config/_metrics_service_remote_write.alloy.txt
@@ -21,7 +21,11 @@ prometheus.remote_write "metrics_service" {
       client_secret_file = {{ .oauth2.clientSecretFile | quote }}
       {{- end }}
       {{- if .oauth2.endpointParams }}
-      endpoint_params = {{ .oauth2.endpointParams | toJson }}
+      endpoint_params = {
+      {{- range $k, $v := .oauth2.endpointParams }}
+        {{ $k }} = {{ $v | quote }},
+      {{- end }}
+      }
       {{- end }}
       {{- if .oauth2.proxyURL }}
       proxy_url = {{ .oauth2.proxyURL | quote }}

--- a/charts/k8s-monitoring/templates/log-service-credentials.yaml
+++ b/charts/k8s-monitoring/templates/log-service-credentials.yaml
@@ -18,8 +18,8 @@ data:
 {{- if .tenantId }}
   {{ .tenantIdKey }}: {{ .tenantId | toString | b64enc | quote }}
 {{- end }}
-{{- if .oauth2.clientID }}
-  {{ .oauth2.clientIDKey }}: {{ .oauth2.clientID | toString | b64enc | quote }}
+{{- if .oauth2.clientId }}
+  {{ .oauth2.clientIdKey }}: {{ .oauth2.clientId | toString | b64enc | quote }}
 {{- end }}
 {{- if .oauth2.clientSecret }}
   {{ .oauth2.clientSecretKey }}: {{ .oauth2.clientSecret | toString | b64enc | quote }}

--- a/charts/k8s-monitoring/templates/metrics-service-credentials.yaml
+++ b/charts/k8s-monitoring/templates/metrics-service-credentials.yaml
@@ -18,8 +18,8 @@ data:
 {{- if .tenantId }}
   {{ .tenantIdKey }}: {{ .tenantId | toString | b64enc | quote }}
 {{- end }}
-{{- if .oauth2.clientID }}
-  {{ .oauth2.clientIDKey }}: {{ .oauth2.clientID | toString | b64enc | quote }}
+{{- if .oauth2.clientId }}
+  {{ .oauth2.clientIdKey }}: {{ .oauth2.clientId | toString | b64enc | quote }}
 {{- end }}
 {{- if .oauth2.clientSecret }}
   {{ .oauth2.clientSecretKey }}: {{ .oauth2.clientSecret | toString | b64enc | quote }}


### PR DESCRIPTION
Thanks for the fast review & merge of #678. Sadly I introduced couple of bugs (I thought the configuration language was HCL, but it's not, it only looks kinda like it :smiling_face_with_tear:)

**Changes:**
 - Correct format of `endpoint_params` object.
 - Typo in secret by using `ID` instead of `Id`.

---
For input:
```yaml
    externalServices:
      loki:
        host: "https:/example.org"
        authMode: "oauth2"
        oauth2:
          tokenURL: "https://example.org"
          clientId: "example"
          clientSecretFile: "/var/run/secrets/kubernetes.io/serviceaccount/token"
          endpointParams:
            grant_type: "client_credentials"
            client_assertion_type: "urn:ietf:params:oauth:client-assertion-type:jwt-bearer"
```

Example of broken version config:
```
    loki.write "logs_service" {
      endpoint {
        url = nonsensitive(remote.kubernetes.secret.logs_service.data["host"]) + "/loki/api/v1/push"
        tenant_id = nonsensitive(remote.kubernetes.secret.logs_service.data["tenantId"])

        oauth2 {
          client_id = nonsensitive(remote.kubernetes.secret.logs_service.data["id"])
          client_secret_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
          endpoint_params = {"client_assertion_type":"urn:ietf:params:oauth:client-assertion-type:jwt-bearer","grant_type":"client_credentials"}
          token_url = "https://example.org"
        }
      }
    }
```

New working version:
```
    loki.write "logs_service" {
      endpoint {
        url = nonsensitive(remote.kubernetes.secret.logs_service.data["host"]) + "/loki/api/v1/push"
        tenant_id = nonsensitive(remote.kubernetes.secret.logs_service.data["tenantId"])

        oauth2 {
          client_id = nonsensitive(remote.kubernetes.secret.logs_service.data["id"])
          client_secret_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
          endpoint_params = {
            client_assertion_type = "urn:ietf:params:oauth:client-assertion-type:jwt-bearer",
            grant_type = "client_credentials",
          }
          token_url = "https://example.org"
        }
      }
    }
```

Secret now also correctly contains `id`:
```yaml
kind: Secret
apiVersion: v1
metadata:
  name: loki-k8s-monitoring
  namespace: monitoring-system
type: Opaque
data:
  host: d2hhdCBkaWQgeW91IGV4cGVjdD8K
  id: d2hhdCBkaWQgeW91IGV4cGVjdD8K
```