### PR TITLE
Adding a conditional to enable or disable bearer token in auto discovery

### DIFF
--- a/charts/k8s-monitoring/README.md
+++ b/charts/k8s-monitoring/README.md
@@ -500,7 +500,7 @@ The Prometheus and Loki services may be hosted on the same cluster, or remotely 
 | metrics.autoDiscover.metricsTuning.excludeMetrics | list | `[]` | Metrics to drop. Can use regular expressions. |
 | metrics.autoDiscover.metricsTuning.includeMetrics | list | `[]` | Metrics to keep. Can use regular expressions. An empty list means keep all. |
 | metrics.autoDiscover.scrapeInterval | string | 60s | How frequently to scrape metrics from auto-discovered entities. Overrides metrics.scrapeInterval |
-| metrics.autoDiscover.bearerToken | bool | `true` | Sets bearer_token_file line in the prometheus.scrape annotation_autodiscovery.|
+| metrics.autoDiscover.bearerToken.enabled | bool | `true` | Sets bearer_token_file line in the prometheus.scrape annotation_autodiscovery.|
 
 ### Metrics Job: cAdvisor
 

--- a/charts/k8s-monitoring/README.md
+++ b/charts/k8s-monitoring/README.md
@@ -493,6 +493,7 @@ The Prometheus and Loki services may be hosted on the same cluster, or remotely 
 | metrics.autoDiscover.annotations.metricsScheme | string | `"k8s.grafana.com/metrics.scheme"` | Annotation for setting the metrics scheme, default: http. |
 | metrics.autoDiscover.annotations.metricsScrapeInterval | string | `"k8s.grafana.com/metrics.scrapeInterval"` | Annotation for overriding the scrape interval for this service or pod. Value should be a duration like "15s, 1m". Overrides metrics.autoDiscover.scrapeInterval |
 | metrics.autoDiscover.annotations.scrape | string | `"k8s.grafana.com/scrape"` | Annotation for enabling scraping for this service or pod. Value should be either "true" or "false" |
+| metrics.autoDiscover.bearerToken | object | `{"enabled":true}` | Sets bearer_token_file line in the prometheus.scrape annotation_autodiscovery. |
 | metrics.autoDiscover.enabled | bool | `true` | Enable annotation-based auto-discovery |
 | metrics.autoDiscover.extraMetricRelabelingRules | string | `""` | Rule blocks to be added to the prometheus.relabel component for auto-discovered entities. These relabeling rules are applied post-scrape against the metrics returned from the scraped target, no `__meta*` labels are present. ([docs](https://grafana.com/docs/alloy/latest/reference/components/prometheus.relabel/#rule-block)) |
 | metrics.autoDiscover.extraRelabelingRules | string | `""` | Rule blocks to be added to the discovery.relabel component for auto-discovered entities. These relabeling rules are applied pre-scrape against the targets from service discovery. Before the scrape, any remaining target labels that start with `__` (i.e. `__meta_kubernetes*`) are dropped. ([docs](https://grafana.com/docs/alloy/latest/reference/components/discovery.relabel/#rule-block)) |
@@ -500,7 +501,6 @@ The Prometheus and Loki services may be hosted on the same cluster, or remotely 
 | metrics.autoDiscover.metricsTuning.excludeMetrics | list | `[]` | Metrics to drop. Can use regular expressions. |
 | metrics.autoDiscover.metricsTuning.includeMetrics | list | `[]` | Metrics to keep. Can use regular expressions. An empty list means keep all. |
 | metrics.autoDiscover.scrapeInterval | string | 60s | How frequently to scrape metrics from auto-discovered entities. Overrides metrics.scrapeInterval |
-| metrics.autoDiscover.bearerToken.enabled | bool | `true` | Sets bearer_token_file line in the prometheus.scrape annotation_autodiscovery.|
 
 ### Metrics Job: cAdvisor
 

--- a/charts/k8s-monitoring/README.md
+++ b/charts/k8s-monitoring/README.md
@@ -500,6 +500,7 @@ The Prometheus and Loki services may be hosted on the same cluster, or remotely 
 | metrics.autoDiscover.metricsTuning.excludeMetrics | list | `[]` | Metrics to drop. Can use regular expressions. |
 | metrics.autoDiscover.metricsTuning.includeMetrics | list | `[]` | Metrics to keep. Can use regular expressions. An empty list means keep all. |
 | metrics.autoDiscover.scrapeInterval | string | 60s | How frequently to scrape metrics from auto-discovered entities. Overrides metrics.scrapeInterval |
+| metrics.autoDiscover.bearerToken | bool | `true` | Sets bearer_token_file line in the prometheus.scrape annotation_autodiscovery.|
 
 ### Metrics Job: cAdvisor
 

--- a/charts/k8s-monitoring/templates/alloy_config/_annotation_autodiscovery.alloy.txt
+++ b/charts/k8s-monitoring/templates/alloy_config/_annotation_autodiscovery.alloy.txt
@@ -170,7 +170,7 @@ prometheus.scrape "annotation_autodiscovery_http" {
   targets = discovery.relabel.annotation_autodiscovery_http.output
   scrape_interval = {{ .Values.metrics.autoDiscover.scrapeInterval | default .Values.metrics.scrapeInterval | quote }}
   honor_labels = true
-{{- if .Values.metrics.autoDiscover.bearerToken }}
+{{- if .Values.metrics.autoDiscover.bearerToken.enabled }}
   bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
 {{- end }}
 {{- if .Values.alloy.alloy.clustering.enabled }}
@@ -185,7 +185,7 @@ prometheus.scrape "annotation_autodiscovery_https" {
   targets = discovery.relabel.annotation_autodiscovery_https.output
   scrape_interval = {{ .Values.metrics.autoDiscover.scrapeInterval | default .Values.metrics.scrapeInterval | quote }}
   honor_labels = true
-{{- if .Values.metrics.autoDiscover.bearerToken }}
+{{- if .Values.metrics.autoDiscover.bearerToken.enabled }}
   bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
 {{- end }}
   tls_config {

--- a/charts/k8s-monitoring/templates/alloy_config/_annotation_autodiscovery.alloy.txt
+++ b/charts/k8s-monitoring/templates/alloy_config/_annotation_autodiscovery.alloy.txt
@@ -170,7 +170,9 @@ prometheus.scrape "annotation_autodiscovery_http" {
   targets = discovery.relabel.annotation_autodiscovery_http.output
   scrape_interval = {{ .Values.metrics.autoDiscover.scrapeInterval | default .Values.metrics.scrapeInterval | quote }}
   honor_labels = true
+{{- if .Values.metrics.autoDiscover.BearerToken }}
   bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+{{- end }}
 {{- if .Values.alloy.alloy.clustering.enabled }}
   clustering {
     enabled = true
@@ -183,7 +185,9 @@ prometheus.scrape "annotation_autodiscovery_https" {
   targets = discovery.relabel.annotation_autodiscovery_https.output
   scrape_interval = {{ .Values.metrics.autoDiscover.scrapeInterval | default .Values.metrics.scrapeInterval | quote }}
   honor_labels = true
+{{- if .Values.metrics.autoDiscover.BearerToken }}
   bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+{{- end }}
   tls_config {
     insecure_skip_verify = true
   }

--- a/charts/k8s-monitoring/templates/alloy_config/_annotation_autodiscovery.alloy.txt
+++ b/charts/k8s-monitoring/templates/alloy_config/_annotation_autodiscovery.alloy.txt
@@ -170,7 +170,7 @@ prometheus.scrape "annotation_autodiscovery_http" {
   targets = discovery.relabel.annotation_autodiscovery_http.output
   scrape_interval = {{ .Values.metrics.autoDiscover.scrapeInterval | default .Values.metrics.scrapeInterval | quote }}
   honor_labels = true
-{{- if .Values.metrics.autoDiscover.BearerToken }}
+{{- if .Values.metrics.autoDiscover.bearerToken }}
   bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
 {{- end }}
 {{- if .Values.alloy.alloy.clustering.enabled }}
@@ -185,7 +185,7 @@ prometheus.scrape "annotation_autodiscovery_https" {
   targets = discovery.relabel.annotation_autodiscovery_https.output
   scrape_interval = {{ .Values.metrics.autoDiscover.scrapeInterval | default .Values.metrics.scrapeInterval | quote }}
   honor_labels = true
-{{- if .Values.metrics.autoDiscover.BearerToken }}
+{{- if .Values.metrics.autoDiscover.bearerToken }}
   bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
 {{- end }}
   tls_config {

--- a/charts/k8s-monitoring/values.schema.json
+++ b/charts/k8s-monitoring/values.schema.json
@@ -1264,7 +1264,12 @@
                             ]
                         },
                         "bearerToken": {
-                            "type": "boolean"
+                            "type": "object",
+                            "properties": {
+                                "enabled": {
+                                    "type": "boolean"
+                                }
+                            }
                         },
                         "metricsTuning": {
                             "type": "object",

--- a/charts/k8s-monitoring/values.schema.json
+++ b/charts/k8s-monitoring/values.schema.json
@@ -1263,7 +1263,7 @@
                                 "null"
                             ]
                         },
-                        "BearerToken": {
+                        "bearerToken": {
                             "type": "boolean"
                         },
                         "metricsTuning": {

--- a/charts/k8s-monitoring/values.schema.json
+++ b/charts/k8s-monitoring/values.schema.json
@@ -1263,6 +1263,9 @@
                                 "null"
                             ]
                         },
+                        "BearerToken": {
+                            "type": "boolean"
+                        },
                         "metricsTuning": {
                             "type": "object",
                             "properties": {

--- a/charts/k8s-monitoring/values.yaml
+++ b/charts/k8s-monitoring/values.yaml
@@ -585,7 +585,8 @@ metrics:
 
     # -- Sets bearer_token_file line in the prometheus.scrape annotation_autodiscovery.
     # @section -- Metrics Job: Auto-Discovery
-    bearerToken: true
+    bearerToken:
+      enabled: true
 
   # Metrics from Grafana Alloy
   # @section -- Metrics -> Alloy Job

--- a/charts/k8s-monitoring/values.yaml
+++ b/charts/k8s-monitoring/values.yaml
@@ -583,6 +583,10 @@ metrics:
     # @section -- Metrics Job: Auto-Discovery
     maxCacheSize:
 
+    # -- That toggles inclusions of the bearer_token_file line in the configuration.
+    # @section -- Metrics Job: Auto-Discovery
+    BearerToken: true
+
   # Metrics from Grafana Alloy
   # @section -- Metrics -> Alloy Job
   alloy:

--- a/charts/k8s-monitoring/values.yaml
+++ b/charts/k8s-monitoring/values.yaml
@@ -583,9 +583,9 @@ metrics:
     # @section -- Metrics Job: Auto-Discovery
     maxCacheSize:
 
-    # -- That toggles inclusions of the bearer_token_file line in the configuration.
+    # -- Sets bearer_token_file line in the prometheus.scrape annotation_autodiscovery.
     # @section -- Metrics Job: Auto-Discovery
-    BearerToken: true
+    bearerToken: true
 
   # Metrics from Grafana Alloy
   # @section -- Metrics -> Alloy Job


### PR DESCRIPTION
This is to allow users to disable or enable the usage of sa bearer token in auto discovery, this was add on version 1.3.0, but users don't have a option to disable it if this is not needed. Unauthenticated services using Service Account without token or services not behind something like kube-rbac-proxy is returning 400 error.

https://github.com/grafana/k8s-monitoring-helm/pull/580
