### PR TITLE
Use the release label instead of the app.kubernetes.io/instance label

### DIFF
--- a/charts/k8s-monitoring/Makefile
+++ b/charts/k8s-monitoring/Makefile
@@ -23,12 +23,15 @@ values.schema.json: values.yaml schema-mods/enums-and-types.json schema-mods/req
 			| del(.properties["kube-state-metrics"].properties.autosharding) \
 			| del(.properties["kube-state-metrics"].properties.nodeSelector) \
 			| del(.properties["kube-state-metrics"].properties.prometheusScrape) \
+			| del(.properties["kube-state-metrics"].properties.releaseLabel) \
 			| del(.properties["kube-state-metrics"].properties.updateStrategy) \
 			| del(.properties["prometheus-node-exporter"].properties.nodeSelector) \
 			| del(.properties["prometheus-node-exporter"].properties.podAnnotations) \
+			| del(.properties["prometheus-node-exporter"].properties.releaseLabel) \
 			| del(.properties["prometheus-node-exporter"].properties.service) \
 			| del(.properties["prometheus-windows-exporter"].properties.config) \
 			| del(.properties["prometheus-windows-exporter"].properties.podAnnotations) \
+			| del(.properties["prometheus-windows-exporter"].properties.releaseLabel) \
 			| del(.properties.logs.properties.pod_logs.properties.labels.properties) \
 			| del(.properties.opencost.properties.opencost)' values.schema.generated.json) \
 		schema-mods/enums-and-types.json \

--- a/charts/k8s-monitoring/templates/alloy_config/_alloy.alloy.txt
+++ b/charts/k8s-monitoring/templates/alloy_config/_alloy.alloy.txt
@@ -18,11 +18,6 @@ up
 // Grafana Alloy
 discovery.relabel "alloy" {
   targets = discovery.kubernetes.pods.targets
-  rule {
-    source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_instance"]
-    regex = "{{ .Release.Name }}"
-    action = "keep"
-  }
   {{- range $k, $v := .Values.metrics.alloy.labelMatchers }}
   rule {
     source_labels = ["__meta_kubernetes_pod_label_{{ include "escape_label" $k }}"]

--- a/charts/k8s-monitoring/templates/alloy_config/_kube_state_metrics.alloy.txt
+++ b/charts/k8s-monitoring/templates/alloy_config/_kube_state_metrics.alloy.txt
@@ -13,7 +13,7 @@ discovery.relabel "kube_state_metrics" {
   targets = discovery.kubernetes.services.targets
 {{- if (index .Values "kube-state-metrics").enabled }}
   rule {
-    source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_instance"]
+    source_labels = ["__meta_kubernetes_service_label_release"]
     regex = "{{ .Release.Name }}"
     action = "keep"
   }

--- a/charts/k8s-monitoring/templates/alloy_config/_node_exporter.alloy.txt
+++ b/charts/k8s-monitoring/templates/alloy_config/_node_exporter.alloy.txt
@@ -20,7 +20,7 @@ discovery.relabel "node_exporter" {
   targets = discovery.kubernetes.pods.targets
 {{- if (index .Values "prometheus-node-exporter").enabled }}
   rule {
-    source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_instance"]
+    source_labels = ["__meta_kubernetes_pod_label_release"]
     regex = "{{ .Release.Name }}"
     action = "keep"
   }

--- a/charts/k8s-monitoring/templates/alloy_config/_opencost.txt
+++ b/charts/k8s-monitoring/templates/alloy_config/_opencost.txt
@@ -11,11 +11,6 @@
 // OpenCost
 discovery.relabel "opencost" {
   targets = discovery.kubernetes.services.targets
-  rule {
-    source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_instance"]
-    regex = "{{ .Release.Name }}"
-    action = "keep"
-  }
   {{- range $k, $v := .Values.metrics.cost.labelMatchers }}
   rule {
     source_labels = ["__meta_kubernetes_service_label_{{ include "escape_label" $k }}"]

--- a/charts/k8s-monitoring/templates/alloy_config/_windows_exporter.alloy.txt
+++ b/charts/k8s-monitoring/templates/alloy_config/_windows_exporter.alloy.txt
@@ -13,7 +13,7 @@ discovery.relabel "windows_exporter" {
   targets = discovery.kubernetes.pods.targets
 {{- if (index .Values "prometheus-windows-exporter").enabled }}
   rule {
-    source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_instance"]
+    source_labels = ["__meta_kubernetes_pod_label_release"]
     regex = "{{ .Release.Name }}"
     action = "keep"
   }

--- a/charts/k8s-monitoring/values.yaml
+++ b/charts/k8s-monitoring/values.yaml
@@ -2019,9 +2019,13 @@ kube-state-metrics:
   # do not want to scrape metrics from Kube State Metrics.
   # @section -- Deployment: [Kube State Metrics](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-state-metrics)
   enabled: true
+
   # @ignored
   nodeSelector:
     kubernetes.io/os: linux
+
+  # @ignored - Enable the release label
+  releaseLabel: true
 
   # @ignored - Disable autosharding
   autosharding:
@@ -2060,6 +2064,9 @@ prometheus-node-exporter:
                 operator: NotIn
                 values: [fargate]
 
+  # @ignored - Enable the release label
+  releaseLabel: true
+
   # @ignored - Set annotation to override the job label
   podAnnotations:
     k8s.grafana.com/logs.job: integrations/node_exporter
@@ -2087,6 +2094,9 @@ prometheus-windows-exporter:
     collector:
       service:
         services-where: "Name='containerd' or Name='kubelet'"
+
+  # @ignored - Enable the release label
+  releaseLabel: true
 
   # @ignored - Set annotation to override the job label
   podAnnotations:

--- a/examples/alloy-autoscaling-and-storage/metrics.alloy
+++ b/examples/alloy-autoscaling-and-storage/metrics.alloy
@@ -316,11 +316,6 @@ prometheus.relabel "annotation_autodiscovery" {
 discovery.relabel "alloy" {
   targets = discovery.kubernetes.pods.targets
   rule {
-    source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_instance"]
-    regex = "k8smon"
-    action = "keep"
-  }
-  rule {
     source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
     regex = "alloy.*"
     action = "keep"
@@ -624,11 +619,6 @@ prometheus.relabel "node_exporter" {
 // OpenCost
 discovery.relabel "opencost" {
   targets = discovery.kubernetes.services.targets
-  rule {
-    source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_instance"]
-    regex = "k8smon"
-    action = "keep"
-  }
   rule {
     source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_name"]
     regex = "opencost"

--- a/examples/alloy-autoscaling-and-storage/metrics.alloy
+++ b/examples/alloy-autoscaling-and-storage/metrics.alloy
@@ -538,7 +538,7 @@ prometheus.relabel "cadvisor" {
 discovery.relabel "kube_state_metrics" {
   targets = discovery.kubernetes.services.targets
   rule {
-    source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_instance"]
+    source_labels = ["__meta_kubernetes_service_label_release"]
     regex = "k8smon"
     action = "keep"
   }
@@ -578,7 +578,7 @@ prometheus.relabel "kube_state_metrics" {
 discovery.relabel "node_exporter" {
   targets = discovery.kubernetes.pods.targets
   rule {
-    source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_instance"]
+    source_labels = ["__meta_kubernetes_pod_label_release"]
     regex = "k8smon"
     action = "keep"
   }

--- a/examples/alloy-autoscaling-and-storage/output.yaml
+++ b/examples/alloy-autoscaling-and-storage/output.yaml
@@ -448,11 +448,6 @@ data:
     discovery.relabel "alloy" {
       targets = discovery.kubernetes.pods.targets
       rule {
-        source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_instance"]
-        regex = "k8smon"
-        action = "keep"
-      }
-      rule {
         source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
         regex = "alloy.*"
         action = "keep"
@@ -756,11 +751,6 @@ data:
     // OpenCost
     discovery.relabel "opencost" {
       targets = discovery.kubernetes.services.targets
-      rule {
-        source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_instance"]
-        regex = "k8smon"
-        action = "keep"
-      }
       rule {
         source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_name"]
         regex = "opencost"
@@ -59382,11 +59372,6 @@ data:
     discovery.relabel "alloy" {
       targets = discovery.kubernetes.pods.targets
       rule {
-        source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_instance"]
-        regex = "k8smon"
-        action = "keep"
-      }
-      rule {
         source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
         regex = "alloy.*"
         action = "keep"
@@ -59690,11 +59675,6 @@ data:
     // OpenCost
     discovery.relabel "opencost" {
       targets = discovery.kubernetes.services.targets
-      rule {
-        source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_instance"]
-        regex = "k8smon"
-        action = "keep"
-      }
       rule {
         source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_name"]
         regex = "opencost"

--- a/examples/alloy-autoscaling-and-storage/output.yaml
+++ b/examples/alloy-autoscaling-and-storage/output.yaml
@@ -60,6 +60,7 @@ metadata:
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/instance: k8smon
     app.kubernetes.io/version: "2.13.0"
+    release: k8smon
   name: k8smon-kube-state-metrics
   namespace: default
 ---
@@ -92,6 +93,7 @@ metadata:
     app.kubernetes.io/name: prometheus-node-exporter
     app.kubernetes.io/instance: k8smon
     app.kubernetes.io/version: "1.8.2"
+    release: k8smon
 automountServiceAccountToken: false
 ---
 # Source: k8s-monitoring/templates/log-service-credentials.yaml
@@ -668,7 +670,7 @@ data:
     discovery.relabel "kube_state_metrics" {
       targets = discovery.kubernetes.services.targets
       rule {
-        source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_instance"]
+        source_labels = ["__meta_kubernetes_service_label_release"]
         regex = "k8smon"
         action = "keep"
       }
@@ -708,7 +710,7 @@ data:
     discovery.relabel "node_exporter" {
       targets = discovery.kubernetes.pods.targets
       rule {
-        source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_instance"]
+        source_labels = ["__meta_kubernetes_pod_label_release"]
         regex = "k8smon"
         action = "keep"
       }
@@ -57686,6 +57688,7 @@ metadata:
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/instance: k8smon
     app.kubernetes.io/version: "2.13.0"
+    release: k8smon
   name: k8smon-kube-state-metrics
 rules:
 
@@ -57997,6 +58000,7 @@ metadata:
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/instance: k8smon
     app.kubernetes.io/version: "2.13.0"
+    release: k8smon
   name: k8smon-kube-state-metrics
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -58217,6 +58221,7 @@ metadata:
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/instance: k8smon
     app.kubernetes.io/version: "2.13.0"
+    release: k8smon
   annotations:
 spec:
   type: "ClusterIP"
@@ -58267,6 +58272,7 @@ metadata:
     app.kubernetes.io/name: prometheus-node-exporter
     app.kubernetes.io/instance: k8smon
     app.kubernetes.io/version: "1.8.2"
+    release: k8smon
 spec:
   type: ClusterIP
   ports:
@@ -58445,6 +58451,7 @@ metadata:
     app.kubernetes.io/name: prometheus-node-exporter
     app.kubernetes.io/instance: k8smon
     app.kubernetes.io/version: "1.8.2"
+    release: k8smon
 spec:
   selector:
     matchLabels:
@@ -58468,6 +58475,7 @@ spec:
         app.kubernetes.io/name: prometheus-node-exporter
         app.kubernetes.io/instance: k8smon
         app.kubernetes.io/version: "1.8.2"
+        release: k8smon
     spec:
       automountServiceAccountToken: false
       securityContext:
@@ -58651,6 +58659,7 @@ metadata:
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/instance: k8smon
     app.kubernetes.io/version: "2.13.0"
+    release: k8smon
 spec:
   selector:
     matchLabels:      
@@ -58670,6 +58679,7 @@ spec:
         app.kubernetes.io/name: kube-state-metrics
         app.kubernetes.io/instance: k8smon
         app.kubernetes.io/version: "2.13.0"
+        release: k8smon
     spec:
       automountServiceAccountToken: true
       hostNetwork: false
@@ -59594,7 +59604,7 @@ data:
     discovery.relabel "kube_state_metrics" {
       targets = discovery.kubernetes.services.targets
       rule {
-        source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_instance"]
+        source_labels = ["__meta_kubernetes_service_label_release"]
         regex = "k8smon"
         action = "keep"
       }
@@ -59634,7 +59644,7 @@ data:
     discovery.relabel "node_exporter" {
       targets = discovery.kubernetes.pods.targets
       rule {
-        source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_instance"]
+        source_labels = ["__meta_kubernetes_pod_label_release"]
         regex = "k8smon"
         action = "keep"
       }

--- a/examples/application-observability/metrics.alloy
+++ b/examples/application-observability/metrics.alloy
@@ -348,11 +348,6 @@ prometheus.relabel "annotation_autodiscovery" {
 discovery.relabel "alloy" {
   targets = discovery.kubernetes.pods.targets
   rule {
-    source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_instance"]
-    regex = "k8smon"
-    action = "keep"
-  }
-  rule {
     source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
     regex = "alloy.*"
     action = "keep"
@@ -656,11 +651,6 @@ prometheus.relabel "node_exporter" {
 // OpenCost
 discovery.relabel "opencost" {
   targets = discovery.kubernetes.services.targets
-  rule {
-    source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_instance"]
-    regex = "k8smon"
-    action = "keep"
-  }
   rule {
     source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_name"]
     regex = "opencost"

--- a/examples/application-observability/metrics.alloy
+++ b/examples/application-observability/metrics.alloy
@@ -570,7 +570,7 @@ prometheus.relabel "cadvisor" {
 discovery.relabel "kube_state_metrics" {
   targets = discovery.kubernetes.services.targets
   rule {
-    source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_instance"]
+    source_labels = ["__meta_kubernetes_service_label_release"]
     regex = "k8smon"
     action = "keep"
   }
@@ -610,7 +610,7 @@ prometheus.relabel "kube_state_metrics" {
 discovery.relabel "node_exporter" {
   targets = discovery.kubernetes.pods.targets
   rule {
-    source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_instance"]
+    source_labels = ["__meta_kubernetes_pod_label_release"]
     regex = "k8smon"
     action = "keep"
   }

--- a/examples/application-observability/output.yaml
+++ b/examples/application-observability/output.yaml
@@ -76,6 +76,7 @@ metadata:
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/instance: k8smon
     app.kubernetes.io/version: "2.13.0"
+    release: k8smon
   name: k8smon-kube-state-metrics
   namespace: default
 ---
@@ -108,6 +109,7 @@ metadata:
     app.kubernetes.io/name: prometheus-node-exporter
     app.kubernetes.io/instance: k8smon
     app.kubernetes.io/version: "1.8.2"
+    release: k8smon
 automountServiceAccountToken: false
 ---
 # Source: k8s-monitoring/templates/log-service-credentials.yaml
@@ -742,7 +744,7 @@ data:
     discovery.relabel "kube_state_metrics" {
       targets = discovery.kubernetes.services.targets
       rule {
-        source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_instance"]
+        source_labels = ["__meta_kubernetes_service_label_release"]
         regex = "k8smon"
         action = "keep"
       }
@@ -782,7 +784,7 @@ data:
     discovery.relabel "node_exporter" {
       targets = discovery.kubernetes.pods.targets
       rule {
-        source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_instance"]
+        source_labels = ["__meta_kubernetes_pod_label_release"]
         regex = "k8smon"
         action = "keep"
       }
@@ -58810,6 +58812,7 @@ metadata:
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/instance: k8smon
     app.kubernetes.io/version: "2.13.0"
+    release: k8smon
   name: k8smon-kube-state-metrics
 rules:
 
@@ -59144,6 +59147,7 @@ metadata:
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/instance: k8smon
     app.kubernetes.io/version: "2.13.0"
+    release: k8smon
   name: k8smon-kube-state-metrics
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -59390,6 +59394,7 @@ metadata:
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/instance: k8smon
     app.kubernetes.io/version: "2.13.0"
+    release: k8smon
   annotations:
 spec:
   type: "ClusterIP"
@@ -59440,6 +59445,7 @@ metadata:
     app.kubernetes.io/name: prometheus-node-exporter
     app.kubernetes.io/instance: k8smon
     app.kubernetes.io/version: "1.8.2"
+    release: k8smon
 spec:
   type: ClusterIP
   ports:
@@ -59699,6 +59705,7 @@ metadata:
     app.kubernetes.io/name: prometheus-node-exporter
     app.kubernetes.io/instance: k8smon
     app.kubernetes.io/version: "1.8.2"
+    release: k8smon
 spec:
   selector:
     matchLabels:
@@ -59722,6 +59729,7 @@ spec:
         app.kubernetes.io/name: prometheus-node-exporter
         app.kubernetes.io/instance: k8smon
         app.kubernetes.io/version: "1.8.2"
+        release: k8smon
     spec:
       automountServiceAccountToken: false
       securityContext:
@@ -59905,6 +59913,7 @@ metadata:
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/instance: k8smon
     app.kubernetes.io/version: "2.13.0"
+    release: k8smon
 spec:
   selector:
     matchLabels:      
@@ -59924,6 +59933,7 @@ spec:
         app.kubernetes.io/name: kube-state-metrics
         app.kubernetes.io/instance: k8smon
         app.kubernetes.io/version: "2.13.0"
+        release: k8smon
     spec:
       automountServiceAccountToken: true
       hostNetwork: false
@@ -60823,7 +60833,7 @@ data:
     discovery.relabel "kube_state_metrics" {
       targets = discovery.kubernetes.services.targets
       rule {
-        source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_instance"]
+        source_labels = ["__meta_kubernetes_service_label_release"]
         regex = "k8smon"
         action = "keep"
       }
@@ -60863,7 +60873,7 @@ data:
     discovery.relabel "node_exporter" {
       targets = discovery.kubernetes.pods.targets
       rule {
-        source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_instance"]
+        source_labels = ["__meta_kubernetes_pod_label_release"]
         regex = "k8smon"
         action = "keep"
       }

--- a/examples/application-observability/output.yaml
+++ b/examples/application-observability/output.yaml
@@ -522,11 +522,6 @@ data:
     discovery.relabel "alloy" {
       targets = discovery.kubernetes.pods.targets
       rule {
-        source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_instance"]
-        regex = "k8smon"
-        action = "keep"
-      }
-      rule {
         source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
         regex = "alloy.*"
         action = "keep"
@@ -830,11 +825,6 @@ data:
     // OpenCost
     discovery.relabel "opencost" {
       targets = discovery.kubernetes.services.targets
-      rule {
-        source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_instance"]
-        regex = "k8smon"
-        action = "keep"
-      }
       rule {
         source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_name"]
         regex = "opencost"
@@ -60611,11 +60601,6 @@ data:
     discovery.relabel "alloy" {
       targets = discovery.kubernetes.pods.targets
       rule {
-        source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_instance"]
-        regex = "k8smon"
-        action = "keep"
-      }
-      rule {
         source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
         regex = "alloy.*"
         action = "keep"
@@ -60919,11 +60904,6 @@ data:
     // OpenCost
     discovery.relabel "opencost" {
       targets = discovery.kubernetes.services.targets
-      rule {
-        source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_instance"]
-        regex = "k8smon"
-        action = "keep"
-      }
       rule {
         source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_name"]
         regex = "opencost"

--- a/examples/control-plane-metrics/metrics.alloy
+++ b/examples/control-plane-metrics/metrics.alloy
@@ -316,11 +316,6 @@ prometheus.relabel "annotation_autodiscovery" {
 discovery.relabel "alloy" {
   targets = discovery.kubernetes.pods.targets
   rule {
-    source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_instance"]
-    regex = "k8smon"
-    action = "keep"
-  }
-  rule {
     source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
     regex = "alloy.*"
     action = "keep"
@@ -780,11 +775,6 @@ prometheus.relabel "node_exporter" {
 // OpenCost
 discovery.relabel "opencost" {
   targets = discovery.kubernetes.services.targets
-  rule {
-    source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_instance"]
-    regex = "k8smon"
-    action = "keep"
-  }
   rule {
     source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_name"]
     regex = "opencost"

--- a/examples/control-plane-metrics/metrics.alloy
+++ b/examples/control-plane-metrics/metrics.alloy
@@ -694,7 +694,7 @@ prometheus.relabel "kube_proxy" {
 discovery.relabel "kube_state_metrics" {
   targets = discovery.kubernetes.services.targets
   rule {
-    source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_instance"]
+    source_labels = ["__meta_kubernetes_service_label_release"]
     regex = "k8smon"
     action = "keep"
   }
@@ -734,7 +734,7 @@ prometheus.relabel "kube_state_metrics" {
 discovery.relabel "node_exporter" {
   targets = discovery.kubernetes.pods.targets
   rule {
-    source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_instance"]
+    source_labels = ["__meta_kubernetes_pod_label_release"]
     regex = "k8smon"
     action = "keep"
   }

--- a/examples/control-plane-metrics/output.yaml
+++ b/examples/control-plane-metrics/output.yaml
@@ -449,11 +449,6 @@ data:
     discovery.relabel "alloy" {
       targets = discovery.kubernetes.pods.targets
       rule {
-        source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_instance"]
-        regex = "k8smon"
-        action = "keep"
-      }
-      rule {
         source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
         regex = "alloy.*"
         action = "keep"
@@ -913,11 +908,6 @@ data:
     // OpenCost
     discovery.relabel "opencost" {
       targets = discovery.kubernetes.services.targets
-      rule {
-        source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_instance"]
-        regex = "k8smon"
-        action = "keep"
-      }
       rule {
         source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_name"]
         regex = "opencost"
@@ -59475,11 +59465,6 @@ data:
     discovery.relabel "alloy" {
       targets = discovery.kubernetes.pods.targets
       rule {
-        source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_instance"]
-        regex = "k8smon"
-        action = "keep"
-      }
-      rule {
         source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
         regex = "alloy.*"
         action = "keep"
@@ -59939,11 +59924,6 @@ data:
     // OpenCost
     discovery.relabel "opencost" {
       targets = discovery.kubernetes.services.targets
-      rule {
-        source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_instance"]
-        regex = "k8smon"
-        action = "keep"
-      }
       rule {
         source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_name"]
         regex = "opencost"

--- a/examples/control-plane-metrics/output.yaml
+++ b/examples/control-plane-metrics/output.yaml
@@ -60,6 +60,7 @@ metadata:
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/instance: k8smon
     app.kubernetes.io/version: "2.13.0"
+    release: k8smon
   name: k8smon-kube-state-metrics
   namespace: default
 ---
@@ -92,6 +93,7 @@ metadata:
     app.kubernetes.io/name: prometheus-node-exporter
     app.kubernetes.io/instance: k8smon
     app.kubernetes.io/version: "1.8.2"
+    release: k8smon
 automountServiceAccountToken: false
 ---
 # Source: k8s-monitoring/templates/log-service-credentials.yaml
@@ -825,7 +827,7 @@ data:
     discovery.relabel "kube_state_metrics" {
       targets = discovery.kubernetes.services.targets
       rule {
-        source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_instance"]
+        source_labels = ["__meta_kubernetes_service_label_release"]
         regex = "k8smon"
         action = "keep"
       }
@@ -865,7 +867,7 @@ data:
     discovery.relabel "node_exporter" {
       targets = discovery.kubernetes.pods.targets
       rule {
-        source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_instance"]
+        source_labels = ["__meta_kubernetes_pod_label_release"]
         regex = "k8smon"
         action = "keep"
       }
@@ -57843,6 +57845,7 @@ metadata:
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/instance: k8smon
     app.kubernetes.io/version: "2.13.0"
+    release: k8smon
   name: k8smon-kube-state-metrics
 rules:
 
@@ -58154,6 +58157,7 @@ metadata:
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/instance: k8smon
     app.kubernetes.io/version: "2.13.0"
+    release: k8smon
   name: k8smon-kube-state-metrics
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -58374,6 +58378,7 @@ metadata:
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/instance: k8smon
     app.kubernetes.io/version: "2.13.0"
+    release: k8smon
   annotations:
 spec:
   type: "ClusterIP"
@@ -58424,6 +58429,7 @@ metadata:
     app.kubernetes.io/name: prometheus-node-exporter
     app.kubernetes.io/instance: k8smon
     app.kubernetes.io/version: "1.8.2"
+    release: k8smon
 spec:
   type: ClusterIP
   ports:
@@ -58595,6 +58601,7 @@ metadata:
     app.kubernetes.io/name: prometheus-node-exporter
     app.kubernetes.io/instance: k8smon
     app.kubernetes.io/version: "1.8.2"
+    release: k8smon
 spec:
   selector:
     matchLabels:
@@ -58618,6 +58625,7 @@ spec:
         app.kubernetes.io/name: prometheus-node-exporter
         app.kubernetes.io/instance: k8smon
         app.kubernetes.io/version: "1.8.2"
+        release: k8smon
     spec:
       automountServiceAccountToken: false
       securityContext:
@@ -58801,6 +58809,7 @@ metadata:
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/instance: k8smon
     app.kubernetes.io/version: "2.13.0"
+    release: k8smon
 spec:
   selector:
     matchLabels:      
@@ -58820,6 +58829,7 @@ spec:
         app.kubernetes.io/name: kube-state-metrics
         app.kubernetes.io/instance: k8smon
         app.kubernetes.io/version: "2.13.0"
+        release: k8smon
     spec:
       automountServiceAccountToken: true
       hostNetwork: false
@@ -59843,7 +59853,7 @@ data:
     discovery.relabel "kube_state_metrics" {
       targets = discovery.kubernetes.services.targets
       rule {
-        source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_instance"]
+        source_labels = ["__meta_kubernetes_service_label_release"]
         regex = "k8smon"
         action = "keep"
       }
@@ -59883,7 +59893,7 @@ data:
     discovery.relabel "node_exporter" {
       targets = discovery.kubernetes.pods.targets
       rule {
-        source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_instance"]
+        source_labels = ["__meta_kubernetes_pod_label_release"]
         regex = "k8smon"
         action = "keep"
       }

--- a/examples/custom-config/metrics.alloy
+++ b/examples/custom-config/metrics.alloy
@@ -316,11 +316,6 @@ prometheus.relabel "annotation_autodiscovery" {
 discovery.relabel "alloy" {
   targets = discovery.kubernetes.pods.targets
   rule {
-    source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_instance"]
-    regex = "k8smon"
-    action = "keep"
-  }
-  rule {
     source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
     regex = "alloy.*"
     action = "keep"
@@ -624,11 +619,6 @@ prometheus.relabel "node_exporter" {
 // OpenCost
 discovery.relabel "opencost" {
   targets = discovery.kubernetes.services.targets
-  rule {
-    source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_instance"]
-    regex = "k8smon"
-    action = "keep"
-  }
   rule {
     source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_name"]
     regex = "opencost"

--- a/examples/custom-config/metrics.alloy
+++ b/examples/custom-config/metrics.alloy
@@ -538,7 +538,7 @@ prometheus.relabel "cadvisor" {
 discovery.relabel "kube_state_metrics" {
   targets = discovery.kubernetes.services.targets
   rule {
-    source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_instance"]
+    source_labels = ["__meta_kubernetes_service_label_release"]
     regex = "k8smon"
     action = "keep"
   }
@@ -578,7 +578,7 @@ prometheus.relabel "kube_state_metrics" {
 discovery.relabel "node_exporter" {
   targets = discovery.kubernetes.pods.targets
   rule {
-    source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_instance"]
+    source_labels = ["__meta_kubernetes_pod_label_release"]
     regex = "k8smon"
     action = "keep"
   }

--- a/examples/custom-config/output.yaml
+++ b/examples/custom-config/output.yaml
@@ -448,11 +448,6 @@ data:
     discovery.relabel "alloy" {
       targets = discovery.kubernetes.pods.targets
       rule {
-        source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_instance"]
-        regex = "k8smon"
-        action = "keep"
-      }
-      rule {
         source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
         regex = "alloy.*"
         action = "keep"
@@ -756,11 +751,6 @@ data:
     // OpenCost
     discovery.relabel "opencost" {
       targets = discovery.kubernetes.services.targets
-      rule {
-        source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_instance"]
-        regex = "k8smon"
-        action = "keep"
-      }
       rule {
         source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_name"]
         regex = "opencost"
@@ -59411,11 +59401,6 @@ data:
     discovery.relabel "alloy" {
       targets = discovery.kubernetes.pods.targets
       rule {
-        source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_instance"]
-        regex = "k8smon"
-        action = "keep"
-      }
-      rule {
         source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
         regex = "alloy.*"
         action = "keep"
@@ -59719,11 +59704,6 @@ data:
     // OpenCost
     discovery.relabel "opencost" {
       targets = discovery.kubernetes.services.targets
-      rule {
-        source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_instance"]
-        regex = "k8smon"
-        action = "keep"
-      }
       rule {
         source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_name"]
         regex = "opencost"

--- a/examples/custom-config/output.yaml
+++ b/examples/custom-config/output.yaml
@@ -60,6 +60,7 @@ metadata:
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/instance: k8smon
     app.kubernetes.io/version: "2.13.0"
+    release: k8smon
   name: k8smon-kube-state-metrics
   namespace: default
 ---
@@ -92,6 +93,7 @@ metadata:
     app.kubernetes.io/name: prometheus-node-exporter
     app.kubernetes.io/instance: k8smon
     app.kubernetes.io/version: "1.8.2"
+    release: k8smon
 automountServiceAccountToken: false
 ---
 # Source: k8s-monitoring/templates/log-service-credentials.yaml
@@ -668,7 +670,7 @@ data:
     discovery.relabel "kube_state_metrics" {
       targets = discovery.kubernetes.services.targets
       rule {
-        source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_instance"]
+        source_labels = ["__meta_kubernetes_service_label_release"]
         regex = "k8smon"
         action = "keep"
       }
@@ -708,7 +710,7 @@ data:
     discovery.relabel "node_exporter" {
       targets = discovery.kubernetes.pods.targets
       rule {
-        source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_instance"]
+        source_labels = ["__meta_kubernetes_pod_label_release"]
         regex = "k8smon"
         action = "keep"
       }
@@ -57779,6 +57781,7 @@ metadata:
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/instance: k8smon
     app.kubernetes.io/version: "2.13.0"
+    release: k8smon
   name: k8smon-kube-state-metrics
 rules:
 
@@ -58090,6 +58093,7 @@ metadata:
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/instance: k8smon
     app.kubernetes.io/version: "2.13.0"
+    release: k8smon
   name: k8smon-kube-state-metrics
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -58310,6 +58314,7 @@ metadata:
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/instance: k8smon
     app.kubernetes.io/version: "2.13.0"
+    release: k8smon
   annotations:
 spec:
   type: "ClusterIP"
@@ -58360,6 +58365,7 @@ metadata:
     app.kubernetes.io/name: prometheus-node-exporter
     app.kubernetes.io/instance: k8smon
     app.kubernetes.io/version: "1.8.2"
+    release: k8smon
 spec:
   type: ClusterIP
   ports:
@@ -58531,6 +58537,7 @@ metadata:
     app.kubernetes.io/name: prometheus-node-exporter
     app.kubernetes.io/instance: k8smon
     app.kubernetes.io/version: "1.8.2"
+    release: k8smon
 spec:
   selector:
     matchLabels:
@@ -58554,6 +58561,7 @@ spec:
         app.kubernetes.io/name: prometheus-node-exporter
         app.kubernetes.io/instance: k8smon
         app.kubernetes.io/version: "1.8.2"
+        release: k8smon
     spec:
       automountServiceAccountToken: false
       securityContext:
@@ -58737,6 +58745,7 @@ metadata:
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/instance: k8smon
     app.kubernetes.io/version: "2.13.0"
+    release: k8smon
 spec:
   selector:
     matchLabels:      
@@ -58756,6 +58765,7 @@ spec:
         app.kubernetes.io/name: kube-state-metrics
         app.kubernetes.io/instance: k8smon
         app.kubernetes.io/version: "2.13.0"
+        release: k8smon
     spec:
       automountServiceAccountToken: true
       hostNetwork: false
@@ -59623,7 +59633,7 @@ data:
     discovery.relabel "kube_state_metrics" {
       targets = discovery.kubernetes.services.targets
       rule {
-        source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_instance"]
+        source_labels = ["__meta_kubernetes_service_label_release"]
         regex = "k8smon"
         action = "keep"
       }
@@ -59663,7 +59673,7 @@ data:
     discovery.relabel "node_exporter" {
       targets = discovery.kubernetes.pods.targets
       rule {
-        source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_instance"]
+        source_labels = ["__meta_kubernetes_pod_label_release"]
         regex = "k8smon"
         action = "keep"
       }

--- a/examples/custom-metrics-tuning/metrics.alloy
+++ b/examples/custom-metrics-tuning/metrics.alloy
@@ -520,7 +520,7 @@ prometheus.relabel "cadvisor" {
 discovery.relabel "kube_state_metrics" {
   targets = discovery.kubernetes.services.targets
   rule {
-    source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_instance"]
+    source_labels = ["__meta_kubernetes_service_label_release"]
     regex = "k8smon"
     action = "keep"
   }
@@ -555,7 +555,7 @@ prometheus.relabel "kube_state_metrics" {
 discovery.relabel "node_exporter" {
   targets = discovery.kubernetes.pods.targets
   rule {
-    source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_instance"]
+    source_labels = ["__meta_kubernetes_pod_label_release"]
     regex = "k8smon"
     action = "keep"
   }

--- a/examples/custom-metrics-tuning/metrics.alloy
+++ b/examples/custom-metrics-tuning/metrics.alloy
@@ -298,11 +298,6 @@ prometheus.relabel "annotation_autodiscovery" {
 discovery.relabel "alloy" {
   targets = discovery.kubernetes.pods.targets
   rule {
-    source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_instance"]
-    regex = "k8smon"
-    action = "keep"
-  }
-  rule {
     source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
     regex = "alloy.*"
     action = "keep"
@@ -601,11 +596,6 @@ prometheus.relabel "node_exporter" {
 // OpenCost
 discovery.relabel "opencost" {
   targets = discovery.kubernetes.services.targets
-  rule {
-    source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_instance"]
-    regex = "k8smon"
-    action = "keep"
-  }
   rule {
     source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_name"]
     regex = "opencost"

--- a/examples/custom-metrics-tuning/output.yaml
+++ b/examples/custom-metrics-tuning/output.yaml
@@ -28,6 +28,7 @@ metadata:
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/instance: k8smon
     app.kubernetes.io/version: "2.13.0"
+    release: k8smon
   name: k8smon-kube-state-metrics
   namespace: default
 ---
@@ -60,6 +61,7 @@ metadata:
     app.kubernetes.io/name: prometheus-node-exporter
     app.kubernetes.io/instance: k8smon
     app.kubernetes.io/version: "1.8.2"
+    release: k8smon
 automountServiceAccountToken: false
 ---
 # Source: k8s-monitoring/templates/metrics-service-credentials.yaml
@@ -605,7 +607,7 @@ data:
     discovery.relabel "kube_state_metrics" {
       targets = discovery.kubernetes.services.targets
       rule {
-        source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_instance"]
+        source_labels = ["__meta_kubernetes_service_label_release"]
         regex = "k8smon"
         action = "keep"
       }
@@ -640,7 +642,7 @@ data:
     discovery.relabel "node_exporter" {
       targets = discovery.kubernetes.pods.targets
       rule {
-        source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_instance"]
+        source_labels = ["__meta_kubernetes_pod_label_release"]
         regex = "k8smon"
         action = "keep"
       }
@@ -57128,6 +57130,7 @@ metadata:
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/instance: k8smon
     app.kubernetes.io/version: "2.13.0"
+    release: k8smon
   name: k8smon-kube-state-metrics
 rules:
 
@@ -57393,6 +57396,7 @@ metadata:
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/instance: k8smon
     app.kubernetes.io/version: "2.13.0"
+    release: k8smon
   name: k8smon-kube-state-metrics
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -57561,6 +57565,7 @@ metadata:
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/instance: k8smon
     app.kubernetes.io/version: "2.13.0"
+    release: k8smon
   annotations:
 spec:
   type: "ClusterIP"
@@ -57611,6 +57616,7 @@ metadata:
     app.kubernetes.io/name: prometheus-node-exporter
     app.kubernetes.io/instance: k8smon
     app.kubernetes.io/version: "1.8.2"
+    release: k8smon
 spec:
   type: ClusterIP
   ports:
@@ -57693,6 +57699,7 @@ metadata:
     app.kubernetes.io/name: prometheus-node-exporter
     app.kubernetes.io/instance: k8smon
     app.kubernetes.io/version: "1.8.2"
+    release: k8smon
 spec:
   selector:
     matchLabels:
@@ -57716,6 +57723,7 @@ spec:
         app.kubernetes.io/name: prometheus-node-exporter
         app.kubernetes.io/instance: k8smon
         app.kubernetes.io/version: "1.8.2"
+        release: k8smon
     spec:
       automountServiceAccountToken: false
       securityContext:
@@ -57818,6 +57826,7 @@ metadata:
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/instance: k8smon
     app.kubernetes.io/version: "2.13.0"
+    release: k8smon
 spec:
   selector:
     matchLabels:      
@@ -57837,6 +57846,7 @@ spec:
         app.kubernetes.io/name: kube-state-metrics
         app.kubernetes.io/instance: k8smon
         app.kubernetes.io/version: "2.13.0"
+        release: k8smon
     spec:
       automountServiceAccountToken: true
       hostNetwork: false
@@ -58686,7 +58696,7 @@ data:
     discovery.relabel "kube_state_metrics" {
       targets = discovery.kubernetes.services.targets
       rule {
-        source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_instance"]
+        source_labels = ["__meta_kubernetes_service_label_release"]
         regex = "k8smon"
         action = "keep"
       }
@@ -58721,7 +58731,7 @@ data:
     discovery.relabel "node_exporter" {
       targets = discovery.kubernetes.pods.targets
       rule {
-        source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_instance"]
+        source_labels = ["__meta_kubernetes_pod_label_release"]
         regex = "k8smon"
         action = "keep"
       }

--- a/examples/custom-metrics-tuning/output.yaml
+++ b/examples/custom-metrics-tuning/output.yaml
@@ -385,11 +385,6 @@ data:
     discovery.relabel "alloy" {
       targets = discovery.kubernetes.pods.targets
       rule {
-        source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_instance"]
-        regex = "k8smon"
-        action = "keep"
-      }
-      rule {
         source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
         regex = "alloy.*"
         action = "keep"
@@ -688,11 +683,6 @@ data:
     // OpenCost
     discovery.relabel "opencost" {
       targets = discovery.kubernetes.services.targets
-      rule {
-        source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_instance"]
-        regex = "k8smon"
-        action = "keep"
-      }
       rule {
         source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_name"]
         regex = "opencost"
@@ -58474,11 +58464,6 @@ data:
     discovery.relabel "alloy" {
       targets = discovery.kubernetes.pods.targets
       rule {
-        source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_instance"]
-        regex = "k8smon"
-        action = "keep"
-      }
-      rule {
         source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
         regex = "alloy.*"
         action = "keep"
@@ -58777,11 +58762,6 @@ data:
     // OpenCost
     discovery.relabel "opencost" {
       targets = discovery.kubernetes.services.targets
-      rule {
-        source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_instance"]
-        regex = "k8smon"
-        action = "keep"
-      }
       rule {
         source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_name"]
         regex = "opencost"

--- a/examples/custom-pricing/metrics.alloy
+++ b/examples/custom-pricing/metrics.alloy
@@ -316,11 +316,6 @@ prometheus.relabel "annotation_autodiscovery" {
 discovery.relabel "alloy" {
   targets = discovery.kubernetes.pods.targets
   rule {
-    source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_instance"]
-    regex = "k8smon"
-    action = "keep"
-  }
-  rule {
     source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
     regex = "alloy.*"
     action = "keep"
@@ -624,11 +619,6 @@ prometheus.relabel "node_exporter" {
 // OpenCost
 discovery.relabel "opencost" {
   targets = discovery.kubernetes.services.targets
-  rule {
-    source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_instance"]
-    regex = "k8smon"
-    action = "keep"
-  }
   rule {
     source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_name"]
     regex = "opencost"

--- a/examples/custom-pricing/metrics.alloy
+++ b/examples/custom-pricing/metrics.alloy
@@ -538,7 +538,7 @@ prometheus.relabel "cadvisor" {
 discovery.relabel "kube_state_metrics" {
   targets = discovery.kubernetes.services.targets
   rule {
-    source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_instance"]
+    source_labels = ["__meta_kubernetes_service_label_release"]
     regex = "k8smon"
     action = "keep"
   }
@@ -578,7 +578,7 @@ prometheus.relabel "kube_state_metrics" {
 discovery.relabel "node_exporter" {
   targets = discovery.kubernetes.pods.targets
   rule {
-    source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_instance"]
+    source_labels = ["__meta_kubernetes_pod_label_release"]
     regex = "k8smon"
     action = "keep"
   }

--- a/examples/custom-pricing/output.yaml
+++ b/examples/custom-pricing/output.yaml
@@ -60,6 +60,7 @@ metadata:
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/instance: k8smon
     app.kubernetes.io/version: "2.13.0"
+    release: k8smon
   name: k8smon-kube-state-metrics
   namespace: default
 ---
@@ -92,6 +93,7 @@ metadata:
     app.kubernetes.io/name: prometheus-node-exporter
     app.kubernetes.io/instance: k8smon
     app.kubernetes.io/version: "1.8.2"
+    release: k8smon
 automountServiceAccountToken: false
 ---
 # Source: k8s-monitoring/templates/log-service-credentials.yaml
@@ -690,7 +692,7 @@ data:
     discovery.relabel "kube_state_metrics" {
       targets = discovery.kubernetes.services.targets
       rule {
-        source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_instance"]
+        source_labels = ["__meta_kubernetes_service_label_release"]
         regex = "k8smon"
         action = "keep"
       }
@@ -730,7 +732,7 @@ data:
     discovery.relabel "node_exporter" {
       targets = discovery.kubernetes.pods.targets
       rule {
-        source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_instance"]
+        source_labels = ["__meta_kubernetes_pod_label_release"]
         regex = "k8smon"
         action = "keep"
       }
@@ -57708,6 +57710,7 @@ metadata:
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/instance: k8smon
     app.kubernetes.io/version: "2.13.0"
+    release: k8smon
   name: k8smon-kube-state-metrics
 rules:
 
@@ -58019,6 +58022,7 @@ metadata:
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/instance: k8smon
     app.kubernetes.io/version: "2.13.0"
+    release: k8smon
   name: k8smon-kube-state-metrics
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -58239,6 +58243,7 @@ metadata:
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/instance: k8smon
     app.kubernetes.io/version: "2.13.0"
+    release: k8smon
   annotations:
 spec:
   type: "ClusterIP"
@@ -58289,6 +58294,7 @@ metadata:
     app.kubernetes.io/name: prometheus-node-exporter
     app.kubernetes.io/instance: k8smon
     app.kubernetes.io/version: "1.8.2"
+    release: k8smon
 spec:
   type: ClusterIP
   ports:
@@ -58460,6 +58466,7 @@ metadata:
     app.kubernetes.io/name: prometheus-node-exporter
     app.kubernetes.io/instance: k8smon
     app.kubernetes.io/version: "1.8.2"
+    release: k8smon
 spec:
   selector:
     matchLabels:
@@ -58483,6 +58490,7 @@ spec:
         app.kubernetes.io/name: prometheus-node-exporter
         app.kubernetes.io/instance: k8smon
         app.kubernetes.io/version: "1.8.2"
+        release: k8smon
     spec:
       automountServiceAccountToken: false
       securityContext:
@@ -58666,6 +58674,7 @@ metadata:
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/instance: k8smon
     app.kubernetes.io/version: "2.13.0"
+    release: k8smon
 spec:
   selector:
     matchLabels:      
@@ -58685,6 +58694,7 @@ spec:
         app.kubernetes.io/name: kube-state-metrics
         app.kubernetes.io/instance: k8smon
         app.kubernetes.io/version: "2.13.0"
+        release: k8smon
     spec:
       automountServiceAccountToken: true
       hostNetwork: false
@@ -59563,7 +59573,7 @@ data:
     discovery.relabel "kube_state_metrics" {
       targets = discovery.kubernetes.services.targets
       rule {
-        source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_instance"]
+        source_labels = ["__meta_kubernetes_service_label_release"]
         regex = "k8smon"
         action = "keep"
       }
@@ -59603,7 +59613,7 @@ data:
     discovery.relabel "node_exporter" {
       targets = discovery.kubernetes.pods.targets
       rule {
-        source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_instance"]
+        source_labels = ["__meta_kubernetes_pod_label_release"]
         regex = "k8smon"
         action = "keep"
       }

--- a/examples/custom-pricing/output.yaml
+++ b/examples/custom-pricing/output.yaml
@@ -470,11 +470,6 @@ data:
     discovery.relabel "alloy" {
       targets = discovery.kubernetes.pods.targets
       rule {
-        source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_instance"]
-        regex = "k8smon"
-        action = "keep"
-      }
-      rule {
         source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
         regex = "alloy.*"
         action = "keep"
@@ -778,11 +773,6 @@ data:
     // OpenCost
     discovery.relabel "opencost" {
       targets = discovery.kubernetes.services.targets
-      rule {
-        source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_instance"]
-        regex = "k8smon"
-        action = "keep"
-      }
       rule {
         source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_name"]
         regex = "opencost"
@@ -59351,11 +59341,6 @@ data:
     discovery.relabel "alloy" {
       targets = discovery.kubernetes.pods.targets
       rule {
-        source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_instance"]
-        regex = "k8smon"
-        action = "keep"
-      }
-      rule {
         source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
         regex = "alloy.*"
         action = "keep"
@@ -59659,11 +59644,6 @@ data:
     // OpenCost
     discovery.relabel "opencost" {
       targets = discovery.kubernetes.services.targets
-      rule {
-        source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_instance"]
-        regex = "k8smon"
-        action = "keep"
-      }
       rule {
         source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_name"]
         regex = "opencost"

--- a/examples/custom-prometheus-operator-rules/metrics.alloy
+++ b/examples/custom-prometheus-operator-rules/metrics.alloy
@@ -545,7 +545,7 @@ prometheus.relabel "cadvisor" {
 discovery.relabel "kube_state_metrics" {
   targets = discovery.kubernetes.services.targets
   rule {
-    source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_instance"]
+    source_labels = ["__meta_kubernetes_service_label_release"]
     regex = "k8smon"
     action = "keep"
   }
@@ -590,7 +590,7 @@ prometheus.relabel "kube_state_metrics" {
 discovery.relabel "node_exporter" {
   targets = discovery.kubernetes.pods.targets
   rule {
-    source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_instance"]
+    source_labels = ["__meta_kubernetes_pod_label_release"]
     regex = "k8smon"
     action = "keep"
   }

--- a/examples/custom-prometheus-operator-rules/metrics.alloy
+++ b/examples/custom-prometheus-operator-rules/metrics.alloy
@@ -308,11 +308,6 @@ prometheus.relabel "annotation_autodiscovery" {
 discovery.relabel "alloy" {
   targets = discovery.kubernetes.pods.targets
   rule {
-    source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_instance"]
-    regex = "k8smon"
-    action = "keep"
-  }
-  rule {
     source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
     regex = "alloy.*"
     action = "keep"
@@ -641,11 +636,6 @@ prometheus.relabel "node_exporter" {
 // OpenCost
 discovery.relabel "opencost" {
   targets = discovery.kubernetes.services.targets
-  rule {
-    source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_instance"]
-    regex = "k8smon"
-    action = "keep"
-  }
   rule {
     source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_name"]
     regex = "opencost"

--- a/examples/custom-prometheus-operator-rules/output.yaml
+++ b/examples/custom-prometheus-operator-rules/output.yaml
@@ -395,11 +395,6 @@ data:
     discovery.relabel "alloy" {
       targets = discovery.kubernetes.pods.targets
       rule {
-        source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_instance"]
-        regex = "k8smon"
-        action = "keep"
-      }
-      rule {
         source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
         regex = "alloy.*"
         action = "keep"
@@ -728,11 +723,6 @@ data:
     // OpenCost
     discovery.relabel "opencost" {
       targets = discovery.kubernetes.services.targets
-      rule {
-        source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_instance"]
-        regex = "k8smon"
-        action = "keep"
-      }
       rule {
         source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_name"]
         regex = "opencost"
@@ -58566,11 +58556,6 @@ data:
     discovery.relabel "alloy" {
       targets = discovery.kubernetes.pods.targets
       rule {
-        source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_instance"]
-        regex = "k8smon"
-        action = "keep"
-      }
-      rule {
         source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
         regex = "alloy.*"
         action = "keep"
@@ -58899,11 +58884,6 @@ data:
     // OpenCost
     discovery.relabel "opencost" {
       targets = discovery.kubernetes.services.targets
-      rule {
-        source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_instance"]
-        regex = "k8smon"
-        action = "keep"
-      }
       rule {
         source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_name"]
         regex = "opencost"

--- a/examples/custom-prometheus-operator-rules/output.yaml
+++ b/examples/custom-prometheus-operator-rules/output.yaml
@@ -28,6 +28,7 @@ metadata:
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/instance: k8smon
     app.kubernetes.io/version: "2.13.0"
+    release: k8smon
   name: k8smon-kube-state-metrics
   namespace: default
 ---
@@ -60,6 +61,7 @@ metadata:
     app.kubernetes.io/name: prometheus-node-exporter
     app.kubernetes.io/instance: k8smon
     app.kubernetes.io/version: "1.8.2"
+    release: k8smon
 automountServiceAccountToken: false
 ---
 # Source: k8s-monitoring/templates/metrics-service-credentials.yaml
@@ -630,7 +632,7 @@ data:
     discovery.relabel "kube_state_metrics" {
       targets = discovery.kubernetes.services.targets
       rule {
-        source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_instance"]
+        source_labels = ["__meta_kubernetes_service_label_release"]
         regex = "k8smon"
         action = "keep"
       }
@@ -675,7 +677,7 @@ data:
     discovery.relabel "node_exporter" {
       targets = discovery.kubernetes.pods.targets
       rule {
-        source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_instance"]
+        source_labels = ["__meta_kubernetes_pod_label_release"]
         regex = "k8smon"
         action = "keep"
       }
@@ -57210,6 +57212,7 @@ metadata:
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/instance: k8smon
     app.kubernetes.io/version: "2.13.0"
+    release: k8smon
   name: k8smon-kube-state-metrics
 rules:
 
@@ -57475,6 +57478,7 @@ metadata:
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/instance: k8smon
     app.kubernetes.io/version: "2.13.0"
+    release: k8smon
   name: k8smon-kube-state-metrics
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -57643,6 +57647,7 @@ metadata:
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/instance: k8smon
     app.kubernetes.io/version: "2.13.0"
+    release: k8smon
   annotations:
 spec:
   type: "ClusterIP"
@@ -57693,6 +57698,7 @@ metadata:
     app.kubernetes.io/name: prometheus-node-exporter
     app.kubernetes.io/instance: k8smon
     app.kubernetes.io/version: "1.8.2"
+    release: k8smon
 spec:
   type: ClusterIP
   ports:
@@ -57775,6 +57781,7 @@ metadata:
     app.kubernetes.io/name: prometheus-node-exporter
     app.kubernetes.io/instance: k8smon
     app.kubernetes.io/version: "1.8.2"
+    release: k8smon
 spec:
   selector:
     matchLabels:
@@ -57798,6 +57805,7 @@ spec:
         app.kubernetes.io/name: prometheus-node-exporter
         app.kubernetes.io/instance: k8smon
         app.kubernetes.io/version: "1.8.2"
+        release: k8smon
     spec:
       automountServiceAccountToken: false
       securityContext:
@@ -57900,6 +57908,7 @@ metadata:
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/instance: k8smon
     app.kubernetes.io/version: "2.13.0"
+    release: k8smon
 spec:
   selector:
     matchLabels:      
@@ -57919,6 +57928,7 @@ spec:
         app.kubernetes.io/name: kube-state-metrics
         app.kubernetes.io/instance: k8smon
         app.kubernetes.io/version: "2.13.0"
+        release: k8smon
     spec:
       automountServiceAccountToken: true
       hostNetwork: false
@@ -58793,7 +58803,7 @@ data:
     discovery.relabel "kube_state_metrics" {
       targets = discovery.kubernetes.services.targets
       rule {
-        source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_instance"]
+        source_labels = ["__meta_kubernetes_service_label_release"]
         regex = "k8smon"
         action = "keep"
       }
@@ -58838,7 +58848,7 @@ data:
     discovery.relabel "node_exporter" {
       targets = discovery.kubernetes.pods.targets
       rule {
-        source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_instance"]
+        source_labels = ["__meta_kubernetes_pod_label_release"]
         regex = "k8smon"
         action = "keep"
       }

--- a/examples/default-values/metrics.alloy
+++ b/examples/default-values/metrics.alloy
@@ -316,11 +316,6 @@ prometheus.relabel "annotation_autodiscovery" {
 discovery.relabel "alloy" {
   targets = discovery.kubernetes.pods.targets
   rule {
-    source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_instance"]
-    regex = "k8smon"
-    action = "keep"
-  }
-  rule {
     source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
     regex = "alloy.*"
     action = "keep"
@@ -624,11 +619,6 @@ prometheus.relabel "node_exporter" {
 // OpenCost
 discovery.relabel "opencost" {
   targets = discovery.kubernetes.services.targets
-  rule {
-    source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_instance"]
-    regex = "k8smon"
-    action = "keep"
-  }
   rule {
     source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_name"]
     regex = "opencost"

--- a/examples/default-values/metrics.alloy
+++ b/examples/default-values/metrics.alloy
@@ -538,7 +538,7 @@ prometheus.relabel "cadvisor" {
 discovery.relabel "kube_state_metrics" {
   targets = discovery.kubernetes.services.targets
   rule {
-    source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_instance"]
+    source_labels = ["__meta_kubernetes_service_label_release"]
     regex = "k8smon"
     action = "keep"
   }
@@ -578,7 +578,7 @@ prometheus.relabel "kube_state_metrics" {
 discovery.relabel "node_exporter" {
   targets = discovery.kubernetes.pods.targets
   rule {
-    source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_instance"]
+    source_labels = ["__meta_kubernetes_pod_label_release"]
     regex = "k8smon"
     action = "keep"
   }

--- a/examples/default-values/output.yaml
+++ b/examples/default-values/output.yaml
@@ -60,6 +60,7 @@ metadata:
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/instance: k8smon
     app.kubernetes.io/version: "2.13.0"
+    release: k8smon
   name: k8smon-kube-state-metrics
   namespace: default
 ---
@@ -92,6 +93,7 @@ metadata:
     app.kubernetes.io/name: prometheus-node-exporter
     app.kubernetes.io/instance: k8smon
     app.kubernetes.io/version: "1.8.2"
+    release: k8smon
 automountServiceAccountToken: false
 ---
 # Source: k8s-monitoring/templates/log-service-credentials.yaml
@@ -668,7 +670,7 @@ data:
     discovery.relabel "kube_state_metrics" {
       targets = discovery.kubernetes.services.targets
       rule {
-        source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_instance"]
+        source_labels = ["__meta_kubernetes_service_label_release"]
         regex = "k8smon"
         action = "keep"
       }
@@ -708,7 +710,7 @@ data:
     discovery.relabel "node_exporter" {
       targets = discovery.kubernetes.pods.targets
       rule {
-        source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_instance"]
+        source_labels = ["__meta_kubernetes_pod_label_release"]
         regex = "k8smon"
         action = "keep"
       }
@@ -57686,6 +57688,7 @@ metadata:
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/instance: k8smon
     app.kubernetes.io/version: "2.13.0"
+    release: k8smon
   name: k8smon-kube-state-metrics
 rules:
 
@@ -57997,6 +58000,7 @@ metadata:
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/instance: k8smon
     app.kubernetes.io/version: "2.13.0"
+    release: k8smon
   name: k8smon-kube-state-metrics
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -58217,6 +58221,7 @@ metadata:
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/instance: k8smon
     app.kubernetes.io/version: "2.13.0"
+    release: k8smon
   annotations:
 spec:
   type: "ClusterIP"
@@ -58267,6 +58272,7 @@ metadata:
     app.kubernetes.io/name: prometheus-node-exporter
     app.kubernetes.io/instance: k8smon
     app.kubernetes.io/version: "1.8.2"
+    release: k8smon
 spec:
   type: ClusterIP
   ports:
@@ -58438,6 +58444,7 @@ metadata:
     app.kubernetes.io/name: prometheus-node-exporter
     app.kubernetes.io/instance: k8smon
     app.kubernetes.io/version: "1.8.2"
+    release: k8smon
 spec:
   selector:
     matchLabels:
@@ -58461,6 +58468,7 @@ spec:
         app.kubernetes.io/name: prometheus-node-exporter
         app.kubernetes.io/instance: k8smon
         app.kubernetes.io/version: "1.8.2"
+        release: k8smon
     spec:
       automountServiceAccountToken: false
       securityContext:
@@ -58644,6 +58652,7 @@ metadata:
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/instance: k8smon
     app.kubernetes.io/version: "2.13.0"
+    release: k8smon
 spec:
   selector:
     matchLabels:      
@@ -58663,6 +58672,7 @@ spec:
         app.kubernetes.io/name: kube-state-metrics
         app.kubernetes.io/instance: k8smon
         app.kubernetes.io/version: "2.13.0"
+        release: k8smon
     spec:
       automountServiceAccountToken: true
       hostNetwork: false
@@ -59530,7 +59540,7 @@ data:
     discovery.relabel "kube_state_metrics" {
       targets = discovery.kubernetes.services.targets
       rule {
-        source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_instance"]
+        source_labels = ["__meta_kubernetes_service_label_release"]
         regex = "k8smon"
         action = "keep"
       }
@@ -59570,7 +59580,7 @@ data:
     discovery.relabel "node_exporter" {
       targets = discovery.kubernetes.pods.targets
       rule {
-        source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_instance"]
+        source_labels = ["__meta_kubernetes_pod_label_release"]
         regex = "k8smon"
         action = "keep"
       }

--- a/examples/default-values/output.yaml
+++ b/examples/default-values/output.yaml
@@ -448,11 +448,6 @@ data:
     discovery.relabel "alloy" {
       targets = discovery.kubernetes.pods.targets
       rule {
-        source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_instance"]
-        regex = "k8smon"
-        action = "keep"
-      }
-      rule {
         source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
         regex = "alloy.*"
         action = "keep"
@@ -756,11 +751,6 @@ data:
     // OpenCost
     discovery.relabel "opencost" {
       targets = discovery.kubernetes.services.targets
-      rule {
-        source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_instance"]
-        regex = "k8smon"
-        action = "keep"
-      }
       rule {
         source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_name"]
         regex = "opencost"
@@ -59318,11 +59308,6 @@ data:
     discovery.relabel "alloy" {
       targets = discovery.kubernetes.pods.targets
       rule {
-        source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_instance"]
-        regex = "k8smon"
-        action = "keep"
-      }
-      rule {
         source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
         regex = "alloy.*"
         action = "keep"
@@ -59626,11 +59611,6 @@ data:
     // OpenCost
     discovery.relabel "opencost" {
       targets = discovery.kubernetes.services.targets
-      rule {
-        source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_instance"]
-        regex = "k8smon"
-        action = "keep"
-      }
       rule {
         source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_name"]
         regex = "opencost"

--- a/examples/eks-fargate/metrics.alloy
+++ b/examples/eks-fargate/metrics.alloy
@@ -538,7 +538,7 @@ prometheus.relabel "cadvisor" {
 discovery.relabel "kube_state_metrics" {
   targets = discovery.kubernetes.services.targets
   rule {
-    source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_instance"]
+    source_labels = ["__meta_kubernetes_service_label_release"]
     regex = "k8smon"
     action = "keep"
   }

--- a/examples/eks-fargate/metrics.alloy
+++ b/examples/eks-fargate/metrics.alloy
@@ -316,11 +316,6 @@ prometheus.relabel "annotation_autodiscovery" {
 discovery.relabel "alloy" {
   targets = discovery.kubernetes.pods.targets
   rule {
-    source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_instance"]
-    regex = "k8smon"
-    action = "keep"
-  }
-  rule {
     source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
     regex = "alloy.*"
     action = "keep"
@@ -577,11 +572,6 @@ prometheus.relabel "kube_state_metrics" {
 // OpenCost
 discovery.relabel "opencost" {
   targets = discovery.kubernetes.services.targets
-  rule {
-    source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_instance"]
-    regex = "k8smon"
-    action = "keep"
-  }
   rule {
     source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_name"]
     regex = "opencost"

--- a/examples/eks-fargate/output.yaml
+++ b/examples/eks-fargate/output.yaml
@@ -431,11 +431,6 @@ data:
     discovery.relabel "alloy" {
       targets = discovery.kubernetes.pods.targets
       rule {
-        source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_instance"]
-        regex = "k8smon"
-        action = "keep"
-      }
-      rule {
         source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
         regex = "alloy.*"
         action = "keep"
@@ -692,11 +687,6 @@ data:
     // OpenCost
     discovery.relabel "opencost" {
       targets = discovery.kubernetes.services.targets
-      rule {
-        source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_instance"]
-        regex = "k8smon"
-        action = "keep"
-      }
       rule {
         source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_name"]
         regex = "opencost"
@@ -59118,11 +59108,6 @@ data:
     discovery.relabel "alloy" {
       targets = discovery.kubernetes.pods.targets
       rule {
-        source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_instance"]
-        regex = "k8smon"
-        action = "keep"
-      }
-      rule {
         source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
         regex = "alloy.*"
         action = "keep"
@@ -59379,11 +59364,6 @@ data:
     // OpenCost
     discovery.relabel "opencost" {
       targets = discovery.kubernetes.services.targets
-      rule {
-        source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_instance"]
-        regex = "k8smon"
-        action = "keep"
-      }
       rule {
         source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_name"]
         regex = "opencost"

--- a/examples/eks-fargate/output.yaml
+++ b/examples/eks-fargate/output.yaml
@@ -60,6 +60,7 @@ metadata:
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/instance: k8smon
     app.kubernetes.io/version: "2.13.0"
+    release: k8smon
   name: k8smon-kube-state-metrics
   namespace: default
 ---
@@ -652,7 +653,7 @@ data:
     discovery.relabel "kube_state_metrics" {
       targets = discovery.kubernetes.services.targets
       rule {
-        source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_instance"]
+        source_labels = ["__meta_kubernetes_service_label_release"]
         regex = "k8smon"
         action = "keep"
       }
@@ -57610,6 +57611,7 @@ metadata:
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/instance: k8smon
     app.kubernetes.io/version: "2.13.0"
+    release: k8smon
   name: k8smon-kube-state-metrics
 rules:
 
@@ -57921,6 +57923,7 @@ metadata:
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/instance: k8smon
     app.kubernetes.io/version: "2.13.0"
+    release: k8smon
   name: k8smon-kube-state-metrics
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -58174,6 +58177,7 @@ metadata:
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/instance: k8smon
     app.kubernetes.io/version: "2.13.0"
+    release: k8smon
   annotations:
 spec:
   type: "ClusterIP"
@@ -58448,6 +58452,7 @@ metadata:
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/instance: k8smon
     app.kubernetes.io/version: "2.13.0"
+    release: k8smon
 spec:
   selector:
     matchLabels:      
@@ -58467,6 +58472,7 @@ spec:
         app.kubernetes.io/name: kube-state-metrics
         app.kubernetes.io/instance: k8smon
         app.kubernetes.io/version: "2.13.0"
+        release: k8smon
     spec:
       automountServiceAccountToken: true
       hostNetwork: false
@@ -59334,7 +59340,7 @@ data:
     discovery.relabel "kube_state_metrics" {
       targets = discovery.kubernetes.services.targets
       rule {
-        source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_instance"]
+        source_labels = ["__meta_kubernetes_service_label_release"]
         regex = "k8smon"
         action = "keep"
       }

--- a/examples/extra-rules/metrics.alloy
+++ b/examples/extra-rules/metrics.alloy
@@ -563,7 +563,7 @@ prometheus.relabel "cadvisor" {
 discovery.relabel "kube_state_metrics" {
   targets = discovery.kubernetes.services.targets
   rule {
-    source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_instance"]
+    source_labels = ["__meta_kubernetes_service_label_release"]
     regex = "k8smon"
     action = "keep"
   }
@@ -613,7 +613,7 @@ prometheus.relabel "kube_state_metrics" {
 discovery.relabel "node_exporter" {
   targets = discovery.kubernetes.pods.targets
   rule {
-    source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_instance"]
+    source_labels = ["__meta_kubernetes_pod_label_release"]
     regex = "k8smon"
     action = "keep"
   }

--- a/examples/extra-rules/metrics.alloy
+++ b/examples/extra-rules/metrics.alloy
@@ -326,11 +326,6 @@ prometheus.relabel "annotation_autodiscovery" {
 discovery.relabel "alloy" {
   targets = discovery.kubernetes.pods.targets
   rule {
-    source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_instance"]
-    regex = "k8smon"
-    action = "keep"
-  }
-  rule {
     source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
     regex = "alloy.*"
     action = "keep"
@@ -664,11 +659,6 @@ prometheus.relabel "node_exporter" {
 // OpenCost
 discovery.relabel "opencost" {
   targets = discovery.kubernetes.services.targets
-  rule {
-    source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_instance"]
-    regex = "k8smon"
-    action = "keep"
-  }
   rule {
     source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_name"]
     regex = "opencost"

--- a/examples/extra-rules/output.yaml
+++ b/examples/extra-rules/output.yaml
@@ -459,11 +459,6 @@ data:
     discovery.relabel "alloy" {
       targets = discovery.kubernetes.pods.targets
       rule {
-        source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_instance"]
-        regex = "k8smon"
-        action = "keep"
-      }
-      rule {
         source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
         regex = "alloy.*"
         action = "keep"
@@ -797,11 +792,6 @@ data:
     // OpenCost
     discovery.relabel "opencost" {
       targets = discovery.kubernetes.services.targets
-      rule {
-        source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_instance"]
-        regex = "k8smon"
-        action = "keep"
-      }
       rule {
         source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_name"]
         regex = "opencost"
@@ -59450,11 +59440,6 @@ data:
     discovery.relabel "alloy" {
       targets = discovery.kubernetes.pods.targets
       rule {
-        source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_instance"]
-        regex = "k8smon"
-        action = "keep"
-      }
-      rule {
         source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
         regex = "alloy.*"
         action = "keep"
@@ -59788,11 +59773,6 @@ data:
     // OpenCost
     discovery.relabel "opencost" {
       targets = discovery.kubernetes.services.targets
-      rule {
-        source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_instance"]
-        regex = "k8smon"
-        action = "keep"
-      }
       rule {
         source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_name"]
         regex = "opencost"

--- a/examples/extra-rules/output.yaml
+++ b/examples/extra-rules/output.yaml
@@ -60,6 +60,7 @@ metadata:
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/instance: k8smon
     app.kubernetes.io/version: "2.13.0"
+    release: k8smon
   name: k8smon-kube-state-metrics
   namespace: default
 ---
@@ -92,6 +93,7 @@ metadata:
     app.kubernetes.io/name: prometheus-node-exporter
     app.kubernetes.io/instance: k8smon
     app.kubernetes.io/version: "1.8.2"
+    release: k8smon
 automountServiceAccountToken: false
 ---
 # Source: k8s-monitoring/templates/log-service-credentials.yaml
@@ -694,7 +696,7 @@ data:
     discovery.relabel "kube_state_metrics" {
       targets = discovery.kubernetes.services.targets
       rule {
-        source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_instance"]
+        source_labels = ["__meta_kubernetes_service_label_release"]
         regex = "k8smon"
         action = "keep"
       }
@@ -744,7 +746,7 @@ data:
     discovery.relabel "node_exporter" {
       targets = discovery.kubernetes.pods.targets
       rule {
-        source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_instance"]
+        source_labels = ["__meta_kubernetes_pod_label_release"]
         regex = "k8smon"
         action = "keep"
       }
@@ -57808,6 +57810,7 @@ metadata:
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/instance: k8smon
     app.kubernetes.io/version: "2.13.0"
+    release: k8smon
   name: k8smon-kube-state-metrics
 rules:
 
@@ -58119,6 +58122,7 @@ metadata:
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/instance: k8smon
     app.kubernetes.io/version: "2.13.0"
+    release: k8smon
   name: k8smon-kube-state-metrics
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -58339,6 +58343,7 @@ metadata:
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/instance: k8smon
     app.kubernetes.io/version: "2.13.0"
+    release: k8smon
   annotations:
 spec:
   type: "ClusterIP"
@@ -58389,6 +58394,7 @@ metadata:
     app.kubernetes.io/name: prometheus-node-exporter
     app.kubernetes.io/instance: k8smon
     app.kubernetes.io/version: "1.8.2"
+    release: k8smon
 spec:
   type: ClusterIP
   ports:
@@ -58560,6 +58566,7 @@ metadata:
     app.kubernetes.io/name: prometheus-node-exporter
     app.kubernetes.io/instance: k8smon
     app.kubernetes.io/version: "1.8.2"
+    release: k8smon
 spec:
   selector:
     matchLabels:
@@ -58583,6 +58590,7 @@ spec:
         app.kubernetes.io/name: prometheus-node-exporter
         app.kubernetes.io/instance: k8smon
         app.kubernetes.io/version: "1.8.2"
+        release: k8smon
     spec:
       automountServiceAccountToken: false
       securityContext:
@@ -58766,6 +58774,7 @@ metadata:
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/instance: k8smon
     app.kubernetes.io/version: "2.13.0"
+    release: k8smon
 spec:
   selector:
     matchLabels:      
@@ -58785,6 +58794,7 @@ spec:
         app.kubernetes.io/name: kube-state-metrics
         app.kubernetes.io/instance: k8smon
         app.kubernetes.io/version: "2.13.0"
+        release: k8smon
     spec:
       automountServiceAccountToken: true
       hostNetwork: false
@@ -59677,7 +59687,7 @@ data:
     discovery.relabel "kube_state_metrics" {
       targets = discovery.kubernetes.services.targets
       rule {
-        source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_instance"]
+        source_labels = ["__meta_kubernetes_service_label_release"]
         regex = "k8smon"
         action = "keep"
       }
@@ -59727,7 +59737,7 @@ data:
     discovery.relabel "node_exporter" {
       targets = discovery.kubernetes.pods.targets
       rule {
-        source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_instance"]
+        source_labels = ["__meta_kubernetes_pod_label_release"]
         regex = "k8smon"
         action = "keep"
       }

--- a/examples/gke-autopilot/metrics.alloy
+++ b/examples/gke-autopilot/metrics.alloy
@@ -538,7 +538,7 @@ prometheus.relabel "cadvisor" {
 discovery.relabel "kube_state_metrics" {
   targets = discovery.kubernetes.services.targets
   rule {
-    source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_instance"]
+    source_labels = ["__meta_kubernetes_service_label_release"]
     regex = "k8smon"
     action = "keep"
   }

--- a/examples/gke-autopilot/metrics.alloy
+++ b/examples/gke-autopilot/metrics.alloy
@@ -316,11 +316,6 @@ prometheus.relabel "annotation_autodiscovery" {
 discovery.relabel "alloy" {
   targets = discovery.kubernetes.pods.targets
   rule {
-    source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_instance"]
-    regex = "k8smon"
-    action = "keep"
-  }
-  rule {
     source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
     regex = "alloy.*"
     action = "keep"
@@ -577,11 +572,6 @@ prometheus.relabel "kube_state_metrics" {
 // OpenCost
 discovery.relabel "opencost" {
   targets = discovery.kubernetes.services.targets
-  rule {
-    source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_instance"]
-    regex = "k8smon"
-    action = "keep"
-  }
   rule {
     source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_name"]
     regex = "opencost"

--- a/examples/gke-autopilot/output.yaml
+++ b/examples/gke-autopilot/output.yaml
@@ -431,11 +431,6 @@ data:
     discovery.relabel "alloy" {
       targets = discovery.kubernetes.pods.targets
       rule {
-        source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_instance"]
-        regex = "k8smon"
-        action = "keep"
-      }
-      rule {
         source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
         regex = "alloy.*"
         action = "keep"
@@ -692,11 +687,6 @@ data:
     // OpenCost
     discovery.relabel "opencost" {
       targets = discovery.kubernetes.services.targets
-      rule {
-        source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_instance"]
-        regex = "k8smon"
-        action = "keep"
-      }
       rule {
         source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_name"]
         regex = "opencost"
@@ -59101,11 +59091,6 @@ data:
     discovery.relabel "alloy" {
       targets = discovery.kubernetes.pods.targets
       rule {
-        source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_instance"]
-        regex = "k8smon"
-        action = "keep"
-      }
-      rule {
         source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
         regex = "alloy.*"
         action = "keep"
@@ -59362,11 +59347,6 @@ data:
     // OpenCost
     discovery.relabel "opencost" {
       targets = discovery.kubernetes.services.targets
-      rule {
-        source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_instance"]
-        regex = "k8smon"
-        action = "keep"
-      }
       rule {
         source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_name"]
         regex = "opencost"

--- a/examples/gke-autopilot/output.yaml
+++ b/examples/gke-autopilot/output.yaml
@@ -60,6 +60,7 @@ metadata:
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/instance: k8smon
     app.kubernetes.io/version: "2.13.0"
+    release: k8smon
   name: k8smon-kube-state-metrics
   namespace: default
 ---
@@ -652,7 +653,7 @@ data:
     discovery.relabel "kube_state_metrics" {
       targets = discovery.kubernetes.services.targets
       rule {
-        source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_instance"]
+        source_labels = ["__meta_kubernetes_service_label_release"]
         regex = "k8smon"
         action = "keep"
       }
@@ -57623,6 +57624,7 @@ metadata:
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/instance: k8smon
     app.kubernetes.io/version: "2.13.0"
+    release: k8smon
   name: k8smon-kube-state-metrics
 rules:
 
@@ -57934,6 +57936,7 @@ metadata:
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/instance: k8smon
     app.kubernetes.io/version: "2.13.0"
+    release: k8smon
   name: k8smon-kube-state-metrics
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -58154,6 +58157,7 @@ metadata:
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/instance: k8smon
     app.kubernetes.io/version: "2.13.0"
+    release: k8smon
   annotations:
 spec:
   type: "ClusterIP"
@@ -58431,6 +58435,7 @@ metadata:
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/instance: k8smon
     app.kubernetes.io/version: "2.13.0"
+    release: k8smon
 spec:
   selector:
     matchLabels:      
@@ -58450,6 +58455,7 @@ spec:
         app.kubernetes.io/name: kube-state-metrics
         app.kubernetes.io/instance: k8smon
         app.kubernetes.io/version: "2.13.0"
+        release: k8smon
     spec:
       automountServiceAccountToken: true
       hostNetwork: false
@@ -59317,7 +59323,7 @@ data:
     discovery.relabel "kube_state_metrics" {
       targets = discovery.kubernetes.services.targets
       rule {
-        source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_instance"]
+        source_labels = ["__meta_kubernetes_service_label_release"]
         regex = "k8smon"
         action = "keep"
       }

--- a/examples/ibm-cloud/metrics.alloy
+++ b/examples/ibm-cloud/metrics.alloy
@@ -316,11 +316,6 @@ prometheus.relabel "annotation_autodiscovery" {
 discovery.relabel "alloy" {
   targets = discovery.kubernetes.pods.targets
   rule {
-    source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_instance"]
-    regex = "k8smon"
-    action = "keep"
-  }
-  rule {
     source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
     regex = "alloy.*"
     action = "keep"
@@ -624,11 +619,6 @@ prometheus.relabel "node_exporter" {
 // OpenCost
 discovery.relabel "opencost" {
   targets = discovery.kubernetes.services.targets
-  rule {
-    source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_instance"]
-    regex = "k8smon"
-    action = "keep"
-  }
   rule {
     source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_name"]
     regex = "opencost"

--- a/examples/ibm-cloud/metrics.alloy
+++ b/examples/ibm-cloud/metrics.alloy
@@ -538,7 +538,7 @@ prometheus.relabel "cadvisor" {
 discovery.relabel "kube_state_metrics" {
   targets = discovery.kubernetes.services.targets
   rule {
-    source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_instance"]
+    source_labels = ["__meta_kubernetes_service_label_release"]
     regex = "k8smon"
     action = "keep"
   }
@@ -578,7 +578,7 @@ prometheus.relabel "kube_state_metrics" {
 discovery.relabel "node_exporter" {
   targets = discovery.kubernetes.pods.targets
   rule {
-    source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_instance"]
+    source_labels = ["__meta_kubernetes_pod_label_release"]
     regex = "k8smon"
     action = "keep"
   }

--- a/examples/ibm-cloud/output.yaml
+++ b/examples/ibm-cloud/output.yaml
@@ -60,6 +60,7 @@ metadata:
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/instance: k8smon
     app.kubernetes.io/version: "2.13.0"
+    release: k8smon
   name: k8smon-kube-state-metrics
   namespace: default
 ---
@@ -92,6 +93,7 @@ metadata:
     app.kubernetes.io/name: prometheus-node-exporter
     app.kubernetes.io/instance: k8smon
     app.kubernetes.io/version: "1.8.2"
+    release: k8smon
 automountServiceAccountToken: false
 ---
 # Source: k8s-monitoring/templates/log-service-credentials.yaml
@@ -668,7 +670,7 @@ data:
     discovery.relabel "kube_state_metrics" {
       targets = discovery.kubernetes.services.targets
       rule {
-        source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_instance"]
+        source_labels = ["__meta_kubernetes_service_label_release"]
         regex = "k8smon"
         action = "keep"
       }
@@ -708,7 +710,7 @@ data:
     discovery.relabel "node_exporter" {
       targets = discovery.kubernetes.pods.targets
       rule {
-        source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_instance"]
+        source_labels = ["__meta_kubernetes_pod_label_release"]
         regex = "k8smon"
         action = "keep"
       }
@@ -57686,6 +57688,7 @@ metadata:
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/instance: k8smon
     app.kubernetes.io/version: "2.13.0"
+    release: k8smon
   name: k8smon-kube-state-metrics
 rules:
 
@@ -57997,6 +58000,7 @@ metadata:
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/instance: k8smon
     app.kubernetes.io/version: "2.13.0"
+    release: k8smon
   name: k8smon-kube-state-metrics
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -58217,6 +58221,7 @@ metadata:
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/instance: k8smon
     app.kubernetes.io/version: "2.13.0"
+    release: k8smon
   annotations:
 spec:
   type: "ClusterIP"
@@ -58267,6 +58272,7 @@ metadata:
     app.kubernetes.io/name: prometheus-node-exporter
     app.kubernetes.io/instance: k8smon
     app.kubernetes.io/version: "1.8.2"
+    release: k8smon
 spec:
   type: ClusterIP
   ports:
@@ -58444,6 +58450,7 @@ metadata:
     app.kubernetes.io/name: prometheus-node-exporter
     app.kubernetes.io/instance: k8smon
     app.kubernetes.io/version: "1.8.2"
+    release: k8smon
 spec:
   selector:
     matchLabels:
@@ -58467,6 +58474,7 @@ spec:
         app.kubernetes.io/name: prometheus-node-exporter
         app.kubernetes.io/instance: k8smon
         app.kubernetes.io/version: "1.8.2"
+        release: k8smon
     spec:
       automountServiceAccountToken: false
       securityContext:
@@ -58650,6 +58658,7 @@ metadata:
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/instance: k8smon
     app.kubernetes.io/version: "2.13.0"
+    release: k8smon
 spec:
   selector:
     matchLabels:      
@@ -58669,6 +58678,7 @@ spec:
         app.kubernetes.io/name: kube-state-metrics
         app.kubernetes.io/instance: k8smon
         app.kubernetes.io/version: "2.13.0"
+        release: k8smon
     spec:
       automountServiceAccountToken: true
       hostNetwork: false
@@ -59536,7 +59546,7 @@ data:
     discovery.relabel "kube_state_metrics" {
       targets = discovery.kubernetes.services.targets
       rule {
-        source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_instance"]
+        source_labels = ["__meta_kubernetes_service_label_release"]
         regex = "k8smon"
         action = "keep"
       }
@@ -59576,7 +59586,7 @@ data:
     discovery.relabel "node_exporter" {
       targets = discovery.kubernetes.pods.targets
       rule {
-        source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_instance"]
+        source_labels = ["__meta_kubernetes_pod_label_release"]
         regex = "k8smon"
         action = "keep"
       }

--- a/examples/ibm-cloud/output.yaml
+++ b/examples/ibm-cloud/output.yaml
@@ -448,11 +448,6 @@ data:
     discovery.relabel "alloy" {
       targets = discovery.kubernetes.pods.targets
       rule {
-        source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_instance"]
-        regex = "k8smon"
-        action = "keep"
-      }
-      rule {
         source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
         regex = "alloy.*"
         action = "keep"
@@ -756,11 +751,6 @@ data:
     // OpenCost
     discovery.relabel "opencost" {
       targets = discovery.kubernetes.services.targets
-      rule {
-        source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_instance"]
-        regex = "k8smon"
-        action = "keep"
-      }
       rule {
         source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_name"]
         regex = "opencost"
@@ -59324,11 +59314,6 @@ data:
     discovery.relabel "alloy" {
       targets = discovery.kubernetes.pods.targets
       rule {
-        source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_instance"]
-        regex = "k8smon"
-        action = "keep"
-      }
-      rule {
         source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
         regex = "alloy.*"
         action = "keep"
@@ -59632,11 +59617,6 @@ data:
     // OpenCost
     discovery.relabel "opencost" {
       targets = discovery.kubernetes.services.targets
-      rule {
-        source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_instance"]
-        regex = "k8smon"
-        action = "keep"
-      }
       rule {
         source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_name"]
         regex = "opencost"

--- a/examples/metric-module-imports-extra-config/metrics.alloy
+++ b/examples/metric-module-imports-extra-config/metrics.alloy
@@ -316,11 +316,6 @@ prometheus.relabel "annotation_autodiscovery" {
 discovery.relabel "alloy" {
   targets = discovery.kubernetes.pods.targets
   rule {
-    source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_instance"]
-    regex = "k8smon"
-    action = "keep"
-  }
-  rule {
     source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
     regex = "alloy.*"
     action = "keep"
@@ -624,11 +619,6 @@ prometheus.relabel "node_exporter" {
 // OpenCost
 discovery.relabel "opencost" {
   targets = discovery.kubernetes.services.targets
-  rule {
-    source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_instance"]
-    regex = "k8smon"
-    action = "keep"
-  }
   rule {
     source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_name"]
     regex = "opencost"

--- a/examples/metric-module-imports-extra-config/metrics.alloy
+++ b/examples/metric-module-imports-extra-config/metrics.alloy
@@ -538,7 +538,7 @@ prometheus.relabel "cadvisor" {
 discovery.relabel "kube_state_metrics" {
   targets = discovery.kubernetes.services.targets
   rule {
-    source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_instance"]
+    source_labels = ["__meta_kubernetes_service_label_release"]
     regex = "k8smon"
     action = "keep"
   }
@@ -578,7 +578,7 @@ prometheus.relabel "kube_state_metrics" {
 discovery.relabel "node_exporter" {
   targets = discovery.kubernetes.pods.targets
   rule {
-    source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_instance"]
+    source_labels = ["__meta_kubernetes_pod_label_release"]
     regex = "k8smon"
     action = "keep"
   }

--- a/examples/metric-module-imports-extra-config/output.yaml
+++ b/examples/metric-module-imports-extra-config/output.yaml
@@ -60,6 +60,7 @@ metadata:
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/instance: k8smon
     app.kubernetes.io/version: "2.13.0"
+    release: k8smon
   name: k8smon-kube-state-metrics
   namespace: default
 ---
@@ -92,6 +93,7 @@ metadata:
     app.kubernetes.io/name: prometheus-node-exporter
     app.kubernetes.io/instance: k8smon
     app.kubernetes.io/version: "1.8.2"
+    release: k8smon
 automountServiceAccountToken: false
 ---
 # Source: k8s-monitoring/templates/log-service-credentials.yaml
@@ -668,7 +670,7 @@ data:
     discovery.relabel "kube_state_metrics" {
       targets = discovery.kubernetes.services.targets
       rule {
-        source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_instance"]
+        source_labels = ["__meta_kubernetes_service_label_release"]
         regex = "k8smon"
         action = "keep"
       }
@@ -708,7 +710,7 @@ data:
     discovery.relabel "node_exporter" {
       targets = discovery.kubernetes.pods.targets
       rule {
-        source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_instance"]
+        source_labels = ["__meta_kubernetes_pod_label_release"]
         regex = "k8smon"
         action = "keep"
       }
@@ -57702,6 +57704,7 @@ metadata:
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/instance: k8smon
     app.kubernetes.io/version: "2.13.0"
+    release: k8smon
   name: k8smon-kube-state-metrics
 rules:
 
@@ -58013,6 +58016,7 @@ metadata:
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/instance: k8smon
     app.kubernetes.io/version: "2.13.0"
+    release: k8smon
   name: k8smon-kube-state-metrics
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -58233,6 +58237,7 @@ metadata:
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/instance: k8smon
     app.kubernetes.io/version: "2.13.0"
+    release: k8smon
   annotations:
 spec:
   type: "ClusterIP"
@@ -58283,6 +58288,7 @@ metadata:
     app.kubernetes.io/name: prometheus-node-exporter
     app.kubernetes.io/instance: k8smon
     app.kubernetes.io/version: "1.8.2"
+    release: k8smon
 spec:
   type: ClusterIP
   ports:
@@ -58454,6 +58460,7 @@ metadata:
     app.kubernetes.io/name: prometheus-node-exporter
     app.kubernetes.io/instance: k8smon
     app.kubernetes.io/version: "1.8.2"
+    release: k8smon
 spec:
   selector:
     matchLabels:
@@ -58477,6 +58484,7 @@ spec:
         app.kubernetes.io/name: prometheus-node-exporter
         app.kubernetes.io/instance: k8smon
         app.kubernetes.io/version: "1.8.2"
+        release: k8smon
     spec:
       automountServiceAccountToken: false
       securityContext:
@@ -58660,6 +58668,7 @@ metadata:
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/instance: k8smon
     app.kubernetes.io/version: "2.13.0"
+    release: k8smon
 spec:
   selector:
     matchLabels:      
@@ -58679,6 +58688,7 @@ spec:
         app.kubernetes.io/name: kube-state-metrics
         app.kubernetes.io/instance: k8smon
         app.kubernetes.io/version: "2.13.0"
+        release: k8smon
     spec:
       automountServiceAccountToken: true
       hostNetwork: false
@@ -59546,7 +59556,7 @@ data:
     discovery.relabel "kube_state_metrics" {
       targets = discovery.kubernetes.services.targets
       rule {
-        source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_instance"]
+        source_labels = ["__meta_kubernetes_service_label_release"]
         regex = "k8smon"
         action = "keep"
       }
@@ -59586,7 +59596,7 @@ data:
     discovery.relabel "node_exporter" {
       targets = discovery.kubernetes.pods.targets
       rule {
-        source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_instance"]
+        source_labels = ["__meta_kubernetes_pod_label_release"]
         regex = "k8smon"
         action = "keep"
       }

--- a/examples/metric-module-imports-extra-config/output.yaml
+++ b/examples/metric-module-imports-extra-config/output.yaml
@@ -448,11 +448,6 @@ data:
     discovery.relabel "alloy" {
       targets = discovery.kubernetes.pods.targets
       rule {
-        source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_instance"]
-        regex = "k8smon"
-        action = "keep"
-      }
-      rule {
         source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
         regex = "alloy.*"
         action = "keep"
@@ -756,11 +751,6 @@ data:
     // OpenCost
     discovery.relabel "opencost" {
       targets = discovery.kubernetes.services.targets
-      rule {
-        source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_instance"]
-        regex = "k8smon"
-        action = "keep"
-      }
       rule {
         source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_name"]
         regex = "opencost"
@@ -59334,11 +59324,6 @@ data:
     discovery.relabel "alloy" {
       targets = discovery.kubernetes.pods.targets
       rule {
-        source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_instance"]
-        regex = "k8smon"
-        action = "keep"
-      }
-      rule {
         source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
         regex = "alloy.*"
         action = "keep"
@@ -59642,11 +59627,6 @@ data:
     // OpenCost
     discovery.relabel "opencost" {
       targets = discovery.kubernetes.services.targets
-      rule {
-        source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_instance"]
-        regex = "k8smon"
-        action = "keep"
-      }
       rule {
         source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_name"]
         regex = "opencost"

--- a/examples/metric-module-imports/metrics.alloy
+++ b/examples/metric-module-imports/metrics.alloy
@@ -316,11 +316,6 @@ prometheus.relabel "annotation_autodiscovery" {
 discovery.relabel "alloy" {
   targets = discovery.kubernetes.pods.targets
   rule {
-    source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_instance"]
-    regex = "k8smon"
-    action = "keep"
-  }
-  rule {
     source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
     regex = "alloy.*"
     action = "keep"
@@ -624,11 +619,6 @@ prometheus.relabel "node_exporter" {
 // OpenCost
 discovery.relabel "opencost" {
   targets = discovery.kubernetes.services.targets
-  rule {
-    source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_instance"]
-    regex = "k8smon"
-    action = "keep"
-  }
   rule {
     source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_name"]
     regex = "opencost"

--- a/examples/metric-module-imports/metrics.alloy
+++ b/examples/metric-module-imports/metrics.alloy
@@ -538,7 +538,7 @@ prometheus.relabel "cadvisor" {
 discovery.relabel "kube_state_metrics" {
   targets = discovery.kubernetes.services.targets
   rule {
-    source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_instance"]
+    source_labels = ["__meta_kubernetes_service_label_release"]
     regex = "k8smon"
     action = "keep"
   }
@@ -578,7 +578,7 @@ prometheus.relabel "kube_state_metrics" {
 discovery.relabel "node_exporter" {
   targets = discovery.kubernetes.pods.targets
   rule {
-    source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_instance"]
+    source_labels = ["__meta_kubernetes_pod_label_release"]
     regex = "k8smon"
     action = "keep"
   }

--- a/examples/metric-module-imports/output.yaml
+++ b/examples/metric-module-imports/output.yaml
@@ -448,11 +448,6 @@ data:
     discovery.relabel "alloy" {
       targets = discovery.kubernetes.pods.targets
       rule {
-        source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_instance"]
-        regex = "k8smon"
-        action = "keep"
-      }
-      rule {
         source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
         regex = "alloy.*"
         action = "keep"
@@ -756,11 +751,6 @@ data:
     // OpenCost
     discovery.relabel "opencost" {
       targets = discovery.kubernetes.services.targets
-      rule {
-        source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_instance"]
-        regex = "k8smon"
-        action = "keep"
-      }
       rule {
         source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_name"]
         regex = "opencost"
@@ -59495,11 +59485,6 @@ data:
     discovery.relabel "alloy" {
       targets = discovery.kubernetes.pods.targets
       rule {
-        source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_instance"]
-        regex = "k8smon"
-        action = "keep"
-      }
-      rule {
         source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
         regex = "alloy.*"
         action = "keep"
@@ -59803,11 +59788,6 @@ data:
     // OpenCost
     discovery.relabel "opencost" {
       targets = discovery.kubernetes.services.targets
-      rule {
-        source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_instance"]
-        regex = "k8smon"
-        action = "keep"
-      }
       rule {
         source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_name"]
         regex = "opencost"

--- a/examples/metric-module-imports/output.yaml
+++ b/examples/metric-module-imports/output.yaml
@@ -60,6 +60,7 @@ metadata:
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/instance: k8smon
     app.kubernetes.io/version: "2.13.0"
+    release: k8smon
   name: k8smon-kube-state-metrics
   namespace: default
 ---
@@ -92,6 +93,7 @@ metadata:
     app.kubernetes.io/name: prometheus-node-exporter
     app.kubernetes.io/instance: k8smon
     app.kubernetes.io/version: "1.8.2"
+    release: k8smon
 automountServiceAccountToken: false
 ---
 # Source: k8s-monitoring/templates/log-service-credentials.yaml
@@ -668,7 +670,7 @@ data:
     discovery.relabel "kube_state_metrics" {
       targets = discovery.kubernetes.services.targets
       rule {
-        source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_instance"]
+        source_labels = ["__meta_kubernetes_service_label_release"]
         regex = "k8smon"
         action = "keep"
       }
@@ -708,7 +710,7 @@ data:
     discovery.relabel "node_exporter" {
       targets = discovery.kubernetes.pods.targets
       rule {
-        source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_instance"]
+        source_labels = ["__meta_kubernetes_pod_label_release"]
         regex = "k8smon"
         action = "keep"
       }
@@ -57863,6 +57865,7 @@ metadata:
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/instance: k8smon
     app.kubernetes.io/version: "2.13.0"
+    release: k8smon
   name: k8smon-kube-state-metrics
 rules:
 
@@ -58174,6 +58177,7 @@ metadata:
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/instance: k8smon
     app.kubernetes.io/version: "2.13.0"
+    release: k8smon
   name: k8smon-kube-state-metrics
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -58394,6 +58398,7 @@ metadata:
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/instance: k8smon
     app.kubernetes.io/version: "2.13.0"
+    release: k8smon
   annotations:
 spec:
   type: "ClusterIP"
@@ -58444,6 +58449,7 @@ metadata:
     app.kubernetes.io/name: prometheus-node-exporter
     app.kubernetes.io/instance: k8smon
     app.kubernetes.io/version: "1.8.2"
+    release: k8smon
 spec:
   type: ClusterIP
   ports:
@@ -58615,6 +58621,7 @@ metadata:
     app.kubernetes.io/name: prometheus-node-exporter
     app.kubernetes.io/instance: k8smon
     app.kubernetes.io/version: "1.8.2"
+    release: k8smon
 spec:
   selector:
     matchLabels:
@@ -58638,6 +58645,7 @@ spec:
         app.kubernetes.io/name: prometheus-node-exporter
         app.kubernetes.io/instance: k8smon
         app.kubernetes.io/version: "1.8.2"
+        release: k8smon
     spec:
       automountServiceAccountToken: false
       securityContext:
@@ -58821,6 +58829,7 @@ metadata:
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/instance: k8smon
     app.kubernetes.io/version: "2.13.0"
+    release: k8smon
 spec:
   selector:
     matchLabels:      
@@ -58840,6 +58849,7 @@ spec:
         app.kubernetes.io/name: kube-state-metrics
         app.kubernetes.io/instance: k8smon
         app.kubernetes.io/version: "2.13.0"
+        release: k8smon
     spec:
       automountServiceAccountToken: true
       hostNetwork: false
@@ -59707,7 +59717,7 @@ data:
     discovery.relabel "kube_state_metrics" {
       targets = discovery.kubernetes.services.targets
       rule {
-        source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_instance"]
+        source_labels = ["__meta_kubernetes_service_label_release"]
         regex = "k8smon"
         action = "keep"
       }
@@ -59747,7 +59757,7 @@ data:
     discovery.relabel "node_exporter" {
       targets = discovery.kubernetes.pods.targets
       rule {
-        source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_instance"]
+        source_labels = ["__meta_kubernetes_pod_label_release"]
         regex = "k8smon"
         action = "keep"
       }

--- a/examples/metrics-only/metrics.alloy
+++ b/examples/metrics-only/metrics.alloy
@@ -520,7 +520,7 @@ prometheus.relabel "cadvisor" {
 discovery.relabel "kube_state_metrics" {
   targets = discovery.kubernetes.services.targets
   rule {
-    source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_instance"]
+    source_labels = ["__meta_kubernetes_service_label_release"]
     regex = "k8smon"
     action = "keep"
   }
@@ -560,7 +560,7 @@ prometheus.relabel "kube_state_metrics" {
 discovery.relabel "node_exporter" {
   targets = discovery.kubernetes.pods.targets
   rule {
-    source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_instance"]
+    source_labels = ["__meta_kubernetes_pod_label_release"]
     regex = "k8smon"
     action = "keep"
   }

--- a/examples/metrics-only/metrics.alloy
+++ b/examples/metrics-only/metrics.alloy
@@ -298,11 +298,6 @@ prometheus.relabel "annotation_autodiscovery" {
 discovery.relabel "alloy" {
   targets = discovery.kubernetes.pods.targets
   rule {
-    source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_instance"]
-    regex = "k8smon"
-    action = "keep"
-  }
-  rule {
     source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
     regex = "alloy.*"
     action = "keep"
@@ -606,11 +601,6 @@ prometheus.relabel "node_exporter" {
 // OpenCost
 discovery.relabel "opencost" {
   targets = discovery.kubernetes.services.targets
-  rule {
-    source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_instance"]
-    regex = "k8smon"
-    action = "keep"
-  }
   rule {
     source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_name"]
     regex = "opencost"

--- a/examples/metrics-only/output.yaml
+++ b/examples/metrics-only/output.yaml
@@ -28,6 +28,7 @@ metadata:
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/instance: k8smon
     app.kubernetes.io/version: "2.13.0"
+    release: k8smon
   name: k8smon-kube-state-metrics
   namespace: default
 ---
@@ -60,6 +61,7 @@ metadata:
     app.kubernetes.io/name: prometheus-node-exporter
     app.kubernetes.io/instance: k8smon
     app.kubernetes.io/version: "1.8.2"
+    release: k8smon
 automountServiceAccountToken: false
 ---
 # Source: k8s-monitoring/templates/metrics-service-credentials.yaml
@@ -606,7 +608,7 @@ data:
     discovery.relabel "kube_state_metrics" {
       targets = discovery.kubernetes.services.targets
       rule {
-        source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_instance"]
+        source_labels = ["__meta_kubernetes_service_label_release"]
         regex = "k8smon"
         action = "keep"
       }
@@ -646,7 +648,7 @@ data:
     discovery.relabel "node_exporter" {
       targets = discovery.kubernetes.pods.targets
       rule {
-        source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_instance"]
+        source_labels = ["__meta_kubernetes_pod_label_release"]
         regex = "k8smon"
         action = "keep"
       }
@@ -57134,6 +57136,7 @@ metadata:
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/instance: k8smon
     app.kubernetes.io/version: "2.13.0"
+    release: k8smon
   name: k8smon-kube-state-metrics
 rules:
 
@@ -57399,6 +57402,7 @@ metadata:
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/instance: k8smon
     app.kubernetes.io/version: "2.13.0"
+    release: k8smon
   name: k8smon-kube-state-metrics
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -57567,6 +57571,7 @@ metadata:
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/instance: k8smon
     app.kubernetes.io/version: "2.13.0"
+    release: k8smon
   annotations:
 spec:
   type: "ClusterIP"
@@ -57617,6 +57622,7 @@ metadata:
     app.kubernetes.io/name: prometheus-node-exporter
     app.kubernetes.io/instance: k8smon
     app.kubernetes.io/version: "1.8.2"
+    release: k8smon
 spec:
   type: ClusterIP
   ports:
@@ -57699,6 +57705,7 @@ metadata:
     app.kubernetes.io/name: prometheus-node-exporter
     app.kubernetes.io/instance: k8smon
     app.kubernetes.io/version: "1.8.2"
+    release: k8smon
 spec:
   selector:
     matchLabels:
@@ -57722,6 +57729,7 @@ spec:
         app.kubernetes.io/name: prometheus-node-exporter
         app.kubernetes.io/instance: k8smon
         app.kubernetes.io/version: "1.8.2"
+        release: k8smon
     spec:
       automountServiceAccountToken: false
       securityContext:
@@ -57824,6 +57832,7 @@ metadata:
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/instance: k8smon
     app.kubernetes.io/version: "2.13.0"
+    release: k8smon
 spec:
   selector:
     matchLabels:      
@@ -57843,6 +57852,7 @@ spec:
         app.kubernetes.io/name: kube-state-metrics
         app.kubernetes.io/instance: k8smon
         app.kubernetes.io/version: "2.13.0"
+        release: k8smon
     spec:
       automountServiceAccountToken: true
       hostNetwork: false
@@ -58692,7 +58702,7 @@ data:
     discovery.relabel "kube_state_metrics" {
       targets = discovery.kubernetes.services.targets
       rule {
-        source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_instance"]
+        source_labels = ["__meta_kubernetes_service_label_release"]
         regex = "k8smon"
         action = "keep"
       }
@@ -58732,7 +58742,7 @@ data:
     discovery.relabel "node_exporter" {
       targets = discovery.kubernetes.pods.targets
       rule {
-        source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_instance"]
+        source_labels = ["__meta_kubernetes_pod_label_release"]
         regex = "k8smon"
         action = "keep"
       }

--- a/examples/metrics-only/output.yaml
+++ b/examples/metrics-only/output.yaml
@@ -386,11 +386,6 @@ data:
     discovery.relabel "alloy" {
       targets = discovery.kubernetes.pods.targets
       rule {
-        source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_instance"]
-        regex = "k8smon"
-        action = "keep"
-      }
-      rule {
         source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
         regex = "alloy.*"
         action = "keep"
@@ -694,11 +689,6 @@ data:
     // OpenCost
     discovery.relabel "opencost" {
       targets = discovery.kubernetes.services.targets
-      rule {
-        source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_instance"]
-        regex = "k8smon"
-        action = "keep"
-      }
       rule {
         source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_name"]
         regex = "opencost"
@@ -58480,11 +58470,6 @@ data:
     discovery.relabel "alloy" {
       targets = discovery.kubernetes.pods.targets
       rule {
-        source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_instance"]
-        regex = "k8smon"
-        action = "keep"
-      }
-      rule {
         source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
         regex = "alloy.*"
         action = "keep"
@@ -58788,11 +58773,6 @@ data:
     // OpenCost
     discovery.relabel "opencost" {
       targets = discovery.kubernetes.services.targets
-      rule {
-        source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_instance"]
-        regex = "k8smon"
-        action = "keep"
-      }
       rule {
         source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_name"]
         regex = "opencost"

--- a/examples/openshift-compatible/metrics.alloy
+++ b/examples/openshift-compatible/metrics.alloy
@@ -316,11 +316,6 @@ prometheus.relabel "annotation_autodiscovery" {
 discovery.relabel "alloy" {
   targets = discovery.kubernetes.pods.targets
   rule {
-    source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_instance"]
-    regex = "k8smon"
-    action = "keep"
-  }
-  rule {
     source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
     regex = "alloy.*"
     action = "keep"
@@ -625,11 +620,6 @@ prometheus.relabel "node_exporter" {
 // OpenCost
 discovery.relabel "opencost" {
   targets = discovery.kubernetes.services.targets
-  rule {
-    source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_instance"]
-    regex = "k8smon"
-    action = "keep"
-  }
   rule {
     source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_name"]
     regex = "opencost"

--- a/examples/openshift-compatible/output.yaml
+++ b/examples/openshift-compatible/output.yaml
@@ -414,11 +414,6 @@ data:
     discovery.relabel "alloy" {
       targets = discovery.kubernetes.pods.targets
       rule {
-        source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_instance"]
-        regex = "k8smon"
-        action = "keep"
-      }
-      rule {
         source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
         regex = "alloy.*"
         action = "keep"
@@ -723,11 +718,6 @@ data:
     // OpenCost
     discovery.relabel "opencost" {
       targets = discovery.kubernetes.services.targets
-      rule {
-        source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_instance"]
-        regex = "k8smon"
-        action = "keep"
-      }
       rule {
         source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_name"]
         regex = "opencost"
@@ -59152,11 +59142,6 @@ data:
     discovery.relabel "alloy" {
       targets = discovery.kubernetes.pods.targets
       rule {
-        source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_instance"]
-        regex = "k8smon"
-        action = "keep"
-      }
-      rule {
         source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
         regex = "alloy.*"
         action = "keep"
@@ -59461,11 +59446,6 @@ data:
     // OpenCost
     discovery.relabel "opencost" {
       targets = discovery.kubernetes.services.targets
-      rule {
-        source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_instance"]
-        regex = "k8smon"
-        action = "keep"
-      }
       rule {
         source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_name"]
         regex = "opencost"

--- a/examples/otel-metrics-service/metrics.alloy
+++ b/examples/otel-metrics-service/metrics.alloy
@@ -316,11 +316,6 @@ prometheus.relabel "annotation_autodiscovery" {
 discovery.relabel "alloy" {
   targets = discovery.kubernetes.pods.targets
   rule {
-    source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_instance"]
-    regex = "k8smon"
-    action = "keep"
-  }
-  rule {
     source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
     regex = "alloy.*"
     action = "keep"
@@ -624,11 +619,6 @@ prometheus.relabel "node_exporter" {
 // OpenCost
 discovery.relabel "opencost" {
   targets = discovery.kubernetes.services.targets
-  rule {
-    source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_instance"]
-    regex = "k8smon"
-    action = "keep"
-  }
   rule {
     source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_name"]
     regex = "opencost"

--- a/examples/otel-metrics-service/metrics.alloy
+++ b/examples/otel-metrics-service/metrics.alloy
@@ -538,7 +538,7 @@ prometheus.relabel "cadvisor" {
 discovery.relabel "kube_state_metrics" {
   targets = discovery.kubernetes.services.targets
   rule {
-    source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_instance"]
+    source_labels = ["__meta_kubernetes_service_label_release"]
     regex = "k8smon"
     action = "keep"
   }
@@ -578,7 +578,7 @@ prometheus.relabel "kube_state_metrics" {
 discovery.relabel "node_exporter" {
   targets = discovery.kubernetes.pods.targets
   rule {
-    source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_instance"]
+    source_labels = ["__meta_kubernetes_pod_label_release"]
     regex = "k8smon"
     action = "keep"
   }

--- a/examples/otel-metrics-service/output.yaml
+++ b/examples/otel-metrics-service/output.yaml
@@ -60,6 +60,7 @@ metadata:
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/instance: k8smon
     app.kubernetes.io/version: "2.13.0"
+    release: k8smon
   name: k8smon-kube-state-metrics
   namespace: default
 ---
@@ -92,6 +93,7 @@ metadata:
     app.kubernetes.io/name: prometheus-node-exporter
     app.kubernetes.io/instance: k8smon
     app.kubernetes.io/version: "1.8.2"
+    release: k8smon
 automountServiceAccountToken: false
 ---
 # Source: k8s-monitoring/templates/log-service-credentials.yaml
@@ -668,7 +670,7 @@ data:
     discovery.relabel "kube_state_metrics" {
       targets = discovery.kubernetes.services.targets
       rule {
-        source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_instance"]
+        source_labels = ["__meta_kubernetes_service_label_release"]
         regex = "k8smon"
         action = "keep"
       }
@@ -708,7 +710,7 @@ data:
     discovery.relabel "node_exporter" {
       targets = discovery.kubernetes.pods.targets
       rule {
-        source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_instance"]
+        source_labels = ["__meta_kubernetes_pod_label_release"]
         regex = "k8smon"
         action = "keep"
       }
@@ -57703,6 +57705,7 @@ metadata:
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/instance: k8smon
     app.kubernetes.io/version: "2.13.0"
+    release: k8smon
   name: k8smon-kube-state-metrics
 rules:
 
@@ -58014,6 +58017,7 @@ metadata:
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/instance: k8smon
     app.kubernetes.io/version: "2.13.0"
+    release: k8smon
   name: k8smon-kube-state-metrics
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -58234,6 +58238,7 @@ metadata:
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/instance: k8smon
     app.kubernetes.io/version: "2.13.0"
+    release: k8smon
   annotations:
 spec:
   type: "ClusterIP"
@@ -58284,6 +58289,7 @@ metadata:
     app.kubernetes.io/name: prometheus-node-exporter
     app.kubernetes.io/instance: k8smon
     app.kubernetes.io/version: "1.8.2"
+    release: k8smon
 spec:
   type: ClusterIP
   ports:
@@ -58455,6 +58461,7 @@ metadata:
     app.kubernetes.io/name: prometheus-node-exporter
     app.kubernetes.io/instance: k8smon
     app.kubernetes.io/version: "1.8.2"
+    release: k8smon
 spec:
   selector:
     matchLabels:
@@ -58478,6 +58485,7 @@ spec:
         app.kubernetes.io/name: prometheus-node-exporter
         app.kubernetes.io/instance: k8smon
         app.kubernetes.io/version: "1.8.2"
+        release: k8smon
     spec:
       automountServiceAccountToken: false
       securityContext:
@@ -58661,6 +58669,7 @@ metadata:
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/instance: k8smon
     app.kubernetes.io/version: "2.13.0"
+    release: k8smon
 spec:
   selector:
     matchLabels:      
@@ -58680,6 +58689,7 @@ spec:
         app.kubernetes.io/name: kube-state-metrics
         app.kubernetes.io/instance: k8smon
         app.kubernetes.io/version: "2.13.0"
+        release: k8smon
     spec:
       automountServiceAccountToken: true
       hostNetwork: false
@@ -59547,7 +59557,7 @@ data:
     discovery.relabel "kube_state_metrics" {
       targets = discovery.kubernetes.services.targets
       rule {
-        source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_instance"]
+        source_labels = ["__meta_kubernetes_service_label_release"]
         regex = "k8smon"
         action = "keep"
       }
@@ -59587,7 +59597,7 @@ data:
     discovery.relabel "node_exporter" {
       targets = discovery.kubernetes.pods.targets
       rule {
-        source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_instance"]
+        source_labels = ["__meta_kubernetes_pod_label_release"]
         regex = "k8smon"
         action = "keep"
       }

--- a/examples/otel-metrics-service/output.yaml
+++ b/examples/otel-metrics-service/output.yaml
@@ -448,11 +448,6 @@ data:
     discovery.relabel "alloy" {
       targets = discovery.kubernetes.pods.targets
       rule {
-        source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_instance"]
-        regex = "k8smon"
-        action = "keep"
-      }
-      rule {
         source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
         regex = "alloy.*"
         action = "keep"
@@ -756,11 +751,6 @@ data:
     // OpenCost
     discovery.relabel "opencost" {
       targets = discovery.kubernetes.services.targets
-      rule {
-        source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_instance"]
-        regex = "k8smon"
-        action = "keep"
-      }
       rule {
         source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_name"]
         regex = "opencost"
@@ -59335,11 +59325,6 @@ data:
     discovery.relabel "alloy" {
       targets = discovery.kubernetes.pods.targets
       rule {
-        source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_instance"]
-        regex = "k8smon"
-        action = "keep"
-      }
-      rule {
         source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
         regex = "alloy.*"
         action = "keep"
@@ -59643,11 +59628,6 @@ data:
     // OpenCost
     discovery.relabel "opencost" {
       targets = discovery.kubernetes.services.targets
-      rule {
-        source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_instance"]
-        regex = "k8smon"
-        action = "keep"
-      }
       rule {
         source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_name"]
         regex = "opencost"

--- a/examples/pod-labels/metrics.alloy
+++ b/examples/pod-labels/metrics.alloy
@@ -575,7 +575,7 @@ prometheus.relabel "cadvisor" {
 discovery.relabel "kube_state_metrics" {
   targets = discovery.kubernetes.services.targets
   rule {
-    source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_instance"]
+    source_labels = ["__meta_kubernetes_service_label_release"]
     regex = "k8smon"
     action = "keep"
   }
@@ -615,7 +615,7 @@ prometheus.relabel "kube_state_metrics" {
 discovery.relabel "node_exporter" {
   targets = discovery.kubernetes.pods.targets
   rule {
-    source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_instance"]
+    source_labels = ["__meta_kubernetes_pod_label_release"]
     regex = "k8smon"
     action = "keep"
   }

--- a/examples/pod-labels/metrics.alloy
+++ b/examples/pod-labels/metrics.alloy
@@ -353,11 +353,6 @@ prometheus.relabel "annotation_autodiscovery" {
 discovery.relabel "alloy" {
   targets = discovery.kubernetes.pods.targets
   rule {
-    source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_instance"]
-    regex = "k8smon"
-    action = "keep"
-  }
-  rule {
     source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
     regex = "alloy.*"
     action = "keep"
@@ -661,11 +656,6 @@ prometheus.relabel "node_exporter" {
 // OpenCost
 discovery.relabel "opencost" {
   targets = discovery.kubernetes.services.targets
-  rule {
-    source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_instance"]
-    regex = "k8smon"
-    action = "keep"
-  }
   rule {
     source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_name"]
     regex = "opencost"

--- a/examples/pod-labels/output.yaml
+++ b/examples/pod-labels/output.yaml
@@ -498,11 +498,6 @@ data:
     discovery.relabel "alloy" {
       targets = discovery.kubernetes.pods.targets
       rule {
-        source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_instance"]
-        regex = "k8smon"
-        action = "keep"
-      }
-      rule {
         source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
         regex = "alloy.*"
         action = "keep"
@@ -806,11 +801,6 @@ data:
     // OpenCost
     discovery.relabel "opencost" {
       targets = discovery.kubernetes.services.targets
-      rule {
-        source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_instance"]
-        regex = "k8smon"
-        action = "keep"
-      }
       rule {
         source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_name"]
         regex = "opencost"
@@ -59431,11 +59421,6 @@ data:
     discovery.relabel "alloy" {
       targets = discovery.kubernetes.pods.targets
       rule {
-        source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_instance"]
-        regex = "k8smon"
-        action = "keep"
-      }
-      rule {
         source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
         regex = "alloy.*"
         action = "keep"
@@ -59739,11 +59724,6 @@ data:
     // OpenCost
     discovery.relabel "opencost" {
       targets = discovery.kubernetes.services.targets
-      rule {
-        source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_instance"]
-        regex = "k8smon"
-        action = "keep"
-      }
       rule {
         source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_name"]
         regex = "opencost"

--- a/examples/pod-labels/output.yaml
+++ b/examples/pod-labels/output.yaml
@@ -60,6 +60,7 @@ metadata:
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/instance: k8smon
     app.kubernetes.io/version: "2.13.0"
+    release: k8smon
   name: k8smon-kube-state-metrics
   namespace: default
 ---
@@ -92,6 +93,7 @@ metadata:
     app.kubernetes.io/name: prometheus-node-exporter
     app.kubernetes.io/instance: k8smon
     app.kubernetes.io/version: "1.8.2"
+    release: k8smon
 automountServiceAccountToken: false
 ---
 # Source: k8s-monitoring/templates/log-service-credentials.yaml
@@ -718,7 +720,7 @@ data:
     discovery.relabel "kube_state_metrics" {
       targets = discovery.kubernetes.services.targets
       rule {
-        source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_instance"]
+        source_labels = ["__meta_kubernetes_service_label_release"]
         regex = "k8smon"
         action = "keep"
       }
@@ -758,7 +760,7 @@ data:
     discovery.relabel "node_exporter" {
       targets = discovery.kubernetes.pods.targets
       rule {
-        source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_instance"]
+        source_labels = ["__meta_kubernetes_pod_label_release"]
         regex = "k8smon"
         action = "keep"
       }
@@ -57762,6 +57764,7 @@ metadata:
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/instance: k8smon
     app.kubernetes.io/version: "2.13.0"
+    release: k8smon
   name: k8smon-kube-state-metrics
 rules:
 
@@ -58073,6 +58076,7 @@ metadata:
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/instance: k8smon
     app.kubernetes.io/version: "2.13.0"
+    release: k8smon
   name: k8smon-kube-state-metrics
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -58293,6 +58297,7 @@ metadata:
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/instance: k8smon
     app.kubernetes.io/version: "2.13.0"
+    release: k8smon
   annotations:
 spec:
   type: "ClusterIP"
@@ -58343,6 +58348,7 @@ metadata:
     app.kubernetes.io/name: prometheus-node-exporter
     app.kubernetes.io/instance: k8smon
     app.kubernetes.io/version: "1.8.2"
+    release: k8smon
 spec:
   type: ClusterIP
   ports:
@@ -58514,6 +58520,7 @@ metadata:
     app.kubernetes.io/name: prometheus-node-exporter
     app.kubernetes.io/instance: k8smon
     app.kubernetes.io/version: "1.8.2"
+    release: k8smon
 spec:
   selector:
     matchLabels:
@@ -58537,6 +58544,7 @@ spec:
         app.kubernetes.io/name: prometheus-node-exporter
         app.kubernetes.io/instance: k8smon
         app.kubernetes.io/version: "1.8.2"
+        release: k8smon
     spec:
       automountServiceAccountToken: false
       securityContext:
@@ -58720,6 +58728,7 @@ metadata:
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/instance: k8smon
     app.kubernetes.io/version: "2.13.0"
+    release: k8smon
 spec:
   selector:
     matchLabels:      
@@ -58739,6 +58748,7 @@ spec:
         app.kubernetes.io/name: kube-state-metrics
         app.kubernetes.io/instance: k8smon
         app.kubernetes.io/version: "2.13.0"
+        release: k8smon
     spec:
       automountServiceAccountToken: true
       hostNetwork: false
@@ -59643,7 +59653,7 @@ data:
     discovery.relabel "kube_state_metrics" {
       targets = discovery.kubernetes.services.targets
       rule {
-        source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_instance"]
+        source_labels = ["__meta_kubernetes_service_label_release"]
         regex = "k8smon"
         action = "keep"
       }
@@ -59683,7 +59693,7 @@ data:
     discovery.relabel "node_exporter" {
       targets = discovery.kubernetes.pods.targets
       rule {
-        source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_instance"]
+        source_labels = ["__meta_kubernetes_pod_label_release"]
         regex = "k8smon"
         action = "keep"
       }

--- a/examples/private-image-registry/metrics.alloy
+++ b/examples/private-image-registry/metrics.alloy
@@ -316,11 +316,6 @@ prometheus.relabel "annotation_autodiscovery" {
 discovery.relabel "alloy" {
   targets = discovery.kubernetes.pods.targets
   rule {
-    source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_instance"]
-    regex = "k8smon"
-    action = "keep"
-  }
-  rule {
     source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
     regex = "alloy.*"
     action = "keep"
@@ -624,11 +619,6 @@ prometheus.relabel "node_exporter" {
 // OpenCost
 discovery.relabel "opencost" {
   targets = discovery.kubernetes.services.targets
-  rule {
-    source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_instance"]
-    regex = "k8smon"
-    action = "keep"
-  }
   rule {
     source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_name"]
     regex = "opencost"

--- a/examples/private-image-registry/metrics.alloy
+++ b/examples/private-image-registry/metrics.alloy
@@ -538,7 +538,7 @@ prometheus.relabel "cadvisor" {
 discovery.relabel "kube_state_metrics" {
   targets = discovery.kubernetes.services.targets
   rule {
-    source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_instance"]
+    source_labels = ["__meta_kubernetes_service_label_release"]
     regex = "k8smon"
     action = "keep"
   }
@@ -578,7 +578,7 @@ prometheus.relabel "kube_state_metrics" {
 discovery.relabel "node_exporter" {
   targets = discovery.kubernetes.pods.targets
   rule {
-    source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_instance"]
+    source_labels = ["__meta_kubernetes_pod_label_release"]
     regex = "k8smon"
     action = "keep"
   }

--- a/examples/private-image-registry/output.yaml
+++ b/examples/private-image-registry/output.yaml
@@ -452,11 +452,6 @@ data:
     discovery.relabel "alloy" {
       targets = discovery.kubernetes.pods.targets
       rule {
-        source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_instance"]
-        regex = "k8smon"
-        action = "keep"
-      }
-      rule {
         source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
         regex = "alloy.*"
         action = "keep"
@@ -760,11 +755,6 @@ data:
     // OpenCost
     discovery.relabel "opencost" {
       targets = discovery.kubernetes.services.targets
-      rule {
-        source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_instance"]
-        regex = "k8smon"
-        action = "keep"
-      }
       rule {
         source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_name"]
         regex = "opencost"
@@ -59334,11 +59324,6 @@ data:
     discovery.relabel "alloy" {
       targets = discovery.kubernetes.pods.targets
       rule {
-        source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_instance"]
-        regex = "k8smon"
-        action = "keep"
-      }
-      rule {
         source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
         regex = "alloy.*"
         action = "keep"
@@ -59642,11 +59627,6 @@ data:
     // OpenCost
     discovery.relabel "opencost" {
       targets = discovery.kubernetes.services.targets
-      rule {
-        source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_instance"]
-        regex = "k8smon"
-        action = "keep"
-      }
       rule {
         source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_name"]
         regex = "opencost"

--- a/examples/private-image-registry/output.yaml
+++ b/examples/private-image-registry/output.yaml
@@ -60,6 +60,7 @@ metadata:
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/instance: k8smon
     app.kubernetes.io/version: "2.13.0"
+    release: k8smon
   name: k8smon-kube-state-metrics
   namespace: default
 imagePullSecrets:  
@@ -94,6 +95,7 @@ metadata:
     app.kubernetes.io/name: prometheus-node-exporter
     app.kubernetes.io/instance: k8smon
     app.kubernetes.io/version: "1.8.2"
+    release: k8smon
 automountServiceAccountToken: false
 imagePullSecrets:  
   - name: my-registry-creds
@@ -672,7 +674,7 @@ data:
     discovery.relabel "kube_state_metrics" {
       targets = discovery.kubernetes.services.targets
       rule {
-        source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_instance"]
+        source_labels = ["__meta_kubernetes_service_label_release"]
         regex = "k8smon"
         action = "keep"
       }
@@ -712,7 +714,7 @@ data:
     discovery.relabel "node_exporter" {
       targets = discovery.kubernetes.pods.targets
       rule {
-        source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_instance"]
+        source_labels = ["__meta_kubernetes_pod_label_release"]
         regex = "k8smon"
         action = "keep"
       }
@@ -57690,6 +57692,7 @@ metadata:
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/instance: k8smon
     app.kubernetes.io/version: "2.13.0"
+    release: k8smon
   name: k8smon-kube-state-metrics
 rules:
 
@@ -58001,6 +58004,7 @@ metadata:
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/instance: k8smon
     app.kubernetes.io/version: "2.13.0"
+    release: k8smon
   name: k8smon-kube-state-metrics
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -58221,6 +58225,7 @@ metadata:
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/instance: k8smon
     app.kubernetes.io/version: "2.13.0"
+    release: k8smon
   annotations:
 spec:
   type: "ClusterIP"
@@ -58271,6 +58276,7 @@ metadata:
     app.kubernetes.io/name: prometheus-node-exporter
     app.kubernetes.io/instance: k8smon
     app.kubernetes.io/version: "1.8.2"
+    release: k8smon
 spec:
   type: ClusterIP
   ports:
@@ -58444,6 +58450,7 @@ metadata:
     app.kubernetes.io/name: prometheus-node-exporter
     app.kubernetes.io/instance: k8smon
     app.kubernetes.io/version: "1.8.2"
+    release: k8smon
 spec:
   selector:
     matchLabels:
@@ -58467,6 +58474,7 @@ spec:
         app.kubernetes.io/name: prometheus-node-exporter
         app.kubernetes.io/instance: k8smon
         app.kubernetes.io/version: "1.8.2"
+        release: k8smon
     spec:
       automountServiceAccountToken: false
       securityContext:
@@ -58654,6 +58662,7 @@ metadata:
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/instance: k8smon
     app.kubernetes.io/version: "2.13.0"
+    release: k8smon
 spec:
   selector:
     matchLabels:      
@@ -58673,6 +58682,7 @@ spec:
         app.kubernetes.io/name: kube-state-metrics
         app.kubernetes.io/instance: k8smon
         app.kubernetes.io/version: "2.13.0"
+        release: k8smon
     spec:
       automountServiceAccountToken: true
       hostNetwork: false
@@ -59546,7 +59556,7 @@ data:
     discovery.relabel "kube_state_metrics" {
       targets = discovery.kubernetes.services.targets
       rule {
-        source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_instance"]
+        source_labels = ["__meta_kubernetes_service_label_release"]
         regex = "k8smon"
         action = "keep"
       }
@@ -59586,7 +59596,7 @@ data:
     discovery.relabel "node_exporter" {
       targets = discovery.kubernetes.pods.targets
       rule {
-        source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_instance"]
+        source_labels = ["__meta_kubernetes_pod_label_release"]
         regex = "k8smon"
         action = "keep"
       }

--- a/examples/profiles-enabled/metrics.alloy
+++ b/examples/profiles-enabled/metrics.alloy
@@ -316,11 +316,6 @@ prometheus.relabel "annotation_autodiscovery" {
 discovery.relabel "alloy" {
   targets = discovery.kubernetes.pods.targets
   rule {
-    source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_instance"]
-    regex = "k8smon"
-    action = "keep"
-  }
-  rule {
     source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
     regex = "alloy.*"
     action = "keep"
@@ -624,11 +619,6 @@ prometheus.relabel "node_exporter" {
 // OpenCost
 discovery.relabel "opencost" {
   targets = discovery.kubernetes.services.targets
-  rule {
-    source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_instance"]
-    regex = "k8smon"
-    action = "keep"
-  }
   rule {
     source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_name"]
     regex = "opencost"

--- a/examples/profiles-enabled/metrics.alloy
+++ b/examples/profiles-enabled/metrics.alloy
@@ -538,7 +538,7 @@ prometheus.relabel "cadvisor" {
 discovery.relabel "kube_state_metrics" {
   targets = discovery.kubernetes.services.targets
   rule {
-    source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_instance"]
+    source_labels = ["__meta_kubernetes_service_label_release"]
     regex = "k8smon"
     action = "keep"
   }
@@ -578,7 +578,7 @@ prometheus.relabel "kube_state_metrics" {
 discovery.relabel "node_exporter" {
   targets = discovery.kubernetes.pods.targets
   rule {
-    source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_instance"]
+    source_labels = ["__meta_kubernetes_pod_label_release"]
     regex = "k8smon"
     action = "keep"
   }

--- a/examples/profiles-enabled/output.yaml
+++ b/examples/profiles-enabled/output.yaml
@@ -477,11 +477,6 @@ data:
     discovery.relabel "alloy" {
       targets = discovery.kubernetes.pods.targets
       rule {
-        source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_instance"]
-        regex = "k8smon"
-        action = "keep"
-      }
-      rule {
         source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
         regex = "alloy.*"
         action = "keep"
@@ -785,11 +780,6 @@ data:
     // OpenCost
     discovery.relabel "opencost" {
       targets = discovery.kubernetes.services.targets
-      rule {
-        source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_instance"]
-        regex = "k8smon"
-        action = "keep"
-      }
       rule {
         source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_name"]
         regex = "opencost"
@@ -60514,11 +60504,6 @@ data:
     discovery.relabel "alloy" {
       targets = discovery.kubernetes.pods.targets
       rule {
-        source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_instance"]
-        regex = "k8smon"
-        action = "keep"
-      }
-      rule {
         source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
         regex = "alloy.*"
         action = "keep"
@@ -60822,11 +60807,6 @@ data:
     // OpenCost
     discovery.relabel "opencost" {
       targets = discovery.kubernetes.services.targets
-      rule {
-        source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_instance"]
-        regex = "k8smon"
-        action = "keep"
-      }
       rule {
         source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_name"]
         regex = "opencost"

--- a/examples/profiles-enabled/output.yaml
+++ b/examples/profiles-enabled/output.yaml
@@ -76,6 +76,7 @@ metadata:
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/instance: k8smon
     app.kubernetes.io/version: "2.13.0"
+    release: k8smon
   name: k8smon-kube-state-metrics
   namespace: default
 ---
@@ -108,6 +109,7 @@ metadata:
     app.kubernetes.io/name: prometheus-node-exporter
     app.kubernetes.io/instance: k8smon
     app.kubernetes.io/version: "1.8.2"
+    release: k8smon
 automountServiceAccountToken: false
 ---
 # Source: k8s-monitoring/templates/log-service-credentials.yaml
@@ -697,7 +699,7 @@ data:
     discovery.relabel "kube_state_metrics" {
       targets = discovery.kubernetes.services.targets
       rule {
-        source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_instance"]
+        source_labels = ["__meta_kubernetes_service_label_release"]
         regex = "k8smon"
         action = "keep"
       }
@@ -737,7 +739,7 @@ data:
     discovery.relabel "node_exporter" {
       targets = discovery.kubernetes.pods.targets
       rule {
-        source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_instance"]
+        source_labels = ["__meta_kubernetes_pod_label_release"]
         regex = "k8smon"
         action = "keep"
       }
@@ -58745,6 +58747,7 @@ metadata:
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/instance: k8smon
     app.kubernetes.io/version: "2.13.0"
+    release: k8smon
   name: k8smon-kube-state-metrics
 rules:
 
@@ -59079,6 +59082,7 @@ metadata:
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/instance: k8smon
     app.kubernetes.io/version: "2.13.0"
+    release: k8smon
   name: k8smon-kube-state-metrics
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -59325,6 +59329,7 @@ metadata:
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/instance: k8smon
     app.kubernetes.io/version: "2.13.0"
+    release: k8smon
   annotations:
 spec:
   type: "ClusterIP"
@@ -59375,6 +59380,7 @@ metadata:
     app.kubernetes.io/name: prometheus-node-exporter
     app.kubernetes.io/instance: k8smon
     app.kubernetes.io/version: "1.8.2"
+    release: k8smon
 spec:
   type: ClusterIP
   ports:
@@ -59634,6 +59640,7 @@ metadata:
     app.kubernetes.io/name: prometheus-node-exporter
     app.kubernetes.io/instance: k8smon
     app.kubernetes.io/version: "1.8.2"
+    release: k8smon
 spec:
   selector:
     matchLabels:
@@ -59657,6 +59664,7 @@ spec:
         app.kubernetes.io/name: prometheus-node-exporter
         app.kubernetes.io/instance: k8smon
         app.kubernetes.io/version: "1.8.2"
+        release: k8smon
     spec:
       automountServiceAccountToken: false
       securityContext:
@@ -59840,6 +59848,7 @@ metadata:
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/instance: k8smon
     app.kubernetes.io/version: "2.13.0"
+    release: k8smon
 spec:
   selector:
     matchLabels:      
@@ -59859,6 +59868,7 @@ spec:
         app.kubernetes.io/name: kube-state-metrics
         app.kubernetes.io/instance: k8smon
         app.kubernetes.io/version: "2.13.0"
+        release: k8smon
     spec:
       automountServiceAccountToken: true
       hostNetwork: false
@@ -60726,7 +60736,7 @@ data:
     discovery.relabel "kube_state_metrics" {
       targets = discovery.kubernetes.services.targets
       rule {
-        source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_instance"]
+        source_labels = ["__meta_kubernetes_service_label_release"]
         regex = "k8smon"
         action = "keep"
       }
@@ -60766,7 +60776,7 @@ data:
     discovery.relabel "node_exporter" {
       targets = discovery.kubernetes.pods.targets
       rule {
-        source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_instance"]
+        source_labels = ["__meta_kubernetes_pod_label_release"]
         regex = "k8smon"
         action = "keep"
       }

--- a/examples/proxies/metrics.alloy
+++ b/examples/proxies/metrics.alloy
@@ -316,11 +316,6 @@ prometheus.relabel "annotation_autodiscovery" {
 discovery.relabel "alloy" {
   targets = discovery.kubernetes.pods.targets
   rule {
-    source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_instance"]
-    regex = "k8smon"
-    action = "keep"
-  }
-  rule {
     source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
     regex = "alloy.*"
     action = "keep"
@@ -624,11 +619,6 @@ prometheus.relabel "node_exporter" {
 // OpenCost
 discovery.relabel "opencost" {
   targets = discovery.kubernetes.services.targets
-  rule {
-    source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_instance"]
-    regex = "k8smon"
-    action = "keep"
-  }
   rule {
     source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_name"]
     regex = "opencost"

--- a/examples/proxies/metrics.alloy
+++ b/examples/proxies/metrics.alloy
@@ -538,7 +538,7 @@ prometheus.relabel "cadvisor" {
 discovery.relabel "kube_state_metrics" {
   targets = discovery.kubernetes.services.targets
   rule {
-    source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_instance"]
+    source_labels = ["__meta_kubernetes_service_label_release"]
     regex = "k8smon"
     action = "keep"
   }
@@ -578,7 +578,7 @@ prometheus.relabel "kube_state_metrics" {
 discovery.relabel "node_exporter" {
   targets = discovery.kubernetes.pods.targets
   rule {
-    source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_instance"]
+    source_labels = ["__meta_kubernetes_pod_label_release"]
     regex = "k8smon"
     action = "keep"
   }

--- a/examples/proxies/output.yaml
+++ b/examples/proxies/output.yaml
@@ -60,6 +60,7 @@ metadata:
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/instance: k8smon
     app.kubernetes.io/version: "2.13.0"
+    release: k8smon
   name: k8smon-kube-state-metrics
   namespace: default
 ---
@@ -92,6 +93,7 @@ metadata:
     app.kubernetes.io/name: prometheus-node-exporter
     app.kubernetes.io/instance: k8smon
     app.kubernetes.io/version: "1.8.2"
+    release: k8smon
 automountServiceAccountToken: false
 ---
 # Source: k8s-monitoring/templates/log-service-credentials.yaml
@@ -668,7 +670,7 @@ data:
     discovery.relabel "kube_state_metrics" {
       targets = discovery.kubernetes.services.targets
       rule {
-        source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_instance"]
+        source_labels = ["__meta_kubernetes_service_label_release"]
         regex = "k8smon"
         action = "keep"
       }
@@ -708,7 +710,7 @@ data:
     discovery.relabel "node_exporter" {
       targets = discovery.kubernetes.pods.targets
       rule {
-        source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_instance"]
+        source_labels = ["__meta_kubernetes_pod_label_release"]
         regex = "k8smon"
         action = "keep"
       }
@@ -57702,6 +57704,7 @@ metadata:
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/instance: k8smon
     app.kubernetes.io/version: "2.13.0"
+    release: k8smon
   name: k8smon-kube-state-metrics
 rules:
 
@@ -58013,6 +58016,7 @@ metadata:
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/instance: k8smon
     app.kubernetes.io/version: "2.13.0"
+    release: k8smon
   name: k8smon-kube-state-metrics
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -58233,6 +58237,7 @@ metadata:
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/instance: k8smon
     app.kubernetes.io/version: "2.13.0"
+    release: k8smon
   annotations:
 spec:
   type: "ClusterIP"
@@ -58283,6 +58288,7 @@ metadata:
     app.kubernetes.io/name: prometheus-node-exporter
     app.kubernetes.io/instance: k8smon
     app.kubernetes.io/version: "1.8.2"
+    release: k8smon
 spec:
   type: ClusterIP
   ports:
@@ -58454,6 +58460,7 @@ metadata:
     app.kubernetes.io/name: prometheus-node-exporter
     app.kubernetes.io/instance: k8smon
     app.kubernetes.io/version: "1.8.2"
+    release: k8smon
 spec:
   selector:
     matchLabels:
@@ -58477,6 +58484,7 @@ spec:
         app.kubernetes.io/name: prometheus-node-exporter
         app.kubernetes.io/instance: k8smon
         app.kubernetes.io/version: "1.8.2"
+        release: k8smon
     spec:
       automountServiceAccountToken: false
       securityContext:
@@ -58660,6 +58668,7 @@ metadata:
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/instance: k8smon
     app.kubernetes.io/version: "2.13.0"
+    release: k8smon
 spec:
   selector:
     matchLabels:      
@@ -58679,6 +58688,7 @@ spec:
         app.kubernetes.io/name: kube-state-metrics
         app.kubernetes.io/instance: k8smon
         app.kubernetes.io/version: "2.13.0"
+        release: k8smon
     spec:
       automountServiceAccountToken: true
       hostNetwork: false
@@ -59546,7 +59556,7 @@ data:
     discovery.relabel "kube_state_metrics" {
       targets = discovery.kubernetes.services.targets
       rule {
-        source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_instance"]
+        source_labels = ["__meta_kubernetes_service_label_release"]
         regex = "k8smon"
         action = "keep"
       }
@@ -59586,7 +59596,7 @@ data:
     discovery.relabel "node_exporter" {
       targets = discovery.kubernetes.pods.targets
       rule {
-        source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_instance"]
+        source_labels = ["__meta_kubernetes_pod_label_release"]
         regex = "k8smon"
         action = "keep"
       }

--- a/examples/proxies/output.yaml
+++ b/examples/proxies/output.yaml
@@ -448,11 +448,6 @@ data:
     discovery.relabel "alloy" {
       targets = discovery.kubernetes.pods.targets
       rule {
-        source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_instance"]
-        regex = "k8smon"
-        action = "keep"
-      }
-      rule {
         source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
         regex = "alloy.*"
         action = "keep"
@@ -756,11 +751,6 @@ data:
     // OpenCost
     discovery.relabel "opencost" {
       targets = discovery.kubernetes.services.targets
-      rule {
-        source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_instance"]
-        regex = "k8smon"
-        action = "keep"
-      }
       rule {
         source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_name"]
         regex = "opencost"
@@ -59334,11 +59324,6 @@ data:
     discovery.relabel "alloy" {
       targets = discovery.kubernetes.pods.targets
       rule {
-        source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_instance"]
-        regex = "k8smon"
-        action = "keep"
-      }
-      rule {
         source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
         regex = "alloy.*"
         action = "keep"
@@ -59642,11 +59627,6 @@ data:
     // OpenCost
     discovery.relabel "opencost" {
       targets = discovery.kubernetes.services.targets
-      rule {
-        source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_instance"]
-        regex = "k8smon"
-        action = "keep"
-      }
       rule {
         source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_name"]
         regex = "opencost"

--- a/examples/scrape-intervals/metrics.alloy
+++ b/examples/scrape-intervals/metrics.alloy
@@ -520,7 +520,7 @@ prometheus.relabel "cadvisor" {
 discovery.relabel "kube_state_metrics" {
   targets = discovery.kubernetes.services.targets
   rule {
-    source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_instance"]
+    source_labels = ["__meta_kubernetes_service_label_release"]
     regex = "k8smon"
     action = "keep"
   }
@@ -560,7 +560,7 @@ prometheus.relabel "kube_state_metrics" {
 discovery.relabel "node_exporter" {
   targets = discovery.kubernetes.pods.targets
   rule {
-    source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_instance"]
+    source_labels = ["__meta_kubernetes_pod_label_release"]
     regex = "k8smon"
     action = "keep"
   }

--- a/examples/scrape-intervals/metrics.alloy
+++ b/examples/scrape-intervals/metrics.alloy
@@ -298,11 +298,6 @@ prometheus.relabel "annotation_autodiscovery" {
 discovery.relabel "alloy" {
   targets = discovery.kubernetes.pods.targets
   rule {
-    source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_instance"]
-    regex = "k8smon"
-    action = "keep"
-  }
-  rule {
     source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
     regex = "alloy.*"
     action = "keep"
@@ -606,11 +601,6 @@ prometheus.relabel "node_exporter" {
 // OpenCost
 discovery.relabel "opencost" {
   targets = discovery.kubernetes.services.targets
-  rule {
-    source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_instance"]
-    regex = "k8smon"
-    action = "keep"
-  }
   rule {
     source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_name"]
     regex = "opencost"

--- a/examples/scrape-intervals/output.yaml
+++ b/examples/scrape-intervals/output.yaml
@@ -385,11 +385,6 @@ data:
     discovery.relabel "alloy" {
       targets = discovery.kubernetes.pods.targets
       rule {
-        source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_instance"]
-        regex = "k8smon"
-        action = "keep"
-      }
-      rule {
         source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
         regex = "alloy.*"
         action = "keep"
@@ -693,11 +688,6 @@ data:
     // OpenCost
     discovery.relabel "opencost" {
       targets = discovery.kubernetes.services.targets
-      rule {
-        source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_instance"]
-        regex = "k8smon"
-        action = "keep"
-      }
       rule {
         source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_name"]
         regex = "opencost"
@@ -58479,11 +58469,6 @@ data:
     discovery.relabel "alloy" {
       targets = discovery.kubernetes.pods.targets
       rule {
-        source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_instance"]
-        regex = "k8smon"
-        action = "keep"
-      }
-      rule {
         source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
         regex = "alloy.*"
         action = "keep"
@@ -58787,11 +58772,6 @@ data:
     // OpenCost
     discovery.relabel "opencost" {
       targets = discovery.kubernetes.services.targets
-      rule {
-        source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_instance"]
-        regex = "k8smon"
-        action = "keep"
-      }
       rule {
         source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_name"]
         regex = "opencost"

--- a/examples/scrape-intervals/output.yaml
+++ b/examples/scrape-intervals/output.yaml
@@ -28,6 +28,7 @@ metadata:
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/instance: k8smon
     app.kubernetes.io/version: "2.13.0"
+    release: k8smon
   name: k8smon-kube-state-metrics
   namespace: default
 ---
@@ -60,6 +61,7 @@ metadata:
     app.kubernetes.io/name: prometheus-node-exporter
     app.kubernetes.io/instance: k8smon
     app.kubernetes.io/version: "1.8.2"
+    release: k8smon
 automountServiceAccountToken: false
 ---
 # Source: k8s-monitoring/templates/metrics-service-credentials.yaml
@@ -605,7 +607,7 @@ data:
     discovery.relabel "kube_state_metrics" {
       targets = discovery.kubernetes.services.targets
       rule {
-        source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_instance"]
+        source_labels = ["__meta_kubernetes_service_label_release"]
         regex = "k8smon"
         action = "keep"
       }
@@ -645,7 +647,7 @@ data:
     discovery.relabel "node_exporter" {
       targets = discovery.kubernetes.pods.targets
       rule {
-        source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_instance"]
+        source_labels = ["__meta_kubernetes_pod_label_release"]
         regex = "k8smon"
         action = "keep"
       }
@@ -57133,6 +57135,7 @@ metadata:
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/instance: k8smon
     app.kubernetes.io/version: "2.13.0"
+    release: k8smon
   name: k8smon-kube-state-metrics
 rules:
 
@@ -57398,6 +57401,7 @@ metadata:
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/instance: k8smon
     app.kubernetes.io/version: "2.13.0"
+    release: k8smon
   name: k8smon-kube-state-metrics
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -57566,6 +57570,7 @@ metadata:
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/instance: k8smon
     app.kubernetes.io/version: "2.13.0"
+    release: k8smon
   annotations:
 spec:
   type: "ClusterIP"
@@ -57616,6 +57621,7 @@ metadata:
     app.kubernetes.io/name: prometheus-node-exporter
     app.kubernetes.io/instance: k8smon
     app.kubernetes.io/version: "1.8.2"
+    release: k8smon
 spec:
   type: ClusterIP
   ports:
@@ -57698,6 +57704,7 @@ metadata:
     app.kubernetes.io/name: prometheus-node-exporter
     app.kubernetes.io/instance: k8smon
     app.kubernetes.io/version: "1.8.2"
+    release: k8smon
 spec:
   selector:
     matchLabels:
@@ -57721,6 +57728,7 @@ spec:
         app.kubernetes.io/name: prometheus-node-exporter
         app.kubernetes.io/instance: k8smon
         app.kubernetes.io/version: "1.8.2"
+        release: k8smon
     spec:
       automountServiceAccountToken: false
       securityContext:
@@ -57823,6 +57831,7 @@ metadata:
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/instance: k8smon
     app.kubernetes.io/version: "2.13.0"
+    release: k8smon
 spec:
   selector:
     matchLabels:      
@@ -57842,6 +57851,7 @@ spec:
         app.kubernetes.io/name: kube-state-metrics
         app.kubernetes.io/instance: k8smon
         app.kubernetes.io/version: "2.13.0"
+        release: k8smon
     spec:
       automountServiceAccountToken: true
       hostNetwork: false
@@ -58691,7 +58701,7 @@ data:
     discovery.relabel "kube_state_metrics" {
       targets = discovery.kubernetes.services.targets
       rule {
-        source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_instance"]
+        source_labels = ["__meta_kubernetes_service_label_release"]
         regex = "k8smon"
         action = "keep"
       }
@@ -58731,7 +58741,7 @@ data:
     discovery.relabel "node_exporter" {
       targets = discovery.kubernetes.pods.targets
       rule {
-        source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_instance"]
+        source_labels = ["__meta_kubernetes_pod_label_release"]
         regex = "k8smon"
         action = "keep"
       }

--- a/examples/service-integrations/metrics.alloy
+++ b/examples/service-integrations/metrics.alloy
@@ -316,11 +316,6 @@ prometheus.relabel "annotation_autodiscovery" {
 discovery.relabel "alloy" {
   targets = discovery.kubernetes.pods.targets
   rule {
-    source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_instance"]
-    regex = "k8smon"
-    action = "keep"
-  }
-  rule {
     source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
     regex = "alloy.*"
     action = "keep"
@@ -624,11 +619,6 @@ prometheus.relabel "node_exporter" {
 // OpenCost
 discovery.relabel "opencost" {
   targets = discovery.kubernetes.services.targets
-  rule {
-    source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_instance"]
-    regex = "k8smon"
-    action = "keep"
-  }
   rule {
     source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_name"]
     regex = "opencost"

--- a/examples/service-integrations/metrics.alloy
+++ b/examples/service-integrations/metrics.alloy
@@ -538,7 +538,7 @@ prometheus.relabel "cadvisor" {
 discovery.relabel "kube_state_metrics" {
   targets = discovery.kubernetes.services.targets
   rule {
-    source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_instance"]
+    source_labels = ["__meta_kubernetes_service_label_release"]
     regex = "k8smon"
     action = "keep"
   }
@@ -578,7 +578,7 @@ prometheus.relabel "kube_state_metrics" {
 discovery.relabel "node_exporter" {
   targets = discovery.kubernetes.pods.targets
   rule {
-    source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_instance"]
+    source_labels = ["__meta_kubernetes_pod_label_release"]
     regex = "k8smon"
     action = "keep"
   }

--- a/examples/service-integrations/output.yaml
+++ b/examples/service-integrations/output.yaml
@@ -448,11 +448,6 @@ data:
     discovery.relabel "alloy" {
       targets = discovery.kubernetes.pods.targets
       rule {
-        source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_instance"]
-        regex = "k8smon"
-        action = "keep"
-      }
-      rule {
         source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
         regex = "alloy.*"
         action = "keep"
@@ -756,11 +751,6 @@ data:
     // OpenCost
     discovery.relabel "opencost" {
       targets = discovery.kubernetes.services.targets
-      rule {
-        source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_instance"]
-        regex = "k8smon"
-        action = "keep"
-      }
       rule {
         source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_name"]
         regex = "opencost"
@@ -59353,11 +59343,6 @@ data:
     discovery.relabel "alloy" {
       targets = discovery.kubernetes.pods.targets
       rule {
-        source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_instance"]
-        regex = "k8smon"
-        action = "keep"
-      }
-      rule {
         source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
         regex = "alloy.*"
         action = "keep"
@@ -59661,11 +59646,6 @@ data:
     // OpenCost
     discovery.relabel "opencost" {
       targets = discovery.kubernetes.services.targets
-      rule {
-        source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_instance"]
-        regex = "k8smon"
-        action = "keep"
-      }
       rule {
         source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_name"]
         regex = "opencost"

--- a/examples/service-integrations/output.yaml
+++ b/examples/service-integrations/output.yaml
@@ -60,6 +60,7 @@ metadata:
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/instance: k8smon
     app.kubernetes.io/version: "2.13.0"
+    release: k8smon
   name: k8smon-kube-state-metrics
   namespace: default
 ---
@@ -92,6 +93,7 @@ metadata:
     app.kubernetes.io/name: prometheus-node-exporter
     app.kubernetes.io/instance: k8smon
     app.kubernetes.io/version: "1.8.2"
+    release: k8smon
 automountServiceAccountToken: false
 ---
 # Source: k8s-monitoring/templates/log-service-credentials.yaml
@@ -668,7 +670,7 @@ data:
     discovery.relabel "kube_state_metrics" {
       targets = discovery.kubernetes.services.targets
       rule {
-        source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_instance"]
+        source_labels = ["__meta_kubernetes_service_label_release"]
         regex = "k8smon"
         action = "keep"
       }
@@ -708,7 +710,7 @@ data:
     discovery.relabel "node_exporter" {
       targets = discovery.kubernetes.pods.targets
       rule {
-        source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_instance"]
+        source_labels = ["__meta_kubernetes_pod_label_release"]
         regex = "k8smon"
         action = "keep"
       }
@@ -57721,6 +57723,7 @@ metadata:
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/instance: k8smon
     app.kubernetes.io/version: "2.13.0"
+    release: k8smon
   name: k8smon-kube-state-metrics
 rules:
 
@@ -58032,6 +58035,7 @@ metadata:
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/instance: k8smon
     app.kubernetes.io/version: "2.13.0"
+    release: k8smon
   name: k8smon-kube-state-metrics
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -58252,6 +58256,7 @@ metadata:
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/instance: k8smon
     app.kubernetes.io/version: "2.13.0"
+    release: k8smon
   annotations:
 spec:
   type: "ClusterIP"
@@ -58302,6 +58307,7 @@ metadata:
     app.kubernetes.io/name: prometheus-node-exporter
     app.kubernetes.io/instance: k8smon
     app.kubernetes.io/version: "1.8.2"
+    release: k8smon
 spec:
   type: ClusterIP
   ports:
@@ -58473,6 +58479,7 @@ metadata:
     app.kubernetes.io/name: prometheus-node-exporter
     app.kubernetes.io/instance: k8smon
     app.kubernetes.io/version: "1.8.2"
+    release: k8smon
 spec:
   selector:
     matchLabels:
@@ -58496,6 +58503,7 @@ spec:
         app.kubernetes.io/name: prometheus-node-exporter
         app.kubernetes.io/instance: k8smon
         app.kubernetes.io/version: "1.8.2"
+        release: k8smon
     spec:
       automountServiceAccountToken: false
       securityContext:
@@ -58679,6 +58687,7 @@ metadata:
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/instance: k8smon
     app.kubernetes.io/version: "2.13.0"
+    release: k8smon
 spec:
   selector:
     matchLabels:      
@@ -58698,6 +58707,7 @@ spec:
         app.kubernetes.io/name: kube-state-metrics
         app.kubernetes.io/instance: k8smon
         app.kubernetes.io/version: "2.13.0"
+        release: k8smon
     spec:
       automountServiceAccountToken: true
       hostNetwork: false
@@ -59565,7 +59575,7 @@ data:
     discovery.relabel "kube_state_metrics" {
       targets = discovery.kubernetes.services.targets
       rule {
-        source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_instance"]
+        source_labels = ["__meta_kubernetes_service_label_release"]
         regex = "k8smon"
         action = "keep"
       }
@@ -59605,7 +59615,7 @@ data:
     discovery.relabel "node_exporter" {
       targets = discovery.kubernetes.pods.targets
       rule {
-        source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_instance"]
+        source_labels = ["__meta_kubernetes_pod_label_release"]
         regex = "k8smon"
         action = "keep"
       }

--- a/examples/specific-namespace/metrics.alloy
+++ b/examples/specific-namespace/metrics.alloy
@@ -321,11 +321,6 @@ prometheus.relabel "annotation_autodiscovery" {
 discovery.relabel "alloy" {
   targets = discovery.kubernetes.pods.targets
   rule {
-    source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_instance"]
-    regex = "k8smon"
-    action = "keep"
-  }
-  rule {
     source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
     regex = "alloy.*"
     action = "keep"
@@ -654,11 +649,6 @@ prometheus.relabel "node_exporter" {
 // OpenCost
 discovery.relabel "opencost" {
   targets = discovery.kubernetes.services.targets
-  rule {
-    source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_instance"]
-    regex = "k8smon"
-    action = "keep"
-  }
   rule {
     source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_name"]
     regex = "opencost"

--- a/examples/specific-namespace/metrics.alloy
+++ b/examples/specific-namespace/metrics.alloy
@@ -558,7 +558,7 @@ prometheus.relabel "cadvisor" {
 discovery.relabel "kube_state_metrics" {
   targets = discovery.kubernetes.services.targets
   rule {
-    source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_instance"]
+    source_labels = ["__meta_kubernetes_service_label_release"]
     regex = "k8smon"
     action = "keep"
   }
@@ -603,7 +603,7 @@ prometheus.relabel "kube_state_metrics" {
 discovery.relabel "node_exporter" {
   targets = discovery.kubernetes.pods.targets
   rule {
-    source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_instance"]
+    source_labels = ["__meta_kubernetes_pod_label_release"]
     regex = "k8smon"
     action = "keep"
   }

--- a/examples/specific-namespace/output.yaml
+++ b/examples/specific-namespace/output.yaml
@@ -60,6 +60,7 @@ metadata:
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/instance: k8smon
     app.kubernetes.io/version: "2.13.0"
+    release: k8smon
   name: k8smon-kube-state-metrics
   namespace: default
 ---
@@ -92,6 +93,7 @@ metadata:
     app.kubernetes.io/name: prometheus-node-exporter
     app.kubernetes.io/instance: k8smon
     app.kubernetes.io/version: "1.8.2"
+    release: k8smon
 automountServiceAccountToken: false
 ---
 # Source: k8s-monitoring/templates/log-service-credentials.yaml
@@ -688,7 +690,7 @@ data:
     discovery.relabel "kube_state_metrics" {
       targets = discovery.kubernetes.services.targets
       rule {
-        source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_instance"]
+        source_labels = ["__meta_kubernetes_service_label_release"]
         regex = "k8smon"
         action = "keep"
       }
@@ -733,7 +735,7 @@ data:
     discovery.relabel "node_exporter" {
       targets = discovery.kubernetes.pods.targets
       rule {
-        source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_instance"]
+        source_labels = ["__meta_kubernetes_pod_label_release"]
         regex = "k8smon"
         action = "keep"
       }
@@ -57750,6 +57752,7 @@ metadata:
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/instance: k8smon
     app.kubernetes.io/version: "2.13.0"
+    release: k8smon
   name: k8smon-kube-state-metrics
 rules:
 
@@ -58061,6 +58064,7 @@ metadata:
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/instance: k8smon
     app.kubernetes.io/version: "2.13.0"
+    release: k8smon
   name: k8smon-kube-state-metrics
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -58281,6 +58285,7 @@ metadata:
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/instance: k8smon
     app.kubernetes.io/version: "2.13.0"
+    release: k8smon
   annotations:
 spec:
   type: "ClusterIP"
@@ -58331,6 +58336,7 @@ metadata:
     app.kubernetes.io/name: prometheus-node-exporter
     app.kubernetes.io/instance: k8smon
     app.kubernetes.io/version: "1.8.2"
+    release: k8smon
 spec:
   type: ClusterIP
   ports:
@@ -58502,6 +58508,7 @@ metadata:
     app.kubernetes.io/name: prometheus-node-exporter
     app.kubernetes.io/instance: k8smon
     app.kubernetes.io/version: "1.8.2"
+    release: k8smon
 spec:
   selector:
     matchLabels:
@@ -58525,6 +58532,7 @@ spec:
         app.kubernetes.io/name: prometheus-node-exporter
         app.kubernetes.io/instance: k8smon
         app.kubernetes.io/version: "1.8.2"
+        release: k8smon
     spec:
       automountServiceAccountToken: false
       securityContext:
@@ -58708,6 +58716,7 @@ metadata:
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/instance: k8smon
     app.kubernetes.io/version: "2.13.0"
+    release: k8smon
 spec:
   selector:
     matchLabels:      
@@ -58727,6 +58736,7 @@ spec:
         app.kubernetes.io/name: kube-state-metrics
         app.kubernetes.io/instance: k8smon
         app.kubernetes.io/version: "2.13.0"
+        release: k8smon
     spec:
       automountServiceAccountToken: true
       hostNetwork: false
@@ -59614,7 +59624,7 @@ data:
     discovery.relabel "kube_state_metrics" {
       targets = discovery.kubernetes.services.targets
       rule {
-        source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_instance"]
+        source_labels = ["__meta_kubernetes_service_label_release"]
         regex = "k8smon"
         action = "keep"
       }
@@ -59659,7 +59669,7 @@ data:
     discovery.relabel "node_exporter" {
       targets = discovery.kubernetes.pods.targets
       rule {
-        source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_instance"]
+        source_labels = ["__meta_kubernetes_pod_label_release"]
         regex = "k8smon"
         action = "keep"
       }

--- a/examples/specific-namespace/output.yaml
+++ b/examples/specific-namespace/output.yaml
@@ -453,11 +453,6 @@ data:
     discovery.relabel "alloy" {
       targets = discovery.kubernetes.pods.targets
       rule {
-        source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_instance"]
-        regex = "k8smon"
-        action = "keep"
-      }
-      rule {
         source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
         regex = "alloy.*"
         action = "keep"
@@ -786,11 +781,6 @@ data:
     // OpenCost
     discovery.relabel "opencost" {
       targets = discovery.kubernetes.services.targets
-      rule {
-        source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_instance"]
-        regex = "k8smon"
-        action = "keep"
-      }
       rule {
         source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_name"]
         regex = "opencost"
@@ -59387,11 +59377,6 @@ data:
     discovery.relabel "alloy" {
       targets = discovery.kubernetes.pods.targets
       rule {
-        source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_instance"]
-        regex = "k8smon"
-        action = "keep"
-      }
-      rule {
         source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
         regex = "alloy.*"
         action = "keep"
@@ -59720,11 +59705,6 @@ data:
     // OpenCost
     discovery.relabel "opencost" {
       targets = discovery.kubernetes.services.targets
-      rule {
-        source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_instance"]
-        regex = "k8smon"
-        action = "keep"
-      }
       rule {
         source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_name"]
         regex = "opencost"

--- a/examples/traces-enabled/metrics.alloy
+++ b/examples/traces-enabled/metrics.alloy
@@ -624,7 +624,7 @@ prometheus.relabel "cadvisor" {
 discovery.relabel "kube_state_metrics" {
   targets = discovery.kubernetes.services.targets
   rule {
-    source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_instance"]
+    source_labels = ["__meta_kubernetes_service_label_release"]
     regex = "k8smon"
     action = "keep"
   }
@@ -664,7 +664,7 @@ prometheus.relabel "kube_state_metrics" {
 discovery.relabel "node_exporter" {
   targets = discovery.kubernetes.pods.targets
   rule {
-    source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_instance"]
+    source_labels = ["__meta_kubernetes_pod_label_release"]
     regex = "k8smon"
     action = "keep"
   }

--- a/examples/traces-enabled/metrics.alloy
+++ b/examples/traces-enabled/metrics.alloy
@@ -402,11 +402,6 @@ prometheus.relabel "annotation_autodiscovery" {
 discovery.relabel "alloy" {
   targets = discovery.kubernetes.pods.targets
   rule {
-    source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_instance"]
-    regex = "k8smon"
-    action = "keep"
-  }
-  rule {
     source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
     regex = "alloy.*"
     action = "keep"
@@ -710,11 +705,6 @@ prometheus.relabel "node_exporter" {
 // OpenCost
 discovery.relabel "opencost" {
   targets = discovery.kubernetes.services.targets
-  rule {
-    source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_instance"]
-    regex = "k8smon"
-    action = "keep"
-  }
   rule {
     source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_name"]
     regex = "opencost"

--- a/examples/traces-enabled/output.yaml
+++ b/examples/traces-enabled/output.yaml
@@ -60,6 +60,7 @@ metadata:
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/instance: k8smon
     app.kubernetes.io/version: "2.13.0"
+    release: k8smon
   name: k8smon-kube-state-metrics
   namespace: default
 ---
@@ -92,6 +93,7 @@ metadata:
     app.kubernetes.io/name: prometheus-node-exporter
     app.kubernetes.io/instance: k8smon
     app.kubernetes.io/version: "1.8.2"
+    release: k8smon
 automountServiceAccountToken: false
 ---
 # Source: k8s-monitoring/templates/log-service-credentials.yaml
@@ -767,7 +769,7 @@ data:
     discovery.relabel "kube_state_metrics" {
       targets = discovery.kubernetes.services.targets
       rule {
-        source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_instance"]
+        source_labels = ["__meta_kubernetes_service_label_release"]
         regex = "k8smon"
         action = "keep"
       }
@@ -807,7 +809,7 @@ data:
     discovery.relabel "node_exporter" {
       targets = discovery.kubernetes.pods.targets
       rule {
-        source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_instance"]
+        source_labels = ["__meta_kubernetes_pod_label_release"]
         regex = "k8smon"
         action = "keep"
       }
@@ -57805,6 +57807,7 @@ metadata:
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/instance: k8smon
     app.kubernetes.io/version: "2.13.0"
+    release: k8smon
   name: k8smon-kube-state-metrics
 rules:
 
@@ -58116,6 +58119,7 @@ metadata:
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/instance: k8smon
     app.kubernetes.io/version: "2.13.0"
+    release: k8smon
   name: k8smon-kube-state-metrics
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -58336,6 +58340,7 @@ metadata:
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/instance: k8smon
     app.kubernetes.io/version: "2.13.0"
+    release: k8smon
   annotations:
 spec:
   type: "ClusterIP"
@@ -58386,6 +58391,7 @@ metadata:
     app.kubernetes.io/name: prometheus-node-exporter
     app.kubernetes.io/instance: k8smon
     app.kubernetes.io/version: "1.8.2"
+    release: k8smon
 spec:
   type: ClusterIP
   ports:
@@ -58557,6 +58563,7 @@ metadata:
     app.kubernetes.io/name: prometheus-node-exporter
     app.kubernetes.io/instance: k8smon
     app.kubernetes.io/version: "1.8.2"
+    release: k8smon
 spec:
   selector:
     matchLabels:
@@ -58580,6 +58587,7 @@ spec:
         app.kubernetes.io/name: prometheus-node-exporter
         app.kubernetes.io/instance: k8smon
         app.kubernetes.io/version: "1.8.2"
+        release: k8smon
     spec:
       automountServiceAccountToken: false
       securityContext:
@@ -58763,6 +58771,7 @@ metadata:
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/instance: k8smon
     app.kubernetes.io/version: "2.13.0"
+    release: k8smon
 spec:
   selector:
     matchLabels:      
@@ -58782,6 +58791,7 @@ spec:
         app.kubernetes.io/name: kube-state-metrics
         app.kubernetes.io/instance: k8smon
         app.kubernetes.io/version: "2.13.0"
+        release: k8smon
     spec:
       automountServiceAccountToken: true
       hostNetwork: false
@@ -59735,7 +59745,7 @@ data:
     discovery.relabel "kube_state_metrics" {
       targets = discovery.kubernetes.services.targets
       rule {
-        source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_instance"]
+        source_labels = ["__meta_kubernetes_service_label_release"]
         regex = "k8smon"
         action = "keep"
       }
@@ -59775,7 +59785,7 @@ data:
     discovery.relabel "node_exporter" {
       targets = discovery.kubernetes.pods.targets
       rule {
-        source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_instance"]
+        source_labels = ["__meta_kubernetes_pod_label_release"]
         regex = "k8smon"
         action = "keep"
       }

--- a/examples/traces-enabled/output.yaml
+++ b/examples/traces-enabled/output.yaml
@@ -547,11 +547,6 @@ data:
     discovery.relabel "alloy" {
       targets = discovery.kubernetes.pods.targets
       rule {
-        source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_instance"]
-        regex = "k8smon"
-        action = "keep"
-      }
-      rule {
         source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
         regex = "alloy.*"
         action = "keep"
@@ -855,11 +850,6 @@ data:
     // OpenCost
     discovery.relabel "opencost" {
       targets = discovery.kubernetes.services.targets
-      rule {
-        source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_instance"]
-        regex = "k8smon"
-        action = "keep"
-      }
       rule {
         source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_name"]
         regex = "opencost"
@@ -59523,11 +59513,6 @@ data:
     discovery.relabel "alloy" {
       targets = discovery.kubernetes.pods.targets
       rule {
-        source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_instance"]
-        regex = "k8smon"
-        action = "keep"
-      }
-      rule {
         source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
         regex = "alloy.*"
         action = "keep"
@@ -59831,11 +59816,6 @@ data:
     // OpenCost
     discovery.relabel "opencost" {
       targets = discovery.kubernetes.services.targets
-      rule {
-        source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_instance"]
-        regex = "k8smon"
-        action = "keep"
-      }
       rule {
         source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_name"]
         regex = "opencost"

--- a/examples/windows-exporter/metrics.alloy
+++ b/examples/windows-exporter/metrics.alloy
@@ -316,11 +316,6 @@ prometheus.relabel "annotation_autodiscovery" {
 discovery.relabel "alloy" {
   targets = discovery.kubernetes.pods.targets
   rule {
-    source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_instance"]
-    regex = "k8smon"
-    action = "keep"
-  }
-  rule {
     source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
     regex = "alloy.*"
     action = "keep"
@@ -693,11 +688,6 @@ prometheus.relabel "windows_exporter" {
 // OpenCost
 discovery.relabel "opencost" {
   targets = discovery.kubernetes.services.targets
-  rule {
-    source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_instance"]
-    regex = "k8smon"
-    action = "keep"
-  }
   rule {
     source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_name"]
     regex = "opencost"

--- a/examples/windows-exporter/metrics.alloy
+++ b/examples/windows-exporter/metrics.alloy
@@ -538,7 +538,7 @@ prometheus.relabel "cadvisor" {
 discovery.relabel "kube_state_metrics" {
   targets = discovery.kubernetes.services.targets
   rule {
-    source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_instance"]
+    source_labels = ["__meta_kubernetes_service_label_release"]
     regex = "k8smon"
     action = "keep"
   }
@@ -578,7 +578,7 @@ prometheus.relabel "kube_state_metrics" {
 discovery.relabel "node_exporter" {
   targets = discovery.kubernetes.pods.targets
   rule {
-    source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_instance"]
+    source_labels = ["__meta_kubernetes_pod_label_release"]
     regex = "k8smon"
     action = "keep"
   }
@@ -625,7 +625,7 @@ prometheus.relabel "node_exporter" {
 discovery.relabel "windows_exporter" {
   targets = discovery.kubernetes.pods.targets
   rule {
-    source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_instance"]
+    source_labels = ["__meta_kubernetes_pod_label_release"]
     regex = "k8smon"
     action = "keep"
   }

--- a/examples/windows-exporter/output.yaml
+++ b/examples/windows-exporter/output.yaml
@@ -487,11 +487,6 @@ data:
     discovery.relabel "alloy" {
       targets = discovery.kubernetes.pods.targets
       rule {
-        source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_instance"]
-        regex = "k8smon"
-        action = "keep"
-      }
-      rule {
         source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
         regex = "alloy.*"
         action = "keep"
@@ -864,11 +859,6 @@ data:
     // OpenCost
     discovery.relabel "opencost" {
       targets = discovery.kubernetes.services.targets
-      rule {
-        source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_instance"]
-        regex = "k8smon"
-        action = "keep"
-      }
       rule {
         source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_name"]
         regex = "opencost"
@@ -59556,11 +59546,6 @@ data:
     discovery.relabel "alloy" {
       targets = discovery.kubernetes.pods.targets
       rule {
-        source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_instance"]
-        regex = "k8smon"
-        action = "keep"
-      }
-      rule {
         source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
         regex = "alloy.*"
         action = "keep"
@@ -59933,11 +59918,6 @@ data:
     // OpenCost
     discovery.relabel "opencost" {
       targets = discovery.kubernetes.services.targets
-      rule {
-        source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_instance"]
-        regex = "k8smon"
-        action = "keep"
-      }
       rule {
         source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_name"]
         regex = "opencost"

--- a/examples/windows-exporter/output.yaml
+++ b/examples/windows-exporter/output.yaml
@@ -60,6 +60,7 @@ metadata:
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/instance: k8smon
     app.kubernetes.io/version: "2.13.0"
+    release: k8smon
   name: k8smon-kube-state-metrics
   namespace: default
 ---
@@ -92,6 +93,7 @@ metadata:
     app.kubernetes.io/name: prometheus-node-exporter
     app.kubernetes.io/instance: k8smon
     app.kubernetes.io/version: "1.8.2"
+    release: k8smon
 automountServiceAccountToken: false
 ---
 # Source: k8s-monitoring/charts/prometheus-windows-exporter/templates/serviceaccount.yaml
@@ -108,6 +110,7 @@ metadata:
     app.kubernetes.io/name: prometheus-windows-exporter
     app.kubernetes.io/instance: k8smon
     app.kubernetes.io/version: "0.25.1"
+    release: k8smon
 ---
 # Source: k8s-monitoring/templates/log-service-credentials.yaml
 apiVersion: v1
@@ -149,6 +152,7 @@ metadata:
     app.kubernetes.io/name: prometheus-windows-exporter
     app.kubernetes.io/instance: k8smon
     app.kubernetes.io/version: "0.25.1"
+    release: k8smon
 data:
   config.yml: |
     collectors:
@@ -705,7 +709,7 @@ data:
     discovery.relabel "kube_state_metrics" {
       targets = discovery.kubernetes.services.targets
       rule {
-        source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_instance"]
+        source_labels = ["__meta_kubernetes_service_label_release"]
         regex = "k8smon"
         action = "keep"
       }
@@ -745,7 +749,7 @@ data:
     discovery.relabel "node_exporter" {
       targets = discovery.kubernetes.pods.targets
       rule {
-        source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_instance"]
+        source_labels = ["__meta_kubernetes_pod_label_release"]
         regex = "k8smon"
         action = "keep"
       }
@@ -792,7 +796,7 @@ data:
     discovery.relabel "windows_exporter" {
       targets = discovery.kubernetes.pods.targets
       rule {
-        source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_instance"]
+        source_labels = ["__meta_kubernetes_pod_label_release"]
         regex = "k8smon"
         action = "keep"
       }
@@ -57792,6 +57796,7 @@ metadata:
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/instance: k8smon
     app.kubernetes.io/version: "2.13.0"
+    release: k8smon
   name: k8smon-kube-state-metrics
 rules:
 
@@ -58103,6 +58108,7 @@ metadata:
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/instance: k8smon
     app.kubernetes.io/version: "2.13.0"
+    release: k8smon
   name: k8smon-kube-state-metrics
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -58323,6 +58329,7 @@ metadata:
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/instance: k8smon
     app.kubernetes.io/version: "2.13.0"
+    release: k8smon
   annotations:
 spec:
   type: "ClusterIP"
@@ -58373,6 +58380,7 @@ metadata:
     app.kubernetes.io/name: prometheus-node-exporter
     app.kubernetes.io/instance: k8smon
     app.kubernetes.io/version: "1.8.2"
+    release: k8smon
 spec:
   type: ClusterIP
   ports:
@@ -58398,6 +58406,7 @@ metadata:
     app.kubernetes.io/name: prometheus-windows-exporter
     app.kubernetes.io/instance: k8smon
     app.kubernetes.io/version: "0.25.1"
+    release: k8smon
   annotations:
     prometheus.io/scrape: "true"
 spec:
@@ -58572,6 +58581,7 @@ metadata:
     app.kubernetes.io/name: prometheus-node-exporter
     app.kubernetes.io/instance: k8smon
     app.kubernetes.io/version: "1.8.2"
+    release: k8smon
 spec:
   selector:
     matchLabels:
@@ -58595,6 +58605,7 @@ spec:
         app.kubernetes.io/name: prometheus-node-exporter
         app.kubernetes.io/instance: k8smon
         app.kubernetes.io/version: "1.8.2"
+        release: k8smon
     spec:
       automountServiceAccountToken: false
       securityContext:
@@ -58697,6 +58708,7 @@ metadata:
     app.kubernetes.io/name: prometheus-windows-exporter
     app.kubernetes.io/instance: k8smon
     app.kubernetes.io/version: "0.25.1"
+    release: k8smon
 spec:
   selector:
     matchLabels:
@@ -58719,6 +58731,7 @@ spec:
         app.kubernetes.io/name: prometheus-windows-exporter
         app.kubernetes.io/instance: k8smon
         app.kubernetes.io/version: "0.25.1"
+        release: k8smon
     spec:
       automountServiceAccountToken: false
       securityContext:
@@ -58877,6 +58890,7 @@ metadata:
     app.kubernetes.io/name: kube-state-metrics
     app.kubernetes.io/instance: k8smon
     app.kubernetes.io/version: "2.13.0"
+    release: k8smon
 spec:
   selector:
     matchLabels:      
@@ -58896,6 +58910,7 @@ spec:
         app.kubernetes.io/name: kube-state-metrics
         app.kubernetes.io/instance: k8smon
         app.kubernetes.io/version: "2.13.0"
+        release: k8smon
     spec:
       automountServiceAccountToken: true
       hostNetwork: false
@@ -59763,7 +59778,7 @@ data:
     discovery.relabel "kube_state_metrics" {
       targets = discovery.kubernetes.services.targets
       rule {
-        source_labels = ["__meta_kubernetes_service_label_app_kubernetes_io_instance"]
+        source_labels = ["__meta_kubernetes_service_label_release"]
         regex = "k8smon"
         action = "keep"
       }
@@ -59803,7 +59818,7 @@ data:
     discovery.relabel "node_exporter" {
       targets = discovery.kubernetes.pods.targets
       rule {
-        source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_instance"]
+        source_labels = ["__meta_kubernetes_pod_label_release"]
         regex = "k8smon"
         action = "keep"
       }
@@ -59850,7 +59865,7 @@ data:
     discovery.relabel "windows_exporter" {
       targets = discovery.kubernetes.pods.targets
       rule {
-        source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_instance"]
+        source_labels = ["__meta_kubernetes_pod_label_release"]
         regex = "k8smon"
         action = "keep"
       }


### PR DESCRIPTION
This improves the experience for ArgoCD users.