### PR TITLE
Add the ability to set headers for all external services.

### DIFF
--- a/charts/k8s-monitoring/README.md
+++ b/charts/k8s-monitoring/README.md
@@ -225,8 +225,10 @@ The Prometheus and Loki services may be hosted on the same cluster, or remotely 
 | externalServices.loki.basicAuth.passwordKey | string | `"password"` | The key for the password property in the secret |
 | externalServices.loki.basicAuth.username | string | `""` | Loki basic auth username |
 | externalServices.loki.basicAuth.usernameKey | string | `"username"` | The key for the username property in the secret |
-| externalServices.loki.externalLabels | object | `{}` | Custom labels to be added to all logs and events, all values are treated as strings and automatically quoted. |
-| externalServices.loki.externalLabelsFrom | object | `{}` | Custom labels to be added to all logs and events through a dynamic reference, all values are treated as raw strings and not quoted. |
+| externalServices.loki.externalLabels | object | `{}` | Custom labels to be added to all logs and events. All values are treated as strings and automatically quoted. |
+| externalServices.loki.externalLabelsFrom | object | `{}` | Custom labels to be added to all logs and events through a dynamic reference. All values are treated as raw strings and not quoted. |
+| externalServices.loki.extraHeaders | object | `{}` | Extra headers to be set when sending metrics. All values are treated as strings and automatically quoted. |
+| externalServices.loki.extraHeadersFrom | object | `{}` | Extra headers to be set when sending metrics through a dynamic reference. All values are treated as raw strings and not quoted. |
 | externalServices.loki.host | string | `""` | Loki host where logs and events will be sent |
 | externalServices.loki.hostKey | string | `"host"` | The key for the host property in the secret |
 | externalServices.loki.oauth2.clientId | string | `""` | Loki OAuth2 client ID |
@@ -267,8 +269,10 @@ The Prometheus and Loki services may be hosted on the same cluster, or remotely 
 | externalServices.prometheus.basicAuth.passwordKey | string | `"password"` | The key for the password property in the secret |
 | externalServices.prometheus.basicAuth.username | string | `""` | Prometheus basic auth username |
 | externalServices.prometheus.basicAuth.usernameKey | string | `"username"` | The key for the username property in the secret |
-| externalServices.prometheus.externalLabels | object | `{}` | Custom labels to be added to all time series, all values are treated as strings and automatically quoted. |
-| externalServices.prometheus.externalLabelsFrom | object | `{}` | Custom labels to be added to all time series through a dynamic reference, all values are treated as raw strings and not quoted. |
+| externalServices.prometheus.externalLabels | object | `{}` | Custom labels to be added to all time series. All values are treated as strings and automatically quoted. |
+| externalServices.prometheus.externalLabelsFrom | object | `{}` | Custom labels to be added to all time series through a dynamic reference. All values are treated as raw strings and not quoted. |
+| externalServices.prometheus.extraHeaders | object | `{}` | Extra headers to be set when sending metrics. All values are treated as strings and automatically quoted. |
+| externalServices.prometheus.extraHeadersFrom | object | `{}` | Extra headers to be set when sending metrics through a dynamic reference. All values are treated as raw strings and not quoted. |
 | externalServices.prometheus.host | string | `""` | Prometheus host where metrics will be sent |
 | externalServices.prometheus.hostKey | string | `"host"` | The key for the host property in the secret |
 | externalServices.prometheus.oauth2.clientId | string | `""` | Prometheus OAuth2 client ID |
@@ -323,8 +327,10 @@ The Prometheus and Loki services may be hosted on the same cluster, or remotely 
 | externalServices.pyroscope.basicAuth.passwordKey | string | `"password"` | The key for the password property in the secret |
 | externalServices.pyroscope.basicAuth.username | string | `""` | Pyroscope basic auth username |
 | externalServices.pyroscope.basicAuth.usernameKey | string | `"username"` | The key for the username property in the secret |
-| externalServices.pyroscope.externalLabels | object | `{}` | Custom labels to be added to all profiles, all values are treated as strings and automatically quoted. |
-| externalServices.pyroscope.externalLabelsFrom | object | `{}` | Custom labels to be added to all profiles through a dynamic reference, all values are treated as raw strings and not quoted. |
+| externalServices.pyroscope.externalLabels | object | `{}` | Custom labels to be added to all profiles. All values are treated as strings and automatically quoted. |
+| externalServices.pyroscope.externalLabelsFrom | object | `{}` | Custom labels to be added to all profiles through a dynamic reference. All values are treated as raw strings and not quoted. |
+| externalServices.pyroscope.extraHeaders | object | `{}` | Extra headers to be set when sending metrics. All values are treated as strings and automatically quoted. |
+| externalServices.pyroscope.extraHeadersFrom | object | `{}` | Extra headers to be set when sending metrics through a dynamic reference. All values are treated as raw strings and not quoted. |
 | externalServices.pyroscope.host | string | `""` | Pyroscope host where profiles will be sent |
 | externalServices.pyroscope.hostKey | string | `"host"` | The key for the host property in the secret |
 | externalServices.pyroscope.proxyURL | string | `""` | HTTP proxy to proxy requests to Pyroscope through. |
@@ -344,6 +350,8 @@ The Prometheus and Loki services may be hosted on the same cluster, or remotely 
 | externalServices.tempo.basicAuth.passwordKey | string | `"password"` | The key for the password property in the secret |
 | externalServices.tempo.basicAuth.username | string | `""` | Tempo basic auth username |
 | externalServices.tempo.basicAuth.usernameKey | string | `"username"` | The key for the username property in the secret |
+| externalServices.tempo.extraHeaders | object | `{}` | Extra headers to be set when sending metrics. All values are treated as strings and automatically quoted. |
+| externalServices.tempo.extraHeadersFrom | object | `{}` | Extra headers to be set when sending metrics through a dynamic reference. All values are treated as raw strings and not quoted. |
 | externalServices.tempo.host | string | `""` | Tempo host where traces will be sent |
 | externalServices.tempo.hostKey | string | `"host"` | The key for the host property in the secret |
 | externalServices.tempo.protocol | string | `"otlp"` | The type of server protocol for writing metrics Options:   * "otlp" will use OTLP   * "otlphttp" will use OTLP HTTP |

--- a/charts/k8s-monitoring/templates/alloy_config/_logs_service_loki.alloy.txt
+++ b/charts/k8s-monitoring/templates/alloy_config/_logs_service_loki.alloy.txt
@@ -5,6 +5,16 @@ loki.write "logs_service" {
   endpoint {
     url = nonsensitive(remote.kubernetes.secret.logs_service.data[{{ .hostKey | quote }}]) + "{{ .writeEndpoint }}"
     tenant_id = nonsensitive(remote.kubernetes.secret.logs_service.data[{{ .tenantIdKey | quote }}])
+{{- if or .extraHeaders .extraHeadersFrom }}
+    headers {
+{{- range $key, $value := .extraHeaders }}
+      {{ $key | quote }} = {{ $value | quote }},
+{{- end }}
+{{- range $key, $value := .extraHeadersFrom }}
+      {{ $key | quote }} = {{ $value }},
+{{- end }}
+    }
+{{- end }}
 {{- if .proxyURL }}
     proxy_url = {{ .proxyURL | quote }}
 {{- end }}

--- a/charts/k8s-monitoring/templates/alloy_config/_logs_service_otlp.alloy.txt
+++ b/charts/k8s-monitoring/templates/alloy_config/_logs_service_otlp.alloy.txt
@@ -71,9 +71,15 @@ otelcol.exporter.otlphttp "logs_service" {
 {{ if or (.basicAuth.username) (.basicAuth.password) }}
     auth = otelcol.auth.basic.logs_service.handler
 {{- end }}
-{{- if .tenantId }}
-    headers = { "X-Scope-OrgID" = nonsensitive(remote.kubernetes.secret.logs_service.data[{{ .tenantIdKey | quote }}]) }
+    headers = {
+      "X-Scope-OrgID" = nonsensitive(remote.kubernetes.secret.logs_service.data[{{ .tenantIdKey | quote }}]),
+{{- range $key, $value := .extraHeaders }}
+      {{ $key | quote }} = {{ $value | quote }},
 {{- end }}
+{{- range $key, $value := .extraHeadersFrom }}
+      {{ $key | quote }} = {{ $value }},
+{{- end }}
+    }
 {{- if .tls }}
     tls {
     {{- range $k, $v := .tls }}

--- a/charts/k8s-monitoring/templates/alloy_config/_metrics_service_otlp.alloy.txt
+++ b/charts/k8s-monitoring/templates/alloy_config/_metrics_service_otlp.alloy.txt
@@ -71,9 +71,15 @@ otelcol.exporter.otlphttp "metrics_service" {
 {{ if or (.basicAuth.username) (.basicAuth.password) }}
     auth = otelcol.auth.basic.metrics_service.handler
 {{- end }}
-{{- if .tenantId }}
-    headers = { "X-Scope-OrgID" = nonsensitive(remote.kubernetes.secret.metrics_service.data[{{ .tenantIdKey | quote }}]) }
+    headers = {
+      "X-Scope-OrgID" = nonsensitive(remote.kubernetes.secret.metrics_service.data[{{ .tenantIdKey | quote }}]),
+{{- range $key, $value := .extraHeaders }}
+      {{ $key | quote }} = {{ $value | quote }},
 {{- end }}
+{{- range $key, $value := .extraHeadersFrom }}
+      {{ $key | quote }} = {{ $value }},
+{{- end }}
+    }
 {{- if .tls }}
     tls {
     {{- range $k, $v := .tls }}

--- a/charts/k8s-monitoring/templates/alloy_config/_metrics_service_remote_write.alloy.txt
+++ b/charts/k8s-monitoring/templates/alloy_config/_metrics_service_remote_write.alloy.txt
@@ -3,7 +3,15 @@
 prometheus.remote_write "metrics_service" {
   endpoint {
     url = nonsensitive(remote.kubernetes.secret.metrics_service.data[{{ .hostKey | quote }}]) + "{{ .writeEndpoint }}"
-    headers = { "X-Scope-OrgID" = nonsensitive(remote.kubernetes.secret.metrics_service.data[{{ .tenantIdKey | quote }}]) }
+    headers = {
+      "X-Scope-OrgID" = nonsensitive(remote.kubernetes.secret.metrics_service.data[{{ .tenantIdKey | quote }}]),
+{{- range $key, $value := .extraHeaders }}
+      {{ $key | quote }} = {{ $value | quote }},
+{{- end }}
+{{- range $key, $value := .extraHeadersFrom }}
+      {{ $key | quote }} = {{ $value }},
+{{- end }}
+    }
 {{- if .proxyURL }}
     proxy_url = {{ .proxyURL | quote }}
 {{- end }}

--- a/charts/k8s-monitoring/templates/alloy_config/_profiles_service.alloy.txt
+++ b/charts/k8s-monitoring/templates/alloy_config/_profiles_service.alloy.txt
@@ -9,7 +9,15 @@ remote.kubernetes.secret "profiles_service" {
 pyroscope.write "profiles_service" {
   endpoint {
     url = nonsensitive(remote.kubernetes.secret.profiles_service.data[{{ .hostKey | quote }}])
-    headers = { "X-Scope-OrgID" = nonsensitive(remote.kubernetes.secret.profiles_service.data[{{ .tenantIdKey | quote }}]) }
+    headers = {
+      "X-Scope-OrgID" = nonsensitive(remote.kubernetes.secret.profiles_service.data[{{ .tenantIdKey | quote }}]),
+{{- range $key, $value := .extraHeaders }}
+      {{ $key | quote }} = {{ $value | quote }},
+{{- end }}
+{{- range $key, $value := .extraHeadersFrom }}
+      {{ $key | quote }} = {{ $value }},
+{{- end }}
+    }
 {{ if eq .authMode "basic" }}
     basic_auth {
       username = nonsensitive(remote.kubernetes.secret.profiles_service.data[{{ .basicAuth.usernameKey | quote }}])

--- a/charts/k8s-monitoring/templates/alloy_config/_traces_service.alloy.txt
+++ b/charts/k8s-monitoring/templates/alloy_config/_traces_service.alloy.txt
@@ -22,7 +22,15 @@ otelcol.exporter.otlphttp "traces_service" {
 {{ if eq .authMode "basic" }}
     auth = otelcol.auth.basic.traces_service.handler
 {{- end }}
-    headers = { "X-Scope-OrgID" = nonsensitive(remote.kubernetes.secret.traces_service.data[{{ .tenantIdKey | quote }}]) }
+    headers = {
+      "X-Scope-OrgID" = nonsensitive(remote.kubernetes.secret.metrics_service.data[{{ .tenantIdKey | quote }}]),
+{{- range $key, $value := .extraHeaders }}
+      {{ $key | quote }} = {{ $value | quote }},
+{{- end }}
+{{- range $key, $value := .extraHeadersFrom }}
+      {{ $key | quote }} = {{ $value }},
+{{- end }}
+    }
 {{- if .tlsOptions }}
     tls {
 {{ .tlsOptions | indent 6 }}

--- a/charts/k8s-monitoring/values.yaml
+++ b/charts/k8s-monitoring/values.yaml
@@ -33,16 +33,29 @@ externalServices:
     # -- HTTP proxy to proxy requests to Prometheus through.
     # @section -- External Services (Prometheus)
     proxyURL: ""
+
     # -- Prometheus metrics query endpoint. Preset for Grafana Cloud Metrics instances.
     # @section -- External Services (Prometheus)
     queryEndpoint: /api/prom/api/v1/query
     # -- Prometheus metrics write endpoint. Preset for Grafana Cloud Metrics instances.
     # @section -- External Services (Prometheus)
     writeEndpoint: /api/prom/push
-    # -- Custom labels to be added to all time series, all values are treated as strings and automatically quoted.
+
+    # -- Extra headers to be set when sending metrics.
+    # All values are treated as strings and automatically quoted.
+    # @section -- External Services (Prometheus)
+    extraHeaders: {}
+    # -- Extra headers to be set when sending metrics through a dynamic reference.
+    # All values are treated as raw strings and not quoted.
+    # @section -- External Services (Prometheus)
+    extraHeadersFrom: {}
+
+    # -- Custom labels to be added to all time series.
+    # All values are treated as strings and automatically quoted.
     # @section -- External Services (Prometheus)
     externalLabels: {}
-    # -- Custom labels to be added to all time series through a dynamic reference, all values are treated as raw strings and not quoted.
+    # -- Custom labels to be added to all time series through a dynamic reference.
+    # All values are treated as raw strings and not quoted.
     # @section -- External Services (Prometheus)
     externalLabelsFrom: {}
     # -- Rule blocks to be added to the [write_relabel_config block](https://grafana.com/docs/alloy/latest/reference/components/prometheus.remote_write/#write_relabel_config-block)
@@ -235,18 +248,33 @@ externalServices:
     # -- HTTP proxy to proxy requests to Loki through.
     # @section -- External Services (Loki)
     proxyURL: ""
+
     # -- Loki logs query endpoint.
     # @section -- External Services (Loki)
     queryEndpoint: /loki/api/v1/query
     # -- Loki logs write endpoint.
     # @section -- External Services (Loki)
     writeEndpoint: /loki/api/v1/push
-    # -- Custom labels to be added to all logs and events, all values are treated as strings and automatically quoted.
+
+    # -- Extra headers to be set when sending metrics.
+    # All values are treated as strings and automatically quoted.
+    # @section -- External Services (Loki)
+    extraHeaders: {}
+
+    # -- Extra headers to be set when sending metrics through a dynamic reference.
+    # All values are treated as raw strings and not quoted.
+    # @section -- External Services (Loki)
+    extraHeadersFrom: {}
+
+    # -- Custom labels to be added to all logs and events.
+    # All values are treated as strings and automatically quoted.
     # @section -- External Services (Loki)
     externalLabels: {}
-    # -- Custom labels to be added to all logs and events through a dynamic reference, all values are treated as raw strings and not quoted.
+    # -- Custom labels to be added to all logs and events through a dynamic reference.
+    # All values are treated as raw strings and not quoted.
     # @section -- External Services (Loki)
     externalLabelsFrom: {}
+
     # -- Loki tenant ID
     # @section -- External Services (Loki)
     tenantId: ""
@@ -365,6 +393,15 @@ externalServices:
     # @section -- External Services (Tempo)
     searchEndpoint: /api/search
 
+    # -- Extra headers to be set when sending metrics.
+    # All values are treated as strings and automatically quoted.
+    # @section -- External Services (Tempo)
+    extraHeaders: {}
+    # -- Extra headers to be set when sending metrics through a dynamic reference.
+    # All values are treated as raw strings and not quoted.
+    # @section -- External Services (Tempo)
+    extraHeadersFrom: {}
+
     # -- The type of server protocol for writing metrics
     # Options:
     #   * "otlp" will use OTLP
@@ -434,10 +471,21 @@ externalServices:
     # @section -- External Services (Pyroscope)
     proxyURL: ""
 
-    # -- Custom labels to be added to all profiles, all values are treated as strings and automatically quoted.
+    # -- Extra headers to be set when sending metrics.
+    # All values are treated as strings and automatically quoted.
+    # @section -- External Services (Pyroscope)
+    extraHeaders: {}
+    # -- Extra headers to be set when sending metrics through a dynamic reference.
+    # All values are treated as raw strings and not quoted.
+    # @section -- External Services (Pyroscope)
+    extraHeadersFrom: {}
+
+    # -- Custom labels to be added to all profiles.
+    # All values are treated as strings and automatically quoted.
     # @section -- External Services (Pyroscope)
     externalLabels: {}
-    # -- Custom labels to be added to all profiles through a dynamic reference, all values are treated as raw strings and not quoted.
+    # -- Custom labels to be added to all profiles through a dynamic reference.
+    # All values are treated as raw strings and not quoted.
     # @section -- External Services (Pyroscope)
     externalLabelsFrom: {}
 

--- a/examples/alloy-autoscaling-and-storage/metrics.alloy
+++ b/examples/alloy-autoscaling-and-storage/metrics.alloy
@@ -720,7 +720,9 @@ prometheus.relabel "metrics_service" {
 prometheus.remote_write "metrics_service" {
   endpoint {
     url = nonsensitive(remote.kubernetes.secret.metrics_service.data["host"]) + "/api/prom/push"
-    headers = { "X-Scope-OrgID" = nonsensitive(remote.kubernetes.secret.metrics_service.data["tenantId"]) }
+    headers = {
+      "X-Scope-OrgID" = nonsensitive(remote.kubernetes.secret.metrics_service.data["tenantId"]),
+    }
 
     basic_auth {
       username = nonsensitive(remote.kubernetes.secret.metrics_service.data["username"])

--- a/examples/alloy-autoscaling-and-storage/output.yaml
+++ b/examples/alloy-autoscaling-and-storage/output.yaml
@@ -852,7 +852,9 @@ data:
     prometheus.remote_write "metrics_service" {
       endpoint {
         url = nonsensitive(remote.kubernetes.secret.metrics_service.data["host"]) + "/api/prom/push"
-        headers = { "X-Scope-OrgID" = nonsensitive(remote.kubernetes.secret.metrics_service.data["tenantId"]) }
+        headers = {
+          "X-Scope-OrgID" = nonsensitive(remote.kubernetes.secret.metrics_service.data["tenantId"]),
+        }
     
         basic_auth {
           username = nonsensitive(remote.kubernetes.secret.metrics_service.data["username"])
@@ -59776,7 +59778,9 @@ data:
     prometheus.remote_write "metrics_service" {
       endpoint {
         url = nonsensitive(remote.kubernetes.secret.metrics_service.data["host"]) + "/api/prom/push"
-        headers = { "X-Scope-OrgID" = nonsensitive(remote.kubernetes.secret.metrics_service.data["tenantId"]) }
+        headers = {
+          "X-Scope-OrgID" = nonsensitive(remote.kubernetes.secret.metrics_service.data["tenantId"]),
+        }
     
         basic_auth {
           username = nonsensitive(remote.kubernetes.secret.metrics_service.data["username"])

--- a/examples/application-observability/metrics.alloy
+++ b/examples/application-observability/metrics.alloy
@@ -752,7 +752,9 @@ prometheus.relabel "metrics_service" {
 prometheus.remote_write "metrics_service" {
   endpoint {
     url = nonsensitive(remote.kubernetes.secret.metrics_service.data["host"]) + "/api/prom/push"
-    headers = { "X-Scope-OrgID" = nonsensitive(remote.kubernetes.secret.metrics_service.data["tenantId"]) }
+    headers = {
+      "X-Scope-OrgID" = nonsensitive(remote.kubernetes.secret.metrics_service.data["tenantId"]),
+    }
 
     basic_auth {
       username = nonsensitive(remote.kubernetes.secret.metrics_service.data["username"])
@@ -869,7 +871,9 @@ otelcol.exporter.otlp "traces_service" {
     endpoint = nonsensitive(remote.kubernetes.secret.traces_service.data["host"])
 
     auth = otelcol.auth.basic.traces_service.handler
-    headers = { "X-Scope-OrgID" = nonsensitive(remote.kubernetes.secret.traces_service.data["tenantId"]) }
+    headers = {
+      "X-Scope-OrgID" = nonsensitive(remote.kubernetes.secret.metrics_service.data["tenantId"]),
+    }
   }
 }
 

--- a/examples/application-observability/output.yaml
+++ b/examples/application-observability/output.yaml
@@ -926,7 +926,9 @@ data:
     prometheus.remote_write "metrics_service" {
       endpoint {
         url = nonsensitive(remote.kubernetes.secret.metrics_service.data["host"]) + "/api/prom/push"
-        headers = { "X-Scope-OrgID" = nonsensitive(remote.kubernetes.secret.metrics_service.data["tenantId"]) }
+        headers = {
+          "X-Scope-OrgID" = nonsensitive(remote.kubernetes.secret.metrics_service.data["tenantId"]),
+        }
     
         basic_auth {
           username = nonsensitive(remote.kubernetes.secret.metrics_service.data["username"])
@@ -1043,7 +1045,9 @@ data:
         endpoint = nonsensitive(remote.kubernetes.secret.traces_service.data["host"])
     
         auth = otelcol.auth.basic.traces_service.handler
-        headers = { "X-Scope-OrgID" = nonsensitive(remote.kubernetes.secret.traces_service.data["tenantId"]) }
+        headers = {
+          "X-Scope-OrgID" = nonsensitive(remote.kubernetes.secret.metrics_service.data["tenantId"]),
+        }
       }
     }
     
@@ -2190,7 +2194,9 @@ data:
     pyroscope.write "profiles_service" {
       endpoint {
         url = nonsensitive(remote.kubernetes.secret.profiles_service.data["host"])
-        headers = { "X-Scope-OrgID" = nonsensitive(remote.kubernetes.secret.profiles_service.data["tenantId"]) }
+        headers = {
+          "X-Scope-OrgID" = nonsensitive(remote.kubernetes.secret.profiles_service.data["tenantId"]),
+        }
     
         basic_auth {
           username = nonsensitive(remote.kubernetes.secret.profiles_service.data["username"])
@@ -61005,7 +61011,9 @@ data:
     prometheus.remote_write "metrics_service" {
       endpoint {
         url = nonsensitive(remote.kubernetes.secret.metrics_service.data["host"]) + "/api/prom/push"
-        headers = { "X-Scope-OrgID" = nonsensitive(remote.kubernetes.secret.metrics_service.data["tenantId"]) }
+        headers = {
+          "X-Scope-OrgID" = nonsensitive(remote.kubernetes.secret.metrics_service.data["tenantId"]),
+        }
     
         basic_auth {
           username = nonsensitive(remote.kubernetes.secret.metrics_service.data["username"])
@@ -61122,7 +61130,9 @@ data:
         endpoint = nonsensitive(remote.kubernetes.secret.traces_service.data["host"])
     
         auth = otelcol.auth.basic.traces_service.handler
-        headers = { "X-Scope-OrgID" = nonsensitive(remote.kubernetes.secret.traces_service.data["tenantId"]) }
+        headers = {
+          "X-Scope-OrgID" = nonsensitive(remote.kubernetes.secret.metrics_service.data["tenantId"]),
+        }
       }
     }
     
@@ -62241,7 +62251,9 @@ data:
     pyroscope.write "profiles_service" {
       endpoint {
         url = nonsensitive(remote.kubernetes.secret.profiles_service.data["host"])
-        headers = { "X-Scope-OrgID" = nonsensitive(remote.kubernetes.secret.profiles_service.data["tenantId"]) }
+        headers = {
+          "X-Scope-OrgID" = nonsensitive(remote.kubernetes.secret.profiles_service.data["tenantId"]),
+        }
     
         basic_auth {
           username = nonsensitive(remote.kubernetes.secret.profiles_service.data["username"])

--- a/examples/application-observability/profiles.alloy
+++ b/examples/application-observability/profiles.alloy
@@ -903,7 +903,9 @@ remote.kubernetes.secret "profiles_service" {
 pyroscope.write "profiles_service" {
   endpoint {
     url = nonsensitive(remote.kubernetes.secret.profiles_service.data["host"])
-    headers = { "X-Scope-OrgID" = nonsensitive(remote.kubernetes.secret.profiles_service.data["tenantId"]) }
+    headers = {
+      "X-Scope-OrgID" = nonsensitive(remote.kubernetes.secret.profiles_service.data["tenantId"]),
+    }
 
     basic_auth {
       username = nonsensitive(remote.kubernetes.secret.profiles_service.data["username"])

--- a/examples/azure-aks/metrics.alloy
+++ b/examples/azure-aks/metrics.alloy
@@ -720,7 +720,9 @@ prometheus.relabel "metrics_service" {
 prometheus.remote_write "metrics_service" {
   endpoint {
     url = nonsensitive(remote.kubernetes.secret.metrics_service.data["host"]) + "/api/prom/push"
-    headers = { "X-Scope-OrgID" = nonsensitive(remote.kubernetes.secret.metrics_service.data["tenantId"]) }
+    headers = {
+      "X-Scope-OrgID" = nonsensitive(remote.kubernetes.secret.metrics_service.data["tenantId"]),
+    }
 
     basic_auth {
       username = nonsensitive(remote.kubernetes.secret.metrics_service.data["username"])

--- a/examples/azure-aks/output.yaml
+++ b/examples/azure-aks/output.yaml
@@ -852,7 +852,9 @@ data:
     prometheus.remote_write "metrics_service" {
       endpoint {
         url = nonsensitive(remote.kubernetes.secret.metrics_service.data["host"]) + "/api/prom/push"
-        headers = { "X-Scope-OrgID" = nonsensitive(remote.kubernetes.secret.metrics_service.data["tenantId"]) }
+        headers = {
+          "X-Scope-OrgID" = nonsensitive(remote.kubernetes.secret.metrics_service.data["tenantId"]),
+        }
     
         basic_auth {
           username = nonsensitive(remote.kubernetes.secret.metrics_service.data["username"])
@@ -59720,7 +59722,9 @@ data:
     prometheus.remote_write "metrics_service" {
       endpoint {
         url = nonsensitive(remote.kubernetes.secret.metrics_service.data["host"]) + "/api/prom/push"
-        headers = { "X-Scope-OrgID" = nonsensitive(remote.kubernetes.secret.metrics_service.data["tenantId"]) }
+        headers = {
+          "X-Scope-OrgID" = nonsensitive(remote.kubernetes.secret.metrics_service.data["tenantId"]),
+        }
     
         basic_auth {
           username = nonsensitive(remote.kubernetes.secret.metrics_service.data["username"])

--- a/examples/control-plane-metrics/metrics.alloy
+++ b/examples/control-plane-metrics/metrics.alloy
@@ -876,7 +876,9 @@ prometheus.relabel "metrics_service" {
 prometheus.remote_write "metrics_service" {
   endpoint {
     url = nonsensitive(remote.kubernetes.secret.metrics_service.data["host"]) + "/api/prom/push"
-    headers = { "X-Scope-OrgID" = nonsensitive(remote.kubernetes.secret.metrics_service.data["tenantId"]) }
+    headers = {
+      "X-Scope-OrgID" = nonsensitive(remote.kubernetes.secret.metrics_service.data["tenantId"]),
+    }
 
     basic_auth {
       username = nonsensitive(remote.kubernetes.secret.metrics_service.data["username"])

--- a/examples/control-plane-metrics/output.yaml
+++ b/examples/control-plane-metrics/output.yaml
@@ -1009,7 +1009,9 @@ data:
     prometheus.remote_write "metrics_service" {
       endpoint {
         url = nonsensitive(remote.kubernetes.secret.metrics_service.data["host"]) + "/api/prom/push"
-        headers = { "X-Scope-OrgID" = nonsensitive(remote.kubernetes.secret.metrics_service.data["tenantId"]) }
+        headers = {
+          "X-Scope-OrgID" = nonsensitive(remote.kubernetes.secret.metrics_service.data["tenantId"]),
+        }
     
         basic_auth {
           username = nonsensitive(remote.kubernetes.secret.metrics_service.data["username"])
@@ -60025,7 +60027,9 @@ data:
     prometheus.remote_write "metrics_service" {
       endpoint {
         url = nonsensitive(remote.kubernetes.secret.metrics_service.data["host"]) + "/api/prom/push"
-        headers = { "X-Scope-OrgID" = nonsensitive(remote.kubernetes.secret.metrics_service.data["tenantId"]) }
+        headers = {
+          "X-Scope-OrgID" = nonsensitive(remote.kubernetes.secret.metrics_service.data["tenantId"]),
+        }
     
         basic_auth {
           username = nonsensitive(remote.kubernetes.secret.metrics_service.data["username"])

--- a/examples/custom-config/metrics.alloy
+++ b/examples/custom-config/metrics.alloy
@@ -720,7 +720,9 @@ prometheus.relabel "metrics_service" {
 prometheus.remote_write "metrics_service" {
   endpoint {
     url = nonsensitive(remote.kubernetes.secret.metrics_service.data["host"]) + "/api/prom/push"
-    headers = { "X-Scope-OrgID" = nonsensitive(remote.kubernetes.secret.metrics_service.data["tenantId"]) }
+    headers = {
+      "X-Scope-OrgID" = nonsensitive(remote.kubernetes.secret.metrics_service.data["tenantId"]),
+    }
 
     basic_auth {
       username = nonsensitive(remote.kubernetes.secret.metrics_service.data["username"])

--- a/examples/custom-config/output.yaml
+++ b/examples/custom-config/output.yaml
@@ -852,7 +852,9 @@ data:
     prometheus.remote_write "metrics_service" {
       endpoint {
         url = nonsensitive(remote.kubernetes.secret.metrics_service.data["host"]) + "/api/prom/push"
-        headers = { "X-Scope-OrgID" = nonsensitive(remote.kubernetes.secret.metrics_service.data["tenantId"]) }
+        headers = {
+          "X-Scope-OrgID" = nonsensitive(remote.kubernetes.secret.metrics_service.data["tenantId"]),
+        }
     
         basic_auth {
           username = nonsensitive(remote.kubernetes.secret.metrics_service.data["username"])
@@ -59805,7 +59807,9 @@ data:
     prometheus.remote_write "metrics_service" {
       endpoint {
         url = nonsensitive(remote.kubernetes.secret.metrics_service.data["host"]) + "/api/prom/push"
-        headers = { "X-Scope-OrgID" = nonsensitive(remote.kubernetes.secret.metrics_service.data["tenantId"]) }
+        headers = {
+          "X-Scope-OrgID" = nonsensitive(remote.kubernetes.secret.metrics_service.data["tenantId"]),
+        }
     
         basic_auth {
           username = nonsensitive(remote.kubernetes.secret.metrics_service.data["username"])

--- a/examples/custom-metrics-tuning/metrics.alloy
+++ b/examples/custom-metrics-tuning/metrics.alloy
@@ -697,7 +697,9 @@ prometheus.relabel "metrics_service" {
 prometheus.remote_write "metrics_service" {
   endpoint {
     url = nonsensitive(remote.kubernetes.secret.metrics_service.data["host"]) + "/api/prom/push"
-    headers = { "X-Scope-OrgID" = nonsensitive(remote.kubernetes.secret.metrics_service.data["tenantId"]) }
+    headers = {
+      "X-Scope-OrgID" = nonsensitive(remote.kubernetes.secret.metrics_service.data["tenantId"]),
+    }
 
     basic_auth {
       username = nonsensitive(remote.kubernetes.secret.metrics_service.data["username"])

--- a/examples/custom-metrics-tuning/output.yaml
+++ b/examples/custom-metrics-tuning/output.yaml
@@ -784,7 +784,9 @@ data:
     prometheus.remote_write "metrics_service" {
       endpoint {
         url = nonsensitive(remote.kubernetes.secret.metrics_service.data["host"]) + "/api/prom/push"
-        headers = { "X-Scope-OrgID" = nonsensitive(remote.kubernetes.secret.metrics_service.data["tenantId"]) }
+        headers = {
+          "X-Scope-OrgID" = nonsensitive(remote.kubernetes.secret.metrics_service.data["tenantId"]),
+        }
     
         basic_auth {
           username = nonsensitive(remote.kubernetes.secret.metrics_service.data["username"])
@@ -58863,7 +58865,9 @@ data:
     prometheus.remote_write "metrics_service" {
       endpoint {
         url = nonsensitive(remote.kubernetes.secret.metrics_service.data["host"]) + "/api/prom/push"
-        headers = { "X-Scope-OrgID" = nonsensitive(remote.kubernetes.secret.metrics_service.data["tenantId"]) }
+        headers = {
+          "X-Scope-OrgID" = nonsensitive(remote.kubernetes.secret.metrics_service.data["tenantId"]),
+        }
     
         basic_auth {
           username = nonsensitive(remote.kubernetes.secret.metrics_service.data["username"])

--- a/examples/custom-pricing/metrics.alloy
+++ b/examples/custom-pricing/metrics.alloy
@@ -720,7 +720,9 @@ prometheus.relabel "metrics_service" {
 prometheus.remote_write "metrics_service" {
   endpoint {
     url = nonsensitive(remote.kubernetes.secret.metrics_service.data["host"]) + "/api/prom/push"
-    headers = { "X-Scope-OrgID" = nonsensitive(remote.kubernetes.secret.metrics_service.data["tenantId"]) }
+    headers = {
+      "X-Scope-OrgID" = nonsensitive(remote.kubernetes.secret.metrics_service.data["tenantId"]),
+    }
 
     basic_auth {
       username = nonsensitive(remote.kubernetes.secret.metrics_service.data["username"])

--- a/examples/custom-pricing/output.yaml
+++ b/examples/custom-pricing/output.yaml
@@ -874,7 +874,9 @@ data:
     prometheus.remote_write "metrics_service" {
       endpoint {
         url = nonsensitive(remote.kubernetes.secret.metrics_service.data["host"]) + "/api/prom/push"
-        headers = { "X-Scope-OrgID" = nonsensitive(remote.kubernetes.secret.metrics_service.data["tenantId"]) }
+        headers = {
+          "X-Scope-OrgID" = nonsensitive(remote.kubernetes.secret.metrics_service.data["tenantId"]),
+        }
     
         basic_auth {
           username = nonsensitive(remote.kubernetes.secret.metrics_service.data["username"])
@@ -59745,7 +59747,9 @@ data:
     prometheus.remote_write "metrics_service" {
       endpoint {
         url = nonsensitive(remote.kubernetes.secret.metrics_service.data["host"]) + "/api/prom/push"
-        headers = { "X-Scope-OrgID" = nonsensitive(remote.kubernetes.secret.metrics_service.data["tenantId"]) }
+        headers = {
+          "X-Scope-OrgID" = nonsensitive(remote.kubernetes.secret.metrics_service.data["tenantId"]),
+        }
     
         basic_auth {
           username = nonsensitive(remote.kubernetes.secret.metrics_service.data["username"])

--- a/examples/custom-prometheus-operator-rules/metrics.alloy
+++ b/examples/custom-prometheus-operator-rules/metrics.alloy
@@ -779,7 +779,9 @@ prometheus.relabel "metrics_service" {
 prometheus.remote_write "metrics_service" {
   endpoint {
     url = nonsensitive(remote.kubernetes.secret.metrics_service.data["host"]) + "/api/prom/push"
-    headers = { "X-Scope-OrgID" = nonsensitive(remote.kubernetes.secret.metrics_service.data["tenantId"]) }
+    headers = {
+      "X-Scope-OrgID" = nonsensitive(remote.kubernetes.secret.metrics_service.data["tenantId"]),
+    }
 
     basic_auth {
       username = nonsensitive(remote.kubernetes.secret.metrics_service.data["username"])

--- a/examples/custom-prometheus-operator-rules/output.yaml
+++ b/examples/custom-prometheus-operator-rules/output.yaml
@@ -866,7 +866,9 @@ data:
     prometheus.remote_write "metrics_service" {
       endpoint {
         url = nonsensitive(remote.kubernetes.secret.metrics_service.data["host"]) + "/api/prom/push"
-        headers = { "X-Scope-OrgID" = nonsensitive(remote.kubernetes.secret.metrics_service.data["tenantId"]) }
+        headers = {
+          "X-Scope-OrgID" = nonsensitive(remote.kubernetes.secret.metrics_service.data["tenantId"]),
+        }
     
         basic_auth {
           username = nonsensitive(remote.kubernetes.secret.metrics_service.data["username"])
@@ -59027,7 +59029,9 @@ data:
     prometheus.remote_write "metrics_service" {
       endpoint {
         url = nonsensitive(remote.kubernetes.secret.metrics_service.data["host"]) + "/api/prom/push"
-        headers = { "X-Scope-OrgID" = nonsensitive(remote.kubernetes.secret.metrics_service.data["tenantId"]) }
+        headers = {
+          "X-Scope-OrgID" = nonsensitive(remote.kubernetes.secret.metrics_service.data["tenantId"]),
+        }
     
         basic_auth {
           username = nonsensitive(remote.kubernetes.secret.metrics_service.data["username"])

--- a/examples/default-values/metrics.alloy
+++ b/examples/default-values/metrics.alloy
@@ -720,7 +720,9 @@ prometheus.relabel "metrics_service" {
 prometheus.remote_write "metrics_service" {
   endpoint {
     url = nonsensitive(remote.kubernetes.secret.metrics_service.data["host"]) + "/api/prom/push"
-    headers = { "X-Scope-OrgID" = nonsensitive(remote.kubernetes.secret.metrics_service.data["tenantId"]) }
+    headers = {
+      "X-Scope-OrgID" = nonsensitive(remote.kubernetes.secret.metrics_service.data["tenantId"]),
+    }
 
     basic_auth {
       username = nonsensitive(remote.kubernetes.secret.metrics_service.data["username"])

--- a/examples/default-values/output.yaml
+++ b/examples/default-values/output.yaml
@@ -852,7 +852,9 @@ data:
     prometheus.remote_write "metrics_service" {
       endpoint {
         url = nonsensitive(remote.kubernetes.secret.metrics_service.data["host"]) + "/api/prom/push"
-        headers = { "X-Scope-OrgID" = nonsensitive(remote.kubernetes.secret.metrics_service.data["tenantId"]) }
+        headers = {
+          "X-Scope-OrgID" = nonsensitive(remote.kubernetes.secret.metrics_service.data["tenantId"]),
+        }
     
         basic_auth {
           username = nonsensitive(remote.kubernetes.secret.metrics_service.data["username"])
@@ -59712,7 +59714,9 @@ data:
     prometheus.remote_write "metrics_service" {
       endpoint {
         url = nonsensitive(remote.kubernetes.secret.metrics_service.data["host"]) + "/api/prom/push"
-        headers = { "X-Scope-OrgID" = nonsensitive(remote.kubernetes.secret.metrics_service.data["tenantId"]) }
+        headers = {
+          "X-Scope-OrgID" = nonsensitive(remote.kubernetes.secret.metrics_service.data["tenantId"]),
+        }
     
         basic_auth {
           username = nonsensitive(remote.kubernetes.secret.metrics_service.data["username"])

--- a/examples/eks-fargate/metrics.alloy
+++ b/examples/eks-fargate/metrics.alloy
@@ -673,7 +673,9 @@ prometheus.relabel "metrics_service" {
 prometheus.remote_write "metrics_service" {
   endpoint {
     url = nonsensitive(remote.kubernetes.secret.metrics_service.data["host"]) + "/api/prom/push"
-    headers = { "X-Scope-OrgID" = nonsensitive(remote.kubernetes.secret.metrics_service.data["tenantId"]) }
+    headers = {
+      "X-Scope-OrgID" = nonsensitive(remote.kubernetes.secret.metrics_service.data["tenantId"]),
+    }
 
     basic_auth {
       username = nonsensitive(remote.kubernetes.secret.metrics_service.data["username"])

--- a/examples/eks-fargate/output.yaml
+++ b/examples/eks-fargate/output.yaml
@@ -788,7 +788,9 @@ data:
     prometheus.remote_write "metrics_service" {
       endpoint {
         url = nonsensitive(remote.kubernetes.secret.metrics_service.data["host"]) + "/api/prom/push"
-        headers = { "X-Scope-OrgID" = nonsensitive(remote.kubernetes.secret.metrics_service.data["tenantId"]) }
+        headers = {
+          "X-Scope-OrgID" = nonsensitive(remote.kubernetes.secret.metrics_service.data["tenantId"]),
+        }
     
         basic_auth {
           username = nonsensitive(remote.kubernetes.secret.metrics_service.data["username"])
@@ -59465,7 +59467,9 @@ data:
     prometheus.remote_write "metrics_service" {
       endpoint {
         url = nonsensitive(remote.kubernetes.secret.metrics_service.data["host"]) + "/api/prom/push"
-        headers = { "X-Scope-OrgID" = nonsensitive(remote.kubernetes.secret.metrics_service.data["tenantId"]) }
+        headers = {
+          "X-Scope-OrgID" = nonsensitive(remote.kubernetes.secret.metrics_service.data["tenantId"]),
+        }
     
         basic_auth {
           username = nonsensitive(remote.kubernetes.secret.metrics_service.data["username"])

--- a/examples/environment-variables/metrics.alloy
+++ b/examples/environment-variables/metrics.alloy
@@ -764,7 +764,9 @@ prometheus.relabel "metrics_service" {
 prometheus.remote_write "metrics_service" {
   endpoint {
     url = nonsensitive(remote.kubernetes.secret.metrics_service.data["host"]) + "/api/prom/push"
-    headers = { "X-Scope-OrgID" = nonsensitive(remote.kubernetes.secret.metrics_service.data["tenantId"]) }
+    headers = {
+      "X-Scope-OrgID" = nonsensitive(remote.kubernetes.secret.metrics_service.data["tenantId"]),
+    }
 
     basic_auth {
       username = nonsensitive(remote.kubernetes.secret.metrics_service.data["username"])

--- a/examples/environment-variables/output.yaml
+++ b/examples/environment-variables/output.yaml
@@ -896,7 +896,9 @@ data:
     prometheus.remote_write "metrics_service" {
       endpoint {
         url = nonsensitive(remote.kubernetes.secret.metrics_service.data["host"]) + "/api/prom/push"
-        headers = { "X-Scope-OrgID" = nonsensitive(remote.kubernetes.secret.metrics_service.data["tenantId"]) }
+        headers = {
+          "X-Scope-OrgID" = nonsensitive(remote.kubernetes.secret.metrics_service.data["tenantId"]),
+        }
     
         basic_auth {
           username = nonsensitive(remote.kubernetes.secret.metrics_service.data["username"])
@@ -59814,7 +59816,9 @@ data:
     prometheus.remote_write "metrics_service" {
       endpoint {
         url = nonsensitive(remote.kubernetes.secret.metrics_service.data["host"]) + "/api/prom/push"
-        headers = { "X-Scope-OrgID" = nonsensitive(remote.kubernetes.secret.metrics_service.data["tenantId"]) }
+        headers = {
+          "X-Scope-OrgID" = nonsensitive(remote.kubernetes.secret.metrics_service.data["tenantId"]),
+        }
     
         basic_auth {
           username = nonsensitive(remote.kubernetes.secret.metrics_service.data["username"])

--- a/examples/extra-rules/metrics.alloy
+++ b/examples/extra-rules/metrics.alloy
@@ -780,7 +780,9 @@ prometheus.relabel "metrics_service" {
 prometheus.remote_write "metrics_service" {
   endpoint {
     url = nonsensitive(remote.kubernetes.secret.metrics_service.data["host"]) + "/api/prom/push"
-    headers = { "X-Scope-OrgID" = nonsensitive(remote.kubernetes.secret.metrics_service.data["tenantId"]) }
+    headers = {
+      "X-Scope-OrgID" = nonsensitive(remote.kubernetes.secret.metrics_service.data["tenantId"]),
+    }
 
     basic_auth {
       username = nonsensitive(remote.kubernetes.secret.metrics_service.data["username"])

--- a/examples/extra-rules/output.yaml
+++ b/examples/extra-rules/output.yaml
@@ -913,7 +913,9 @@ data:
     prometheus.remote_write "metrics_service" {
       endpoint {
         url = nonsensitive(remote.kubernetes.secret.metrics_service.data["host"]) + "/api/prom/push"
-        headers = { "X-Scope-OrgID" = nonsensitive(remote.kubernetes.secret.metrics_service.data["tenantId"]) }
+        headers = {
+          "X-Scope-OrgID" = nonsensitive(remote.kubernetes.secret.metrics_service.data["tenantId"]),
+        }
     
         basic_auth {
           username = nonsensitive(remote.kubernetes.secret.metrics_service.data["username"])
@@ -59894,7 +59896,9 @@ data:
     prometheus.remote_write "metrics_service" {
       endpoint {
         url = nonsensitive(remote.kubernetes.secret.metrics_service.data["host"]) + "/api/prom/push"
-        headers = { "X-Scope-OrgID" = nonsensitive(remote.kubernetes.secret.metrics_service.data["tenantId"]) }
+        headers = {
+          "X-Scope-OrgID" = nonsensitive(remote.kubernetes.secret.metrics_service.data["tenantId"]),
+        }
     
         basic_auth {
           username = nonsensitive(remote.kubernetes.secret.metrics_service.data["username"])

--- a/examples/gke-autopilot/metrics.alloy
+++ b/examples/gke-autopilot/metrics.alloy
@@ -673,7 +673,9 @@ prometheus.relabel "metrics_service" {
 prometheus.remote_write "metrics_service" {
   endpoint {
     url = nonsensitive(remote.kubernetes.secret.metrics_service.data["host"]) + "/api/prom/push"
-    headers = { "X-Scope-OrgID" = nonsensitive(remote.kubernetes.secret.metrics_service.data["tenantId"]) }
+    headers = {
+      "X-Scope-OrgID" = nonsensitive(remote.kubernetes.secret.metrics_service.data["tenantId"]),
+    }
 
     basic_auth {
       username = nonsensitive(remote.kubernetes.secret.metrics_service.data["username"])

--- a/examples/gke-autopilot/output.yaml
+++ b/examples/gke-autopilot/output.yaml
@@ -788,7 +788,9 @@ data:
     prometheus.remote_write "metrics_service" {
       endpoint {
         url = nonsensitive(remote.kubernetes.secret.metrics_service.data["host"]) + "/api/prom/push"
-        headers = { "X-Scope-OrgID" = nonsensitive(remote.kubernetes.secret.metrics_service.data["tenantId"]) }
+        headers = {
+          "X-Scope-OrgID" = nonsensitive(remote.kubernetes.secret.metrics_service.data["tenantId"]),
+        }
     
         basic_auth {
           username = nonsensitive(remote.kubernetes.secret.metrics_service.data["username"])
@@ -59448,7 +59450,9 @@ data:
     prometheus.remote_write "metrics_service" {
       endpoint {
         url = nonsensitive(remote.kubernetes.secret.metrics_service.data["host"]) + "/api/prom/push"
-        headers = { "X-Scope-OrgID" = nonsensitive(remote.kubernetes.secret.metrics_service.data["tenantId"]) }
+        headers = {
+          "X-Scope-OrgID" = nonsensitive(remote.kubernetes.secret.metrics_service.data["tenantId"]),
+        }
     
         basic_auth {
           username = nonsensitive(remote.kubernetes.secret.metrics_service.data["username"])

--- a/examples/ibm-cloud/metrics.alloy
+++ b/examples/ibm-cloud/metrics.alloy
@@ -720,7 +720,9 @@ prometheus.relabel "metrics_service" {
 prometheus.remote_write "metrics_service" {
   endpoint {
     url = nonsensitive(remote.kubernetes.secret.metrics_service.data["host"]) + "/api/prom/push"
-    headers = { "X-Scope-OrgID" = nonsensitive(remote.kubernetes.secret.metrics_service.data["tenantId"]) }
+    headers = {
+      "X-Scope-OrgID" = nonsensitive(remote.kubernetes.secret.metrics_service.data["tenantId"]),
+    }
 
     basic_auth {
       username = nonsensitive(remote.kubernetes.secret.metrics_service.data["username"])

--- a/examples/ibm-cloud/output.yaml
+++ b/examples/ibm-cloud/output.yaml
@@ -852,7 +852,9 @@ data:
     prometheus.remote_write "metrics_service" {
       endpoint {
         url = nonsensitive(remote.kubernetes.secret.metrics_service.data["host"]) + "/api/prom/push"
-        headers = { "X-Scope-OrgID" = nonsensitive(remote.kubernetes.secret.metrics_service.data["tenantId"]) }
+        headers = {
+          "X-Scope-OrgID" = nonsensitive(remote.kubernetes.secret.metrics_service.data["tenantId"]),
+        }
     
         basic_auth {
           username = nonsensitive(remote.kubernetes.secret.metrics_service.data["username"])
@@ -59718,7 +59720,9 @@ data:
     prometheus.remote_write "metrics_service" {
       endpoint {
         url = nonsensitive(remote.kubernetes.secret.metrics_service.data["host"]) + "/api/prom/push"
-        headers = { "X-Scope-OrgID" = nonsensitive(remote.kubernetes.secret.metrics_service.data["tenantId"]) }
+        headers = {
+          "X-Scope-OrgID" = nonsensitive(remote.kubernetes.secret.metrics_service.data["tenantId"]),
+        }
     
         basic_auth {
           username = nonsensitive(remote.kubernetes.secret.metrics_service.data["username"])

--- a/examples/metric-module-imports-extra-config/metrics.alloy
+++ b/examples/metric-module-imports-extra-config/metrics.alloy
@@ -720,7 +720,9 @@ prometheus.relabel "metrics_service" {
 prometheus.remote_write "metrics_service" {
   endpoint {
     url = nonsensitive(remote.kubernetes.secret.metrics_service.data["host"]) + "/api/prom/push"
-    headers = { "X-Scope-OrgID" = nonsensitive(remote.kubernetes.secret.metrics_service.data["tenantId"]) }
+    headers = {
+      "X-Scope-OrgID" = nonsensitive(remote.kubernetes.secret.metrics_service.data["tenantId"]),
+    }
 
     basic_auth {
       username = nonsensitive(remote.kubernetes.secret.metrics_service.data["username"])

--- a/examples/metric-module-imports-extra-config/output.yaml
+++ b/examples/metric-module-imports-extra-config/output.yaml
@@ -852,7 +852,9 @@ data:
     prometheus.remote_write "metrics_service" {
       endpoint {
         url = nonsensitive(remote.kubernetes.secret.metrics_service.data["host"]) + "/api/prom/push"
-        headers = { "X-Scope-OrgID" = nonsensitive(remote.kubernetes.secret.metrics_service.data["tenantId"]) }
+        headers = {
+          "X-Scope-OrgID" = nonsensitive(remote.kubernetes.secret.metrics_service.data["tenantId"]),
+        }
     
         basic_auth {
           username = nonsensitive(remote.kubernetes.secret.metrics_service.data["username"])
@@ -59728,7 +59730,9 @@ data:
     prometheus.remote_write "metrics_service" {
       endpoint {
         url = nonsensitive(remote.kubernetes.secret.metrics_service.data["host"]) + "/api/prom/push"
-        headers = { "X-Scope-OrgID" = nonsensitive(remote.kubernetes.secret.metrics_service.data["tenantId"]) }
+        headers = {
+          "X-Scope-OrgID" = nonsensitive(remote.kubernetes.secret.metrics_service.data["tenantId"]),
+        }
     
         basic_auth {
           username = nonsensitive(remote.kubernetes.secret.metrics_service.data["username"])

--- a/examples/metric-module-imports/metrics.alloy
+++ b/examples/metric-module-imports/metrics.alloy
@@ -897,7 +897,9 @@ prometheus.relabel "metrics_service" {
 prometheus.remote_write "metrics_service" {
   endpoint {
     url = nonsensitive(remote.kubernetes.secret.metrics_service.data["host"]) + "/api/prom/push"
-    headers = { "X-Scope-OrgID" = nonsensitive(remote.kubernetes.secret.metrics_service.data["tenantId"]) }
+    headers = {
+      "X-Scope-OrgID" = nonsensitive(remote.kubernetes.secret.metrics_service.data["tenantId"]),
+    }
 
     basic_auth {
       username = nonsensitive(remote.kubernetes.secret.metrics_service.data["username"])

--- a/examples/metric-module-imports/output.yaml
+++ b/examples/metric-module-imports/output.yaml
@@ -1029,7 +1029,9 @@ data:
     prometheus.remote_write "metrics_service" {
       endpoint {
         url = nonsensitive(remote.kubernetes.secret.metrics_service.data["host"]) + "/api/prom/push"
-        headers = { "X-Scope-OrgID" = nonsensitive(remote.kubernetes.secret.metrics_service.data["tenantId"]) }
+        headers = {
+          "X-Scope-OrgID" = nonsensitive(remote.kubernetes.secret.metrics_service.data["tenantId"]),
+        }
     
         basic_auth {
           username = nonsensitive(remote.kubernetes.secret.metrics_service.data["username"])
@@ -60066,7 +60068,9 @@ data:
     prometheus.remote_write "metrics_service" {
       endpoint {
         url = nonsensitive(remote.kubernetes.secret.metrics_service.data["host"]) + "/api/prom/push"
-        headers = { "X-Scope-OrgID" = nonsensitive(remote.kubernetes.secret.metrics_service.data["tenantId"]) }
+        headers = {
+          "X-Scope-OrgID" = nonsensitive(remote.kubernetes.secret.metrics_service.data["tenantId"]),
+        }
     
         basic_auth {
           username = nonsensitive(remote.kubernetes.secret.metrics_service.data["username"])

--- a/examples/metrics-only/metrics.alloy
+++ b/examples/metrics-only/metrics.alloy
@@ -702,7 +702,9 @@ prometheus.relabel "metrics_service" {
 prometheus.remote_write "metrics_service" {
   endpoint {
     url = nonsensitive(remote.kubernetes.secret.metrics_service.data["host"]) + "/api/prom/push"
-    headers = { "X-Scope-OrgID" = nonsensitive(remote.kubernetes.secret.metrics_service.data["tenantId"]) }
+    headers = {
+      "X-Scope-OrgID" = nonsensitive(remote.kubernetes.secret.metrics_service.data["tenantId"]),
+    }
 
     basic_auth {
       username = nonsensitive(remote.kubernetes.secret.metrics_service.data["username"])

--- a/examples/metrics-only/output.yaml
+++ b/examples/metrics-only/output.yaml
@@ -790,7 +790,9 @@ data:
     prometheus.remote_write "metrics_service" {
       endpoint {
         url = nonsensitive(remote.kubernetes.secret.metrics_service.data["host"]) + "/api/prom/push"
-        headers = { "X-Scope-OrgID" = nonsensitive(remote.kubernetes.secret.metrics_service.data["tenantId"]) }
+        headers = {
+          "X-Scope-OrgID" = nonsensitive(remote.kubernetes.secret.metrics_service.data["tenantId"]),
+        }
     
         basic_auth {
           username = nonsensitive(remote.kubernetes.secret.metrics_service.data["username"])
@@ -58874,7 +58876,9 @@ data:
     prometheus.remote_write "metrics_service" {
       endpoint {
         url = nonsensitive(remote.kubernetes.secret.metrics_service.data["host"]) + "/api/prom/push"
-        headers = { "X-Scope-OrgID" = nonsensitive(remote.kubernetes.secret.metrics_service.data["tenantId"]) }
+        headers = {
+          "X-Scope-OrgID" = nonsensitive(remote.kubernetes.secret.metrics_service.data["tenantId"]),
+        }
     
         basic_auth {
           username = nonsensitive(remote.kubernetes.secret.metrics_service.data["username"])

--- a/examples/openshift-compatible/metrics.alloy
+++ b/examples/openshift-compatible/metrics.alloy
@@ -721,7 +721,9 @@ prometheus.relabel "metrics_service" {
 prometheus.remote_write "metrics_service" {
   endpoint {
     url = nonsensitive(remote.kubernetes.secret.metrics_service.data["host"]) + "/api/prom/push"
-    headers = { "X-Scope-OrgID" = nonsensitive(remote.kubernetes.secret.metrics_service.data["tenantId"]) }
+    headers = {
+      "X-Scope-OrgID" = nonsensitive(remote.kubernetes.secret.metrics_service.data["tenantId"]),
+    }
     proxy_url = "http://192.168.1.100:8080"
 
     basic_auth {

--- a/examples/openshift-compatible/output.yaml
+++ b/examples/openshift-compatible/output.yaml
@@ -819,7 +819,9 @@ data:
     prometheus.remote_write "metrics_service" {
       endpoint {
         url = nonsensitive(remote.kubernetes.secret.metrics_service.data["host"]) + "/api/prom/push"
-        headers = { "X-Scope-OrgID" = nonsensitive(remote.kubernetes.secret.metrics_service.data["tenantId"]) }
+        headers = {
+          "X-Scope-OrgID" = nonsensitive(remote.kubernetes.secret.metrics_service.data["tenantId"]),
+        }
         proxy_url = "http://192.168.1.100:8080"
     
         basic_auth {
@@ -59547,7 +59549,9 @@ data:
     prometheus.remote_write "metrics_service" {
       endpoint {
         url = nonsensitive(remote.kubernetes.secret.metrics_service.data["host"]) + "/api/prom/push"
-        headers = { "X-Scope-OrgID" = nonsensitive(remote.kubernetes.secret.metrics_service.data["tenantId"]) }
+        headers = {
+          "X-Scope-OrgID" = nonsensitive(remote.kubernetes.secret.metrics_service.data["tenantId"]),
+        }
         proxy_url = "http://192.168.1.100:8080"
     
         basic_auth {

--- a/examples/otel-metrics-service/metrics.alloy
+++ b/examples/otel-metrics-service/metrics.alloy
@@ -762,6 +762,9 @@ otelcol.exporter.otlphttp "metrics_service" {
     endpoint = nonsensitive(remote.kubernetes.secret.metrics_service.data["host"]) + "/api/v1/otlp"
 
     auth = otelcol.auth.basic.metrics_service.handler
+    headers = {
+      "X-Scope-OrgID" = nonsensitive(remote.kubernetes.secret.metrics_service.data["tenantId"]),
+    }
     tls {
       insecure_skip_verify = true
     }

--- a/examples/otel-metrics-service/output.yaml
+++ b/examples/otel-metrics-service/output.yaml
@@ -894,6 +894,9 @@ data:
         endpoint = nonsensitive(remote.kubernetes.secret.metrics_service.data["host"]) + "/api/v1/otlp"
     
         auth = otelcol.auth.basic.metrics_service.handler
+        headers = {
+          "X-Scope-OrgID" = nonsensitive(remote.kubernetes.secret.metrics_service.data["tenantId"]),
+        }
         tls {
           insecure_skip_verify = true
         }
@@ -59771,6 +59774,9 @@ data:
         endpoint = nonsensitive(remote.kubernetes.secret.metrics_service.data["host"]) + "/api/v1/otlp"
     
         auth = otelcol.auth.basic.metrics_service.handler
+        headers = {
+          "X-Scope-OrgID" = nonsensitive(remote.kubernetes.secret.metrics_service.data["tenantId"]),
+        }
         tls {
           insecure_skip_verify = true
         }

--- a/examples/pod-labels/metrics.alloy
+++ b/examples/pod-labels/metrics.alloy
@@ -757,7 +757,9 @@ prometheus.relabel "metrics_service" {
 prometheus.remote_write "metrics_service" {
   endpoint {
     url = nonsensitive(remote.kubernetes.secret.metrics_service.data["host"]) + "/api/prom/push"
-    headers = { "X-Scope-OrgID" = nonsensitive(remote.kubernetes.secret.metrics_service.data["tenantId"]) }
+    headers = {
+      "X-Scope-OrgID" = nonsensitive(remote.kubernetes.secret.metrics_service.data["tenantId"]),
+    }
 
     basic_auth {
       username = nonsensitive(remote.kubernetes.secret.metrics_service.data["username"])
@@ -874,7 +876,9 @@ otelcol.exporter.otlp "traces_service" {
     endpoint = nonsensitive(remote.kubernetes.secret.traces_service.data["host"])
 
     auth = otelcol.auth.basic.traces_service.handler
-    headers = { "X-Scope-OrgID" = nonsensitive(remote.kubernetes.secret.traces_service.data["tenantId"]) }
+    headers = {
+      "X-Scope-OrgID" = nonsensitive(remote.kubernetes.secret.metrics_service.data["tenantId"]),
+    }
   }
 }
 

--- a/examples/pod-labels/output.yaml
+++ b/examples/pod-labels/output.yaml
@@ -902,7 +902,9 @@ data:
     prometheus.remote_write "metrics_service" {
       endpoint {
         url = nonsensitive(remote.kubernetes.secret.metrics_service.data["host"]) + "/api/prom/push"
-        headers = { "X-Scope-OrgID" = nonsensitive(remote.kubernetes.secret.metrics_service.data["tenantId"]) }
+        headers = {
+          "X-Scope-OrgID" = nonsensitive(remote.kubernetes.secret.metrics_service.data["tenantId"]),
+        }
     
         basic_auth {
           username = nonsensitive(remote.kubernetes.secret.metrics_service.data["username"])
@@ -1019,7 +1021,9 @@ data:
         endpoint = nonsensitive(remote.kubernetes.secret.traces_service.data["host"])
     
         auth = otelcol.auth.basic.traces_service.handler
-        headers = { "X-Scope-OrgID" = nonsensitive(remote.kubernetes.secret.traces_service.data["tenantId"]) }
+        headers = {
+          "X-Scope-OrgID" = nonsensitive(remote.kubernetes.secret.metrics_service.data["tenantId"]),
+        }
       }
     }
     
@@ -59825,7 +59829,9 @@ data:
     prometheus.remote_write "metrics_service" {
       endpoint {
         url = nonsensitive(remote.kubernetes.secret.metrics_service.data["host"]) + "/api/prom/push"
-        headers = { "X-Scope-OrgID" = nonsensitive(remote.kubernetes.secret.metrics_service.data["tenantId"]) }
+        headers = {
+          "X-Scope-OrgID" = nonsensitive(remote.kubernetes.secret.metrics_service.data["tenantId"]),
+        }
     
         basic_auth {
           username = nonsensitive(remote.kubernetes.secret.metrics_service.data["username"])
@@ -59942,7 +59948,9 @@ data:
         endpoint = nonsensitive(remote.kubernetes.secret.traces_service.data["host"])
     
         auth = otelcol.auth.basic.traces_service.handler
-        headers = { "X-Scope-OrgID" = nonsensitive(remote.kubernetes.secret.traces_service.data["tenantId"]) }
+        headers = {
+          "X-Scope-OrgID" = nonsensitive(remote.kubernetes.secret.metrics_service.data["tenantId"]),
+        }
       }
     }
     

--- a/examples/private-image-registry/metrics.alloy
+++ b/examples/private-image-registry/metrics.alloy
@@ -720,7 +720,9 @@ prometheus.relabel "metrics_service" {
 prometheus.remote_write "metrics_service" {
   endpoint {
     url = nonsensitive(remote.kubernetes.secret.metrics_service.data["host"]) + "/api/prom/push"
-    headers = { "X-Scope-OrgID" = nonsensitive(remote.kubernetes.secret.metrics_service.data["tenantId"]) }
+    headers = {
+      "X-Scope-OrgID" = nonsensitive(remote.kubernetes.secret.metrics_service.data["tenantId"]),
+    }
 
     basic_auth {
       username = nonsensitive(remote.kubernetes.secret.metrics_service.data["username"])

--- a/examples/private-image-registry/output.yaml
+++ b/examples/private-image-registry/output.yaml
@@ -856,7 +856,9 @@ data:
     prometheus.remote_write "metrics_service" {
       endpoint {
         url = nonsensitive(remote.kubernetes.secret.metrics_service.data["host"]) + "/api/prom/push"
-        headers = { "X-Scope-OrgID" = nonsensitive(remote.kubernetes.secret.metrics_service.data["tenantId"]) }
+        headers = {
+          "X-Scope-OrgID" = nonsensitive(remote.kubernetes.secret.metrics_service.data["tenantId"]),
+        }
     
         basic_auth {
           username = nonsensitive(remote.kubernetes.secret.metrics_service.data["username"])
@@ -59728,7 +59730,9 @@ data:
     prometheus.remote_write "metrics_service" {
       endpoint {
         url = nonsensitive(remote.kubernetes.secret.metrics_service.data["host"]) + "/api/prom/push"
-        headers = { "X-Scope-OrgID" = nonsensitive(remote.kubernetes.secret.metrics_service.data["tenantId"]) }
+        headers = {
+          "X-Scope-OrgID" = nonsensitive(remote.kubernetes.secret.metrics_service.data["tenantId"]),
+        }
     
         basic_auth {
           username = nonsensitive(remote.kubernetes.secret.metrics_service.data["username"])

--- a/examples/profiles-enabled/metrics.alloy
+++ b/examples/profiles-enabled/metrics.alloy
@@ -720,7 +720,9 @@ prometheus.relabel "metrics_service" {
 prometheus.remote_write "metrics_service" {
   endpoint {
     url = nonsensitive(remote.kubernetes.secret.metrics_service.data["host"]) + "/api/prom/push"
-    headers = { "X-Scope-OrgID" = nonsensitive(remote.kubernetes.secret.metrics_service.data["tenantId"]) }
+    headers = {
+      "X-Scope-OrgID" = nonsensitive(remote.kubernetes.secret.metrics_service.data["tenantId"]),
+    }
 
     basic_auth {
       username = nonsensitive(remote.kubernetes.secret.metrics_service.data["username"])

--- a/examples/profiles-enabled/output.yaml
+++ b/examples/profiles-enabled/output.yaml
@@ -881,7 +881,9 @@ data:
     prometheus.remote_write "metrics_service" {
       endpoint {
         url = nonsensitive(remote.kubernetes.secret.metrics_service.data["host"]) + "/api/prom/push"
-        headers = { "X-Scope-OrgID" = nonsensitive(remote.kubernetes.secret.metrics_service.data["tenantId"]) }
+        headers = {
+          "X-Scope-OrgID" = nonsensitive(remote.kubernetes.secret.metrics_service.data["tenantId"]),
+        }
     
         basic_auth {
           username = nonsensitive(remote.kubernetes.secret.metrics_service.data["username"])
@@ -2125,7 +2127,9 @@ data:
     pyroscope.write "profiles_service" {
       endpoint {
         url = nonsensitive(remote.kubernetes.secret.profiles_service.data["host"])
-        headers = { "X-Scope-OrgID" = nonsensitive(remote.kubernetes.secret.profiles_service.data["tenantId"]) }
+        headers = {
+          "X-Scope-OrgID" = nonsensitive(remote.kubernetes.secret.profiles_service.data["tenantId"]),
+        }
     
         basic_auth {
           username = nonsensitive(remote.kubernetes.secret.profiles_service.data["username"])
@@ -60908,7 +60912,9 @@ data:
     prometheus.remote_write "metrics_service" {
       endpoint {
         url = nonsensitive(remote.kubernetes.secret.metrics_service.data["host"]) + "/api/prom/push"
-        headers = { "X-Scope-OrgID" = nonsensitive(remote.kubernetes.secret.metrics_service.data["tenantId"]) }
+        headers = {
+          "X-Scope-OrgID" = nonsensitive(remote.kubernetes.secret.metrics_service.data["tenantId"]),
+        }
     
         basic_auth {
           username = nonsensitive(remote.kubernetes.secret.metrics_service.data["username"])
@@ -62124,7 +62130,9 @@ data:
     pyroscope.write "profiles_service" {
       endpoint {
         url = nonsensitive(remote.kubernetes.secret.profiles_service.data["host"])
-        headers = { "X-Scope-OrgID" = nonsensitive(remote.kubernetes.secret.profiles_service.data["tenantId"]) }
+        headers = {
+          "X-Scope-OrgID" = nonsensitive(remote.kubernetes.secret.profiles_service.data["tenantId"]),
+        }
     
         basic_auth {
           username = nonsensitive(remote.kubernetes.secret.profiles_service.data["username"])

--- a/examples/profiles-enabled/profiles.alloy
+++ b/examples/profiles-enabled/profiles.alloy
@@ -903,7 +903,9 @@ remote.kubernetes.secret "profiles_service" {
 pyroscope.write "profiles_service" {
   endpoint {
     url = nonsensitive(remote.kubernetes.secret.profiles_service.data["host"])
-    headers = { "X-Scope-OrgID" = nonsensitive(remote.kubernetes.secret.profiles_service.data["tenantId"]) }
+    headers = {
+      "X-Scope-OrgID" = nonsensitive(remote.kubernetes.secret.profiles_service.data["tenantId"]),
+    }
 
     basic_auth {
       username = nonsensitive(remote.kubernetes.secret.profiles_service.data["username"])

--- a/examples/proxies/metrics.alloy
+++ b/examples/proxies/metrics.alloy
@@ -720,7 +720,9 @@ prometheus.relabel "metrics_service" {
 prometheus.remote_write "metrics_service" {
   endpoint {
     url = nonsensitive(remote.kubernetes.secret.metrics_service.data["host"]) + "/api/prom/push"
-    headers = { "X-Scope-OrgID" = nonsensitive(remote.kubernetes.secret.metrics_service.data["tenantId"]) }
+    headers = {
+      "X-Scope-OrgID" = nonsensitive(remote.kubernetes.secret.metrics_service.data["tenantId"]),
+    }
     proxy_url = "https://localhost:8080"
 
     basic_auth {

--- a/examples/proxies/output.yaml
+++ b/examples/proxies/output.yaml
@@ -852,7 +852,9 @@ data:
     prometheus.remote_write "metrics_service" {
       endpoint {
         url = nonsensitive(remote.kubernetes.secret.metrics_service.data["host"]) + "/api/prom/push"
-        headers = { "X-Scope-OrgID" = nonsensitive(remote.kubernetes.secret.metrics_service.data["tenantId"]) }
+        headers = {
+          "X-Scope-OrgID" = nonsensitive(remote.kubernetes.secret.metrics_service.data["tenantId"]),
+        }
         proxy_url = "https://localhost:8080"
     
         basic_auth {
@@ -59728,7 +59730,9 @@ data:
     prometheus.remote_write "metrics_service" {
       endpoint {
         url = nonsensitive(remote.kubernetes.secret.metrics_service.data["host"]) + "/api/prom/push"
-        headers = { "X-Scope-OrgID" = nonsensitive(remote.kubernetes.secret.metrics_service.data["tenantId"]) }
+        headers = {
+          "X-Scope-OrgID" = nonsensitive(remote.kubernetes.secret.metrics_service.data["tenantId"]),
+        }
         proxy_url = "https://localhost:8080"
     
         basic_auth {

--- a/examples/scrape-intervals/metrics.alloy
+++ b/examples/scrape-intervals/metrics.alloy
@@ -702,7 +702,9 @@ prometheus.relabel "metrics_service" {
 prometheus.remote_write "metrics_service" {
   endpoint {
     url = nonsensitive(remote.kubernetes.secret.metrics_service.data["host"]) + "/api/prom/push"
-    headers = { "X-Scope-OrgID" = nonsensitive(remote.kubernetes.secret.metrics_service.data["tenantId"]) }
+    headers = {
+      "X-Scope-OrgID" = nonsensitive(remote.kubernetes.secret.metrics_service.data["tenantId"]),
+    }
 
     basic_auth {
       username = nonsensitive(remote.kubernetes.secret.metrics_service.data["username"])

--- a/examples/scrape-intervals/output.yaml
+++ b/examples/scrape-intervals/output.yaml
@@ -789,7 +789,9 @@ data:
     prometheus.remote_write "metrics_service" {
       endpoint {
         url = nonsensitive(remote.kubernetes.secret.metrics_service.data["host"]) + "/api/prom/push"
-        headers = { "X-Scope-OrgID" = nonsensitive(remote.kubernetes.secret.metrics_service.data["tenantId"]) }
+        headers = {
+          "X-Scope-OrgID" = nonsensitive(remote.kubernetes.secret.metrics_service.data["tenantId"]),
+        }
     
         basic_auth {
           username = nonsensitive(remote.kubernetes.secret.metrics_service.data["username"])
@@ -58873,7 +58875,9 @@ data:
     prometheus.remote_write "metrics_service" {
       endpoint {
         url = nonsensitive(remote.kubernetes.secret.metrics_service.data["host"]) + "/api/prom/push"
-        headers = { "X-Scope-OrgID" = nonsensitive(remote.kubernetes.secret.metrics_service.data["tenantId"]) }
+        headers = {
+          "X-Scope-OrgID" = nonsensitive(remote.kubernetes.secret.metrics_service.data["tenantId"]),
+        }
     
         basic_auth {
           username = nonsensitive(remote.kubernetes.secret.metrics_service.data["username"])

--- a/examples/service-integrations/metrics.alloy
+++ b/examples/service-integrations/metrics.alloy
@@ -720,7 +720,9 @@ prometheus.relabel "metrics_service" {
 prometheus.remote_write "metrics_service" {
   endpoint {
     url = nonsensitive(remote.kubernetes.secret.metrics_service.data["host"]) + "/api/prom/push"
-    headers = { "X-Scope-OrgID" = nonsensitive(remote.kubernetes.secret.metrics_service.data["tenantId"]) }
+    headers = {
+      "X-Scope-OrgID" = nonsensitive(remote.kubernetes.secret.metrics_service.data["tenantId"]),
+    }
 
     basic_auth {
       username = nonsensitive(remote.kubernetes.secret.metrics_service.data["username"])

--- a/examples/service-integrations/output.yaml
+++ b/examples/service-integrations/output.yaml
@@ -852,7 +852,9 @@ data:
     prometheus.remote_write "metrics_service" {
       endpoint {
         url = nonsensitive(remote.kubernetes.secret.metrics_service.data["host"]) + "/api/prom/push"
-        headers = { "X-Scope-OrgID" = nonsensitive(remote.kubernetes.secret.metrics_service.data["tenantId"]) }
+        headers = {
+          "X-Scope-OrgID" = nonsensitive(remote.kubernetes.secret.metrics_service.data["tenantId"]),
+        }
     
         basic_auth {
           username = nonsensitive(remote.kubernetes.secret.metrics_service.data["username"])
@@ -59747,7 +59749,9 @@ data:
     prometheus.remote_write "metrics_service" {
       endpoint {
         url = nonsensitive(remote.kubernetes.secret.metrics_service.data["host"]) + "/api/prom/push"
-        headers = { "X-Scope-OrgID" = nonsensitive(remote.kubernetes.secret.metrics_service.data["tenantId"]) }
+        headers = {
+          "X-Scope-OrgID" = nonsensitive(remote.kubernetes.secret.metrics_service.data["tenantId"]),
+        }
     
         basic_auth {
           username = nonsensitive(remote.kubernetes.secret.metrics_service.data["username"])

--- a/examples/specific-namespace/metrics.alloy
+++ b/examples/specific-namespace/metrics.alloy
@@ -778,7 +778,9 @@ prometheus.relabel "metrics_service" {
 prometheus.remote_write "metrics_service" {
   endpoint {
     url = nonsensitive(remote.kubernetes.secret.metrics_service.data["host"]) + "/api/prom/push"
-    headers = { "X-Scope-OrgID" = nonsensitive(remote.kubernetes.secret.metrics_service.data["tenantId"]) }
+    headers = {
+      "X-Scope-OrgID" = nonsensitive(remote.kubernetes.secret.metrics_service.data["tenantId"]),
+    }
 
     basic_auth {
       username = nonsensitive(remote.kubernetes.secret.metrics_service.data["username"])

--- a/examples/specific-namespace/output.yaml
+++ b/examples/specific-namespace/output.yaml
@@ -910,7 +910,9 @@ data:
     prometheus.remote_write "metrics_service" {
       endpoint {
         url = nonsensitive(remote.kubernetes.secret.metrics_service.data["host"]) + "/api/prom/push"
-        headers = { "X-Scope-OrgID" = nonsensitive(remote.kubernetes.secret.metrics_service.data["tenantId"]) }
+        headers = {
+          "X-Scope-OrgID" = nonsensitive(remote.kubernetes.secret.metrics_service.data["tenantId"]),
+        }
     
         basic_auth {
           username = nonsensitive(remote.kubernetes.secret.metrics_service.data["username"])
@@ -59834,7 +59836,9 @@ data:
     prometheus.remote_write "metrics_service" {
       endpoint {
         url = nonsensitive(remote.kubernetes.secret.metrics_service.data["host"]) + "/api/prom/push"
-        headers = { "X-Scope-OrgID" = nonsensitive(remote.kubernetes.secret.metrics_service.data["tenantId"]) }
+        headers = {
+          "X-Scope-OrgID" = nonsensitive(remote.kubernetes.secret.metrics_service.data["tenantId"]),
+        }
     
         basic_auth {
           username = nonsensitive(remote.kubernetes.secret.metrics_service.data["username"])

--- a/examples/traces-enabled/metrics.alloy
+++ b/examples/traces-enabled/metrics.alloy
@@ -806,7 +806,9 @@ prometheus.relabel "metrics_service" {
 prometheus.remote_write "metrics_service" {
   endpoint {
     url = nonsensitive(remote.kubernetes.secret.metrics_service.data["host"]) + "/api/prom/push"
-    headers = { "X-Scope-OrgID" = nonsensitive(remote.kubernetes.secret.metrics_service.data["tenantId"]) }
+    headers = {
+      "X-Scope-OrgID" = nonsensitive(remote.kubernetes.secret.metrics_service.data["tenantId"]),
+    }
 
     basic_auth {
       username = nonsensitive(remote.kubernetes.secret.metrics_service.data["username"])
@@ -923,7 +925,9 @@ otelcol.exporter.otlp "traces_service" {
     endpoint = nonsensitive(remote.kubernetes.secret.traces_service.data["host"])
 
     auth = otelcol.auth.basic.traces_service.handler
-    headers = { "X-Scope-OrgID" = nonsensitive(remote.kubernetes.secret.traces_service.data["tenantId"]) }
+    headers = {
+      "X-Scope-OrgID" = nonsensitive(remote.kubernetes.secret.metrics_service.data["tenantId"]),
+    }
   }
 }
 

--- a/examples/traces-enabled/output.yaml
+++ b/examples/traces-enabled/output.yaml
@@ -951,7 +951,9 @@ data:
     prometheus.remote_write "metrics_service" {
       endpoint {
         url = nonsensitive(remote.kubernetes.secret.metrics_service.data["host"]) + "/api/prom/push"
-        headers = { "X-Scope-OrgID" = nonsensitive(remote.kubernetes.secret.metrics_service.data["tenantId"]) }
+        headers = {
+          "X-Scope-OrgID" = nonsensitive(remote.kubernetes.secret.metrics_service.data["tenantId"]),
+        }
     
         basic_auth {
           username = nonsensitive(remote.kubernetes.secret.metrics_service.data["username"])
@@ -1068,7 +1070,9 @@ data:
         endpoint = nonsensitive(remote.kubernetes.secret.traces_service.data["host"])
     
         auth = otelcol.auth.basic.traces_service.handler
-        headers = { "X-Scope-OrgID" = nonsensitive(remote.kubernetes.secret.traces_service.data["tenantId"]) }
+        headers = {
+          "X-Scope-OrgID" = nonsensitive(remote.kubernetes.secret.metrics_service.data["tenantId"]),
+        }
       }
     }
     
@@ -59917,7 +59921,9 @@ data:
     prometheus.remote_write "metrics_service" {
       endpoint {
         url = nonsensitive(remote.kubernetes.secret.metrics_service.data["host"]) + "/api/prom/push"
-        headers = { "X-Scope-OrgID" = nonsensitive(remote.kubernetes.secret.metrics_service.data["tenantId"]) }
+        headers = {
+          "X-Scope-OrgID" = nonsensitive(remote.kubernetes.secret.metrics_service.data["tenantId"]),
+        }
     
         basic_auth {
           username = nonsensitive(remote.kubernetes.secret.metrics_service.data["username"])
@@ -60034,7 +60040,9 @@ data:
         endpoint = nonsensitive(remote.kubernetes.secret.traces_service.data["host"])
     
         auth = otelcol.auth.basic.traces_service.handler
-        headers = { "X-Scope-OrgID" = nonsensitive(remote.kubernetes.secret.traces_service.data["tenantId"]) }
+        headers = {
+          "X-Scope-OrgID" = nonsensitive(remote.kubernetes.secret.metrics_service.data["tenantId"]),
+        }
       }
     }
     

--- a/examples/windows-exporter/metrics.alloy
+++ b/examples/windows-exporter/metrics.alloy
@@ -789,7 +789,9 @@ prometheus.relabel "metrics_service" {
 prometheus.remote_write "metrics_service" {
   endpoint {
     url = nonsensitive(remote.kubernetes.secret.metrics_service.data["host"]) + "/api/prom/push"
-    headers = { "X-Scope-OrgID" = nonsensitive(remote.kubernetes.secret.metrics_service.data["tenantId"]) }
+    headers = {
+      "X-Scope-OrgID" = nonsensitive(remote.kubernetes.secret.metrics_service.data["tenantId"]),
+    }
 
     basic_auth {
       username = nonsensitive(remote.kubernetes.secret.metrics_service.data["username"])

--- a/examples/windows-exporter/output.yaml
+++ b/examples/windows-exporter/output.yaml
@@ -960,7 +960,9 @@ data:
     prometheus.remote_write "metrics_service" {
       endpoint {
         url = nonsensitive(remote.kubernetes.secret.metrics_service.data["host"]) + "/api/prom/push"
-        headers = { "X-Scope-OrgID" = nonsensitive(remote.kubernetes.secret.metrics_service.data["tenantId"]) }
+        headers = {
+          "X-Scope-OrgID" = nonsensitive(remote.kubernetes.secret.metrics_service.data["tenantId"]),
+        }
     
         basic_auth {
           username = nonsensitive(remote.kubernetes.secret.metrics_service.data["username"])
@@ -60019,7 +60021,9 @@ data:
     prometheus.remote_write "metrics_service" {
       endpoint {
         url = nonsensitive(remote.kubernetes.secret.metrics_service.data["host"]) + "/api/prom/push"
-        headers = { "X-Scope-OrgID" = nonsensitive(remote.kubernetes.secret.metrics_service.data["tenantId"]) }
+        headers = {
+          "X-Scope-OrgID" = nonsensitive(remote.kubernetes.secret.metrics_service.data["tenantId"]),
+        }
     
         basic_auth {
           username = nonsensitive(remote.kubernetes.secret.metrics_service.data["username"])


### PR DESCRIPTION
This adds:
* `extraHeaders` and `extraHeadersFrom` fields for the four data destinations that we support and sets the header values for those
    * `extraHeaders` treats values as a string for the Alloy component
    * `extraHeadersFrom` does not, which lets you use other alloy components, like environment variables, or configmap references
    
    