### PR TITLE
Add ARM64 tolerations to alloy, ksm, and opencost

### DIFF
--- a/charts/k8s-monitoring/README.md
+++ b/charts/k8s-monitoring/README.md
@@ -223,7 +223,7 @@ The Prometheus and Loki services may be hosted on the same cluster, or remotely 
 | configValidator.extraLabels | object | `{}` | Extra labels to add to the test config validator job. |
 | configValidator.nodeSelector | object | `{"kubernetes.io/os":"linux"}` | nodeSelector to apply to the config validator job. |
 | configValidator.serviceAccount | object | `{"name":""}` | Service Account to use for the config validator job. |
-| configValidator.tolerations | list | `[]` | Tolerations to apply to the config validator job. |
+| configValidator.tolerations | list | `[{"effect":"NoSchedule","key":"kubernetes.io/arch","operator":"Equal","value":"arm64"}]` | Tolerations to apply to the config validator job. |
 
 ### External Services (Loki)
 

--- a/charts/k8s-monitoring/values.yaml
+++ b/charts/k8s-monitoring/values.yaml
@@ -1990,6 +1990,14 @@ configValidator:
   nodeSelector:
     kubernetes.io/os: linux
 
+  # -- Tolerations to apply to the config validator job.
+  # @section -- Config Validator Job
+  tolerations:
+    - key: "kubernetes.io/arch"
+      operator: "Equal"
+      value: "arm64"
+      effect: "NoSchedule"
+
   # -- Extra annotations to add to the test config validator job.
   # @section -- Config Validator Job
   extraAnnotations: {}
@@ -1997,10 +2005,6 @@ configValidator:
   # -- Extra labels to add to the test config validator job.
   # @section -- Config Validator Job
   extraLabels: {}
-
-  # -- Tolerations to apply to the config validator job.
-  # @section -- Config Validator Job
-  tolerations: []
 
   # -- Service Account to use for the config validator job.
   # @section -- Config Validator Job
@@ -2134,6 +2138,13 @@ kube-state-metrics:
   # @ignored
   nodeSelector:
     kubernetes.io/os: linux
+
+  # @ignored
+  tolerations:
+    - key: "kubernetes.io/arch"
+      operator: "Equal"
+      value: "arm64"
+      effect: "NoSchedule"
 
   # @ignored - Enable the release label
   releaseLabel: true
@@ -2288,6 +2299,13 @@ opencost:
     nodeSelector:
       kubernetes.io/os: linux
 
+    # @ignored -- This skips including these values in README.md
+    tolerations:
+      - key: "kubernetes.io/arch"
+        operator: "Equal"
+        value: "arm64"
+        effect: "NoSchedule"
+
 # Settings for the Kepler deployment
 # You can use this sections to make modifications to the Kepler deployment.
 # See https://github.com/sustainable-computing-io/kepler-helm-chart/tree/main/chart/kepler for available values.
@@ -2407,8 +2425,15 @@ alloy:
   # @ignored
   controller:
     type: statefulset
+
     nodeSelector:
       kubernetes.io/os: linux
+
+    tolerations:
+      - key: "kubernetes.io/arch"
+        operator: "Equal"
+        value: "arm64"
+        effect: "NoSchedule"
 
     podAnnotations:
       k8s.grafana.com/logs.job: integrations/alloy
@@ -2448,6 +2473,12 @@ alloy-events:
     replicas: 1  # Only one replica should be used, otherwise multiple copies of cluster events might get sent to Loki.
     nodeSelector:
       kubernetes.io/os: linux
+
+    tolerations:
+      - key: "kubernetes.io/arch"
+        operator: "Equal"
+        value: "arm64"
+        effect: "NoSchedule"
 
     podAnnotations:
       k8s.grafana.com/logs.job: integrations/alloy

--- a/examples/alloy-autoscaling-and-storage/output.yaml
+++ b/examples/alloy-autoscaling-and-storage/output.yaml
@@ -68086,6 +68086,11 @@ spec:
       dnsPolicy: ClusterFirst
       nodeSelector:
         kubernetes.io/os: linux
+      tolerations:
+        - effect: NoSchedule
+          key: kubernetes.io/arch
+          operator: Equal
+          value: arm64
       volumes:
         - name: config
           configMap:
@@ -68180,6 +68185,11 @@ spec:
           readOnlyRootFilesystem: true
       nodeSelector:
         kubernetes.io/os: linux
+      tolerations:
+        - effect: NoSchedule
+          key: kubernetes.io/arch
+          operator: Equal
+          value: arm64
 ---
 # Source: k8s-monitoring/charts/opencost/templates/deployment.yaml
 apiVersion: apps/v1
@@ -68212,6 +68222,11 @@ spec:
         app.kubernetes.io/instance: k8smon
     spec:
       serviceAccountName: k8smon-opencost
+      tolerations:
+        - effect: NoSchedule
+          key: kubernetes.io/arch
+          operator: Equal
+          value: arm64
       nodeSelector:
         kubernetes.io/os: linux
       containers:
@@ -68445,6 +68460,11 @@ spec:
       dnsPolicy: ClusterFirst
       nodeSelector:
         kubernetes.io/os: linux
+      tolerations:
+        - effect: NoSchedule
+          key: kubernetes.io/arch
+          operator: Equal
+          value: arm64
       volumes:
         - name: config
           configMap:
@@ -69619,6 +69639,11 @@ spec:
   restartPolicy: Never
   nodeSelector:
         kubernetes.io/os: linux
+  tolerations:
+        - effect: NoSchedule
+          key: kubernetes.io/arch
+          operator: Equal
+          value: arm64
   containers:
     - name: alloy
       image: "docker.io/grafana/alloy:v1.3.1"

--- a/examples/application-observability/output.yaml
+++ b/examples/application-observability/output.yaml
@@ -69344,6 +69344,11 @@ spec:
       dnsPolicy: ClusterFirst
       nodeSelector:
         kubernetes.io/os: linux
+      tolerations:
+        - effect: NoSchedule
+          key: kubernetes.io/arch
+          operator: Equal
+          value: arm64
       volumes:
         - name: config
           configMap:
@@ -69438,6 +69443,11 @@ spec:
           readOnlyRootFilesystem: true
       nodeSelector:
         kubernetes.io/os: linux
+      tolerations:
+        - effect: NoSchedule
+          key: kubernetes.io/arch
+          operator: Equal
+          value: arm64
 ---
 # Source: k8s-monitoring/charts/opencost/templates/deployment.yaml
 apiVersion: apps/v1
@@ -69470,6 +69480,11 @@ spec:
         app.kubernetes.io/instance: k8smon
     spec:
       serviceAccountName: k8smon-opencost
+      tolerations:
+        - effect: NoSchedule
+          key: kubernetes.io/arch
+          operator: Equal
+          value: arm64
       nodeSelector:
         kubernetes.io/os: linux
       containers:
@@ -69660,6 +69675,11 @@ spec:
       dnsPolicy: ClusterFirst
       nodeSelector:
         kubernetes.io/os: linux
+      tolerations:
+        - effect: NoSchedule
+          key: kubernetes.io/arch
+          operator: Equal
+          value: arm64
       volumes:
         - name: config
           configMap:
@@ -71798,6 +71818,11 @@ spec:
   restartPolicy: Never
   nodeSelector:
         kubernetes.io/os: linux
+  tolerations:
+        - effect: NoSchedule
+          key: kubernetes.io/arch
+          operator: Equal
+          value: arm64
   containers:
     - name: alloy
       image: "docker.io/grafana/alloy:v1.3.1"

--- a/examples/azure-aks/output.yaml
+++ b/examples/azure-aks/output.yaml
@@ -68081,6 +68081,11 @@ spec:
       dnsPolicy: ClusterFirst
       nodeSelector:
         kubernetes.io/os: linux
+      tolerations:
+        - effect: NoSchedule
+          key: kubernetes.io/arch
+          operator: Equal
+          value: arm64
       volumes:
         - name: config
           configMap:
@@ -68178,6 +68183,11 @@ spec:
           readOnlyRootFilesystem: true
       nodeSelector:
         kubernetes.io/os: linux
+      tolerations:
+        - effect: NoSchedule
+          key: kubernetes.io/arch
+          operator: Equal
+          value: arm64
 ---
 # Source: k8s-monitoring/charts/opencost/templates/deployment.yaml
 apiVersion: apps/v1
@@ -68212,6 +68222,11 @@ spec:
         kubernetes.azure.com/set-kube-service-host-fqdn: "true"
     spec:
       serviceAccountName: k8smon-opencost
+      tolerations:
+        - effect: NoSchedule
+          key: kubernetes.io/arch
+          operator: Equal
+          value: arm64
       nodeSelector:
         kubernetes.io/os: linux
       containers:
@@ -68403,6 +68418,11 @@ spec:
       dnsPolicy: ClusterFirst
       nodeSelector:
         kubernetes.io/os: linux
+      tolerations:
+        - effect: NoSchedule
+          key: kubernetes.io/arch
+          operator: Equal
+          value: arm64
       volumes:
         - name: config
           configMap:
@@ -69563,6 +69583,11 @@ spec:
   restartPolicy: Never
   nodeSelector:
         kubernetes.io/os: linux
+  tolerations:
+        - effect: NoSchedule
+          key: kubernetes.io/arch
+          operator: Equal
+          value: arm64
   containers:
     - name: alloy
       image: "docker.io/grafana/alloy:v1.3.1"

--- a/examples/bearer-token-auth/output.yaml
+++ b/examples/bearer-token-auth/output.yaml
@@ -68075,6 +68075,11 @@ spec:
       dnsPolicy: ClusterFirst
       nodeSelector:
         kubernetes.io/os: linux
+      tolerations:
+        - effect: NoSchedule
+          key: kubernetes.io/arch
+          operator: Equal
+          value: arm64
       volumes:
         - name: config
           configMap:
@@ -68169,6 +68174,11 @@ spec:
           readOnlyRootFilesystem: true
       nodeSelector:
         kubernetes.io/os: linux
+      tolerations:
+        - effect: NoSchedule
+          key: kubernetes.io/arch
+          operator: Equal
+          value: arm64
 ---
 # Source: k8s-monitoring/charts/opencost/templates/deployment.yaml
 apiVersion: apps/v1
@@ -68201,6 +68211,11 @@ spec:
         app.kubernetes.io/instance: k8smon
     spec:
       serviceAccountName: k8smon-opencost
+      tolerations:
+        - effect: NoSchedule
+          key: kubernetes.io/arch
+          operator: Equal
+          value: arm64
       nodeSelector:
         kubernetes.io/os: linux
       containers:
@@ -68391,6 +68406,11 @@ spec:
       dnsPolicy: ClusterFirst
       nodeSelector:
         kubernetes.io/os: linux
+      tolerations:
+        - effect: NoSchedule
+          key: kubernetes.io/arch
+          operator: Equal
+          value: arm64
       volumes:
         - name: config
           configMap:
@@ -69548,6 +69568,11 @@ spec:
   restartPolicy: Never
   nodeSelector:
         kubernetes.io/os: linux
+  tolerations:
+        - effect: NoSchedule
+          key: kubernetes.io/arch
+          operator: Equal
+          value: arm64
   containers:
     - name: alloy
       image: "docker.io/grafana/alloy:v1.3.1"

--- a/examples/beyla/output.yaml
+++ b/examples/beyla/output.yaml
@@ -68343,6 +68343,11 @@ spec:
       dnsPolicy: ClusterFirst
       nodeSelector:
         kubernetes.io/os: linux
+      tolerations:
+        - effect: NoSchedule
+          key: kubernetes.io/arch
+          operator: Equal
+          value: arm64
       volumes:
         - name: config
           configMap:
@@ -68437,6 +68442,11 @@ spec:
           readOnlyRootFilesystem: true
       nodeSelector:
         kubernetes.io/os: linux
+      tolerations:
+        - effect: NoSchedule
+          key: kubernetes.io/arch
+          operator: Equal
+          value: arm64
 ---
 # Source: k8s-monitoring/charts/opencost/templates/deployment.yaml
 apiVersion: apps/v1
@@ -68469,6 +68479,11 @@ spec:
         app.kubernetes.io/instance: k8smon
     spec:
       serviceAccountName: k8smon-opencost
+      tolerations:
+        - effect: NoSchedule
+          key: kubernetes.io/arch
+          operator: Equal
+          value: arm64
       nodeSelector:
         kubernetes.io/os: linux
       containers:
@@ -68659,6 +68674,11 @@ spec:
       dnsPolicy: ClusterFirst
       nodeSelector:
         kubernetes.io/os: linux
+      tolerations:
+        - effect: NoSchedule
+          key: kubernetes.io/arch
+          operator: Equal
+          value: arm64
       volumes:
         - name: config
           configMap:
@@ -69915,6 +69935,11 @@ spec:
   restartPolicy: Never
   nodeSelector:
         kubernetes.io/os: linux
+  tolerations:
+        - effect: NoSchedule
+          key: kubernetes.io/arch
+          operator: Equal
+          value: arm64
   containers:
     - name: alloy
       image: "docker.io/grafana/alloy:v1.3.1"

--- a/examples/control-plane-metrics/output.yaml
+++ b/examples/control-plane-metrics/output.yaml
@@ -68236,6 +68236,11 @@ spec:
       dnsPolicy: ClusterFirst
       nodeSelector:
         kubernetes.io/os: linux
+      tolerations:
+        - effect: NoSchedule
+          key: kubernetes.io/arch
+          operator: Equal
+          value: arm64
       volumes:
         - name: config
           configMap:
@@ -68330,6 +68335,11 @@ spec:
           readOnlyRootFilesystem: true
       nodeSelector:
         kubernetes.io/os: linux
+      tolerations:
+        - effect: NoSchedule
+          key: kubernetes.io/arch
+          operator: Equal
+          value: arm64
 ---
 # Source: k8s-monitoring/charts/opencost/templates/deployment.yaml
 apiVersion: apps/v1
@@ -68362,6 +68372,11 @@ spec:
         app.kubernetes.io/instance: k8smon
     spec:
       serviceAccountName: k8smon-opencost
+      tolerations:
+        - effect: NoSchedule
+          key: kubernetes.io/arch
+          operator: Equal
+          value: arm64
       nodeSelector:
         kubernetes.io/os: linux
       containers:
@@ -68552,6 +68567,11 @@ spec:
       dnsPolicy: ClusterFirst
       nodeSelector:
         kubernetes.io/os: linux
+      tolerations:
+        - effect: NoSchedule
+          key: kubernetes.io/arch
+          operator: Equal
+          value: arm64
       volumes:
         - name: config
           configMap:
@@ -69884,6 +69904,11 @@ spec:
   restartPolicy: Never
   nodeSelector:
         kubernetes.io/os: linux
+  tolerations:
+        - effect: NoSchedule
+          key: kubernetes.io/arch
+          operator: Equal
+          value: arm64
   containers:
     - name: alloy
       image: "docker.io/grafana/alloy:v1.3.1"

--- a/examples/custom-config/output.yaml
+++ b/examples/custom-config/output.yaml
@@ -68172,6 +68172,11 @@ spec:
       dnsPolicy: ClusterFirst
       nodeSelector:
         kubernetes.io/os: linux
+      tolerations:
+        - effect: NoSchedule
+          key: kubernetes.io/arch
+          operator: Equal
+          value: arm64
       volumes:
         - name: config
           configMap:
@@ -68266,6 +68271,11 @@ spec:
           readOnlyRootFilesystem: true
       nodeSelector:
         kubernetes.io/os: linux
+      tolerations:
+        - effect: NoSchedule
+          key: kubernetes.io/arch
+          operator: Equal
+          value: arm64
 ---
 # Source: k8s-monitoring/charts/opencost/templates/deployment.yaml
 apiVersion: apps/v1
@@ -68298,6 +68308,11 @@ spec:
         app.kubernetes.io/instance: k8smon
     spec:
       serviceAccountName: k8smon-opencost
+      tolerations:
+        - effect: NoSchedule
+          key: kubernetes.io/arch
+          operator: Equal
+          value: arm64
       nodeSelector:
         kubernetes.io/os: linux
       containers:
@@ -68488,6 +68503,11 @@ spec:
       dnsPolicy: ClusterFirst
       nodeSelector:
         kubernetes.io/os: linux
+      tolerations:
+        - effect: NoSchedule
+          key: kubernetes.io/arch
+          operator: Equal
+          value: arm64
       volumes:
         - name: config
           configMap:
@@ -69741,6 +69761,11 @@ spec:
   restartPolicy: Never
   nodeSelector:
         kubernetes.io/os: linux
+  tolerations:
+        - effect: NoSchedule
+          key: kubernetes.io/arch
+          operator: Equal
+          value: arm64
   containers:
     - name: alloy
       image: "docker.io/grafana/alloy:v1.3.1"

--- a/examples/custom-metrics-tuning/output.yaml
+++ b/examples/custom-metrics-tuning/output.yaml
@@ -67347,6 +67347,11 @@ spec:
           readOnlyRootFilesystem: true
       nodeSelector:
         kubernetes.io/os: linux
+      tolerations:
+        - effect: NoSchedule
+          key: kubernetes.io/arch
+          operator: Equal
+          value: arm64
 ---
 # Source: k8s-monitoring/charts/opencost/templates/deployment.yaml
 apiVersion: apps/v1
@@ -67379,6 +67384,11 @@ spec:
         app.kubernetes.io/instance: k8smon
     spec:
       serviceAccountName: k8smon-opencost
+      tolerations:
+        - effect: NoSchedule
+          key: kubernetes.io/arch
+          operator: Equal
+          value: arm64
       nodeSelector:
         kubernetes.io/os: linux
       containers:
@@ -67569,6 +67579,11 @@ spec:
       dnsPolicy: ClusterFirst
       nodeSelector:
         kubernetes.io/os: linux
+      tolerations:
+        - effect: NoSchedule
+          key: kubernetes.io/arch
+          operator: Equal
+          value: arm64
       volumes:
         - name: config
           configMap:
@@ -68432,6 +68447,11 @@ spec:
   restartPolicy: Never
   nodeSelector:
         kubernetes.io/os: linux
+  tolerations:
+        - effect: NoSchedule
+          key: kubernetes.io/arch
+          operator: Equal
+          value: arm64
   containers:
     - name: alloy
       image: "docker.io/grafana/alloy:v1.3.1"

--- a/examples/custom-pricing/output.yaml
+++ b/examples/custom-pricing/output.yaml
@@ -68101,6 +68101,11 @@ spec:
       dnsPolicy: ClusterFirst
       nodeSelector:
         kubernetes.io/os: linux
+      tolerations:
+        - effect: NoSchedule
+          key: kubernetes.io/arch
+          operator: Equal
+          value: arm64
       volumes:
         - name: config
           configMap:
@@ -68195,6 +68200,11 @@ spec:
           readOnlyRootFilesystem: true
       nodeSelector:
         kubernetes.io/os: linux
+      tolerations:
+        - effect: NoSchedule
+          key: kubernetes.io/arch
+          operator: Equal
+          value: arm64
 ---
 # Source: k8s-monitoring/charts/opencost/templates/deployment.yaml
 apiVersion: apps/v1
@@ -68227,6 +68237,11 @@ spec:
         app.kubernetes.io/instance: k8smon
     spec:
       serviceAccountName: k8smon-opencost
+      tolerations:
+        - effect: NoSchedule
+          key: kubernetes.io/arch
+          operator: Equal
+          value: arm64
       nodeSelector:
         kubernetes.io/os: linux
       containers:
@@ -68428,6 +68443,11 @@ spec:
       dnsPolicy: ClusterFirst
       nodeSelector:
         kubernetes.io/os: linux
+      tolerations:
+        - effect: NoSchedule
+          key: kubernetes.io/arch
+          operator: Equal
+          value: arm64
       volumes:
         - name: config
           configMap:
@@ -69588,6 +69608,11 @@ spec:
   restartPolicy: Never
   nodeSelector:
         kubernetes.io/os: linux
+  tolerations:
+        - effect: NoSchedule
+          key: kubernetes.io/arch
+          operator: Equal
+          value: arm64
   containers:
     - name: alloy
       image: "docker.io/grafana/alloy:v1.3.1"

--- a/examples/custom-prometheus-operator-rules/output.yaml
+++ b/examples/custom-prometheus-operator-rules/output.yaml
@@ -67429,6 +67429,11 @@ spec:
           readOnlyRootFilesystem: true
       nodeSelector:
         kubernetes.io/os: linux
+      tolerations:
+        - effect: NoSchedule
+          key: kubernetes.io/arch
+          operator: Equal
+          value: arm64
 ---
 # Source: k8s-monitoring/charts/opencost/templates/deployment.yaml
 apiVersion: apps/v1
@@ -67461,6 +67466,11 @@ spec:
         app.kubernetes.io/instance: k8smon
     spec:
       serviceAccountName: k8smon-opencost
+      tolerations:
+        - effect: NoSchedule
+          key: kubernetes.io/arch
+          operator: Equal
+          value: arm64
       nodeSelector:
         kubernetes.io/os: linux
       containers:
@@ -67651,6 +67661,11 @@ spec:
       dnsPolicy: ClusterFirst
       nodeSelector:
         kubernetes.io/os: linux
+      tolerations:
+        - effect: NoSchedule
+          key: kubernetes.io/arch
+          operator: Equal
+          value: arm64
       volumes:
         - name: config
           configMap:
@@ -68596,6 +68611,11 @@ spec:
   restartPolicy: Never
   nodeSelector:
         kubernetes.io/os: linux
+  tolerations:
+        - effect: NoSchedule
+          key: kubernetes.io/arch
+          operator: Equal
+          value: arm64
   containers:
     - name: alloy
       image: "docker.io/grafana/alloy:v1.3.1"

--- a/examples/default-values/output.yaml
+++ b/examples/default-values/output.yaml
@@ -68079,6 +68079,11 @@ spec:
       dnsPolicy: ClusterFirst
       nodeSelector:
         kubernetes.io/os: linux
+      tolerations:
+        - effect: NoSchedule
+          key: kubernetes.io/arch
+          operator: Equal
+          value: arm64
       volumes:
         - name: config
           configMap:
@@ -68173,6 +68178,11 @@ spec:
           readOnlyRootFilesystem: true
       nodeSelector:
         kubernetes.io/os: linux
+      tolerations:
+        - effect: NoSchedule
+          key: kubernetes.io/arch
+          operator: Equal
+          value: arm64
 ---
 # Source: k8s-monitoring/charts/opencost/templates/deployment.yaml
 apiVersion: apps/v1
@@ -68205,6 +68215,11 @@ spec:
         app.kubernetes.io/instance: k8smon
     spec:
       serviceAccountName: k8smon-opencost
+      tolerations:
+        - effect: NoSchedule
+          key: kubernetes.io/arch
+          operator: Equal
+          value: arm64
       nodeSelector:
         kubernetes.io/os: linux
       containers:
@@ -68395,6 +68410,11 @@ spec:
       dnsPolicy: ClusterFirst
       nodeSelector:
         kubernetes.io/os: linux
+      tolerations:
+        - effect: NoSchedule
+          key: kubernetes.io/arch
+          operator: Equal
+          value: arm64
       volumes:
         - name: config
           configMap:
@@ -69555,6 +69575,11 @@ spec:
   restartPolicy: Never
   nodeSelector:
         kubernetes.io/os: linux
+  tolerations:
+        - effect: NoSchedule
+          key: kubernetes.io/arch
+          operator: Equal
+          value: arm64
   containers:
     - name: alloy
       image: "docker.io/grafana/alloy:v1.3.1"

--- a/examples/eks-fargate/output.yaml
+++ b/examples/eks-fargate/output.yaml
@@ -67793,6 +67793,11 @@ spec:
       dnsPolicy: ClusterFirst
       nodeSelector:
         kubernetes.io/os: linux
+      tolerations:
+        - effect: NoSchedule
+          key: kubernetes.io/arch
+          operator: Equal
+          value: arm64
       volumes:
         - name: config
           configMap:
@@ -67974,6 +67979,11 @@ spec:
           readOnlyRootFilesystem: true
       nodeSelector:
         kubernetes.io/os: linux
+      tolerations:
+        - effect: NoSchedule
+          key: kubernetes.io/arch
+          operator: Equal
+          value: arm64
 ---
 # Source: k8s-monitoring/charts/opencost/templates/deployment.yaml
 apiVersion: apps/v1
@@ -68006,6 +68016,11 @@ spec:
         app.kubernetes.io/instance: k8smon
     spec:
       serviceAccountName: k8smon-opencost
+      tolerations:
+        - effect: NoSchedule
+          key: kubernetes.io/arch
+          operator: Equal
+          value: arm64
       nodeSelector:
         kubernetes.io/os: linux
       containers:
@@ -68196,6 +68211,11 @@ spec:
       dnsPolicy: ClusterFirst
       nodeSelector:
         kubernetes.io/os: linux
+      tolerations:
+        - effect: NoSchedule
+          key: kubernetes.io/arch
+          operator: Equal
+          value: arm64
       volumes:
         - name: config
           configMap:
@@ -69292,6 +69312,11 @@ spec:
   restartPolicy: Never
   nodeSelector:
         kubernetes.io/os: linux
+  tolerations:
+        - effect: NoSchedule
+          key: kubernetes.io/arch
+          operator: Equal
+          value: arm64
   containers:
     - name: alloy
       image: "docker.io/grafana/alloy:v1.3.1"

--- a/examples/environment-variables/output.yaml
+++ b/examples/environment-variables/output.yaml
@@ -68134,6 +68134,11 @@ spec:
       dnsPolicy: ClusterFirst
       nodeSelector:
         kubernetes.io/os: linux
+      tolerations:
+        - effect: NoSchedule
+          key: kubernetes.io/arch
+          operator: Equal
+          value: arm64
       volumes:
         - name: config
           configMap:
@@ -68228,6 +68233,11 @@ spec:
           readOnlyRootFilesystem: true
       nodeSelector:
         kubernetes.io/os: linux
+      tolerations:
+        - effect: NoSchedule
+          key: kubernetes.io/arch
+          operator: Equal
+          value: arm64
 ---
 # Source: k8s-monitoring/charts/opencost/templates/deployment.yaml
 apiVersion: apps/v1
@@ -68260,6 +68270,11 @@ spec:
         app.kubernetes.io/instance: k8smon
     spec:
       serviceAccountName: k8smon-opencost
+      tolerations:
+        - effect: NoSchedule
+          key: kubernetes.io/arch
+          operator: Equal
+          value: arm64
       nodeSelector:
         kubernetes.io/os: linux
       containers:
@@ -68453,6 +68468,11 @@ spec:
       dnsPolicy: ClusterFirst
       nodeSelector:
         kubernetes.io/os: linux
+      tolerations:
+        - effect: NoSchedule
+          key: kubernetes.io/arch
+          operator: Equal
+          value: arm64
       volumes:
         - name: config
           configMap:
@@ -69659,6 +69679,11 @@ spec:
   restartPolicy: Never
   nodeSelector:
         kubernetes.io/os: linux
+  tolerations:
+        - effect: NoSchedule
+          key: kubernetes.io/arch
+          operator: Equal
+          value: arm64
   containers:
     - name: alloy
       image: "docker.io/grafana/alloy:v1.3.1"

--- a/examples/extra-rules/output.yaml
+++ b/examples/extra-rules/output.yaml
@@ -68201,6 +68201,11 @@ spec:
       dnsPolicy: ClusterFirst
       nodeSelector:
         kubernetes.io/os: linux
+      tolerations:
+        - effect: NoSchedule
+          key: kubernetes.io/arch
+          operator: Equal
+          value: arm64
       volumes:
         - name: config
           configMap:
@@ -68295,6 +68300,11 @@ spec:
           readOnlyRootFilesystem: true
       nodeSelector:
         kubernetes.io/os: linux
+      tolerations:
+        - effect: NoSchedule
+          key: kubernetes.io/arch
+          operator: Equal
+          value: arm64
 ---
 # Source: k8s-monitoring/charts/opencost/templates/deployment.yaml
 apiVersion: apps/v1
@@ -68327,6 +68337,11 @@ spec:
         app.kubernetes.io/instance: k8smon
     spec:
       serviceAccountName: k8smon-opencost
+      tolerations:
+        - effect: NoSchedule
+          key: kubernetes.io/arch
+          operator: Equal
+          value: arm64
       nodeSelector:
         kubernetes.io/os: linux
       containers:
@@ -68517,6 +68532,11 @@ spec:
       dnsPolicy: ClusterFirst
       nodeSelector:
         kubernetes.io/os: linux
+      tolerations:
+        - effect: NoSchedule
+          key: kubernetes.io/arch
+          operator: Equal
+          value: arm64
       volumes:
         - name: config
           configMap:
@@ -69798,6 +69818,11 @@ spec:
   restartPolicy: Never
   nodeSelector:
         kubernetes.io/os: linux
+  tolerations:
+        - effect: NoSchedule
+          key: kubernetes.io/arch
+          operator: Equal
+          value: arm64
   containers:
     - name: alloy
       image: "docker.io/grafana/alloy:v1.3.1"

--- a/examples/gke-autopilot/output.yaml
+++ b/examples/gke-autopilot/output.yaml
@@ -67862,6 +67862,11 @@ spec:
       dnsPolicy: ClusterFirst
       nodeSelector:
         kubernetes.io/os: linux
+      tolerations:
+        - effect: NoSchedule
+          key: kubernetes.io/arch
+          operator: Equal
+          value: arm64
       volumes:
         - name: config
           configMap:
@@ -67956,6 +67961,11 @@ spec:
           readOnlyRootFilesystem: true
       nodeSelector:
         kubernetes.io/os: linux
+      tolerations:
+        - effect: NoSchedule
+          key: kubernetes.io/arch
+          operator: Equal
+          value: arm64
 ---
 # Source: k8s-monitoring/charts/opencost/templates/deployment.yaml
 apiVersion: apps/v1
@@ -67988,6 +67998,11 @@ spec:
         app.kubernetes.io/instance: k8smon
     spec:
       serviceAccountName: k8smon-opencost
+      tolerations:
+        - effect: NoSchedule
+          key: kubernetes.io/arch
+          operator: Equal
+          value: arm64
       nodeSelector:
         kubernetes.io/os: linux
       containers:
@@ -68178,6 +68193,11 @@ spec:
       dnsPolicy: ClusterFirst
       nodeSelector:
         kubernetes.io/os: linux
+      tolerations:
+        - effect: NoSchedule
+          key: kubernetes.io/arch
+          operator: Equal
+          value: arm64
       volumes:
         - name: config
           configMap:
@@ -69287,6 +69307,11 @@ spec:
   restartPolicy: Never
   nodeSelector:
         kubernetes.io/os: linux
+  tolerations:
+        - effect: NoSchedule
+          key: kubernetes.io/arch
+          operator: Equal
+          value: arm64
   containers:
     - name: alloy
       image: "docker.io/grafana/alloy:v1.3.1"

--- a/examples/ibm-cloud/output.yaml
+++ b/examples/ibm-cloud/output.yaml
@@ -68085,6 +68085,11 @@ spec:
       dnsPolicy: ClusterFirst
       nodeSelector:
         kubernetes.io/os: linux
+      tolerations:
+        - effect: NoSchedule
+          key: kubernetes.io/arch
+          operator: Equal
+          value: arm64
       volumes:
         - name: config
           configMap:
@@ -68179,6 +68184,11 @@ spec:
           readOnlyRootFilesystem: true
       nodeSelector:
         kubernetes.io/os: linux
+      tolerations:
+        - effect: NoSchedule
+          key: kubernetes.io/arch
+          operator: Equal
+          value: arm64
 ---
 # Source: k8s-monitoring/charts/opencost/templates/deployment.yaml
 apiVersion: apps/v1
@@ -68211,6 +68221,11 @@ spec:
         app.kubernetes.io/instance: k8smon
     spec:
       serviceAccountName: k8smon-opencost
+      tolerations:
+        - effect: NoSchedule
+          key: kubernetes.io/arch
+          operator: Equal
+          value: arm64
       nodeSelector:
         kubernetes.io/os: linux
       containers:
@@ -68401,6 +68416,11 @@ spec:
       dnsPolicy: ClusterFirst
       nodeSelector:
         kubernetes.io/os: linux
+      tolerations:
+        - effect: NoSchedule
+          key: kubernetes.io/arch
+          operator: Equal
+          value: arm64
       volumes:
         - name: config
           configMap:
@@ -69561,6 +69581,11 @@ spec:
   restartPolicy: Never
   nodeSelector:
         kubernetes.io/os: linux
+  tolerations:
+        - effect: NoSchedule
+          key: kubernetes.io/arch
+          operator: Equal
+          value: arm64
   containers:
     - name: alloy
       image: "docker.io/grafana/alloy:v1.3.1"

--- a/examples/logs-journal/output.yaml
+++ b/examples/logs-journal/output.yaml
@@ -756,6 +756,11 @@ spec:
       dnsPolicy: ClusterFirst
       nodeSelector:
         kubernetes.io/os: linux
+      tolerations:
+        - effect: NoSchedule
+          key: kubernetes.io/arch
+          operator: Equal
+          value: arm64
       volumes:
         - name: config
           configMap:
@@ -1118,6 +1123,11 @@ spec:
   restartPolicy: Never
   nodeSelector:
         kubernetes.io/os: linux
+  tolerations:
+        - effect: NoSchedule
+          key: kubernetes.io/arch
+          operator: Equal
+          value: arm64
   containers:
     - name: alloy
       image: "docker.io/grafana/alloy:%!s(<nil>)"

--- a/examples/logs-only/output.yaml
+++ b/examples/logs-only/output.yaml
@@ -729,6 +729,11 @@ spec:
       dnsPolicy: ClusterFirst
       nodeSelector:
         kubernetes.io/os: linux
+      tolerations:
+        - effect: NoSchedule
+          key: kubernetes.io/arch
+          operator: Equal
+          value: arm64
       volumes:
         - name: config
           configMap:
@@ -1170,6 +1175,11 @@ spec:
   restartPolicy: Never
   nodeSelector:
         kubernetes.io/os: linux
+  tolerations:
+        - effect: NoSchedule
+          key: kubernetes.io/arch
+          operator: Equal
+          value: arm64
   containers:
     - name: alloy
       image: "docker.io/grafana/alloy:%!s(<nil>)"

--- a/examples/metric-module-imports-extra-config/output.yaml
+++ b/examples/metric-module-imports-extra-config/output.yaml
@@ -68095,6 +68095,11 @@ spec:
       dnsPolicy: ClusterFirst
       nodeSelector:
         kubernetes.io/os: linux
+      tolerations:
+        - effect: NoSchedule
+          key: kubernetes.io/arch
+          operator: Equal
+          value: arm64
       volumes:
         - name: config
           configMap:
@@ -68189,6 +68194,11 @@ spec:
           readOnlyRootFilesystem: true
       nodeSelector:
         kubernetes.io/os: linux
+      tolerations:
+        - effect: NoSchedule
+          key: kubernetes.io/arch
+          operator: Equal
+          value: arm64
 ---
 # Source: k8s-monitoring/charts/opencost/templates/deployment.yaml
 apiVersion: apps/v1
@@ -68221,6 +68231,11 @@ spec:
         app.kubernetes.io/instance: k8smon
     spec:
       serviceAccountName: k8smon-opencost
+      tolerations:
+        - effect: NoSchedule
+          key: kubernetes.io/arch
+          operator: Equal
+          value: arm64
       nodeSelector:
         kubernetes.io/os: linux
       containers:
@@ -68411,6 +68426,11 @@ spec:
       dnsPolicy: ClusterFirst
       nodeSelector:
         kubernetes.io/os: linux
+      tolerations:
+        - effect: NoSchedule
+          key: kubernetes.io/arch
+          operator: Equal
+          value: arm64
       volumes:
         - name: config
           configMap:
@@ -69587,6 +69607,11 @@ spec:
   restartPolicy: Never
   nodeSelector:
         kubernetes.io/os: linux
+  tolerations:
+        - effect: NoSchedule
+          key: kubernetes.io/arch
+          operator: Equal
+          value: arm64
   containers:
     - name: alloy
       image: "docker.io/grafana/alloy:v1.3.1"

--- a/examples/metric-module-imports/output.yaml
+++ b/examples/metric-module-imports/output.yaml
@@ -68256,6 +68256,11 @@ spec:
       dnsPolicy: ClusterFirst
       nodeSelector:
         kubernetes.io/os: linux
+      tolerations:
+        - effect: NoSchedule
+          key: kubernetes.io/arch
+          operator: Equal
+          value: arm64
       volumes:
         - name: config
           configMap:
@@ -68350,6 +68355,11 @@ spec:
           readOnlyRootFilesystem: true
       nodeSelector:
         kubernetes.io/os: linux
+      tolerations:
+        - effect: NoSchedule
+          key: kubernetes.io/arch
+          operator: Equal
+          value: arm64
 ---
 # Source: k8s-monitoring/charts/opencost/templates/deployment.yaml
 apiVersion: apps/v1
@@ -68382,6 +68392,11 @@ spec:
         app.kubernetes.io/instance: k8smon
     spec:
       serviceAccountName: k8smon-opencost
+      tolerations:
+        - effect: NoSchedule
+          key: kubernetes.io/arch
+          operator: Equal
+          value: arm64
       nodeSelector:
         kubernetes.io/os: linux
       containers:
@@ -68572,6 +68587,11 @@ spec:
       dnsPolicy: ClusterFirst
       nodeSelector:
         kubernetes.io/os: linux
+      tolerations:
+        - effect: NoSchedule
+          key: kubernetes.io/arch
+          operator: Equal
+          value: arm64
       volumes:
         - name: config
           configMap:
@@ -69909,6 +69929,11 @@ spec:
   restartPolicy: Never
   nodeSelector:
         kubernetes.io/os: linux
+  tolerations:
+        - effect: NoSchedule
+          key: kubernetes.io/arch
+          operator: Equal
+          value: arm64
   containers:
     - name: alloy
       image: "docker.io/grafana/alloy:v1.3.1"

--- a/examples/metrics-only/output.yaml
+++ b/examples/metrics-only/output.yaml
@@ -67353,6 +67353,11 @@ spec:
           readOnlyRootFilesystem: true
       nodeSelector:
         kubernetes.io/os: linux
+      tolerations:
+        - effect: NoSchedule
+          key: kubernetes.io/arch
+          operator: Equal
+          value: arm64
 ---
 # Source: k8s-monitoring/charts/opencost/templates/deployment.yaml
 apiVersion: apps/v1
@@ -67385,6 +67390,11 @@ spec:
         app.kubernetes.io/instance: k8smon
     spec:
       serviceAccountName: k8smon-opencost
+      tolerations:
+        - effect: NoSchedule
+          key: kubernetes.io/arch
+          operator: Equal
+          value: arm64
       nodeSelector:
         kubernetes.io/os: linux
       containers:
@@ -67575,6 +67585,11 @@ spec:
       dnsPolicy: ClusterFirst
       nodeSelector:
         kubernetes.io/os: linux
+      tolerations:
+        - effect: NoSchedule
+          key: kubernetes.io/arch
+          operator: Equal
+          value: arm64
       volumes:
         - name: config
           configMap:
@@ -68443,6 +68458,11 @@ spec:
   restartPolicy: Never
   nodeSelector:
         kubernetes.io/os: linux
+  tolerations:
+        - effect: NoSchedule
+          key: kubernetes.io/arch
+          operator: Equal
+          value: arm64
   containers:
     - name: alloy
       image: "docker.io/grafana/alloy:v1.3.1"

--- a/examples/openshift-compatible/output.yaml
+++ b/examples/openshift-compatible/output.yaml
@@ -67824,6 +67824,11 @@ spec:
       dnsPolicy: ClusterFirst
       nodeSelector:
         kubernetes.io/os: linux
+      tolerations:
+        - effect: NoSchedule
+          key: kubernetes.io/arch
+          operator: Equal
+          value: arm64
       volumes:
         - name: config
           configMap:
@@ -67860,6 +67865,11 @@ spec:
         app.kubernetes.io/instance: k8smon
     spec:
       serviceAccountName: k8smon-opencost
+      tolerations:
+        - effect: NoSchedule
+          key: kubernetes.io/arch
+          operator: Equal
+          value: arm64
       nodeSelector:
         kubernetes.io/os: linux
       containers:
@@ -68072,6 +68082,11 @@ spec:
       dnsPolicy: ClusterFirst
       nodeSelector:
         kubernetes.io/os: linux
+      tolerations:
+        - effect: NoSchedule
+          key: kubernetes.io/arch
+          operator: Equal
+          value: arm64
       volumes:
         - name: config
           configMap:
@@ -69394,6 +69409,11 @@ spec:
   restartPolicy: Never
   nodeSelector:
         kubernetes.io/os: linux
+  tolerations:
+        - effect: NoSchedule
+          key: kubernetes.io/arch
+          operator: Equal
+          value: arm64
   containers:
     - name: alloy
       image: "docker.io/grafana/alloy:v1.3.1"

--- a/examples/otel-metrics-service/output.yaml
+++ b/examples/otel-metrics-service/output.yaml
@@ -68097,6 +68097,11 @@ spec:
       dnsPolicy: ClusterFirst
       nodeSelector:
         kubernetes.io/os: linux
+      tolerations:
+        - effect: NoSchedule
+          key: kubernetes.io/arch
+          operator: Equal
+          value: arm64
       volumes:
         - name: config
           configMap:
@@ -68191,6 +68196,11 @@ spec:
           readOnlyRootFilesystem: true
       nodeSelector:
         kubernetes.io/os: linux
+      tolerations:
+        - effect: NoSchedule
+          key: kubernetes.io/arch
+          operator: Equal
+          value: arm64
 ---
 # Source: k8s-monitoring/charts/opencost/templates/deployment.yaml
 apiVersion: apps/v1
@@ -68223,6 +68233,11 @@ spec:
         app.kubernetes.io/instance: k8smon
     spec:
       serviceAccountName: k8smon-opencost
+      tolerations:
+        - effect: NoSchedule
+          key: kubernetes.io/arch
+          operator: Equal
+          value: arm64
       nodeSelector:
         kubernetes.io/os: linux
       containers:
@@ -68413,6 +68428,11 @@ spec:
       dnsPolicy: ClusterFirst
       nodeSelector:
         kubernetes.io/os: linux
+      tolerations:
+        - effect: NoSchedule
+          key: kubernetes.io/arch
+          operator: Equal
+          value: arm64
       volumes:
         - name: config
           configMap:
@@ -69591,6 +69611,11 @@ spec:
   restartPolicy: Never
   nodeSelector:
         kubernetes.io/os: linux
+  tolerations:
+        - effect: NoSchedule
+          key: kubernetes.io/arch
+          operator: Equal
+          value: arm64
   containers:
     - name: alloy
       image: "docker.io/grafana/alloy:v1.3.1"

--- a/examples/pod-labels/output.yaml
+++ b/examples/pod-labels/output.yaml
@@ -68157,6 +68157,11 @@ spec:
       dnsPolicy: ClusterFirst
       nodeSelector:
         kubernetes.io/os: linux
+      tolerations:
+        - effect: NoSchedule
+          key: kubernetes.io/arch
+          operator: Equal
+          value: arm64
       volumes:
         - name: config
           configMap:
@@ -68251,6 +68256,11 @@ spec:
           readOnlyRootFilesystem: true
       nodeSelector:
         kubernetes.io/os: linux
+      tolerations:
+        - effect: NoSchedule
+          key: kubernetes.io/arch
+          operator: Equal
+          value: arm64
 ---
 # Source: k8s-monitoring/charts/opencost/templates/deployment.yaml
 apiVersion: apps/v1
@@ -68283,6 +68293,11 @@ spec:
         app.kubernetes.io/instance: k8smon
     spec:
       serviceAccountName: k8smon-opencost
+      tolerations:
+        - effect: NoSchedule
+          key: kubernetes.io/arch
+          operator: Equal
+          value: arm64
       nodeSelector:
         kubernetes.io/os: linux
       containers:
@@ -68473,6 +68488,11 @@ spec:
       dnsPolicy: ClusterFirst
       nodeSelector:
         kubernetes.io/os: linux
+      tolerations:
+        - effect: NoSchedule
+          key: kubernetes.io/arch
+          operator: Equal
+          value: arm64
       volumes:
         - name: config
           configMap:
@@ -69702,6 +69722,11 @@ spec:
   restartPolicy: Never
   nodeSelector:
         kubernetes.io/os: linux
+  tolerations:
+        - effect: NoSchedule
+          key: kubernetes.io/arch
+          operator: Equal
+          value: arm64
   containers:
     - name: alloy
       image: "docker.io/grafana/alloy:v1.3.1"

--- a/examples/private-image-registry/output.yaml
+++ b/examples/private-image-registry/output.yaml
@@ -68089,6 +68089,11 @@ spec:
       dnsPolicy: ClusterFirst
       nodeSelector:
         kubernetes.io/os: linux
+      tolerations:
+        - effect: NoSchedule
+          key: kubernetes.io/arch
+          operator: Equal
+          value: arm64
       volumes:
         - name: config
           configMap:
@@ -68185,6 +68190,11 @@ spec:
         - name: my-registry-creds
       nodeSelector:
         kubernetes.io/os: linux
+      tolerations:
+        - effect: NoSchedule
+          key: kubernetes.io/arch
+          operator: Equal
+          value: arm64
 ---
 # Source: k8s-monitoring/charts/opencost/templates/deployment.yaml
 apiVersion: apps/v1
@@ -68219,6 +68229,11 @@ spec:
       imagePullSecrets:
         - name: my-registry-creds
       serviceAccountName: k8smon-opencost
+      tolerations:
+        - effect: NoSchedule
+          key: kubernetes.io/arch
+          operator: Equal
+          value: arm64
       nodeSelector:
         kubernetes.io/os: linux
       containers:
@@ -68411,6 +68426,11 @@ spec:
       dnsPolicy: ClusterFirst
       nodeSelector:
         kubernetes.io/os: linux
+      tolerations:
+        - effect: NoSchedule
+          key: kubernetes.io/arch
+          operator: Equal
+          value: arm64
       volumes:
         - name: config
           configMap:
@@ -69573,6 +69593,11 @@ spec:
   restartPolicy: Never
   nodeSelector:
         kubernetes.io/os: linux
+  tolerations:
+        - effect: NoSchedule
+          key: kubernetes.io/arch
+          operator: Equal
+          value: arm64
   containers:
     - name: alloy
       image: "my.registry.com/grafana/alloy:v1.3.1"

--- a/examples/profiles-enabled/output.yaml
+++ b/examples/profiles-enabled/output.yaml
@@ -69277,6 +69277,11 @@ spec:
       dnsPolicy: ClusterFirst
       nodeSelector:
         kubernetes.io/os: linux
+      tolerations:
+        - effect: NoSchedule
+          key: kubernetes.io/arch
+          operator: Equal
+          value: arm64
       volumes:
         - name: config
           configMap:
@@ -69371,6 +69376,11 @@ spec:
           readOnlyRootFilesystem: true
       nodeSelector:
         kubernetes.io/os: linux
+      tolerations:
+        - effect: NoSchedule
+          key: kubernetes.io/arch
+          operator: Equal
+          value: arm64
 ---
 # Source: k8s-monitoring/charts/opencost/templates/deployment.yaml
 apiVersion: apps/v1
@@ -69403,6 +69413,11 @@ spec:
         app.kubernetes.io/instance: k8smon
     spec:
       serviceAccountName: k8smon-opencost
+      tolerations:
+        - effect: NoSchedule
+          key: kubernetes.io/arch
+          operator: Equal
+          value: arm64
       nodeSelector:
         kubernetes.io/os: linux
       containers:
@@ -69593,6 +69608,11 @@ spec:
       dnsPolicy: ClusterFirst
       nodeSelector:
         kubernetes.io/os: linux
+      tolerations:
+        - effect: NoSchedule
+          key: kubernetes.io/arch
+          operator: Equal
+          value: arm64
       volumes:
         - name: config
           configMap:
@@ -71677,6 +71697,11 @@ spec:
   restartPolicy: Never
   nodeSelector:
         kubernetes.io/os: linux
+  tolerations:
+        - effect: NoSchedule
+          key: kubernetes.io/arch
+          operator: Equal
+          value: arm64
   containers:
     - name: alloy
       image: "docker.io/grafana/alloy:v1.3.1"

--- a/examples/proxies/output.yaml
+++ b/examples/proxies/output.yaml
@@ -68095,6 +68095,11 @@ spec:
       dnsPolicy: ClusterFirst
       nodeSelector:
         kubernetes.io/os: linux
+      tolerations:
+        - effect: NoSchedule
+          key: kubernetes.io/arch
+          operator: Equal
+          value: arm64
       volumes:
         - name: config
           configMap:
@@ -68189,6 +68194,11 @@ spec:
           readOnlyRootFilesystem: true
       nodeSelector:
         kubernetes.io/os: linux
+      tolerations:
+        - effect: NoSchedule
+          key: kubernetes.io/arch
+          operator: Equal
+          value: arm64
 ---
 # Source: k8s-monitoring/charts/opencost/templates/deployment.yaml
 apiVersion: apps/v1
@@ -68221,6 +68231,11 @@ spec:
         app.kubernetes.io/instance: k8smon
     spec:
       serviceAccountName: k8smon-opencost
+      tolerations:
+        - effect: NoSchedule
+          key: kubernetes.io/arch
+          operator: Equal
+          value: arm64
       nodeSelector:
         kubernetes.io/os: linux
       containers:
@@ -68411,6 +68426,11 @@ spec:
       dnsPolicy: ClusterFirst
       nodeSelector:
         kubernetes.io/os: linux
+      tolerations:
+        - effect: NoSchedule
+          key: kubernetes.io/arch
+          operator: Equal
+          value: arm64
       volumes:
         - name: config
           configMap:
@@ -69587,6 +69607,11 @@ spec:
   restartPolicy: Never
   nodeSelector:
         kubernetes.io/os: linux
+  tolerations:
+        - effect: NoSchedule
+          key: kubernetes.io/arch
+          operator: Equal
+          value: arm64
   containers:
     - name: alloy
       image: "docker.io/grafana/alloy:v1.3.1"

--- a/examples/scrape-intervals/output.yaml
+++ b/examples/scrape-intervals/output.yaml
@@ -67352,6 +67352,11 @@ spec:
           readOnlyRootFilesystem: true
       nodeSelector:
         kubernetes.io/os: linux
+      tolerations:
+        - effect: NoSchedule
+          key: kubernetes.io/arch
+          operator: Equal
+          value: arm64
 ---
 # Source: k8s-monitoring/charts/opencost/templates/deployment.yaml
 apiVersion: apps/v1
@@ -67384,6 +67389,11 @@ spec:
         app.kubernetes.io/instance: k8smon
     spec:
       serviceAccountName: k8smon-opencost
+      tolerations:
+        - effect: NoSchedule
+          key: kubernetes.io/arch
+          operator: Equal
+          value: arm64
       nodeSelector:
         kubernetes.io/os: linux
       containers:
@@ -67574,6 +67584,11 @@ spec:
       dnsPolicy: ClusterFirst
       nodeSelector:
         kubernetes.io/os: linux
+      tolerations:
+        - effect: NoSchedule
+          key: kubernetes.io/arch
+          operator: Equal
+          value: arm64
       volumes:
         - name: config
           configMap:
@@ -68442,6 +68457,11 @@ spec:
   restartPolicy: Never
   nodeSelector:
         kubernetes.io/os: linux
+  tolerations:
+        - effect: NoSchedule
+          key: kubernetes.io/arch
+          operator: Equal
+          value: arm64
   containers:
     - name: alloy
       image: "docker.io/grafana/alloy:v1.3.1"

--- a/examples/service-integrations/output.yaml
+++ b/examples/service-integrations/output.yaml
@@ -68114,6 +68114,11 @@ spec:
       dnsPolicy: ClusterFirst
       nodeSelector:
         kubernetes.io/os: linux
+      tolerations:
+        - effect: NoSchedule
+          key: kubernetes.io/arch
+          operator: Equal
+          value: arm64
       volumes:
         - name: config
           configMap:
@@ -68208,6 +68213,11 @@ spec:
           readOnlyRootFilesystem: true
       nodeSelector:
         kubernetes.io/os: linux
+      tolerations:
+        - effect: NoSchedule
+          key: kubernetes.io/arch
+          operator: Equal
+          value: arm64
 ---
 # Source: k8s-monitoring/charts/opencost/templates/deployment.yaml
 apiVersion: apps/v1
@@ -68240,6 +68250,11 @@ spec:
         app.kubernetes.io/instance: k8smon
     spec:
       serviceAccountName: k8smon-opencost
+      tolerations:
+        - effect: NoSchedule
+          key: kubernetes.io/arch
+          operator: Equal
+          value: arm64
       nodeSelector:
         kubernetes.io/os: linux
       containers:
@@ -68430,6 +68445,11 @@ spec:
       dnsPolicy: ClusterFirst
       nodeSelector:
         kubernetes.io/os: linux
+      tolerations:
+        - effect: NoSchedule
+          key: kubernetes.io/arch
+          operator: Equal
+          value: arm64
       volumes:
         - name: config
           configMap:
@@ -69645,6 +69665,11 @@ spec:
   restartPolicy: Never
   nodeSelector:
         kubernetes.io/os: linux
+  tolerations:
+        - effect: NoSchedule
+          key: kubernetes.io/arch
+          operator: Equal
+          value: arm64
   containers:
     - name: alloy
       image: "docker.io/grafana/alloy:v1.3.1"

--- a/examples/specific-namespace/output.yaml
+++ b/examples/specific-namespace/output.yaml
@@ -68143,6 +68143,11 @@ spec:
       dnsPolicy: ClusterFirst
       nodeSelector:
         kubernetes.io/os: linux
+      tolerations:
+        - effect: NoSchedule
+          key: kubernetes.io/arch
+          operator: Equal
+          value: arm64
       volumes:
         - name: config
           configMap:
@@ -68237,6 +68242,11 @@ spec:
           readOnlyRootFilesystem: true
       nodeSelector:
         kubernetes.io/os: linux
+      tolerations:
+        - effect: NoSchedule
+          key: kubernetes.io/arch
+          operator: Equal
+          value: arm64
 ---
 # Source: k8s-monitoring/charts/opencost/templates/deployment.yaml
 apiVersion: apps/v1
@@ -68269,6 +68279,11 @@ spec:
         app.kubernetes.io/instance: k8smon
     spec:
       serviceAccountName: k8smon-opencost
+      tolerations:
+        - effect: NoSchedule
+          key: kubernetes.io/arch
+          operator: Equal
+          value: arm64
       nodeSelector:
         kubernetes.io/os: linux
       containers:
@@ -68459,6 +68474,11 @@ spec:
       dnsPolicy: ClusterFirst
       nodeSelector:
         kubernetes.io/os: linux
+      tolerations:
+        - effect: NoSchedule
+          key: kubernetes.io/arch
+          operator: Equal
+          value: arm64
       volumes:
         - name: config
           configMap:
@@ -69683,6 +69703,11 @@ spec:
   restartPolicy: Never
   nodeSelector:
         kubernetes.io/os: linux
+  tolerations:
+        - effect: NoSchedule
+          key: kubernetes.io/arch
+          operator: Equal
+          value: arm64
   containers:
     - name: alloy
       image: "docker.io/grafana/alloy:v1.3.1"

--- a/examples/traces-enabled/output.yaml
+++ b/examples/traces-enabled/output.yaml
@@ -68200,6 +68200,11 @@ spec:
       dnsPolicy: ClusterFirst
       nodeSelector:
         kubernetes.io/os: linux
+      tolerations:
+        - effect: NoSchedule
+          key: kubernetes.io/arch
+          operator: Equal
+          value: arm64
       volumes:
         - name: config
           configMap:
@@ -68294,6 +68299,11 @@ spec:
           readOnlyRootFilesystem: true
       nodeSelector:
         kubernetes.io/os: linux
+      tolerations:
+        - effect: NoSchedule
+          key: kubernetes.io/arch
+          operator: Equal
+          value: arm64
 ---
 # Source: k8s-monitoring/charts/opencost/templates/deployment.yaml
 apiVersion: apps/v1
@@ -68326,6 +68336,11 @@ spec:
         app.kubernetes.io/instance: k8smon
     spec:
       serviceAccountName: k8smon-opencost
+      tolerations:
+        - effect: NoSchedule
+          key: kubernetes.io/arch
+          operator: Equal
+          value: arm64
       nodeSelector:
         kubernetes.io/os: linux
       containers:
@@ -68516,6 +68531,11 @@ spec:
       dnsPolicy: ClusterFirst
       nodeSelector:
         kubernetes.io/os: linux
+      tolerations:
+        - effect: NoSchedule
+          key: kubernetes.io/arch
+          operator: Equal
+          value: arm64
       volumes:
         - name: config
           configMap:
@@ -69784,6 +69804,11 @@ spec:
   restartPolicy: Never
   nodeSelector:
         kubernetes.io/os: linux
+  tolerations:
+        - effect: NoSchedule
+          key: kubernetes.io/arch
+          operator: Equal
+          value: arm64
   containers:
     - name: alloy
       image: "docker.io/grafana/alloy:v1.3.1"

--- a/examples/windows-exporter/output.yaml
+++ b/examples/windows-exporter/output.yaml
@@ -68317,6 +68317,11 @@ spec:
       dnsPolicy: ClusterFirst
       nodeSelector:
         kubernetes.io/os: linux
+      tolerations:
+        - effect: NoSchedule
+          key: kubernetes.io/arch
+          operator: Equal
+          value: arm64
       volumes:
         - name: config
           configMap:
@@ -68411,6 +68416,11 @@ spec:
           readOnlyRootFilesystem: true
       nodeSelector:
         kubernetes.io/os: linux
+      tolerations:
+        - effect: NoSchedule
+          key: kubernetes.io/arch
+          operator: Equal
+          value: arm64
 ---
 # Source: k8s-monitoring/charts/opencost/templates/deployment.yaml
 apiVersion: apps/v1
@@ -68443,6 +68453,11 @@ spec:
         app.kubernetes.io/instance: k8smon
     spec:
       serviceAccountName: k8smon-opencost
+      tolerations:
+        - effect: NoSchedule
+          key: kubernetes.io/arch
+          operator: Equal
+          value: arm64
       nodeSelector:
         kubernetes.io/os: linux
       containers:
@@ -68633,6 +68648,11 @@ spec:
       dnsPolicy: ClusterFirst
       nodeSelector:
         kubernetes.io/os: linux
+      tolerations:
+        - effect: NoSchedule
+          key: kubernetes.io/arch
+          operator: Equal
+          value: arm64
       volumes:
         - name: config
           configMap:
@@ -69866,6 +69886,11 @@ spec:
   restartPolicy: Never
   nodeSelector:
         kubernetes.io/os: linux
+  tolerations:
+        - effect: NoSchedule
+          key: kubernetes.io/arch
+          operator: Equal
+          value: arm64
   containers:
     - name: alloy
       image: "docker.io/grafana/alloy:v1.3.1"


### PR DESCRIPTION
This allows them to be scheduled on ARM64 nodes. GKE puts a NoSchedule taint on ARM64 nodes, so workloads need to add the toleration to event be scheduled there.