### PR TITLE
The presence of __tmp_port was breaking deduplication rules.

### DIFF
--- a/charts/k8s-monitoring/templates/alloy_config/_annotation_autodiscovery.alloy.txt
+++ b/charts/k8s-monitoring/templates/alloy_config/_annotation_autodiscovery.alloy.txt
@@ -40,6 +40,10 @@ discovery.relabel "annotation_autodiscovery_pods" {
     action = "keepequal"
     target_label = "__tmp_port"
   }
+  rule {
+    action = "labeldrop"
+    regex = "__tmp_port"
+  }
 
   // If the metrics port number annotation has a value, override the target address to use it, regardless whether it is
   // one of the declared ports on that Pod.
@@ -127,6 +131,10 @@ discovery.relabel "annotation_autodiscovery_services" {
     source_labels = ["__meta_kubernetes_service_port_number"]
     action = "keepequal"
     target_label = "__tmp_port"
+  }
+  rule {
+    action = "labeldrop"
+    regex = "__tmp_port"
   }
 
   rule {

--- a/examples/alloy-autoscaling-and-storage/metrics.alloy
+++ b/examples/alloy-autoscaling-and-storage/metrics.alloy
@@ -168,6 +168,10 @@ discovery.relabel "annotation_autodiscovery_pods" {
     action = "keepequal"
     target_label = "__tmp_port"
   }
+  rule {
+    action = "labeldrop"
+    regex = "__tmp_port"
+  }
 
   // If the metrics port number annotation has a value, override the target address to use it, regardless whether it is
   // one of the declared ports on that Pod.
@@ -249,6 +253,10 @@ discovery.relabel "annotation_autodiscovery_services" {
     source_labels = ["__meta_kubernetes_service_port_number"]
     action = "keepequal"
     target_label = "__tmp_port"
+  }
+  rule {
+    action = "labeldrop"
+    regex = "__tmp_port"
   }
 
   rule {

--- a/examples/alloy-autoscaling-and-storage/output.yaml
+++ b/examples/alloy-autoscaling-and-storage/output.yaml
@@ -300,6 +300,10 @@ data:
         action = "keepequal"
         target_label = "__tmp_port"
       }
+      rule {
+        action = "labeldrop"
+        regex = "__tmp_port"
+      }
     
       // If the metrics port number annotation has a value, override the target address to use it, regardless whether it is
       // one of the declared ports on that Pod.
@@ -381,6 +385,10 @@ data:
         source_labels = ["__meta_kubernetes_service_port_number"]
         action = "keepequal"
         target_label = "__tmp_port"
+      }
+      rule {
+        action = "labeldrop"
+        regex = "__tmp_port"
       }
     
       rule {
@@ -68695,6 +68703,10 @@ data:
         action = "keepequal"
         target_label = "__tmp_port"
       }
+      rule {
+        action = "labeldrop"
+        regex = "__tmp_port"
+      }
     
       // If the metrics port number annotation has a value, override the target address to use it, regardless whether it is
       // one of the declared ports on that Pod.
@@ -68776,6 +68788,10 @@ data:
         source_labels = ["__meta_kubernetes_service_port_number"]
         action = "keepequal"
         target_label = "__tmp_port"
+      }
+      rule {
+        action = "labeldrop"
+        regex = "__tmp_port"
       }
     
       rule {

--- a/examples/application-observability/metrics.alloy
+++ b/examples/application-observability/metrics.alloy
@@ -200,6 +200,10 @@ discovery.relabel "annotation_autodiscovery_pods" {
     action = "keepequal"
     target_label = "__tmp_port"
   }
+  rule {
+    action = "labeldrop"
+    regex = "__tmp_port"
+  }
 
   // If the metrics port number annotation has a value, override the target address to use it, regardless whether it is
   // one of the declared ports on that Pod.
@@ -281,6 +285,10 @@ discovery.relabel "annotation_autodiscovery_services" {
     source_labels = ["__meta_kubernetes_service_port_number"]
     action = "keepequal"
     target_label = "__tmp_port"
+  }
+  rule {
+    action = "labeldrop"
+    regex = "__tmp_port"
   }
 
   rule {

--- a/examples/application-observability/output.yaml
+++ b/examples/application-observability/output.yaml
@@ -374,6 +374,10 @@ data:
         action = "keepequal"
         target_label = "__tmp_port"
       }
+      rule {
+        action = "labeldrop"
+        regex = "__tmp_port"
+      }
     
       // If the metrics port number annotation has a value, override the target address to use it, regardless whether it is
       // one of the declared ports on that Pod.
@@ -455,6 +459,10 @@ data:
         source_labels = ["__meta_kubernetes_service_port_number"]
         action = "keepequal"
         target_label = "__tmp_port"
+      }
+      rule {
+        action = "labeldrop"
+        regex = "__tmp_port"
       }
     
       rule {
@@ -69928,6 +69936,10 @@ data:
         action = "keepequal"
         target_label = "__tmp_port"
       }
+      rule {
+        action = "labeldrop"
+        regex = "__tmp_port"
+      }
     
       // If the metrics port number annotation has a value, override the target address to use it, regardless whether it is
       // one of the declared ports on that Pod.
@@ -70009,6 +70021,10 @@ data:
         source_labels = ["__meta_kubernetes_service_port_number"]
         action = "keepequal"
         target_label = "__tmp_port"
+      }
+      rule {
+        action = "labeldrop"
+        regex = "__tmp_port"
       }
     
       rule {

--- a/examples/azure-aks/metrics.alloy
+++ b/examples/azure-aks/metrics.alloy
@@ -168,6 +168,10 @@ discovery.relabel "annotation_autodiscovery_pods" {
     action = "keepequal"
     target_label = "__tmp_port"
   }
+  rule {
+    action = "labeldrop"
+    regex = "__tmp_port"
+  }
 
   // If the metrics port number annotation has a value, override the target address to use it, regardless whether it is
   // one of the declared ports on that Pod.
@@ -249,6 +253,10 @@ discovery.relabel "annotation_autodiscovery_services" {
     source_labels = ["__meta_kubernetes_service_port_number"]
     action = "keepequal"
     target_label = "__tmp_port"
+  }
+  rule {
+    action = "labeldrop"
+    regex = "__tmp_port"
   }
 
   rule {

--- a/examples/azure-aks/output.yaml
+++ b/examples/azure-aks/output.yaml
@@ -300,6 +300,10 @@ data:
         action = "keepequal"
         target_label = "__tmp_port"
       }
+      rule {
+        action = "labeldrop"
+        regex = "__tmp_port"
+      }
     
       // If the metrics port number annotation has a value, override the target address to use it, regardless whether it is
       // one of the declared ports on that Pod.
@@ -381,6 +385,10 @@ data:
         source_labels = ["__meta_kubernetes_service_port_number"]
         action = "keepequal"
         target_label = "__tmp_port"
+      }
+      rule {
+        action = "labeldrop"
+        regex = "__tmp_port"
       }
     
       rule {
@@ -68639,6 +68647,10 @@ data:
         action = "keepequal"
         target_label = "__tmp_port"
       }
+      rule {
+        action = "labeldrop"
+        regex = "__tmp_port"
+      }
     
       // If the metrics port number annotation has a value, override the target address to use it, regardless whether it is
       // one of the declared ports on that Pod.
@@ -68720,6 +68732,10 @@ data:
         source_labels = ["__meta_kubernetes_service_port_number"]
         action = "keepequal"
         target_label = "__tmp_port"
+      }
+      rule {
+        action = "labeldrop"
+        regex = "__tmp_port"
       }
     
       rule {

--- a/examples/bearer-token-auth/metrics.alloy
+++ b/examples/bearer-token-auth/metrics.alloy
@@ -168,6 +168,10 @@ discovery.relabel "annotation_autodiscovery_pods" {
     action = "keepequal"
     target_label = "__tmp_port"
   }
+  rule {
+    action = "labeldrop"
+    regex = "__tmp_port"
+  }
 
   // If the metrics port number annotation has a value, override the target address to use it, regardless whether it is
   // one of the declared ports on that Pod.
@@ -249,6 +253,10 @@ discovery.relabel "annotation_autodiscovery_services" {
     source_labels = ["__meta_kubernetes_service_port_number"]
     action = "keepequal"
     target_label = "__tmp_port"
+  }
+  rule {
+    action = "labeldrop"
+    regex = "__tmp_port"
   }
 
   rule {

--- a/examples/bearer-token-auth/output.yaml
+++ b/examples/bearer-token-auth/output.yaml
@@ -299,6 +299,10 @@ data:
         action = "keepequal"
         target_label = "__tmp_port"
       }
+      rule {
+        action = "labeldrop"
+        regex = "__tmp_port"
+      }
     
       // If the metrics port number annotation has a value, override the target address to use it, regardless whether it is
       // one of the declared ports on that Pod.
@@ -380,6 +384,10 @@ data:
         source_labels = ["__meta_kubernetes_service_port_number"]
         action = "keepequal"
         target_label = "__tmp_port"
+      }
+      rule {
+        action = "labeldrop"
+        regex = "__tmp_port"
       }
     
       rule {
@@ -68627,6 +68635,10 @@ data:
         action = "keepequal"
         target_label = "__tmp_port"
       }
+      rule {
+        action = "labeldrop"
+        regex = "__tmp_port"
+      }
     
       // If the metrics port number annotation has a value, override the target address to use it, regardless whether it is
       // one of the declared ports on that Pod.
@@ -68708,6 +68720,10 @@ data:
         source_labels = ["__meta_kubernetes_service_port_number"]
         action = "keepequal"
         target_label = "__tmp_port"
+      }
+      rule {
+        action = "labeldrop"
+        regex = "__tmp_port"
       }
     
       rule {

--- a/examples/beyla/metrics.alloy
+++ b/examples/beyla/metrics.alloy
@@ -200,6 +200,10 @@ discovery.relabel "annotation_autodiscovery_pods" {
     action = "keepequal"
     target_label = "__tmp_port"
   }
+  rule {
+    action = "labeldrop"
+    regex = "__tmp_port"
+  }
 
   // If the metrics port number annotation has a value, override the target address to use it, regardless whether it is
   // one of the declared ports on that Pod.
@@ -281,6 +285,10 @@ discovery.relabel "annotation_autodiscovery_services" {
     source_labels = ["__meta_kubernetes_service_port_number"]
     action = "keepequal"
     target_label = "__tmp_port"
+  }
+  rule {
+    action = "labeldrop"
+    regex = "__tmp_port"
   }
 
   rule {

--- a/examples/beyla/output.yaml
+++ b/examples/beyla/output.yaml
@@ -361,6 +361,10 @@ data:
         action = "keepequal"
         target_label = "__tmp_port"
       }
+      rule {
+        action = "labeldrop"
+        regex = "__tmp_port"
+      }
     
       // If the metrics port number annotation has a value, override the target address to use it, regardless whether it is
       // one of the declared ports on that Pod.
@@ -442,6 +446,10 @@ data:
         source_labels = ["__meta_kubernetes_service_port_number"]
         action = "keepequal"
         target_label = "__tmp_port"
+      }
+      rule {
+        action = "labeldrop"
+        regex = "__tmp_port"
       }
     
       rule {
@@ -68939,6 +68947,10 @@ data:
         action = "keepequal"
         target_label = "__tmp_port"
       }
+      rule {
+        action = "labeldrop"
+        regex = "__tmp_port"
+      }
     
       // If the metrics port number annotation has a value, override the target address to use it, regardless whether it is
       // one of the declared ports on that Pod.
@@ -69020,6 +69032,10 @@ data:
         source_labels = ["__meta_kubernetes_service_port_number"]
         action = "keepequal"
         target_label = "__tmp_port"
+      }
+      rule {
+        action = "labeldrop"
+        regex = "__tmp_port"
       }
     
       rule {

--- a/examples/control-plane-metrics/metrics.alloy
+++ b/examples/control-plane-metrics/metrics.alloy
@@ -168,6 +168,10 @@ discovery.relabel "annotation_autodiscovery_pods" {
     action = "keepequal"
     target_label = "__tmp_port"
   }
+  rule {
+    action = "labeldrop"
+    regex = "__tmp_port"
+  }
 
   // If the metrics port number annotation has a value, override the target address to use it, regardless whether it is
   // one of the declared ports on that Pod.
@@ -249,6 +253,10 @@ discovery.relabel "annotation_autodiscovery_services" {
     source_labels = ["__meta_kubernetes_service_port_number"]
     action = "keepequal"
     target_label = "__tmp_port"
+  }
+  rule {
+    action = "labeldrop"
+    regex = "__tmp_port"
   }
 
   rule {

--- a/examples/control-plane-metrics/output.yaml
+++ b/examples/control-plane-metrics/output.yaml
@@ -301,6 +301,10 @@ data:
         action = "keepequal"
         target_label = "__tmp_port"
       }
+      rule {
+        action = "labeldrop"
+        regex = "__tmp_port"
+      }
     
       // If the metrics port number annotation has a value, override the target address to use it, regardless whether it is
       // one of the declared ports on that Pod.
@@ -382,6 +386,10 @@ data:
         source_labels = ["__meta_kubernetes_service_port_number"]
         action = "keepequal"
         target_label = "__tmp_port"
+      }
+      rule {
+        action = "labeldrop"
+        regex = "__tmp_port"
       }
     
       rule {
@@ -68788,6 +68796,10 @@ data:
         action = "keepequal"
         target_label = "__tmp_port"
       }
+      rule {
+        action = "labeldrop"
+        regex = "__tmp_port"
+      }
     
       // If the metrics port number annotation has a value, override the target address to use it, regardless whether it is
       // one of the declared ports on that Pod.
@@ -68869,6 +68881,10 @@ data:
         source_labels = ["__meta_kubernetes_service_port_number"]
         action = "keepequal"
         target_label = "__tmp_port"
+      }
+      rule {
+        action = "labeldrop"
+        regex = "__tmp_port"
       }
     
       rule {

--- a/examples/custom-config/metrics.alloy
+++ b/examples/custom-config/metrics.alloy
@@ -168,6 +168,10 @@ discovery.relabel "annotation_autodiscovery_pods" {
     action = "keepequal"
     target_label = "__tmp_port"
   }
+  rule {
+    action = "labeldrop"
+    regex = "__tmp_port"
+  }
 
   // If the metrics port number annotation has a value, override the target address to use it, regardless whether it is
   // one of the declared ports on that Pod.
@@ -249,6 +253,10 @@ discovery.relabel "annotation_autodiscovery_services" {
     source_labels = ["__meta_kubernetes_service_port_number"]
     action = "keepequal"
     target_label = "__tmp_port"
+  }
+  rule {
+    action = "labeldrop"
+    regex = "__tmp_port"
   }
 
   rule {

--- a/examples/custom-config/output.yaml
+++ b/examples/custom-config/output.yaml
@@ -300,6 +300,10 @@ data:
         action = "keepequal"
         target_label = "__tmp_port"
       }
+      rule {
+        action = "labeldrop"
+        regex = "__tmp_port"
+      }
     
       // If the metrics port number annotation has a value, override the target address to use it, regardless whether it is
       // one of the declared ports on that Pod.
@@ -381,6 +385,10 @@ data:
         source_labels = ["__meta_kubernetes_service_port_number"]
         action = "keepequal"
         target_label = "__tmp_port"
+      }
+      rule {
+        action = "labeldrop"
+        regex = "__tmp_port"
       }
     
       rule {
@@ -68724,6 +68732,10 @@ data:
         action = "keepequal"
         target_label = "__tmp_port"
       }
+      rule {
+        action = "labeldrop"
+        regex = "__tmp_port"
+      }
     
       // If the metrics port number annotation has a value, override the target address to use it, regardless whether it is
       // one of the declared ports on that Pod.
@@ -68805,6 +68817,10 @@ data:
         source_labels = ["__meta_kubernetes_service_port_number"]
         action = "keepequal"
         target_label = "__tmp_port"
+      }
+      rule {
+        action = "labeldrop"
+        regex = "__tmp_port"
       }
     
       rule {

--- a/examples/custom-metrics-tuning/metrics.alloy
+++ b/examples/custom-metrics-tuning/metrics.alloy
@@ -150,6 +150,10 @@ discovery.relabel "annotation_autodiscovery_pods" {
     action = "keepequal"
     target_label = "__tmp_port"
   }
+  rule {
+    action = "labeldrop"
+    regex = "__tmp_port"
+  }
 
   // If the metrics port number annotation has a value, override the target address to use it, regardless whether it is
   // one of the declared ports on that Pod.
@@ -231,6 +235,10 @@ discovery.relabel "annotation_autodiscovery_services" {
     source_labels = ["__meta_kubernetes_service_port_number"]
     action = "keepequal"
     target_label = "__tmp_port"
+  }
+  rule {
+    action = "labeldrop"
+    regex = "__tmp_port"
   }
 
   rule {

--- a/examples/custom-metrics-tuning/output.yaml
+++ b/examples/custom-metrics-tuning/output.yaml
@@ -237,6 +237,10 @@ data:
         action = "keepequal"
         target_label = "__tmp_port"
       }
+      rule {
+        action = "labeldrop"
+        regex = "__tmp_port"
+      }
     
       // If the metrics port number annotation has a value, override the target address to use it, regardless whether it is
       // one of the declared ports on that Pod.
@@ -318,6 +322,10 @@ data:
         source_labels = ["__meta_kubernetes_service_port_number"]
         action = "keepequal"
         target_label = "__tmp_port"
+      }
+      rule {
+        action = "labeldrop"
+        regex = "__tmp_port"
       }
     
       rule {
@@ -67782,6 +67790,10 @@ data:
         action = "keepequal"
         target_label = "__tmp_port"
       }
+      rule {
+        action = "labeldrop"
+        regex = "__tmp_port"
+      }
     
       // If the metrics port number annotation has a value, override the target address to use it, regardless whether it is
       // one of the declared ports on that Pod.
@@ -67863,6 +67875,10 @@ data:
         source_labels = ["__meta_kubernetes_service_port_number"]
         action = "keepequal"
         target_label = "__tmp_port"
+      }
+      rule {
+        action = "labeldrop"
+        regex = "__tmp_port"
       }
     
       rule {

--- a/examples/custom-pricing/metrics.alloy
+++ b/examples/custom-pricing/metrics.alloy
@@ -168,6 +168,10 @@ discovery.relabel "annotation_autodiscovery_pods" {
     action = "keepequal"
     target_label = "__tmp_port"
   }
+  rule {
+    action = "labeldrop"
+    regex = "__tmp_port"
+  }
 
   // If the metrics port number annotation has a value, override the target address to use it, regardless whether it is
   // one of the declared ports on that Pod.
@@ -249,6 +253,10 @@ discovery.relabel "annotation_autodiscovery_services" {
     source_labels = ["__meta_kubernetes_service_port_number"]
     action = "keepequal"
     target_label = "__tmp_port"
+  }
+  rule {
+    action = "labeldrop"
+    regex = "__tmp_port"
   }
 
   rule {

--- a/examples/custom-pricing/output.yaml
+++ b/examples/custom-pricing/output.yaml
@@ -322,6 +322,10 @@ data:
         action = "keepequal"
         target_label = "__tmp_port"
       }
+      rule {
+        action = "labeldrop"
+        regex = "__tmp_port"
+      }
     
       // If the metrics port number annotation has a value, override the target address to use it, regardless whether it is
       // one of the declared ports on that Pod.
@@ -403,6 +407,10 @@ data:
         source_labels = ["__meta_kubernetes_service_port_number"]
         action = "keepequal"
         target_label = "__tmp_port"
+      }
+      rule {
+        action = "labeldrop"
+        regex = "__tmp_port"
       }
     
       rule {
@@ -68664,6 +68672,10 @@ data:
         action = "keepequal"
         target_label = "__tmp_port"
       }
+      rule {
+        action = "labeldrop"
+        regex = "__tmp_port"
+      }
     
       // If the metrics port number annotation has a value, override the target address to use it, regardless whether it is
       // one of the declared ports on that Pod.
@@ -68745,6 +68757,10 @@ data:
         source_labels = ["__meta_kubernetes_service_port_number"]
         action = "keepequal"
         target_label = "__tmp_port"
+      }
+      rule {
+        action = "labeldrop"
+        regex = "__tmp_port"
       }
     
       rule {

--- a/examples/custom-prometheus-operator-rules/metrics.alloy
+++ b/examples/custom-prometheus-operator-rules/metrics.alloy
@@ -150,6 +150,10 @@ discovery.relabel "annotation_autodiscovery_pods" {
     action = "keepequal"
     target_label = "__tmp_port"
   }
+  rule {
+    action = "labeldrop"
+    regex = "__tmp_port"
+  }
 
   // If the metrics port number annotation has a value, override the target address to use it, regardless whether it is
   // one of the declared ports on that Pod.
@@ -236,6 +240,10 @@ discovery.relabel "annotation_autodiscovery_services" {
     source_labels = ["__meta_kubernetes_service_port_number"]
     action = "keepequal"
     target_label = "__tmp_port"
+  }
+  rule {
+    action = "labeldrop"
+    regex = "__tmp_port"
   }
 
   rule {

--- a/examples/custom-prometheus-operator-rules/output.yaml
+++ b/examples/custom-prometheus-operator-rules/output.yaml
@@ -237,6 +237,10 @@ data:
         action = "keepequal"
         target_label = "__tmp_port"
       }
+      rule {
+        action = "labeldrop"
+        regex = "__tmp_port"
+      }
     
       // If the metrics port number annotation has a value, override the target address to use it, regardless whether it is
       // one of the declared ports on that Pod.
@@ -323,6 +327,10 @@ data:
         source_labels = ["__meta_kubernetes_service_port_number"]
         action = "keepequal"
         target_label = "__tmp_port"
+      }
+      rule {
+        action = "labeldrop"
+        regex = "__tmp_port"
       }
     
       rule {
@@ -67864,6 +67872,10 @@ data:
         action = "keepequal"
         target_label = "__tmp_port"
       }
+      rule {
+        action = "labeldrop"
+        regex = "__tmp_port"
+      }
     
       // If the metrics port number annotation has a value, override the target address to use it, regardless whether it is
       // one of the declared ports on that Pod.
@@ -67950,6 +67962,10 @@ data:
         source_labels = ["__meta_kubernetes_service_port_number"]
         action = "keepequal"
         target_label = "__tmp_port"
+      }
+      rule {
+        action = "labeldrop"
+        regex = "__tmp_port"
       }
     
       rule {

--- a/examples/default-values/metrics.alloy
+++ b/examples/default-values/metrics.alloy
@@ -168,6 +168,10 @@ discovery.relabel "annotation_autodiscovery_pods" {
     action = "keepequal"
     target_label = "__tmp_port"
   }
+  rule {
+    action = "labeldrop"
+    regex = "__tmp_port"
+  }
 
   // If the metrics port number annotation has a value, override the target address to use it, regardless whether it is
   // one of the declared ports on that Pod.
@@ -249,6 +253,10 @@ discovery.relabel "annotation_autodiscovery_services" {
     source_labels = ["__meta_kubernetes_service_port_number"]
     action = "keepequal"
     target_label = "__tmp_port"
+  }
+  rule {
+    action = "labeldrop"
+    regex = "__tmp_port"
   }
 
   rule {

--- a/examples/default-values/output.yaml
+++ b/examples/default-values/output.yaml
@@ -300,6 +300,10 @@ data:
         action = "keepequal"
         target_label = "__tmp_port"
       }
+      rule {
+        action = "labeldrop"
+        regex = "__tmp_port"
+      }
     
       // If the metrics port number annotation has a value, override the target address to use it, regardless whether it is
       // one of the declared ports on that Pod.
@@ -381,6 +385,10 @@ data:
         source_labels = ["__meta_kubernetes_service_port_number"]
         action = "keepequal"
         target_label = "__tmp_port"
+      }
+      rule {
+        action = "labeldrop"
+        regex = "__tmp_port"
       }
     
       rule {
@@ -68631,6 +68639,10 @@ data:
         action = "keepequal"
         target_label = "__tmp_port"
       }
+      rule {
+        action = "labeldrop"
+        regex = "__tmp_port"
+      }
     
       // If the metrics port number annotation has a value, override the target address to use it, regardless whether it is
       // one of the declared ports on that Pod.
@@ -68712,6 +68724,10 @@ data:
         source_labels = ["__meta_kubernetes_service_port_number"]
         action = "keepequal"
         target_label = "__tmp_port"
+      }
+      rule {
+        action = "labeldrop"
+        regex = "__tmp_port"
       }
     
       rule {

--- a/examples/eks-fargate/metrics.alloy
+++ b/examples/eks-fargate/metrics.alloy
@@ -168,6 +168,10 @@ discovery.relabel "annotation_autodiscovery_pods" {
     action = "keepequal"
     target_label = "__tmp_port"
   }
+  rule {
+    action = "labeldrop"
+    regex = "__tmp_port"
+  }
 
   // If the metrics port number annotation has a value, override the target address to use it, regardless whether it is
   // one of the declared ports on that Pod.
@@ -249,6 +253,10 @@ discovery.relabel "annotation_autodiscovery_services" {
     source_labels = ["__meta_kubernetes_service_port_number"]
     action = "keepequal"
     target_label = "__tmp_port"
+  }
+  rule {
+    action = "labeldrop"
+    regex = "__tmp_port"
   }
 
   rule {

--- a/examples/eks-fargate/output.yaml
+++ b/examples/eks-fargate/output.yaml
@@ -283,6 +283,10 @@ data:
         action = "keepequal"
         target_label = "__tmp_port"
       }
+      rule {
+        action = "labeldrop"
+        regex = "__tmp_port"
+      }
     
       // If the metrics port number annotation has a value, override the target address to use it, regardless whether it is
       // one of the declared ports on that Pod.
@@ -364,6 +368,10 @@ data:
         source_labels = ["__meta_kubernetes_service_port_number"]
         action = "keepequal"
         target_label = "__tmp_port"
+      }
+      rule {
+        action = "labeldrop"
+        regex = "__tmp_port"
       }
     
       rule {
@@ -68432,6 +68440,10 @@ data:
         action = "keepequal"
         target_label = "__tmp_port"
       }
+      rule {
+        action = "labeldrop"
+        regex = "__tmp_port"
+      }
     
       // If the metrics port number annotation has a value, override the target address to use it, regardless whether it is
       // one of the declared ports on that Pod.
@@ -68513,6 +68525,10 @@ data:
         source_labels = ["__meta_kubernetes_service_port_number"]
         action = "keepequal"
         target_label = "__tmp_port"
+      }
+      rule {
+        action = "labeldrop"
+        regex = "__tmp_port"
       }
     
       rule {

--- a/examples/environment-variables/metrics.alloy
+++ b/examples/environment-variables/metrics.alloy
@@ -168,6 +168,10 @@ discovery.relabel "annotation_autodiscovery_pods" {
     action = "keepequal"
     target_label = "__tmp_port"
   }
+  rule {
+    action = "labeldrop"
+    regex = "__tmp_port"
+  }
 
   // If the metrics port number annotation has a value, override the target address to use it, regardless whether it is
   // one of the declared ports on that Pod.
@@ -249,6 +253,10 @@ discovery.relabel "annotation_autodiscovery_services" {
     source_labels = ["__meta_kubernetes_service_port_number"]
     action = "keepequal"
     target_label = "__tmp_port"
+  }
+  rule {
+    action = "labeldrop"
+    regex = "__tmp_port"
   }
 
   rule {

--- a/examples/environment-variables/output.yaml
+++ b/examples/environment-variables/output.yaml
@@ -300,6 +300,10 @@ data:
         action = "keepequal"
         target_label = "__tmp_port"
       }
+      rule {
+        action = "labeldrop"
+        regex = "__tmp_port"
+      }
     
       // If the metrics port number annotation has a value, override the target address to use it, regardless whether it is
       // one of the declared ports on that Pod.
@@ -381,6 +385,10 @@ data:
         source_labels = ["__meta_kubernetes_service_port_number"]
         action = "keepequal"
         target_label = "__tmp_port"
+      }
+      rule {
+        action = "labeldrop"
+        regex = "__tmp_port"
       }
     
       rule {
@@ -68689,6 +68697,10 @@ data:
         action = "keepequal"
         target_label = "__tmp_port"
       }
+      rule {
+        action = "labeldrop"
+        regex = "__tmp_port"
+      }
     
       // If the metrics port number annotation has a value, override the target address to use it, regardless whether it is
       // one of the declared ports on that Pod.
@@ -68770,6 +68782,10 @@ data:
         source_labels = ["__meta_kubernetes_service_port_number"]
         action = "keepequal"
         target_label = "__tmp_port"
+      }
+      rule {
+        action = "labeldrop"
+        regex = "__tmp_port"
       }
     
       rule {

--- a/examples/extra-rules/metrics.alloy
+++ b/examples/extra-rules/metrics.alloy
@@ -168,6 +168,10 @@ discovery.relabel "annotation_autodiscovery_pods" {
     action = "keepequal"
     target_label = "__tmp_port"
   }
+  rule {
+    action = "labeldrop"
+    regex = "__tmp_port"
+  }
 
   // If the metrics port number annotation has a value, override the target address to use it, regardless whether it is
   // one of the declared ports on that Pod.
@@ -254,6 +258,10 @@ discovery.relabel "annotation_autodiscovery_services" {
     source_labels = ["__meta_kubernetes_service_port_number"]
     action = "keepequal"
     target_label = "__tmp_port"
+  }
+  rule {
+    action = "labeldrop"
+    regex = "__tmp_port"
   }
 
   rule {

--- a/examples/extra-rules/output.yaml
+++ b/examples/extra-rules/output.yaml
@@ -301,6 +301,10 @@ data:
         action = "keepequal"
         target_label = "__tmp_port"
       }
+      rule {
+        action = "labeldrop"
+        regex = "__tmp_port"
+      }
     
       // If the metrics port number annotation has a value, override the target address to use it, regardless whether it is
       // one of the declared ports on that Pod.
@@ -387,6 +391,10 @@ data:
         source_labels = ["__meta_kubernetes_service_port_number"]
         action = "keepequal"
         target_label = "__tmp_port"
+      }
+      rule {
+        action = "labeldrop"
+        regex = "__tmp_port"
       }
     
       rule {
@@ -68753,6 +68761,10 @@ data:
         action = "keepequal"
         target_label = "__tmp_port"
       }
+      rule {
+        action = "labeldrop"
+        regex = "__tmp_port"
+      }
     
       // If the metrics port number annotation has a value, override the target address to use it, regardless whether it is
       // one of the declared ports on that Pod.
@@ -68839,6 +68851,10 @@ data:
         source_labels = ["__meta_kubernetes_service_port_number"]
         action = "keepequal"
         target_label = "__tmp_port"
+      }
+      rule {
+        action = "labeldrop"
+        regex = "__tmp_port"
       }
     
       rule {

--- a/examples/gke-autopilot/metrics.alloy
+++ b/examples/gke-autopilot/metrics.alloy
@@ -168,6 +168,10 @@ discovery.relabel "annotation_autodiscovery_pods" {
     action = "keepequal"
     target_label = "__tmp_port"
   }
+  rule {
+    action = "labeldrop"
+    regex = "__tmp_port"
+  }
 
   // If the metrics port number annotation has a value, override the target address to use it, regardless whether it is
   // one of the declared ports on that Pod.
@@ -249,6 +253,10 @@ discovery.relabel "annotation_autodiscovery_services" {
     source_labels = ["__meta_kubernetes_service_port_number"]
     action = "keepequal"
     target_label = "__tmp_port"
+  }
+  rule {
+    action = "labeldrop"
+    regex = "__tmp_port"
   }
 
   rule {

--- a/examples/gke-autopilot/output.yaml
+++ b/examples/gke-autopilot/output.yaml
@@ -283,6 +283,10 @@ data:
         action = "keepequal"
         target_label = "__tmp_port"
       }
+      rule {
+        action = "labeldrop"
+        regex = "__tmp_port"
+      }
     
       // If the metrics port number annotation has a value, override the target address to use it, regardless whether it is
       // one of the declared ports on that Pod.
@@ -364,6 +368,10 @@ data:
         source_labels = ["__meta_kubernetes_service_port_number"]
         action = "keepequal"
         target_label = "__tmp_port"
+      }
+      rule {
+        action = "labeldrop"
+        regex = "__tmp_port"
       }
     
       rule {
@@ -68414,6 +68422,10 @@ data:
         action = "keepequal"
         target_label = "__tmp_port"
       }
+      rule {
+        action = "labeldrop"
+        regex = "__tmp_port"
+      }
     
       // If the metrics port number annotation has a value, override the target address to use it, regardless whether it is
       // one of the declared ports on that Pod.
@@ -68495,6 +68507,10 @@ data:
         source_labels = ["__meta_kubernetes_service_port_number"]
         action = "keepequal"
         target_label = "__tmp_port"
+      }
+      rule {
+        action = "labeldrop"
+        regex = "__tmp_port"
       }
     
       rule {

--- a/examples/ibm-cloud/metrics.alloy
+++ b/examples/ibm-cloud/metrics.alloy
@@ -168,6 +168,10 @@ discovery.relabel "annotation_autodiscovery_pods" {
     action = "keepequal"
     target_label = "__tmp_port"
   }
+  rule {
+    action = "labeldrop"
+    regex = "__tmp_port"
+  }
 
   // If the metrics port number annotation has a value, override the target address to use it, regardless whether it is
   // one of the declared ports on that Pod.
@@ -249,6 +253,10 @@ discovery.relabel "annotation_autodiscovery_services" {
     source_labels = ["__meta_kubernetes_service_port_number"]
     action = "keepequal"
     target_label = "__tmp_port"
+  }
+  rule {
+    action = "labeldrop"
+    regex = "__tmp_port"
   }
 
   rule {

--- a/examples/ibm-cloud/output.yaml
+++ b/examples/ibm-cloud/output.yaml
@@ -300,6 +300,10 @@ data:
         action = "keepequal"
         target_label = "__tmp_port"
       }
+      rule {
+        action = "labeldrop"
+        regex = "__tmp_port"
+      }
     
       // If the metrics port number annotation has a value, override the target address to use it, regardless whether it is
       // one of the declared ports on that Pod.
@@ -381,6 +385,10 @@ data:
         source_labels = ["__meta_kubernetes_service_port_number"]
         action = "keepequal"
         target_label = "__tmp_port"
+      }
+      rule {
+        action = "labeldrop"
+        regex = "__tmp_port"
       }
     
       rule {
@@ -68637,6 +68645,10 @@ data:
         action = "keepequal"
         target_label = "__tmp_port"
       }
+      rule {
+        action = "labeldrop"
+        regex = "__tmp_port"
+      }
     
       // If the metrics port number annotation has a value, override the target address to use it, regardless whether it is
       // one of the declared ports on that Pod.
@@ -68718,6 +68730,10 @@ data:
         source_labels = ["__meta_kubernetes_service_port_number"]
         action = "keepequal"
         target_label = "__tmp_port"
+      }
+      rule {
+        action = "labeldrop"
+        regex = "__tmp_port"
       }
     
       rule {

--- a/examples/metric-module-imports-extra-config/metrics.alloy
+++ b/examples/metric-module-imports-extra-config/metrics.alloy
@@ -168,6 +168,10 @@ discovery.relabel "annotation_autodiscovery_pods" {
     action = "keepequal"
     target_label = "__tmp_port"
   }
+  rule {
+    action = "labeldrop"
+    regex = "__tmp_port"
+  }
 
   // If the metrics port number annotation has a value, override the target address to use it, regardless whether it is
   // one of the declared ports on that Pod.
@@ -249,6 +253,10 @@ discovery.relabel "annotation_autodiscovery_services" {
     source_labels = ["__meta_kubernetes_service_port_number"]
     action = "keepequal"
     target_label = "__tmp_port"
+  }
+  rule {
+    action = "labeldrop"
+    regex = "__tmp_port"
   }
 
   rule {

--- a/examples/metric-module-imports-extra-config/output.yaml
+++ b/examples/metric-module-imports-extra-config/output.yaml
@@ -300,6 +300,10 @@ data:
         action = "keepequal"
         target_label = "__tmp_port"
       }
+      rule {
+        action = "labeldrop"
+        regex = "__tmp_port"
+      }
     
       // If the metrics port number annotation has a value, override the target address to use it, regardless whether it is
       // one of the declared ports on that Pod.
@@ -381,6 +385,10 @@ data:
         source_labels = ["__meta_kubernetes_service_port_number"]
         action = "keepequal"
         target_label = "__tmp_port"
+      }
+      rule {
+        action = "labeldrop"
+        regex = "__tmp_port"
       }
     
       rule {
@@ -68647,6 +68655,10 @@ data:
         action = "keepequal"
         target_label = "__tmp_port"
       }
+      rule {
+        action = "labeldrop"
+        regex = "__tmp_port"
+      }
     
       // If the metrics port number annotation has a value, override the target address to use it, regardless whether it is
       // one of the declared ports on that Pod.
@@ -68728,6 +68740,10 @@ data:
         source_labels = ["__meta_kubernetes_service_port_number"]
         action = "keepequal"
         target_label = "__tmp_port"
+      }
+      rule {
+        action = "labeldrop"
+        regex = "__tmp_port"
       }
     
       rule {

--- a/examples/metric-module-imports/metrics.alloy
+++ b/examples/metric-module-imports/metrics.alloy
@@ -168,6 +168,10 @@ discovery.relabel "annotation_autodiscovery_pods" {
     action = "keepequal"
     target_label = "__tmp_port"
   }
+  rule {
+    action = "labeldrop"
+    regex = "__tmp_port"
+  }
 
   // If the metrics port number annotation has a value, override the target address to use it, regardless whether it is
   // one of the declared ports on that Pod.
@@ -249,6 +253,10 @@ discovery.relabel "annotation_autodiscovery_services" {
     source_labels = ["__meta_kubernetes_service_port_number"]
     action = "keepequal"
     target_label = "__tmp_port"
+  }
+  rule {
+    action = "labeldrop"
+    regex = "__tmp_port"
   }
 
   rule {

--- a/examples/metric-module-imports/output.yaml
+++ b/examples/metric-module-imports/output.yaml
@@ -300,6 +300,10 @@ data:
         action = "keepequal"
         target_label = "__tmp_port"
       }
+      rule {
+        action = "labeldrop"
+        regex = "__tmp_port"
+      }
     
       // If the metrics port number annotation has a value, override the target address to use it, regardless whether it is
       // one of the declared ports on that Pod.
@@ -381,6 +385,10 @@ data:
         source_labels = ["__meta_kubernetes_service_port_number"]
         action = "keepequal"
         target_label = "__tmp_port"
+      }
+      rule {
+        action = "labeldrop"
+        regex = "__tmp_port"
       }
     
       rule {
@@ -68808,6 +68816,10 @@ data:
         action = "keepequal"
         target_label = "__tmp_port"
       }
+      rule {
+        action = "labeldrop"
+        regex = "__tmp_port"
+      }
     
       // If the metrics port number annotation has a value, override the target address to use it, regardless whether it is
       // one of the declared ports on that Pod.
@@ -68889,6 +68901,10 @@ data:
         source_labels = ["__meta_kubernetes_service_port_number"]
         action = "keepequal"
         target_label = "__tmp_port"
+      }
+      rule {
+        action = "labeldrop"
+        regex = "__tmp_port"
       }
     
       rule {

--- a/examples/metrics-only/metrics.alloy
+++ b/examples/metrics-only/metrics.alloy
@@ -150,6 +150,10 @@ discovery.relabel "annotation_autodiscovery_pods" {
     action = "keepequal"
     target_label = "__tmp_port"
   }
+  rule {
+    action = "labeldrop"
+    regex = "__tmp_port"
+  }
 
   // If the metrics port number annotation has a value, override the target address to use it, regardless whether it is
   // one of the declared ports on that Pod.
@@ -231,6 +235,10 @@ discovery.relabel "annotation_autodiscovery_services" {
     source_labels = ["__meta_kubernetes_service_port_number"]
     action = "keepequal"
     target_label = "__tmp_port"
+  }
+  rule {
+    action = "labeldrop"
+    regex = "__tmp_port"
   }
 
   rule {

--- a/examples/metrics-only/output.yaml
+++ b/examples/metrics-only/output.yaml
@@ -238,6 +238,10 @@ data:
         action = "keepequal"
         target_label = "__tmp_port"
       }
+      rule {
+        action = "labeldrop"
+        regex = "__tmp_port"
+      }
     
       // If the metrics port number annotation has a value, override the target address to use it, regardless whether it is
       // one of the declared ports on that Pod.
@@ -319,6 +323,10 @@ data:
         source_labels = ["__meta_kubernetes_service_port_number"]
         action = "keepequal"
         target_label = "__tmp_port"
+      }
+      rule {
+        action = "labeldrop"
+        regex = "__tmp_port"
       }
     
       rule {
@@ -67788,6 +67796,10 @@ data:
         action = "keepequal"
         target_label = "__tmp_port"
       }
+      rule {
+        action = "labeldrop"
+        regex = "__tmp_port"
+      }
     
       // If the metrics port number annotation has a value, override the target address to use it, regardless whether it is
       // one of the declared ports on that Pod.
@@ -67869,6 +67881,10 @@ data:
         source_labels = ["__meta_kubernetes_service_port_number"]
         action = "keepequal"
         target_label = "__tmp_port"
+      }
+      rule {
+        action = "labeldrop"
+        regex = "__tmp_port"
       }
     
       rule {

--- a/examples/openshift-compatible/metrics.alloy
+++ b/examples/openshift-compatible/metrics.alloy
@@ -168,6 +168,10 @@ discovery.relabel "annotation_autodiscovery_pods" {
     action = "keepequal"
     target_label = "__tmp_port"
   }
+  rule {
+    action = "labeldrop"
+    regex = "__tmp_port"
+  }
 
   // If the metrics port number annotation has a value, override the target address to use it, regardless whether it is
   // one of the declared ports on that Pod.
@@ -249,6 +253,10 @@ discovery.relabel "annotation_autodiscovery_services" {
     source_labels = ["__meta_kubernetes_service_port_number"]
     action = "keepequal"
     target_label = "__tmp_port"
+  }
+  rule {
+    action = "labeldrop"
+    regex = "__tmp_port"
   }
 
   rule {

--- a/examples/openshift-compatible/output.yaml
+++ b/examples/openshift-compatible/output.yaml
@@ -266,6 +266,10 @@ data:
         action = "keepequal"
         target_label = "__tmp_port"
       }
+      rule {
+        action = "labeldrop"
+        regex = "__tmp_port"
+      }
     
       // If the metrics port number annotation has a value, override the target address to use it, regardless whether it is
       // one of the declared ports on that Pod.
@@ -347,6 +351,10 @@ data:
         source_labels = ["__meta_kubernetes_service_port_number"]
         action = "keepequal"
         target_label = "__tmp_port"
+      }
+      rule {
+        action = "labeldrop"
+        regex = "__tmp_port"
       }
     
       rule {
@@ -68460,6 +68468,10 @@ data:
         action = "keepequal"
         target_label = "__tmp_port"
       }
+      rule {
+        action = "labeldrop"
+        regex = "__tmp_port"
+      }
     
       // If the metrics port number annotation has a value, override the target address to use it, regardless whether it is
       // one of the declared ports on that Pod.
@@ -68541,6 +68553,10 @@ data:
         source_labels = ["__meta_kubernetes_service_port_number"]
         action = "keepequal"
         target_label = "__tmp_port"
+      }
+      rule {
+        action = "labeldrop"
+        regex = "__tmp_port"
       }
     
       rule {

--- a/examples/otel-metrics-service/metrics.alloy
+++ b/examples/otel-metrics-service/metrics.alloy
@@ -168,6 +168,10 @@ discovery.relabel "annotation_autodiscovery_pods" {
     action = "keepequal"
     target_label = "__tmp_port"
   }
+  rule {
+    action = "labeldrop"
+    regex = "__tmp_port"
+  }
 
   // If the metrics port number annotation has a value, override the target address to use it, regardless whether it is
   // one of the declared ports on that Pod.
@@ -249,6 +253,10 @@ discovery.relabel "annotation_autodiscovery_services" {
     source_labels = ["__meta_kubernetes_service_port_number"]
     action = "keepequal"
     target_label = "__tmp_port"
+  }
+  rule {
+    action = "labeldrop"
+    regex = "__tmp_port"
   }
 
   rule {

--- a/examples/otel-metrics-service/output.yaml
+++ b/examples/otel-metrics-service/output.yaml
@@ -300,6 +300,10 @@ data:
         action = "keepequal"
         target_label = "__tmp_port"
       }
+      rule {
+        action = "labeldrop"
+        regex = "__tmp_port"
+      }
     
       // If the metrics port number annotation has a value, override the target address to use it, regardless whether it is
       // one of the declared ports on that Pod.
@@ -381,6 +385,10 @@ data:
         source_labels = ["__meta_kubernetes_service_port_number"]
         action = "keepequal"
         target_label = "__tmp_port"
+      }
+      rule {
+        action = "labeldrop"
+        regex = "__tmp_port"
       }
     
       rule {
@@ -68649,6 +68657,10 @@ data:
         action = "keepequal"
         target_label = "__tmp_port"
       }
+      rule {
+        action = "labeldrop"
+        regex = "__tmp_port"
+      }
     
       // If the metrics port number annotation has a value, override the target address to use it, regardless whether it is
       // one of the declared ports on that Pod.
@@ -68730,6 +68742,10 @@ data:
         source_labels = ["__meta_kubernetes_service_port_number"]
         action = "keepequal"
         target_label = "__tmp_port"
+      }
+      rule {
+        action = "labeldrop"
+        regex = "__tmp_port"
       }
     
       rule {

--- a/examples/pod-labels/metrics.alloy
+++ b/examples/pod-labels/metrics.alloy
@@ -205,6 +205,10 @@ discovery.relabel "annotation_autodiscovery_pods" {
     action = "keepequal"
     target_label = "__tmp_port"
   }
+  rule {
+    action = "labeldrop"
+    regex = "__tmp_port"
+  }
 
   // If the metrics port number annotation has a value, override the target address to use it, regardless whether it is
   // one of the declared ports on that Pod.
@@ -286,6 +290,10 @@ discovery.relabel "annotation_autodiscovery_services" {
     source_labels = ["__meta_kubernetes_service_port_number"]
     action = "keepequal"
     target_label = "__tmp_port"
+  }
+  rule {
+    action = "labeldrop"
+    regex = "__tmp_port"
   }
 
   rule {

--- a/examples/pod-labels/output.yaml
+++ b/examples/pod-labels/output.yaml
@@ -350,6 +350,10 @@ data:
         action = "keepequal"
         target_label = "__tmp_port"
       }
+      rule {
+        action = "labeldrop"
+        regex = "__tmp_port"
+      }
     
       // If the metrics port number annotation has a value, override the target address to use it, regardless whether it is
       // one of the declared ports on that Pod.
@@ -431,6 +435,10 @@ data:
         source_labels = ["__meta_kubernetes_service_port_number"]
         action = "keepequal"
         target_label = "__tmp_port"
+      }
+      rule {
+        action = "labeldrop"
+        regex = "__tmp_port"
       }
     
       rule {
@@ -68746,6 +68754,10 @@ data:
         action = "keepequal"
         target_label = "__tmp_port"
       }
+      rule {
+        action = "labeldrop"
+        regex = "__tmp_port"
+      }
     
       // If the metrics port number annotation has a value, override the target address to use it, regardless whether it is
       // one of the declared ports on that Pod.
@@ -68827,6 +68839,10 @@ data:
         source_labels = ["__meta_kubernetes_service_port_number"]
         action = "keepequal"
         target_label = "__tmp_port"
+      }
+      rule {
+        action = "labeldrop"
+        regex = "__tmp_port"
       }
     
       rule {

--- a/examples/private-image-registry/metrics.alloy
+++ b/examples/private-image-registry/metrics.alloy
@@ -168,6 +168,10 @@ discovery.relabel "annotation_autodiscovery_pods" {
     action = "keepequal"
     target_label = "__tmp_port"
   }
+  rule {
+    action = "labeldrop"
+    regex = "__tmp_port"
+  }
 
   // If the metrics port number annotation has a value, override the target address to use it, regardless whether it is
   // one of the declared ports on that Pod.
@@ -249,6 +253,10 @@ discovery.relabel "annotation_autodiscovery_services" {
     source_labels = ["__meta_kubernetes_service_port_number"]
     action = "keepequal"
     target_label = "__tmp_port"
+  }
+  rule {
+    action = "labeldrop"
+    regex = "__tmp_port"
   }
 
   rule {

--- a/examples/private-image-registry/output.yaml
+++ b/examples/private-image-registry/output.yaml
@@ -304,6 +304,10 @@ data:
         action = "keepequal"
         target_label = "__tmp_port"
       }
+      rule {
+        action = "labeldrop"
+        regex = "__tmp_port"
+      }
     
       // If the metrics port number annotation has a value, override the target address to use it, regardless whether it is
       // one of the declared ports on that Pod.
@@ -385,6 +389,10 @@ data:
         source_labels = ["__meta_kubernetes_service_port_number"]
         action = "keepequal"
         target_label = "__tmp_port"
+      }
+      rule {
+        action = "labeldrop"
+        regex = "__tmp_port"
       }
     
       rule {
@@ -68647,6 +68655,10 @@ data:
         action = "keepequal"
         target_label = "__tmp_port"
       }
+      rule {
+        action = "labeldrop"
+        regex = "__tmp_port"
+      }
     
       // If the metrics port number annotation has a value, override the target address to use it, regardless whether it is
       // one of the declared ports on that Pod.
@@ -68728,6 +68740,10 @@ data:
         source_labels = ["__meta_kubernetes_service_port_number"]
         action = "keepequal"
         target_label = "__tmp_port"
+      }
+      rule {
+        action = "labeldrop"
+        regex = "__tmp_port"
       }
     
       rule {

--- a/examples/profiles-enabled/metrics.alloy
+++ b/examples/profiles-enabled/metrics.alloy
@@ -168,6 +168,10 @@ discovery.relabel "annotation_autodiscovery_pods" {
     action = "keepequal"
     target_label = "__tmp_port"
   }
+  rule {
+    action = "labeldrop"
+    regex = "__tmp_port"
+  }
 
   // If the metrics port number annotation has a value, override the target address to use it, regardless whether it is
   // one of the declared ports on that Pod.
@@ -249,6 +253,10 @@ discovery.relabel "annotation_autodiscovery_services" {
     source_labels = ["__meta_kubernetes_service_port_number"]
     action = "keepequal"
     target_label = "__tmp_port"
+  }
+  rule {
+    action = "labeldrop"
+    regex = "__tmp_port"
   }
 
   rule {

--- a/examples/profiles-enabled/output.yaml
+++ b/examples/profiles-enabled/output.yaml
@@ -329,6 +329,10 @@ data:
         action = "keepequal"
         target_label = "__tmp_port"
       }
+      rule {
+        action = "labeldrop"
+        regex = "__tmp_port"
+      }
     
       // If the metrics port number annotation has a value, override the target address to use it, regardless whether it is
       // one of the declared ports on that Pod.
@@ -410,6 +414,10 @@ data:
         source_labels = ["__meta_kubernetes_service_port_number"]
         action = "keepequal"
         target_label = "__tmp_port"
+      }
+      rule {
+        action = "labeldrop"
+        regex = "__tmp_port"
       }
     
       rule {
@@ -69829,6 +69837,10 @@ data:
         action = "keepequal"
         target_label = "__tmp_port"
       }
+      rule {
+        action = "labeldrop"
+        regex = "__tmp_port"
+      }
     
       // If the metrics port number annotation has a value, override the target address to use it, regardless whether it is
       // one of the declared ports on that Pod.
@@ -69910,6 +69922,10 @@ data:
         source_labels = ["__meta_kubernetes_service_port_number"]
         action = "keepequal"
         target_label = "__tmp_port"
+      }
+      rule {
+        action = "labeldrop"
+        regex = "__tmp_port"
       }
     
       rule {

--- a/examples/proxies/metrics.alloy
+++ b/examples/proxies/metrics.alloy
@@ -168,6 +168,10 @@ discovery.relabel "annotation_autodiscovery_pods" {
     action = "keepequal"
     target_label = "__tmp_port"
   }
+  rule {
+    action = "labeldrop"
+    regex = "__tmp_port"
+  }
 
   // If the metrics port number annotation has a value, override the target address to use it, regardless whether it is
   // one of the declared ports on that Pod.
@@ -249,6 +253,10 @@ discovery.relabel "annotation_autodiscovery_services" {
     source_labels = ["__meta_kubernetes_service_port_number"]
     action = "keepequal"
     target_label = "__tmp_port"
+  }
+  rule {
+    action = "labeldrop"
+    regex = "__tmp_port"
   }
 
   rule {

--- a/examples/proxies/output.yaml
+++ b/examples/proxies/output.yaml
@@ -300,6 +300,10 @@ data:
         action = "keepequal"
         target_label = "__tmp_port"
       }
+      rule {
+        action = "labeldrop"
+        regex = "__tmp_port"
+      }
     
       // If the metrics port number annotation has a value, override the target address to use it, regardless whether it is
       // one of the declared ports on that Pod.
@@ -381,6 +385,10 @@ data:
         source_labels = ["__meta_kubernetes_service_port_number"]
         action = "keepequal"
         target_label = "__tmp_port"
+      }
+      rule {
+        action = "labeldrop"
+        regex = "__tmp_port"
       }
     
       rule {
@@ -68647,6 +68655,10 @@ data:
         action = "keepequal"
         target_label = "__tmp_port"
       }
+      rule {
+        action = "labeldrop"
+        regex = "__tmp_port"
+      }
     
       // If the metrics port number annotation has a value, override the target address to use it, regardless whether it is
       // one of the declared ports on that Pod.
@@ -68728,6 +68740,10 @@ data:
         source_labels = ["__meta_kubernetes_service_port_number"]
         action = "keepequal"
         target_label = "__tmp_port"
+      }
+      rule {
+        action = "labeldrop"
+        regex = "__tmp_port"
       }
     
       rule {

--- a/examples/scrape-intervals/metrics.alloy
+++ b/examples/scrape-intervals/metrics.alloy
@@ -150,6 +150,10 @@ discovery.relabel "annotation_autodiscovery_pods" {
     action = "keepequal"
     target_label = "__tmp_port"
   }
+  rule {
+    action = "labeldrop"
+    regex = "__tmp_port"
+  }
 
   // If the metrics port number annotation has a value, override the target address to use it, regardless whether it is
   // one of the declared ports on that Pod.
@@ -231,6 +235,10 @@ discovery.relabel "annotation_autodiscovery_services" {
     source_labels = ["__meta_kubernetes_service_port_number"]
     action = "keepequal"
     target_label = "__tmp_port"
+  }
+  rule {
+    action = "labeldrop"
+    regex = "__tmp_port"
   }
 
   rule {

--- a/examples/scrape-intervals/output.yaml
+++ b/examples/scrape-intervals/output.yaml
@@ -237,6 +237,10 @@ data:
         action = "keepequal"
         target_label = "__tmp_port"
       }
+      rule {
+        action = "labeldrop"
+        regex = "__tmp_port"
+      }
     
       // If the metrics port number annotation has a value, override the target address to use it, regardless whether it is
       // one of the declared ports on that Pod.
@@ -318,6 +322,10 @@ data:
         source_labels = ["__meta_kubernetes_service_port_number"]
         action = "keepequal"
         target_label = "__tmp_port"
+      }
+      rule {
+        action = "labeldrop"
+        regex = "__tmp_port"
       }
     
       rule {
@@ -67787,6 +67795,10 @@ data:
         action = "keepequal"
         target_label = "__tmp_port"
       }
+      rule {
+        action = "labeldrop"
+        regex = "__tmp_port"
+      }
     
       // If the metrics port number annotation has a value, override the target address to use it, regardless whether it is
       // one of the declared ports on that Pod.
@@ -67868,6 +67880,10 @@ data:
         source_labels = ["__meta_kubernetes_service_port_number"]
         action = "keepequal"
         target_label = "__tmp_port"
+      }
+      rule {
+        action = "labeldrop"
+        regex = "__tmp_port"
       }
     
       rule {

--- a/examples/service-integrations/metrics.alloy
+++ b/examples/service-integrations/metrics.alloy
@@ -168,6 +168,10 @@ discovery.relabel "annotation_autodiscovery_pods" {
     action = "keepequal"
     target_label = "__tmp_port"
   }
+  rule {
+    action = "labeldrop"
+    regex = "__tmp_port"
+  }
 
   // If the metrics port number annotation has a value, override the target address to use it, regardless whether it is
   // one of the declared ports on that Pod.
@@ -249,6 +253,10 @@ discovery.relabel "annotation_autodiscovery_services" {
     source_labels = ["__meta_kubernetes_service_port_number"]
     action = "keepequal"
     target_label = "__tmp_port"
+  }
+  rule {
+    action = "labeldrop"
+    regex = "__tmp_port"
   }
 
   rule {

--- a/examples/service-integrations/output.yaml
+++ b/examples/service-integrations/output.yaml
@@ -300,6 +300,10 @@ data:
         action = "keepequal"
         target_label = "__tmp_port"
       }
+      rule {
+        action = "labeldrop"
+        regex = "__tmp_port"
+      }
     
       // If the metrics port number annotation has a value, override the target address to use it, regardless whether it is
       // one of the declared ports on that Pod.
@@ -381,6 +385,10 @@ data:
         source_labels = ["__meta_kubernetes_service_port_number"]
         action = "keepequal"
         target_label = "__tmp_port"
+      }
+      rule {
+        action = "labeldrop"
+        regex = "__tmp_port"
       }
     
       rule {
@@ -68666,6 +68674,10 @@ data:
         action = "keepequal"
         target_label = "__tmp_port"
       }
+      rule {
+        action = "labeldrop"
+        regex = "__tmp_port"
+      }
     
       // If the metrics port number annotation has a value, override the target address to use it, regardless whether it is
       // one of the declared ports on that Pod.
@@ -68747,6 +68759,10 @@ data:
         source_labels = ["__meta_kubernetes_service_port_number"]
         action = "keepequal"
         target_label = "__tmp_port"
+      }
+      rule {
+        action = "labeldrop"
+        regex = "__tmp_port"
       }
     
       rule {

--- a/examples/specific-namespace/metrics.alloy
+++ b/examples/specific-namespace/metrics.alloy
@@ -168,6 +168,10 @@ discovery.relabel "annotation_autodiscovery_pods" {
     action = "keepequal"
     target_label = "__tmp_port"
   }
+  rule {
+    action = "labeldrop"
+    regex = "__tmp_port"
+  }
 
   // If the metrics port number annotation has a value, override the target address to use it, regardless whether it is
   // one of the declared ports on that Pod.
@@ -249,6 +253,10 @@ discovery.relabel "annotation_autodiscovery_services" {
     source_labels = ["__meta_kubernetes_service_port_number"]
     action = "keepequal"
     target_label = "__tmp_port"
+  }
+  rule {
+    action = "labeldrop"
+    regex = "__tmp_port"
   }
 
   rule {

--- a/examples/specific-namespace/output.yaml
+++ b/examples/specific-namespace/output.yaml
@@ -300,6 +300,10 @@ data:
         action = "keepequal"
         target_label = "__tmp_port"
       }
+      rule {
+        action = "labeldrop"
+        regex = "__tmp_port"
+      }
     
       // If the metrics port number annotation has a value, override the target address to use it, regardless whether it is
       // one of the declared ports on that Pod.
@@ -381,6 +385,10 @@ data:
         source_labels = ["__meta_kubernetes_service_port_number"]
         action = "keepequal"
         target_label = "__tmp_port"
+      }
+      rule {
+        action = "labeldrop"
+        regex = "__tmp_port"
       }
     
       rule {
@@ -68695,6 +68703,10 @@ data:
         action = "keepequal"
         target_label = "__tmp_port"
       }
+      rule {
+        action = "labeldrop"
+        regex = "__tmp_port"
+      }
     
       // If the metrics port number annotation has a value, override the target address to use it, regardless whether it is
       // one of the declared ports on that Pod.
@@ -68776,6 +68788,10 @@ data:
         source_labels = ["__meta_kubernetes_service_port_number"]
         action = "keepequal"
         target_label = "__tmp_port"
+      }
+      rule {
+        action = "labeldrop"
+        regex = "__tmp_port"
       }
     
       rule {

--- a/examples/traces-enabled/metrics.alloy
+++ b/examples/traces-enabled/metrics.alloy
@@ -254,6 +254,10 @@ discovery.relabel "annotation_autodiscovery_pods" {
     action = "keepequal"
     target_label = "__tmp_port"
   }
+  rule {
+    action = "labeldrop"
+    regex = "__tmp_port"
+  }
 
   // If the metrics port number annotation has a value, override the target address to use it, regardless whether it is
   // one of the declared ports on that Pod.
@@ -335,6 +339,10 @@ discovery.relabel "annotation_autodiscovery_services" {
     source_labels = ["__meta_kubernetes_service_port_number"]
     action = "keepequal"
     target_label = "__tmp_port"
+  }
+  rule {
+    action = "labeldrop"
+    regex = "__tmp_port"
   }
 
   rule {

--- a/examples/traces-enabled/output.yaml
+++ b/examples/traces-enabled/output.yaml
@@ -399,6 +399,10 @@ data:
         action = "keepequal"
         target_label = "__tmp_port"
       }
+      rule {
+        action = "labeldrop"
+        regex = "__tmp_port"
+      }
     
       // If the metrics port number annotation has a value, override the target address to use it, regardless whether it is
       // one of the declared ports on that Pod.
@@ -480,6 +484,10 @@ data:
         source_labels = ["__meta_kubernetes_service_port_number"]
         action = "keepequal"
         target_label = "__tmp_port"
+      }
+      rule {
+        action = "labeldrop"
+        regex = "__tmp_port"
       }
     
       rule {
@@ -68838,6 +68846,10 @@ data:
         action = "keepequal"
         target_label = "__tmp_port"
       }
+      rule {
+        action = "labeldrop"
+        regex = "__tmp_port"
+      }
     
       // If the metrics port number annotation has a value, override the target address to use it, regardless whether it is
       // one of the declared ports on that Pod.
@@ -68919,6 +68931,10 @@ data:
         source_labels = ["__meta_kubernetes_service_port_number"]
         action = "keepequal"
         target_label = "__tmp_port"
+      }
+      rule {
+        action = "labeldrop"
+        regex = "__tmp_port"
       }
     
       rule {

--- a/examples/windows-exporter/metrics.alloy
+++ b/examples/windows-exporter/metrics.alloy
@@ -168,6 +168,10 @@ discovery.relabel "annotation_autodiscovery_pods" {
     action = "keepequal"
     target_label = "__tmp_port"
   }
+  rule {
+    action = "labeldrop"
+    regex = "__tmp_port"
+  }
 
   // If the metrics port number annotation has a value, override the target address to use it, regardless whether it is
   // one of the declared ports on that Pod.
@@ -249,6 +253,10 @@ discovery.relabel "annotation_autodiscovery_services" {
     source_labels = ["__meta_kubernetes_service_port_number"]
     action = "keepequal"
     target_label = "__tmp_port"
+  }
+  rule {
+    action = "labeldrop"
+    regex = "__tmp_port"
   }
 
   rule {

--- a/examples/windows-exporter/output.yaml
+++ b/examples/windows-exporter/output.yaml
@@ -339,6 +339,10 @@ data:
         action = "keepequal"
         target_label = "__tmp_port"
       }
+      rule {
+        action = "labeldrop"
+        regex = "__tmp_port"
+      }
     
       // If the metrics port number annotation has a value, override the target address to use it, regardless whether it is
       // one of the declared ports on that Pod.
@@ -420,6 +424,10 @@ data:
         source_labels = ["__meta_kubernetes_service_port_number"]
         action = "keepequal"
         target_label = "__tmp_port"
+      }
+      rule {
+        action = "labeldrop"
+        regex = "__tmp_port"
       }
     
       rule {
@@ -68869,6 +68877,10 @@ data:
         action = "keepequal"
         target_label = "__tmp_port"
       }
+      rule {
+        action = "labeldrop"
+        regex = "__tmp_port"
+      }
     
       // If the metrics port number annotation has a value, override the target address to use it, regardless whether it is
       // one of the declared ports on that Pod.
@@ -68950,6 +68962,10 @@ data:
         source_labels = ["__meta_kubernetes_service_port_number"]
         action = "keepequal"
         target_label = "__tmp_port"
+      }
+      rule {
+        action = "labeldrop"
+        regex = "__tmp_port"
       }
     
       rule {


### PR DESCRIPTION
When annotation autodiscovery was written, it was understood that labels starting with `__` wouldn't affect the deduplication rules, and just labels and `__address__` was important. However, all labels, except `__meta` labels are used in deduplicating targets, even though `__` labels are dropped before scraping.