### PR TITLE
Use the new skipConfigMapCheck field

### DIFF
--- a/charts/k8s-monitoring-v1/values.yaml
+++ b/charts/k8s-monitoring-v1/values.yaml
@@ -2385,7 +2385,7 @@ beyla:
   enabled: false
 
   config:
-    # @ignored -- This allows this chart create the ConfigMap while also keeping the default name
+    # @ignored -- This allows this chart to create the ConfigMap while also keeping the default name
     skipConfigMapCheck: true
     # @ignored -- This allows this chart to create the Beyla ConfigMap with required modifications
     create: false

--- a/charts/k8s-monitoring-v1/values.yaml
+++ b/charts/k8s-monitoring-v1/values.yaml
@@ -2385,8 +2385,8 @@ beyla:
   enabled: false
 
   config:
-    # @ignored -- This allows this chart to use the default Beyla ConfigMap name
-    name: null
+    # @ignored -- This allows this chart create the ConfigMap while also keeping the default name
+    skipConfigMapCheck: true
     # @ignored -- This allows this chart to create the Beyla ConfigMap with required modifications
     create: false
     # -- The Configuration for Beyla


### PR DESCRIPTION
This avoids an error when skipping configmap creation but not naming it. Only happens with specific versions of helm, but now it'll work everywhere.

Field in the beyla chart:
https://github.com/grafana/beyla/blob/main/charts/beyla/values.yaml#L183-L184

ConfigMap check in beyla chart:
https://github.com/grafana/beyla/blob/main/charts/beyla/templates/configmap.yaml#L1-L5