### PR TITLE
fix: prom destination template config error and change externalLabels to extraLabels

### DIFF
--- a/charts/k8s-monitoring/docs/examples/extra-rules/alloy-metrics.alloy
+++ b/charts/k8s-monitoring/docs/examples/extra-rules/alloy-metrics.alloy
@@ -41,6 +41,10 @@ prometheus.remote_write "prometheus" {
       action = "drop"
     }
   }
+  external_labels = {
+    site = "lab2",
+    region = env("REGION"),
+  }
 }
 // Feature: Cluster Metrics
 declare "cluster_metrics" {

--- a/charts/k8s-monitoring/docs/examples/extra-rules/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/extra-rules/output.yaml
@@ -316,6 +316,10 @@ data:
           action = "drop"
         }
       }
+      external_labels = {
+        site = "lab2",
+        region = env("REGION"),
+      }
     }
     // Feature: Cluster Metrics
     declare "cluster_metrics" {

--- a/charts/k8s-monitoring/templates/destinations/_destination_prometheus.tpl
+++ b/charts/k8s-monitoring/templates/destinations/_destination_prometheus.tpl
@@ -90,17 +90,17 @@ prometheus.remote_write {{ include "helper.alloy_name" .name | quote }} {
 {{- if .metricProcessingRules }}
 {{ .metricProcessingRules | indent 4 }}
 {{- end }}
-
-{{- if or .externalLabels .externalLabelsFrom }}
+  }
+{{- if or .extraLabels .extraLabelsFrom }}
   external_labels = {
-  {{- range $key, $value := .externalLabels }}
+  {{- range $key, $value := .extraLabels }}
     {{ $key }} = {{ $value | quote }},
   {{- end }}
-  {{- range $key, $value := .externalLabelsFrom }}
+  {{- range $key, $value := .extraLabelsFrom }}
     {{ $key }} = {{ $value }},
   {{- end }}
-{{- end }}
   }
+{{- end }}
 }
 {{- end }}
 {{- end }}


### PR DESCRIPTION
Noticed that the examples showed extraLabels instead of externalLabels. When I changed my values to externalLabels I was getting an EOF config error when adding the labels. The block was not closed correctly. 

I'm also happy to change the documentation to externalLabels as the argument is called external_labels in the documenation. https://grafana.com/docs/alloy/latest/reference/components/prometheus/prometheus.remote_write/#arguments 