### PR TITLE
Set apiserver enabled default to false in feature-cluster-metrics values

### DIFF
--- a/charts/feature-cluster-metrics/README.md
+++ b/charts/feature-cluster-metrics/README.md
@@ -166,7 +166,7 @@ Actual integration testing in a live environment should be done in the main [k8s
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| apiServer.enabled | string | false | Scrape metrics from the API Server |
+| apiServer.enabled | bool | false | Scrape metrics from the API Server |
 | apiServer.extraDiscoveryRules | string | `""` | Rule blocks to be added to the discovery.relabel component for the API Server. These relabeling rules are applied pre-scrape against the targets from service discovery. Before the scrape, any remaining target labels that start with `__` (i.e. `__meta_kubernetes*`) are dropped. ([docs](https://grafana.com/docs/alloy/latest/reference/components/discovery.relabel/#rule-block)) |
 | apiServer.extraMetricProcessingRules | string | `""` | Rule blocks to be added to the prometheus.relabel component for the API Server. These relabeling rules are applied post-scrape against the metrics returned from the scraped target, no `__meta*` labels are present. ([docs](https://grafana.com/docs/alloy/latest/reference/components/prometheus.relabel/#rule-block)) |
 | apiServer.maxCacheSize | string | `nil` | Sets the max_cache_size for cadvisor prometheus.relabel component. This should be at least 2x-5x your largest scrape target or samples appended rate. ([docs](https://grafana.com/docs/alloy/latest/reference/components/prometheus.relabel/#arguments)) Overrides metrics.maxCacheSize |

--- a/charts/feature-cluster-metrics/README.md
+++ b/charts/feature-cluster-metrics/README.md
@@ -166,7 +166,7 @@ Actual integration testing in a live environment should be done in the main [k8s
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| apiServer.enabled | bool | false | Scrape metrics from the API Server |
+| apiServer.enabled | bool | `false` | Scrape metrics from the API Server. |
 | apiServer.extraDiscoveryRules | string | `""` | Rule blocks to be added to the discovery.relabel component for the API Server. These relabeling rules are applied pre-scrape against the targets from service discovery. Before the scrape, any remaining target labels that start with `__` (i.e. `__meta_kubernetes*`) are dropped. ([docs](https://grafana.com/docs/alloy/latest/reference/components/discovery.relabel/#rule-block)) |
 | apiServer.extraMetricProcessingRules | string | `""` | Rule blocks to be added to the prometheus.relabel component for the API Server. These relabeling rules are applied post-scrape against the metrics returned from the scraped target, no `__meta*` labels are present. ([docs](https://grafana.com/docs/alloy/latest/reference/components/prometheus.relabel/#rule-block)) |
 | apiServer.maxCacheSize | string | `nil` | Sets the max_cache_size for cadvisor prometheus.relabel component. This should be at least 2x-5x your largest scrape target or samples appended rate. ([docs](https://grafana.com/docs/alloy/latest/reference/components/prometheus.relabel/#arguments)) Overrides metrics.maxCacheSize |
@@ -251,7 +251,7 @@ Actual integration testing in a live environment should be done in the main [k8s
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| kubeControllerManager.enabled | string | false | Scrape metrics from the Kube Controller Manager |
+| kubeControllerManager.enabled | bool | `false` | Scrape metrics from the Kube Controller Manager |
 | kubeControllerManager.extraDiscoveryRules | string | `""` | Rule blocks to be added to the discovery.relabel component for the Kube Controller Manager. These relabeling rules are applied pre-scrape against the targets from service discovery. Before the scrape, any remaining target labels that start with `__` (i.e. `__meta_kubernetes*`) are dropped. ([docs](https://grafana.com/docs/alloy/latest/reference/components/discovery.relabel/#rule-block)) |
 | kubeControllerManager.extraMetricProcessingRules | string | `""` | Rule blocks to be added to the prometheus.relabel component for the Kube Controller Manager. These relabeling rules are applied post-scrape against the metrics returned from the scraped target, no `__meta*` labels are present. ([docs](https://grafana.com/docs/alloy/latest/reference/components/prometheus.relabel/#rule-block)) |
 | kubeControllerManager.maxCacheSize | string | `nil` | Sets the max_cache_size for cadvisor prometheus.relabel component. This should be at least 2x-5x your largest scrape target or samples appended rate. ([docs](https://grafana.com/docs/alloy/latest/reference/components/prometheus.relabel/#arguments)) Overrides metrics.maxCacheSize |
@@ -264,7 +264,7 @@ Actual integration testing in a live environment should be done in the main [k8s
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| kubeProxy.enabled | string | false | Scrape metrics from the Kube Proxy |
+| kubeProxy.enabled | bool | `false` | Scrape metrics from the Kube Proxy |
 | kubeProxy.extraDiscoveryRules | string | `""` | Rule blocks to be added to the discovery.relabel component for the Kube Proxy. These relabeling rules are applied pre-scrape against the targets from service discovery. Before the scrape, any remaining target labels that start with `__` (i.e. `__meta_kubernetes*`) are dropped. ([docs](https://grafana.com/docs/alloy/latest/reference/components/discovery.relabel/#rule-block)) |
 | kubeProxy.extraMetricProcessingRules | string | `""` | Rule blocks to be added to the prometheus.relabel component for the Kube Proxy. These relabeling rules are applied post-scrape against the metrics returned from the scraped target, no `__meta*` labels are present. ([docs](https://grafana.com/docs/alloy/latest/reference/components/prometheus.relabel/#rule-block)) |
 | kubeProxy.maxCacheSize | string | `nil` | Sets the max_cache_size for cadvisor prometheus.relabel component. This should be at least 2x-5x your largest scrape target or samples appended rate. ([docs](https://grafana.com/docs/alloy/latest/reference/components/prometheus.relabel/#arguments)) Overrides metrics.maxCacheSize |
@@ -277,7 +277,7 @@ Actual integration testing in a live environment should be done in the main [k8s
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| kubeScheduler.enabled | string | false | Scrape metrics from the Kube Scheduler |
+| kubeScheduler.enabled | bool | `false` | Scrape metrics from the Kube Scheduler |
 | kubeScheduler.extraDiscoveryRules | string | `""` | Rule blocks to be added to the discovery.relabel component for the Kube Scheduler. These relabeling rules are applied pre-scrape against the targets from service discovery. Before the scrape, any remaining target labels that start with `__` (i.e. `__meta_kubernetes*`) are dropped. ([docs](https://grafana.com/docs/alloy/latest/reference/components/discovery.relabel/#rule-block)) |
 | kubeScheduler.extraMetricProcessingRules | string | `""` | Rule blocks to be added to the prometheus.relabel component for the Kube Scheduler. These relabeling rules are applied post-scrape against the metrics returned from the scraped target, no `__meta*` labels are present. ([docs](https://grafana.com/docs/alloy/latest/reference/components/prometheus.relabel/#rule-block)) |
 | kubeScheduler.maxCacheSize | string | `nil` | Sets the max_cache_size for cadvisor prometheus.relabel component. This should be at least 2x-5x your largest scrape target or samples appended rate. ([docs](https://grafana.com/docs/alloy/latest/reference/components/prometheus.relabel/#arguments)) Overrides metrics.maxCacheSize |

--- a/charts/feature-cluster-metrics/schema-mods/types-and-enums.json
+++ b/charts/feature-cluster-metrics/schema-mods/types-and-enums.json
@@ -1,5 +1,9 @@
 {
   "properties": {
+    "apiServer": {"properties": {"enabled": {"type": ["null", "boolean"]}}},
+    "kubeControllerManager": {"properties": {"enabled": {"type": ["null", "boolean"]}}},
+    "kubeProxy": {"properties": {"enabled": {"type": ["null", "boolean"]}}},
+    "kubeScheduler": {"properties": {"enabled": {"type": ["null", "boolean"]}}},
     "global": {"properties": {"platform": {"enum": ["", "openshift"]}}}
   }
 }

--- a/charts/feature-cluster-metrics/values.schema.json
+++ b/charts/feature-cluster-metrics/values.schema.json
@@ -6,7 +6,10 @@
             "type": "object",
             "properties": {
                 "enabled": {
-                    "type": "boolean"
+                    "type": [
+                        "null",
+                        "boolean"
+                    ]
                 },
                 "extraDiscoveryRules": {
                     "type": "string"
@@ -277,7 +280,10 @@
             "type": "object",
             "properties": {
                 "enabled": {
-                    "type": "null"
+                    "type": [
+                        "null",
+                        "boolean"
+                    ]
                 },
                 "extraDiscoveryRules": {
                     "type": "string"
@@ -311,7 +317,10 @@
             "type": "object",
             "properties": {
                 "enabled": {
-                    "type": "null"
+                    "type": [
+                        "null",
+                        "boolean"
+                    ]
                 },
                 "extraDiscoveryRules": {
                     "type": "string"
@@ -345,7 +354,10 @@
             "type": "object",
             "properties": {
                 "enabled": {
-                    "type": "null"
+                    "type": [
+                        "null",
+                        "boolean"
+                    ]
                 },
                 "extraDiscoveryRules": {
                     "type": "string"

--- a/charts/feature-cluster-metrics/values.schema.json
+++ b/charts/feature-cluster-metrics/values.schema.json
@@ -6,7 +6,7 @@
             "type": "object",
             "properties": {
                 "enabled": {
-                    "type": "null"
+                    "type": "boolean"
                 },
                 "extraDiscoveryRules": {
                     "type": "string"

--- a/charts/feature-cluster-metrics/values.yaml
+++ b/charts/feature-cluster-metrics/values.yaml
@@ -187,10 +187,10 @@ cadvisor:
 
 # API Server metrics gather information about the Kubernetes API Server.
 apiServer:
-  # -- Scrape metrics from the API Server
-  # @default -- false
+  # -- (bool) Scrape metrics from the API Server.
+  # @default -- `false`
   # @section -- API Server
-  enabled: false
+  enabled: 
 
   # -- How frequently to scrape metrics from the API Server
   # Overrides metrics.scrapeInterval

--- a/charts/feature-cluster-metrics/values.yaml
+++ b/charts/feature-cluster-metrics/values.yaml
@@ -190,7 +190,7 @@ apiServer:
   # -- Scrape metrics from the API Server
   # @default -- false
   # @section -- API Server
-  enabled:
+  enabled: false
 
   # -- How frequently to scrape metrics from the API Server
   # Overrides metrics.scrapeInterval

--- a/charts/feature-cluster-metrics/values.yaml
+++ b/charts/feature-cluster-metrics/values.yaml
@@ -190,7 +190,7 @@ apiServer:
   # -- (bool) Scrape metrics from the API Server.
   # @default -- `false`
   # @section -- API Server
-  enabled: 
+  enabled:
 
   # -- How frequently to scrape metrics from the API Server
   # Overrides metrics.scrapeInterval
@@ -230,8 +230,8 @@ apiServer:
 
 # Metrics from the Kube Controller Manager
 kubeControllerManager:
-  # -- Scrape metrics from the Kube Controller Manager
-  # @default -- false
+  # -- (bool) Scrape metrics from the Kube Controller Manager
+  # @default -- `false`
   # @section -- Kube Controller Manager
   enabled:
 
@@ -277,8 +277,8 @@ kubeControllerManager:
 
 # Metrics from the Kube Proxy
 kubeProxy:
-  # -- Scrape metrics from the Kube Proxy
-  # @default -- false
+  # -- (bool) Scrape metrics from the Kube Proxy
+  # @default -- `false`
   # @section -- Kube Proxy
   enabled:
 
@@ -324,8 +324,8 @@ kubeProxy:
 
 # Metrics from the Kube Scheduler
 kubeScheduler:
-  # -- Scrape metrics from the Kube Scheduler
-  # @default -- false
+  # -- (bool) Scrape metrics from the Kube Scheduler
+  # @default -- `false`
   # @section -- Kube Scheduler
   enabled:
 


### PR DESCRIPTION
I noticed this when playing around with the k8s-monitoring v2 chart - the apiserver enabled field wasn't set to default to `false` in the values yaml, so the generated schema only allowed "null" for the value.