### PR TITLE
Add urlFrom value for k8s-monitoring v2 destinations

### DIFF
--- a/charts/k8s-monitoring/destinations/loki-values.yaml
+++ b/charts/k8s-monitoring/destinations/loki-values.yaml
@@ -7,6 +7,10 @@ name: ""
 # @section -- General
 url: ""
 
+# -- Raw config for accessing the URL.
+# @section -- General
+urlFrom: ""
+
 # -- The Proxy URL for the Loki destination.
 # @section -- General
 proxyURL: ""

--- a/charts/k8s-monitoring/destinations/otlp-values.yaml
+++ b/charts/k8s-monitoring/destinations/otlp-values.yaml
@@ -27,6 +27,10 @@ logs:
 # @section -- General
 url: ""
 
+# -- Raw config for accessing the URL.
+# @section -- General
+urlFrom: ""
+
 # -- The tenant ID for the OTLP destination.
 # @section -- General
 tenantId: ""

--- a/charts/k8s-monitoring/destinations/prometheus-values.yaml
+++ b/charts/k8s-monitoring/destinations/prometheus-values.yaml
@@ -7,6 +7,10 @@ name: ""
 # @section -- General
 url: ""
 
+# -- Raw config for accessing the URL.
+# @section -- General
+urlFrom: ""
+
 # -- The Proxy URL for the Prometheus destination.
 # @section -- General
 proxyURL: ""

--- a/charts/k8s-monitoring/destinations/pyroscope-values.yaml
+++ b/charts/k8s-monitoring/destinations/pyroscope-values.yaml
@@ -7,6 +7,10 @@ name: ""
 # @section -- General
 url: ""
 
+# -- Raw config for accessing the URL.
+# @section -- General
+urlFrom: ""
+
 # -- The Proxy URL for the Pyroscope destination.
 # @section -- General
 proxyURL: ""

--- a/charts/k8s-monitoring/docs/destinations/loki.md
+++ b/charts/k8s-monitoring/docs/destinations/loki.md
@@ -43,6 +43,7 @@ This defines the options for defining a destination for logs that use the Loki p
 | tenantIdFrom | string | `""` | Raw config for accessing the tenant ID. |
 | tenantIdKey | string | `"tenantId"` | The key for storing the tenant ID in the secret. |
 | url | string | `""` | The URL for the Loki destination. |
+| urlFrom | string | `""` | Raw config for accessing the URL. |
 
 ### Secret
 

--- a/charts/k8s-monitoring/docs/destinations/otlp.md
+++ b/charts/k8s-monitoring/docs/destinations/otlp.md
@@ -42,6 +42,7 @@ This defines the options for defining a destination for OpenTelemetry data that 
 | tenantIdFrom | string | `""` | Raw config for accessing the tenant ID. |
 | tenantIdKey | string | `"tenantId"` | The key for storing the tenant ID in the secret. |
 | url | string | `""` | The URL for the OTLP destination. |
+| urlFrom | string | `""` | Raw config for accessing the URL. |
 | writeBufferSize | string | `""` | Size of the write buffer the gRPC client to use for writing requests. |
 
 ### Telemetry

--- a/charts/k8s-monitoring/docs/destinations/prometheus.md
+++ b/charts/k8s-monitoring/docs/destinations/prometheus.md
@@ -64,6 +64,7 @@ This defines the options for defining a destination for metrics that use the Pro
 | tenantIdFrom | string | `""` | Raw config for accessing the tenant ID. |
 | tenantIdKey | string | `"tenantId"` | The key for storing the tenant ID in the secret. |
 | url | string | `""` | The URL for the Prometheus destination. |
+| urlFrom | string | `""` | Raw config for accessing the URL. |
 
 ### Queue Configuration
 

--- a/charts/k8s-monitoring/docs/destinations/pyroscope.md
+++ b/charts/k8s-monitoring/docs/destinations/pyroscope.md
@@ -41,6 +41,7 @@ This defines the options for defining a destination for profiles that use the Py
 | tenantIdFrom | string | `""` | Raw config for accessing the tenant ID. |
 | tenantIdKey | string | `"tenantId"` | The key for storing the tenant ID in the secret. |
 | url | string | `""` | The URL for the Pyroscope destination. |
+| urlFrom | string | `""` | Raw config for accessing the URL. |
 
 ### Secret
 

--- a/charts/k8s-monitoring/schema-mods/definitions/loki-destination.schema.json
+++ b/charts/k8s-monitoring/schema-mods/definitions/loki-destination.schema.json
@@ -118,6 +118,9 @@
         "url": {
             "type": "string"
         },
+        "urlFrom": {
+            "type": "string"
+        },
         "type": {
             "type": "string",
             "const": "loki"

--- a/charts/k8s-monitoring/schema-mods/definitions/otlp-destination.schema.json
+++ b/charts/k8s-monitoring/schema-mods/definitions/otlp-destination.schema.json
@@ -142,6 +142,9 @@
         "url": {
             "type": "string"
         },
+        "urlFrom": {
+            "type": "string"
+        },
         "writeBufferSize": {
             "type": "string"
         },

--- a/charts/k8s-monitoring/schema-mods/definitions/prometheus-destination.schema.json
+++ b/charts/k8s-monitoring/schema-mods/definitions/prometheus-destination.schema.json
@@ -188,6 +188,9 @@
         "url": {
             "type": "string"
         },
+        "urlFrom": {
+            "type": "string"
+        },
         "type": {
             "type": "string",
             "const": "prometheus"

--- a/charts/k8s-monitoring/schema-mods/definitions/pyroscope-destination.schema.json
+++ b/charts/k8s-monitoring/schema-mods/definitions/pyroscope-destination.schema.json
@@ -112,6 +112,9 @@
         "url": {
             "type": "string"
         },
+        "urlFrom": {
+            "type": "string"
+        },
         "type": {
             "type": "string",
             "const": "pyroscope"

--- a/charts/k8s-monitoring/templates/destinations/_destination_loki.tpl
+++ b/charts/k8s-monitoring/templates/destinations/_destination_loki.tpl
@@ -7,7 +7,11 @@ otelcol.exporter.loki {{ include "helper.alloy_name" .name | quote }} {
 
 loki.write {{ include "helper.alloy_name" .name | quote }} {
   endpoint {
-    url = {{ .url | quote }}
+{{- if .urlFrom }} 
+    url = {{ .urlFrom }}
+{{- else }}
+    url = {{ .url | quote }} 
+{{- end }}
 {{- if eq (include "destinations.secret.uses_secret" (dict "destination" . "key" "tenantId")) "true" }}
     tenant_id = {{ include "destinations.secret.read" (dict "destination" . "key" "tenantId" "nonsensitive" true) }}
 {{- end }}

--- a/charts/k8s-monitoring/templates/destinations/_destination_otlp.tpl
+++ b/charts/k8s-monitoring/templates/destinations/_destination_otlp.tpl
@@ -60,7 +60,11 @@ otelcol.exporter.otlp {{ include "helper.alloy_name" .name | quote }} {
 otelcol.exporter.otlphttp {{ include "helper.alloy_name" .name | quote }} {
 {{- end }}
   client {
-    endpoint = {{ .url | quote }}
+{{- if .urlFrom }} 
+    endpoint = {{ .urlFrom }}
+{{- else }}
+    endpoint = {{ .url | quote }} 
+{{- end }}
 {{- if eq .authMode "basic" }}
     auth = otelcol.auth.basic.{{ include "helper.alloy_name" .name }}.handler
 {{- else if eq .authMode "bearerToken" }}

--- a/charts/k8s-monitoring/templates/destinations/_destination_prometheus.tpl
+++ b/charts/k8s-monitoring/templates/destinations/_destination_prometheus.tpl
@@ -7,7 +7,11 @@ otelcol.exporter.prometheus {{ include "helper.alloy_name" .name | quote }} {
 
 prometheus.remote_write {{ include "helper.alloy_name" .name | quote }} {
   endpoint {
-    url = {{ .url | quote }}
+{{- if .urlFrom }} 
+    url = {{ .urlFrom }}
+{{- else }}
+    url = {{ .url | quote }} 
+{{- end }}
     headers = {
 {{- if ne (include "destinations.auth.type" .) "sigv4" }}
   {{- if eq (include "destinations.secret.uses_secret" (dict "destination" . "key" "tenantId")) "true" }}

--- a/charts/k8s-monitoring/templates/destinations/_destination_pyroscope.tpl
+++ b/charts/k8s-monitoring/templates/destinations/_destination_pyroscope.tpl
@@ -3,7 +3,11 @@
 {{- with merge .destination $defaultValues }}
 pyroscope.write {{ include "helper.alloy_name" .name | quote }} {
   endpoint {
-    url = {{ .url | quote }}
+{{- if .urlFrom }} 
+    url = {{ .urlFrom }}
+{{- else }}
+    url = {{ .url | quote }} 
+{{- end }}
     headers = {
 {{- if eq (include "destinations.secret.uses_secret" (dict "destination" . "key" "tenantId")) "true" }}
       "X-Scope-OrgID" = {{ include "destinations.secret.read" (dict "destination" . "key" "tenantId" "nonsensitive" true) }},

--- a/charts/k8s-monitoring/values.schema.json
+++ b/charts/k8s-monitoring/values.schema.json
@@ -867,6 +867,9 @@
                 "url": {
                     "type": "string"
                 },
+                "urlFrom": {
+                    "type": "string"
+                },
                 "type": {
                     "type": "string",
                     "const": "loki"
@@ -1026,6 +1029,9 @@
                     }
                 },
                 "url": {
+                    "type": "string"
+                },
+                "urlFrom": {
                     "type": "string"
                 },
                 "writeBufferSize": {
@@ -1239,6 +1245,9 @@
                 "url": {
                     "type": "string"
                 },
+                "urlFrom": {
+                    "type": "string"
+                },
                 "type": {
                     "type": "string",
                     "const": "prometheus"
@@ -1368,6 +1377,9 @@
                     }
                 },
                 "url": {
+                    "type": "string"
+                },
+                "urlFrom": {
                     "type": "string"
                 },
                 "type": {


### PR DESCRIPTION
Adds a `urlFrom` values for destinations in k8s-monitoring-v2. 

This allows setting the URL using unquoted raw config, which can allow setting it from an environment variable, among other things. 

In my specific use case, this is useful when using k8s-monitoring as a subchart and wanting to set a top-level value URL that applies for all destination endpoints. Basically, wrapping `k8s-monitoring` and exposing a simplified set of values for consumers of our system. A simplified example below:

```yaml
# default values.yaml in wrapper chart

# Consumers using the wrapper helm chart can just set this value. It creates a ConfigMap with the appropriate URLs for different services based on this main url.
observabilityGatewayUrl: ""
# Ex:
# apiVersion: v1
# kind: ConfigMap
# metadata:
#   name: observability-config
#   namespace: {{ .Release.Namespace }} 
# data:
#   OBSERVABILITY_METRICS_URL: {{ printf "%s/%s" .Values.observabilityGatewayUrl "mimir/api/v1/push" }}
#   OBSERVABILITY_LOGS_URL: {{ printf "%s/%s" .Values.observabilityGatewayUrl "loki/api/v1/" }}

# k8s-monitoring subchart configuration
k8s-monitoring:
  destinations:
    - name: mimir
      type: prometheus
      urlFrom: env("OBSERVABILITY_METRICS_URL")
    - name: loki
      type: loki
      urlFrom: env("OBSERVABILITY_LOGS_URL")

  alloy-metrics:
    alloy:
      envFrom:
      - configMapRef:
          name: observability-config
  alloy-logs:
    alloy:
      envFrom:
      - configMapRef:
          name: observability-config
```
Alternatively, we could also pass the url through the `tpl` function so we could just template it directly in the values. Maybe that's easier? 
```
url = {{ tpl .url | quote }} 
```
and then:
```yaml
observabilityGatewayUrl: ""

k8s-monitoring:
  destinations:
    - name: mimir
      type: prometheus
      url: "{{ .Values.observabilityGatewayUrl }}/mimir/api/v1/push"
```

urlFrom might still be useful, regardless.

k8s-monitoring-v1 doesn't really need this feature as it already pulls the host from either the created secret or an existing secret.