### PR TITLE
v1: Add oauth2 support to OTLP output

### DIFF
--- a/charts/k8s-monitoring-v1/templates/alloy_config/_logs_service_otlp.alloy.txt
+++ b/charts/k8s-monitoring-v1/templates/alloy_config/_logs_service_otlp.alloy.txt
@@ -60,6 +60,34 @@ otelcol.auth.basic "logs_service" {
   password = remote.kubernetes.secret.logs_service.data[{{ .basicAuth.passwordKey | quote }}]
 }
 {{- end }}
+{{- if eq .authMode "oauth2" }}
+otelcol.auth.oauth2 "logs_service" {
+  {{- if eq .oauth2.clientId "" }}
+  client_id = nonsensitive(remote.kubernetes.secret.logs_service.data[{{ .oauth2.clientIdKey | quote }}])
+  {{- else }}
+  client_id = {{ .oauth2.clientId | quote }}
+  {{- end }}
+
+  {{- if eq .oauth2.clientSecretFile "" }}
+  client_secret = remote.kubernetes.secret.logs_service.data[{{ .oauth2.clientSecretKey | quote }}]
+  {{- else }}
+  client_secret_file = {{ .oauth2.clientSecretFile | quote }}
+  {{- end }}
+  {{- if .oauth2.endpointParams }}
+  endpoint_params = {
+  {{- range $k, $v := .oauth2.endpointParams }}
+    {{ $k }} = {{ $v | quote }},
+  {{- end }}
+  }
+  {{- end }}
+  {{- if .oauth2.scopes }}
+  scopes = {{ .oauth2.scopes | toJson }}
+  {{- end }}
+  {{- if .oauth2.tokenURL }}
+  token_url = {{ required ".Values.oauth2.tokenURL is a required value when .Values.authMode is oauth2" .oauth2.tokenURL | quote }}
+  {{- end }}
+}
+{{- end }}
 {{ if eq .protocol "otlp" }}
 otelcol.exporter.otlp "logs_service" {
 {{- end }}
@@ -70,6 +98,9 @@ otelcol.exporter.otlphttp "logs_service" {
     endpoint = nonsensitive(remote.kubernetes.secret.logs_service.data[{{ .hostKey | quote }}]) + "{{ .writeEndpoint }}"
 {{ if or (.basicAuth.username) (.basicAuth.password) }}
     auth = otelcol.auth.basic.logs_service.handler
+{{- end }}
+{{ if eq .authMode "oauth2" }}
+    auth = otelcol.auth.oauth2.logs_service.handler
 {{- end }}
     headers = {
       "X-Scope-OrgID" = nonsensitive(remote.kubernetes.secret.logs_service.data[{{ .tenantIdKey | quote }}]),

--- a/charts/k8s-monitoring-v1/templates/alloy_config/_metrics_service_otlp.alloy.txt
+++ b/charts/k8s-monitoring-v1/templates/alloy_config/_metrics_service_otlp.alloy.txt
@@ -60,6 +60,34 @@ otelcol.auth.basic "metrics_service" {
   password = remote.kubernetes.secret.metrics_service.data[{{ .basicAuth.passwordKey | quote }}]
 }
 {{- end }}
+{{- if eq .authMode "oauth2" }}
+otelcol.auth.oauth2 "metrics_service" {
+  {{- if eq .oauth2.clientId "" }}
+  client_id = nonsensitive(remote.kubernetes.secret.metrics_service.data[{{ .oauth2.clientIdKey | quote }}])
+  {{- else }}
+  client_id = {{ .oauth2.clientId | quote }}
+  {{- end }}
+
+  {{- if eq .oauth2.clientSecretFile "" }}
+  client_secret = remote.kubernetes.secret.metrics_service.data[{{ .oauth2.clientSecretKey | quote }}]
+  {{- else }}
+  client_secret_file = {{ .oauth2.clientSecretFile | quote }}
+  {{- end }}
+  {{- if .oauth2.endpointParams }}
+  endpoint_params = {
+  {{- range $k, $v := .oauth2.endpointParams }}
+    {{ $k }} = {{ $v | quote }},
+  {{- end }}
+  }
+  {{- end }}
+  {{- if .oauth2.scopes }}
+  scopes = {{ .oauth2.scopes | toJson }}
+  {{- end }}
+  {{- if .oauth2.tokenURL }}
+  token_url = {{ required ".Values.oauth2.tokenURL is a required value when .Values.authMode is oauth2" .oauth2.tokenURL | quote }}
+  {{- end }}
+}
+{{- end }}
 {{ if eq .protocol "otlp" }}
 otelcol.exporter.otlp "metrics_service" {
 {{- end }}
@@ -70,6 +98,9 @@ otelcol.exporter.otlphttp "metrics_service" {
     endpoint = nonsensitive(remote.kubernetes.secret.metrics_service.data[{{ .hostKey | quote }}]) + "{{ .writeEndpoint }}"
 {{ if or (.basicAuth.username) (.basicAuth.password) }}
     auth = otelcol.auth.basic.metrics_service.handler
+{{- end }}
+{{ if eq .authMode "oauth2" }}
+    auth = otelcol.auth.oauth2.metrics_service.handler
 {{- end }}
     headers = {
       "X-Scope-OrgID" = nonsensitive(remote.kubernetes.secret.metrics_service.data[{{ .tenantIdKey | quote }}]),


### PR DESCRIPTION
We needed the OTLP configuration to support oauth2 for our specific architecture. I basically copied the configuration from the remote_write side and modified it for the slight differences between the components and it's been working well for us. `make build` and `make test` both pass, but I haven't added any test cases for this specifically so that's not surprising.