### PR TITLE
ci: adds auto-approve workflows for deps

### DIFF
--- a/.github/workflows/auto-approve-chart-deps.yml
+++ b/.github/workflows/auto-approve-chart-deps.yml
@@ -1,0 +1,26 @@
+name: Chart deps auto-approve
+on:
+  pull_request:
+    paths:
+      - "charts/*/charts/*.tgz"
+      - "!charts/k8s-monitoring/charts/*.tgz"
+
+permissions:
+  pull-requests: write
+
+jobs:
+  auto-approve-chart-deps:
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.user.login == 'petewall' && github.repository == 'grafana/k8s-monitoring-helm'
+    steps:
+      - uses: actions/checkout@v4
+      - name: Approve a PR if not already approved
+        run: |
+          gh pr checkout "$PR_URL" # sets the upstream metadata for `gh pr status`
+          if [ "$(gh pr status --json reviewDecision -q .currentBranch.reviewDecision)" != "APPROVED" ];
+          then gh pr review --approve "$PR_URL"
+          else echo "PR already approved, skipping additional approvals to minimize emails/notification noise.";
+          fi
+        env:
+          PR_URL: ${{github.event.pull_request.html_url}}
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/auto-approve-dependabot.yml
+++ b/.github/workflows/auto-approve-dependabot.yml
@@ -1,0 +1,25 @@
+name: Dependabot auto-approve
+on: pull_request
+
+permissions:
+  pull-requests: write
+
+jobs:
+  dependabot:
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.user.login == 'dependabot[bot]' && github.repository == 'grafana/k8s-monitoring-helm'
+    steps:
+      - name: Dependabot metadata
+        id: dependabot-metadata
+        uses: dependabot/fetch-metadata@v2
+      - uses: actions/checkout@v4
+      - name: Approve a PR if not already approved
+        run: |
+          gh pr checkout "$PR_URL" # sets the upstream metadata for `gh pr status`
+          if [ "$(gh pr status --json reviewDecision -q .currentBranch.reviewDecision)" != "APPROVED" ];
+          then gh pr review --approve "$PR_URL"
+          else echo "PR already approved, skipping additional approvals to minimize emails/notification noise.";
+          fi
+        env:
+          PR_URL: ${{github.event.pull_request.html_url}}
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
New GitHub workflows:

- `.github/workflows/auto-approve-chart-deps.yml` should auto-approve PRs created by the "Check for dependency updates" workflow.
- `.github/workflows/auto-approve-dependabot.yml` should auto-approve PRs created by dependabot

Based on this doc:

- https://github.com/dependabot/fetch-metadata?tab=readme-ov-file#auto-approving

If you like this look of this, auto-merge can follow in a separate PR - but this first requires a repo setting update to support that. See:

- https://github.com/dependabot/fetch-metadata?tab=readme-ov-file#enabling-auto-merge