### PR TITLE
PodLog objects always go onto the alloy instance, not alloy-logs

### DIFF
--- a/charts/k8s-monitoring-v1/templates/alloy_config/_operator_objects.txt
+++ b/charts/k8s-monitoring-v1/templates/alloy_config/_operator_objects.txt
@@ -139,7 +139,7 @@ loki.source.podlogs "podlogs_objects" {
 {{ .Values.logs.podLogsObjects.selector | indent 4 }}
   }
 {{- end }}
-{{- if (index .Values "alloy-logs").alloy.clustering.enabled }}
+{{- if .Values.alloy.alloy.clustering.enabled }}
   clustering {
     enabled = true
   }


### PR DESCRIPTION
 We should determine clustering based on alloy