### PR TITLE
Add `scrape_protocols` to `prometheus.scrape` Components for Native Histograms

### DIFF
--- a/charts/k8s-monitoring-v1/templates/alloy_config/_alloy.alloy.txt
+++ b/charts/k8s-monitoring-v1/templates/alloy_config/_alloy.alloy.txt
@@ -55,6 +55,10 @@ prometheus.scrape "alloy" {
   targets = discovery.relabel.alloy.output
   scrape_interval = {{ .Values.metrics.alloy.scrapeInterval | default .Values.metrics.scrapeInterval | quote }}
   forward_to = [prometheus.relabel.alloy.receiver]
+{{- if .Values.externalServices.prometheus.sendNativeHistograms }}
+  scrape_protocols = ["PrometheusProto", "OpenMetricsText1.0.0", "OpenMetricsText0.0.1", "PrometheusText0.0.4"]
+  scrape_classic_histograms = true
+{{- end }}
 {{- if .Values.alloy.alloy.clustering.enabled }}
   clustering {
     enabled = true

--- a/charts/k8s-monitoring-v1/templates/alloy_config/_annotation_autodiscovery.alloy.txt
+++ b/charts/k8s-monitoring-v1/templates/alloy_config/_annotation_autodiscovery.alloy.txt
@@ -181,6 +181,10 @@ prometheus.scrape "annotation_autodiscovery_http" {
 {{- if .Values.metrics.autoDiscover.bearerToken.enabled }}
   bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
 {{- end }}
+{{- if .Values.externalServices.prometheus.sendNativeHistograms }}
+  scrape_protocols = ["PrometheusProto", "OpenMetricsText1.0.0", "OpenMetricsText0.0.1", "PrometheusText0.0.4"]
+  scrape_classic_histograms = true
+{{- end }}
 {{- if .Values.alloy.alloy.clustering.enabled }}
   clustering {
     enabled = true
@@ -199,6 +203,10 @@ prometheus.scrape "annotation_autodiscovery_https" {
   tls_config {
     insecure_skip_verify = true
   }
+{{- if .Values.externalServices.prometheus.sendNativeHistograms }}
+  scrape_protocols = ["PrometheusProto", "OpenMetricsText1.0.0", "OpenMetricsText0.0.1", "PrometheusText0.0.4"]
+  scrape_classic_histograms = true
+{{- end }}
 {{- if .Values.alloy.alloy.clustering.enabled }}
   clustering {
     enabled = true

--- a/charts/k8s-monitoring-v1/templates/alloy_config/_apiserver.alloy.txt
+++ b/charts/k8s-monitoring-v1/templates/alloy_config/_apiserver.alloy.txt
@@ -34,6 +34,10 @@ prometheus.scrape "apiserver" {
   tls_config {
     insecure_skip_verify = true
   }
+{{- if .Values.externalServices.prometheus.sendNativeHistograms }}
+  scrape_protocols = ["PrometheusProto", "OpenMetricsText1.0.0", "OpenMetricsText0.0.1", "PrometheusText0.0.4"]
+  scrape_classic_histograms = true
+{{- end }}
 {{- if .Values.alloy.alloy.clustering.enabled }}
   clustering {
     enabled = true

--- a/charts/k8s-monitoring-v1/templates/alloy_config/_beyla.txt
+++ b/charts/k8s-monitoring-v1/templates/alloy_config/_beyla.txt
@@ -26,6 +26,10 @@ prometheus.scrape "beyla_applications" {
   targets         = discovery.relabel.beyla.output
   honor_labels    = true
   scrape_interval = {{ .Values.metrics.beyla.scrapeInterval | default .Values.metrics.scrapeInterval | quote }}
+{{- if .Values.externalServices.prometheus.sendNativeHistograms }}
+  scrape_protocols = ["PrometheusProto", "OpenMetricsText1.0.0", "OpenMetricsText0.0.1", "PrometheusText0.0.4"]
+  scrape_classic_histograms = true
+{{- end }}
 {{- if .Values.alloy.alloy.clustering.enabled }}
   clustering {
     enabled = true
@@ -40,6 +44,10 @@ prometheus.scrape "beyla_internal" {
   job_name        = "integrations/beyla"
   honor_labels    = true
   scrape_interval = {{ .Values.metrics.beyla.scrapeInterval | default .Values.metrics.scrapeInterval | quote }}
+{{- if .Values.externalServices.prometheus.sendNativeHistograms }}
+  scrape_protocols = ["PrometheusProto", "OpenMetricsText1.0.0", "OpenMetricsText0.0.1", "PrometheusText0.0.4"]
+  scrape_classic_histograms = true
+{{- end }}
 {{- if .Values.alloy.alloy.clustering.enabled }}
   clustering {
     enabled = true

--- a/charts/k8s-monitoring-v1/templates/alloy_config/_cadvisor.alloy.txt
+++ b/charts/k8s-monitoring-v1/templates/alloy_config/_cadvisor.alloy.txt
@@ -45,6 +45,10 @@ prometheus.scrape "cadvisor" {
   tls_config {
     insecure_skip_verify = true
   }
+{{- if .Values.externalServices.prometheus.sendNativeHistograms }}
+  scrape_protocols = ["PrometheusProto", "OpenMetricsText1.0.0", "OpenMetricsText0.0.1", "PrometheusText0.0.4"]
+  scrape_classic_histograms = true
+{{- end }}
 {{- if .Values.alloy.alloy.clustering.enabled }}
   clustering {
     enabled = true

--- a/charts/k8s-monitoring-v1/templates/alloy_config/_kepler.txt
+++ b/charts/k8s-monitoring-v1/templates/alloy_config/_kepler.txt
@@ -36,6 +36,10 @@ prometheus.scrape "kepler" {
   job_name   = "integrations/kepler"
   honor_labels = true
   scrape_interval = {{ .Values.metrics.kepler.scrapeInterval | default .Values.metrics.scrapeInterval | quote }}
+{{- if .Values.externalServices.prometheus.sendNativeHistograms }}
+  scrape_protocols = ["PrometheusProto", "OpenMetricsText1.0.0", "OpenMetricsText0.0.1", "PrometheusText0.0.4"]
+  scrape_classic_histograms = true
+{{- end }}
 {{- if .Values.alloy.alloy.clustering.enabled }}
   clustering {
     enabled = true

--- a/charts/k8s-monitoring-v1/templates/alloy_config/_kube_controller_manager.alloy.txt
+++ b/charts/k8s-monitoring-v1/templates/alloy_config/_kube_controller_manager.alloy.txt
@@ -34,6 +34,10 @@ prometheus.scrape "kube_controller_manager" {
   tls_config {
     insecure_skip_verify = true
   }
+{{- if .Values.externalServices.prometheus.sendNativeHistograms }}
+  scrape_protocols = ["PrometheusProto", "OpenMetricsText1.0.0", "OpenMetricsText0.0.1", "PrometheusText0.0.4"]
+  scrape_classic_histograms = true
+{{- end }}
 {{- if .Values.alloy.alloy.clustering.enabled }}
   clustering {
     enabled = true

--- a/charts/k8s-monitoring-v1/templates/alloy_config/_kube_proxy.alloy.txt
+++ b/charts/k8s-monitoring-v1/templates/alloy_config/_kube_proxy.alloy.txt
@@ -30,6 +30,10 @@ prometheus.scrape "kube_proxy" {
   targets    = discovery.relabel.kube_proxy.output
   scheme     = "http"
   scrape_interval = {{ .Values.metrics.kubeProxy.scrapeInterval | default .Values.metrics.scrapeInterval | quote }}
+{{- if .Values.externalServices.prometheus.sendNativeHistograms }}
+  scrape_protocols = ["PrometheusProto", "OpenMetricsText1.0.0", "OpenMetricsText0.0.1", "PrometheusText0.0.4"]
+  scrape_classic_histograms = true
+{{- end }}
 {{- if .Values.alloy.alloy.clustering.enabled }}
   clustering {
     enabled = true

--- a/charts/k8s-monitoring-v1/templates/alloy_config/_kube_scheduler.alloy.txt
+++ b/charts/k8s-monitoring-v1/templates/alloy_config/_kube_scheduler.alloy.txt
@@ -34,6 +34,10 @@ prometheus.scrape "kube_scheduler" {
   tls_config {
     insecure_skip_verify = true
   }
+{{- if .Values.externalServices.prometheus.sendNativeHistograms }}
+  scrape_protocols = ["PrometheusProto", "OpenMetricsText1.0.0", "OpenMetricsText0.0.1", "PrometheusText0.0.4"]
+  scrape_classic_histograms = true
+{{- end }}
 {{- if .Values.alloy.alloy.clustering.enabled }}
   clustering {
     enabled = true

--- a/charts/k8s-monitoring-v1/templates/alloy_config/_kube_state_metrics.alloy.txt
+++ b/charts/k8s-monitoring-v1/templates/alloy_config/_kube_state_metrics.alloy.txt
@@ -42,6 +42,10 @@ prometheus.scrape "kube_state_metrics" {
   job_name   = "integrations/kubernetes/kube-state-metrics"
   targets    = discovery.relabel.kube_state_metrics.output
   scrape_interval = {{ (index .Values.metrics "kube-state-metrics").scrapeInterval | default .Values.metrics.scrapeInterval | quote }}
+{{- if .Values.externalServices.prometheus.sendNativeHistograms }}
+  scrape_protocols = ["PrometheusProto", "OpenMetricsText1.0.0", "OpenMetricsText0.0.1", "PrometheusText0.0.4"]
+  scrape_classic_histograms = true
+{{- end }}
 {{- if .Values.alloy.alloy.clustering.enabled }}
   clustering {
     enabled = true

--- a/charts/k8s-monitoring-v1/templates/alloy_config/_kubelet.alloy.txt
+++ b/charts/k8s-monitoring-v1/templates/alloy_config/_kubelet.alloy.txt
@@ -40,6 +40,10 @@ prometheus.scrape "kubelet" {
   tls_config {
     insecure_skip_verify = true
   }
+{{- if .Values.externalServices.prometheus.sendNativeHistograms }}
+  scrape_protocols = ["PrometheusProto", "OpenMetricsText1.0.0", "OpenMetricsText0.0.1", "PrometheusText0.0.4"]
+  scrape_classic_histograms = true
+{{- end }}
 {{- if .Values.alloy.alloy.clustering.enabled }}
   clustering {
     enabled = true

--- a/charts/k8s-monitoring-v1/templates/alloy_config/_kubelet_resource.alloy.txt
+++ b/charts/k8s-monitoring-v1/templates/alloy_config/_kubelet_resource.alloy.txt
@@ -45,6 +45,10 @@ prometheus.scrape "kubelet_resource" {
   tls_config {
     insecure_skip_verify = true
   }
+{{- if .Values.externalServices.prometheus.sendNativeHistograms }}
+  scrape_protocols = ["PrometheusProto", "OpenMetricsText1.0.0", "OpenMetricsText0.0.1", "PrometheusText0.0.4"]
+  scrape_classic_histograms = true
+{{- end }}
 {{- if .Values.alloy.alloy.clustering.enabled }}
   clustering {
     enabled = true

--- a/charts/k8s-monitoring-v1/templates/alloy_config/_kubernetes_monitoring_telemetry.alloy.txt
+++ b/charts/k8s-monitoring-v1/templates/alloy_config/_kubernetes_monitoring_telemetry.alloy.txt
@@ -25,6 +25,10 @@ prometheus.scrape "kubernetes_monitoring_telemetry" {
   job_name   = "integrations/kubernetes/kubernetes_monitoring_telemetry"
   targets    = discovery.relabel.kubernetes_monitoring_telemetry.output
   scrape_interval = {{ .Values.metrics.kubernetesMonitoring.scrapeInterval | default .Values.metrics.scrapeInterval | quote }}
+{{- if .Values.externalServices.prometheus.sendNativeHistograms }}
+  scrape_protocols = ["PrometheusProto", "OpenMetricsText1.0.0", "OpenMetricsText0.0.1", "PrometheusText0.0.4"]
+  scrape_classic_histograms = true
+{{- end }}
 {{- if .Values.alloy.alloy.clustering.enabled }}
   clustering {
     enabled = true

--- a/charts/k8s-monitoring-v1/templates/alloy_config/_node_exporter.alloy.txt
+++ b/charts/k8s-monitoring-v1/templates/alloy_config/_node_exporter.alloy.txt
@@ -49,6 +49,10 @@ prometheus.scrape "node_exporter" {
   job_name   = "integrations/node_exporter"
   targets  = discovery.relabel.node_exporter.output
   scrape_interval = {{ (index .Values.metrics "node-exporter").scrapeInterval | default .Values.metrics.scrapeInterval | quote }}
+{{- if .Values.externalServices.prometheus.sendNativeHistograms }}
+  scrape_protocols = ["PrometheusProto", "OpenMetricsText1.0.0", "OpenMetricsText0.0.1", "PrometheusText0.0.4"]
+  scrape_classic_histograms = true
+{{- end }}
 {{- if .Values.alloy.alloy.clustering.enabled }}
   clustering {
     enabled = true

--- a/charts/k8s-monitoring-v1/templates/alloy_config/_opencost.txt
+++ b/charts/k8s-monitoring-v1/templates/alloy_config/_opencost.txt
@@ -36,6 +36,10 @@ prometheus.scrape "opencost" {
   job_name   = "integrations/kubernetes/opencost"
   honor_labels = true
   scrape_interval = {{ .Values.metrics.cost.scrapeInterval | default .Values.metrics.scrapeInterval | quote }}
+{{- if .Values.externalServices.prometheus.sendNativeHistograms }}
+  scrape_protocols = ["PrometheusProto", "OpenMetricsText1.0.0", "OpenMetricsText0.0.1", "PrometheusText0.0.4"]
+  scrape_classic_histograms = true
+{{- end }}
 {{- if .Values.alloy.alloy.clustering.enabled }}
   clustering {
     enabled = true

--- a/charts/k8s-monitoring-v1/templates/alloy_config/_windows_exporter.alloy.txt
+++ b/charts/k8s-monitoring-v1/templates/alloy_config/_windows_exporter.alloy.txt
@@ -47,6 +47,10 @@ prometheus.scrape "windows_exporter" {
   job_name   = "integrations/windows-exporter"
   targets  = discovery.relabel.windows_exporter.output
   scrape_interval = {{ (index .Values.metrics "windows-exporter").scrapeInterval | default .Values.metrics.scrapeInterval | quote }}
+{{- if .Values.externalServices.prometheus.sendNativeHistograms }}
+  scrape_protocols = ["PrometheusProto", "OpenMetricsText1.0.0", "OpenMetricsText0.0.1", "PrometheusText0.0.4"]
+  scrape_classic_histograms = true
+{{- end }}
 {{- if .Values.alloy.alloy.clustering.enabled }}
   clustering {
     enabled = true


### PR DESCRIPTION
This is an initial attempt to add support for scraping Native Histograms with the HTTP Protobuf Scrape Protocol.

See https://grafana.com/docs/mimir/latest/send/native-histograms/#scrape-and-send-native-histograms-with-grafana-alloy for more context and [here](https://grafana.com/docs/alloy/latest/reference/components/prometheus/prometheus.scrape/#arguments) for the Arguments in Alloy.

This will allow Native Histograms to be correctly scraped and then sent to the Metrics Backend when Enabled.

Closes #881 

In a future update the ability to set the Scrape Protocols via a Value may be needed, but this should work for now.