### PR TITLE
fix: chart dep PR user is github-actions[bot]

### DIFF
--- a/.github/workflows/auto-approve-chart-deps.yml
+++ b/.github/workflows/auto-approve-chart-deps.yml
@@ -13,7 +13,7 @@ permissions:
 jobs:
   auto-approve-chart-deps:
     runs-on: ubuntu-latest
-    if: github.event.pull_request.user.login == 'petewall' && github.repository == 'grafana/k8s-monitoring-helm'
+    if: github.event.pull_request.user.login == 'github-actions[bot]' && github.repository == 'grafana/k8s-monitoring-helm'
     steps:
       - uses: actions/checkout@v4
       - name: Approve a PR if not already approved


### PR DESCRIPTION
Looks like #949 and #950 were not automatically approved. I think it's because although the commit is by `petewall`, it is actually `github-actions[bot]` that creates the PR.