### PR TITLE
Fix errors in clustermetrics validation

### DIFF
--- a/charts/k8s-monitoring/templates/features/_feature_cluster_metrics.tpl
+++ b/charts/k8s-monitoring/templates/features/_feature_cluster_metrics.tpl
@@ -66,7 +66,7 @@ cluster_metrics "feature" {
       {{- if eq $destinationName $.Values.clusterMetrics.opencost.metricsSource }}
         {{- $destinationFound = true }}
         {{- $destination := index $.Values.destinations $index }}
-        {{- $destinationUrl := $destination.url }}
+        {{- $destinationUrl := $destination.url | default $destination.fromUrl | default "" }}
         {{- $openCostMetricsUrl := $destinationUrl }}
         {{- if regexMatch "/api/prom/push" $destinationUrl }}
           {{- $openCostMetricsUrl = (regexReplaceAll "^(.*)/api/prom/push$" $destinationUrl "${1}/api/prom") }}


### PR DESCRIPTION
This PR fixes the following error:

When using `urlFrom` in the prometheus destination, it only uses the `url` field and throws due to url being `Nil`:

```
$ helm dep up; helm template observability .
Hang tight while we grab the latest from your chart repositories...
...Successfully got an update from the "grafana" chart repository
Update Complete. ⎈Happy Helming!⎈
Saving 1 charts
Deleting outdated charts
Error: template: observability/charts/k8s-monitoring/charts/k8s-monitoring/templates/validations.yaml:9:6: executing "observability/charts/k8s-monitoring/charts/k8s-monitoring/templates/validations.yaml" at <include (printf "features.%s.validate" $feature) $>: error calling include: template: observability/charts/k8s-monitoring/charts/k8s-monitoring/templates/features/_feature_cluster_metrics.tpl:71:43: executing "features.clusterMetrics.validate" at <$destinationUrl>: invalid value; expected string

Use --debug flag to render out invalid YAML
```