### PR TITLE
Adding optional spanlogs feature for converting OTEL traces to logs

### DIFF
--- a/charts/k8s-monitoring-v1/templates/alloy_config/_processors.alloy.txt
+++ b/charts/k8s-monitoring-v1/templates/alloy_config/_processors.alloy.txt
@@ -47,7 +47,7 @@ otelcol.processor.resourcedetection "default" {
 {{- if .Values.logs.enabled }}
     logs    = [otelcol.processor.k8sattributes.default.input]
 {{- end }}
-{{- if .Values.traces.enabled }}
+{{- if or .Values.traces.enabled .Values.receivers.processors.otlp_traces_to_logs.enabled }}
     traces  = [otelcol.processor.k8sattributes.default.input]
 {{- end }}
   }
@@ -86,7 +86,7 @@ otelcol.processor.k8sattributes "default" {
 {{- if .Values.logs.enabled }}
     logs    = [otelcol.processor.attributes.default.input]
 {{- end }}
-{{- if .Values.traces.enabled }}
+{{- if or .Values.traces.enabled .Values.receivers.processors.otlp_traces_to_logs.enabled }}
     traces  = [otelcol.processor.attributes.default.input]
 {{- end }}
   }
@@ -155,10 +155,10 @@ otelcol.processor.attributes "default" {
 {{- if .Values.logs.enabled }}
     logs    = [otelcol.processor.transform.default.input]
 {{- end }}
-{{- if .Values.traces.enabled }}
+{{- if or .Values.traces.enabled .Values.receivers.processors.otlp_traces_to_logs.enabled }}
     traces  = [
       otelcol.processor.transform.default.input,
-    {{- if and .Values.metrics.enabled .Values.receivers.grafanaCloudMetrics.enabled }}
+    {{- if and .Values.metrics.enabled .Values.traces.enabled .Values.receivers.grafanaCloudMetrics.enabled }}
       otelcol.connector.host_info.default.input,
     {{- end }}
     ]
@@ -257,7 +257,7 @@ otelcol.processor.transform "default" {
   }
 {{- end }}
 {{- end }}
-{{- if .Values.traces.enabled }}
+{{- if or .Values.traces.enabled .Values.receivers.processors.otlp_traces_to_logs.enabled }}
   trace_statements {
     context = "resource"
     statements = [
@@ -298,7 +298,7 @@ otelcol.processor.transform "default" {
 {{- if .Values.logs.enabled }}
     logs = [otelcol.processor.filter.default.input]
 {{- end }}
-{{- if .Values.traces.enabled }}
+{{- if or .Values.traces.enabled .Values.receivers.processors.otlp_traces_to_logs.enabled }}
     traces = [otelcol.processor.filter.default.input]
 {{- end }}
   }
@@ -334,7 +334,7 @@ otelcol.processor.filter "default" {
     ]
   }
 {{- end }}
-{{- if and .Values.traces.enabled (or .Values.traces.receiver.filters.span .Values.traces.receiver.filters.spanevent) }}
+{{- if and (or .Values.traces.enabled .Values.receivers.processors.otlp_traces_to_logs.enabled) (or .Values.traces.receiver.filters.span .Values.traces.receiver.filters.spanevent) }}
   traces {
 {{- if .Values.traces.receiver.filters.span }}
     span = [

--- a/charts/k8s-monitoring-v1/templates/alloy_config/_processors.alloy.txt
+++ b/charts/k8s-monitoring-v1/templates/alloy_config/_processors.alloy.txt
@@ -360,11 +360,27 @@ otelcol.processor.filter "default" {
 {{- if .Values.logs.enabled }}
     logs = [otelcol.processor.batch.batch_processor.input]
 {{- end }}
-{{- if .Values.traces.enabled }}
+
+{{- if and .Values.traces.enabled .Values.receivers.processors.otlp_traces_to_logs.enabled }}
+    traces = [otelcol.connector.spanlogs.default.input, otelcol.processor.batch.batch_processor.input]
+{{- else if .Values.receivers.processors.otlp_traces_to_logs.enabled }}
+    traces = [otelcol.connector.spanlogs.default.input]
+{{- else if .Values.traces.enabled }}
     traces = [otelcol.processor.batch.batch_processor.input]
 {{- end }}
   }
 }
+
+{{- if .Values.receivers.processors.otlp_traces_to_logs.enabled }}
+otelcol.connector.spanlogs "default" {
+  roots           = true
+  spans           = true
+  processes       = true
+  output {
+    logs = [otelcol.processor.batch.batch_processor.input]
+  }
+}
+{{- end }}
 
 otelcol.processor.batch "batch_processor" {
 {{- with .Values.receivers.processors.batch }}

--- a/charts/k8s-monitoring-v1/templates/alloy_config/_receivers_otlp.alloy.txt
+++ b/charts/k8s-monitoring-v1/templates/alloy_config/_receivers_otlp.alloy.txt
@@ -44,7 +44,7 @@ otelcol.receiver.otlp "receiver" {
 {{- if .Values.logs.enabled }}
     logs = [otelcol.processor.resourcedetection.default.input]
 {{- end }}
-{{- if .Values.traces.enabled }}
+{{- if or .Values.traces.enabled .Values.receivers.processors.otlp_traces_to_logs.enabled }}
     traces = [otelcol.processor.resourcedetection.default.input]
 {{- end }}
   }

--- a/charts/k8s-monitoring-v1/values.yaml
+++ b/charts/k8s-monitoring-v1/values.yaml
@@ -2129,6 +2129,11 @@ receivers:
           - os
         resourceAttributes: {}
 
+    # Use a spanlog to convert OTLP traces to logs
+    otlp_traces_to_logs:
+      enabled: false
+
+
   grafanaCloudMetrics:
     # -- Generate host info metrics from telemetry data, used in Application Observability in Grafana Cloud.
     # @section -- OTEL Receivers (Processors)


### PR DESCRIPTION
I'm starting this as a draft PR since it would need at least a little cleanup + adding more settings on the spanlogs object.  It also is only targeting the v1.x code currently. Before I dive into any other changes, I'd like to get some feedback from the maintainers & community to see how you'd prefer seeing this implemented.