### PR TITLE
de-duplicate targets from portNumber annotation

### DIFF
--- a/charts/feature-annotation-autodiscovery/templates/_module.alloy.tpl
+++ b/charts/feature-annotation-autodiscovery/templates/_module.alloy.tpl
@@ -49,6 +49,18 @@ declare "annotation_autodiscovery" {
       target_label = "__tmp_port"
     }
 
+    // Keep only targets with container portNumber that matches annotation port number.
+    rule {
+      source_labels = ["{{ include "pod_annotation" .Values.annotations.metricsPortNumber }}"]
+      regex = "(.+)"
+      target_label = "__tmp_port_number"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_pod_container_port_number"]
+      action = "keepequal"
+      target_label = "__tmp_port_number"
+    }
+
     // If the metrics port number annotation has a value, override the target address to use it, regardless whether it is
     // one of the declared ports on that Pod.
     rule {


### PR DESCRIPTION
We ran into an issue where sidecar containers (i.e vault agent) get registered as targets due to inheriting the pod's annotations for autodiscovery and resulting in alloy scraping the pod multiple times. This fix does a similar check as the portName check above it, and removes these additional targets if the `portNumber` annotation is specified and the container does not have a corresponding port number exposed.