### PR TITLE
v2: Allow overriding Alloy modules configmaps name prefix

### DIFF
--- a/charts/feature-cluster-metrics/templates/_helpers_modules.tpl
+++ b/charts/feature-cluster-metrics/templates/_helpers_modules.tpl
@@ -3,7 +3,7 @@
 {{- define "alloyModules.load" }}
 {{- if eq .Values.global.alloyModules.source "configMap" }}
 {{- $pathParts := regexSplit "/" .path -1 }}
-{{- $configMapName := printf "%s-alloy-module-%s" $.Release.Name (index $pathParts 1) }}
+{{- $configMapName := printf "%s-alloy-module-%s" (include "helper.global_fullname" .) (index $pathParts 1) }}
 {{- $moduleFile := (slice $pathParts 2) | join "_" }}
 remote.kubernetes.configmap {{ .name | quote }} {
   name = {{ $configMapName | quote }}

--- a/charts/feature-integrations/templates/_helpers_modules.tpl
+++ b/charts/feature-integrations/templates/_helpers_modules.tpl
@@ -3,7 +3,7 @@
 {{- define "alloyModules.load" }}
 {{- if eq .Values.global.alloyModules.source "configMap" }}
 {{- $pathParts := regexSplit "/" .path -1 }}
-{{- $configMapName := printf "%s-alloy-module-%s" $.Release.Name (index $pathParts 1) }}
+{{- $configMapName := printf "%s-alloy-module-%s" (include "helper.global_fullname" .) (index $pathParts 1) }}
 {{- $moduleFile := (slice $pathParts 2) | join "_" }}
 remote.kubernetes.configmap {{ .name | quote }} {
   name = {{ $configMapName | quote }}

--- a/charts/k8s-monitoring/templates/_helpers.tpl
+++ b/charts/k8s-monitoring/templates/_helpers.tpl
@@ -19,6 +19,20 @@
 {{- end }}
 {{- end }}
 
+{{/* Used to override Alloy modules configmap name prefix including its reference */}}
+{{- define "helper.global_fullname" -}}
+{{- if .Values.global.fullnameOverride }}
+{{- .Values.global.fullnameOverride | trunc 63 | trimSuffix "-" | lower }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.global.nameOverride | lower }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" | lower }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" | lower }}
+{{- end }}
+{{- end }}
+{{- end }}
+
 {{- define "english_list" }}
 {{- if eq (len .) 0 }}
 {{- else if eq (len .) 1 }}

--- a/charts/k8s-monitoring/templates/alloy-modules-configmaps.yaml
+++ b/charts/k8s-monitoring/templates/alloy-modules-configmaps.yaml
@@ -6,7 +6,7 @@
 {{- end }}
 {{- range $module :=  uniq $modules }}
   {{- $pathParts := regexSplit "/" $module -1 }}
-  {{- $configMapName := printf "%s-alloy-module-%s" $.Release.Name (index $pathParts 1) }}
+  {{- $configMapName := printf "%s-alloy-module-%s" (include "helper.global_fullname" $) (index $pathParts 1) }}
   {{- if not (hasKey $configMaps $configMapName) }}
     {{- $configMaps = $configMaps | merge (dict $configMapName (list $module)) }}
   {{- else }}

--- a/charts/k8s-monitoring/templates/features/_feature_cluster_metrics.tpl
+++ b/charts/k8s-monitoring/templates/features/_feature_cluster_metrics.tpl
@@ -10,7 +10,7 @@
 {{- if .Values.clusterMetrics.enabled -}}
 {{- $destinations := include "features.clusterMetrics.destinations" . | fromYamlArray }}
 // Feature: Cluster Metrics
-{{- include "feature.clusterMetrics.module" (dict "Values" $.Values.clusterMetrics "Files" $.Subcharts.clusterMetrics.Files "Release" $.Release) }}
+{{- include "feature.clusterMetrics.module" (dict "Values" $.Values.clusterMetrics "Files" $.Subcharts.clusterMetrics.Files "Release" $.Release "Chart" $.Chart) }}
 cluster_metrics "feature" {
   metrics_destinations = [
     {{ include "destinations.alloy.targets" (dict "destinations" $.Values.destinations "names" $destinations "type" "metrics" "ecosystem" "prometheus") | indent 4 | trim }}

--- a/charts/k8s-monitoring/templates/features/_feature_integrations.tpl
+++ b/charts/k8s-monitoring/templates/features/_feature_integrations.tpl
@@ -12,7 +12,7 @@
 {{- end }}
 
 {{- define "features.integrations.metrics.include" }}
-{{- $values := dict "Chart" $.Subcharts.integrations.Chart "Values" .Values.integrations "Files" $.Subcharts.integrations.Files "Release" $.Release }}
+{{- $values := dict "Chart" $.Subcharts.integrations.Chart "Values" .Values.integrations "Files" $.Subcharts.integrations.Files "Release" $.Release "Chart" $.Chart }}
 {{- $destinations := include "features.integrations.destinations" . | fromYamlArray }}
 {{- $integrations := include "feature.integrations.configured.metrics" $values | fromYamlArray }}
 {{- range $integrationType := $integrations }}

--- a/charts/k8s-monitoring/values.schema.json
+++ b/charts/k8s-monitoring/values.schema.json
@@ -959,6 +959,9 @@
                         }
                     }
                 },
+                "fullnameOverride": {
+                    "type": "string"
+                },
                 "maxCacheSize": {
                     "type": "integer"
                 },


### PR DESCRIPTION
fix for #994

Using .Values.global was the simplest way to pass fullnameOverride to both umbrella & child charts.

With:
```
clusterMetrics:
  enabled: true
  kepler:
    fullnameOverride: kepler
  opencost:
    fullnameOverride: opencost
podLogs:
  enabled: true
nodeLogs:
  enabled: true
clusterEvents:
  enabled: true

alloy-metrics:
  fullnameOverride: alloy-metrics
  enabled: true
alloy-logs:
  fullnameOverride: alloy-logs
  enabled: true
alloy-singleton:
  fullnameOverride: alloy-singleton
  enabled: true
  ```
  configmap name will be like: `very-long-release-name-alloy-module-kubernetes`
  
  adding:
  ```
global:
  fullnameOverride: k8s-monitoring
  ```
will render configmap name as `k8s-monitoring-alloy-module-kubernetes`:
```
---
# Source: k8s-monitoring/charts/k8s-monitoring/templates/alloy-modules-configmaps.yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: k8s-monitoring-alloy-module-kubernetes
// ...REMOVED FOR CLARITY
```
including its reference in resulting configmap data:
```
---
# Source: k8s-monitoring/charts/k8s-monitoring/templates/alloy-config.yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: alloy-metrics
  namespace: monitoring
data:
  config.alloy: |-
    // Destination: prometheus (prometheus)
// ...REMOVED FOR CLARITY
    // Feature: Cluster Metrics
    declare "cluster_metrics" {
      argument "metrics_destinations" {
        comment = "Must be a list of metric destinations where collected metrics should be forwarded to"
      }
      
      remote.kubernetes.configmap "kubernetes" {
        name = "k8s-monitoring-alloy-module-kubernetes"
        namespace = "monitoring"
      }
// ...REMOVED FOR CLARITY
```