### PR TITLE
Add dependencies on the databases for the test chart.

### DIFF
--- a/charts/k8s-monitoring/docs/examples/features/integrations/mysql/README.md
+++ b/charts/k8s-monitoring/docs/examples/features/integrations/mysql/README.md
@@ -2,7 +2,7 @@
 (NOTE: Do not edit README.md directly. It is a generated file!)
 (      To make changes, please modify values.yaml or description.txt and run `make examples`)
 -->
-# Integration: Loki
+# Integration: MySQL
 
 This example demonstrates how to gather metrics and logs from [MySQL](https://www.mysql.com/).
 

--- a/charts/k8s-monitoring/docs/examples/features/integrations/mysql/description.txt
+++ b/charts/k8s-monitoring/docs/examples/features/integrations/mysql/description.txt
@@ -1,3 +1,3 @@
-# Integration: Loki
+# Integration: MySQL
 
 This example demonstrates how to gather metrics and logs from [MySQL](https://www.mysql.com/).

--- a/charts/k8s-monitoring/tests/integration/anntoation-autodiscovery/deployments/query-test.yaml
+++ b/charts/k8s-monitoring/tests/integration/anntoation-autodiscovery/deployments/query-test.yaml
@@ -25,6 +25,9 @@ spec:
         kind: GitRepository
         name: k8s-monitoring-test
       interval: 1m
+  dependsOn:
+    - name: prometheus
+      namespace: prometheus
   values:
     tests:
       - env:

--- a/charts/k8s-monitoring/tests/integration/auth/deployments/query-test.yaml
+++ b/charts/k8s-monitoring/tests/integration/auth/deployments/query-test.yaml
@@ -25,6 +25,11 @@ spec:
         kind: GitRepository
         name: k8s-monitoring-test
       interval: 1m
+  dependsOn:
+    - name: loki
+      namespace: loki
+    - name: prometheus
+      namespace: prometheus
   values:
     tests:
       - env:

--- a/charts/k8s-monitoring/tests/integration/auto-instrumentation/deployments/query-test.yaml
+++ b/charts/k8s-monitoring/tests/integration/auto-instrumentation/deployments/query-test.yaml
@@ -25,6 +25,9 @@ spec:
         kind: GitRepository
         name: k8s-monitoring-test
       interval: 1m
+  dependsOn:
+    - name: prometheus
+      namespace: prometheus
   values:
     tests:
       - env:

--- a/charts/k8s-monitoring/tests/integration/cluster-monitoring/deployments/query-test.yaml
+++ b/charts/k8s-monitoring/tests/integration/cluster-monitoring/deployments/query-test.yaml
@@ -25,6 +25,11 @@ spec:
         kind: GitRepository
         name: k8s-monitoring-test
       interval: 1m
+  dependsOn:
+    - name: loki
+      namespace: loki
+    - name: prometheus
+      namespace: prometheus
   values:
     tests:
       - env:

--- a/charts/k8s-monitoring/tests/integration/control-plane-monitoring/deployments/query-test.yaml
+++ b/charts/k8s-monitoring/tests/integration/control-plane-monitoring/deployments/query-test.yaml
@@ -25,6 +25,11 @@ spec:
         kind: GitRepository
         name: k8s-monitoring-test
       interval: 1m
+  dependsOn:
+    - name: loki
+      namespace: loki
+    - name: prometheus
+      namespace: prometheus
   values:
     tests:
       - env:

--- a/charts/k8s-monitoring/tests/integration/integration-cert-manager/deployments/query-test.yaml
+++ b/charts/k8s-monitoring/tests/integration/integration-cert-manager/deployments/query-test.yaml
@@ -25,6 +25,9 @@ spec:
         kind: GitRepository
         name: k8s-monitoring-test
       interval: 1m
+  dependsOn:
+    - name: prometheus
+      namespace: prometheus
   values:
     tests:
       - env:

--- a/charts/k8s-monitoring/tests/integration/integration-grafana/deployments/query-test.yaml
+++ b/charts/k8s-monitoring/tests/integration/integration-grafana/deployments/query-test.yaml
@@ -25,6 +25,11 @@ spec:
         kind: GitRepository
         name: k8s-monitoring-test
       interval: 1m
+  dependsOn:
+    - name: loki
+      namespace: loki
+    - name: prometheus
+      namespace: prometheus
   values:
     tests:
       - env:

--- a/charts/k8s-monitoring/tests/integration/integration-loki/deployments/query-test.yaml
+++ b/charts/k8s-monitoring/tests/integration/integration-loki/deployments/query-test.yaml
@@ -25,6 +25,11 @@ spec:
         kind: GitRepository
         name: k8s-monitoring-test
       interval: 1m
+  dependsOn:
+    - name: loki
+      namespace: loki
+    - name: prometheus
+      namespace: prometheus
   values:
     tests:
       - env:

--- a/charts/k8s-monitoring/tests/integration/integration-mysql/deployments/query-test.yaml
+++ b/charts/k8s-monitoring/tests/integration/integration-mysql/deployments/query-test.yaml
@@ -25,6 +25,11 @@ spec:
         kind: GitRepository
         name: k8s-monitoring-test
       interval: 1m
+  dependsOn:
+    - name: loki
+      namespace: loki
+    - name: prometheus
+      namespace: prometheus
   values:
     tests:
       - env:

--- a/charts/k8s-monitoring/tests/integration/profiling/deployments/query-test.yaml
+++ b/charts/k8s-monitoring/tests/integration/profiling/deployments/query-test.yaml
@@ -25,6 +25,9 @@ spec:
         kind: GitRepository
         name: k8s-monitoring-test
       interval: 1m
+  dependsOn:
+    - name: pyroscope
+      namespace: pyroscope
   values:
     tests:
       - env:

--- a/charts/k8s-monitoring/tests/integration/statsd/deployments/query-test.yaml
+++ b/charts/k8s-monitoring/tests/integration/statsd/deployments/query-test.yaml
@@ -25,6 +25,9 @@ spec:
         kind: GitRepository
         name: k8s-monitoring-test
       interval: 1m
+  dependsOn:
+    - name: prometheus
+      namespace: prometheus
   values:
     tests:
       - env:

--- a/scripts/run-cluster-test.sh
+++ b/scripts/run-cluster-test.sh
@@ -98,12 +98,15 @@ echo helm upgrade --install k8smon ${PARENT_DIR}/charts/k8s-monitoring -f ${TEST
 helm upgrade --install k8smon ${PARENT_DIR}/charts/k8s-monitoring -f ${TEST_DIRECTORY}/values.yaml --set "cluster.name=${clusterName}" --set "clusterMetrics.opencost.opencost.exporter.defaultClusterId=${clusterName}" --wait
 
 # Ensure that the test chart has been deployed
-for i in $(seq 1 60); do
-  if helm ls | grep k8s-monitoring-test | grep deployed > /dev/null; then
+TWO_MINUTES=120
+for i in $(seq 1 ${TWO_MINUTES}); do
+  if helm status k8s-monitoring-test | grep "STATUS: deployed" > /dev/null 2>&1; then
     break
   fi
-  if [ $i -eq 60 ]; then
+  if [ $i -eq ${TWO_MINUTES} ]; then
     echo "k8s-monitoring-test Helm chart failed to deploy"
+    helm status k8s-monitoring-test
+    flux events --for HelmRelease/k8s-monitoring-test --namespace default
     exit 1
   fi
   sleep 1


### PR DESCRIPTION
This should help ensure that the DBs are online and ready for queries before deploying the chart that will run the queries