### PR TITLE
Fix otlp-gateway readme typo

### DIFF
--- a/charts/k8s-monitoring/docs/examples/destinations/otlp-gateway/README.md
+++ b/charts/k8s-monitoring/docs/examples/destinations/otlp-gateway/README.md
@@ -4,7 +4,7 @@
 -->
 # OTLP Gateway Example
 
-Some cloud services allow for sending all telemetry data to a single endpoint, which will then distribute thte data to
+Some cloud services allow for sending all telemetry data to a single endpoint, which will then distribute the data to
 the appropriate backend databases for storage. In this Helm chart, the
 [OTLP Destination](https://grafana.com/docs/grafana-cloud/send-data/otlp/send-data-otlp/) makes this possible. This
 means that you can define a single destination for all of your telemetry data.

--- a/charts/k8s-monitoring/docs/examples/destinations/otlp-gateway/description.txt
+++ b/charts/k8s-monitoring/docs/examples/destinations/otlp-gateway/description.txt
@@ -1,6 +1,6 @@
 # OTLP Gateway Example
 
-Some cloud services allow for sending all telemetry data to a single endpoint, which will then distribute thte data to
+Some cloud services allow for sending all telemetry data to a single endpoint, which will then distribute the data to
 the appropriate backend databases for storage. In this Helm chart, the
 [OTLP Destination](https://grafana.com/docs/grafana-cloud/send-data/otlp/send-data-otlp/) makes this possible. This
 means that you can define a single destination for all of your telemetry data.


### PR DESCRIPTION
Teeny fix - `thte` -> `the`