### PR TITLE
Add interval processor, spanlogs connector, and spanmetrics connector

### DIFF
--- a/charts/k8s-monitoring/charts/feature-application-observability/README.md
+++ b/charts/k8s-monitoring/charts/feature-application-observability/README.md
@@ -61,6 +61,15 @@ Be sure perform actual integration testing in a live environment in the main [k8
 |-----|------|---------|-------------|
 | processors.grafanaCloudMetrics.enabled | bool | `true` | Generate host info metrics from telemetry data, used in Application Observability in Grafana Cloud. |
 
+### Processors: Interval
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| processors.interval.enabled | bool | `false` | Utilize an interval processor to aggregates metrics and periodically forwards the latest values to the next component in the pipeline. |
+| processors.interval.interval | string | `"60s"` | The interval at which to emit aggregated metrics. |
+| processors.interval.passthrough.gauge | bool | `false` | Determines whether gauge metrics should be passed through as they are or aggregated. |
+| processors.interval.passthrough.summary | bool | `false` | Determines whether summary metrics should be passed through as they are or aggregated. |
+
 ### Processors: K8s Attributes
 
 | Key | Type | Default | Description |

--- a/charts/k8s-monitoring/charts/feature-application-observability/README.md
+++ b/charts/k8s-monitoring/charts/feature-application-observability/README.md
@@ -73,6 +73,7 @@ Be sure perform actual integration testing in a live environment in the main [k8
 | connectors.spanMetrics.histogram.exponential.maxSize | int | `160` | Maximum number of buckets per positive or negative number range. |
 | connectors.spanMetrics.histogram.type | string | `"explicit"` | Type of histograms to create. Must be either "explicit" or "exponential". |
 | connectors.spanMetrics.histogram.unit | string | `"ms"` | The histogram unit. |
+| connectors.spanMetrics.namespace | string | `"traces.span.metrics"` | The Metric namespace. |
 
 ### General settings
 

--- a/charts/k8s-monitoring/charts/feature-application-observability/README.md
+++ b/charts/k8s-monitoring/charts/feature-application-observability/README.md
@@ -50,7 +50,7 @@ Be sure perform actual integration testing in a live environment in the main [k8
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| connectors.spanLogs.enabled | bool | `false` | Use a span logs connector which creates metrics from spans. |
+| connectors.spanLogs.enabled | bool | `false` | Use a span logs connector which creates logs from spans. |
 | connectors.spanLogs.labels | list | `[]` | A list of keys that will be logged as labels. |
 | connectors.spanLogs.process | bool | `false` | Log one line for every process. |
 | connectors.spanLogs.processAttributes | list | `[]` | Additional process attributes to log. |

--- a/charts/k8s-monitoring/charts/feature-application-observability/README.md
+++ b/charts/k8s-monitoring/charts/feature-application-observability/README.md
@@ -44,7 +44,7 @@ Be sure perform actual integration testing in a live environment in the main [k8
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| connectors.grafanaCloudMetrics.enabled | bool | `true` | Generate host info metrics from telemetry data, used in Application Observability in Grafana Cloud. |
+| connectors.grafanaCloudMetrics.enabled | bool | `true` | Generate host info metrics from telemetry data. These metrics are required for using Application Observability in Grafana Cloud. Note: Enabling this may incur additional costs. See https://grafana.com/docs/grafana-cloud/monitor-applications/application-observability/pricing/ |
 
 ### Connectors: Span Logs
 

--- a/charts/k8s-monitoring/charts/feature-application-observability/README.md
+++ b/charts/k8s-monitoring/charts/feature-application-observability/README.md
@@ -40,6 +40,40 @@ Be sure perform actual integration testing in a live environment in the main [k8
 
 ## Values
 
+### Connectors: Grafana Cloud Host Info
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| connectors.grafanaCloudMetrics.enabled | bool | `true` | Generate host info metrics from telemetry data, used in Application Observability in Grafana Cloud. |
+
+### Connectors: Span Logs
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| connectors.spanLogs.enabled | bool | `false` | Use a span logs connector which creates metrics from spans. |
+| connectors.spanLogs.labels | list | `[]` | A list of keys that will be logged as labels. |
+| connectors.spanLogs.process | bool | `false` | Log one line for every process. |
+| connectors.spanLogs.processAttributes | list | `[]` | Additional process attributes to log. |
+| connectors.spanLogs.roots | bool | `false` | Log one line for every root span of a trace. |
+| connectors.spanLogs.spanAttributes | list | `[]` | Additional span attributes to log. |
+| connectors.spanLogs.spans | bool | `false` | Create a log line for each span. This can lead to a large number of logs. |
+
+### Connectors: Span Metrics
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| connectors.spanMetrics.dimensions | list | `[]` | Define dimensions to be added. Some are set internally by default: [service.name, span.name, span.kind, status.code] Example: - name: "http.status_code" - name: "http.method"   default: "GET" |
+| connectors.spanMetrics.dimensionsCacheSize | int | `1000` | How many dimensions to cache |
+| connectors.spanMetrics.enabled | bool | `false` | Use a span metrics connector which creates metrics from spans. |
+| connectors.spanMetrics.events.enabled | bool | `false` | Capture events metrics, which track span events. |
+| connectors.spanMetrics.exemplars.enabled | bool | `false` | Attach exemplars to histograms. |
+| connectors.spanMetrics.exemplars.maxPerDataPoint | number | `nil` | Limits the number of exemplars that can be added to a unique dimension set. |
+| connectors.spanMetrics.histogram.enabled | bool | `true` | Capture histogram metrics, derived from spans’ durations. |
+| connectors.spanMetrics.histogram.explicit.buckets | list | `["2ms","4ms","6ms","8ms","10ms","50ms","100ms","200ms","400ms","800ms","1s","1400ms","2s","5s","10s","15s"]` | The histogram buckets to use. |
+| connectors.spanMetrics.histogram.exponential.maxSize | int | `160` | Maximum number of buckets per positive or negative number range. |
+| connectors.spanMetrics.histogram.type | string | `"explicit"` | Type of histograms to create. Must be either "explicit" or "exponential". |
+| connectors.spanMetrics.histogram.unit | string | `"ms"` | The histogram unit. |
+
 ### General settings
 
 | Key | Type | Default | Description |
@@ -55,17 +89,11 @@ Be sure perform actual integration testing in a live environment in the main [k8
 | processors.batch.size | int | `16384` | What batch size to use, in bytes |
 | processors.batch.timeout | string | `"2s"` | How long before sending (Processors) |
 
-### Processors: Grafana Cloud Host Info
-
-| Key | Type | Default | Description |
-|-----|------|---------|-------------|
-| processors.grafanaCloudMetrics.enabled | bool | `true` | Generate host info metrics from telemetry data, used in Application Observability in Grafana Cloud. |
-
 ### Processors: Interval
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| processors.interval.enabled | bool | `false` | Utilize an interval processor to aggregates metrics and periodically forwards the latest values to the next component in the pipeline. |
+| processors.interval.enabled | bool | `false` | Utilize an interval processor to aggregate metrics and periodically forward the latest values to the next component in the pipeline. |
 | processors.interval.interval | string | `"60s"` | The interval at which to emit aggregated metrics. |
 | processors.interval.passthrough.gauge | bool | `false` | Determines whether gauge metrics should be passed through as they are or aggregated. |
 | processors.interval.passthrough.summary | bool | `false` | Determines whether summary metrics should be passed through as they are or aggregated. |

--- a/charts/k8s-monitoring/charts/feature-application-observability/schema-mods/types-and-enums.json
+++ b/charts/k8s-monitoring/charts/feature-application-observability/schema-mods/types-and-enums.json
@@ -1,0 +1,13 @@
+{
+  "properties": {
+    "connectors": {
+      "properties": {
+        "spanMetrics": {
+          "properties": {
+            "histogram": {"properties": {"type": {"enum": ["explicit", "exponential"]}}}
+          }
+        }
+      }
+    }
+  }
+}

--- a/charts/k8s-monitoring/charts/feature-application-observability/templates/_connector_host_info.tpl
+++ b/charts/k8s-monitoring/charts/feature-application-observability/templates/_connector_host_info.tpl
@@ -6,8 +6,8 @@ otelcol.connector.host_info "{{ .name | default "default" }}" {
   host_identifiers = [ "k8s.node.name" ]
 
   output {
-{{- if and .metricsOutput .Values.metrics.enabled }}
-    metrics = {{ .metricsOutput }}
+{{- if and .metrics .Values.metrics.enabled }}
+    metrics = {{ .metrics }}
 {{- end }}
   }
 }

--- a/charts/k8s-monitoring/charts/feature-application-observability/templates/_connector_span_logs.tpl
+++ b/charts/k8s-monitoring/charts/feature-application-observability/templates/_connector_span_logs.tpl
@@ -1,0 +1,31 @@
+{{/* Inputs: Values (values) metricsOutput, name */}}
+{{/* https://grafana.com/docs/alloy/latest/reference/components/otelcol/otelcol.connector.spanlogs/ */}}
+{{- define "feature.applicationObservability.connector.spanlogs.alloy.target" }}otelcol.connector.spanlogs.{{ .name | default "default" }}.input{{- end }}
+{{- define "feature.applicationObservability.connector.spanlogs.alloy" }}
+otelcol.connector.spanlogs "{{ .name | default "default" }}" {
+{{- if .Values.connectors.spanLogs.spans }}
+  spans = true
+{{- end }}
+{{- if .Values.connectors.spanLogs.spansAttributes }}
+  spans_attributes = {{ .Values.connectors.spanLogs.spansAttributes | toJson }}
+{{- end }}
+{{- if .Values.connectors.spanLogs.roots }}
+  roots = true
+{{- end }}
+{{- if .Values.connectors.spanLogs.process }}
+  process = true
+{{- end }}
+{{- if .Values.connectors.spanLogs.processAttributes }}
+  process_attributes = {{ .Values.connectors.spanLogs.processAttributes | toJson }}
+{{- end }}
+{{- if .Values.connectors.spanLogs.labels }}
+  labels = {{ .Values.connectors.spanLogs.labels | toJson }}
+{{- end }}
+
+  output {
+{{- if and .logs .Values.logs.enabled }}
+    logs = {{ .logs }}
+{{- end }}
+  }
+}
+{{- end }}

--- a/charts/k8s-monitoring/charts/feature-application-observability/templates/_connector_span_metrics.tpl
+++ b/charts/k8s-monitoring/charts/feature-application-observability/templates/_connector_span_metrics.tpl
@@ -12,6 +12,7 @@ otelcol.connector.spanmetrics "{{ .name | default "default" }}" {
   }
 {{- end }}
   dimensions_cache_size = {{ .Values.connectors.spanMetrics.dimensionsCacheSize }}
+  namespace = {{ .Values.connectors.spanMetrics.namespace | quote }}
 {{- if .Values.connectors.spanMetrics.events.enabled }}
   events {
     enabled = true

--- a/charts/k8s-monitoring/charts/feature-application-observability/templates/_connector_span_metrics.tpl
+++ b/charts/k8s-monitoring/charts/feature-application-observability/templates/_connector_span_metrics.tpl
@@ -1,0 +1,50 @@
+{{/* Inputs: Values (values) metricsOutput, name */}}
+{{/* https://grafana.com/docs/alloy/latest/reference/components/otelcol/otelcol.connector.spanmetrics/ */}}
+{{- define "feature.applicationObservability.connector.spanmetrics.alloy.target" }}otelcol.connector.spanmetrics.{{ .name | default "default" }}.input{{- end }}
+{{- define "feature.applicationObservability.connector.spanmetrics.alloy" }}
+otelcol.connector.spanmetrics "{{ .name | default "default" }}" {
+{{- range $dimension := .Values.connectors.spanMetrics.dimensions }}
+  dimension {
+    name = {{ $dimension.name | quote }}
+{{- if $dimension.default }}
+    default = {{ $dimension.default | quote }}
+{{- end }}
+  }
+{{- end }}
+  dimensions_cache_size = {{ .Values.connectors.spanMetrics.dimensionsCacheSize }}
+{{- if .Values.connectors.spanMetrics.events.enabled }}
+  events {
+    enabled = true
+  }
+{{- end }}
+{{ if .Values.connectors.spanMetrics.exemplars.enabled }}
+  exemplars {
+    enabled = true
+{{- if .Values.connectors.spanMetrics.exemplars.maxPerDataPoint }}
+    max_per_data_point = {{ .Values.connectors.spanMetrics.exemplars.maxPerDataPoint }}
+{{- end }}
+  }
+{{- end }}
+{{- if .Values.connectors.spanMetrics.histogram.enabled }}
+  histogram {
+    disable = false
+    unit = {{ .Values.connectors.spanMetrics.histogram.unit | quote }}
+{{- if eq .Values.connectors.spanMetrics.histogram.type "explicit" }}
+    explicit {
+      buckets = {{ .Values.connectors.spanMetrics.histogram.explicit.buckets | toJson }}
+    }
+{{- else if eq .Values.connectors.spanMetrics.histogram.type "exponential" }}
+    exponential {
+      max_size = {{ .Values.connectors.spanMetrics.histogram.exponential.maxSize }}
+    }
+{{- end }}
+  }
+{{- end }}
+
+  output {
+{{- if and .metrics .Values.metrics.enabled }}
+    metrics = {{ .metrics }}
+{{- end }}
+  }
+}
+{{- end }}

--- a/charts/k8s-monitoring/charts/feature-application-observability/templates/_module.alloy.tpl
+++ b/charts/k8s-monitoring/charts/feature-application-observability/templates/_module.alloy.tpl
@@ -1,14 +1,4 @@
 {{- define "feature.applicationObservability.module" }}
-{{- $metricsNext := "" }}
-{{- $logsNext := "" }}
-{{- $resourceDetection := include "feature.applicationObservability.processor.resourcedetection.alloy.target" dict }}
-{{- $k8sAttributes := include "feature.applicationObservability.processor.k8sattributes.alloy.target" dict }}
-{{- $grafanaCloudMetrics := include "feature.applicationObservability.connector.host_info.alloy.target" dict }}
-{{- $transform := include "feature.applicationObservability.processor.transform.alloy.target" dict }}
-{{- $filter := include "feature.applicationObservability.processor.filter.alloy.target" dict }}
-{{- $batch := include "feature.applicationObservability.processor.batch.alloy.target" dict }}
-{{- $interval := include "feature.applicationObservability.processor.interval.alloy.target" dict }}
-{{- $memoryLimiter := include "feature.applicationObservability.processor.memory_limiter.alloy.target" dict }}
 declare "application_observability" {
   argument "metrics_destinations" {
     comment = "Must be a list of metrics destinations where collected metrics should be forwarded to"
@@ -21,86 +11,24 @@ declare "application_observability" {
   argument "traces_destinations" {
     comment = "Must be a list of trace destinations where collected trace should be forwarded to"
   }
+{{- $pipeline := include "feature.applicationObservability.pipeline" . | fromYamlArray }}
+{{- range $component := $pipeline }}
+  {{- $args := (dict "Values" $.Values "name" $component.name) }}
 
-  // Receivers --> Resource Detection Processor
-  {{- $next := printf "[%s]" $resourceDetection }}
-  {{- include "feature.applicationObservability.receiver.otlp.alloy" (dict "Values" $.Values "metricsOutput" $next "logsOutput" $next "tracesOutput" $next ) | indent 2 }}
-  {{- include "feature.applicationObservability.receiver.jaeger.alloy" (dict "Values" $.Values "tracesOutput" $next ) | indent 2 }}
-  {{- include "feature.applicationObservability.receiver.zipkin.alloy" (dict "Values" $.Values "tracesOutput" $next ) | indent 2 }}
+  {{- range $dataType := (list "metrics" "logs" "traces")}}
+    {{- if kindIs "string" (index $component.targets $dataType) }}
+      {{- $args = merge $args (dict $dataType (index $component.targets $dataType)) }}
+    {{- else if kindIs "slice" (index $component.targets $dataType) }}
+      {{- $targets := list }}
+      {{- range $target := (index $component.targets $dataType) }}
+        {{- $targets = append $targets (include (printf "feature.applicationObservability.%s.alloy.target" $target.component) $target) }}
+      {{- end }}
+      {{- $args = merge $args (dict $dataType (printf "[%s]" (join ", " $targets))) }}
+    {{- end }}
+  {{- end }}
 
-  // Resource Detection Processor --> K8s Attribute Processor
-  {{- $next = printf "[%s]" $k8sAttributes }}
-  {{- include "feature.applicationObservability.processor.resourcedetection.alloy" (dict "Values" $.Values "metricsOutput" $next "logsOutput" $next "tracesOutput" $next ) | indent 2 }}
-
-  // K8s Attribute Processor --> Transform Processor
-  {{- $tracesNext := list $transform }}
-  {{- $next = printf "[%s]" $transform }}
-{{- if (index .Values.processors "grafanaCloudMetrics").enabled | default .Values.connectors.grafanaCloudMetrics.enabled }}
-  // Resource Detection Processor Traces --> Host Info Connector
-  {{- $tracesNext = append $tracesNext $grafanaCloudMetrics }}
-{{- end -}}
-  {{- $tracesNext = printf "[%s]" ($tracesNext | join ", ")}}
-  {{- include "feature.applicationObservability.processor.k8sattributes.alloy" (dict "Values" $.Values "metricsOutput" $next "logsOutput" $next "tracesOutput" $tracesNext ) | indent 2 }}
-
-{{- if (index .Values.processors "grafanaCloudMetrics").enabled | default .Values.connectors.grafanaCloudMetrics.enabled }}
-  // Host Info Connector --> Batch Processor
-  {{- $next = printf "[%s]" $batch }}
-  {{- include "feature.applicationObservability.connector.host_info.alloy" (dict "Values" $.Values "metricsOutput" $next ) | indent 2 }}
-{{- end }}
-
-{{ if eq (include "feature.applicationObservability.processor.filter.enabled" .) "true" }}
-  // Transform Processor --> Filter Processor
-  {{- $next = printf "[%s]" $filter }}
-{{- else }}
-  // Transform Processor --> Batch Processor
-  {{- $next = printf "[%s]" $batch }}
-{{- end }}
-  {{- include "feature.applicationObservability.processor.transform.alloy" (dict "Values" $.Values "metricsOutput" $next "logsOutput" $next "tracesOutput" $next ) | indent 2 }}
-{{ if eq (include "feature.applicationObservability.processor.filter.enabled" .) "true" }}
-  // Filter Processor --> Batch Processor
-  {{- $next = printf "[%s]" $batch }}
-  {{- include "feature.applicationObservability.processor.filter.alloy" (dict "Values" $.Values "metricsOutput" $next "logsOutput" $next "tracesOutput" $next ) | indent 2 }}
-{{- end }}
-
-{{- if .Values.processors.memoryLimiter.enabled }}
-  // Batch Processor --> Memory Limiter
-  {{- $metricsNext = printf "[%s]" $memoryLimiter }}
-  {{- $logsNext = printf "[%s]" $memoryLimiter }}
-  {{- $tracesNext = printf "[%s]" $memoryLimiter }}
-{{- else if .Values.processors.interval.enabled }}
-  // Batch Processor --> Interval
-  {{- $metricsNext = printf "[%s]" $interval }}
-  {{- $logsNext = printf "[%s]" $interval }}
-  {{- $tracesNext = printf "[%s]" $interval }}
-{{- else }}
-  // Batch Processor --> Destinations
-  {{- $metricsNext = "argument.metrics_destinations.value" }}
-  {{- $logsNext = "argument.logs_destinations.value" }}
-  {{- $tracesNext = "argument.traces_destinations.value" }}
-{{- end }}
-  {{- include "feature.applicationObservability.processor.batch.alloy" (dict "Values" $.Values "metricsOutput" $metricsNext "logsOutput" $logsNext "tracesOutput" $tracesNext ) | indent 2 }}
-
-{{- if .Values.processors.memoryLimiter.enabled }}
-{{- if .Values.processors.interval.enabled }}
-  // Memory Limiter --> Interval
-  {{- $metricsNext = printf "[%s]" $interval }}
-  {{- $logsNext = printf "[%s]" $interval }}
-  {{- $tracesNext = printf "[%s]" $interval }}
-{{- else }}
-  // Memory Limiter --> Destinations
-  {{- $metricsNext = "argument.metrics_destinations.value" }}
-  {{- $logsNext = "argument.logs_destinations.value" }}
-  {{- $tracesNext = "argument.traces_destinations.value" }}
-{{- end }}
-  {{- include "feature.applicationObservability.processor.memory_limiter.alloy" (dict "Values" $.Values "metricsOutput" $metricsNext "logsOutput" $logsNext "tracesOutput" $tracesNext ) | indent 2 }}
-{{- end }}
-
-{{- if .Values.processors.interval.enabled }}
-  // Interval --> Destinations
-  {{- $metricsNext = "argument.metrics_destinations.value" }}
-  {{- $logsNext = "argument.logs_destinations.value" }}
-  {{- $tracesNext = "argument.traces_destinations.value" }}
-  {{- include "feature.applicationObservability.processor.interval.alloy" (dict "Values" $.Values "metricsOutput" $metricsNext "logsOutput" $logsNext "tracesOutput" $tracesNext ) | indent 2 }}
+  // {{ $component.description }}
+  {{- include (printf "feature.applicationObservability.%s.alloy" $component.component) $args | indent 2 }}
 {{- end }}
 }
 {{- end }}

--- a/charts/k8s-monitoring/charts/feature-application-observability/templates/_module.alloy.tpl
+++ b/charts/k8s-monitoring/charts/feature-application-observability/templates/_module.alloy.tpl
@@ -7,6 +7,7 @@
 {{- $transform := include "feature.applicationObservability.processor.transform.alloy.target" dict }}
 {{- $filter := include "feature.applicationObservability.processor.filter.alloy.target" dict }}
 {{- $batch := include "feature.applicationObservability.processor.batch.alloy.target" dict }}
+{{- $interval := include "feature.applicationObservability.processor.interval.alloy.target" dict }}
 {{- $memoryLimiter := include "feature.applicationObservability.processor.memory_limiter.alloy.target" dict }}
 declare "application_observability" {
   argument "metrics_destinations" {
@@ -66,6 +67,11 @@ declare "application_observability" {
   {{- $metricsNext = printf "[%s]" $memoryLimiter }}
   {{- $logsNext = printf "[%s]" $memoryLimiter }}
   {{- $tracesNext = printf "[%s]" $memoryLimiter }}
+{{- else if .Values.processors.interval.enabled }}
+  // Batch Processor --> Interval
+  {{- $metricsNext = printf "[%s]" $interval }}
+  {{- $logsNext = printf "[%s]" $interval }}
+  {{- $tracesNext = printf "[%s]" $interval }}
 {{- else }}
   // Batch Processor --> Destinations
   {{- $metricsNext = "argument.metrics_destinations.value" }}
@@ -75,11 +81,26 @@ declare "application_observability" {
   {{- include "feature.applicationObservability.processor.batch.alloy" (dict "Values" $.Values "metricsOutput" $metricsNext "logsOutput" $logsNext "tracesOutput" $tracesNext ) | indent 2 }}
 
 {{- if .Values.processors.memoryLimiter.enabled }}
+{{- if .Values.processors.interval.enabled }}
+  // Memory Limiter --> Interval
+  {{- $metricsNext = printf "[%s]" $interval }}
+  {{- $logsNext = printf "[%s]" $interval }}
+  {{- $tracesNext = printf "[%s]" $interval }}
+{{- else }}
   // Memory Limiter --> Destinations
   {{- $metricsNext = "argument.metrics_destinations.value" }}
   {{- $logsNext = "argument.logs_destinations.value" }}
   {{- $tracesNext = "argument.traces_destinations.value" }}
+{{- end }}
   {{- include "feature.applicationObservability.processor.memory_limiter.alloy" (dict "Values" $.Values "metricsOutput" $metricsNext "logsOutput" $logsNext "tracesOutput" $tracesNext ) | indent 2 }}
+{{- end }}
+
+{{- if .Values.processors.interval.enabled }}
+  // Interval --> Destinations
+  {{- $metricsNext = "argument.metrics_destinations.value" }}
+  {{- $logsNext = "argument.logs_destinations.value" }}
+  {{- $tracesNext = "argument.traces_destinations.value" }}
+  {{- include "feature.applicationObservability.processor.interval.alloy" (dict "Values" $.Values "metricsOutput" $metricsNext "logsOutput" $logsNext "tracesOutput" $tracesNext ) | indent 2 }}
 {{- end }}
 }
 {{- end }}

--- a/charts/k8s-monitoring/charts/feature-application-observability/templates/_module.alloy.tpl
+++ b/charts/k8s-monitoring/charts/feature-application-observability/templates/_module.alloy.tpl
@@ -35,14 +35,14 @@ declare "application_observability" {
   // K8s Attribute Processor --> Transform Processor
   {{- $tracesNext := list $transform }}
   {{- $next = printf "[%s]" $transform }}
-{{- if .Values.processors.grafanaCloudMetrics.enabled }}
+{{- if (index .Values.processors "grafanaCloudMetrics").enabled | default .Values.connectors.grafanaCloudMetrics.enabled }}
   // Resource Detection Processor Traces --> Host Info Connector
   {{- $tracesNext = append $tracesNext $grafanaCloudMetrics }}
 {{- end -}}
   {{- $tracesNext = printf "[%s]" ($tracesNext | join ", ")}}
   {{- include "feature.applicationObservability.processor.k8sattributes.alloy" (dict "Values" $.Values "metricsOutput" $next "logsOutput" $next "tracesOutput" $tracesNext ) | indent 2 }}
 
-{{- if .Values.processors.grafanaCloudMetrics.enabled }}
+{{- if (index .Values.processors "grafanaCloudMetrics").enabled | default .Values.connectors.grafanaCloudMetrics.enabled }}
   // Host Info Connector --> Batch Processor
   {{- $next = printf "[%s]" $batch }}
   {{- include "feature.applicationObservability.connector.host_info.alloy" (dict "Values" $.Values "metricsOutput" $next ) | indent 2 }}

--- a/charts/k8s-monitoring/charts/feature-application-observability/templates/_pipeline.tpl
+++ b/charts/k8s-monitoring/charts/feature-application-observability/templates/_pipeline.tpl
@@ -1,0 +1,108 @@
+{{- define "feature.applicationObservability.pipeline" }}
+# Format:
+# - name: Alloy component name
+#   description: Human friendly description of the component
+#   component: Component slug (used for including "feature.applicationObservability.%s.alloy")
+#   targets:
+#     <type>: <list>
+#       - name: Name of the target
+#         component: Component slug (used for including "feature.applicationObservability.%s.alloy.target")
+#     <type>: <string> Raw target string (useful for terminating with argument.<type>_destinations.value)
+#     <type>: <null>   No target defined for this type
+{{- if or .Values.receivers.otlp.grpc.enabled .Values.receivers.otlp.http.enabled }}
+- name: default
+  description: OTLP Receiver
+  component: receiver.otlp
+  targets:
+    metrics: [{name: default, component: processor.resourcedetection}]
+    logs: [{name: default, component: processor.resourcedetection}]
+    traces: [{name: default, component: processor.resourcedetection}]
+{{- end }}
+{{- if or .Values.receivers.jaeger.grpc.enabled .Values.receivers.jaeger.thriftBinary.enabled .Values.receivers.jaeger.thriftCompact.enabled .Values.receivers.jaeger.thriftHttp.enabled }}
+- name: default
+  description: Jaeger Receiver
+  component: receiver.jaeger
+  targets:
+    traces: [{name: default, component: processor.resourcedetection}]
+{{- end }}
+{{- if .Values.receivers.zipkin.enabled }}
+- name: default
+  description: Zipkin Receiver
+  component: receiver.zipkin
+  targets:
+    traces: [{name: default, component: processor.resourcedetection}]
+{{- end }}
+
+- name: default
+  description: Resource Detection Processor
+  component: processor.resourcedetection
+  targets:
+    metrics: [{name: default, component: processor.k8sattributes}]
+    logs: [{name: default, component: processor.k8sattributes}]
+    traces: [{name: default, component: processor.k8sattributes}]
+
+- name: default
+  description: K8s Attributes Processor
+  component: processor.k8sattributes
+  targets:
+    metrics: [{name: default, component: processor.transform}]
+    logs: [{name: default, component: processor.transform}]
+{{- if (index .Values.processors "grafanaCloudMetrics").enabled | default .Values.connectors.grafanaCloudMetrics.enabled }}
+    traces: [{name: default, component: processor.transform}, {name: default, component: connector.host_info}]
+
+- name: default
+  description: Host Info Connector
+  component: connector.host_info
+  targets:
+    metrics: [{name: default, component: processor.batch}]
+{{- else }}
+    traces: [{name: default, component: processor.transform}]
+{{- end }}
+
+- name: default
+  description: Transform Processor
+  component: processor.transform
+  targets:
+{{- if eq (include "feature.applicationObservability.processor.filter.enabled" .) "true" }}
+    metrics: [{name: default, component: processor.filter}]
+    logs: [{name: default, component: processor.filter}]
+    traces: [{name: default, component: processor.filter}]
+
+- name: default
+  description: Filter Processor
+  component: processor.filter
+  targets:
+{{- end }}
+    metrics: [{name: default, component: processor.batch}]
+    logs: [{name: default, component: processor.batch}]
+    traces: [{name: default, component: processor.batch}]
+
+- name: default
+  description: Batch Processor
+  component: processor.batch
+  targets:
+{{- if .Values.processors.memoryLimiter.enabled }}
+    metrics: [{name: default, component: processor.memory_limiter}]
+    logs: [{name: default, component: processor.memory_limiter}]
+    traces: [{name: default, component: processor.memory_limiter}]
+
+- name: default
+  description: Memory Limiter
+  component: processor.memory_limiter
+  targets:
+{{- end }}
+{{- if .Values.processors.interval.enabled }}
+    metrics: [{name: default, component: processor.interval}]
+    logs: [{name: default, component: processor.interval}]
+    traces: [{name: default, component: processor.interval}]
+
+- name: default
+  description: Interval Processor
+  component: processor.interval
+  targets:
+{{- end }}
+    metrics: argument.metrics_destinations.value
+    logs: argument.logs_destinations.value
+    traces: argument.traces_destinations.value
+
+{{- end }}

--- a/charts/k8s-monitoring/charts/feature-application-observability/templates/_processor_batch.tpl
+++ b/charts/k8s-monitoring/charts/feature-application-observability/templates/_processor_batch.tpl
@@ -2,6 +2,10 @@
 {{- define "feature.applicationObservability.processor.batch.alloy.target" }}otelcol.processor.batch.{{ .name | default "default" }}.input{{ end }}
 {{- define "feature.applicationObservability.processor.batch.alloy" }}
 otelcol.processor.batch {{ .name | default "default" | quote }} {
+  send_batch_size = {{ .Values.processors.batch.size }}
+  send_batch_max_size = {{ .Values.processors.batch.maxSize }}
+  timeout = {{ .Values.processors.batch.timeout | quote}}
+
   output {
 {{- if and .metricsOutput .Values.metrics.enabled }}
     metrics = {{ .metricsOutput }}

--- a/charts/k8s-monitoring/charts/feature-application-observability/templates/_processor_batch.tpl
+++ b/charts/k8s-monitoring/charts/feature-application-observability/templates/_processor_batch.tpl
@@ -7,14 +7,14 @@ otelcol.processor.batch {{ .name | default "default" | quote }} {
   timeout = {{ .Values.processors.batch.timeout | quote}}
 
   output {
-{{- if and .metricsOutput .Values.metrics.enabled }}
-    metrics = {{ .metricsOutput }}
+{{- if and .metrics .Values.metrics.enabled }}
+    metrics = {{ .metrics }}
 {{- end }}
-{{- if and .logsOutput .Values.logs.enabled }}
-    logs = {{ .logsOutput }}
+{{- if and .logs .Values.logs.enabled }}
+    logs = {{ .logs }}
 {{- end }}
-{{- if and .tracesOutput .Values.traces.enabled }}
-    traces = {{ .tracesOutput }}
+{{- if and .traces .Values.traces.enabled }}
+    traces = {{ .traces }}
 {{- end }}
   }
 }

--- a/charts/k8s-monitoring/charts/feature-application-observability/templates/_processor_filter.tpl
+++ b/charts/k8s-monitoring/charts/feature-application-observability/templates/_processor_filter.tpl
@@ -60,14 +60,14 @@ otelcol.processor.filter "{{ .name | default "default" }}" {
   }
 {{- end }}
   output {
-{{- if and .metricsOutput .Values.metrics.enabled }}
-    metrics = {{ .metricsOutput }}
+{{- if and .metrics .Values.metrics.enabled }}
+    metrics = {{ .metrics }}
 {{- end }}
-{{- if and .logsOutput .Values.logs.enabled }}
-    logs = {{ .logsOutput }}
+{{- if and .logs .Values.logs.enabled }}
+    logs = {{ .logs }}
 {{- end }}
-{{- if and .tracesOutput .Values.traces.enabled }}
-    traces = {{ .tracesOutput }}
+{{- if and .traces .Values.traces.enabled }}
+    traces = {{ .traces }}
 {{- end }}
   }
 }

--- a/charts/k8s-monitoring/charts/feature-application-observability/templates/_processor_interval.tpl
+++ b/charts/k8s-monitoring/charts/feature-application-observability/templates/_processor_interval.tpl
@@ -9,14 +9,14 @@ otelcol.processor.interval {{ .name | default "default" | quote }} {
   }
 
   output {
-{{- if and .metricsOutput .Values.metrics.enabled }}
-    metrics = {{ .metricsOutput }}
+{{- if and .metrics .Values.metrics.enabled }}
+    metrics = {{ .metrics }}
 {{- end }}
-{{- if and .logsOutput .Values.logs.enabled }}
-    logs = {{ .logsOutput }}
+{{- if and .logs .Values.logs.enabled }}
+    logs = {{ .logs }}
 {{- end }}
-{{- if and .tracesOutput .Values.traces.enabled }}
-    traces = {{ .tracesOutput }}
+{{- if and .traces .Values.traces.enabled }}
+    traces = {{ .traces }}
 {{- end }}
   }
 }

--- a/charts/k8s-monitoring/charts/feature-application-observability/templates/_processor_interval.tpl
+++ b/charts/k8s-monitoring/charts/feature-application-observability/templates/_processor_interval.tpl
@@ -1,0 +1,23 @@
+{{/* Inputs: Values (values) metricsOutput, logsOutput, tracesOutput, name */}}
+{{- define "feature.applicationObservability.processor.interval.alloy.target" }}otelcol.processor.interval.{{ .name | default "default" }}.input{{ end }}
+{{- define "feature.applicationObservability.processor.interval.alloy" }}
+otelcol.processor.interval {{ .name | default "default" | quote }} {
+  interval = {{ .Values.processors.interval.interval | quote }}
+  passthrough {
+    gauge = {{ .Values.processors.interval.passthrough.gauge }}
+    summary = {{ .Values.processors.interval.passthrough.summary }}
+  }
+
+  output {
+{{- if and .metricsOutput .Values.metrics.enabled }}
+    metrics = {{ .metricsOutput }}
+{{- end }}
+{{- if and .logsOutput .Values.logs.enabled }}
+    logs = {{ .logsOutput }}
+{{- end }}
+{{- if and .tracesOutput .Values.traces.enabled }}
+    traces = {{ .tracesOutput }}
+{{- end }}
+  }
+}
+{{- end }}

--- a/charts/k8s-monitoring/charts/feature-application-observability/templates/_processor_k8sattributes.tpl
+++ b/charts/k8s-monitoring/charts/feature-application-observability/templates/_processor_k8sattributes.tpl
@@ -29,14 +29,14 @@ otelcol.processor.k8sattributes "{{ .name | default "default" }}" {
   }
 
   output {
-{{- if and .metricsOutput .Values.metrics.enabled }}
-    metrics = {{ .metricsOutput }}
+{{- if and .metrics .Values.metrics.enabled }}
+    metrics = {{ .metrics }}
 {{- end }}
-{{- if and .logsOutput .Values.logs.enabled }}
-    logs = {{ .logsOutput }}
+{{- if and .logs .Values.logs.enabled }}
+    logs = {{ .logs }}
 {{- end }}
-{{- if and .tracesOutput .Values.traces.enabled }}
-    traces = {{ .tracesOutput }}
+{{- if and .traces .Values.traces.enabled }}
+    traces = {{ .traces }}
 {{- end }}
   }
 }

--- a/charts/k8s-monitoring/charts/feature-application-observability/templates/_processor_memory_limiter.tpl
+++ b/charts/k8s-monitoring/charts/feature-application-observability/templates/_processor_memory_limiter.tpl
@@ -6,14 +6,14 @@ otelcol.processor.memory_limiter "{{ .name | default "default" }}" {
   limit = {{ .Values.processors.memoryLimiter.limit | quote }}
 
   output {
-{{- if and .metricsOutput .Values.metrics.enabled }}
-    metrics = {{ .metricsOutput }}
+{{- if and .metrics .Values.metrics.enabled }}
+    metrics = {{ .metrics }}
 {{- end }}
-{{- if and .logsOutput .Values.logs.enabled }}
-    logs = {{ .logsOutput }}
+{{- if and .logs .Values.logs.enabled }}
+    logs = {{ .logs }}
 {{- end }}
-{{- if and .tracesOutput .Values.traces.enabled }}
-    traces = {{ .tracesOutput }}
+{{- if and .traces .Values.traces.enabled }}
+    traces = {{ .traces }}
 {{- end }}
   }
 }

--- a/charts/k8s-monitoring/charts/feature-application-observability/templates/_processor_resourcedetection.tpl
+++ b/charts/k8s-monitoring/charts/feature-application-observability/templates/_processor_resourcedetection.tpl
@@ -9,14 +9,14 @@ otelcol.processor.resourcedetection "{{ .name | default "default" }}" {
   }
 
   output {
-{{- if and .metricsOutput .Values.metrics.enabled }}
-    metrics = {{ .metricsOutput }}
+{{- if and .metrics .Values.metrics.enabled }}
+    metrics = {{ .metrics }}
 {{- end }}
-{{- if and .logsOutput .Values.logs.enabled }}
-    logs = {{ .logsOutput }}
+{{- if and .logs .Values.logs.enabled }}
+    logs = {{ .logs }}
 {{- end }}
-{{- if and .tracesOutput .Values.traces.enabled }}
-    traces = {{ .tracesOutput }}
+{{- if and .traces .Values.traces.enabled }}
+    traces = {{ .traces }}
 {{- end }}
   }
 }

--- a/charts/k8s-monitoring/charts/feature-application-observability/templates/_processor_transform.tpl
+++ b/charts/k8s-monitoring/charts/feature-application-observability/templates/_processor_transform.tpl
@@ -96,14 +96,14 @@ otelcol.processor.transform "{{ .name | default "default" }}" {
 {{- end }}
 
   output {
-{{- if and .metricsOutput .Values.metrics.enabled }}
-    metrics = {{ .metricsOutput }}
+{{- if and .metrics .Values.metrics.enabled }}
+    metrics = {{ .metrics }}
 {{- end }}
-{{- if and .logsOutput .Values.logs.enabled }}
-    logs = {{ .logsOutput }}
+{{- if and .logs .Values.logs.enabled }}
+    logs = {{ .logs }}
 {{- end }}
-{{- if and .tracesOutput .Values.traces.enabled }}
-    traces = {{ .tracesOutput }}
+{{- if and .traces .Values.traces.enabled }}
+    traces = {{ .traces }}
 {{- end }}
   }
 }

--- a/charts/k8s-monitoring/charts/feature-application-observability/templates/_receiver_jaeger.tpl
+++ b/charts/k8s-monitoring/charts/feature-application-observability/templates/_receiver_jaeger.tpl
@@ -1,6 +1,5 @@
 {{/* Inputs: Values (values) tracesOutput */}}
 {{- define "feature.applicationObservability.receiver.jaeger.alloy" }}
-{{- if or .Values.receivers.jaeger.grpc.enabled .Values.receivers.jaeger.thriftBinary.enabled .Values.receivers.jaeger.thriftCompact.enabled .Values.receivers.jaeger.thriftHttp.enabled }}
 otelcol.receiver.jaeger "receiver" {
   protocols {
 {{- if .Values.receivers.jaeger.grpc.enabled }}
@@ -29,10 +28,9 @@ otelcol.receiver.jaeger "receiver" {
     disable_high_cardinality_metrics = {{ not .Values.receivers.jaeger.includeDebugMetrics }}
   }
   output {
-{{- if and .tracesOutput .Values.traces.enabled }}
-    traces = {{ .tracesOutput }}
+{{- if and .traces .Values.traces.enabled }}
+    traces = {{ .traces }}
 {{- end }}
   }
 }
-{{- end }}
 {{- end }}

--- a/charts/k8s-monitoring/charts/feature-application-observability/templates/_receiver_otlp.tpl
+++ b/charts/k8s-monitoring/charts/feature-application-observability/templates/_receiver_otlp.tpl
@@ -1,6 +1,5 @@
 {{/* Inputs: Values (values) metricsOutput, logsOutput, tracesOutput */}}
 {{- define "feature.applicationObservability.receiver.otlp.alloy" }}
-{{- if or .Values.receivers.otlp.grpc.enabled .Values.receivers.otlp.http.enabled }}
 otelcol.receiver.otlp "receiver" {
 {{- if .Values.receivers.otlp.grpc.enabled }}
   grpc {
@@ -16,16 +15,15 @@ otelcol.receiver.otlp "receiver" {
     disable_high_cardinality_metrics = {{ not .Values.receivers.otlp.includeDebugMetrics }}
   }
   output {
-{{- if and .metricsOutput .Values.metrics.enabled }}
-    metrics = {{ .metricsOutput }}
+{{- if and .metrics .Values.metrics.enabled }}
+    metrics = {{ .metrics }}
 {{- end }}
-{{- if and .logsOutput .Values.logs.enabled }}
-    logs = {{ .logsOutput }}
+{{- if and .logs .Values.logs.enabled }}
+    logs = {{ .logs }}
 {{- end }}
-{{- if and .tracesOutput .Values.traces.enabled }}
-    traces = {{ .tracesOutput }}
+{{- if and .traces .Values.traces.enabled }}
+    traces = {{ .traces }}
 {{- end }}
   }
 }
-{{- end }}
 {{- end }}

--- a/charts/k8s-monitoring/charts/feature-application-observability/templates/_receiver_zipkin.tpl
+++ b/charts/k8s-monitoring/charts/feature-application-observability/templates/_receiver_zipkin.tpl
@@ -1,16 +1,14 @@
 {{/* Inputs: Values (values) tracesOutput */}}
 {{- define "feature.applicationObservability.receiver.zipkin.alloy" }}
-{{- if .Values.receivers.zipkin.enabled }}
 otelcol.receiver.zipkin "receiver" {
   endpoint = "0.0.0.0:{{ .Values.receivers.zipkin.port | int }}"
   debug_metrics {
     disable_high_cardinality_metrics = {{ not .Values.receivers.zipkin.includeDebugMetrics }}
   }
   output {
-{{- if and .tracesOutput .Values.traces.enabled }}
-    traces = {{ .tracesOutput }}
+{{- if and .traces .Values.traces.enabled }}
+    traces = {{ .traces }}
 {{- end }}
   }
 }
-{{- end }}
 {{- end }}

--- a/charts/k8s-monitoring/charts/feature-application-observability/tests/default_test.yaml
+++ b/charts/k8s-monitoring/charts/feature-application-observability/tests/default_test.yaml
@@ -42,7 +42,7 @@ tests:
                 comment = "Must be a list of trace destinations where collected trace should be forwarded to"
               }
 
-              // Receivers --> Resource Detection Processor
+              // OTLP Receiver
               otelcol.receiver.otlp "receiver" {
                 grpc {
                   endpoint = "0.0.0.0:4317"
@@ -59,6 +59,8 @@ tests:
                   traces = [otelcol.processor.resourcedetection.default.input]
                 }
               }
+            
+              // Jaeger Receiver
               otelcol.receiver.jaeger "receiver" {
                 protocols {
                   grpc {
@@ -82,6 +84,8 @@ tests:
                   traces = [otelcol.processor.resourcedetection.default.input]
                 }
               }
+
+              // Zipkin Receiver
               otelcol.receiver.zipkin "receiver" {
                 endpoint = "0.0.0.0:9411"
                 debug_metrics {
@@ -92,7 +96,7 @@ tests:
                 }
               }
 
-              // Resource Detection Processor --> K8s Attribute Processor
+              // Resource Detection Processor
               otelcol.processor.resourcedetection "default" {
                 detectors = ["env", "system"]
                 system {
@@ -105,9 +109,8 @@ tests:
                   traces = [otelcol.processor.k8sattributes.default.input]
                 }
               }
-
-              // K8s Attribute Processor --> Transform Processor
-              // Resource Detection Processor Traces --> Host Info Connector
+          
+              // K8s Attributes Processor
               otelcol.processor.k8sattributes "default" {
                 extract {
                   metadata = ["k8s.namespace.name","k8s.pod.name","k8s.deployment.name","k8s.statefulset.name","k8s.daemonset.name","k8s.cronjob.name","k8s.job.name","k8s.node.name","k8s.pod.uid","k8s.pod.start_time"]
@@ -124,7 +127,8 @@ tests:
                   traces = [otelcol.processor.transform.default.input, otelcol.connector.host_info.default.input]
                 }
               }
-              // Host Info Connector --> Batch Processor
+
+              // Host Info Connector
               otelcol.connector.host_info "default" {
                 host_identifiers = [ "k8s.node.name" ]
 
@@ -132,9 +136,8 @@ tests:
                   metrics = [otelcol.processor.batch.default.input]
                 }
               }
-
-
-              // Transform Processor --> Batch Processor
+            
+              // Transform Processor
               otelcol.processor.transform "default" {
                 error_mode = "ignore"
                 log_statements {
@@ -153,7 +156,7 @@ tests:
                 }
               }
 
-              // Batch Processor --> Destinations
+              // Batch Processor
               otelcol.processor.batch "default" {
                 send_batch_size = 16384
                 send_batch_max_size = 0

--- a/charts/k8s-monitoring/charts/feature-application-observability/tests/interval_test.yaml
+++ b/charts/k8s-monitoring/charts/feature-application-observability/tests/interval_test.yaml
@@ -45,7 +45,7 @@ tests:
                 comment = "Must be a list of trace destinations where collected trace should be forwarded to"
               }
           
-              // Receivers --> Resource Detection Processor
+              // OTLP Receiver
               otelcol.receiver.otlp "receiver" {
                 grpc {
                   endpoint = "0.0.0.0:4317"
@@ -62,18 +62,21 @@ tests:
                   traces = [otelcol.processor.resourcedetection.default.input]
                 }
               }
+
+              // Jaeger Receiver
               otelcol.receiver.jaeger "receiver" {
-                protocols {grpc {
-                    endpoint = "0.0.0.0:0"
+                protocols {
+                  grpc {
+                    endpoint = "0.0.0.0:14250"
                   }
                   thrift_binary {
-                    endpoint = "0.0.0.0:0"
+                    endpoint = "0.0.0.0:6832"
                   }
                   thrift_compact {
-                    endpoint = "0.0.0.0:0"
+                    endpoint = "0.0.0.0:6831"
                   }
                   thrift_http {
-                    endpoint = "0.0.0.0:0"
+                    endpoint = "0.0.0.0:14268"
                   }
                 }
           
@@ -84,6 +87,8 @@ tests:
                   traces = [otelcol.processor.resourcedetection.default.input]
                 }
               }
+
+              // Zipkin Receiver
               otelcol.receiver.zipkin "receiver" {
                 endpoint = "0.0.0.0:9411"
                 debug_metrics {
@@ -94,7 +99,7 @@ tests:
                 }
               }
           
-              // Resource Detection Processor --> K8s Attribute Processor
+              // Resource Detection Processor
               otelcol.processor.resourcedetection "default" {
                 detectors = ["env", "system"]
                 system {
@@ -108,8 +113,7 @@ tests:
                 }
               }
           
-              // K8s Attribute Processor --> Transform Processor
-              // Resource Detection Processor Traces --> Host Info Connector
+              // K8s Attributes Processor
               otelcol.processor.k8sattributes "default" {
                 extract {
                   metadata = ["k8s.namespace.name","k8s.pod.name","k8s.deployment.name","k8s.statefulset.name","k8s.daemonset.name","k8s.cronjob.name","k8s.job.name","k8s.node.name","k8s.pod.uid","k8s.pod.start_time"]
@@ -126,7 +130,8 @@ tests:
                   traces = [otelcol.processor.transform.default.input, otelcol.connector.host_info.default.input]
                 }
               }
-              // Host Info Connector --> Batch Processor
+
+              // Host Info Connector
               otelcol.connector.host_info "default" {
                 host_identifiers = [ "k8s.node.name" ]
           
@@ -135,8 +140,7 @@ tests:
                 }
               }
             
-            
-              // Transform Processor --> Batch Processor
+              // Transform Processor
               otelcol.processor.transform "default" {
                 error_mode = "ignore"
                 log_statements {
@@ -155,7 +159,7 @@ tests:
                 }
               }
 
-              // Batch Processor --> Interval
+              // Batch Processor
               otelcol.processor.batch "default" {
                 send_batch_size = 16384
                 send_batch_max_size = 0
@@ -167,7 +171,8 @@ tests:
                   traces = [otelcol.processor.interval.default.input]
                 }
               }
-              // Interval --> Destinations
+
+              // Interval Processor
               otelcol.processor.interval "default" {
                 interval = "60s"
                 passthrough {

--- a/charts/k8s-monitoring/charts/feature-application-observability/tests/interval_test.yaml
+++ b/charts/k8s-monitoring/charts/feature-application-observability/tests/interval_test.yaml
@@ -1,11 +1,14 @@
 # yamllint disable rule:document-start rule:line-length rule:trailing-spaces
-suite: Test default values
+suite: Test with interval processor
 templates:
   - configmap.yaml
 tests:
-  - it: creates the default pipeline
+  - it: creates the pipeline with the interval processor
     set:
       deployAsConfigMap: true
+      processors:
+        interval:
+          enabled: true
       receivers:
         otlp:
           grpc:
@@ -33,15 +36,15 @@ tests:
               argument "metrics_destinations" {
                 comment = "Must be a list of metrics destinations where collected metrics should be forwarded to"
               }
-
+          
               argument "logs_destinations" {
                 comment = "Must be a list of log destinations where collected logs should be forwarded to"
               }
-
+          
               argument "traces_destinations" {
                 comment = "Must be a list of trace destinations where collected trace should be forwarded to"
               }
-
+          
               // Receivers --> Resource Detection Processor
               otelcol.receiver.otlp "receiver" {
                 grpc {
@@ -60,21 +63,20 @@ tests:
                 }
               }
               otelcol.receiver.jaeger "receiver" {
-                protocols {
-                  grpc {
-                    endpoint = "0.0.0.0:14250"
+                protocols {grpc {
+                    endpoint = "0.0.0.0:0"
                   }
                   thrift_binary {
-                    endpoint = "0.0.0.0:6832"
+                    endpoint = "0.0.0.0:0"
                   }
                   thrift_compact {
-                    endpoint = "0.0.0.0:6831"
+                    endpoint = "0.0.0.0:0"
                   }
                   thrift_http {
-                    endpoint = "0.0.0.0:14268"
+                    endpoint = "0.0.0.0:0"
                   }
                 }
-
+          
                 debug_metrics {
                   disable_high_cardinality_metrics = true
                 }
@@ -91,21 +93,21 @@ tests:
                   traces = [otelcol.processor.resourcedetection.default.input]
                 }
               }
-
+          
               // Resource Detection Processor --> K8s Attribute Processor
               otelcol.processor.resourcedetection "default" {
                 detectors = ["env", "system"]
                 system {
                   hostname_sources = ["os"]
                 }
-
+          
                 output {
                   metrics = [otelcol.processor.k8sattributes.default.input]
                   logs = [otelcol.processor.k8sattributes.default.input]
                   traces = [otelcol.processor.k8sattributes.default.input]
                 }
               }
-
+          
               // K8s Attribute Processor --> Transform Processor
               // Resource Detection Processor Traces --> Host Info Connector
               otelcol.processor.k8sattributes "default" {
@@ -117,7 +119,7 @@ tests:
                     from = "connection"
                   }
                 }
-
+          
                 output {
                   metrics = [otelcol.processor.transform.default.input]
                   logs = [otelcol.processor.transform.default.input]
@@ -127,13 +129,13 @@ tests:
               // Host Info Connector --> Batch Processor
               otelcol.connector.host_info "default" {
                 host_identifiers = [ "k8s.node.name" ]
-
+          
                 output {
                   metrics = [otelcol.processor.batch.default.input]
                 }
               }
-
-
+            
+            
               // Transform Processor --> Batch Processor
               otelcol.processor.transform "default" {
                 error_mode = "ignore"
@@ -145,7 +147,7 @@ tests:
                     "set(attributes[\"loki.resource.labels\"], \"cluster, namespace, job, pod\")",
                   ]
                 }
-
+          
                 output {
                   metrics = [otelcol.processor.batch.default.input]
                   logs = [otelcol.processor.batch.default.input]
@@ -153,12 +155,26 @@ tests:
                 }
               }
 
-              // Batch Processor --> Destinations
+              // Batch Processor --> Interval
               otelcol.processor.batch "default" {
                 send_batch_size = 16384
                 send_batch_max_size = 0
                 timeout = "2s"
 
+                output {
+                  metrics = [otelcol.processor.interval.default.input]
+                  logs = [otelcol.processor.interval.default.input]
+                  traces = [otelcol.processor.interval.default.input]
+                }
+              }
+              // Interval --> Destinations
+              otelcol.processor.interval "default" {
+                interval = "60s"
+                passthrough {
+                  gauge = false
+                  summary = false
+                }
+          
                 output {
                   metrics = argument.metrics_destinations.value
                   logs = argument.logs_destinations.value

--- a/charts/k8s-monitoring/charts/feature-application-observability/tests/memorylimiter_test.yaml
+++ b/charts/k8s-monitoring/charts/feature-application-observability/tests/memorylimiter_test.yaml
@@ -1,0 +1,130 @@
+# yamllint disable rule:document-start rule:line-length rule:trailing-spaces
+suite: Test with interval processor
+templates:
+  - configmap.yaml
+tests:
+  - it: creates the pipeline with the interval processor
+    set:
+      deployAsConfigMap: true
+      processors:
+        memoryLimiter:
+          enabled: true
+          limit: 100MiB
+      receivers:
+        zipkin:
+          enabled: true
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - equal:
+          path: data["module.alloy"]
+          value: |-
+            declare "application_observability" {
+              argument "metrics_destinations" {
+                comment = "Must be a list of metrics destinations where collected metrics should be forwarded to"
+              }
+          
+              argument "logs_destinations" {
+                comment = "Must be a list of log destinations where collected logs should be forwarded to"
+              }
+          
+              argument "traces_destinations" {
+                comment = "Must be a list of trace destinations where collected trace should be forwarded to"
+              }
+          
+              // Zipkin Receiver
+              otelcol.receiver.zipkin "receiver" {
+                endpoint = "0.0.0.0:9411"
+                debug_metrics {
+                  disable_high_cardinality_metrics = true
+                }
+                output {
+                  traces = [otelcol.processor.memory_limiter.default.input]
+                }
+              }
+            
+              // Memory Limiter
+              otelcol.processor.memory_limiter "default" {
+                check_interval = "1s"
+                limit = "100MiB"
+
+                output {
+                  metrics = [otelcol.processor.resourcedetection.default.input]
+                  logs = [otelcol.processor.resourcedetection.default.input]
+                  traces = [otelcol.processor.resourcedetection.default.input]
+                }
+              }
+          
+              // Resource Detection Processor
+              otelcol.processor.resourcedetection "default" {
+                detectors = ["env", "system"]
+                system {
+                  hostname_sources = ["os"]
+                }
+          
+                output {
+                  metrics = [otelcol.processor.k8sattributes.default.input]
+                  logs = [otelcol.processor.k8sattributes.default.input]
+                  traces = [otelcol.processor.k8sattributes.default.input]
+                }
+              }
+          
+              // K8s Attributes Processor
+              otelcol.processor.k8sattributes "default" {
+                extract {
+                  metadata = ["k8s.namespace.name","k8s.pod.name","k8s.deployment.name","k8s.statefulset.name","k8s.daemonset.name","k8s.cronjob.name","k8s.job.name","k8s.node.name","k8s.pod.uid","k8s.pod.start_time"]
+                }
+                pod_association {
+                  source {
+                    from = "connection"
+                  }
+                }
+          
+                output {
+                  metrics = [otelcol.processor.transform.default.input]
+                  logs = [otelcol.processor.transform.default.input]
+                  traces = [otelcol.processor.transform.default.input, otelcol.connector.host_info.default.input]
+                }
+              }
+
+              // Host Info Connector
+              otelcol.connector.host_info "default" {
+                host_identifiers = [ "k8s.node.name" ]
+          
+                output {
+                  metrics = [otelcol.processor.batch.default.input]
+                }
+              }
+            
+              // Transform Processor
+              otelcol.processor.transform "default" {
+                error_mode = "ignore"
+                log_statements {
+                  context = "resource"
+                  statements = [
+                    "set(attributes[\"pod\"], attributes[\"k8s.pod.name\"])",
+                    "set(attributes[\"namespace\"], attributes[\"k8s.namespace.name\"])",
+                    "set(attributes[\"loki.resource.labels\"], \"cluster, namespace, job, pod\")",
+                  ]
+                }
+          
+                output {
+                  metrics = [otelcol.processor.batch.default.input]
+                  logs = [otelcol.processor.batch.default.input]
+                  traces = [otelcol.processor.batch.default.input]
+                }
+              }
+
+              // Batch Processor
+              otelcol.processor.batch "default" {
+                send_batch_size = 16384
+                send_batch_max_size = 0
+                timeout = "2s"
+
+                output {
+                  metrics = argument.metrics_destinations.value
+                  logs = argument.logs_destinations.value
+                  traces = argument.traces_destinations.value
+                }
+              }
+            }

--- a/charts/k8s-monitoring/charts/feature-application-observability/tests/spanlogs_test.yaml
+++ b/charts/k8s-monitoring/charts/feature-application-observability/tests/spanlogs_test.yaml
@@ -1,0 +1,150 @@
+# yamllint disable rule:document-start rule:line-length rule:trailing-spaces
+suite: Test with spanmetrics processor
+templates:
+  - configmap.yaml
+tests:
+  - it: creates the pipeline with the spanmetrics connector
+    set:
+      deployAsConfigMap: true
+      processors:
+        interval:
+          enabled: true
+      connectors:
+        spanLogs:
+          enabled: true
+          spans: true
+      receivers:
+        otlp:
+          grpc:
+            enabled: true
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - equal:
+          path: data["module.alloy"]
+          value: |-
+            declare "application_observability" {
+              argument "metrics_destinations" {
+                comment = "Must be a list of metrics destinations where collected metrics should be forwarded to"
+              }
+          
+              argument "logs_destinations" {
+                comment = "Must be a list of log destinations where collected logs should be forwarded to"
+              }
+          
+              argument "traces_destinations" {
+                comment = "Must be a list of trace destinations where collected trace should be forwarded to"
+              }
+          
+              // OTLP Receiver
+              otelcol.receiver.otlp "receiver" {
+                grpc {
+                  endpoint = "0.0.0.0:4317"
+                }
+                debug_metrics {
+                  disable_high_cardinality_metrics = true
+                }
+                output {
+                  metrics = [otelcol.processor.resourcedetection.default.input]
+                  logs = [otelcol.processor.resourcedetection.default.input]
+                  traces = [otelcol.processor.resourcedetection.default.input]
+                }
+              }
+
+              // Resource Detection Processor
+              otelcol.processor.resourcedetection "default" {
+                detectors = ["env", "system"]
+                system {
+                  hostname_sources = ["os"]
+                }
+          
+                output {
+                  metrics = [otelcol.processor.k8sattributes.default.input]
+                  logs = [otelcol.processor.k8sattributes.default.input]
+                  traces = [otelcol.processor.k8sattributes.default.input]
+                }
+              }
+          
+              // K8s Attributes Processor
+              otelcol.processor.k8sattributes "default" {
+                extract {
+                  metadata = ["k8s.namespace.name","k8s.pod.name","k8s.deployment.name","k8s.statefulset.name","k8s.daemonset.name","k8s.cronjob.name","k8s.job.name","k8s.node.name","k8s.pod.uid","k8s.pod.start_time"]
+                }
+                pod_association {
+                  source {
+                    from = "connection"
+                  }
+                }
+          
+                output {
+                  metrics = [otelcol.processor.transform.default.input]
+                  logs = [otelcol.processor.transform.default.input]
+                  traces = [otelcol.processor.transform.default.input, otelcol.connector.host_info.default.input]
+                }
+              }
+
+              // Host Info Connector
+              otelcol.connector.host_info "default" {
+                host_identifiers = [ "k8s.node.name" ]
+          
+                output {
+                  metrics = [otelcol.processor.batch.default.input]
+                }
+              }
+            
+              // Transform Processor
+              otelcol.processor.transform "default" {
+                error_mode = "ignore"
+                log_statements {
+                  context = "resource"
+                  statements = [
+                    "set(attributes[\"pod\"], attributes[\"k8s.pod.name\"])",
+                    "set(attributes[\"namespace\"], attributes[\"k8s.namespace.name\"])",
+                    "set(attributes[\"loki.resource.labels\"], \"cluster, namespace, job, pod\")",
+                  ]
+                }
+          
+                output {
+                  metrics = [otelcol.processor.batch.default.input]
+                  logs = [otelcol.processor.batch.default.input]
+                  traces = [otelcol.connector.spanlogs.default.input, otelcol.processor.batch.default.input]
+                }
+              }
+
+              // Span Logs Connector
+              otelcol.connector.spanlogs "default" {
+                spans = true
+
+                output {
+                  logs = [otelcol.processor.batch.default.input]
+                }
+              }
+
+              // Batch Processor
+              otelcol.processor.batch "default" {
+                send_batch_size = 16384
+                send_batch_max_size = 0
+                timeout = "2s"
+
+                output {
+                  metrics = [otelcol.processor.interval.default.input]
+                  logs = [otelcol.processor.interval.default.input]
+                  traces = [otelcol.processor.interval.default.input]
+                }
+              }
+
+              // Interval Processor
+              otelcol.processor.interval "default" {
+                interval = "60s"
+                passthrough {
+                  gauge = false
+                  summary = false
+                }
+          
+                output {
+                  metrics = argument.metrics_destinations.value
+                  logs = argument.logs_destinations.value
+                  traces = argument.traces_destinations.value
+                }
+              }
+            }

--- a/charts/k8s-monitoring/charts/feature-application-observability/tests/spanmetrics_test.yaml
+++ b/charts/k8s-monitoring/charts/feature-application-observability/tests/spanmetrics_test.yaml
@@ -1,0 +1,168 @@
+# yamllint disable rule:document-start rule:line-length rule:trailing-spaces
+suite: Test with spanmetrics processor
+templates:
+  - configmap.yaml
+tests:
+  - it: creates the pipeline with the spanmetrics connector
+    set:
+      deployAsConfigMap: true
+      processors:
+        interval:
+          enabled: true
+      connectors:
+        spanMetrics:
+          enabled: true
+          dimensions:
+            - name: "http.status_code"
+            - name: "http.method"
+              default: "GET"
+      receivers:
+        otlp:
+          grpc:
+            enabled: true
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - equal:
+          path: data["module.alloy"]
+          value: |-
+            declare "application_observability" {
+              argument "metrics_destinations" {
+                comment = "Must be a list of metrics destinations where collected metrics should be forwarded to"
+              }
+          
+              argument "logs_destinations" {
+                comment = "Must be a list of log destinations where collected logs should be forwarded to"
+              }
+          
+              argument "traces_destinations" {
+                comment = "Must be a list of trace destinations where collected trace should be forwarded to"
+              }
+          
+              // OTLP Receiver
+              otelcol.receiver.otlp "receiver" {
+                grpc {
+                  endpoint = "0.0.0.0:4317"
+                }
+                debug_metrics {
+                  disable_high_cardinality_metrics = true
+                }
+                output {
+                  metrics = [otelcol.processor.resourcedetection.default.input]
+                  logs = [otelcol.processor.resourcedetection.default.input]
+                  traces = [otelcol.processor.resourcedetection.default.input]
+                }
+              }
+
+              // Resource Detection Processor
+              otelcol.processor.resourcedetection "default" {
+                detectors = ["env", "system"]
+                system {
+                  hostname_sources = ["os"]
+                }
+          
+                output {
+                  metrics = [otelcol.processor.k8sattributes.default.input]
+                  logs = [otelcol.processor.k8sattributes.default.input]
+                  traces = [otelcol.processor.k8sattributes.default.input]
+                }
+              }
+          
+              // K8s Attributes Processor
+              otelcol.processor.k8sattributes "default" {
+                extract {
+                  metadata = ["k8s.namespace.name","k8s.pod.name","k8s.deployment.name","k8s.statefulset.name","k8s.daemonset.name","k8s.cronjob.name","k8s.job.name","k8s.node.name","k8s.pod.uid","k8s.pod.start_time"]
+                }
+                pod_association {
+                  source {
+                    from = "connection"
+                  }
+                }
+          
+                output {
+                  metrics = [otelcol.processor.transform.default.input]
+                  logs = [otelcol.processor.transform.default.input]
+                  traces = [otelcol.processor.transform.default.input, otelcol.connector.host_info.default.input]
+                }
+              }
+
+              // Host Info Connector
+              otelcol.connector.host_info "default" {
+                host_identifiers = [ "k8s.node.name" ]
+          
+                output {
+                  metrics = [otelcol.processor.batch.default.input]
+                }
+              }
+            
+              // Transform Processor
+              otelcol.processor.transform "default" {
+                error_mode = "ignore"
+                log_statements {
+                  context = "resource"
+                  statements = [
+                    "set(attributes[\"pod\"], attributes[\"k8s.pod.name\"])",
+                    "set(attributes[\"namespace\"], attributes[\"k8s.namespace.name\"])",
+                    "set(attributes[\"loki.resource.labels\"], \"cluster, namespace, job, pod\")",
+                  ]
+                }
+          
+                output {
+                  metrics = [otelcol.processor.batch.default.input]
+                  logs = [otelcol.processor.batch.default.input]
+                  traces = [otelcol.connector.spanmetrics.default.input, otelcol.processor.batch.default.input]
+                }
+              }
+
+              // Span Metrics Connector
+              otelcol.connector.spanmetrics "default" {
+                dimension {
+                  name = "http.status_code"
+                }
+                dimension {
+                  name = "http.method"
+                  default = "GET"
+                }
+                dimensions_cache_size = 1000
+
+                histogram {
+                  disable = false
+                  unit = "ms"
+                  explicit {
+                    buckets = ["2ms","4ms","6ms","8ms","10ms","50ms","100ms","200ms","400ms","800ms","1s","1400ms","2s","5s","10s","15s"]
+                  }
+                }
+
+                output {
+                  metrics = [otelcol.processor.batch.default.input]
+                }
+              }
+
+              // Batch Processor
+              otelcol.processor.batch "default" {
+                send_batch_size = 16384
+                send_batch_max_size = 0
+                timeout = "2s"
+
+                output {
+                  metrics = [otelcol.processor.interval.default.input]
+                  logs = [otelcol.processor.interval.default.input]
+                  traces = [otelcol.processor.interval.default.input]
+                }
+              }
+
+              // Interval Processor
+              otelcol.processor.interval "default" {
+                interval = "60s"
+                passthrough {
+                  gauge = false
+                  summary = false
+                }
+          
+                output {
+                  metrics = argument.metrics_destinations.value
+                  logs = argument.logs_destinations.value
+                  traces = argument.traces_destinations.value
+                }
+              }
+            }

--- a/charts/k8s-monitoring/charts/feature-application-observability/tests/spanmetrics_test.yaml
+++ b/charts/k8s-monitoring/charts/feature-application-observability/tests/spanmetrics_test.yaml
@@ -124,6 +124,7 @@ tests:
                   default = "GET"
                 }
                 dimensions_cache_size = 1000
+                namespace = "traces.span.metrics"
 
                 histogram {
                   disable = false

--- a/charts/k8s-monitoring/charts/feature-application-observability/values.schema.json
+++ b/charts/k8s-monitoring/charts/feature-application-observability/values.schema.json
@@ -102,6 +102,28 @@
                         }
                     }
                 },
+                "interval": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean"
+                        },
+                        "interval": {
+                            "type": "string"
+                        },
+                        "passthrough": {
+                            "type": "object",
+                            "properties": {
+                                "gauge": {
+                                    "type": "boolean"
+                                },
+                                "summary": {
+                                    "type": "boolean"
+                                }
+                            }
+                        }
+                    }
+                },
                 "k8sattributes": {
                     "type": "object",
                     "properties": {

--- a/charts/k8s-monitoring/charts/feature-application-observability/values.schema.json
+++ b/charts/k8s-monitoring/charts/feature-application-observability/values.schema.json
@@ -96,7 +96,11 @@
                                     }
                                 },
                                 "type": {
-                                    "type": "string"
+                                    "type": "string",
+                                    "enum": [
+                                        "explicit",
+                                        "exponential"
+                                    ]
                                 },
                                 "unit": {
                                     "type": "string"

--- a/charts/k8s-monitoring/charts/feature-application-observability/values.schema.json
+++ b/charts/k8s-monitoring/charts/feature-application-observability/values.schema.json
@@ -2,6 +2,111 @@
     "$schema": "http://json-schema.org/schema#",
     "type": "object",
     "properties": {
+        "connectors": {
+            "type": "object",
+            "properties": {
+                "grafanaCloudMetrics": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean"
+                        }
+                    }
+                },
+                "spanLogs": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean"
+                        },
+                        "labels": {
+                            "type": "array"
+                        },
+                        "process": {
+                            "type": "boolean"
+                        },
+                        "processAttributes": {
+                            "type": "array"
+                        },
+                        "roots": {
+                            "type": "boolean"
+                        },
+                        "spanAttributes": {
+                            "type": "array"
+                        },
+                        "spans": {
+                            "type": "boolean"
+                        }
+                    }
+                },
+                "spanMetrics": {
+                    "type": "object",
+                    "properties": {
+                        "dimensions": {
+                            "type": "array"
+                        },
+                        "dimensionsCacheSize": {
+                            "type": "integer"
+                        },
+                        "enabled": {
+                            "type": "boolean"
+                        },
+                        "events": {
+                            "type": "object",
+                            "properties": {
+                                "enabled": {
+                                    "type": "boolean"
+                                }
+                            }
+                        },
+                        "exemplars": {
+                            "type": "object",
+                            "properties": {
+                                "enabled": {
+                                    "type": "boolean"
+                                },
+                                "maxPerDataPoint": {
+                                    "type": "null"
+                                }
+                            }
+                        },
+                        "histogram": {
+                            "type": "object",
+                            "properties": {
+                                "enabled": {
+                                    "type": "boolean"
+                                },
+                                "explicit": {
+                                    "type": "object",
+                                    "properties": {
+                                        "buckets": {
+                                            "type": "array",
+                                            "items": {
+                                                "type": "string"
+                                            }
+                                        }
+                                    }
+                                },
+                                "exponential": {
+                                    "type": "object",
+                                    "properties": {
+                                        "maxSize": {
+                                            "type": "integer"
+                                        }
+                                    }
+                                },
+                                "type": {
+                                    "type": "string"
+                                },
+                                "unit": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "deployAsConfigMap": {
             "type": "boolean"
         },
@@ -91,14 +196,6 @@
                         },
                         "timeout": {
                             "type": "string"
-                        }
-                    }
-                },
-                "grafanaCloudMetrics": {
-                    "type": "object",
-                    "properties": {
-                        "enabled": {
-                            "type": "boolean"
                         }
                     }
                 },

--- a/charts/k8s-monitoring/charts/feature-application-observability/values.schema.json
+++ b/charts/k8s-monitoring/charts/feature-application-observability/values.schema.json
@@ -106,6 +106,9 @@
                                     "type": "string"
                                 }
                             }
+                        },
+                        "namespace": {
+                            "type": "string"
                         }
                     }
                 }

--- a/charts/k8s-monitoring/charts/feature-application-observability/values.yaml
+++ b/charts/k8s-monitoring/charts/feature-application-observability/values.yaml
@@ -133,7 +133,9 @@ processors:
 # Connectors are components that create new telemetry data from existing telemetry data.
 connectors:
   grafanaCloudMetrics:
-    # -- Generate host info metrics from telemetry data, used in Application Observability in Grafana Cloud.
+    # -- Generate host info metrics from telemetry data. These metrics are required for using Application Observability
+    # in Grafana Cloud. Note: Enabling this may incur additional costs.
+    # See https://grafana.com/docs/grafana-cloud/monitor-applications/application-observability/pricing/
     # @section -- Connectors: Grafana Cloud Host Info
     enabled: true
 

--- a/charts/k8s-monitoring/charts/feature-application-observability/values.yaml
+++ b/charts/k8s-monitoring/charts/feature-application-observability/values.yaml
@@ -139,7 +139,7 @@ connectors:
 
   # Span Logs connector settings.
   spanLogs:
-    # -- Use a span logs connector which creates metrics from spans.
+    # -- Use a span logs connector which creates logs from spans.
     # @section -- Connectors: Span Logs
     enabled: false
 

--- a/charts/k8s-monitoring/charts/feature-application-observability/values.yaml
+++ b/charts/k8s-monitoring/charts/feature-application-observability/values.yaml
@@ -184,6 +184,10 @@ connectors:
     # @section -- Connectors: Span Metrics
     dimensionsCacheSize: 1000
 
+    # -- The Metric namespace.
+    # @section -- Connectors: Span Metrics
+    namespace: traces.span.metrics
+
     events:
       # -- Capture events metrics, which track span events.
       # @section -- Connectors: Span Metrics

--- a/charts/k8s-monitoring/charts/feature-application-observability/values.yaml
+++ b/charts/k8s-monitoring/charts/feature-application-observability/values.yaml
@@ -64,12 +64,8 @@ receivers:
     # @section -- Receivers: Zipkin
     includeDebugMetrics: false
 
+# Processors are components that modify the telemetry data, such as filtering, batching, and adding metadata.
 processors:
-  grafanaCloudMetrics:
-    # -- Generate host info metrics from telemetry data, used in Application Observability in Grafana Cloud.
-    # @section -- Processors: Grafana Cloud Host Info
-    enabled: true
-
   batch:
     # -- What batch size to use, in bytes
     # @section -- Processors: Batch
@@ -82,7 +78,7 @@ processors:
     timeout: 2s
 
   interval:
-    # -- Utilize an interval processor to aggregates metrics and periodically forwards the latest values to the next
+    # -- Utilize an interval processor to aggregate metrics and periodically forward the latest values to the next
     # component in the pipeline.
     # @section -- Processors: Interval
     enabled: false
@@ -133,6 +129,99 @@ processors:
     # -- Maximum amount of memory targeted to be allocated by the process heap.
     # @section -- Processors: Memory Limiter
     limit: 0MiB
+
+# Connectors are components that create new telemetry data from existing telemetry data.
+connectors:
+  grafanaCloudMetrics:
+    # -- Generate host info metrics from telemetry data, used in Application Observability in Grafana Cloud.
+    # @section -- Connectors: Grafana Cloud Host Info
+    enabled: true
+
+  # Span Logs connector settings.
+  spanLogs:
+    # -- Use a span logs connector which creates metrics from spans.
+    # @section -- Connectors: Span Logs
+    enabled: false
+
+    # -- Create a log line for each span. This can lead to a large number of logs.
+    # @section -- Connectors: Span Logs
+    spans: false
+    # -- Additional span attributes to log.
+    # @section -- Connectors: Span Logs
+    spanAttributes: []
+
+    # -- Log one line for every root span of a trace.
+    # @section -- Connectors: Span Logs
+    roots: false
+
+    # -- Log one line for every process.
+    # @section -- Connectors: Span Logs
+    process: false
+    # -- Additional process attributes to log.
+    # @section -- Connectors: Span Logs
+    processAttributes: []
+
+    # -- A list of keys that will be logged as labels.
+    # @section -- Connectors: Span Logs
+    labels: []
+
+  # Span Metrics connector settings.
+  spanMetrics:
+    # -- Use a span metrics connector which creates metrics from spans.
+    # @section -- Connectors: Span Metrics
+    enabled: false
+
+    # -- Define dimensions to be added.
+    # Some are set internally by default: [service.name, span.name, span.kind, status.code]
+    # Example:
+    # - name: "http.status_code"
+    # - name: "http.method"
+    #   default: "GET"
+    # @section -- Connectors: Span Metrics
+    dimensions: []
+
+    # -- How many dimensions to cache
+    # @section -- Connectors: Span Metrics
+    dimensionsCacheSize: 1000
+
+    events:
+      # -- Capture events metrics, which track span events.
+      # @section -- Connectors: Span Metrics
+      enabled: false
+
+    exemplars:
+      # -- Attach exemplars to histograms.
+      # @section -- Connectors: Span Metrics
+      enabled: false
+
+      # -- (number) Limits the number of exemplars that can be added to a unique dimension set.
+      # @section -- Connectors: Span Metrics
+      maxPerDataPoint:
+
+    histogram:
+      # -- Capture histogram metrics, derived from spans’ durations.
+      # @section -- Connectors: Span Metrics
+      enabled: true
+
+      # -- Type of histograms to create. Must be either "explicit" or "exponential".
+      # @section -- Connectors: Span Metrics
+      type: explicit
+
+      # -- The histogram unit.
+      # @section -- Connectors: Span Metrics
+      unit: ms
+
+      # Settings for explicit histograms.
+      explicit:
+        # -- The histogram buckets to use.
+        # @section -- Connectors: Span Metrics
+        buckets: ["2ms", "4ms", "6ms", "8ms", "10ms", "50ms", "100ms", "200ms", "400ms", "800ms", "1s", "1400ms", "2s", "5s", "10s", "15s"]
+
+      # Settings for exponential histograms.
+      exponential:
+        # -- Maximum number of buckets per positive or negative number range.
+        # @section -- Connectors: Span Metrics
+        maxSize: 160
 
 metrics:
   enabled: true

--- a/charts/k8s-monitoring/charts/feature-application-observability/values.yaml
+++ b/charts/k8s-monitoring/charts/feature-application-observability/values.yaml
@@ -81,6 +81,25 @@ processors:
     # @section -- Processors: Batch
     timeout: 2s
 
+  interval:
+    # -- Utilize an interval processor to aggregates metrics and periodically forwards the latest values to the next
+    # component in the pipeline.
+    # @section -- Processors: Interval
+    enabled: false
+
+    # -- The interval at which to emit aggregated metrics.
+    # @section -- Processors: Interval
+    interval: 60s
+
+    passthrough:
+      # -- Determines whether gauge metrics should be passed through as they are or aggregated.
+      # @section -- Processors: Interval
+      gauge: false
+
+      # -- Determines whether summary metrics should be passed through as they are or aggregated.
+      # @section -- Processors: Interval
+      summary: false
+
   k8sattributes:
     # -- Kubernetes metadata to extract and add to the attributes of the received telemetry data.
     # @section -- Processors: K8s Attributes

--- a/charts/k8s-monitoring/docs/examples/auth/bearer-token/alloy-receiver.alloy
+++ b/charts/k8s-monitoring/docs/examples/auth/bearer-token/alloy-receiver.alloy
@@ -151,7 +151,7 @@ declare "application_observability" {
     comment = "Must be a list of trace destinations where collected trace should be forwarded to"
   }
 
-  // Receivers --> Resource Detection Processor    
+  // Jaeger Receiver  
   otelcol.receiver.jaeger "receiver" {
     protocols {
       thrift_http {
@@ -165,9 +165,9 @@ declare "application_observability" {
     output {
       traces = [otelcol.processor.resourcedetection.default.input]
     }
-  }  
+  }
 
-  // Resource Detection Processor --> K8s Attribute Processor  
+  // Resource Detection Processor  
   otelcol.processor.resourcedetection "default" {
     detectors = ["env", "system"]
     system {
@@ -181,8 +181,7 @@ declare "application_observability" {
     }
   }
 
-  // K8s Attribute Processor --> Transform Processor
-  // Resource Detection Processor Traces --> Host Info Connector  
+  // K8s Attributes Processor  
   otelcol.processor.k8sattributes "default" {
     extract {
       metadata = ["k8s.namespace.name","k8s.pod.name","k8s.deployment.name","k8s.statefulset.name","k8s.daemonset.name","k8s.cronjob.name","k8s.job.name","k8s.node.name","k8s.pod.uid","k8s.pod.start_time"]
@@ -199,7 +198,8 @@ declare "application_observability" {
       traces = [otelcol.processor.transform.default.input, otelcol.connector.host_info.default.input]
     }
   }
-  // Host Info Connector --> Batch Processor  
+
+  // Host Info Connector  
   otelcol.connector.host_info "default" {
     host_identifiers = [ "k8s.node.name" ]
   
@@ -208,8 +208,7 @@ declare "application_observability" {
     }
   }
 
-
-  // Transform Processor --> Batch Processor  
+  // Transform Processor  
   otelcol.processor.transform "default" {
     error_mode = "ignore"
     log_statements {
@@ -228,7 +227,7 @@ declare "application_observability" {
     }
   }
 
-  // Batch Processor --> Destinations  
+  // Batch Processor  
   otelcol.processor.batch "default" {
     send_batch_size = 16384
     send_batch_max_size = 0

--- a/charts/k8s-monitoring/docs/examples/auth/bearer-token/alloy-receiver.alloy
+++ b/charts/k8s-monitoring/docs/examples/auth/bearer-token/alloy-receiver.alloy
@@ -230,6 +230,10 @@ declare "application_observability" {
 
   // Batch Processor --> Destinations  
   otelcol.processor.batch "default" {
+    send_batch_size = 16384
+    send_batch_max_size = 0
+    timeout = "2s"
+  
     output {
       metrics = argument.metrics_destinations.value
       logs = argument.logs_destinations.value

--- a/charts/k8s-monitoring/docs/examples/auth/bearer-token/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/auth/bearer-token/output.yaml
@@ -631,6 +631,10 @@ data:
     
       // Batch Processor --> Destinations  
       otelcol.processor.batch "default" {
+        send_batch_size = 16384
+        send_batch_max_size = 0
+        timeout = "2s"
+      
         output {
           metrics = argument.metrics_destinations.value
           logs = argument.logs_destinations.value

--- a/charts/k8s-monitoring/docs/examples/auth/bearer-token/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/auth/bearer-token/output.yaml
@@ -552,7 +552,7 @@ data:
         comment = "Must be a list of trace destinations where collected trace should be forwarded to"
       }
     
-      // Receivers --> Resource Detection Processor    
+      // Jaeger Receiver  
       otelcol.receiver.jaeger "receiver" {
         protocols {
           thrift_http {
@@ -566,9 +566,9 @@ data:
         output {
           traces = [otelcol.processor.resourcedetection.default.input]
         }
-      }  
+      }
     
-      // Resource Detection Processor --> K8s Attribute Processor  
+      // Resource Detection Processor  
       otelcol.processor.resourcedetection "default" {
         detectors = ["env", "system"]
         system {
@@ -582,8 +582,7 @@ data:
         }
       }
     
-      // K8s Attribute Processor --> Transform Processor
-      // Resource Detection Processor Traces --> Host Info Connector  
+      // K8s Attributes Processor  
       otelcol.processor.k8sattributes "default" {
         extract {
           metadata = ["k8s.namespace.name","k8s.pod.name","k8s.deployment.name","k8s.statefulset.name","k8s.daemonset.name","k8s.cronjob.name","k8s.job.name","k8s.node.name","k8s.pod.uid","k8s.pod.start_time"]
@@ -600,7 +599,8 @@ data:
           traces = [otelcol.processor.transform.default.input, otelcol.connector.host_info.default.input]
         }
       }
-      // Host Info Connector --> Batch Processor  
+    
+      // Host Info Connector  
       otelcol.connector.host_info "default" {
         host_identifiers = [ "k8s.node.name" ]
       
@@ -609,8 +609,7 @@ data:
         }
       }
     
-    
-      // Transform Processor --> Batch Processor  
+      // Transform Processor  
       otelcol.processor.transform "default" {
         error_mode = "ignore"
         log_statements {
@@ -629,7 +628,7 @@ data:
         }
       }
     
-      // Batch Processor --> Destinations  
+      // Batch Processor  
       otelcol.processor.batch "default" {
         send_batch_size = 16384
         send_batch_max_size = 0

--- a/charts/k8s-monitoring/docs/examples/auth/embedded-secrets/alloy-receiver.alloy
+++ b/charts/k8s-monitoring/docs/examples/auth/embedded-secrets/alloy-receiver.alloy
@@ -217,6 +217,10 @@ declare "application_observability" {
 
   // Batch Processor --> Destinations  
   otelcol.processor.batch "default" {
+    send_batch_size = 16384
+    send_batch_max_size = 0
+    timeout = "2s"
+  
     output {
       metrics = argument.metrics_destinations.value
       logs = argument.logs_destinations.value

--- a/charts/k8s-monitoring/docs/examples/auth/embedded-secrets/alloy-receiver.alloy
+++ b/charts/k8s-monitoring/docs/examples/auth/embedded-secrets/alloy-receiver.alloy
@@ -139,7 +139,7 @@ declare "application_observability" {
     comment = "Must be a list of trace destinations where collected trace should be forwarded to"
   }
 
-  // Receivers --> Resource Detection Processor  
+  // OTLP Receiver  
   otelcol.receiver.otlp "receiver" {
     grpc {
       endpoint = "0.0.0.0:4317"
@@ -152,9 +152,9 @@ declare "application_observability" {
       logs = [otelcol.processor.resourcedetection.default.input]
       traces = [otelcol.processor.resourcedetection.default.input]
     }
-  }    
+  }
 
-  // Resource Detection Processor --> K8s Attribute Processor  
+  // Resource Detection Processor  
   otelcol.processor.resourcedetection "default" {
     detectors = ["env", "system"]
     system {
@@ -168,8 +168,7 @@ declare "application_observability" {
     }
   }
 
-  // K8s Attribute Processor --> Transform Processor
-  // Resource Detection Processor Traces --> Host Info Connector  
+  // K8s Attributes Processor  
   otelcol.processor.k8sattributes "default" {
     extract {
       metadata = ["k8s.namespace.name","k8s.pod.name","k8s.deployment.name","k8s.statefulset.name","k8s.daemonset.name","k8s.cronjob.name","k8s.job.name","k8s.node.name","k8s.pod.uid","k8s.pod.start_time"]
@@ -186,7 +185,8 @@ declare "application_observability" {
       traces = [otelcol.processor.transform.default.input, otelcol.connector.host_info.default.input]
     }
   }
-  // Host Info Connector --> Batch Processor  
+
+  // Host Info Connector  
   otelcol.connector.host_info "default" {
     host_identifiers = [ "k8s.node.name" ]
   
@@ -195,8 +195,7 @@ declare "application_observability" {
     }
   }
 
-
-  // Transform Processor --> Batch Processor  
+  // Transform Processor  
   otelcol.processor.transform "default" {
     error_mode = "ignore"
     log_statements {
@@ -215,7 +214,7 @@ declare "application_observability" {
     }
   }
 
-  // Batch Processor --> Destinations  
+  // Batch Processor  
   otelcol.processor.batch "default" {
     send_batch_size = 16384
     send_batch_max_size = 0

--- a/charts/k8s-monitoring/docs/examples/auth/embedded-secrets/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/auth/embedded-secrets/output.yaml
@@ -607,6 +607,10 @@ data:
     
       // Batch Processor --> Destinations  
       otelcol.processor.batch "default" {
+        send_batch_size = 16384
+        send_batch_max_size = 0
+        timeout = "2s"
+      
         output {
           metrics = argument.metrics_destinations.value
           logs = argument.logs_destinations.value

--- a/charts/k8s-monitoring/docs/examples/auth/embedded-secrets/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/auth/embedded-secrets/output.yaml
@@ -529,7 +529,7 @@ data:
         comment = "Must be a list of trace destinations where collected trace should be forwarded to"
       }
     
-      // Receivers --> Resource Detection Processor  
+      // OTLP Receiver  
       otelcol.receiver.otlp "receiver" {
         grpc {
           endpoint = "0.0.0.0:4317"
@@ -542,9 +542,9 @@ data:
           logs = [otelcol.processor.resourcedetection.default.input]
           traces = [otelcol.processor.resourcedetection.default.input]
         }
-      }    
+      }
     
-      // Resource Detection Processor --> K8s Attribute Processor  
+      // Resource Detection Processor  
       otelcol.processor.resourcedetection "default" {
         detectors = ["env", "system"]
         system {
@@ -558,8 +558,7 @@ data:
         }
       }
     
-      // K8s Attribute Processor --> Transform Processor
-      // Resource Detection Processor Traces --> Host Info Connector  
+      // K8s Attributes Processor  
       otelcol.processor.k8sattributes "default" {
         extract {
           metadata = ["k8s.namespace.name","k8s.pod.name","k8s.deployment.name","k8s.statefulset.name","k8s.daemonset.name","k8s.cronjob.name","k8s.job.name","k8s.node.name","k8s.pod.uid","k8s.pod.start_time"]
@@ -576,7 +575,8 @@ data:
           traces = [otelcol.processor.transform.default.input, otelcol.connector.host_info.default.input]
         }
       }
-      // Host Info Connector --> Batch Processor  
+    
+      // Host Info Connector  
       otelcol.connector.host_info "default" {
         host_identifiers = [ "k8s.node.name" ]
       
@@ -585,8 +585,7 @@ data:
         }
       }
     
-    
-      // Transform Processor --> Batch Processor  
+      // Transform Processor  
       otelcol.processor.transform "default" {
         error_mode = "ignore"
         log_statements {
@@ -605,7 +604,7 @@ data:
         }
       }
     
-      // Batch Processor --> Destinations  
+      // Batch Processor  
       otelcol.processor.batch "default" {
         send_batch_size = 16384
         send_batch_max_size = 0

--- a/charts/k8s-monitoring/docs/examples/auth/external-secrets/alloy-receiver.alloy
+++ b/charts/k8s-monitoring/docs/examples/auth/external-secrets/alloy-receiver.alloy
@@ -250,6 +250,10 @@ declare "application_observability" {
 
   // Batch Processor --> Destinations  
   otelcol.processor.batch "default" {
+    send_batch_size = 16384
+    send_batch_max_size = 0
+    timeout = "2s"
+  
     output {
       metrics = argument.metrics_destinations.value
       logs = argument.logs_destinations.value

--- a/charts/k8s-monitoring/docs/examples/auth/external-secrets/alloy-receiver.alloy
+++ b/charts/k8s-monitoring/docs/examples/auth/external-secrets/alloy-receiver.alloy
@@ -171,7 +171,7 @@ declare "application_observability" {
     comment = "Must be a list of trace destinations where collected trace should be forwarded to"
   }
 
-  // Receivers --> Resource Detection Processor    
+  // Jaeger Receiver  
   otelcol.receiver.jaeger "receiver" {
     protocols {
       grpc {
@@ -185,9 +185,9 @@ declare "application_observability" {
     output {
       traces = [otelcol.processor.resourcedetection.default.input]
     }
-  }  
+  }
 
-  // Resource Detection Processor --> K8s Attribute Processor  
+  // Resource Detection Processor  
   otelcol.processor.resourcedetection "default" {
     detectors = ["env", "system"]
     system {
@@ -201,8 +201,7 @@ declare "application_observability" {
     }
   }
 
-  // K8s Attribute Processor --> Transform Processor
-  // Resource Detection Processor Traces --> Host Info Connector  
+  // K8s Attributes Processor  
   otelcol.processor.k8sattributes "default" {
     extract {
       metadata = ["k8s.namespace.name","k8s.pod.name","k8s.deployment.name","k8s.statefulset.name","k8s.daemonset.name","k8s.cronjob.name","k8s.job.name","k8s.node.name","k8s.pod.uid","k8s.pod.start_time"]
@@ -219,7 +218,8 @@ declare "application_observability" {
       traces = [otelcol.processor.transform.default.input, otelcol.connector.host_info.default.input]
     }
   }
-  // Host Info Connector --> Batch Processor  
+
+  // Host Info Connector  
   otelcol.connector.host_info "default" {
     host_identifiers = [ "k8s.node.name" ]
   
@@ -228,8 +228,7 @@ declare "application_observability" {
     }
   }
 
-
-  // Transform Processor --> Batch Processor  
+  // Transform Processor  
   otelcol.processor.transform "default" {
     error_mode = "ignore"
     log_statements {
@@ -248,7 +247,7 @@ declare "application_observability" {
     }
   }
 
-  // Batch Processor --> Destinations  
+  // Batch Processor  
   otelcol.processor.batch "default" {
     send_batch_size = 16384
     send_batch_max_size = 0

--- a/charts/k8s-monitoring/docs/examples/auth/external-secrets/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/auth/external-secrets/output.yaml
@@ -660,6 +660,10 @@ data:
     
       // Batch Processor --> Destinations  
       otelcol.processor.batch "default" {
+        send_batch_size = 16384
+        send_batch_max_size = 0
+        timeout = "2s"
+      
         output {
           metrics = argument.metrics_destinations.value
           logs = argument.logs_destinations.value

--- a/charts/k8s-monitoring/docs/examples/auth/external-secrets/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/auth/external-secrets/output.yaml
@@ -581,7 +581,7 @@ data:
         comment = "Must be a list of trace destinations where collected trace should be forwarded to"
       }
     
-      // Receivers --> Resource Detection Processor    
+      // Jaeger Receiver  
       otelcol.receiver.jaeger "receiver" {
         protocols {
           grpc {
@@ -595,9 +595,9 @@ data:
         output {
           traces = [otelcol.processor.resourcedetection.default.input]
         }
-      }  
+      }
     
-      // Resource Detection Processor --> K8s Attribute Processor  
+      // Resource Detection Processor  
       otelcol.processor.resourcedetection "default" {
         detectors = ["env", "system"]
         system {
@@ -611,8 +611,7 @@ data:
         }
       }
     
-      // K8s Attribute Processor --> Transform Processor
-      // Resource Detection Processor Traces --> Host Info Connector  
+      // K8s Attributes Processor  
       otelcol.processor.k8sattributes "default" {
         extract {
           metadata = ["k8s.namespace.name","k8s.pod.name","k8s.deployment.name","k8s.statefulset.name","k8s.daemonset.name","k8s.cronjob.name","k8s.job.name","k8s.node.name","k8s.pod.uid","k8s.pod.start_time"]
@@ -629,7 +628,8 @@ data:
           traces = [otelcol.processor.transform.default.input, otelcol.connector.host_info.default.input]
         }
       }
-      // Host Info Connector --> Batch Processor  
+    
+      // Host Info Connector  
       otelcol.connector.host_info "default" {
         host_identifiers = [ "k8s.node.name" ]
       
@@ -638,8 +638,7 @@ data:
         }
       }
     
-    
-      // Transform Processor --> Batch Processor  
+      // Transform Processor  
       otelcol.processor.transform "default" {
         error_mode = "ignore"
         log_statements {
@@ -658,7 +657,7 @@ data:
         }
       }
     
-      // Batch Processor --> Destinations  
+      // Batch Processor  
       otelcol.processor.batch "default" {
         send_batch_size = 16384
         send_batch_max_size = 0

--- a/charts/k8s-monitoring/docs/examples/features/application-observability/default/alloy-receiver.alloy
+++ b/charts/k8s-monitoring/docs/examples/features/application-observability/default/alloy-receiver.alloy
@@ -73,7 +73,7 @@ declare "application_observability" {
     comment = "Must be a list of trace destinations where collected trace should be forwarded to"
   }
 
-  // Receivers --> Resource Detection Processor  
+  // OTLP Receiver  
   otelcol.receiver.otlp "receiver" {
     http {
       endpoint = "0.0.0.0:4318"
@@ -86,9 +86,9 @@ declare "application_observability" {
       logs = [otelcol.processor.resourcedetection.default.input]
       traces = [otelcol.processor.resourcedetection.default.input]
     }
-  }    
+  }
 
-  // Resource Detection Processor --> K8s Attribute Processor  
+  // Resource Detection Processor  
   otelcol.processor.resourcedetection "default" {
     detectors = ["env", "system"]
     system {
@@ -102,8 +102,7 @@ declare "application_observability" {
     }
   }
 
-  // K8s Attribute Processor --> Transform Processor
-  // Resource Detection Processor Traces --> Host Info Connector  
+  // K8s Attributes Processor  
   otelcol.processor.k8sattributes "default" {
     extract {
       metadata = ["k8s.namespace.name","k8s.pod.name","k8s.deployment.name","k8s.statefulset.name","k8s.daemonset.name","k8s.cronjob.name","k8s.job.name","k8s.node.name","k8s.pod.uid","k8s.pod.start_time"]
@@ -120,7 +119,8 @@ declare "application_observability" {
       traces = [otelcol.processor.transform.default.input, otelcol.connector.host_info.default.input]
     }
   }
-  // Host Info Connector --> Batch Processor  
+
+  // Host Info Connector  
   otelcol.connector.host_info "default" {
     host_identifiers = [ "k8s.node.name" ]
   
@@ -129,8 +129,7 @@ declare "application_observability" {
     }
   }
 
-
-  // Transform Processor --> Batch Processor  
+  // Transform Processor  
   otelcol.processor.transform "default" {
     error_mode = "ignore"
     log_statements {
@@ -149,7 +148,7 @@ declare "application_observability" {
     }
   }
 
-  // Batch Processor --> Destinations  
+  // Batch Processor  
   otelcol.processor.batch "default" {
     send_batch_size = 16384
     send_batch_max_size = 0

--- a/charts/k8s-monitoring/docs/examples/features/application-observability/default/alloy-receiver.alloy
+++ b/charts/k8s-monitoring/docs/examples/features/application-observability/default/alloy-receiver.alloy
@@ -151,6 +151,10 @@ declare "application_observability" {
 
   // Batch Processor --> Destinations  
   otelcol.processor.batch "default" {
+    send_batch_size = 16384
+    send_batch_max_size = 0
+    timeout = "2s"
+  
     output {
       metrics = argument.metrics_destinations.value
       logs = argument.logs_destinations.value

--- a/charts/k8s-monitoring/docs/examples/features/application-observability/default/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/features/application-observability/default/output.yaml
@@ -176,6 +176,10 @@ data:
     
       // Batch Processor --> Destinations  
       otelcol.processor.batch "default" {
+        send_batch_size = 16384
+        send_batch_max_size = 0
+        timeout = "2s"
+      
         output {
           metrics = argument.metrics_destinations.value
           logs = argument.logs_destinations.value

--- a/charts/k8s-monitoring/docs/examples/features/application-observability/default/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/features/application-observability/default/output.yaml
@@ -98,7 +98,7 @@ data:
         comment = "Must be a list of trace destinations where collected trace should be forwarded to"
       }
     
-      // Receivers --> Resource Detection Processor  
+      // OTLP Receiver  
       otelcol.receiver.otlp "receiver" {
         http {
           endpoint = "0.0.0.0:4318"
@@ -111,9 +111,9 @@ data:
           logs = [otelcol.processor.resourcedetection.default.input]
           traces = [otelcol.processor.resourcedetection.default.input]
         }
-      }    
+      }
     
-      // Resource Detection Processor --> K8s Attribute Processor  
+      // Resource Detection Processor  
       otelcol.processor.resourcedetection "default" {
         detectors = ["env", "system"]
         system {
@@ -127,8 +127,7 @@ data:
         }
       }
     
-      // K8s Attribute Processor --> Transform Processor
-      // Resource Detection Processor Traces --> Host Info Connector  
+      // K8s Attributes Processor  
       otelcol.processor.k8sattributes "default" {
         extract {
           metadata = ["k8s.namespace.name","k8s.pod.name","k8s.deployment.name","k8s.statefulset.name","k8s.daemonset.name","k8s.cronjob.name","k8s.job.name","k8s.node.name","k8s.pod.uid","k8s.pod.start_time"]
@@ -145,7 +144,8 @@ data:
           traces = [otelcol.processor.transform.default.input, otelcol.connector.host_info.default.input]
         }
       }
-      // Host Info Connector --> Batch Processor  
+    
+      // Host Info Connector  
       otelcol.connector.host_info "default" {
         host_identifiers = [ "k8s.node.name" ]
       
@@ -154,8 +154,7 @@ data:
         }
       }
     
-    
-      // Transform Processor --> Batch Processor  
+      // Transform Processor  
       otelcol.processor.transform "default" {
         error_mode = "ignore"
         log_statements {
@@ -174,7 +173,7 @@ data:
         }
       }
     
-      // Batch Processor --> Destinations  
+      // Batch Processor  
       otelcol.processor.batch "default" {
         send_batch_size = 16384
         send_batch_max_size = 0

--- a/charts/k8s-monitoring/docs/examples/features/auto-instrumentation/beyla-metrics-and-traces/alloy-receiver.alloy
+++ b/charts/k8s-monitoring/docs/examples/features/auto-instrumentation/beyla-metrics-and-traces/alloy-receiver.alloy
@@ -73,7 +73,7 @@ declare "application_observability" {
     comment = "Must be a list of trace destinations where collected trace should be forwarded to"
   }
 
-  // Receivers --> Resource Detection Processor  
+  // OTLP Receiver  
   otelcol.receiver.otlp "receiver" {
     grpc {
       endpoint = "0.0.0.0:4317"
@@ -86,9 +86,9 @@ declare "application_observability" {
       logs = [otelcol.processor.resourcedetection.default.input]
       traces = [otelcol.processor.resourcedetection.default.input]
     }
-  }    
+  }
 
-  // Resource Detection Processor --> K8s Attribute Processor  
+  // Resource Detection Processor  
   otelcol.processor.resourcedetection "default" {
     detectors = ["env", "system"]
     system {
@@ -102,8 +102,7 @@ declare "application_observability" {
     }
   }
 
-  // K8s Attribute Processor --> Transform Processor
-  // Resource Detection Processor Traces --> Host Info Connector  
+  // K8s Attributes Processor  
   otelcol.processor.k8sattributes "default" {
     extract {
       metadata = ["k8s.namespace.name","k8s.pod.name","k8s.deployment.name","k8s.statefulset.name","k8s.daemonset.name","k8s.cronjob.name","k8s.job.name","k8s.node.name","k8s.pod.uid","k8s.pod.start_time"]
@@ -120,7 +119,8 @@ declare "application_observability" {
       traces = [otelcol.processor.transform.default.input, otelcol.connector.host_info.default.input]
     }
   }
-  // Host Info Connector --> Batch Processor  
+
+  // Host Info Connector  
   otelcol.connector.host_info "default" {
     host_identifiers = [ "k8s.node.name" ]
   
@@ -129,8 +129,7 @@ declare "application_observability" {
     }
   }
 
-
-  // Transform Processor --> Batch Processor  
+  // Transform Processor  
   otelcol.processor.transform "default" {
     error_mode = "ignore"
     log_statements {
@@ -149,7 +148,7 @@ declare "application_observability" {
     }
   }
 
-  // Batch Processor --> Destinations  
+  // Batch Processor  
   otelcol.processor.batch "default" {
     send_batch_size = 16384
     send_batch_max_size = 0

--- a/charts/k8s-monitoring/docs/examples/features/auto-instrumentation/beyla-metrics-and-traces/alloy-receiver.alloy
+++ b/charts/k8s-monitoring/docs/examples/features/auto-instrumentation/beyla-metrics-and-traces/alloy-receiver.alloy
@@ -151,6 +151,10 @@ declare "application_observability" {
 
   // Batch Processor --> Destinations  
   otelcol.processor.batch "default" {
+    send_batch_size = 16384
+    send_batch_max_size = 0
+    timeout = "2s"
+  
     output {
       metrics = argument.metrics_destinations.value
       logs = argument.logs_destinations.value

--- a/charts/k8s-monitoring/docs/examples/features/auto-instrumentation/beyla-metrics-and-traces/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/features/auto-instrumentation/beyla-metrics-and-traces/output.yaml
@@ -386,6 +386,10 @@ data:
     
       // Batch Processor --> Destinations  
       otelcol.processor.batch "default" {
+        send_batch_size = 16384
+        send_batch_max_size = 0
+        timeout = "2s"
+      
         output {
           metrics = argument.metrics_destinations.value
           logs = argument.logs_destinations.value

--- a/charts/k8s-monitoring/docs/examples/features/auto-instrumentation/beyla-metrics-and-traces/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/features/auto-instrumentation/beyla-metrics-and-traces/output.yaml
@@ -308,7 +308,7 @@ data:
         comment = "Must be a list of trace destinations where collected trace should be forwarded to"
       }
     
-      // Receivers --> Resource Detection Processor  
+      // OTLP Receiver  
       otelcol.receiver.otlp "receiver" {
         grpc {
           endpoint = "0.0.0.0:4317"
@@ -321,9 +321,9 @@ data:
           logs = [otelcol.processor.resourcedetection.default.input]
           traces = [otelcol.processor.resourcedetection.default.input]
         }
-      }    
+      }
     
-      // Resource Detection Processor --> K8s Attribute Processor  
+      // Resource Detection Processor  
       otelcol.processor.resourcedetection "default" {
         detectors = ["env", "system"]
         system {
@@ -337,8 +337,7 @@ data:
         }
       }
     
-      // K8s Attribute Processor --> Transform Processor
-      // Resource Detection Processor Traces --> Host Info Connector  
+      // K8s Attributes Processor  
       otelcol.processor.k8sattributes "default" {
         extract {
           metadata = ["k8s.namespace.name","k8s.pod.name","k8s.deployment.name","k8s.statefulset.name","k8s.daemonset.name","k8s.cronjob.name","k8s.job.name","k8s.node.name","k8s.pod.uid","k8s.pod.start_time"]
@@ -355,7 +354,8 @@ data:
           traces = [otelcol.processor.transform.default.input, otelcol.connector.host_info.default.input]
         }
       }
-      // Host Info Connector --> Batch Processor  
+    
+      // Host Info Connector  
       otelcol.connector.host_info "default" {
         host_identifiers = [ "k8s.node.name" ]
       
@@ -364,8 +364,7 @@ data:
         }
       }
     
-    
-      // Transform Processor --> Batch Processor  
+      // Transform Processor  
       otelcol.processor.transform "default" {
         error_mode = "ignore"
         log_statements {
@@ -384,7 +383,7 @@ data:
         }
       }
     
-      // Batch Processor --> Destinations  
+      // Batch Processor  
       otelcol.processor.batch "default" {
         send_batch_size = 16384
         send_batch_max_size = 0

--- a/charts/k8s-monitoring/docs/examples/meta-monitoring/alloy-receiver.alloy
+++ b/charts/k8s-monitoring/docs/examples/meta-monitoring/alloy-receiver.alloy
@@ -128,7 +128,7 @@ declare "application_observability" {
     comment = "Must be a list of trace destinations where collected trace should be forwarded to"
   }
 
-  // Receivers --> Resource Detection Processor    
+  // Jaeger Receiver  
   otelcol.receiver.jaeger "receiver" {
     protocols {
       thrift_http {
@@ -142,9 +142,9 @@ declare "application_observability" {
     output {
       traces = [otelcol.processor.resourcedetection.default.input]
     }
-  }  
+  }
 
-  // Resource Detection Processor --> K8s Attribute Processor  
+  // Resource Detection Processor  
   otelcol.processor.resourcedetection "default" {
     detectors = ["env", "system"]
     system {
@@ -158,8 +158,7 @@ declare "application_observability" {
     }
   }
 
-  // K8s Attribute Processor --> Transform Processor
-  // Resource Detection Processor Traces --> Host Info Connector  
+  // K8s Attributes Processor  
   otelcol.processor.k8sattributes "default" {
     extract {
       metadata = ["k8s.namespace.name","k8s.pod.name","k8s.deployment.name","k8s.statefulset.name","k8s.daemonset.name","k8s.cronjob.name","k8s.job.name","k8s.node.name","k8s.pod.uid","k8s.pod.start_time"]
@@ -176,7 +175,8 @@ declare "application_observability" {
       traces = [otelcol.processor.transform.default.input, otelcol.connector.host_info.default.input]
     }
   }
-  // Host Info Connector --> Batch Processor  
+
+  // Host Info Connector  
   otelcol.connector.host_info "default" {
     host_identifiers = [ "k8s.node.name" ]
   
@@ -185,8 +185,7 @@ declare "application_observability" {
     }
   }
 
-
-  // Transform Processor --> Batch Processor  
+  // Transform Processor  
   otelcol.processor.transform "default" {
     error_mode = "ignore"
     log_statements {
@@ -205,8 +204,12 @@ declare "application_observability" {
     }
   }
 
-  // Batch Processor --> Destinations  
+  // Batch Processor  
   otelcol.processor.batch "default" {
+    send_batch_size = 16384
+    send_batch_max_size = 0
+    timeout = "2s"
+  
     output {
       metrics = argument.metrics_destinations.value
       logs = argument.logs_destinations.value

--- a/charts/k8s-monitoring/docs/examples/meta-monitoring/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/meta-monitoring/output.yaml
@@ -2030,7 +2030,7 @@ data:
         comment = "Must be a list of trace destinations where collected trace should be forwarded to"
       }
     
-      // Receivers --> Resource Detection Processor    
+      // Jaeger Receiver  
       otelcol.receiver.jaeger "receiver" {
         protocols {
           thrift_http {
@@ -2044,9 +2044,9 @@ data:
         output {
           traces = [otelcol.processor.resourcedetection.default.input]
         }
-      }  
+      }
     
-      // Resource Detection Processor --> K8s Attribute Processor  
+      // Resource Detection Processor  
       otelcol.processor.resourcedetection "default" {
         detectors = ["env", "system"]
         system {
@@ -2060,8 +2060,7 @@ data:
         }
       }
     
-      // K8s Attribute Processor --> Transform Processor
-      // Resource Detection Processor Traces --> Host Info Connector  
+      // K8s Attributes Processor  
       otelcol.processor.k8sattributes "default" {
         extract {
           metadata = ["k8s.namespace.name","k8s.pod.name","k8s.deployment.name","k8s.statefulset.name","k8s.daemonset.name","k8s.cronjob.name","k8s.job.name","k8s.node.name","k8s.pod.uid","k8s.pod.start_time"]
@@ -2078,7 +2077,8 @@ data:
           traces = [otelcol.processor.transform.default.input, otelcol.connector.host_info.default.input]
         }
       }
-      // Host Info Connector --> Batch Processor  
+    
+      // Host Info Connector  
       otelcol.connector.host_info "default" {
         host_identifiers = [ "k8s.node.name" ]
       
@@ -2087,8 +2087,7 @@ data:
         }
       }
     
-    
-      // Transform Processor --> Batch Processor  
+      // Transform Processor  
       otelcol.processor.transform "default" {
         error_mode = "ignore"
         log_statements {
@@ -2107,8 +2106,12 @@ data:
         }
       }
     
-      // Batch Processor --> Destinations  
+      // Batch Processor  
       otelcol.processor.batch "default" {
+        send_batch_size = 16384
+        send_batch_max_size = 0
+        timeout = "2s"
+      
         output {
           metrics = argument.metrics_destinations.value
           logs = argument.logs_destinations.value

--- a/charts/k8s-monitoring/docs/examples/proxies/alloy-receiver.alloy
+++ b/charts/k8s-monitoring/docs/examples/proxies/alloy-receiver.alloy
@@ -203,6 +203,10 @@ declare "application_observability" {
 
   // Batch Processor --> Destinations  
   otelcol.processor.batch "default" {
+    send_batch_size = 16384
+    send_batch_max_size = 0
+    timeout = "2s"
+  
     output {
       metrics = argument.metrics_destinations.value
       logs = argument.logs_destinations.value

--- a/charts/k8s-monitoring/docs/examples/proxies/alloy-receiver.alloy
+++ b/charts/k8s-monitoring/docs/examples/proxies/alloy-receiver.alloy
@@ -129,7 +129,7 @@ declare "application_observability" {
     comment = "Must be a list of trace destinations where collected trace should be forwarded to"
   }
 
-  // Receivers --> Resource Detection Processor      
+  // Zipkin Receiver  
   otelcol.receiver.zipkin "receiver" {
     endpoint = "0.0.0.0:9411"
     debug_metrics {
@@ -140,7 +140,7 @@ declare "application_observability" {
     }
   }
 
-  // Resource Detection Processor --> K8s Attribute Processor  
+  // Resource Detection Processor  
   otelcol.processor.resourcedetection "default" {
     detectors = ["env", "system"]
     system {
@@ -154,8 +154,7 @@ declare "application_observability" {
     }
   }
 
-  // K8s Attribute Processor --> Transform Processor
-  // Resource Detection Processor Traces --> Host Info Connector  
+  // K8s Attributes Processor  
   otelcol.processor.k8sattributes "default" {
     extract {
       metadata = ["k8s.namespace.name","k8s.pod.name","k8s.deployment.name","k8s.statefulset.name","k8s.daemonset.name","k8s.cronjob.name","k8s.job.name","k8s.node.name","k8s.pod.uid","k8s.pod.start_time"]
@@ -172,7 +171,8 @@ declare "application_observability" {
       traces = [otelcol.processor.transform.default.input, otelcol.connector.host_info.default.input]
     }
   }
-  // Host Info Connector --> Batch Processor  
+
+  // Host Info Connector  
   otelcol.connector.host_info "default" {
     host_identifiers = [ "k8s.node.name" ]
   
@@ -181,8 +181,7 @@ declare "application_observability" {
     }
   }
 
-
-  // Transform Processor --> Batch Processor  
+  // Transform Processor  
   otelcol.processor.transform "default" {
     error_mode = "ignore"
     log_statements {
@@ -201,7 +200,7 @@ declare "application_observability" {
     }
   }
 
-  // Batch Processor --> Destinations  
+  // Batch Processor  
   otelcol.processor.batch "default" {
     send_batch_size = 16384
     send_batch_max_size = 0

--- a/charts/k8s-monitoring/docs/examples/proxies/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/proxies/output.yaml
@@ -1031,6 +1031,10 @@ data:
     
       // Batch Processor --> Destinations  
       otelcol.processor.batch "default" {
+        send_batch_size = 16384
+        send_batch_max_size = 0
+        timeout = "2s"
+      
         output {
           metrics = argument.metrics_destinations.value
           logs = argument.logs_destinations.value

--- a/charts/k8s-monitoring/docs/examples/proxies/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/proxies/output.yaml
@@ -957,7 +957,7 @@ data:
         comment = "Must be a list of trace destinations where collected trace should be forwarded to"
       }
     
-      // Receivers --> Resource Detection Processor      
+      // Zipkin Receiver  
       otelcol.receiver.zipkin "receiver" {
         endpoint = "0.0.0.0:9411"
         debug_metrics {
@@ -968,7 +968,7 @@ data:
         }
       }
     
-      // Resource Detection Processor --> K8s Attribute Processor  
+      // Resource Detection Processor  
       otelcol.processor.resourcedetection "default" {
         detectors = ["env", "system"]
         system {
@@ -982,8 +982,7 @@ data:
         }
       }
     
-      // K8s Attribute Processor --> Transform Processor
-      // Resource Detection Processor Traces --> Host Info Connector  
+      // K8s Attributes Processor  
       otelcol.processor.k8sattributes "default" {
         extract {
           metadata = ["k8s.namespace.name","k8s.pod.name","k8s.deployment.name","k8s.statefulset.name","k8s.daemonset.name","k8s.cronjob.name","k8s.job.name","k8s.node.name","k8s.pod.uid","k8s.pod.start_time"]
@@ -1000,7 +999,8 @@ data:
           traces = [otelcol.processor.transform.default.input, otelcol.connector.host_info.default.input]
         }
       }
-      // Host Info Connector --> Batch Processor  
+    
+      // Host Info Connector  
       otelcol.connector.host_info "default" {
         host_identifiers = [ "k8s.node.name" ]
       
@@ -1009,8 +1009,7 @@ data:
         }
       }
     
-    
-      // Transform Processor --> Batch Processor  
+      // Transform Processor  
       otelcol.processor.transform "default" {
         error_mode = "ignore"
         log_statements {
@@ -1029,7 +1028,7 @@ data:
         }
       }
     
-      // Batch Processor --> Destinations  
+      // Batch Processor  
       otelcol.processor.batch "default" {
         send_batch_size = 16384
         send_batch_max_size = 0

--- a/charts/k8s-monitoring/tests/integration/auto-instrumentation/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/integration/auto-instrumentation/.rendered/output.yaml
@@ -374,7 +374,7 @@ data:
         comment = "Must be a list of trace destinations where collected trace should be forwarded to"
       }
     
-      // Receivers --> Resource Detection Processor  
+      // OTLP Receiver  
       otelcol.receiver.otlp "receiver" {
         grpc {
           endpoint = "0.0.0.0:4317"
@@ -387,9 +387,9 @@ data:
           logs = [otelcol.processor.resourcedetection.default.input]
           traces = [otelcol.processor.resourcedetection.default.input]
         }
-      }    
+      }
     
-      // Resource Detection Processor --> K8s Attribute Processor  
+      // Resource Detection Processor  
       otelcol.processor.resourcedetection "default" {
         detectors = ["env", "system"]
         system {
@@ -403,8 +403,7 @@ data:
         }
       }
     
-      // K8s Attribute Processor --> Transform Processor
-      // Resource Detection Processor Traces --> Host Info Connector  
+      // K8s Attributes Processor  
       otelcol.processor.k8sattributes "default" {
         extract {
           metadata = ["k8s.namespace.name","k8s.pod.name","k8s.deployment.name","k8s.statefulset.name","k8s.daemonset.name","k8s.cronjob.name","k8s.job.name","k8s.node.name","k8s.pod.uid","k8s.pod.start_time"]
@@ -421,7 +420,8 @@ data:
           traces = [otelcol.processor.transform.default.input, otelcol.connector.host_info.default.input]
         }
       }
-      // Host Info Connector --> Batch Processor  
+    
+      // Host Info Connector  
       otelcol.connector.host_info "default" {
         host_identifiers = [ "k8s.node.name" ]
       
@@ -430,8 +430,7 @@ data:
         }
       }
     
-    
-      // Transform Processor --> Batch Processor  
+      // Transform Processor  
       otelcol.processor.transform "default" {
         error_mode = "ignore"
         log_statements {
@@ -450,7 +449,7 @@ data:
         }
       }
     
-      // Batch Processor --> Destinations  
+      // Batch Processor  
       otelcol.processor.batch "default" {
         send_batch_size = 16384
         send_batch_max_size = 0

--- a/charts/k8s-monitoring/tests/integration/auto-instrumentation/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/integration/auto-instrumentation/.rendered/output.yaml
@@ -452,6 +452,10 @@ data:
     
       // Batch Processor --> Destinations  
       otelcol.processor.batch "default" {
+        send_batch_size = 16384
+        send_batch_max_size = 0
+        timeout = "2s"
+      
         output {
           metrics = argument.metrics_destinations.value
           logs = argument.logs_destinations.value


### PR DESCRIPTION
This change adds the ability to use the following components to the AppO11y pipeline:
* interval processor
* spanlogs connector
* spanmetrics connector

It also moves the memory limiter to just after the receivers.

Finally, it also refactors how the pipeline is built, using a `pipeline.tpl` file. (this resulted in many components needing to change their `.metricsOutput` reference to `.metrics`, etc...)

Added unit tests to show how the pipeline changes when injecting the new components.