### PR TITLE
fix sigv4 rendering in Prometheus template for #1122

### DIFF
--- a/charts/k8s-monitoring/templates/destinations/_destination_prometheus.tpl
+++ b/charts/k8s-monitoring/templates/destinations/_destination_prometheus.tpl
@@ -88,7 +88,7 @@ prometheus.remote_write {{ include "helper.alloy_name" .name | quote }} {
       {{- if .auth.sigv4.roleArn }}
       role_arn = {{ .auth.sigv4.roleArn | quote }}
       {{- end }}
-      {{- if include "secrets.read" (dict "object" . "key" "auth.sigv4.secretKey") }}
+      {{- if eq (include "secrets.usesSecret" (dict "object" . "key" "auth.sigv4.secretKey")) "true" }}
       secret_key = {{ include "secrets.read" (dict "object" . "key" "auth.sigv4.secretKey") }}
       {{- end }}
     }

--- a/charts/k8s-monitoring/templates/destinations/_destination_prometheus.tpl
+++ b/charts/k8s-monitoring/templates/destinations/_destination_prometheus.tpl
@@ -76,7 +76,7 @@ prometheus.remote_write {{ include "helper.alloy_name" .name | quote }} {
     }
 {{- else if eq (include "secrets.authType" .) "sigv4" }}
     sigv4 {
-      {{- if include "secrets.read" (dict "object" . "key" "auth.sigv4.accessKey" "nonsensitive" true) }}
+      {{- if eq (include "secrets.usesSecret" (dict "object" . "key" "auth.sigv4.accessKey")) "true" }}
       access_key = {{ include "secrets.read" (dict "object" . "key" "auth.sigv4.accessKey" "nonsensitive" true) }}
       {{- end }}
       {{- if .auth.sigv4.profile }}

--- a/charts/k8s-monitoring/templates/destinations/_destination_prometheus.tpl
+++ b/charts/k8s-monitoring/templates/destinations/_destination_prometheus.tpl
@@ -76,7 +76,9 @@ prometheus.remote_write {{ include "helper.alloy_name" .name | quote }} {
     }
 {{- else if eq (include "secrets.authType" .) "sigv4" }}
     sigv4 {
+      {{- if include "secrets.read" (dict "object" . "key" "auth.sigv4.accessKey" "nonsensitive" true) }}
       access_key = {{ include "secrets.read" (dict "object" . "key" "auth.sigv4.accessKey" "nonsensitive" true) }}
+      {{- end }}
       {{- if .auth.sigv4.profile }}
       profile = {{ .auth.sigv4.profile | quote }}
       {{- end }}
@@ -86,9 +88,10 @@ prometheus.remote_write {{ include "helper.alloy_name" .name | quote }} {
       {{- if .auth.sigv4.roleArn }}
       role_arn = {{ .auth.sigv4.roleArn | quote }}
       {{- end }}
+      {{- if include "secrets.read" (dict "object" . "key" "auth.sigv4.secretKey") }}
       secret_key = {{ include "secrets.read" (dict "object" . "key" "auth.sigv4.secretKey") }}
+      {{- end }}
     }
-{{- end }}
 
 {{- if .tls }}
     tls_config {

--- a/charts/k8s-monitoring/templates/destinations/_destination_prometheus.tpl
+++ b/charts/k8s-monitoring/templates/destinations/_destination_prometheus.tpl
@@ -92,6 +92,7 @@ prometheus.remote_write {{ include "helper.alloy_name" .name | quote }} {
       secret_key = {{ include "secrets.read" (dict "object" . "key" "auth.sigv4.secretKey") }}
       {{- end }}
     }
+{{- end }}
 
 {{- if .tls }}
     tls_config {


### PR DESCRIPTION
fixup to remove access_key and secret_key rendering if they are not already defined in values.yaml.  Fixes #1122 