### PR TITLE
Actually use certFile and keyFile settings

### DIFF
--- a/charts/k8s-monitoring/templates/destinations/_destination_loki.tpl
+++ b/charts/k8s-monitoring/templates/destinations/_destination_loki.tpl
@@ -79,10 +79,14 @@ loki.write {{ include "helper.alloy_name" .name | quote }} {
       {{- else if eq (include "secrets.usesSecret" (dict "object" . "key" "tls.ca")) "true" }}
       ca_pem = {{ include "secrets.read" (dict "object" . "key" "tls.ca" "nonsensitive" true) }}
       {{- end }}
-      {{- if eq (include "secrets.usesSecret" (dict "object" . "key" "tls.cert")) "true" }}
+      {{- if .tls.certFile }}
+      cert_file = {{ .tls.certFile | quote }}
+      {{- else if eq (include "secrets.usesSecret" (dict "object" . "key" "tls.cert")) "true" }}
       cert_pem = {{ include "secrets.read" (dict "object" . "key" "tls.cert" "nonsensitive" true) }}
       {{- end }}
-      {{- if eq (include "secrets.usesSecret" (dict "object" . "key" "tls.key")) "true" }}
+      {{- if .tls.keyFile }}
+      key_file = {{ .tls.keyFile | quote }}
+      {{- else if eq (include "secrets.usesSecret" (dict "object" . "key" "tls.key")) "true" }}
       key_pem = {{ include "secrets.read" (dict "object" . "key" "tls.key") }}
       {{- end }}
     }

--- a/charts/k8s-monitoring/templates/destinations/_destination_otlp.tpl
+++ b/charts/k8s-monitoring/templates/destinations/_destination_otlp.tpl
@@ -304,10 +304,14 @@ otelcol.exporter.otlphttp {{ include "helper.alloy_name" .name | quote }} {
       {{- else if eq (include "secrets.usesSecret" (dict "object" . "key" "tls.ca")) "true" }}
       ca_pem = {{ include "secrets.read" (dict "object" . "key" "tls.ca" "nonsensitive" true) }}
       {{- end }}
-      {{- if eq (include "secrets.usesSecret" (dict "object" . "key" "tls.cert")) "true" }}
+      {{- if .tls.certFile }}
+      cert_file = {{ .tls.certFile | quote }}
+      {{- else if eq (include "secrets.usesSecret" (dict "object" . "key" "tls.cert")) "true" }}
       cert_pem = {{ include "secrets.read" (dict "object" . "key" "tls.cert" "nonsensitive" true) }}
       {{- end }}
-      {{- if eq (include "secrets.usesSecret" (dict "object" . "key" "tls.key")) "true" }}
+      {{- if .tls.keyFile }}
+      key_file = {{ .tls.keyFile | quote }}
+      {{- else if eq (include "secrets.usesSecret" (dict "object" . "key" "tls.key")) "true" }}
       key_pem = {{ include "secrets.read" (dict "object" . "key" "tls.key") }}
       {{- end }}
     }

--- a/charts/k8s-monitoring/templates/destinations/_destination_prometheus.tpl
+++ b/charts/k8s-monitoring/templates/destinations/_destination_prometheus.tpl
@@ -102,10 +102,14 @@ prometheus.remote_write {{ include "helper.alloy_name" .name | quote }} {
       {{- else if eq (include "secrets.usesSecret" (dict "object" . "key" "tls.ca")) "true" }}
       ca_pem = {{ include "secrets.read" (dict "object" . "key" "tls.ca" "nonsensitive" true) }}
       {{- end }}
-      {{- if eq (include "secrets.usesSecret" (dict "object" . "key" "tls.cert")) "true" }}
+      {{- if .tls.certFile }}
+      cert_file = {{ .tls.certFile | quote }}
+      {{- else if eq (include "secrets.usesSecret" (dict "object" . "key" "tls.cert")) "true" }}
       cert_pem = {{ include "secrets.read" (dict "object" . "key" "tls.cert" "nonsensitive" true) }}
       {{- end }}
-      {{- if eq (include "secrets.usesSecret" (dict "object" . "key" "tls.key")) "true" }}
+      {{- if .tls.keyFile }}
+      key_file = {{ .tls.keyFile | quote }}
+      {{- else if eq (include "secrets.usesSecret" (dict "object" . "key" "tls.key")) "true" }}
       key_pem = {{ include "secrets.read" (dict "object" . "key" "tls.key") }}
       {{- end }}
     }

--- a/charts/k8s-monitoring/templates/destinations/_destination_pyroscope.tpl
+++ b/charts/k8s-monitoring/templates/destinations/_destination_pyroscope.tpl
@@ -71,10 +71,14 @@ pyroscope.write {{ include "helper.alloy_name" .name | quote }} {
       {{- else if eq (include "secrets.usesSecret" (dict "object" . "key" "tls.ca")) "true" }}
       ca_pem = {{ include "secrets.read" (dict "object" . "key" "tls.ca" "nonsensitive" true) }}
       {{- end }}
-      {{- if eq (include "secrets.usesSecret" (dict "object" . "key" "tls.cert")) "true" }}
+      {{- if .tls.certFile }}
+      cert_file = {{ .tls.certFile | quote }}
+      {{- else if eq (include "secrets.usesSecret" (dict "object" . "key" "tls.cert")) "true" }}
       cert_pem = {{ include "secrets.read" (dict "object" . "key" "tls.cert" "nonsensitive" true) }}
       {{- end }}
-      {{- if eq (include "secrets.usesSecret" (dict "object" . "key" "tls.key")) "true" }}
+      {{- if .tls.keyFile }}
+      key_file = {{ .tls.keyFile | quote }}
+      {{- else if eq (include "secrets.usesSecret" (dict "object" . "key" "tls.key")) "true" }}
       key_pem = {{ include "secrets.read" (dict "object" . "key" "tls.key") }}
       {{- end }}
     }


### PR DESCRIPTION
Just like `caFile`, if these are provided, it'll use them instead of trying to find them in the secret.