### PR TITLE
Extend Beyla configuration example

### DIFF
--- a/charts/k8s-monitoring-v1/docs/examples/beyla/README.md
+++ b/charts/k8s-monitoring-v1/docs/examples/beyla/README.md
@@ -35,4 +35,13 @@ traces:
 
 beyla:
   enabled: true
+  # Check Beyla Helm chart documentation in https://github.com/grafana/beyla/blob/main/charts/beyla/README.md
+  image:
+    tag: latest
+  config:
+    data:
+      # Check Beyla configuration file format in https://grafana.com/docs/beyla/latest/configure/
+      discovery:
+        services:
+          k8s_deployment_name: .*-prod
 ```


### PR DESCRIPTION
Users often don't know where to extend/override the Beyla configuration. Extending the example with a placeholder example.