### PR TITLE
set service_name label for podLogs

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,3 +2,4 @@ charts/**/docs/examples/** linguist-generated=true
 charts/**/docs/examples/README.md linguist-generated=false
 charts/**/docs/examples/**/README.md linguist-generated=false
 charts/**/docs/examples/**/values.yaml linguist-generated=false
+charts/k8s-monitoring/tests/**/.rendered/output.yaml linguist-generated=true

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -119,11 +119,11 @@ jobs:
           if [ "${{ matrix.dir }}" == "k8s-monitoring" ]; then
             # Skip checking subchart files for k8s-monitoring, which are always modified, even if the contents are identical
             if ! git diff --exit-code -- ':!charts/*.tgz'; then
-              echo "Generated files in charts/${{ matrix.dir }} are not up to date. Please run 'make all' and commit the changes."
+              echo "Generated files in charts/${{ matrix.dir }} are not up to date. Please run 'make build' and commit the changes."
               exit 1
             fi
           elif ! git diff --exit-code .; then
-            echo "Generated files in charts/${{ matrix.dir }} are not up to date. Please run 'make all' and commit the changes."
+            echo "Generated files in charts/${{ matrix.dir }} are not up to date. Please run 'make build' and commit the changes."
             exit 1
           else
             echo "Generated files in charts/${{ matrix.dir }} are up to date."

--- a/charts/k8s-monitoring/charts/feature-pod-logs/README.md
+++ b/charts/k8s-monitoring/charts/feature-pod-logs/README.md
@@ -43,7 +43,7 @@ Be sure perform actual integration testing in a live environment in the main [k8
 | annotations | object | `{"job":"k8s.grafana.com/logs.job"}` | Log labels to set with values copied from the Kubernetes Pod annotations. Format: `<log_label>: <kubernetes_annotation>`. |
 | extraLogProcessingStages | string | `""` | Stage blocks to be added to the loki.process component for pod logs. ([docs](https://grafana.com/docs/alloy/latest/reference/components/loki/loki.process/#blocks)) This value is templated so that you can refer to other values from this file. |
 | labels | object | `{"app_kubernetes_io_name":"app.kubernetes.io/name"}` | Log labels to set with values copied from the Kubernetes Pod labels. Format: `<log_label>: <kubernetes_label>`. |
-| labelsToKeep | list | `["app_kubernetes_io_name","container","instance","job","level","namespace","pod","service_name"]` | The list of labels to keep on the logs, all other pipeline labels will be dropped. |
+| labelsToKeep | list | `["app_kubernetes_io_name","container","instance","job","level","namespace","pod","service_name","service_namespace","deployment_environment","deployment_environment_name"]` | The list of labels to keep on the logs, all other pipeline labels will be dropped. |
 | staticLabels | object | `{}` | Log labels to set with static values. |
 | staticLabelsFrom | object | `{}` | Log labels to set with static values, not quoted so it can reference config components. |
 

--- a/charts/k8s-monitoring/charts/feature-pod-logs/templates/_common_pod_discovery.alloy.tpl
+++ b/charts/k8s-monitoring/charts/feature-pod-logs/templates/_common_pod_discovery.alloy.tpl
@@ -61,6 +61,28 @@ discovery.relabel "filtered_pods" {
     regex = "__meta_kubernetes_pod_annotation_(.+)"
   }
 
+  // explicitly set service_name. if not set, loki will automatically try to populate a default.
+  // see https://grafana.com/docs/loki/latest/get-started/labels/#default-labels-for-all-users
+  //
+  // choose the first value found from the following ordered list:
+  // - pod.annotation[resource.opentelemetry.io/service.name]
+  // - pod.label[app.kubernetes.io/name]
+  // - k8s.pod.name
+  // - k8s.container.name
+  rule {
+    action = "replace"
+    source_labels = [
+      "__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_name",
+      "__meta_kubernetes_pod_label_app_kubernetes_io_name",
+      "__meta_kubernetes_pod_name",
+      "__meta_kubernetes_pod_container_name",
+    ]
+    separator = ";"
+    regex = "^(?:;*)?([^;]+).*$"
+    replacement = "$1"
+    target_label = "service_name"
+  }
+
 {{- if .Values.extraDiscoveryRules }}
 {{ .Values.extraDiscoveryRules | indent 2 }}
 {{- end }}

--- a/charts/k8s-monitoring/charts/feature-pod-logs/templates/_common_pod_discovery.alloy.tpl
+++ b/charts/k8s-monitoring/charts/feature-pod-logs/templates/_common_pod_discovery.alloy.tpl
@@ -83,6 +83,26 @@ discovery.relabel "filtered_pods" {
     target_label = "service_name"
   }
 
+  // set service_namespace
+  rule {
+    action = "replace"
+    source_labels = ["__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_namespace"]
+    target_label = "service_namespace"
+  }
+
+  // set deployment_environment and deployment_environment_name
+  rule {
+    action = "replace"
+    source_labels = ["__meta_kubernetes_pod_annotation_resource_opentelemetry_io_deployment_environment_name"]
+    target_label = "deployment_environment_name"
+  }
+  rule {
+    action = "replace"
+    source_labels = ["__meta_kubernetes_pod_annotation_resource_opentelemetry_io_deployment_environment"]
+    target_label = "deployment_environment"
+  }
+
+
 {{- if .Values.extraDiscoveryRules }}
 {{ .Values.extraDiscoveryRules | indent 2 }}
 {{- end }}

--- a/charts/k8s-monitoring/charts/feature-pod-logs/tests/default_test.yaml
+++ b/charts/k8s-monitoring/charts/feature-pod-logs/tests/default_test.yaml
@@ -95,6 +95,25 @@ tests:
                 }
               }
 
+              // set service_namespace
+              rule {
+                action = "replace"
+                source_labels = ["__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_namespace"]
+                target_label = "service_namespace"
+              }
+            
+              // set deployment_environment and deployment_environment_name
+              rule {
+                action = "replace"
+                source_labels = ["__meta_kubernetes_pod_annotation_resource_opentelemetry_io_deployment_environment_name"]
+                target_label = "deployment_environment_name"
+              }
+              rule {
+                action = "replace"
+                source_labels = ["__meta_kubernetes_pod_annotation_resource_opentelemetry_io_deployment_environment"]
+                target_label = "deployment_environment"
+              }
+
               discovery.kubernetes "pods" {
                 role = "pod"
                 selectors {
@@ -268,6 +287,25 @@ tests:
                 }
               }
 
+              // set service_namespace
+              rule {
+                action = "replace"
+                source_labels = ["__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_namespace"]
+                target_label = "service_namespace"
+              }
+            
+              // set deployment_environment and deployment_environment_name
+              rule {
+                action = "replace"
+                source_labels = ["__meta_kubernetes_pod_annotation_resource_opentelemetry_io_deployment_environment_name"]
+                target_label = "deployment_environment_name"
+              }
+              rule {
+                action = "replace"
+                source_labels = ["__meta_kubernetes_pod_annotation_resource_opentelemetry_io_deployment_environment"]
+                target_label = "deployment_environment"
+              }
+
               discovery.kubernetes "pods" {
                 role = "pod"
                 selectors {
@@ -437,6 +475,25 @@ tests:
                   replacement = "$1"
                   target_label = "service_name"
                 }
+              }
+
+              // set service_namespace
+              rule {
+                action = "replace"
+                source_labels = ["__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_namespace"]
+                target_label = "service_namespace"
+              }
+            
+              // set deployment_environment and deployment_environment_name
+              rule {
+                action = "replace"
+                source_labels = ["__meta_kubernetes_pod_annotation_resource_opentelemetry_io_deployment_environment_name"]
+                target_label = "deployment_environment_name"
+              }
+              rule {
+                action = "replace"
+                source_labels = ["__meta_kubernetes_pod_annotation_resource_opentelemetry_io_deployment_environment"]
+                target_label = "deployment_environment"
               }
 
               discovery.kubernetes "pods" {
@@ -616,6 +673,25 @@ tests:
                   replacement = "$1"
                   target_label = "service_name"
                 }
+              }
+
+              // set service_namespace
+              rule {
+                action = "replace"
+                source_labels = ["__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_namespace"]
+                target_label = "service_namespace"
+              }
+            
+              // set deployment_environment and deployment_environment_name
+              rule {
+                action = "replace"
+                source_labels = ["__meta_kubernetes_pod_annotation_resource_opentelemetry_io_deployment_environment_name"]
+                target_label = "deployment_environment_name"
+              }
+              rule {
+                action = "replace"
+                source_labels = ["__meta_kubernetes_pod_annotation_resource_opentelemetry_io_deployment_environment"]
+                target_label = "deployment_environment"
               }
 
               discovery.kubernetes "pods" {

--- a/charts/k8s-monitoring/charts/feature-pod-logs/tests/default_test.yaml
+++ b/charts/k8s-monitoring/charts/feature-pod-logs/tests/default_test.yaml
@@ -71,6 +71,28 @@ tests:
                   action = "labelmap"
                   regex = "__meta_kubernetes_pod_annotation_(.+)"
                 }
+
+                // explicitly set service_name. if not set, loki will automatically try to populate a default.
+                // see https://grafana.com/docs/loki/latest/get-started/labels/#default-labels-for-all-users
+                //
+                // choose the first value found from the following ordered list:
+                // - pod.annotation[resource.opentelemetry.io/service.name]
+                // - pod.label[app.kubernetes.io/name]
+                // - k8s.pod.name
+                // - k8s.container.name
+                rule {
+                  action = "replace"
+                  source_labels = [
+                    "__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_name",
+                    "__meta_kubernetes_pod_label_app_kubernetes_io_name",
+                    "__meta_kubernetes_pod_name",
+                    "__meta_kubernetes_pod_container_name",
+                  ]
+                  separator = ";"
+                  regex = "^(?:;*)?([^;]+).*$"
+                  replacement = "$1"
+                  target_label = "service_name"
+                }
               }
 
               discovery.kubernetes "pods" {
@@ -222,6 +244,28 @@ tests:
                   action = "labelmap"
                   regex = "__meta_kubernetes_pod_annotation_(.+)"
                 }
+
+                // explicitly set service_name. if not set, loki will automatically try to populate a default.
+                // see https://grafana.com/docs/loki/latest/get-started/labels/#default-labels-for-all-users
+                //
+                // choose the first value found from the following ordered list:
+                // - pod.annotation[resource.opentelemetry.io/service.name]
+                // - pod.label[app.kubernetes.io/name]
+                // - k8s.pod.name
+                // - k8s.container.name
+                rule {
+                  action = "replace"
+                  source_labels = [
+                    "__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_name",
+                    "__meta_kubernetes_pod_label_app_kubernetes_io_name",
+                    "__meta_kubernetes_pod_name",
+                    "__meta_kubernetes_pod_container_name",
+                  ]
+                  separator = ";"
+                  regex = "^(?:;*)?([^;]+).*$"
+                  replacement = "$1"
+                  target_label = "service_name"
+                }
               }
 
               discovery.kubernetes "pods" {
@@ -370,6 +414,28 @@ tests:
                 rule {
                   action = "labelmap"
                   regex = "__meta_kubernetes_pod_annotation_(.+)"
+                }
+
+                // explicitly set service_name. if not set, loki will automatically try to populate a default.
+                // see https://grafana.com/docs/loki/latest/get-started/labels/#default-labels-for-all-users
+                //
+                // choose the first value found from the following ordered list:
+                // - pod.annotation[resource.opentelemetry.io/service.name]
+                // - pod.label[app.kubernetes.io/name]
+                // - k8s.pod.name
+                // - k8s.container.name
+                rule {
+                  action = "replace"
+                  source_labels = [
+                    "__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_name",
+                    "__meta_kubernetes_pod_label_app_kubernetes_io_name",
+                    "__meta_kubernetes_pod_name",
+                    "__meta_kubernetes_pod_container_name",
+                  ]
+                  separator = ";"
+                  regex = "^(?:;*)?([^;]+).*$"
+                  replacement = "$1"
+                  target_label = "service_name"
                 }
               }
 
@@ -527,6 +593,28 @@ tests:
                 rule {
                   action = "labelmap"
                   regex = "__meta_kubernetes_pod_annotation_(.+)"
+                }
+
+                // explicitly set service_name. if not set, loki will automatically try to populate a default.
+                // see https://grafana.com/docs/loki/latest/get-started/labels/#default-labels-for-all-users
+                //
+                // choose the first value found from the following ordered list:
+                // - pod.annotation[resource.opentelemetry.io/service.name]
+                // - pod.label[app.kubernetes.io/name]
+                // - k8s.pod.name
+                // - k8s.container.name
+                rule {
+                  action = "replace"
+                  source_labels = [
+                    "__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_name",
+                    "__meta_kubernetes_pod_label_app_kubernetes_io_name",
+                    "__meta_kubernetes_pod_name",
+                    "__meta_kubernetes_pod_container_name",
+                  ]
+                  separator = ";"
+                  regex = "^(?:;*)?([^;]+).*$"
+                  replacement = "$1"
+                  target_label = "service_name"
                 }
               }
 

--- a/charts/k8s-monitoring/charts/feature-pod-logs/tests/default_test.yaml
+++ b/charts/k8s-monitoring/charts/feature-pod-logs/tests/default_test.yaml
@@ -93,25 +93,25 @@ tests:
                   replacement = "$1"
                   target_label = "service_name"
                 }
-              }
 
-              // set service_namespace
-              rule {
-                action = "replace"
-                source_labels = ["__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_namespace"]
-                target_label = "service_namespace"
-              }
+                // set service_namespace
+                rule {
+                  action = "replace"
+                  source_labels = ["__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_namespace"]
+                  target_label = "service_namespace"
+                }
             
-              // set deployment_environment and deployment_environment_name
-              rule {
-                action = "replace"
-                source_labels = ["__meta_kubernetes_pod_annotation_resource_opentelemetry_io_deployment_environment_name"]
-                target_label = "deployment_environment_name"
-              }
-              rule {
-                action = "replace"
-                source_labels = ["__meta_kubernetes_pod_annotation_resource_opentelemetry_io_deployment_environment"]
-                target_label = "deployment_environment"
+                // set deployment_environment and deployment_environment_name
+                rule {
+                  action = "replace"
+                  source_labels = ["__meta_kubernetes_pod_annotation_resource_opentelemetry_io_deployment_environment_name"]
+                  target_label = "deployment_environment_name"
+                }
+                rule {
+                  action = "replace"
+                  source_labels = ["__meta_kubernetes_pod_annotation_resource_opentelemetry_io_deployment_environment"]
+                  target_label = "deployment_environment"
+                }
               }
 
               discovery.kubernetes "pods" {
@@ -183,7 +183,7 @@ tests:
 
                 // Only keep the labels that are defined in the `keepLabels` list.
                 stage.label_keep {
-                  values = ["app_kubernetes_io_name","container","instance","job","level","namespace","pod","service_name","integration"]
+                  values = ["app_kubernetes_io_name","container","instance","job","level","namespace","pod","service_name","service_namespace","deployment_environment","deployment_environment_name","integration"]
                 }
 
                 forward_to = argument.logs_destinations.value
@@ -285,25 +285,25 @@ tests:
                   replacement = "$1"
                   target_label = "service_name"
                 }
-              }
 
-              // set service_namespace
-              rule {
-                action = "replace"
-                source_labels = ["__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_namespace"]
-                target_label = "service_namespace"
-              }
-            
-              // set deployment_environment and deployment_environment_name
-              rule {
-                action = "replace"
-                source_labels = ["__meta_kubernetes_pod_annotation_resource_opentelemetry_io_deployment_environment_name"]
-                target_label = "deployment_environment_name"
-              }
-              rule {
-                action = "replace"
-                source_labels = ["__meta_kubernetes_pod_annotation_resource_opentelemetry_io_deployment_environment"]
-                target_label = "deployment_environment"
+                // set service_namespace
+                rule {
+                  action = "replace"
+                  source_labels = ["__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_namespace"]
+                  target_label = "service_namespace"
+                }
+              
+                // set deployment_environment and deployment_environment_name
+                rule {
+                  action = "replace"
+                  source_labels = ["__meta_kubernetes_pod_annotation_resource_opentelemetry_io_deployment_environment_name"]
+                  target_label = "deployment_environment_name"
+                }
+                rule {
+                  action = "replace"
+                  source_labels = ["__meta_kubernetes_pod_annotation_resource_opentelemetry_io_deployment_environment"]
+                  target_label = "deployment_environment"
+                }
               }
 
               discovery.kubernetes "pods" {
@@ -375,7 +375,7 @@ tests:
 
                 // Only keep the labels that are defined in the `keepLabels` list.
                 stage.label_keep {
-                  values = ["k8s_container_name","k8s_namespace","k8s_pod_name","k8s_pod_label_app_kubernetes_io_name","integration"]
+                  values = ["app_kubernetes_io_name","container","instance","job","level","namespace","pod","service_name","service_namespace","deployment_environment","deployment_environment_name","integration"]
                 }
 
                 forward_to = argument.logs_destinations.value
@@ -475,25 +475,25 @@ tests:
                   replacement = "$1"
                   target_label = "service_name"
                 }
-              }
 
-              // set service_namespace
-              rule {
-                action = "replace"
-                source_labels = ["__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_namespace"]
-                target_label = "service_namespace"
-              }
+                // set service_namespace
+                rule {
+                  action = "replace"
+                  source_labels = ["__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_namespace"]
+                  target_label = "service_namespace"
+                }
             
-              // set deployment_environment and deployment_environment_name
-              rule {
-                action = "replace"
-                source_labels = ["__meta_kubernetes_pod_annotation_resource_opentelemetry_io_deployment_environment_name"]
-                target_label = "deployment_environment_name"
-              }
-              rule {
-                action = "replace"
-                source_labels = ["__meta_kubernetes_pod_annotation_resource_opentelemetry_io_deployment_environment"]
-                target_label = "deployment_environment"
+                // set deployment_environment and deployment_environment_name
+                rule {
+                  action = "replace"
+                  source_labels = ["__meta_kubernetes_pod_annotation_resource_opentelemetry_io_deployment_environment_name"]
+                  target_label = "deployment_environment_name"
+                }
+                rule {
+                  action = "replace"
+                  source_labels = ["__meta_kubernetes_pod_annotation_resource_opentelemetry_io_deployment_environment"]
+                  target_label = "deployment_environment"
+                }
               }
 
               discovery.kubernetes "pods" {
@@ -572,7 +572,7 @@ tests:
 
                 // Only keep the labels that are defined in the `keepLabels` list.
                 stage.label_keep {
-                  values = ["app_kubernetes_io_name","container","instance","job","level","namespace","pod","service_name","integration"]
+                  values = ["app_kubernetes_io_name","container","instance","job","level","namespace","pod","service_name","service_namespace","deployment_environment","deployment_environment_name","integration"]
                 }
 
                 forward_to = argument.logs_destinations.value
@@ -673,25 +673,25 @@ tests:
                   replacement = "$1"
                   target_label = "service_name"
                 }
-              }
 
-              // set service_namespace
-              rule {
-                action = "replace"
-                source_labels = ["__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_namespace"]
-                target_label = "service_namespace"
-              }
+                // set service_namespace
+                rule {
+                  action = "replace"
+                  source_labels = ["__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_namespace"]
+                  target_label = "service_namespace"
+                }
             
-              // set deployment_environment and deployment_environment_name
-              rule {
-                action = "replace"
-                source_labels = ["__meta_kubernetes_pod_annotation_resource_opentelemetry_io_deployment_environment_name"]
-                target_label = "deployment_environment_name"
-              }
-              rule {
-                action = "replace"
-                source_labels = ["__meta_kubernetes_pod_annotation_resource_opentelemetry_io_deployment_environment"]
-                target_label = "deployment_environment"
+                // set deployment_environment and deployment_environment_name
+                rule {
+                  action = "replace"
+                  source_labels = ["__meta_kubernetes_pod_annotation_resource_opentelemetry_io_deployment_environment_name"]
+                  target_label = "deployment_environment_name"
+                }
+                rule {
+                  action = "replace"
+                  source_labels = ["__meta_kubernetes_pod_annotation_resource_opentelemetry_io_deployment_environment"]
+                  target_label = "deployment_environment"
+                }
               }
 
               discovery.kubernetes "pods" {
@@ -770,7 +770,7 @@ tests:
 
                 // Only keep the labels that are defined in the `keepLabels` list.
                 stage.label_keep {
-                  values = ["app_kubernetes_io_name","container","instance","job","level","namespace","pod","service_name","integration"]
+                  values = ["app_kubernetes_io_name","container","instance","job","level","namespace","pod","service_name","service_namespace","deployment_environment","deployment_environment_name","integration"]
                 }
 
                 forward_to = argument.logs_destinations.value

--- a/charts/k8s-monitoring/charts/feature-pod-logs/tests/default_test.yaml
+++ b/charts/k8s-monitoring/charts/feature-pod-logs/tests/default_test.yaml
@@ -100,7 +100,7 @@ tests:
                   source_labels = ["__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_namespace"]
                   target_label = "service_namespace"
                 }
-            
+
                 // set deployment_environment and deployment_environment_name
                 rule {
                   action = "replace"
@@ -292,7 +292,7 @@ tests:
                   source_labels = ["__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_namespace"]
                   target_label = "service_namespace"
                 }
-              
+
                 // set deployment_environment and deployment_environment_name
                 rule {
                   action = "replace"
@@ -375,7 +375,7 @@ tests:
 
                 // Only keep the labels that are defined in the `keepLabels` list.
                 stage.label_keep {
-                  values = ["app_kubernetes_io_name","container","instance","job","level","namespace","pod","service_name","service_namespace","deployment_environment","deployment_environment_name","integration"]
+                  values = ["k8s_container_name","k8s_namespace","k8s_pod_name","k8s_pod_label_app_kubernetes_io_name","integration"]
                 }
 
                 forward_to = argument.logs_destinations.value
@@ -482,7 +482,7 @@ tests:
                   source_labels = ["__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_namespace"]
                   target_label = "service_namespace"
                 }
-            
+
                 // set deployment_environment and deployment_environment_name
                 rule {
                   action = "replace"
@@ -680,7 +680,7 @@ tests:
                   source_labels = ["__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_namespace"]
                   target_label = "service_namespace"
                 }
-            
+
                 // set deployment_environment and deployment_environment_name
                 rule {
                   action = "replace"

--- a/charts/k8s-monitoring/charts/feature-pod-logs/values.yaml
+++ b/charts/k8s-monitoring/charts/feature-pod-logs/values.yaml
@@ -71,6 +71,9 @@ labelsToKeep:
   - namespace
   - pod
   - service_name
+  - service_namespace
+  - deployment_environment
+  - deployment_environment_name
 
 # -- The structured metadata mappings to set.
 # To not set any structured metadata, set this to an empty object (e.g. `{}`)

--- a/charts/k8s-monitoring/docs/examples/auth/bearer-token/alloy-logs.alloy
+++ b/charts/k8s-monitoring/docs/examples/auth/bearer-token/alloy-logs.alloy
@@ -77,6 +77,28 @@ declare "pod_logs" {
       action = "labelmap"
       regex = "__meta_kubernetes_pod_annotation_(.+)"
     }
+  
+    // explicitly set service_name. if not set, loki will automatically try to populate a default.
+    // see https://grafana.com/docs/loki/latest/get-started/labels/#default-labels-for-all-users
+    //
+    // choose the first value found from the following ordered list:
+    // - pod.annotation[resource.opentelemetry.io/service.name]
+    // - pod.label[app.kubernetes.io/name]
+    // - k8s.pod.name
+    // - k8s.container.name
+    rule {
+      action = "replace"
+      source_labels = [
+        "__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_name",
+        "__meta_kubernetes_pod_label_app_kubernetes_io_name",
+        "__meta_kubernetes_pod_name",
+        "__meta_kubernetes_pod_container_name",
+      ]
+      separator = ";"
+      regex = "^(?:;*)?([^;]+).*$"
+      replacement = "$1"
+      target_label = "service_name"
+    }
   }
   
   discovery.kubernetes "pods" {

--- a/charts/k8s-monitoring/docs/examples/auth/bearer-token/alloy-logs.alloy
+++ b/charts/k8s-monitoring/docs/examples/auth/bearer-token/alloy-logs.alloy
@@ -99,6 +99,25 @@ declare "pod_logs" {
       replacement = "$1"
       target_label = "service_name"
     }
+  
+    // set service_namespace
+    rule {
+      action = "replace"
+      source_labels = ["__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_namespace"]
+      target_label = "service_namespace"
+    }
+  
+    // set deployment_environment and deployment_environment_name
+    rule {
+      action = "replace"
+      source_labels = ["__meta_kubernetes_pod_annotation_resource_opentelemetry_io_deployment_environment_name"]
+      target_label = "deployment_environment_name"
+    }
+    rule {
+      action = "replace"
+      source_labels = ["__meta_kubernetes_pod_annotation_resource_opentelemetry_io_deployment_environment"]
+      target_label = "deployment_environment"
+    }
   }
   
   discovery.kubernetes "pods" {
@@ -170,7 +189,7 @@ declare "pod_logs" {
   
     // Only keep the labels that are defined in the `keepLabels` list.
     stage.label_keep {
-      values = ["app_kubernetes_io_name","container","instance","job","level","namespace","pod","service_name","integration"]
+      values = ["app_kubernetes_io_name","container","instance","job","level","namespace","pod","service_name","service_namespace","deployment_environment","deployment_environment_name","integration"]
     }
   
     forward_to = argument.logs_destinations.value

--- a/charts/k8s-monitoring/docs/examples/auth/bearer-token/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/auth/bearer-token/output.yaml
@@ -308,6 +308,28 @@ data:
           action = "labelmap"
           regex = "__meta_kubernetes_pod_annotation_(.+)"
         }
+      
+        // explicitly set service_name. if not set, loki will automatically try to populate a default.
+        // see https://grafana.com/docs/loki/latest/get-started/labels/#default-labels-for-all-users
+        //
+        // choose the first value found from the following ordered list:
+        // - pod.annotation[resource.opentelemetry.io/service.name]
+        // - pod.label[app.kubernetes.io/name]
+        // - k8s.pod.name
+        // - k8s.container.name
+        rule {
+          action = "replace"
+          source_labels = [
+            "__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_name",
+            "__meta_kubernetes_pod_label_app_kubernetes_io_name",
+            "__meta_kubernetes_pod_name",
+            "__meta_kubernetes_pod_container_name",
+          ]
+          separator = ";"
+          regex = "^(?:;*)?([^;]+).*$"
+          replacement = "$1"
+          target_label = "service_name"
+        }
       }
       
       discovery.kubernetes "pods" {

--- a/charts/k8s-monitoring/docs/examples/auth/bearer-token/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/auth/bearer-token/output.yaml
@@ -330,6 +330,25 @@ data:
           replacement = "$1"
           target_label = "service_name"
         }
+      
+        // set service_namespace
+        rule {
+          action = "replace"
+          source_labels = ["__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_namespace"]
+          target_label = "service_namespace"
+        }
+      
+        // set deployment_environment and deployment_environment_name
+        rule {
+          action = "replace"
+          source_labels = ["__meta_kubernetes_pod_annotation_resource_opentelemetry_io_deployment_environment_name"]
+          target_label = "deployment_environment_name"
+        }
+        rule {
+          action = "replace"
+          source_labels = ["__meta_kubernetes_pod_annotation_resource_opentelemetry_io_deployment_environment"]
+          target_label = "deployment_environment"
+        }
       }
       
       discovery.kubernetes "pods" {
@@ -401,7 +420,7 @@ data:
       
         // Only keep the labels that are defined in the `keepLabels` list.
         stage.label_keep {
-          values = ["app_kubernetes_io_name","container","instance","job","level","namespace","pod","service_name","integration"]
+          values = ["app_kubernetes_io_name","container","instance","job","level","namespace","pod","service_name","service_namespace","deployment_environment","deployment_environment_name","integration"]
         }
       
         forward_to = argument.logs_destinations.value

--- a/charts/k8s-monitoring/docs/examples/auth/embedded-secrets/alloy-logs.alloy
+++ b/charts/k8s-monitoring/docs/examples/auth/embedded-secrets/alloy-logs.alloy
@@ -77,6 +77,28 @@ declare "pod_logs" {
       action = "labelmap"
       regex = "__meta_kubernetes_pod_annotation_(.+)"
     }
+  
+    // explicitly set service_name. if not set, loki will automatically try to populate a default.
+    // see https://grafana.com/docs/loki/latest/get-started/labels/#default-labels-for-all-users
+    //
+    // choose the first value found from the following ordered list:
+    // - pod.annotation[resource.opentelemetry.io/service.name]
+    // - pod.label[app.kubernetes.io/name]
+    // - k8s.pod.name
+    // - k8s.container.name
+    rule {
+      action = "replace"
+      source_labels = [
+        "__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_name",
+        "__meta_kubernetes_pod_label_app_kubernetes_io_name",
+        "__meta_kubernetes_pod_name",
+        "__meta_kubernetes_pod_container_name",
+      ]
+      separator = ";"
+      regex = "^(?:;*)?([^;]+).*$"
+      replacement = "$1"
+      target_label = "service_name"
+    }
   }
   
   discovery.kubernetes "pods" {

--- a/charts/k8s-monitoring/docs/examples/auth/embedded-secrets/alloy-logs.alloy
+++ b/charts/k8s-monitoring/docs/examples/auth/embedded-secrets/alloy-logs.alloy
@@ -99,6 +99,25 @@ declare "pod_logs" {
       replacement = "$1"
       target_label = "service_name"
     }
+  
+    // set service_namespace
+    rule {
+      action = "replace"
+      source_labels = ["__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_namespace"]
+      target_label = "service_namespace"
+    }
+  
+    // set deployment_environment and deployment_environment_name
+    rule {
+      action = "replace"
+      source_labels = ["__meta_kubernetes_pod_annotation_resource_opentelemetry_io_deployment_environment_name"]
+      target_label = "deployment_environment_name"
+    }
+    rule {
+      action = "replace"
+      source_labels = ["__meta_kubernetes_pod_annotation_resource_opentelemetry_io_deployment_environment"]
+      target_label = "deployment_environment"
+    }
   }
   
   discovery.kubernetes "pods" {
@@ -170,7 +189,7 @@ declare "pod_logs" {
   
     // Only keep the labels that are defined in the `keepLabels` list.
     stage.label_keep {
-      values = ["app_kubernetes_io_name","container","instance","job","level","namespace","pod","service_name","integration"]
+      values = ["app_kubernetes_io_name","container","instance","job","level","namespace","pod","service_name","service_namespace","deployment_environment","deployment_environment_name","integration"]
     }
   
     forward_to = argument.logs_destinations.value

--- a/charts/k8s-monitoring/docs/examples/auth/embedded-secrets/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/auth/embedded-secrets/output.yaml
@@ -297,6 +297,28 @@ data:
           action = "labelmap"
           regex = "__meta_kubernetes_pod_annotation_(.+)"
         }
+      
+        // explicitly set service_name. if not set, loki will automatically try to populate a default.
+        // see https://grafana.com/docs/loki/latest/get-started/labels/#default-labels-for-all-users
+        //
+        // choose the first value found from the following ordered list:
+        // - pod.annotation[resource.opentelemetry.io/service.name]
+        // - pod.label[app.kubernetes.io/name]
+        // - k8s.pod.name
+        // - k8s.container.name
+        rule {
+          action = "replace"
+          source_labels = [
+            "__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_name",
+            "__meta_kubernetes_pod_label_app_kubernetes_io_name",
+            "__meta_kubernetes_pod_name",
+            "__meta_kubernetes_pod_container_name",
+          ]
+          separator = ";"
+          regex = "^(?:;*)?([^;]+).*$"
+          replacement = "$1"
+          target_label = "service_name"
+        }
       }
       
       discovery.kubernetes "pods" {

--- a/charts/k8s-monitoring/docs/examples/auth/embedded-secrets/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/auth/embedded-secrets/output.yaml
@@ -319,6 +319,25 @@ data:
           replacement = "$1"
           target_label = "service_name"
         }
+      
+        // set service_namespace
+        rule {
+          action = "replace"
+          source_labels = ["__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_namespace"]
+          target_label = "service_namespace"
+        }
+      
+        // set deployment_environment and deployment_environment_name
+        rule {
+          action = "replace"
+          source_labels = ["__meta_kubernetes_pod_annotation_resource_opentelemetry_io_deployment_environment_name"]
+          target_label = "deployment_environment_name"
+        }
+        rule {
+          action = "replace"
+          source_labels = ["__meta_kubernetes_pod_annotation_resource_opentelemetry_io_deployment_environment"]
+          target_label = "deployment_environment"
+        }
       }
       
       discovery.kubernetes "pods" {
@@ -390,7 +409,7 @@ data:
       
         // Only keep the labels that are defined in the `keepLabels` list.
         stage.label_keep {
-          values = ["app_kubernetes_io_name","container","instance","job","level","namespace","pod","service_name","integration"]
+          values = ["app_kubernetes_io_name","container","instance","job","level","namespace","pod","service_name","service_namespace","deployment_environment","deployment_environment_name","integration"]
         }
       
         forward_to = argument.logs_destinations.value

--- a/charts/k8s-monitoring/docs/examples/auth/external-secrets/alloy-logs.alloy
+++ b/charts/k8s-monitoring/docs/examples/auth/external-secrets/alloy-logs.alloy
@@ -89,6 +89,28 @@ declare "pod_logs" {
       action = "labelmap"
       regex = "__meta_kubernetes_pod_annotation_(.+)"
     }
+  
+    // explicitly set service_name. if not set, loki will automatically try to populate a default.
+    // see https://grafana.com/docs/loki/latest/get-started/labels/#default-labels-for-all-users
+    //
+    // choose the first value found from the following ordered list:
+    // - pod.annotation[resource.opentelemetry.io/service.name]
+    // - pod.label[app.kubernetes.io/name]
+    // - k8s.pod.name
+    // - k8s.container.name
+    rule {
+      action = "replace"
+      source_labels = [
+        "__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_name",
+        "__meta_kubernetes_pod_label_app_kubernetes_io_name",
+        "__meta_kubernetes_pod_name",
+        "__meta_kubernetes_pod_container_name",
+      ]
+      separator = ";"
+      regex = "^(?:;*)?([^;]+).*$"
+      replacement = "$1"
+      target_label = "service_name"
+    }
   }
   
   discovery.kubernetes "pods" {

--- a/charts/k8s-monitoring/docs/examples/auth/external-secrets/alloy-logs.alloy
+++ b/charts/k8s-monitoring/docs/examples/auth/external-secrets/alloy-logs.alloy
@@ -111,6 +111,25 @@ declare "pod_logs" {
       replacement = "$1"
       target_label = "service_name"
     }
+  
+    // set service_namespace
+    rule {
+      action = "replace"
+      source_labels = ["__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_namespace"]
+      target_label = "service_namespace"
+    }
+  
+    // set deployment_environment and deployment_environment_name
+    rule {
+      action = "replace"
+      source_labels = ["__meta_kubernetes_pod_annotation_resource_opentelemetry_io_deployment_environment_name"]
+      target_label = "deployment_environment_name"
+    }
+    rule {
+      action = "replace"
+      source_labels = ["__meta_kubernetes_pod_annotation_resource_opentelemetry_io_deployment_environment"]
+      target_label = "deployment_environment"
+    }
   }
   
   discovery.kubernetes "pods" {
@@ -182,7 +201,7 @@ declare "pod_logs" {
   
     // Only keep the labels that are defined in the `keepLabels` list.
     stage.label_keep {
-      values = ["app_kubernetes_io_name","container","instance","job","level","namespace","pod","service_name","integration"]
+      values = ["app_kubernetes_io_name","container","instance","job","level","namespace","pod","service_name","service_namespace","deployment_environment","deployment_environment_name","integration"]
     }
   
     forward_to = argument.logs_destinations.value

--- a/charts/k8s-monitoring/docs/examples/auth/external-secrets/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/auth/external-secrets/output.yaml
@@ -317,6 +317,28 @@ data:
           action = "labelmap"
           regex = "__meta_kubernetes_pod_annotation_(.+)"
         }
+      
+        // explicitly set service_name. if not set, loki will automatically try to populate a default.
+        // see https://grafana.com/docs/loki/latest/get-started/labels/#default-labels-for-all-users
+        //
+        // choose the first value found from the following ordered list:
+        // - pod.annotation[resource.opentelemetry.io/service.name]
+        // - pod.label[app.kubernetes.io/name]
+        // - k8s.pod.name
+        // - k8s.container.name
+        rule {
+          action = "replace"
+          source_labels = [
+            "__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_name",
+            "__meta_kubernetes_pod_label_app_kubernetes_io_name",
+            "__meta_kubernetes_pod_name",
+            "__meta_kubernetes_pod_container_name",
+          ]
+          separator = ";"
+          regex = "^(?:;*)?([^;]+).*$"
+          replacement = "$1"
+          target_label = "service_name"
+        }
       }
       
       discovery.kubernetes "pods" {

--- a/charts/k8s-monitoring/docs/examples/auth/external-secrets/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/auth/external-secrets/output.yaml
@@ -339,6 +339,25 @@ data:
           replacement = "$1"
           target_label = "service_name"
         }
+      
+        // set service_namespace
+        rule {
+          action = "replace"
+          source_labels = ["__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_namespace"]
+          target_label = "service_namespace"
+        }
+      
+        // set deployment_environment and deployment_environment_name
+        rule {
+          action = "replace"
+          source_labels = ["__meta_kubernetes_pod_annotation_resource_opentelemetry_io_deployment_environment_name"]
+          target_label = "deployment_environment_name"
+        }
+        rule {
+          action = "replace"
+          source_labels = ["__meta_kubernetes_pod_annotation_resource_opentelemetry_io_deployment_environment"]
+          target_label = "deployment_environment"
+        }
       }
       
       discovery.kubernetes "pods" {
@@ -410,7 +429,7 @@ data:
       
         // Only keep the labels that are defined in the `keepLabels` list.
         stage.label_keep {
-          values = ["app_kubernetes_io_name","container","instance","job","level","namespace","pod","service_name","integration"]
+          values = ["app_kubernetes_io_name","container","instance","job","level","namespace","pod","service_name","service_namespace","deployment_environment","deployment_environment_name","integration"]
         }
       
         forward_to = argument.logs_destinations.value

--- a/charts/k8s-monitoring/docs/examples/auth/oauth2/alloy-logs.alloy
+++ b/charts/k8s-monitoring/docs/examples/auth/oauth2/alloy-logs.alloy
@@ -309,6 +309,25 @@ declare "pod_logs" {
       replacement = "$1"
       target_label = "service_name"
     }
+  
+    // set service_namespace
+    rule {
+      action = "replace"
+      source_labels = ["__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_namespace"]
+      target_label = "service_namespace"
+    }
+  
+    // set deployment_environment and deployment_environment_name
+    rule {
+      action = "replace"
+      source_labels = ["__meta_kubernetes_pod_annotation_resource_opentelemetry_io_deployment_environment_name"]
+      target_label = "deployment_environment_name"
+    }
+    rule {
+      action = "replace"
+      source_labels = ["__meta_kubernetes_pod_annotation_resource_opentelemetry_io_deployment_environment"]
+      target_label = "deployment_environment"
+    }
   }
   
   discovery.kubernetes "pods" {
@@ -380,7 +399,7 @@ declare "pod_logs" {
   
     // Only keep the labels that are defined in the `keepLabels` list.
     stage.label_keep {
-      values = ["app_kubernetes_io_name","container","instance","job","level","namespace","pod","service_name","integration"]
+      values = ["app_kubernetes_io_name","container","instance","job","level","namespace","pod","service_name","service_namespace","deployment_environment","deployment_environment_name","integration"]
     }
   
     forward_to = argument.logs_destinations.value

--- a/charts/k8s-monitoring/docs/examples/auth/oauth2/alloy-logs.alloy
+++ b/charts/k8s-monitoring/docs/examples/auth/oauth2/alloy-logs.alloy
@@ -287,6 +287,28 @@ declare "pod_logs" {
       action = "labelmap"
       regex = "__meta_kubernetes_pod_annotation_(.+)"
     }
+  
+    // explicitly set service_name. if not set, loki will automatically try to populate a default.
+    // see https://grafana.com/docs/loki/latest/get-started/labels/#default-labels-for-all-users
+    //
+    // choose the first value found from the following ordered list:
+    // - pod.annotation[resource.opentelemetry.io/service.name]
+    // - pod.label[app.kubernetes.io/name]
+    // - k8s.pod.name
+    // - k8s.container.name
+    rule {
+      action = "replace"
+      source_labels = [
+        "__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_name",
+        "__meta_kubernetes_pod_label_app_kubernetes_io_name",
+        "__meta_kubernetes_pod_name",
+        "__meta_kubernetes_pod_container_name",
+      ]
+      separator = ";"
+      regex = "^(?:;*)?([^;]+).*$"
+      replacement = "$1"
+      target_label = "service_name"
+    }
   }
   
   discovery.kubernetes "pods" {

--- a/charts/k8s-monitoring/docs/examples/auth/oauth2/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/auth/oauth2/output.yaml
@@ -1214,6 +1214,28 @@ data:
           action = "labelmap"
           regex = "__meta_kubernetes_pod_annotation_(.+)"
         }
+      
+        // explicitly set service_name. if not set, loki will automatically try to populate a default.
+        // see https://grafana.com/docs/loki/latest/get-started/labels/#default-labels-for-all-users
+        //
+        // choose the first value found from the following ordered list:
+        // - pod.annotation[resource.opentelemetry.io/service.name]
+        // - pod.label[app.kubernetes.io/name]
+        // - k8s.pod.name
+        // - k8s.container.name
+        rule {
+          action = "replace"
+          source_labels = [
+            "__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_name",
+            "__meta_kubernetes_pod_label_app_kubernetes_io_name",
+            "__meta_kubernetes_pod_name",
+            "__meta_kubernetes_pod_container_name",
+          ]
+          separator = ";"
+          regex = "^(?:;*)?([^;]+).*$"
+          replacement = "$1"
+          target_label = "service_name"
+        }
       }
       
       discovery.kubernetes "pods" {

--- a/charts/k8s-monitoring/docs/examples/auth/oauth2/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/auth/oauth2/output.yaml
@@ -1236,6 +1236,25 @@ data:
           replacement = "$1"
           target_label = "service_name"
         }
+      
+        // set service_namespace
+        rule {
+          action = "replace"
+          source_labels = ["__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_namespace"]
+          target_label = "service_namespace"
+        }
+      
+        // set deployment_environment and deployment_environment_name
+        rule {
+          action = "replace"
+          source_labels = ["__meta_kubernetes_pod_annotation_resource_opentelemetry_io_deployment_environment_name"]
+          target_label = "deployment_environment_name"
+        }
+        rule {
+          action = "replace"
+          source_labels = ["__meta_kubernetes_pod_annotation_resource_opentelemetry_io_deployment_environment"]
+          target_label = "deployment_environment"
+        }
       }
       
       discovery.kubernetes "pods" {
@@ -1307,7 +1326,7 @@ data:
       
         // Only keep the labels that are defined in the `keepLabels` list.
         stage.label_keep {
-          values = ["app_kubernetes_io_name","container","instance","job","level","namespace","pod","service_name","integration"]
+          values = ["app_kubernetes_io_name","container","instance","job","level","namespace","pod","service_name","service_namespace","deployment_environment","deployment_environment_name","integration"]
         }
       
         forward_to = argument.logs_destinations.value

--- a/charts/k8s-monitoring/docs/examples/collector-storage/alloy-logs.alloy
+++ b/charts/k8s-monitoring/docs/examples/collector-storage/alloy-logs.alloy
@@ -76,6 +76,28 @@ declare "pod_logs" {
       action = "labelmap"
       regex = "__meta_kubernetes_pod_annotation_(.+)"
     }
+  
+    // explicitly set service_name. if not set, loki will automatically try to populate a default.
+    // see https://grafana.com/docs/loki/latest/get-started/labels/#default-labels-for-all-users
+    //
+    // choose the first value found from the following ordered list:
+    // - pod.annotation[resource.opentelemetry.io/service.name]
+    // - pod.label[app.kubernetes.io/name]
+    // - k8s.pod.name
+    // - k8s.container.name
+    rule {
+      action = "replace"
+      source_labels = [
+        "__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_name",
+        "__meta_kubernetes_pod_label_app_kubernetes_io_name",
+        "__meta_kubernetes_pod_name",
+        "__meta_kubernetes_pod_container_name",
+      ]
+      separator = ";"
+      regex = "^(?:;*)?([^;]+).*$"
+      replacement = "$1"
+      target_label = "service_name"
+    }
   }
   
   discovery.kubernetes "pods" {

--- a/charts/k8s-monitoring/docs/examples/collector-storage/alloy-logs.alloy
+++ b/charts/k8s-monitoring/docs/examples/collector-storage/alloy-logs.alloy
@@ -98,6 +98,25 @@ declare "pod_logs" {
       replacement = "$1"
       target_label = "service_name"
     }
+  
+    // set service_namespace
+    rule {
+      action = "replace"
+      source_labels = ["__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_namespace"]
+      target_label = "service_namespace"
+    }
+  
+    // set deployment_environment and deployment_environment_name
+    rule {
+      action = "replace"
+      source_labels = ["__meta_kubernetes_pod_annotation_resource_opentelemetry_io_deployment_environment_name"]
+      target_label = "deployment_environment_name"
+    }
+    rule {
+      action = "replace"
+      source_labels = ["__meta_kubernetes_pod_annotation_resource_opentelemetry_io_deployment_environment"]
+      target_label = "deployment_environment"
+    }
   }
   
   discovery.kubernetes "pods" {
@@ -169,7 +188,7 @@ declare "pod_logs" {
   
     // Only keep the labels that are defined in the `keepLabels` list.
     stage.label_keep {
-      values = ["app_kubernetes_io_name","container","instance","job","level","namespace","pod","service_name","integration"]
+      values = ["app_kubernetes_io_name","container","instance","job","level","namespace","pod","service_name","service_namespace","deployment_environment","deployment_environment_name","integration"]
     }
   
     forward_to = argument.logs_destinations.value

--- a/charts/k8s-monitoring/docs/examples/collector-storage/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/collector-storage/output.yaml
@@ -530,6 +530,28 @@ data:
           action = "labelmap"
           regex = "__meta_kubernetes_pod_annotation_(.+)"
         }
+      
+        // explicitly set service_name. if not set, loki will automatically try to populate a default.
+        // see https://grafana.com/docs/loki/latest/get-started/labels/#default-labels-for-all-users
+        //
+        // choose the first value found from the following ordered list:
+        // - pod.annotation[resource.opentelemetry.io/service.name]
+        // - pod.label[app.kubernetes.io/name]
+        // - k8s.pod.name
+        // - k8s.container.name
+        rule {
+          action = "replace"
+          source_labels = [
+            "__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_name",
+            "__meta_kubernetes_pod_label_app_kubernetes_io_name",
+            "__meta_kubernetes_pod_name",
+            "__meta_kubernetes_pod_container_name",
+          ]
+          separator = ";"
+          regex = "^(?:;*)?([^;]+).*$"
+          replacement = "$1"
+          target_label = "service_name"
+        }
       }
       
       discovery.kubernetes "pods" {

--- a/charts/k8s-monitoring/docs/examples/collector-storage/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/collector-storage/output.yaml
@@ -552,6 +552,25 @@ data:
           replacement = "$1"
           target_label = "service_name"
         }
+      
+        // set service_namespace
+        rule {
+          action = "replace"
+          source_labels = ["__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_namespace"]
+          target_label = "service_namespace"
+        }
+      
+        // set deployment_environment and deployment_environment_name
+        rule {
+          action = "replace"
+          source_labels = ["__meta_kubernetes_pod_annotation_resource_opentelemetry_io_deployment_environment_name"]
+          target_label = "deployment_environment_name"
+        }
+        rule {
+          action = "replace"
+          source_labels = ["__meta_kubernetes_pod_annotation_resource_opentelemetry_io_deployment_environment"]
+          target_label = "deployment_environment"
+        }
       }
       
       discovery.kubernetes "pods" {
@@ -623,7 +642,7 @@ data:
       
         // Only keep the labels that are defined in the `keepLabels` list.
         stage.label_keep {
-          values = ["app_kubernetes_io_name","container","instance","job","level","namespace","pod","service_name","integration"]
+          values = ["app_kubernetes_io_name","container","instance","job","level","namespace","pod","service_name","service_namespace","deployment_environment","deployment_environment_name","integration"]
         }
       
         forward_to = argument.logs_destinations.value

--- a/charts/k8s-monitoring/docs/examples/destinations/otlp-endpoint/alloy-logs.alloy
+++ b/charts/k8s-monitoring/docs/examples/destinations/otlp-endpoint/alloy-logs.alloy
@@ -129,6 +129,28 @@ declare "pod_logs" {
       action = "labelmap"
       regex = "__meta_kubernetes_pod_annotation_(.+)"
     }
+  
+    // explicitly set service_name. if not set, loki will automatically try to populate a default.
+    // see https://grafana.com/docs/loki/latest/get-started/labels/#default-labels-for-all-users
+    //
+    // choose the first value found from the following ordered list:
+    // - pod.annotation[resource.opentelemetry.io/service.name]
+    // - pod.label[app.kubernetes.io/name]
+    // - k8s.pod.name
+    // - k8s.container.name
+    rule {
+      action = "replace"
+      source_labels = [
+        "__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_name",
+        "__meta_kubernetes_pod_label_app_kubernetes_io_name",
+        "__meta_kubernetes_pod_name",
+        "__meta_kubernetes_pod_container_name",
+      ]
+      separator = ";"
+      regex = "^(?:;*)?([^;]+).*$"
+      replacement = "$1"
+      target_label = "service_name"
+    }
   }
   
   discovery.kubernetes "pods" {

--- a/charts/k8s-monitoring/docs/examples/destinations/otlp-endpoint/alloy-logs.alloy
+++ b/charts/k8s-monitoring/docs/examples/destinations/otlp-endpoint/alloy-logs.alloy
@@ -151,6 +151,25 @@ declare "pod_logs" {
       replacement = "$1"
       target_label = "service_name"
     }
+  
+    // set service_namespace
+    rule {
+      action = "replace"
+      source_labels = ["__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_namespace"]
+      target_label = "service_namespace"
+    }
+  
+    // set deployment_environment and deployment_environment_name
+    rule {
+      action = "replace"
+      source_labels = ["__meta_kubernetes_pod_annotation_resource_opentelemetry_io_deployment_environment_name"]
+      target_label = "deployment_environment_name"
+    }
+    rule {
+      action = "replace"
+      source_labels = ["__meta_kubernetes_pod_annotation_resource_opentelemetry_io_deployment_environment"]
+      target_label = "deployment_environment"
+    }
   }
   
   discovery.kubernetes "pods" {
@@ -222,7 +241,7 @@ declare "pod_logs" {
   
     // Only keep the labels that are defined in the `keepLabels` list.
     stage.label_keep {
-      values = ["app_kubernetes_io_name","container","instance","job","level","namespace","pod","service_name","integration"]
+      values = ["app_kubernetes_io_name","container","instance","job","level","namespace","pod","service_name","service_namespace","deployment_environment","deployment_environment_name","integration"]
     }
   
     forward_to = argument.logs_destinations.value

--- a/charts/k8s-monitoring/docs/examples/destinations/otlp-endpoint/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/destinations/otlp-endpoint/output.yaml
@@ -616,6 +616,28 @@ data:
           action = "labelmap"
           regex = "__meta_kubernetes_pod_annotation_(.+)"
         }
+      
+        // explicitly set service_name. if not set, loki will automatically try to populate a default.
+        // see https://grafana.com/docs/loki/latest/get-started/labels/#default-labels-for-all-users
+        //
+        // choose the first value found from the following ordered list:
+        // - pod.annotation[resource.opentelemetry.io/service.name]
+        // - pod.label[app.kubernetes.io/name]
+        // - k8s.pod.name
+        // - k8s.container.name
+        rule {
+          action = "replace"
+          source_labels = [
+            "__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_name",
+            "__meta_kubernetes_pod_label_app_kubernetes_io_name",
+            "__meta_kubernetes_pod_name",
+            "__meta_kubernetes_pod_container_name",
+          ]
+          separator = ";"
+          regex = "^(?:;*)?([^;]+).*$"
+          replacement = "$1"
+          target_label = "service_name"
+        }
       }
       
       discovery.kubernetes "pods" {

--- a/charts/k8s-monitoring/docs/examples/destinations/otlp-endpoint/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/destinations/otlp-endpoint/output.yaml
@@ -638,6 +638,25 @@ data:
           replacement = "$1"
           target_label = "service_name"
         }
+      
+        // set service_namespace
+        rule {
+          action = "replace"
+          source_labels = ["__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_namespace"]
+          target_label = "service_namespace"
+        }
+      
+        // set deployment_environment and deployment_environment_name
+        rule {
+          action = "replace"
+          source_labels = ["__meta_kubernetes_pod_annotation_resource_opentelemetry_io_deployment_environment_name"]
+          target_label = "deployment_environment_name"
+        }
+        rule {
+          action = "replace"
+          source_labels = ["__meta_kubernetes_pod_annotation_resource_opentelemetry_io_deployment_environment"]
+          target_label = "deployment_environment"
+        }
       }
       
       discovery.kubernetes "pods" {
@@ -709,7 +728,7 @@ data:
       
         // Only keep the labels that are defined in the `keepLabels` list.
         stage.label_keep {
-          values = ["app_kubernetes_io_name","container","instance","job","level","namespace","pod","service_name","integration"]
+          values = ["app_kubernetes_io_name","container","instance","job","level","namespace","pod","service_name","service_namespace","deployment_environment","deployment_environment_name","integration"]
         }
       
         forward_to = argument.logs_destinations.value

--- a/charts/k8s-monitoring/docs/examples/extra-rules/alloy-logs.alloy
+++ b/charts/k8s-monitoring/docs/examples/extra-rules/alloy-logs.alloy
@@ -100,6 +100,25 @@ declare "pod_logs" {
       replacement = "$1"
       target_label = "service_name"
     }
+  
+    // set service_namespace
+    rule {
+      action = "replace"
+      source_labels = ["__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_namespace"]
+      target_label = "service_namespace"
+    }
+  
+    // set deployment_environment and deployment_environment_name
+    rule {
+      action = "replace"
+      source_labels = ["__meta_kubernetes_pod_annotation_resource_opentelemetry_io_deployment_environment_name"]
+      target_label = "deployment_environment_name"
+    }
+    rule {
+      action = "replace"
+      source_labels = ["__meta_kubernetes_pod_annotation_resource_opentelemetry_io_deployment_environment"]
+      target_label = "deployment_environment"
+    }
     rule {
       source_labels = ["__meta_kubernetes_namespace"]
       regex = "production"
@@ -197,7 +216,7 @@ declare "pod_logs" {
   
     // Only keep the labels that are defined in the `keepLabels` list.
     stage.label_keep {
-      values = ["app_kubernetes_io_name","container","instance","job","level","namespace","pod","service_name","integration"]
+      values = ["app_kubernetes_io_name","container","instance","job","level","namespace","pod","service_name","service_namespace","deployment_environment","deployment_environment_name","integration"]
     }
   
     forward_to = argument.logs_destinations.value

--- a/charts/k8s-monitoring/docs/examples/extra-rules/alloy-logs.alloy
+++ b/charts/k8s-monitoring/docs/examples/extra-rules/alloy-logs.alloy
@@ -78,6 +78,28 @@ declare "pod_logs" {
       action = "labelmap"
       regex = "__meta_kubernetes_pod_annotation_(.+)"
     }
+  
+    // explicitly set service_name. if not set, loki will automatically try to populate a default.
+    // see https://grafana.com/docs/loki/latest/get-started/labels/#default-labels-for-all-users
+    //
+    // choose the first value found from the following ordered list:
+    // - pod.annotation[resource.opentelemetry.io/service.name]
+    // - pod.label[app.kubernetes.io/name]
+    // - k8s.pod.name
+    // - k8s.container.name
+    rule {
+      action = "replace"
+      source_labels = [
+        "__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_name",
+        "__meta_kubernetes_pod_label_app_kubernetes_io_name",
+        "__meta_kubernetes_pod_name",
+        "__meta_kubernetes_pod_container_name",
+      ]
+      separator = ";"
+      regex = "^(?:;*)?([^;]+).*$"
+      replacement = "$1"
+      target_label = "service_name"
+    }
     rule {
       source_labels = ["__meta_kubernetes_namespace"]
       regex = "production"

--- a/charts/k8s-monitoring/docs/examples/extra-rules/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/extra-rules/output.yaml
@@ -755,6 +755,25 @@ data:
           replacement = "$1"
           target_label = "service_name"
         }
+      
+        // set service_namespace
+        rule {
+          action = "replace"
+          source_labels = ["__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_namespace"]
+          target_label = "service_namespace"
+        }
+      
+        // set deployment_environment and deployment_environment_name
+        rule {
+          action = "replace"
+          source_labels = ["__meta_kubernetes_pod_annotation_resource_opentelemetry_io_deployment_environment_name"]
+          target_label = "deployment_environment_name"
+        }
+        rule {
+          action = "replace"
+          source_labels = ["__meta_kubernetes_pod_annotation_resource_opentelemetry_io_deployment_environment"]
+          target_label = "deployment_environment"
+        }
         rule {
           source_labels = ["__meta_kubernetes_namespace"]
           regex = "production"
@@ -852,7 +871,7 @@ data:
       
         // Only keep the labels that are defined in the `keepLabels` list.
         stage.label_keep {
-          values = ["app_kubernetes_io_name","container","instance","job","level","namespace","pod","service_name","integration"]
+          values = ["app_kubernetes_io_name","container","instance","job","level","namespace","pod","service_name","service_namespace","deployment_environment","deployment_environment_name","integration"]
         }
       
         forward_to = argument.logs_destinations.value

--- a/charts/k8s-monitoring/docs/examples/extra-rules/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/extra-rules/output.yaml
@@ -733,6 +733,28 @@ data:
           action = "labelmap"
           regex = "__meta_kubernetes_pod_annotation_(.+)"
         }
+      
+        // explicitly set service_name. if not set, loki will automatically try to populate a default.
+        // see https://grafana.com/docs/loki/latest/get-started/labels/#default-labels-for-all-users
+        //
+        // choose the first value found from the following ordered list:
+        // - pod.annotation[resource.opentelemetry.io/service.name]
+        // - pod.label[app.kubernetes.io/name]
+        // - k8s.pod.name
+        // - k8s.container.name
+        rule {
+          action = "replace"
+          source_labels = [
+            "__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_name",
+            "__meta_kubernetes_pod_label_app_kubernetes_io_name",
+            "__meta_kubernetes_pod_name",
+            "__meta_kubernetes_pod_container_name",
+          ]
+          separator = ";"
+          regex = "^(?:;*)?([^;]+).*$"
+          replacement = "$1"
+          target_label = "service_name"
+        }
         rule {
           source_labels = ["__meta_kubernetes_namespace"]
           regex = "production"

--- a/charts/k8s-monitoring/docs/examples/features/cluster-metrics/control-plane-monitoring/alloy-logs.alloy
+++ b/charts/k8s-monitoring/docs/examples/features/cluster-metrics/control-plane-monitoring/alloy-logs.alloy
@@ -76,6 +76,28 @@ declare "pod_logs" {
       action = "labelmap"
       regex = "__meta_kubernetes_pod_annotation_(.+)"
     }
+  
+    // explicitly set service_name. if not set, loki will automatically try to populate a default.
+    // see https://grafana.com/docs/loki/latest/get-started/labels/#default-labels-for-all-users
+    //
+    // choose the first value found from the following ordered list:
+    // - pod.annotation[resource.opentelemetry.io/service.name]
+    // - pod.label[app.kubernetes.io/name]
+    // - k8s.pod.name
+    // - k8s.container.name
+    rule {
+      action = "replace"
+      source_labels = [
+        "__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_name",
+        "__meta_kubernetes_pod_label_app_kubernetes_io_name",
+        "__meta_kubernetes_pod_name",
+        "__meta_kubernetes_pod_container_name",
+      ]
+      separator = ";"
+      regex = "^(?:;*)?([^;]+).*$"
+      replacement = "$1"
+      target_label = "service_name"
+    }
   }
   
   discovery.kubernetes "pods" {

--- a/charts/k8s-monitoring/docs/examples/features/cluster-metrics/control-plane-monitoring/alloy-logs.alloy
+++ b/charts/k8s-monitoring/docs/examples/features/cluster-metrics/control-plane-monitoring/alloy-logs.alloy
@@ -98,6 +98,25 @@ declare "pod_logs" {
       replacement = "$1"
       target_label = "service_name"
     }
+  
+    // set service_namespace
+    rule {
+      action = "replace"
+      source_labels = ["__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_namespace"]
+      target_label = "service_namespace"
+    }
+  
+    // set deployment_environment and deployment_environment_name
+    rule {
+      action = "replace"
+      source_labels = ["__meta_kubernetes_pod_annotation_resource_opentelemetry_io_deployment_environment_name"]
+      target_label = "deployment_environment_name"
+    }
+    rule {
+      action = "replace"
+      source_labels = ["__meta_kubernetes_pod_annotation_resource_opentelemetry_io_deployment_environment"]
+      target_label = "deployment_environment"
+    }
   }
   
   discovery.kubernetes "pods" {
@@ -169,7 +188,7 @@ declare "pod_logs" {
   
     // Only keep the labels that are defined in the `keepLabels` list.
     stage.label_keep {
-      values = ["app_kubernetes_io_name","container","instance","job","level","namespace","pod","service_name","integration"]
+      values = ["app_kubernetes_io_name","container","instance","job","level","namespace","pod","service_name","service_namespace","deployment_environment","deployment_environment_name","integration"]
     }
   
     forward_to = argument.logs_destinations.value

--- a/charts/k8s-monitoring/docs/examples/features/cluster-metrics/control-plane-monitoring/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/features/cluster-metrics/control-plane-monitoring/output.yaml
@@ -851,6 +851,28 @@ data:
           action = "labelmap"
           regex = "__meta_kubernetes_pod_annotation_(.+)"
         }
+      
+        // explicitly set service_name. if not set, loki will automatically try to populate a default.
+        // see https://grafana.com/docs/loki/latest/get-started/labels/#default-labels-for-all-users
+        //
+        // choose the first value found from the following ordered list:
+        // - pod.annotation[resource.opentelemetry.io/service.name]
+        // - pod.label[app.kubernetes.io/name]
+        // - k8s.pod.name
+        // - k8s.container.name
+        rule {
+          action = "replace"
+          source_labels = [
+            "__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_name",
+            "__meta_kubernetes_pod_label_app_kubernetes_io_name",
+            "__meta_kubernetes_pod_name",
+            "__meta_kubernetes_pod_container_name",
+          ]
+          separator = ";"
+          regex = "^(?:;*)?([^;]+).*$"
+          replacement = "$1"
+          target_label = "service_name"
+        }
       }
       
       discovery.kubernetes "pods" {

--- a/charts/k8s-monitoring/docs/examples/features/cluster-metrics/control-plane-monitoring/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/features/cluster-metrics/control-plane-monitoring/output.yaml
@@ -873,6 +873,25 @@ data:
           replacement = "$1"
           target_label = "service_name"
         }
+      
+        // set service_namespace
+        rule {
+          action = "replace"
+          source_labels = ["__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_namespace"]
+          target_label = "service_namespace"
+        }
+      
+        // set deployment_environment and deployment_environment_name
+        rule {
+          action = "replace"
+          source_labels = ["__meta_kubernetes_pod_annotation_resource_opentelemetry_io_deployment_environment_name"]
+          target_label = "deployment_environment_name"
+        }
+        rule {
+          action = "replace"
+          source_labels = ["__meta_kubernetes_pod_annotation_resource_opentelemetry_io_deployment_environment"]
+          target_label = "deployment_environment"
+        }
       }
       
       discovery.kubernetes "pods" {
@@ -944,7 +963,7 @@ data:
       
         // Only keep the labels that are defined in the `keepLabels` list.
         stage.label_keep {
-          values = ["app_kubernetes_io_name","container","instance","job","level","namespace","pod","service_name","integration"]
+          values = ["app_kubernetes_io_name","container","instance","job","level","namespace","pod","service_name","service_namespace","deployment_environment","deployment_environment_name","integration"]
         }
       
         forward_to = argument.logs_destinations.value

--- a/charts/k8s-monitoring/docs/examples/features/integrations/grafana/alloy-logs.alloy
+++ b/charts/k8s-monitoring/docs/examples/features/integrations/grafana/alloy-logs.alloy
@@ -98,6 +98,25 @@ declare "pod_logs" {
       replacement = "$1"
       target_label = "service_name"
     }
+  
+    // set service_namespace
+    rule {
+      action = "replace"
+      source_labels = ["__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_namespace"]
+      target_label = "service_namespace"
+    }
+  
+    // set deployment_environment and deployment_environment_name
+    rule {
+      action = "replace"
+      source_labels = ["__meta_kubernetes_pod_annotation_resource_opentelemetry_io_deployment_environment_name"]
+      target_label = "deployment_environment_name"
+    }
+    rule {
+      action = "replace"
+      source_labels = ["__meta_kubernetes_pod_annotation_resource_opentelemetry_io_deployment_environment"]
+      target_label = "deployment_environment"
+    }
     rule {
       source_labels = ["__meta_kubernetes_namespace","__meta_kubernetes_pod_label_app_kubernetes_io_name"]
       separator = ";"
@@ -214,7 +233,7 @@ declare "pod_logs" {
   
     // Only keep the labels that are defined in the `keepLabels` list.
     stage.label_keep {
-      values = ["app_kubernetes_io_name","container","instance","job","level","namespace","pod","service_name","integration"]
+      values = ["app_kubernetes_io_name","container","instance","job","level","namespace","pod","service_name","service_namespace","deployment_environment","deployment_environment_name","integration"]
     }
   
     forward_to = argument.logs_destinations.value

--- a/charts/k8s-monitoring/docs/examples/features/integrations/grafana/alloy-logs.alloy
+++ b/charts/k8s-monitoring/docs/examples/features/integrations/grafana/alloy-logs.alloy
@@ -76,6 +76,28 @@ declare "pod_logs" {
       action = "labelmap"
       regex = "__meta_kubernetes_pod_annotation_(.+)"
     }
+  
+    // explicitly set service_name. if not set, loki will automatically try to populate a default.
+    // see https://grafana.com/docs/loki/latest/get-started/labels/#default-labels-for-all-users
+    //
+    // choose the first value found from the following ordered list:
+    // - pod.annotation[resource.opentelemetry.io/service.name]
+    // - pod.label[app.kubernetes.io/name]
+    // - k8s.pod.name
+    // - k8s.container.name
+    rule {
+      action = "replace"
+      source_labels = [
+        "__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_name",
+        "__meta_kubernetes_pod_label_app_kubernetes_io_name",
+        "__meta_kubernetes_pod_name",
+        "__meta_kubernetes_pod_container_name",
+      ]
+      separator = ";"
+      regex = "^(?:;*)?([^;]+).*$"
+      replacement = "$1"
+      target_label = "service_name"
+    }
     rule {
       source_labels = ["__meta_kubernetes_namespace","__meta_kubernetes_pod_label_app_kubernetes_io_name"]
       separator = ";"

--- a/charts/k8s-monitoring/docs/examples/features/integrations/grafana/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/features/integrations/grafana/output.yaml
@@ -452,6 +452,28 @@ data:
           action = "labelmap"
           regex = "__meta_kubernetes_pod_annotation_(.+)"
         }
+      
+        // explicitly set service_name. if not set, loki will automatically try to populate a default.
+        // see https://grafana.com/docs/loki/latest/get-started/labels/#default-labels-for-all-users
+        //
+        // choose the first value found from the following ordered list:
+        // - pod.annotation[resource.opentelemetry.io/service.name]
+        // - pod.label[app.kubernetes.io/name]
+        // - k8s.pod.name
+        // - k8s.container.name
+        rule {
+          action = "replace"
+          source_labels = [
+            "__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_name",
+            "__meta_kubernetes_pod_label_app_kubernetes_io_name",
+            "__meta_kubernetes_pod_name",
+            "__meta_kubernetes_pod_container_name",
+          ]
+          separator = ";"
+          regex = "^(?:;*)?([^;]+).*$"
+          replacement = "$1"
+          target_label = "service_name"
+        }
         rule {
           source_labels = ["__meta_kubernetes_namespace","__meta_kubernetes_pod_label_app_kubernetes_io_name"]
           separator = ";"

--- a/charts/k8s-monitoring/docs/examples/features/integrations/grafana/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/features/integrations/grafana/output.yaml
@@ -474,6 +474,25 @@ data:
           replacement = "$1"
           target_label = "service_name"
         }
+      
+        // set service_namespace
+        rule {
+          action = "replace"
+          source_labels = ["__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_namespace"]
+          target_label = "service_namespace"
+        }
+      
+        // set deployment_environment and deployment_environment_name
+        rule {
+          action = "replace"
+          source_labels = ["__meta_kubernetes_pod_annotation_resource_opentelemetry_io_deployment_environment_name"]
+          target_label = "deployment_environment_name"
+        }
+        rule {
+          action = "replace"
+          source_labels = ["__meta_kubernetes_pod_annotation_resource_opentelemetry_io_deployment_environment"]
+          target_label = "deployment_environment"
+        }
         rule {
           source_labels = ["__meta_kubernetes_namespace","__meta_kubernetes_pod_label_app_kubernetes_io_name"]
           separator = ";"
@@ -590,7 +609,7 @@ data:
       
         // Only keep the labels that are defined in the `keepLabels` list.
         stage.label_keep {
-          values = ["app_kubernetes_io_name","container","instance","job","level","namespace","pod","service_name","integration"]
+          values = ["app_kubernetes_io_name","container","instance","job","level","namespace","pod","service_name","service_namespace","deployment_environment","deployment_environment_name","integration"]
         }
       
         forward_to = argument.logs_destinations.value

--- a/charts/k8s-monitoring/docs/examples/features/integrations/loki/alloy-logs.alloy
+++ b/charts/k8s-monitoring/docs/examples/features/integrations/loki/alloy-logs.alloy
@@ -76,6 +76,28 @@ declare "pod_logs" {
       action = "labelmap"
       regex = "__meta_kubernetes_pod_annotation_(.+)"
     }
+  
+    // explicitly set service_name. if not set, loki will automatically try to populate a default.
+    // see https://grafana.com/docs/loki/latest/get-started/labels/#default-labels-for-all-users
+    //
+    // choose the first value found from the following ordered list:
+    // - pod.annotation[resource.opentelemetry.io/service.name]
+    // - pod.label[app.kubernetes.io/name]
+    // - k8s.pod.name
+    // - k8s.container.name
+    rule {
+      action = "replace"
+      source_labels = [
+        "__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_name",
+        "__meta_kubernetes_pod_label_app_kubernetes_io_name",
+        "__meta_kubernetes_pod_name",
+        "__meta_kubernetes_pod_container_name",
+      ]
+      separator = ";"
+      regex = "^(?:;*)?([^;]+).*$"
+      replacement = "$1"
+      target_label = "service_name"
+    }
     // add static label of integration="loki" and instance="name" to pods that match the selector so they can be identified in the loki.process stages
     rule {
       source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]

--- a/charts/k8s-monitoring/docs/examples/features/integrations/loki/alloy-logs.alloy
+++ b/charts/k8s-monitoring/docs/examples/features/integrations/loki/alloy-logs.alloy
@@ -98,6 +98,25 @@ declare "pod_logs" {
       replacement = "$1"
       target_label = "service_name"
     }
+  
+    // set service_namespace
+    rule {
+      action = "replace"
+      source_labels = ["__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_namespace"]
+      target_label = "service_namespace"
+    }
+  
+    // set deployment_environment and deployment_environment_name
+    rule {
+      action = "replace"
+      source_labels = ["__meta_kubernetes_pod_annotation_resource_opentelemetry_io_deployment_environment_name"]
+      target_label = "deployment_environment_name"
+    }
+    rule {
+      action = "replace"
+      source_labels = ["__meta_kubernetes_pod_annotation_resource_opentelemetry_io_deployment_environment"]
+      target_label = "deployment_environment"
+    }
     // add static label of integration="loki" and instance="name" to pods that match the selector so they can be identified in the loki.process stages
     rule {
       source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
@@ -222,7 +241,7 @@ declare "pod_logs" {
   
     // Only keep the labels that are defined in the `keepLabels` list.
     stage.label_keep {
-      values = ["app_kubernetes_io_name","container","instance","job","level","namespace","pod","service_name","integration"]
+      values = ["app_kubernetes_io_name","container","instance","job","level","namespace","pod","service_name","service_namespace","deployment_environment","deployment_environment_name","integration"]
     }
   
     forward_to = argument.logs_destinations.value

--- a/charts/k8s-monitoring/docs/examples/features/integrations/loki/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/features/integrations/loki/output.yaml
@@ -509,6 +509,25 @@ data:
           replacement = "$1"
           target_label = "service_name"
         }
+      
+        // set service_namespace
+        rule {
+          action = "replace"
+          source_labels = ["__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_namespace"]
+          target_label = "service_namespace"
+        }
+      
+        // set deployment_environment and deployment_environment_name
+        rule {
+          action = "replace"
+          source_labels = ["__meta_kubernetes_pod_annotation_resource_opentelemetry_io_deployment_environment_name"]
+          target_label = "deployment_environment_name"
+        }
+        rule {
+          action = "replace"
+          source_labels = ["__meta_kubernetes_pod_annotation_resource_opentelemetry_io_deployment_environment"]
+          target_label = "deployment_environment"
+        }
         // add static label of integration="loki" and instance="name" to pods that match the selector so they can be identified in the loki.process stages
         rule {
           source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
@@ -633,7 +652,7 @@ data:
       
         // Only keep the labels that are defined in the `keepLabels` list.
         stage.label_keep {
-          values = ["app_kubernetes_io_name","container","instance","job","level","namespace","pod","service_name","integration"]
+          values = ["app_kubernetes_io_name","container","instance","job","level","namespace","pod","service_name","service_namespace","deployment_environment","deployment_environment_name","integration"]
         }
       
         forward_to = argument.logs_destinations.value

--- a/charts/k8s-monitoring/docs/examples/features/integrations/loki/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/features/integrations/loki/output.yaml
@@ -487,6 +487,28 @@ data:
           action = "labelmap"
           regex = "__meta_kubernetes_pod_annotation_(.+)"
         }
+      
+        // explicitly set service_name. if not set, loki will automatically try to populate a default.
+        // see https://grafana.com/docs/loki/latest/get-started/labels/#default-labels-for-all-users
+        //
+        // choose the first value found from the following ordered list:
+        // - pod.annotation[resource.opentelemetry.io/service.name]
+        // - pod.label[app.kubernetes.io/name]
+        // - k8s.pod.name
+        // - k8s.container.name
+        rule {
+          action = "replace"
+          source_labels = [
+            "__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_name",
+            "__meta_kubernetes_pod_label_app_kubernetes_io_name",
+            "__meta_kubernetes_pod_name",
+            "__meta_kubernetes_pod_container_name",
+          ]
+          separator = ";"
+          regex = "^(?:;*)?([^;]+).*$"
+          replacement = "$1"
+          target_label = "service_name"
+        }
         // add static label of integration="loki" and instance="name" to pods that match the selector so they can be identified in the loki.process stages
         rule {
           source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]

--- a/charts/k8s-monitoring/docs/examples/features/integrations/mimir/alloy-logs.alloy
+++ b/charts/k8s-monitoring/docs/examples/features/integrations/mimir/alloy-logs.alloy
@@ -98,6 +98,25 @@ declare "pod_logs" {
       replacement = "$1"
       target_label = "service_name"
     }
+  
+    // set service_namespace
+    rule {
+      action = "replace"
+      source_labels = ["__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_namespace"]
+      target_label = "service_namespace"
+    }
+  
+    // set deployment_environment and deployment_environment_name
+    rule {
+      action = "replace"
+      source_labels = ["__meta_kubernetes_pod_annotation_resource_opentelemetry_io_deployment_environment_name"]
+      target_label = "deployment_environment_name"
+    }
+    rule {
+      action = "replace"
+      source_labels = ["__meta_kubernetes_pod_annotation_resource_opentelemetry_io_deployment_environment"]
+      target_label = "deployment_environment"
+    }
     // add static label of integration="mimir" and instance="name" to pods that match the selector so they can be identified in the mimir.process stages
     rule {
       source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
@@ -222,7 +241,7 @@ declare "pod_logs" {
   
     // Only keep the labels that are defined in the `keepLabels` list.
     stage.label_keep {
-      values = ["app_kubernetes_io_name","container","instance","job","level","namespace","pod","service_name","integration"]
+      values = ["app_kubernetes_io_name","container","instance","job","level","namespace","pod","service_name","service_namespace","deployment_environment","deployment_environment_name","integration"]
     }
   
     forward_to = argument.logs_destinations.value

--- a/charts/k8s-monitoring/docs/examples/features/integrations/mimir/alloy-logs.alloy
+++ b/charts/k8s-monitoring/docs/examples/features/integrations/mimir/alloy-logs.alloy
@@ -76,6 +76,28 @@ declare "pod_logs" {
       action = "labelmap"
       regex = "__meta_kubernetes_pod_annotation_(.+)"
     }
+  
+    // explicitly set service_name. if not set, loki will automatically try to populate a default.
+    // see https://grafana.com/docs/loki/latest/get-started/labels/#default-labels-for-all-users
+    //
+    // choose the first value found from the following ordered list:
+    // - pod.annotation[resource.opentelemetry.io/service.name]
+    // - pod.label[app.kubernetes.io/name]
+    // - k8s.pod.name
+    // - k8s.container.name
+    rule {
+      action = "replace"
+      source_labels = [
+        "__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_name",
+        "__meta_kubernetes_pod_label_app_kubernetes_io_name",
+        "__meta_kubernetes_pod_name",
+        "__meta_kubernetes_pod_container_name",
+      ]
+      separator = ";"
+      regex = "^(?:;*)?([^;]+).*$"
+      replacement = "$1"
+      target_label = "service_name"
+    }
     // add static label of integration="mimir" and instance="name" to pods that match the selector so they can be identified in the mimir.process stages
     rule {
       source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]

--- a/charts/k8s-monitoring/docs/examples/features/integrations/mimir/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/features/integrations/mimir/output.yaml
@@ -487,6 +487,28 @@ data:
           action = "labelmap"
           regex = "__meta_kubernetes_pod_annotation_(.+)"
         }
+      
+        // explicitly set service_name. if not set, loki will automatically try to populate a default.
+        // see https://grafana.com/docs/loki/latest/get-started/labels/#default-labels-for-all-users
+        //
+        // choose the first value found from the following ordered list:
+        // - pod.annotation[resource.opentelemetry.io/service.name]
+        // - pod.label[app.kubernetes.io/name]
+        // - k8s.pod.name
+        // - k8s.container.name
+        rule {
+          action = "replace"
+          source_labels = [
+            "__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_name",
+            "__meta_kubernetes_pod_label_app_kubernetes_io_name",
+            "__meta_kubernetes_pod_name",
+            "__meta_kubernetes_pod_container_name",
+          ]
+          separator = ";"
+          regex = "^(?:;*)?([^;]+).*$"
+          replacement = "$1"
+          target_label = "service_name"
+        }
         // add static label of integration="mimir" and instance="name" to pods that match the selector so they can be identified in the mimir.process stages
         rule {
           source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]

--- a/charts/k8s-monitoring/docs/examples/features/integrations/mimir/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/features/integrations/mimir/output.yaml
@@ -509,6 +509,25 @@ data:
           replacement = "$1"
           target_label = "service_name"
         }
+      
+        // set service_namespace
+        rule {
+          action = "replace"
+          source_labels = ["__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_namespace"]
+          target_label = "service_namespace"
+        }
+      
+        // set deployment_environment and deployment_environment_name
+        rule {
+          action = "replace"
+          source_labels = ["__meta_kubernetes_pod_annotation_resource_opentelemetry_io_deployment_environment_name"]
+          target_label = "deployment_environment_name"
+        }
+        rule {
+          action = "replace"
+          source_labels = ["__meta_kubernetes_pod_annotation_resource_opentelemetry_io_deployment_environment"]
+          target_label = "deployment_environment"
+        }
         // add static label of integration="mimir" and instance="name" to pods that match the selector so they can be identified in the mimir.process stages
         rule {
           source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
@@ -633,7 +652,7 @@ data:
       
         // Only keep the labels that are defined in the `keepLabels` list.
         stage.label_keep {
-          values = ["app_kubernetes_io_name","container","instance","job","level","namespace","pod","service_name","integration"]
+          values = ["app_kubernetes_io_name","container","instance","job","level","namespace","pod","service_name","service_namespace","deployment_environment","deployment_environment_name","integration"]
         }
       
         forward_to = argument.logs_destinations.value

--- a/charts/k8s-monitoring/docs/examples/features/integrations/mysql/alloy-logs.alloy
+++ b/charts/k8s-monitoring/docs/examples/features/integrations/mysql/alloy-logs.alloy
@@ -76,6 +76,28 @@ declare "pod_logs" {
       action = "labelmap"
       regex = "__meta_kubernetes_pod_annotation_(.+)"
     }
+  
+    // explicitly set service_name. if not set, loki will automatically try to populate a default.
+    // see https://grafana.com/docs/loki/latest/get-started/labels/#default-labels-for-all-users
+    //
+    // choose the first value found from the following ordered list:
+    // - pod.annotation[resource.opentelemetry.io/service.name]
+    // - pod.label[app.kubernetes.io/name]
+    // - k8s.pod.name
+    // - k8s.container.name
+    rule {
+      action = "replace"
+      source_labels = [
+        "__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_name",
+        "__meta_kubernetes_pod_label_app_kubernetes_io_name",
+        "__meta_kubernetes_pod_name",
+        "__meta_kubernetes_pod_container_name",
+      ]
+      separator = ";"
+      regex = "^(?:;*)?([^;]+).*$"
+      replacement = "$1"
+      target_label = "service_name"
+    }
     rule {
       source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_instance"]
       separator = ";"

--- a/charts/k8s-monitoring/docs/examples/features/integrations/mysql/alloy-logs.alloy
+++ b/charts/k8s-monitoring/docs/examples/features/integrations/mysql/alloy-logs.alloy
@@ -98,6 +98,25 @@ declare "pod_logs" {
       replacement = "$1"
       target_label = "service_name"
     }
+  
+    // set service_namespace
+    rule {
+      action = "replace"
+      source_labels = ["__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_namespace"]
+      target_label = "service_namespace"
+    }
+  
+    // set deployment_environment and deployment_environment_name
+    rule {
+      action = "replace"
+      source_labels = ["__meta_kubernetes_pod_annotation_resource_opentelemetry_io_deployment_environment_name"]
+      target_label = "deployment_environment_name"
+    }
+    rule {
+      action = "replace"
+      source_labels = ["__meta_kubernetes_pod_annotation_resource_opentelemetry_io_deployment_environment"]
+      target_label = "deployment_environment"
+    }
     rule {
       source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_instance"]
       separator = ";"
@@ -228,7 +247,7 @@ declare "pod_logs" {
   
     // Only keep the labels that are defined in the `keepLabels` list.
     stage.label_keep {
-      values = ["app_kubernetes_io_name","container","instance","job","level","namespace","pod","service_name","integration"]
+      values = ["app_kubernetes_io_name","container","instance","job","level","namespace","pod","service_name","service_namespace","deployment_environment","deployment_environment_name","integration"]
     }
   
     forward_to = argument.logs_destinations.value

--- a/charts/k8s-monitoring/docs/examples/features/integrations/mysql/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/features/integrations/mysql/output.yaml
@@ -327,6 +327,25 @@ data:
           replacement = "$1"
           target_label = "service_name"
         }
+      
+        // set service_namespace
+        rule {
+          action = "replace"
+          source_labels = ["__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_namespace"]
+          target_label = "service_namespace"
+        }
+      
+        // set deployment_environment and deployment_environment_name
+        rule {
+          action = "replace"
+          source_labels = ["__meta_kubernetes_pod_annotation_resource_opentelemetry_io_deployment_environment_name"]
+          target_label = "deployment_environment_name"
+        }
+        rule {
+          action = "replace"
+          source_labels = ["__meta_kubernetes_pod_annotation_resource_opentelemetry_io_deployment_environment"]
+          target_label = "deployment_environment"
+        }
         rule {
           source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_instance"]
           separator = ";"
@@ -457,7 +476,7 @@ data:
       
         // Only keep the labels that are defined in the `keepLabels` list.
         stage.label_keep {
-          values = ["app_kubernetes_io_name","container","instance","job","level","namespace","pod","service_name","integration"]
+          values = ["app_kubernetes_io_name","container","instance","job","level","namespace","pod","service_name","service_namespace","deployment_environment","deployment_environment_name","integration"]
         }
       
         forward_to = argument.logs_destinations.value

--- a/charts/k8s-monitoring/docs/examples/features/integrations/mysql/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/features/integrations/mysql/output.yaml
@@ -305,6 +305,28 @@ data:
           action = "labelmap"
           regex = "__meta_kubernetes_pod_annotation_(.+)"
         }
+      
+        // explicitly set service_name. if not set, loki will automatically try to populate a default.
+        // see https://grafana.com/docs/loki/latest/get-started/labels/#default-labels-for-all-users
+        //
+        // choose the first value found from the following ordered list:
+        // - pod.annotation[resource.opentelemetry.io/service.name]
+        // - pod.label[app.kubernetes.io/name]
+        // - k8s.pod.name
+        // - k8s.container.name
+        rule {
+          action = "replace"
+          source_labels = [
+            "__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_name",
+            "__meta_kubernetes_pod_label_app_kubernetes_io_name",
+            "__meta_kubernetes_pod_name",
+            "__meta_kubernetes_pod_container_name",
+          ]
+          separator = ";"
+          regex = "^(?:;*)?([^;]+).*$"
+          replacement = "$1"
+          target_label = "service_name"
+        }
         rule {
           source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_instance"]
           separator = ";"

--- a/charts/k8s-monitoring/docs/examples/features/pod-logs/default/alloy-logs.alloy
+++ b/charts/k8s-monitoring/docs/examples/features/pod-logs/default/alloy-logs.alloy
@@ -76,6 +76,28 @@ declare "pod_logs" {
       action = "labelmap"
       regex = "__meta_kubernetes_pod_annotation_(.+)"
     }
+  
+    // explicitly set service_name. if not set, loki will automatically try to populate a default.
+    // see https://grafana.com/docs/loki/latest/get-started/labels/#default-labels-for-all-users
+    //
+    // choose the first value found from the following ordered list:
+    // - pod.annotation[resource.opentelemetry.io/service.name]
+    // - pod.label[app.kubernetes.io/name]
+    // - k8s.pod.name
+    // - k8s.container.name
+    rule {
+      action = "replace"
+      source_labels = [
+        "__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_name",
+        "__meta_kubernetes_pod_label_app_kubernetes_io_name",
+        "__meta_kubernetes_pod_name",
+        "__meta_kubernetes_pod_container_name",
+      ]
+      separator = ";"
+      regex = "^(?:;*)?([^;]+).*$"
+      replacement = "$1"
+      target_label = "service_name"
+    }
   }
   
   discovery.kubernetes "pods" {

--- a/charts/k8s-monitoring/docs/examples/features/pod-logs/default/alloy-logs.alloy
+++ b/charts/k8s-monitoring/docs/examples/features/pod-logs/default/alloy-logs.alloy
@@ -98,6 +98,25 @@ declare "pod_logs" {
       replacement = "$1"
       target_label = "service_name"
     }
+  
+    // set service_namespace
+    rule {
+      action = "replace"
+      source_labels = ["__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_namespace"]
+      target_label = "service_namespace"
+    }
+  
+    // set deployment_environment and deployment_environment_name
+    rule {
+      action = "replace"
+      source_labels = ["__meta_kubernetes_pod_annotation_resource_opentelemetry_io_deployment_environment_name"]
+      target_label = "deployment_environment_name"
+    }
+    rule {
+      action = "replace"
+      source_labels = ["__meta_kubernetes_pod_annotation_resource_opentelemetry_io_deployment_environment"]
+      target_label = "deployment_environment"
+    }
   }
   
   discovery.kubernetes "pods" {
@@ -169,7 +188,7 @@ declare "pod_logs" {
   
     // Only keep the labels that are defined in the `keepLabels` list.
     stage.label_keep {
-      values = ["app_kubernetes_io_name","container","instance","job","level","namespace","pod","service_name","integration"]
+      values = ["app_kubernetes_io_name","container","instance","job","level","namespace","pod","service_name","service_namespace","deployment_environment","deployment_environment_name","integration"]
     }
   
     forward_to = argument.logs_destinations.value

--- a/charts/k8s-monitoring/docs/examples/features/pod-logs/default/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/features/pod-logs/default/output.yaml
@@ -101,6 +101,28 @@ data:
           action = "labelmap"
           regex = "__meta_kubernetes_pod_annotation_(.+)"
         }
+      
+        // explicitly set service_name. if not set, loki will automatically try to populate a default.
+        // see https://grafana.com/docs/loki/latest/get-started/labels/#default-labels-for-all-users
+        //
+        // choose the first value found from the following ordered list:
+        // - pod.annotation[resource.opentelemetry.io/service.name]
+        // - pod.label[app.kubernetes.io/name]
+        // - k8s.pod.name
+        // - k8s.container.name
+        rule {
+          action = "replace"
+          source_labels = [
+            "__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_name",
+            "__meta_kubernetes_pod_label_app_kubernetes_io_name",
+            "__meta_kubernetes_pod_name",
+            "__meta_kubernetes_pod_container_name",
+          ]
+          separator = ";"
+          regex = "^(?:;*)?([^;]+).*$"
+          replacement = "$1"
+          target_label = "service_name"
+        }
       }
       
       discovery.kubernetes "pods" {

--- a/charts/k8s-monitoring/docs/examples/features/pod-logs/default/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/features/pod-logs/default/output.yaml
@@ -123,6 +123,25 @@ data:
           replacement = "$1"
           target_label = "service_name"
         }
+      
+        // set service_namespace
+        rule {
+          action = "replace"
+          source_labels = ["__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_namespace"]
+          target_label = "service_namespace"
+        }
+      
+        // set deployment_environment and deployment_environment_name
+        rule {
+          action = "replace"
+          source_labels = ["__meta_kubernetes_pod_annotation_resource_opentelemetry_io_deployment_environment_name"]
+          target_label = "deployment_environment_name"
+        }
+        rule {
+          action = "replace"
+          source_labels = ["__meta_kubernetes_pod_annotation_resource_opentelemetry_io_deployment_environment"]
+          target_label = "deployment_environment"
+        }
       }
       
       discovery.kubernetes "pods" {
@@ -194,7 +213,7 @@ data:
       
         // Only keep the labels that are defined in the `keepLabels` list.
         stage.label_keep {
-          values = ["app_kubernetes_io_name","container","instance","job","level","namespace","pod","service_name","integration"]
+          values = ["app_kubernetes_io_name","container","instance","job","level","namespace","pod","service_name","service_namespace","deployment_environment","deployment_environment_name","integration"]
         }
       
         forward_to = argument.logs_destinations.value

--- a/charts/k8s-monitoring/docs/examples/meta-monitoring/alloy-singleton.alloy
+++ b/charts/k8s-monitoring/docs/examples/meta-monitoring/alloy-singleton.alloy
@@ -439,6 +439,28 @@ declare "pod_logs" {
       action = "labelmap"
       regex = "__meta_kubernetes_pod_annotation_(.+)"
     }
+  
+    // explicitly set service_name. if not set, loki will automatically try to populate a default.
+    // see https://grafana.com/docs/loki/latest/get-started/labels/#default-labels-for-all-users
+    //
+    // choose the first value found from the following ordered list:
+    // - pod.annotation[resource.opentelemetry.io/service.name]
+    // - pod.label[app.kubernetes.io/name]
+    // - k8s.pod.name
+    // - k8s.container.name
+    rule {
+      action = "replace"
+      source_labels = [
+        "__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_name",
+        "__meta_kubernetes_pod_label_app_kubernetes_io_name",
+        "__meta_kubernetes_pod_name",
+        "__meta_kubernetes_pod_container_name",
+      ]
+      separator = ";"
+      regex = "^(?:;*)?([^;]+).*$"
+      replacement = "$1"
+      target_label = "service_name"
+    }
     rule {
       source_labels = ["__meta_kubernetes_namespace","__meta_kubernetes_pod_label_app_kubernetes_io_name"]
       separator = ";"

--- a/charts/k8s-monitoring/docs/examples/meta-monitoring/alloy-singleton.alloy
+++ b/charts/k8s-monitoring/docs/examples/meta-monitoring/alloy-singleton.alloy
@@ -461,6 +461,25 @@ declare "pod_logs" {
       replacement = "$1"
       target_label = "service_name"
     }
+  
+    // set service_namespace
+    rule {
+      action = "replace"
+      source_labels = ["__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_namespace"]
+      target_label = "service_namespace"
+    }
+  
+    // set deployment_environment and deployment_environment_name
+    rule {
+      action = "replace"
+      source_labels = ["__meta_kubernetes_pod_annotation_resource_opentelemetry_io_deployment_environment_name"]
+      target_label = "deployment_environment_name"
+    }
+    rule {
+      action = "replace"
+      source_labels = ["__meta_kubernetes_pod_annotation_resource_opentelemetry_io_deployment_environment"]
+      target_label = "deployment_environment"
+    }
     rule {
       source_labels = ["__meta_kubernetes_namespace","__meta_kubernetes_pod_label_app_kubernetes_io_name"]
       separator = ";"

--- a/charts/k8s-monitoring/docs/examples/meta-monitoring/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/meta-monitoring/output.yaml
@@ -536,6 +536,25 @@ data:
           replacement = "$1"
           target_label = "service_name"
         }
+      
+        // set service_namespace
+        rule {
+          action = "replace"
+          source_labels = ["__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_namespace"]
+          target_label = "service_namespace"
+        }
+      
+        // set deployment_environment and deployment_environment_name
+        rule {
+          action = "replace"
+          source_labels = ["__meta_kubernetes_pod_annotation_resource_opentelemetry_io_deployment_environment_name"]
+          target_label = "deployment_environment_name"
+        }
+        rule {
+          action = "replace"
+          source_labels = ["__meta_kubernetes_pod_annotation_resource_opentelemetry_io_deployment_environment"]
+          target_label = "deployment_environment"
+        }
         rule {
           source_labels = ["__meta_kubernetes_namespace","__meta_kubernetes_pod_label_app_kubernetes_io_name"]
           separator = ";"

--- a/charts/k8s-monitoring/docs/examples/meta-monitoring/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/meta-monitoring/output.yaml
@@ -514,6 +514,28 @@ data:
           action = "labelmap"
           regex = "__meta_kubernetes_pod_annotation_(.+)"
         }
+      
+        // explicitly set service_name. if not set, loki will automatically try to populate a default.
+        // see https://grafana.com/docs/loki/latest/get-started/labels/#default-labels-for-all-users
+        //
+        // choose the first value found from the following ordered list:
+        // - pod.annotation[resource.opentelemetry.io/service.name]
+        // - pod.label[app.kubernetes.io/name]
+        // - k8s.pod.name
+        // - k8s.container.name
+        rule {
+          action = "replace"
+          source_labels = [
+            "__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_name",
+            "__meta_kubernetes_pod_label_app_kubernetes_io_name",
+            "__meta_kubernetes_pod_name",
+            "__meta_kubernetes_pod_container_name",
+          ]
+          separator = ";"
+          regex = "^(?:;*)?([^;]+).*$"
+          replacement = "$1"
+          target_label = "service_name"
+        }
         rule {
           source_labels = ["__meta_kubernetes_namespace","__meta_kubernetes_pod_label_app_kubernetes_io_name"]
           separator = ";"

--- a/charts/k8s-monitoring/docs/examples/platforms/azure-aks/alloy-logs.alloy
+++ b/charts/k8s-monitoring/docs/examples/platforms/azure-aks/alloy-logs.alloy
@@ -76,6 +76,28 @@ declare "pod_logs" {
       action = "labelmap"
       regex = "__meta_kubernetes_pod_annotation_(.+)"
     }
+  
+    // explicitly set service_name. if not set, loki will automatically try to populate a default.
+    // see https://grafana.com/docs/loki/latest/get-started/labels/#default-labels-for-all-users
+    //
+    // choose the first value found from the following ordered list:
+    // - pod.annotation[resource.opentelemetry.io/service.name]
+    // - pod.label[app.kubernetes.io/name]
+    // - k8s.pod.name
+    // - k8s.container.name
+    rule {
+      action = "replace"
+      source_labels = [
+        "__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_name",
+        "__meta_kubernetes_pod_label_app_kubernetes_io_name",
+        "__meta_kubernetes_pod_name",
+        "__meta_kubernetes_pod_container_name",
+      ]
+      separator = ";"
+      regex = "^(?:;*)?([^;]+).*$"
+      replacement = "$1"
+      target_label = "service_name"
+    }
   }
   
   discovery.kubernetes "pods" {

--- a/charts/k8s-monitoring/docs/examples/platforms/azure-aks/alloy-logs.alloy
+++ b/charts/k8s-monitoring/docs/examples/platforms/azure-aks/alloy-logs.alloy
@@ -98,6 +98,25 @@ declare "pod_logs" {
       replacement = "$1"
       target_label = "service_name"
     }
+  
+    // set service_namespace
+    rule {
+      action = "replace"
+      source_labels = ["__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_namespace"]
+      target_label = "service_namespace"
+    }
+  
+    // set deployment_environment and deployment_environment_name
+    rule {
+      action = "replace"
+      source_labels = ["__meta_kubernetes_pod_annotation_resource_opentelemetry_io_deployment_environment_name"]
+      target_label = "deployment_environment_name"
+    }
+    rule {
+      action = "replace"
+      source_labels = ["__meta_kubernetes_pod_annotation_resource_opentelemetry_io_deployment_environment"]
+      target_label = "deployment_environment"
+    }
   }
   
   discovery.kubernetes "pods" {
@@ -169,7 +188,7 @@ declare "pod_logs" {
   
     // Only keep the labels that are defined in the `keepLabels` list.
     stage.label_keep {
-      values = ["app_kubernetes_io_name","container","instance","job","level","namespace","pod","service_name","integration"]
+      values = ["app_kubernetes_io_name","container","instance","job","level","namespace","pod","service_name","service_namespace","deployment_environment","deployment_environment_name","integration"]
     }
   
     forward_to = argument.logs_destinations.value

--- a/charts/k8s-monitoring/docs/examples/platforms/azure-aks/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/platforms/azure-aks/output.yaml
@@ -699,6 +699,28 @@ data:
           action = "labelmap"
           regex = "__meta_kubernetes_pod_annotation_(.+)"
         }
+      
+        // explicitly set service_name. if not set, loki will automatically try to populate a default.
+        // see https://grafana.com/docs/loki/latest/get-started/labels/#default-labels-for-all-users
+        //
+        // choose the first value found from the following ordered list:
+        // - pod.annotation[resource.opentelemetry.io/service.name]
+        // - pod.label[app.kubernetes.io/name]
+        // - k8s.pod.name
+        // - k8s.container.name
+        rule {
+          action = "replace"
+          source_labels = [
+            "__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_name",
+            "__meta_kubernetes_pod_label_app_kubernetes_io_name",
+            "__meta_kubernetes_pod_name",
+            "__meta_kubernetes_pod_container_name",
+          ]
+          separator = ";"
+          regex = "^(?:;*)?([^;]+).*$"
+          replacement = "$1"
+          target_label = "service_name"
+        }
       }
       
       discovery.kubernetes "pods" {

--- a/charts/k8s-monitoring/docs/examples/platforms/azure-aks/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/platforms/azure-aks/output.yaml
@@ -721,6 +721,25 @@ data:
           replacement = "$1"
           target_label = "service_name"
         }
+      
+        // set service_namespace
+        rule {
+          action = "replace"
+          source_labels = ["__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_namespace"]
+          target_label = "service_namespace"
+        }
+      
+        // set deployment_environment and deployment_environment_name
+        rule {
+          action = "replace"
+          source_labels = ["__meta_kubernetes_pod_annotation_resource_opentelemetry_io_deployment_environment_name"]
+          target_label = "deployment_environment_name"
+        }
+        rule {
+          action = "replace"
+          source_labels = ["__meta_kubernetes_pod_annotation_resource_opentelemetry_io_deployment_environment"]
+          target_label = "deployment_environment"
+        }
       }
       
       discovery.kubernetes "pods" {
@@ -792,7 +811,7 @@ data:
       
         // Only keep the labels that are defined in the `keepLabels` list.
         stage.label_keep {
-          values = ["app_kubernetes_io_name","container","instance","job","level","namespace","pod","service_name","integration"]
+          values = ["app_kubernetes_io_name","container","instance","job","level","namespace","pod","service_name","service_namespace","deployment_environment","deployment_environment_name","integration"]
         }
       
         forward_to = argument.logs_destinations.value

--- a/charts/k8s-monitoring/docs/examples/platforms/eks-fargate/alloy-logs.alloy
+++ b/charts/k8s-monitoring/docs/examples/platforms/eks-fargate/alloy-logs.alloy
@@ -98,6 +98,25 @@ declare "pod_logs" {
       replacement = "$1"
       target_label = "service_name"
     }
+  
+    // set service_namespace
+    rule {
+      action = "replace"
+      source_labels = ["__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_namespace"]
+      target_label = "service_namespace"
+    }
+  
+    // set deployment_environment and deployment_environment_name
+    rule {
+      action = "replace"
+      source_labels = ["__meta_kubernetes_pod_annotation_resource_opentelemetry_io_deployment_environment_name"]
+      target_label = "deployment_environment_name"
+    }
+    rule {
+      action = "replace"
+      source_labels = ["__meta_kubernetes_pod_annotation_resource_opentelemetry_io_deployment_environment"]
+      target_label = "deployment_environment"
+    }
   }
   
   discovery.kubernetes "pods" {
@@ -149,7 +168,7 @@ declare "pod_logs" {
   
     // Only keep the labels that are defined in the `keepLabels` list.
     stage.label_keep {
-      values = ["app_kubernetes_io_name","container","instance","job","level","namespace","pod","service_name","integration"]
+      values = ["app_kubernetes_io_name","container","instance","job","level","namespace","pod","service_name","service_namespace","deployment_environment","deployment_environment_name","integration"]
     }
   
     forward_to = argument.logs_destinations.value

--- a/charts/k8s-monitoring/docs/examples/platforms/eks-fargate/alloy-logs.alloy
+++ b/charts/k8s-monitoring/docs/examples/platforms/eks-fargate/alloy-logs.alloy
@@ -76,6 +76,28 @@ declare "pod_logs" {
       action = "labelmap"
       regex = "__meta_kubernetes_pod_annotation_(.+)"
     }
+  
+    // explicitly set service_name. if not set, loki will automatically try to populate a default.
+    // see https://grafana.com/docs/loki/latest/get-started/labels/#default-labels-for-all-users
+    //
+    // choose the first value found from the following ordered list:
+    // - pod.annotation[resource.opentelemetry.io/service.name]
+    // - pod.label[app.kubernetes.io/name]
+    // - k8s.pod.name
+    // - k8s.container.name
+    rule {
+      action = "replace"
+      source_labels = [
+        "__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_name",
+        "__meta_kubernetes_pod_label_app_kubernetes_io_name",
+        "__meta_kubernetes_pod_name",
+        "__meta_kubernetes_pod_container_name",
+      ]
+      separator = ";"
+      regex = "^(?:;*)?([^;]+).*$"
+      replacement = "$1"
+      target_label = "service_name"
+    }
   }
   
   discovery.kubernetes "pods" {

--- a/charts/k8s-monitoring/docs/examples/platforms/eks-fargate/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/platforms/eks-fargate/output.yaml
@@ -666,6 +666,25 @@ data:
           replacement = "$1"
           target_label = "service_name"
         }
+      
+        // set service_namespace
+        rule {
+          action = "replace"
+          source_labels = ["__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_namespace"]
+          target_label = "service_namespace"
+        }
+      
+        // set deployment_environment and deployment_environment_name
+        rule {
+          action = "replace"
+          source_labels = ["__meta_kubernetes_pod_annotation_resource_opentelemetry_io_deployment_environment_name"]
+          target_label = "deployment_environment_name"
+        }
+        rule {
+          action = "replace"
+          source_labels = ["__meta_kubernetes_pod_annotation_resource_opentelemetry_io_deployment_environment"]
+          target_label = "deployment_environment"
+        }
       }
       
       discovery.kubernetes "pods" {
@@ -717,7 +736,7 @@ data:
       
         // Only keep the labels that are defined in the `keepLabels` list.
         stage.label_keep {
-          values = ["app_kubernetes_io_name","container","instance","job","level","namespace","pod","service_name","integration"]
+          values = ["app_kubernetes_io_name","container","instance","job","level","namespace","pod","service_name","service_namespace","deployment_environment","deployment_environment_name","integration"]
         }
       
         forward_to = argument.logs_destinations.value

--- a/charts/k8s-monitoring/docs/examples/platforms/eks-fargate/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/platforms/eks-fargate/output.yaml
@@ -644,6 +644,28 @@ data:
           action = "labelmap"
           regex = "__meta_kubernetes_pod_annotation_(.+)"
         }
+      
+        // explicitly set service_name. if not set, loki will automatically try to populate a default.
+        // see https://grafana.com/docs/loki/latest/get-started/labels/#default-labels-for-all-users
+        //
+        // choose the first value found from the following ordered list:
+        // - pod.annotation[resource.opentelemetry.io/service.name]
+        // - pod.label[app.kubernetes.io/name]
+        // - k8s.pod.name
+        // - k8s.container.name
+        rule {
+          action = "replace"
+          source_labels = [
+            "__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_name",
+            "__meta_kubernetes_pod_label_app_kubernetes_io_name",
+            "__meta_kubernetes_pod_name",
+            "__meta_kubernetes_pod_container_name",
+          ]
+          separator = ";"
+          regex = "^(?:;*)?([^;]+).*$"
+          replacement = "$1"
+          target_label = "service_name"
+        }
       }
       
       discovery.kubernetes "pods" {

--- a/charts/k8s-monitoring/docs/examples/platforms/gke-autopilot/alloy-logs.alloy
+++ b/charts/k8s-monitoring/docs/examples/platforms/gke-autopilot/alloy-logs.alloy
@@ -76,6 +76,28 @@ declare "pod_logs" {
       action = "labelmap"
       regex = "__meta_kubernetes_pod_annotation_(.+)"
     }
+  
+    // explicitly set service_name. if not set, loki will automatically try to populate a default.
+    // see https://grafana.com/docs/loki/latest/get-started/labels/#default-labels-for-all-users
+    //
+    // choose the first value found from the following ordered list:
+    // - pod.annotation[resource.opentelemetry.io/service.name]
+    // - pod.label[app.kubernetes.io/name]
+    // - k8s.pod.name
+    // - k8s.container.name
+    rule {
+      action = "replace"
+      source_labels = [
+        "__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_name",
+        "__meta_kubernetes_pod_label_app_kubernetes_io_name",
+        "__meta_kubernetes_pod_name",
+        "__meta_kubernetes_pod_container_name",
+      ]
+      separator = ";"
+      regex = "^(?:;*)?([^;]+).*$"
+      replacement = "$1"
+      target_label = "service_name"
+    }
   }
   
   discovery.kubernetes "pods" {

--- a/charts/k8s-monitoring/docs/examples/platforms/gke-autopilot/alloy-logs.alloy
+++ b/charts/k8s-monitoring/docs/examples/platforms/gke-autopilot/alloy-logs.alloy
@@ -98,6 +98,25 @@ declare "pod_logs" {
       replacement = "$1"
       target_label = "service_name"
     }
+  
+    // set service_namespace
+    rule {
+      action = "replace"
+      source_labels = ["__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_namespace"]
+      target_label = "service_namespace"
+    }
+  
+    // set deployment_environment and deployment_environment_name
+    rule {
+      action = "replace"
+      source_labels = ["__meta_kubernetes_pod_annotation_resource_opentelemetry_io_deployment_environment_name"]
+      target_label = "deployment_environment_name"
+    }
+    rule {
+      action = "replace"
+      source_labels = ["__meta_kubernetes_pod_annotation_resource_opentelemetry_io_deployment_environment"]
+      target_label = "deployment_environment"
+    }
   }
   
   discovery.kubernetes "pods" {
@@ -169,7 +188,7 @@ declare "pod_logs" {
   
     // Only keep the labels that are defined in the `keepLabels` list.
     stage.label_keep {
-      values = ["app_kubernetes_io_name","container","instance","job","level","namespace","pod","service_name","integration"]
+      values = ["app_kubernetes_io_name","container","instance","job","level","namespace","pod","service_name","service_namespace","deployment_environment","deployment_environment_name","integration"]
     }
   
     forward_to = argument.logs_destinations.value

--- a/charts/k8s-monitoring/docs/examples/platforms/gke-autopilot/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/platforms/gke-autopilot/output.yaml
@@ -666,6 +666,25 @@ data:
           replacement = "$1"
           target_label = "service_name"
         }
+      
+        // set service_namespace
+        rule {
+          action = "replace"
+          source_labels = ["__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_namespace"]
+          target_label = "service_namespace"
+        }
+      
+        // set deployment_environment and deployment_environment_name
+        rule {
+          action = "replace"
+          source_labels = ["__meta_kubernetes_pod_annotation_resource_opentelemetry_io_deployment_environment_name"]
+          target_label = "deployment_environment_name"
+        }
+        rule {
+          action = "replace"
+          source_labels = ["__meta_kubernetes_pod_annotation_resource_opentelemetry_io_deployment_environment"]
+          target_label = "deployment_environment"
+        }
       }
       
       discovery.kubernetes "pods" {
@@ -737,7 +756,7 @@ data:
       
         // Only keep the labels that are defined in the `keepLabels` list.
         stage.label_keep {
-          values = ["app_kubernetes_io_name","container","instance","job","level","namespace","pod","service_name","integration"]
+          values = ["app_kubernetes_io_name","container","instance","job","level","namespace","pod","service_name","service_namespace","deployment_environment","deployment_environment_name","integration"]
         }
       
         forward_to = argument.logs_destinations.value

--- a/charts/k8s-monitoring/docs/examples/platforms/gke-autopilot/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/platforms/gke-autopilot/output.yaml
@@ -644,6 +644,28 @@ data:
           action = "labelmap"
           regex = "__meta_kubernetes_pod_annotation_(.+)"
         }
+      
+        // explicitly set service_name. if not set, loki will automatically try to populate a default.
+        // see https://grafana.com/docs/loki/latest/get-started/labels/#default-labels-for-all-users
+        //
+        // choose the first value found from the following ordered list:
+        // - pod.annotation[resource.opentelemetry.io/service.name]
+        // - pod.label[app.kubernetes.io/name]
+        // - k8s.pod.name
+        // - k8s.container.name
+        rule {
+          action = "replace"
+          source_labels = [
+            "__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_name",
+            "__meta_kubernetes_pod_label_app_kubernetes_io_name",
+            "__meta_kubernetes_pod_name",
+            "__meta_kubernetes_pod_container_name",
+          ]
+          separator = ";"
+          regex = "^(?:;*)?([^;]+).*$"
+          replacement = "$1"
+          target_label = "service_name"
+        }
       }
       
       discovery.kubernetes "pods" {

--- a/charts/k8s-monitoring/docs/examples/platforms/openshift/alloy-logs.alloy
+++ b/charts/k8s-monitoring/docs/examples/platforms/openshift/alloy-logs.alloy
@@ -76,6 +76,28 @@ declare "pod_logs" {
       action = "labelmap"
       regex = "__meta_kubernetes_pod_annotation_(.+)"
     }
+  
+    // explicitly set service_name. if not set, loki will automatically try to populate a default.
+    // see https://grafana.com/docs/loki/latest/get-started/labels/#default-labels-for-all-users
+    //
+    // choose the first value found from the following ordered list:
+    // - pod.annotation[resource.opentelemetry.io/service.name]
+    // - pod.label[app.kubernetes.io/name]
+    // - k8s.pod.name
+    // - k8s.container.name
+    rule {
+      action = "replace"
+      source_labels = [
+        "__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_name",
+        "__meta_kubernetes_pod_label_app_kubernetes_io_name",
+        "__meta_kubernetes_pod_name",
+        "__meta_kubernetes_pod_container_name",
+      ]
+      separator = ";"
+      regex = "^(?:;*)?([^;]+).*$"
+      replacement = "$1"
+      target_label = "service_name"
+    }
   }
   
   discovery.kubernetes "pods" {

--- a/charts/k8s-monitoring/docs/examples/platforms/openshift/alloy-logs.alloy
+++ b/charts/k8s-monitoring/docs/examples/platforms/openshift/alloy-logs.alloy
@@ -98,6 +98,25 @@ declare "pod_logs" {
       replacement = "$1"
       target_label = "service_name"
     }
+  
+    // set service_namespace
+    rule {
+      action = "replace"
+      source_labels = ["__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_namespace"]
+      target_label = "service_namespace"
+    }
+  
+    // set deployment_environment and deployment_environment_name
+    rule {
+      action = "replace"
+      source_labels = ["__meta_kubernetes_pod_annotation_resource_opentelemetry_io_deployment_environment_name"]
+      target_label = "deployment_environment_name"
+    }
+    rule {
+      action = "replace"
+      source_labels = ["__meta_kubernetes_pod_annotation_resource_opentelemetry_io_deployment_environment"]
+      target_label = "deployment_environment"
+    }
   }
   
   discovery.kubernetes "pods" {
@@ -169,7 +188,7 @@ declare "pod_logs" {
   
     // Only keep the labels that are defined in the `keepLabels` list.
     stage.label_keep {
-      values = ["app_kubernetes_io_name","container","instance","job","level","namespace","pod","service_name","integration"]
+      values = ["app_kubernetes_io_name","container","instance","job","level","namespace","pod","service_name","service_namespace","deployment_environment","deployment_environment_name","integration"]
     }
   
     forward_to = argument.logs_destinations.value

--- a/charts/k8s-monitoring/docs/examples/platforms/openshift/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/platforms/openshift/output.yaml
@@ -741,6 +741,25 @@ data:
           replacement = "$1"
           target_label = "service_name"
         }
+      
+        // set service_namespace
+        rule {
+          action = "replace"
+          source_labels = ["__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_namespace"]
+          target_label = "service_namespace"
+        }
+      
+        // set deployment_environment and deployment_environment_name
+        rule {
+          action = "replace"
+          source_labels = ["__meta_kubernetes_pod_annotation_resource_opentelemetry_io_deployment_environment_name"]
+          target_label = "deployment_environment_name"
+        }
+        rule {
+          action = "replace"
+          source_labels = ["__meta_kubernetes_pod_annotation_resource_opentelemetry_io_deployment_environment"]
+          target_label = "deployment_environment"
+        }
       }
       
       discovery.kubernetes "pods" {
@@ -812,7 +831,7 @@ data:
       
         // Only keep the labels that are defined in the `keepLabels` list.
         stage.label_keep {
-          values = ["app_kubernetes_io_name","container","instance","job","level","namespace","pod","service_name","integration"]
+          values = ["app_kubernetes_io_name","container","instance","job","level","namespace","pod","service_name","service_namespace","deployment_environment","deployment_environment_name","integration"]
         }
       
         forward_to = argument.logs_destinations.value

--- a/charts/k8s-monitoring/docs/examples/platforms/openshift/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/platforms/openshift/output.yaml
@@ -719,6 +719,28 @@ data:
           action = "labelmap"
           regex = "__meta_kubernetes_pod_annotation_(.+)"
         }
+      
+        // explicitly set service_name. if not set, loki will automatically try to populate a default.
+        // see https://grafana.com/docs/loki/latest/get-started/labels/#default-labels-for-all-users
+        //
+        // choose the first value found from the following ordered list:
+        // - pod.annotation[resource.opentelemetry.io/service.name]
+        // - pod.label[app.kubernetes.io/name]
+        // - k8s.pod.name
+        // - k8s.container.name
+        rule {
+          action = "replace"
+          source_labels = [
+            "__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_name",
+            "__meta_kubernetes_pod_label_app_kubernetes_io_name",
+            "__meta_kubernetes_pod_name",
+            "__meta_kubernetes_pod_container_name",
+          ]
+          separator = ";"
+          regex = "^(?:;*)?([^;]+).*$"
+          replacement = "$1"
+          target_label = "service_name"
+        }
       }
       
       discovery.kubernetes "pods" {

--- a/charts/k8s-monitoring/docs/examples/pod-labels-and-annotations/alloy-logs.alloy
+++ b/charts/k8s-monitoring/docs/examples/pod-labels-and-annotations/alloy-logs.alloy
@@ -76,6 +76,28 @@ declare "pod_logs" {
       action = "labelmap"
       regex = "__meta_kubernetes_pod_annotation_(.+)"
     }
+  
+    // explicitly set service_name. if not set, loki will automatically try to populate a default.
+    // see https://grafana.com/docs/loki/latest/get-started/labels/#default-labels-for-all-users
+    //
+    // choose the first value found from the following ordered list:
+    // - pod.annotation[resource.opentelemetry.io/service.name]
+    // - pod.label[app.kubernetes.io/name]
+    // - k8s.pod.name
+    // - k8s.container.name
+    rule {
+      action = "replace"
+      source_labels = [
+        "__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_name",
+        "__meta_kubernetes_pod_label_app_kubernetes_io_name",
+        "__meta_kubernetes_pod_name",
+        "__meta_kubernetes_pod_container_name",
+      ]
+      separator = ";"
+      regex = "^(?:;*)?([^;]+).*$"
+      replacement = "$1"
+      target_label = "service_name"
+    }
   }
   
   discovery.kubernetes "pods" {

--- a/charts/k8s-monitoring/docs/examples/pod-labels-and-annotations/alloy-logs.alloy
+++ b/charts/k8s-monitoring/docs/examples/pod-labels-and-annotations/alloy-logs.alloy
@@ -98,6 +98,25 @@ declare "pod_logs" {
       replacement = "$1"
       target_label = "service_name"
     }
+  
+    // set service_namespace
+    rule {
+      action = "replace"
+      source_labels = ["__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_namespace"]
+      target_label = "service_namespace"
+    }
+  
+    // set deployment_environment and deployment_environment_name
+    rule {
+      action = "replace"
+      source_labels = ["__meta_kubernetes_pod_annotation_resource_opentelemetry_io_deployment_environment_name"]
+      target_label = "deployment_environment_name"
+    }
+    rule {
+      action = "replace"
+      source_labels = ["__meta_kubernetes_pod_annotation_resource_opentelemetry_io_deployment_environment"]
+      target_label = "deployment_environment"
+    }
   }
   
   discovery.kubernetes "pods" {

--- a/charts/k8s-monitoring/docs/examples/pod-labels-and-annotations/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/pod-labels-and-annotations/output.yaml
@@ -569,6 +569,25 @@ data:
           replacement = "$1"
           target_label = "service_name"
         }
+      
+        // set service_namespace
+        rule {
+          action = "replace"
+          source_labels = ["__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_namespace"]
+          target_label = "service_namespace"
+        }
+      
+        // set deployment_environment and deployment_environment_name
+        rule {
+          action = "replace"
+          source_labels = ["__meta_kubernetes_pod_annotation_resource_opentelemetry_io_deployment_environment_name"]
+          target_label = "deployment_environment_name"
+        }
+        rule {
+          action = "replace"
+          source_labels = ["__meta_kubernetes_pod_annotation_resource_opentelemetry_io_deployment_environment"]
+          target_label = "deployment_environment"
+        }
       }
       
       discovery.kubernetes "pods" {

--- a/charts/k8s-monitoring/docs/examples/pod-labels-and-annotations/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/pod-labels-and-annotations/output.yaml
@@ -547,6 +547,28 @@ data:
           action = "labelmap"
           regex = "__meta_kubernetes_pod_annotation_(.+)"
         }
+      
+        // explicitly set service_name. if not set, loki will automatically try to populate a default.
+        // see https://grafana.com/docs/loki/latest/get-started/labels/#default-labels-for-all-users
+        //
+        // choose the first value found from the following ordered list:
+        // - pod.annotation[resource.opentelemetry.io/service.name]
+        // - pod.label[app.kubernetes.io/name]
+        // - k8s.pod.name
+        // - k8s.container.name
+        rule {
+          action = "replace"
+          source_labels = [
+            "__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_name",
+            "__meta_kubernetes_pod_label_app_kubernetes_io_name",
+            "__meta_kubernetes_pod_name",
+            "__meta_kubernetes_pod_container_name",
+          ]
+          separator = ";"
+          regex = "^(?:;*)?([^;]+).*$"
+          replacement = "$1"
+          target_label = "service_name"
+        }
       }
       
       discovery.kubernetes "pods" {

--- a/charts/k8s-monitoring/docs/examples/private-image-registries/globally/alloy-logs.alloy
+++ b/charts/k8s-monitoring/docs/examples/private-image-registries/globally/alloy-logs.alloy
@@ -76,6 +76,28 @@ declare "pod_logs" {
       action = "labelmap"
       regex = "__meta_kubernetes_pod_annotation_(.+)"
     }
+  
+    // explicitly set service_name. if not set, loki will automatically try to populate a default.
+    // see https://grafana.com/docs/loki/latest/get-started/labels/#default-labels-for-all-users
+    //
+    // choose the first value found from the following ordered list:
+    // - pod.annotation[resource.opentelemetry.io/service.name]
+    // - pod.label[app.kubernetes.io/name]
+    // - k8s.pod.name
+    // - k8s.container.name
+    rule {
+      action = "replace"
+      source_labels = [
+        "__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_name",
+        "__meta_kubernetes_pod_label_app_kubernetes_io_name",
+        "__meta_kubernetes_pod_name",
+        "__meta_kubernetes_pod_container_name",
+      ]
+      separator = ";"
+      regex = "^(?:;*)?([^;]+).*$"
+      replacement = "$1"
+      target_label = "service_name"
+    }
   }
   
   discovery.kubernetes "pods" {

--- a/charts/k8s-monitoring/docs/examples/private-image-registries/globally/alloy-logs.alloy
+++ b/charts/k8s-monitoring/docs/examples/private-image-registries/globally/alloy-logs.alloy
@@ -98,6 +98,25 @@ declare "pod_logs" {
       replacement = "$1"
       target_label = "service_name"
     }
+  
+    // set service_namespace
+    rule {
+      action = "replace"
+      source_labels = ["__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_namespace"]
+      target_label = "service_namespace"
+    }
+  
+    // set deployment_environment and deployment_environment_name
+    rule {
+      action = "replace"
+      source_labels = ["__meta_kubernetes_pod_annotation_resource_opentelemetry_io_deployment_environment_name"]
+      target_label = "deployment_environment_name"
+    }
+    rule {
+      action = "replace"
+      source_labels = ["__meta_kubernetes_pod_annotation_resource_opentelemetry_io_deployment_environment"]
+      target_label = "deployment_environment"
+    }
   }
   
   discovery.kubernetes "pods" {
@@ -169,7 +188,7 @@ declare "pod_logs" {
   
     // Only keep the labels that are defined in the `keepLabels` list.
     stage.label_keep {
-      values = ["app_kubernetes_io_name","container","instance","job","level","namespace","pod","service_name","integration"]
+      values = ["app_kubernetes_io_name","container","instance","job","level","namespace","pod","service_name","service_namespace","deployment_environment","deployment_environment_name","integration"]
     }
   
     forward_to = argument.logs_destinations.value

--- a/charts/k8s-monitoring/docs/examples/private-image-registries/globally/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/private-image-registries/globally/output.yaml
@@ -558,6 +558,25 @@ data:
           replacement = "$1"
           target_label = "service_name"
         }
+      
+        // set service_namespace
+        rule {
+          action = "replace"
+          source_labels = ["__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_namespace"]
+          target_label = "service_namespace"
+        }
+      
+        // set deployment_environment and deployment_environment_name
+        rule {
+          action = "replace"
+          source_labels = ["__meta_kubernetes_pod_annotation_resource_opentelemetry_io_deployment_environment_name"]
+          target_label = "deployment_environment_name"
+        }
+        rule {
+          action = "replace"
+          source_labels = ["__meta_kubernetes_pod_annotation_resource_opentelemetry_io_deployment_environment"]
+          target_label = "deployment_environment"
+        }
       }
       
       discovery.kubernetes "pods" {
@@ -629,7 +648,7 @@ data:
       
         // Only keep the labels that are defined in the `keepLabels` list.
         stage.label_keep {
-          values = ["app_kubernetes_io_name","container","instance","job","level","namespace","pod","service_name","integration"]
+          values = ["app_kubernetes_io_name","container","instance","job","level","namespace","pod","service_name","service_namespace","deployment_environment","deployment_environment_name","integration"]
         }
       
         forward_to = argument.logs_destinations.value

--- a/charts/k8s-monitoring/docs/examples/private-image-registries/globally/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/private-image-registries/globally/output.yaml
@@ -536,6 +536,28 @@ data:
           action = "labelmap"
           regex = "__meta_kubernetes_pod_annotation_(.+)"
         }
+      
+        // explicitly set service_name. if not set, loki will automatically try to populate a default.
+        // see https://grafana.com/docs/loki/latest/get-started/labels/#default-labels-for-all-users
+        //
+        // choose the first value found from the following ordered list:
+        // - pod.annotation[resource.opentelemetry.io/service.name]
+        // - pod.label[app.kubernetes.io/name]
+        // - k8s.pod.name
+        // - k8s.container.name
+        rule {
+          action = "replace"
+          source_labels = [
+            "__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_name",
+            "__meta_kubernetes_pod_label_app_kubernetes_io_name",
+            "__meta_kubernetes_pod_name",
+            "__meta_kubernetes_pod_container_name",
+          ]
+          separator = ";"
+          regex = "^(?:;*)?([^;]+).*$"
+          replacement = "$1"
+          target_label = "service_name"
+        }
       }
       
       discovery.kubernetes "pods" {

--- a/charts/k8s-monitoring/docs/examples/proxies/alloy-logs.alloy
+++ b/charts/k8s-monitoring/docs/examples/proxies/alloy-logs.alloy
@@ -76,6 +76,28 @@ declare "pod_logs" {
       action = "labelmap"
       regex = "__meta_kubernetes_pod_annotation_(.+)"
     }
+  
+    // explicitly set service_name. if not set, loki will automatically try to populate a default.
+    // see https://grafana.com/docs/loki/latest/get-started/labels/#default-labels-for-all-users
+    //
+    // choose the first value found from the following ordered list:
+    // - pod.annotation[resource.opentelemetry.io/service.name]
+    // - pod.label[app.kubernetes.io/name]
+    // - k8s.pod.name
+    // - k8s.container.name
+    rule {
+      action = "replace"
+      source_labels = [
+        "__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_name",
+        "__meta_kubernetes_pod_label_app_kubernetes_io_name",
+        "__meta_kubernetes_pod_name",
+        "__meta_kubernetes_pod_container_name",
+      ]
+      separator = ";"
+      regex = "^(?:;*)?([^;]+).*$"
+      replacement = "$1"
+      target_label = "service_name"
+    }
   }
   
   discovery.kubernetes "pods" {

--- a/charts/k8s-monitoring/docs/examples/proxies/alloy-logs.alloy
+++ b/charts/k8s-monitoring/docs/examples/proxies/alloy-logs.alloy
@@ -98,6 +98,25 @@ declare "pod_logs" {
       replacement = "$1"
       target_label = "service_name"
     }
+  
+    // set service_namespace
+    rule {
+      action = "replace"
+      source_labels = ["__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_namespace"]
+      target_label = "service_namespace"
+    }
+  
+    // set deployment_environment and deployment_environment_name
+    rule {
+      action = "replace"
+      source_labels = ["__meta_kubernetes_pod_annotation_resource_opentelemetry_io_deployment_environment_name"]
+      target_label = "deployment_environment_name"
+    }
+    rule {
+      action = "replace"
+      source_labels = ["__meta_kubernetes_pod_annotation_resource_opentelemetry_io_deployment_environment"]
+      target_label = "deployment_environment"
+    }
   }
   
   discovery.kubernetes "pods" {
@@ -169,7 +188,7 @@ declare "pod_logs" {
   
     // Only keep the labels that are defined in the `keepLabels` list.
     stage.label_keep {
-      values = ["app_kubernetes_io_name","container","instance","job","level","namespace","pod","service_name","integration"]
+      values = ["app_kubernetes_io_name","container","instance","job","level","namespace","pod","service_name","service_namespace","deployment_environment","deployment_environment_name","integration"]
     }
   
     forward_to = argument.logs_destinations.value

--- a/charts/k8s-monitoring/docs/examples/proxies/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/proxies/output.yaml
@@ -735,6 +735,28 @@ data:
           action = "labelmap"
           regex = "__meta_kubernetes_pod_annotation_(.+)"
         }
+      
+        // explicitly set service_name. if not set, loki will automatically try to populate a default.
+        // see https://grafana.com/docs/loki/latest/get-started/labels/#default-labels-for-all-users
+        //
+        // choose the first value found from the following ordered list:
+        // - pod.annotation[resource.opentelemetry.io/service.name]
+        // - pod.label[app.kubernetes.io/name]
+        // - k8s.pod.name
+        // - k8s.container.name
+        rule {
+          action = "replace"
+          source_labels = [
+            "__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_name",
+            "__meta_kubernetes_pod_label_app_kubernetes_io_name",
+            "__meta_kubernetes_pod_name",
+            "__meta_kubernetes_pod_container_name",
+          ]
+          separator = ";"
+          regex = "^(?:;*)?([^;]+).*$"
+          replacement = "$1"
+          target_label = "service_name"
+        }
       }
       
       discovery.kubernetes "pods" {

--- a/charts/k8s-monitoring/docs/examples/proxies/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/proxies/output.yaml
@@ -757,6 +757,25 @@ data:
           replacement = "$1"
           target_label = "service_name"
         }
+      
+        // set service_namespace
+        rule {
+          action = "replace"
+          source_labels = ["__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_namespace"]
+          target_label = "service_namespace"
+        }
+      
+        // set deployment_environment and deployment_environment_name
+        rule {
+          action = "replace"
+          source_labels = ["__meta_kubernetes_pod_annotation_resource_opentelemetry_io_deployment_environment_name"]
+          target_label = "deployment_environment_name"
+        }
+        rule {
+          action = "replace"
+          source_labels = ["__meta_kubernetes_pod_annotation_resource_opentelemetry_io_deployment_environment"]
+          target_label = "deployment_environment"
+        }
       }
       
       discovery.kubernetes "pods" {
@@ -828,7 +847,7 @@ data:
       
         // Only keep the labels that are defined in the `keepLabels` list.
         stage.label_keep {
-          values = ["app_kubernetes_io_name","container","instance","job","level","namespace","pod","service_name","integration"]
+          values = ["app_kubernetes_io_name","container","instance","job","level","namespace","pod","service_name","service_namespace","deployment_environment","deployment_environment_name","integration"]
         }
       
         forward_to = argument.logs_destinations.value

--- a/charts/k8s-monitoring/docs/examples/tolerations/alloy-logs.alloy
+++ b/charts/k8s-monitoring/docs/examples/tolerations/alloy-logs.alloy
@@ -76,6 +76,28 @@ declare "pod_logs" {
       action = "labelmap"
       regex = "__meta_kubernetes_pod_annotation_(.+)"
     }
+  
+    // explicitly set service_name. if not set, loki will automatically try to populate a default.
+    // see https://grafana.com/docs/loki/latest/get-started/labels/#default-labels-for-all-users
+    //
+    // choose the first value found from the following ordered list:
+    // - pod.annotation[resource.opentelemetry.io/service.name]
+    // - pod.label[app.kubernetes.io/name]
+    // - k8s.pod.name
+    // - k8s.container.name
+    rule {
+      action = "replace"
+      source_labels = [
+        "__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_name",
+        "__meta_kubernetes_pod_label_app_kubernetes_io_name",
+        "__meta_kubernetes_pod_name",
+        "__meta_kubernetes_pod_container_name",
+      ]
+      separator = ";"
+      regex = "^(?:;*)?([^;]+).*$"
+      replacement = "$1"
+      target_label = "service_name"
+    }
   }
   
   discovery.kubernetes "pods" {

--- a/charts/k8s-monitoring/docs/examples/tolerations/alloy-logs.alloy
+++ b/charts/k8s-monitoring/docs/examples/tolerations/alloy-logs.alloy
@@ -98,6 +98,25 @@ declare "pod_logs" {
       replacement = "$1"
       target_label = "service_name"
     }
+  
+    // set service_namespace
+    rule {
+      action = "replace"
+      source_labels = ["__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_namespace"]
+      target_label = "service_namespace"
+    }
+  
+    // set deployment_environment and deployment_environment_name
+    rule {
+      action = "replace"
+      source_labels = ["__meta_kubernetes_pod_annotation_resource_opentelemetry_io_deployment_environment_name"]
+      target_label = "deployment_environment_name"
+    }
+    rule {
+      action = "replace"
+      source_labels = ["__meta_kubernetes_pod_annotation_resource_opentelemetry_io_deployment_environment"]
+      target_label = "deployment_environment"
+    }
   }
   
   discovery.kubernetes "pods" {
@@ -169,7 +188,7 @@ declare "pod_logs" {
   
     // Only keep the labels that are defined in the `keepLabels` list.
     stage.label_keep {
-      values = ["app_kubernetes_io_name","container","instance","job","level","namespace","pod","service_name","integration"]
+      values = ["app_kubernetes_io_name","container","instance","job","level","namespace","pod","service_name","service_namespace","deployment_environment","deployment_environment_name","integration"]
     }
   
     forward_to = argument.logs_destinations.value

--- a/charts/k8s-monitoring/docs/examples/tolerations/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/tolerations/output.yaml
@@ -530,6 +530,28 @@ data:
           action = "labelmap"
           regex = "__meta_kubernetes_pod_annotation_(.+)"
         }
+      
+        // explicitly set service_name. if not set, loki will automatically try to populate a default.
+        // see https://grafana.com/docs/loki/latest/get-started/labels/#default-labels-for-all-users
+        //
+        // choose the first value found from the following ordered list:
+        // - pod.annotation[resource.opentelemetry.io/service.name]
+        // - pod.label[app.kubernetes.io/name]
+        // - k8s.pod.name
+        // - k8s.container.name
+        rule {
+          action = "replace"
+          source_labels = [
+            "__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_name",
+            "__meta_kubernetes_pod_label_app_kubernetes_io_name",
+            "__meta_kubernetes_pod_name",
+            "__meta_kubernetes_pod_container_name",
+          ]
+          separator = ";"
+          regex = "^(?:;*)?([^;]+).*$"
+          replacement = "$1"
+          target_label = "service_name"
+        }
       }
       
       discovery.kubernetes "pods" {

--- a/charts/k8s-monitoring/docs/examples/tolerations/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/tolerations/output.yaml
@@ -552,6 +552,25 @@ data:
           replacement = "$1"
           target_label = "service_name"
         }
+      
+        // set service_namespace
+        rule {
+          action = "replace"
+          source_labels = ["__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_namespace"]
+          target_label = "service_namespace"
+        }
+      
+        // set deployment_environment and deployment_environment_name
+        rule {
+          action = "replace"
+          source_labels = ["__meta_kubernetes_pod_annotation_resource_opentelemetry_io_deployment_environment_name"]
+          target_label = "deployment_environment_name"
+        }
+        rule {
+          action = "replace"
+          source_labels = ["__meta_kubernetes_pod_annotation_resource_opentelemetry_io_deployment_environment"]
+          target_label = "deployment_environment"
+        }
       }
       
       discovery.kubernetes "pods" {
@@ -623,7 +642,7 @@ data:
       
         // Only keep the labels that are defined in the `keepLabels` list.
         stage.label_keep {
-          values = ["app_kubernetes_io_name","container","instance","job","level","namespace","pod","service_name","integration"]
+          values = ["app_kubernetes_io_name","container","instance","job","level","namespace","pod","service_name","service_namespace","deployment_environment","deployment_environment_name","integration"]
         }
       
         forward_to = argument.logs_destinations.value

--- a/charts/k8s-monitoring/tests/integration/auth/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/integration/auth/.rendered/output.yaml
@@ -735,6 +735,25 @@ data:
           replacement = "$1"
           target_label = "service_name"
         }
+      
+        // set service_namespace
+        rule {
+          action = "replace"
+          source_labels = ["__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_namespace"]
+          target_label = "service_namespace"
+        }
+      
+        // set deployment_environment and deployment_environment_name
+        rule {
+          action = "replace"
+          source_labels = ["__meta_kubernetes_pod_annotation_resource_opentelemetry_io_deployment_environment_name"]
+          target_label = "deployment_environment_name"
+        }
+        rule {
+          action = "replace"
+          source_labels = ["__meta_kubernetes_pod_annotation_resource_opentelemetry_io_deployment_environment"]
+          target_label = "deployment_environment"
+        }
       }
       
       discovery.kubernetes "pods" {
@@ -809,7 +828,7 @@ data:
       
         // Only keep the labels that are defined in the `keepLabels` list.
         stage.label_keep {
-          values = ["app_kubernetes_io_name","container","instance","job","level","namespace","pod","service_name","integration"]
+          values = ["app_kubernetes_io_name","container","instance","job","level","namespace","pod","service_name","service_namespace","deployment_environment","deployment_environment_name","integration"]
         }
       
         forward_to = argument.logs_destinations.value

--- a/charts/k8s-monitoring/tests/integration/auth/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/integration/auth/.rendered/output.yaml
@@ -713,6 +713,28 @@ data:
           action = "labelmap"
           regex = "__meta_kubernetes_pod_annotation_(.+)"
         }
+      
+        // explicitly set service_name. if not set, loki will automatically try to populate a default.
+        // see https://grafana.com/docs/loki/latest/get-started/labels/#default-labels-for-all-users
+        //
+        // choose the first value found from the following ordered list:
+        // - pod.annotation[resource.opentelemetry.io/service.name]
+        // - pod.label[app.kubernetes.io/name]
+        // - k8s.pod.name
+        // - k8s.container.name
+        rule {
+          action = "replace"
+          source_labels = [
+            "__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_name",
+            "__meta_kubernetes_pod_label_app_kubernetes_io_name",
+            "__meta_kubernetes_pod_name",
+            "__meta_kubernetes_pod_container_name",
+          ]
+          separator = ";"
+          regex = "^(?:;*)?([^;]+).*$"
+          replacement = "$1"
+          target_label = "service_name"
+        }
       }
       
       discovery.kubernetes "pods" {

--- a/charts/k8s-monitoring/tests/integration/cluster-monitoring/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/integration/cluster-monitoring/.rendered/output.yaml
@@ -871,6 +871,28 @@ data:
           action = "labelmap"
           regex = "__meta_kubernetes_pod_annotation_(.+)"
         }
+      
+        // explicitly set service_name. if not set, loki will automatically try to populate a default.
+        // see https://grafana.com/docs/loki/latest/get-started/labels/#default-labels-for-all-users
+        //
+        // choose the first value found from the following ordered list:
+        // - pod.annotation[resource.opentelemetry.io/service.name]
+        // - pod.label[app.kubernetes.io/name]
+        // - k8s.pod.name
+        // - k8s.container.name
+        rule {
+          action = "replace"
+          source_labels = [
+            "__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_name",
+            "__meta_kubernetes_pod_label_app_kubernetes_io_name",
+            "__meta_kubernetes_pod_name",
+            "__meta_kubernetes_pod_container_name",
+          ]
+          separator = ";"
+          regex = "^(?:;*)?([^;]+).*$"
+          replacement = "$1"
+          target_label = "service_name"
+        }
       }
       
       discovery.kubernetes "pods" {

--- a/charts/k8s-monitoring/tests/integration/cluster-monitoring/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/integration/cluster-monitoring/.rendered/output.yaml
@@ -893,6 +893,25 @@ data:
           replacement = "$1"
           target_label = "service_name"
         }
+      
+        // set service_namespace
+        rule {
+          action = "replace"
+          source_labels = ["__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_namespace"]
+          target_label = "service_namespace"
+        }
+      
+        // set deployment_environment and deployment_environment_name
+        rule {
+          action = "replace"
+          source_labels = ["__meta_kubernetes_pod_annotation_resource_opentelemetry_io_deployment_environment_name"]
+          target_label = "deployment_environment_name"
+        }
+        rule {
+          action = "replace"
+          source_labels = ["__meta_kubernetes_pod_annotation_resource_opentelemetry_io_deployment_environment"]
+          target_label = "deployment_environment"
+        }
       }
       
       discovery.kubernetes "pods" {
@@ -964,7 +983,7 @@ data:
       
         // Only keep the labels that are defined in the `keepLabels` list.
         stage.label_keep {
-          values = ["app_kubernetes_io_name","container","instance","job","level","namespace","pod","service_name","integration"]
+          values = ["app_kubernetes_io_name","container","instance","job","level","namespace","pod","service_name","service_namespace","deployment_environment","deployment_environment_name","integration"]
         }
       
         forward_to = argument.logs_destinations.value

--- a/charts/k8s-monitoring/tests/integration/control-plane-monitoring/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/integration/control-plane-monitoring/.rendered/output.yaml
@@ -848,6 +848,28 @@ data:
           action = "labelmap"
           regex = "__meta_kubernetes_pod_annotation_(.+)"
         }
+      
+        // explicitly set service_name. if not set, loki will automatically try to populate a default.
+        // see https://grafana.com/docs/loki/latest/get-started/labels/#default-labels-for-all-users
+        //
+        // choose the first value found from the following ordered list:
+        // - pod.annotation[resource.opentelemetry.io/service.name]
+        // - pod.label[app.kubernetes.io/name]
+        // - k8s.pod.name
+        // - k8s.container.name
+        rule {
+          action = "replace"
+          source_labels = [
+            "__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_name",
+            "__meta_kubernetes_pod_label_app_kubernetes_io_name",
+            "__meta_kubernetes_pod_name",
+            "__meta_kubernetes_pod_container_name",
+          ]
+          separator = ";"
+          regex = "^(?:;*)?([^;]+).*$"
+          replacement = "$1"
+          target_label = "service_name"
+        }
       }
       
       discovery.kubernetes "pods" {

--- a/charts/k8s-monitoring/tests/integration/control-plane-monitoring/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/integration/control-plane-monitoring/.rendered/output.yaml
@@ -870,6 +870,25 @@ data:
           replacement = "$1"
           target_label = "service_name"
         }
+      
+        // set service_namespace
+        rule {
+          action = "replace"
+          source_labels = ["__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_namespace"]
+          target_label = "service_namespace"
+        }
+      
+        // set deployment_environment and deployment_environment_name
+        rule {
+          action = "replace"
+          source_labels = ["__meta_kubernetes_pod_annotation_resource_opentelemetry_io_deployment_environment_name"]
+          target_label = "deployment_environment_name"
+        }
+        rule {
+          action = "replace"
+          source_labels = ["__meta_kubernetes_pod_annotation_resource_opentelemetry_io_deployment_environment"]
+          target_label = "deployment_environment"
+        }
       }
       
       discovery.kubernetes "pods" {
@@ -941,7 +960,7 @@ data:
       
         // Only keep the labels that are defined in the `keepLabels` list.
         stage.label_keep {
-          values = ["app_kubernetes_io_name","container","instance","job","level","namespace","pod","service_name","integration"]
+          values = ["app_kubernetes_io_name","container","instance","job","level","namespace","pod","service_name","service_namespace","deployment_environment","deployment_environment_name","integration"]
         }
       
         forward_to = argument.logs_destinations.value

--- a/charts/k8s-monitoring/tests/integration/integration-grafana/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/integration/integration-grafana/.rendered/output.yaml
@@ -1007,6 +1007,25 @@ data:
           replacement = "$1"
           target_label = "service_name"
         }
+      
+        // set service_namespace
+        rule {
+          action = "replace"
+          source_labels = ["__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_namespace"]
+          target_label = "service_namespace"
+        }
+      
+        // set deployment_environment and deployment_environment_name
+        rule {
+          action = "replace"
+          source_labels = ["__meta_kubernetes_pod_annotation_resource_opentelemetry_io_deployment_environment_name"]
+          target_label = "deployment_environment_name"
+        }
+        rule {
+          action = "replace"
+          source_labels = ["__meta_kubernetes_pod_annotation_resource_opentelemetry_io_deployment_environment"]
+          target_label = "deployment_environment"
+        }
         rule {
           source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
           separator = ";"
@@ -1123,7 +1142,7 @@ data:
       
         // Only keep the labels that are defined in the `keepLabels` list.
         stage.label_keep {
-          values = ["app_kubernetes_io_name","container","instance","job","level","namespace","pod","service_name","integration"]
+          values = ["app_kubernetes_io_name","container","instance","job","level","namespace","pod","service_name","service_namespace","deployment_environment","deployment_environment_name","integration"]
         }
       
         forward_to = argument.logs_destinations.value

--- a/charts/k8s-monitoring/tests/integration/integration-grafana/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/integration/integration-grafana/.rendered/output.yaml
@@ -985,6 +985,28 @@ data:
           action = "labelmap"
           regex = "__meta_kubernetes_pod_annotation_(.+)"
         }
+      
+        // explicitly set service_name. if not set, loki will automatically try to populate a default.
+        // see https://grafana.com/docs/loki/latest/get-started/labels/#default-labels-for-all-users
+        //
+        // choose the first value found from the following ordered list:
+        // - pod.annotation[resource.opentelemetry.io/service.name]
+        // - pod.label[app.kubernetes.io/name]
+        // - k8s.pod.name
+        // - k8s.container.name
+        rule {
+          action = "replace"
+          source_labels = [
+            "__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_name",
+            "__meta_kubernetes_pod_label_app_kubernetes_io_name",
+            "__meta_kubernetes_pod_name",
+            "__meta_kubernetes_pod_container_name",
+          ]
+          separator = ";"
+          regex = "^(?:;*)?([^;]+).*$"
+          replacement = "$1"
+          target_label = "service_name"
+        }
         rule {
           source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
           separator = ";"

--- a/charts/k8s-monitoring/tests/integration/integration-loki/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/integration/integration-loki/.rendered/output.yaml
@@ -1042,6 +1042,25 @@ data:
           replacement = "$1"
           target_label = "service_name"
         }
+      
+        // set service_namespace
+        rule {
+          action = "replace"
+          source_labels = ["__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_namespace"]
+          target_label = "service_namespace"
+        }
+      
+        // set deployment_environment and deployment_environment_name
+        rule {
+          action = "replace"
+          source_labels = ["__meta_kubernetes_pod_annotation_resource_opentelemetry_io_deployment_environment_name"]
+          target_label = "deployment_environment_name"
+        }
+        rule {
+          action = "replace"
+          source_labels = ["__meta_kubernetes_pod_annotation_resource_opentelemetry_io_deployment_environment"]
+          target_label = "deployment_environment"
+        }
         // add static label of integration="loki" and instance="name" to pods that match the selector so they can be identified in the loki.process stages
         rule {
           source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
@@ -1166,7 +1185,7 @@ data:
       
         // Only keep the labels that are defined in the `keepLabels` list.
         stage.label_keep {
-          values = ["app_kubernetes_io_name","container","instance","job","level","namespace","pod","service_name","integration"]
+          values = ["app_kubernetes_io_name","container","instance","job","level","namespace","pod","service_name","service_namespace","deployment_environment","deployment_environment_name","integration"]
         }
       
         forward_to = argument.logs_destinations.value

--- a/charts/k8s-monitoring/tests/integration/integration-loki/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/integration/integration-loki/.rendered/output.yaml
@@ -1020,6 +1020,28 @@ data:
           action = "labelmap"
           regex = "__meta_kubernetes_pod_annotation_(.+)"
         }
+      
+        // explicitly set service_name. if not set, loki will automatically try to populate a default.
+        // see https://grafana.com/docs/loki/latest/get-started/labels/#default-labels-for-all-users
+        //
+        // choose the first value found from the following ordered list:
+        // - pod.annotation[resource.opentelemetry.io/service.name]
+        // - pod.label[app.kubernetes.io/name]
+        // - k8s.pod.name
+        // - k8s.container.name
+        rule {
+          action = "replace"
+          source_labels = [
+            "__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_name",
+            "__meta_kubernetes_pod_label_app_kubernetes_io_name",
+            "__meta_kubernetes_pod_name",
+            "__meta_kubernetes_pod_container_name",
+          ]
+          separator = ";"
+          regex = "^(?:;*)?([^;]+).*$"
+          replacement = "$1"
+          target_label = "service_name"
+        }
         // add static label of integration="loki" and instance="name" to pods that match the selector so they can be identified in the loki.process stages
         rule {
           source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]

--- a/charts/k8s-monitoring/tests/integration/integration-mysql/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/integration/integration-mysql/.rendered/output.yaml
@@ -292,6 +292,28 @@ data:
           action = "labelmap"
           regex = "__meta_kubernetes_pod_annotation_(.+)"
         }
+      
+        // explicitly set service_name. if not set, loki will automatically try to populate a default.
+        // see https://grafana.com/docs/loki/latest/get-started/labels/#default-labels-for-all-users
+        //
+        // choose the first value found from the following ordered list:
+        // - pod.annotation[resource.opentelemetry.io/service.name]
+        // - pod.label[app.kubernetes.io/name]
+        // - k8s.pod.name
+        // - k8s.container.name
+        rule {
+          action = "replace"
+          source_labels = [
+            "__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_name",
+            "__meta_kubernetes_pod_label_app_kubernetes_io_name",
+            "__meta_kubernetes_pod_name",
+            "__meta_kubernetes_pod_container_name",
+          ]
+          separator = ";"
+          regex = "^(?:;*)?([^;]+).*$"
+          replacement = "$1"
+          target_label = "service_name"
+        }
         rule {
           source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_instance"]
           separator = ";"

--- a/charts/k8s-monitoring/tests/integration/integration-mysql/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/integration/integration-mysql/.rendered/output.yaml
@@ -314,6 +314,25 @@ data:
           replacement = "$1"
           target_label = "service_name"
         }
+      
+        // set service_namespace
+        rule {
+          action = "replace"
+          source_labels = ["__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_namespace"]
+          target_label = "service_namespace"
+        }
+      
+        // set deployment_environment and deployment_environment_name
+        rule {
+          action = "replace"
+          source_labels = ["__meta_kubernetes_pod_annotation_resource_opentelemetry_io_deployment_environment_name"]
+          target_label = "deployment_environment_name"
+        }
+        rule {
+          action = "replace"
+          source_labels = ["__meta_kubernetes_pod_annotation_resource_opentelemetry_io_deployment_environment"]
+          target_label = "deployment_environment"
+        }
         rule {
           source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_instance"]
           separator = ";"
@@ -430,7 +449,7 @@ data:
       
         // Only keep the labels that are defined in the `keepLabels` list.
         stage.label_keep {
-          values = ["app_kubernetes_io_name","container","instance","job","level","namespace","pod","service_name","integration"]
+          values = ["app_kubernetes_io_name","container","instance","job","level","namespace","pod","service_name","service_namespace","deployment_environment","deployment_environment_name","integration"]
         }
       
         forward_to = argument.logs_destinations.value

--- a/charts/k8s-monitoring/tests/integration/istio-service-mesh/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/integration/istio-service-mesh/.rendered/output.yaml
@@ -993,6 +993,25 @@ data:
           replacement = "$1"
           target_label = "service_name"
         }
+      
+        // set service_namespace
+        rule {
+          action = "replace"
+          source_labels = ["__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_namespace"]
+          target_label = "service_namespace"
+        }
+      
+        // set deployment_environment and deployment_environment_name
+        rule {
+          action = "replace"
+          source_labels = ["__meta_kubernetes_pod_annotation_resource_opentelemetry_io_deployment_environment_name"]
+          target_label = "deployment_environment_name"
+        }
+        rule {
+          action = "replace"
+          source_labels = ["__meta_kubernetes_pod_annotation_resource_opentelemetry_io_deployment_environment"]
+          target_label = "deployment_environment"
+        }
       }
       
       discovery.kubernetes "pods" {
@@ -1064,7 +1083,7 @@ data:
       
         // Only keep the labels that are defined in the `keepLabels` list.
         stage.label_keep {
-          values = ["app_kubernetes_io_name","container","instance","job","level","namespace","pod","service_name","integration"]
+          values = ["app_kubernetes_io_name","container","instance","job","level","namespace","pod","service_name","service_namespace","deployment_environment","deployment_environment_name","integration"]
         }
       
         forward_to = argument.logs_destinations.value

--- a/charts/k8s-monitoring/tests/integration/istio-service-mesh/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/integration/istio-service-mesh/.rendered/output.yaml
@@ -971,6 +971,28 @@ data:
           action = "labelmap"
           regex = "__meta_kubernetes_pod_annotation_(.+)"
         }
+      
+        // explicitly set service_name. if not set, loki will automatically try to populate a default.
+        // see https://grafana.com/docs/loki/latest/get-started/labels/#default-labels-for-all-users
+        //
+        // choose the first value found from the following ordered list:
+        // - pod.annotation[resource.opentelemetry.io/service.name]
+        // - pod.label[app.kubernetes.io/name]
+        // - k8s.pod.name
+        // - k8s.container.name
+        rule {
+          action = "replace"
+          source_labels = [
+            "__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_name",
+            "__meta_kubernetes_pod_label_app_kubernetes_io_name",
+            "__meta_kubernetes_pod_name",
+            "__meta_kubernetes_pod_container_name",
+          ]
+          separator = ";"
+          regex = "^(?:;*)?([^;]+).*$"
+          replacement = "$1"
+          target_label = "service_name"
+        }
       }
       
       discovery.kubernetes "pods" {

--- a/charts/k8s-monitoring/tests/integration/split-destinations/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/integration/split-destinations/.rendered/output.yaml
@@ -718,6 +718,25 @@ data:
           replacement = "$1"
           target_label = "service_name"
         }
+      
+        // set service_namespace
+        rule {
+          action = "replace"
+          source_labels = ["__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_namespace"]
+          target_label = "service_namespace"
+        }
+      
+        // set deployment_environment and deployment_environment_name
+        rule {
+          action = "replace"
+          source_labels = ["__meta_kubernetes_pod_annotation_resource_opentelemetry_io_deployment_environment_name"]
+          target_label = "deployment_environment_name"
+        }
+        rule {
+          action = "replace"
+          source_labels = ["__meta_kubernetes_pod_annotation_resource_opentelemetry_io_deployment_environment"]
+          target_label = "deployment_environment"
+        }
       }
       
       discovery.kubernetes "pods" {
@@ -789,7 +808,7 @@ data:
       
         // Only keep the labels that are defined in the `keepLabels` list.
         stage.label_keep {
-          values = ["app_kubernetes_io_name","container","instance","job","level","namespace","pod","service_name","integration"]
+          values = ["app_kubernetes_io_name","container","instance","job","level","namespace","pod","service_name","service_namespace","deployment_environment","deployment_environment_name","integration"]
         }
       
         forward_to = argument.logs_destinations.value

--- a/charts/k8s-monitoring/tests/integration/split-destinations/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/integration/split-destinations/.rendered/output.yaml
@@ -696,6 +696,28 @@ data:
           action = "labelmap"
           regex = "__meta_kubernetes_pod_annotation_(.+)"
         }
+      
+        // explicitly set service_name. if not set, loki will automatically try to populate a default.
+        // see https://grafana.com/docs/loki/latest/get-started/labels/#default-labels-for-all-users
+        //
+        // choose the first value found from the following ordered list:
+        // - pod.annotation[resource.opentelemetry.io/service.name]
+        // - pod.label[app.kubernetes.io/name]
+        // - k8s.pod.name
+        // - k8s.container.name
+        rule {
+          action = "replace"
+          source_labels = [
+            "__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_name",
+            "__meta_kubernetes_pod_label_app_kubernetes_io_name",
+            "__meta_kubernetes_pod_name",
+            "__meta_kubernetes_pod_container_name",
+          ]
+          separator = ";"
+          regex = "^(?:;*)?([^;]+).*$"
+          replacement = "$1"
+          target_label = "service_name"
+        }
       }
       
       discovery.kubernetes "pods" {

--- a/charts/k8s-monitoring/tests/platform/eks-with-windows/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/platform/eks-with-windows/.rendered/output.yaml
@@ -1202,6 +1202,28 @@ data:
           action = "labelmap"
           regex = "__meta_kubernetes_pod_annotation_(.+)"
         }
+      
+        // explicitly set service_name. if not set, loki will automatically try to populate a default.
+        // see https://grafana.com/docs/loki/latest/get-started/labels/#default-labels-for-all-users
+        //
+        // choose the first value found from the following ordered list:
+        // - pod.annotation[resource.opentelemetry.io/service.name]
+        // - pod.label[app.kubernetes.io/name]
+        // - k8s.pod.name
+        // - k8s.container.name
+        rule {
+          action = "replace"
+          source_labels = [
+            "__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_name",
+            "__meta_kubernetes_pod_label_app_kubernetes_io_name",
+            "__meta_kubernetes_pod_name",
+            "__meta_kubernetes_pod_container_name",
+          ]
+          separator = ";"
+          regex = "^(?:;*)?([^;]+).*$"
+          replacement = "$1"
+          target_label = "service_name"
+        }
       }
       
       discovery.kubernetes "pods" {

--- a/charts/k8s-monitoring/tests/platform/eks-with-windows/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/platform/eks-with-windows/.rendered/output.yaml
@@ -1224,6 +1224,25 @@ data:
           replacement = "$1"
           target_label = "service_name"
         }
+      
+        // set service_namespace
+        rule {
+          action = "replace"
+          source_labels = ["__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_namespace"]
+          target_label = "service_namespace"
+        }
+      
+        // set deployment_environment and deployment_environment_name
+        rule {
+          action = "replace"
+          source_labels = ["__meta_kubernetes_pod_annotation_resource_opentelemetry_io_deployment_environment_name"]
+          target_label = "deployment_environment_name"
+        }
+        rule {
+          action = "replace"
+          source_labels = ["__meta_kubernetes_pod_annotation_resource_opentelemetry_io_deployment_environment"]
+          target_label = "deployment_environment"
+        }
       }
       
       discovery.kubernetes "pods" {
@@ -1295,7 +1314,7 @@ data:
       
         // Only keep the labels that are defined in the `keepLabels` list.
         stage.label_keep {
-          values = ["app_kubernetes_io_name","container","instance","job","level","namespace","pod","service_name","integration"]
+          values = ["app_kubernetes_io_name","container","instance","job","level","namespace","pod","service_name","service_namespace","deployment_environment","deployment_environment_name","integration"]
         }
       
         forward_to = argument.logs_destinations.value

--- a/charts/k8s-monitoring/tests/platform/gke-autopilot/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/platform/gke-autopilot/.rendered/output.yaml
@@ -805,6 +805,28 @@ data:
           action = "labelmap"
           regex = "__meta_kubernetes_pod_annotation_(.+)"
         }
+      
+        // explicitly set service_name. if not set, loki will automatically try to populate a default.
+        // see https://grafana.com/docs/loki/latest/get-started/labels/#default-labels-for-all-users
+        //
+        // choose the first value found from the following ordered list:
+        // - pod.annotation[resource.opentelemetry.io/service.name]
+        // - pod.label[app.kubernetes.io/name]
+        // - k8s.pod.name
+        // - k8s.container.name
+        rule {
+          action = "replace"
+          source_labels = [
+            "__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_name",
+            "__meta_kubernetes_pod_label_app_kubernetes_io_name",
+            "__meta_kubernetes_pod_name",
+            "__meta_kubernetes_pod_container_name",
+          ]
+          separator = ";"
+          regex = "^(?:;*)?([^;]+).*$"
+          replacement = "$1"
+          target_label = "service_name"
+        }
       }
       
       discovery.kubernetes "pods" {

--- a/charts/k8s-monitoring/tests/platform/gke-autopilot/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/platform/gke-autopilot/.rendered/output.yaml
@@ -827,6 +827,25 @@ data:
           replacement = "$1"
           target_label = "service_name"
         }
+      
+        // set service_namespace
+        rule {
+          action = "replace"
+          source_labels = ["__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_namespace"]
+          target_label = "service_namespace"
+        }
+      
+        // set deployment_environment and deployment_environment_name
+        rule {
+          action = "replace"
+          source_labels = ["__meta_kubernetes_pod_annotation_resource_opentelemetry_io_deployment_environment_name"]
+          target_label = "deployment_environment_name"
+        }
+        rule {
+          action = "replace"
+          source_labels = ["__meta_kubernetes_pod_annotation_resource_opentelemetry_io_deployment_environment"]
+          target_label = "deployment_environment"
+        }
       }
       
       discovery.kubernetes "pods" {
@@ -898,7 +917,7 @@ data:
       
         // Only keep the labels that are defined in the `keepLabels` list.
         stage.label_keep {
-          values = ["app_kubernetes_io_name","container","instance","job","level","namespace","pod","service_name","integration"]
+          values = ["app_kubernetes_io_name","container","instance","job","level","namespace","pod","service_name","service_namespace","deployment_environment","deployment_environment_name","integration"]
         }
       
         forward_to = argument.logs_destinations.value

--- a/charts/k8s-monitoring/tests/platform/grafana-cloud-features/k8s-monitoring/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/platform/grafana-cloud-features/k8s-monitoring/.rendered/output.yaml
@@ -1158,6 +1158,28 @@ data:
           action = "labelmap"
           regex = "__meta_kubernetes_pod_annotation_(.+)"
         }
+      
+        // explicitly set service_name. if not set, loki will automatically try to populate a default.
+        // see https://grafana.com/docs/loki/latest/get-started/labels/#default-labels-for-all-users
+        //
+        // choose the first value found from the following ordered list:
+        // - pod.annotation[resource.opentelemetry.io/service.name]
+        // - pod.label[app.kubernetes.io/name]
+        // - k8s.pod.name
+        // - k8s.container.name
+        rule {
+          action = "replace"
+          source_labels = [
+            "__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_name",
+            "__meta_kubernetes_pod_label_app_kubernetes_io_name",
+            "__meta_kubernetes_pod_name",
+            "__meta_kubernetes_pod_container_name",
+          ]
+          separator = ";"
+          regex = "^(?:;*)?([^;]+).*$"
+          replacement = "$1"
+          target_label = "service_name"
+        }
       }
       
       discovery.kubernetes "pods" {

--- a/charts/k8s-monitoring/tests/platform/grafana-cloud-features/k8s-monitoring/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/platform/grafana-cloud-features/k8s-monitoring/.rendered/output.yaml
@@ -1180,6 +1180,25 @@ data:
           replacement = "$1"
           target_label = "service_name"
         }
+      
+        // set service_namespace
+        rule {
+          action = "replace"
+          source_labels = ["__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_namespace"]
+          target_label = "service_namespace"
+        }
+      
+        // set deployment_environment and deployment_environment_name
+        rule {
+          action = "replace"
+          source_labels = ["__meta_kubernetes_pod_annotation_resource_opentelemetry_io_deployment_environment_name"]
+          target_label = "deployment_environment_name"
+        }
+        rule {
+          action = "replace"
+          source_labels = ["__meta_kubernetes_pod_annotation_resource_opentelemetry_io_deployment_environment"]
+          target_label = "deployment_environment"
+        }
       }
       
       discovery.kubernetes "pods" {
@@ -1251,7 +1270,7 @@ data:
       
         // Only keep the labels that are defined in the `keepLabels` list.
         stage.label_keep {
-          values = ["app_kubernetes_io_name","container","instance","job","level","namespace","pod","service_name","integration"]
+          values = ["app_kubernetes_io_name","container","instance","job","level","namespace","pod","service_name","service_namespace","deployment_environment","deployment_environment_name","integration"]
         }
       
         forward_to = argument.logs_destinations.value

--- a/charts/k8s-monitoring/tests/platform/grafana-cloud-features/k8s-monitoring/Makefile
+++ b/charts/k8s-monitoring/tests/platform/grafana-cloud-features/k8s-monitoring/Makefile
@@ -7,6 +7,8 @@ deployments/test-variables.yaml:
 	kubectl create configmap test-variables \
 		--from-literal=CLUSTER="$(shell yq eval '.cluster.name' values.yaml)-$$RANDOM_NUMBER" \
 		--from-literal=RANDOM_NUMBER="$$RANDOM_NUMBER" \
+		--from-literal=ANNOTATION_POD_LOG_SERVICE_NAME="hello-kubernetes-annotation" \
+		--from-literal=LABEL_POD_LOG_SERVICE_NAME="hello-kubernetes-label" \
 		-o yaml --dry-run=client >> $@
 
 deployments/grafana-cloud-credentials.yaml:

--- a/charts/k8s-monitoring/tests/platform/grafana-cloud-features/k8s-monitoring/deployments/query-test.yaml
+++ b/charts/k8s-monitoring/tests/platform/grafana-cloud-features/k8s-monitoring/deployments/query-test.yaml
@@ -72,6 +72,18 @@ spec:
           - query: count_over_time({cluster="$CLUSTER", job!="integrations/kubernetes/eventhandler"}[1h])
             type: logql
 
+          # Pod logs service_name label
+          - query: count_over_time({cluster="$CLUSTER", service_name!=""}[1h])
+            type: logql
+
+          # Pod logs service_name label from resource.opentelemetry.io/service.name annotation
+          - query: count_over_time({cluster="$CLUSTER", service_name="$ANNOTATION_POD_LOG_SERVICE_NAME"}[1h])
+            type: logql
+
+          # Pod logs service_name label from app.kubernetes.io/name label
+          - query: count_over_time({cluster="$CLUSTER", service_name="$LABEL_POD_LOG_SERVICE_NAME"}[1h])
+            type: logql
+
           # Alloy integration
           - query: alloy_build_info{cluster="$CLUSTER"}
             type: promql
@@ -82,3 +94,110 @@ spec:
             expect:
               value: 1
               operator: ==
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: hello-kubernetes-test-0
+  labels:
+    app.kubernetes.io/name: "hello-kubernetes-label"
+    app.kubernetes.io/instance: test
+    app.kubernetes.io/version: "1.10"
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: "hello-kubernetes-label"
+      app.kubernetes.io/instance: test
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: "hello-kubernetes-label"
+        app.kubernetes.io/instance: test
+    spec:
+      containers:
+        - name: hello-kubernetes
+          image: "paulbouwer/hello-kubernetes:1.10"
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /
+              port: http
+          readinessProbe:
+            httpGet:
+              path: /
+              port: http
+          env:
+            - name: KUBERNETES_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: KUBERNETES_POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: KUBERNETES_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: CONTAINER_IMAGE
+              value: "paulbouwer/hello-kubernetes:1.10"
+---
+# Source: hello-kubernetes/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: hello-kubernetes-test-1
+  labels:
+    app.kubernetes.io/name: "hello-kubernetes-label"
+    app.kubernetes.io/instance: test
+    app.kubernetes.io/version: "1.10"
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: "hello-kubernetes-label"
+      app.kubernetes.io/instance: test
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: "hello-kubernetes-label"
+        app.kubernetes.io/instance: test
+      annotations:
+        resource.opentelemetry.io/service.name: "hello-kubernetes-annotation"
+    spec:
+      containers:
+        - name: hello-kubernetes
+          image: "paulbouwer/hello-kubernetes:1.10"
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /
+              port: http
+          readinessProbe:
+            httpGet:
+              path: /
+              port: http
+          env:
+            - name: KUBERNETES_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: KUBERNETES_POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: KUBERNETES_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: CONTAINER_IMAGE
+              value: "paulbouwer/hello-kubernetes:1.10"

--- a/charts/k8s-monitoring/tests/platform/grafana-cloud-features/k8s-monitoring/deployments/query-test.yaml
+++ b/charts/k8s-monitoring/tests/platform/grafana-cloud-features/k8s-monitoring/deployments/query-test.yaml
@@ -84,6 +84,19 @@ spec:
           - query: count_over_time({cluster="$CLUSTER", service_name="$LABEL_POD_LOG_SERVICE_NAME"}[1h])
             type: logql
 
+          # Pod logs service_namespace label from resource.opentelemetry.io/service.namespace annotation
+          - query: count_over_time({cluster="$CLUSTER", service_namespace="hello-kubernetes"}[1h])
+            type: logql
+
+          # Pod logs deployment_environment label from resource.opentelemetry.io/deployment.environment annotation
+          - query: count_over_time({cluster="$CLUSTER", deployment_environment="hello-kubernetes"}[1h])
+            type: logql
+
+          # Pod logs deployment_environment_name label from resource.opentelemetry.io/deployment.environment.name
+          # annotation
+          - query: count_over_time({cluster="$CLUSTER", deployment_environment_name="hello-kubernetes"}[1h])
+            type: logql
+
           # Alloy integration
           - query: alloy_build_info{cluster="$CLUSTER"}
             type: promql
@@ -169,6 +182,9 @@ spec:
         app.kubernetes.io/instance: test
       annotations:
         resource.opentelemetry.io/service.name: "hello-kubernetes-annotation"
+        resource.opentelemetry.io/service.namespace: "hello-kubernetes"
+        resource.opentelemetry.io/deployment.environment: "hello-kubernetes"
+        resource.opentelemetry.io/deployment.environment.name: "hello-kubernetes"
     spec:
       containers:
         - name: hello-kubernetes


### PR DESCRIPTION
This PR sets `service_name`, `service_namespace`, `deployment_environment`, and `deployment_environment_name` labels on Loki pod logs. This works when sent to loki destinations. I'll follow this PR up with updates for pod logs sent to OTLP destinations.

The labels are set according to the following rules:
- `service_name` label set by taking the first non-empty value from these Kubernetes metadata fields (in order): the pod annotation `resource.opentelemetry.io/service.name`, the pod label `app.kubernetes.io/name`, the pod’s name, or the container’s name.
- `service_namespace` set by `resource.opentelemetry.io/service.namespace` pod annotation.
- `deployment_environment` set by `resource.opentelemetry.io/deployment.environment` pod annotation.
- `deployment_environment_name` set by `resource.opentelemetry.io/deployment.environment.name` pod annotation.

If not set, Loki will attempt to set a default value according to these rules: https://grafana.com/docs/loki/latest/get-started/labels/#default-labels-for-all-users