### PR TITLE
fix: pod logs label keep

### DIFF
--- a/charts/k8s-monitoring/charts/feature-pod-logs/templates/_common_log_processing.alloy.tpl
+++ b/charts/k8s-monitoring/charts/feature-pod-logs/templates/_common_log_processing.alloy.tpl
@@ -50,13 +50,6 @@ loki.process "pod_logs" {
     }
   }
 {{- end }}
-{{- with .Values.labelsToKeep }}
-
-  // Only keep the labels that are defined in the `keepLabels` list.
-  stage.label_keep {
-    values = {{ append . "integration" | toJson }}
-  }
-{{- end }}
 
 {{- if or .Values.staticLabels .Values.staticLabelsFrom }}
 
@@ -73,6 +66,14 @@ loki.process "pod_logs" {
 {{- end }}
 {{- if .Values.extraLogProcessingStages }}
 {{ tpl .Values.extraLogProcessingStages $ | indent 2 }}
+{{- end }}
+
+{{- with .Values.labelsToKeep }}
+
+  // Only keep the labels that are defined in the `keepLabels` list.
+  stage.label_keep {
+    values = {{ append . "integration" | toJson }}
+  }
 {{- end }}
 
   forward_to = argument.logs_destinations.value

--- a/charts/k8s-monitoring/charts/feature-pod-logs/tests/default_test.yaml
+++ b/charts/k8s-monitoring/charts/feature-pod-logs/tests/default_test.yaml
@@ -473,7 +473,7 @@ tests:
               argument "logs_destinations" {
                 comment = "Must be a list of log destinations where collected logs should be forwarded to"
               }
-            
+
               discovery.relabel "filtered_pods" {
                 targets = discovery.kubernetes.pods.targets
                 rule {
@@ -498,7 +498,7 @@ tests:
                   replacement = "$1"
                   target_label = "job"
                 }
-            
+
                 // set the container runtime as a label
                 rule {
                   action = "replace"
@@ -507,21 +507,21 @@ tests:
                   replacement = "$1"
                   target_label = "tmp_container_runtime"
                 }
-            
+
                 // set the job label from the k8s.grafana.com/logs.job annotation if it exists
                 rule {
                   source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_job"]
                   regex = "(.+)"
                   target_label = "job"
                 }
-            
+
                 // make all labels on the pod available to the pipeline as labels,
                 // they are omitted before write to loki via stage.label_keep unless explicitly set
                 rule {
                   action = "labelmap"
                   regex = "__meta_kubernetes_pod_label_(.+)"
                 }
-            
+
                 // make all annotations on the pod available to the pipeline as labels,
                 // they are omitted before write to loki via stage.label_keep unless explicitly set
                 rule {
@@ -529,7 +529,7 @@ tests:
                   regex = "__meta_kubernetes_pod_annotation_(.+)"
                 }
               }
-            
+
               discovery.kubernetes "pods" {
                 role = "pod"
                 selectors {
@@ -537,10 +537,10 @@ tests:
                   field = "spec.nodeName=" + sys.env("HOSTNAME")
                 }
               }
-            
+
               discovery.relabel "filtered_pods_with_paths" {
                 targets = discovery.relabel.filtered_pods.output
-            
+
                 rule {
                   source_labels = ["__meta_kubernetes_pod_uid", "__meta_kubernetes_pod_container_name"]
                   separator = "/"
@@ -549,22 +549,22 @@ tests:
                   target_label = "__path__"
                 }
               }
-            
+
               local.file_match "pod_logs" {
                 path_targets = discovery.relabel.filtered_pods_with_paths.output
               }
-            
+
               loki.source.file "pod_logs" {
                 targets    = local.file_match.pod_logs.targets
                 forward_to = [loki.process.pod_logs.receiver]
               }
-            
+
               loki.process "pod_logs" {
                 stage.match {
                   selector = "{tmp_container_runtime=~\"containerd|cri-o\"}"
                   // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
                   stage.cri {}
-            
+
                   // Set the extract flags and stream values as labels
                   stage.labels {
                     values = {
@@ -573,12 +573,12 @@ tests:
                     }
                   }
                 }
-            
+
                 stage.match {
                   selector = "{tmp_container_runtime=\"docker\"}"
                   // the docker processing stage extracts the following k/v pairs: log, stream, time
                   stage.docker {}
-            
+
                   // Set the extract stream value as a label
                   stage.labels {
                     values = {
@@ -586,7 +586,7 @@ tests:
                     }
                   }
                 }
-            
+
                 // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
                 // namespace, pod, and container labels. Drop any structured metadata. Also drop the temporary
                 // container runtime label as it is no longer needed.
@@ -596,19 +596,19 @@ tests:
                     "tmp_container_runtime",
                   ]
                 }
-            
-                // Only keep the labels that are defined in the `keepLabels` list.
-                stage.label_keep {
-                  values = ["app_kubernetes_io_name","container","instance","job","level","namespace","pod","service_name","integration"]
-                }
-            
+
                 stage.static_labels {
                   values = {
                     region = "central",
                     color = sys.env("COLOR"),
                   }
                 }
-            
+
+                // Only keep the labels that are defined in the `keepLabels` list.
+                stage.label_keep {
+                  values = ["app_kubernetes_io_name","container","instance","job","level","namespace","pod","service_name","integration"]
+                }
+
                 forward_to = argument.logs_destinations.value
               }
             }

--- a/charts/k8s-monitoring/docs/examples/extra-rules/alloy-logs.alloy
+++ b/charts/k8s-monitoring/docs/examples/extra-rules/alloy-logs.alloy
@@ -152,11 +152,6 @@ declare "pod_logs" {
       ]
     }
   
-    // Only keep the labels that are defined in the `keepLabels` list.
-    stage.label_keep {
-      values = ["app_kubernetes_io_name","container","instance","job","level","namespace","pod","service_name","integration"]
-    }
-  
     stage.static_labels {
       values = {
         site = "lab2",
@@ -176,6 +171,11 @@ declare "pod_logs" {
         sku  = "",
         count = "",
       }
+    }
+  
+    // Only keep the labels that are defined in the `keepLabels` list.
+    stage.label_keep {
+      values = ["app_kubernetes_io_name","container","instance","job","level","namespace","pod","service_name","integration"]
     }
   
     forward_to = argument.logs_destinations.value

--- a/charts/k8s-monitoring/docs/examples/extra-rules/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/extra-rules/output.yaml
@@ -807,11 +807,6 @@ data:
           ]
         }
       
-        // Only keep the labels that are defined in the `keepLabels` list.
-        stage.label_keep {
-          values = ["app_kubernetes_io_name","container","instance","job","level","namespace","pod","service_name","integration"]
-        }
-      
         stage.static_labels {
           values = {
             site = "lab2",
@@ -831,6 +826,11 @@ data:
             sku  = "",
             count = "",
           }
+        }
+      
+        // Only keep the labels that are defined in the `keepLabels` list.
+        stage.label_keep {
+          values = ["app_kubernetes_io_name","container","instance","job","level","namespace","pod","service_name","integration"]
         }
       
         forward_to = argument.logs_destinations.value

--- a/charts/k8s-monitoring/docs/examples/features/integrations/grafana/alloy-logs.alloy
+++ b/charts/k8s-monitoring/docs/examples/features/integrations/grafana/alloy-logs.alloy
@@ -158,11 +158,6 @@ declare "pod_logs" {
         "tmp_container_runtime",
       ]
     }
-  
-    // Only keep the labels that are defined in the `keepLabels` list.
-    stage.label_keep {
-      values = ["app_kubernetes_io_name","container","instance","job","level","namespace","pod","service_name","integration"]
-    }
     // Integration: Loki
     stage.match {
       selector = "{job=\"integrations/grafana\",instance=\"grafana\",namespace=~\"o11y\"}"
@@ -193,6 +188,11 @@ declare "pod_logs" {
         expression = "( t=[^ ]+\\s+)"
         replace = ""
       }
+    }
+  
+    // Only keep the labels that are defined in the `keepLabels` list.
+    stage.label_keep {
+      values = ["app_kubernetes_io_name","container","instance","job","level","namespace","pod","service_name","integration"]
     }
   
     forward_to = argument.logs_destinations.value

--- a/charts/k8s-monitoring/docs/examples/features/integrations/grafana/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/features/integrations/grafana/output.yaml
@@ -534,11 +534,6 @@ data:
             "tmp_container_runtime",
           ]
         }
-      
-        // Only keep the labels that are defined in the `keepLabels` list.
-        stage.label_keep {
-          values = ["app_kubernetes_io_name","container","instance","job","level","namespace","pod","service_name","integration"]
-        }
         // Integration: Loki
         stage.match {
           selector = "{job=\"integrations/grafana\",instance=\"grafana\",namespace=~\"o11y\"}"
@@ -569,6 +564,11 @@ data:
             expression = "( t=[^ ]+\\s+)"
             replace = ""
           }
+        }
+      
+        // Only keep the labels that are defined in the `keepLabels` list.
+        stage.label_keep {
+          values = ["app_kubernetes_io_name","container","instance","job","level","namespace","pod","service_name","integration"]
         }
       
         forward_to = argument.logs_destinations.value

--- a/charts/k8s-monitoring/docs/examples/features/integrations/loki/alloy-logs.alloy
+++ b/charts/k8s-monitoring/docs/examples/features/integrations/loki/alloy-logs.alloy
@@ -167,11 +167,6 @@ declare "pod_logs" {
         "tmp_container_runtime",
       ]
     }
-  
-    // Only keep the labels that are defined in the `keepLabels` list.
-    stage.label_keep {
-      values = ["app_kubernetes_io_name","container","instance","job","level","namespace","pod","service_name","integration"]
-    }
     // Integration: Loki
     stage.match {
       selector = "{integration=\"loki\",instance=\"loki\"}"
@@ -201,6 +196,11 @@ declare "pod_logs" {
         replace = ""
       }
     
+    }
+  
+    // Only keep the labels that are defined in the `keepLabels` list.
+    stage.label_keep {
+      values = ["app_kubernetes_io_name","container","instance","job","level","namespace","pod","service_name","integration"]
     }
   
     forward_to = argument.logs_destinations.value

--- a/charts/k8s-monitoring/docs/examples/features/integrations/loki/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/features/integrations/loki/output.yaml
@@ -578,11 +578,6 @@ data:
             "tmp_container_runtime",
           ]
         }
-      
-        // Only keep the labels that are defined in the `keepLabels` list.
-        stage.label_keep {
-          values = ["app_kubernetes_io_name","container","instance","job","level","namespace","pod","service_name","integration"]
-        }
         // Integration: Loki
         stage.match {
           selector = "{integration=\"loki\",instance=\"loki\"}"
@@ -612,6 +607,11 @@ data:
             replace = ""
           }
         
+        }
+      
+        // Only keep the labels that are defined in the `keepLabels` list.
+        stage.label_keep {
+          values = ["app_kubernetes_io_name","container","instance","job","level","namespace","pod","service_name","integration"]
         }
       
         forward_to = argument.logs_destinations.value

--- a/charts/k8s-monitoring/docs/examples/features/integrations/mimir/alloy-logs.alloy
+++ b/charts/k8s-monitoring/docs/examples/features/integrations/mimir/alloy-logs.alloy
@@ -167,11 +167,6 @@ declare "pod_logs" {
         "tmp_container_runtime",
       ]
     }
-  
-    // Only keep the labels that are defined in the `keepLabels` list.
-    stage.label_keep {
-      values = ["app_kubernetes_io_name","container","instance","job","level","namespace","pod","service_name","integration"]
-    }
     // Integration: Mimir
     stage.match {
       selector = "{integration=\"mimir\",instance=\"mimir\"}"
@@ -201,6 +196,11 @@ declare "pod_logs" {
         replace = ""
       }
     
+    }
+  
+    // Only keep the labels that are defined in the `keepLabels` list.
+    stage.label_keep {
+      values = ["app_kubernetes_io_name","container","instance","job","level","namespace","pod","service_name","integration"]
     }
   
     forward_to = argument.logs_destinations.value

--- a/charts/k8s-monitoring/docs/examples/features/integrations/mimir/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/features/integrations/mimir/output.yaml
@@ -578,11 +578,6 @@ data:
             "tmp_container_runtime",
           ]
         }
-      
-        // Only keep the labels that are defined in the `keepLabels` list.
-        stage.label_keep {
-          values = ["app_kubernetes_io_name","container","instance","job","level","namespace","pod","service_name","integration"]
-        }
         // Integration: Mimir
         stage.match {
           selector = "{integration=\"mimir\",instance=\"mimir\"}"
@@ -612,6 +607,11 @@ data:
             replace = ""
           }
         
+        }
+      
+        // Only keep the labels that are defined in the `keepLabels` list.
+        stage.label_keep {
+          values = ["app_kubernetes_io_name","container","instance","job","level","namespace","pod","service_name","integration"]
         }
       
         forward_to = argument.logs_destinations.value

--- a/charts/k8s-monitoring/docs/examples/features/integrations/mysql/alloy-logs.alloy
+++ b/charts/k8s-monitoring/docs/examples/features/integrations/mysql/alloy-logs.alloy
@@ -172,11 +172,6 @@ declare "pod_logs" {
         "tmp_container_runtime",
       ]
     }
-  
-    // Only keep the labels that are defined in the `keepLabels` list.
-    stage.label_keep {
-      values = ["app_kubernetes_io_name","container","instance","job","level","namespace","pod","service_name","integration"]
-    }
     // Integration: MySQL
     stage.match {
       selector = "{integration=\"mysql\"}"
@@ -207,6 +202,11 @@ declare "pod_logs" {
       stage.label_drop {
         values = ["integration"]
       }
+    }
+  
+    // Only keep the labels that are defined in the `keepLabels` list.
+    stage.label_keep {
+      values = ["app_kubernetes_io_name","container","instance","job","level","namespace","pod","service_name","integration"]
     }
   
     forward_to = argument.logs_destinations.value

--- a/charts/k8s-monitoring/docs/examples/features/integrations/mysql/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/features/integrations/mysql/output.yaml
@@ -401,11 +401,6 @@ data:
             "tmp_container_runtime",
           ]
         }
-      
-        // Only keep the labels that are defined in the `keepLabels` list.
-        stage.label_keep {
-          values = ["app_kubernetes_io_name","container","instance","job","level","namespace","pod","service_name","integration"]
-        }
         // Integration: MySQL
         stage.match {
           selector = "{integration=\"mysql\"}"
@@ -436,6 +431,11 @@ data:
           stage.label_drop {
             values = ["integration"]
           }
+        }
+      
+        // Only keep the labels that are defined in the `keepLabels` list.
+        stage.label_keep {
+          values = ["app_kubernetes_io_name","container","instance","job","level","namespace","pod","service_name","integration"]
         }
       
         forward_to = argument.logs_destinations.value

--- a/charts/k8s-monitoring/docs/examples/meta-monitoring/README.md
+++ b/charts/k8s-monitoring/docs/examples/meta-monitoring/README.md
@@ -117,7 +117,9 @@ clusterMetrics:
   kube-state-metrics:
     enabled: true
     namespaces:
+      - collectors
       - logs
+      - metrics
       - o11y
     extraMetricProcessingRules: |-
       rule {
@@ -147,6 +149,16 @@ nodeLogs:
 
 podLogs:
   enabled: true
+  labelsToKeep:
+    - app
+    - app_kubernetes_io_name
+    - component
+    - container
+    - job
+    - level
+    - namespace
+    - pod
+    - service_name
   gatherMethod: kubernetesApi
   collector: alloy-singleton
   namespaces:

--- a/charts/k8s-monitoring/docs/examples/meta-monitoring/alloy-singleton.alloy
+++ b/charts/k8s-monitoring/docs/examples/meta-monitoring/alloy-singleton.alloy
@@ -552,11 +552,6 @@ declare "pod_logs" {
         "tmp_container_runtime",
       ]
     }
-  
-    // Only keep the labels that are defined in the `keepLabels` list.
-    stage.label_keep {
-      values = ["app_kubernetes_io_name","container","instance","job","level","namespace","pod","service_name","integration"]
-    }
     // Integration: Loki
     stage.match {
       selector = "{job=\"integrations/grafana\",instance=\"grafana\",namespace=~\"o11y\"}"
@@ -700,6 +695,11 @@ declare "pod_logs" {
         }
       }
     
+    }
+  
+    // Only keep the labels that are defined in the `keepLabels` list.
+    stage.label_keep {
+      values = ["app","app_kubernetes_io_name","component","container","job","level","namespace","pod","service_name","integration"]
     }
   
     forward_to = argument.logs_destinations.value

--- a/charts/k8s-monitoring/docs/examples/meta-monitoring/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/meta-monitoring/output.yaml
@@ -627,11 +627,6 @@ data:
             "tmp_container_runtime",
           ]
         }
-      
-        // Only keep the labels that are defined in the `keepLabels` list.
-        stage.label_keep {
-          values = ["app_kubernetes_io_name","container","instance","job","level","namespace","pod","service_name","integration"]
-        }
         // Integration: Loki
         stage.match {
           selector = "{job=\"integrations/grafana\",instance=\"grafana\",namespace=~\"o11y\"}"
@@ -775,6 +770,11 @@ data:
             }
           }
         
+        }
+      
+        // Only keep the labels that are defined in the `keepLabels` list.
+        stage.label_keep {
+          values = ["app","app_kubernetes_io_name","component","container","job","level","namespace","pod","service_name","integration"]
         }
       
         forward_to = argument.logs_destinations.value
@@ -4547,7 +4547,7 @@ spec:
         - --port=8080
         - --resources=certificatesigningrequests,configmaps,cronjobs,daemonsets,deployments,endpoints,horizontalpodautoscalers,ingresses,jobs,leases,limitranges,mutatingwebhookconfigurations,namespaces,networkpolicies,nodes,persistentvolumeclaims,persistentvolumes,poddisruptionbudgets,pods,replicasets,replicationcontrollers,resourcequotas,secrets,services,statefulsets,storageclasses,validatingwebhookconfigurations,volumeattachments
         - --metric-labels-allowlist=nodes=[agentpool,alpha.eksctl.io/cluster-name,alpha.eksctl.io/nodegroup-name,beta.kubernetes.io/instance-type,cloud.google.com/gke-nodepool,cluster_name,ec2_amazonaws_com_Name,ec2_amazonaws_com_aws_autoscaling_groupName,ec2_amazonaws_com_aws_autoscaling_group_name,ec2_amazonaws_com_name,eks_amazonaws_com_nodegroup,k8s_io_cloud_provider_aws,karpenter.sh/nodepool,kubernetes.azure.com/cluster,kubernetes.io/arch,kubernetes.io/hostname,kubernetes.io/os,node.kubernetes.io/instance-type,topology.kubernetes.io/region,topology.kubernetes.io/zone]
-        - --namespaces=logs,o11y
+        - --namespaces=collectors,logs,metrics,o11y
         imagePullPolicy: IfNotPresent
         image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.14.0
         ports:

--- a/charts/k8s-monitoring/docs/examples/meta-monitoring/values.yaml
+++ b/charts/k8s-monitoring/docs/examples/meta-monitoring/values.yaml
@@ -108,7 +108,9 @@ clusterMetrics:
   kube-state-metrics:
     enabled: true
     namespaces:
+      - collectors
       - logs
+      - metrics
       - o11y
     extraMetricProcessingRules: |-
       rule {
@@ -138,6 +140,16 @@ nodeLogs:
 
 podLogs:
   enabled: true
+  labelsToKeep:
+    - app
+    - app_kubernetes_io_name
+    - component
+    - container
+    - job
+    - level
+    - namespace
+    - pod
+    - service_name
   gatherMethod: kubernetesApi
   collector: alloy-singleton
   namespaces:

--- a/charts/k8s-monitoring/tests/integration/integration-grafana/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/integration/integration-grafana/.rendered/output.yaml
@@ -1067,11 +1067,6 @@ data:
             "tmp_container_runtime",
           ]
         }
-      
-        // Only keep the labels that are defined in the `keepLabels` list.
-        stage.label_keep {
-          values = ["app_kubernetes_io_name","container","instance","job","level","namespace","pod","service_name","integration"]
-        }
         // Integration: Loki
         stage.match {
           selector = "{job=\"integrations/grafana\",instance=\"grafana\"}"
@@ -1102,6 +1097,11 @@ data:
             expression = "( t=[^ ]+\\s+)"
             replace = ""
           }
+        }
+      
+        // Only keep the labels that are defined in the `keepLabels` list.
+        stage.label_keep {
+          values = ["app_kubernetes_io_name","container","instance","job","level","namespace","pod","service_name","integration"]
         }
       
         forward_to = argument.logs_destinations.value

--- a/charts/k8s-monitoring/tests/integration/integration-loki/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/integration/integration-loki/.rendered/output.yaml
@@ -1111,11 +1111,6 @@ data:
             "tmp_container_runtime",
           ]
         }
-      
-        // Only keep the labels that are defined in the `keepLabels` list.
-        stage.label_keep {
-          values = ["app_kubernetes_io_name","container","instance","job","level","namespace","pod","service_name","integration"]
-        }
         // Integration: Loki
         stage.match {
           selector = "{integration=\"loki\",instance=\"loki\"}"
@@ -1145,6 +1140,11 @@ data:
             replace = ""
           }
         
+        }
+      
+        // Only keep the labels that are defined in the `keepLabels` list.
+        stage.label_keep {
+          values = ["app_kubernetes_io_name","container","instance","job","level","namespace","pod","service_name","integration"]
         }
       
         forward_to = argument.logs_destinations.value

--- a/charts/k8s-monitoring/tests/integration/integration-mysql/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/integration/integration-mysql/.rendered/output.yaml
@@ -374,11 +374,6 @@ data:
             "tmp_container_runtime",
           ]
         }
-      
-        // Only keep the labels that are defined in the `keepLabels` list.
-        stage.label_keep {
-          values = ["app_kubernetes_io_name","container","instance","job","level","namespace","pod","service_name","integration"]
-        }
         // Integration: MySQL
         stage.match {
           selector = "{integration=\"mysql\"}"
@@ -409,6 +404,11 @@ data:
           stage.label_drop {
             values = ["integration"]
           }
+        }
+      
+        // Only keep the labels that are defined in the `keepLabels` list.
+        stage.label_keep {
+          values = ["app_kubernetes_io_name","container","instance","job","level","namespace","pod","service_name","integration"]
         }
       
         forward_to = argument.logs_destinations.value


### PR DESCRIPTION
The label keep stage was being inserted before extraLogProcessingStages.  When integrations create labels as part of their processing, those labels may or may not be desired to be kept be the user.   Making this change eliminates the need to have each integration define its own set of labels to keep. 