### PR TITLE
Rlankfo/batch size

### DIFF
--- a/charts/k8s-monitoring/charts/feature-application-observability/README.md
+++ b/charts/k8s-monitoring/charts/feature-application-observability/README.md
@@ -86,8 +86,8 @@ Be sure perform actual integration testing in a live environment in the main [k8
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| processors.batch.maxSize | int | `0` | The upper limit of the amount of data contained in a single batch, in bytes. When set to 0, batches can be any size. |
-| processors.batch.size | int | `16384` | What batch size to use, in bytes |
+| processors.batch.maxSize | int | `0` | The upper limit of the amount of data contained in a single batch. When set to 0, batches can be any size. |
+| processors.batch.size | int | `8192` | What batch size to use |
 | processors.batch.timeout | string | `"2s"` | How long before sending (Processors) |
 
 ### Processors: Interval

--- a/charts/k8s-monitoring/charts/feature-application-observability/tests/default_test.yaml
+++ b/charts/k8s-monitoring/charts/feature-application-observability/tests/default_test.yaml
@@ -158,7 +158,7 @@ tests:
 
               // Batch Processor
               otelcol.processor.batch "default" {
-                send_batch_size = 16384
+                send_batch_size = 8192
                 send_batch_max_size = 0
                 timeout = "2s"
 

--- a/charts/k8s-monitoring/charts/feature-application-observability/tests/interval_test.yaml
+++ b/charts/k8s-monitoring/charts/feature-application-observability/tests/interval_test.yaml
@@ -161,7 +161,7 @@ tests:
 
               // Batch Processor
               otelcol.processor.batch "default" {
-                send_batch_size = 16384
+                send_batch_size = 8192
                 send_batch_max_size = 0
                 timeout = "2s"
 

--- a/charts/k8s-monitoring/charts/feature-application-observability/tests/memorylimiter_test.yaml
+++ b/charts/k8s-monitoring/charts/feature-application-observability/tests/memorylimiter_test.yaml
@@ -117,7 +117,7 @@ tests:
 
               // Batch Processor
               otelcol.processor.batch "default" {
-                send_batch_size = 16384
+                send_batch_size = 8192
                 send_batch_max_size = 0
                 timeout = "2s"
 

--- a/charts/k8s-monitoring/charts/feature-application-observability/tests/spanlogs_test.yaml
+++ b/charts/k8s-monitoring/charts/feature-application-observability/tests/spanlogs_test.yaml
@@ -122,7 +122,7 @@ tests:
 
               // Batch Processor
               otelcol.processor.batch "default" {
-                send_batch_size = 16384
+                send_batch_size = 8192
                 send_batch_max_size = 0
                 timeout = "2s"
 

--- a/charts/k8s-monitoring/charts/feature-application-observability/tests/spanmetrics_test.yaml
+++ b/charts/k8s-monitoring/charts/feature-application-observability/tests/spanmetrics_test.yaml
@@ -141,7 +141,7 @@ tests:
 
               // Batch Processor
               otelcol.processor.batch "default" {
-                send_batch_size = 16384
+                send_batch_size = 8192
                 send_batch_max_size = 0
                 timeout = "2s"
 

--- a/charts/k8s-monitoring/charts/feature-application-observability/values.yaml
+++ b/charts/k8s-monitoring/charts/feature-application-observability/values.yaml
@@ -67,10 +67,10 @@ receivers:
 # Processors are components that modify the telemetry data, such as filtering, batching, and adding metadata.
 processors:
   batch:
-    # -- What batch size to use, in bytes
+    # -- What batch size to use
     # @section -- Processors: Batch
-    size: 16384
-    # -- The upper limit of the amount of data contained in a single batch, in bytes. When set to 0, batches can be any size.
+    size: 8192
+    # -- The upper limit of the amount of data contained in a single batch. When set to 0, batches can be any size.
     # @section -- Processors: Batch
     maxSize: 0
     # -- How long before sending (Processors)

--- a/charts/k8s-monitoring/docs/examples/auth/bearer-token/alloy-receiver.alloy
+++ b/charts/k8s-monitoring/docs/examples/auth/bearer-token/alloy-receiver.alloy
@@ -228,7 +228,7 @@ declare "application_observability" {
 
   // Batch Processor
   otelcol.processor.batch "default" {
-    send_batch_size = 16384
+    send_batch_size = 8192
     send_batch_max_size = 0
     timeout = "2s"
 

--- a/charts/k8s-monitoring/docs/examples/auth/bearer-token/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/auth/bearer-token/output.yaml
@@ -666,7 +666,7 @@ data:
     
       // Batch Processor
       otelcol.processor.batch "default" {
-        send_batch_size = 16384
+        send_batch_size = 8192
         send_batch_max_size = 0
         timeout = "2s"
     

--- a/charts/k8s-monitoring/docs/examples/auth/embedded-secrets/alloy-receiver.alloy
+++ b/charts/k8s-monitoring/docs/examples/auth/embedded-secrets/alloy-receiver.alloy
@@ -215,7 +215,7 @@ declare "application_observability" {
 
   // Batch Processor
   otelcol.processor.batch "default" {
-    send_batch_size = 16384
+    send_batch_size = 8192
     send_batch_max_size = 0
     timeout = "2s"
 

--- a/charts/k8s-monitoring/docs/examples/auth/embedded-secrets/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/auth/embedded-secrets/output.yaml
@@ -642,7 +642,7 @@ data:
     
       // Batch Processor
       otelcol.processor.batch "default" {
-        send_batch_size = 16384
+        send_batch_size = 8192
         send_batch_max_size = 0
         timeout = "2s"
     

--- a/charts/k8s-monitoring/docs/examples/auth/external-secrets/alloy-receiver.alloy
+++ b/charts/k8s-monitoring/docs/examples/auth/external-secrets/alloy-receiver.alloy
@@ -248,7 +248,7 @@ declare "application_observability" {
 
   // Batch Processor
   otelcol.processor.batch "default" {
-    send_batch_size = 16384
+    send_batch_size = 8192
     send_batch_max_size = 0
     timeout = "2s"
 

--- a/charts/k8s-monitoring/docs/examples/auth/external-secrets/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/auth/external-secrets/output.yaml
@@ -695,7 +695,7 @@ data:
     
       // Batch Processor
       otelcol.processor.batch "default" {
-        send_batch_size = 16384
+        send_batch_size = 8192
         send_batch_max_size = 0
         timeout = "2s"
     

--- a/charts/k8s-monitoring/docs/examples/features/application-observability/default/alloy-receiver.alloy
+++ b/charts/k8s-monitoring/docs/examples/features/application-observability/default/alloy-receiver.alloy
@@ -149,7 +149,7 @@ declare "application_observability" {
 
   // Batch Processor
   otelcol.processor.batch "default" {
-    send_batch_size = 16384
+    send_batch_size = 8192
     send_batch_max_size = 0
     timeout = "2s"
 

--- a/charts/k8s-monitoring/docs/examples/features/application-observability/default/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/features/application-observability/default/output.yaml
@@ -174,7 +174,7 @@ data:
     
       // Batch Processor
       otelcol.processor.batch "default" {
-        send_batch_size = 16384
+        send_batch_size = 8192
         send_batch_max_size = 0
         timeout = "2s"
     

--- a/charts/k8s-monitoring/docs/examples/features/auto-instrumentation/beyla-metrics-and-traces/alloy-receiver.alloy
+++ b/charts/k8s-monitoring/docs/examples/features/auto-instrumentation/beyla-metrics-and-traces/alloy-receiver.alloy
@@ -149,7 +149,7 @@ declare "application_observability" {
 
   // Batch Processor
   otelcol.processor.batch "default" {
-    send_batch_size = 16384
+    send_batch_size = 8192
     send_batch_max_size = 0
     timeout = "2s"
 

--- a/charts/k8s-monitoring/docs/examples/features/auto-instrumentation/beyla-metrics-and-traces/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/features/auto-instrumentation/beyla-metrics-and-traces/output.yaml
@@ -380,7 +380,7 @@ data:
     
       // Batch Processor
       otelcol.processor.batch "default" {
-        send_batch_size = 16384
+        send_batch_size = 8192
         send_batch_max_size = 0
         timeout = "2s"
     

--- a/charts/k8s-monitoring/docs/examples/meta-monitoring/alloy-receiver.alloy
+++ b/charts/k8s-monitoring/docs/examples/meta-monitoring/alloy-receiver.alloy
@@ -205,7 +205,7 @@ declare "application_observability" {
 
   // Batch Processor
   otelcol.processor.batch "default" {
-    send_batch_size = 16384
+    send_batch_size = 8192
     send_batch_max_size = 0
     timeout = "2s"
 

--- a/charts/k8s-monitoring/docs/examples/meta-monitoring/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/meta-monitoring/output.yaml
@@ -2142,7 +2142,7 @@ data:
     
       // Batch Processor
       otelcol.processor.batch "default" {
-        send_batch_size = 16384
+        send_batch_size = 8192
         send_batch_max_size = 0
         timeout = "2s"
     

--- a/charts/k8s-monitoring/docs/examples/pod-labels-and-annotations/alloy-receiver.alloy
+++ b/charts/k8s-monitoring/docs/examples/pod-labels-and-annotations/alloy-receiver.alloy
@@ -205,7 +205,7 @@ declare "application_observability" {
 
   // Batch Processor
   otelcol.processor.batch "default" {
-    send_batch_size = 16384
+    send_batch_size = 8192
     send_batch_max_size = 0
     timeout = "2s"
 

--- a/charts/k8s-monitoring/docs/examples/pod-labels-and-annotations/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/pod-labels-and-annotations/output.yaml
@@ -890,7 +890,7 @@ data:
     
       // Batch Processor
       otelcol.processor.batch "default" {
-        send_batch_size = 16384
+        send_batch_size = 8192
         send_batch_max_size = 0
         timeout = "2s"
     

--- a/charts/k8s-monitoring/docs/examples/proxies/alloy-receiver.alloy
+++ b/charts/k8s-monitoring/docs/examples/proxies/alloy-receiver.alloy
@@ -201,7 +201,7 @@ declare "application_observability" {
 
   // Batch Processor
   otelcol.processor.batch "default" {
-    send_batch_size = 16384
+    send_batch_size = 8192
     send_batch_max_size = 0
     timeout = "2s"
 

--- a/charts/k8s-monitoring/docs/examples/proxies/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/proxies/output.yaml
@@ -1065,7 +1065,7 @@ data:
     
       // Batch Processor
       otelcol.processor.batch "default" {
-        send_batch_size = 16384
+        send_batch_size = 8192
         send_batch_max_size = 0
         timeout = "2s"
     

--- a/charts/k8s-monitoring/tests/integration/auto-instrumentation/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/integration/auto-instrumentation/.rendered/output.yaml
@@ -446,7 +446,7 @@ data:
     
       // Batch Processor
       otelcol.processor.batch "default" {
-        send_batch_size = 16384
+        send_batch_size = 8192
         send_batch_max_size = 0
         timeout = "2s"
     


### PR DESCRIPTION
Batch size is the "number of spans, metric data points, or log records after which a batch will be sent regardless of the timeout". See https://github.com/open-telemetry/opentelemetry-collector/blob/main/processor/batchprocessor/README.md#batch-processor

This PR sets default batch size for feature-application-observability chart to 8192.
