### PR TITLE
chore(templates-destinations): handle if destination protocol is not set to grpc or http

### DIFF
--- a/charts/k8s-monitoring/templates/destinations/_destination_otlp.tpl
+++ b/charts/k8s-monitoring/templates/destinations/_destination_otlp.tpl
@@ -261,6 +261,15 @@ otelcol.processor.memory_limiter {{ include "helper.alloy_name" .name | quote }}
 otelcol.exporter.otlp {{ include "helper.alloy_name" .name | quote }} {
 {{- else if eq .protocol "http" }}
 otelcol.exporter.otlphttp {{ include "helper.alloy_name" .name | quote }} {
+{{- else }}
+{{- $msg := list "" "Protocol must be either 'grpc' or 'http', got '%s'" .protocol }}
+{{- $msg = append $msg "For example, please set:" }}
+{{- $msg = append $msg "destinations:" }}
+{{- $msg = append $msg "  otlp:" }}
+{{- $msg = append $msg "    protocol:" }}
+{{- $msg = append $msg "      - grpc" }}
+{{- $msg = append $msg "      - http" }}
+{{- fail (join "\n" $msg) }}
 {{- end }}
   client {
 {{- if .urlFrom }}


### PR DESCRIPTION
We encountered an unexpected error due to mistakenly setting "otelhttp" as the protocol, which prevented the Alloy receiver from starting due to a configuration issue in config.alloy