### PR TITLE
Fix Pod log annotation and label assignment

### DIFF
--- a/charts/k8s-monitoring/charts/feature-pod-logs/templates/_common_pod_discovery.alloy.tpl
+++ b/charts/k8s-monitoring/charts/feature-pod-logs/templates/_common_pod_discovery.alloy.tpl
@@ -98,12 +98,14 @@ discovery.relabel "filtered_pods" {
 {{- range $label, $k8sAnnotation := .Values.annotations }}
   rule {
     source_labels = ["{{ include "pod_annotation" $k8sAnnotation }}"]
+    regex = "(.+)"
     target_label = {{ $label | quote }}
   }
 {{- end }}
 {{- range $label, $k8sLabels := .Values.labels }}
   rule {
     source_labels = ["{{ include "pod_label" $k8sLabels }}"]
+    regex = "(.+)"
     target_label = {{ $label | quote }}
   }
 {{- end }}

--- a/charts/k8s-monitoring/charts/feature-pod-logs/tests/default_test.yaml
+++ b/charts/k8s-monitoring/charts/feature-pod-logs/tests/default_test.yaml
@@ -107,10 +107,12 @@ tests:
                 }
                 rule {
                   source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_job"]
+                  regex = "(.+)"
                   target_label = "job"
                 }
                 rule {
                   source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+                  regex = "(.+)"
                   target_label = "app_kubernetes_io_name"
                 }
               }
@@ -300,10 +302,12 @@ tests:
                 }
                 rule {
                   source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_job"]
+                  regex = "(.+)"
                   target_label = "job"
                 }
                 rule {
                   source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+                  regex = "(.+)"
                   target_label = "app_kubernetes_io_name"
                 }
               }
@@ -491,10 +495,12 @@ tests:
                 }
                 rule {
                   source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_job"]
+                  regex = "(.+)"
                   target_label = "job"
                 }
                 rule {
                   source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+                  regex = "(.+)"
                   target_label = "app_kubernetes_io_name"
                 }
               }
@@ -690,10 +696,12 @@ tests:
                 }
                 rule {
                   source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_job"]
+                  regex = "(.+)"
                   target_label = "job"
                 }
                 rule {
                   source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+                  regex = "(.+)"
                   target_label = "app_kubernetes_io_name"
                 }
               }

--- a/charts/k8s-monitoring/docs/examples/auth/bearer-token/alloy-logs.alloy
+++ b/charts/k8s-monitoring/docs/examples/auth/bearer-token/alloy-logs.alloy
@@ -112,10 +112,12 @@ declare "pod_logs" {
     }
     rule {
       source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_job"]
+      regex = "(.+)"
       target_label = "job"
     }
     rule {
       source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+      regex = "(.+)"
       target_label = "app_kubernetes_io_name"
     }
   }

--- a/charts/k8s-monitoring/docs/examples/auth/bearer-token/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/auth/bearer-token/output.yaml
@@ -339,10 +339,12 @@ data:
         }
         rule {
           source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_job"]
+          regex = "(.+)"
           target_label = "job"
         }
         rule {
           source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+          regex = "(.+)"
           target_label = "app_kubernetes_io_name"
         }
       }

--- a/charts/k8s-monitoring/docs/examples/auth/embedded-secrets/alloy-logs.alloy
+++ b/charts/k8s-monitoring/docs/examples/auth/embedded-secrets/alloy-logs.alloy
@@ -112,10 +112,12 @@ declare "pod_logs" {
     }
     rule {
       source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_job"]
+      regex = "(.+)"
       target_label = "job"
     }
     rule {
       source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+      regex = "(.+)"
       target_label = "app_kubernetes_io_name"
     }
   }

--- a/charts/k8s-monitoring/docs/examples/auth/embedded-secrets/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/auth/embedded-secrets/output.yaml
@@ -328,10 +328,12 @@ data:
         }
         rule {
           source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_job"]
+          regex = "(.+)"
           target_label = "job"
         }
         rule {
           source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+          regex = "(.+)"
           target_label = "app_kubernetes_io_name"
         }
       }

--- a/charts/k8s-monitoring/docs/examples/auth/external-secrets/alloy-logs.alloy
+++ b/charts/k8s-monitoring/docs/examples/auth/external-secrets/alloy-logs.alloy
@@ -124,10 +124,12 @@ declare "pod_logs" {
     }
     rule {
       source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_job"]
+      regex = "(.+)"
       target_label = "job"
     }
     rule {
       source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+      regex = "(.+)"
       target_label = "app_kubernetes_io_name"
     }
   }

--- a/charts/k8s-monitoring/docs/examples/auth/external-secrets/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/auth/external-secrets/output.yaml
@@ -348,10 +348,12 @@ data:
         }
         rule {
           source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_job"]
+          regex = "(.+)"
           target_label = "job"
         }
         rule {
           source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+          regex = "(.+)"
           target_label = "app_kubernetes_io_name"
         }
       }

--- a/charts/k8s-monitoring/docs/examples/auth/oauth2/alloy-logs.alloy
+++ b/charts/k8s-monitoring/docs/examples/auth/oauth2/alloy-logs.alloy
@@ -321,10 +321,12 @@ declare "pod_logs" {
     }
     rule {
       source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_job"]
+      regex = "(.+)"
       target_label = "job"
     }
     rule {
       source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+      regex = "(.+)"
       target_label = "app_kubernetes_io_name"
     }
   }

--- a/charts/k8s-monitoring/docs/examples/auth/oauth2/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/auth/oauth2/output.yaml
@@ -1241,10 +1241,12 @@ data:
         }
         rule {
           source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_job"]
+          regex = "(.+)"
           target_label = "job"
         }
         rule {
           source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+          regex = "(.+)"
           target_label = "app_kubernetes_io_name"
         }
       }

--- a/charts/k8s-monitoring/docs/examples/collector-storage/alloy-logs.alloy
+++ b/charts/k8s-monitoring/docs/examples/collector-storage/alloy-logs.alloy
@@ -111,10 +111,12 @@ declare "pod_logs" {
     }
     rule {
       source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_job"]
+      regex = "(.+)"
       target_label = "job"
     }
     rule {
       source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+      regex = "(.+)"
       target_label = "app_kubernetes_io_name"
     }
   }

--- a/charts/k8s-monitoring/docs/examples/collector-storage/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/collector-storage/output.yaml
@@ -561,10 +561,12 @@ data:
         }
         rule {
           source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_job"]
+          regex = "(.+)"
           target_label = "job"
         }
         rule {
           source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+          regex = "(.+)"
           target_label = "app_kubernetes_io_name"
         }
       }

--- a/charts/k8s-monitoring/docs/examples/destinations/otlp-endpoint/alloy-logs.alloy
+++ b/charts/k8s-monitoring/docs/examples/destinations/otlp-endpoint/alloy-logs.alloy
@@ -164,10 +164,12 @@ declare "pod_logs" {
     }
     rule {
       source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_job"]
+      regex = "(.+)"
       target_label = "job"
     }
     rule {
       source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+      regex = "(.+)"
       target_label = "app_kubernetes_io_name"
     }
   }

--- a/charts/k8s-monitoring/docs/examples/destinations/otlp-endpoint/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/destinations/otlp-endpoint/output.yaml
@@ -647,10 +647,12 @@ data:
         }
         rule {
           source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_job"]
+          regex = "(.+)"
           target_label = "job"
         }
         rule {
           source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+          regex = "(.+)"
           target_label = "app_kubernetes_io_name"
         }
       }

--- a/charts/k8s-monitoring/docs/examples/extra-rules/alloy-logs.alloy
+++ b/charts/k8s-monitoring/docs/examples/extra-rules/alloy-logs.alloy
@@ -113,10 +113,12 @@ declare "pod_logs" {
     }
     rule {
       source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_job"]
+      regex = "(.+)"
       target_label = "job"
     }
     rule {
       source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+      regex = "(.+)"
       target_label = "app_kubernetes_io_name"
     }
     rule {

--- a/charts/k8s-monitoring/docs/examples/extra-rules/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/extra-rules/output.yaml
@@ -763,10 +763,12 @@ data:
         }
         rule {
           source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_job"]
+          regex = "(.+)"
           target_label = "job"
         }
         rule {
           source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+          regex = "(.+)"
           target_label = "app_kubernetes_io_name"
         }
         rule {

--- a/charts/k8s-monitoring/docs/examples/features/cluster-metrics/control-plane-monitoring/alloy-logs.alloy
+++ b/charts/k8s-monitoring/docs/examples/features/cluster-metrics/control-plane-monitoring/alloy-logs.alloy
@@ -111,10 +111,12 @@ declare "pod_logs" {
     }
     rule {
       source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_job"]
+      regex = "(.+)"
       target_label = "job"
     }
     rule {
       source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+      regex = "(.+)"
       target_label = "app_kubernetes_io_name"
     }
   }

--- a/charts/k8s-monitoring/docs/examples/features/cluster-metrics/control-plane-monitoring/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/features/cluster-metrics/control-plane-monitoring/output.yaml
@@ -880,10 +880,12 @@ data:
         }
         rule {
           source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_job"]
+          regex = "(.+)"
           target_label = "job"
         }
         rule {
           source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+          regex = "(.+)"
           target_label = "app_kubernetes_io_name"
         }
       }

--- a/charts/k8s-monitoring/docs/examples/features/integrations/grafana/alloy-logs.alloy
+++ b/charts/k8s-monitoring/docs/examples/features/integrations/grafana/alloy-logs.alloy
@@ -111,10 +111,12 @@ declare "pod_logs" {
     }
     rule {
       source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_job"]
+      regex = "(.+)"
       target_label = "job"
     }
     rule {
       source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+      regex = "(.+)"
       target_label = "app_kubernetes_io_name"
     }
     rule {

--- a/charts/k8s-monitoring/docs/examples/features/integrations/grafana/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/features/integrations/grafana/output.yaml
@@ -483,10 +483,12 @@ data:
         }
         rule {
           source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_job"]
+          regex = "(.+)"
           target_label = "job"
         }
         rule {
           source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+          regex = "(.+)"
           target_label = "app_kubernetes_io_name"
         }
         rule {

--- a/charts/k8s-monitoring/docs/examples/features/integrations/loki/alloy-logs.alloy
+++ b/charts/k8s-monitoring/docs/examples/features/integrations/loki/alloy-logs.alloy
@@ -111,10 +111,12 @@ declare "pod_logs" {
     }
     rule {
       source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_job"]
+      regex = "(.+)"
       target_label = "job"
     }
     rule {
       source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+      regex = "(.+)"
       target_label = "app_kubernetes_io_name"
     }
     // add static label of integration="loki" and instance="name" to pods that match the selector so they can be identified in the loki.process stages

--- a/charts/k8s-monitoring/docs/examples/features/integrations/loki/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/features/integrations/loki/output.yaml
@@ -518,10 +518,12 @@ data:
         }
         rule {
           source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_job"]
+          regex = "(.+)"
           target_label = "job"
         }
         rule {
           source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+          regex = "(.+)"
           target_label = "app_kubernetes_io_name"
         }
         // add static label of integration="loki" and instance="name" to pods that match the selector so they can be identified in the loki.process stages

--- a/charts/k8s-monitoring/docs/examples/features/integrations/mimir/alloy-logs.alloy
+++ b/charts/k8s-monitoring/docs/examples/features/integrations/mimir/alloy-logs.alloy
@@ -111,10 +111,12 @@ declare "pod_logs" {
     }
     rule {
       source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_job"]
+      regex = "(.+)"
       target_label = "job"
     }
     rule {
       source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+      regex = "(.+)"
       target_label = "app_kubernetes_io_name"
     }
     // add static label of integration="mimir" and instance="name" to pods that match the selector so they can be identified in the mimir.process stages

--- a/charts/k8s-monitoring/docs/examples/features/integrations/mimir/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/features/integrations/mimir/output.yaml
@@ -518,10 +518,12 @@ data:
         }
         rule {
           source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_job"]
+          regex = "(.+)"
           target_label = "job"
         }
         rule {
           source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+          regex = "(.+)"
           target_label = "app_kubernetes_io_name"
         }
         // add static label of integration="mimir" and instance="name" to pods that match the selector so they can be identified in the mimir.process stages

--- a/charts/k8s-monitoring/docs/examples/features/integrations/mysql/alloy-logs.alloy
+++ b/charts/k8s-monitoring/docs/examples/features/integrations/mysql/alloy-logs.alloy
@@ -111,10 +111,12 @@ declare "pod_logs" {
     }
     rule {
       source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_job"]
+      regex = "(.+)"
       target_label = "job"
     }
     rule {
       source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+      regex = "(.+)"
       target_label = "app_kubernetes_io_name"
     }
     rule {

--- a/charts/k8s-monitoring/docs/examples/features/integrations/mysql/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/features/integrations/mysql/output.yaml
@@ -336,10 +336,12 @@ data:
         }
         rule {
           source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_job"]
+          regex = "(.+)"
           target_label = "job"
         }
         rule {
           source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+          regex = "(.+)"
           target_label = "app_kubernetes_io_name"
         }
         rule {

--- a/charts/k8s-monitoring/docs/examples/features/pod-logs/default/alloy-logs.alloy
+++ b/charts/k8s-monitoring/docs/examples/features/pod-logs/default/alloy-logs.alloy
@@ -111,10 +111,12 @@ declare "pod_logs" {
     }
     rule {
       source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_job"]
+      regex = "(.+)"
       target_label = "job"
     }
     rule {
       source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+      regex = "(.+)"
       target_label = "app_kubernetes_io_name"
     }
   }

--- a/charts/k8s-monitoring/docs/examples/features/pod-logs/default/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/features/pod-logs/default/output.yaml
@@ -136,10 +136,12 @@ data:
         }
         rule {
           source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_job"]
+          regex = "(.+)"
           target_label = "job"
         }
         rule {
           source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+          regex = "(.+)"
           target_label = "app_kubernetes_io_name"
         }
       }

--- a/charts/k8s-monitoring/docs/examples/meta-monitoring/alloy-singleton.alloy
+++ b/charts/k8s-monitoring/docs/examples/meta-monitoring/alloy-singleton.alloy
@@ -472,10 +472,12 @@ declare "pod_logs" {
     }
     rule {
       source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_job"]
+      regex = "(.+)"
       target_label = "job"
     }
     rule {
       source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+      regex = "(.+)"
       target_label = "app_kubernetes_io_name"
     }
     rule {

--- a/charts/k8s-monitoring/docs/examples/meta-monitoring/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/meta-monitoring/output.yaml
@@ -547,10 +547,12 @@ data:
         }
         rule {
           source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_job"]
+          regex = "(.+)"
           target_label = "job"
         }
         rule {
           source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+          regex = "(.+)"
           target_label = "app_kubernetes_io_name"
         }
         rule {

--- a/charts/k8s-monitoring/docs/examples/platforms/azure-aks/alloy-logs.alloy
+++ b/charts/k8s-monitoring/docs/examples/platforms/azure-aks/alloy-logs.alloy
@@ -111,10 +111,12 @@ declare "pod_logs" {
     }
     rule {
       source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_job"]
+      regex = "(.+)"
       target_label = "job"
     }
     rule {
       source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+      regex = "(.+)"
       target_label = "app_kubernetes_io_name"
     }
   }

--- a/charts/k8s-monitoring/docs/examples/platforms/azure-aks/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/platforms/azure-aks/output.yaml
@@ -729,10 +729,12 @@ data:
         }
         rule {
           source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_job"]
+          regex = "(.+)"
           target_label = "job"
         }
         rule {
           source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+          regex = "(.+)"
           target_label = "app_kubernetes_io_name"
         }
       }

--- a/charts/k8s-monitoring/docs/examples/platforms/eks-fargate/alloy-logs.alloy
+++ b/charts/k8s-monitoring/docs/examples/platforms/eks-fargate/alloy-logs.alloy
@@ -111,10 +111,12 @@ declare "pod_logs" {
     }
     rule {
       source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_job"]
+      regex = "(.+)"
       target_label = "job"
     }
     rule {
       source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+      regex = "(.+)"
       target_label = "app_kubernetes_io_name"
     }
   }

--- a/charts/k8s-monitoring/docs/examples/platforms/eks-fargate/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/platforms/eks-fargate/output.yaml
@@ -674,10 +674,12 @@ data:
         }
         rule {
           source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_job"]
+          regex = "(.+)"
           target_label = "job"
         }
         rule {
           source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+          regex = "(.+)"
           target_label = "app_kubernetes_io_name"
         }
       }

--- a/charts/k8s-monitoring/docs/examples/platforms/gke-autopilot/alloy-logs.alloy
+++ b/charts/k8s-monitoring/docs/examples/platforms/gke-autopilot/alloy-logs.alloy
@@ -111,10 +111,12 @@ declare "pod_logs" {
     }
     rule {
       source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_job"]
+      regex = "(.+)"
       target_label = "job"
     }
     rule {
       source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+      regex = "(.+)"
       target_label = "app_kubernetes_io_name"
     }
   }

--- a/charts/k8s-monitoring/docs/examples/platforms/gke-autopilot/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/platforms/gke-autopilot/output.yaml
@@ -674,10 +674,12 @@ data:
         }
         rule {
           source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_job"]
+          regex = "(.+)"
           target_label = "job"
         }
         rule {
           source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+          regex = "(.+)"
           target_label = "app_kubernetes_io_name"
         }
       }

--- a/charts/k8s-monitoring/docs/examples/platforms/openshift/alloy-logs.alloy
+++ b/charts/k8s-monitoring/docs/examples/platforms/openshift/alloy-logs.alloy
@@ -111,10 +111,12 @@ declare "pod_logs" {
     }
     rule {
       source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_job"]
+      regex = "(.+)"
       target_label = "job"
     }
     rule {
       source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+      regex = "(.+)"
       target_label = "app_kubernetes_io_name"
     }
   }

--- a/charts/k8s-monitoring/docs/examples/platforms/openshift/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/platforms/openshift/output.yaml
@@ -749,10 +749,12 @@ data:
         }
         rule {
           source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_job"]
+          regex = "(.+)"
           target_label = "job"
         }
         rule {
           source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+          regex = "(.+)"
           target_label = "app_kubernetes_io_name"
         }
       }

--- a/charts/k8s-monitoring/docs/examples/pod-labels-and-annotations/alloy-logs.alloy
+++ b/charts/k8s-monitoring/docs/examples/pod-labels-and-annotations/alloy-logs.alloy
@@ -111,18 +111,22 @@ declare "pod_logs" {
     }
     rule {
       source_labels = ["__meta_kubernetes_pod_annotation_example_com_environment"]
+      regex = "(.+)"
       target_label = "environment"
     }
     rule {
       source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_job"]
+      regex = "(.+)"
       target_label = "job"
     }
     rule {
       source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+      regex = "(.+)"
       target_label = "app_kubernetes_io_name"
     }
     rule {
       source_labels = ["__meta_kubernetes_pod_label_example_com_name"]
+      regex = "(.+)"
       target_label = "name"
     }
   }

--- a/charts/k8s-monitoring/docs/examples/pod-labels-and-annotations/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/pod-labels-and-annotations/output.yaml
@@ -578,18 +578,22 @@ data:
         }
         rule {
           source_labels = ["__meta_kubernetes_pod_annotation_example_com_environment"]
+          regex = "(.+)"
           target_label = "environment"
         }
         rule {
           source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_job"]
+          regex = "(.+)"
           target_label = "job"
         }
         rule {
           source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+          regex = "(.+)"
           target_label = "app_kubernetes_io_name"
         }
         rule {
           source_labels = ["__meta_kubernetes_pod_label_example_com_name"]
+          regex = "(.+)"
           target_label = "name"
         }
       }

--- a/charts/k8s-monitoring/docs/examples/private-image-registries/globally/alloy-logs.alloy
+++ b/charts/k8s-monitoring/docs/examples/private-image-registries/globally/alloy-logs.alloy
@@ -111,10 +111,12 @@ declare "pod_logs" {
     }
     rule {
       source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_job"]
+      regex = "(.+)"
       target_label = "job"
     }
     rule {
       source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+      regex = "(.+)"
       target_label = "app_kubernetes_io_name"
     }
   }

--- a/charts/k8s-monitoring/docs/examples/private-image-registries/globally/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/private-image-registries/globally/output.yaml
@@ -567,10 +567,12 @@ data:
         }
         rule {
           source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_job"]
+          regex = "(.+)"
           target_label = "job"
         }
         rule {
           source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+          regex = "(.+)"
           target_label = "app_kubernetes_io_name"
         }
       }

--- a/charts/k8s-monitoring/docs/examples/proxies/alloy-logs.alloy
+++ b/charts/k8s-monitoring/docs/examples/proxies/alloy-logs.alloy
@@ -112,10 +112,12 @@ declare "pod_logs" {
     }
     rule {
       source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_job"]
+      regex = "(.+)"
       target_label = "job"
     }
     rule {
       source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+      regex = "(.+)"
       target_label = "app_kubernetes_io_name"
     }
   }

--- a/charts/k8s-monitoring/docs/examples/proxies/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/proxies/output.yaml
@@ -767,10 +767,12 @@ data:
         }
         rule {
           source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_job"]
+          regex = "(.+)"
           target_label = "job"
         }
         rule {
           source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+          regex = "(.+)"
           target_label = "app_kubernetes_io_name"
         }
       }

--- a/charts/k8s-monitoring/docs/examples/tolerations/alloy-logs.alloy
+++ b/charts/k8s-monitoring/docs/examples/tolerations/alloy-logs.alloy
@@ -111,10 +111,12 @@ declare "pod_logs" {
     }
     rule {
       source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_job"]
+      regex = "(.+)"
       target_label = "job"
     }
     rule {
       source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+      regex = "(.+)"
       target_label = "app_kubernetes_io_name"
     }
   }

--- a/charts/k8s-monitoring/docs/examples/tolerations/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/tolerations/output.yaml
@@ -561,10 +561,12 @@ data:
         }
         rule {
           source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_job"]
+          regex = "(.+)"
           target_label = "job"
         }
         rule {
           source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+          regex = "(.+)"
           target_label = "app_kubernetes_io_name"
         }
       }

--- a/charts/k8s-monitoring/tests/integration/auth/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/integration/auth/.rendered/output.yaml
@@ -744,10 +744,12 @@ data:
         }
         rule {
           source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_job"]
+          regex = "(.+)"
           target_label = "job"
         }
         rule {
           source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+          regex = "(.+)"
           target_label = "app_kubernetes_io_name"
         }
       }

--- a/charts/k8s-monitoring/tests/integration/cluster-monitoring/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/integration/cluster-monitoring/.rendered/output.yaml
@@ -901,10 +901,12 @@ data:
         }
         rule {
           source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_job"]
+          regex = "(.+)"
           target_label = "job"
         }
         rule {
           source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+          regex = "(.+)"
           target_label = "app_kubernetes_io_name"
         }
       }

--- a/charts/k8s-monitoring/tests/integration/control-plane-monitoring/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/integration/control-plane-monitoring/.rendered/output.yaml
@@ -878,10 +878,12 @@ data:
         }
         rule {
           source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_job"]
+          regex = "(.+)"
           target_label = "job"
         }
         rule {
           source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+          regex = "(.+)"
           target_label = "app_kubernetes_io_name"
         }
       }

--- a/charts/k8s-monitoring/tests/integration/integration-grafana/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/integration/integration-grafana/.rendered/output.yaml
@@ -1014,10 +1014,12 @@ data:
         }
         rule {
           source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_job"]
+          regex = "(.+)"
           target_label = "job"
         }
         rule {
           source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+          regex = "(.+)"
           target_label = "app_kubernetes_io_name"
         }
         rule {

--- a/charts/k8s-monitoring/tests/integration/integration-loki/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/integration/integration-loki/.rendered/output.yaml
@@ -1049,10 +1049,12 @@ data:
         }
         rule {
           source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_job"]
+          regex = "(.+)"
           target_label = "job"
         }
         rule {
           source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+          regex = "(.+)"
           target_label = "app_kubernetes_io_name"
         }
         // add static label of integration="loki" and instance="name" to pods that match the selector so they can be identified in the loki.process stages

--- a/charts/k8s-monitoring/tests/integration/integration-tempo/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/integration/integration-tempo/.rendered/output.yaml
@@ -1049,10 +1049,12 @@ data:
         }
         rule {
           source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_job"]
+          regex = "(.+)"
           target_label = "job"
         }
         rule {
           source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+          regex = "(.+)"
           target_label = "app_kubernetes_io_name"
         }
         // add static label of integration="tempo" and instance="name" to pods that match the selector so they can be identified in the tempo.process stages

--- a/charts/k8s-monitoring/tests/integration/istio-service-mesh/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/integration/istio-service-mesh/.rendered/output.yaml
@@ -1000,10 +1000,12 @@ data:
         }
         rule {
           source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_job"]
+          regex = "(.+)"
           target_label = "job"
         }
         rule {
           source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+          regex = "(.+)"
           target_label = "app_kubernetes_io_name"
         }
       }

--- a/charts/k8s-monitoring/tests/integration/pod-logs/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/integration/pod-logs/.rendered/output.yaml
@@ -15,22 +15,6 @@ metadata:
     app.kubernetes.io/part-of: alloy
     app.kubernetes.io/component: rbac
 ---
-# Source: k8s-monitoring/charts/alloy-metrics/templates/serviceaccount.yaml
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: k8smon-alloy-metrics
-  namespace: default
-  labels:
-    helm.sh/chart: alloy-metrics-0.11.0
-    app.kubernetes.io/name: alloy-metrics
-    app.kubernetes.io/instance: k8smon
-    
-    app.kubernetes.io/version: "v1.6.1"
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/part-of: alloy
-    app.kubernetes.io/component: rbac
----
 # Source: k8s-monitoring/templates/destination_secret.yaml
 apiVersion: v1
 kind: Secret
@@ -42,155 +26,6 @@ data:
   tenantId: "MQ=="
   username: "bG9raQ=="
   password: "bG9raXBhc3N3b3Jk"
----
-# Source: k8s-monitoring/templates/alloy-config.yaml
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: k8smon-alloy-metrics
-  namespace: default
-data:
-  config.alloy: |-
-    // Destination: localPrometheus (prometheus)
-    otelcol.exporter.prometheus "localprometheus" {
-      add_metric_suffixes = true
-      forward_to = [prometheus.remote_write.localprometheus.receiver]
-    }
-    
-    prometheus.remote_write "localprometheus" {
-      endpoint {
-        url = "http://prometheus-server.prometheus.svc:9090/api/v1/write"
-        headers = {
-        }
-        tls_config {
-          insecure_skip_verify = false
-        }
-        send_native_histograms = false
-    
-        queue_config {
-          capacity = 10000
-          min_shards = 1
-          max_shards = 50
-          max_samples_per_send = 2000
-          batch_send_deadline = "5s"
-          min_backoff = "30ms"
-          max_backoff = "5s"
-          retry_on_http_429 = true
-          sample_age_limit = "0s"
-        }
-    
-        write_relabel_config {
-          source_labels = ["cluster"]
-          regex = ""
-          replacement = "mysql-integration-test"
-          target_label = "cluster"
-        }
-        write_relabel_config {
-          source_labels = ["k8s.cluster.name"]
-          regex = ""
-          replacement = "mysql-integration-test"
-          target_label = "cluster"
-        }
-      }
-    
-      wal {
-        truncate_frequency = "2h"
-        min_keepalive_time = "5m"
-        max_keepalive_time = "8h"
-      }
-    }
-    declare "mysql_integration" {
-      argument "metrics_destinations" {
-        comment = "Must be a list of metric destinations where collected metrics should be forwarded to"
-      }
-    
-    
-      remote.kubernetes.secret "test_database" {
-        name      = "test-database-mysql"
-        namespace = "mysql"
-      }
-    
-      prometheus.exporter.mysql "test_database" {
-        data_source_name = string.format("%s:%s@(%s:%d)/",
-          "root",
-          remote.kubernetes.secret.test_database.data["mysql-root-password"],
-          "test-database-mysql.mysql.svc",
-          3306,
-        )
-        enable_collectors = ["heartbeat","mysql.user"]
-      }
-      prometheus.scrape "test_database" {
-        targets    = prometheus.exporter.mysql.test_database.targets
-        job_name   = "integration/mysql"
-        forward_to = [prometheus.relabel.test_database.receiver]
-      }
-    
-      prometheus.relabel "test_database" {
-        max_cache_size = 100000
-        rule {
-          target_label = "instance"
-          replacement = "test-database"
-        }
-        forward_to = argument.metrics_destinations.value
-      }
-    }
-    mysql_integration "integration" {
-      metrics_destinations = [
-        prometheus.remote_write.localprometheus.receiver,
-      ]
-    }
-    // Self Reporting
-    prometheus.exporter.unix "kubernetes_monitoring_telemetry" {
-      set_collectors = ["textfile"]
-      textfile {
-        directory = "/etc/alloy"
-      }
-    }
-    
-    discovery.relabel "kubernetes_monitoring_telemetry" {
-      targets = prometheus.exporter.unix.kubernetes_monitoring_telemetry.targets
-      rule {
-        target_label = "instance"
-        action = "replace"
-        replacement = "k8smon"
-      }
-      rule {
-        target_label = "job"
-        action = "replace"
-        replacement = "integrations/kubernetes/kubernetes_monitoring_telemetry"
-      }
-    }
-    
-    prometheus.scrape "kubernetes_monitoring_telemetry" {
-      job_name   = "integrations/kubernetes/kubernetes_monitoring_telemetry"
-      targets    = discovery.relabel.kubernetes_monitoring_telemetry.output
-      scrape_interval = "60s"
-      clustering {
-        enabled = true
-      }
-      forward_to = [prometheus.relabel.kubernetes_monitoring_telemetry.receiver]
-    }
-    
-    prometheus.relabel "kubernetes_monitoring_telemetry" {
-      rule {
-        source_labels = ["__name__"]
-        regex = "grafana_kubernetes_monitoring_.*"
-        action = "keep"
-      }
-      forward_to = [
-        prometheus.remote_write.localprometheus.receiver,
-      ]
-    }
-
-  self-reporting-metric.prom: |
-    
-    # HELP grafana_kubernetes_monitoring_build_info A metric to report the version of the Kubernetes Monitoring Helm chart
-    # TYPE grafana_kubernetes_monitoring_build_info gauge
-    grafana_kubernetes_monitoring_build_info{version="2.0.8", namespace="default"} 1
-    # HELP grafana_kubernetes_monitoring_feature_info A metric to report the enabled features of the Kubernetes Monitoring Helm chart
-    # TYPE grafana_kubernetes_monitoring_feature_info gauge
-    grafana_kubernetes_monitoring_feature_info{feature="podLogs", method="volumes", version="1.0.0"} 1
-    grafana_kubernetes_monitoring_feature_info{feature="integrations", sources="mysql", version="1.0.0"} 1
 ---
 # Source: k8s-monitoring/templates/alloy-config.yaml
 apiVersion: v1
@@ -218,8 +53,8 @@ data:
         }
       }
       external_labels = {
-        cluster = "mysql-integration-test",
-        "k8s_cluster_name" = "mysql-integration-test",
+        cluster = "pod-logs-feature-test",
+        "k8s_cluster_name" = "pod-logs-feature-test",
       }
     }
     
@@ -331,20 +166,6 @@ data:
           regex = "(.+)"
           target_label = "app_kubernetes_io_name"
         }
-        rule {
-          source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_instance"]
-          separator = ";"
-          regex = "(?:test-database)"
-          target_label = "integration"
-          replacement = "mysql"
-        }
-        rule {
-          source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_instance"]
-          separator = ";"
-          regex = "(?:test-database)"
-          target_label = "instance"
-          replacement = "test-database"
-        }
       }
     
       discovery.kubernetes "pods" {
@@ -412,37 +233,6 @@ data:
             "filename",
             "tmp_container_runtime",
           ]
-        }
-        // Integration: MySQL
-        stage.match {
-          selector = "{integration=\"mysql\"}"
-    
-          stage.regex {
-            expression = `(?P<timestamp>.+) (?P<thread>[\d]+) \[(?P<label>.+?)\]( \[(?P<err_code>.+?)\] \[(?P<subsystem>.+?)\])? (?P<msg>.+)`
-          }
-    
-          stage.labels {
-            values = {
-              level = "label",
-              err_code = "err_code",
-              subsystem = "subsystem",
-            }
-          }
-    
-          stage.drop {
-            expression = "^ *$"
-            drop_counter_reason = "drop empty lines"
-          }
-    
-          stage.static_labels {
-            values = {
-              job = "integrations/mysql",
-            }
-          }
-    
-          stage.label_drop {
-            values = ["integration"]
-          }
         }
     
         // Only keep the labels that are defined in the `keepLabels` list.
@@ -559,106 +349,6 @@ rules:
     resources: ["replicasets"]
     verbs: ["get", "list", "watch"]
 ---
-# Source: k8s-monitoring/charts/alloy-metrics/templates/rbac.yaml
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  name: k8smon-alloy-metrics
-  labels:
-    helm.sh/chart: alloy-metrics-0.11.0
-    app.kubernetes.io/name: alloy-metrics
-    app.kubernetes.io/instance: k8smon
-    
-    app.kubernetes.io/version: "v1.6.1"
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/part-of: alloy
-    app.kubernetes.io/component: rbac
-rules:
-  # Rules which allow discovery.kubernetes to function.
-  - apiGroups:
-      - ""
-      - "discovery.k8s.io"
-      - "networking.k8s.io"
-    resources:
-      - endpoints
-      - endpointslices
-      - ingresses
-      - nodes
-      - nodes/proxy
-      - nodes/metrics
-      - pods
-      - services
-    verbs:
-      - get
-      - list
-      - watch
-  # Rules which allow loki.source.kubernetes and loki.source.podlogs to work.
-  - apiGroups:
-      - ""
-    resources:
-      - pods
-      - pods/log
-      - namespaces
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - "monitoring.grafana.com"
-    resources:
-      - podlogs
-    verbs:
-      - get
-      - list
-      - watch
-  # Rules which allow mimir.rules.kubernetes to work.
-  - apiGroups: ["monitoring.coreos.com"]
-    resources:
-      - prometheusrules
-    verbs:
-      - get
-      - list
-      - watch
-  - nonResourceURLs:
-      - /metrics
-    verbs:
-      - get
-  # Rules for prometheus.kubernetes.*
-  - apiGroups: ["monitoring.coreos.com"]
-    resources:
-      - podmonitors
-      - servicemonitors
-      - probes
-    verbs:
-      - get
-      - list
-      - watch
-  # Rules which allow eventhandler to work.
-  - apiGroups:
-      - ""
-    resources:
-      - events
-    verbs:
-      - get
-      - list
-      - watch
-  # needed for remote.kubernetes.*
-  - apiGroups: [""]
-    resources:
-      - "configmaps"
-      - "secrets"
-    verbs:
-      - get
-      - list
-      - watch
-  # needed for otelcol.processor.k8sattributes
-  - apiGroups: ["apps"]
-    resources: ["replicasets"]
-    verbs: ["get", "list", "watch"]
-  - apiGroups: ["extensions"]
-    resources: ["replicasets"]
-    verbs: ["get", "list", "watch"]
----
 # Source: k8s-monitoring/charts/alloy-logs/templates/rbac.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -682,29 +372,6 @@ subjects:
     name: k8smon-alloy-logs
     namespace: default
 ---
-# Source: k8s-monitoring/charts/alloy-metrics/templates/rbac.yaml
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: k8smon-alloy-metrics
-  labels:
-    helm.sh/chart: alloy-metrics-0.11.0
-    app.kubernetes.io/name: alloy-metrics
-    app.kubernetes.io/instance: k8smon
-    
-    app.kubernetes.io/version: "v1.6.1"
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/part-of: alloy
-    app.kubernetes.io/component: rbac
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: k8smon-alloy-metrics
-subjects:
-  - kind: ServiceAccount
-    name: k8smon-alloy-metrics
-    namespace: default
----
 # Source: k8s-monitoring/charts/alloy-logs/templates/service.yaml
 apiVersion: v1
 kind: Service
@@ -723,65 +390,6 @@ spec:
   type: ClusterIP
   selector:
     app.kubernetes.io/name: alloy-logs
-    app.kubernetes.io/instance: k8smon
-  internalTrafficPolicy: Cluster
-  ports:
-    - name: http-metrics
-      port: 12345
-      targetPort: 12345
-      protocol: "TCP"
----
-# Source: k8s-monitoring/charts/alloy-metrics/templates/cluster_service.yaml
-apiVersion: v1
-kind: Service
-metadata:
-  name: k8smon-alloy-metrics-cluster
-  labels:
-    helm.sh/chart: alloy-metrics-0.11.0
-    app.kubernetes.io/name: alloy-metrics
-    app.kubernetes.io/instance: k8smon
-    
-    app.kubernetes.io/version: "v1.6.1"
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/part-of: alloy
-    app.kubernetes.io/component: networking
-spec:
-  type: ClusterIP
-  clusterIP: 'None'
-  publishNotReadyAddresses: true
-  selector:
-    app.kubernetes.io/name: alloy-metrics
-    app.kubernetes.io/instance: k8smon
-  ports:
-    # Do not include the -metrics suffix in the port name, otherwise metrics
-    # can be double-collected with the non-headless Service if it's also
-    # enabled.
-    #
-    # This service should only be used for clustering, and not metric
-    # collection.
-    - name: http
-      port: 12345
-      targetPort: 12345
-      protocol: "TCP"
----
-# Source: k8s-monitoring/charts/alloy-metrics/templates/service.yaml
-apiVersion: v1
-kind: Service
-metadata:
-  name: k8smon-alloy-metrics
-  labels:
-    helm.sh/chart: alloy-metrics-0.11.0
-    app.kubernetes.io/name: alloy-metrics
-    app.kubernetes.io/instance: k8smon
-    
-    app.kubernetes.io/version: "v1.6.1"
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/part-of: alloy
-    app.kubernetes.io/component: networking
-spec:
-  type: ClusterIP
-  selector:
-    app.kubernetes.io/name: alloy-metrics
     app.kubernetes.io/instance: k8smon
   internalTrafficPolicy: Cluster
   ports:
@@ -903,111 +511,3 @@ spec:
         - name: dockercontainers
           hostPath:
             path: /var/lib/docker/containers
----
-# Source: k8s-monitoring/charts/alloy-metrics/templates/controllers/statefulset.yaml
-apiVersion: apps/v1
-kind: StatefulSet
-metadata:
-  name: k8smon-alloy-metrics
-  labels:
-    helm.sh/chart: alloy-metrics-0.11.0
-    app.kubernetes.io/name: alloy-metrics
-    app.kubernetes.io/instance: k8smon
-    
-    app.kubernetes.io/version: "v1.6.1"
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/part-of: alloy
-spec:
-  replicas: 1
-  podManagementPolicy: Parallel
-  minReadySeconds: 10
-  serviceName: k8smon-alloy-metrics
-  selector:
-    matchLabels:
-      app.kubernetes.io/name: alloy-metrics
-      app.kubernetes.io/instance: k8smon
-  template:
-    metadata:
-      annotations:
-        kubectl.kubernetes.io/default-container: alloy
-        k8s.grafana.com/logs.job: integrations/alloy
-      labels:
-        app.kubernetes.io/name: alloy-metrics
-        app.kubernetes.io/instance: k8smon
-    spec:
-      serviceAccountName: k8smon-alloy-metrics
-      containers:
-        - name: alloy
-          image: docker.io/grafana/alloy:v1.6.1
-          imagePullPolicy: IfNotPresent
-          args:
-            - run
-            - /etc/alloy/config.alloy
-            - --storage.path=/tmp/alloy
-            - --server.http.listen-addr=0.0.0.0:12345
-            - --server.http.ui-path-prefix=/
-            - --cluster.enabled=true
-            - --cluster.join-addresses=k8smon-alloy-metrics-cluster
-            - --cluster.name=alloy-metrics
-            - --stability.level=generally-available
-          env:
-            - name: ALLOY_DEPLOY_MODE
-              value: "helm"
-            - name: HOSTNAME
-              valueFrom:
-                fieldRef:
-                  fieldPath: spec.nodeName
-          ports:
-            - containerPort: 12345
-              name: http-metrics
-          readinessProbe:
-            httpGet:
-              path: /-/ready
-              port: 12345
-              scheme: HTTP
-            initialDelaySeconds: 10
-            timeoutSeconds: 1
-          securityContext:
-            allowPrivilegeEscalation: false
-            capabilities:
-              add:
-              - CHOWN
-              - DAC_OVERRIDE
-              - FOWNER
-              - FSETID
-              - KILL
-              - SETGID
-              - SETUID
-              - SETPCAP
-              - NET_BIND_SERVICE
-              - NET_RAW
-              - SYS_CHROOT
-              - MKNOD
-              - AUDIT_WRITE
-              - SETFCAP
-              drop:
-              - ALL
-            seccompProfile:
-              type: RuntimeDefault
-          volumeMounts:
-            - name: config
-              mountPath: /etc/alloy
-        - name: config-reloader
-          image: ghcr.io/jimmidyson/configmap-reload:v0.14.0
-          args:
-            - --volume-dir=/etc/alloy
-            - --webhook-url=http://localhost:12345/-/reload
-          volumeMounts:
-            - name: config
-              mountPath: /etc/alloy
-          resources:
-            requests:
-              cpu: 1m
-              memory: 5Mi
-      dnsPolicy: ClusterFirst
-      nodeSelector:
-        kubernetes.io/os: linux
-      volumes:
-        - name: config
-          configMap:
-            name: k8smon-alloy-metrics

--- a/charts/k8s-monitoring/tests/integration/pod-logs/deployments/grafana.yaml
+++ b/charts/k8s-monitoring/tests/integration/pod-logs/deployments/grafana.yaml
@@ -1,0 +1,50 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: grafana
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: grafana
+  namespace: grafana
+spec:
+  interval: 1m
+  url: https://grafana.github.io/helm-charts
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: grafana
+  namespace: grafana
+spec:
+  interval: 1m
+  chart:
+    spec:
+      chart: grafana
+      sourceRef:
+        kind: HelmRepository
+        name: grafana
+        namespace: grafana
+      interval: 1m
+  values:
+    grafana.ini:
+      auth.anonymous:
+        enabled: true
+        org_role: Admin
+    datasources:
+      datasources.yaml:
+        apiVersion: 1
+        datasources:
+          - name: Loki
+            type: loki
+            url: http://loki-gateway.loki.svc:8080
+            isDefault: true
+            basicAuth: true
+            basicAuthUser: loki
+            jsonData:
+              httpHeaderName1: X-Scope-OrgID
+            secureJsonData:
+              basicAuthPassword: lokipassword
+              httpHeaderValue1: "1"

--- a/charts/k8s-monitoring/tests/integration/pod-logs/deployments/loki.yaml
+++ b/charts/k8s-monitoring/tests/integration/pod-logs/deployments/loki.yaml
@@ -1,0 +1,71 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: loki
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: grafana
+  namespace: loki
+spec:
+  interval: 1m
+  url: https://grafana.github.io/helm-charts
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: loki
+  namespace: loki
+spec:
+  interval: 1m
+  chart:
+    spec:
+      chart: loki
+      sourceRef:
+        kind: HelmRepository
+        name: grafana
+        namespace: loki
+      interval:
+  values:
+    deploymentMode: SingleBinary
+    loki:
+      commonConfig:
+        replication_factor: 1
+      storage:
+        type: 'filesystem'
+      schemaConfig:
+        configs:
+          - from: "2024-01-01"
+            store: tsdb
+            index:
+              prefix: loki_index_
+              period: 24h
+            object_store: filesystem  # we're storing on filesystem so there's no real persistence here.
+            schema: v13
+    singleBinary:
+      replicas: 1
+    read:
+      replicas: 0
+    backend:
+      replicas: 0
+    write:
+      replicas: 0
+
+    chunksCache:
+      enabled: false
+    resultsCache:
+      enabled: false
+    lokiCanary:
+      enabled: false
+    test:
+      enabled: false
+
+    gateway:
+      basicAuth:
+        enabled: true
+        username: loki
+        password: lokipassword
+      service:
+        port: 8080

--- a/charts/k8s-monitoring/tests/integration/pod-logs/deployments/query-test.yaml
+++ b/charts/k8s-monitoring/tests/integration/pod-logs/deployments/query-test.yaml
@@ -1,0 +1,46 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: GitRepository
+metadata:
+  name: k8s-monitoring-test
+spec:
+  interval: 1m
+  url: https://github.com/grafana/k8s-monitoring-helm
+  ref:
+    branch: main
+  ignore: |
+    /*
+    !/charts/k8s-monitoring-test
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: k8s-monitoring-test
+spec:
+  interval: 1m
+  chart:
+    spec:
+      chart: charts/k8s-monitoring-test
+      sourceRef:
+        kind: GitRepository
+        name: k8s-monitoring-test
+      interval: 1m
+  dependsOn:
+    - name: loki
+      namespace: loki
+  values:
+    tests:
+      - env:
+          CLUSTER: pod-logs-feature-test
+          LOKI_URL: http://loki.loki.svc:3100/loki/api/v1/query
+          LOKI_TENANTID: 1
+          LOKI_USER: loki
+          LOKI_PASS: lokipassword
+
+        queries:
+          # Gets Pod logs based on default job label
+          - query: count_over_time({cluster="$CLUSTER", job="production/busybox", namespace="production"}[1h])
+            type: logql
+          # Gets Pod logs based on annotation job label
+          - query: count_over_time({cluster="$CLUSTER", job="dev-pod", namespace="development"}[1h])
+            type: logql

--- a/charts/k8s-monitoring/tests/integration/pod-logs/deployments/workloads.yaml
+++ b/charts/k8s-monitoring/tests/integration/pod-logs/deployments/workloads.yaml
@@ -1,0 +1,64 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: development
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: dev-pod
+  namespace: development
+  annotations:
+    k8s.grafana.com/logs.job: dev-pod
+spec:
+  containers:
+    - name: busybox
+      image: busybox
+      args:
+        - /bin/sh
+        - -c
+        - |
+          echo "level=INFO Starting..."
+          while true; do
+            if [ $RANDOM -gt ${ERROR_THRESHOLD} ]; then
+              echo "level=ERROR Something went wrong"
+            else
+              echo "level=INFO Everything is fine"
+            fi
+            sleep 5
+          done
+      env:
+        - name: ERROR_THRESHOLD
+          value: "10000"
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: production
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: prod-pod
+  namespace: production
+spec:
+  containers:
+    - name: busybox
+      image: busybox
+      args:
+        - /bin/sh
+        - -c
+        - |
+          echo "level=INFO Starting..."
+          while true; do
+            if [ $RANDOM -gt ${ERROR_THRESHOLD} ]; then
+              echo "level=ERROR Something went wrong"
+            else
+              echo "level=INFO Everything is fine"
+            fi
+            sleep 5
+          done
+      env:
+        - name: ERROR_THRESHOLD
+          value: "10000"

--- a/charts/k8s-monitoring/tests/integration/pod-logs/values.yaml
+++ b/charts/k8s-monitoring/tests/integration/pod-logs/values.yaml
@@ -1,0 +1,19 @@
+---
+cluster:
+  name: pod-logs-feature-test
+
+destinations:
+  - name: localLoki
+    type: loki
+    url: http://loki.loki.svc:3100/loki/api/v1/push
+    tenantId: "1"
+    auth:
+      type: basic
+      username: loki
+      password: lokipassword
+
+podLogs:
+  enabled: true
+
+alloy-logs:
+  enabled: true

--- a/charts/k8s-monitoring/tests/integration/split-destinations/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/integration/split-destinations/.rendered/output.yaml
@@ -727,10 +727,12 @@ data:
         }
         rule {
           source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_job"]
+          regex = "(.+)"
           target_label = "job"
         }
         rule {
           source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+          regex = "(.+)"
           target_label = "app_kubernetes_io_name"
         }
       }

--- a/charts/k8s-monitoring/tests/platform/eks-with-windows/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/platform/eks-with-windows/.rendered/output.yaml
@@ -1230,10 +1230,12 @@ data:
         }
         rule {
           source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_job"]
+          regex = "(.+)"
           target_label = "job"
         }
         rule {
           source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+          regex = "(.+)"
           target_label = "app_kubernetes_io_name"
         }
       }

--- a/charts/k8s-monitoring/tests/platform/gke-autopilot/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/platform/gke-autopilot/.rendered/output.yaml
@@ -834,10 +834,12 @@ data:
         }
         rule {
           source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_job"]
+          regex = "(.+)"
           target_label = "job"
         }
         rule {
           source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+          regex = "(.+)"
           target_label = "app_kubernetes_io_name"
         }
       }

--- a/charts/k8s-monitoring/tests/platform/grafana-cloud/app-observability/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/platform/grafana-cloud/app-observability/.rendered/output.yaml
@@ -165,10 +165,12 @@ data:
         }
         rule {
           source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_job"]
+          regex = "(.+)"
           target_label = "job"
         }
         rule {
           source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+          regex = "(.+)"
           target_label = "app_kubernetes_io_name"
         }
       }

--- a/charts/k8s-monitoring/tests/platform/grafana-cloud/k8s-monitoring/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/platform/grafana-cloud/k8s-monitoring/.rendered/output.yaml
@@ -1187,10 +1187,12 @@ data:
         }
         rule {
           source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_job"]
+          regex = "(.+)"
           target_label = "job"
         }
         rule {
           source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+          regex = "(.+)"
           target_label = "app_kubernetes_io_name"
         }
       }


### PR DESCRIPTION
Before, it was using the implicit `(.*)` regex, which means it would unset labels if the annotation was not defined.
Because we have `k8s.grafana.com/logs.job` ==> `job`, it means we always removed the job label.

Added an integration test to validate the change (it reproduced the failure initially)