### PR TITLE
Better type comparison for the secrets unittest

### DIFF
--- a/charts/k8s-monitoring/templates/secrets/test/secrets.yaml
+++ b/charts/k8s-monitoring/templates/secrets/test/secrets.yaml
@@ -2,6 +2,7 @@
 - auth.username
 - auth.password
 {{- end }}
+{{- if eq (((index .Values "testing") | default false) | toString) "true" }}
 {{- $noAuth := dict "type" "unittest.secrets"}}
 {{- $usernameAndPassword := dict "type" "unittest.secrets" "auth" (dict "username" "my-username" "password" "my-password") }}
 {{- $embeddedSecret := deepCopy $usernameAndPassword | merge (dict "secret" (dict "embed" true)) }}
@@ -10,7 +11,6 @@
 {{- $externalNoKeys := dict "type" "unittest.secrets" "secret" (dict "create" false) "auth" dict }}
 {{- $externalOneKey := deepCopy $externalNoKeys | merge (dict "auth" (dict "usernameKey" "user")) }}
 {{- $externalBothKeys := deepCopy $externalNoKeys | merge (dict "auth" (dict "usernameKey" "user" "passwordKey" "pass")) }}
-{{- if eq .Values.testing "true" }}
 ---
 apiVersion: v1
 kind: ConfigMap

--- a/charts/k8s-monitoring/tests/unittest_secrets_test.yaml
+++ b/charts/k8s-monitoring/tests/unittest_secrets_test.yaml
@@ -5,7 +5,7 @@ templates:
 tests:
   - it: secrets.authType works appropriately
     set:
-      testing: "true"
+      testing: true
     asserts:
       - {equal: {path: "data.testEmpty",          value: "none"   }, documentIndex: 0 }
       - {equal: {path: "data.testEmptyAuth",      value: "none"   }, documentIndex: 0 }


### PR DESCRIPTION
This better handles when `testing` is empty, a boolean, or a string.