### PR TITLE
fix: receiver extraService selector

### DIFF
--- a/charts/k8s-monitoring/templates/receiver-service.yaml
+++ b/charts/k8s-monitoring/templates/receiver-service.yaml
@@ -21,7 +21,7 @@ spec:
   clusterIP: {{ (index .Values "alloy-receiver").service.clusterIP }}
   {{- end }}
   selector:
-    {{- include "alloy.selectorLabels" . | nindent 4 }}
+    {{- include "alloy.selectorLabels" (index .Subcharts "alloy-receiver") | nindent 4 }}
   {{- if semverCompare ">=1.26-0" .Capabilities.KubeVersion.Version }}
   internalTrafficPolicy: {{ (index .Values "alloy-receiver").service.internalTrafficPolicy}}
   {{- end }}


### PR DESCRIPTION
For now `app.kubernetes.io/name` is set to `k8s-monitoring` instead of `alloy-receiver`, so no alloy-receiver's pods are matched by extraService's selector.