### PR TITLE
Add Receivers block to App O11y in Values

### DIFF
--- a/charts/k8s-monitoring/README.md
+++ b/charts/k8s-monitoring/README.md
@@ -297,7 +297,8 @@ podLogs:
 |-----|------|---------|-------------|
 | applicationObservability | object | Disabled | Application Observability. Requires destinations that supports metrics, logs, and traces. To see the valid options, please see the [Application Observability feature documentation](https://github.com/grafana/k8s-monitoring-helm/tree/main/charts/k8s-monitoring/charts/feature-application-observability). |
 | applicationObservability.destinations | list | `[]` | The destinations where application data will be sent. If empty, all capable destinations will be used. |
-| applicationObservability.enabled | bool | `false` | Enable gathering Kubernetes Pod logs. |
+| applicationObservability.enabled | bool | `false` | Enable receiving Application Observability. |
+| applicationObservability.receivers | object | `{}` | The receivers used for receiving application data. |
 
 ### Features - Auto-Instrumentation
 

--- a/charts/k8s-monitoring/values.schema.json
+++ b/charts/k8s-monitoring/values.schema.json
@@ -937,6 +937,9 @@
                 },
                 "enabled": {
                     "type": "boolean"
+                },
+                "receivers": {
+                    "type": "object"
                 }
             }
         },

--- a/charts/k8s-monitoring/values.yaml
+++ b/charts/k8s-monitoring/values.yaml
@@ -134,13 +134,17 @@ podLogs:
 # @default -- Disabled
 # @section -- Features - Application Observability
 applicationObservability:
-  # -- Enable gathering Kubernetes Pod logs.
+  # -- Enable receiving Application Observability.
   # @section -- Features - Application Observability
   enabled: false
 
   # -- The destinations where application data will be sent. If empty, all capable destinations will be used.
   # @section -- Features - Application Observability
   destinations: []
+
+  # -- The receivers used for receiving application data.
+  # @section -- Features - Application Observability
+  receivers: {}
 
   # -- Which collector to assign this feature to. Do not change this unless you are sure of what you are doing.
   # @section -- Features - Application Observability


### PR DESCRIPTION
When leveraging the Application Observability functionality, you need to specify the receivers block so Alloy knows what is enabled (i.e. otlp, grpc etc).

The current Values file does not have receivers: {}, and you only find out it's needed via the Validation when running Helm.

This PR simply just adds it in with no config, but links back to the documentation. There's also a fix on the type of what the function is for (currently states pod logs, now updated to enabling the receiving of application observability).