### PR TITLE
feat: add pod_association sources

### DIFF
--- a/charts/k8s-monitoring/charts/feature-application-observability/templates/_processor_k8sattributes.tpl
+++ b/charts/k8s-monitoring/charts/feature-application-observability/templates/_processor_k8sattributes.tpl
@@ -24,6 +24,14 @@ otelcol.processor.k8sattributes "{{ .name | default "default" }}" {
   }
   pod_association {
     source {
+      from = "resource_attribute"
+      name = "k8s.pod.ip"
+    }
+    source {
+      from = "resource_attribute"
+      name = "k8s.pod.uid"
+    }
+    source {
       from = "connection"
     }
   }

--- a/charts/k8s-monitoring/charts/feature-application-observability/tests/default_test.yaml
+++ b/charts/k8s-monitoring/charts/feature-application-observability/tests/default_test.yaml
@@ -117,6 +117,14 @@ tests:
                 }
                 pod_association {
                   source {
+                    from = "resource_attribute"
+                    name = "k8s.pod.ip"
+                  }
+                  source {
+                    from = "resource_attribute"
+                    name = "k8s.pod.uid"
+                  }
+                  source {
                     from = "connection"
                   }
                 }

--- a/charts/k8s-monitoring/charts/feature-application-observability/tests/interval_test.yaml
+++ b/charts/k8s-monitoring/charts/feature-application-observability/tests/interval_test.yaml
@@ -120,6 +120,14 @@ tests:
                 }
                 pod_association {
                   source {
+                    from = "resource_attribute"
+                    name = "k8s.pod.ip"
+                  }
+                  source {
+                    from = "resource_attribute"
+                    name = "k8s.pod.uid"
+                  }
+                  source {
                     from = "connection"
                   }
                 }

--- a/charts/k8s-monitoring/charts/feature-application-observability/tests/memorylimiter_test.yaml
+++ b/charts/k8s-monitoring/charts/feature-application-observability/tests/memorylimiter_test.yaml
@@ -76,6 +76,14 @@ tests:
                 }
                 pod_association {
                   source {
+                    from = "resource_attribute"
+                    name = "k8s.pod.ip"
+                  }
+                  source {
+                    from = "resource_attribute"
+                    name = "k8s.pod.uid"
+                  }
+                  source {
                     from = "connection"
                   }
                 }

--- a/charts/k8s-monitoring/charts/feature-application-observability/tests/spanlogs_test.yaml
+++ b/charts/k8s-monitoring/charts/feature-application-observability/tests/spanlogs_test.yaml
@@ -72,6 +72,14 @@ tests:
                 }
                 pod_association {
                   source {
+                    from = "resource_attribute"
+                    name = "k8s.pod.ip"
+                  }
+                  source {
+                    from = "resource_attribute"
+                    name = "k8s.pod.uid"
+                  }
+                  source {
                     from = "connection"
                   }
                 }

--- a/charts/k8s-monitoring/charts/feature-application-observability/tests/spanmetrics_test.yaml
+++ b/charts/k8s-monitoring/charts/feature-application-observability/tests/spanmetrics_test.yaml
@@ -75,6 +75,14 @@ tests:
                 }
                 pod_association {
                   source {
+                    from = "resource_attribute"
+                    name = "k8s.pod.ip"
+                  }
+                  source {
+                    from = "resource_attribute"
+                    name = "k8s.pod.uid"
+                  }
+                  source {
                     from = "connection"
                   }
                 }

--- a/charts/k8s-monitoring/docs/examples/auth/bearer-token/alloy-receiver.alloy
+++ b/charts/k8s-monitoring/docs/examples/auth/bearer-token/alloy-receiver.alloy
@@ -187,6 +187,14 @@ declare "application_observability" {
     }
     pod_association {
       source {
+        from = "resource_attribute"
+        name = "k8s.pod.ip"
+      }
+      source {
+        from = "resource_attribute"
+        name = "k8s.pod.uid"
+      }
+      source {
         from = "connection"
       }
     }

--- a/charts/k8s-monitoring/docs/examples/auth/bearer-token/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/auth/bearer-token/output.yaml
@@ -627,6 +627,14 @@ data:
         }
         pod_association {
           source {
+            from = "resource_attribute"
+            name = "k8s.pod.ip"
+          }
+          source {
+            from = "resource_attribute"
+            name = "k8s.pod.uid"
+          }
+          source {
             from = "connection"
           }
         }

--- a/charts/k8s-monitoring/docs/examples/auth/embedded-secrets/alloy-receiver.alloy
+++ b/charts/k8s-monitoring/docs/examples/auth/embedded-secrets/alloy-receiver.alloy
@@ -174,6 +174,14 @@ declare "application_observability" {
     }
     pod_association {
       source {
+        from = "resource_attribute"
+        name = "k8s.pod.ip"
+      }
+      source {
+        from = "resource_attribute"
+        name = "k8s.pod.uid"
+      }
+      source {
         from = "connection"
       }
     }

--- a/charts/k8s-monitoring/docs/examples/auth/embedded-secrets/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/auth/embedded-secrets/output.yaml
@@ -603,6 +603,14 @@ data:
         }
         pod_association {
           source {
+            from = "resource_attribute"
+            name = "k8s.pod.ip"
+          }
+          source {
+            from = "resource_attribute"
+            name = "k8s.pod.uid"
+          }
+          source {
             from = "connection"
           }
         }

--- a/charts/k8s-monitoring/docs/examples/auth/external-secrets/alloy-receiver.alloy
+++ b/charts/k8s-monitoring/docs/examples/auth/external-secrets/alloy-receiver.alloy
@@ -207,6 +207,14 @@ declare "application_observability" {
     }
     pod_association {
       source {
+        from = "resource_attribute"
+        name = "k8s.pod.ip"
+      }
+      source {
+        from = "resource_attribute"
+        name = "k8s.pod.uid"
+      }
+      source {
         from = "connection"
       }
     }

--- a/charts/k8s-monitoring/docs/examples/auth/external-secrets/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/auth/external-secrets/output.yaml
@@ -656,6 +656,14 @@ data:
         }
         pod_association {
           source {
+            from = "resource_attribute"
+            name = "k8s.pod.ip"
+          }
+          source {
+            from = "resource_attribute"
+            name = "k8s.pod.uid"
+          }
+          source {
             from = "connection"
           }
         }

--- a/charts/k8s-monitoring/docs/examples/features/application-observability/default/alloy-receiver.alloy
+++ b/charts/k8s-monitoring/docs/examples/features/application-observability/default/alloy-receiver.alloy
@@ -108,6 +108,14 @@ declare "application_observability" {
     }
     pod_association {
       source {
+        from = "resource_attribute"
+        name = "k8s.pod.ip"
+      }
+      source {
+        from = "resource_attribute"
+        name = "k8s.pod.uid"
+      }
+      source {
         from = "connection"
       }
     }

--- a/charts/k8s-monitoring/docs/examples/features/application-observability/default/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/features/application-observability/default/output.yaml
@@ -133,6 +133,14 @@ data:
         }
         pod_association {
           source {
+            from = "resource_attribute"
+            name = "k8s.pod.ip"
+          }
+          source {
+            from = "resource_attribute"
+            name = "k8s.pod.uid"
+          }
+          source {
             from = "connection"
           }
         }

--- a/charts/k8s-monitoring/docs/examples/features/auto-instrumentation/beyla-metrics-and-traces/alloy-receiver.alloy
+++ b/charts/k8s-monitoring/docs/examples/features/auto-instrumentation/beyla-metrics-and-traces/alloy-receiver.alloy
@@ -108,6 +108,14 @@ declare "application_observability" {
     }
     pod_association {
       source {
+        from = "resource_attribute"
+        name = "k8s.pod.ip"
+      }
+      source {
+        from = "resource_attribute"
+        name = "k8s.pod.uid"
+      }
+      source {
         from = "connection"
       }
     }

--- a/charts/k8s-monitoring/docs/examples/features/auto-instrumentation/beyla-metrics-and-traces/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/features/auto-instrumentation/beyla-metrics-and-traces/output.yaml
@@ -339,6 +339,14 @@ data:
         }
         pod_association {
           source {
+            from = "resource_attribute"
+            name = "k8s.pod.ip"
+          }
+          source {
+            from = "resource_attribute"
+            name = "k8s.pod.uid"
+          }
+          source {
             from = "connection"
           }
         }

--- a/charts/k8s-monitoring/docs/examples/meta-monitoring/alloy-receiver.alloy
+++ b/charts/k8s-monitoring/docs/examples/meta-monitoring/alloy-receiver.alloy
@@ -164,6 +164,14 @@ declare "application_observability" {
     }
     pod_association {
       source {
+        from = "resource_attribute"
+        name = "k8s.pod.ip"
+      }
+      source {
+        from = "resource_attribute"
+        name = "k8s.pod.uid"
+      }
+      source {
         from = "connection"
       }
     }

--- a/charts/k8s-monitoring/docs/examples/meta-monitoring/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/meta-monitoring/output.yaml
@@ -2114,6 +2114,14 @@ data:
         }
         pod_association {
           source {
+            from = "resource_attribute"
+            name = "k8s.pod.ip"
+          }
+          source {
+            from = "resource_attribute"
+            name = "k8s.pod.uid"
+          }
+          source {
             from = "connection"
           }
         }

--- a/charts/k8s-monitoring/docs/examples/pod-labels-and-annotations/alloy-receiver.alloy
+++ b/charts/k8s-monitoring/docs/examples/pod-labels-and-annotations/alloy-receiver.alloy
@@ -164,6 +164,14 @@ declare "application_observability" {
     }
     pod_association {
       source {
+        from = "resource_attribute"
+        name = "k8s.pod.ip"
+      }
+      source {
+        from = "resource_attribute"
+        name = "k8s.pod.uid"
+      }
+      source {
         from = "connection"
       }
     }

--- a/charts/k8s-monitoring/docs/examples/pod-labels-and-annotations/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/pod-labels-and-annotations/output.yaml
@@ -853,6 +853,14 @@ data:
         }
         pod_association {
           source {
+            from = "resource_attribute"
+            name = "k8s.pod.ip"
+          }
+          source {
+            from = "resource_attribute"
+            name = "k8s.pod.uid"
+          }
+          source {
             from = "connection"
           }
         }

--- a/charts/k8s-monitoring/docs/examples/proxies/alloy-receiver.alloy
+++ b/charts/k8s-monitoring/docs/examples/proxies/alloy-receiver.alloy
@@ -161,6 +161,14 @@ declare "application_observability" {
     }
     pod_association {
       source {
+        from = "resource_attribute"
+        name = "k8s.pod.ip"
+      }
+      source {
+        from = "resource_attribute"
+        name = "k8s.pod.uid"
+      }
+      source {
         from = "connection"
       }
     }

--- a/charts/k8s-monitoring/docs/examples/proxies/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/proxies/output.yaml
@@ -1029,6 +1029,14 @@ data:
         }
         pod_association {
           source {
+            from = "resource_attribute"
+            name = "k8s.pod.ip"
+          }
+          source {
+            from = "resource_attribute"
+            name = "k8s.pod.uid"
+          }
+          source {
             from = "connection"
           }
         }

--- a/charts/k8s-monitoring/tests/integration/auto-instrumentation/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/integration/auto-instrumentation/.rendered/output.yaml
@@ -405,6 +405,14 @@ data:
         }
         pod_association {
           source {
+            from = "resource_attribute"
+            name = "k8s.pod.ip"
+          }
+          source {
+            from = "resource_attribute"
+            name = "k8s.pod.uid"
+          }
+          source {
             from = "connection"
           }
         }

--- a/charts/k8s-monitoring/tests/platform/grafana-cloud/app-observability/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/platform/grafana-cloud/app-observability/.rendered/output.yaml
@@ -417,6 +417,14 @@ data:
         }
         pod_association {
           source {
+            from = "resource_attribute"
+            name = "k8s.pod.ip"
+          }
+          source {
+            from = "resource_attribute"
+            name = "k8s.pod.uid"
+          }
+          source {
             from = "connection"
           }
         }


### PR DESCRIPTION
Using `k8s.pod.ip` and `k8s.pod.uid` resource attributes might be a better defaults for `k8sattributes` processor. Especially because `internalTrafficPolicy` on alloy-receiver's service is set to `Cluster` by default, so there is a chance that alloy would see a node ip address instead of pod's one and wouldn't be able to add k8s attributes.

This sources are also added by default in [Opentelemetry Collector chart](https://github.com/open-telemetry/opentelemetry-helm-charts/blob/opentelemetry-collector-0.116.0/charts/opentelemetry-collector/templates/_config.tpl#L215).
