### PR TITLE
fix: pod_association

### DIFF
--- a/charts/k8s-monitoring/charts/feature-application-observability/templates/_processor_k8sattributes.tpl
+++ b/charts/k8s-monitoring/charts/feature-application-observability/templates/_processor_k8sattributes.tpl
@@ -27,10 +27,14 @@ otelcol.processor.k8sattributes "{{ .name | default "default" }}" {
       from = "resource_attribute"
       name = "k8s.pod.ip"
     }
+  }
+  pod_association {
     source {
       from = "resource_attribute"
       name = "k8s.pod.uid"
     }
+  }
+  pod_association {
     source {
       from = "connection"
     }

--- a/charts/k8s-monitoring/charts/feature-application-observability/tests/default_test.yaml
+++ b/charts/k8s-monitoring/charts/feature-application-observability/tests/default_test.yaml
@@ -121,10 +121,14 @@ tests:
                     from = "resource_attribute"
                     name = "k8s.pod.ip"
                   }
+                }
+                pod_association {
                   source {
                     from = "resource_attribute"
                     name = "k8s.pod.uid"
                   }
+                }
+                pod_association {
                   source {
                     from = "connection"
                   }

--- a/charts/k8s-monitoring/charts/feature-application-observability/tests/interval_test.yaml
+++ b/charts/k8s-monitoring/charts/feature-application-observability/tests/interval_test.yaml
@@ -124,10 +124,14 @@ tests:
                     from = "resource_attribute"
                     name = "k8s.pod.ip"
                   }
+                }
+                pod_association {
                   source {
                     from = "resource_attribute"
                     name = "k8s.pod.uid"
                   }
+                }
+                pod_association {
                   source {
                     from = "connection"
                   }

--- a/charts/k8s-monitoring/charts/feature-application-observability/tests/memorylimiter_test.yaml
+++ b/charts/k8s-monitoring/charts/feature-application-observability/tests/memorylimiter_test.yaml
@@ -80,10 +80,14 @@ tests:
                     from = "resource_attribute"
                     name = "k8s.pod.ip"
                   }
+                }
+                pod_association {
                   source {
                     from = "resource_attribute"
                     name = "k8s.pod.uid"
                   }
+                }
+                pod_association {
                   source {
                     from = "connection"
                   }

--- a/charts/k8s-monitoring/charts/feature-application-observability/tests/resourcedetection_test.yaml
+++ b/charts/k8s-monitoring/charts/feature-application-observability/tests/resourcedetection_test.yaml
@@ -64,10 +64,14 @@ tests:
                     from = "resource_attribute"
                     name = "k8s.pod.ip"
                   }
+                }
+                pod_association {
                   source {
                     from = "resource_attribute"
                     name = "k8s.pod.uid"
                   }
+                }
+                pod_association {
                   source {
                     from = "connection"
                   }
@@ -192,10 +196,14 @@ tests:
                     from = "resource_attribute"
                     name = "k8s.pod.ip"
                   }
+                }
+                pod_association {
                   source {
                     from = "resource_attribute"
                     name = "k8s.pod.uid"
                   }
+                }
+                pod_association {
                   source {
                     from = "connection"
                   }
@@ -324,10 +332,14 @@ tests:
                     from = "resource_attribute"
                     name = "k8s.pod.ip"
                   }
+                }
+                pod_association {
                   source {
                     from = "resource_attribute"
                     name = "k8s.pod.uid"
                   }
+                }
+                pod_association {
                   source {
                     from = "connection"
                   }

--- a/charts/k8s-monitoring/charts/feature-application-observability/tests/spanlogs_test.yaml
+++ b/charts/k8s-monitoring/charts/feature-application-observability/tests/spanlogs_test.yaml
@@ -76,10 +76,14 @@ tests:
                     from = "resource_attribute"
                     name = "k8s.pod.ip"
                   }
+                }
+                pod_association {
                   source {
                     from = "resource_attribute"
                     name = "k8s.pod.uid"
                   }
+                }
+                pod_association {
                   source {
                     from = "connection"
                   }

--- a/charts/k8s-monitoring/charts/feature-application-observability/tests/spanmetrics_test.yaml
+++ b/charts/k8s-monitoring/charts/feature-application-observability/tests/spanmetrics_test.yaml
@@ -79,10 +79,14 @@ tests:
                     from = "resource_attribute"
                     name = "k8s.pod.ip"
                   }
+                }
+                pod_association {
                   source {
                     from = "resource_attribute"
                     name = "k8s.pod.uid"
                   }
+                }
+                pod_association {
                   source {
                     from = "connection"
                   }

--- a/charts/k8s-monitoring/docs/examples/auth/bearer-token/alloy-receiver.alloy
+++ b/charts/k8s-monitoring/docs/examples/auth/bearer-token/alloy-receiver.alloy
@@ -226,10 +226,14 @@ declare "application_observability" {
         from = "resource_attribute"
         name = "k8s.pod.ip"
       }
+    }
+    pod_association {
       source {
         from = "resource_attribute"
         name = "k8s.pod.uid"
       }
+    }
+    pod_association {
       source {
         from = "connection"
       }

--- a/charts/k8s-monitoring/docs/examples/auth/bearer-token/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/auth/bearer-token/output.yaml
@@ -666,10 +666,14 @@ data:
             from = "resource_attribute"
             name = "k8s.pod.ip"
           }
+        }
+        pod_association {
           source {
             from = "resource_attribute"
             name = "k8s.pod.uid"
           }
+        }
+        pod_association {
           source {
             from = "connection"
           }

--- a/charts/k8s-monitoring/docs/examples/auth/embedded-secrets/alloy-receiver.alloy
+++ b/charts/k8s-monitoring/docs/examples/auth/embedded-secrets/alloy-receiver.alloy
@@ -213,10 +213,14 @@ declare "application_observability" {
         from = "resource_attribute"
         name = "k8s.pod.ip"
       }
+    }
+    pod_association {
       source {
         from = "resource_attribute"
         name = "k8s.pod.uid"
       }
+    }
+    pod_association {
       source {
         from = "connection"
       }

--- a/charts/k8s-monitoring/docs/examples/auth/embedded-secrets/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/auth/embedded-secrets/output.yaml
@@ -642,10 +642,14 @@ data:
             from = "resource_attribute"
             name = "k8s.pod.ip"
           }
+        }
+        pod_association {
           source {
             from = "resource_attribute"
             name = "k8s.pod.uid"
           }
+        }
+        pod_association {
           source {
             from = "connection"
           }

--- a/charts/k8s-monitoring/docs/examples/auth/external-secrets/alloy-receiver.alloy
+++ b/charts/k8s-monitoring/docs/examples/auth/external-secrets/alloy-receiver.alloy
@@ -246,10 +246,14 @@ declare "application_observability" {
         from = "resource_attribute"
         name = "k8s.pod.ip"
       }
+    }
+    pod_association {
       source {
         from = "resource_attribute"
         name = "k8s.pod.uid"
       }
+    }
+    pod_association {
       source {
         from = "connection"
       }

--- a/charts/k8s-monitoring/docs/examples/auth/external-secrets/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/auth/external-secrets/output.yaml
@@ -695,10 +695,14 @@ data:
             from = "resource_attribute"
             name = "k8s.pod.ip"
           }
+        }
+        pod_association {
           source {
             from = "resource_attribute"
             name = "k8s.pod.uid"
           }
+        }
+        pod_association {
           source {
             from = "connection"
           }

--- a/charts/k8s-monitoring/docs/examples/features/application-observability/default/alloy-receiver.alloy
+++ b/charts/k8s-monitoring/docs/examples/features/application-observability/default/alloy-receiver.alloy
@@ -147,10 +147,14 @@ declare "application_observability" {
         from = "resource_attribute"
         name = "k8s.pod.ip"
       }
+    }
+    pod_association {
       source {
         from = "resource_attribute"
         name = "k8s.pod.uid"
       }
+    }
+    pod_association {
       source {
         from = "connection"
       }

--- a/charts/k8s-monitoring/docs/examples/features/application-observability/default/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/features/application-observability/default/output.yaml
@@ -172,10 +172,14 @@ data:
             from = "resource_attribute"
             name = "k8s.pod.ip"
           }
+        }
+        pod_association {
           source {
             from = "resource_attribute"
             name = "k8s.pod.uid"
           }
+        }
+        pod_association {
           source {
             from = "connection"
           }

--- a/charts/k8s-monitoring/docs/examples/features/auto-instrumentation/beyla-metrics-and-traces/alloy-receiver.alloy
+++ b/charts/k8s-monitoring/docs/examples/features/auto-instrumentation/beyla-metrics-and-traces/alloy-receiver.alloy
@@ -147,10 +147,14 @@ declare "application_observability" {
         from = "resource_attribute"
         name = "k8s.pod.ip"
       }
+    }
+    pod_association {
       source {
         from = "resource_attribute"
         name = "k8s.pod.uid"
       }
+    }
+    pod_association {
       source {
         from = "connection"
       }

--- a/charts/k8s-monitoring/docs/examples/features/auto-instrumentation/beyla-metrics-and-traces/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/features/auto-instrumentation/beyla-metrics-and-traces/output.yaml
@@ -413,10 +413,14 @@ data:
             from = "resource_attribute"
             name = "k8s.pod.ip"
           }
+        }
+        pod_association {
           source {
             from = "resource_attribute"
             name = "k8s.pod.uid"
           }
+        }
+        pod_association {
           source {
             from = "connection"
           }

--- a/charts/k8s-monitoring/docs/examples/meta-monitoring/alloy-receiver.alloy
+++ b/charts/k8s-monitoring/docs/examples/meta-monitoring/alloy-receiver.alloy
@@ -203,10 +203,14 @@ declare "application_observability" {
         from = "resource_attribute"
         name = "k8s.pod.ip"
       }
+    }
+    pod_association {
       source {
         from = "resource_attribute"
         name = "k8s.pod.uid"
       }
+    }
+    pod_association {
       source {
         from = "connection"
       }

--- a/charts/k8s-monitoring/docs/examples/meta-monitoring/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/meta-monitoring/output.yaml
@@ -2188,10 +2188,14 @@ data:
             from = "resource_attribute"
             name = "k8s.pod.ip"
           }
+        }
+        pod_association {
           source {
             from = "resource_attribute"
             name = "k8s.pod.uid"
           }
+        }
+        pod_association {
           source {
             from = "connection"
           }

--- a/charts/k8s-monitoring/docs/examples/pod-labels-and-annotations/alloy-receiver.alloy
+++ b/charts/k8s-monitoring/docs/examples/pod-labels-and-annotations/alloy-receiver.alloy
@@ -166,10 +166,14 @@ declare "application_observability" {
         from = "resource_attribute"
         name = "k8s.pod.ip"
       }
+    }
+    pod_association {
       source {
         from = "resource_attribute"
         name = "k8s.pod.uid"
       }
+    }
+    pod_association {
       source {
         from = "connection"
       }

--- a/charts/k8s-monitoring/docs/examples/pod-labels-and-annotations/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/pod-labels-and-annotations/output.yaml
@@ -855,10 +855,14 @@ data:
             from = "resource_attribute"
             name = "k8s.pod.ip"
           }
+        }
+        pod_association {
           source {
             from = "resource_attribute"
             name = "k8s.pod.uid"
           }
+        }
+        pod_association {
           source {
             from = "connection"
           }

--- a/charts/k8s-monitoring/docs/examples/proxies/alloy-receiver.alloy
+++ b/charts/k8s-monitoring/docs/examples/proxies/alloy-receiver.alloy
@@ -200,10 +200,14 @@ declare "application_observability" {
         from = "resource_attribute"
         name = "k8s.pod.ip"
       }
+    }
+    pod_association {
       source {
         from = "resource_attribute"
         name = "k8s.pod.uid"
       }
+    }
+    pod_association {
       source {
         from = "connection"
       }

--- a/charts/k8s-monitoring/docs/examples/proxies/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/proxies/output.yaml
@@ -1068,10 +1068,14 @@ data:
             from = "resource_attribute"
             name = "k8s.pod.ip"
           }
+        }
+        pod_association {
           source {
             from = "resource_attribute"
             name = "k8s.pod.uid"
           }
+        }
+        pod_association {
           source {
             from = "connection"
           }

--- a/charts/k8s-monitoring/tests/integration/auto-instrumentation/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/integration/auto-instrumentation/.rendered/output.yaml
@@ -444,10 +444,14 @@ data:
             from = "resource_attribute"
             name = "k8s.pod.ip"
           }
+        }
+        pod_association {
           source {
             from = "resource_attribute"
             name = "k8s.pod.uid"
           }
+        }
+        pod_association {
           source {
             from = "connection"
           }

--- a/charts/k8s-monitoring/tests/integration/split-destinations/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/integration/split-destinations/.rendered/output.yaml
@@ -1254,10 +1254,14 @@ data:
             from = "resource_attribute"
             name = "k8s.pod.ip"
           }
+        }
+        pod_association {
           source {
             from = "resource_attribute"
             name = "k8s.pod.uid"
           }
+        }
+        pod_association {
           source {
             from = "connection"
           }

--- a/charts/k8s-monitoring/tests/platform/grafana-cloud/app-observability/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/platform/grafana-cloud/app-observability/.rendered/output.yaml
@@ -513,10 +513,14 @@ data:
             from = "resource_attribute"
             name = "k8s.pod.ip"
           }
+        }
+        pod_association {
           source {
             from = "resource_attribute"
             name = "k8s.pod.uid"
           }
+        }
+        pod_association {
           source {
             from = "connection"
           }


### PR DESCRIPTION
I'm sorry, I made a mistake in https://github.com/grafana/k8s-monitoring-helm/pull/1239, there are must be three `pod_association` instead of three `source` inside one `pod_association`. All `source` blocks has to match for the pod to be associated with a signal but we want it to be associated when one of the conditions is met (as in [Opentelemetry Collector chart](https://github.com/open-telemetry/opentelemetry-helm-charts/blob/opentelemetry-collector-0.116.0/charts/opentelemetry-collector/templates/_config.tpl#L215)).