### PR TITLE
Allow specifying custom selector label for control-plane components

### DIFF
--- a/charts/k8s-monitoring/charts/feature-cluster-metrics/README.md
+++ b/charts/k8s-monitoring/charts/feature-cluster-metrics/README.md
@@ -221,6 +221,7 @@ Be sure perform actual integration testing in a live environment in the main [k8
 | kubeControllerManager.metricsTuning.includeMetrics | list | `[]` | Metrics to keep. Can use regular expressions. An empty list means keep all. |
 | kubeControllerManager.port | int | `10257` | Port number used by the Kube Controller Manager, set by `--secure-port.` |
 | kubeControllerManager.scrapeInterval | string | 60s | How frequently to scrape metrics from the Kube Controller Manager Overrides metrics.scrapeInterval |
+| kubeControllerManager.selectorLabel | string | `"component=kube-controller-manager"` | Selector label. |
 
 ### KubeDNS
 
@@ -247,6 +248,7 @@ Be sure perform actual integration testing in a live environment in the main [k8
 | kubeProxy.metricsTuning.includeMetrics | list | `[]` | Metrics to keep. Can use regular expressions. An empty list means keep all. |
 | kubeProxy.port | int | `10249` | Port number used by the Kube Proxy, set in `--metrics-bind-address`. |
 | kubeProxy.scrapeInterval | string | 60s | How frequently to scrape metrics from the Kube Proxy Overrides metrics.scrapeInterval |
+| kubeProxy.selectorLabel | string | `"k8s-app=kube-proxy"` | Selector label. |
 
 ### Kube Scheduler
 
@@ -261,6 +263,7 @@ Be sure perform actual integration testing in a live environment in the main [k8
 | kubeScheduler.metricsTuning.includeMetrics | list | `[]` | Metrics to keep. Can use regular expressions. An empty list means keep all. |
 | kubeScheduler.port | int | `10259` | Port number used by the Kube Scheduler, set by `--secure-port`. |
 | kubeScheduler.scrapeInterval | string | 60s | How frequently to scrape metrics from the Kube Scheduler Overrides metrics.scrapeInterval |
+| kubeScheduler.selectorLabel | string | `"component=kube-scheduler"` | Selector label. |
 
 ### Kubelet
 

--- a/charts/k8s-monitoring/charts/feature-cluster-metrics/templates/_kube_controller_manager.alloy.tpl
+++ b/charts/k8s-monitoring/charts/feature-cluster-metrics/templates/_kube_controller_manager.alloy.tpl
@@ -10,7 +10,7 @@ discovery.kubernetes "kube_controller_manager" {
   }
   selectors {
     role = "pod"
-    label = "component=kube-controller-manager"
+    label = {{ .Values.kubeControllerManager.selectorLabel | quote }}
   }
 }
 

--- a/charts/k8s-monitoring/charts/feature-cluster-metrics/templates/_kube_proxy.alloy.tpl
+++ b/charts/k8s-monitoring/charts/feature-cluster-metrics/templates/_kube_proxy.alloy.tpl
@@ -10,7 +10,7 @@ discovery.kubernetes "kube_proxy" {
   }
   selectors {
     role = "pod"
-    label = "k8s-app=kube-proxy"
+    label = {{ .Values.kubeProxy.selectorLabel | quote }}
   }
 }
 

--- a/charts/k8s-monitoring/charts/feature-cluster-metrics/templates/_kube_scheduler.alloy.tpl
+++ b/charts/k8s-monitoring/charts/feature-cluster-metrics/templates/_kube_scheduler.alloy.tpl
@@ -10,7 +10,7 @@ discovery.kubernetes "kube_scheduler" {
   }
   selectors {
     role = "pod"
-    label = "component=kube-scheduler"
+    label = {{ .Values.kubeScheduler.selectorLabel | quote }}
   }
 }
 

--- a/charts/k8s-monitoring/charts/feature-cluster-metrics/values.schema.json
+++ b/charts/k8s-monitoring/charts/feature-cluster-metrics/values.schema.json
@@ -404,6 +404,9 @@
                 },
                 "scrapeInterval": {
                     "type": "string"
+                },
+                "selectorLabel": {
+                    "type": "string"
                 }
             }
         },
@@ -478,6 +481,9 @@
                 },
                 "scrapeInterval": {
                     "type": "string"
+                },
+                "selectorLabel": {
+                    "type": "string"
                 }
             }
         },
@@ -517,6 +523,9 @@
                     "type": "integer"
                 },
                 "scrapeInterval": {
+                    "type": "string"
+                },
+                "selectorLabel": {
                     "type": "string"
                 }
             }

--- a/charts/k8s-monitoring/charts/feature-cluster-metrics/values.yaml
+++ b/charts/k8s-monitoring/charts/feature-cluster-metrics/values.yaml
@@ -232,6 +232,10 @@ kubeControllerManager:
   # @section -- Kube Controller Manager
   jobLabel: "kube-controller-manager"
 
+  # -- Selector label.
+  # @section -- Kube Controller Manager
+  selectorLabel: "component=kube-controller-manager"
+
   # -- Port number used by the Kube Controller Manager, set by `--secure-port.`
   # @section -- Kube Controller Manager
   port: 10257
@@ -323,6 +327,10 @@ kubeProxy:
   # @section -- Kube Proxy
   jobLabel: "integrations/kubernetes/kube-proxy"
 
+  # -- Selector label.
+  # @section -- Kube Proxy
+  selectorLabel: "k8s-app=kube-proxy"
+
   # -- Port number used by the Kube Proxy, set in `--metrics-bind-address`.
   # @section -- Kube Proxy
   port: 10249
@@ -373,6 +381,10 @@ kubeScheduler:
   # -- The value for the job label.
   # @section -- Kube Scheduler
   jobLabel: "kube-scheduler"
+
+  # -- Selector label.
+  # @section -- Kube Scheduler
+  selectorLabel: "component=kube-scheduler"
 
   # -- Port number used by the Kube Scheduler, set by `--secure-port`.
   # @section -- Kube Scheduler


### PR DESCRIPTION
The selector label for metrics scraping of K8s control-plane components is currently hardcoded in templates. This PR allows specifying a custom selector label for the kube-scheduler, kube-proxy and kube-controller-manager components.