### PR TITLE
Fix typo and unnecessary TODO in comments

### DIFF
--- a/charts/k8s-monitoring/charts/feature-integrations/default-allow-lists/mimir.yaml
+++ b/charts/k8s-monitoring/charts/feature-integrations/default-allow-lists/mimir.yaml
@@ -1,5 +1,5 @@
 ---
-# The set of metrics from Grafana Loki required for the Grafana Loki integration
+# The set of metrics from Grafana Mimir required for the Grafana Mimir integration
 - cortex_alertmanager_alerts
 - cortex_alertmanager_alerts_invalid_total
 - cortex_alertmanager_alerts_received_total

--- a/charts/k8s-monitoring/charts/feature-integrations/default-allow-lists/tempo.yaml
+++ b/charts/k8s-monitoring/charts/feature-integrations/default-allow-lists/tempo.yaml
@@ -1,6 +1,5 @@
 ---
 # The set of metrics from Grafana Tempo required for the Grafana Tempo integration
-## TODO: Populate this list
 - container_cpu_usage_seconds_total
 - container_memory_working_set_bytes
 - container_network_receive_bytes_total


### PR DESCRIPTION
This updates a typo `Loki` -> `Mimir` in a comment, and removes the TODO from the tempo metric names as the list has been populated.