### PR TITLE
Fix Tempo validator's default check

### DIFF
--- a/charts/k8s-monitoring/templates/destinations/_destination_validations.tpl
+++ b/charts/k8s-monitoring/templates/destinations/_destination_validations.tpl
@@ -47,8 +47,8 @@
 
         {{/* Check if OTLP destination using Grafana Cloud Tempo checks */}}
         {{- if and (regexMatch "tempo-.+grafana\\.net" $destination.url) }}
-          {{- if ne $destination.protocol "grpc" }}
-            {{ fail (printf "\nDestination #%d (%s) is using Grafana Cloud Traces but has incorrect protocol '%s'. Grafana Cloud Traces requires 'grpc'.\nPlease set:\ndestinations:\n  - name: %s\n    type: otlp\n    url: %s\n    protocol: grpc" $i $destination.name ($destination.protocol | default "grpc (default)") $destination.name $destination.url) }}
+          {{- if ne ($destination.protocol | default "grpc") "grpc" }}
+            {{ fail (printf "\nDestination #%d (%s) is using Grafana Cloud Traces but has incorrect protocol '%s'. Grafana Cloud Traces requires 'grpc'.\nPlease set:\ndestinations:\n  - name: %s\n    type: otlp\n    url: %s\n    protocol: grpc" $i $destination.name $destination.protocol $destination.name $destination.url) }}
           {{- end }}
           {{- if eq (dig "metrics" "enabled" true $destination) true }}
             {{ fail (printf "\nDestination #%d (%s) is using Grafana Cloud Traces but has metrics enabled. Tempo only supports traces.\nPlease set:\ndestinations:\n  - name: %s\n    type: otlp\n    url: %s\n    metrics:\n      enabled: false" $i $destination.name $destination.name $destination.url) }}

--- a/charts/k8s-monitoring/tests/destination_validations_test.yaml
+++ b/charts/k8s-monitoring/tests/destination_validations_test.yaml
@@ -146,7 +146,6 @@ tests:
         - name: Grafana Cloud Traces
           type: otlp
           url: https://tempo-test.grafana.net
-          protocol: grpc
           metrics: {enabled: true}
           logs: {enabled: false}
           traces: {enabled: true}
@@ -171,7 +170,6 @@ tests:
         - name: Grafana Cloud Traces
           type: otlp
           url: https://tempo-test.grafana.net
-          protocol: grpc
           metrics: {enabled: false}
           logs: {enabled: true}
           traces: {enabled: true}


### PR DESCRIPTION
Before, it would fail if you didn't specify a protocol, even though the default is "grpc" already.