### PR TITLE
Don't validate credentials configured as external

### DIFF
--- a/charts/k8s-monitoring/templates/destinations/_destination_validations.tpl
+++ b/charts/k8s-monitoring/templates/destinations/_destination_validations.tpl
@@ -64,11 +64,13 @@
     {{- end }}
 
     {{- if eq (include "secrets.authType" $destination) "basic" }}
-      {{- if eq (include "secrets.usesSecret" (dict "object" $destination "key" "auth.username")) "false" }}
-        {{ fail (printf "\nDestination #%d (%s) is using basic auth but does not have a username.\nPlease set:\ndestinations:\n  - name: %s\n    auth:\n      type: basic\n      username: my-username\n      password: my-password" $i $destination.name $destination.name) }}
-      {{- end }}
-      {{- if eq (include "secrets.usesSecret" (dict "object" $destination "key" "auth.password")) "false" }}
-        {{ fail (printf "\nDestination #%d (%s) is using basic auth but does not have a password.\nPlease set:\ndestinations:\n  - name: %s\n    auth:\n      type: basic\n      username: my-username\n      password: my-password" $i $destination.name $destination.name) }}
+      {{- if ne (include "secrets.secretType" (get $destination "auth")) "external" }}
+        {{- if eq (include "secrets.usesSecret" (dict "object" $destination "key" "auth.username")) "false" }}
+          {{ fail (printf "\nDestination #%d (%s) is using basic auth but does not have a username.\nPlease set:\ndestinations:\n  - name: %s\n    auth:\n      type: basic\n      username: my-username\n      password: my-password" $i $destination.name $destination.name) }}
+        {{- end }}
+        {{- if eq (include "secrets.usesSecret" (dict "object" $destination "key" "auth.password")) "false" }}
+          {{ fail (printf "\nDestination #%d (%s) is using basic auth but does not have a password.\nPlease set:\ndestinations:\n  - name: %s\n    auth:\n      type: basic\n      username: my-username\n      password: my-password" $i $destination.name $destination.name) }}
+        {{- end }}
       {{- end }}
     {{- end }}
   {{- end }}


### PR DESCRIPTION
It's currently not possible to reference external secrets for credentials as the linter is trying to validate parameters that you've deliberately not included.

This change keeps the existing validation around keys for secrets managed by this chart but disables it when referencing an external secret.

Resolves #1364