### PR TITLE
Add example for MongoDB Atlas, which is non-obvious

### DIFF
--- a/charts/k8s-monitoring/docs/examples/service-integrations/mongodb-atlas/README.md
+++ b/charts/k8s-monitoring/docs/examples/service-integrations/mongodb-atlas/README.md
@@ -7,7 +7,7 @@
 To gather metrics from MongoDB Atlas databases, Alloy uses the `discovery.http` component to ask MongoDB for the correct
 URL for scraping metrics. It will then scrape the metrics from the URL provided by MongoDB.
 
-There are settings that must be set on the MongoDB side to permit this scraping. Refer to the
+Certain settings must be configured in MongoDB Atlas to allow scraping. Refer to the
 [Integrate with Prometheus](https://www.mongodb.com/docs/atlas/tutorial/prometheus-integration/) documentation for full
 details.
 

--- a/charts/k8s-monitoring/docs/examples/service-integrations/mongodb-atlas/README.md
+++ b/charts/k8s-monitoring/docs/examples/service-integrations/mongodb-atlas/README.md
@@ -1,0 +1,60 @@
+<!--
+(NOTE: Do not edit README.md directly. It is a generated file!)
+(      To make changes, please modify values.yaml or description.txt and run `make examples`)
+-->
+# MongoDB Atlas databases
+
+To gather metrics from MongoDB Atlas databases, Alloy uses the `discovery.http` component to ask MongoDB for the correct
+URL for scraping metrics. It will then scrape the metrics from the URL provided by MongoDB.
+
+There are settings that must be set on the MongoDB side to permit this scraping. Refer to the
+[Integrate with Prometheus](https://www.mongodb.com/docs/atlas/tutorial/prometheus-integration/) documentation for full
+details.
+
+In this example, we utilize the `extraConfig` section to define the `discovery.http` component to request the scrape
+target, and the `prometheus.scrape` component to scrape the database metrics. It uses a Kubernetes secret to store the
+username, password, and group ID for the MongoDB Atlas database.
+
+## Values
+
+```yaml
+---
+cluster:
+  name: mongodb-atlas-integration-cluster
+
+destinations:
+  - name: prometheus
+    type: prometheus
+    url: http://prometheus.prometheus.svc:9090/api/v1/write
+
+alloy-metrics:
+  enabled: true
+  extraConfig: |-
+    remote.kubernetes.secret "mongodb_atlas" {
+      name = "mongodb-atlas"
+      namespace = "monitoring"
+    }
+    
+    discovery.http "mongodb_atlas" {
+      url = string.format("https://cloud.mongodb.com/prometheus/v1.0/groups/%s/discovery", remote.kubernetes.secret.mongodb_atlas.data["group_id"])
+
+      basic_auth {
+        username = nonsensitive(remote.kubernetes.secret.mongodb_atlas.data["username"])
+        password = remote.kubernetes.secret.mongodb_atlas.data["password"]
+      }
+    }
+  
+    prometheus.scrape "mongodb_atlas" {
+      targets         = discovery.http.mongodb_atlas.targets
+      job_name        = "integrations/mongodb-atlas"
+      scrape_interval = "10s"
+      scheme          = "https"
+  
+      basic_auth {
+        username = nonsensitive(remote.kubernetes.secret.mongodb_atlas.data["username"])
+        password = remote.kubernetes.secret.mongodb_atlas.data["password"]
+      }
+  
+      forward_to = [prometheus.remote_write.prometheus.receiver]
+    }
+```

--- a/charts/k8s-monitoring/docs/examples/service-integrations/mongodb-atlas/alloy-metrics.alloy
+++ b/charts/k8s-monitoring/docs/examples/service-integrations/mongodb-atlas/alloy-metrics.alloy
@@ -1,0 +1,120 @@
+// Destination: prometheus (prometheus)
+otelcol.exporter.prometheus "prometheus" {
+  add_metric_suffixes = true
+  forward_to = [prometheus.remote_write.prometheus.receiver]
+}
+
+prometheus.remote_write "prometheus" {
+  endpoint {
+    url = "http://prometheus.prometheus.svc:9090/api/v1/write"
+    headers = {
+    }
+    tls_config {
+      insecure_skip_verify = false
+    }
+    send_native_histograms = false
+
+    queue_config {
+      capacity = 10000
+      min_shards = 1
+      max_shards = 50
+      max_samples_per_send = 2000
+      batch_send_deadline = "5s"
+      min_backoff = "30ms"
+      max_backoff = "5s"
+      retry_on_http_429 = true
+      sample_age_limit = "0s"
+    }
+
+    write_relabel_config {
+      source_labels = ["cluster"]
+      regex = ""
+      replacement = "mongodb-atlas-integration-cluster"
+      target_label = "cluster"
+    }
+    write_relabel_config {
+      source_labels = ["k8s.cluster.name"]
+      regex = ""
+      replacement = "mongodb-atlas-integration-cluster"
+      target_label = "cluster"
+    }
+  }
+
+  wal {
+    truncate_frequency = "2h"
+    min_keepalive_time = "5m"
+    max_keepalive_time = "8h"
+  }
+}
+// Self Reporting
+prometheus.exporter.unix "kubernetes_monitoring_telemetry" {
+  set_collectors = ["textfile"]
+  textfile {
+    directory = "/etc/alloy"
+  }
+}
+
+discovery.relabel "kubernetes_monitoring_telemetry" {
+  targets = prometheus.exporter.unix.kubernetes_monitoring_telemetry.targets
+  rule {
+    target_label = "instance"
+    action = "replace"
+    replacement = "k8smon"
+  }
+  rule {
+    target_label = "job"
+    action = "replace"
+    replacement = "integrations/kubernetes/kubernetes_monitoring_telemetry"
+  }
+}
+
+prometheus.scrape "kubernetes_monitoring_telemetry" {
+  job_name   = "integrations/kubernetes/kubernetes_monitoring_telemetry"
+  targets    = discovery.relabel.kubernetes_monitoring_telemetry.output
+  scrape_interval = "60s"
+  clustering {
+    enabled = true
+  }
+  forward_to = [prometheus.relabel.kubernetes_monitoring_telemetry.receiver]
+}
+
+prometheus.relabel "kubernetes_monitoring_telemetry" {
+  rule {
+    source_labels = ["__name__"]
+    regex = "grafana_kubernetes_monitoring_.*"
+    action = "keep"
+  }
+  forward_to = [
+    prometheus.remote_write.prometheus.receiver,
+  ]
+}
+
+
+
+remote.kubernetes.secret "mongodb_atlas" {
+  name = "mongodb-atlas"
+  namespace = "monitoring"
+}
+
+discovery.http "mongodb_atlas" {
+  url = string.format("https://cloud.mongodb.com/prometheus/v1.0/groups/%s/discovery", remote.kubernetes.secret.mongodb_atlas.data["group_id"])
+
+  basic_auth {
+    username = nonsensitive(remote.kubernetes.secret.mongodb_atlas.data["username"])
+    password = remote.kubernetes.secret.mongodb_atlas.data["password"]
+  }
+}
+
+prometheus.scrape "mongodb_atlas" {
+  targets         = discovery.http.mongodb_atlas.targets
+  job_name        = "integrations/mongodb-atlas"
+  scrape_interval = "10s"
+  scheme          = "https"
+
+  basic_auth {
+    username = nonsensitive(remote.kubernetes.secret.mongodb_atlas.data["username"])
+    password = remote.kubernetes.secret.mongodb_atlas.data["password"]
+  }
+
+  forward_to = [prometheus.remote_write.prometheus.receiver]
+}

--- a/charts/k8s-monitoring/docs/examples/service-integrations/mongodb-atlas/description.txt
+++ b/charts/k8s-monitoring/docs/examples/service-integrations/mongodb-atlas/description.txt
@@ -1,0 +1,12 @@
+# MongoDB Atlas databases
+
+To gather metrics from MongoDB Atlas databases, Alloy uses the `discovery.http` component to ask MongoDB for the correct
+URL for scraping metrics. It will then scrape the metrics from the URL provided by MongoDB.
+
+There are settings that must be set on the MongoDB side to permit this scraping. Refer to the
+[Integrate with Prometheus](https://www.mongodb.com/docs/atlas/tutorial/prometheus-integration/) documentation for full
+details.
+
+In this example, we utilize the `extraConfig` section to define the `discovery.http` component to request the scrape
+target, and the `prometheus.scrape` component to scrape the database metrics. It uses a Kubernetes secret to store the
+username, password, and group ID for the MongoDB Atlas database.

--- a/charts/k8s-monitoring/docs/examples/service-integrations/mongodb-atlas/description.txt
+++ b/charts/k8s-monitoring/docs/examples/service-integrations/mongodb-atlas/description.txt
@@ -3,7 +3,7 @@
 To gather metrics from MongoDB Atlas databases, Alloy uses the `discovery.http` component to ask MongoDB for the correct
 URL for scraping metrics. It will then scrape the metrics from the URL provided by MongoDB.
 
-There are settings that must be set on the MongoDB side to permit this scraping. Refer to the
+Certain settings must be configured in MongoDB Atlas to allow scraping. Refer to the
 [Integrate with Prometheus](https://www.mongodb.com/docs/atlas/tutorial/prometheus-integration/) documentation for full
 details.
 

--- a/charts/k8s-monitoring/docs/examples/service-integrations/mongodb-atlas/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/service-integrations/mongodb-atlas/output.yaml
@@ -1,0 +1,447 @@
+---
+# Source: k8s-monitoring/charts/alloy-metrics/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+automountServiceAccountToken: true
+metadata:
+  name: k8smon-alloy-metrics
+  namespace: default
+  labels:
+    helm.sh/chart: alloy-metrics-0.12.5
+    app.kubernetes.io/name: alloy-metrics
+    app.kubernetes.io/instance: k8smon
+    
+    app.kubernetes.io/version: "v1.7.4"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: alloy
+    app.kubernetes.io/component: rbac
+---
+# Source: k8s-monitoring/templates/alloy-config.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: k8smon-alloy-metrics
+  namespace: default
+data:
+  config.alloy: |-
+    // Destination: prometheus (prometheus)
+    otelcol.exporter.prometheus "prometheus" {
+      add_metric_suffixes = true
+      forward_to = [prometheus.remote_write.prometheus.receiver]
+    }
+    
+    prometheus.remote_write "prometheus" {
+      endpoint {
+        url = "http://prometheus.prometheus.svc:9090/api/v1/write"
+        headers = {
+        }
+        tls_config {
+          insecure_skip_verify = false
+        }
+        send_native_histograms = false
+    
+        queue_config {
+          capacity = 10000
+          min_shards = 1
+          max_shards = 50
+          max_samples_per_send = 2000
+          batch_send_deadline = "5s"
+          min_backoff = "30ms"
+          max_backoff = "5s"
+          retry_on_http_429 = true
+          sample_age_limit = "0s"
+        }
+    
+        write_relabel_config {
+          source_labels = ["cluster"]
+          regex = ""
+          replacement = "mongodb-atlas-integration-cluster"
+          target_label = "cluster"
+        }
+        write_relabel_config {
+          source_labels = ["k8s.cluster.name"]
+          regex = ""
+          replacement = "mongodb-atlas-integration-cluster"
+          target_label = "cluster"
+        }
+      }
+    
+      wal {
+        truncate_frequency = "2h"
+        min_keepalive_time = "5m"
+        max_keepalive_time = "8h"
+      }
+    }
+    // Self Reporting
+    prometheus.exporter.unix "kubernetes_monitoring_telemetry" {
+      set_collectors = ["textfile"]
+      textfile {
+        directory = "/etc/alloy"
+      }
+    }
+    
+    discovery.relabel "kubernetes_monitoring_telemetry" {
+      targets = prometheus.exporter.unix.kubernetes_monitoring_telemetry.targets
+      rule {
+        target_label = "instance"
+        action = "replace"
+        replacement = "k8smon"
+      }
+      rule {
+        target_label = "job"
+        action = "replace"
+        replacement = "integrations/kubernetes/kubernetes_monitoring_telemetry"
+      }
+    }
+    
+    prometheus.scrape "kubernetes_monitoring_telemetry" {
+      job_name   = "integrations/kubernetes/kubernetes_monitoring_telemetry"
+      targets    = discovery.relabel.kubernetes_monitoring_telemetry.output
+      scrape_interval = "60s"
+      clustering {
+        enabled = true
+      }
+      forward_to = [prometheus.relabel.kubernetes_monitoring_telemetry.receiver]
+    }
+    
+    prometheus.relabel "kubernetes_monitoring_telemetry" {
+      rule {
+        source_labels = ["__name__"]
+        regex = "grafana_kubernetes_monitoring_.*"
+        action = "keep"
+      }
+      forward_to = [
+        prometheus.remote_write.prometheus.receiver,
+      ]
+    }
+    
+    
+    
+    remote.kubernetes.secret "mongodb_atlas" {
+      name = "mongodb-atlas"
+      namespace = "monitoring"
+    }
+    
+    discovery.http "mongodb_atlas" {
+      url = string.format("https://cloud.mongodb.com/prometheus/v1.0/groups/%s/discovery", remote.kubernetes.secret.mongodb_atlas.data["group_id"])
+    
+      basic_auth {
+        username = nonsensitive(remote.kubernetes.secret.mongodb_atlas.data["username"])
+        password = remote.kubernetes.secret.mongodb_atlas.data["password"]
+      }
+    }
+    
+    prometheus.scrape "mongodb_atlas" {
+      targets         = discovery.http.mongodb_atlas.targets
+      job_name        = "integrations/mongodb-atlas"
+      scrape_interval = "10s"
+      scheme          = "https"
+    
+      basic_auth {
+        username = nonsensitive(remote.kubernetes.secret.mongodb_atlas.data["username"])
+        password = remote.kubernetes.secret.mongodb_atlas.data["password"]
+      }
+    
+      forward_to = [prometheus.remote_write.prometheus.receiver]
+    }
+
+  self-reporting-metric.prom: |
+    
+    # HELP grafana_kubernetes_monitoring_build_info A metric to report the version of the Kubernetes Monitoring Helm chart
+    # TYPE grafana_kubernetes_monitoring_build_info gauge
+    grafana_kubernetes_monitoring_build_info{version="2.0.21", namespace="default"} 1
+    # HELP grafana_kubernetes_monitoring_feature_info A metric to report the enabled features of the Kubernetes Monitoring Helm chart
+    # TYPE grafana_kubernetes_monitoring_feature_info gauge
+---
+# Source: k8s-monitoring/charts/alloy-metrics/templates/rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: k8smon-alloy-metrics
+  labels:
+    helm.sh/chart: alloy-metrics-0.12.5
+    app.kubernetes.io/name: alloy-metrics
+    app.kubernetes.io/instance: k8smon
+    
+    app.kubernetes.io/version: "v1.7.4"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: alloy
+    app.kubernetes.io/component: rbac
+rules:
+  # Rules which allow discovery.kubernetes to function.
+  - apiGroups:
+      - ""
+      - "discovery.k8s.io"
+      - "networking.k8s.io"
+    resources:
+      - endpoints
+      - endpointslices
+      - ingresses
+      - nodes
+      - nodes/proxy
+      - nodes/metrics
+      - pods
+      - services
+    verbs:
+      - get
+      - list
+      - watch
+  # Rules which allow loki.source.kubernetes and loki.source.podlogs to work.
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+      - pods/log
+      - namespaces
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - "monitoring.grafana.com"
+    resources:
+      - podlogs
+    verbs:
+      - get
+      - list
+      - watch
+  # Rules which allow mimir.rules.kubernetes to work.
+  - apiGroups: ["monitoring.coreos.com"]
+    resources:
+      - prometheusrules
+    verbs:
+      - get
+      - list
+      - watch
+  - nonResourceURLs:
+      - /metrics
+    verbs:
+      - get
+  # Rules for prometheus.kubernetes.*
+  - apiGroups: ["monitoring.coreos.com"]
+    resources:
+      - podmonitors
+      - servicemonitors
+      - probes
+    verbs:
+      - get
+      - list
+      - watch
+  # Rules which allow eventhandler to work.
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - get
+      - list
+      - watch
+  # needed for remote.kubernetes.*
+  - apiGroups: [""]
+    resources:
+      - "configmaps"
+      - "secrets"
+    verbs:
+      - get
+      - list
+      - watch
+  # needed for otelcol.processor.k8sattributes
+  - apiGroups: ["apps"]
+    resources: ["replicasets"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["extensions"]
+    resources: ["replicasets"]
+    verbs: ["get", "list", "watch"]
+---
+# Source: k8s-monitoring/charts/alloy-metrics/templates/rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: k8smon-alloy-metrics
+  labels:
+    helm.sh/chart: alloy-metrics-0.12.5
+    app.kubernetes.io/name: alloy-metrics
+    app.kubernetes.io/instance: k8smon
+    
+    app.kubernetes.io/version: "v1.7.4"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: alloy
+    app.kubernetes.io/component: rbac
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: k8smon-alloy-metrics
+subjects:
+  - kind: ServiceAccount
+    name: k8smon-alloy-metrics
+    namespace: default
+---
+# Source: k8s-monitoring/charts/alloy-metrics/templates/cluster_service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: k8smon-alloy-metrics-cluster
+  namespace: default
+  labels:
+    helm.sh/chart: alloy-metrics-0.12.5
+    app.kubernetes.io/name: alloy-metrics
+    app.kubernetes.io/instance: k8smon
+    
+    app.kubernetes.io/version: "v1.7.4"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: alloy
+    app.kubernetes.io/component: networking
+spec:
+  type: ClusterIP
+  clusterIP: 'None'
+  publishNotReadyAddresses: true
+  selector:
+    app.kubernetes.io/name: alloy-metrics
+    app.kubernetes.io/instance: k8smon
+  ports:
+    # Do not include the -metrics suffix in the port name, otherwise metrics
+    # can be double-collected with the non-headless Service if it's also
+    # enabled.
+    #
+    # This service should only be used for clustering, and not metric
+    # collection.
+    - name: http
+      port: 12345
+      targetPort: 12345
+      protocol: "TCP"
+---
+# Source: k8s-monitoring/charts/alloy-metrics/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: k8smon-alloy-metrics
+  namespace: default
+  labels:
+    helm.sh/chart: alloy-metrics-0.12.5
+    app.kubernetes.io/name: alloy-metrics
+    app.kubernetes.io/instance: k8smon
+    
+    app.kubernetes.io/version: "v1.7.4"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: alloy
+    app.kubernetes.io/component: networking
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: alloy-metrics
+    app.kubernetes.io/instance: k8smon
+  internalTrafficPolicy: Cluster
+  ports:
+    - name: http-metrics
+      port: 12345
+      targetPort: 12345
+      protocol: "TCP"
+---
+# Source: k8s-monitoring/charts/alloy-metrics/templates/controllers/statefulset.yaml
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: k8smon-alloy-metrics
+  namespace: default
+  labels:
+    helm.sh/chart: alloy-metrics-0.12.5
+    app.kubernetes.io/name: alloy-metrics
+    app.kubernetes.io/instance: k8smon
+    
+    app.kubernetes.io/version: "v1.7.4"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: alloy
+spec:
+  replicas: 1
+  podManagementPolicy: Parallel
+  minReadySeconds: 10
+  serviceName: k8smon-alloy-metrics
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: alloy-metrics
+      app.kubernetes.io/instance: k8smon
+  template:
+    metadata:
+      annotations:
+        kubectl.kubernetes.io/default-container: alloy
+        k8s.grafana.com/logs.job: integrations/alloy
+      labels:
+        app.kubernetes.io/name: alloy-metrics
+        app.kubernetes.io/instance: k8smon
+    spec:
+      serviceAccountName: k8smon-alloy-metrics
+      containers:
+        - name: alloy
+          image: docker.io/grafana/alloy:v1.7.4
+          imagePullPolicy: IfNotPresent
+          args:
+            - run
+            - /etc/alloy/config.alloy
+            - --storage.path=/tmp/alloy
+            - --server.http.listen-addr=0.0.0.0:12345
+            - --server.http.ui-path-prefix=/
+            - --cluster.enabled=true
+            - --cluster.join-addresses=k8smon-alloy-metrics-cluster
+            - --cluster.name=alloy-metrics
+            - --stability.level=generally-available
+          env:
+            - name: ALLOY_DEPLOY_MODE
+              value: "helm"
+            - name: HOSTNAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+          ports:
+            - containerPort: 12345
+              name: http-metrics
+          readinessProbe:
+            httpGet:
+              path: /-/ready
+              port: 12345
+              scheme: HTTP
+            initialDelaySeconds: 10
+            timeoutSeconds: 1
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              add:
+              - CHOWN
+              - DAC_OVERRIDE
+              - FOWNER
+              - FSETID
+              - KILL
+              - SETGID
+              - SETUID
+              - SETPCAP
+              - NET_BIND_SERVICE
+              - NET_RAW
+              - SYS_CHROOT
+              - MKNOD
+              - AUDIT_WRITE
+              - SETFCAP
+              drop:
+              - ALL
+            seccompProfile:
+              type: RuntimeDefault
+          volumeMounts:
+            - name: config
+              mountPath: /etc/alloy
+        - name: config-reloader
+          image: ghcr.io/jimmidyson/configmap-reload:v0.14.0
+          args:
+            - --volume-dir=/etc/alloy
+            - --webhook-url=http://localhost:12345/-/reload
+          volumeMounts:
+            - name: config
+              mountPath: /etc/alloy
+          resources:
+            requests:
+              cpu: 1m
+              memory: 5Mi
+      dnsPolicy: ClusterFirst
+      nodeSelector:
+        kubernetes.io/os: linux
+      volumes:
+        - name: config
+          configMap:
+            name: k8smon-alloy-metrics

--- a/charts/k8s-monitoring/docs/examples/service-integrations/mongodb-atlas/values.yaml
+++ b/charts/k8s-monitoring/docs/examples/service-integrations/mongodb-atlas/values.yaml
@@ -1,0 +1,39 @@
+---
+cluster:
+  name: mongodb-atlas-integration-cluster
+
+destinations:
+  - name: prometheus
+    type: prometheus
+    url: http://prometheus.prometheus.svc:9090/api/v1/write
+
+alloy-metrics:
+  enabled: true
+  extraConfig: |-
+    remote.kubernetes.secret "mongodb_atlas" {
+      name = "mongodb-atlas"
+      namespace = "monitoring"
+    }
+    
+    discovery.http "mongodb_atlas" {
+      url = string.format("https://cloud.mongodb.com/prometheus/v1.0/groups/%s/discovery", remote.kubernetes.secret.mongodb_atlas.data["group_id"])
+
+      basic_auth {
+        username = nonsensitive(remote.kubernetes.secret.mongodb_atlas.data["username"])
+        password = remote.kubernetes.secret.mongodb_atlas.data["password"]
+      }
+    }
+  
+    prometheus.scrape "mongodb_atlas" {
+      targets         = discovery.http.mongodb_atlas.targets
+      job_name        = "integrations/mongodb-atlas"
+      scrape_interval = "10s"
+      scheme          = "https"
+  
+      basic_auth {
+        username = nonsensitive(remote.kubernetes.secret.mongodb_atlas.data["username"])
+        password = remote.kubernetes.secret.mongodb_atlas.data["password"]
+      }
+  
+      forward_to = [prometheus.remote_write.prometheus.receiver]
+    }


### PR DESCRIPTION
To get metrics from a MongoDB Atlas (hosted) database, you first need to ask Mongo for the scrape URL.

This example shows how to implement `discovery.http` to do the remote service discovery.