### PR TITLE
Update OpenShift SecurityContextConstraints for alloy-profiles to enable allowHostPID and allowPrivilegeEscalation

### DIFF
--- a/charts/k8s-monitoring/templates/platform_specific/openshift/alloy-profiles-scc.yaml
+++ b/charts/k8s-monitoring/templates/platform_specific/openshift/alloy-profiles-scc.yaml
@@ -7,9 +7,9 @@ metadata:
 allowHostDirVolumePlugin: false
 allowHostIPC: false
 allowHostNetwork: false
-allowHostPID: false
+allowHostPID: true
 allowHostPorts: false
-allowPrivilegeEscalation: false
+allowPrivilegeEscalation: true
 allowPrivilegedContainer: true
 allowedCapabilities:
 - CHOWN


### PR DESCRIPTION
Mismatch caused pod creation to fail on OpenShift v4.18.1 with a security context constraint validation error.

* `values.yaml` had `alloy-profiles.controller.hostPID: true`, which conflicted with `allowHostPID: false` in the SCC.
* `alloy-profiles-scc.yaml` had `allowPrivilegedContainer: true`, which meant `allowPrivilegeEscalation: false` was not allowed.



