### PR TITLE
The proxyURL is not honored by the k8s-monitoring helm template.

### DIFF
--- a/charts/k8s-monitoring/README.md
+++ b/charts/k8s-monitoring/README.md
@@ -167,6 +167,7 @@ podLogs:
 | alloy-logs.remoteConfig.enabled | bool | `false` | Enable fetching configuration from a remote config server. |
 | alloy-logs.remoteConfig.extraAttributes | object | `{}` | Attributes to be added to this collector when requesting configuration. |
 | alloy-logs.remoteConfig.pollFrequency | string | `"5m"` | The frequency at which to poll the remote config server for updates. |
+| alloy-logs.remoteConfig.proxyURL | string | `""` | The proxy URL to use of the remote config server. |
 | alloy-logs.remoteConfig.secret.create | bool | `true` | Whether to create a secret for the remote config server. |
 | alloy-logs.remoteConfig.secret.embed | bool | `false` | If true, skip secret creation and embed the credentials directly into the configuration. |
 | alloy-logs.remoteConfig.secret.name | string | `""` | The name of the secret to create. |
@@ -177,7 +178,6 @@ podLogs:
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| alloy-logs.remoteConfig.proxyURL | string | `""` | The proxy URL to use of the remote config server. |
 | alloy-metrics.controller.replicas | int | `1` | The number of replicas for the Alloy Metrics instance. |
 | alloy-metrics.controller.type | string | `"statefulset"` | The type of controller to use for the Alloy Metrics instance. |
 | alloy-metrics.enabled | bool | `false` | Deploy the Alloy instance for collecting metrics. |
@@ -201,9 +201,6 @@ podLogs:
 | alloy-metrics.remoteConfig.secret.name | string | `""` | The name of the secret to create. |
 | alloy-metrics.remoteConfig.secret.namespace | string | `""` | The namespace for the secret. |
 | alloy-metrics.remoteConfig.url | string | `""` | The URL of the remote config server. |
-| alloy-profiles.remoteConfig.proxyURL | string | `""` | The proxy URL to use of the remote config server. |
-| alloy-receiver.remoteConfig.proxyURL | string | `""` | The proxy URL to use of the remote config server. |
-| alloy-singleton.remoteConfig.proxyURL | string | `""` | The proxy URL to use of the remote config server. |
 
 ### Collectors - Alloy Profiles
 
@@ -225,6 +222,7 @@ podLogs:
 | alloy-profiles.remoteConfig.enabled | bool | `false` | Enable fetching configuration from a remote config server. |
 | alloy-profiles.remoteConfig.extraAttributes | object | `{}` | Attributes to be added to this collector when requesting configuration. |
 | alloy-profiles.remoteConfig.pollFrequency | string | `"5m"` | The frequency at which to poll the remote config server for updates. |
+| alloy-profiles.remoteConfig.proxyURL | string | `""` | The proxy URL to use of the remote config server. |
 | alloy-profiles.remoteConfig.secret.create | bool | `true` | Whether to create a secret for the remote config server. |
 | alloy-profiles.remoteConfig.secret.embed | bool | `false` | If true, skip secret creation and embed the credentials directly into the configuration. |
 | alloy-profiles.remoteConfig.secret.name | string | `""` | The name of the secret to create. |
@@ -255,6 +253,7 @@ podLogs:
 | alloy-receiver.remoteConfig.enabled | bool | `false` | Enable fetching configuration from a remote config server. |
 | alloy-receiver.remoteConfig.extraAttributes | object | `{}` | Attributes to be added to this collector when requesting configuration. |
 | alloy-receiver.remoteConfig.pollFrequency | string | `"5m"` | The frequency at which to poll the remote config server for updates. |
+| alloy-receiver.remoteConfig.proxyURL | string | `""` | The proxy URL to use of the remote config server. |
 | alloy-receiver.remoteConfig.secret.create | bool | `true` | Whether to create a secret for the remote config server. |
 | alloy-receiver.remoteConfig.secret.embed | bool | `false` | If true, skip secret creation and embed the credentials directly into the configuration. |
 | alloy-receiver.remoteConfig.secret.name | string | `""` | The name of the secret to create. |
@@ -282,6 +281,7 @@ podLogs:
 | alloy-singleton.remoteConfig.enabled | bool | `false` | Enable fetching configuration from a remote config server. |
 | alloy-singleton.remoteConfig.extraAttributes | object | `{}` | Attributes to be added to this collector when requesting configuration. |
 | alloy-singleton.remoteConfig.pollFrequency | string | `"5m"` | The frequency at which to poll the remote config server for updates. |
+| alloy-singleton.remoteConfig.proxyURL | string | `""` | The proxy URL to use of the remote config server. |
 | alloy-singleton.remoteConfig.secret.create | bool | `true` | Whether to create a secret for the remote config server. |
 | alloy-singleton.remoteConfig.secret.embed | bool | `false` | If true, skip secret creation and embed the credentials directly into the configuration. |
 | alloy-singleton.remoteConfig.secret.name | string | `""` | The name of the secret to create. |

--- a/charts/k8s-monitoring/README.md
+++ b/charts/k8s-monitoring/README.md
@@ -177,6 +177,7 @@ podLogs:
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
+| alloy-logs.remoteConfig.proxyURL | string | `""` | The proxy URL to use of the remote config server. |
 | alloy-metrics.controller.replicas | int | `1` | The number of replicas for the Alloy Metrics instance. |
 | alloy-metrics.controller.type | string | `"statefulset"` | The type of controller to use for the Alloy Metrics instance. |
 | alloy-metrics.enabled | bool | `false` | Deploy the Alloy instance for collecting metrics. |
@@ -194,11 +195,15 @@ podLogs:
 | alloy-metrics.remoteConfig.enabled | bool | `false` | Enable fetching configuration from a remote config server. |
 | alloy-metrics.remoteConfig.extraAttributes | object | `{}` | Attributes to be added to this collector when requesting configuration. |
 | alloy-metrics.remoteConfig.pollFrequency | string | `"5m"` | The frequency at which to poll the remote config server for updates. |
+| alloy-metrics.remoteConfig.proxyURL | string | `""` | The proxy URL to use of the remote config server. |
 | alloy-metrics.remoteConfig.secret.create | bool | `true` | Whether to create a secret for the remote config server. |
 | alloy-metrics.remoteConfig.secret.embed | bool | `false` | If true, skip secret creation and embed the credentials directly into the configuration. |
 | alloy-metrics.remoteConfig.secret.name | string | `""` | The name of the secret to create. |
 | alloy-metrics.remoteConfig.secret.namespace | string | `""` | The namespace for the secret. |
 | alloy-metrics.remoteConfig.url | string | `""` | The URL of the remote config server. |
+| alloy-profiles.remoteConfig.proxyURL | string | `""` | The proxy URL to use of the remote config server. |
+| alloy-receiver.remoteConfig.proxyURL | string | `""` | The proxy URL to use of the remote config server. |
+| alloy-singleton.remoteConfig.proxyURL | string | `""` | The proxy URL to use of the remote config server. |
 
 ### Collectors - Alloy Profiles
 

--- a/charts/k8s-monitoring/templates/collectors/_collector_remoteConfig.tpl
+++ b/charts/k8s-monitoring/templates/collectors/_collector_remoteConfig.tpl
@@ -8,6 +8,9 @@
 remotecfg {
   id = sys.env("GCLOUD_FM_COLLECTOR_ID")
   url = {{ .url | quote }}
+{{- if .proxyURL }}
+  proxy_url = {{ .proxyURL | quote }}
+{{- end }}
 {{- if eq (include "secrets.authType" .) "basic" }}
   basic_auth {
     username = {{ include "secrets.read" (dict "object" . "key" "auth.username" "nonsensitive" true) }}

--- a/charts/k8s-monitoring/values.schema.json
+++ b/charts/k8s-monitoring/values.schema.json
@@ -203,6 +203,9 @@
                         },
                         "url": {
                             "type": "string"
+                        },
+                        "proxyURL": {
+                            "type": "string"
                         }
                     }
                 }
@@ -390,6 +393,9 @@
                         },
                         "url": {
                             "type": "string"
+                        },
+                        "proxyURL": {
+                            "type": "string"
                         }
                     }
                 }
@@ -574,6 +580,9 @@
                             }
                         },
                         "url": {
+                            "type": "string"
+                        },
+                        "proxyURL": {
                             "type": "string"
                         }
                     }
@@ -940,6 +949,9 @@
                             }
                         },
                         "url": {
+                            "type": "string"
+                        },
+                        "proxyURL": {
                             "type": "string"
                         }
                     }

--- a/charts/k8s-monitoring/values.schema.json
+++ b/charts/k8s-monitoring/values.schema.json
@@ -184,6 +184,9 @@
                         "pollFrequency": {
                             "type": "string"
                         },
+                        "proxyURL": {
+                            "type": "string"
+                        },
                         "secret": {
                             "type": "object",
                             "properties": {
@@ -202,9 +205,6 @@
                             }
                         },
                         "url": {
-                            "type": "string"
-                        },
-                        "proxyURL": {
                             "type": "string"
                         }
                     }
@@ -374,6 +374,9 @@
                         "pollFrequency": {
                             "type": "string"
                         },
+                        "proxyURL": {
+                            "type": "string"
+                        },
                         "secret": {
                             "type": "object",
                             "properties": {
@@ -392,9 +395,6 @@
                             }
                         },
                         "url": {
-                            "type": "string"
-                        },
-                        "proxyURL": {
                             "type": "string"
                         }
                     }
@@ -562,6 +562,9 @@
                         "pollFrequency": {
                             "type": "string"
                         },
+                        "proxyURL": {
+                            "type": "string"
+                        },
                         "secret": {
                             "type": "object",
                             "properties": {
@@ -580,9 +583,6 @@
                             }
                         },
                         "url": {
-                            "type": "string"
-                        },
-                        "proxyURL": {
                             "type": "string"
                         }
                     }
@@ -753,6 +753,9 @@
                             "type": "object"
                         },
                         "pollFrequency": {
+                            "type": "string"
+                        },
+                        "proxyURL": {
                             "type": "string"
                         },
                         "secret": {
@@ -931,6 +934,9 @@
                         "pollFrequency": {
                             "type": "string"
                         },
+                        "proxyURL": {
+                            "type": "string"
+                        },
                         "secret": {
                             "type": "object",
                             "properties": {
@@ -949,9 +955,6 @@
                             }
                         },
                         "url": {
-                            "type": "string"
-                        },
-                        "proxyURL": {
                             "type": "string"
                         }
                     }

--- a/charts/k8s-monitoring/values.yaml
+++ b/charts/k8s-monitoring/values.yaml
@@ -431,7 +431,7 @@ alloy-singleton:
     url: ""
 
     # -- The proxy URL to use of the remote config server.
-    # @section -- Collectors - Alloy Metrics
+    # @section -- Collectors - Alloy Singleton
     proxyURL: ""
 
     auth:
@@ -555,7 +555,7 @@ alloy-logs:
     url: ""
 
     # -- The proxy URL to use of the remote config server.
-    # @section -- Collectors - Alloy Metrics
+    # @section -- Collectors - Alloy Logs
     proxyURL: ""
 
     auth:
@@ -693,7 +693,7 @@ alloy-receiver:
     url: ""
 
     # -- The proxy URL to use of the remote config server.
-    # @section -- Collectors - Alloy Metrics
+    # @section -- Collectors - Alloy Receiver
     proxyURL: ""
 
     auth:
@@ -830,7 +830,7 @@ alloy-profiles:
     url: ""
 
     # -- The proxy URL to use of the remote config server.
-    # @section -- Collectors - Alloy Metrics
+    # @section -- Collectors - Alloy Profiles
     proxyURL: ""
 
     auth:

--- a/charts/k8s-monitoring/values.yaml
+++ b/charts/k8s-monitoring/values.yaml
@@ -301,6 +301,10 @@ alloy-metrics:
     # @section -- Collectors - Alloy Metrics
     url: ""
 
+    # -- The proxy URL to use of the remote config server.
+    # @section -- Collectors - Alloy Metrics
+    proxyURL: ""
+
     auth:
       # -- The type of authentication to use for the remote config server.
       # @section -- Collectors - Alloy Metrics
@@ -426,6 +430,10 @@ alloy-singleton:
     # @section -- Collectors - Alloy Singleton
     url: ""
 
+    # -- The proxy URL to use of the remote config server.
+    # @section -- Collectors - Alloy Metrics
+    proxyURL: ""
+
     auth:
       # -- The type of authentication to use for the remote config server.
       # @section -- Collectors - Alloy Singleton
@@ -545,6 +553,10 @@ alloy-logs:
     # -- The URL of the remote config server.
     # @section -- Collectors - Alloy Logs
     url: ""
+
+    # -- The proxy URL to use of the remote config server.
+    # @section -- Collectors - Alloy Metrics
+    proxyURL: ""
 
     auth:
       # -- The type of authentication to use for the remote config server.
@@ -680,6 +692,10 @@ alloy-receiver:
     # @section -- Collectors - Alloy Receiver
     url: ""
 
+    # -- The proxy URL to use of the remote config server.
+    # @section -- Collectors - Alloy Metrics
+    proxyURL: ""
+
     auth:
       # -- The type of authentication to use for the remote config server.
       # @section -- Collectors - Alloy Receiver
@@ -812,6 +828,10 @@ alloy-profiles:
     # -- The URL of the remote config server.
     # @section -- Collectors - Alloy Profiles
     url: ""
+
+    # -- The proxy URL to use of the remote config server.
+    # @section -- Collectors - Alloy Metrics
+    proxyURL: ""
 
     auth:
       # -- The type of authentication to use for the remote config server.


### PR DESCRIPTION
`proxyURL` is specified in the [schema](https://github.com/grafana/k8s-monitoring-helm/blob/8075584af7292ec5248877aede16bf28edef9044/charts/k8s-monitoring/values.schema.json), but the field is not honored when specified. Hence fixed the bug.