### PR TITLE
For K8s Helm documentation, add explanation for urlFrom

### DIFF
--- a/charts/k8s-monitoring/destinations/prometheus-values.yaml
+++ b/charts/k8s-monitoring/destinations/prometheus-values.yaml
@@ -7,7 +7,7 @@ name: ""
 # @section -- General
 url: ""
 
-# -- Raw config for accessing the URL. Lets you insert raw Alloy references so you can load the URL from any number of places, such as loading values from config maps to HTTP calls. For example: `urlFrom: sys.env("PROMETHEUS_URL")` 
+# -- Raw config for accessing the URL. Lets you insert raw Alloy references so you can load the URL from any number of places, such as loading values from config maps to HTTP calls. For example: `urlFrom: sys.env("PROMETHEUS_URL")`
 # @section -- General
 urlFrom: ""
 

--- a/charts/k8s-monitoring/destinations/prometheus-values.yaml
+++ b/charts/k8s-monitoring/destinations/prometheus-values.yaml
@@ -7,7 +7,7 @@ name: ""
 # @section -- General
 url: ""
 
-# -- Raw config for accessing the URL.
+# -- Raw config for accessing the URL. Lets you insert raw Alloy references so you can load the URL from any number of places, such as loading values from config maps to HTTP calls. For example: `urlFrom: sys.env("PROMETHEUS_URL")` 
 # @section -- General
 urlFrom: ""
 

--- a/charts/k8s-monitoring/docs/destinations/prometheus.md
+++ b/charts/k8s-monitoring/docs/destinations/prometheus.md
@@ -84,7 +84,7 @@ This defines the options for defining a destination for metrics that use the Pro
 | tenantIdFrom | string | `""` | Raw config for accessing the tenant ID. |
 | tenantIdKey | string | `"tenantId"` | The key for storing the tenant ID in the secret. |
 | url | string | `""` | The URL for the Prometheus destination. |
-| urlFrom | string | `""` | Raw config for accessing the URL. |
+| urlFrom | string | `""` | Raw config for accessing the URL. Lets you insert raw Alloy references so you can load the URL from any number of places, such as loading values from config maps to HTTP calls. For example: `urlFrom: sys.env("PROMETHEUS_URL")` |
 
 ### OpenTelemetry Conversion
 


### PR DESCRIPTION
From [slack convo](https://raintank-corp.slack.com/archives/C06S3NJLA4W/p1743541145619669), added more explanation to distinguish between url and urlFrom