### PR TITLE
Drop deployemnt label for clusterMetrics when no component is managed by helmchart

### DIFF
--- a/charts/k8s-monitoring/charts/feature-cluster-metrics/templates/_notes.tpl
+++ b/charts/k8s-monitoring/charts/feature-cluster-metrics/templates/_notes.tpl
@@ -41,5 +41,7 @@ Scrape Kubernetes Cluster metrics
 {{- if .Values.kepler.enabled }}{{- $deployments = append $deployments "kepler" }}{{ end }}
 version: {{ .Chart.Version }}
 sources: {{ $sources | join "," }}
+{{- if ne (len $deployments) 0 }}
 deployments: {{ $deployments | join "," }}
+{{- end }}
 {{- end }}

--- a/charts/k8s-monitoring/tests/integration/auth/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/integration/auth/.rendered/output.yaml
@@ -788,7 +788,7 @@ data:
     grafana_kubernetes_monitoring_build_info{version="2.0.23", namespace="default"} 1
     # HELP grafana_kubernetes_monitoring_feature_info A metric to report the enabled features of the Kubernetes Monitoring Helm chart
     # TYPE grafana_kubernetes_monitoring_feature_info gauge
-    grafana_kubernetes_monitoring_feature_info{deployments="%!s(<nil>)", feature="clusterMetrics", sources="kubelet", version="1.0.0"} 1
+    grafana_kubernetes_monitoring_feature_info{feature="clusterMetrics", sources="kubelet", version="1.0.0"} 1
     grafana_kubernetes_monitoring_feature_info{feature="podLogs", method="volumes", version="1.0.0"} 1
 ---
 # Source: k8s-monitoring/templates/alloy-config.yaml


### PR DESCRIPTION
when all clusterMetrics components are managed outside of this helm chart (`deploy: false`), the `self-reporting-metric.prom` snippet includes a label value `deployments="%!s(<nil>)"`.\
This PR checks whether there are deployments managed by this chart and only then creates the label.