### PR TITLE
Fix infinite diff in openshift alloy logs scc

### DIFF
--- a/charts/k8s-monitoring/docs/examples/platforms/openshift/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/platforms/openshift/output.yaml
@@ -2776,9 +2776,9 @@ supplementalGroups:
   type: RunAsAny
 users: []
 volumes:
-- hostPath
 - configMap
 - emptyDir
+- hostPath
 - projected
 - secret
 ---

--- a/charts/k8s-monitoring/templates/platform_specific/openshift/alloy-logs-scc.yaml
+++ b/charts/k8s-monitoring/templates/platform_specific/openshift/alloy-logs-scc.yaml
@@ -47,11 +47,11 @@ supplementalGroups:
   type: RunAsAny
 users: []
 volumes:
+- configMap
+- emptyDir
 {{- if $usesHostPathVolumes }}
 - hostPath
 {{- end }}
-- configMap
-- emptyDir
 - projected
 - secret
 ---

--- a/charts/k8s-monitoring/tests/platform/openshift/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/platform/openshift/.rendered/output.yaml
@@ -2563,9 +2563,9 @@ supplementalGroups:
   type: RunAsAny
 users: []
 volumes:
-- hostPath
 - configMap
 - emptyDir
+- hostPath
 - projected
 - secret
 ---


### PR DESCRIPTION
The current scc for alloy logs in openshift renders the scc with hostpath first in the array. But it seems openshift reorders this upon apply. But this causes gitops systems to detect a diff and causes a lot of unecessary syncs.

This is similar to how the scc looks for `charts/k8s-monitoring-v1/templates/platform_specific/openshift/alloy-scc.yaml`, so I assume this was the case there as well.

<img width="1018" alt="image" src="https://github.com/user-attachments/assets/fe71e006-dafb-4139-87b9-8aca0a5f5f08" />
