### PR TITLE
Node Label Support 

### DIFF
--- a/charts/k8s-monitoring/charts/feature-annotation-autodiscovery/README.md
+++ b/charts/k8s-monitoring/charts/feature-annotation-autodiscovery/README.md
@@ -108,6 +108,18 @@ Be sure perform actual integration testing in a live environment in the main [k8
 | global.scrapeInterval | string | `"60s"` | How frequently to scrape metrics. |
 | global.scrapeTimeout | string | `"10s"` | The scrape timeout for discovered pods and services. |
 
+### Node Labels
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| nodeLabels.availabilityZone | bool | `false` | Whether or not to add the availability\_zone label |
+| nodeLabels.instanceType | bool | `false` | Whether or not to add the instance\_type label |
+| nodeLabels.nodeArchitecture | bool | `false` | Whether or not to add the node architecture label |
+| nodeLabels.nodeOS | bool | `false` | Whether or not to add the os label |
+| nodeLabels.nodePool | bool | `false` | Whether or not to attach the nodepool label |
+| nodeLabels.nodeRole | bool | `false` | Whether or not to add the node\_role label |
+| nodeLabels.region | bool | `false` | Whether or not to add the region label |
+
 ### Pod Discovery Settings
 
 | Key | Type | Default | Description |

--- a/charts/k8s-monitoring/charts/feature-annotation-autodiscovery/templates/_nodes_common.tpl
+++ b/charts/k8s-monitoring/charts/feature-annotation-autodiscovery/templates/_nodes_common.tpl
@@ -1,0 +1,102 @@
+{{- define "feature.annotationAutodiscovery.attachNodeMetadata" }}
+{{- $attachMetadata := false -}}
+{{- $attachMetadata = or $attachMetadata .Values.nodeLabels.nodePool -}}
+{{- $attachMetadata = or $attachMetadata .Values.nodeLabels.region -}}
+{{- $attachMetadata = or $attachMetadata .Values.nodeLabels.availabilityZone -}}
+{{- $attachMetadata = or $attachMetadata .Values.nodeLabels.nodeRole -}}
+{{- $attachMetadata = or $attachMetadata .Values.nodeLabels.nodeOS -}}
+{{- $attachMetadata = or $attachMetadata .Values.nodeLabels.nodeArchitecture -}}
+{{- $attachMetadata = or $attachMetadata .Values.nodeLabels.instanceType -}}
+{{- if eq $attachMetadata true }}
+attach_metadata {
+  node = true
+}
+{{- end }}
+{{- end }}
+
+{{- define "feature.annotationAutodiscovery.nodeDiscoveryRules" }}
+{{- if eq .Values.nodeLabels.nodePool true }}
+
+rule {
+  source_labels = [
+    "__meta_kubernetes_node_label_karpenter_sh_nodepool",
+    "__meta_kubernetes_node_label_cloud_google_com_gke_nodepool",
+    "__meta_kubernetes_node_label_eks_amazonaws_com_nodegroup",
+    "__meta_kubernetes_node_label_kubernetes_azure_com_agentpool",
+    "__meta_kubernetes_node_label_agentpool",
+  ]
+  regex = "^(?:;*)?([^;]+).*$"
+  target_label = "nodepool"
+}
+{{- end }}
+{{- if eq .Values.nodeLabels.region true }}
+
+rule {
+  source_labels = [
+    "__meta_kubernetes_node_label_topology_kubernetes_io_region",
+    "__meta_kubernetes_node_label_failure_domain_beta_kubernetes_io_region",
+  ]
+  regex = "^(?:;*)?([^;]+).*$"
+  target_label = "region"
+}
+{{- end }}
+{{- if eq .Values.nodeLabels.availabilityZone true }}
+
+rule {
+  source_labels = [
+    "__meta_kubernetes_node_label_topology_kubernetes_io_zone",
+    "__meta_kubernetes_node_label_failure_domain_beta_kubernetes_io_zone",
+    "__meta_kubernetes_node_label_topology_gke_io_zone",
+  ]
+  regex = "^(?:;*)?([^;]+).*$"
+  target_label = "availability_zone"
+}
+{{- end }}
+{{- if eq .Values.nodeLabels.nodeRole true }}
+
+rule {
+  source_labels = [
+    "__meta_kubernetes_node_label_kubernetes_io_role",
+    "__meta_kubernetes_node_label_node_kubernetes_io_role",
+    "__meta_kubernetes_node_label_node_role",
+    "__meta_kubernetes_node_label_role",
+  ]
+  regex = "^(?:;*)?([^;]+).*$"
+  target_label = "node_role"
+}
+{{- end }}
+{{- if eq .Values.nodeLabels.nodeOS true }}
+
+rule {
+  source_labels = [
+    "__meta_kubernetes_node_label_kubernetes_io_os",
+    "__meta_kubernetes_node_label_os_kubernetes_io",
+    "__meta_kubernetes_node_label_os",
+  ]
+  regex = "^(?:;*)?([^;]+).*$"
+  target_label = "os"
+}
+{{- end }}
+{{- if eq .Values.nodeLabels.nodeArchitecture true }}
+
+rule {
+  source_labels = [
+    "__meta_kubernetes_node_label_kubernetes_io_arch",
+    "__meta_kubernetes_node_label_beta_kubernetes_io_arch",
+  ]
+  regex = "^(?:;*)?([^;]+).*$"
+  target_label = "architecture"
+}
+{{- end }}
+{{- if eq .Values.nodeLabels.instanceType true }}
+
+rule {
+  source_labels = [
+    "__meta_kubernetes_node_label_node_kubernetes_io_instance_type",
+    "__meta_kubernetes_node_label_beta_kubernetes_io_instance_type",
+  ]
+  regex = "^(?:;*)?([^;]+).*$"
+  target_label = "instance_type"
+}
+{{- end }}
+{{- end }}

--- a/charts/k8s-monitoring/charts/feature-annotation-autodiscovery/templates/_pods.alloy.tpl
+++ b/charts/k8s-monitoring/charts/feature-annotation-autodiscovery/templates/_pods.alloy.tpl
@@ -28,6 +28,7 @@ discovery.kubernetes "pods" {
     label = {{ $labelSelectors | join "," | quote }}
   }
 {{- end }}
+{{- include "feature.annotationAutodiscovery.attachNodeMetadata" . | indent 2 }}
 }
 
 discovery.relabel "annotation_autodiscovery_pods" {
@@ -186,6 +187,7 @@ discovery.relabel "annotation_autodiscovery_pods" {
     replacement = "pod"
   }
 {{- end }}
+{{- include "feature.annotationAutodiscovery.nodeDiscoveryRules" . | indent 2 }}
 {{- if .Values.extraDiscoveryRules }}
 {{ .Values.extraDiscoveryRules | indent 4 }}
 {{- end }}

--- a/charts/k8s-monitoring/charts/feature-annotation-autodiscovery/tests/node_labels_test.yaml
+++ b/charts/k8s-monitoring/charts/feature-annotation-autodiscovery/tests/node_labels_test.yaml
@@ -1,0 +1,292 @@
+# yamllint disable rule:document-start rule:line-length rule:trailing-spaces
+suite: Test - Annotation Autodiscovery - Node Labels
+templates:
+  - configmap.yaml
+tests:
+  - it: should add the node pool label rules to the discovery relabel
+    set:
+      deployAsConfigMap: true
+      nodeLabels:
+        nodePool: true
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - matchRegex:
+          path: data["module.alloy"]
+          # The pattern should look like this, but since the regex is escaped, it will be a bit different
+          #   rule {
+          #     source_labels = [
+          #       "__meta_kubernetes_node_label_karpenter_sh_nodepool",
+          #       "__meta_kubernetes_node_label_cloud_google_com_gke_nodepool",
+          #       "__meta_kubernetes_node_label_eks_amazonaws_com_nodegroup",
+          #       "__meta_kubernetes_node_label_kubernetes_azure_com_agentpool",
+          #       "__meta_kubernetes_node_label_agentpool",
+          #     ]
+          #     regex = "^(?:;*)?([^;]+).*$"
+          #     target_label = "nodepool"
+          #   }
+          pattern: |-
+            \s*  rule \{
+            \s*    source_labels = \[
+            \s*      "__meta_kubernetes_node_label_karpenter_sh_nodepool",
+            \s*      "__meta_kubernetes_node_label_cloud_google_com_gke_nodepool",
+            \s*      "__meta_kubernetes_node_label_eks_amazonaws_com_nodegroup",
+            \s*      "__meta_kubernetes_node_label_kubernetes_azure_com_agentpool",
+            \s*      "__meta_kubernetes_node_label_agentpool",
+            \s*    \]
+            \s*    regex = "\^\(\?:;\*\)\?\(\[\^;\]\+\)\.\*\$"
+            \s*    target_label = "nodepool"
+            \s*  \}
+      - matchRegex:
+          path: data["module.alloy"]
+          # The pattern should look like this, but since the regex is escaped, it will be a bit different
+          # attach_metadata {
+          #   node = true
+          # }
+          pattern: |-
+            \s*  attach_metadata \{
+            \s*    node = true
+            \s*  \}
+
+
+  - it: should add the node region label rules to the discovery relabel
+    set:
+      deployAsConfigMap: true
+      nodeLabels:
+        region: true
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - matchRegex:
+          path: data["module.alloy"]
+          # The pattern should look like this, but since the regex is escaped, it will be a bit different
+          # rule {
+          #   source_labels = [
+          #     "__meta_kubernetes_node_label_topology_kubernetes_io_region",
+          #     "__meta_kubernetes_node_label_failure_domain_beta_kubernetes_io_region",
+          #   ]
+          #   regex = "^(?:;*)?([^;]+).*$"
+          #   target_label = "region"
+          # }
+          pattern: |-
+            \s*  rule \{
+            \s*    source_labels = \[
+            \s*      "__meta_kubernetes_node_label_topology_kubernetes_io_region",
+            \s*      "__meta_kubernetes_node_label_failure_domain_beta_kubernetes_io_region",
+            \s*    \]
+            \s*    regex = "\^\(\?:;\*\)\?\(\[\^;\]\+\)\.\*\$"
+            \s*    target_label = "region"
+            \s*  \}
+      - matchRegex:
+          path: data["module.alloy"]
+          # The pattern should look like this, but since the regex is escaped, it will be a bit different
+          # attach_metadata {
+          #   node = true
+          # }
+          pattern: |-
+            \s*  attach_metadata \{
+            \s*    node = true
+            \s*  \}
+
+  - it: should add the node availability zone label rules to the discovery relabel
+    set:
+      deployAsConfigMap: true
+      nodeLabels:
+        availabilityZone: true
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - matchRegex:
+          path: data["module.alloy"]
+          # The pattern should look like this, but since the regex is escaped, it will be a bit different
+          # rule {
+          #   source_labels = [
+          #     "__meta_kubernetes_node_label_topology_kubernetes_io_zone",
+          #     "__meta_kubernetes_node_label_failure_domain_beta_kubernetes_io_zone",
+          #     "__meta_kubernetes_node_label_topology_gke_io_zone",
+          #   ]
+          #   regex = "^(?:;*)?([^;]+).*$"
+          #   target_label = "availability_zone"
+          # }
+          pattern: |-
+            \s*  rule \{
+            \s*    source_labels = \[
+            \s*      "__meta_kubernetes_node_label_topology_kubernetes_io_zone",
+            \s*      "__meta_kubernetes_node_label_failure_domain_beta_kubernetes_io_zone",
+            \s*      "__meta_kubernetes_node_label_topology_gke_io_zone",
+            \s*    \]
+            \s*    regex = "\^\(\?:;\*\)\?\(\[\^;\]\+\)\.\*\$"
+            \s*    target_label = "availability_zone"
+            \s*  \}
+      - matchRegex:
+          path: data["module.alloy"]
+          # The pattern should look like this, but since the regex is escaped, it will be a bit different
+          # attach_metadata {
+          #   node = true
+          # }
+          pattern: |-
+            \s*  attach_metadata \{
+            \s*    node = true
+            \s*  \}
+
+  - it: should add the node role label rules to the discovery relabel
+    set:
+      deployAsConfigMap: true
+      nodeLabels:
+        nodeRole: true
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - matchRegex:
+          path: data["module.alloy"]
+          # The pattern should look like this, but since the regex is escaped, it will be a bit different
+          # rule {
+          #   source_labels = [
+          #     "__meta_kubernetes_node_label_kubernetes_io_role",
+          #     "__meta_kubernetes_node_label_node_kubernetes_io_role",
+          #     "__meta_kubernetes_node_label_node_role",
+          #     "__meta_kubernetes_node_label_role",
+          #   ]
+          #   regex = "^(?:;*)?([^;]+).*$"
+          #   target_label = "node_role"
+          # }
+          pattern: |-
+            \s*  rule \{
+            \s*    source_labels = \[
+            \s*      "__meta_kubernetes_node_label_kubernetes_io_role",
+            \s*      "__meta_kubernetes_node_label_node_kubernetes_io_role",
+            \s*      "__meta_kubernetes_node_label_node_role",
+            \s*      "__meta_kubernetes_node_label_role",
+            \s*    \]
+            \s*    regex = "\^\(\?:;\*\)\?\(\[\^;\]\+\)\.\*\$"
+            \s*    target_label = "node_role"
+            \s*  \}
+      - matchRegex:
+          path: data["module.alloy"]
+          # The pattern should look like this, but since the regex is escaped, it will be a bit different
+          # attach_metadata {
+          #   node = true
+          # }
+          pattern: |-
+            \s*  attach_metadata \{
+            \s*    node = true
+            \s*  \}
+
+  - it: should add the node os label rules to the discovery relabel
+    set:
+      deployAsConfigMap: true
+      nodeLabels:
+        nodeOS: true
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - matchRegex:
+          path: data["module.alloy"]
+          # The pattern should look like this, but since the regex is escaped, it will be a bit different
+          # rule {
+          #   source_labels = [
+          #     "__meta_kubernetes_node_label_kubernetes_io_os",
+          #     "__meta_kubernetes_node_label_os_kubernetes_io",
+          #     "__meta_kubernetes_node_label_os",
+          #   ]
+          #   regex = "^(?:;*)?([^;]+).*$"
+          #   target_label = "os"
+          # }
+          pattern: |-
+            \s*  rule \{
+            \s*    source_labels = \[
+            \s*      "__meta_kubernetes_node_label_kubernetes_io_os",
+            \s*      "__meta_kubernetes_node_label_os_kubernetes_io",
+            \s*      "__meta_kubernetes_node_label_os",
+            \s*    \]
+            \s*    regex = "\^\(\?:;\*\)\?\(\[\^;\]\+\)\.\*\$"
+            \s*    target_label = "os"
+            \s*  \}
+      - matchRegex:
+          path: data["module.alloy"]
+          # The pattern should look like this, but since the regex is escaped, it will be a bit different
+          # attach_metadata {
+          #   node = true
+          # }
+          pattern: |-
+            \s*  attach_metadata \{
+            \s*    node = true
+            \s*  \}
+
+  - it: should add the node architecture label rules to the discovery relabel
+    set:
+      deployAsConfigMap: true
+      nodeLabels:
+        nodeArchitecture: true
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - matchRegex:
+          path: data["module.alloy"]
+          # The pattern should look like this, but since the regex is escaped, it will be a bit different
+          # rule {
+          #   source_labels = [
+          #     "__meta_kubernetes_node_label_kubernetes_io_arch",
+          #     "__meta_kubernetes_node_label_beta_kubernetes_io_arch",
+          #   ]
+          #   regex = "^(?:;*)?([^;]+).*$"
+          #   target_label = "architecture"
+          # }
+          pattern: |-
+            \s*  rule \{
+            \s*    source_labels = \[
+            \s*      "__meta_kubernetes_node_label_kubernetes_io_arch",
+            \s*      "__meta_kubernetes_node_label_beta_kubernetes_io_arch",
+            \s*    \]
+            \s*    regex = "\^\(\?:;\*\)\?\(\[\^;\]\+\)\.\*\$"
+            \s*    target_label = "architecture"
+            \s*  \}
+      - matchRegex:
+          path: data["module.alloy"]
+          # The pattern should look like this, but since the regex is escaped, it will be a bit different
+          # attach_metadata {
+          #   node = true
+          # }
+          pattern: |-
+            \s*  attach_metadata \{
+            \s*    node = true
+            \s*  \}
+
+  - it: should add the node instance type label rules to the discovery relabel
+    set:
+      deployAsConfigMap: true
+      nodeLabels:
+        instanceType: true
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - matchRegex:
+          path: data["module.alloy"]
+          # The pattern should look like this, but since the regex is escaped, it will be a bit different
+          # rule {
+          #   source_labels = [
+          #     "__meta_kubernetes_node_label_node_kubernetes_io_instance_type",
+          #     "__meta_kubernetes_node_label_beta_kubernetes_io_instance_type",
+          #   ]
+          #   regex = "^(?:;*)?([^;]+).*$"
+          #   target_label = "instance_type"
+          # }
+          pattern: |-
+            \s*  rule \{
+            \s*    source_labels = \[
+            \s*      "__meta_kubernetes_node_label_node_kubernetes_io_instance_type",
+            \s*      "__meta_kubernetes_node_label_beta_kubernetes_io_instance_type",
+            \s*    \]
+            \s*    regex = "\^\(\?:;\*\)\?\(\[\^;\]\+\)\.\*\$"
+            \s*    target_label = "instance_type"
+            \s*  \}
+      - matchRegex:
+          path: data["module.alloy"]
+          # The pattern should look like this, but since the regex is escaped, it will be a bit different
+          # attach_metadata {
+          #   node = true
+          # }
+          pattern: |-
+            \s*  attach_metadata \{
+            \s*    node = true
+            \s*  \}

--- a/charts/k8s-monitoring/charts/feature-annotation-autodiscovery/values.schema.json
+++ b/charts/k8s-monitoring/charts/feature-annotation-autodiscovery/values.schema.json
@@ -103,6 +103,32 @@
         "namespaces": {
             "type": "array"
         },
+        "nodeLabels": {
+            "type": "object",
+            "properties": {
+                "availabilityZone": {
+                    "type": "boolean"
+                },
+                "instanceType": {
+                    "type": "boolean"
+                },
+                "nodeArchitecture": {
+                    "type": "boolean"
+                },
+                "nodeOS": {
+                    "type": "boolean"
+                },
+                "nodePool": {
+                    "type": "boolean"
+                },
+                "nodeRole": {
+                    "type": "boolean"
+                },
+                "region": {
+                    "type": "boolean"
+                }
+            }
+        },
         "pods": {
             "type": "object",
             "properties": {

--- a/charts/k8s-monitoring/charts/feature-annotation-autodiscovery/values.yaml
+++ b/charts/k8s-monitoring/charts/feature-annotation-autodiscovery/values.yaml
@@ -75,6 +75,30 @@ excludeNamespaces: []
 # @section -- Discovery Settings
 labelSelectors: {}
 
+# Configures which node labels to attach to the metrics collected for pod autodiscovery jobs
+nodeLabels:
+  # -- Whether or not to attach the nodepool label
+  # @section -- Node Labels
+  nodePool: false
+  # -- Whether or not to add the region label
+  # @section -- Node Labels
+  region: false
+  # -- Whether or not to add the availability\_zone label
+  # @section -- Node Labels
+  availabilityZone: false
+  # -- Whether or not to add the node\_role label
+  # @section -- Node Labels
+  nodeRole: false
+  # -- Whether or not to add the os label
+  # @section -- Node Labels
+  nodeOS: false
+  # -- Whether or not to add the node architecture label
+  # @section -- Node Labels
+  nodeArchitecture: false
+  # -- Whether or not to add the instance\_type label
+  # @section -- Node Labels
+  instanceType: false
+
 pods:
   # -- Enable discovering Pods with annotations.
   # @section -- Pod Discovery Settings

--- a/charts/k8s-monitoring/charts/feature-cluster-metrics/README.md
+++ b/charts/k8s-monitoring/charts/feature-cluster-metrics/README.md
@@ -341,6 +341,18 @@ Be sure perform actual integration testing in a live environment in the main [k8
 | node-exporter.service.portName | string | `"metrics"` | The port name used by Node Exporter. |
 | node-exporter.service.scheme | string | `"http"` | The scrape scheme used by Node Exporter. |
 
+### Node Labels
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| nodeLabels.availabilityZone | bool | `false` | Whether or not to add the availability\_zone label |
+| nodeLabels.instanceType | bool | `false` | Whether or not to add the instance\_type label |
+| nodeLabels.nodeArchitecture | bool | `false` | Whether or not to add the node architecture label |
+| nodeLabels.nodeOS | bool | `false` | Whether or not to add the os label |
+| nodeLabels.nodePool | bool | `false` | Whether or not to attach the nodepool label |
+| nodeLabels.nodeRole | bool | `false` | Whether or not to add the node\_role label |
+| nodeLabels.region | bool | `false` | Whether or not to add the region label |
+
 ### OpenCost
 
 | Key | Type | Default | Description |

--- a/charts/k8s-monitoring/charts/feature-cluster-metrics/templates/_api_server.alloy.tpl
+++ b/charts/k8s-monitoring/charts/feature-cluster-metrics/templates/_api_server.alloy.tpl
@@ -14,6 +14,7 @@ discovery.kubernetes "apiserver" {
   namespaces {
     names = ["default"]
   }
+{{- include "feature.clusterMetrics.attachNodeMetadata" . | indent 2 }}
 }
 
 discovery.relabel "apiserver" {
@@ -40,6 +41,7 @@ discovery.relabel "apiserver" {
     target_label = "source"
   }
 
+{{- include "feature.clusterMetrics.nodeDiscoveryRules" . | indent 2 }}
 {{- if .Values.apiServer.extraDiscoveryRules }}
   {{ .Values.apiServer.extraDiscoveryRules | indent 2 }}
 {{- end }}

--- a/charts/k8s-monitoring/charts/feature-cluster-metrics/templates/_cadvisor.alloy.tpl
+++ b/charts/k8s-monitoring/charts/feature-cluster-metrics/templates/_cadvisor.alloy.tpl
@@ -16,7 +16,7 @@
 
 // cAdvisor
 discovery.relabel "cadvisor" {
-  targets = discovery.kubernetes.nodes.targets
+  targets = discovery.relabel.nodes.output
 {{- if eq .Values.cadvisor.nodeAddressFormat "proxy" }}
   rule {
     target_label = "__address__"
@@ -34,31 +34,6 @@ discovery.relabel "cadvisor" {
     target_label  = "__metrics_path__"
   }
 {{- end }}
-  rule {
-    source_labels = ["__meta_kubernetes_node_name"]
-    target_label  = "node"
-  }
-  // set the app name if specified as metadata labels "app:" or "app.kubernetes.io/name:" or "k8s-app:"
-  rule {
-    action = "replace"
-    source_labels = [
-      "__meta_kubernetes_node_label_app_kubernetes_io_name",
-      "__meta_kubernetes_node_label_k8s_app",
-      "__meta_kubernetes_node_label_app",
-    ]
-    separator = ";"
-    regex = "^(?:;*)?([^;]+).*$"
-    replacement = "$1"
-    target_label = "app"
-  }
-
-  // set a source label
-  rule {
-    action = "replace"
-    replacement = "kubernetes"
-    target_label = "source"
-  }
-
 {{- if .Values.cadvisor.extraDiscoveryRules }}
 {{ .Values.cadvisor.extraDiscoveryRules | indent 2 }}
 {{- end }}

--- a/charts/k8s-monitoring/charts/feature-cluster-metrics/templates/_kepler.alloy.tpl
+++ b/charts/k8s-monitoring/charts/feature-cluster-metrics/templates/_kepler.alloy.tpl
@@ -27,6 +27,7 @@ discovery.kubernetes "kepler" {
     role = "pod"
     label = {{ $labelSelectors | join "," | quote }}
   }
+{{- include "feature.clusterMetrics.attachNodeMetadata" . | indent 2 }}
 }
 
 discovery.relabel "kepler" {
@@ -36,6 +37,7 @@ discovery.relabel "kepler" {
     action = "replace"
     target_label = "instance"
   }
+{{- include "feature.clusterMetrics.nodeDiscoveryRules" . | indent 2 }}
 {{- if .Values.kepler.extraDiscoveryRules }}
 {{ .Values.kepler.extraDiscoveryRules | indent 2 }}
 {{- end }}

--- a/charts/k8s-monitoring/charts/feature-cluster-metrics/templates/_kube_controller_manager.alloy.tpl
+++ b/charts/k8s-monitoring/charts/feature-cluster-metrics/templates/_kube_controller_manager.alloy.tpl
@@ -12,6 +12,7 @@ discovery.kubernetes "kube_controller_manager" {
     role = "pod"
     label = {{ .Values.kubeControllerManager.selectorLabel | quote }}
   }
+{{- include "feature.clusterMetrics.attachNodeMetadata" . | indent 2 }}
 }
 
 discovery.relabel "kube_controller_manager" {
@@ -21,6 +22,7 @@ discovery.relabel "kube_controller_manager" {
     replacement = "$1:{{ .Values.kubeControllerManager.port }}"
     target_label = "__address__"
   }
+{{- include "feature.clusterMetrics.nodeDiscoveryRules" . | indent 2 }}
 {{- if .Values.kubeControllerManager.extraDiscoveryRules }}
 {{ .Values.kubeControllerManager.extraDiscoveryRules | indent 2 }}
 {{- end }}

--- a/charts/k8s-monitoring/charts/feature-cluster-metrics/templates/_kube_dns.alloy.tpl
+++ b/charts/k8s-monitoring/charts/feature-cluster-metrics/templates/_kube_dns.alloy.tpl
@@ -13,6 +13,7 @@ discovery.kubernetes "kube_dns" {
     role = "endpoints"
     label = "k8s-app=kube-dns"
   }
+{{- include "feature.clusterMetrics.attachNodeMetadata" . | indent 2 }}
 }
 
 discovery.relabel "kube_dns" {
@@ -97,6 +98,7 @@ discovery.relabel "kube_dns" {
     replacement = "kubernetes"
     target_label = "source"
   }
+{{- include "feature.clusterMetrics.nodeDiscoveryRules" . | indent 2 }}
 {{- if .Values.kubeDNS.extraDiscoveryRules }}
 {{ .Values.kubeDNS.extraDiscoveryRules | indent 2 }}
 {{- end }}

--- a/charts/k8s-monitoring/charts/feature-cluster-metrics/templates/_kube_proxy.alloy.tpl
+++ b/charts/k8s-monitoring/charts/feature-cluster-metrics/templates/_kube_proxy.alloy.tpl
@@ -12,6 +12,7 @@ discovery.kubernetes "kube_proxy" {
     role = "pod"
     label = {{ .Values.kubeProxy.selectorLabel | quote }}
   }
+{{- include "feature.clusterMetrics.attachNodeMetadata" . | indent 2 }}
 }
 
 discovery.relabel "kube_proxy" {
@@ -21,6 +22,7 @@ discovery.relabel "kube_proxy" {
     replacement = "$1:{{ .Values.kubeProxy.port }}"
     target_label = "__address__"
   }
+{{- include "feature.clusterMetrics.nodeDiscoveryRules" . | indent 2 }}
 {{- if .Values.kubeProxy.extraDiscoveryRules }}
 {{ .Values.kubeProxy.extraDiscoveryRules | indent 2 }}
 {{- end }}

--- a/charts/k8s-monitoring/charts/feature-cluster-metrics/templates/_kube_scheduler.alloy.tpl
+++ b/charts/k8s-monitoring/charts/feature-cluster-metrics/templates/_kube_scheduler.alloy.tpl
@@ -12,6 +12,7 @@ discovery.kubernetes "kube_scheduler" {
     role = "pod"
     label = {{ .Values.kubeScheduler.selectorLabel | quote }}
   }
+{{- include "feature.clusterMetrics.attachNodeMetadata" . | indent 2 }}
 }
 
 discovery.relabel "kube_scheduler" {
@@ -21,6 +22,7 @@ discovery.relabel "kube_scheduler" {
     replacement = "$1:{{ .Values.kubeScheduler.port }}"
     target_label = "__address__"
   }
+{{- include "feature.clusterMetrics.nodeDiscoveryRules" . | indent 2 }}
 {{- if .Values.kubeScheduler.extraDiscoveryRules }}
 {{ .Values.kubeScheduler.extraDiscoveryRules | indent 2 }}
 {{- end }}

--- a/charts/k8s-monitoring/charts/feature-cluster-metrics/templates/_kubelet.alloy.tpl
+++ b/charts/k8s-monitoring/charts/feature-cluster-metrics/templates/_kubelet.alloy.tpl
@@ -16,7 +16,7 @@
 
 // Kubelet
 discovery.relabel "kubelet" {
-  targets = discovery.kubernetes.nodes.targets
+  targets = discovery.relabel.nodes.output
 {{- if eq .Values.kubelet.nodeAddressFormat "proxy" }}
   rule {
     target_label = "__address__"
@@ -27,32 +27,6 @@ discovery.relabel "kubelet" {
     regex         = "(.+)"
     replacement   = "/api/v1/nodes/${1}/proxy/metrics"
     target_label  = "__metrics_path__"
-  }
-  // set the node label
-  rule {
-    source_labels = ["__meta_kubernetes_node_name"]
-    target_label  = "node"
-  }
-
-  // set the app name if specified as metadata labels "app:" or "app.kubernetes.io/name:" or "k8s-app:"
-  rule {
-    action = "replace"
-    source_labels = [
-      "__meta_kubernetes_node_label_app_kubernetes_io_name",
-      "__meta_kubernetes_node_label_k8s_app",
-      "__meta_kubernetes_node_label_app",
-    ]
-    separator = ";"
-    regex = "^(?:;*)?([^;]+).*$"
-    replacement = "$1"
-    target_label = "app"
-  }
-
-  // set a source label
-  rule {
-    action = "replace"
-    replacement = "kubernetes"
-    target_label = "source"
   }
 {{- end }}
 {{- if .Values.kubelet.extraDiscoveryRules }}

--- a/charts/k8s-monitoring/charts/feature-cluster-metrics/templates/_kubelet_probes.alloy.tpl
+++ b/charts/k8s-monitoring/charts/feature-cluster-metrics/templates/_kubelet_probes.alloy.tpl
@@ -16,7 +16,7 @@
 
 // Kubelet Probes
 discovery.relabel "kubelet_probes" {
-  targets = discovery.kubernetes.nodes.targets
+  targets = discovery.relabel.nodes.output
 {{- if eq .Values.kubeletProbes.nodeAddressFormat "proxy" }}
   rule {
     target_label = "__address__"
@@ -34,32 +34,6 @@ discovery.relabel "kubelet_probes" {
     target_label  = "__metrics_path__"
   }
 {{- end }}
-  // set the node label
-  rule {
-    source_labels = ["__meta_kubernetes_node_name"]
-    target_label  = "node"
-  }
-
-  // set the app name if specified as metadata labels "app:" or "app.kubernetes.io/name:" or "k8s-app:"
-  rule {
-    action = "replace"
-    source_labels = [
-      "__meta_kubernetes_node_label_app_kubernetes_io_name",
-      "__meta_kubernetes_node_label_k8s_app",
-      "__meta_kubernetes_node_label_app",
-    ]
-    separator = ";"
-    regex = "^(?:;*)?([^;]+).*$"
-    replacement = "$1"
-    target_label = "app"
-  }
-
-  // set a source label
-  rule {
-    action = "replace"
-    replacement = "kubernetes"
-    target_label = "source"
-  }
 {{- if .Values.kubeletProbes.extraRelabelingRules }}
 {{ .Values.kubeletProbes.extraRelabelingRules | indent 2 }}
 {{- end }}

--- a/charts/k8s-monitoring/charts/feature-cluster-metrics/templates/_module.alloy.tpl
+++ b/charts/k8s-monitoring/charts/feature-cluster-metrics/templates/_module.alloy.tpl
@@ -13,6 +13,20 @@ declare "cluster_metrics" {
   discovery.kubernetes "nodes" {
     role = "node"
   }
+
+  discovery.relabel "nodes" {
+    targets = discovery.kubernetes.nodes.targets
+    rule {
+      source_labels = ["__meta_kubernetes_node_name"]
+      target_label  = "node"
+    }
+
+    rule {
+      replacement = "kubernetes"
+      target_label = "source"
+    }
+    {{ include "feature.clusterMetrics.nodeDiscoveryRules" . | indent 4 }}
+  }
   {{- end }}
   {{- include "feature.clusterMetrics.kubelet.alloy" . | indent 2 }}
   {{- include "feature.clusterMetrics.kubeletResource.alloy" . | indent 2 }}

--- a/charts/k8s-monitoring/charts/feature-cluster-metrics/templates/_node_exporter.alloy.tpl
+++ b/charts/k8s-monitoring/charts/feature-cluster-metrics/templates/_node_exporter.alloy.tpl
@@ -42,6 +42,7 @@ discovery.kubernetes "node_exporter" {
     names = [{{ (index .Values "node-exporter").namespace | quote }}]
   }
 {{- end }}
+{{- include "feature.clusterMetrics.attachNodeMetadata" . | indent 2 }}
 }
 
 discovery.relabel "node_exporter" {
@@ -135,6 +136,7 @@ discovery.relabel "node_exporter" {
     target_label = "source"
   }
 
+{{- include "feature.clusterMetrics.nodeDiscoveryRules" . | indent 2 }}
 {{- if (index .Values "node-exporter").extraDiscoveryRules }}
   {{ (index .Values "node-exporter").extraDiscoveryRules | nindent 2 }}
 {{- end }}

--- a/charts/k8s-monitoring/charts/feature-cluster-metrics/templates/_nodes_common.tpl
+++ b/charts/k8s-monitoring/charts/feature-cluster-metrics/templates/_nodes_common.tpl
@@ -1,0 +1,102 @@
+{{- define "feature.clusterMetrics.attachNodeMetadata" }}
+{{- $attachMetadata := false -}}
+{{- $attachMetadata = or $attachMetadata .Values.nodeLabels.nodePool -}}
+{{- $attachMetadata = or $attachMetadata .Values.nodeLabels.region -}}
+{{- $attachMetadata = or $attachMetadata .Values.nodeLabels.availabilityZone -}}
+{{- $attachMetadata = or $attachMetadata .Values.nodeLabels.nodeRole -}}
+{{- $attachMetadata = or $attachMetadata .Values.nodeLabels.nodeOS -}}
+{{- $attachMetadata = or $attachMetadata .Values.nodeLabels.nodeArchitecture -}}
+{{- $attachMetadata = or $attachMetadata .Values.nodeLabels.instanceType -}}
+{{- if eq $attachMetadata true }}
+attach_metadata {
+  node = true
+}
+{{- end }}
+{{- end }}
+
+{{- define "feature.clusterMetrics.nodeDiscoveryRules" }}
+{{- if eq .Values.nodeLabels.nodePool true }}
+
+rule {
+  source_labels = [
+    "__meta_kubernetes_node_label_karpenter_sh_nodepool",
+    "__meta_kubernetes_node_label_cloud_google_com_gke_nodepool",
+    "__meta_kubernetes_node_label_eks_amazonaws_com_nodegroup",
+    "__meta_kubernetes_node_label_kubernetes_azure_com_agentpool",
+    "__meta_kubernetes_node_label_agentpool",
+  ]
+  regex = "^(?:;*)?([^;]+).*$"
+  target_label = "nodepool"
+}
+{{- end }}
+{{- if eq .Values.nodeLabels.region true }}
+
+rule {
+  source_labels = [
+    "__meta_kubernetes_node_label_topology_kubernetes_io_region",
+    "__meta_kubernetes_node_label_failure_domain_beta_kubernetes_io_region",
+  ]
+  regex = "^(?:;*)?([^;]+).*$"
+  target_label = "region"
+}
+{{- end }}
+{{- if eq .Values.nodeLabels.availabilityZone true }}
+
+rule {
+  source_labels = [
+    "__meta_kubernetes_node_label_topology_kubernetes_io_zone",
+    "__meta_kubernetes_node_label_failure_domain_beta_kubernetes_io_zone",
+    "__meta_kubernetes_node_label_topology_gke_io_zone",
+  ]
+  regex = "^(?:;*)?([^;]+).*$"
+  target_label = "availability_zone"
+}
+{{- end }}
+{{- if eq .Values.nodeLabels.nodeRole true }}
+
+rule {
+  source_labels = [
+    "__meta_kubernetes_node_label_kubernetes_io_role",
+    "__meta_kubernetes_node_label_node_kubernetes_io_role",
+    "__meta_kubernetes_node_label_node_role",
+    "__meta_kubernetes_node_label_role",
+  ]
+  regex = "^(?:;*)?([^;]+).*$"
+  target_label = "node_role"
+}
+{{- end }}
+{{- if eq .Values.nodeLabels.nodeOS true }}
+
+rule {
+  source_labels = [
+    "__meta_kubernetes_node_label_kubernetes_io_os",
+    "__meta_kubernetes_node_label_os_kubernetes_io",
+    "__meta_kubernetes_node_label_os",
+  ]
+  regex = "^(?:;*)?([^;]+).*$"
+  target_label = "os"
+}
+{{- end }}
+{{- if eq .Values.nodeLabels.nodeArchitecture true }}
+
+rule {
+  source_labels = [
+    "__meta_kubernetes_node_label_kubernetes_io_arch",
+    "__meta_kubernetes_node_label_beta_kubernetes_io_arch",
+  ]
+  regex = "^(?:;*)?([^;]+).*$"
+  target_label = "architecture"
+}
+{{- end }}
+{{- if eq .Values.nodeLabels.instanceType true }}
+
+rule {
+  source_labels = [
+    "__meta_kubernetes_node_label_node_kubernetes_io_instance_type",
+    "__meta_kubernetes_node_label_beta_kubernetes_io_instance_type",
+  ]
+  regex = "^(?:;*)?([^;]+).*$"
+  target_label = "instance_type"
+}
+{{- end }}
+{{- end }}

--- a/charts/k8s-monitoring/charts/feature-cluster-metrics/templates/_opencost.alloy.tpl
+++ b/charts/k8s-monitoring/charts/feature-cluster-metrics/templates/_opencost.alloy.tpl
@@ -27,6 +27,7 @@ discovery.kubernetes "opencost" {
     role = "pod"
     label = {{ $labelSelectors | join "," | quote }}
   }
+{{- include "feature.clusterMetrics.attachNodeMetadata" . | indent 2 }}
 }
 
 discovery.relabel "opencost" {
@@ -36,6 +37,7 @@ discovery.relabel "opencost" {
     action = "replace"
     target_label = "instance"
   }
+{{- include "feature.clusterMetrics.nodeDiscoveryRules" . | indent 2 }}
 {{- if .Values.opencost.extraDiscoveryRules }}
 {{ .Values.opencost.extraDiscoveryRules | indent 2 }}
 {{- end }}

--- a/charts/k8s-monitoring/charts/feature-cluster-metrics/templates/_windows_exporter.alloy.tpl
+++ b/charts/k8s-monitoring/charts/feature-cluster-metrics/templates/_windows_exporter.alloy.tpl
@@ -39,6 +39,7 @@ discovery.kubernetes "windows_exporter_pods" {
     role = "pod"
     label = {{ $labelSelectors | join "," | quote }}
   }
+{{- include "feature.clusterMetrics.attachNodeMetadata" . | indent 2 }}
 }
 
 discovery.relabel "windows_exporter" {
@@ -48,6 +49,7 @@ discovery.relabel "windows_exporter" {
     action = "replace"
     target_label = "instance"
   }
+{{- include "feature.clusterMetrics.nodeDiscoveryRules" . | indent 2 }}
 {{- if (index .Values "windows-exporter").extraDiscoveryRules }}
   {{ (index .Values "windows-exporter").extraDiscoveryRules | nindent 2 }}
 {{- end }}

--- a/charts/k8s-monitoring/charts/feature-cluster-metrics/tests/__snapshot__/alternative-discovery_test.yaml.snap
+++ b/charts/k8s-monitoring/charts/feature-cluster-metrics/tests/__snapshot__/alternative-discovery_test.yaml.snap
@@ -9,9 +9,23 @@ should be able to find the Kubelet and cAdvisor via the API server proxy:
           role = "node"
         }
 
+        discovery.relabel "nodes" {
+          targets = discovery.kubernetes.nodes.targets
+          rule {
+            source_labels = ["__meta_kubernetes_node_name"]
+            target_label  = "node"
+          }
+
+          rule {
+            replacement = "kubernetes"
+            target_label = "source"
+          }
+
+        }
+
         // Kubelet
         discovery.relabel "kubelet" {
-          targets = discovery.kubernetes.nodes.targets
+          targets = discovery.relabel.nodes.output
           rule {
             target_label = "__address__"
             replacement  = "kubernetes.default.svc.cluster.local:443"
@@ -21,32 +35,6 @@ should be able to find the Kubelet and cAdvisor via the API server proxy:
             regex         = "(.+)"
             replacement   = "/api/v1/nodes/${1}/proxy/metrics"
             target_label  = "__metrics_path__"
-          }
-          // set the node label
-          rule {
-            source_labels = ["__meta_kubernetes_node_name"]
-            target_label  = "node"
-          }
-
-          // set the app name if specified as metadata labels "app:" or "app.kubernetes.io/name:" or "k8s-app:"
-          rule {
-            action = "replace"
-            source_labels = [
-              "__meta_kubernetes_node_label_app_kubernetes_io_name",
-              "__meta_kubernetes_node_label_k8s_app",
-              "__meta_kubernetes_node_label_app",
-            ]
-            separator = ";"
-            regex = "^(?:;*)?([^;]+).*$"
-            replacement = "$1"
-            target_label = "app"
-          }
-
-          // set a source label
-          rule {
-            action = "replace"
-            replacement = "kubernetes"
-            target_label = "source"
           }
         }
 
@@ -83,7 +71,7 @@ should be able to find the Kubelet and cAdvisor via the API server proxy:
 
         // Kubelet Resources
         discovery.relabel "kubelet_resources" {
-          targets = discovery.kubernetes.nodes.targets
+          targets = discovery.relabel.nodes.output
           rule {
             target_label = "__address__"
             replacement  = "kubernetes.default.svc.cluster.local:443"
@@ -95,36 +83,10 @@ should be able to find the Kubelet and cAdvisor via the API server proxy:
             target_label  = "__metrics_path__"
           }
 
-          // set the node label
-          rule {
-            source_labels = ["__meta_kubernetes_node_name"]
-            target_label  = "node"
-          }
-
-          // set the app name if specified as metadata labels "app:" or "app.kubernetes.io/name:" or "k8s-app:"
-          rule {
-            action = "replace"
-            source_labels = [
-              "__meta_kubernetes_node_label_app_kubernetes_io_name",
-              "__meta_kubernetes_node_label_k8s_app",
-              "__meta_kubernetes_node_label_app",
-            ]
-            separator = ";"
-            regex = "^(?:;*)?([^;]+).*$"
-            replacement = "$1"
-            target_label = "app"
-          }
-
-          // set a source label
-          rule {
-            action = "replace"
-            replacement = "kubernetes"
-            target_label = "source"
-          }
         }
 
         prometheus.scrape "kubelet_resources" {
-          targets  = discovery.relabel.kubelet_resources.output
+          targets = discovery.relabel.kubelet_resources.output
           job_name = "integrations/kubernetes/resources"
           scheme   = "https"
           scrape_interval = "60s"
@@ -156,7 +118,7 @@ should be able to find the Kubelet and cAdvisor via the API server proxy:
 
         // Kubelet Probes
         discovery.relabel "kubelet_probes" {
-          targets = discovery.kubernetes.nodes.targets
+          targets = discovery.relabel.nodes.output
           rule {
             target_label = "__address__"
             replacement  = "kubernetes.default.svc.cluster.local:443"
@@ -168,32 +130,6 @@ should be able to find the Kubelet and cAdvisor via the API server proxy:
             target_label  = "__metrics_path__"
           }
 
-          // set the node label
-          rule {
-            source_labels = ["__meta_kubernetes_node_name"]
-            target_label  = "node"
-          }
-
-          // set the app name if specified as metadata labels "app:" or "app.kubernetes.io/name:" or "k8s-app:"
-          rule {
-            action = "replace"
-            source_labels = [
-              "__meta_kubernetes_node_label_app_kubernetes_io_name",
-              "__meta_kubernetes_node_label_k8s_app",
-              "__meta_kubernetes_node_label_app",
-            ]
-            separator = ";"
-            regex = "^(?:;*)?([^;]+).*$"
-            replacement = "$1"
-            target_label = "app"
-          }
-
-          // set a source label
-          rule {
-            action = "replace"
-            replacement = "kubernetes"
-            target_label = "source"
-          }
         }
 
         prometheus.scrape "kubelet_probes" {
@@ -229,7 +165,7 @@ should be able to find the Kubelet and cAdvisor via the API server proxy:
 
         // cAdvisor
         discovery.relabel "cadvisor" {
-          targets = discovery.kubernetes.nodes.targets
+          targets = discovery.relabel.nodes.output
           rule {
             target_label = "__address__"
             replacement  = "kubernetes.default.svc.cluster.local:443"
@@ -241,30 +177,6 @@ should be able to find the Kubelet and cAdvisor via the API server proxy:
             target_label  = "__metrics_path__"
           }
 
-          rule {
-            source_labels = ["__meta_kubernetes_node_name"]
-            target_label  = "node"
-          }
-          // set the app name if specified as metadata labels "app:" or "app.kubernetes.io/name:" or "k8s-app:"
-          rule {
-            action = "replace"
-            source_labels = [
-              "__meta_kubernetes_node_label_app_kubernetes_io_name",
-              "__meta_kubernetes_node_label_k8s_app",
-              "__meta_kubernetes_node_label_app",
-            ]
-            separator = ";"
-            regex = "^(?:;*)?([^;]+).*$"
-            replacement = "$1"
-            target_label = "app"
-          }
-
-          // set a source label
-          rule {
-            action = "replace"
-            replacement = "kubernetes"
-            target_label = "source"
-          }
         }
 
         prometheus.scrape "cadvisor" {
@@ -609,9 +521,23 @@ should be able to look for kube-state-metrics via pods, rather than endpoints:
           role = "node"
         }
 
+        discovery.relabel "nodes" {
+          targets = discovery.kubernetes.nodes.targets
+          rule {
+            source_labels = ["__meta_kubernetes_node_name"]
+            target_label  = "node"
+          }
+
+          rule {
+            replacement = "kubernetes"
+            target_label = "source"
+          }
+
+        }
+
         // Kubelet
         discovery.relabel "kubelet" {
-          targets = discovery.kubernetes.nodes.targets
+          targets = discovery.relabel.nodes.output
         }
 
         prometheus.scrape "kubelet" {
@@ -647,41 +573,15 @@ should be able to look for kube-state-metrics via pods, rather than endpoints:
 
         // Kubelet Resources
         discovery.relabel "kubelet_resources" {
-          targets = discovery.kubernetes.nodes.targets
+          targets = discovery.relabel.nodes.output
           rule {
             replacement   = "/metrics/resource"
             target_label  = "__metrics_path__"
           }
-          // set the node label
-          rule {
-            source_labels = ["__meta_kubernetes_node_name"]
-            target_label  = "node"
-          }
-
-          // set the app name if specified as metadata labels "app:" or "app.kubernetes.io/name:" or "k8s-app:"
-          rule {
-            action = "replace"
-            source_labels = [
-              "__meta_kubernetes_node_label_app_kubernetes_io_name",
-              "__meta_kubernetes_node_label_k8s_app",
-              "__meta_kubernetes_node_label_app",
-            ]
-            separator = ";"
-            regex = "^(?:;*)?([^;]+).*$"
-            replacement = "$1"
-            target_label = "app"
-          }
-
-          // set a source label
-          rule {
-            action = "replace"
-            replacement = "kubernetes"
-            target_label = "source"
-          }
         }
 
         prometheus.scrape "kubelet_resources" {
-          targets  = discovery.relabel.kubelet_resources.output
+          targets = discovery.relabel.kubelet_resources.output
           job_name = "integrations/kubernetes/resources"
           scheme   = "https"
           scrape_interval = "60s"
@@ -713,34 +613,10 @@ should be able to look for kube-state-metrics via pods, rather than endpoints:
 
         // cAdvisor
         discovery.relabel "cadvisor" {
-          targets = discovery.kubernetes.nodes.targets
+          targets = discovery.relabel.nodes.output
           rule {
             replacement   = "/metrics/cadvisor"
             target_label  = "__metrics_path__"
-          }
-          rule {
-            source_labels = ["__meta_kubernetes_node_name"]
-            target_label  = "node"
-          }
-          // set the app name if specified as metadata labels "app:" or "app.kubernetes.io/name:" or "k8s-app:"
-          rule {
-            action = "replace"
-            source_labels = [
-              "__meta_kubernetes_node_label_app_kubernetes_io_name",
-              "__meta_kubernetes_node_label_k8s_app",
-              "__meta_kubernetes_node_label_app",
-            ]
-            separator = ";"
-            regex = "^(?:;*)?([^;]+).*$"
-            replacement = "$1"
-            target_label = "app"
-          }
-
-          // set a source label
-          rule {
-            action = "replace"
-            replacement = "kubernetes"
-            target_label = "source"
           }
         }
 

--- a/charts/k8s-monitoring/charts/feature-cluster-metrics/tests/__snapshot__/control_plane_test.yaml.snap
+++ b/charts/k8s-monitoring/charts/feature-cluster-metrics/tests/__snapshot__/control_plane_test.yaml.snap
@@ -9,9 +9,23 @@ should render the configuration with control plane components included:
           role = "node"
         }
 
+        discovery.relabel "nodes" {
+          targets = discovery.kubernetes.nodes.targets
+          rule {
+            source_labels = ["__meta_kubernetes_node_name"]
+            target_label  = "node"
+          }
+
+          rule {
+            replacement = "kubernetes"
+            target_label = "source"
+          }
+
+        }
+
         // Kubelet
         discovery.relabel "kubelet" {
-          targets = discovery.kubernetes.nodes.targets
+          targets = discovery.relabel.nodes.output
         }
 
         prometheus.scrape "kubelet" {
@@ -47,41 +61,15 @@ should render the configuration with control plane components included:
 
         // Kubelet Resources
         discovery.relabel "kubelet_resources" {
-          targets = discovery.kubernetes.nodes.targets
+          targets = discovery.relabel.nodes.output
           rule {
             replacement   = "/metrics/resource"
             target_label  = "__metrics_path__"
           }
-          // set the node label
-          rule {
-            source_labels = ["__meta_kubernetes_node_name"]
-            target_label  = "node"
-          }
-
-          // set the app name if specified as metadata labels "app:" or "app.kubernetes.io/name:" or "k8s-app:"
-          rule {
-            action = "replace"
-            source_labels = [
-              "__meta_kubernetes_node_label_app_kubernetes_io_name",
-              "__meta_kubernetes_node_label_k8s_app",
-              "__meta_kubernetes_node_label_app",
-            ]
-            separator = ";"
-            regex = "^(?:;*)?([^;]+).*$"
-            replacement = "$1"
-            target_label = "app"
-          }
-
-          // set a source label
-          rule {
-            action = "replace"
-            replacement = "kubernetes"
-            target_label = "source"
-          }
         }
 
         prometheus.scrape "kubelet_resources" {
-          targets  = discovery.relabel.kubelet_resources.output
+          targets = discovery.relabel.kubelet_resources.output
           job_name = "integrations/kubernetes/resources"
           scheme   = "https"
           scrape_interval = "60s"
@@ -113,34 +101,10 @@ should render the configuration with control plane components included:
 
         // cAdvisor
         discovery.relabel "cadvisor" {
-          targets = discovery.kubernetes.nodes.targets
+          targets = discovery.relabel.nodes.output
           rule {
             replacement   = "/metrics/cadvisor"
             target_label  = "__metrics_path__"
-          }
-          rule {
-            source_labels = ["__meta_kubernetes_node_name"]
-            target_label  = "node"
-          }
-          // set the app name if specified as metadata labels "app:" or "app.kubernetes.io/name:" or "k8s-app:"
-          rule {
-            action = "replace"
-            source_labels = [
-              "__meta_kubernetes_node_label_app_kubernetes_io_name",
-              "__meta_kubernetes_node_label_k8s_app",
-              "__meta_kubernetes_node_label_app",
-            ]
-            separator = ";"
-            regex = "^(?:;*)?([^;]+).*$"
-            replacement = "$1"
-            target_label = "app"
-          }
-
-          // set a source label
-          rule {
-            action = "replace"
-            replacement = "kubernetes"
-            target_label = "source"
           }
         }
 

--- a/charts/k8s-monitoring/charts/feature-cluster-metrics/tests/__snapshot__/custom_rules_test.yaml.snap
+++ b/charts/k8s-monitoring/charts/feature-cluster-metrics/tests/__snapshot__/custom_rules_test.yaml.snap
@@ -9,9 +9,23 @@ should render the default configuration:
           role = "node"
         }
 
+        discovery.relabel "nodes" {
+          targets = discovery.kubernetes.nodes.targets
+          rule {
+            source_labels = ["__meta_kubernetes_node_name"]
+            target_label  = "node"
+          }
+
+          rule {
+            replacement = "kubernetes"
+            target_label = "source"
+          }
+
+        }
+
         // Kubelet
         discovery.relabel "kubelet" {
-          targets = discovery.kubernetes.nodes.targets
+          targets = discovery.relabel.nodes.output
           rule {
             target_label = "color"
             replacement = "red"
@@ -51,41 +65,15 @@ should render the default configuration:
 
         // Kubelet Resources
         discovery.relabel "kubelet_resources" {
-          targets = discovery.kubernetes.nodes.targets
+          targets = discovery.relabel.nodes.output
           rule {
             replacement   = "/metrics/resource"
             target_label  = "__metrics_path__"
           }
-          // set the node label
-          rule {
-            source_labels = ["__meta_kubernetes_node_name"]
-            target_label  = "node"
-          }
-
-          // set the app name if specified as metadata labels "app:" or "app.kubernetes.io/name:" or "k8s-app:"
-          rule {
-            action = "replace"
-            source_labels = [
-              "__meta_kubernetes_node_label_app_kubernetes_io_name",
-              "__meta_kubernetes_node_label_k8s_app",
-              "__meta_kubernetes_node_label_app",
-            ]
-            separator = ";"
-            regex = "^(?:;*)?([^;]+).*$"
-            replacement = "$1"
-            target_label = "app"
-          }
-
-          // set a source label
-          rule {
-            action = "replace"
-            replacement = "kubernetes"
-            target_label = "source"
-          }
         }
 
         prometheus.scrape "kubelet_resources" {
-          targets  = discovery.relabel.kubelet_resources.output
+          targets = discovery.relabel.kubelet_resources.output
           job_name = "integrations/kubernetes/resources"
           scheme   = "https"
           scrape_interval = "60s"
@@ -117,34 +105,10 @@ should render the default configuration:
 
         // cAdvisor
         discovery.relabel "cadvisor" {
-          targets = discovery.kubernetes.nodes.targets
+          targets = discovery.relabel.nodes.output
           rule {
             replacement   = "/metrics/cadvisor"
             target_label  = "__metrics_path__"
-          }
-          rule {
-            source_labels = ["__meta_kubernetes_node_name"]
-            target_label  = "node"
-          }
-          // set the app name if specified as metadata labels "app:" or "app.kubernetes.io/name:" or "k8s-app:"
-          rule {
-            action = "replace"
-            source_labels = [
-              "__meta_kubernetes_node_label_app_kubernetes_io_name",
-              "__meta_kubernetes_node_label_k8s_app",
-              "__meta_kubernetes_node_label_app",
-            ]
-            separator = ";"
-            regex = "^(?:;*)?([^;]+).*$"
-            replacement = "$1"
-            target_label = "app"
-          }
-
-          // set a source label
-          rule {
-            action = "replace"
-            replacement = "kubernetes"
-            target_label = "source"
           }
         }
 

--- a/charts/k8s-monitoring/charts/feature-cluster-metrics/tests/__snapshot__/default_test.yaml.snap
+++ b/charts/k8s-monitoring/charts/feature-cluster-metrics/tests/__snapshot__/default_test.yaml.snap
@@ -9,9 +9,23 @@ should render the default configuration:
           role = "node"
         }
 
+        discovery.relabel "nodes" {
+          targets = discovery.kubernetes.nodes.targets
+          rule {
+            source_labels = ["__meta_kubernetes_node_name"]
+            target_label  = "node"
+          }
+
+          rule {
+            replacement = "kubernetes"
+            target_label = "source"
+          }
+
+        }
+
         // Kubelet
         discovery.relabel "kubelet" {
-          targets = discovery.kubernetes.nodes.targets
+          targets = discovery.relabel.nodes.output
         }
 
         prometheus.scrape "kubelet" {
@@ -47,41 +61,15 @@ should render the default configuration:
 
         // Kubelet Resources
         discovery.relabel "kubelet_resources" {
-          targets = discovery.kubernetes.nodes.targets
+          targets = discovery.relabel.nodes.output
           rule {
             replacement   = "/metrics/resource"
             target_label  = "__metrics_path__"
           }
-          // set the node label
-          rule {
-            source_labels = ["__meta_kubernetes_node_name"]
-            target_label  = "node"
-          }
-
-          // set the app name if specified as metadata labels "app:" or "app.kubernetes.io/name:" or "k8s-app:"
-          rule {
-            action = "replace"
-            source_labels = [
-              "__meta_kubernetes_node_label_app_kubernetes_io_name",
-              "__meta_kubernetes_node_label_k8s_app",
-              "__meta_kubernetes_node_label_app",
-            ]
-            separator = ";"
-            regex = "^(?:;*)?([^;]+).*$"
-            replacement = "$1"
-            target_label = "app"
-          }
-
-          // set a source label
-          rule {
-            action = "replace"
-            replacement = "kubernetes"
-            target_label = "source"
-          }
         }
 
         prometheus.scrape "kubelet_resources" {
-          targets  = discovery.relabel.kubelet_resources.output
+          targets = discovery.relabel.kubelet_resources.output
           job_name = "integrations/kubernetes/resources"
           scheme   = "https"
           scrape_interval = "60s"
@@ -113,34 +101,10 @@ should render the default configuration:
 
         // cAdvisor
         discovery.relabel "cadvisor" {
-          targets = discovery.kubernetes.nodes.targets
+          targets = discovery.relabel.nodes.output
           rule {
             replacement   = "/metrics/cadvisor"
             target_label  = "__metrics_path__"
-          }
-          rule {
-            source_labels = ["__meta_kubernetes_node_name"]
-            target_label  = "node"
-          }
-          // set the app name if specified as metadata labels "app:" or "app.kubernetes.io/name:" or "k8s-app:"
-          rule {
-            action = "replace"
-            source_labels = [
-              "__meta_kubernetes_node_label_app_kubernetes_io_name",
-              "__meta_kubernetes_node_label_k8s_app",
-              "__meta_kubernetes_node_label_app",
-            ]
-            separator = ";"
-            regex = "^(?:;*)?([^;]+).*$"
-            replacement = "$1"
-            target_label = "app"
-          }
-
-          // set a source label
-          rule {
-            action = "replace"
-            replacement = "kubernetes"
-            target_label = "source"
           }
         }
 

--- a/charts/k8s-monitoring/charts/feature-cluster-metrics/tests/__snapshot__/kepler_test.yaml.snap
+++ b/charts/k8s-monitoring/charts/feature-cluster-metrics/tests/__snapshot__/kepler_test.yaml.snap
@@ -9,9 +9,23 @@ should render the configuration with Kepler:
           role = "node"
         }
 
+        discovery.relabel "nodes" {
+          targets = discovery.kubernetes.nodes.targets
+          rule {
+            source_labels = ["__meta_kubernetes_node_name"]
+            target_label  = "node"
+          }
+
+          rule {
+            replacement = "kubernetes"
+            target_label = "source"
+          }
+
+        }
+
         // Kubelet
         discovery.relabel "kubelet" {
-          targets = discovery.kubernetes.nodes.targets
+          targets = discovery.relabel.nodes.output
         }
 
         prometheus.scrape "kubelet" {
@@ -47,41 +61,15 @@ should render the configuration with Kepler:
 
         // Kubelet Resources
         discovery.relabel "kubelet_resources" {
-          targets = discovery.kubernetes.nodes.targets
+          targets = discovery.relabel.nodes.output
           rule {
             replacement   = "/metrics/resource"
             target_label  = "__metrics_path__"
           }
-          // set the node label
-          rule {
-            source_labels = ["__meta_kubernetes_node_name"]
-            target_label  = "node"
-          }
-
-          // set the app name if specified as metadata labels "app:" or "app.kubernetes.io/name:" or "k8s-app:"
-          rule {
-            action = "replace"
-            source_labels = [
-              "__meta_kubernetes_node_label_app_kubernetes_io_name",
-              "__meta_kubernetes_node_label_k8s_app",
-              "__meta_kubernetes_node_label_app",
-            ]
-            separator = ";"
-            regex = "^(?:;*)?([^;]+).*$"
-            replacement = "$1"
-            target_label = "app"
-          }
-
-          // set a source label
-          rule {
-            action = "replace"
-            replacement = "kubernetes"
-            target_label = "source"
-          }
         }
 
         prometheus.scrape "kubelet_resources" {
-          targets  = discovery.relabel.kubelet_resources.output
+          targets = discovery.relabel.kubelet_resources.output
           job_name = "integrations/kubernetes/resources"
           scheme   = "https"
           scrape_interval = "60s"
@@ -113,34 +101,10 @@ should render the configuration with Kepler:
 
         // cAdvisor
         discovery.relabel "cadvisor" {
-          targets = discovery.kubernetes.nodes.targets
+          targets = discovery.relabel.nodes.output
           rule {
             replacement   = "/metrics/cadvisor"
             target_label  = "__metrics_path__"
-          }
-          rule {
-            source_labels = ["__meta_kubernetes_node_name"]
-            target_label  = "node"
-          }
-          // set the app name if specified as metadata labels "app:" or "app.kubernetes.io/name:" or "k8s-app:"
-          rule {
-            action = "replace"
-            source_labels = [
-              "__meta_kubernetes_node_label_app_kubernetes_io_name",
-              "__meta_kubernetes_node_label_k8s_app",
-              "__meta_kubernetes_node_label_app",
-            ]
-            separator = ";"
-            regex = "^(?:;*)?([^;]+).*$"
-            replacement = "$1"
-            target_label = "app"
-          }
-
-          // set a source label
-          rule {
-            action = "replace"
-            replacement = "kubernetes"
-            target_label = "source"
           }
         }
 

--- a/charts/k8s-monitoring/charts/feature-cluster-metrics/tests/__snapshot__/metrics_tuning_test.yaml.snap
+++ b/charts/k8s-monitoring/charts/feature-cluster-metrics/tests/__snapshot__/metrics_tuning_test.yaml.snap
@@ -9,9 +9,23 @@ should render with modified metrics tuning settings:
           role = "node"
         }
 
+        discovery.relabel "nodes" {
+          targets = discovery.kubernetes.nodes.targets
+          rule {
+            source_labels = ["__meta_kubernetes_node_name"]
+            target_label  = "node"
+          }
+
+          rule {
+            replacement = "kubernetes"
+            target_label = "source"
+          }
+
+        }
+
         // Kubelet
         discovery.relabel "kubelet" {
-          targets = discovery.kubernetes.nodes.targets
+          targets = discovery.relabel.nodes.output
         }
 
         prometheus.scrape "kubelet" {
@@ -47,41 +61,15 @@ should render with modified metrics tuning settings:
 
         // Kubelet Resources
         discovery.relabel "kubelet_resources" {
-          targets = discovery.kubernetes.nodes.targets
+          targets = discovery.relabel.nodes.output
           rule {
             replacement   = "/metrics/resource"
             target_label  = "__metrics_path__"
           }
-          // set the node label
-          rule {
-            source_labels = ["__meta_kubernetes_node_name"]
-            target_label  = "node"
-          }
-
-          // set the app name if specified as metadata labels "app:" or "app.kubernetes.io/name:" or "k8s-app:"
-          rule {
-            action = "replace"
-            source_labels = [
-              "__meta_kubernetes_node_label_app_kubernetes_io_name",
-              "__meta_kubernetes_node_label_k8s_app",
-              "__meta_kubernetes_node_label_app",
-            ]
-            separator = ";"
-            regex = "^(?:;*)?([^;]+).*$"
-            replacement = "$1"
-            target_label = "app"
-          }
-
-          // set a source label
-          rule {
-            action = "replace"
-            replacement = "kubernetes"
-            target_label = "source"
-          }
         }
 
         prometheus.scrape "kubelet_resources" {
-          targets  = discovery.relabel.kubelet_resources.output
+          targets = discovery.relabel.kubelet_resources.output
           job_name = "integrations/kubernetes/resources"
           scheme   = "https"
           scrape_interval = "60s"
@@ -113,34 +101,10 @@ should render with modified metrics tuning settings:
 
         // cAdvisor
         discovery.relabel "cadvisor" {
-          targets = discovery.kubernetes.nodes.targets
+          targets = discovery.relabel.nodes.output
           rule {
             replacement   = "/metrics/cadvisor"
             target_label  = "__metrics_path__"
-          }
-          rule {
-            source_labels = ["__meta_kubernetes_node_name"]
-            target_label  = "node"
-          }
-          // set the app name if specified as metadata labels "app:" or "app.kubernetes.io/name:" or "k8s-app:"
-          rule {
-            action = "replace"
-            source_labels = [
-              "__meta_kubernetes_node_label_app_kubernetes_io_name",
-              "__meta_kubernetes_node_label_k8s_app",
-              "__meta_kubernetes_node_label_app",
-            ]
-            separator = ";"
-            regex = "^(?:;*)?([^;]+).*$"
-            replacement = "$1"
-            target_label = "app"
-          }
-
-          // set a source label
-          rule {
-            action = "replace"
-            replacement = "kubernetes"
-            target_label = "source"
           }
         }
 

--- a/charts/k8s-monitoring/charts/feature-cluster-metrics/tests/__snapshot__/opencost_test.yaml.snap
+++ b/charts/k8s-monitoring/charts/feature-cluster-metrics/tests/__snapshot__/opencost_test.yaml.snap
@@ -9,9 +9,23 @@ should render the configuration with OpenCost:
           role = "node"
         }
 
+        discovery.relabel "nodes" {
+          targets = discovery.kubernetes.nodes.targets
+          rule {
+            source_labels = ["__meta_kubernetes_node_name"]
+            target_label  = "node"
+          }
+
+          rule {
+            replacement = "kubernetes"
+            target_label = "source"
+          }
+
+        }
+
         // Kubelet
         discovery.relabel "kubelet" {
-          targets = discovery.kubernetes.nodes.targets
+          targets = discovery.relabel.nodes.output
         }
 
         prometheus.scrape "kubelet" {
@@ -47,41 +61,15 @@ should render the configuration with OpenCost:
 
         // Kubelet Resources
         discovery.relabel "kubelet_resources" {
-          targets = discovery.kubernetes.nodes.targets
+          targets = discovery.relabel.nodes.output
           rule {
             replacement   = "/metrics/resource"
             target_label  = "__metrics_path__"
           }
-          // set the node label
-          rule {
-            source_labels = ["__meta_kubernetes_node_name"]
-            target_label  = "node"
-          }
-
-          // set the app name if specified as metadata labels "app:" or "app.kubernetes.io/name:" or "k8s-app:"
-          rule {
-            action = "replace"
-            source_labels = [
-              "__meta_kubernetes_node_label_app_kubernetes_io_name",
-              "__meta_kubernetes_node_label_k8s_app",
-              "__meta_kubernetes_node_label_app",
-            ]
-            separator = ";"
-            regex = "^(?:;*)?([^;]+).*$"
-            replacement = "$1"
-            target_label = "app"
-          }
-
-          // set a source label
-          rule {
-            action = "replace"
-            replacement = "kubernetes"
-            target_label = "source"
-          }
         }
 
         prometheus.scrape "kubelet_resources" {
-          targets  = discovery.relabel.kubelet_resources.output
+          targets = discovery.relabel.kubelet_resources.output
           job_name = "integrations/kubernetes/resources"
           scheme   = "https"
           scrape_interval = "60s"
@@ -113,34 +101,10 @@ should render the configuration with OpenCost:
 
         // cAdvisor
         discovery.relabel "cadvisor" {
-          targets = discovery.kubernetes.nodes.targets
+          targets = discovery.relabel.nodes.output
           rule {
             replacement   = "/metrics/cadvisor"
             target_label  = "__metrics_path__"
-          }
-          rule {
-            source_labels = ["__meta_kubernetes_node_name"]
-            target_label  = "node"
-          }
-          // set the app name if specified as metadata labels "app:" or "app.kubernetes.io/name:" or "k8s-app:"
-          rule {
-            action = "replace"
-            source_labels = [
-              "__meta_kubernetes_node_label_app_kubernetes_io_name",
-              "__meta_kubernetes_node_label_k8s_app",
-              "__meta_kubernetes_node_label_app",
-            ]
-            separator = ";"
-            regex = "^(?:;*)?([^;]+).*$"
-            replacement = "$1"
-            target_label = "app"
-          }
-
-          // set a source label
-          rule {
-            action = "replace"
-            replacement = "kubernetes"
-            target_label = "source"
           }
         }
 

--- a/charts/k8s-monitoring/charts/feature-cluster-metrics/tests/__snapshot__/openshift_test.yaml.snap
+++ b/charts/k8s-monitoring/charts/feature-cluster-metrics/tests/__snapshot__/openshift_test.yaml.snap
@@ -9,9 +9,23 @@ can adapt to locally deployed kube-state-metrics and Node Exporter instances:
           role = "node"
         }
 
+        discovery.relabel "nodes" {
+          targets = discovery.kubernetes.nodes.targets
+          rule {
+            source_labels = ["__meta_kubernetes_node_name"]
+            target_label  = "node"
+          }
+
+          rule {
+            replacement = "kubernetes"
+            target_label = "source"
+          }
+
+        }
+
         // Kubelet
         discovery.relabel "kubelet" {
-          targets = discovery.kubernetes.nodes.targets
+          targets = discovery.relabel.nodes.output
         }
 
         prometheus.scrape "kubelet" {
@@ -47,41 +61,15 @@ can adapt to locally deployed kube-state-metrics and Node Exporter instances:
 
         // Kubelet Resources
         discovery.relabel "kubelet_resources" {
-          targets = discovery.kubernetes.nodes.targets
+          targets = discovery.relabel.nodes.output
           rule {
             replacement   = "/metrics/resource"
             target_label  = "__metrics_path__"
           }
-          // set the node label
-          rule {
-            source_labels = ["__meta_kubernetes_node_name"]
-            target_label  = "node"
-          }
-
-          // set the app name if specified as metadata labels "app:" or "app.kubernetes.io/name:" or "k8s-app:"
-          rule {
-            action = "replace"
-            source_labels = [
-              "__meta_kubernetes_node_label_app_kubernetes_io_name",
-              "__meta_kubernetes_node_label_k8s_app",
-              "__meta_kubernetes_node_label_app",
-            ]
-            separator = ";"
-            regex = "^(?:;*)?([^;]+).*$"
-            replacement = "$1"
-            target_label = "app"
-          }
-
-          // set a source label
-          rule {
-            action = "replace"
-            replacement = "kubernetes"
-            target_label = "source"
-          }
         }
 
         prometheus.scrape "kubelet_resources" {
-          targets  = discovery.relabel.kubelet_resources.output
+          targets = discovery.relabel.kubelet_resources.output
           job_name = "integrations/kubernetes/resources"
           scheme   = "https"
           scrape_interval = "60s"
@@ -113,34 +101,10 @@ can adapt to locally deployed kube-state-metrics and Node Exporter instances:
 
         // cAdvisor
         discovery.relabel "cadvisor" {
-          targets = discovery.kubernetes.nodes.targets
+          targets = discovery.relabel.nodes.output
           rule {
             replacement   = "/metrics/cadvisor"
             target_label  = "__metrics_path__"
-          }
-          rule {
-            source_labels = ["__meta_kubernetes_node_name"]
-            target_label  = "node"
-          }
-          // set the app name if specified as metadata labels "app:" or "app.kubernetes.io/name:" or "k8s-app:"
-          rule {
-            action = "replace"
-            source_labels = [
-              "__meta_kubernetes_node_label_app_kubernetes_io_name",
-              "__meta_kubernetes_node_label_k8s_app",
-              "__meta_kubernetes_node_label_app",
-            ]
-            separator = ";"
-            regex = "^(?:;*)?([^;]+).*$"
-            replacement = "$1"
-            target_label = "app"
-          }
-
-          // set a source label
-          rule {
-            action = "replace"
-            replacement = "kubernetes"
-            target_label = "source"
           }
         }
 

--- a/charts/k8s-monitoring/charts/feature-cluster-metrics/tests/node-labels_test.yaml
+++ b/charts/k8s-monitoring/charts/feature-cluster-metrics/tests/node-labels_test.yaml
@@ -1,0 +1,293 @@
+---
+# yamllint disable rule:document-start rule:line-length rule:trailing-spaces rule:empty-lines
+suite: Test - Cluster Metrics - Node Labels
+templates:
+  - configmap.yaml
+tests:
+  - it: should add the node pool label rules to the discovery relabel
+    set:
+      deployAsConfigMap: true
+      nodeLabels:
+        nodePool: true
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - matchRegex:
+          path: data["module.alloy"]
+          # The pattern should look like this, but since the regex is escaped, it will be a bit different
+          #   rule {
+          #     source_labels = [
+          #       "__meta_kubernetes_node_label_karpenter_sh_nodepool",
+          #       "__meta_kubernetes_node_label_cloud_google_com_gke_nodepool",
+          #       "__meta_kubernetes_node_label_eks_amazonaws_com_nodegroup",
+          #       "__meta_kubernetes_node_label_kubernetes_azure_com_agentpool",
+          #       "__meta_kubernetes_node_label_agentpool",
+          #     ]
+          #     regex = "^(?:;*)?([^;]+).*$"
+          #     target_label = "nodepool"
+          #   }
+          pattern: |-
+            \s*  rule \{
+            \s*    source_labels = \[
+            \s*      "__meta_kubernetes_node_label_karpenter_sh_nodepool",
+            \s*      "__meta_kubernetes_node_label_cloud_google_com_gke_nodepool",
+            \s*      "__meta_kubernetes_node_label_eks_amazonaws_com_nodegroup",
+            \s*      "__meta_kubernetes_node_label_kubernetes_azure_com_agentpool",
+            \s*      "__meta_kubernetes_node_label_agentpool",
+            \s*    \]
+            \s*    regex = "\^\(\?:;\*\)\?\(\[\^;\]\+\)\.\*\$"
+            \s*    target_label = "nodepool"
+            \s*  \}
+      - matchRegex:
+          path: data["module.alloy"]
+          # The pattern should look like this, but since the regex is escaped, it will be a bit different
+          # attach_metadata {
+          #   node = true
+          # }
+          pattern: |-
+            \s*  attach_metadata \{
+            \s*    node = true
+            \s*  \}
+
+
+  - it: should add the node region label rules to the discovery relabel
+    set:
+      deployAsConfigMap: true
+      nodeLabels:
+        region: true
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - matchRegex:
+          path: data["module.alloy"]
+          # The pattern should look like this, but since the regex is escaped, it will be a bit different
+          # rule {
+          #   source_labels = [
+          #     "__meta_kubernetes_node_label_topology_kubernetes_io_region",
+          #     "__meta_kubernetes_node_label_failure_domain_beta_kubernetes_io_region",
+          #   ]
+          #   regex = "^(?:;*)?([^;]+).*$"
+          #   target_label = "region"
+          # }
+          pattern: |-
+            \s*  rule \{
+            \s*    source_labels = \[
+            \s*      "__meta_kubernetes_node_label_topology_kubernetes_io_region",
+            \s*      "__meta_kubernetes_node_label_failure_domain_beta_kubernetes_io_region",
+            \s*    \]
+            \s*    regex = "\^\(\?:;\*\)\?\(\[\^;\]\+\)\.\*\$"
+            \s*    target_label = "region"
+            \s*  \}
+      - matchRegex:
+          path: data["module.alloy"]
+          # The pattern should look like this, but since the regex is escaped, it will be a bit different
+          # attach_metadata {
+          #   node = true
+          # }
+          pattern: |-
+            \s*  attach_metadata \{
+            \s*    node = true
+            \s*  \}
+
+  - it: should add the node availability zone label rules to the discovery relabel
+    set:
+      deployAsConfigMap: true
+      nodeLabels:
+        availabilityZone: true
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - matchRegex:
+          path: data["module.alloy"]
+          # The pattern should look like this, but since the regex is escaped, it will be a bit different
+          # rule {
+          #   source_labels = [
+          #     "__meta_kubernetes_node_label_topology_kubernetes_io_zone",
+          #     "__meta_kubernetes_node_label_failure_domain_beta_kubernetes_io_zone",
+          #     "__meta_kubernetes_node_label_topology_gke_io_zone",
+          #   ]
+          #   regex = "^(?:;*)?([^;]+).*$"
+          #   target_label = "availability_zone"
+          # }
+          pattern: |-
+            \s*  rule \{
+            \s*    source_labels = \[
+            \s*      "__meta_kubernetes_node_label_topology_kubernetes_io_zone",
+            \s*      "__meta_kubernetes_node_label_failure_domain_beta_kubernetes_io_zone",
+            \s*      "__meta_kubernetes_node_label_topology_gke_io_zone",
+            \s*    \]
+            \s*    regex = "\^\(\?:;\*\)\?\(\[\^;\]\+\)\.\*\$"
+            \s*    target_label = "availability_zone"
+            \s*  \}
+      - matchRegex:
+          path: data["module.alloy"]
+          # The pattern should look like this, but since the regex is escaped, it will be a bit different
+          # attach_metadata {
+          #   node = true
+          # }
+          pattern: |-
+            \s*  attach_metadata \{
+            \s*    node = true
+            \s*  \}
+
+  - it: should add the node role label rules to the discovery relabel
+    set:
+      deployAsConfigMap: true
+      nodeLabels:
+        nodeRole: true
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - matchRegex:
+          path: data["module.alloy"]
+          # The pattern should look like this, but since the regex is escaped, it will be a bit different
+          # rule {
+          #   source_labels = [
+          #     "__meta_kubernetes_node_label_kubernetes_io_role",
+          #     "__meta_kubernetes_node_label_node_kubernetes_io_role",
+          #     "__meta_kubernetes_node_label_node_role",
+          #     "__meta_kubernetes_node_label_role",
+          #   ]
+          #   regex = "^(?:;*)?([^;]+).*$"
+          #   target_label = "node_role"
+          # }
+          pattern: |-
+            \s*  rule \{
+            \s*    source_labels = \[
+            \s*      "__meta_kubernetes_node_label_kubernetes_io_role",
+            \s*      "__meta_kubernetes_node_label_node_kubernetes_io_role",
+            \s*      "__meta_kubernetes_node_label_node_role",
+            \s*      "__meta_kubernetes_node_label_role",
+            \s*    \]
+            \s*    regex = "\^\(\?:;\*\)\?\(\[\^;\]\+\)\.\*\$"
+            \s*    target_label = "node_role"
+            \s*  \}
+      - matchRegex:
+          path: data["module.alloy"]
+          # The pattern should look like this, but since the regex is escaped, it will be a bit different
+          # attach_metadata {
+          #   node = true
+          # }
+          pattern: |-
+            \s*  attach_metadata \{
+            \s*    node = true
+            \s*  \}
+
+  - it: should add the node os label rules to the discovery relabel
+    set:
+      deployAsConfigMap: true
+      nodeLabels:
+        nodeOS: true
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - matchRegex:
+          path: data["module.alloy"]
+          # The pattern should look like this, but since the regex is escaped, it will be a bit different
+          # rule {
+          #   source_labels = [
+          #     "__meta_kubernetes_node_label_kubernetes_io_os",
+          #     "__meta_kubernetes_node_label_os_kubernetes_io",
+          #     "__meta_kubernetes_node_label_os",
+          #   ]
+          #   regex = "^(?:;*)?([^;]+).*$"
+          #   target_label = "os"
+          # }
+          pattern: |-
+            \s*  rule \{
+            \s*    source_labels = \[
+            \s*      "__meta_kubernetes_node_label_kubernetes_io_os",
+            \s*      "__meta_kubernetes_node_label_os_kubernetes_io",
+            \s*      "__meta_kubernetes_node_label_os",
+            \s*    \]
+            \s*    regex = "\^\(\?:;\*\)\?\(\[\^;\]\+\)\.\*\$"
+            \s*    target_label = "os"
+            \s*  \}
+      - matchRegex:
+          path: data["module.alloy"]
+          # The pattern should look like this, but since the regex is escaped, it will be a bit different
+          # attach_metadata {
+          #   node = true
+          # }
+          pattern: |-
+            \s*  attach_metadata \{
+            \s*    node = true
+            \s*  \}
+
+  - it: should add the node architecture label rules to the discovery relabel
+    set:
+      deployAsConfigMap: true
+      nodeLabels:
+        nodeArchitecture: true
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - matchRegex:
+          path: data["module.alloy"]
+          # The pattern should look like this, but since the regex is escaped, it will be a bit different
+          # rule {
+          #   source_labels = [
+          #     "__meta_kubernetes_node_label_kubernetes_io_arch",
+          #     "__meta_kubernetes_node_label_beta_kubernetes_io_arch",
+          #   ]
+          #   regex = "^(?:;*)?([^;]+).*$"
+          #   target_label = "architecture"
+          # }
+          pattern: |-
+            \s*  rule \{
+            \s*    source_labels = \[
+            \s*      "__meta_kubernetes_node_label_kubernetes_io_arch",
+            \s*      "__meta_kubernetes_node_label_beta_kubernetes_io_arch",
+            \s*    \]
+            \s*    regex = "\^\(\?:;\*\)\?\(\[\^;\]\+\)\.\*\$"
+            \s*    target_label = "architecture"
+            \s*  \}
+      - matchRegex:
+          path: data["module.alloy"]
+          # The pattern should look like this, but since the regex is escaped, it will be a bit different
+          # attach_metadata {
+          #   node = true
+          # }
+          pattern: |-
+            \s*  attach_metadata \{
+            \s*    node = true
+            \s*  \}
+
+  - it: should add the node instance type label rules to the discovery relabel
+    set:
+      deployAsConfigMap: true
+      nodeLabels:
+        instanceType: true
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - matchRegex:
+          path: data["module.alloy"]
+          # The pattern should look like this, but since the regex is escaped, it will be a bit different
+          # rule {
+          #   source_labels = [
+          #     "__meta_kubernetes_node_label_node_kubernetes_io_instance_type",
+          #     "__meta_kubernetes_node_label_beta_kubernetes_io_instance_type",
+          #   ]
+          #   regex = "^(?:;*)?([^;]+).*$"
+          #   target_label = "instance_type"
+          # }
+          pattern: |-
+            \s*  rule \{
+            \s*    source_labels = \[
+            \s*      "__meta_kubernetes_node_label_node_kubernetes_io_instance_type",
+            \s*      "__meta_kubernetes_node_label_beta_kubernetes_io_instance_type",
+            \s*    \]
+            \s*    regex = "\^\(\?:;\*\)\?\(\[\^;\]\+\)\.\*\$"
+            \s*    target_label = "instance_type"
+            \s*  \}
+      - matchRegex:
+          path: data["module.alloy"]
+          # The pattern should look like this, but since the regex is escaped, it will be a bit different
+          # attach_metadata {
+          #   node = true
+          # }
+          pattern: |-
+            \s*  attach_metadata \{
+            \s*    node = true
+            \s*  \}

--- a/charts/k8s-monitoring/charts/feature-cluster-metrics/tests/openshift-kepler-scc_test.yaml
+++ b/charts/k8s-monitoring/charts/feature-cluster-metrics/tests/openshift-kepler-scc_test.yaml
@@ -38,8 +38,6 @@ tests:
       deployAsConfigMap: true
       kepler:
         enabled: true
-    documentSelector:
-      skipEmptyTemplates: true
     asserts:
       - hasDocuments:
           count: 0

--- a/charts/k8s-monitoring/charts/feature-cluster-metrics/values.schema.json
+++ b/charts/k8s-monitoring/charts/feature-cluster-metrics/values.schema.json
@@ -823,6 +823,32 @@
                 }
             }
         },
+        "nodeLabels": {
+            "type": "object",
+            "properties": {
+                "availabilityZone": {
+                    "type": "boolean"
+                },
+                "instanceType": {
+                    "type": "boolean"
+                },
+                "nodeArchitecture": {
+                    "type": "boolean"
+                },
+                "nodeOS": {
+                    "type": "boolean"
+                },
+                "nodePool": {
+                    "type": "boolean"
+                },
+                "nodeRole": {
+                    "type": "boolean"
+                },
+                "region": {
+                    "type": "boolean"
+                }
+            }
+        },
         "opencost": {
             "type": "object",
             "properties": {

--- a/charts/k8s-monitoring/charts/feature-cluster-metrics/values.yaml
+++ b/charts/k8s-monitoring/charts/feature-cluster-metrics/values.yaml
@@ -34,6 +34,30 @@ global:
     # @section -- Global Settings
     branch: main
 
+# Configures which node labels to attach to the metrics collected
+nodeLabels:
+  # -- Whether or not to attach the nodepool label
+  # @section -- Node Labels
+  nodePool: false
+  # -- Whether or not to add the region label
+  # @section -- Node Labels
+  region: false
+  # -- Whether or not to add the availability\_zone label
+  # @section -- Node Labels
+  availabilityZone: false
+  # -- Whether or not to add the node\_role label
+  # @section -- Node Labels
+  nodeRole: false
+  # -- Whether or not to add the os label
+  # @section -- Node Labels
+  nodeOS: false
+  # -- Whether or not to add the node architecture label
+  # @section -- Node Labels
+  nodeArchitecture: false
+  # -- Whether or not to add the instance\_type label
+  # @section -- Node Labels
+  instanceType: false
+
 controlPlane:
   # -- enable all Kubernetes Control Plane metrics sources. This includes api-server, kube-scheduler,
   # kube-controller-manager, and KubeDNS.

--- a/charts/k8s-monitoring/charts/feature-integrations/README.md
+++ b/charts/k8s-monitoring/charts/feature-integrations/README.md
@@ -130,6 +130,18 @@ Be sure perform actual integration testing in a live environment in the main [k8
 |-----|------|---------|-------------|
 | mysql | object | `{"instances":[]}` | Scrape metrics/logs from MySQL |
 
+### Node Labels
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| nodeLabels.availabilityZone | bool | `false` | Whether or not to add the availability\_zone label |
+| nodeLabels.instanceType | bool | `false` | Whether or not to add the instance\_type label |
+| nodeLabels.nodeArchitecture | bool | `false` | Whether or not to add the node architecture label |
+| nodeLabels.nodeOS | bool | `false` | Whether or not to add the os label |
+| nodeLabels.nodePool | bool | `false` | Whether or not to attach the nodepool label |
+| nodeLabels.nodeRole | bool | `false` | Whether or not to add the node\_role label |
+| nodeLabels.region | bool | `false` | Whether or not to add the region label |
+
 ### Integration: Tempo
 
 | Key | Type | Default | Description |

--- a/charts/k8s-monitoring/charts/feature-integrations/templates/_helpers.tpl
+++ b/charts/k8s-monitoring/charts/feature-integrations/templates/_helpers.tpl
@@ -45,7 +45,7 @@ If release name contains chart name it will be used as a full name.
 {{- end }}
 {{- end }}
 
-{{- define "commonRelabelings" }}
+{{- define "feature.integrations.commonDiscoveryRules" }}
 rule {
   source_labels = ["__meta_kubernetes_namespace"]
   target_label  = "namespace"
@@ -117,4 +117,21 @@ rule {
   replacement = "kubernetes"
   target_label = "source"
 }
+{{ include "feature.integrations.nodeDiscoveryRules" . }}
+{{- end }}
+
+{{- define "feature.integrations.attachNodeMetadata" }}
+{{- $attachMetadata := false -}}
+{{- $attachMetadata = or $attachMetadata .Values.nodeLabels.nodePool -}}
+{{- $attachMetadata = or $attachMetadata .Values.nodeLabels.region -}}
+{{- $attachMetadata = or $attachMetadata .Values.nodeLabels.availabilityZone -}}
+{{- $attachMetadata = or $attachMetadata .Values.nodeLabels.nodeRole -}}
+{{- $attachMetadata = or $attachMetadata .Values.nodeLabels.nodeOS -}}
+{{- $attachMetadata = or $attachMetadata .Values.nodeLabels.nodeArchitecture -}}
+{{- $attachMetadata = or $attachMetadata .Values.nodeLabels.instanceType -}}
+{{- if eq $attachMetadata true }}
+attach_metadata {
+  node = true
+}
+{{- end }}
 {{- end }}

--- a/charts/k8s-monitoring/charts/feature-integrations/templates/_integration_alloy.tpl
+++ b/charts/k8s-monitoring/charts/feature-integrations/templates/_integration_alloy.tpl
@@ -56,6 +56,7 @@ declare "alloy_integration" {
       namespaces {
         names = coalesce(argument.namespaces.value, [])
       }
+      {{- include "feature.integrations.attachNodeMetadata" . | nindent 6 }}
     }
 
     // alloy relabelings (pre-scrape)
@@ -75,7 +76,7 @@ declare "alloy_integration" {
         action = "keep"
       }
 
-      {{ include "commonRelabelings" . | nindent 4 }}
+      {{- include "feature.integrations.commonDiscoveryRules" . | nindent 6 }}
     }
 
     export "output" {

--- a/charts/k8s-monitoring/charts/feature-integrations/templates/_integration_grafana_metrics.tpl
+++ b/charts/k8s-monitoring/charts/feature-integrations/templates/_integration_grafana_metrics.tpl
@@ -55,6 +55,7 @@ declare "grafana_integration" {
       namespaces {
         names = coalesce(argument.namespaces.value, [])
       }
+      {{- include "feature.integrations.attachNodeMetadata" . | nindent 6 }}
     }
 
     // grafana relabelings (pre-scrape)
@@ -74,7 +75,7 @@ declare "grafana_integration" {
         action = "keep"
       }
 
-      {{ include "commonRelabelings" . | nindent 4 }}
+      {{ include "feature.integrations.commonDiscoveryRules" . | nindent 6 }}
     }
 
     export "output" {

--- a/charts/k8s-monitoring/charts/feature-integrations/templates/_integration_loki_metrics.tpl
+++ b/charts/k8s-monitoring/charts/feature-integrations/templates/_integration_loki_metrics.tpl
@@ -55,6 +55,7 @@ declare "loki_integration" {
       namespaces {
         names = coalesce(argument.namespaces.value, [])
       }
+      {{- include "feature.integrations.attachNodeMetadata" . | nindent 6 }}
     }
 
     // loki relabelings (pre-scrape)
@@ -81,7 +82,7 @@ declare "loki_integration" {
         target_label = "job"
       }
 
-      {{ include "commonRelabelings" . | nindent 4 }}
+      {{ include "feature.integrations.commonDiscoveryRules" . | nindent 6 }}
     }
 
     export "output" {

--- a/charts/k8s-monitoring/charts/feature-integrations/templates/_integration_mimir_metrics.tpl
+++ b/charts/k8s-monitoring/charts/feature-integrations/templates/_integration_mimir_metrics.tpl
@@ -55,6 +55,7 @@ declare "mimir_integration" {
       namespaces {
         names = coalesce(argument.namespaces.value, [])
       }
+      {{- include "feature.integrations.attachNodeMetadata" . | nindent 6 }}
     }
 
     // mimir relabelings (pre-scrape)
@@ -81,7 +82,7 @@ declare "mimir_integration" {
         target_label = "job"
       }
 
-      {{ include "commonRelabelings" . | nindent 4 }}
+      {{- include "feature.integrations.commonDiscoveryRules" . | nindent 6 }}
     }
 
     export "output" {

--- a/charts/k8s-monitoring/charts/feature-integrations/templates/_integration_tempo_metrics.tpl
+++ b/charts/k8s-monitoring/charts/feature-integrations/templates/_integration_tempo_metrics.tpl
@@ -55,6 +55,7 @@ declare "tempo_integration" {
       namespaces {
         names = coalesce(argument.namespaces.value, [])
       }
+      {{- include "feature.integrations.attachNodeMetadata" . | nindent 6 }}
     }
 
     // tempo relabelings (pre-scrape)
@@ -81,7 +82,7 @@ declare "tempo_integration" {
         target_label = "job"
       }
 
-      {{ include "commonRelabelings" . | nindent 4 }}
+      {{ include "feature.integrations.commonDiscoveryRules" . | nindent 6 }}
     }
 
     export "output" {

--- a/charts/k8s-monitoring/charts/feature-integrations/templates/_nodes_common.tpl
+++ b/charts/k8s-monitoring/charts/feature-integrations/templates/_nodes_common.tpl
@@ -1,0 +1,86 @@
+{{- define "feature.integrations.nodeDiscoveryRules" }}
+{{- if eq .Values.nodeLabels.nodePool true }}
+
+rule {
+  source_labels = [
+    "__meta_kubernetes_node_label_karpenter_sh_nodepool",
+    "__meta_kubernetes_node_label_cloud_google_com_gke_nodepool",
+    "__meta_kubernetes_node_label_eks_amazonaws_com_nodegroup",
+    "__meta_kubernetes_node_label_kubernetes_azure_com_agentpool",
+    "__meta_kubernetes_node_label_agentpool",
+  ]
+  regex = "^(?:;*)?([^;]+).*$"
+  target_label = "nodepool"
+}
+{{- end }}
+{{- if eq .Values.nodeLabels.region true }}
+
+rule {
+  source_labels = [
+    "__meta_kubernetes_node_label_topology_kubernetes_io_region",
+    "__meta_kubernetes_node_label_failure_domain_beta_kubernetes_io_region",
+  ]
+  regex = "^(?:;*)?([^;]+).*$"
+  target_label = "region"
+}
+{{- end }}
+{{- if eq .Values.nodeLabels.availabilityZone true }}
+
+rule {
+  source_labels = [
+    "__meta_kubernetes_node_label_topology_kubernetes_io_zone",
+    "__meta_kubernetes_node_label_failure_domain_beta_kubernetes_io_zone",
+    "__meta_kubernetes_node_label_topology_gke_io_zone",
+  ]
+  regex = "^(?:;*)?([^;]+).*$"
+  target_label = "availability_zone"
+}
+{{- end }}
+{{- if eq .Values.nodeLabels.nodeRole true }}
+
+rule {
+  source_labels = [
+    "__meta_kubernetes_node_label_kubernetes_io_role",
+    "__meta_kubernetes_node_label_node_kubernetes_io_role",
+    "__meta_kubernetes_node_label_node_role",
+    "__meta_kubernetes_node_label_role",
+  ]
+  regex = "^(?:;*)?([^;]+).*$"
+  target_label = "node_role"
+}
+{{- end }}
+{{- if eq .Values.nodeLabels.nodeOS true }}
+
+rule {
+  source_labels = [
+    "__meta_kubernetes_node_label_kubernetes_io_os",
+    "__meta_kubernetes_node_label_os_kubernetes_io",
+    "__meta_kubernetes_node_label_os",
+  ]
+  regex = "^(?:;*)?([^;]+).*$"
+  target_label = "os"
+}
+{{- end }}
+{{- if eq .Values.nodeLabels.nodeArchitecture true }}
+
+rule {
+  source_labels = [
+    "__meta_kubernetes_node_label_kubernetes_io_arch",
+    "__meta_kubernetes_node_label_beta_kubernetes_io_arch",
+  ]
+  regex = "^(?:;*)?([^;]+).*$"
+  target_label = "architecture"
+}
+{{- end }}
+{{- if eq .Values.nodeLabels.instanceType true }}
+
+rule {
+  source_labels = [
+    "__meta_kubernetes_node_label_node_kubernetes_io_instance_type",
+    "__meta_kubernetes_node_label_beta_kubernetes_io_instance_type",
+  ]
+  regex = "^(?:;*)?([^;]+).*$"
+  target_label = "instance_type"
+}
+{{- end }}
+{{- end }}

--- a/charts/k8s-monitoring/charts/feature-integrations/tests/__snapshot__/alloy_test.yaml.snap
+++ b/charts/k8s-monitoring/charts/feature-integrations/tests/__snapshot__/alloy_test.yaml.snap
@@ -40,6 +40,7 @@ should create the Alloy config:
             namespaces {
               names = coalesce(argument.namespaces.value, [])
             }
+
           }
 
           // alloy relabelings (pre-scrape)
@@ -59,79 +60,78 @@ should create the Alloy config:
               action = "keep"
             }
 
+            rule {
+              source_labels = ["__meta_kubernetes_namespace"]
+              target_label  = "namespace"
+            }
 
+            rule {
+              source_labels = ["__meta_kubernetes_pod_name"]
+              target_label  = "pod"
+            }
 
-          rule {
-            source_labels = ["__meta_kubernetes_namespace"]
-            target_label  = "namespace"
-          }
+            rule {
+              source_labels = ["__meta_kubernetes_pod_container_name"]
+              target_label  = "container"
+            }
 
-          rule {
-            source_labels = ["__meta_kubernetes_pod_name"]
-            target_label  = "pod"
-          }
+            // set the workload to the controller kind and name
+            rule {
+              action = "lowercase"
+              source_labels = ["__meta_kubernetes_pod_controller_kind"]
+              target_label  = "workload_type"
+            }
 
-          rule {
-            source_labels = ["__meta_kubernetes_pod_container_name"]
-            target_label  = "container"
-          }
+            rule {
+              source_labels = ["__meta_kubernetes_pod_controller_name"]
+              target_label  = "workload"
+            }
 
-          // set the workload to the controller kind and name
-          rule {
-            action = "lowercase"
-            source_labels = ["__meta_kubernetes_pod_controller_kind"]
-            target_label  = "workload_type"
-          }
+            // remove the hash from the ReplicaSet
+            rule {
+              source_labels = [
+                "workload_type",
+                "workload",
+              ]
+              separator = "/"
+              regex = "replicaset/(.+)-.+$"
+              target_label  = "workload"
+            }
 
-          rule {
-            source_labels = ["__meta_kubernetes_pod_controller_name"]
-            target_label  = "workload"
-          }
+            // set the app name if specified as metadata labels "app:" or "app.kubernetes.io/name:" or "k8s-app:"
+            rule {
+              action = "replace"
+              source_labels = [
+                "__meta_kubernetes_pod_label_app_kubernetes_io_name",
+                "__meta_kubernetes_pod_label_k8s_app",
+                "__meta_kubernetes_pod_label_app",
+              ]
+              separator = ";"
+              regex = "^(?:;*)?([^;]+).*$"
+              replacement = "$1"
+              target_label = "app"
+            }
 
-          // remove the hash from the ReplicaSet
-          rule {
-            source_labels = [
-              "workload_type",
-              "workload",
-            ]
-            separator = "/"
-            regex = "replicaset/(.+)-.+$"
-            target_label  = "workload"
-          }
+            // set the component if specified as metadata labels "component:" or "app.kubernetes.io/component:" or "k8s-component:"
+            rule {
+              action = "replace"
+              source_labels = [
+                "__meta_kubernetes_pod_label_app_kubernetes_io_component",
+                "__meta_kubernetes_pod_label_k8s_component",
+                "__meta_kubernetes_pod_label_component",
+              ]
+              regex = "^(?:;*)?([^;]+).*$"
+              replacement = "$1"
+              target_label = "component"
+            }
 
-          // set the app name if specified as metadata labels "app:" or "app.kubernetes.io/name:" or "k8s-app:"
-          rule {
-            action = "replace"
-            source_labels = [
-              "__meta_kubernetes_pod_label_app_kubernetes_io_name",
-              "__meta_kubernetes_pod_label_k8s_app",
-              "__meta_kubernetes_pod_label_app",
-            ]
-            separator = ";"
-            regex = "^(?:;*)?([^;]+).*$"
-            replacement = "$1"
-            target_label = "app"
-          }
+            // set a source label
+            rule {
+              action = "replace"
+              replacement = "kubernetes"
+              target_label = "source"
+            }
 
-          // set the component if specified as metadata labels "component:" or "app.kubernetes.io/component:" or "k8s-component:"
-          rule {
-            action = "replace"
-            source_labels = [
-              "__meta_kubernetes_pod_label_app_kubernetes_io_component",
-              "__meta_kubernetes_pod_label_k8s_component",
-              "__meta_kubernetes_pod_label_component",
-            ]
-            regex = "^(?:;*)?([^;]+).*$"
-            replacement = "$1"
-            target_label = "component"
-          }
-
-          // set a source label
-          rule {
-            action = "replace"
-            replacement = "kubernetes"
-            target_label = "source"
-          }
           }
 
           export "output" {

--- a/charts/k8s-monitoring/charts/feature-integrations/tests/__snapshot__/grafana_logs_test.yaml.snap
+++ b/charts/k8s-monitoring/charts/feature-integrations/tests/__snapshot__/grafana_logs_test.yaml.snap
@@ -40,6 +40,7 @@ should add the grafana processing stage to the logs config:
             namespaces {
               names = coalesce(argument.namespaces.value, [])
             }
+
           }
 
           // grafana relabelings (pre-scrape)
@@ -61,77 +62,78 @@ should add the grafana processing stage to the logs config:
 
 
 
-          rule {
-            source_labels = ["__meta_kubernetes_namespace"]
-            target_label  = "namespace"
-          }
+            rule {
+              source_labels = ["__meta_kubernetes_namespace"]
+              target_label  = "namespace"
+            }
 
-          rule {
-            source_labels = ["__meta_kubernetes_pod_name"]
-            target_label  = "pod"
-          }
+            rule {
+              source_labels = ["__meta_kubernetes_pod_name"]
+              target_label  = "pod"
+            }
 
-          rule {
-            source_labels = ["__meta_kubernetes_pod_container_name"]
-            target_label  = "container"
-          }
+            rule {
+              source_labels = ["__meta_kubernetes_pod_container_name"]
+              target_label  = "container"
+            }
 
-          // set the workload to the controller kind and name
-          rule {
-            action = "lowercase"
-            source_labels = ["__meta_kubernetes_pod_controller_kind"]
-            target_label  = "workload_type"
-          }
+            // set the workload to the controller kind and name
+            rule {
+              action = "lowercase"
+              source_labels = ["__meta_kubernetes_pod_controller_kind"]
+              target_label  = "workload_type"
+            }
 
-          rule {
-            source_labels = ["__meta_kubernetes_pod_controller_name"]
-            target_label  = "workload"
-          }
+            rule {
+              source_labels = ["__meta_kubernetes_pod_controller_name"]
+              target_label  = "workload"
+            }
 
-          // remove the hash from the ReplicaSet
-          rule {
-            source_labels = [
-              "workload_type",
-              "workload",
-            ]
-            separator = "/"
-            regex = "replicaset/(.+)-.+$"
-            target_label  = "workload"
-          }
+            // remove the hash from the ReplicaSet
+            rule {
+              source_labels = [
+                "workload_type",
+                "workload",
+              ]
+              separator = "/"
+              regex = "replicaset/(.+)-.+$"
+              target_label  = "workload"
+            }
 
-          // set the app name if specified as metadata labels "app:" or "app.kubernetes.io/name:" or "k8s-app:"
-          rule {
-            action = "replace"
-            source_labels = [
-              "__meta_kubernetes_pod_label_app_kubernetes_io_name",
-              "__meta_kubernetes_pod_label_k8s_app",
-              "__meta_kubernetes_pod_label_app",
-            ]
-            separator = ";"
-            regex = "^(?:;*)?([^;]+).*$"
-            replacement = "$1"
-            target_label = "app"
-          }
+            // set the app name if specified as metadata labels "app:" or "app.kubernetes.io/name:" or "k8s-app:"
+            rule {
+              action = "replace"
+              source_labels = [
+                "__meta_kubernetes_pod_label_app_kubernetes_io_name",
+                "__meta_kubernetes_pod_label_k8s_app",
+                "__meta_kubernetes_pod_label_app",
+              ]
+              separator = ";"
+              regex = "^(?:;*)?([^;]+).*$"
+              replacement = "$1"
+              target_label = "app"
+            }
 
-          // set the component if specified as metadata labels "component:" or "app.kubernetes.io/component:" or "k8s-component:"
-          rule {
-            action = "replace"
-            source_labels = [
-              "__meta_kubernetes_pod_label_app_kubernetes_io_component",
-              "__meta_kubernetes_pod_label_k8s_component",
-              "__meta_kubernetes_pod_label_component",
-            ]
-            regex = "^(?:;*)?([^;]+).*$"
-            replacement = "$1"
-            target_label = "component"
-          }
+            // set the component if specified as metadata labels "component:" or "app.kubernetes.io/component:" or "k8s-component:"
+            rule {
+              action = "replace"
+              source_labels = [
+                "__meta_kubernetes_pod_label_app_kubernetes_io_component",
+                "__meta_kubernetes_pod_label_k8s_component",
+                "__meta_kubernetes_pod_label_component",
+              ]
+              regex = "^(?:;*)?([^;]+).*$"
+              replacement = "$1"
+              target_label = "component"
+            }
 
-          // set a source label
-          rule {
-            action = "replace"
-            replacement = "kubernetes"
-            target_label = "source"
-          }
+            // set a source label
+            rule {
+              action = "replace"
+              replacement = "kubernetes"
+              target_label = "source"
+            }
+
           }
 
           export "output" {

--- a/charts/k8s-monitoring/charts/feature-integrations/tests/__snapshot__/grafana_metrics_test.yaml.snap
+++ b/charts/k8s-monitoring/charts/feature-integrations/tests/__snapshot__/grafana_metrics_test.yaml.snap
@@ -40,6 +40,7 @@ should create the grafana metrics config:
             namespaces {
               names = coalesce(argument.namespaces.value, [])
             }
+
           }
 
           // grafana relabelings (pre-scrape)
@@ -61,77 +62,78 @@ should create the grafana metrics config:
 
 
 
-          rule {
-            source_labels = ["__meta_kubernetes_namespace"]
-            target_label  = "namespace"
-          }
+            rule {
+              source_labels = ["__meta_kubernetes_namespace"]
+              target_label  = "namespace"
+            }
 
-          rule {
-            source_labels = ["__meta_kubernetes_pod_name"]
-            target_label  = "pod"
-          }
+            rule {
+              source_labels = ["__meta_kubernetes_pod_name"]
+              target_label  = "pod"
+            }
 
-          rule {
-            source_labels = ["__meta_kubernetes_pod_container_name"]
-            target_label  = "container"
-          }
+            rule {
+              source_labels = ["__meta_kubernetes_pod_container_name"]
+              target_label  = "container"
+            }
 
-          // set the workload to the controller kind and name
-          rule {
-            action = "lowercase"
-            source_labels = ["__meta_kubernetes_pod_controller_kind"]
-            target_label  = "workload_type"
-          }
+            // set the workload to the controller kind and name
+            rule {
+              action = "lowercase"
+              source_labels = ["__meta_kubernetes_pod_controller_kind"]
+              target_label  = "workload_type"
+            }
 
-          rule {
-            source_labels = ["__meta_kubernetes_pod_controller_name"]
-            target_label  = "workload"
-          }
+            rule {
+              source_labels = ["__meta_kubernetes_pod_controller_name"]
+              target_label  = "workload"
+            }
 
-          // remove the hash from the ReplicaSet
-          rule {
-            source_labels = [
-              "workload_type",
-              "workload",
-            ]
-            separator = "/"
-            regex = "replicaset/(.+)-.+$"
-            target_label  = "workload"
-          }
+            // remove the hash from the ReplicaSet
+            rule {
+              source_labels = [
+                "workload_type",
+                "workload",
+              ]
+              separator = "/"
+              regex = "replicaset/(.+)-.+$"
+              target_label  = "workload"
+            }
 
-          // set the app name if specified as metadata labels "app:" or "app.kubernetes.io/name:" or "k8s-app:"
-          rule {
-            action = "replace"
-            source_labels = [
-              "__meta_kubernetes_pod_label_app_kubernetes_io_name",
-              "__meta_kubernetes_pod_label_k8s_app",
-              "__meta_kubernetes_pod_label_app",
-            ]
-            separator = ";"
-            regex = "^(?:;*)?([^;]+).*$"
-            replacement = "$1"
-            target_label = "app"
-          }
+            // set the app name if specified as metadata labels "app:" or "app.kubernetes.io/name:" or "k8s-app:"
+            rule {
+              action = "replace"
+              source_labels = [
+                "__meta_kubernetes_pod_label_app_kubernetes_io_name",
+                "__meta_kubernetes_pod_label_k8s_app",
+                "__meta_kubernetes_pod_label_app",
+              ]
+              separator = ";"
+              regex = "^(?:;*)?([^;]+).*$"
+              replacement = "$1"
+              target_label = "app"
+            }
 
-          // set the component if specified as metadata labels "component:" or "app.kubernetes.io/component:" or "k8s-component:"
-          rule {
-            action = "replace"
-            source_labels = [
-              "__meta_kubernetes_pod_label_app_kubernetes_io_component",
-              "__meta_kubernetes_pod_label_k8s_component",
-              "__meta_kubernetes_pod_label_component",
-            ]
-            regex = "^(?:;*)?([^;]+).*$"
-            replacement = "$1"
-            target_label = "component"
-          }
+            // set the component if specified as metadata labels "component:" or "app.kubernetes.io/component:" or "k8s-component:"
+            rule {
+              action = "replace"
+              source_labels = [
+                "__meta_kubernetes_pod_label_app_kubernetes_io_component",
+                "__meta_kubernetes_pod_label_k8s_component",
+                "__meta_kubernetes_pod_label_component",
+              ]
+              regex = "^(?:;*)?([^;]+).*$"
+              replacement = "$1"
+              target_label = "component"
+            }
 
-          // set a source label
-          rule {
-            action = "replace"
-            replacement = "kubernetes"
-            target_label = "source"
-          }
+            // set a source label
+            rule {
+              action = "replace"
+              replacement = "kubernetes"
+              target_label = "source"
+            }
+
           }
 
           export "output" {

--- a/charts/k8s-monitoring/charts/feature-integrations/tests/__snapshot__/loki_logs_test.yaml.snap
+++ b/charts/k8s-monitoring/charts/feature-integrations/tests/__snapshot__/loki_logs_test.yaml.snap
@@ -40,6 +40,7 @@ should add the Loki processing stage to the logs config:
             namespaces {
               names = coalesce(argument.namespaces.value, [])
             }
+
           }
 
           // loki relabelings (pre-scrape)
@@ -68,77 +69,78 @@ should add the Loki processing stage to the logs config:
 
 
 
-          rule {
-            source_labels = ["__meta_kubernetes_namespace"]
-            target_label  = "namespace"
-          }
+            rule {
+              source_labels = ["__meta_kubernetes_namespace"]
+              target_label  = "namespace"
+            }
 
-          rule {
-            source_labels = ["__meta_kubernetes_pod_name"]
-            target_label  = "pod"
-          }
+            rule {
+              source_labels = ["__meta_kubernetes_pod_name"]
+              target_label  = "pod"
+            }
 
-          rule {
-            source_labels = ["__meta_kubernetes_pod_container_name"]
-            target_label  = "container"
-          }
+            rule {
+              source_labels = ["__meta_kubernetes_pod_container_name"]
+              target_label  = "container"
+            }
 
-          // set the workload to the controller kind and name
-          rule {
-            action = "lowercase"
-            source_labels = ["__meta_kubernetes_pod_controller_kind"]
-            target_label  = "workload_type"
-          }
+            // set the workload to the controller kind and name
+            rule {
+              action = "lowercase"
+              source_labels = ["__meta_kubernetes_pod_controller_kind"]
+              target_label  = "workload_type"
+            }
 
-          rule {
-            source_labels = ["__meta_kubernetes_pod_controller_name"]
-            target_label  = "workload"
-          }
+            rule {
+              source_labels = ["__meta_kubernetes_pod_controller_name"]
+              target_label  = "workload"
+            }
 
-          // remove the hash from the ReplicaSet
-          rule {
-            source_labels = [
-              "workload_type",
-              "workload",
-            ]
-            separator = "/"
-            regex = "replicaset/(.+)-.+$"
-            target_label  = "workload"
-          }
+            // remove the hash from the ReplicaSet
+            rule {
+              source_labels = [
+                "workload_type",
+                "workload",
+              ]
+              separator = "/"
+              regex = "replicaset/(.+)-.+$"
+              target_label  = "workload"
+            }
 
-          // set the app name if specified as metadata labels "app:" or "app.kubernetes.io/name:" or "k8s-app:"
-          rule {
-            action = "replace"
-            source_labels = [
-              "__meta_kubernetes_pod_label_app_kubernetes_io_name",
-              "__meta_kubernetes_pod_label_k8s_app",
-              "__meta_kubernetes_pod_label_app",
-            ]
-            separator = ";"
-            regex = "^(?:;*)?([^;]+).*$"
-            replacement = "$1"
-            target_label = "app"
-          }
+            // set the app name if specified as metadata labels "app:" or "app.kubernetes.io/name:" or "k8s-app:"
+            rule {
+              action = "replace"
+              source_labels = [
+                "__meta_kubernetes_pod_label_app_kubernetes_io_name",
+                "__meta_kubernetes_pod_label_k8s_app",
+                "__meta_kubernetes_pod_label_app",
+              ]
+              separator = ";"
+              regex = "^(?:;*)?([^;]+).*$"
+              replacement = "$1"
+              target_label = "app"
+            }
 
-          // set the component if specified as metadata labels "component:" or "app.kubernetes.io/component:" or "k8s-component:"
-          rule {
-            action = "replace"
-            source_labels = [
-              "__meta_kubernetes_pod_label_app_kubernetes_io_component",
-              "__meta_kubernetes_pod_label_k8s_component",
-              "__meta_kubernetes_pod_label_component",
-            ]
-            regex = "^(?:;*)?([^;]+).*$"
-            replacement = "$1"
-            target_label = "component"
-          }
+            // set the component if specified as metadata labels "component:" or "app.kubernetes.io/component:" or "k8s-component:"
+            rule {
+              action = "replace"
+              source_labels = [
+                "__meta_kubernetes_pod_label_app_kubernetes_io_component",
+                "__meta_kubernetes_pod_label_k8s_component",
+                "__meta_kubernetes_pod_label_component",
+              ]
+              regex = "^(?:;*)?([^;]+).*$"
+              replacement = "$1"
+              target_label = "component"
+            }
 
-          // set a source label
-          rule {
-            action = "replace"
-            replacement = "kubernetes"
-            target_label = "source"
-          }
+            // set a source label
+            rule {
+              action = "replace"
+              replacement = "kubernetes"
+              target_label = "source"
+            }
+
           }
 
           export "output" {

--- a/charts/k8s-monitoring/charts/feature-integrations/tests/__snapshot__/loki_metrics_test.yaml.snap
+++ b/charts/k8s-monitoring/charts/feature-integrations/tests/__snapshot__/loki_metrics_test.yaml.snap
@@ -40,6 +40,7 @@ should create the loki metrics config:
             namespaces {
               names = coalesce(argument.namespaces.value, [])
             }
+
           }
 
           // loki relabelings (pre-scrape)
@@ -68,77 +69,78 @@ should create the loki metrics config:
 
 
 
-          rule {
-            source_labels = ["__meta_kubernetes_namespace"]
-            target_label  = "namespace"
-          }
+            rule {
+              source_labels = ["__meta_kubernetes_namespace"]
+              target_label  = "namespace"
+            }
 
-          rule {
-            source_labels = ["__meta_kubernetes_pod_name"]
-            target_label  = "pod"
-          }
+            rule {
+              source_labels = ["__meta_kubernetes_pod_name"]
+              target_label  = "pod"
+            }
 
-          rule {
-            source_labels = ["__meta_kubernetes_pod_container_name"]
-            target_label  = "container"
-          }
+            rule {
+              source_labels = ["__meta_kubernetes_pod_container_name"]
+              target_label  = "container"
+            }
 
-          // set the workload to the controller kind and name
-          rule {
-            action = "lowercase"
-            source_labels = ["__meta_kubernetes_pod_controller_kind"]
-            target_label  = "workload_type"
-          }
+            // set the workload to the controller kind and name
+            rule {
+              action = "lowercase"
+              source_labels = ["__meta_kubernetes_pod_controller_kind"]
+              target_label  = "workload_type"
+            }
 
-          rule {
-            source_labels = ["__meta_kubernetes_pod_controller_name"]
-            target_label  = "workload"
-          }
+            rule {
+              source_labels = ["__meta_kubernetes_pod_controller_name"]
+              target_label  = "workload"
+            }
 
-          // remove the hash from the ReplicaSet
-          rule {
-            source_labels = [
-              "workload_type",
-              "workload",
-            ]
-            separator = "/"
-            regex = "replicaset/(.+)-.+$"
-            target_label  = "workload"
-          }
+            // remove the hash from the ReplicaSet
+            rule {
+              source_labels = [
+                "workload_type",
+                "workload",
+              ]
+              separator = "/"
+              regex = "replicaset/(.+)-.+$"
+              target_label  = "workload"
+            }
 
-          // set the app name if specified as metadata labels "app:" or "app.kubernetes.io/name:" or "k8s-app:"
-          rule {
-            action = "replace"
-            source_labels = [
-              "__meta_kubernetes_pod_label_app_kubernetes_io_name",
-              "__meta_kubernetes_pod_label_k8s_app",
-              "__meta_kubernetes_pod_label_app",
-            ]
-            separator = ";"
-            regex = "^(?:;*)?([^;]+).*$"
-            replacement = "$1"
-            target_label = "app"
-          }
+            // set the app name if specified as metadata labels "app:" or "app.kubernetes.io/name:" or "k8s-app:"
+            rule {
+              action = "replace"
+              source_labels = [
+                "__meta_kubernetes_pod_label_app_kubernetes_io_name",
+                "__meta_kubernetes_pod_label_k8s_app",
+                "__meta_kubernetes_pod_label_app",
+              ]
+              separator = ";"
+              regex = "^(?:;*)?([^;]+).*$"
+              replacement = "$1"
+              target_label = "app"
+            }
 
-          // set the component if specified as metadata labels "component:" or "app.kubernetes.io/component:" or "k8s-component:"
-          rule {
-            action = "replace"
-            source_labels = [
-              "__meta_kubernetes_pod_label_app_kubernetes_io_component",
-              "__meta_kubernetes_pod_label_k8s_component",
-              "__meta_kubernetes_pod_label_component",
-            ]
-            regex = "^(?:;*)?([^;]+).*$"
-            replacement = "$1"
-            target_label = "component"
-          }
+            // set the component if specified as metadata labels "component:" or "app.kubernetes.io/component:" or "k8s-component:"
+            rule {
+              action = "replace"
+              source_labels = [
+                "__meta_kubernetes_pod_label_app_kubernetes_io_component",
+                "__meta_kubernetes_pod_label_k8s_component",
+                "__meta_kubernetes_pod_label_component",
+              ]
+              regex = "^(?:;*)?([^;]+).*$"
+              replacement = "$1"
+              target_label = "component"
+            }
 
-          // set a source label
-          rule {
-            action = "replace"
-            replacement = "kubernetes"
-            target_label = "source"
-          }
+            // set a source label
+            rule {
+              action = "replace"
+              replacement = "kubernetes"
+              target_label = "source"
+            }
+
           }
 
           export "output" {

--- a/charts/k8s-monitoring/charts/feature-integrations/tests/__snapshot__/mimir_logs_test.yaml.snap
+++ b/charts/k8s-monitoring/charts/feature-integrations/tests/__snapshot__/mimir_logs_test.yaml.snap
@@ -40,6 +40,7 @@ should add the Mimir processing stage to the logs config:
             namespaces {
               names = coalesce(argument.namespaces.value, [])
             }
+
           }
 
           // mimir relabelings (pre-scrape)
@@ -66,79 +67,78 @@ should add the Mimir processing stage to the logs config:
               target_label = "job"
             }
 
+            rule {
+              source_labels = ["__meta_kubernetes_namespace"]
+              target_label  = "namespace"
+            }
 
+            rule {
+              source_labels = ["__meta_kubernetes_pod_name"]
+              target_label  = "pod"
+            }
 
-          rule {
-            source_labels = ["__meta_kubernetes_namespace"]
-            target_label  = "namespace"
-          }
+            rule {
+              source_labels = ["__meta_kubernetes_pod_container_name"]
+              target_label  = "container"
+            }
 
-          rule {
-            source_labels = ["__meta_kubernetes_pod_name"]
-            target_label  = "pod"
-          }
+            // set the workload to the controller kind and name
+            rule {
+              action = "lowercase"
+              source_labels = ["__meta_kubernetes_pod_controller_kind"]
+              target_label  = "workload_type"
+            }
 
-          rule {
-            source_labels = ["__meta_kubernetes_pod_container_name"]
-            target_label  = "container"
-          }
+            rule {
+              source_labels = ["__meta_kubernetes_pod_controller_name"]
+              target_label  = "workload"
+            }
 
-          // set the workload to the controller kind and name
-          rule {
-            action = "lowercase"
-            source_labels = ["__meta_kubernetes_pod_controller_kind"]
-            target_label  = "workload_type"
-          }
+            // remove the hash from the ReplicaSet
+            rule {
+              source_labels = [
+                "workload_type",
+                "workload",
+              ]
+              separator = "/"
+              regex = "replicaset/(.+)-.+$"
+              target_label  = "workload"
+            }
 
-          rule {
-            source_labels = ["__meta_kubernetes_pod_controller_name"]
-            target_label  = "workload"
-          }
+            // set the app name if specified as metadata labels "app:" or "app.kubernetes.io/name:" or "k8s-app:"
+            rule {
+              action = "replace"
+              source_labels = [
+                "__meta_kubernetes_pod_label_app_kubernetes_io_name",
+                "__meta_kubernetes_pod_label_k8s_app",
+                "__meta_kubernetes_pod_label_app",
+              ]
+              separator = ";"
+              regex = "^(?:;*)?([^;]+).*$"
+              replacement = "$1"
+              target_label = "app"
+            }
 
-          // remove the hash from the ReplicaSet
-          rule {
-            source_labels = [
-              "workload_type",
-              "workload",
-            ]
-            separator = "/"
-            regex = "replicaset/(.+)-.+$"
-            target_label  = "workload"
-          }
+            // set the component if specified as metadata labels "component:" or "app.kubernetes.io/component:" or "k8s-component:"
+            rule {
+              action = "replace"
+              source_labels = [
+                "__meta_kubernetes_pod_label_app_kubernetes_io_component",
+                "__meta_kubernetes_pod_label_k8s_component",
+                "__meta_kubernetes_pod_label_component",
+              ]
+              regex = "^(?:;*)?([^;]+).*$"
+              replacement = "$1"
+              target_label = "component"
+            }
 
-          // set the app name if specified as metadata labels "app:" or "app.kubernetes.io/name:" or "k8s-app:"
-          rule {
-            action = "replace"
-            source_labels = [
-              "__meta_kubernetes_pod_label_app_kubernetes_io_name",
-              "__meta_kubernetes_pod_label_k8s_app",
-              "__meta_kubernetes_pod_label_app",
-            ]
-            separator = ";"
-            regex = "^(?:;*)?([^;]+).*$"
-            replacement = "$1"
-            target_label = "app"
-          }
+            // set a source label
+            rule {
+              action = "replace"
+              replacement = "kubernetes"
+              target_label = "source"
+            }
 
-          // set the component if specified as metadata labels "component:" or "app.kubernetes.io/component:" or "k8s-component:"
-          rule {
-            action = "replace"
-            source_labels = [
-              "__meta_kubernetes_pod_label_app_kubernetes_io_component",
-              "__meta_kubernetes_pod_label_k8s_component",
-              "__meta_kubernetes_pod_label_component",
-            ]
-            regex = "^(?:;*)?([^;]+).*$"
-            replacement = "$1"
-            target_label = "component"
-          }
-
-          // set a source label
-          rule {
-            action = "replace"
-            replacement = "kubernetes"
-            target_label = "source"
-          }
           }
 
           export "output" {

--- a/charts/k8s-monitoring/charts/feature-integrations/tests/__snapshot__/mimir_metrics_test.yaml.snap
+++ b/charts/k8s-monitoring/charts/feature-integrations/tests/__snapshot__/mimir_metrics_test.yaml.snap
@@ -40,6 +40,7 @@ should create the mimir metrics config:
             namespaces {
               names = coalesce(argument.namespaces.value, [])
             }
+
           }
 
           // mimir relabelings (pre-scrape)
@@ -66,79 +67,78 @@ should create the mimir metrics config:
               target_label = "job"
             }
 
+            rule {
+              source_labels = ["__meta_kubernetes_namespace"]
+              target_label  = "namespace"
+            }
 
+            rule {
+              source_labels = ["__meta_kubernetes_pod_name"]
+              target_label  = "pod"
+            }
 
-          rule {
-            source_labels = ["__meta_kubernetes_namespace"]
-            target_label  = "namespace"
-          }
+            rule {
+              source_labels = ["__meta_kubernetes_pod_container_name"]
+              target_label  = "container"
+            }
 
-          rule {
-            source_labels = ["__meta_kubernetes_pod_name"]
-            target_label  = "pod"
-          }
+            // set the workload to the controller kind and name
+            rule {
+              action = "lowercase"
+              source_labels = ["__meta_kubernetes_pod_controller_kind"]
+              target_label  = "workload_type"
+            }
 
-          rule {
-            source_labels = ["__meta_kubernetes_pod_container_name"]
-            target_label  = "container"
-          }
+            rule {
+              source_labels = ["__meta_kubernetes_pod_controller_name"]
+              target_label  = "workload"
+            }
 
-          // set the workload to the controller kind and name
-          rule {
-            action = "lowercase"
-            source_labels = ["__meta_kubernetes_pod_controller_kind"]
-            target_label  = "workload_type"
-          }
+            // remove the hash from the ReplicaSet
+            rule {
+              source_labels = [
+                "workload_type",
+                "workload",
+              ]
+              separator = "/"
+              regex = "replicaset/(.+)-.+$"
+              target_label  = "workload"
+            }
 
-          rule {
-            source_labels = ["__meta_kubernetes_pod_controller_name"]
-            target_label  = "workload"
-          }
+            // set the app name if specified as metadata labels "app:" or "app.kubernetes.io/name:" or "k8s-app:"
+            rule {
+              action = "replace"
+              source_labels = [
+                "__meta_kubernetes_pod_label_app_kubernetes_io_name",
+                "__meta_kubernetes_pod_label_k8s_app",
+                "__meta_kubernetes_pod_label_app",
+              ]
+              separator = ";"
+              regex = "^(?:;*)?([^;]+).*$"
+              replacement = "$1"
+              target_label = "app"
+            }
 
-          // remove the hash from the ReplicaSet
-          rule {
-            source_labels = [
-              "workload_type",
-              "workload",
-            ]
-            separator = "/"
-            regex = "replicaset/(.+)-.+$"
-            target_label  = "workload"
-          }
+            // set the component if specified as metadata labels "component:" or "app.kubernetes.io/component:" or "k8s-component:"
+            rule {
+              action = "replace"
+              source_labels = [
+                "__meta_kubernetes_pod_label_app_kubernetes_io_component",
+                "__meta_kubernetes_pod_label_k8s_component",
+                "__meta_kubernetes_pod_label_component",
+              ]
+              regex = "^(?:;*)?([^;]+).*$"
+              replacement = "$1"
+              target_label = "component"
+            }
 
-          // set the app name if specified as metadata labels "app:" or "app.kubernetes.io/name:" or "k8s-app:"
-          rule {
-            action = "replace"
-            source_labels = [
-              "__meta_kubernetes_pod_label_app_kubernetes_io_name",
-              "__meta_kubernetes_pod_label_k8s_app",
-              "__meta_kubernetes_pod_label_app",
-            ]
-            separator = ";"
-            regex = "^(?:;*)?([^;]+).*$"
-            replacement = "$1"
-            target_label = "app"
-          }
+            // set a source label
+            rule {
+              action = "replace"
+              replacement = "kubernetes"
+              target_label = "source"
+            }
 
-          // set the component if specified as metadata labels "component:" or "app.kubernetes.io/component:" or "k8s-component:"
-          rule {
-            action = "replace"
-            source_labels = [
-              "__meta_kubernetes_pod_label_app_kubernetes_io_component",
-              "__meta_kubernetes_pod_label_k8s_component",
-              "__meta_kubernetes_pod_label_component",
-            ]
-            regex = "^(?:;*)?([^;]+).*$"
-            replacement = "$1"
-            target_label = "component"
-          }
-
-          // set a source label
-          rule {
-            action = "replace"
-            replacement = "kubernetes"
-            target_label = "source"
-          }
           }
 
           export "output" {

--- a/charts/k8s-monitoring/charts/feature-integrations/tests/__snapshot__/tempo_logs_test.yaml.snap
+++ b/charts/k8s-monitoring/charts/feature-integrations/tests/__snapshot__/tempo_logs_test.yaml.snap
@@ -40,6 +40,7 @@ should add the Tempo processing stage to the logs config:
             namespaces {
               names = coalesce(argument.namespaces.value, [])
             }
+
           }
 
           // tempo relabelings (pre-scrape)
@@ -68,77 +69,78 @@ should add the Tempo processing stage to the logs config:
 
 
 
-          rule {
-            source_labels = ["__meta_kubernetes_namespace"]
-            target_label  = "namespace"
-          }
+            rule {
+              source_labels = ["__meta_kubernetes_namespace"]
+              target_label  = "namespace"
+            }
 
-          rule {
-            source_labels = ["__meta_kubernetes_pod_name"]
-            target_label  = "pod"
-          }
+            rule {
+              source_labels = ["__meta_kubernetes_pod_name"]
+              target_label  = "pod"
+            }
 
-          rule {
-            source_labels = ["__meta_kubernetes_pod_container_name"]
-            target_label  = "container"
-          }
+            rule {
+              source_labels = ["__meta_kubernetes_pod_container_name"]
+              target_label  = "container"
+            }
 
-          // set the workload to the controller kind and name
-          rule {
-            action = "lowercase"
-            source_labels = ["__meta_kubernetes_pod_controller_kind"]
-            target_label  = "workload_type"
-          }
+            // set the workload to the controller kind and name
+            rule {
+              action = "lowercase"
+              source_labels = ["__meta_kubernetes_pod_controller_kind"]
+              target_label  = "workload_type"
+            }
 
-          rule {
-            source_labels = ["__meta_kubernetes_pod_controller_name"]
-            target_label  = "workload"
-          }
+            rule {
+              source_labels = ["__meta_kubernetes_pod_controller_name"]
+              target_label  = "workload"
+            }
 
-          // remove the hash from the ReplicaSet
-          rule {
-            source_labels = [
-              "workload_type",
-              "workload",
-            ]
-            separator = "/"
-            regex = "replicaset/(.+)-.+$"
-            target_label  = "workload"
-          }
+            // remove the hash from the ReplicaSet
+            rule {
+              source_labels = [
+                "workload_type",
+                "workload",
+              ]
+              separator = "/"
+              regex = "replicaset/(.+)-.+$"
+              target_label  = "workload"
+            }
 
-          // set the app name if specified as metadata labels "app:" or "app.kubernetes.io/name:" or "k8s-app:"
-          rule {
-            action = "replace"
-            source_labels = [
-              "__meta_kubernetes_pod_label_app_kubernetes_io_name",
-              "__meta_kubernetes_pod_label_k8s_app",
-              "__meta_kubernetes_pod_label_app",
-            ]
-            separator = ";"
-            regex = "^(?:;*)?([^;]+).*$"
-            replacement = "$1"
-            target_label = "app"
-          }
+            // set the app name if specified as metadata labels "app:" or "app.kubernetes.io/name:" or "k8s-app:"
+            rule {
+              action = "replace"
+              source_labels = [
+                "__meta_kubernetes_pod_label_app_kubernetes_io_name",
+                "__meta_kubernetes_pod_label_k8s_app",
+                "__meta_kubernetes_pod_label_app",
+              ]
+              separator = ";"
+              regex = "^(?:;*)?([^;]+).*$"
+              replacement = "$1"
+              target_label = "app"
+            }
 
-          // set the component if specified as metadata labels "component:" or "app.kubernetes.io/component:" or "k8s-component:"
-          rule {
-            action = "replace"
-            source_labels = [
-              "__meta_kubernetes_pod_label_app_kubernetes_io_component",
-              "__meta_kubernetes_pod_label_k8s_component",
-              "__meta_kubernetes_pod_label_component",
-            ]
-            regex = "^(?:;*)?([^;]+).*$"
-            replacement = "$1"
-            target_label = "component"
-          }
+            // set the component if specified as metadata labels "component:" or "app.kubernetes.io/component:" or "k8s-component:"
+            rule {
+              action = "replace"
+              source_labels = [
+                "__meta_kubernetes_pod_label_app_kubernetes_io_component",
+                "__meta_kubernetes_pod_label_k8s_component",
+                "__meta_kubernetes_pod_label_component",
+              ]
+              regex = "^(?:;*)?([^;]+).*$"
+              replacement = "$1"
+              target_label = "component"
+            }
 
-          // set a source label
-          rule {
-            action = "replace"
-            replacement = "kubernetes"
-            target_label = "source"
-          }
+            // set a source label
+            rule {
+              action = "replace"
+              replacement = "kubernetes"
+              target_label = "source"
+            }
+
           }
 
           export "output" {

--- a/charts/k8s-monitoring/charts/feature-integrations/tests/__snapshot__/tempo_metrics_test.yaml.snap
+++ b/charts/k8s-monitoring/charts/feature-integrations/tests/__snapshot__/tempo_metrics_test.yaml.snap
@@ -40,6 +40,7 @@ should create the tempo metrics config:
             namespaces {
               names = coalesce(argument.namespaces.value, [])
             }
+
           }
 
           // tempo relabelings (pre-scrape)
@@ -68,77 +69,78 @@ should create the tempo metrics config:
 
 
 
-          rule {
-            source_labels = ["__meta_kubernetes_namespace"]
-            target_label  = "namespace"
-          }
+            rule {
+              source_labels = ["__meta_kubernetes_namespace"]
+              target_label  = "namespace"
+            }
 
-          rule {
-            source_labels = ["__meta_kubernetes_pod_name"]
-            target_label  = "pod"
-          }
+            rule {
+              source_labels = ["__meta_kubernetes_pod_name"]
+              target_label  = "pod"
+            }
 
-          rule {
-            source_labels = ["__meta_kubernetes_pod_container_name"]
-            target_label  = "container"
-          }
+            rule {
+              source_labels = ["__meta_kubernetes_pod_container_name"]
+              target_label  = "container"
+            }
 
-          // set the workload to the controller kind and name
-          rule {
-            action = "lowercase"
-            source_labels = ["__meta_kubernetes_pod_controller_kind"]
-            target_label  = "workload_type"
-          }
+            // set the workload to the controller kind and name
+            rule {
+              action = "lowercase"
+              source_labels = ["__meta_kubernetes_pod_controller_kind"]
+              target_label  = "workload_type"
+            }
 
-          rule {
-            source_labels = ["__meta_kubernetes_pod_controller_name"]
-            target_label  = "workload"
-          }
+            rule {
+              source_labels = ["__meta_kubernetes_pod_controller_name"]
+              target_label  = "workload"
+            }
 
-          // remove the hash from the ReplicaSet
-          rule {
-            source_labels = [
-              "workload_type",
-              "workload",
-            ]
-            separator = "/"
-            regex = "replicaset/(.+)-.+$"
-            target_label  = "workload"
-          }
+            // remove the hash from the ReplicaSet
+            rule {
+              source_labels = [
+                "workload_type",
+                "workload",
+              ]
+              separator = "/"
+              regex = "replicaset/(.+)-.+$"
+              target_label  = "workload"
+            }
 
-          // set the app name if specified as metadata labels "app:" or "app.kubernetes.io/name:" or "k8s-app:"
-          rule {
-            action = "replace"
-            source_labels = [
-              "__meta_kubernetes_pod_label_app_kubernetes_io_name",
-              "__meta_kubernetes_pod_label_k8s_app",
-              "__meta_kubernetes_pod_label_app",
-            ]
-            separator = ";"
-            regex = "^(?:;*)?([^;]+).*$"
-            replacement = "$1"
-            target_label = "app"
-          }
+            // set the app name if specified as metadata labels "app:" or "app.kubernetes.io/name:" or "k8s-app:"
+            rule {
+              action = "replace"
+              source_labels = [
+                "__meta_kubernetes_pod_label_app_kubernetes_io_name",
+                "__meta_kubernetes_pod_label_k8s_app",
+                "__meta_kubernetes_pod_label_app",
+              ]
+              separator = ";"
+              regex = "^(?:;*)?([^;]+).*$"
+              replacement = "$1"
+              target_label = "app"
+            }
 
-          // set the component if specified as metadata labels "component:" or "app.kubernetes.io/component:" or "k8s-component:"
-          rule {
-            action = "replace"
-            source_labels = [
-              "__meta_kubernetes_pod_label_app_kubernetes_io_component",
-              "__meta_kubernetes_pod_label_k8s_component",
-              "__meta_kubernetes_pod_label_component",
-            ]
-            regex = "^(?:;*)?([^;]+).*$"
-            replacement = "$1"
-            target_label = "component"
-          }
+            // set the component if specified as metadata labels "component:" or "app.kubernetes.io/component:" or "k8s-component:"
+            rule {
+              action = "replace"
+              source_labels = [
+                "__meta_kubernetes_pod_label_app_kubernetes_io_component",
+                "__meta_kubernetes_pod_label_k8s_component",
+                "__meta_kubernetes_pod_label_component",
+              ]
+              regex = "^(?:;*)?([^;]+).*$"
+              replacement = "$1"
+              target_label = "component"
+            }
 
-          // set a source label
-          rule {
-            action = "replace"
-            replacement = "kubernetes"
-            target_label = "source"
-          }
+            // set a source label
+            rule {
+              action = "replace"
+              replacement = "kubernetes"
+              target_label = "source"
+            }
+
           }
 
           export "output" {

--- a/charts/k8s-monitoring/charts/feature-integrations/tests/alloy_test.yaml
+++ b/charts/k8s-monitoring/charts/feature-integrations/tests/alloy_test.yaml
@@ -35,3 +35,279 @@ tests:
       - matchRegex:
           path: data["metrics.alloy"]
           pattern: \s+keep_metrics \= "up\|scrape_samples_scraped\|example_metric"
+
+  - it: should add the attach_metadata block to the discovery.kubernetes
+    set:
+      deployAsConfigMap: true
+      alloy:
+        instances:
+          - name: alloy-metrics
+            labelSelectors:
+              app.kubernetes.io/name: alloy-metrics
+      nodeLabels:
+        nodePool: true
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - matchRegex:
+          path: data["metrics.alloy"]
+          # The pattern should look like this, but since the regex is escaped, it will be a bit different
+          # attach_metadata {
+          #   node = true
+          # }
+          pattern: |-
+            \s*  attach_metadata \{
+            \s*    node = true
+            \s*  \}
+
+  - it: should add the node pool label rules to the discovery relabel
+    set:
+      deployAsConfigMap: true
+      alloy:
+        instances:
+          - name: alloy-metrics
+            labelSelectors:
+              app.kubernetes.io/name: alloy-metrics
+      nodeLabels:
+        nodePool: true
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - matchRegex:
+          path: data["metrics.alloy"]
+          # The pattern should look like this, but since the regex is escaped, it will be a bit different
+          #   rule {
+          #     source_labels = [
+          #       "__meta_kubernetes_node_label_karpenter_sh_nodepool",
+          #       "__meta_kubernetes_node_label_cloud_google_com_gke_nodepool",
+          #       "__meta_kubernetes_node_label_eks_amazonaws_com_nodegroup",
+          #       "__meta_kubernetes_node_label_kubernetes_azure_com_agentpool",
+          #       "__meta_kubernetes_node_label_agentpool",
+          #     ]
+          #     regex = "^(?:;*)?([^;]+).*$"
+          #     target_label = "nodepool"
+          #   }
+          pattern: |-
+            \s*  rule \{
+            \s*    source_labels = \[
+            \s*      "__meta_kubernetes_node_label_karpenter_sh_nodepool",
+            \s*      "__meta_kubernetes_node_label_cloud_google_com_gke_nodepool",
+            \s*      "__meta_kubernetes_node_label_eks_amazonaws_com_nodegroup",
+            \s*      "__meta_kubernetes_node_label_kubernetes_azure_com_agentpool",
+            \s*      "__meta_kubernetes_node_label_agentpool",
+            \s*    \]
+            \s*    regex = "\^\(\?:;\*\)\?\(\[\^;\]\+\)\.\*\$"
+            \s*    target_label = "nodepool"
+            \s*  \}
+
+  - it: should add the node region label rules to the discovery relabel
+    set:
+      deployAsConfigMap: true
+      alloy:
+        instances:
+          - name: alloy-metrics
+            labelSelectors:
+              app.kubernetes.io/name: alloy-metrics
+      nodeLabels:
+        region: true
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - matchRegex:
+          path: data["metrics.alloy"]
+          # The pattern should look like this, but since the regex is escaped, it will be a bit different
+          # rule {
+          #   source_labels = [
+          #     "__meta_kubernetes_node_label_topology_kubernetes_io_region",
+          #     "__meta_kubernetes_node_label_failure_domain_beta_kubernetes_io_region",
+          #   ]
+          #   regex = "^(?:;*)?([^;]+).*$"
+          #   target_label = "region"
+          # }
+          pattern: |-
+            \s*  rule \{
+            \s*    source_labels = \[
+            \s*      "__meta_kubernetes_node_label_topology_kubernetes_io_region",
+            \s*      "__meta_kubernetes_node_label_failure_domain_beta_kubernetes_io_region",
+            \s*    \]
+            \s*    regex = "\^\(\?:;\*\)\?\(\[\^;\]\+\)\.\*\$"
+            \s*    target_label = "region"
+            \s*  \}
+
+  - it: should add the node availability zone label rules to the discovery relabel
+    set:
+      deployAsConfigMap: true
+      alloy:
+        instances:
+          - name: alloy-metrics
+            labelSelectors:
+              app.kubernetes.io/name: alloy-metrics
+      nodeLabels:
+        availabilityZone: true
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - matchRegex:
+          path: data["metrics.alloy"]
+          # The pattern should look like this, but since the regex is escaped, it will be a bit different
+          # rule {
+          #   source_labels = [
+          #     "__meta_kubernetes_node_label_topology_kubernetes_io_zone",
+          #     "__meta_kubernetes_node_label_failure_domain_beta_kubernetes_io_zone",
+          #     "__meta_kubernetes_node_label_topology_gke_io_zone",
+          #   ]
+          #   regex = "^(?:;*)?([^;]+).*$"
+          #   target_label = "availability_zone"
+          # }
+          pattern: |-
+            \s*  rule \{
+            \s*    source_labels = \[
+            \s*      "__meta_kubernetes_node_label_topology_kubernetes_io_zone",
+            \s*      "__meta_kubernetes_node_label_failure_domain_beta_kubernetes_io_zone",
+            \s*      "__meta_kubernetes_node_label_topology_gke_io_zone",
+            \s*    \]
+            \s*    regex = "\^\(\?:;\*\)\?\(\[\^;\]\+\)\.\*\$"
+            \s*    target_label = "availability_zone"
+            \s*  \}
+
+  - it: should add the node role label rules to the discovery relabel
+    set:
+      deployAsConfigMap: true
+      alloy:
+        instances:
+          - name: alloy-metrics
+            labelSelectors:
+              app.kubernetes.io/name: alloy-metrics
+      nodeLabels:
+        nodeRole: true
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - matchRegex:
+          path: data["metrics.alloy"]
+          # The pattern should look like this, but since the regex is escaped, it will be a bit different
+          # rule {
+          #   source_labels = [
+          #     "__meta_kubernetes_node_label_kubernetes_io_role",
+          #     "__meta_kubernetes_node_label_node_kubernetes_io_role",
+          #     "__meta_kubernetes_node_label_node_role",
+          #     "__meta_kubernetes_node_label_role",
+          #   ]
+          #   regex = "^(?:;*)?([^;]+).*$"
+          #   target_label = "node_role"
+          # }
+          pattern: |-
+            \s*  rule \{
+            \s*    source_labels = \[
+            \s*      "__meta_kubernetes_node_label_kubernetes_io_role",
+            \s*      "__meta_kubernetes_node_label_node_kubernetes_io_role",
+            \s*      "__meta_kubernetes_node_label_node_role",
+            \s*      "__meta_kubernetes_node_label_role",
+            \s*    \]
+            \s*    regex = "\^\(\?:;\*\)\?\(\[\^;\]\+\)\.\*\$"
+            \s*    target_label = "node_role"
+            \s*  \}
+
+  - it: should add the node os label rules to the discovery relabel
+    set:
+      deployAsConfigMap: true
+      alloy:
+        instances:
+          - name: alloy-metrics
+            labelSelectors:
+              app.kubernetes.io/name: alloy-metrics
+      nodeLabels:
+        nodeOS: true
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - matchRegex:
+          path: data["metrics.alloy"]
+          # The pattern should look like this, but since the regex is escaped, it will be a bit different
+          # rule {
+          #   source_labels = [
+          #     "__meta_kubernetes_node_label_kubernetes_io_os",
+          #     "__meta_kubernetes_node_label_os_kubernetes_io",
+          #     "__meta_kubernetes_node_label_os",
+          #   ]
+          #   regex = "^(?:;*)?([^;]+).*$"
+          #   target_label = "os"
+          # }
+          pattern: |-
+            \s*  rule \{
+            \s*    source_labels = \[
+            \s*      "__meta_kubernetes_node_label_kubernetes_io_os",
+            \s*      "__meta_kubernetes_node_label_os_kubernetes_io",
+            \s*      "__meta_kubernetes_node_label_os",
+            \s*    \]
+            \s*    regex = "\^\(\?:;\*\)\?\(\[\^;\]\+\)\.\*\$"
+            \s*    target_label = "os"
+            \s*  \}
+
+  - it: should add the node architecture label rules to the discovery relabel
+    set:
+      deployAsConfigMap: true
+      alloy:
+        instances:
+          - name: alloy-metrics
+            labelSelectors:
+              app.kubernetes.io/name: alloy-metrics
+      nodeLabels:
+        nodeArchitecture: true
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - matchRegex:
+          path: data["metrics.alloy"]
+          # The pattern should look like this, but since the regex is escaped, it will be a bit different
+          # rule {
+          #   source_labels = [
+          #     "__meta_kubernetes_node_label_kubernetes_io_arch",
+          #     "__meta_kubernetes_node_label_beta_kubernetes_io_arch",
+          #   ]
+          #   regex = "^(?:;*)?([^;]+).*$"
+          #   target_label = "architecture"
+          # }
+          pattern: |-
+            \s*  rule \{
+            \s*    source_labels = \[
+            \s*      "__meta_kubernetes_node_label_kubernetes_io_arch",
+            \s*      "__meta_kubernetes_node_label_beta_kubernetes_io_arch",
+            \s*    \]
+            \s*    regex = "\^\(\?:;\*\)\?\(\[\^;\]\+\)\.\*\$"
+            \s*    target_label = "architecture"
+            \s*  \}
+
+  - it: should add the node instance type label rules to the discovery relabel
+    set:
+      deployAsConfigMap: true
+      alloy:
+        instances:
+          - name: alloy-metrics
+            labelSelectors:
+              app.kubernetes.io/name: alloy-metrics
+      nodeLabels:
+        instanceType: true
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - matchRegex:
+          path: data["metrics.alloy"]
+          # The pattern should look like this, but since the regex is escaped, it will be a bit different
+          # rule {
+          #   source_labels = [
+          #     "__meta_kubernetes_node_label_node_kubernetes_io_instance_type",
+          #     "__meta_kubernetes_node_label_beta_kubernetes_io_instance_type",
+          #   ]
+          #   regex = "^(?:;*)?([^;]+).*$"
+          #   target_label = "instance_type"
+          # }
+          pattern: |-
+            \s*  rule \{
+            \s*    source_labels = \[
+            \s*      "__meta_kubernetes_node_label_node_kubernetes_io_instance_type",
+            \s*      "__meta_kubernetes_node_label_beta_kubernetes_io_instance_type",
+            \s*    \]
+            \s*    regex = "\^\(\?:;\*\)\?\(\[\^;\]\+\)\.\*\$"
+            \s*    target_label = "instance_type"
+            \s*  \}

--- a/charts/k8s-monitoring/charts/feature-integrations/tests/grafana_logs_test.yaml
+++ b/charts/k8s-monitoring/charts/feature-integrations/tests/grafana_logs_test.yaml
@@ -34,7 +34,6 @@ tests:
           # The pattern should look like this, but since the regex is escaped, it will be a bit different
           # rule {
           #   source_labels = ["__meta_kubernetes_namespace","__meta_kubernetes_pod_label_app_kubernetes_io_name"]
-          #   separator = ";"
           #   regex = "(?:k8smon);(?:grafana)"
           #   target_label = "job"
           #   replacement = "integrations/grafana"

--- a/charts/k8s-monitoring/charts/feature-integrations/tests/grafana_metrics_test.yaml
+++ b/charts/k8s-monitoring/charts/feature-integrations/tests/grafana_metrics_test.yaml
@@ -70,3 +70,279 @@ tests:
       - matchRegex:
           path: data["metrics.alloy"]
           pattern: drop_metrics = "foo\|bar"
+
+  - it: should add the attach_metadata block to the discovery.kubernetes
+    set:
+      deployAsConfigMap: true
+      grafana:
+        instances:
+          - name: grafana
+            labelSelectors:
+              app.kubernetes.io/name: grafana
+      nodeLabels:
+        nodePool: true
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - matchRegex:
+          path: data["metrics.alloy"]
+          # The pattern should look like this, but since the regex is escaped, it will be a bit different
+          # attach_metadata {
+          #   node = true
+          # }
+          pattern: |-
+            \s*  attach_metadata \{
+            \s*    node = true
+            \s*  \}
+
+  - it: should add the node pool label rules to the discovery relabel
+    set:
+      deployAsConfigMap: true
+      grafana:
+        instances:
+          - name: grafana
+            labelSelectors:
+              app.kubernetes.io/name: grafana
+      nodeLabels:
+        nodePool: true
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - matchRegex:
+          path: data["metrics.alloy"]
+          # The pattern should look like this, but since the regex is escaped, it will be a bit different
+          #   rule {
+          #     source_labels = [
+          #       "__meta_kubernetes_node_label_karpenter_sh_nodepool",
+          #       "__meta_kubernetes_node_label_cloud_google_com_gke_nodepool",
+          #       "__meta_kubernetes_node_label_eks_amazonaws_com_nodegroup",
+          #       "__meta_kubernetes_node_label_kubernetes_azure_com_agentpool",
+          #       "__meta_kubernetes_node_label_agentpool",
+          #     ]
+          #     regex = "^(?:;*)?([^;]+).*$"
+          #     target_label = "nodepool"
+          #   }
+          pattern: |-
+            \s*  rule \{
+            \s*    source_labels = \[
+            \s*      "__meta_kubernetes_node_label_karpenter_sh_nodepool",
+            \s*      "__meta_kubernetes_node_label_cloud_google_com_gke_nodepool",
+            \s*      "__meta_kubernetes_node_label_eks_amazonaws_com_nodegroup",
+            \s*      "__meta_kubernetes_node_label_kubernetes_azure_com_agentpool",
+            \s*      "__meta_kubernetes_node_label_agentpool",
+            \s*    \]
+            \s*    regex = "\^\(\?:;\*\)\?\(\[\^;\]\+\)\.\*\$"
+            \s*    target_label = "nodepool"
+            \s*  \}
+
+  - it: should add the node region label rules to the discovery relabel
+    set:
+      deployAsConfigMap: true
+      grafana:
+        instances:
+          - name: grafana
+            labelSelectors:
+              app.kubernetes.io/name: grafana
+      nodeLabels:
+        region: true
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - matchRegex:
+          path: data["metrics.alloy"]
+          # The pattern should look like this, but since the regex is escaped, it will be a bit different
+          # rule {
+          #   source_labels = [
+          #     "__meta_kubernetes_node_label_topology_kubernetes_io_region",
+          #     "__meta_kubernetes_node_label_failure_domain_beta_kubernetes_io_region",
+          #   ]
+          #   regex = "^(?:;*)?([^;]+).*$"
+          #   target_label = "region"
+          # }
+          pattern: |-
+            \s*  rule \{
+            \s*    source_labels = \[
+            \s*      "__meta_kubernetes_node_label_topology_kubernetes_io_region",
+            \s*      "__meta_kubernetes_node_label_failure_domain_beta_kubernetes_io_region",
+            \s*    \]
+            \s*    regex = "\^\(\?:;\*\)\?\(\[\^;\]\+\)\.\*\$"
+            \s*    target_label = "region"
+            \s*  \}
+
+  - it: should add the node availability zone label rules to the discovery relabel
+    set:
+      deployAsConfigMap: true
+      grafana:
+        instances:
+          - name: grafana
+            labelSelectors:
+              app.kubernetes.io/name: grafana
+      nodeLabels:
+        availabilityZone: true
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - matchRegex:
+          path: data["metrics.alloy"]
+          # The pattern should look like this, but since the regex is escaped, it will be a bit different
+          # rule {
+          #   source_labels = [
+          #     "__meta_kubernetes_node_label_topology_kubernetes_io_zone",
+          #     "__meta_kubernetes_node_label_failure_domain_beta_kubernetes_io_zone",
+          #     "__meta_kubernetes_node_label_topology_gke_io_zone",
+          #   ]
+          #   regex = "^(?:;*)?([^;]+).*$"
+          #   target_label = "availability_zone"
+          # }
+          pattern: |-
+            \s*  rule \{
+            \s*    source_labels = \[
+            \s*      "__meta_kubernetes_node_label_topology_kubernetes_io_zone",
+            \s*      "__meta_kubernetes_node_label_failure_domain_beta_kubernetes_io_zone",
+            \s*      "__meta_kubernetes_node_label_topology_gke_io_zone",
+            \s*    \]
+            \s*    regex = "\^\(\?:;\*\)\?\(\[\^;\]\+\)\.\*\$"
+            \s*    target_label = "availability_zone"
+            \s*  \}
+
+  - it: should add the node role label rules to the discovery relabel
+    set:
+      deployAsConfigMap: true
+      grafana:
+        instances:
+          - name: grafana
+            labelSelectors:
+              app.kubernetes.io/name: grafana
+      nodeLabels:
+        nodeRole: true
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - matchRegex:
+          path: data["metrics.alloy"]
+          # The pattern should look like this, but since the regex is escaped, it will be a bit different
+          # rule {
+          #   source_labels = [
+          #     "__meta_kubernetes_node_label_kubernetes_io_role",
+          #     "__meta_kubernetes_node_label_node_kubernetes_io_role",
+          #     "__meta_kubernetes_node_label_node_role",
+          #     "__meta_kubernetes_node_label_role",
+          #   ]
+          #   regex = "^(?:;*)?([^;]+).*$"
+          #   target_label = "node_role"
+          # }
+          pattern: |-
+            \s*  rule \{
+            \s*    source_labels = \[
+            \s*      "__meta_kubernetes_node_label_kubernetes_io_role",
+            \s*      "__meta_kubernetes_node_label_node_kubernetes_io_role",
+            \s*      "__meta_kubernetes_node_label_node_role",
+            \s*      "__meta_kubernetes_node_label_role",
+            \s*    \]
+            \s*    regex = "\^\(\?:;\*\)\?\(\[\^;\]\+\)\.\*\$"
+            \s*    target_label = "node_role"
+            \s*  \}
+
+  - it: should add the node os label rules to the discovery relabel
+    set:
+      deployAsConfigMap: true
+      grafana:
+        instances:
+          - name: grafana
+            labelSelectors:
+              app.kubernetes.io/name: grafana
+      nodeLabels:
+        nodeOS: true
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - matchRegex:
+          path: data["metrics.alloy"]
+          # The pattern should look like this, but since the regex is escaped, it will be a bit different
+          # rule {
+          #   source_labels = [
+          #     "__meta_kubernetes_node_label_kubernetes_io_os",
+          #     "__meta_kubernetes_node_label_os_kubernetes_io",
+          #     "__meta_kubernetes_node_label_os",
+          #   ]
+          #   regex = "^(?:;*)?([^;]+).*$"
+          #   target_label = "os"
+          # }
+          pattern: |-
+            \s*  rule \{
+            \s*    source_labels = \[
+            \s*      "__meta_kubernetes_node_label_kubernetes_io_os",
+            \s*      "__meta_kubernetes_node_label_os_kubernetes_io",
+            \s*      "__meta_kubernetes_node_label_os",
+            \s*    \]
+            \s*    regex = "\^\(\?:;\*\)\?\(\[\^;\]\+\)\.\*\$"
+            \s*    target_label = "os"
+            \s*  \}
+
+  - it: should add the node architecture label rules to the discovery relabel
+    set:
+      deployAsConfigMap: true
+      grafana:
+        instances:
+          - name: grafana
+            labelSelectors:
+              app.kubernetes.io/name: grafana
+      nodeLabels:
+        nodeArchitecture: true
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - matchRegex:
+          path: data["metrics.alloy"]
+          # The pattern should look like this, but since the regex is escaped, it will be a bit different
+          # rule {
+          #   source_labels = [
+          #     "__meta_kubernetes_node_label_kubernetes_io_arch",
+          #     "__meta_kubernetes_node_label_beta_kubernetes_io_arch",
+          #   ]
+          #   regex = "^(?:;*)?([^;]+).*$"
+          #   target_label = "architecture"
+          # }
+          pattern: |-
+            \s*  rule \{
+            \s*    source_labels = \[
+            \s*      "__meta_kubernetes_node_label_kubernetes_io_arch",
+            \s*      "__meta_kubernetes_node_label_beta_kubernetes_io_arch",
+            \s*    \]
+            \s*    regex = "\^\(\?:;\*\)\?\(\[\^;\]\+\)\.\*\$"
+            \s*    target_label = "architecture"
+            \s*  \}
+
+  - it: should add the node instance type label rules to the discovery relabel
+    set:
+      deployAsConfigMap: true
+      grafana:
+        instances:
+          - name: grafana
+            labelSelectors:
+              app.kubernetes.io/name: grafana
+      nodeLabels:
+        instanceType: true
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - matchRegex:
+          path: data["metrics.alloy"]
+          # The pattern should look like this, but since the regex is escaped, it will be a bit different
+          # rule {
+          #   source_labels = [
+          #     "__meta_kubernetes_node_label_node_kubernetes_io_instance_type",
+          #     "__meta_kubernetes_node_label_beta_kubernetes_io_instance_type",
+          #   ]
+          #   regex = "^(?:;*)?([^;]+).*$"
+          #   target_label = "instance_type"
+          # }
+          pattern: |-
+            \s*  rule \{
+            \s*    source_labels = \[
+            \s*      "__meta_kubernetes_node_label_node_kubernetes_io_instance_type",
+            \s*      "__meta_kubernetes_node_label_beta_kubernetes_io_instance_type",
+            \s*    \]
+            \s*    regex = "\^\(\?:;\*\)\?\(\[\^;\]\+\)\.\*\$"
+            \s*    target_label = "instance_type"
+            \s*  \}

--- a/charts/k8s-monitoring/charts/feature-integrations/tests/loki_logs_test.yaml
+++ b/charts/k8s-monitoring/charts/feature-integrations/tests/loki_logs_test.yaml
@@ -36,7 +36,6 @@ tests:
           # The pattern should look like this, but since the regex is escaped, it will be a bit different
           # rule {
           #   source_labels = ["__meta_kubernetes_namespace","__meta_kubernetes_pod_label_app_kubernetes_io_name"]
-          #   separator = ";"
           #   regex = "(?:k8smon);(?:loki)"
           #   target_label = "integration"
           #   replacement = "loki"

--- a/charts/k8s-monitoring/charts/feature-integrations/tests/loki_metrics_test.yaml
+++ b/charts/k8s-monitoring/charts/feature-integrations/tests/loki_metrics_test.yaml
@@ -86,3 +86,279 @@ tests:
       - matchRegex:
           path: data["metrics.alloy"]
           pattern: drop_metrics = "foo\|bar"
+
+  - it: should add the attach_metadata block to the discovery.kubernetes
+    set:
+      deployAsConfigMap: true
+      loki:
+        instances:
+          - name: loki
+            labelSelectors:
+              app.kubernetes.io/name: loki
+      nodeLabels:
+        nodePool: true
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - matchRegex:
+          path: data["metrics.alloy"]
+          # The pattern should look like this, but since the regex is escaped, it will be a bit different
+          # attach_metadata {
+          #   node = true
+          # }
+          pattern: |-
+            \s*  attach_metadata \{
+            \s*    node = true
+            \s*  \}
+
+  - it: should add the node pool label rules to the discovery relabel
+    set:
+      deployAsConfigMap: true
+      loki:
+        instances:
+          - name: loki
+            labelSelectors:
+              app.kubernetes.io/name: loki
+      nodeLabels:
+        nodePool: true
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - matchRegex:
+          path: data["metrics.alloy"]
+          # The pattern should look like this, but since the regex is escaped, it will be a bit different
+          #   rule {
+          #     source_labels = [
+          #       "__meta_kubernetes_node_label_karpenter_sh_nodepool",
+          #       "__meta_kubernetes_node_label_cloud_google_com_gke_nodepool",
+          #       "__meta_kubernetes_node_label_eks_amazonaws_com_nodegroup",
+          #       "__meta_kubernetes_node_label_kubernetes_azure_com_agentpool",
+          #       "__meta_kubernetes_node_label_agentpool",
+          #     ]
+          #     regex = "^(?:;*)?([^;]+).*$"
+          #     target_label = "nodepool"
+          #   }
+          pattern: |-
+            \s*  rule \{
+            \s*    source_labels = \[
+            \s*      "__meta_kubernetes_node_label_karpenter_sh_nodepool",
+            \s*      "__meta_kubernetes_node_label_cloud_google_com_gke_nodepool",
+            \s*      "__meta_kubernetes_node_label_eks_amazonaws_com_nodegroup",
+            \s*      "__meta_kubernetes_node_label_kubernetes_azure_com_agentpool",
+            \s*      "__meta_kubernetes_node_label_agentpool",
+            \s*    \]
+            \s*    regex = "\^\(\?:;\*\)\?\(\[\^;\]\+\)\.\*\$"
+            \s*    target_label = "nodepool"
+            \s*  \}
+
+  - it: should add the node region label rules to the discovery relabel
+    set:
+      deployAsConfigMap: true
+      loki:
+        instances:
+          - name: loki
+            labelSelectors:
+              app.kubernetes.io/name: loki
+      nodeLabels:
+        region: true
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - matchRegex:
+          path: data["metrics.alloy"]
+          # The pattern should look like this, but since the regex is escaped, it will be a bit different
+          # rule {
+          #   source_labels = [
+          #     "__meta_kubernetes_node_label_topology_kubernetes_io_region",
+          #     "__meta_kubernetes_node_label_failure_domain_beta_kubernetes_io_region",
+          #   ]
+          #   regex = "^(?:;*)?([^;]+).*$"
+          #   target_label = "region"
+          # }
+          pattern: |-
+            \s*  rule \{
+            \s*    source_labels = \[
+            \s*      "__meta_kubernetes_node_label_topology_kubernetes_io_region",
+            \s*      "__meta_kubernetes_node_label_failure_domain_beta_kubernetes_io_region",
+            \s*    \]
+            \s*    regex = "\^\(\?:;\*\)\?\(\[\^;\]\+\)\.\*\$"
+            \s*    target_label = "region"
+            \s*  \}
+
+  - it: should add the node availability zone label rules to the discovery relabel
+    set:
+      deployAsConfigMap: true
+      loki:
+        instances:
+          - name: loki
+            labelSelectors:
+              app.kubernetes.io/name: loki
+      nodeLabels:
+        availabilityZone: true
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - matchRegex:
+          path: data["metrics.alloy"]
+          # The pattern should look like this, but since the regex is escaped, it will be a bit different
+          # rule {
+          #   source_labels = [
+          #     "__meta_kubernetes_node_label_topology_kubernetes_io_zone",
+          #     "__meta_kubernetes_node_label_failure_domain_beta_kubernetes_io_zone",
+          #     "__meta_kubernetes_node_label_topology_gke_io_zone",
+          #   ]
+          #   regex = "^(?:;*)?([^;]+).*$"
+          #   target_label = "availability_zone"
+          # }
+          pattern: |-
+            \s*  rule \{
+            \s*    source_labels = \[
+            \s*      "__meta_kubernetes_node_label_topology_kubernetes_io_zone",
+            \s*      "__meta_kubernetes_node_label_failure_domain_beta_kubernetes_io_zone",
+            \s*      "__meta_kubernetes_node_label_topology_gke_io_zone",
+            \s*    \]
+            \s*    regex = "\^\(\?:;\*\)\?\(\[\^;\]\+\)\.\*\$"
+            \s*    target_label = "availability_zone"
+            \s*  \}
+
+  - it: should add the node role label rules to the discovery relabel
+    set:
+      deployAsConfigMap: true
+      loki:
+        instances:
+          - name: loki
+            labelSelectors:
+              app.kubernetes.io/name: loki
+      nodeLabels:
+        nodeRole: true
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - matchRegex:
+          path: data["metrics.alloy"]
+          # The pattern should look like this, but since the regex is escaped, it will be a bit different
+          # rule {
+          #   source_labels = [
+          #     "__meta_kubernetes_node_label_kubernetes_io_role",
+          #     "__meta_kubernetes_node_label_node_kubernetes_io_role",
+          #     "__meta_kubernetes_node_label_node_role",
+          #     "__meta_kubernetes_node_label_role",
+          #   ]
+          #   regex = "^(?:;*)?([^;]+).*$"
+          #   target_label = "node_role"
+          # }
+          pattern: |-
+            \s*  rule \{
+            \s*    source_labels = \[
+            \s*      "__meta_kubernetes_node_label_kubernetes_io_role",
+            \s*      "__meta_kubernetes_node_label_node_kubernetes_io_role",
+            \s*      "__meta_kubernetes_node_label_node_role",
+            \s*      "__meta_kubernetes_node_label_role",
+            \s*    \]
+            \s*    regex = "\^\(\?:;\*\)\?\(\[\^;\]\+\)\.\*\$"
+            \s*    target_label = "node_role"
+            \s*  \}
+
+  - it: should add the node os label rules to the discovery relabel
+    set:
+      deployAsConfigMap: true
+      loki:
+        instances:
+          - name: loki
+            labelSelectors:
+              app.kubernetes.io/name: loki
+      nodeLabels:
+        nodeOS: true
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - matchRegex:
+          path: data["metrics.alloy"]
+          # The pattern should look like this, but since the regex is escaped, it will be a bit different
+          # rule {
+          #   source_labels = [
+          #     "__meta_kubernetes_node_label_kubernetes_io_os",
+          #     "__meta_kubernetes_node_label_os_kubernetes_io",
+          #     "__meta_kubernetes_node_label_os",
+          #   ]
+          #   regex = "^(?:;*)?([^;]+).*$"
+          #   target_label = "os"
+          # }
+          pattern: |-
+            \s*  rule \{
+            \s*    source_labels = \[
+            \s*      "__meta_kubernetes_node_label_kubernetes_io_os",
+            \s*      "__meta_kubernetes_node_label_os_kubernetes_io",
+            \s*      "__meta_kubernetes_node_label_os",
+            \s*    \]
+            \s*    regex = "\^\(\?:;\*\)\?\(\[\^;\]\+\)\.\*\$"
+            \s*    target_label = "os"
+            \s*  \}
+
+  - it: should add the node architecture label rules to the discovery relabel
+    set:
+      deployAsConfigMap: true
+      loki:
+        instances:
+          - name: loki
+            labelSelectors:
+              app.kubernetes.io/name: loki
+      nodeLabels:
+        nodeArchitecture: true
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - matchRegex:
+          path: data["metrics.alloy"]
+          # The pattern should look like this, but since the regex is escaped, it will be a bit different
+          # rule {
+          #   source_labels = [
+          #     "__meta_kubernetes_node_label_kubernetes_io_arch",
+          #     "__meta_kubernetes_node_label_beta_kubernetes_io_arch",
+          #   ]
+          #   regex = "^(?:;*)?([^;]+).*$"
+          #   target_label = "architecture"
+          # }
+          pattern: |-
+            \s*  rule \{
+            \s*    source_labels = \[
+            \s*      "__meta_kubernetes_node_label_kubernetes_io_arch",
+            \s*      "__meta_kubernetes_node_label_beta_kubernetes_io_arch",
+            \s*    \]
+            \s*    regex = "\^\(\?:;\*\)\?\(\[\^;\]\+\)\.\*\$"
+            \s*    target_label = "architecture"
+            \s*  \}
+
+  - it: should add the node instance type label rules to the discovery relabel
+    set:
+      deployAsConfigMap: true
+      loki:
+        instances:
+          - name: loki
+            labelSelectors:
+              app.kubernetes.io/name: loki
+      nodeLabels:
+        instanceType: true
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - matchRegex:
+          path: data["metrics.alloy"]
+          # The pattern should look like this, but since the regex is escaped, it will be a bit different
+          # rule {
+          #   source_labels = [
+          #     "__meta_kubernetes_node_label_node_kubernetes_io_instance_type",
+          #     "__meta_kubernetes_node_label_beta_kubernetes_io_instance_type",
+          #   ]
+          #   regex = "^(?:;*)?([^;]+).*$"
+          #   target_label = "instance_type"
+          # }
+          pattern: |-
+            \s*  rule \{
+            \s*    source_labels = \[
+            \s*      "__meta_kubernetes_node_label_node_kubernetes_io_instance_type",
+            \s*      "__meta_kubernetes_node_label_beta_kubernetes_io_instance_type",
+            \s*    \]
+            \s*    regex = "\^\(\?:;\*\)\?\(\[\^;\]\+\)\.\*\$"
+            \s*    target_label = "instance_type"
+            \s*  \}

--- a/charts/k8s-monitoring/charts/feature-integrations/tests/mimir_logs_test.yaml
+++ b/charts/k8s-monitoring/charts/feature-integrations/tests/mimir_logs_test.yaml
@@ -36,7 +36,6 @@ tests:
           # The pattern should look like this, but since the regex is escaped, it will be a bit different
           # rule {
           #   source_labels = ["__meta_kubernetes_namespace","__meta_kubernetes_pod_label_app_kubernetes_io_name"]
-          #   separator = ";"
           #   regex = "(?:k8smon);(?:mimir)"
           #   target_label = "integration"
           #   replacement = "mimir"

--- a/charts/k8s-monitoring/charts/feature-integrations/tests/mimir_metrics_test.yaml
+++ b/charts/k8s-monitoring/charts/feature-integrations/tests/mimir_metrics_test.yaml
@@ -86,3 +86,279 @@ tests:
       - matchRegex:
           path: data["metrics.alloy"]
           pattern: drop_metrics = "foo\|bar"
+
+  - it: should add the attach_metadata block to the discovery.kubernetes
+    set:
+      deployAsConfigMap: true
+      mimir:
+        instances:
+          - name: mimir
+            labelSelectors:
+              app.kubernetes.io/name: mimir
+      nodeLabels:
+        nodePool: true
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - matchRegex:
+          path: data["metrics.alloy"]
+          # The pattern should look like this, but since the regex is escaped, it will be a bit different
+          # attach_metadata {
+          #   node = true
+          # }
+          pattern: |-
+            \s*  attach_metadata \{
+            \s*    node = true
+            \s*  \}
+
+  - it: should add the node pool label rules to the discovery relabel
+    set:
+      deployAsConfigMap: true
+      mimir:
+        instances:
+          - name: mimir
+            labelSelectors:
+              app.kubernetes.io/name: mimir
+      nodeLabels:
+        nodePool: true
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - matchRegex:
+          path: data["metrics.alloy"]
+          # The pattern should look like this, but since the regex is escaped, it will be a bit different
+          #   rule {
+          #     source_labels = [
+          #       "__meta_kubernetes_node_label_karpenter_sh_nodepool",
+          #       "__meta_kubernetes_node_label_cloud_google_com_gke_nodepool",
+          #       "__meta_kubernetes_node_label_eks_amazonaws_com_nodegroup",
+          #       "__meta_kubernetes_node_label_kubernetes_azure_com_agentpool",
+          #       "__meta_kubernetes_node_label_agentpool",
+          #     ]
+          #     regex = "^(?:;*)?([^;]+).*$"
+          #     target_label = "nodepool"
+          #   }
+          pattern: |-
+            \s*  rule \{
+            \s*    source_labels = \[
+            \s*      "__meta_kubernetes_node_label_karpenter_sh_nodepool",
+            \s*      "__meta_kubernetes_node_label_cloud_google_com_gke_nodepool",
+            \s*      "__meta_kubernetes_node_label_eks_amazonaws_com_nodegroup",
+            \s*      "__meta_kubernetes_node_label_kubernetes_azure_com_agentpool",
+            \s*      "__meta_kubernetes_node_label_agentpool",
+            \s*    \]
+            \s*    regex = "\^\(\?:;\*\)\?\(\[\^;\]\+\)\.\*\$"
+            \s*    target_label = "nodepool"
+            \s*  \}
+
+  - it: should add the node region label rules to the discovery relabel
+    set:
+      deployAsConfigMap: true
+      mimir:
+        instances:
+          - name: mimir
+            labelSelectors:
+              app.kubernetes.io/name: mimir
+      nodeLabels:
+        region: true
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - matchRegex:
+          path: data["metrics.alloy"]
+          # The pattern should look like this, but since the regex is escaped, it will be a bit different
+          # rule {
+          #   source_labels = [
+          #     "__meta_kubernetes_node_label_topology_kubernetes_io_region",
+          #     "__meta_kubernetes_node_label_failure_domain_beta_kubernetes_io_region",
+          #   ]
+          #   regex = "^(?:;*)?([^;]+).*$"
+          #   target_label = "region"
+          # }
+          pattern: |-
+            \s*  rule \{
+            \s*    source_labels = \[
+            \s*      "__meta_kubernetes_node_label_topology_kubernetes_io_region",
+            \s*      "__meta_kubernetes_node_label_failure_domain_beta_kubernetes_io_region",
+            \s*    \]
+            \s*    regex = "\^\(\?:;\*\)\?\(\[\^;\]\+\)\.\*\$"
+            \s*    target_label = "region"
+            \s*  \}
+
+  - it: should add the node availability zone label rules to the discovery relabel
+    set:
+      deployAsConfigMap: true
+      mimir:
+        instances:
+          - name: mimir
+            labelSelectors:
+              app.kubernetes.io/name: mimir
+      nodeLabels:
+        availabilityZone: true
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - matchRegex:
+          path: data["metrics.alloy"]
+          # The pattern should look like this, but since the regex is escaped, it will be a bit different
+          # rule {
+          #   source_labels = [
+          #     "__meta_kubernetes_node_label_topology_kubernetes_io_zone",
+          #     "__meta_kubernetes_node_label_failure_domain_beta_kubernetes_io_zone",
+          #     "__meta_kubernetes_node_label_topology_gke_io_zone",
+          #   ]
+          #   regex = "^(?:;*)?([^;]+).*$"
+          #   target_label = "availability_zone"
+          # }
+          pattern: |-
+            \s*  rule \{
+            \s*    source_labels = \[
+            \s*      "__meta_kubernetes_node_label_topology_kubernetes_io_zone",
+            \s*      "__meta_kubernetes_node_label_failure_domain_beta_kubernetes_io_zone",
+            \s*      "__meta_kubernetes_node_label_topology_gke_io_zone",
+            \s*    \]
+            \s*    regex = "\^\(\?:;\*\)\?\(\[\^;\]\+\)\.\*\$"
+            \s*    target_label = "availability_zone"
+            \s*  \}
+
+  - it: should add the node role label rules to the discovery relabel
+    set:
+      deployAsConfigMap: true
+      mimir:
+        instances:
+          - name: mimir
+            labelSelectors:
+              app.kubernetes.io/name: mimir
+      nodeLabels:
+        nodeRole: true
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - matchRegex:
+          path: data["metrics.alloy"]
+          # The pattern should look like this, but since the regex is escaped, it will be a bit different
+          # rule {
+          #   source_labels = [
+          #     "__meta_kubernetes_node_label_kubernetes_io_role",
+          #     "__meta_kubernetes_node_label_node_kubernetes_io_role",
+          #     "__meta_kubernetes_node_label_node_role",
+          #     "__meta_kubernetes_node_label_role",
+          #   ]
+          #   regex = "^(?:;*)?([^;]+).*$"
+          #   target_label = "node_role"
+          # }
+          pattern: |-
+            \s*  rule \{
+            \s*    source_labels = \[
+            \s*      "__meta_kubernetes_node_label_kubernetes_io_role",
+            \s*      "__meta_kubernetes_node_label_node_kubernetes_io_role",
+            \s*      "__meta_kubernetes_node_label_node_role",
+            \s*      "__meta_kubernetes_node_label_role",
+            \s*    \]
+            \s*    regex = "\^\(\?:;\*\)\?\(\[\^;\]\+\)\.\*\$"
+            \s*    target_label = "node_role"
+            \s*  \}
+
+  - it: should add the node os label rules to the discovery relabel
+    set:
+      deployAsConfigMap: true
+      mimir:
+        instances:
+          - name: mimir
+            labelSelectors:
+              app.kubernetes.io/name: mimir
+      nodeLabels:
+        nodeOS: true
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - matchRegex:
+          path: data["metrics.alloy"]
+          # The pattern should look like this, but since the regex is escaped, it will be a bit different
+          # rule {
+          #   source_labels = [
+          #     "__meta_kubernetes_node_label_kubernetes_io_os",
+          #     "__meta_kubernetes_node_label_os_kubernetes_io",
+          #     "__meta_kubernetes_node_label_os",
+          #   ]
+          #   regex = "^(?:;*)?([^;]+).*$"
+          #   target_label = "os"
+          # }
+          pattern: |-
+            \s*  rule \{
+            \s*    source_labels = \[
+            \s*      "__meta_kubernetes_node_label_kubernetes_io_os",
+            \s*      "__meta_kubernetes_node_label_os_kubernetes_io",
+            \s*      "__meta_kubernetes_node_label_os",
+            \s*    \]
+            \s*    regex = "\^\(\?:;\*\)\?\(\[\^;\]\+\)\.\*\$"
+            \s*    target_label = "os"
+            \s*  \}
+
+  - it: should add the node architecture label rules to the discovery relabel
+    set:
+      deployAsConfigMap: true
+      mimir:
+        instances:
+          - name: mimir
+            labelSelectors:
+              app.kubernetes.io/name: mimir
+      nodeLabels:
+        nodeArchitecture: true
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - matchRegex:
+          path: data["metrics.alloy"]
+          # The pattern should look like this, but since the regex is escaped, it will be a bit different
+          # rule {
+          #   source_labels = [
+          #     "__meta_kubernetes_node_label_kubernetes_io_arch",
+          #     "__meta_kubernetes_node_label_beta_kubernetes_io_arch",
+          #   ]
+          #   regex = "^(?:;*)?([^;]+).*$"
+          #   target_label = "architecture"
+          # }
+          pattern: |-
+            \s*  rule \{
+            \s*    source_labels = \[
+            \s*      "__meta_kubernetes_node_label_kubernetes_io_arch",
+            \s*      "__meta_kubernetes_node_label_beta_kubernetes_io_arch",
+            \s*    \]
+            \s*    regex = "\^\(\?:;\*\)\?\(\[\^;\]\+\)\.\*\$"
+            \s*    target_label = "architecture"
+            \s*  \}
+
+  - it: should add the node instance type label rules to the discovery relabel
+    set:
+      deployAsConfigMap: true
+      mimir:
+        instances:
+          - name: mimir
+            labelSelectors:
+              app.kubernetes.io/name: mimir
+      nodeLabels:
+        instanceType: true
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - matchRegex:
+          path: data["metrics.alloy"]
+          # The pattern should look like this, but since the regex is escaped, it will be a bit different
+          # rule {
+          #   source_labels = [
+          #     "__meta_kubernetes_node_label_node_kubernetes_io_instance_type",
+          #     "__meta_kubernetes_node_label_beta_kubernetes_io_instance_type",
+          #   ]
+          #   regex = "^(?:;*)?([^;]+).*$"
+          #   target_label = "instance_type"
+          # }
+          pattern: |-
+            \s*  rule \{
+            \s*    source_labels = \[
+            \s*      "__meta_kubernetes_node_label_node_kubernetes_io_instance_type",
+            \s*      "__meta_kubernetes_node_label_beta_kubernetes_io_instance_type",
+            \s*    \]
+            \s*    regex = "\^\(\?:;\*\)\?\(\[\^;\]\+\)\.\*\$"
+            \s*    target_label = "instance_type"
+            \s*  \}

--- a/charts/k8s-monitoring/charts/feature-integrations/tests/mysql_logs_test.yaml
+++ b/charts/k8s-monitoring/charts/feature-integrations/tests/mysql_logs_test.yaml
@@ -93,7 +93,6 @@ tests:
           # The pattern should look like this, but since the regex is escaped, it will be a bit different
           # rule {
           #   source_labels = ["__meta_kubernetes_namespace","__meta_kubernetes_pod_label_app_kubernetes_io_name"]
-          #   separator = ";"
           #   regex = "(?:k8smon);(?:mysql)"
           #   target_label = "integration"
           #   replacement = "mysql"

--- a/charts/k8s-monitoring/charts/feature-integrations/tests/tempo_logs_test.yaml
+++ b/charts/k8s-monitoring/charts/feature-integrations/tests/tempo_logs_test.yaml
@@ -36,7 +36,6 @@ tests:
           # The pattern should look like this, but since the regex is escaped, it will be a bit different
           # rule {
           #   source_labels = ["__meta_kubernetes_namespace","__meta_kubernetes_pod_label_app_kubernetes_io_name"]
-          #   separator = ";"
           #   regex = "(?:k8smon);(?:tempo)"
           #   target_label = "integration"
           #   replacement = "tempo"

--- a/charts/k8s-monitoring/charts/feature-integrations/tests/tempo_metrics_test.yaml
+++ b/charts/k8s-monitoring/charts/feature-integrations/tests/tempo_metrics_test.yaml
@@ -103,3 +103,279 @@ tests:
       - matchRegex:
           path: data["metrics.alloy"]
           pattern: drop_metrics = "foo\|bar"
+
+  - it: should add the attach_metadata block to the discovery.kubernetes
+    set:
+      deployAsConfigMap: true
+      tempo:
+        instances:
+          - name: tempo
+            labelSelectors:
+              app.kubernetes.io/name: tempo
+      nodeLabels:
+        nodePool: true
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - matchRegex:
+          path: data["metrics.alloy"]
+          # The pattern should look like this, but since the regex is escaped, it will be a bit different
+          # attach_metadata {
+          #   node = true
+          # }
+          pattern: |-
+            \s*  attach_metadata \{
+            \s*    node = true
+            \s*  \}
+
+  - it: should add the node pool label rules to the discovery relabel
+    set:
+      deployAsConfigMap: true
+      tempo:
+        instances:
+          - name: tempo
+            labelSelectors:
+              app.kubernetes.io/name: tempo
+      nodeLabels:
+        nodePool: true
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - matchRegex:
+          path: data["metrics.alloy"]
+          # The pattern should look like this, but since the regex is escaped, it will be a bit different
+          #   rule {
+          #     source_labels = [
+          #       "__meta_kubernetes_node_label_karpenter_sh_nodepool",
+          #       "__meta_kubernetes_node_label_cloud_google_com_gke_nodepool",
+          #       "__meta_kubernetes_node_label_eks_amazonaws_com_nodegroup",
+          #       "__meta_kubernetes_node_label_kubernetes_azure_com_agentpool",
+          #       "__meta_kubernetes_node_label_agentpool",
+          #     ]
+          #     regex = "^(?:;*)?([^;]+).*$"
+          #     target_label = "nodepool"
+          #   }
+          pattern: |-
+            \s*  rule \{
+            \s*    source_labels = \[
+            \s*      "__meta_kubernetes_node_label_karpenter_sh_nodepool",
+            \s*      "__meta_kubernetes_node_label_cloud_google_com_gke_nodepool",
+            \s*      "__meta_kubernetes_node_label_eks_amazonaws_com_nodegroup",
+            \s*      "__meta_kubernetes_node_label_kubernetes_azure_com_agentpool",
+            \s*      "__meta_kubernetes_node_label_agentpool",
+            \s*    \]
+            \s*    regex = "\^\(\?:;\*\)\?\(\[\^;\]\+\)\.\*\$"
+            \s*    target_label = "nodepool"
+            \s*  \}
+
+  - it: should add the node region label rules to the discovery relabel
+    set:
+      deployAsConfigMap: true
+      tempo:
+        instances:
+          - name: tempo
+            labelSelectors:
+              app.kubernetes.io/name: tempo
+      nodeLabels:
+        region: true
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - matchRegex:
+          path: data["metrics.alloy"]
+          # The pattern should look like this, but since the regex is escaped, it will be a bit different
+          # rule {
+          #   source_labels = [
+          #     "__meta_kubernetes_node_label_topology_kubernetes_io_region",
+          #     "__meta_kubernetes_node_label_failure_domain_beta_kubernetes_io_region",
+          #   ]
+          #   regex = "^(?:;*)?([^;]+).*$"
+          #   target_label = "region"
+          # }
+          pattern: |-
+            \s*  rule \{
+            \s*    source_labels = \[
+            \s*      "__meta_kubernetes_node_label_topology_kubernetes_io_region",
+            \s*      "__meta_kubernetes_node_label_failure_domain_beta_kubernetes_io_region",
+            \s*    \]
+            \s*    regex = "\^\(\?:;\*\)\?\(\[\^;\]\+\)\.\*\$"
+            \s*    target_label = "region"
+            \s*  \}
+
+  - it: should add the node availability zone label rules to the discovery relabel
+    set:
+      deployAsConfigMap: true
+      tempo:
+        instances:
+          - name: tempo
+            labelSelectors:
+              app.kubernetes.io/name: tempo
+      nodeLabels:
+        availabilityZone: true
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - matchRegex:
+          path: data["metrics.alloy"]
+          # The pattern should look like this, but since the regex is escaped, it will be a bit different
+          # rule {
+          #   source_labels = [
+          #     "__meta_kubernetes_node_label_topology_kubernetes_io_zone",
+          #     "__meta_kubernetes_node_label_failure_domain_beta_kubernetes_io_zone",
+          #     "__meta_kubernetes_node_label_topology_gke_io_zone",
+          #   ]
+          #   regex = "^(?:;*)?([^;]+).*$"
+          #   target_label = "availability_zone"
+          # }
+          pattern: |-
+            \s*  rule \{
+            \s*    source_labels = \[
+            \s*      "__meta_kubernetes_node_label_topology_kubernetes_io_zone",
+            \s*      "__meta_kubernetes_node_label_failure_domain_beta_kubernetes_io_zone",
+            \s*      "__meta_kubernetes_node_label_topology_gke_io_zone",
+            \s*    \]
+            \s*    regex = "\^\(\?:;\*\)\?\(\[\^;\]\+\)\.\*\$"
+            \s*    target_label = "availability_zone"
+            \s*  \}
+
+  - it: should add the node role label rules to the discovery relabel
+    set:
+      deployAsConfigMap: true
+      tempo:
+        instances:
+          - name: tempo
+            labelSelectors:
+              app.kubernetes.io/name: tempo
+      nodeLabels:
+        nodeRole: true
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - matchRegex:
+          path: data["metrics.alloy"]
+          # The pattern should look like this, but since the regex is escaped, it will be a bit different
+          # rule {
+          #   source_labels = [
+          #     "__meta_kubernetes_node_label_kubernetes_io_role",
+          #     "__meta_kubernetes_node_label_node_kubernetes_io_role",
+          #     "__meta_kubernetes_node_label_node_role",
+          #     "__meta_kubernetes_node_label_role",
+          #   ]
+          #   regex = "^(?:;*)?([^;]+).*$"
+          #   target_label = "node_role"
+          # }
+          pattern: |-
+            \s*  rule \{
+            \s*    source_labels = \[
+            \s*      "__meta_kubernetes_node_label_kubernetes_io_role",
+            \s*      "__meta_kubernetes_node_label_node_kubernetes_io_role",
+            \s*      "__meta_kubernetes_node_label_node_role",
+            \s*      "__meta_kubernetes_node_label_role",
+            \s*    \]
+            \s*    regex = "\^\(\?:;\*\)\?\(\[\^;\]\+\)\.\*\$"
+            \s*    target_label = "node_role"
+            \s*  \}
+
+  - it: should add the node os label rules to the discovery relabel
+    set:
+      deployAsConfigMap: true
+      tempo:
+        instances:
+          - name: tempo
+            labelSelectors:
+              app.kubernetes.io/name: tempo
+      nodeLabels:
+        nodeOS: true
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - matchRegex:
+          path: data["metrics.alloy"]
+          # The pattern should look like this, but since the regex is escaped, it will be a bit different
+          # rule {
+          #   source_labels = [
+          #     "__meta_kubernetes_node_label_kubernetes_io_os",
+          #     "__meta_kubernetes_node_label_os_kubernetes_io",
+          #     "__meta_kubernetes_node_label_os",
+          #   ]
+          #   regex = "^(?:;*)?([^;]+).*$"
+          #   target_label = "os"
+          # }
+          pattern: |-
+            \s*  rule \{
+            \s*    source_labels = \[
+            \s*      "__meta_kubernetes_node_label_kubernetes_io_os",
+            \s*      "__meta_kubernetes_node_label_os_kubernetes_io",
+            \s*      "__meta_kubernetes_node_label_os",
+            \s*    \]
+            \s*    regex = "\^\(\?:;\*\)\?\(\[\^;\]\+\)\.\*\$"
+            \s*    target_label = "os"
+            \s*  \}
+
+  - it: should add the node architecture label rules to the discovery relabel
+    set:
+      deployAsConfigMap: true
+      tempo:
+        instances:
+          - name: tempo
+            labelSelectors:
+              app.kubernetes.io/name: tempo
+      nodeLabels:
+        nodeArchitecture: true
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - matchRegex:
+          path: data["metrics.alloy"]
+          # The pattern should look like this, but since the regex is escaped, it will be a bit different
+          # rule {
+          #   source_labels = [
+          #     "__meta_kubernetes_node_label_kubernetes_io_arch",
+          #     "__meta_kubernetes_node_label_beta_kubernetes_io_arch",
+          #   ]
+          #   regex = "^(?:;*)?([^;]+).*$"
+          #   target_label = "architecture"
+          # }
+          pattern: |-
+            \s*  rule \{
+            \s*    source_labels = \[
+            \s*      "__meta_kubernetes_node_label_kubernetes_io_arch",
+            \s*      "__meta_kubernetes_node_label_beta_kubernetes_io_arch",
+            \s*    \]
+            \s*    regex = "\^\(\?:;\*\)\?\(\[\^;\]\+\)\.\*\$"
+            \s*    target_label = "architecture"
+            \s*  \}
+
+  - it: should add the node instance type label rules to the discovery relabel
+    set:
+      deployAsConfigMap: true
+      tempo:
+        instances:
+          - name: tempo
+            labelSelectors:
+              app.kubernetes.io/name: tempo
+      nodeLabels:
+        instanceType: true
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - matchRegex:
+          path: data["metrics.alloy"]
+          # The pattern should look like this, but since the regex is escaped, it will be a bit different
+          # rule {
+          #   source_labels = [
+          #     "__meta_kubernetes_node_label_node_kubernetes_io_instance_type",
+          #     "__meta_kubernetes_node_label_beta_kubernetes_io_instance_type",
+          #   ]
+          #   regex = "^(?:;*)?([^;]+).*$"
+          #   target_label = "instance_type"
+          # }
+          pattern: |-
+            \s*  rule \{
+            \s*    source_labels = \[
+            \s*      "__meta_kubernetes_node_label_node_kubernetes_io_instance_type",
+            \s*      "__meta_kubernetes_node_label_beta_kubernetes_io_instance_type",
+            \s*    \]
+            \s*    regex = "\^\(\?:;\*\)\?\(\[\^;\]\+\)\.\*\$"
+            \s*    target_label = "instance_type"
+            \s*  \}

--- a/charts/k8s-monitoring/charts/feature-integrations/values.schema.json
+++ b/charts/k8s-monitoring/charts/feature-integrations/values.schema.json
@@ -89,6 +89,32 @@
         "nameOverride": {
             "type": "string"
         },
+        "nodeLabels": {
+            "type": "object",
+            "properties": {
+                "availabilityZone": {
+                    "type": "boolean"
+                },
+                "instanceType": {
+                    "type": "boolean"
+                },
+                "nodeArchitecture": {
+                    "type": "boolean"
+                },
+                "nodeOS": {
+                    "type": "boolean"
+                },
+                "nodePool": {
+                    "type": "boolean"
+                },
+                "nodeRole": {
+                    "type": "boolean"
+                },
+                "region": {
+                    "type": "boolean"
+                }
+            }
+        },
         "tempo": {
             "type": "object",
             "properties": {

--- a/charts/k8s-monitoring/charts/feature-integrations/values.yaml
+++ b/charts/k8s-monitoring/charts/feature-integrations/values.yaml
@@ -26,6 +26,30 @@ global:
     # @section -- Global Settings
     branch: main
 
+# Configures which node labels to attach to the metrics collected for integrations that perform service discovery
+nodeLabels:
+  # -- Whether or not to attach the nodepool label
+  # @section -- Node Labels
+  nodePool: false
+  # -- Whether or not to add the region label
+  # @section -- Node Labels
+  region: false
+  # -- Whether or not to add the availability\_zone label
+  # @section -- Node Labels
+  availabilityZone: false
+  # -- Whether or not to add the node\_role label
+  # @section -- Node Labels
+  nodeRole: false
+  # -- Whether or not to add the os label
+  # @section -- Node Labels
+  nodeOS: false
+  # -- Whether or not to add the node architecture label
+  # @section -- Node Labels
+  nodeArchitecture: false
+  # -- Whether or not to add the instance\_type label
+  # @section -- Node Labels
+  instanceType: false
+
 # -- Scrape metrics/logs from Grafana Alloy
 # @section -- Integration: Alloy
 alloy:

--- a/charts/k8s-monitoring/charts/feature-pod-logs/templates/_api.alloy.tpl
+++ b/charts/k8s-monitoring/charts/feature-pod-logs/templates/_api.alloy.tpl
@@ -6,6 +6,7 @@ discovery.kubernetes "pods" {
     names = {{ .Values.namespaces | toJson }}
   }
 {{- end }}
+{{- include "feature.podLogs.attachNodeMetadata" . | indent 2 }}
 }
 
 loki.source.kubernetes "pod_logs" {

--- a/charts/k8s-monitoring/charts/feature-pod-logs/templates/_common_pod_discovery.alloy.tpl
+++ b/charts/k8s-monitoring/charts/feature-pod-logs/templates/_common_pod_discovery.alloy.tpl
@@ -96,6 +96,7 @@ discovery.relabel "filtered_pods" {
     target_label = {{ $label | quote }}
   }
 {{- end }}
+{{- include "feature.podLogs.nodeDiscoveryRules" . | indent 2 }}
 
 {{- if .Values.extraDiscoveryRules }}
 {{ .Values.extraDiscoveryRules | indent 2 }}

--- a/charts/k8s-monitoring/charts/feature-pod-logs/templates/_helpers.tpl
+++ b/charts/k8s-monitoring/charts/feature-pod-logs/templates/_helpers.tpl
@@ -27,4 +27,3 @@ If release name contains chart name it will be used as a full name.
 {{- define "pod_annotation" -}}
 {{ printf "__meta_kubernetes_pod_annotation_%s" (include "escape_label" .) }}
 {{- end }}
-

--- a/charts/k8s-monitoring/charts/feature-pod-logs/templates/_nodes_common.tpl
+++ b/charts/k8s-monitoring/charts/feature-pod-logs/templates/_nodes_common.tpl
@@ -1,0 +1,102 @@
+{{- define "feature.podLogs.attachNodeMetadata" }}
+{{- $attachMetadata := false -}}
+{{- $attachMetadata = or $attachMetadata .Values.nodeLabels.nodePool -}}
+{{- $attachMetadata = or $attachMetadata .Values.nodeLabels.region -}}
+{{- $attachMetadata = or $attachMetadata .Values.nodeLabels.availabilityZone -}}
+{{- $attachMetadata = or $attachMetadata .Values.nodeLabels.nodeRole -}}
+{{- $attachMetadata = or $attachMetadata .Values.nodeLabels.nodeOS -}}
+{{- $attachMetadata = or $attachMetadata .Values.nodeLabels.nodeArchitecture -}}
+{{- $attachMetadata = or $attachMetadata .Values.nodeLabels.instanceType -}}
+{{- if eq $attachMetadata true }}
+attach_metadata {
+  node = true
+}
+{{- end }}
+{{- end }}
+
+{{- define "feature.podLogs.nodeDiscoveryRules" }}
+{{- if eq .Values.nodeLabels.nodePool true }}
+
+rule {
+  source_labels = [
+    "__meta_kubernetes_node_label_karpenter_sh_nodepool",
+    "__meta_kubernetes_node_label_cloud_google_com_gke_nodepool",
+    "__meta_kubernetes_node_label_eks_amazonaws_com_nodegroup",
+    "__meta_kubernetes_node_label_kubernetes_azure_com_agentpool",
+    "__meta_kubernetes_node_label_agentpool",
+  ]
+  regex = "^(?:;*)?([^;]+).*$"
+  target_label = "nodepool"
+}
+{{- end }}
+{{- if eq .Values.nodeLabels.region true }}
+
+rule {
+  source_labels = [
+    "__meta_kubernetes_node_label_topology_kubernetes_io_region",
+    "__meta_kubernetes_node_label_failure_domain_beta_kubernetes_io_region",
+  ]
+  regex = "^(?:;*)?([^;]+).*$"
+  target_label = "region"
+}
+{{- end }}
+{{- if eq .Values.nodeLabels.availabilityZone true }}
+
+rule {
+  source_labels = [
+    "__meta_kubernetes_node_label_topology_kubernetes_io_zone",
+    "__meta_kubernetes_node_label_failure_domain_beta_kubernetes_io_zone",
+    "__meta_kubernetes_node_label_topology_gke_io_zone",
+  ]
+  regex = "^(?:;*)?([^;]+).*$"
+  target_label = "availability_zone"
+}
+{{- end }}
+{{- if eq .Values.nodeLabels.nodeRole true }}
+
+rule {
+  source_labels = [
+    "__meta_kubernetes_node_label_kubernetes_io_role",
+    "__meta_kubernetes_node_label_node_kubernetes_io_role",
+    "__meta_kubernetes_node_label_node_role",
+    "__meta_kubernetes_node_label_role",
+  ]
+  regex = "^(?:;*)?([^;]+).*$"
+  target_label = "node_role"
+}
+{{- end }}
+{{- if eq .Values.nodeLabels.nodeOS true }}
+
+rule {
+  source_labels = [
+    "__meta_kubernetes_node_label_kubernetes_io_os",
+    "__meta_kubernetes_node_label_os_kubernetes_io",
+    "__meta_kubernetes_node_label_os",
+  ]
+  regex = "^(?:;*)?([^;]+).*$"
+  target_label = "os"
+}
+{{- end }}
+{{- if eq .Values.nodeLabels.nodeArchitecture true }}
+
+rule {
+  source_labels = [
+    "__meta_kubernetes_node_label_kubernetes_io_arch",
+    "__meta_kubernetes_node_label_beta_kubernetes_io_arch",
+  ]
+  regex = "^(?:;*)?([^;]+).*$"
+  target_label = "architecture"
+}
+{{- end }}
+{{- if eq .Values.nodeLabels.instanceType true }}
+
+rule {
+  source_labels = [
+    "__meta_kubernetes_node_label_node_kubernetes_io_instance_type",
+    "__meta_kubernetes_node_label_beta_kubernetes_io_instance_type",
+  ]
+  regex = "^(?:;*)?([^;]+).*$"
+  target_label = "instance_type"
+}
+{{- end }}
+{{- end }}

--- a/charts/k8s-monitoring/charts/feature-pod-logs/templates/_volumes.alloy.tpl
+++ b/charts/k8s-monitoring/charts/feature-pod-logs/templates/_volumes.alloy.tpl
@@ -10,6 +10,7 @@ discovery.kubernetes "pods" {
     names = {{ .Values.namespaces | toJson }}
   }
 {{- end }}
+{{- include "feature.podLogs.attachNodeMetadata" . | indent 2 }}
 }
 
 discovery.relabel "filtered_pods_with_paths" {

--- a/charts/k8s-monitoring/charts/feature-pod-logs/tests/node_labels_test.yaml
+++ b/charts/k8s-monitoring/charts/feature-pod-logs/tests/node_labels_test.yaml
@@ -1,0 +1,345 @@
+# yamllint disable rule:document-start rule:line-length rule:trailing-spaces
+suite: Test - Pod Logs - Node Labels
+templates:
+  - configmap.yaml
+tests:
+  - it: should add the attach_metadata block to the discovery.kubernetes
+    set:
+      deployAsConfigMap: true
+      nodeLabels:
+        nodePool: true
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - matchRegex:
+          path: data["module.alloy"]
+          # The pattern should look like this, but since the regex is escaped, it will be a bit different
+          # attach_metadata {
+          #   node = true
+          # }
+          pattern: |-
+            \s*  attach_metadata \{
+            \s*    node = true
+            \s*  \}
+
+  - it: should add the node pool label rules to the discovery relabel
+    set:
+      deployAsConfigMap: true
+      nodeLabels:
+        nodePool: true
+      structuredMetadata:
+        nodepool: nodepool
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - matchRegex:
+          path: data["module.alloy"]
+          # The pattern should look like this, but since the regex is escaped, it will be a bit different
+          #   rule {
+          #     source_labels = [
+          #       "__meta_kubernetes_node_label_karpenter_sh_nodepool",
+          #       "__meta_kubernetes_node_label_cloud_google_com_gke_nodepool",
+          #       "__meta_kubernetes_node_label_eks_amazonaws_com_nodegroup",
+          #       "__meta_kubernetes_node_label_kubernetes_azure_com_agentpool",
+          #       "__meta_kubernetes_node_label_agentpool",
+          #     ]
+          #     regex = "^(?:;*)?([^;]+).*$"
+          #     target_label = "nodepool"
+          #   }
+          pattern: |-
+            \s*  rule \{
+            \s*    source_labels = \[
+            \s*      "__meta_kubernetes_node_label_karpenter_sh_nodepool",
+            \s*      "__meta_kubernetes_node_label_cloud_google_com_gke_nodepool",
+            \s*      "__meta_kubernetes_node_label_eks_amazonaws_com_nodegroup",
+            \s*      "__meta_kubernetes_node_label_kubernetes_azure_com_agentpool",
+            \s*      "__meta_kubernetes_node_label_agentpool",
+            \s*    \]
+            \s*    regex = "\^\(\?:;\*\)\?\(\[\^;\]\+\)\.\*\$"
+            \s*    target_label = "nodepool"
+            \s*  \}
+      - matchRegex:
+          path: data["module.alloy"]
+          # stage.structured_metadata {
+          #   values = {
+          #     "nodepool" = "nodepool",
+          #   }
+          # }
+          pattern: |-
+            \s*  stage.structured_metadata \{
+            \s*    values = \{
+            \s*      "nodepool" = "nodepool",
+            \s*    \}
+            \s*  \}
+
+  - it: should add the node region label rules to the discovery relabel
+    set:
+      deployAsConfigMap: true
+      nodeLabels:
+        region: true
+      structuredMetadata:
+        region: region
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - matchRegex:
+          path: data["module.alloy"]
+          # The pattern should look like this, but since the regex is escaped, it will be a bit different
+          # rule {
+          #   source_labels = [
+          #     "__meta_kubernetes_node_label_topology_kubernetes_io_region",
+          #     "__meta_kubernetes_node_label_failure_domain_beta_kubernetes_io_region",
+          #   ]
+          #   regex = "^(?:;*)?([^;]+).*$"
+          #   target_label = "region"
+          # }
+          pattern: |-
+            \s*  rule \{
+            \s*    source_labels = \[
+            \s*      "__meta_kubernetes_node_label_topology_kubernetes_io_region",
+            \s*      "__meta_kubernetes_node_label_failure_domain_beta_kubernetes_io_region",
+            \s*    \]
+            \s*    regex = "\^\(\?:;\*\)\?\(\[\^;\]\+\)\.\*\$"
+            \s*    target_label = "region"
+            \s*  \}
+      - matchRegex:
+          path: data["module.alloy"]
+          # stage.structured_metadata {
+          #   values = {
+          #     "nodepool" = "nodepool",
+          #   }
+          # }
+          pattern: |-
+            \s*  stage.structured_metadata \{
+            \s*    values = \{
+            \s*      "region" = "region",
+            \s*    \}
+            \s*  \}
+
+  - it: should add the node availability zone label rules to the discovery relabel
+    set:
+      deployAsConfigMap: true
+      nodeLabels:
+        availabilityZone: true
+      structuredMetadata:
+        availability_zone: availability_zone
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - matchRegex:
+          path: data["module.alloy"]
+          # The pattern should look like this, but since the regex is escaped, it will be a bit different
+          # rule {
+          #   source_labels = [
+          #     "__meta_kubernetes_node_label_topology_kubernetes_io_zone",
+          #     "__meta_kubernetes_node_label_failure_domain_beta_kubernetes_io_zone",
+          #     "__meta_kubernetes_node_label_topology_gke_io_zone",
+          #   ]
+          #   regex = "^(?:;*)?([^;]+).*$"
+          #   target_label = "availability_zone"
+          # }
+          pattern: |-
+            \s*  rule \{
+            \s*    source_labels = \[
+            \s*      "__meta_kubernetes_node_label_topology_kubernetes_io_zone",
+            \s*      "__meta_kubernetes_node_label_failure_domain_beta_kubernetes_io_zone",
+            \s*      "__meta_kubernetes_node_label_topology_gke_io_zone",
+            \s*    \]
+            \s*    regex = "\^\(\?:;\*\)\?\(\[\^;\]\+\)\.\*\$"
+            \s*    target_label = "availability_zone"
+            \s*  \}
+      - matchRegex:
+          path: data["module.alloy"]
+          # stage.structured_metadata {
+          #   values = {
+          #     "nodepool" = "nodepool",
+          #   }
+          # }
+          pattern: |-
+            \s*  stage.structured_metadata \{
+            \s*    values = \{
+            \s*      "availability_zone" = "availability_zone",
+            \s*    \}
+            \s*  \}
+
+  - it: should add the node role label rules to the discovery relabel
+    set:
+      deployAsConfigMap: true
+      nodeLabels:
+        nodeRole: true
+      structuredMetadata:
+        node_role: node_role
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - matchRegex:
+          path: data["module.alloy"]
+          # The pattern should look like this, but since the regex is escaped, it will be a bit different
+          # rule {
+          #   source_labels = [
+          #     "__meta_kubernetes_node_label_kubernetes_io_role",
+          #     "__meta_kubernetes_node_label_node_kubernetes_io_role",
+          #     "__meta_kubernetes_node_label_node_role",
+          #     "__meta_kubernetes_node_label_role",
+          #   ]
+          #   regex = "^(?:;*)?([^;]+).*$"
+          #   target_label = "node_role"
+          # }
+          pattern: |-
+            \s*  rule \{
+            \s*    source_labels = \[
+            \s*      "__meta_kubernetes_node_label_kubernetes_io_role",
+            \s*      "__meta_kubernetes_node_label_node_kubernetes_io_role",
+            \s*      "__meta_kubernetes_node_label_node_role",
+            \s*      "__meta_kubernetes_node_label_role",
+            \s*    \]
+            \s*    regex = "\^\(\?:;\*\)\?\(\[\^;\]\+\)\.\*\$"
+            \s*    target_label = "node_role"
+            \s*  \}
+      - matchRegex:
+          path: data["module.alloy"]
+          # stage.structured_metadata {
+          #   values = {
+          #     "nodepool" = "nodepool",
+          #   }
+          # }
+          pattern: |-
+            \s*  stage.structured_metadata \{
+            \s*    values = \{
+            \s*      "node_role" = "node_role",
+            \s*    \}
+            \s*  \}
+
+  - it: should add the node os label rules to the discovery relabel
+    set:
+      deployAsConfigMap: true
+      nodeLabels:
+        nodeOS: true
+      structuredMetadata:
+        os: os
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - matchRegex:
+          path: data["module.alloy"]
+          # The pattern should look like this, but since the regex is escaped, it will be a bit different
+          # rule {
+          #   source_labels = [
+          #     "__meta_kubernetes_node_label_kubernetes_io_os",
+          #     "__meta_kubernetes_node_label_os_kubernetes_io",
+          #     "__meta_kubernetes_node_label_os",
+          #   ]
+          #   regex = "^(?:;*)?([^;]+).*$"
+          #   target_label = "os"
+          # }
+          pattern: |-
+            \s*  rule \{
+            \s*    source_labels = \[
+            \s*      "__meta_kubernetes_node_label_kubernetes_io_os",
+            \s*      "__meta_kubernetes_node_label_os_kubernetes_io",
+            \s*      "__meta_kubernetes_node_label_os",
+            \s*    \]
+            \s*    regex = "\^\(\?:;\*\)\?\(\[\^;\]\+\)\.\*\$"
+            \s*    target_label = "os"
+            \s*  \}
+      - matchRegex:
+          path: data["module.alloy"]
+          # stage.structured_metadata {
+          #   values = {
+          #     "nodepool" = "nodepool",
+          #   }
+          # }
+          pattern: |-
+            \s*  stage.structured_metadata \{
+            \s*    values = \{
+            \s*      "os" = "os",
+            \s*    \}
+            \s*  \}
+
+  - it: should add the node architecture label rules to the discovery relabel
+    set:
+      deployAsConfigMap: true
+      nodeLabels:
+        nodeArchitecture: true
+      structuredMetadata:
+        architecture: architecture
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - matchRegex:
+          path: data["module.alloy"]
+          # The pattern should look like this, but since the regex is escaped, it will be a bit different
+          # rule {
+          #   source_labels = [
+          #     "__meta_kubernetes_node_label_kubernetes_io_arch",
+          #     "__meta_kubernetes_node_label_beta_kubernetes_io_arch",
+          #   ]
+          #   regex = "^(?:;*)?([^;]+).*$"
+          #   target_label = "architecture"
+          # }
+          pattern: |-
+            \s*  rule \{
+            \s*    source_labels = \[
+            \s*      "__meta_kubernetes_node_label_kubernetes_io_arch",
+            \s*      "__meta_kubernetes_node_label_beta_kubernetes_io_arch",
+            \s*    \]
+            \s*    regex = "\^\(\?:;\*\)\?\(\[\^;\]\+\)\.\*\$"
+            \s*    target_label = "architecture"
+            \s*  \}
+      - matchRegex:
+          path: data["module.alloy"]
+          # stage.structured_metadata {
+          #   values = {
+          #     "nodepool" = "nodepool",
+          #   }
+          # }
+          pattern: |-
+            \s*  stage.structured_metadata \{
+            \s*    values = \{
+            \s*      "architecture" = "architecture",
+            \s*    \}
+            \s*  \}
+
+  - it: should add the node instance type label rules to the discovery relabel
+    set:
+      deployAsConfigMap: true
+      nodeLabels:
+        instanceType: true
+      structuredMetadata:
+        instance_type: instance_type
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - matchRegex:
+          path: data["module.alloy"]
+          # The pattern should look like this, but since the regex is escaped, it will be a bit different
+          # rule {
+          #   source_labels = [
+          #     "__meta_kubernetes_node_label_node_kubernetes_io_instance_type",
+          #     "__meta_kubernetes_node_label_beta_kubernetes_io_instance_type",
+          #   ]
+          #   regex = "^(?:;*)?([^;]+).*$"
+          #   target_label = "instance_type"
+          # }
+          pattern: |-
+            \s*  rule \{
+            \s*    source_labels = \[
+            \s*      "__meta_kubernetes_node_label_node_kubernetes_io_instance_type",
+            \s*      "__meta_kubernetes_node_label_beta_kubernetes_io_instance_type",
+            \s*    \]
+            \s*    regex = "\^\(\?:;\*\)\?\(\[\^;\]\+\)\.\*\$"
+            \s*    target_label = "instance_type"
+            \s*  \}
+      - matchRegex:
+          path: data["module.alloy"]
+          # stage.structured_metadata {
+          #   values = {
+          #     "nodepool" = "nodepool",
+          #   }
+          # }
+          pattern: |-
+            \s*  stage.structured_metadata \{
+            \s*    values = \{
+            \s*      "instance_type" = "instance_type",
+            \s*    \}
+            \s*  \}

--- a/charts/k8s-monitoring/docs/examples/auth/oauth2/alloy-metrics.alloy
+++ b/charts/k8s-monitoring/docs/examples/auth/oauth2/alloy-metrics.alloy
@@ -310,9 +310,23 @@ declare "cluster_metrics" {
     role = "node"
   }
 
+  discovery.relabel "nodes" {
+    targets = discovery.kubernetes.nodes.targets
+    rule {
+      source_labels = ["__meta_kubernetes_node_name"]
+      target_label  = "node"
+    }
+
+    rule {
+      replacement = "kubernetes"
+      target_label = "source"
+    }
+
+  }
+
   // Kubelet
   discovery.relabel "kubelet" {
-    targets = discovery.kubernetes.nodes.targets
+    targets = discovery.relabel.nodes.output
   }
 
   prometheus.scrape "kubelet" {
@@ -348,41 +362,15 @@ declare "cluster_metrics" {
 
   // Kubelet Resources
   discovery.relabel "kubelet_resources" {
-    targets = discovery.kubernetes.nodes.targets
+    targets = discovery.relabel.nodes.output
     rule {
       replacement   = "/metrics/resource"
       target_label  = "__metrics_path__"
     }
-    // set the node label
-    rule {
-      source_labels = ["__meta_kubernetes_node_name"]
-      target_label  = "node"
-    }
-
-    // set the app name if specified as metadata labels "app:" or "app.kubernetes.io/name:" or "k8s-app:"
-    rule {
-      action = "replace"
-      source_labels = [
-        "__meta_kubernetes_node_label_app_kubernetes_io_name",
-        "__meta_kubernetes_node_label_k8s_app",
-        "__meta_kubernetes_node_label_app",
-      ]
-      separator = ";"
-      regex = "^(?:;*)?([^;]+).*$"
-      replacement = "$1"
-      target_label = "app"
-    }
-
-    // set a source label
-    rule {
-      action = "replace"
-      replacement = "kubernetes"
-      target_label = "source"
-    }
   }
 
   prometheus.scrape "kubelet_resources" {
-    targets  = discovery.relabel.kubelet_resources.output
+    targets = discovery.relabel.kubelet_resources.output
     job_name = "integrations/kubernetes/resources"
     scheme   = "https"
     scrape_interval = "60s"
@@ -414,34 +402,10 @@ declare "cluster_metrics" {
 
   // cAdvisor
   discovery.relabel "cadvisor" {
-    targets = discovery.kubernetes.nodes.targets
+    targets = discovery.relabel.nodes.output
     rule {
       replacement   = "/metrics/cadvisor"
       target_label  = "__metrics_path__"
-    }
-    rule {
-      source_labels = ["__meta_kubernetes_node_name"]
-      target_label  = "node"
-    }
-    // set the app name if specified as metadata labels "app:" or "app.kubernetes.io/name:" or "k8s-app:"
-    rule {
-      action = "replace"
-      source_labels = [
-        "__meta_kubernetes_node_label_app_kubernetes_io_name",
-        "__meta_kubernetes_node_label_k8s_app",
-        "__meta_kubernetes_node_label_app",
-      ]
-      separator = ";"
-      regex = "^(?:;*)?([^;]+).*$"
-      replacement = "$1"
-      target_label = "app"
-    }
-
-    // set a source label
-    rule {
-      action = "replace"
-      replacement = "kubernetes"
-      target_label = "source"
     }
   }
 

--- a/charts/k8s-monitoring/docs/examples/auth/oauth2/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/auth/oauth2/output.yaml
@@ -450,9 +450,23 @@ data:
         role = "node"
       }
     
+      discovery.relabel "nodes" {
+        targets = discovery.kubernetes.nodes.targets
+        rule {
+          source_labels = ["__meta_kubernetes_node_name"]
+          target_label  = "node"
+        }
+    
+        rule {
+          replacement = "kubernetes"
+          target_label = "source"
+        }
+    
+      }
+    
       // Kubelet
       discovery.relabel "kubelet" {
-        targets = discovery.kubernetes.nodes.targets
+        targets = discovery.relabel.nodes.output
       }
     
       prometheus.scrape "kubelet" {
@@ -488,41 +502,15 @@ data:
     
       // Kubelet Resources
       discovery.relabel "kubelet_resources" {
-        targets = discovery.kubernetes.nodes.targets
+        targets = discovery.relabel.nodes.output
         rule {
           replacement   = "/metrics/resource"
           target_label  = "__metrics_path__"
         }
-        // set the node label
-        rule {
-          source_labels = ["__meta_kubernetes_node_name"]
-          target_label  = "node"
-        }
-    
-        // set the app name if specified as metadata labels "app:" or "app.kubernetes.io/name:" or "k8s-app:"
-        rule {
-          action = "replace"
-          source_labels = [
-            "__meta_kubernetes_node_label_app_kubernetes_io_name",
-            "__meta_kubernetes_node_label_k8s_app",
-            "__meta_kubernetes_node_label_app",
-          ]
-          separator = ";"
-          regex = "^(?:;*)?([^;]+).*$"
-          replacement = "$1"
-          target_label = "app"
-        }
-    
-        // set a source label
-        rule {
-          action = "replace"
-          replacement = "kubernetes"
-          target_label = "source"
-        }
       }
     
       prometheus.scrape "kubelet_resources" {
-        targets  = discovery.relabel.kubelet_resources.output
+        targets = discovery.relabel.kubelet_resources.output
         job_name = "integrations/kubernetes/resources"
         scheme   = "https"
         scrape_interval = "60s"
@@ -554,34 +542,10 @@ data:
     
       // cAdvisor
       discovery.relabel "cadvisor" {
-        targets = discovery.kubernetes.nodes.targets
+        targets = discovery.relabel.nodes.output
         rule {
           replacement   = "/metrics/cadvisor"
           target_label  = "__metrics_path__"
-        }
-        rule {
-          source_labels = ["__meta_kubernetes_node_name"]
-          target_label  = "node"
-        }
-        // set the app name if specified as metadata labels "app:" or "app.kubernetes.io/name:" or "k8s-app:"
-        rule {
-          action = "replace"
-          source_labels = [
-            "__meta_kubernetes_node_label_app_kubernetes_io_name",
-            "__meta_kubernetes_node_label_k8s_app",
-            "__meta_kubernetes_node_label_app",
-          ]
-          separator = ";"
-          regex = "^(?:;*)?([^;]+).*$"
-          replacement = "$1"
-          target_label = "app"
-        }
-    
-        // set a source label
-        rule {
-          action = "replace"
-          replacement = "kubernetes"
-          target_label = "source"
         }
       }
     

--- a/charts/k8s-monitoring/docs/examples/auth/sigv4/alloy-metrics.alloy
+++ b/charts/k8s-monitoring/docs/examples/auth/sigv4/alloy-metrics.alloy
@@ -7,9 +7,23 @@ declare "cluster_metrics" {
     role = "node"
   }
 
+  discovery.relabel "nodes" {
+    targets = discovery.kubernetes.nodes.targets
+    rule {
+      source_labels = ["__meta_kubernetes_node_name"]
+      target_label  = "node"
+    }
+
+    rule {
+      replacement = "kubernetes"
+      target_label = "source"
+    }
+
+  }
+
   // Kubelet
   discovery.relabel "kubelet" {
-    targets = discovery.kubernetes.nodes.targets
+    targets = discovery.relabel.nodes.output
   }
 
   prometheus.scrape "kubelet" {
@@ -45,41 +59,15 @@ declare "cluster_metrics" {
 
   // Kubelet Resources
   discovery.relabel "kubelet_resources" {
-    targets = discovery.kubernetes.nodes.targets
+    targets = discovery.relabel.nodes.output
     rule {
       replacement   = "/metrics/resource"
       target_label  = "__metrics_path__"
     }
-    // set the node label
-    rule {
-      source_labels = ["__meta_kubernetes_node_name"]
-      target_label  = "node"
-    }
-
-    // set the app name if specified as metadata labels "app:" or "app.kubernetes.io/name:" or "k8s-app:"
-    rule {
-      action = "replace"
-      source_labels = [
-        "__meta_kubernetes_node_label_app_kubernetes_io_name",
-        "__meta_kubernetes_node_label_k8s_app",
-        "__meta_kubernetes_node_label_app",
-      ]
-      separator = ";"
-      regex = "^(?:;*)?([^;]+).*$"
-      replacement = "$1"
-      target_label = "app"
-    }
-
-    // set a source label
-    rule {
-      action = "replace"
-      replacement = "kubernetes"
-      target_label = "source"
-    }
   }
 
   prometheus.scrape "kubelet_resources" {
-    targets  = discovery.relabel.kubelet_resources.output
+    targets = discovery.relabel.kubelet_resources.output
     job_name = "integrations/kubernetes/resources"
     scheme   = "https"
     scrape_interval = "60s"
@@ -111,34 +99,10 @@ declare "cluster_metrics" {
 
   // cAdvisor
   discovery.relabel "cadvisor" {
-    targets = discovery.kubernetes.nodes.targets
+    targets = discovery.relabel.nodes.output
     rule {
       replacement   = "/metrics/cadvisor"
       target_label  = "__metrics_path__"
-    }
-    rule {
-      source_labels = ["__meta_kubernetes_node_name"]
-      target_label  = "node"
-    }
-    // set the app name if specified as metadata labels "app:" or "app.kubernetes.io/name:" or "k8s-app:"
-    rule {
-      action = "replace"
-      source_labels = [
-        "__meta_kubernetes_node_label_app_kubernetes_io_name",
-        "__meta_kubernetes_node_label_k8s_app",
-        "__meta_kubernetes_node_label_app",
-      ]
-      separator = ";"
-      regex = "^(?:;*)?([^;]+).*$"
-      replacement = "$1"
-      target_label = "app"
-    }
-
-    // set a source label
-    rule {
-      action = "replace"
-      replacement = "kubernetes"
-      target_label = "source"
     }
   }
 

--- a/charts/k8s-monitoring/docs/examples/auth/sigv4/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/auth/sigv4/output.yaml
@@ -116,9 +116,23 @@ data:
         role = "node"
       }
     
+      discovery.relabel "nodes" {
+        targets = discovery.kubernetes.nodes.targets
+        rule {
+          source_labels = ["__meta_kubernetes_node_name"]
+          target_label  = "node"
+        }
+    
+        rule {
+          replacement = "kubernetes"
+          target_label = "source"
+        }
+    
+      }
+    
       // Kubelet
       discovery.relabel "kubelet" {
-        targets = discovery.kubernetes.nodes.targets
+        targets = discovery.relabel.nodes.output
       }
     
       prometheus.scrape "kubelet" {
@@ -154,41 +168,15 @@ data:
     
       // Kubelet Resources
       discovery.relabel "kubelet_resources" {
-        targets = discovery.kubernetes.nodes.targets
+        targets = discovery.relabel.nodes.output
         rule {
           replacement   = "/metrics/resource"
           target_label  = "__metrics_path__"
         }
-        // set the node label
-        rule {
-          source_labels = ["__meta_kubernetes_node_name"]
-          target_label  = "node"
-        }
-    
-        // set the app name if specified as metadata labels "app:" or "app.kubernetes.io/name:" or "k8s-app:"
-        rule {
-          action = "replace"
-          source_labels = [
-            "__meta_kubernetes_node_label_app_kubernetes_io_name",
-            "__meta_kubernetes_node_label_k8s_app",
-            "__meta_kubernetes_node_label_app",
-          ]
-          separator = ";"
-          regex = "^(?:;*)?([^;]+).*$"
-          replacement = "$1"
-          target_label = "app"
-        }
-    
-        // set a source label
-        rule {
-          action = "replace"
-          replacement = "kubernetes"
-          target_label = "source"
-        }
       }
     
       prometheus.scrape "kubelet_resources" {
-        targets  = discovery.relabel.kubelet_resources.output
+        targets = discovery.relabel.kubelet_resources.output
         job_name = "integrations/kubernetes/resources"
         scheme   = "https"
         scrape_interval = "60s"
@@ -220,34 +208,10 @@ data:
     
       // cAdvisor
       discovery.relabel "cadvisor" {
-        targets = discovery.kubernetes.nodes.targets
+        targets = discovery.relabel.nodes.output
         rule {
           replacement   = "/metrics/cadvisor"
           target_label  = "__metrics_path__"
-        }
-        rule {
-          source_labels = ["__meta_kubernetes_node_name"]
-          target_label  = "node"
-        }
-        // set the app name if specified as metadata labels "app:" or "app.kubernetes.io/name:" or "k8s-app:"
-        rule {
-          action = "replace"
-          source_labels = [
-            "__meta_kubernetes_node_label_app_kubernetes_io_name",
-            "__meta_kubernetes_node_label_k8s_app",
-            "__meta_kubernetes_node_label_app",
-          ]
-          separator = ";"
-          regex = "^(?:;*)?([^;]+).*$"
-          replacement = "$1"
-          target_label = "app"
-        }
-    
-        // set a source label
-        rule {
-          action = "replace"
-          replacement = "kubernetes"
-          target_label = "source"
         }
       }
     

--- a/charts/k8s-monitoring/docs/examples/collector-storage/alloy-metrics.alloy
+++ b/charts/k8s-monitoring/docs/examples/collector-storage/alloy-metrics.alloy
@@ -7,9 +7,23 @@ declare "cluster_metrics" {
     role = "node"
   }
 
+  discovery.relabel "nodes" {
+    targets = discovery.kubernetes.nodes.targets
+    rule {
+      source_labels = ["__meta_kubernetes_node_name"]
+      target_label  = "node"
+    }
+
+    rule {
+      replacement = "kubernetes"
+      target_label = "source"
+    }
+
+  }
+
   // Kubelet
   discovery.relabel "kubelet" {
-    targets = discovery.kubernetes.nodes.targets
+    targets = discovery.relabel.nodes.output
   }
 
   prometheus.scrape "kubelet" {
@@ -45,41 +59,15 @@ declare "cluster_metrics" {
 
   // Kubelet Resources
   discovery.relabel "kubelet_resources" {
-    targets = discovery.kubernetes.nodes.targets
+    targets = discovery.relabel.nodes.output
     rule {
       replacement   = "/metrics/resource"
       target_label  = "__metrics_path__"
     }
-    // set the node label
-    rule {
-      source_labels = ["__meta_kubernetes_node_name"]
-      target_label  = "node"
-    }
-
-    // set the app name if specified as metadata labels "app:" or "app.kubernetes.io/name:" or "k8s-app:"
-    rule {
-      action = "replace"
-      source_labels = [
-        "__meta_kubernetes_node_label_app_kubernetes_io_name",
-        "__meta_kubernetes_node_label_k8s_app",
-        "__meta_kubernetes_node_label_app",
-      ]
-      separator = ";"
-      regex = "^(?:;*)?([^;]+).*$"
-      replacement = "$1"
-      target_label = "app"
-    }
-
-    // set a source label
-    rule {
-      action = "replace"
-      replacement = "kubernetes"
-      target_label = "source"
-    }
   }
 
   prometheus.scrape "kubelet_resources" {
-    targets  = discovery.relabel.kubelet_resources.output
+    targets = discovery.relabel.kubelet_resources.output
     job_name = "integrations/kubernetes/resources"
     scheme   = "https"
     scrape_interval = "60s"
@@ -111,34 +99,10 @@ declare "cluster_metrics" {
 
   // cAdvisor
   discovery.relabel "cadvisor" {
-    targets = discovery.kubernetes.nodes.targets
+    targets = discovery.relabel.nodes.output
     rule {
       replacement   = "/metrics/cadvisor"
       target_label  = "__metrics_path__"
-    }
-    rule {
-      source_labels = ["__meta_kubernetes_node_name"]
-      target_label  = "node"
-    }
-    // set the app name if specified as metadata labels "app:" or "app.kubernetes.io/name:" or "k8s-app:"
-    rule {
-      action = "replace"
-      source_labels = [
-        "__meta_kubernetes_node_label_app_kubernetes_io_name",
-        "__meta_kubernetes_node_label_k8s_app",
-        "__meta_kubernetes_node_label_app",
-      ]
-      separator = ";"
-      regex = "^(?:;*)?([^;]+).*$"
-      replacement = "$1"
-      target_label = "app"
-    }
-
-    // set a source label
-    rule {
-      action = "replace"
-      replacement = "kubernetes"
-      target_label = "source"
     }
   }
 

--- a/charts/k8s-monitoring/docs/examples/collector-storage/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/collector-storage/output.yaml
@@ -121,9 +121,23 @@ data:
         role = "node"
       }
     
+      discovery.relabel "nodes" {
+        targets = discovery.kubernetes.nodes.targets
+        rule {
+          source_labels = ["__meta_kubernetes_node_name"]
+          target_label  = "node"
+        }
+    
+        rule {
+          replacement = "kubernetes"
+          target_label = "source"
+        }
+    
+      }
+    
       // Kubelet
       discovery.relabel "kubelet" {
-        targets = discovery.kubernetes.nodes.targets
+        targets = discovery.relabel.nodes.output
       }
     
       prometheus.scrape "kubelet" {
@@ -159,41 +173,15 @@ data:
     
       // Kubelet Resources
       discovery.relabel "kubelet_resources" {
-        targets = discovery.kubernetes.nodes.targets
+        targets = discovery.relabel.nodes.output
         rule {
           replacement   = "/metrics/resource"
           target_label  = "__metrics_path__"
         }
-        // set the node label
-        rule {
-          source_labels = ["__meta_kubernetes_node_name"]
-          target_label  = "node"
-        }
-    
-        // set the app name if specified as metadata labels "app:" or "app.kubernetes.io/name:" or "k8s-app:"
-        rule {
-          action = "replace"
-          source_labels = [
-            "__meta_kubernetes_node_label_app_kubernetes_io_name",
-            "__meta_kubernetes_node_label_k8s_app",
-            "__meta_kubernetes_node_label_app",
-          ]
-          separator = ";"
-          regex = "^(?:;*)?([^;]+).*$"
-          replacement = "$1"
-          target_label = "app"
-        }
-    
-        // set a source label
-        rule {
-          action = "replace"
-          replacement = "kubernetes"
-          target_label = "source"
-        }
       }
     
       prometheus.scrape "kubelet_resources" {
-        targets  = discovery.relabel.kubelet_resources.output
+        targets = discovery.relabel.kubelet_resources.output
         job_name = "integrations/kubernetes/resources"
         scheme   = "https"
         scrape_interval = "60s"
@@ -225,34 +213,10 @@ data:
     
       // cAdvisor
       discovery.relabel "cadvisor" {
-        targets = discovery.kubernetes.nodes.targets
+        targets = discovery.relabel.nodes.output
         rule {
           replacement   = "/metrics/cadvisor"
           target_label  = "__metrics_path__"
-        }
-        rule {
-          source_labels = ["__meta_kubernetes_node_name"]
-          target_label  = "node"
-        }
-        // set the app name if specified as metadata labels "app:" or "app.kubernetes.io/name:" or "k8s-app:"
-        rule {
-          action = "replace"
-          source_labels = [
-            "__meta_kubernetes_node_label_app_kubernetes_io_name",
-            "__meta_kubernetes_node_label_k8s_app",
-            "__meta_kubernetes_node_label_app",
-          ]
-          separator = ";"
-          regex = "^(?:;*)?([^;]+).*$"
-          replacement = "$1"
-          target_label = "app"
-        }
-    
-        // set a source label
-        rule {
-          action = "replace"
-          replacement = "kubernetes"
-          target_label = "source"
         }
       }
     

--- a/charts/k8s-monitoring/docs/examples/destinations/otlp-endpoint/alloy-metrics.alloy
+++ b/charts/k8s-monitoring/docs/examples/destinations/otlp-endpoint/alloy-metrics.alloy
@@ -7,9 +7,23 @@ declare "cluster_metrics" {
     role = "node"
   }
 
+  discovery.relabel "nodes" {
+    targets = discovery.kubernetes.nodes.targets
+    rule {
+      source_labels = ["__meta_kubernetes_node_name"]
+      target_label  = "node"
+    }
+
+    rule {
+      replacement = "kubernetes"
+      target_label = "source"
+    }
+
+  }
+
   // Kubelet
   discovery.relabel "kubelet" {
-    targets = discovery.kubernetes.nodes.targets
+    targets = discovery.relabel.nodes.output
   }
 
   prometheus.scrape "kubelet" {
@@ -45,41 +59,15 @@ declare "cluster_metrics" {
 
   // Kubelet Resources
   discovery.relabel "kubelet_resources" {
-    targets = discovery.kubernetes.nodes.targets
+    targets = discovery.relabel.nodes.output
     rule {
       replacement   = "/metrics/resource"
       target_label  = "__metrics_path__"
     }
-    // set the node label
-    rule {
-      source_labels = ["__meta_kubernetes_node_name"]
-      target_label  = "node"
-    }
-
-    // set the app name if specified as metadata labels "app:" or "app.kubernetes.io/name:" or "k8s-app:"
-    rule {
-      action = "replace"
-      source_labels = [
-        "__meta_kubernetes_node_label_app_kubernetes_io_name",
-        "__meta_kubernetes_node_label_k8s_app",
-        "__meta_kubernetes_node_label_app",
-      ]
-      separator = ";"
-      regex = "^(?:;*)?([^;]+).*$"
-      replacement = "$1"
-      target_label = "app"
-    }
-
-    // set a source label
-    rule {
-      action = "replace"
-      replacement = "kubernetes"
-      target_label = "source"
-    }
   }
 
   prometheus.scrape "kubelet_resources" {
-    targets  = discovery.relabel.kubelet_resources.output
+    targets = discovery.relabel.kubelet_resources.output
     job_name = "integrations/kubernetes/resources"
     scheme   = "https"
     scrape_interval = "60s"
@@ -111,34 +99,10 @@ declare "cluster_metrics" {
 
   // cAdvisor
   discovery.relabel "cadvisor" {
-    targets = discovery.kubernetes.nodes.targets
+    targets = discovery.relabel.nodes.output
     rule {
       replacement   = "/metrics/cadvisor"
       target_label  = "__metrics_path__"
-    }
-    rule {
-      source_labels = ["__meta_kubernetes_node_name"]
-      target_label  = "node"
-    }
-    // set the app name if specified as metadata labels "app:" or "app.kubernetes.io/name:" or "k8s-app:"
-    rule {
-      action = "replace"
-      source_labels = [
-        "__meta_kubernetes_node_label_app_kubernetes_io_name",
-        "__meta_kubernetes_node_label_k8s_app",
-        "__meta_kubernetes_node_label_app",
-      ]
-      separator = ";"
-      regex = "^(?:;*)?([^;]+).*$"
-      replacement = "$1"
-      target_label = "app"
-    }
-
-    // set a source label
-    rule {
-      action = "replace"
-      replacement = "kubernetes"
-      target_label = "source"
     }
   }
 

--- a/charts/k8s-monitoring/docs/examples/destinations/otlp-endpoint/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/destinations/otlp-endpoint/output.yaml
@@ -132,9 +132,23 @@ data:
         role = "node"
       }
     
+      discovery.relabel "nodes" {
+        targets = discovery.kubernetes.nodes.targets
+        rule {
+          source_labels = ["__meta_kubernetes_node_name"]
+          target_label  = "node"
+        }
+    
+        rule {
+          replacement = "kubernetes"
+          target_label = "source"
+        }
+    
+      }
+    
       // Kubelet
       discovery.relabel "kubelet" {
-        targets = discovery.kubernetes.nodes.targets
+        targets = discovery.relabel.nodes.output
       }
     
       prometheus.scrape "kubelet" {
@@ -170,41 +184,15 @@ data:
     
       // Kubelet Resources
       discovery.relabel "kubelet_resources" {
-        targets = discovery.kubernetes.nodes.targets
+        targets = discovery.relabel.nodes.output
         rule {
           replacement   = "/metrics/resource"
           target_label  = "__metrics_path__"
         }
-        // set the node label
-        rule {
-          source_labels = ["__meta_kubernetes_node_name"]
-          target_label  = "node"
-        }
-    
-        // set the app name if specified as metadata labels "app:" or "app.kubernetes.io/name:" or "k8s-app:"
-        rule {
-          action = "replace"
-          source_labels = [
-            "__meta_kubernetes_node_label_app_kubernetes_io_name",
-            "__meta_kubernetes_node_label_k8s_app",
-            "__meta_kubernetes_node_label_app",
-          ]
-          separator = ";"
-          regex = "^(?:;*)?([^;]+).*$"
-          replacement = "$1"
-          target_label = "app"
-        }
-    
-        // set a source label
-        rule {
-          action = "replace"
-          replacement = "kubernetes"
-          target_label = "source"
-        }
       }
     
       prometheus.scrape "kubelet_resources" {
-        targets  = discovery.relabel.kubelet_resources.output
+        targets = discovery.relabel.kubelet_resources.output
         job_name = "integrations/kubernetes/resources"
         scheme   = "https"
         scrape_interval = "60s"
@@ -236,34 +224,10 @@ data:
     
       // cAdvisor
       discovery.relabel "cadvisor" {
-        targets = discovery.kubernetes.nodes.targets
+        targets = discovery.relabel.nodes.output
         rule {
           replacement   = "/metrics/cadvisor"
           target_label  = "__metrics_path__"
-        }
-        rule {
-          source_labels = ["__meta_kubernetes_node_name"]
-          target_label  = "node"
-        }
-        // set the app name if specified as metadata labels "app:" or "app.kubernetes.io/name:" or "k8s-app:"
-        rule {
-          action = "replace"
-          source_labels = [
-            "__meta_kubernetes_node_label_app_kubernetes_io_name",
-            "__meta_kubernetes_node_label_k8s_app",
-            "__meta_kubernetes_node_label_app",
-          ]
-          separator = ";"
-          regex = "^(?:;*)?([^;]+).*$"
-          replacement = "$1"
-          target_label = "app"
-        }
-    
-        // set a source label
-        rule {
-          action = "replace"
-          replacement = "kubernetes"
-          target_label = "source"
         }
       }
     

--- a/charts/k8s-monitoring/docs/examples/exclude-by-namespace/alloy-metrics.alloy
+++ b/charts/k8s-monitoring/docs/examples/exclude-by-namespace/alloy-metrics.alloy
@@ -373,9 +373,23 @@ declare "cluster_metrics" {
     role = "node"
   }
 
+  discovery.relabel "nodes" {
+    targets = discovery.kubernetes.nodes.targets
+    rule {
+      source_labels = ["__meta_kubernetes_node_name"]
+      target_label  = "node"
+    }
+
+    rule {
+      replacement = "kubernetes"
+      target_label = "source"
+    }
+
+  }
+
   // Kubelet
   discovery.relabel "kubelet" {
-    targets = discovery.kubernetes.nodes.targets
+    targets = discovery.relabel.nodes.output
   }
 
   prometheus.scrape "kubelet" {
@@ -411,41 +425,15 @@ declare "cluster_metrics" {
 
   // Kubelet Resources
   discovery.relabel "kubelet_resources" {
-    targets = discovery.kubernetes.nodes.targets
+    targets = discovery.relabel.nodes.output
     rule {
       replacement   = "/metrics/resource"
       target_label  = "__metrics_path__"
     }
-    // set the node label
-    rule {
-      source_labels = ["__meta_kubernetes_node_name"]
-      target_label  = "node"
-    }
-
-    // set the app name if specified as metadata labels "app:" or "app.kubernetes.io/name:" or "k8s-app:"
-    rule {
-      action = "replace"
-      source_labels = [
-        "__meta_kubernetes_node_label_app_kubernetes_io_name",
-        "__meta_kubernetes_node_label_k8s_app",
-        "__meta_kubernetes_node_label_app",
-      ]
-      separator = ";"
-      regex = "^(?:;*)?([^;]+).*$"
-      replacement = "$1"
-      target_label = "app"
-    }
-
-    // set a source label
-    rule {
-      action = "replace"
-      replacement = "kubernetes"
-      target_label = "source"
-    }
   }
 
   prometheus.scrape "kubelet_resources" {
-    targets  = discovery.relabel.kubelet_resources.output
+    targets = discovery.relabel.kubelet_resources.output
     job_name = "integrations/kubernetes/resources"
     scheme   = "https"
     scrape_interval = "60s"
@@ -477,34 +465,10 @@ declare "cluster_metrics" {
 
   // cAdvisor
   discovery.relabel "cadvisor" {
-    targets = discovery.kubernetes.nodes.targets
+    targets = discovery.relabel.nodes.output
     rule {
       replacement   = "/metrics/cadvisor"
       target_label  = "__metrics_path__"
-    }
-    rule {
-      source_labels = ["__meta_kubernetes_node_name"]
-      target_label  = "node"
-    }
-    // set the app name if specified as metadata labels "app:" or "app.kubernetes.io/name:" or "k8s-app:"
-    rule {
-      action = "replace"
-      source_labels = [
-        "__meta_kubernetes_node_label_app_kubernetes_io_name",
-        "__meta_kubernetes_node_label_k8s_app",
-        "__meta_kubernetes_node_label_app",
-      ]
-      separator = ";"
-      regex = "^(?:;*)?([^;]+).*$"
-      replacement = "$1"
-      target_label = "app"
-    }
-
-    // set a source label
-    rule {
-      action = "replace"
-      replacement = "kubernetes"
-      target_label = "source"
     }
   }
 

--- a/charts/k8s-monitoring/docs/examples/exclude-by-namespace/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/exclude-by-namespace/output.yaml
@@ -551,9 +551,23 @@ data:
         role = "node"
       }
     
+      discovery.relabel "nodes" {
+        targets = discovery.kubernetes.nodes.targets
+        rule {
+          source_labels = ["__meta_kubernetes_node_name"]
+          target_label  = "node"
+        }
+    
+        rule {
+          replacement = "kubernetes"
+          target_label = "source"
+        }
+    
+      }
+    
       // Kubelet
       discovery.relabel "kubelet" {
-        targets = discovery.kubernetes.nodes.targets
+        targets = discovery.relabel.nodes.output
       }
     
       prometheus.scrape "kubelet" {
@@ -589,41 +603,15 @@ data:
     
       // Kubelet Resources
       discovery.relabel "kubelet_resources" {
-        targets = discovery.kubernetes.nodes.targets
+        targets = discovery.relabel.nodes.output
         rule {
           replacement   = "/metrics/resource"
           target_label  = "__metrics_path__"
         }
-        // set the node label
-        rule {
-          source_labels = ["__meta_kubernetes_node_name"]
-          target_label  = "node"
-        }
-    
-        // set the app name if specified as metadata labels "app:" or "app.kubernetes.io/name:" or "k8s-app:"
-        rule {
-          action = "replace"
-          source_labels = [
-            "__meta_kubernetes_node_label_app_kubernetes_io_name",
-            "__meta_kubernetes_node_label_k8s_app",
-            "__meta_kubernetes_node_label_app",
-          ]
-          separator = ";"
-          regex = "^(?:;*)?([^;]+).*$"
-          replacement = "$1"
-          target_label = "app"
-        }
-    
-        // set a source label
-        rule {
-          action = "replace"
-          replacement = "kubernetes"
-          target_label = "source"
-        }
       }
     
       prometheus.scrape "kubelet_resources" {
-        targets  = discovery.relabel.kubelet_resources.output
+        targets = discovery.relabel.kubelet_resources.output
         job_name = "integrations/kubernetes/resources"
         scheme   = "https"
         scrape_interval = "60s"
@@ -655,34 +643,10 @@ data:
     
       // cAdvisor
       discovery.relabel "cadvisor" {
-        targets = discovery.kubernetes.nodes.targets
+        targets = discovery.relabel.nodes.output
         rule {
           replacement   = "/metrics/cadvisor"
           target_label  = "__metrics_path__"
-        }
-        rule {
-          source_labels = ["__meta_kubernetes_node_name"]
-          target_label  = "node"
-        }
-        // set the app name if specified as metadata labels "app:" or "app.kubernetes.io/name:" or "k8s-app:"
-        rule {
-          action = "replace"
-          source_labels = [
-            "__meta_kubernetes_node_label_app_kubernetes_io_name",
-            "__meta_kubernetes_node_label_k8s_app",
-            "__meta_kubernetes_node_label_app",
-          ]
-          separator = ";"
-          regex = "^(?:;*)?([^;]+).*$"
-          replacement = "$1"
-          target_label = "app"
-        }
-    
-        // set a source label
-        rule {
-          action = "replace"
-          replacement = "kubernetes"
-          target_label = "source"
         }
       }
     

--- a/charts/k8s-monitoring/docs/examples/extra-rules/alloy-metrics.alloy
+++ b/charts/k8s-monitoring/docs/examples/extra-rules/alloy-metrics.alloy
@@ -7,9 +7,23 @@ declare "cluster_metrics" {
     role = "node"
   }
 
+  discovery.relabel "nodes" {
+    targets = discovery.kubernetes.nodes.targets
+    rule {
+      source_labels = ["__meta_kubernetes_node_name"]
+      target_label  = "node"
+    }
+
+    rule {
+      replacement = "kubernetes"
+      target_label = "source"
+    }
+
+  }
+
   // Kubelet
   discovery.relabel "kubelet" {
-    targets = discovery.kubernetes.nodes.targets
+    targets = discovery.relabel.nodes.output
   }
 
   prometheus.scrape "kubelet" {
@@ -45,41 +59,15 @@ declare "cluster_metrics" {
 
   // Kubelet Resources
   discovery.relabel "kubelet_resources" {
-    targets = discovery.kubernetes.nodes.targets
+    targets = discovery.relabel.nodes.output
     rule {
       replacement   = "/metrics/resource"
       target_label  = "__metrics_path__"
     }
-    // set the node label
-    rule {
-      source_labels = ["__meta_kubernetes_node_name"]
-      target_label  = "node"
-    }
-
-    // set the app name if specified as metadata labels "app:" or "app.kubernetes.io/name:" or "k8s-app:"
-    rule {
-      action = "replace"
-      source_labels = [
-        "__meta_kubernetes_node_label_app_kubernetes_io_name",
-        "__meta_kubernetes_node_label_k8s_app",
-        "__meta_kubernetes_node_label_app",
-      ]
-      separator = ";"
-      regex = "^(?:;*)?([^;]+).*$"
-      replacement = "$1"
-      target_label = "app"
-    }
-
-    // set a source label
-    rule {
-      action = "replace"
-      replacement = "kubernetes"
-      target_label = "source"
-    }
   }
 
   prometheus.scrape "kubelet_resources" {
-    targets  = discovery.relabel.kubelet_resources.output
+    targets = discovery.relabel.kubelet_resources.output
     job_name = "integrations/kubernetes/resources"
     scheme   = "https"
     scrape_interval = "60s"
@@ -111,34 +99,10 @@ declare "cluster_metrics" {
 
   // cAdvisor
   discovery.relabel "cadvisor" {
-    targets = discovery.kubernetes.nodes.targets
+    targets = discovery.relabel.nodes.output
     rule {
       replacement   = "/metrics/cadvisor"
       target_label  = "__metrics_path__"
-    }
-    rule {
-      source_labels = ["__meta_kubernetes_node_name"]
-      target_label  = "node"
-    }
-    // set the app name if specified as metadata labels "app:" or "app.kubernetes.io/name:" or "k8s-app:"
-    rule {
-      action = "replace"
-      source_labels = [
-        "__meta_kubernetes_node_label_app_kubernetes_io_name",
-        "__meta_kubernetes_node_label_k8s_app",
-        "__meta_kubernetes_node_label_app",
-      ]
-      separator = ";"
-      regex = "^(?:;*)?([^;]+).*$"
-      replacement = "$1"
-      target_label = "app"
-    }
-
-    // set a source label
-    rule {
-      action = "replace"
-      replacement = "kubernetes"
-      target_label = "source"
     }
   }
 

--- a/charts/k8s-monitoring/docs/examples/extra-rules/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/extra-rules/output.yaml
@@ -137,9 +137,23 @@ data:
         role = "node"
       }
     
+      discovery.relabel "nodes" {
+        targets = discovery.kubernetes.nodes.targets
+        rule {
+          source_labels = ["__meta_kubernetes_node_name"]
+          target_label  = "node"
+        }
+    
+        rule {
+          replacement = "kubernetes"
+          target_label = "source"
+        }
+    
+      }
+    
       // Kubelet
       discovery.relabel "kubelet" {
-        targets = discovery.kubernetes.nodes.targets
+        targets = discovery.relabel.nodes.output
       }
     
       prometheus.scrape "kubelet" {
@@ -175,41 +189,15 @@ data:
     
       // Kubelet Resources
       discovery.relabel "kubelet_resources" {
-        targets = discovery.kubernetes.nodes.targets
+        targets = discovery.relabel.nodes.output
         rule {
           replacement   = "/metrics/resource"
           target_label  = "__metrics_path__"
         }
-        // set the node label
-        rule {
-          source_labels = ["__meta_kubernetes_node_name"]
-          target_label  = "node"
-        }
-    
-        // set the app name if specified as metadata labels "app:" or "app.kubernetes.io/name:" or "k8s-app:"
-        rule {
-          action = "replace"
-          source_labels = [
-            "__meta_kubernetes_node_label_app_kubernetes_io_name",
-            "__meta_kubernetes_node_label_k8s_app",
-            "__meta_kubernetes_node_label_app",
-          ]
-          separator = ";"
-          regex = "^(?:;*)?([^;]+).*$"
-          replacement = "$1"
-          target_label = "app"
-        }
-    
-        // set a source label
-        rule {
-          action = "replace"
-          replacement = "kubernetes"
-          target_label = "source"
-        }
       }
     
       prometheus.scrape "kubelet_resources" {
-        targets  = discovery.relabel.kubelet_resources.output
+        targets = discovery.relabel.kubelet_resources.output
         job_name = "integrations/kubernetes/resources"
         scheme   = "https"
         scrape_interval = "60s"
@@ -241,34 +229,10 @@ data:
     
       // cAdvisor
       discovery.relabel "cadvisor" {
-        targets = discovery.kubernetes.nodes.targets
+        targets = discovery.relabel.nodes.output
         rule {
           replacement   = "/metrics/cadvisor"
           target_label  = "__metrics_path__"
-        }
-        rule {
-          source_labels = ["__meta_kubernetes_node_name"]
-          target_label  = "node"
-        }
-        // set the app name if specified as metadata labels "app:" or "app.kubernetes.io/name:" or "k8s-app:"
-        rule {
-          action = "replace"
-          source_labels = [
-            "__meta_kubernetes_node_label_app_kubernetes_io_name",
-            "__meta_kubernetes_node_label_k8s_app",
-            "__meta_kubernetes_node_label_app",
-          ]
-          separator = ";"
-          regex = "^(?:;*)?([^;]+).*$"
-          replacement = "$1"
-          target_label = "app"
-        }
-    
-        // set a source label
-        rule {
-          action = "replace"
-          replacement = "kubernetes"
-          target_label = "source"
         }
       }
     

--- a/charts/k8s-monitoring/docs/examples/features/cluster-metrics/control-plane-monitoring/alloy-metrics.alloy
+++ b/charts/k8s-monitoring/docs/examples/features/cluster-metrics/control-plane-monitoring/alloy-metrics.alloy
@@ -7,9 +7,23 @@ declare "cluster_metrics" {
     role = "node"
   }
 
+  discovery.relabel "nodes" {
+    targets = discovery.kubernetes.nodes.targets
+    rule {
+      source_labels = ["__meta_kubernetes_node_name"]
+      target_label  = "node"
+    }
+
+    rule {
+      replacement = "kubernetes"
+      target_label = "source"
+    }
+
+  }
+
   // Kubelet
   discovery.relabel "kubelet" {
-    targets = discovery.kubernetes.nodes.targets
+    targets = discovery.relabel.nodes.output
   }
 
   prometheus.scrape "kubelet" {
@@ -45,41 +59,15 @@ declare "cluster_metrics" {
 
   // Kubelet Resources
   discovery.relabel "kubelet_resources" {
-    targets = discovery.kubernetes.nodes.targets
+    targets = discovery.relabel.nodes.output
     rule {
       replacement   = "/metrics/resource"
       target_label  = "__metrics_path__"
     }
-    // set the node label
-    rule {
-      source_labels = ["__meta_kubernetes_node_name"]
-      target_label  = "node"
-    }
-
-    // set the app name if specified as metadata labels "app:" or "app.kubernetes.io/name:" or "k8s-app:"
-    rule {
-      action = "replace"
-      source_labels = [
-        "__meta_kubernetes_node_label_app_kubernetes_io_name",
-        "__meta_kubernetes_node_label_k8s_app",
-        "__meta_kubernetes_node_label_app",
-      ]
-      separator = ";"
-      regex = "^(?:;*)?([^;]+).*$"
-      replacement = "$1"
-      target_label = "app"
-    }
-
-    // set a source label
-    rule {
-      action = "replace"
-      replacement = "kubernetes"
-      target_label = "source"
-    }
   }
 
   prometheus.scrape "kubelet_resources" {
-    targets  = discovery.relabel.kubelet_resources.output
+    targets = discovery.relabel.kubelet_resources.output
     job_name = "integrations/kubernetes/resources"
     scheme   = "https"
     scrape_interval = "60s"
@@ -111,34 +99,10 @@ declare "cluster_metrics" {
 
   // cAdvisor
   discovery.relabel "cadvisor" {
-    targets = discovery.kubernetes.nodes.targets
+    targets = discovery.relabel.nodes.output
     rule {
       replacement   = "/metrics/cadvisor"
       target_label  = "__metrics_path__"
-    }
-    rule {
-      source_labels = ["__meta_kubernetes_node_name"]
-      target_label  = "node"
-    }
-    // set the app name if specified as metadata labels "app:" or "app.kubernetes.io/name:" or "k8s-app:"
-    rule {
-      action = "replace"
-      source_labels = [
-        "__meta_kubernetes_node_label_app_kubernetes_io_name",
-        "__meta_kubernetes_node_label_k8s_app",
-        "__meta_kubernetes_node_label_app",
-      ]
-      separator = ";"
-      regex = "^(?:;*)?([^;]+).*$"
-      replacement = "$1"
-      target_label = "app"
-    }
-
-    // set a source label
-    rule {
-      action = "replace"
-      replacement = "kubernetes"
-      target_label = "source"
     }
   }
 

--- a/charts/k8s-monitoring/docs/examples/features/cluster-metrics/control-plane-monitoring/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/features/cluster-metrics/control-plane-monitoring/output.yaml
@@ -137,9 +137,23 @@ data:
         role = "node"
       }
     
+      discovery.relabel "nodes" {
+        targets = discovery.kubernetes.nodes.targets
+        rule {
+          source_labels = ["__meta_kubernetes_node_name"]
+          target_label  = "node"
+        }
+    
+        rule {
+          replacement = "kubernetes"
+          target_label = "source"
+        }
+    
+      }
+    
       // Kubelet
       discovery.relabel "kubelet" {
-        targets = discovery.kubernetes.nodes.targets
+        targets = discovery.relabel.nodes.output
       }
     
       prometheus.scrape "kubelet" {
@@ -175,41 +189,15 @@ data:
     
       // Kubelet Resources
       discovery.relabel "kubelet_resources" {
-        targets = discovery.kubernetes.nodes.targets
+        targets = discovery.relabel.nodes.output
         rule {
           replacement   = "/metrics/resource"
           target_label  = "__metrics_path__"
         }
-        // set the node label
-        rule {
-          source_labels = ["__meta_kubernetes_node_name"]
-          target_label  = "node"
-        }
-    
-        // set the app name if specified as metadata labels "app:" or "app.kubernetes.io/name:" or "k8s-app:"
-        rule {
-          action = "replace"
-          source_labels = [
-            "__meta_kubernetes_node_label_app_kubernetes_io_name",
-            "__meta_kubernetes_node_label_k8s_app",
-            "__meta_kubernetes_node_label_app",
-          ]
-          separator = ";"
-          regex = "^(?:;*)?([^;]+).*$"
-          replacement = "$1"
-          target_label = "app"
-        }
-    
-        // set a source label
-        rule {
-          action = "replace"
-          replacement = "kubernetes"
-          target_label = "source"
-        }
       }
     
       prometheus.scrape "kubelet_resources" {
-        targets  = discovery.relabel.kubelet_resources.output
+        targets = discovery.relabel.kubelet_resources.output
         job_name = "integrations/kubernetes/resources"
         scheme   = "https"
         scrape_interval = "60s"
@@ -241,34 +229,10 @@ data:
     
       // cAdvisor
       discovery.relabel "cadvisor" {
-        targets = discovery.kubernetes.nodes.targets
+        targets = discovery.relabel.nodes.output
         rule {
           replacement   = "/metrics/cadvisor"
           target_label  = "__metrics_path__"
-        }
-        rule {
-          source_labels = ["__meta_kubernetes_node_name"]
-          target_label  = "node"
-        }
-        // set the app name if specified as metadata labels "app:" or "app.kubernetes.io/name:" or "k8s-app:"
-        rule {
-          action = "replace"
-          source_labels = [
-            "__meta_kubernetes_node_label_app_kubernetes_io_name",
-            "__meta_kubernetes_node_label_k8s_app",
-            "__meta_kubernetes_node_label_app",
-          ]
-          separator = ";"
-          regex = "^(?:;*)?([^;]+).*$"
-          replacement = "$1"
-          target_label = "app"
-        }
-    
-        // set a source label
-        rule {
-          action = "replace"
-          replacement = "kubernetes"
-          target_label = "source"
         }
       }
     

--- a/charts/k8s-monitoring/docs/examples/features/cluster-metrics/default/alloy-metrics.alloy
+++ b/charts/k8s-monitoring/docs/examples/features/cluster-metrics/default/alloy-metrics.alloy
@@ -7,9 +7,23 @@ declare "cluster_metrics" {
     role = "node"
   }
 
+  discovery.relabel "nodes" {
+    targets = discovery.kubernetes.nodes.targets
+    rule {
+      source_labels = ["__meta_kubernetes_node_name"]
+      target_label  = "node"
+    }
+
+    rule {
+      replacement = "kubernetes"
+      target_label = "source"
+    }
+
+  }
+
   // Kubelet
   discovery.relabel "kubelet" {
-    targets = discovery.kubernetes.nodes.targets
+    targets = discovery.relabel.nodes.output
   }
 
   prometheus.scrape "kubelet" {
@@ -45,41 +59,15 @@ declare "cluster_metrics" {
 
   // Kubelet Resources
   discovery.relabel "kubelet_resources" {
-    targets = discovery.kubernetes.nodes.targets
+    targets = discovery.relabel.nodes.output
     rule {
       replacement   = "/metrics/resource"
       target_label  = "__metrics_path__"
     }
-    // set the node label
-    rule {
-      source_labels = ["__meta_kubernetes_node_name"]
-      target_label  = "node"
-    }
-
-    // set the app name if specified as metadata labels "app:" or "app.kubernetes.io/name:" or "k8s-app:"
-    rule {
-      action = "replace"
-      source_labels = [
-        "__meta_kubernetes_node_label_app_kubernetes_io_name",
-        "__meta_kubernetes_node_label_k8s_app",
-        "__meta_kubernetes_node_label_app",
-      ]
-      separator = ";"
-      regex = "^(?:;*)?([^;]+).*$"
-      replacement = "$1"
-      target_label = "app"
-    }
-
-    // set a source label
-    rule {
-      action = "replace"
-      replacement = "kubernetes"
-      target_label = "source"
-    }
   }
 
   prometheus.scrape "kubelet_resources" {
-    targets  = discovery.relabel.kubelet_resources.output
+    targets = discovery.relabel.kubelet_resources.output
     job_name = "integrations/kubernetes/resources"
     scheme   = "https"
     scrape_interval = "60s"
@@ -111,34 +99,10 @@ declare "cluster_metrics" {
 
   // cAdvisor
   discovery.relabel "cadvisor" {
-    targets = discovery.kubernetes.nodes.targets
+    targets = discovery.relabel.nodes.output
     rule {
       replacement   = "/metrics/cadvisor"
       target_label  = "__metrics_path__"
-    }
-    rule {
-      source_labels = ["__meta_kubernetes_node_name"]
-      target_label  = "node"
-    }
-    // set the app name if specified as metadata labels "app:" or "app.kubernetes.io/name:" or "k8s-app:"
-    rule {
-      action = "replace"
-      source_labels = [
-        "__meta_kubernetes_node_label_app_kubernetes_io_name",
-        "__meta_kubernetes_node_label_k8s_app",
-        "__meta_kubernetes_node_label_app",
-      ]
-      separator = ";"
-      regex = "^(?:;*)?([^;]+).*$"
-      replacement = "$1"
-      target_label = "app"
-    }
-
-    // set a source label
-    rule {
-      action = "replace"
-      replacement = "kubernetes"
-      target_label = "source"
     }
   }
 

--- a/charts/k8s-monitoring/docs/examples/features/cluster-metrics/default/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/features/cluster-metrics/default/output.yaml
@@ -133,9 +133,23 @@ data:
         role = "node"
       }
     
+      discovery.relabel "nodes" {
+        targets = discovery.kubernetes.nodes.targets
+        rule {
+          source_labels = ["__meta_kubernetes_node_name"]
+          target_label  = "node"
+        }
+    
+        rule {
+          replacement = "kubernetes"
+          target_label = "source"
+        }
+    
+      }
+    
       // Kubelet
       discovery.relabel "kubelet" {
-        targets = discovery.kubernetes.nodes.targets
+        targets = discovery.relabel.nodes.output
       }
     
       prometheus.scrape "kubelet" {
@@ -171,41 +185,15 @@ data:
     
       // Kubelet Resources
       discovery.relabel "kubelet_resources" {
-        targets = discovery.kubernetes.nodes.targets
+        targets = discovery.relabel.nodes.output
         rule {
           replacement   = "/metrics/resource"
           target_label  = "__metrics_path__"
         }
-        // set the node label
-        rule {
-          source_labels = ["__meta_kubernetes_node_name"]
-          target_label  = "node"
-        }
-    
-        // set the app name if specified as metadata labels "app:" or "app.kubernetes.io/name:" or "k8s-app:"
-        rule {
-          action = "replace"
-          source_labels = [
-            "__meta_kubernetes_node_label_app_kubernetes_io_name",
-            "__meta_kubernetes_node_label_k8s_app",
-            "__meta_kubernetes_node_label_app",
-          ]
-          separator = ";"
-          regex = "^(?:;*)?([^;]+).*$"
-          replacement = "$1"
-          target_label = "app"
-        }
-    
-        // set a source label
-        rule {
-          action = "replace"
-          replacement = "kubernetes"
-          target_label = "source"
-        }
       }
     
       prometheus.scrape "kubelet_resources" {
-        targets  = discovery.relabel.kubelet_resources.output
+        targets = discovery.relabel.kubelet_resources.output
         job_name = "integrations/kubernetes/resources"
         scheme   = "https"
         scrape_interval = "60s"
@@ -237,34 +225,10 @@ data:
     
       // cAdvisor
       discovery.relabel "cadvisor" {
-        targets = discovery.kubernetes.nodes.targets
+        targets = discovery.relabel.nodes.output
         rule {
           replacement   = "/metrics/cadvisor"
           target_label  = "__metrics_path__"
-        }
-        rule {
-          source_labels = ["__meta_kubernetes_node_name"]
-          target_label  = "node"
-        }
-        // set the app name if specified as metadata labels "app:" or "app.kubernetes.io/name:" or "k8s-app:"
-        rule {
-          action = "replace"
-          source_labels = [
-            "__meta_kubernetes_node_label_app_kubernetes_io_name",
-            "__meta_kubernetes_node_label_k8s_app",
-            "__meta_kubernetes_node_label_app",
-          ]
-          separator = ";"
-          regex = "^(?:;*)?([^;]+).*$"
-          replacement = "$1"
-          target_label = "app"
-        }
-    
-        // set a source label
-        rule {
-          action = "replace"
-          replacement = "kubernetes"
-          target_label = "source"
         }
       }
     

--- a/charts/k8s-monitoring/docs/examples/features/integrations/alloy/alloy-metrics.alloy
+++ b/charts/k8s-monitoring/docs/examples/features/integrations/alloy/alloy-metrics.alloy
@@ -37,6 +37,7 @@ declare "alloy_integration" {
       namespaces {
         names = coalesce(argument.namespaces.value, [])
       }
+
     }
 
     // alloy relabelings (pre-scrape)
@@ -56,79 +57,78 @@ declare "alloy_integration" {
         action = "keep"
       }
 
+      rule {
+        source_labels = ["__meta_kubernetes_namespace"]
+        target_label  = "namespace"
+      }
 
+      rule {
+        source_labels = ["__meta_kubernetes_pod_name"]
+        target_label  = "pod"
+      }
 
-    rule {
-      source_labels = ["__meta_kubernetes_namespace"]
-      target_label  = "namespace"
-    }
+      rule {
+        source_labels = ["__meta_kubernetes_pod_container_name"]
+        target_label  = "container"
+      }
 
-    rule {
-      source_labels = ["__meta_kubernetes_pod_name"]
-      target_label  = "pod"
-    }
+      // set the workload to the controller kind and name
+      rule {
+        action = "lowercase"
+        source_labels = ["__meta_kubernetes_pod_controller_kind"]
+        target_label  = "workload_type"
+      }
 
-    rule {
-      source_labels = ["__meta_kubernetes_pod_container_name"]
-      target_label  = "container"
-    }
+      rule {
+        source_labels = ["__meta_kubernetes_pod_controller_name"]
+        target_label  = "workload"
+      }
 
-    // set the workload to the controller kind and name
-    rule {
-      action = "lowercase"
-      source_labels = ["__meta_kubernetes_pod_controller_kind"]
-      target_label  = "workload_type"
-    }
+      // remove the hash from the ReplicaSet
+      rule {
+        source_labels = [
+          "workload_type",
+          "workload",
+        ]
+        separator = "/"
+        regex = "replicaset/(.+)-.+$"
+        target_label  = "workload"
+      }
 
-    rule {
-      source_labels = ["__meta_kubernetes_pod_controller_name"]
-      target_label  = "workload"
-    }
+      // set the app name if specified as metadata labels "app:" or "app.kubernetes.io/name:" or "k8s-app:"
+      rule {
+        action = "replace"
+        source_labels = [
+          "__meta_kubernetes_pod_label_app_kubernetes_io_name",
+          "__meta_kubernetes_pod_label_k8s_app",
+          "__meta_kubernetes_pod_label_app",
+        ]
+        separator = ";"
+        regex = "^(?:;*)?([^;]+).*$"
+        replacement = "$1"
+        target_label = "app"
+      }
 
-    // remove the hash from the ReplicaSet
-    rule {
-      source_labels = [
-        "workload_type",
-        "workload",
-      ]
-      separator = "/"
-      regex = "replicaset/(.+)-.+$"
-      target_label  = "workload"
-    }
+      // set the component if specified as metadata labels "component:" or "app.kubernetes.io/component:" or "k8s-component:"
+      rule {
+        action = "replace"
+        source_labels = [
+          "__meta_kubernetes_pod_label_app_kubernetes_io_component",
+          "__meta_kubernetes_pod_label_k8s_component",
+          "__meta_kubernetes_pod_label_component",
+        ]
+        regex = "^(?:;*)?([^;]+).*$"
+        replacement = "$1"
+        target_label = "component"
+      }
 
-    // set the app name if specified as metadata labels "app:" or "app.kubernetes.io/name:" or "k8s-app:"
-    rule {
-      action = "replace"
-      source_labels = [
-        "__meta_kubernetes_pod_label_app_kubernetes_io_name",
-        "__meta_kubernetes_pod_label_k8s_app",
-        "__meta_kubernetes_pod_label_app",
-      ]
-      separator = ";"
-      regex = "^(?:;*)?([^;]+).*$"
-      replacement = "$1"
-      target_label = "app"
-    }
+      // set a source label
+      rule {
+        action = "replace"
+        replacement = "kubernetes"
+        target_label = "source"
+      }
 
-    // set the component if specified as metadata labels "component:" or "app.kubernetes.io/component:" or "k8s-component:"
-    rule {
-      action = "replace"
-      source_labels = [
-        "__meta_kubernetes_pod_label_app_kubernetes_io_component",
-        "__meta_kubernetes_pod_label_k8s_component",
-        "__meta_kubernetes_pod_label_component",
-      ]
-      regex = "^(?:;*)?([^;]+).*$"
-      replacement = "$1"
-      target_label = "component"
-    }
-
-    // set a source label
-    rule {
-      action = "replace"
-      replacement = "kubernetes"
-      target_label = "source"
-    }
     }
 
     export "output" {

--- a/charts/k8s-monitoring/docs/examples/features/integrations/alloy/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/features/integrations/alloy/output.yaml
@@ -62,6 +62,7 @@ data:
           namespaces {
             names = coalesce(argument.namespaces.value, [])
           }
+    
         }
     
         // alloy relabelings (pre-scrape)
@@ -81,79 +82,78 @@ data:
             action = "keep"
           }
     
+          rule {
+            source_labels = ["__meta_kubernetes_namespace"]
+            target_label  = "namespace"
+          }
     
+          rule {
+            source_labels = ["__meta_kubernetes_pod_name"]
+            target_label  = "pod"
+          }
     
-        rule {
-          source_labels = ["__meta_kubernetes_namespace"]
-          target_label  = "namespace"
-        }
+          rule {
+            source_labels = ["__meta_kubernetes_pod_container_name"]
+            target_label  = "container"
+          }
     
-        rule {
-          source_labels = ["__meta_kubernetes_pod_name"]
-          target_label  = "pod"
-        }
+          // set the workload to the controller kind and name
+          rule {
+            action = "lowercase"
+            source_labels = ["__meta_kubernetes_pod_controller_kind"]
+            target_label  = "workload_type"
+          }
     
-        rule {
-          source_labels = ["__meta_kubernetes_pod_container_name"]
-          target_label  = "container"
-        }
+          rule {
+            source_labels = ["__meta_kubernetes_pod_controller_name"]
+            target_label  = "workload"
+          }
     
-        // set the workload to the controller kind and name
-        rule {
-          action = "lowercase"
-          source_labels = ["__meta_kubernetes_pod_controller_kind"]
-          target_label  = "workload_type"
-        }
+          // remove the hash from the ReplicaSet
+          rule {
+            source_labels = [
+              "workload_type",
+              "workload",
+            ]
+            separator = "/"
+            regex = "replicaset/(.+)-.+$"
+            target_label  = "workload"
+          }
     
-        rule {
-          source_labels = ["__meta_kubernetes_pod_controller_name"]
-          target_label  = "workload"
-        }
+          // set the app name if specified as metadata labels "app:" or "app.kubernetes.io/name:" or "k8s-app:"
+          rule {
+            action = "replace"
+            source_labels = [
+              "__meta_kubernetes_pod_label_app_kubernetes_io_name",
+              "__meta_kubernetes_pod_label_k8s_app",
+              "__meta_kubernetes_pod_label_app",
+            ]
+            separator = ";"
+            regex = "^(?:;*)?([^;]+).*$"
+            replacement = "$1"
+            target_label = "app"
+          }
     
-        // remove the hash from the ReplicaSet
-        rule {
-          source_labels = [
-            "workload_type",
-            "workload",
-          ]
-          separator = "/"
-          regex = "replicaset/(.+)-.+$"
-          target_label  = "workload"
-        }
+          // set the component if specified as metadata labels "component:" or "app.kubernetes.io/component:" or "k8s-component:"
+          rule {
+            action = "replace"
+            source_labels = [
+              "__meta_kubernetes_pod_label_app_kubernetes_io_component",
+              "__meta_kubernetes_pod_label_k8s_component",
+              "__meta_kubernetes_pod_label_component",
+            ]
+            regex = "^(?:;*)?([^;]+).*$"
+            replacement = "$1"
+            target_label = "component"
+          }
     
-        // set the app name if specified as metadata labels "app:" or "app.kubernetes.io/name:" or "k8s-app:"
-        rule {
-          action = "replace"
-          source_labels = [
-            "__meta_kubernetes_pod_label_app_kubernetes_io_name",
-            "__meta_kubernetes_pod_label_k8s_app",
-            "__meta_kubernetes_pod_label_app",
-          ]
-          separator = ";"
-          regex = "^(?:;*)?([^;]+).*$"
-          replacement = "$1"
-          target_label = "app"
-        }
+          // set a source label
+          rule {
+            action = "replace"
+            replacement = "kubernetes"
+            target_label = "source"
+          }
     
-        // set the component if specified as metadata labels "component:" or "app.kubernetes.io/component:" or "k8s-component:"
-        rule {
-          action = "replace"
-          source_labels = [
-            "__meta_kubernetes_pod_label_app_kubernetes_io_component",
-            "__meta_kubernetes_pod_label_k8s_component",
-            "__meta_kubernetes_pod_label_component",
-          ]
-          regex = "^(?:;*)?([^;]+).*$"
-          replacement = "$1"
-          target_label = "component"
-        }
-    
-        // set a source label
-        rule {
-          action = "replace"
-          replacement = "kubernetes"
-          target_label = "source"
-        }
         }
     
         export "output" {

--- a/charts/k8s-monitoring/docs/examples/features/integrations/grafana/alloy-metrics.alloy
+++ b/charts/k8s-monitoring/docs/examples/features/integrations/grafana/alloy-metrics.alloy
@@ -37,6 +37,7 @@ declare "grafana_integration" {
       namespaces {
         names = coalesce(argument.namespaces.value, [])
       }
+
     }
 
     // grafana relabelings (pre-scrape)
@@ -58,77 +59,78 @@ declare "grafana_integration" {
 
 
 
-    rule {
-      source_labels = ["__meta_kubernetes_namespace"]
-      target_label  = "namespace"
-    }
+      rule {
+        source_labels = ["__meta_kubernetes_namespace"]
+        target_label  = "namespace"
+      }
 
-    rule {
-      source_labels = ["__meta_kubernetes_pod_name"]
-      target_label  = "pod"
-    }
+      rule {
+        source_labels = ["__meta_kubernetes_pod_name"]
+        target_label  = "pod"
+      }
 
-    rule {
-      source_labels = ["__meta_kubernetes_pod_container_name"]
-      target_label  = "container"
-    }
+      rule {
+        source_labels = ["__meta_kubernetes_pod_container_name"]
+        target_label  = "container"
+      }
 
-    // set the workload to the controller kind and name
-    rule {
-      action = "lowercase"
-      source_labels = ["__meta_kubernetes_pod_controller_kind"]
-      target_label  = "workload_type"
-    }
+      // set the workload to the controller kind and name
+      rule {
+        action = "lowercase"
+        source_labels = ["__meta_kubernetes_pod_controller_kind"]
+        target_label  = "workload_type"
+      }
 
-    rule {
-      source_labels = ["__meta_kubernetes_pod_controller_name"]
-      target_label  = "workload"
-    }
+      rule {
+        source_labels = ["__meta_kubernetes_pod_controller_name"]
+        target_label  = "workload"
+      }
 
-    // remove the hash from the ReplicaSet
-    rule {
-      source_labels = [
-        "workload_type",
-        "workload",
-      ]
-      separator = "/"
-      regex = "replicaset/(.+)-.+$"
-      target_label  = "workload"
-    }
+      // remove the hash from the ReplicaSet
+      rule {
+        source_labels = [
+          "workload_type",
+          "workload",
+        ]
+        separator = "/"
+        regex = "replicaset/(.+)-.+$"
+        target_label  = "workload"
+      }
 
-    // set the app name if specified as metadata labels "app:" or "app.kubernetes.io/name:" or "k8s-app:"
-    rule {
-      action = "replace"
-      source_labels = [
-        "__meta_kubernetes_pod_label_app_kubernetes_io_name",
-        "__meta_kubernetes_pod_label_k8s_app",
-        "__meta_kubernetes_pod_label_app",
-      ]
-      separator = ";"
-      regex = "^(?:;*)?([^;]+).*$"
-      replacement = "$1"
-      target_label = "app"
-    }
+      // set the app name if specified as metadata labels "app:" or "app.kubernetes.io/name:" or "k8s-app:"
+      rule {
+        action = "replace"
+        source_labels = [
+          "__meta_kubernetes_pod_label_app_kubernetes_io_name",
+          "__meta_kubernetes_pod_label_k8s_app",
+          "__meta_kubernetes_pod_label_app",
+        ]
+        separator = ";"
+        regex = "^(?:;*)?([^;]+).*$"
+        replacement = "$1"
+        target_label = "app"
+      }
 
-    // set the component if specified as metadata labels "component:" or "app.kubernetes.io/component:" or "k8s-component:"
-    rule {
-      action = "replace"
-      source_labels = [
-        "__meta_kubernetes_pod_label_app_kubernetes_io_component",
-        "__meta_kubernetes_pod_label_k8s_component",
-        "__meta_kubernetes_pod_label_component",
-      ]
-      regex = "^(?:;*)?([^;]+).*$"
-      replacement = "$1"
-      target_label = "component"
-    }
+      // set the component if specified as metadata labels "component:" or "app.kubernetes.io/component:" or "k8s-component:"
+      rule {
+        action = "replace"
+        source_labels = [
+          "__meta_kubernetes_pod_label_app_kubernetes_io_component",
+          "__meta_kubernetes_pod_label_k8s_component",
+          "__meta_kubernetes_pod_label_component",
+        ]
+        regex = "^(?:;*)?([^;]+).*$"
+        replacement = "$1"
+        target_label = "component"
+      }
 
-    // set a source label
-    rule {
-      action = "replace"
-      replacement = "kubernetes"
-      target_label = "source"
-    }
+      // set a source label
+      rule {
+        action = "replace"
+        replacement = "kubernetes"
+        target_label = "source"
+      }
+
     }
 
     export "output" {

--- a/charts/k8s-monitoring/docs/examples/features/integrations/grafana/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/features/integrations/grafana/output.yaml
@@ -78,6 +78,7 @@ data:
           namespaces {
             names = coalesce(argument.namespaces.value, [])
           }
+    
         }
     
         // grafana relabelings (pre-scrape)
@@ -99,77 +100,78 @@ data:
     
     
     
-        rule {
-          source_labels = ["__meta_kubernetes_namespace"]
-          target_label  = "namespace"
-        }
+          rule {
+            source_labels = ["__meta_kubernetes_namespace"]
+            target_label  = "namespace"
+          }
     
-        rule {
-          source_labels = ["__meta_kubernetes_pod_name"]
-          target_label  = "pod"
-        }
+          rule {
+            source_labels = ["__meta_kubernetes_pod_name"]
+            target_label  = "pod"
+          }
     
-        rule {
-          source_labels = ["__meta_kubernetes_pod_container_name"]
-          target_label  = "container"
-        }
+          rule {
+            source_labels = ["__meta_kubernetes_pod_container_name"]
+            target_label  = "container"
+          }
     
-        // set the workload to the controller kind and name
-        rule {
-          action = "lowercase"
-          source_labels = ["__meta_kubernetes_pod_controller_kind"]
-          target_label  = "workload_type"
-        }
+          // set the workload to the controller kind and name
+          rule {
+            action = "lowercase"
+            source_labels = ["__meta_kubernetes_pod_controller_kind"]
+            target_label  = "workload_type"
+          }
     
-        rule {
-          source_labels = ["__meta_kubernetes_pod_controller_name"]
-          target_label  = "workload"
-        }
+          rule {
+            source_labels = ["__meta_kubernetes_pod_controller_name"]
+            target_label  = "workload"
+          }
     
-        // remove the hash from the ReplicaSet
-        rule {
-          source_labels = [
-            "workload_type",
-            "workload",
-          ]
-          separator = "/"
-          regex = "replicaset/(.+)-.+$"
-          target_label  = "workload"
-        }
+          // remove the hash from the ReplicaSet
+          rule {
+            source_labels = [
+              "workload_type",
+              "workload",
+            ]
+            separator = "/"
+            regex = "replicaset/(.+)-.+$"
+            target_label  = "workload"
+          }
     
-        // set the app name if specified as metadata labels "app:" or "app.kubernetes.io/name:" or "k8s-app:"
-        rule {
-          action = "replace"
-          source_labels = [
-            "__meta_kubernetes_pod_label_app_kubernetes_io_name",
-            "__meta_kubernetes_pod_label_k8s_app",
-            "__meta_kubernetes_pod_label_app",
-          ]
-          separator = ";"
-          regex = "^(?:;*)?([^;]+).*$"
-          replacement = "$1"
-          target_label = "app"
-        }
+          // set the app name if specified as metadata labels "app:" or "app.kubernetes.io/name:" or "k8s-app:"
+          rule {
+            action = "replace"
+            source_labels = [
+              "__meta_kubernetes_pod_label_app_kubernetes_io_name",
+              "__meta_kubernetes_pod_label_k8s_app",
+              "__meta_kubernetes_pod_label_app",
+            ]
+            separator = ";"
+            regex = "^(?:;*)?([^;]+).*$"
+            replacement = "$1"
+            target_label = "app"
+          }
     
-        // set the component if specified as metadata labels "component:" or "app.kubernetes.io/component:" or "k8s-component:"
-        rule {
-          action = "replace"
-          source_labels = [
-            "__meta_kubernetes_pod_label_app_kubernetes_io_component",
-            "__meta_kubernetes_pod_label_k8s_component",
-            "__meta_kubernetes_pod_label_component",
-          ]
-          regex = "^(?:;*)?([^;]+).*$"
-          replacement = "$1"
-          target_label = "component"
-        }
+          // set the component if specified as metadata labels "component:" or "app.kubernetes.io/component:" or "k8s-component:"
+          rule {
+            action = "replace"
+            source_labels = [
+              "__meta_kubernetes_pod_label_app_kubernetes_io_component",
+              "__meta_kubernetes_pod_label_k8s_component",
+              "__meta_kubernetes_pod_label_component",
+            ]
+            regex = "^(?:;*)?([^;]+).*$"
+            replacement = "$1"
+            target_label = "component"
+          }
     
-        // set a source label
-        rule {
-          action = "replace"
-          replacement = "kubernetes"
-          target_label = "source"
-        }
+          // set a source label
+          rule {
+            action = "replace"
+            replacement = "kubernetes"
+            target_label = "source"
+          }
+    
         }
     
         export "output" {

--- a/charts/k8s-monitoring/docs/examples/features/integrations/loki/alloy-metrics.alloy
+++ b/charts/k8s-monitoring/docs/examples/features/integrations/loki/alloy-metrics.alloy
@@ -37,6 +37,7 @@ declare "loki_integration" {
       namespaces {
         names = coalesce(argument.namespaces.value, [])
       }
+
     }
 
     // loki relabelings (pre-scrape)
@@ -65,77 +66,78 @@ declare "loki_integration" {
 
 
 
-    rule {
-      source_labels = ["__meta_kubernetes_namespace"]
-      target_label  = "namespace"
-    }
+      rule {
+        source_labels = ["__meta_kubernetes_namespace"]
+        target_label  = "namespace"
+      }
 
-    rule {
-      source_labels = ["__meta_kubernetes_pod_name"]
-      target_label  = "pod"
-    }
+      rule {
+        source_labels = ["__meta_kubernetes_pod_name"]
+        target_label  = "pod"
+      }
 
-    rule {
-      source_labels = ["__meta_kubernetes_pod_container_name"]
-      target_label  = "container"
-    }
+      rule {
+        source_labels = ["__meta_kubernetes_pod_container_name"]
+        target_label  = "container"
+      }
 
-    // set the workload to the controller kind and name
-    rule {
-      action = "lowercase"
-      source_labels = ["__meta_kubernetes_pod_controller_kind"]
-      target_label  = "workload_type"
-    }
+      // set the workload to the controller kind and name
+      rule {
+        action = "lowercase"
+        source_labels = ["__meta_kubernetes_pod_controller_kind"]
+        target_label  = "workload_type"
+      }
 
-    rule {
-      source_labels = ["__meta_kubernetes_pod_controller_name"]
-      target_label  = "workload"
-    }
+      rule {
+        source_labels = ["__meta_kubernetes_pod_controller_name"]
+        target_label  = "workload"
+      }
 
-    // remove the hash from the ReplicaSet
-    rule {
-      source_labels = [
-        "workload_type",
-        "workload",
-      ]
-      separator = "/"
-      regex = "replicaset/(.+)-.+$"
-      target_label  = "workload"
-    }
+      // remove the hash from the ReplicaSet
+      rule {
+        source_labels = [
+          "workload_type",
+          "workload",
+        ]
+        separator = "/"
+        regex = "replicaset/(.+)-.+$"
+        target_label  = "workload"
+      }
 
-    // set the app name if specified as metadata labels "app:" or "app.kubernetes.io/name:" or "k8s-app:"
-    rule {
-      action = "replace"
-      source_labels = [
-        "__meta_kubernetes_pod_label_app_kubernetes_io_name",
-        "__meta_kubernetes_pod_label_k8s_app",
-        "__meta_kubernetes_pod_label_app",
-      ]
-      separator = ";"
-      regex = "^(?:;*)?([^;]+).*$"
-      replacement = "$1"
-      target_label = "app"
-    }
+      // set the app name if specified as metadata labels "app:" or "app.kubernetes.io/name:" or "k8s-app:"
+      rule {
+        action = "replace"
+        source_labels = [
+          "__meta_kubernetes_pod_label_app_kubernetes_io_name",
+          "__meta_kubernetes_pod_label_k8s_app",
+          "__meta_kubernetes_pod_label_app",
+        ]
+        separator = ";"
+        regex = "^(?:;*)?([^;]+).*$"
+        replacement = "$1"
+        target_label = "app"
+      }
 
-    // set the component if specified as metadata labels "component:" or "app.kubernetes.io/component:" or "k8s-component:"
-    rule {
-      action = "replace"
-      source_labels = [
-        "__meta_kubernetes_pod_label_app_kubernetes_io_component",
-        "__meta_kubernetes_pod_label_k8s_component",
-        "__meta_kubernetes_pod_label_component",
-      ]
-      regex = "^(?:;*)?([^;]+).*$"
-      replacement = "$1"
-      target_label = "component"
-    }
+      // set the component if specified as metadata labels "component:" or "app.kubernetes.io/component:" or "k8s-component:"
+      rule {
+        action = "replace"
+        source_labels = [
+          "__meta_kubernetes_pod_label_app_kubernetes_io_component",
+          "__meta_kubernetes_pod_label_k8s_component",
+          "__meta_kubernetes_pod_label_component",
+        ]
+        regex = "^(?:;*)?([^;]+).*$"
+        replacement = "$1"
+        target_label = "component"
+      }
 
-    // set a source label
-    rule {
-      action = "replace"
-      replacement = "kubernetes"
-      target_label = "source"
-    }
+      // set a source label
+      rule {
+        action = "replace"
+        replacement = "kubernetes"
+        target_label = "source"
+      }
+
     }
 
     export "output" {

--- a/charts/k8s-monitoring/docs/examples/features/integrations/loki/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/features/integrations/loki/output.yaml
@@ -78,6 +78,7 @@ data:
           namespaces {
             names = coalesce(argument.namespaces.value, [])
           }
+    
         }
     
         // loki relabelings (pre-scrape)
@@ -106,77 +107,78 @@ data:
     
     
     
-        rule {
-          source_labels = ["__meta_kubernetes_namespace"]
-          target_label  = "namespace"
-        }
+          rule {
+            source_labels = ["__meta_kubernetes_namespace"]
+            target_label  = "namespace"
+          }
     
-        rule {
-          source_labels = ["__meta_kubernetes_pod_name"]
-          target_label  = "pod"
-        }
+          rule {
+            source_labels = ["__meta_kubernetes_pod_name"]
+            target_label  = "pod"
+          }
     
-        rule {
-          source_labels = ["__meta_kubernetes_pod_container_name"]
-          target_label  = "container"
-        }
+          rule {
+            source_labels = ["__meta_kubernetes_pod_container_name"]
+            target_label  = "container"
+          }
     
-        // set the workload to the controller kind and name
-        rule {
-          action = "lowercase"
-          source_labels = ["__meta_kubernetes_pod_controller_kind"]
-          target_label  = "workload_type"
-        }
+          // set the workload to the controller kind and name
+          rule {
+            action = "lowercase"
+            source_labels = ["__meta_kubernetes_pod_controller_kind"]
+            target_label  = "workload_type"
+          }
     
-        rule {
-          source_labels = ["__meta_kubernetes_pod_controller_name"]
-          target_label  = "workload"
-        }
+          rule {
+            source_labels = ["__meta_kubernetes_pod_controller_name"]
+            target_label  = "workload"
+          }
     
-        // remove the hash from the ReplicaSet
-        rule {
-          source_labels = [
-            "workload_type",
-            "workload",
-          ]
-          separator = "/"
-          regex = "replicaset/(.+)-.+$"
-          target_label  = "workload"
-        }
+          // remove the hash from the ReplicaSet
+          rule {
+            source_labels = [
+              "workload_type",
+              "workload",
+            ]
+            separator = "/"
+            regex = "replicaset/(.+)-.+$"
+            target_label  = "workload"
+          }
     
-        // set the app name if specified as metadata labels "app:" or "app.kubernetes.io/name:" or "k8s-app:"
-        rule {
-          action = "replace"
-          source_labels = [
-            "__meta_kubernetes_pod_label_app_kubernetes_io_name",
-            "__meta_kubernetes_pod_label_k8s_app",
-            "__meta_kubernetes_pod_label_app",
-          ]
-          separator = ";"
-          regex = "^(?:;*)?([^;]+).*$"
-          replacement = "$1"
-          target_label = "app"
-        }
+          // set the app name if specified as metadata labels "app:" or "app.kubernetes.io/name:" or "k8s-app:"
+          rule {
+            action = "replace"
+            source_labels = [
+              "__meta_kubernetes_pod_label_app_kubernetes_io_name",
+              "__meta_kubernetes_pod_label_k8s_app",
+              "__meta_kubernetes_pod_label_app",
+            ]
+            separator = ";"
+            regex = "^(?:;*)?([^;]+).*$"
+            replacement = "$1"
+            target_label = "app"
+          }
     
-        // set the component if specified as metadata labels "component:" or "app.kubernetes.io/component:" or "k8s-component:"
-        rule {
-          action = "replace"
-          source_labels = [
-            "__meta_kubernetes_pod_label_app_kubernetes_io_component",
-            "__meta_kubernetes_pod_label_k8s_component",
-            "__meta_kubernetes_pod_label_component",
-          ]
-          regex = "^(?:;*)?([^;]+).*$"
-          replacement = "$1"
-          target_label = "component"
-        }
+          // set the component if specified as metadata labels "component:" or "app.kubernetes.io/component:" or "k8s-component:"
+          rule {
+            action = "replace"
+            source_labels = [
+              "__meta_kubernetes_pod_label_app_kubernetes_io_component",
+              "__meta_kubernetes_pod_label_k8s_component",
+              "__meta_kubernetes_pod_label_component",
+            ]
+            regex = "^(?:;*)?([^;]+).*$"
+            replacement = "$1"
+            target_label = "component"
+          }
     
-        // set a source label
-        rule {
-          action = "replace"
-          replacement = "kubernetes"
-          target_label = "source"
-        }
+          // set a source label
+          rule {
+            action = "replace"
+            replacement = "kubernetes"
+            target_label = "source"
+          }
+    
         }
     
         export "output" {

--- a/charts/k8s-monitoring/docs/examples/features/integrations/mimir/alloy-metrics.alloy
+++ b/charts/k8s-monitoring/docs/examples/features/integrations/mimir/alloy-metrics.alloy
@@ -37,6 +37,7 @@ declare "mimir_integration" {
       namespaces {
         names = coalesce(argument.namespaces.value, [])
       }
+
     }
 
     // mimir relabelings (pre-scrape)
@@ -63,79 +64,78 @@ declare "mimir_integration" {
         target_label = "job"
       }
 
+      rule {
+        source_labels = ["__meta_kubernetes_namespace"]
+        target_label  = "namespace"
+      }
 
+      rule {
+        source_labels = ["__meta_kubernetes_pod_name"]
+        target_label  = "pod"
+      }
 
-    rule {
-      source_labels = ["__meta_kubernetes_namespace"]
-      target_label  = "namespace"
-    }
+      rule {
+        source_labels = ["__meta_kubernetes_pod_container_name"]
+        target_label  = "container"
+      }
 
-    rule {
-      source_labels = ["__meta_kubernetes_pod_name"]
-      target_label  = "pod"
-    }
+      // set the workload to the controller kind and name
+      rule {
+        action = "lowercase"
+        source_labels = ["__meta_kubernetes_pod_controller_kind"]
+        target_label  = "workload_type"
+      }
 
-    rule {
-      source_labels = ["__meta_kubernetes_pod_container_name"]
-      target_label  = "container"
-    }
+      rule {
+        source_labels = ["__meta_kubernetes_pod_controller_name"]
+        target_label  = "workload"
+      }
 
-    // set the workload to the controller kind and name
-    rule {
-      action = "lowercase"
-      source_labels = ["__meta_kubernetes_pod_controller_kind"]
-      target_label  = "workload_type"
-    }
+      // remove the hash from the ReplicaSet
+      rule {
+        source_labels = [
+          "workload_type",
+          "workload",
+        ]
+        separator = "/"
+        regex = "replicaset/(.+)-.+$"
+        target_label  = "workload"
+      }
 
-    rule {
-      source_labels = ["__meta_kubernetes_pod_controller_name"]
-      target_label  = "workload"
-    }
+      // set the app name if specified as metadata labels "app:" or "app.kubernetes.io/name:" or "k8s-app:"
+      rule {
+        action = "replace"
+        source_labels = [
+          "__meta_kubernetes_pod_label_app_kubernetes_io_name",
+          "__meta_kubernetes_pod_label_k8s_app",
+          "__meta_kubernetes_pod_label_app",
+        ]
+        separator = ";"
+        regex = "^(?:;*)?([^;]+).*$"
+        replacement = "$1"
+        target_label = "app"
+      }
 
-    // remove the hash from the ReplicaSet
-    rule {
-      source_labels = [
-        "workload_type",
-        "workload",
-      ]
-      separator = "/"
-      regex = "replicaset/(.+)-.+$"
-      target_label  = "workload"
-    }
+      // set the component if specified as metadata labels "component:" or "app.kubernetes.io/component:" or "k8s-component:"
+      rule {
+        action = "replace"
+        source_labels = [
+          "__meta_kubernetes_pod_label_app_kubernetes_io_component",
+          "__meta_kubernetes_pod_label_k8s_component",
+          "__meta_kubernetes_pod_label_component",
+        ]
+        regex = "^(?:;*)?([^;]+).*$"
+        replacement = "$1"
+        target_label = "component"
+      }
 
-    // set the app name if specified as metadata labels "app:" or "app.kubernetes.io/name:" or "k8s-app:"
-    rule {
-      action = "replace"
-      source_labels = [
-        "__meta_kubernetes_pod_label_app_kubernetes_io_name",
-        "__meta_kubernetes_pod_label_k8s_app",
-        "__meta_kubernetes_pod_label_app",
-      ]
-      separator = ";"
-      regex = "^(?:;*)?([^;]+).*$"
-      replacement = "$1"
-      target_label = "app"
-    }
+      // set a source label
+      rule {
+        action = "replace"
+        replacement = "kubernetes"
+        target_label = "source"
+      }
 
-    // set the component if specified as metadata labels "component:" or "app.kubernetes.io/component:" or "k8s-component:"
-    rule {
-      action = "replace"
-      source_labels = [
-        "__meta_kubernetes_pod_label_app_kubernetes_io_component",
-        "__meta_kubernetes_pod_label_k8s_component",
-        "__meta_kubernetes_pod_label_component",
-      ]
-      regex = "^(?:;*)?([^;]+).*$"
-      replacement = "$1"
-      target_label = "component"
-    }
-
-    // set a source label
-    rule {
-      action = "replace"
-      replacement = "kubernetes"
-      target_label = "source"
-    }
     }
 
     export "output" {

--- a/charts/k8s-monitoring/docs/examples/features/integrations/mimir/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/features/integrations/mimir/output.yaml
@@ -78,6 +78,7 @@ data:
           namespaces {
             names = coalesce(argument.namespaces.value, [])
           }
+    
         }
     
         // mimir relabelings (pre-scrape)
@@ -104,79 +105,78 @@ data:
             target_label = "job"
           }
     
+          rule {
+            source_labels = ["__meta_kubernetes_namespace"]
+            target_label  = "namespace"
+          }
     
+          rule {
+            source_labels = ["__meta_kubernetes_pod_name"]
+            target_label  = "pod"
+          }
     
-        rule {
-          source_labels = ["__meta_kubernetes_namespace"]
-          target_label  = "namespace"
-        }
+          rule {
+            source_labels = ["__meta_kubernetes_pod_container_name"]
+            target_label  = "container"
+          }
     
-        rule {
-          source_labels = ["__meta_kubernetes_pod_name"]
-          target_label  = "pod"
-        }
+          // set the workload to the controller kind and name
+          rule {
+            action = "lowercase"
+            source_labels = ["__meta_kubernetes_pod_controller_kind"]
+            target_label  = "workload_type"
+          }
     
-        rule {
-          source_labels = ["__meta_kubernetes_pod_container_name"]
-          target_label  = "container"
-        }
+          rule {
+            source_labels = ["__meta_kubernetes_pod_controller_name"]
+            target_label  = "workload"
+          }
     
-        // set the workload to the controller kind and name
-        rule {
-          action = "lowercase"
-          source_labels = ["__meta_kubernetes_pod_controller_kind"]
-          target_label  = "workload_type"
-        }
+          // remove the hash from the ReplicaSet
+          rule {
+            source_labels = [
+              "workload_type",
+              "workload",
+            ]
+            separator = "/"
+            regex = "replicaset/(.+)-.+$"
+            target_label  = "workload"
+          }
     
-        rule {
-          source_labels = ["__meta_kubernetes_pod_controller_name"]
-          target_label  = "workload"
-        }
+          // set the app name if specified as metadata labels "app:" or "app.kubernetes.io/name:" or "k8s-app:"
+          rule {
+            action = "replace"
+            source_labels = [
+              "__meta_kubernetes_pod_label_app_kubernetes_io_name",
+              "__meta_kubernetes_pod_label_k8s_app",
+              "__meta_kubernetes_pod_label_app",
+            ]
+            separator = ";"
+            regex = "^(?:;*)?([^;]+).*$"
+            replacement = "$1"
+            target_label = "app"
+          }
     
-        // remove the hash from the ReplicaSet
-        rule {
-          source_labels = [
-            "workload_type",
-            "workload",
-          ]
-          separator = "/"
-          regex = "replicaset/(.+)-.+$"
-          target_label  = "workload"
-        }
+          // set the component if specified as metadata labels "component:" or "app.kubernetes.io/component:" or "k8s-component:"
+          rule {
+            action = "replace"
+            source_labels = [
+              "__meta_kubernetes_pod_label_app_kubernetes_io_component",
+              "__meta_kubernetes_pod_label_k8s_component",
+              "__meta_kubernetes_pod_label_component",
+            ]
+            regex = "^(?:;*)?([^;]+).*$"
+            replacement = "$1"
+            target_label = "component"
+          }
     
-        // set the app name if specified as metadata labels "app:" or "app.kubernetes.io/name:" or "k8s-app:"
-        rule {
-          action = "replace"
-          source_labels = [
-            "__meta_kubernetes_pod_label_app_kubernetes_io_name",
-            "__meta_kubernetes_pod_label_k8s_app",
-            "__meta_kubernetes_pod_label_app",
-          ]
-          separator = ";"
-          regex = "^(?:;*)?([^;]+).*$"
-          replacement = "$1"
-          target_label = "app"
-        }
+          // set a source label
+          rule {
+            action = "replace"
+            replacement = "kubernetes"
+            target_label = "source"
+          }
     
-        // set the component if specified as metadata labels "component:" or "app.kubernetes.io/component:" or "k8s-component:"
-        rule {
-          action = "replace"
-          source_labels = [
-            "__meta_kubernetes_pod_label_app_kubernetes_io_component",
-            "__meta_kubernetes_pod_label_k8s_component",
-            "__meta_kubernetes_pod_label_component",
-          ]
-          regex = "^(?:;*)?([^;]+).*$"
-          replacement = "$1"
-          target_label = "component"
-        }
-    
-        // set a source label
-        rule {
-          action = "replace"
-          replacement = "kubernetes"
-          target_label = "source"
-        }
         }
     
         export "output" {

--- a/charts/k8s-monitoring/docs/examples/include-by-namespace/alloy-metrics.alloy
+++ b/charts/k8s-monitoring/docs/examples/include-by-namespace/alloy-metrics.alloy
@@ -369,9 +369,23 @@ declare "cluster_metrics" {
     role = "node"
   }
 
+  discovery.relabel "nodes" {
+    targets = discovery.kubernetes.nodes.targets
+    rule {
+      source_labels = ["__meta_kubernetes_node_name"]
+      target_label  = "node"
+    }
+
+    rule {
+      replacement = "kubernetes"
+      target_label = "source"
+    }
+
+  }
+
   // Kubelet
   discovery.relabel "kubelet" {
-    targets = discovery.kubernetes.nodes.targets
+    targets = discovery.relabel.nodes.output
   }
 
   prometheus.scrape "kubelet" {
@@ -407,41 +421,15 @@ declare "cluster_metrics" {
 
   // Kubelet Resources
   discovery.relabel "kubelet_resources" {
-    targets = discovery.kubernetes.nodes.targets
+    targets = discovery.relabel.nodes.output
     rule {
       replacement   = "/metrics/resource"
       target_label  = "__metrics_path__"
     }
-    // set the node label
-    rule {
-      source_labels = ["__meta_kubernetes_node_name"]
-      target_label  = "node"
-    }
-
-    // set the app name if specified as metadata labels "app:" or "app.kubernetes.io/name:" or "k8s-app:"
-    rule {
-      action = "replace"
-      source_labels = [
-        "__meta_kubernetes_node_label_app_kubernetes_io_name",
-        "__meta_kubernetes_node_label_k8s_app",
-        "__meta_kubernetes_node_label_app",
-      ]
-      separator = ";"
-      regex = "^(?:;*)?([^;]+).*$"
-      replacement = "$1"
-      target_label = "app"
-    }
-
-    // set a source label
-    rule {
-      action = "replace"
-      replacement = "kubernetes"
-      target_label = "source"
-    }
   }
 
   prometheus.scrape "kubelet_resources" {
-    targets  = discovery.relabel.kubelet_resources.output
+    targets = discovery.relabel.kubelet_resources.output
     job_name = "integrations/kubernetes/resources"
     scheme   = "https"
     scrape_interval = "60s"
@@ -473,34 +461,10 @@ declare "cluster_metrics" {
 
   // cAdvisor
   discovery.relabel "cadvisor" {
-    targets = discovery.kubernetes.nodes.targets
+    targets = discovery.relabel.nodes.output
     rule {
       replacement   = "/metrics/cadvisor"
       target_label  = "__metrics_path__"
-    }
-    rule {
-      source_labels = ["__meta_kubernetes_node_name"]
-      target_label  = "node"
-    }
-    // set the app name if specified as metadata labels "app:" or "app.kubernetes.io/name:" or "k8s-app:"
-    rule {
-      action = "replace"
-      source_labels = [
-        "__meta_kubernetes_node_label_app_kubernetes_io_name",
-        "__meta_kubernetes_node_label_k8s_app",
-        "__meta_kubernetes_node_label_app",
-      ]
-      separator = ";"
-      regex = "^(?:;*)?([^;]+).*$"
-      replacement = "$1"
-      target_label = "app"
-    }
-
-    // set a source label
-    rule {
-      action = "replace"
-      replacement = "kubernetes"
-      target_label = "source"
     }
   }
 

--- a/charts/k8s-monitoring/docs/examples/include-by-namespace/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/include-by-namespace/output.yaml
@@ -547,9 +547,23 @@ data:
         role = "node"
       }
     
+      discovery.relabel "nodes" {
+        targets = discovery.kubernetes.nodes.targets
+        rule {
+          source_labels = ["__meta_kubernetes_node_name"]
+          target_label  = "node"
+        }
+    
+        rule {
+          replacement = "kubernetes"
+          target_label = "source"
+        }
+    
+      }
+    
       // Kubelet
       discovery.relabel "kubelet" {
-        targets = discovery.kubernetes.nodes.targets
+        targets = discovery.relabel.nodes.output
       }
     
       prometheus.scrape "kubelet" {
@@ -585,41 +599,15 @@ data:
     
       // Kubelet Resources
       discovery.relabel "kubelet_resources" {
-        targets = discovery.kubernetes.nodes.targets
+        targets = discovery.relabel.nodes.output
         rule {
           replacement   = "/metrics/resource"
           target_label  = "__metrics_path__"
         }
-        // set the node label
-        rule {
-          source_labels = ["__meta_kubernetes_node_name"]
-          target_label  = "node"
-        }
-    
-        // set the app name if specified as metadata labels "app:" or "app.kubernetes.io/name:" or "k8s-app:"
-        rule {
-          action = "replace"
-          source_labels = [
-            "__meta_kubernetes_node_label_app_kubernetes_io_name",
-            "__meta_kubernetes_node_label_k8s_app",
-            "__meta_kubernetes_node_label_app",
-          ]
-          separator = ";"
-          regex = "^(?:;*)?([^;]+).*$"
-          replacement = "$1"
-          target_label = "app"
-        }
-    
-        // set a source label
-        rule {
-          action = "replace"
-          replacement = "kubernetes"
-          target_label = "source"
-        }
       }
     
       prometheus.scrape "kubelet_resources" {
-        targets  = discovery.relabel.kubelet_resources.output
+        targets = discovery.relabel.kubelet_resources.output
         job_name = "integrations/kubernetes/resources"
         scheme   = "https"
         scrape_interval = "60s"
@@ -651,34 +639,10 @@ data:
     
       // cAdvisor
       discovery.relabel "cadvisor" {
-        targets = discovery.kubernetes.nodes.targets
+        targets = discovery.relabel.nodes.output
         rule {
           replacement   = "/metrics/cadvisor"
           target_label  = "__metrics_path__"
-        }
-        rule {
-          source_labels = ["__meta_kubernetes_node_name"]
-          target_label  = "node"
-        }
-        // set the app name if specified as metadata labels "app:" or "app.kubernetes.io/name:" or "k8s-app:"
-        rule {
-          action = "replace"
-          source_labels = [
-            "__meta_kubernetes_node_label_app_kubernetes_io_name",
-            "__meta_kubernetes_node_label_k8s_app",
-            "__meta_kubernetes_node_label_app",
-          ]
-          separator = ";"
-          regex = "^(?:;*)?([^;]+).*$"
-          replacement = "$1"
-          target_label = "app"
-        }
-    
-        // set a source label
-        rule {
-          action = "replace"
-          replacement = "kubernetes"
-          target_label = "source"
         }
       }
     

--- a/charts/k8s-monitoring/docs/examples/istio-service-mesh/alloy-metrics.alloy
+++ b/charts/k8s-monitoring/docs/examples/istio-service-mesh/alloy-metrics.alloy
@@ -310,9 +310,23 @@ declare "cluster_metrics" {
     role = "node"
   }
 
+  discovery.relabel "nodes" {
+    targets = discovery.kubernetes.nodes.targets
+    rule {
+      source_labels = ["__meta_kubernetes_node_name"]
+      target_label  = "node"
+    }
+
+    rule {
+      replacement = "kubernetes"
+      target_label = "source"
+    }
+
+  }
+
   // Kubelet
   discovery.relabel "kubelet" {
-    targets = discovery.kubernetes.nodes.targets
+    targets = discovery.relabel.nodes.output
   }
 
   prometheus.scrape "kubelet" {
@@ -348,41 +362,15 @@ declare "cluster_metrics" {
 
   // Kubelet Resources
   discovery.relabel "kubelet_resources" {
-    targets = discovery.kubernetes.nodes.targets
+    targets = discovery.relabel.nodes.output
     rule {
       replacement   = "/metrics/resource"
       target_label  = "__metrics_path__"
     }
-    // set the node label
-    rule {
-      source_labels = ["__meta_kubernetes_node_name"]
-      target_label  = "node"
-    }
-
-    // set the app name if specified as metadata labels "app:" or "app.kubernetes.io/name:" or "k8s-app:"
-    rule {
-      action = "replace"
-      source_labels = [
-        "__meta_kubernetes_node_label_app_kubernetes_io_name",
-        "__meta_kubernetes_node_label_k8s_app",
-        "__meta_kubernetes_node_label_app",
-      ]
-      separator = ";"
-      regex = "^(?:;*)?([^;]+).*$"
-      replacement = "$1"
-      target_label = "app"
-    }
-
-    // set a source label
-    rule {
-      action = "replace"
-      replacement = "kubernetes"
-      target_label = "source"
-    }
   }
 
   prometheus.scrape "kubelet_resources" {
-    targets  = discovery.relabel.kubelet_resources.output
+    targets = discovery.relabel.kubelet_resources.output
     job_name = "integrations/kubernetes/resources"
     scheme   = "https"
     scrape_interval = "60s"
@@ -414,34 +402,10 @@ declare "cluster_metrics" {
 
   // cAdvisor
   discovery.relabel "cadvisor" {
-    targets = discovery.kubernetes.nodes.targets
+    targets = discovery.relabel.nodes.output
     rule {
       replacement   = "/metrics/cadvisor"
       target_label  = "__metrics_path__"
-    }
-    rule {
-      source_labels = ["__meta_kubernetes_node_name"]
-      target_label  = "node"
-    }
-    // set the app name if specified as metadata labels "app:" or "app.kubernetes.io/name:" or "k8s-app:"
-    rule {
-      action = "replace"
-      source_labels = [
-        "__meta_kubernetes_node_label_app_kubernetes_io_name",
-        "__meta_kubernetes_node_label_k8s_app",
-        "__meta_kubernetes_node_label_app",
-      ]
-      separator = ";"
-      regex = "^(?:;*)?([^;]+).*$"
-      replacement = "$1"
-      target_label = "app"
-    }
-
-    // set a source label
-    rule {
-      action = "replace"
-      replacement = "kubernetes"
-      target_label = "source"
     }
   }
 

--- a/charts/k8s-monitoring/docs/examples/istio-service-mesh/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/istio-service-mesh/output.yaml
@@ -408,9 +408,23 @@ data:
         role = "node"
       }
     
+      discovery.relabel "nodes" {
+        targets = discovery.kubernetes.nodes.targets
+        rule {
+          source_labels = ["__meta_kubernetes_node_name"]
+          target_label  = "node"
+        }
+    
+        rule {
+          replacement = "kubernetes"
+          target_label = "source"
+        }
+    
+      }
+    
       // Kubelet
       discovery.relabel "kubelet" {
-        targets = discovery.kubernetes.nodes.targets
+        targets = discovery.relabel.nodes.output
       }
     
       prometheus.scrape "kubelet" {
@@ -446,41 +460,15 @@ data:
     
       // Kubelet Resources
       discovery.relabel "kubelet_resources" {
-        targets = discovery.kubernetes.nodes.targets
+        targets = discovery.relabel.nodes.output
         rule {
           replacement   = "/metrics/resource"
           target_label  = "__metrics_path__"
         }
-        // set the node label
-        rule {
-          source_labels = ["__meta_kubernetes_node_name"]
-          target_label  = "node"
-        }
-    
-        // set the app name if specified as metadata labels "app:" or "app.kubernetes.io/name:" or "k8s-app:"
-        rule {
-          action = "replace"
-          source_labels = [
-            "__meta_kubernetes_node_label_app_kubernetes_io_name",
-            "__meta_kubernetes_node_label_k8s_app",
-            "__meta_kubernetes_node_label_app",
-          ]
-          separator = ";"
-          regex = "^(?:;*)?([^;]+).*$"
-          replacement = "$1"
-          target_label = "app"
-        }
-    
-        // set a source label
-        rule {
-          action = "replace"
-          replacement = "kubernetes"
-          target_label = "source"
-        }
       }
     
       prometheus.scrape "kubelet_resources" {
-        targets  = discovery.relabel.kubelet_resources.output
+        targets = discovery.relabel.kubelet_resources.output
         job_name = "integrations/kubernetes/resources"
         scheme   = "https"
         scrape_interval = "60s"
@@ -512,34 +500,10 @@ data:
     
       // cAdvisor
       discovery.relabel "cadvisor" {
-        targets = discovery.kubernetes.nodes.targets
+        targets = discovery.relabel.nodes.output
         rule {
           replacement   = "/metrics/cadvisor"
           target_label  = "__metrics_path__"
-        }
-        rule {
-          source_labels = ["__meta_kubernetes_node_name"]
-          target_label  = "node"
-        }
-        // set the app name if specified as metadata labels "app:" or "app.kubernetes.io/name:" or "k8s-app:"
-        rule {
-          action = "replace"
-          source_labels = [
-            "__meta_kubernetes_node_label_app_kubernetes_io_name",
-            "__meta_kubernetes_node_label_k8s_app",
-            "__meta_kubernetes_node_label_app",
-          ]
-          separator = ";"
-          regex = "^(?:;*)?([^;]+).*$"
-          replacement = "$1"
-          target_label = "app"
-        }
-    
-        // set a source label
-        rule {
-          action = "replace"
-          replacement = "kubernetes"
-          target_label = "source"
         }
       }
     

--- a/charts/k8s-monitoring/docs/examples/log-metrics/alloy-metrics.alloy
+++ b/charts/k8s-monitoring/docs/examples/log-metrics/alloy-metrics.alloy
@@ -37,6 +37,7 @@ declare "alloy_integration" {
       namespaces {
         names = coalesce(argument.namespaces.value, [])
       }
+
     }
 
     // alloy relabelings (pre-scrape)
@@ -56,79 +57,78 @@ declare "alloy_integration" {
         action = "keep"
       }
 
+      rule {
+        source_labels = ["__meta_kubernetes_namespace"]
+        target_label  = "namespace"
+      }
 
+      rule {
+        source_labels = ["__meta_kubernetes_pod_name"]
+        target_label  = "pod"
+      }
 
-    rule {
-      source_labels = ["__meta_kubernetes_namespace"]
-      target_label  = "namespace"
-    }
+      rule {
+        source_labels = ["__meta_kubernetes_pod_container_name"]
+        target_label  = "container"
+      }
 
-    rule {
-      source_labels = ["__meta_kubernetes_pod_name"]
-      target_label  = "pod"
-    }
+      // set the workload to the controller kind and name
+      rule {
+        action = "lowercase"
+        source_labels = ["__meta_kubernetes_pod_controller_kind"]
+        target_label  = "workload_type"
+      }
 
-    rule {
-      source_labels = ["__meta_kubernetes_pod_container_name"]
-      target_label  = "container"
-    }
+      rule {
+        source_labels = ["__meta_kubernetes_pod_controller_name"]
+        target_label  = "workload"
+      }
 
-    // set the workload to the controller kind and name
-    rule {
-      action = "lowercase"
-      source_labels = ["__meta_kubernetes_pod_controller_kind"]
-      target_label  = "workload_type"
-    }
+      // remove the hash from the ReplicaSet
+      rule {
+        source_labels = [
+          "workload_type",
+          "workload",
+        ]
+        separator = "/"
+        regex = "replicaset/(.+)-.+$"
+        target_label  = "workload"
+      }
 
-    rule {
-      source_labels = ["__meta_kubernetes_pod_controller_name"]
-      target_label  = "workload"
-    }
+      // set the app name if specified as metadata labels "app:" or "app.kubernetes.io/name:" or "k8s-app:"
+      rule {
+        action = "replace"
+        source_labels = [
+          "__meta_kubernetes_pod_label_app_kubernetes_io_name",
+          "__meta_kubernetes_pod_label_k8s_app",
+          "__meta_kubernetes_pod_label_app",
+        ]
+        separator = ";"
+        regex = "^(?:;*)?([^;]+).*$"
+        replacement = "$1"
+        target_label = "app"
+      }
 
-    // remove the hash from the ReplicaSet
-    rule {
-      source_labels = [
-        "workload_type",
-        "workload",
-      ]
-      separator = "/"
-      regex = "replicaset/(.+)-.+$"
-      target_label  = "workload"
-    }
+      // set the component if specified as metadata labels "component:" or "app.kubernetes.io/component:" or "k8s-component:"
+      rule {
+        action = "replace"
+        source_labels = [
+          "__meta_kubernetes_pod_label_app_kubernetes_io_component",
+          "__meta_kubernetes_pod_label_k8s_component",
+          "__meta_kubernetes_pod_label_component",
+        ]
+        regex = "^(?:;*)?([^;]+).*$"
+        replacement = "$1"
+        target_label = "component"
+      }
 
-    // set the app name if specified as metadata labels "app:" or "app.kubernetes.io/name:" or "k8s-app:"
-    rule {
-      action = "replace"
-      source_labels = [
-        "__meta_kubernetes_pod_label_app_kubernetes_io_name",
-        "__meta_kubernetes_pod_label_k8s_app",
-        "__meta_kubernetes_pod_label_app",
-      ]
-      separator = ";"
-      regex = "^(?:;*)?([^;]+).*$"
-      replacement = "$1"
-      target_label = "app"
-    }
+      // set a source label
+      rule {
+        action = "replace"
+        replacement = "kubernetes"
+        target_label = "source"
+      }
 
-    // set the component if specified as metadata labels "component:" or "app.kubernetes.io/component:" or "k8s-component:"
-    rule {
-      action = "replace"
-      source_labels = [
-        "__meta_kubernetes_pod_label_app_kubernetes_io_component",
-        "__meta_kubernetes_pod_label_k8s_component",
-        "__meta_kubernetes_pod_label_component",
-      ]
-      regex = "^(?:;*)?([^;]+).*$"
-      replacement = "$1"
-      target_label = "component"
-    }
-
-    // set a source label
-    rule {
-      action = "replace"
-      replacement = "kubernetes"
-      target_label = "source"
-    }
     }
 
     export "output" {

--- a/charts/k8s-monitoring/docs/examples/log-metrics/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/log-metrics/output.yaml
@@ -78,6 +78,7 @@ data:
           namespaces {
             names = coalesce(argument.namespaces.value, [])
           }
+    
         }
     
         // alloy relabelings (pre-scrape)
@@ -97,79 +98,78 @@ data:
             action = "keep"
           }
     
+          rule {
+            source_labels = ["__meta_kubernetes_namespace"]
+            target_label  = "namespace"
+          }
     
+          rule {
+            source_labels = ["__meta_kubernetes_pod_name"]
+            target_label  = "pod"
+          }
     
-        rule {
-          source_labels = ["__meta_kubernetes_namespace"]
-          target_label  = "namespace"
-        }
+          rule {
+            source_labels = ["__meta_kubernetes_pod_container_name"]
+            target_label  = "container"
+          }
     
-        rule {
-          source_labels = ["__meta_kubernetes_pod_name"]
-          target_label  = "pod"
-        }
+          // set the workload to the controller kind and name
+          rule {
+            action = "lowercase"
+            source_labels = ["__meta_kubernetes_pod_controller_kind"]
+            target_label  = "workload_type"
+          }
     
-        rule {
-          source_labels = ["__meta_kubernetes_pod_container_name"]
-          target_label  = "container"
-        }
+          rule {
+            source_labels = ["__meta_kubernetes_pod_controller_name"]
+            target_label  = "workload"
+          }
     
-        // set the workload to the controller kind and name
-        rule {
-          action = "lowercase"
-          source_labels = ["__meta_kubernetes_pod_controller_kind"]
-          target_label  = "workload_type"
-        }
+          // remove the hash from the ReplicaSet
+          rule {
+            source_labels = [
+              "workload_type",
+              "workload",
+            ]
+            separator = "/"
+            regex = "replicaset/(.+)-.+$"
+            target_label  = "workload"
+          }
     
-        rule {
-          source_labels = ["__meta_kubernetes_pod_controller_name"]
-          target_label  = "workload"
-        }
+          // set the app name if specified as metadata labels "app:" or "app.kubernetes.io/name:" or "k8s-app:"
+          rule {
+            action = "replace"
+            source_labels = [
+              "__meta_kubernetes_pod_label_app_kubernetes_io_name",
+              "__meta_kubernetes_pod_label_k8s_app",
+              "__meta_kubernetes_pod_label_app",
+            ]
+            separator = ";"
+            regex = "^(?:;*)?([^;]+).*$"
+            replacement = "$1"
+            target_label = "app"
+          }
     
-        // remove the hash from the ReplicaSet
-        rule {
-          source_labels = [
-            "workload_type",
-            "workload",
-          ]
-          separator = "/"
-          regex = "replicaset/(.+)-.+$"
-          target_label  = "workload"
-        }
+          // set the component if specified as metadata labels "component:" or "app.kubernetes.io/component:" or "k8s-component:"
+          rule {
+            action = "replace"
+            source_labels = [
+              "__meta_kubernetes_pod_label_app_kubernetes_io_component",
+              "__meta_kubernetes_pod_label_k8s_component",
+              "__meta_kubernetes_pod_label_component",
+            ]
+            regex = "^(?:;*)?([^;]+).*$"
+            replacement = "$1"
+            target_label = "component"
+          }
     
-        // set the app name if specified as metadata labels "app:" or "app.kubernetes.io/name:" or "k8s-app:"
-        rule {
-          action = "replace"
-          source_labels = [
-            "__meta_kubernetes_pod_label_app_kubernetes_io_name",
-            "__meta_kubernetes_pod_label_k8s_app",
-            "__meta_kubernetes_pod_label_app",
-          ]
-          separator = ";"
-          regex = "^(?:;*)?([^;]+).*$"
-          replacement = "$1"
-          target_label = "app"
-        }
+          // set a source label
+          rule {
+            action = "replace"
+            replacement = "kubernetes"
+            target_label = "source"
+          }
     
-        // set the component if specified as metadata labels "component:" or "app.kubernetes.io/component:" or "k8s-component:"
-        rule {
-          action = "replace"
-          source_labels = [
-            "__meta_kubernetes_pod_label_app_kubernetes_io_component",
-            "__meta_kubernetes_pod_label_k8s_component",
-            "__meta_kubernetes_pod_label_component",
-          ]
-          regex = "^(?:;*)?([^;]+).*$"
-          replacement = "$1"
-          target_label = "component"
-        }
-    
-        // set a source label
-        rule {
-          action = "replace"
-          replacement = "kubernetes"
-          target_label = "source"
-        }
         }
     
         export "output" {

--- a/charts/k8s-monitoring/docs/examples/meta-monitoring/README.md
+++ b/charts/k8s-monitoring/docs/examples/meta-monitoring/README.md
@@ -28,6 +28,16 @@ destinations:
 
 integrations:
   collector: alloy-singleton
+  # attach available node labels to all integration metrics collection
+  nodeLabels:
+    nodepool: true
+    region: true
+    availability_zone: true
+    node_role: true
+    os: true
+    architecture: true
+    instance_type: true
+
   alloy:
     instances:
       # monitor the collector gathering and sending meta-monitoring metrics/logs to the meta-monitoring cluster
@@ -95,6 +105,15 @@ clusterEvents:
 clusterMetrics:
   enabled: true
   collector: alloy-singleton
+  nodeLabels:
+    nodePool: true
+    region: true
+    availabilityZone: true
+    nodeRole: true
+    os: true
+    architecture: true
+    instanceType: true
+
   kubelet:
     enabled: false
   kubeletResource:
@@ -144,6 +163,24 @@ nodeLogs:
 podLogs:
   enabled: true
   collector: alloy-singleton
+  nodeLabels:
+    nodePool: true
+    region: true
+    availabilityZone: true
+    nodeRole: true
+    os: true
+    architecture: true
+    instanceType: true
+
+  structuredMetadata:
+    nodepool:
+    region:
+    availability_zone:
+    node_role:
+    os:
+    architecture:
+    instance_type:
+
   labelsToKeep:
     - app
     - app_kubernetes_io_name
@@ -154,6 +191,7 @@ podLogs:
     - namespace
     - pod
     - service_name
+
   gatherMethod: kubernetesApi
   namespaces:
     - collectors

--- a/charts/k8s-monitoring/docs/examples/meta-monitoring/alloy-singleton.alloy
+++ b/charts/k8s-monitoring/docs/examples/meta-monitoring/alloy-singleton.alloy
@@ -7,36 +7,77 @@ declare "cluster_metrics" {
     role = "node"
   }
 
-  // cAdvisor
-  discovery.relabel "cadvisor" {
+  discovery.relabel "nodes" {
     targets = discovery.kubernetes.nodes.targets
-    rule {
-      replacement   = "/metrics/cadvisor"
-      target_label  = "__metrics_path__"
-    }
     rule {
       source_labels = ["__meta_kubernetes_node_name"]
       target_label  = "node"
     }
-    // set the app name if specified as metadata labels "app:" or "app.kubernetes.io/name:" or "k8s-app:"
-    rule {
-      action = "replace"
-      source_labels = [
-        "__meta_kubernetes_node_label_app_kubernetes_io_name",
-        "__meta_kubernetes_node_label_k8s_app",
-        "__meta_kubernetes_node_label_app",
-      ]
-      separator = ";"
-      regex = "^(?:;*)?([^;]+).*$"
-      replacement = "$1"
-      target_label = "app"
-    }
 
-    // set a source label
     rule {
-      action = "replace"
       replacement = "kubernetes"
       target_label = "source"
+    }
+
+
+    rule {
+      source_labels = [
+        "__meta_kubernetes_node_label_karpenter_sh_nodepool",
+        "__meta_kubernetes_node_label_cloud_google_com_gke_nodepool",
+        "__meta_kubernetes_node_label_eks_amazonaws_com_nodegroup",
+        "__meta_kubernetes_node_label_kubernetes_azure_com_agentpool",
+        "__meta_kubernetes_node_label_agentpool",
+      ]
+      regex = "^(?:;*)?([^;]+).*$"
+      target_label = "nodepool"
+    }
+
+    rule {
+      source_labels = [
+        "__meta_kubernetes_node_label_topology_kubernetes_io_region",
+        "__meta_kubernetes_node_label_failure_domain_beta_kubernetes_io_region",
+      ]
+      regex = "^(?:;*)?([^;]+).*$"
+      target_label = "region"
+    }
+
+    rule {
+      source_labels = [
+        "__meta_kubernetes_node_label_topology_kubernetes_io_zone",
+        "__meta_kubernetes_node_label_failure_domain_beta_kubernetes_io_zone",
+        "__meta_kubernetes_node_label_topology_gke_io_zone",
+      ]
+      regex = "^(?:;*)?([^;]+).*$"
+      target_label = "availability_zone"
+    }
+
+    rule {
+      source_labels = [
+        "__meta_kubernetes_node_label_kubernetes_io_role",
+        "__meta_kubernetes_node_label_node_kubernetes_io_role",
+        "__meta_kubernetes_node_label_node_role",
+        "__meta_kubernetes_node_label_role",
+      ]
+      regex = "^(?:;*)?([^;]+).*$"
+      target_label = "node_role"
+    }
+
+    rule {
+      source_labels = [
+        "__meta_kubernetes_node_label_node_kubernetes_io_instance_type",
+        "__meta_kubernetes_node_label_beta_kubernetes_io_instance_type",
+      ]
+      regex = "^(?:;*)?([^;]+).*$"
+      target_label = "instance_type"
+    }
+  }
+
+  // cAdvisor
+  discovery.relabel "cadvisor" {
+    targets = discovery.relabel.nodes.output
+    rule {
+      replacement   = "/metrics/cadvisor"
+      target_label  = "__metrics_path__"
     }
   }
 
@@ -209,6 +250,9 @@ declare "cluster_metrics" {
     namespaces {
       names = ["default"]
     }
+    attach_metadata {
+      node = true
+    }
   }
 
   discovery.relabel "node_exporter" {
@@ -300,6 +344,57 @@ declare "cluster_metrics" {
       action = "replace"
       replacement = "kubernetes"
       target_label = "source"
+    }
+
+    rule {
+      source_labels = [
+        "__meta_kubernetes_node_label_karpenter_sh_nodepool",
+        "__meta_kubernetes_node_label_cloud_google_com_gke_nodepool",
+        "__meta_kubernetes_node_label_eks_amazonaws_com_nodegroup",
+        "__meta_kubernetes_node_label_kubernetes_azure_com_agentpool",
+        "__meta_kubernetes_node_label_agentpool",
+      ]
+      regex = "^(?:;*)?([^;]+).*$"
+      target_label = "nodepool"
+    }
+
+    rule {
+      source_labels = [
+        "__meta_kubernetes_node_label_topology_kubernetes_io_region",
+        "__meta_kubernetes_node_label_failure_domain_beta_kubernetes_io_region",
+      ]
+      regex = "^(?:;*)?([^;]+).*$"
+      target_label = "region"
+    }
+
+    rule {
+      source_labels = [
+        "__meta_kubernetes_node_label_topology_kubernetes_io_zone",
+        "__meta_kubernetes_node_label_failure_domain_beta_kubernetes_io_zone",
+        "__meta_kubernetes_node_label_topology_gke_io_zone",
+      ]
+      regex = "^(?:;*)?([^;]+).*$"
+      target_label = "availability_zone"
+    }
+
+    rule {
+      source_labels = [
+        "__meta_kubernetes_node_label_kubernetes_io_role",
+        "__meta_kubernetes_node_label_node_kubernetes_io_role",
+        "__meta_kubernetes_node_label_node_role",
+        "__meta_kubernetes_node_label_role",
+      ]
+      regex = "^(?:;*)?([^;]+).*$"
+      target_label = "node_role"
+    }
+
+    rule {
+      source_labels = [
+        "__meta_kubernetes_node_label_node_kubernetes_io_instance_type",
+        "__meta_kubernetes_node_label_beta_kubernetes_io_instance_type",
+      ]
+      regex = "^(?:;*)?([^;]+).*$"
+      target_label = "instance_type"
     }
   }
 
@@ -523,6 +618,57 @@ declare "pod_logs" {
       regex = "(.+)"
       target_label = "app_kubernetes_io_name"
     }
+
+    rule {
+      source_labels = [
+        "__meta_kubernetes_node_label_karpenter_sh_nodepool",
+        "__meta_kubernetes_node_label_cloud_google_com_gke_nodepool",
+        "__meta_kubernetes_node_label_eks_amazonaws_com_nodegroup",
+        "__meta_kubernetes_node_label_kubernetes_azure_com_agentpool",
+        "__meta_kubernetes_node_label_agentpool",
+      ]
+      regex = "^(?:;*)?([^;]+).*$"
+      target_label = "nodepool"
+    }
+
+    rule {
+      source_labels = [
+        "__meta_kubernetes_node_label_topology_kubernetes_io_region",
+        "__meta_kubernetes_node_label_failure_domain_beta_kubernetes_io_region",
+      ]
+      regex = "^(?:;*)?([^;]+).*$"
+      target_label = "region"
+    }
+
+    rule {
+      source_labels = [
+        "__meta_kubernetes_node_label_topology_kubernetes_io_zone",
+        "__meta_kubernetes_node_label_failure_domain_beta_kubernetes_io_zone",
+        "__meta_kubernetes_node_label_topology_gke_io_zone",
+      ]
+      regex = "^(?:;*)?([^;]+).*$"
+      target_label = "availability_zone"
+    }
+
+    rule {
+      source_labels = [
+        "__meta_kubernetes_node_label_kubernetes_io_role",
+        "__meta_kubernetes_node_label_node_kubernetes_io_role",
+        "__meta_kubernetes_node_label_node_role",
+        "__meta_kubernetes_node_label_role",
+      ]
+      regex = "^(?:;*)?([^;]+).*$"
+      target_label = "node_role"
+    }
+
+    rule {
+      source_labels = [
+        "__meta_kubernetes_node_label_node_kubernetes_io_instance_type",
+        "__meta_kubernetes_node_label_beta_kubernetes_io_instance_type",
+      ]
+      regex = "^(?:;*)?([^;]+).*$"
+      target_label = "instance_type"
+    }
     rule {
       source_labels = ["__meta_kubernetes_namespace","__meta_kubernetes_pod_label_app_kubernetes_io_name"]
       separator = ";"
@@ -592,6 +738,9 @@ declare "pod_logs" {
     namespaces {
       names = ["collectors","logs","metrics","o11y"]
     }
+    attach_metadata {
+      node = true
+    }
   }
 
   loki.source.kubernetes "pod_logs" {
@@ -635,6 +784,18 @@ declare "pod_logs" {
         "filename",
         "tmp_container_runtime",
       ]
+    }
+    // set the structured metadata values
+    stage.structured_metadata {
+      values = {
+        "architecture" = "architecture",
+        "availability_zone" = "availability_zone",
+        "instance_type" = "instance_type",
+        "node_role" = "node_role",
+        "nodepool" = "nodepool",
+        "os" = "os",
+        "region" = "region",
+      }
     }
     // Integration: Grafana
     stage.match {
@@ -837,6 +998,10 @@ declare "alloy_integration" {
       namespaces {
         names = coalesce(argument.namespaces.value, [])
       }
+
+      attach_metadata {
+        node = true
+      }
     }
 
     // alloy relabelings (pre-scrape)
@@ -856,79 +1021,87 @@ declare "alloy_integration" {
         action = "keep"
       }
 
+      rule {
+        source_labels = ["__meta_kubernetes_namespace"]
+        target_label  = "namespace"
+      }
+
+      rule {
+        source_labels = ["__meta_kubernetes_pod_name"]
+        target_label  = "pod"
+      }
+
+      rule {
+        source_labels = ["__meta_kubernetes_pod_container_name"]
+        target_label  = "container"
+      }
+
+      // set the workload to the controller kind and name
+      rule {
+        action = "lowercase"
+        source_labels = ["__meta_kubernetes_pod_controller_kind"]
+        target_label  = "workload_type"
+      }
+
+      rule {
+        source_labels = ["__meta_kubernetes_pod_controller_name"]
+        target_label  = "workload"
+      }
+
+      // remove the hash from the ReplicaSet
+      rule {
+        source_labels = [
+          "workload_type",
+          "workload",
+        ]
+        separator = "/"
+        regex = "replicaset/(.+)-.+$"
+        target_label  = "workload"
+      }
+
+      // set the app name if specified as metadata labels "app:" or "app.kubernetes.io/name:" or "k8s-app:"
+      rule {
+        action = "replace"
+        source_labels = [
+          "__meta_kubernetes_pod_label_app_kubernetes_io_name",
+          "__meta_kubernetes_pod_label_k8s_app",
+          "__meta_kubernetes_pod_label_app",
+        ]
+        separator = ";"
+        regex = "^(?:;*)?([^;]+).*$"
+        replacement = "$1"
+        target_label = "app"
+      }
+
+      // set the component if specified as metadata labels "component:" or "app.kubernetes.io/component:" or "k8s-component:"
+      rule {
+        action = "replace"
+        source_labels = [
+          "__meta_kubernetes_pod_label_app_kubernetes_io_component",
+          "__meta_kubernetes_pod_label_k8s_component",
+          "__meta_kubernetes_pod_label_component",
+        ]
+        regex = "^(?:;*)?([^;]+).*$"
+        replacement = "$1"
+        target_label = "component"
+      }
+
+      // set a source label
+      rule {
+        action = "replace"
+        replacement = "kubernetes"
+        target_label = "source"
+      }
 
 
-    rule {
-      source_labels = ["__meta_kubernetes_namespace"]
-      target_label  = "namespace"
-    }
-
-    rule {
-      source_labels = ["__meta_kubernetes_pod_name"]
-      target_label  = "pod"
-    }
-
-    rule {
-      source_labels = ["__meta_kubernetes_pod_container_name"]
-      target_label  = "container"
-    }
-
-    // set the workload to the controller kind and name
-    rule {
-      action = "lowercase"
-      source_labels = ["__meta_kubernetes_pod_controller_kind"]
-      target_label  = "workload_type"
-    }
-
-    rule {
-      source_labels = ["__meta_kubernetes_pod_controller_name"]
-      target_label  = "workload"
-    }
-
-    // remove the hash from the ReplicaSet
-    rule {
-      source_labels = [
-        "workload_type",
-        "workload",
-      ]
-      separator = "/"
-      regex = "replicaset/(.+)-.+$"
-      target_label  = "workload"
-    }
-
-    // set the app name if specified as metadata labels "app:" or "app.kubernetes.io/name:" or "k8s-app:"
-    rule {
-      action = "replace"
-      source_labels = [
-        "__meta_kubernetes_pod_label_app_kubernetes_io_name",
-        "__meta_kubernetes_pod_label_k8s_app",
-        "__meta_kubernetes_pod_label_app",
-      ]
-      separator = ";"
-      regex = "^(?:;*)?([^;]+).*$"
-      replacement = "$1"
-      target_label = "app"
-    }
-
-    // set the component if specified as metadata labels "component:" or "app.kubernetes.io/component:" or "k8s-component:"
-    rule {
-      action = "replace"
-      source_labels = [
-        "__meta_kubernetes_pod_label_app_kubernetes_io_component",
-        "__meta_kubernetes_pod_label_k8s_component",
-        "__meta_kubernetes_pod_label_component",
-      ]
-      regex = "^(?:;*)?([^;]+).*$"
-      replacement = "$1"
-      target_label = "component"
-    }
-
-    // set a source label
-    rule {
-      action = "replace"
-      replacement = "kubernetes"
-      target_label = "source"
-    }
+      rule {
+        source_labels = [
+          "__meta_kubernetes_node_label_topology_kubernetes_io_region",
+          "__meta_kubernetes_node_label_failure_domain_beta_kubernetes_io_region",
+        ]
+        regex = "^(?:;*)?([^;]+).*$"
+        target_label = "region"
+      }
     }
 
     export "output" {
@@ -1148,6 +1321,10 @@ declare "grafana_integration" {
       namespaces {
         names = coalesce(argument.namespaces.value, [])
       }
+
+      attach_metadata {
+        node = true
+      }
     }
 
     // grafana relabelings (pre-scrape)
@@ -1169,77 +1346,87 @@ declare "grafana_integration" {
 
 
 
-    rule {
-      source_labels = ["__meta_kubernetes_namespace"]
-      target_label  = "namespace"
-    }
+      rule {
+        source_labels = ["__meta_kubernetes_namespace"]
+        target_label  = "namespace"
+      }
 
-    rule {
-      source_labels = ["__meta_kubernetes_pod_name"]
-      target_label  = "pod"
-    }
+      rule {
+        source_labels = ["__meta_kubernetes_pod_name"]
+        target_label  = "pod"
+      }
 
-    rule {
-      source_labels = ["__meta_kubernetes_pod_container_name"]
-      target_label  = "container"
-    }
+      rule {
+        source_labels = ["__meta_kubernetes_pod_container_name"]
+        target_label  = "container"
+      }
 
-    // set the workload to the controller kind and name
-    rule {
-      action = "lowercase"
-      source_labels = ["__meta_kubernetes_pod_controller_kind"]
-      target_label  = "workload_type"
-    }
+      // set the workload to the controller kind and name
+      rule {
+        action = "lowercase"
+        source_labels = ["__meta_kubernetes_pod_controller_kind"]
+        target_label  = "workload_type"
+      }
 
-    rule {
-      source_labels = ["__meta_kubernetes_pod_controller_name"]
-      target_label  = "workload"
-    }
+      rule {
+        source_labels = ["__meta_kubernetes_pod_controller_name"]
+        target_label  = "workload"
+      }
 
-    // remove the hash from the ReplicaSet
-    rule {
-      source_labels = [
-        "workload_type",
-        "workload",
-      ]
-      separator = "/"
-      regex = "replicaset/(.+)-.+$"
-      target_label  = "workload"
-    }
+      // remove the hash from the ReplicaSet
+      rule {
+        source_labels = [
+          "workload_type",
+          "workload",
+        ]
+        separator = "/"
+        regex = "replicaset/(.+)-.+$"
+        target_label  = "workload"
+      }
 
-    // set the app name if specified as metadata labels "app:" or "app.kubernetes.io/name:" or "k8s-app:"
-    rule {
-      action = "replace"
-      source_labels = [
-        "__meta_kubernetes_pod_label_app_kubernetes_io_name",
-        "__meta_kubernetes_pod_label_k8s_app",
-        "__meta_kubernetes_pod_label_app",
-      ]
-      separator = ";"
-      regex = "^(?:;*)?([^;]+).*$"
-      replacement = "$1"
-      target_label = "app"
-    }
+      // set the app name if specified as metadata labels "app:" or "app.kubernetes.io/name:" or "k8s-app:"
+      rule {
+        action = "replace"
+        source_labels = [
+          "__meta_kubernetes_pod_label_app_kubernetes_io_name",
+          "__meta_kubernetes_pod_label_k8s_app",
+          "__meta_kubernetes_pod_label_app",
+        ]
+        separator = ";"
+        regex = "^(?:;*)?([^;]+).*$"
+        replacement = "$1"
+        target_label = "app"
+      }
 
-    // set the component if specified as metadata labels "component:" or "app.kubernetes.io/component:" or "k8s-component:"
-    rule {
-      action = "replace"
-      source_labels = [
-        "__meta_kubernetes_pod_label_app_kubernetes_io_component",
-        "__meta_kubernetes_pod_label_k8s_component",
-        "__meta_kubernetes_pod_label_component",
-      ]
-      regex = "^(?:;*)?([^;]+).*$"
-      replacement = "$1"
-      target_label = "component"
-    }
+      // set the component if specified as metadata labels "component:" or "app.kubernetes.io/component:" or "k8s-component:"
+      rule {
+        action = "replace"
+        source_labels = [
+          "__meta_kubernetes_pod_label_app_kubernetes_io_component",
+          "__meta_kubernetes_pod_label_k8s_component",
+          "__meta_kubernetes_pod_label_component",
+        ]
+        regex = "^(?:;*)?([^;]+).*$"
+        replacement = "$1"
+        target_label = "component"
+      }
 
-    // set a source label
-    rule {
-      action = "replace"
-      replacement = "kubernetes"
-      target_label = "source"
-    }
+      // set a source label
+      rule {
+        action = "replace"
+        replacement = "kubernetes"
+        target_label = "source"
+      }
+
+
+      rule {
+        source_labels = [
+          "__meta_kubernetes_node_label_topology_kubernetes_io_region",
+          "__meta_kubernetes_node_label_failure_domain_beta_kubernetes_io_region",
+        ]
+        regex = "^(?:;*)?([^;]+).*$"
+        target_label = "region"
+      }
     }
 
     export "output" {
@@ -1388,6 +1575,10 @@ declare "loki_integration" {
       namespaces {
         names = coalesce(argument.namespaces.value, [])
       }
+
+      attach_metadata {
+        node = true
+      }
     }
 
     // loki relabelings (pre-scrape)
@@ -1416,77 +1607,87 @@ declare "loki_integration" {
 
 
 
-    rule {
-      source_labels = ["__meta_kubernetes_namespace"]
-      target_label  = "namespace"
-    }
+      rule {
+        source_labels = ["__meta_kubernetes_namespace"]
+        target_label  = "namespace"
+      }
 
-    rule {
-      source_labels = ["__meta_kubernetes_pod_name"]
-      target_label  = "pod"
-    }
+      rule {
+        source_labels = ["__meta_kubernetes_pod_name"]
+        target_label  = "pod"
+      }
 
-    rule {
-      source_labels = ["__meta_kubernetes_pod_container_name"]
-      target_label  = "container"
-    }
+      rule {
+        source_labels = ["__meta_kubernetes_pod_container_name"]
+        target_label  = "container"
+      }
 
-    // set the workload to the controller kind and name
-    rule {
-      action = "lowercase"
-      source_labels = ["__meta_kubernetes_pod_controller_kind"]
-      target_label  = "workload_type"
-    }
+      // set the workload to the controller kind and name
+      rule {
+        action = "lowercase"
+        source_labels = ["__meta_kubernetes_pod_controller_kind"]
+        target_label  = "workload_type"
+      }
 
-    rule {
-      source_labels = ["__meta_kubernetes_pod_controller_name"]
-      target_label  = "workload"
-    }
+      rule {
+        source_labels = ["__meta_kubernetes_pod_controller_name"]
+        target_label  = "workload"
+      }
 
-    // remove the hash from the ReplicaSet
-    rule {
-      source_labels = [
-        "workload_type",
-        "workload",
-      ]
-      separator = "/"
-      regex = "replicaset/(.+)-.+$"
-      target_label  = "workload"
-    }
+      // remove the hash from the ReplicaSet
+      rule {
+        source_labels = [
+          "workload_type",
+          "workload",
+        ]
+        separator = "/"
+        regex = "replicaset/(.+)-.+$"
+        target_label  = "workload"
+      }
 
-    // set the app name if specified as metadata labels "app:" or "app.kubernetes.io/name:" or "k8s-app:"
-    rule {
-      action = "replace"
-      source_labels = [
-        "__meta_kubernetes_pod_label_app_kubernetes_io_name",
-        "__meta_kubernetes_pod_label_k8s_app",
-        "__meta_kubernetes_pod_label_app",
-      ]
-      separator = ";"
-      regex = "^(?:;*)?([^;]+).*$"
-      replacement = "$1"
-      target_label = "app"
-    }
+      // set the app name if specified as metadata labels "app:" or "app.kubernetes.io/name:" or "k8s-app:"
+      rule {
+        action = "replace"
+        source_labels = [
+          "__meta_kubernetes_pod_label_app_kubernetes_io_name",
+          "__meta_kubernetes_pod_label_k8s_app",
+          "__meta_kubernetes_pod_label_app",
+        ]
+        separator = ";"
+        regex = "^(?:;*)?([^;]+).*$"
+        replacement = "$1"
+        target_label = "app"
+      }
 
-    // set the component if specified as metadata labels "component:" or "app.kubernetes.io/component:" or "k8s-component:"
-    rule {
-      action = "replace"
-      source_labels = [
-        "__meta_kubernetes_pod_label_app_kubernetes_io_component",
-        "__meta_kubernetes_pod_label_k8s_component",
-        "__meta_kubernetes_pod_label_component",
-      ]
-      regex = "^(?:;*)?([^;]+).*$"
-      replacement = "$1"
-      target_label = "component"
-    }
+      // set the component if specified as metadata labels "component:" or "app.kubernetes.io/component:" or "k8s-component:"
+      rule {
+        action = "replace"
+        source_labels = [
+          "__meta_kubernetes_pod_label_app_kubernetes_io_component",
+          "__meta_kubernetes_pod_label_k8s_component",
+          "__meta_kubernetes_pod_label_component",
+        ]
+        regex = "^(?:;*)?([^;]+).*$"
+        replacement = "$1"
+        target_label = "component"
+      }
 
-    // set a source label
-    rule {
-      action = "replace"
-      replacement = "kubernetes"
-      target_label = "source"
-    }
+      // set a source label
+      rule {
+        action = "replace"
+        replacement = "kubernetes"
+        target_label = "source"
+      }
+
+
+      rule {
+        source_labels = [
+          "__meta_kubernetes_node_label_topology_kubernetes_io_region",
+          "__meta_kubernetes_node_label_failure_domain_beta_kubernetes_io_region",
+        ]
+        regex = "^(?:;*)?([^;]+).*$"
+        target_label = "region"
+      }
     }
 
     export "output" {
@@ -1645,6 +1846,10 @@ declare "mimir_integration" {
       namespaces {
         names = coalesce(argument.namespaces.value, [])
       }
+
+      attach_metadata {
+        node = true
+      }
     }
 
     // mimir relabelings (pre-scrape)
@@ -1671,79 +1876,87 @@ declare "mimir_integration" {
         target_label = "job"
       }
 
+      rule {
+        source_labels = ["__meta_kubernetes_namespace"]
+        target_label  = "namespace"
+      }
+
+      rule {
+        source_labels = ["__meta_kubernetes_pod_name"]
+        target_label  = "pod"
+      }
+
+      rule {
+        source_labels = ["__meta_kubernetes_pod_container_name"]
+        target_label  = "container"
+      }
+
+      // set the workload to the controller kind and name
+      rule {
+        action = "lowercase"
+        source_labels = ["__meta_kubernetes_pod_controller_kind"]
+        target_label  = "workload_type"
+      }
+
+      rule {
+        source_labels = ["__meta_kubernetes_pod_controller_name"]
+        target_label  = "workload"
+      }
+
+      // remove the hash from the ReplicaSet
+      rule {
+        source_labels = [
+          "workload_type",
+          "workload",
+        ]
+        separator = "/"
+        regex = "replicaset/(.+)-.+$"
+        target_label  = "workload"
+      }
+
+      // set the app name if specified as metadata labels "app:" or "app.kubernetes.io/name:" or "k8s-app:"
+      rule {
+        action = "replace"
+        source_labels = [
+          "__meta_kubernetes_pod_label_app_kubernetes_io_name",
+          "__meta_kubernetes_pod_label_k8s_app",
+          "__meta_kubernetes_pod_label_app",
+        ]
+        separator = ";"
+        regex = "^(?:;*)?([^;]+).*$"
+        replacement = "$1"
+        target_label = "app"
+      }
+
+      // set the component if specified as metadata labels "component:" or "app.kubernetes.io/component:" or "k8s-component:"
+      rule {
+        action = "replace"
+        source_labels = [
+          "__meta_kubernetes_pod_label_app_kubernetes_io_component",
+          "__meta_kubernetes_pod_label_k8s_component",
+          "__meta_kubernetes_pod_label_component",
+        ]
+        regex = "^(?:;*)?([^;]+).*$"
+        replacement = "$1"
+        target_label = "component"
+      }
+
+      // set a source label
+      rule {
+        action = "replace"
+        replacement = "kubernetes"
+        target_label = "source"
+      }
 
 
-    rule {
-      source_labels = ["__meta_kubernetes_namespace"]
-      target_label  = "namespace"
-    }
-
-    rule {
-      source_labels = ["__meta_kubernetes_pod_name"]
-      target_label  = "pod"
-    }
-
-    rule {
-      source_labels = ["__meta_kubernetes_pod_container_name"]
-      target_label  = "container"
-    }
-
-    // set the workload to the controller kind and name
-    rule {
-      action = "lowercase"
-      source_labels = ["__meta_kubernetes_pod_controller_kind"]
-      target_label  = "workload_type"
-    }
-
-    rule {
-      source_labels = ["__meta_kubernetes_pod_controller_name"]
-      target_label  = "workload"
-    }
-
-    // remove the hash from the ReplicaSet
-    rule {
-      source_labels = [
-        "workload_type",
-        "workload",
-      ]
-      separator = "/"
-      regex = "replicaset/(.+)-.+$"
-      target_label  = "workload"
-    }
-
-    // set the app name if specified as metadata labels "app:" or "app.kubernetes.io/name:" or "k8s-app:"
-    rule {
-      action = "replace"
-      source_labels = [
-        "__meta_kubernetes_pod_label_app_kubernetes_io_name",
-        "__meta_kubernetes_pod_label_k8s_app",
-        "__meta_kubernetes_pod_label_app",
-      ]
-      separator = ";"
-      regex = "^(?:;*)?([^;]+).*$"
-      replacement = "$1"
-      target_label = "app"
-    }
-
-    // set the component if specified as metadata labels "component:" or "app.kubernetes.io/component:" or "k8s-component:"
-    rule {
-      action = "replace"
-      source_labels = [
-        "__meta_kubernetes_pod_label_app_kubernetes_io_component",
-        "__meta_kubernetes_pod_label_k8s_component",
-        "__meta_kubernetes_pod_label_component",
-      ]
-      regex = "^(?:;*)?([^;]+).*$"
-      replacement = "$1"
-      target_label = "component"
-    }
-
-    // set a source label
-    rule {
-      action = "replace"
-      replacement = "kubernetes"
-      target_label = "source"
-    }
+      rule {
+        source_labels = [
+          "__meta_kubernetes_node_label_topology_kubernetes_io_region",
+          "__meta_kubernetes_node_label_failure_domain_beta_kubernetes_io_region",
+        ]
+        regex = "^(?:;*)?([^;]+).*$"
+        target_label = "region"
+      }
     }
 
     export "output" {

--- a/charts/k8s-monitoring/docs/examples/meta-monitoring/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/meta-monitoring/output.yaml
@@ -82,36 +82,77 @@ data:
         role = "node"
       }
     
-      // cAdvisor
-      discovery.relabel "cadvisor" {
+      discovery.relabel "nodes" {
         targets = discovery.kubernetes.nodes.targets
-        rule {
-          replacement   = "/metrics/cadvisor"
-          target_label  = "__metrics_path__"
-        }
         rule {
           source_labels = ["__meta_kubernetes_node_name"]
           target_label  = "node"
         }
-        // set the app name if specified as metadata labels "app:" or "app.kubernetes.io/name:" or "k8s-app:"
-        rule {
-          action = "replace"
-          source_labels = [
-            "__meta_kubernetes_node_label_app_kubernetes_io_name",
-            "__meta_kubernetes_node_label_k8s_app",
-            "__meta_kubernetes_node_label_app",
-          ]
-          separator = ";"
-          regex = "^(?:;*)?([^;]+).*$"
-          replacement = "$1"
-          target_label = "app"
-        }
     
-        // set a source label
         rule {
-          action = "replace"
           replacement = "kubernetes"
           target_label = "source"
+        }
+    
+    
+        rule {
+          source_labels = [
+            "__meta_kubernetes_node_label_karpenter_sh_nodepool",
+            "__meta_kubernetes_node_label_cloud_google_com_gke_nodepool",
+            "__meta_kubernetes_node_label_eks_amazonaws_com_nodegroup",
+            "__meta_kubernetes_node_label_kubernetes_azure_com_agentpool",
+            "__meta_kubernetes_node_label_agentpool",
+          ]
+          regex = "^(?:;*)?([^;]+).*$"
+          target_label = "nodepool"
+        }
+    
+        rule {
+          source_labels = [
+            "__meta_kubernetes_node_label_topology_kubernetes_io_region",
+            "__meta_kubernetes_node_label_failure_domain_beta_kubernetes_io_region",
+          ]
+          regex = "^(?:;*)?([^;]+).*$"
+          target_label = "region"
+        }
+    
+        rule {
+          source_labels = [
+            "__meta_kubernetes_node_label_topology_kubernetes_io_zone",
+            "__meta_kubernetes_node_label_failure_domain_beta_kubernetes_io_zone",
+            "__meta_kubernetes_node_label_topology_gke_io_zone",
+          ]
+          regex = "^(?:;*)?([^;]+).*$"
+          target_label = "availability_zone"
+        }
+    
+        rule {
+          source_labels = [
+            "__meta_kubernetes_node_label_kubernetes_io_role",
+            "__meta_kubernetes_node_label_node_kubernetes_io_role",
+            "__meta_kubernetes_node_label_node_role",
+            "__meta_kubernetes_node_label_role",
+          ]
+          regex = "^(?:;*)?([^;]+).*$"
+          target_label = "node_role"
+        }
+    
+        rule {
+          source_labels = [
+            "__meta_kubernetes_node_label_node_kubernetes_io_instance_type",
+            "__meta_kubernetes_node_label_beta_kubernetes_io_instance_type",
+          ]
+          regex = "^(?:;*)?([^;]+).*$"
+          target_label = "instance_type"
+        }
+      }
+    
+      // cAdvisor
+      discovery.relabel "cadvisor" {
+        targets = discovery.relabel.nodes.output
+        rule {
+          replacement   = "/metrics/cadvisor"
+          target_label  = "__metrics_path__"
         }
       }
     
@@ -284,6 +325,9 @@ data:
         namespaces {
           names = ["default"]
         }
+        attach_metadata {
+          node = true
+        }
       }
     
       discovery.relabel "node_exporter" {
@@ -375,6 +419,57 @@ data:
           action = "replace"
           replacement = "kubernetes"
           target_label = "source"
+        }
+    
+        rule {
+          source_labels = [
+            "__meta_kubernetes_node_label_karpenter_sh_nodepool",
+            "__meta_kubernetes_node_label_cloud_google_com_gke_nodepool",
+            "__meta_kubernetes_node_label_eks_amazonaws_com_nodegroup",
+            "__meta_kubernetes_node_label_kubernetes_azure_com_agentpool",
+            "__meta_kubernetes_node_label_agentpool",
+          ]
+          regex = "^(?:;*)?([^;]+).*$"
+          target_label = "nodepool"
+        }
+    
+        rule {
+          source_labels = [
+            "__meta_kubernetes_node_label_topology_kubernetes_io_region",
+            "__meta_kubernetes_node_label_failure_domain_beta_kubernetes_io_region",
+          ]
+          regex = "^(?:;*)?([^;]+).*$"
+          target_label = "region"
+        }
+    
+        rule {
+          source_labels = [
+            "__meta_kubernetes_node_label_topology_kubernetes_io_zone",
+            "__meta_kubernetes_node_label_failure_domain_beta_kubernetes_io_zone",
+            "__meta_kubernetes_node_label_topology_gke_io_zone",
+          ]
+          regex = "^(?:;*)?([^;]+).*$"
+          target_label = "availability_zone"
+        }
+    
+        rule {
+          source_labels = [
+            "__meta_kubernetes_node_label_kubernetes_io_role",
+            "__meta_kubernetes_node_label_node_kubernetes_io_role",
+            "__meta_kubernetes_node_label_node_role",
+            "__meta_kubernetes_node_label_role",
+          ]
+          regex = "^(?:;*)?([^;]+).*$"
+          target_label = "node_role"
+        }
+    
+        rule {
+          source_labels = [
+            "__meta_kubernetes_node_label_node_kubernetes_io_instance_type",
+            "__meta_kubernetes_node_label_beta_kubernetes_io_instance_type",
+          ]
+          regex = "^(?:;*)?([^;]+).*$"
+          target_label = "instance_type"
         }
       }
     
@@ -598,6 +693,57 @@ data:
           regex = "(.+)"
           target_label = "app_kubernetes_io_name"
         }
+    
+        rule {
+          source_labels = [
+            "__meta_kubernetes_node_label_karpenter_sh_nodepool",
+            "__meta_kubernetes_node_label_cloud_google_com_gke_nodepool",
+            "__meta_kubernetes_node_label_eks_amazonaws_com_nodegroup",
+            "__meta_kubernetes_node_label_kubernetes_azure_com_agentpool",
+            "__meta_kubernetes_node_label_agentpool",
+          ]
+          regex = "^(?:;*)?([^;]+).*$"
+          target_label = "nodepool"
+        }
+    
+        rule {
+          source_labels = [
+            "__meta_kubernetes_node_label_topology_kubernetes_io_region",
+            "__meta_kubernetes_node_label_failure_domain_beta_kubernetes_io_region",
+          ]
+          regex = "^(?:;*)?([^;]+).*$"
+          target_label = "region"
+        }
+    
+        rule {
+          source_labels = [
+            "__meta_kubernetes_node_label_topology_kubernetes_io_zone",
+            "__meta_kubernetes_node_label_failure_domain_beta_kubernetes_io_zone",
+            "__meta_kubernetes_node_label_topology_gke_io_zone",
+          ]
+          regex = "^(?:;*)?([^;]+).*$"
+          target_label = "availability_zone"
+        }
+    
+        rule {
+          source_labels = [
+            "__meta_kubernetes_node_label_kubernetes_io_role",
+            "__meta_kubernetes_node_label_node_kubernetes_io_role",
+            "__meta_kubernetes_node_label_node_role",
+            "__meta_kubernetes_node_label_role",
+          ]
+          regex = "^(?:;*)?([^;]+).*$"
+          target_label = "node_role"
+        }
+    
+        rule {
+          source_labels = [
+            "__meta_kubernetes_node_label_node_kubernetes_io_instance_type",
+            "__meta_kubernetes_node_label_beta_kubernetes_io_instance_type",
+          ]
+          regex = "^(?:;*)?([^;]+).*$"
+          target_label = "instance_type"
+        }
         rule {
           source_labels = ["__meta_kubernetes_namespace","__meta_kubernetes_pod_label_app_kubernetes_io_name"]
           separator = ";"
@@ -667,6 +813,9 @@ data:
         namespaces {
           names = ["collectors","logs","metrics","o11y"]
         }
+        attach_metadata {
+          node = true
+        }
       }
     
       loki.source.kubernetes "pod_logs" {
@@ -710,6 +859,18 @@ data:
             "filename",
             "tmp_container_runtime",
           ]
+        }
+        // set the structured metadata values
+        stage.structured_metadata {
+          values = {
+            "architecture" = "architecture",
+            "availability_zone" = "availability_zone",
+            "instance_type" = "instance_type",
+            "node_role" = "node_role",
+            "nodepool" = "nodepool",
+            "os" = "os",
+            "region" = "region",
+          }
         }
         // Integration: Grafana
         stage.match {
@@ -912,6 +1073,10 @@ data:
           namespaces {
             names = coalesce(argument.namespaces.value, [])
           }
+    
+          attach_metadata {
+            node = true
+          }
         }
     
         // alloy relabelings (pre-scrape)
@@ -931,79 +1096,87 @@ data:
             action = "keep"
           }
     
+          rule {
+            source_labels = ["__meta_kubernetes_namespace"]
+            target_label  = "namespace"
+          }
+    
+          rule {
+            source_labels = ["__meta_kubernetes_pod_name"]
+            target_label  = "pod"
+          }
+    
+          rule {
+            source_labels = ["__meta_kubernetes_pod_container_name"]
+            target_label  = "container"
+          }
+    
+          // set the workload to the controller kind and name
+          rule {
+            action = "lowercase"
+            source_labels = ["__meta_kubernetes_pod_controller_kind"]
+            target_label  = "workload_type"
+          }
+    
+          rule {
+            source_labels = ["__meta_kubernetes_pod_controller_name"]
+            target_label  = "workload"
+          }
+    
+          // remove the hash from the ReplicaSet
+          rule {
+            source_labels = [
+              "workload_type",
+              "workload",
+            ]
+            separator = "/"
+            regex = "replicaset/(.+)-.+$"
+            target_label  = "workload"
+          }
+    
+          // set the app name if specified as metadata labels "app:" or "app.kubernetes.io/name:" or "k8s-app:"
+          rule {
+            action = "replace"
+            source_labels = [
+              "__meta_kubernetes_pod_label_app_kubernetes_io_name",
+              "__meta_kubernetes_pod_label_k8s_app",
+              "__meta_kubernetes_pod_label_app",
+            ]
+            separator = ";"
+            regex = "^(?:;*)?([^;]+).*$"
+            replacement = "$1"
+            target_label = "app"
+          }
+    
+          // set the component if specified as metadata labels "component:" or "app.kubernetes.io/component:" or "k8s-component:"
+          rule {
+            action = "replace"
+            source_labels = [
+              "__meta_kubernetes_pod_label_app_kubernetes_io_component",
+              "__meta_kubernetes_pod_label_k8s_component",
+              "__meta_kubernetes_pod_label_component",
+            ]
+            regex = "^(?:;*)?([^;]+).*$"
+            replacement = "$1"
+            target_label = "component"
+          }
+    
+          // set a source label
+          rule {
+            action = "replace"
+            replacement = "kubernetes"
+            target_label = "source"
+          }
     
     
-        rule {
-          source_labels = ["__meta_kubernetes_namespace"]
-          target_label  = "namespace"
-        }
-    
-        rule {
-          source_labels = ["__meta_kubernetes_pod_name"]
-          target_label  = "pod"
-        }
-    
-        rule {
-          source_labels = ["__meta_kubernetes_pod_container_name"]
-          target_label  = "container"
-        }
-    
-        // set the workload to the controller kind and name
-        rule {
-          action = "lowercase"
-          source_labels = ["__meta_kubernetes_pod_controller_kind"]
-          target_label  = "workload_type"
-        }
-    
-        rule {
-          source_labels = ["__meta_kubernetes_pod_controller_name"]
-          target_label  = "workload"
-        }
-    
-        // remove the hash from the ReplicaSet
-        rule {
-          source_labels = [
-            "workload_type",
-            "workload",
-          ]
-          separator = "/"
-          regex = "replicaset/(.+)-.+$"
-          target_label  = "workload"
-        }
-    
-        // set the app name if specified as metadata labels "app:" or "app.kubernetes.io/name:" or "k8s-app:"
-        rule {
-          action = "replace"
-          source_labels = [
-            "__meta_kubernetes_pod_label_app_kubernetes_io_name",
-            "__meta_kubernetes_pod_label_k8s_app",
-            "__meta_kubernetes_pod_label_app",
-          ]
-          separator = ";"
-          regex = "^(?:;*)?([^;]+).*$"
-          replacement = "$1"
-          target_label = "app"
-        }
-    
-        // set the component if specified as metadata labels "component:" or "app.kubernetes.io/component:" or "k8s-component:"
-        rule {
-          action = "replace"
-          source_labels = [
-            "__meta_kubernetes_pod_label_app_kubernetes_io_component",
-            "__meta_kubernetes_pod_label_k8s_component",
-            "__meta_kubernetes_pod_label_component",
-          ]
-          regex = "^(?:;*)?([^;]+).*$"
-          replacement = "$1"
-          target_label = "component"
-        }
-    
-        // set a source label
-        rule {
-          action = "replace"
-          replacement = "kubernetes"
-          target_label = "source"
-        }
+          rule {
+            source_labels = [
+              "__meta_kubernetes_node_label_topology_kubernetes_io_region",
+              "__meta_kubernetes_node_label_failure_domain_beta_kubernetes_io_region",
+            ]
+            regex = "^(?:;*)?([^;]+).*$"
+            target_label = "region"
+          }
         }
     
         export "output" {
@@ -1223,6 +1396,10 @@ data:
           namespaces {
             names = coalesce(argument.namespaces.value, [])
           }
+    
+          attach_metadata {
+            node = true
+          }
         }
     
         // grafana relabelings (pre-scrape)
@@ -1244,77 +1421,87 @@ data:
     
     
     
-        rule {
-          source_labels = ["__meta_kubernetes_namespace"]
-          target_label  = "namespace"
-        }
+          rule {
+            source_labels = ["__meta_kubernetes_namespace"]
+            target_label  = "namespace"
+          }
     
-        rule {
-          source_labels = ["__meta_kubernetes_pod_name"]
-          target_label  = "pod"
-        }
+          rule {
+            source_labels = ["__meta_kubernetes_pod_name"]
+            target_label  = "pod"
+          }
     
-        rule {
-          source_labels = ["__meta_kubernetes_pod_container_name"]
-          target_label  = "container"
-        }
+          rule {
+            source_labels = ["__meta_kubernetes_pod_container_name"]
+            target_label  = "container"
+          }
     
-        // set the workload to the controller kind and name
-        rule {
-          action = "lowercase"
-          source_labels = ["__meta_kubernetes_pod_controller_kind"]
-          target_label  = "workload_type"
-        }
+          // set the workload to the controller kind and name
+          rule {
+            action = "lowercase"
+            source_labels = ["__meta_kubernetes_pod_controller_kind"]
+            target_label  = "workload_type"
+          }
     
-        rule {
-          source_labels = ["__meta_kubernetes_pod_controller_name"]
-          target_label  = "workload"
-        }
+          rule {
+            source_labels = ["__meta_kubernetes_pod_controller_name"]
+            target_label  = "workload"
+          }
     
-        // remove the hash from the ReplicaSet
-        rule {
-          source_labels = [
-            "workload_type",
-            "workload",
-          ]
-          separator = "/"
-          regex = "replicaset/(.+)-.+$"
-          target_label  = "workload"
-        }
+          // remove the hash from the ReplicaSet
+          rule {
+            source_labels = [
+              "workload_type",
+              "workload",
+            ]
+            separator = "/"
+            regex = "replicaset/(.+)-.+$"
+            target_label  = "workload"
+          }
     
-        // set the app name if specified as metadata labels "app:" or "app.kubernetes.io/name:" or "k8s-app:"
-        rule {
-          action = "replace"
-          source_labels = [
-            "__meta_kubernetes_pod_label_app_kubernetes_io_name",
-            "__meta_kubernetes_pod_label_k8s_app",
-            "__meta_kubernetes_pod_label_app",
-          ]
-          separator = ";"
-          regex = "^(?:;*)?([^;]+).*$"
-          replacement = "$1"
-          target_label = "app"
-        }
+          // set the app name if specified as metadata labels "app:" or "app.kubernetes.io/name:" or "k8s-app:"
+          rule {
+            action = "replace"
+            source_labels = [
+              "__meta_kubernetes_pod_label_app_kubernetes_io_name",
+              "__meta_kubernetes_pod_label_k8s_app",
+              "__meta_kubernetes_pod_label_app",
+            ]
+            separator = ";"
+            regex = "^(?:;*)?([^;]+).*$"
+            replacement = "$1"
+            target_label = "app"
+          }
     
-        // set the component if specified as metadata labels "component:" or "app.kubernetes.io/component:" or "k8s-component:"
-        rule {
-          action = "replace"
-          source_labels = [
-            "__meta_kubernetes_pod_label_app_kubernetes_io_component",
-            "__meta_kubernetes_pod_label_k8s_component",
-            "__meta_kubernetes_pod_label_component",
-          ]
-          regex = "^(?:;*)?([^;]+).*$"
-          replacement = "$1"
-          target_label = "component"
-        }
+          // set the component if specified as metadata labels "component:" or "app.kubernetes.io/component:" or "k8s-component:"
+          rule {
+            action = "replace"
+            source_labels = [
+              "__meta_kubernetes_pod_label_app_kubernetes_io_component",
+              "__meta_kubernetes_pod_label_k8s_component",
+              "__meta_kubernetes_pod_label_component",
+            ]
+            regex = "^(?:;*)?([^;]+).*$"
+            replacement = "$1"
+            target_label = "component"
+          }
     
-        // set a source label
-        rule {
-          action = "replace"
-          replacement = "kubernetes"
-          target_label = "source"
-        }
+          // set a source label
+          rule {
+            action = "replace"
+            replacement = "kubernetes"
+            target_label = "source"
+          }
+    
+    
+          rule {
+            source_labels = [
+              "__meta_kubernetes_node_label_topology_kubernetes_io_region",
+              "__meta_kubernetes_node_label_failure_domain_beta_kubernetes_io_region",
+            ]
+            regex = "^(?:;*)?([^;]+).*$"
+            target_label = "region"
+          }
         }
     
         export "output" {
@@ -1463,6 +1650,10 @@ data:
           namespaces {
             names = coalesce(argument.namespaces.value, [])
           }
+    
+          attach_metadata {
+            node = true
+          }
         }
     
         // loki relabelings (pre-scrape)
@@ -1491,77 +1682,87 @@ data:
     
     
     
-        rule {
-          source_labels = ["__meta_kubernetes_namespace"]
-          target_label  = "namespace"
-        }
+          rule {
+            source_labels = ["__meta_kubernetes_namespace"]
+            target_label  = "namespace"
+          }
     
-        rule {
-          source_labels = ["__meta_kubernetes_pod_name"]
-          target_label  = "pod"
-        }
+          rule {
+            source_labels = ["__meta_kubernetes_pod_name"]
+            target_label  = "pod"
+          }
     
-        rule {
-          source_labels = ["__meta_kubernetes_pod_container_name"]
-          target_label  = "container"
-        }
+          rule {
+            source_labels = ["__meta_kubernetes_pod_container_name"]
+            target_label  = "container"
+          }
     
-        // set the workload to the controller kind and name
-        rule {
-          action = "lowercase"
-          source_labels = ["__meta_kubernetes_pod_controller_kind"]
-          target_label  = "workload_type"
-        }
+          // set the workload to the controller kind and name
+          rule {
+            action = "lowercase"
+            source_labels = ["__meta_kubernetes_pod_controller_kind"]
+            target_label  = "workload_type"
+          }
     
-        rule {
-          source_labels = ["__meta_kubernetes_pod_controller_name"]
-          target_label  = "workload"
-        }
+          rule {
+            source_labels = ["__meta_kubernetes_pod_controller_name"]
+            target_label  = "workload"
+          }
     
-        // remove the hash from the ReplicaSet
-        rule {
-          source_labels = [
-            "workload_type",
-            "workload",
-          ]
-          separator = "/"
-          regex = "replicaset/(.+)-.+$"
-          target_label  = "workload"
-        }
+          // remove the hash from the ReplicaSet
+          rule {
+            source_labels = [
+              "workload_type",
+              "workload",
+            ]
+            separator = "/"
+            regex = "replicaset/(.+)-.+$"
+            target_label  = "workload"
+          }
     
-        // set the app name if specified as metadata labels "app:" or "app.kubernetes.io/name:" or "k8s-app:"
-        rule {
-          action = "replace"
-          source_labels = [
-            "__meta_kubernetes_pod_label_app_kubernetes_io_name",
-            "__meta_kubernetes_pod_label_k8s_app",
-            "__meta_kubernetes_pod_label_app",
-          ]
-          separator = ";"
-          regex = "^(?:;*)?([^;]+).*$"
-          replacement = "$1"
-          target_label = "app"
-        }
+          // set the app name if specified as metadata labels "app:" or "app.kubernetes.io/name:" or "k8s-app:"
+          rule {
+            action = "replace"
+            source_labels = [
+              "__meta_kubernetes_pod_label_app_kubernetes_io_name",
+              "__meta_kubernetes_pod_label_k8s_app",
+              "__meta_kubernetes_pod_label_app",
+            ]
+            separator = ";"
+            regex = "^(?:;*)?([^;]+).*$"
+            replacement = "$1"
+            target_label = "app"
+          }
     
-        // set the component if specified as metadata labels "component:" or "app.kubernetes.io/component:" or "k8s-component:"
-        rule {
-          action = "replace"
-          source_labels = [
-            "__meta_kubernetes_pod_label_app_kubernetes_io_component",
-            "__meta_kubernetes_pod_label_k8s_component",
-            "__meta_kubernetes_pod_label_component",
-          ]
-          regex = "^(?:;*)?([^;]+).*$"
-          replacement = "$1"
-          target_label = "component"
-        }
+          // set the component if specified as metadata labels "component:" or "app.kubernetes.io/component:" or "k8s-component:"
+          rule {
+            action = "replace"
+            source_labels = [
+              "__meta_kubernetes_pod_label_app_kubernetes_io_component",
+              "__meta_kubernetes_pod_label_k8s_component",
+              "__meta_kubernetes_pod_label_component",
+            ]
+            regex = "^(?:;*)?([^;]+).*$"
+            replacement = "$1"
+            target_label = "component"
+          }
     
-        // set a source label
-        rule {
-          action = "replace"
-          replacement = "kubernetes"
-          target_label = "source"
-        }
+          // set a source label
+          rule {
+            action = "replace"
+            replacement = "kubernetes"
+            target_label = "source"
+          }
+    
+    
+          rule {
+            source_labels = [
+              "__meta_kubernetes_node_label_topology_kubernetes_io_region",
+              "__meta_kubernetes_node_label_failure_domain_beta_kubernetes_io_region",
+            ]
+            regex = "^(?:;*)?([^;]+).*$"
+            target_label = "region"
+          }
         }
     
         export "output" {
@@ -1720,6 +1921,10 @@ data:
           namespaces {
             names = coalesce(argument.namespaces.value, [])
           }
+    
+          attach_metadata {
+            node = true
+          }
         }
     
         // mimir relabelings (pre-scrape)
@@ -1746,79 +1951,87 @@ data:
             target_label = "job"
           }
     
+          rule {
+            source_labels = ["__meta_kubernetes_namespace"]
+            target_label  = "namespace"
+          }
+    
+          rule {
+            source_labels = ["__meta_kubernetes_pod_name"]
+            target_label  = "pod"
+          }
+    
+          rule {
+            source_labels = ["__meta_kubernetes_pod_container_name"]
+            target_label  = "container"
+          }
+    
+          // set the workload to the controller kind and name
+          rule {
+            action = "lowercase"
+            source_labels = ["__meta_kubernetes_pod_controller_kind"]
+            target_label  = "workload_type"
+          }
+    
+          rule {
+            source_labels = ["__meta_kubernetes_pod_controller_name"]
+            target_label  = "workload"
+          }
+    
+          // remove the hash from the ReplicaSet
+          rule {
+            source_labels = [
+              "workload_type",
+              "workload",
+            ]
+            separator = "/"
+            regex = "replicaset/(.+)-.+$"
+            target_label  = "workload"
+          }
+    
+          // set the app name if specified as metadata labels "app:" or "app.kubernetes.io/name:" or "k8s-app:"
+          rule {
+            action = "replace"
+            source_labels = [
+              "__meta_kubernetes_pod_label_app_kubernetes_io_name",
+              "__meta_kubernetes_pod_label_k8s_app",
+              "__meta_kubernetes_pod_label_app",
+            ]
+            separator = ";"
+            regex = "^(?:;*)?([^;]+).*$"
+            replacement = "$1"
+            target_label = "app"
+          }
+    
+          // set the component if specified as metadata labels "component:" or "app.kubernetes.io/component:" or "k8s-component:"
+          rule {
+            action = "replace"
+            source_labels = [
+              "__meta_kubernetes_pod_label_app_kubernetes_io_component",
+              "__meta_kubernetes_pod_label_k8s_component",
+              "__meta_kubernetes_pod_label_component",
+            ]
+            regex = "^(?:;*)?([^;]+).*$"
+            replacement = "$1"
+            target_label = "component"
+          }
+    
+          // set a source label
+          rule {
+            action = "replace"
+            replacement = "kubernetes"
+            target_label = "source"
+          }
     
     
-        rule {
-          source_labels = ["__meta_kubernetes_namespace"]
-          target_label  = "namespace"
-        }
-    
-        rule {
-          source_labels = ["__meta_kubernetes_pod_name"]
-          target_label  = "pod"
-        }
-    
-        rule {
-          source_labels = ["__meta_kubernetes_pod_container_name"]
-          target_label  = "container"
-        }
-    
-        // set the workload to the controller kind and name
-        rule {
-          action = "lowercase"
-          source_labels = ["__meta_kubernetes_pod_controller_kind"]
-          target_label  = "workload_type"
-        }
-    
-        rule {
-          source_labels = ["__meta_kubernetes_pod_controller_name"]
-          target_label  = "workload"
-        }
-    
-        // remove the hash from the ReplicaSet
-        rule {
-          source_labels = [
-            "workload_type",
-            "workload",
-          ]
-          separator = "/"
-          regex = "replicaset/(.+)-.+$"
-          target_label  = "workload"
-        }
-    
-        // set the app name if specified as metadata labels "app:" or "app.kubernetes.io/name:" or "k8s-app:"
-        rule {
-          action = "replace"
-          source_labels = [
-            "__meta_kubernetes_pod_label_app_kubernetes_io_name",
-            "__meta_kubernetes_pod_label_k8s_app",
-            "__meta_kubernetes_pod_label_app",
-          ]
-          separator = ";"
-          regex = "^(?:;*)?([^;]+).*$"
-          replacement = "$1"
-          target_label = "app"
-        }
-    
-        // set the component if specified as metadata labels "component:" or "app.kubernetes.io/component:" or "k8s-component:"
-        rule {
-          action = "replace"
-          source_labels = [
-            "__meta_kubernetes_pod_label_app_kubernetes_io_component",
-            "__meta_kubernetes_pod_label_k8s_component",
-            "__meta_kubernetes_pod_label_component",
-          ]
-          regex = "^(?:;*)?([^;]+).*$"
-          replacement = "$1"
-          target_label = "component"
-        }
-    
-        // set a source label
-        rule {
-          action = "replace"
-          replacement = "kubernetes"
-          target_label = "source"
-        }
+          rule {
+            source_labels = [
+              "__meta_kubernetes_node_label_topology_kubernetes_io_region",
+              "__meta_kubernetes_node_label_failure_domain_beta_kubernetes_io_region",
+            ]
+            regex = "^(?:;*)?([^;]+).*$"
+            target_label = "region"
+          }
         }
     
         export "output" {

--- a/charts/k8s-monitoring/docs/examples/meta-monitoring/values.yaml
+++ b/charts/k8s-monitoring/docs/examples/meta-monitoring/values.yaml
@@ -19,6 +19,16 @@ destinations:
 
 integrations:
   collector: alloy-singleton
+  # attach available node labels to all integration metrics collection
+  nodeLabels:
+    nodepool: true
+    region: true
+    availability_zone: true
+    node_role: true
+    os: true
+    architecture: true
+    instance_type: true
+
   alloy:
     instances:
       # monitor the collector gathering and sending meta-monitoring metrics/logs to the meta-monitoring cluster
@@ -86,6 +96,15 @@ clusterEvents:
 clusterMetrics:
   enabled: true
   collector: alloy-singleton
+  nodeLabels:
+    nodePool: true
+    region: true
+    availabilityZone: true
+    nodeRole: true
+    os: true
+    architecture: true
+    instanceType: true
+
   kubelet:
     enabled: false
   kubeletResource:
@@ -135,6 +154,24 @@ nodeLogs:
 podLogs:
   enabled: true
   collector: alloy-singleton
+  nodeLabels:
+    nodePool: true
+    region: true
+    availabilityZone: true
+    nodeRole: true
+    os: true
+    architecture: true
+    instanceType: true
+
+  structuredMetadata:
+    nodepool:
+    region:
+    availability_zone:
+    node_role:
+    os:
+    architecture:
+    instance_type:
+
   labelsToKeep:
     - app
     - app_kubernetes_io_name
@@ -145,6 +182,7 @@ podLogs:
     - namespace
     - pod
     - service_name
+
   gatherMethod: kubernetesApi
   namespaces:
     - collectors

--- a/charts/k8s-monitoring/docs/examples/metrics-tuning/alloy-metrics.alloy
+++ b/charts/k8s-monitoring/docs/examples/metrics-tuning/alloy-metrics.alloy
@@ -324,9 +324,23 @@ declare "cluster_metrics" {
     role = "node"
   }
 
+  discovery.relabel "nodes" {
+    targets = discovery.kubernetes.nodes.targets
+    rule {
+      source_labels = ["__meta_kubernetes_node_name"]
+      target_label  = "node"
+    }
+
+    rule {
+      replacement = "kubernetes"
+      target_label = "source"
+    }
+
+  }
+
   // Kubelet
   discovery.relabel "kubelet" {
-    targets = discovery.kubernetes.nodes.targets
+    targets = discovery.relabel.nodes.output
   }
 
   prometheus.scrape "kubelet" {
@@ -362,41 +376,15 @@ declare "cluster_metrics" {
 
   // Kubelet Resources
   discovery.relabel "kubelet_resources" {
-    targets = discovery.kubernetes.nodes.targets
+    targets = discovery.relabel.nodes.output
     rule {
       replacement   = "/metrics/resource"
       target_label  = "__metrics_path__"
     }
-    // set the node label
-    rule {
-      source_labels = ["__meta_kubernetes_node_name"]
-      target_label  = "node"
-    }
-
-    // set the app name if specified as metadata labels "app:" or "app.kubernetes.io/name:" or "k8s-app:"
-    rule {
-      action = "replace"
-      source_labels = [
-        "__meta_kubernetes_node_label_app_kubernetes_io_name",
-        "__meta_kubernetes_node_label_k8s_app",
-        "__meta_kubernetes_node_label_app",
-      ]
-      separator = ";"
-      regex = "^(?:;*)?([^;]+).*$"
-      replacement = "$1"
-      target_label = "app"
-    }
-
-    // set a source label
-    rule {
-      action = "replace"
-      replacement = "kubernetes"
-      target_label = "source"
-    }
   }
 
   prometheus.scrape "kubelet_resources" {
-    targets  = discovery.relabel.kubelet_resources.output
+    targets = discovery.relabel.kubelet_resources.output
     job_name = "integrations/kubernetes/resources"
     scheme   = "https"
     scrape_interval = "60s"
@@ -428,34 +416,10 @@ declare "cluster_metrics" {
 
   // cAdvisor
   discovery.relabel "cadvisor" {
-    targets = discovery.kubernetes.nodes.targets
+    targets = discovery.relabel.nodes.output
     rule {
       replacement   = "/metrics/cadvisor"
       target_label  = "__metrics_path__"
-    }
-    rule {
-      source_labels = ["__meta_kubernetes_node_name"]
-      target_label  = "node"
-    }
-    // set the app name if specified as metadata labels "app:" or "app.kubernetes.io/name:" or "k8s-app:"
-    rule {
-      action = "replace"
-      source_labels = [
-        "__meta_kubernetes_node_label_app_kubernetes_io_name",
-        "__meta_kubernetes_node_label_k8s_app",
-        "__meta_kubernetes_node_label_app",
-      ]
-      separator = ";"
-      regex = "^(?:;*)?([^;]+).*$"
-      replacement = "$1"
-      target_label = "app"
-    }
-
-    // set a source label
-    rule {
-      action = "replace"
-      replacement = "kubernetes"
-      target_label = "source"
     }
   }
 

--- a/charts/k8s-monitoring/docs/examples/metrics-tuning/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/metrics-tuning/output.yaml
@@ -422,9 +422,23 @@ data:
         role = "node"
       }
     
+      discovery.relabel "nodes" {
+        targets = discovery.kubernetes.nodes.targets
+        rule {
+          source_labels = ["__meta_kubernetes_node_name"]
+          target_label  = "node"
+        }
+    
+        rule {
+          replacement = "kubernetes"
+          target_label = "source"
+        }
+    
+      }
+    
       // Kubelet
       discovery.relabel "kubelet" {
-        targets = discovery.kubernetes.nodes.targets
+        targets = discovery.relabel.nodes.output
       }
     
       prometheus.scrape "kubelet" {
@@ -460,41 +474,15 @@ data:
     
       // Kubelet Resources
       discovery.relabel "kubelet_resources" {
-        targets = discovery.kubernetes.nodes.targets
+        targets = discovery.relabel.nodes.output
         rule {
           replacement   = "/metrics/resource"
           target_label  = "__metrics_path__"
         }
-        // set the node label
-        rule {
-          source_labels = ["__meta_kubernetes_node_name"]
-          target_label  = "node"
-        }
-    
-        // set the app name if specified as metadata labels "app:" or "app.kubernetes.io/name:" or "k8s-app:"
-        rule {
-          action = "replace"
-          source_labels = [
-            "__meta_kubernetes_node_label_app_kubernetes_io_name",
-            "__meta_kubernetes_node_label_k8s_app",
-            "__meta_kubernetes_node_label_app",
-          ]
-          separator = ";"
-          regex = "^(?:;*)?([^;]+).*$"
-          replacement = "$1"
-          target_label = "app"
-        }
-    
-        // set a source label
-        rule {
-          action = "replace"
-          replacement = "kubernetes"
-          target_label = "source"
-        }
       }
     
       prometheus.scrape "kubelet_resources" {
-        targets  = discovery.relabel.kubelet_resources.output
+        targets = discovery.relabel.kubelet_resources.output
         job_name = "integrations/kubernetes/resources"
         scheme   = "https"
         scrape_interval = "60s"
@@ -526,34 +514,10 @@ data:
     
       // cAdvisor
       discovery.relabel "cadvisor" {
-        targets = discovery.kubernetes.nodes.targets
+        targets = discovery.relabel.nodes.output
         rule {
           replacement   = "/metrics/cadvisor"
           target_label  = "__metrics_path__"
-        }
-        rule {
-          source_labels = ["__meta_kubernetes_node_name"]
-          target_label  = "node"
-        }
-        // set the app name if specified as metadata labels "app:" or "app.kubernetes.io/name:" or "k8s-app:"
-        rule {
-          action = "replace"
-          source_labels = [
-            "__meta_kubernetes_node_label_app_kubernetes_io_name",
-            "__meta_kubernetes_node_label_k8s_app",
-            "__meta_kubernetes_node_label_app",
-          ]
-          separator = ";"
-          regex = "^(?:;*)?([^;]+).*$"
-          replacement = "$1"
-          target_label = "app"
-        }
-    
-        // set a source label
-        rule {
-          action = "replace"
-          replacement = "kubernetes"
-          target_label = "source"
         }
       }
     

--- a/charts/k8s-monitoring/docs/examples/node-labels/README.md
+++ b/charts/k8s-monitoring/docs/examples/node-labels/README.md
@@ -1,0 +1,76 @@
+<!--
+(NOTE: Do not edit README.md directly. It is a generated file!)
+(      To make changes, please modify values.yaml or description.txt and run `make examples`)
+-->
+# Node Labels
+
+This example shows how to include node labels on all jobs for nodes, pods and endpoints.
+
+## Values
+
+```yaml
+---
+cluster:
+  name: pod-labels-and-annotations
+
+destinations:
+  - name: prometheus
+    type: prometheus
+    url: http://prometheus.prometheus.svc:9090/api/v1/write
+  - name: loki
+    type: loki
+    url: http://loki.loki.svc:3100/api/push
+  - name: tempo
+    type: otlp
+    url: http://tempo.tempo.svc
+    metrics: {enabled: false}
+    logs: {enabled: false}
+    traces: {enabled: true}
+
+clusterMetrics:
+  enabled: true
+  nodeLabels:
+    nodePool: true
+    region: true
+    availabilityZone: true
+    nodeRole: true
+    os: true
+    architecture: true
+    instanceType: true
+
+podLogs:
+  enabled: true
+  nodeLabels:
+    nodepool: true
+    region: true
+    availability_zone: true
+    node_role: true
+    os: true
+    architecture: true
+    instance_type: true
+  structuredMetadata:
+    node_pool: nodepool
+    region:
+    availability_zone:
+    node_role:
+    node_os: os
+    node_arch: architecture
+    node_type: instance_type
+
+annotationAutodiscovery:
+  nodeLabels:
+    nodePool: true
+    region: true
+    availabilityZone: true
+    nodeRole: true
+    os: true
+    architecture: true
+    instanceType: true
+  enabled: true
+
+alloy-metrics:
+  enabled: true
+
+alloy-logs:
+  enabled: true
+```

--- a/charts/k8s-monitoring/docs/examples/node-labels/alloy-logs.alloy
+++ b/charts/k8s-monitoring/docs/examples/node-labels/alloy-logs.alloy
@@ -1,0 +1,221 @@
+// Feature: Pod Logs
+declare "pod_logs" {
+  argument "logs_destinations" {
+    comment = "Must be a list of log destinations where collected logs should be forwarded to"
+  }
+
+  discovery.relabel "filtered_pods" {
+    targets = discovery.kubernetes.pods.targets
+    rule {
+      source_labels = ["__meta_kubernetes_namespace"]
+      action = "replace"
+      target_label = "namespace"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_pod_name"]
+      action = "replace"
+      target_label = "pod"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_pod_container_name"]
+      action = "replace"
+      target_label = "container"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_namespace", "__meta_kubernetes_pod_container_name"]
+      separator = "/"
+      action = "replace"
+      replacement = "$1"
+      target_label = "job"
+    }
+
+    // set the container runtime as a label
+    rule {
+      action = "replace"
+      source_labels = ["__meta_kubernetes_pod_container_id"]
+      regex = "^(\\S+):\\/\\/.+$"
+      replacement = "$1"
+      target_label = "tmp_container_runtime"
+    }
+
+    // make all labels on the pod available to the pipeline as labels,
+    // they are omitted before write to loki via stage.label_keep unless explicitly set
+    rule {
+      action = "labelmap"
+      regex = "__meta_kubernetes_pod_label_(.+)"
+    }
+
+    // make all annotations on the pod available to the pipeline as labels,
+    // they are omitted before write to loki via stage.label_keep unless explicitly set
+    rule {
+      action = "labelmap"
+      regex = "__meta_kubernetes_pod_annotation_(.+)"
+    }
+
+    // explicitly set service_name. if not set, loki will automatically try to populate a default.
+    // see https://grafana.com/docs/loki/latest/get-started/labels/#default-labels-for-all-users
+    //
+    // choose the first value found from the following ordered list:
+    // - pod.annotation[resource.opentelemetry.io/service.name]
+    // - pod.label[app.kubernetes.io/name]
+    // - k8s.pod.name
+    // - k8s.container.name
+    rule {
+      action = "replace"
+      source_labels = [
+        "__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_name",
+        "__meta_kubernetes_pod_label_app_kubernetes_io_name",
+        "__meta_kubernetes_pod_name",
+        "__meta_kubernetes_pod_container_name",
+      ]
+      separator = ";"
+      regex = "^(?:;*)?([^;]+).*$"
+      replacement = "$1"
+      target_label = "service_name"
+    }
+
+    // set resource attributes
+    rule {
+      action = "labelmap"
+      regex = "__meta_kubernetes_pod_annotation_resource_opentelemetry_io_(.+)"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_job"]
+      regex = "(.+)"
+      target_label = "job"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+      regex = "(.+)"
+      target_label = "app_kubernetes_io_name"
+    }
+
+    rule {
+      source_labels = [
+        "__meta_kubernetes_node_label_topology_kubernetes_io_region",
+        "__meta_kubernetes_node_label_failure_domain_beta_kubernetes_io_region",
+      ]
+      regex = "^(?:;*)?([^;]+).*$"
+      target_label = "region"
+    }
+  }
+
+  discovery.kubernetes "pods" {
+    role = "pod"
+    selectors {
+      role = "pod"
+      field = "spec.nodeName=" + sys.env("HOSTNAME")
+    }
+    attach_metadata {
+      node = true
+    }
+  }
+
+  discovery.relabel "filtered_pods_with_paths" {
+    targets = discovery.relabel.filtered_pods.output
+
+    rule {
+      source_labels = ["__meta_kubernetes_pod_uid", "__meta_kubernetes_pod_container_name"]
+      separator = "/"
+      action = "replace"
+      replacement = "/var/log/pods/*$1/*.log"
+      target_label = "__path__"
+    }
+  }
+
+  local.file_match "pod_logs" {
+    path_targets = discovery.relabel.filtered_pods_with_paths.output
+  }
+
+  loki.source.file "pod_logs" {
+    targets    = local.file_match.pod_logs.targets
+    forward_to = [loki.process.pod_logs.receiver]
+  }
+
+  loki.process "pod_logs" {
+    stage.match {
+      selector = "{tmp_container_runtime=~\"containerd|cri-o\"}"
+      // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
+      stage.cri {}
+
+      // Set the extract flags and stream values as labels
+      stage.labels {
+        values = {
+          flags  = "",
+          stream  = "",
+        }
+      }
+    }
+
+    stage.match {
+      selector = "{tmp_container_runtime=\"docker\"}"
+      // the docker processing stage extracts the following k/v pairs: log, stream, time
+      stage.docker {}
+
+      // Set the extract stream value as a label
+      stage.labels {
+        values = {
+          stream  = "",
+        }
+      }
+    }
+
+    // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
+    // namespace, pod, and container labels. Drop any structured metadata. Also drop the temporary
+    // container runtime label as it is no longer needed.
+    stage.label_drop {
+      values = [
+        "filename",
+        "tmp_container_runtime",
+      ]
+    }
+    // set the structured metadata values
+    stage.structured_metadata {
+      values = {
+        "availability_zone" = "availability_zone",
+        "node_arch" = "architecture",
+        "node_os" = "os",
+        "node_pool" = "nodepool",
+        "node_role" = "node_role",
+        "node_type" = "instance_type",
+        "region" = "region",
+      }
+    }
+
+    // Only keep the labels that are defined in the `keepLabels` list.
+    stage.label_keep {
+      values = ["app_kubernetes_io_name","container","instance","job","level","namespace","pod","service_name","service_namespace","deployment_environment","deployment_environment_name","k8s_pod_name","k8s_namespace_name","k8s_deployment_name","k8s_statefulset_name","k8s_daemonset_name","k8s_cronjob_name","k8s_job_name","k8s_node_name"]
+    }
+
+    forward_to = argument.logs_destinations.value
+  }
+}
+pod_logs "feature" {
+  logs_destinations = [
+    loki.write.loki.receiver,
+  ]
+}
+
+
+
+
+// Destination: loki (loki)
+otelcol.exporter.loki "loki" {
+  forward_to = [loki.write.loki.receiver]
+}
+
+loki.write "loki" {
+  endpoint {
+    url = "http://loki.loki.svc:3100/api/push"
+    tls_config {
+      insecure_skip_verify = false
+    }
+    min_backoff_period = "500ms"
+    max_backoff_period = "5m"
+    max_backoff_retries = "10"
+  }
+  external_labels = {
+    "cluster" = "pod-labels-and-annotations",
+    "k8s_cluster_name" = "pod-labels-and-annotations",
+  }
+}

--- a/charts/k8s-monitoring/docs/examples/node-labels/alloy-metrics.alloy
+++ b/charts/k8s-monitoring/docs/examples/node-labels/alloy-metrics.alloy
@@ -1,0 +1,1054 @@
+// Feature: Annotation Autodiscovery
+declare "annotation_autodiscovery" {
+  argument "metrics_destinations" {
+    comment = "Must be a list of metric destinations where collected metrics should be forwarded to"
+  }
+
+  discovery.kubernetes "pods" {
+    role = "pod"
+    attach_metadata {
+      node = true
+    }
+  }
+
+  discovery.relabel "annotation_autodiscovery_pods" {
+    targets = discovery.kubernetes.pods.targets
+    rule {
+      source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_scrape"]
+      regex = "true"
+      action = "keep"
+    }
+    // Only keep pods that are running, ready, and not init containers.
+    rule {
+      source_labels = [
+        "__meta_kubernetes_pod_phase",
+        "__meta_kubernetes_pod_ready",
+        "__meta_kubernetes_pod_container_init",
+      ]
+      regex = "Running;true;false"
+      action = "keep"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_pod_name"]
+      target_label = "pod"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_pod_container_name"]
+      target_label = "container"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_namespace"]
+      target_label = "namespace"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_job"]
+      target_label = "job"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_instance"]
+      target_label = "instance"
+    }
+
+    // Rules to choose the right container
+    rule {
+      source_labels = ["container"]
+      target_label = "__tmp_container"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_container"]
+      regex = "(.+)"
+      target_label = "__tmp_container"
+    }
+    rule {
+      source_labels = ["container"]
+      action = "keepequal"
+      target_label = "__tmp_container"
+    }
+    rule {
+      action = "labeldrop"
+      regex = "__tmp_container"
+    }
+
+    // Set metrics path
+    rule {
+      source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_path"]
+      regex = "(.+)"
+      target_label = "__metrics_path__"
+    }
+
+    // Set metrics scraping URL parameters
+    rule {
+      action = "labelmap"
+      regex = "__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_param_(.+)"
+      replacement = "__param_$1"
+    }
+
+    // Choose the pod port
+    // The discovery generates a target for each declared container port of the pod.
+    // If the metricsPortName annotation has value, keep only the target where the port name matches the one of the annotation.
+    rule {
+      source_labels = ["__meta_kubernetes_pod_container_port_name"]
+      target_label = "__tmp_port"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_portName"]
+      regex = "(.+)"
+      target_label = "__tmp_port"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_pod_container_port_name"]
+      action = "keepequal"
+      target_label = "__tmp_port"
+    }
+    rule {
+      action = "labeldrop"
+      regex = "__tmp_port"
+    }
+
+    // If the metrics port number annotation has a value, override the target address to use it, regardless whether it is
+    // one of the declared ports on that Pod.
+    rule {
+      source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_portNumber", "__meta_kubernetes_pod_ip"]
+      regex = "(\\d+);(([A-Fa-f0-9]{1,4}::?){1,7}[A-Fa-f0-9]{1,4})"
+      replacement = "[$2]:$1" // IPv6
+      target_label = "__address__"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_portNumber", "__meta_kubernetes_pod_ip"]
+      regex = "(\\d+);((([0-9]+?)(\\.|$)){4})" // IPv4, takes priority over IPv6 when both exists
+      replacement = "$2:$1"
+      target_label = "__address__"
+    }
+
+    rule {
+      source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_scheme"]
+      regex = "(.+)"
+      target_label = "__scheme__"
+    }
+
+    rule {
+      source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_scrapeInterval"]
+      regex = "(.+)"
+      target_label = "__scrape_interval__"
+    }
+    rule {
+      source_labels = ["__scrape_interval__"]
+      regex = ""
+      replacement = "60s"
+      target_label = "__scrape_interval__"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_scrapeTimeout"]
+      regex = "(.+)"
+      target_label = "__scrape_timeout__"
+    }
+    rule {
+      source_labels = ["__scrape_timeout__"]
+      regex = ""
+      replacement = "10s"
+      target_label = "__scrape_timeout__"
+    }
+
+    rule {
+      source_labels = [
+        "__meta_kubernetes_node_label_karpenter_sh_nodepool",
+        "__meta_kubernetes_node_label_cloud_google_com_gke_nodepool",
+        "__meta_kubernetes_node_label_eks_amazonaws_com_nodegroup",
+        "__meta_kubernetes_node_label_kubernetes_azure_com_agentpool",
+        "__meta_kubernetes_node_label_agentpool",
+      ]
+      regex = "^(?:;*)?([^;]+).*$"
+      target_label = "nodepool"
+    }
+
+    rule {
+      source_labels = [
+        "__meta_kubernetes_node_label_topology_kubernetes_io_region",
+        "__meta_kubernetes_node_label_failure_domain_beta_kubernetes_io_region",
+      ]
+      regex = "^(?:;*)?([^;]+).*$"
+      target_label = "region"
+    }
+
+    rule {
+      source_labels = [
+        "__meta_kubernetes_node_label_topology_kubernetes_io_zone",
+        "__meta_kubernetes_node_label_failure_domain_beta_kubernetes_io_zone",
+        "__meta_kubernetes_node_label_topology_gke_io_zone",
+      ]
+      regex = "^(?:;*)?([^;]+).*$"
+      target_label = "availability_zone"
+    }
+
+    rule {
+      source_labels = [
+        "__meta_kubernetes_node_label_kubernetes_io_role",
+        "__meta_kubernetes_node_label_node_kubernetes_io_role",
+        "__meta_kubernetes_node_label_node_role",
+        "__meta_kubernetes_node_label_role",
+      ]
+      regex = "^(?:;*)?([^;]+).*$"
+      target_label = "node_role"
+    }
+
+    rule {
+      source_labels = [
+        "__meta_kubernetes_node_label_node_kubernetes_io_instance_type",
+        "__meta_kubernetes_node_label_beta_kubernetes_io_instance_type",
+      ]
+      regex = "^(?:;*)?([^;]+).*$"
+      target_label = "instance_type"
+    }
+  }
+
+  discovery.kubernetes "services" {
+    role = "service"
+  }
+
+  discovery.relabel "annotation_autodiscovery_services" {
+    targets = discovery.kubernetes.services.targets
+    rule {
+      source_labels = ["__meta_kubernetes_service_annotation_k8s_grafana_com_scrape"]
+      regex = "true"
+      action = "keep"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_service_name"]
+      target_label = "service"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_namespace"]
+      target_label = "namespace"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_service_annotation_k8s_grafana_com_job"]
+      target_label = "job"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_service_annotation_k8s_grafana_com_instance"]
+      target_label = "instance"
+    }
+
+    // Set metrics path
+    rule {
+      source_labels = ["__meta_kubernetes_service_annotation_k8s_grafana_com_metrics_path"]
+      target_label = "__metrics_path__"
+    }
+
+    // Set metrics scraping URL parameters
+    rule {
+      action = "labelmap"
+      regex = "__meta_kubernetes_service_annotation_k8s_grafana_com_metrics_param_(.+)"
+      replacement = "__param_$1"
+    }
+
+    // Choose the service port
+    rule {
+      source_labels = ["__meta_kubernetes_service_port_name"]
+      target_label = "__tmp_port"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_service_annotation_k8s_grafana_com_metrics_portName"]
+      regex = "(.+)"
+      target_label = "__tmp_port"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_service_port_name"]
+      action = "keepequal"
+      target_label = "__tmp_port"
+    }
+
+    rule {
+      source_labels = ["__meta_kubernetes_service_port_number"]
+      target_label = "__tmp_port"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_service_annotation_k8s_grafana_com_metrics_portNumber"]
+      regex = "(.+)"
+      target_label = "__tmp_port"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_service_port_number"]
+      action = "keepequal"
+      target_label = "__tmp_port"
+    }
+    rule {
+      action = "labeldrop"
+      regex = "__tmp_port"
+    }
+
+    rule {
+      source_labels = ["__meta_kubernetes_service_annotation_k8s_grafana_com_metrics_scheme"]
+      regex = "(.+)"
+      target_label = "__scheme__"
+    }
+
+    rule {
+      source_labels = ["__meta_kubernetes_service_annotation_k8s_grafana_com_metrics_scrapeInterval"]
+      regex = "(.+)"
+      target_label = "__scrape_interval__"
+    }
+    rule {
+      source_labels = ["__scrape_interval__"]
+      regex = ""
+      replacement = "60s"
+      target_label = "__scrape_interval__"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_service_annotation_k8s_grafana_com_metrics_scrapeTimeout"]
+      regex = "(.+)"
+      target_label = "__scrape_timeout__"
+    }
+    rule {
+      source_labels = ["__scrape_timeout__"]
+      regex = ""
+      replacement = "10s"
+      target_label = "__scrape_timeout__"
+    }
+  }
+
+  discovery.relabel "annotation_autodiscovery_http" {
+    targets = array.concat(discovery.relabel.annotation_autodiscovery_pods.output, discovery.relabel.annotation_autodiscovery_services.output)
+    rule {
+      source_labels = ["__scheme__"]
+      regex = "https"
+      action = "drop"
+    }
+  }
+
+  discovery.relabel "annotation_autodiscovery_https" {
+    targets = array.concat(discovery.relabel.annotation_autodiscovery_pods.output, discovery.relabel.annotation_autodiscovery_services.output)
+    rule {
+      source_labels = ["__scheme__"]
+      regex = "https"
+      action = "keep"
+    }
+  }
+
+  prometheus.scrape "annotation_autodiscovery_http" {
+    targets = discovery.relabel.annotation_autodiscovery_http.output
+    honor_labels = true
+    bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+    clustering {
+      enabled = true
+    }
+
+    forward_to = argument.metrics_destinations.value
+  }
+
+  prometheus.scrape "annotation_autodiscovery_https" {
+    targets = discovery.relabel.annotation_autodiscovery_https.output
+    honor_labels = true
+    bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+    tls_config {
+      insecure_skip_verify = true
+    }
+    clustering {
+      enabled = true
+    }
+
+    forward_to = argument.metrics_destinations.value
+  }
+}
+annotation_autodiscovery "feature" {
+  metrics_destinations = [
+    prometheus.remote_write.prometheus.receiver,
+  ]
+}
+// Feature: Cluster Metrics
+declare "cluster_metrics" {
+  argument "metrics_destinations" {
+    comment = "Must be a list of metric destinations where collected metrics should be forwarded to"
+  }
+  discovery.kubernetes "nodes" {
+    role = "node"
+  }
+
+  discovery.relabel "nodes" {
+    targets = discovery.kubernetes.nodes.targets
+    rule {
+      source_labels = ["__meta_kubernetes_node_name"]
+      target_label  = "node"
+    }
+
+    rule {
+      replacement = "kubernetes"
+      target_label = "source"
+    }
+
+
+    rule {
+      source_labels = [
+        "__meta_kubernetes_node_label_karpenter_sh_nodepool",
+        "__meta_kubernetes_node_label_cloud_google_com_gke_nodepool",
+        "__meta_kubernetes_node_label_eks_amazonaws_com_nodegroup",
+        "__meta_kubernetes_node_label_kubernetes_azure_com_agentpool",
+        "__meta_kubernetes_node_label_agentpool",
+      ]
+      regex = "^(?:;*)?([^;]+).*$"
+      target_label = "nodepool"
+    }
+
+    rule {
+      source_labels = [
+        "__meta_kubernetes_node_label_topology_kubernetes_io_region",
+        "__meta_kubernetes_node_label_failure_domain_beta_kubernetes_io_region",
+      ]
+      regex = "^(?:;*)?([^;]+).*$"
+      target_label = "region"
+    }
+
+    rule {
+      source_labels = [
+        "__meta_kubernetes_node_label_topology_kubernetes_io_zone",
+        "__meta_kubernetes_node_label_failure_domain_beta_kubernetes_io_zone",
+        "__meta_kubernetes_node_label_topology_gke_io_zone",
+      ]
+      regex = "^(?:;*)?([^;]+).*$"
+      target_label = "availability_zone"
+    }
+
+    rule {
+      source_labels = [
+        "__meta_kubernetes_node_label_kubernetes_io_role",
+        "__meta_kubernetes_node_label_node_kubernetes_io_role",
+        "__meta_kubernetes_node_label_node_role",
+        "__meta_kubernetes_node_label_role",
+      ]
+      regex = "^(?:;*)?([^;]+).*$"
+      target_label = "node_role"
+    }
+
+    rule {
+      source_labels = [
+        "__meta_kubernetes_node_label_node_kubernetes_io_instance_type",
+        "__meta_kubernetes_node_label_beta_kubernetes_io_instance_type",
+      ]
+      regex = "^(?:;*)?([^;]+).*$"
+      target_label = "instance_type"
+    }
+  }
+
+  // Kubelet
+  discovery.relabel "kubelet" {
+    targets = discovery.relabel.nodes.output
+  }
+
+  prometheus.scrape "kubelet" {
+    targets  = discovery.relabel.kubelet.output
+    job_name = "integrations/kubernetes/kubelet"
+    scheme   = "https"
+    scrape_interval = "60s"
+    bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+
+    tls_config {
+      ca_file = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+      insecure_skip_verify = true
+      server_name = "kubernetes"
+    }
+
+    clustering {
+      enabled = true
+    }
+
+    forward_to = [prometheus.relabel.kubelet.receiver]
+  }
+
+  prometheus.relabel "kubelet" {
+    max_cache_size = 100000
+    rule {
+      source_labels = ["__name__"]
+      regex = "up|scrape_samples_scraped|go_goroutines|kubelet_certificate_manager_client_expiration_renew_errors|kubelet_certificate_manager_client_ttl_seconds|kubelet_certificate_manager_server_ttl_seconds|kubelet_cgroup_manager_duration_seconds_bucket|kubelet_cgroup_manager_duration_seconds_count|kubelet_node_config_error|kubelet_node_name|kubelet_pleg_relist_duration_seconds_bucket|kubelet_pleg_relist_duration_seconds_count|kubelet_pleg_relist_interval_seconds_bucket|kubelet_pod_start_duration_seconds_bucket|kubelet_pod_start_duration_seconds_count|kubelet_pod_worker_duration_seconds_bucket|kubelet_pod_worker_duration_seconds_count|kubelet_running_container_count|kubelet_running_containers|kubelet_running_pod_count|kubelet_running_pods|kubelet_runtime_operations_errors_total|kubelet_runtime_operations_total|kubelet_server_expiration_renew_errors|kubelet_volume_stats_available_bytes|kubelet_volume_stats_capacity_bytes|kubelet_volume_stats_inodes|kubelet_volume_stats_inodes_free|kubelet_volume_stats_inodes_used|kubelet_volume_stats_used_bytes|kubernetes_build_info|namespace_workload_pod|process_cpu_seconds_total|process_resident_memory_bytes|rest_client_requests_total|storage_operation_duration_seconds_count|storage_operation_errors_total|volume_manager_total_volumes"
+      action = "keep"
+    }
+
+    forward_to = argument.metrics_destinations.value
+  }
+
+  // Kubelet Resources
+  discovery.relabel "kubelet_resources" {
+    targets = discovery.relabel.nodes.output
+    rule {
+      replacement   = "/metrics/resource"
+      target_label  = "__metrics_path__"
+    }
+  }
+
+  prometheus.scrape "kubelet_resources" {
+    targets = discovery.relabel.kubelet_resources.output
+    job_name = "integrations/kubernetes/resources"
+    scheme   = "https"
+    scrape_interval = "60s"
+    bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+
+    tls_config {
+      ca_file = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+      insecure_skip_verify = true
+      server_name = "kubernetes"
+    }
+
+    clustering {
+      enabled = true
+    }
+
+    forward_to = [prometheus.relabel.kubelet_resources.receiver]
+  }
+
+  prometheus.relabel "kubelet_resources" {
+    max_cache_size = 100000
+    rule {
+      source_labels = ["__name__"]
+      regex = "up|scrape_samples_scraped|node_cpu_usage_seconds_total|node_memory_working_set_bytes"
+      action = "keep"
+    }
+
+    forward_to = argument.metrics_destinations.value
+  }
+
+  // cAdvisor
+  discovery.relabel "cadvisor" {
+    targets = discovery.relabel.nodes.output
+    rule {
+      replacement   = "/metrics/cadvisor"
+      target_label  = "__metrics_path__"
+    }
+  }
+
+  prometheus.scrape "cadvisor" {
+    targets = discovery.relabel.cadvisor.output
+    job_name = "integrations/kubernetes/cadvisor"
+    scheme = "https"
+    scrape_interval = "60s"
+    bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+
+    tls_config {
+      ca_file = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+      insecure_skip_verify = true
+      server_name = "kubernetes"
+    }
+
+    clustering {
+      enabled = true
+    }
+
+    forward_to = [prometheus.relabel.cadvisor.receiver]
+  }
+
+  prometheus.relabel "cadvisor" {
+    max_cache_size = 100000
+    rule {
+      source_labels = ["__name__"]
+      regex = "up|scrape_samples_scraped|container_cpu_cfs_periods_total|container_cpu_cfs_throttled_periods_total|container_cpu_usage_seconds_total|container_fs_reads_bytes_total|container_fs_reads_total|container_fs_writes_bytes_total|container_fs_writes_total|container_memory_cache|container_memory_rss|container_memory_swap|container_memory_working_set_bytes|container_network_receive_bytes_total|container_network_receive_packets_dropped_total|container_network_receive_packets_total|container_network_transmit_bytes_total|container_network_transmit_packets_dropped_total|container_network_transmit_packets_total|machine_memory_bytes"
+      action = "keep"
+    }
+    // Drop empty container labels, addressing https://github.com/google/cadvisor/issues/2688
+    rule {
+      source_labels = ["__name__","container"]
+      separator = "@"
+      regex = "(container_cpu_.*|container_fs_.*|container_memory_.*)@"
+      action = "drop"
+    }
+    // Drop empty image labels, addressing https://github.com/google/cadvisor/issues/2688
+    rule {
+      source_labels = ["__name__","image"]
+      separator = "@"
+      regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_network_.*)@"
+      action = "drop"
+    }
+    // Normalizing unimportant labels (not deleting to continue satisfying <label>!="" checks)
+    rule {
+      source_labels = ["__name__", "boot_id"]
+      separator = "@"
+      regex = "machine_memory_bytes@.*"
+      target_label = "boot_id"
+      replacement = "NA"
+    }
+    rule {
+      source_labels = ["__name__", "system_uuid"]
+      separator = "@"
+      regex = "machine_memory_bytes@.*"
+      target_label = "system_uuid"
+      replacement = "NA"
+    }
+    // Filter out non-physical devices/interfaces
+    rule {
+      source_labels = ["__name__", "device"]
+      separator = "@"
+      regex = "container_fs_.*@(/dev/)?(mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dasd.+)"
+      target_label = "__keepme"
+      replacement = "1"
+    }
+    rule {
+      source_labels = ["__name__", "__keepme"]
+      separator = "@"
+      regex = "container_fs_.*@"
+      action = "drop"
+    }
+    rule {
+      source_labels = ["__name__"]
+      regex = "container_fs_.*"
+      target_label = "__keepme"
+      replacement = ""
+    }
+    rule {
+      source_labels = ["__name__", "interface"]
+      separator = "@"
+      regex = "container_network_.*@(en[ospx][0-9].*|wlan[0-9].*|eth[0-9].*)"
+      target_label = "__keepme"
+      replacement = "1"
+    }
+    rule {
+      source_labels = ["__name__", "__keepme"]
+      separator = "@"
+      regex = "container_network_.*@"
+      action = "drop"
+    }
+    rule {
+      source_labels = ["__name__"]
+      regex = "container_network_.*"
+      target_label = "__keepme"
+      replacement = ""
+    }
+    forward_to = argument.metrics_destinations.value
+  }
+  discovery.kubernetes "kube_state_metrics" {
+    role = "endpoints"
+
+    selectors {
+      role = "endpoints"
+      label = "app.kubernetes.io/name=kube-state-metrics,release=k8smon"
+    }
+    namespaces {
+      names = ["default"]
+    }
+  }
+
+  discovery.relabel "kube_state_metrics" {
+    targets = discovery.kubernetes.kube_state_metrics.targets
+
+    // only keep targets with a matching port name
+    rule {
+      source_labels = ["__meta_kubernetes_pod_container_port_name"]
+      regex = "http"
+      action = "keep"
+    }
+
+    rule {
+      action = "replace"
+      replacement = "kubernetes"
+      target_label = "source"
+    }
+
+  }
+
+  prometheus.scrape "kube_state_metrics" {
+    targets = discovery.relabel.kube_state_metrics.output
+    job_name = "integrations/kubernetes/kube-state-metrics"
+    scrape_interval = "60s"
+    scheme = "http"
+    bearer_token_file = ""
+    tls_config {
+      insecure_skip_verify = true
+    }
+
+    clustering {
+      enabled = true
+    }
+    forward_to = [prometheus.relabel.kube_state_metrics.receiver]
+  }
+
+  prometheus.relabel "kube_state_metrics" {
+    max_cache_size = 100000
+    rule {
+      source_labels = ["__name__"]
+      regex = "up|scrape_samples_scraped|kube_configmap_info|kube_configmap_metadata_resource_version|kube_daemonset.*|kube_deployment_metadata_generation|kube_deployment_spec_replicas|kube_deployment_status_condition|kube_deployment_status_observed_generation|kube_deployment_status_replicas_available|kube_deployment_status_replicas_updated|kube_horizontalpodautoscaler_spec_max_replicas|kube_horizontalpodautoscaler_spec_min_replicas|kube_horizontalpodautoscaler_status_current_replicas|kube_horizontalpodautoscaler_status_desired_replicas|kube_job.*|kube_namespace_status_phase|kube_node.*|kube_persistentvolume_status_phase|kube_persistentvolumeclaim_access_mode|kube_persistentvolumeclaim_info|kube_persistentvolumeclaim_labels|kube_persistentvolumeclaim_resource_requests_storage_bytes|kube_persistentvolumeclaim_status_phase|kube_pod_container_info|kube_pod_container_resource_limits|kube_pod_container_resource_requests|kube_pod_container_status_last_terminated_reason|kube_pod_container_status_restarts_total|kube_pod_container_status_waiting_reason|kube_pod_info|kube_pod_owner|kube_pod_spec_volumes_persistentvolumeclaims_info|kube_pod_start_time|kube_pod_status_phase|kube_pod_status_reason|kube_replicaset.*|kube_resourcequota|kube_secret_metadata_resource_version|kube_statefulset.*"
+      action = "keep"
+    }
+    forward_to = argument.metrics_destinations.value
+  }
+
+  // Node Exporter
+  discovery.kubernetes "node_exporter" {
+    role = "pod"
+
+    selectors {
+      role = "pod"
+      label = "app.kubernetes.io/name=node-exporter,release=k8smon"
+    }
+    namespaces {
+      names = ["default"]
+    }
+    attach_metadata {
+      node = true
+    }
+  }
+
+  discovery.relabel "node_exporter" {
+    targets = discovery.kubernetes.node_exporter.targets
+
+    // keep only the specified metrics port name, and pods that are Running and ready
+    rule {
+      source_labels = [
+        "__meta_kubernetes_pod_container_port_name",
+        "__meta_kubernetes_pod_container_init",
+        "__meta_kubernetes_pod_phase",
+        "__meta_kubernetes_pod_ready",
+      ]
+      separator = "@"
+      regex = "metrics@false@Running@true"
+      action = "keep"
+    }
+
+    // Set the instance label to the node name
+    rule {
+      source_labels = ["__meta_kubernetes_pod_node_name"]
+      action = "replace"
+      target_label = "instance"
+    }
+
+    // set the namespace label
+    rule {
+      source_labels = ["__meta_kubernetes_namespace"]
+      target_label  = "namespace"
+    }
+
+    // set the pod label
+    rule {
+      source_labels = ["__meta_kubernetes_pod_name"]
+      target_label  = "pod"
+    }
+
+    // set the container label
+    rule {
+      source_labels = ["__meta_kubernetes_pod_container_name"]
+      target_label  = "container"
+    }
+
+    // set a workload label
+    rule {
+      source_labels = [
+        "__meta_kubernetes_pod_controller_kind",
+        "__meta_kubernetes_pod_controller_name",
+      ]
+      separator = "/"
+      target_label  = "workload"
+    }
+    // remove the hash from the ReplicaSet
+    rule {
+      source_labels = ["workload"]
+      regex = "(ReplicaSet/.+)-.+"
+      target_label  = "workload"
+    }
+
+    // set the app name if specified as metadata labels "app:" or "app.kubernetes.io/name:" or "k8s-app:"
+    rule {
+      action = "replace"
+      source_labels = [
+        "__meta_kubernetes_pod_label_app_kubernetes_io_name",
+        "__meta_kubernetes_pod_label_k8s_app",
+        "__meta_kubernetes_pod_label_app",
+      ]
+      separator = ";"
+      regex = "^(?:;*)?([^;]+).*$"
+      replacement = "$1"
+      target_label = "app"
+    }
+
+    // set the component if specified as metadata labels "component:" or "app.kubernetes.io/component:" or "k8s-component:"
+    rule {
+      action = "replace"
+      source_labels = [
+        "__meta_kubernetes_pod_label_app_kubernetes_io_component",
+        "__meta_kubernetes_pod_label_k8s_component",
+        "__meta_kubernetes_pod_label_component",
+      ]
+      regex = "^(?:;*)?([^;]+).*$"
+      replacement = "$1"
+      target_label = "component"
+    }
+
+    // set a source label
+    rule {
+      action = "replace"
+      replacement = "kubernetes"
+      target_label = "source"
+    }
+
+    rule {
+      source_labels = [
+        "__meta_kubernetes_node_label_karpenter_sh_nodepool",
+        "__meta_kubernetes_node_label_cloud_google_com_gke_nodepool",
+        "__meta_kubernetes_node_label_eks_amazonaws_com_nodegroup",
+        "__meta_kubernetes_node_label_kubernetes_azure_com_agentpool",
+        "__meta_kubernetes_node_label_agentpool",
+      ]
+      regex = "^(?:;*)?([^;]+).*$"
+      target_label = "nodepool"
+    }
+
+    rule {
+      source_labels = [
+        "__meta_kubernetes_node_label_topology_kubernetes_io_region",
+        "__meta_kubernetes_node_label_failure_domain_beta_kubernetes_io_region",
+      ]
+      regex = "^(?:;*)?([^;]+).*$"
+      target_label = "region"
+    }
+
+    rule {
+      source_labels = [
+        "__meta_kubernetes_node_label_topology_kubernetes_io_zone",
+        "__meta_kubernetes_node_label_failure_domain_beta_kubernetes_io_zone",
+        "__meta_kubernetes_node_label_topology_gke_io_zone",
+      ]
+      regex = "^(?:;*)?([^;]+).*$"
+      target_label = "availability_zone"
+    }
+
+    rule {
+      source_labels = [
+        "__meta_kubernetes_node_label_kubernetes_io_role",
+        "__meta_kubernetes_node_label_node_kubernetes_io_role",
+        "__meta_kubernetes_node_label_node_role",
+        "__meta_kubernetes_node_label_role",
+      ]
+      regex = "^(?:;*)?([^;]+).*$"
+      target_label = "node_role"
+    }
+
+    rule {
+      source_labels = [
+        "__meta_kubernetes_node_label_node_kubernetes_io_instance_type",
+        "__meta_kubernetes_node_label_beta_kubernetes_io_instance_type",
+      ]
+      regex = "^(?:;*)?([^;]+).*$"
+      target_label = "instance_type"
+    }
+  }
+
+  prometheus.scrape "node_exporter" {
+    targets = discovery.relabel.node_exporter.output
+    job_name = "integrations/node_exporter"
+    scrape_interval = "60s"
+    scheme = "http"
+    bearer_token_file = ""
+    tls_config {
+      insecure_skip_verify = true
+    }
+
+    clustering {
+      enabled = true
+    }
+    forward_to = [prometheus.relabel.node_exporter.receiver]
+  }
+
+  prometheus.relabel "node_exporter" {
+    max_cache_size = 100000
+    rule {
+      source_labels = ["__name__"]
+      regex = "up|scrape_samples_scraped|node_cpu.*|node_exporter_build_info|node_filesystem.*|node_memory.*|node_network_receive_bytes_total|node_network_receive_drop_total|node_network_transmit_bytes_total|node_network_transmit_drop_total|process_cpu_seconds_total|process_resident_memory_bytes"
+      action = "keep"
+    }
+    // Drop metrics for certain file systems
+    rule {
+      source_labels = ["__name__", "fstype"]
+      separator = "@"
+      regex = "node_filesystem.*@(ramfs|tmpfs)"
+      action = "drop"
+    }
+    forward_to = argument.metrics_destinations.value
+  }
+
+  discovery.kubernetes "windows_exporter_pods" {
+    role = "pod"
+    namespaces {
+      names = ["default"]
+    }
+    selectors {
+      role = "pod"
+      label = "app.kubernetes.io/name=windows-exporter,release=k8smon"
+    }
+    attach_metadata {
+      node = true
+    }
+  }
+
+  discovery.relabel "windows_exporter" {
+    targets = discovery.kubernetes.windows_exporter_pods.targets
+    rule {
+      source_labels = ["__meta_kubernetes_pod_node_name"]
+      action = "replace"
+      target_label = "instance"
+    }
+
+    rule {
+      source_labels = [
+        "__meta_kubernetes_node_label_karpenter_sh_nodepool",
+        "__meta_kubernetes_node_label_cloud_google_com_gke_nodepool",
+        "__meta_kubernetes_node_label_eks_amazonaws_com_nodegroup",
+        "__meta_kubernetes_node_label_kubernetes_azure_com_agentpool",
+        "__meta_kubernetes_node_label_agentpool",
+      ]
+      regex = "^(?:;*)?([^;]+).*$"
+      target_label = "nodepool"
+    }
+
+    rule {
+      source_labels = [
+        "__meta_kubernetes_node_label_topology_kubernetes_io_region",
+        "__meta_kubernetes_node_label_failure_domain_beta_kubernetes_io_region",
+      ]
+      regex = "^(?:;*)?([^;]+).*$"
+      target_label = "region"
+    }
+
+    rule {
+      source_labels = [
+        "__meta_kubernetes_node_label_topology_kubernetes_io_zone",
+        "__meta_kubernetes_node_label_failure_domain_beta_kubernetes_io_zone",
+        "__meta_kubernetes_node_label_topology_gke_io_zone",
+      ]
+      regex = "^(?:;*)?([^;]+).*$"
+      target_label = "availability_zone"
+    }
+
+    rule {
+      source_labels = [
+        "__meta_kubernetes_node_label_kubernetes_io_role",
+        "__meta_kubernetes_node_label_node_kubernetes_io_role",
+        "__meta_kubernetes_node_label_node_role",
+        "__meta_kubernetes_node_label_role",
+      ]
+      regex = "^(?:;*)?([^;]+).*$"
+      target_label = "node_role"
+    }
+
+    rule {
+      source_labels = [
+        "__meta_kubernetes_node_label_node_kubernetes_io_instance_type",
+        "__meta_kubernetes_node_label_beta_kubernetes_io_instance_type",
+      ]
+      regex = "^(?:;*)?([^;]+).*$"
+      target_label = "instance_type"
+    }
+  }
+
+  prometheus.scrape "windows_exporter" {
+    job_name   = "integrations/windows-exporter"
+    targets  = discovery.relabel.windows_exporter.output
+    scrape_interval = "60s"
+    clustering {
+      enabled = true
+    }
+    forward_to = [prometheus.relabel.windows_exporter.receiver]
+  }
+
+  prometheus.relabel "windows_exporter" {
+    max_cache_size = 100000
+    rule {
+      source_labels = ["__name__"]
+      regex = "up|scrape_samples_scraped|windows_.*|node_cpu_seconds_total|node_filesystem_size_bytes|node_filesystem_avail_bytes|container_cpu_usage_seconds_total"
+      action = "keep"
+    }
+    forward_to = argument.metrics_destinations.value
+  }
+}
+cluster_metrics "feature" {
+  metrics_destinations = [
+    prometheus.remote_write.prometheus.receiver,
+  ]
+}
+// Self Reporting
+prometheus.exporter.unix "kubernetes_monitoring_telemetry" {
+  set_collectors = ["textfile"]
+  textfile {
+    directory = "/etc/alloy"
+  }
+}
+
+discovery.relabel "kubernetes_monitoring_telemetry" {
+  targets = prometheus.exporter.unix.kubernetes_monitoring_telemetry.targets
+  rule {
+    target_label = "instance"
+    action = "replace"
+    replacement = "k8smon"
+  }
+  rule {
+    target_label = "job"
+    action = "replace"
+    replacement = "integrations/kubernetes/kubernetes_monitoring_telemetry"
+  }
+}
+
+prometheus.scrape "kubernetes_monitoring_telemetry" {
+  job_name   = "integrations/kubernetes/kubernetes_monitoring_telemetry"
+  targets    = discovery.relabel.kubernetes_monitoring_telemetry.output
+  scrape_interval = "60s"
+  clustering {
+    enabled = true
+  }
+  forward_to = [prometheus.relabel.kubernetes_monitoring_telemetry.receiver]
+}
+
+prometheus.relabel "kubernetes_monitoring_telemetry" {
+  rule {
+    source_labels = ["__name__"]
+    regex = "grafana_kubernetes_monitoring_.*"
+    action = "keep"
+  }
+  forward_to = [
+    prometheus.remote_write.prometheus.receiver,
+  ]
+}
+
+
+
+
+// Destination: prometheus (prometheus)
+otelcol.exporter.prometheus "prometheus" {
+  add_metric_suffixes = true
+  forward_to = [prometheus.remote_write.prometheus.receiver]
+}
+
+prometheus.remote_write "prometheus" {
+  endpoint {
+    url = "http://prometheus.prometheus.svc:9090/api/v1/write"
+    headers = {
+    }
+    tls_config {
+      insecure_skip_verify = false
+    }
+    send_native_histograms = false
+
+    queue_config {
+      capacity = 10000
+      min_shards = 1
+      max_shards = 50
+      max_samples_per_send = 2000
+      batch_send_deadline = "5s"
+      min_backoff = "30ms"
+      max_backoff = "5s"
+      retry_on_http_429 = true
+      sample_age_limit = "0s"
+    }
+
+    write_relabel_config {
+      source_labels = ["cluster"]
+      regex = ""
+      replacement = "pod-labels-and-annotations"
+      target_label = "cluster"
+    }
+    write_relabel_config {
+      source_labels = ["k8s_cluster_name"]
+      regex = ""
+      replacement = "pod-labels-and-annotations"
+      target_label = "k8s_cluster_name"
+    }
+  }
+
+  wal {
+    truncate_frequency = "2h"
+    min_keepalive_time = "5m"
+    max_keepalive_time = "8h"
+  }
+}

--- a/charts/k8s-monitoring/docs/examples/node-labels/description.txt
+++ b/charts/k8s-monitoring/docs/examples/node-labels/description.txt
@@ -1,0 +1,3 @@
+# Node Labels
+
+This example shows how to include node labels on all jobs for nodes, pods and endpoints.

--- a/charts/k8s-monitoring/docs/examples/node-labels/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/node-labels/output.yaml
@@ -1,0 +1,2547 @@
+---
+# Source: k8s-monitoring/charts/alloy-logs/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+automountServiceAccountToken: true
+metadata:
+  name: k8smon-alloy-logs
+  namespace: default
+  labels:
+    helm.sh/chart: alloy-logs-1.0.2
+    app.kubernetes.io/name: alloy-logs
+    app.kubernetes.io/instance: k8smon
+    app.kubernetes.io/version: "v1.8.2"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: alloy
+    app.kubernetes.io/component: rbac
+---
+# Source: k8s-monitoring/charts/alloy-metrics/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+automountServiceAccountToken: true
+metadata:
+  name: k8smon-alloy-metrics
+  namespace: default
+  labels:
+    helm.sh/chart: alloy-metrics-1.0.2
+    app.kubernetes.io/name: alloy-metrics
+    app.kubernetes.io/instance: k8smon
+    app.kubernetes.io/version: "v1.8.2"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: alloy
+    app.kubernetes.io/component: rbac
+---
+# Source: k8s-monitoring/charts/clusterMetrics/charts/kube-state-metrics/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+automountServiceAccountToken: true
+metadata:
+  labels:    
+    helm.sh/chart: kube-state-metrics-5.33.0
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: metrics
+    app.kubernetes.io/part-of: kube-state-metrics
+    app.kubernetes.io/name: kube-state-metrics
+    app.kubernetes.io/instance: k8smon
+    app.kubernetes.io/version: "2.15.0"
+    release: k8smon
+  name: k8smon-kube-state-metrics
+  namespace: default
+---
+# Source: k8s-monitoring/charts/clusterMetrics/charts/node-exporter/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: k8smon-node-exporter
+  namespace: default
+  labels:
+    helm.sh/chart: node-exporter-4.46.0
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: metrics
+    app.kubernetes.io/part-of: node-exporter
+    app.kubernetes.io/name: node-exporter
+    app.kubernetes.io/instance: k8smon
+    app.kubernetes.io/version: "1.9.1"
+    release: k8smon
+automountServiceAccountToken: false
+---
+# Source: k8s-monitoring/charts/clusterMetrics/charts/windows-exporter/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: k8smon-windows-exporter
+  namespace: default
+  labels:
+    helm.sh/chart: windows-exporter-0.10.0
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: metrics
+    app.kubernetes.io/part-of: windows-exporter
+    app.kubernetes.io/name: windows-exporter
+    app.kubernetes.io/instance: k8smon
+    app.kubernetes.io/version: "0.30.6"
+    release: k8smon
+---
+# Source: k8s-monitoring/charts/clusterMetrics/charts/windows-exporter/templates/config.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: k8smon-windows-exporter
+  namespace: default
+  labels:
+    helm.sh/chart: windows-exporter-0.10.0
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: metrics
+    app.kubernetes.io/part-of: windows-exporter
+    app.kubernetes.io/name: windows-exporter
+    app.kubernetes.io/instance: k8smon
+    app.kubernetes.io/version: "0.30.6"
+    release: k8smon
+data:
+  config.yml: |
+    collectors:
+      enabled: cpu,cs,container,logical_disk,memory,net,os
+    collector:
+      service:
+        services-where: "Name='containerd' or Name='kubelet'"
+---
+# Source: k8s-monitoring/templates/alloy-config.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: k8smon-alloy-metrics
+  namespace: default
+data:
+  config.alloy: |-
+    // Feature: Annotation Autodiscovery
+    declare "annotation_autodiscovery" {
+      argument "metrics_destinations" {
+        comment = "Must be a list of metric destinations where collected metrics should be forwarded to"
+      }
+    
+      discovery.kubernetes "pods" {
+        role = "pod"
+        attach_metadata {
+          node = true
+        }
+      }
+    
+      discovery.relabel "annotation_autodiscovery_pods" {
+        targets = discovery.kubernetes.pods.targets
+        rule {
+          source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_scrape"]
+          regex = "true"
+          action = "keep"
+        }
+        // Only keep pods that are running, ready, and not init containers.
+        rule {
+          source_labels = [
+            "__meta_kubernetes_pod_phase",
+            "__meta_kubernetes_pod_ready",
+            "__meta_kubernetes_pod_container_init",
+          ]
+          regex = "Running;true;false"
+          action = "keep"
+        }
+        rule {
+          source_labels = ["__meta_kubernetes_pod_name"]
+          target_label = "pod"
+        }
+        rule {
+          source_labels = ["__meta_kubernetes_pod_container_name"]
+          target_label = "container"
+        }
+        rule {
+          source_labels = ["__meta_kubernetes_namespace"]
+          target_label = "namespace"
+        }
+        rule {
+          source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_job"]
+          target_label = "job"
+        }
+        rule {
+          source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_instance"]
+          target_label = "instance"
+        }
+    
+        // Rules to choose the right container
+        rule {
+          source_labels = ["container"]
+          target_label = "__tmp_container"
+        }
+        rule {
+          source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_container"]
+          regex = "(.+)"
+          target_label = "__tmp_container"
+        }
+        rule {
+          source_labels = ["container"]
+          action = "keepequal"
+          target_label = "__tmp_container"
+        }
+        rule {
+          action = "labeldrop"
+          regex = "__tmp_container"
+        }
+    
+        // Set metrics path
+        rule {
+          source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_path"]
+          regex = "(.+)"
+          target_label = "__metrics_path__"
+        }
+    
+        // Set metrics scraping URL parameters
+        rule {
+          action = "labelmap"
+          regex = "__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_param_(.+)"
+          replacement = "__param_$1"
+        }
+    
+        // Choose the pod port
+        // The discovery generates a target for each declared container port of the pod.
+        // If the metricsPortName annotation has value, keep only the target where the port name matches the one of the annotation.
+        rule {
+          source_labels = ["__meta_kubernetes_pod_container_port_name"]
+          target_label = "__tmp_port"
+        }
+        rule {
+          source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_portName"]
+          regex = "(.+)"
+          target_label = "__tmp_port"
+        }
+        rule {
+          source_labels = ["__meta_kubernetes_pod_container_port_name"]
+          action = "keepequal"
+          target_label = "__tmp_port"
+        }
+        rule {
+          action = "labeldrop"
+          regex = "__tmp_port"
+        }
+    
+        // If the metrics port number annotation has a value, override the target address to use it, regardless whether it is
+        // one of the declared ports on that Pod.
+        rule {
+          source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_portNumber", "__meta_kubernetes_pod_ip"]
+          regex = "(\\d+);(([A-Fa-f0-9]{1,4}::?){1,7}[A-Fa-f0-9]{1,4})"
+          replacement = "[$2]:$1" // IPv6
+          target_label = "__address__"
+        }
+        rule {
+          source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_portNumber", "__meta_kubernetes_pod_ip"]
+          regex = "(\\d+);((([0-9]+?)(\\.|$)){4})" // IPv4, takes priority over IPv6 when both exists
+          replacement = "$2:$1"
+          target_label = "__address__"
+        }
+    
+        rule {
+          source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_scheme"]
+          regex = "(.+)"
+          target_label = "__scheme__"
+        }
+    
+        rule {
+          source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_scrapeInterval"]
+          regex = "(.+)"
+          target_label = "__scrape_interval__"
+        }
+        rule {
+          source_labels = ["__scrape_interval__"]
+          regex = ""
+          replacement = "60s"
+          target_label = "__scrape_interval__"
+        }
+        rule {
+          source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_scrapeTimeout"]
+          regex = "(.+)"
+          target_label = "__scrape_timeout__"
+        }
+        rule {
+          source_labels = ["__scrape_timeout__"]
+          regex = ""
+          replacement = "10s"
+          target_label = "__scrape_timeout__"
+        }
+    
+        rule {
+          source_labels = [
+            "__meta_kubernetes_node_label_karpenter_sh_nodepool",
+            "__meta_kubernetes_node_label_cloud_google_com_gke_nodepool",
+            "__meta_kubernetes_node_label_eks_amazonaws_com_nodegroup",
+            "__meta_kubernetes_node_label_kubernetes_azure_com_agentpool",
+            "__meta_kubernetes_node_label_agentpool",
+          ]
+          regex = "^(?:;*)?([^;]+).*$"
+          target_label = "nodepool"
+        }
+    
+        rule {
+          source_labels = [
+            "__meta_kubernetes_node_label_topology_kubernetes_io_region",
+            "__meta_kubernetes_node_label_failure_domain_beta_kubernetes_io_region",
+          ]
+          regex = "^(?:;*)?([^;]+).*$"
+          target_label = "region"
+        }
+    
+        rule {
+          source_labels = [
+            "__meta_kubernetes_node_label_topology_kubernetes_io_zone",
+            "__meta_kubernetes_node_label_failure_domain_beta_kubernetes_io_zone",
+            "__meta_kubernetes_node_label_topology_gke_io_zone",
+          ]
+          regex = "^(?:;*)?([^;]+).*$"
+          target_label = "availability_zone"
+        }
+    
+        rule {
+          source_labels = [
+            "__meta_kubernetes_node_label_kubernetes_io_role",
+            "__meta_kubernetes_node_label_node_kubernetes_io_role",
+            "__meta_kubernetes_node_label_node_role",
+            "__meta_kubernetes_node_label_role",
+          ]
+          regex = "^(?:;*)?([^;]+).*$"
+          target_label = "node_role"
+        }
+    
+        rule {
+          source_labels = [
+            "__meta_kubernetes_node_label_node_kubernetes_io_instance_type",
+            "__meta_kubernetes_node_label_beta_kubernetes_io_instance_type",
+          ]
+          regex = "^(?:;*)?([^;]+).*$"
+          target_label = "instance_type"
+        }
+      }
+    
+      discovery.kubernetes "services" {
+        role = "service"
+      }
+    
+      discovery.relabel "annotation_autodiscovery_services" {
+        targets = discovery.kubernetes.services.targets
+        rule {
+          source_labels = ["__meta_kubernetes_service_annotation_k8s_grafana_com_scrape"]
+          regex = "true"
+          action = "keep"
+        }
+        rule {
+          source_labels = ["__meta_kubernetes_service_name"]
+          target_label = "service"
+        }
+        rule {
+          source_labels = ["__meta_kubernetes_namespace"]
+          target_label = "namespace"
+        }
+        rule {
+          source_labels = ["__meta_kubernetes_service_annotation_k8s_grafana_com_job"]
+          target_label = "job"
+        }
+        rule {
+          source_labels = ["__meta_kubernetes_service_annotation_k8s_grafana_com_instance"]
+          target_label = "instance"
+        }
+    
+        // Set metrics path
+        rule {
+          source_labels = ["__meta_kubernetes_service_annotation_k8s_grafana_com_metrics_path"]
+          target_label = "__metrics_path__"
+        }
+    
+        // Set metrics scraping URL parameters
+        rule {
+          action = "labelmap"
+          regex = "__meta_kubernetes_service_annotation_k8s_grafana_com_metrics_param_(.+)"
+          replacement = "__param_$1"
+        }
+    
+        // Choose the service port
+        rule {
+          source_labels = ["__meta_kubernetes_service_port_name"]
+          target_label = "__tmp_port"
+        }
+        rule {
+          source_labels = ["__meta_kubernetes_service_annotation_k8s_grafana_com_metrics_portName"]
+          regex = "(.+)"
+          target_label = "__tmp_port"
+        }
+        rule {
+          source_labels = ["__meta_kubernetes_service_port_name"]
+          action = "keepequal"
+          target_label = "__tmp_port"
+        }
+    
+        rule {
+          source_labels = ["__meta_kubernetes_service_port_number"]
+          target_label = "__tmp_port"
+        }
+        rule {
+          source_labels = ["__meta_kubernetes_service_annotation_k8s_grafana_com_metrics_portNumber"]
+          regex = "(.+)"
+          target_label = "__tmp_port"
+        }
+        rule {
+          source_labels = ["__meta_kubernetes_service_port_number"]
+          action = "keepequal"
+          target_label = "__tmp_port"
+        }
+        rule {
+          action = "labeldrop"
+          regex = "__tmp_port"
+        }
+    
+        rule {
+          source_labels = ["__meta_kubernetes_service_annotation_k8s_grafana_com_metrics_scheme"]
+          regex = "(.+)"
+          target_label = "__scheme__"
+        }
+    
+        rule {
+          source_labels = ["__meta_kubernetes_service_annotation_k8s_grafana_com_metrics_scrapeInterval"]
+          regex = "(.+)"
+          target_label = "__scrape_interval__"
+        }
+        rule {
+          source_labels = ["__scrape_interval__"]
+          regex = ""
+          replacement = "60s"
+          target_label = "__scrape_interval__"
+        }
+        rule {
+          source_labels = ["__meta_kubernetes_service_annotation_k8s_grafana_com_metrics_scrapeTimeout"]
+          regex = "(.+)"
+          target_label = "__scrape_timeout__"
+        }
+        rule {
+          source_labels = ["__scrape_timeout__"]
+          regex = ""
+          replacement = "10s"
+          target_label = "__scrape_timeout__"
+        }
+      }
+    
+      discovery.relabel "annotation_autodiscovery_http" {
+        targets = array.concat(discovery.relabel.annotation_autodiscovery_pods.output, discovery.relabel.annotation_autodiscovery_services.output)
+        rule {
+          source_labels = ["__scheme__"]
+          regex = "https"
+          action = "drop"
+        }
+      }
+    
+      discovery.relabel "annotation_autodiscovery_https" {
+        targets = array.concat(discovery.relabel.annotation_autodiscovery_pods.output, discovery.relabel.annotation_autodiscovery_services.output)
+        rule {
+          source_labels = ["__scheme__"]
+          regex = "https"
+          action = "keep"
+        }
+      }
+    
+      prometheus.scrape "annotation_autodiscovery_http" {
+        targets = discovery.relabel.annotation_autodiscovery_http.output
+        honor_labels = true
+        bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+        clustering {
+          enabled = true
+        }
+    
+        forward_to = argument.metrics_destinations.value
+      }
+    
+      prometheus.scrape "annotation_autodiscovery_https" {
+        targets = discovery.relabel.annotation_autodiscovery_https.output
+        honor_labels = true
+        bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+        tls_config {
+          insecure_skip_verify = true
+        }
+        clustering {
+          enabled = true
+        }
+    
+        forward_to = argument.metrics_destinations.value
+      }
+    }
+    annotation_autodiscovery "feature" {
+      metrics_destinations = [
+        prometheus.remote_write.prometheus.receiver,
+      ]
+    }
+    // Feature: Cluster Metrics
+    declare "cluster_metrics" {
+      argument "metrics_destinations" {
+        comment = "Must be a list of metric destinations where collected metrics should be forwarded to"
+      }
+      discovery.kubernetes "nodes" {
+        role = "node"
+      }
+    
+      discovery.relabel "nodes" {
+        targets = discovery.kubernetes.nodes.targets
+        rule {
+          source_labels = ["__meta_kubernetes_node_name"]
+          target_label  = "node"
+        }
+    
+        rule {
+          replacement = "kubernetes"
+          target_label = "source"
+        }
+    
+    
+        rule {
+          source_labels = [
+            "__meta_kubernetes_node_label_karpenter_sh_nodepool",
+            "__meta_kubernetes_node_label_cloud_google_com_gke_nodepool",
+            "__meta_kubernetes_node_label_eks_amazonaws_com_nodegroup",
+            "__meta_kubernetes_node_label_kubernetes_azure_com_agentpool",
+            "__meta_kubernetes_node_label_agentpool",
+          ]
+          regex = "^(?:;*)?([^;]+).*$"
+          target_label = "nodepool"
+        }
+    
+        rule {
+          source_labels = [
+            "__meta_kubernetes_node_label_topology_kubernetes_io_region",
+            "__meta_kubernetes_node_label_failure_domain_beta_kubernetes_io_region",
+          ]
+          regex = "^(?:;*)?([^;]+).*$"
+          target_label = "region"
+        }
+    
+        rule {
+          source_labels = [
+            "__meta_kubernetes_node_label_topology_kubernetes_io_zone",
+            "__meta_kubernetes_node_label_failure_domain_beta_kubernetes_io_zone",
+            "__meta_kubernetes_node_label_topology_gke_io_zone",
+          ]
+          regex = "^(?:;*)?([^;]+).*$"
+          target_label = "availability_zone"
+        }
+    
+        rule {
+          source_labels = [
+            "__meta_kubernetes_node_label_kubernetes_io_role",
+            "__meta_kubernetes_node_label_node_kubernetes_io_role",
+            "__meta_kubernetes_node_label_node_role",
+            "__meta_kubernetes_node_label_role",
+          ]
+          regex = "^(?:;*)?([^;]+).*$"
+          target_label = "node_role"
+        }
+    
+        rule {
+          source_labels = [
+            "__meta_kubernetes_node_label_node_kubernetes_io_instance_type",
+            "__meta_kubernetes_node_label_beta_kubernetes_io_instance_type",
+          ]
+          regex = "^(?:;*)?([^;]+).*$"
+          target_label = "instance_type"
+        }
+      }
+    
+      // Kubelet
+      discovery.relabel "kubelet" {
+        targets = discovery.relabel.nodes.output
+      }
+    
+      prometheus.scrape "kubelet" {
+        targets  = discovery.relabel.kubelet.output
+        job_name = "integrations/kubernetes/kubelet"
+        scheme   = "https"
+        scrape_interval = "60s"
+        bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+    
+        tls_config {
+          ca_file = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+          insecure_skip_verify = true
+          server_name = "kubernetes"
+        }
+    
+        clustering {
+          enabled = true
+        }
+    
+        forward_to = [prometheus.relabel.kubelet.receiver]
+      }
+    
+      prometheus.relabel "kubelet" {
+        max_cache_size = 100000
+        rule {
+          source_labels = ["__name__"]
+          regex = "up|scrape_samples_scraped|go_goroutines|kubelet_certificate_manager_client_expiration_renew_errors|kubelet_certificate_manager_client_ttl_seconds|kubelet_certificate_manager_server_ttl_seconds|kubelet_cgroup_manager_duration_seconds_bucket|kubelet_cgroup_manager_duration_seconds_count|kubelet_node_config_error|kubelet_node_name|kubelet_pleg_relist_duration_seconds_bucket|kubelet_pleg_relist_duration_seconds_count|kubelet_pleg_relist_interval_seconds_bucket|kubelet_pod_start_duration_seconds_bucket|kubelet_pod_start_duration_seconds_count|kubelet_pod_worker_duration_seconds_bucket|kubelet_pod_worker_duration_seconds_count|kubelet_running_container_count|kubelet_running_containers|kubelet_running_pod_count|kubelet_running_pods|kubelet_runtime_operations_errors_total|kubelet_runtime_operations_total|kubelet_server_expiration_renew_errors|kubelet_volume_stats_available_bytes|kubelet_volume_stats_capacity_bytes|kubelet_volume_stats_inodes|kubelet_volume_stats_inodes_free|kubelet_volume_stats_inodes_used|kubelet_volume_stats_used_bytes|kubernetes_build_info|namespace_workload_pod|process_cpu_seconds_total|process_resident_memory_bytes|rest_client_requests_total|storage_operation_duration_seconds_count|storage_operation_errors_total|volume_manager_total_volumes"
+          action = "keep"
+        }
+    
+        forward_to = argument.metrics_destinations.value
+      }
+    
+      // Kubelet Resources
+      discovery.relabel "kubelet_resources" {
+        targets = discovery.relabel.nodes.output
+        rule {
+          replacement   = "/metrics/resource"
+          target_label  = "__metrics_path__"
+        }
+      }
+    
+      prometheus.scrape "kubelet_resources" {
+        targets = discovery.relabel.kubelet_resources.output
+        job_name = "integrations/kubernetes/resources"
+        scheme   = "https"
+        scrape_interval = "60s"
+        bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+    
+        tls_config {
+          ca_file = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+          insecure_skip_verify = true
+          server_name = "kubernetes"
+        }
+    
+        clustering {
+          enabled = true
+        }
+    
+        forward_to = [prometheus.relabel.kubelet_resources.receiver]
+      }
+    
+      prometheus.relabel "kubelet_resources" {
+        max_cache_size = 100000
+        rule {
+          source_labels = ["__name__"]
+          regex = "up|scrape_samples_scraped|node_cpu_usage_seconds_total|node_memory_working_set_bytes"
+          action = "keep"
+        }
+    
+        forward_to = argument.metrics_destinations.value
+      }
+    
+      // cAdvisor
+      discovery.relabel "cadvisor" {
+        targets = discovery.relabel.nodes.output
+        rule {
+          replacement   = "/metrics/cadvisor"
+          target_label  = "__metrics_path__"
+        }
+      }
+    
+      prometheus.scrape "cadvisor" {
+        targets = discovery.relabel.cadvisor.output
+        job_name = "integrations/kubernetes/cadvisor"
+        scheme = "https"
+        scrape_interval = "60s"
+        bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+    
+        tls_config {
+          ca_file = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+          insecure_skip_verify = true
+          server_name = "kubernetes"
+        }
+    
+        clustering {
+          enabled = true
+        }
+    
+        forward_to = [prometheus.relabel.cadvisor.receiver]
+      }
+    
+      prometheus.relabel "cadvisor" {
+        max_cache_size = 100000
+        rule {
+          source_labels = ["__name__"]
+          regex = "up|scrape_samples_scraped|container_cpu_cfs_periods_total|container_cpu_cfs_throttled_periods_total|container_cpu_usage_seconds_total|container_fs_reads_bytes_total|container_fs_reads_total|container_fs_writes_bytes_total|container_fs_writes_total|container_memory_cache|container_memory_rss|container_memory_swap|container_memory_working_set_bytes|container_network_receive_bytes_total|container_network_receive_packets_dropped_total|container_network_receive_packets_total|container_network_transmit_bytes_total|container_network_transmit_packets_dropped_total|container_network_transmit_packets_total|machine_memory_bytes"
+          action = "keep"
+        }
+        // Drop empty container labels, addressing https://github.com/google/cadvisor/issues/2688
+        rule {
+          source_labels = ["__name__","container"]
+          separator = "@"
+          regex = "(container_cpu_.*|container_fs_.*|container_memory_.*)@"
+          action = "drop"
+        }
+        // Drop empty image labels, addressing https://github.com/google/cadvisor/issues/2688
+        rule {
+          source_labels = ["__name__","image"]
+          separator = "@"
+          regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_network_.*)@"
+          action = "drop"
+        }
+        // Normalizing unimportant labels (not deleting to continue satisfying <label>!="" checks)
+        rule {
+          source_labels = ["__name__", "boot_id"]
+          separator = "@"
+          regex = "machine_memory_bytes@.*"
+          target_label = "boot_id"
+          replacement = "NA"
+        }
+        rule {
+          source_labels = ["__name__", "system_uuid"]
+          separator = "@"
+          regex = "machine_memory_bytes@.*"
+          target_label = "system_uuid"
+          replacement = "NA"
+        }
+        // Filter out non-physical devices/interfaces
+        rule {
+          source_labels = ["__name__", "device"]
+          separator = "@"
+          regex = "container_fs_.*@(/dev/)?(mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dasd.+)"
+          target_label = "__keepme"
+          replacement = "1"
+        }
+        rule {
+          source_labels = ["__name__", "__keepme"]
+          separator = "@"
+          regex = "container_fs_.*@"
+          action = "drop"
+        }
+        rule {
+          source_labels = ["__name__"]
+          regex = "container_fs_.*"
+          target_label = "__keepme"
+          replacement = ""
+        }
+        rule {
+          source_labels = ["__name__", "interface"]
+          separator = "@"
+          regex = "container_network_.*@(en[ospx][0-9].*|wlan[0-9].*|eth[0-9].*)"
+          target_label = "__keepme"
+          replacement = "1"
+        }
+        rule {
+          source_labels = ["__name__", "__keepme"]
+          separator = "@"
+          regex = "container_network_.*@"
+          action = "drop"
+        }
+        rule {
+          source_labels = ["__name__"]
+          regex = "container_network_.*"
+          target_label = "__keepme"
+          replacement = ""
+        }
+        forward_to = argument.metrics_destinations.value
+      }
+      discovery.kubernetes "kube_state_metrics" {
+        role = "endpoints"
+    
+        selectors {
+          role = "endpoints"
+          label = "app.kubernetes.io/name=kube-state-metrics,release=k8smon"
+        }
+        namespaces {
+          names = ["default"]
+        }
+      }
+    
+      discovery.relabel "kube_state_metrics" {
+        targets = discovery.kubernetes.kube_state_metrics.targets
+    
+        // only keep targets with a matching port name
+        rule {
+          source_labels = ["__meta_kubernetes_pod_container_port_name"]
+          regex = "http"
+          action = "keep"
+        }
+    
+        rule {
+          action = "replace"
+          replacement = "kubernetes"
+          target_label = "source"
+        }
+    
+      }
+    
+      prometheus.scrape "kube_state_metrics" {
+        targets = discovery.relabel.kube_state_metrics.output
+        job_name = "integrations/kubernetes/kube-state-metrics"
+        scrape_interval = "60s"
+        scheme = "http"
+        bearer_token_file = ""
+        tls_config {
+          insecure_skip_verify = true
+        }
+    
+        clustering {
+          enabled = true
+        }
+        forward_to = [prometheus.relabel.kube_state_metrics.receiver]
+      }
+    
+      prometheus.relabel "kube_state_metrics" {
+        max_cache_size = 100000
+        rule {
+          source_labels = ["__name__"]
+          regex = "up|scrape_samples_scraped|kube_configmap_info|kube_configmap_metadata_resource_version|kube_daemonset.*|kube_deployment_metadata_generation|kube_deployment_spec_replicas|kube_deployment_status_condition|kube_deployment_status_observed_generation|kube_deployment_status_replicas_available|kube_deployment_status_replicas_updated|kube_horizontalpodautoscaler_spec_max_replicas|kube_horizontalpodautoscaler_spec_min_replicas|kube_horizontalpodautoscaler_status_current_replicas|kube_horizontalpodautoscaler_status_desired_replicas|kube_job.*|kube_namespace_status_phase|kube_node.*|kube_persistentvolume_status_phase|kube_persistentvolumeclaim_access_mode|kube_persistentvolumeclaim_info|kube_persistentvolumeclaim_labels|kube_persistentvolumeclaim_resource_requests_storage_bytes|kube_persistentvolumeclaim_status_phase|kube_pod_container_info|kube_pod_container_resource_limits|kube_pod_container_resource_requests|kube_pod_container_status_last_terminated_reason|kube_pod_container_status_restarts_total|kube_pod_container_status_waiting_reason|kube_pod_info|kube_pod_owner|kube_pod_spec_volumes_persistentvolumeclaims_info|kube_pod_start_time|kube_pod_status_phase|kube_pod_status_reason|kube_replicaset.*|kube_resourcequota|kube_secret_metadata_resource_version|kube_statefulset.*"
+          action = "keep"
+        }
+        forward_to = argument.metrics_destinations.value
+      }
+    
+      // Node Exporter
+      discovery.kubernetes "node_exporter" {
+        role = "pod"
+    
+        selectors {
+          role = "pod"
+          label = "app.kubernetes.io/name=node-exporter,release=k8smon"
+        }
+        namespaces {
+          names = ["default"]
+        }
+        attach_metadata {
+          node = true
+        }
+      }
+    
+      discovery.relabel "node_exporter" {
+        targets = discovery.kubernetes.node_exporter.targets
+    
+        // keep only the specified metrics port name, and pods that are Running and ready
+        rule {
+          source_labels = [
+            "__meta_kubernetes_pod_container_port_name",
+            "__meta_kubernetes_pod_container_init",
+            "__meta_kubernetes_pod_phase",
+            "__meta_kubernetes_pod_ready",
+          ]
+          separator = "@"
+          regex = "metrics@false@Running@true"
+          action = "keep"
+        }
+    
+        // Set the instance label to the node name
+        rule {
+          source_labels = ["__meta_kubernetes_pod_node_name"]
+          action = "replace"
+          target_label = "instance"
+        }
+    
+        // set the namespace label
+        rule {
+          source_labels = ["__meta_kubernetes_namespace"]
+          target_label  = "namespace"
+        }
+    
+        // set the pod label
+        rule {
+          source_labels = ["__meta_kubernetes_pod_name"]
+          target_label  = "pod"
+        }
+    
+        // set the container label
+        rule {
+          source_labels = ["__meta_kubernetes_pod_container_name"]
+          target_label  = "container"
+        }
+    
+        // set a workload label
+        rule {
+          source_labels = [
+            "__meta_kubernetes_pod_controller_kind",
+            "__meta_kubernetes_pod_controller_name",
+          ]
+          separator = "/"
+          target_label  = "workload"
+        }
+        // remove the hash from the ReplicaSet
+        rule {
+          source_labels = ["workload"]
+          regex = "(ReplicaSet/.+)-.+"
+          target_label  = "workload"
+        }
+    
+        // set the app name if specified as metadata labels "app:" or "app.kubernetes.io/name:" or "k8s-app:"
+        rule {
+          action = "replace"
+          source_labels = [
+            "__meta_kubernetes_pod_label_app_kubernetes_io_name",
+            "__meta_kubernetes_pod_label_k8s_app",
+            "__meta_kubernetes_pod_label_app",
+          ]
+          separator = ";"
+          regex = "^(?:;*)?([^;]+).*$"
+          replacement = "$1"
+          target_label = "app"
+        }
+    
+        // set the component if specified as metadata labels "component:" or "app.kubernetes.io/component:" or "k8s-component:"
+        rule {
+          action = "replace"
+          source_labels = [
+            "__meta_kubernetes_pod_label_app_kubernetes_io_component",
+            "__meta_kubernetes_pod_label_k8s_component",
+            "__meta_kubernetes_pod_label_component",
+          ]
+          regex = "^(?:;*)?([^;]+).*$"
+          replacement = "$1"
+          target_label = "component"
+        }
+    
+        // set a source label
+        rule {
+          action = "replace"
+          replacement = "kubernetes"
+          target_label = "source"
+        }
+    
+        rule {
+          source_labels = [
+            "__meta_kubernetes_node_label_karpenter_sh_nodepool",
+            "__meta_kubernetes_node_label_cloud_google_com_gke_nodepool",
+            "__meta_kubernetes_node_label_eks_amazonaws_com_nodegroup",
+            "__meta_kubernetes_node_label_kubernetes_azure_com_agentpool",
+            "__meta_kubernetes_node_label_agentpool",
+          ]
+          regex = "^(?:;*)?([^;]+).*$"
+          target_label = "nodepool"
+        }
+    
+        rule {
+          source_labels = [
+            "__meta_kubernetes_node_label_topology_kubernetes_io_region",
+            "__meta_kubernetes_node_label_failure_domain_beta_kubernetes_io_region",
+          ]
+          regex = "^(?:;*)?([^;]+).*$"
+          target_label = "region"
+        }
+    
+        rule {
+          source_labels = [
+            "__meta_kubernetes_node_label_topology_kubernetes_io_zone",
+            "__meta_kubernetes_node_label_failure_domain_beta_kubernetes_io_zone",
+            "__meta_kubernetes_node_label_topology_gke_io_zone",
+          ]
+          regex = "^(?:;*)?([^;]+).*$"
+          target_label = "availability_zone"
+        }
+    
+        rule {
+          source_labels = [
+            "__meta_kubernetes_node_label_kubernetes_io_role",
+            "__meta_kubernetes_node_label_node_kubernetes_io_role",
+            "__meta_kubernetes_node_label_node_role",
+            "__meta_kubernetes_node_label_role",
+          ]
+          regex = "^(?:;*)?([^;]+).*$"
+          target_label = "node_role"
+        }
+    
+        rule {
+          source_labels = [
+            "__meta_kubernetes_node_label_node_kubernetes_io_instance_type",
+            "__meta_kubernetes_node_label_beta_kubernetes_io_instance_type",
+          ]
+          regex = "^(?:;*)?([^;]+).*$"
+          target_label = "instance_type"
+        }
+      }
+    
+      prometheus.scrape "node_exporter" {
+        targets = discovery.relabel.node_exporter.output
+        job_name = "integrations/node_exporter"
+        scrape_interval = "60s"
+        scheme = "http"
+        bearer_token_file = ""
+        tls_config {
+          insecure_skip_verify = true
+        }
+    
+        clustering {
+          enabled = true
+        }
+        forward_to = [prometheus.relabel.node_exporter.receiver]
+      }
+    
+      prometheus.relabel "node_exporter" {
+        max_cache_size = 100000
+        rule {
+          source_labels = ["__name__"]
+          regex = "up|scrape_samples_scraped|node_cpu.*|node_exporter_build_info|node_filesystem.*|node_memory.*|node_network_receive_bytes_total|node_network_receive_drop_total|node_network_transmit_bytes_total|node_network_transmit_drop_total|process_cpu_seconds_total|process_resident_memory_bytes"
+          action = "keep"
+        }
+        // Drop metrics for certain file systems
+        rule {
+          source_labels = ["__name__", "fstype"]
+          separator = "@"
+          regex = "node_filesystem.*@(ramfs|tmpfs)"
+          action = "drop"
+        }
+        forward_to = argument.metrics_destinations.value
+      }
+    
+      discovery.kubernetes "windows_exporter_pods" {
+        role = "pod"
+        namespaces {
+          names = ["default"]
+        }
+        selectors {
+          role = "pod"
+          label = "app.kubernetes.io/name=windows-exporter,release=k8smon"
+        }
+        attach_metadata {
+          node = true
+        }
+      }
+    
+      discovery.relabel "windows_exporter" {
+        targets = discovery.kubernetes.windows_exporter_pods.targets
+        rule {
+          source_labels = ["__meta_kubernetes_pod_node_name"]
+          action = "replace"
+          target_label = "instance"
+        }
+    
+        rule {
+          source_labels = [
+            "__meta_kubernetes_node_label_karpenter_sh_nodepool",
+            "__meta_kubernetes_node_label_cloud_google_com_gke_nodepool",
+            "__meta_kubernetes_node_label_eks_amazonaws_com_nodegroup",
+            "__meta_kubernetes_node_label_kubernetes_azure_com_agentpool",
+            "__meta_kubernetes_node_label_agentpool",
+          ]
+          regex = "^(?:;*)?([^;]+).*$"
+          target_label = "nodepool"
+        }
+    
+        rule {
+          source_labels = [
+            "__meta_kubernetes_node_label_topology_kubernetes_io_region",
+            "__meta_kubernetes_node_label_failure_domain_beta_kubernetes_io_region",
+          ]
+          regex = "^(?:;*)?([^;]+).*$"
+          target_label = "region"
+        }
+    
+        rule {
+          source_labels = [
+            "__meta_kubernetes_node_label_topology_kubernetes_io_zone",
+            "__meta_kubernetes_node_label_failure_domain_beta_kubernetes_io_zone",
+            "__meta_kubernetes_node_label_topology_gke_io_zone",
+          ]
+          regex = "^(?:;*)?([^;]+).*$"
+          target_label = "availability_zone"
+        }
+    
+        rule {
+          source_labels = [
+            "__meta_kubernetes_node_label_kubernetes_io_role",
+            "__meta_kubernetes_node_label_node_kubernetes_io_role",
+            "__meta_kubernetes_node_label_node_role",
+            "__meta_kubernetes_node_label_role",
+          ]
+          regex = "^(?:;*)?([^;]+).*$"
+          target_label = "node_role"
+        }
+    
+        rule {
+          source_labels = [
+            "__meta_kubernetes_node_label_node_kubernetes_io_instance_type",
+            "__meta_kubernetes_node_label_beta_kubernetes_io_instance_type",
+          ]
+          regex = "^(?:;*)?([^;]+).*$"
+          target_label = "instance_type"
+        }
+      }
+    
+      prometheus.scrape "windows_exporter" {
+        job_name   = "integrations/windows-exporter"
+        targets  = discovery.relabel.windows_exporter.output
+        scrape_interval = "60s"
+        clustering {
+          enabled = true
+        }
+        forward_to = [prometheus.relabel.windows_exporter.receiver]
+      }
+    
+      prometheus.relabel "windows_exporter" {
+        max_cache_size = 100000
+        rule {
+          source_labels = ["__name__"]
+          regex = "up|scrape_samples_scraped|windows_.*|node_cpu_seconds_total|node_filesystem_size_bytes|node_filesystem_avail_bytes|container_cpu_usage_seconds_total"
+          action = "keep"
+        }
+        forward_to = argument.metrics_destinations.value
+      }
+    }
+    cluster_metrics "feature" {
+      metrics_destinations = [
+        prometheus.remote_write.prometheus.receiver,
+      ]
+    }
+    // Self Reporting
+    prometheus.exporter.unix "kubernetes_monitoring_telemetry" {
+      set_collectors = ["textfile"]
+      textfile {
+        directory = "/etc/alloy"
+      }
+    }
+    
+    discovery.relabel "kubernetes_monitoring_telemetry" {
+      targets = prometheus.exporter.unix.kubernetes_monitoring_telemetry.targets
+      rule {
+        target_label = "instance"
+        action = "replace"
+        replacement = "k8smon"
+      }
+      rule {
+        target_label = "job"
+        action = "replace"
+        replacement = "integrations/kubernetes/kubernetes_monitoring_telemetry"
+      }
+    }
+    
+    prometheus.scrape "kubernetes_monitoring_telemetry" {
+      job_name   = "integrations/kubernetes/kubernetes_monitoring_telemetry"
+      targets    = discovery.relabel.kubernetes_monitoring_telemetry.output
+      scrape_interval = "60s"
+      clustering {
+        enabled = true
+      }
+      forward_to = [prometheus.relabel.kubernetes_monitoring_telemetry.receiver]
+    }
+    
+    prometheus.relabel "kubernetes_monitoring_telemetry" {
+      rule {
+        source_labels = ["__name__"]
+        regex = "grafana_kubernetes_monitoring_.*"
+        action = "keep"
+      }
+      forward_to = [
+        prometheus.remote_write.prometheus.receiver,
+      ]
+    }
+    
+    
+    
+    
+    // Destination: prometheus (prometheus)
+    otelcol.exporter.prometheus "prometheus" {
+      add_metric_suffixes = true
+      forward_to = [prometheus.remote_write.prometheus.receiver]
+    }
+    
+    prometheus.remote_write "prometheus" {
+      endpoint {
+        url = "http://prometheus.prometheus.svc:9090/api/v1/write"
+        headers = {
+        }
+        tls_config {
+          insecure_skip_verify = false
+        }
+        send_native_histograms = false
+    
+        queue_config {
+          capacity = 10000
+          min_shards = 1
+          max_shards = 50
+          max_samples_per_send = 2000
+          batch_send_deadline = "5s"
+          min_backoff = "30ms"
+          max_backoff = "5s"
+          retry_on_http_429 = true
+          sample_age_limit = "0s"
+        }
+    
+        write_relabel_config {
+          source_labels = ["cluster"]
+          regex = ""
+          replacement = "pod-labels-and-annotations"
+          target_label = "cluster"
+        }
+        write_relabel_config {
+          source_labels = ["k8s_cluster_name"]
+          regex = ""
+          replacement = "pod-labels-and-annotations"
+          target_label = "k8s_cluster_name"
+        }
+      }
+    
+      wal {
+        truncate_frequency = "2h"
+        min_keepalive_time = "5m"
+        max_keepalive_time = "8h"
+      }
+    }
+
+  self-reporting-metric.prom: |
+    
+    # HELP grafana_kubernetes_monitoring_build_info A metric to report the version of the Kubernetes Monitoring Helm chart
+    # TYPE grafana_kubernetes_monitoring_build_info gauge
+    grafana_kubernetes_monitoring_build_info{version="2.0.27", namespace="default"} 1
+    # HELP grafana_kubernetes_monitoring_feature_info A metric to report the enabled features of the Kubernetes Monitoring Helm chart
+    # TYPE grafana_kubernetes_monitoring_feature_info gauge
+    grafana_kubernetes_monitoring_feature_info{feature="annotationAutodiscovery", version="1.0.0"} 1
+    grafana_kubernetes_monitoring_feature_info{deployments="kube-state-metrics,node-exporter,windows-exporter", feature="clusterMetrics", sources="kubelet,kubeletResource,cadvisor,kube-state-metrics,node-exporter,windows-exporter", version="1.0.0"} 1
+    grafana_kubernetes_monitoring_feature_info{feature="podLogs", method="volumes", version="1.0.0"} 1
+---
+# Source: k8s-monitoring/templates/alloy-config.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: k8smon-alloy-logs
+  namespace: default
+data:
+  config.alloy: |-
+    // Feature: Pod Logs
+    declare "pod_logs" {
+      argument "logs_destinations" {
+        comment = "Must be a list of log destinations where collected logs should be forwarded to"
+      }
+    
+      discovery.relabel "filtered_pods" {
+        targets = discovery.kubernetes.pods.targets
+        rule {
+          source_labels = ["__meta_kubernetes_namespace"]
+          action = "replace"
+          target_label = "namespace"
+        }
+        rule {
+          source_labels = ["__meta_kubernetes_pod_name"]
+          action = "replace"
+          target_label = "pod"
+        }
+        rule {
+          source_labels = ["__meta_kubernetes_pod_container_name"]
+          action = "replace"
+          target_label = "container"
+        }
+        rule {
+          source_labels = ["__meta_kubernetes_namespace", "__meta_kubernetes_pod_container_name"]
+          separator = "/"
+          action = "replace"
+          replacement = "$1"
+          target_label = "job"
+        }
+    
+        // set the container runtime as a label
+        rule {
+          action = "replace"
+          source_labels = ["__meta_kubernetes_pod_container_id"]
+          regex = "^(\\S+):\\/\\/.+$"
+          replacement = "$1"
+          target_label = "tmp_container_runtime"
+        }
+    
+        // make all labels on the pod available to the pipeline as labels,
+        // they are omitted before write to loki via stage.label_keep unless explicitly set
+        rule {
+          action = "labelmap"
+          regex = "__meta_kubernetes_pod_label_(.+)"
+        }
+    
+        // make all annotations on the pod available to the pipeline as labels,
+        // they are omitted before write to loki via stage.label_keep unless explicitly set
+        rule {
+          action = "labelmap"
+          regex = "__meta_kubernetes_pod_annotation_(.+)"
+        }
+    
+        // explicitly set service_name. if not set, loki will automatically try to populate a default.
+        // see https://grafana.com/docs/loki/latest/get-started/labels/#default-labels-for-all-users
+        //
+        // choose the first value found from the following ordered list:
+        // - pod.annotation[resource.opentelemetry.io/service.name]
+        // - pod.label[app.kubernetes.io/name]
+        // - k8s.pod.name
+        // - k8s.container.name
+        rule {
+          action = "replace"
+          source_labels = [
+            "__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_name",
+            "__meta_kubernetes_pod_label_app_kubernetes_io_name",
+            "__meta_kubernetes_pod_name",
+            "__meta_kubernetes_pod_container_name",
+          ]
+          separator = ";"
+          regex = "^(?:;*)?([^;]+).*$"
+          replacement = "$1"
+          target_label = "service_name"
+        }
+    
+        // set resource attributes
+        rule {
+          action = "labelmap"
+          regex = "__meta_kubernetes_pod_annotation_resource_opentelemetry_io_(.+)"
+        }
+        rule {
+          source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_job"]
+          regex = "(.+)"
+          target_label = "job"
+        }
+        rule {
+          source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+          regex = "(.+)"
+          target_label = "app_kubernetes_io_name"
+        }
+    
+        rule {
+          source_labels = [
+            "__meta_kubernetes_node_label_topology_kubernetes_io_region",
+            "__meta_kubernetes_node_label_failure_domain_beta_kubernetes_io_region",
+          ]
+          regex = "^(?:;*)?([^;]+).*$"
+          target_label = "region"
+        }
+      }
+    
+      discovery.kubernetes "pods" {
+        role = "pod"
+        selectors {
+          role = "pod"
+          field = "spec.nodeName=" + sys.env("HOSTNAME")
+        }
+        attach_metadata {
+          node = true
+        }
+      }
+    
+      discovery.relabel "filtered_pods_with_paths" {
+        targets = discovery.relabel.filtered_pods.output
+    
+        rule {
+          source_labels = ["__meta_kubernetes_pod_uid", "__meta_kubernetes_pod_container_name"]
+          separator = "/"
+          action = "replace"
+          replacement = "/var/log/pods/*$1/*.log"
+          target_label = "__path__"
+        }
+      }
+    
+      local.file_match "pod_logs" {
+        path_targets = discovery.relabel.filtered_pods_with_paths.output
+      }
+    
+      loki.source.file "pod_logs" {
+        targets    = local.file_match.pod_logs.targets
+        forward_to = [loki.process.pod_logs.receiver]
+      }
+    
+      loki.process "pod_logs" {
+        stage.match {
+          selector = "{tmp_container_runtime=~\"containerd|cri-o\"}"
+          // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
+          stage.cri {}
+    
+          // Set the extract flags and stream values as labels
+          stage.labels {
+            values = {
+              flags  = "",
+              stream  = "",
+            }
+          }
+        }
+    
+        stage.match {
+          selector = "{tmp_container_runtime=\"docker\"}"
+          // the docker processing stage extracts the following k/v pairs: log, stream, time
+          stage.docker {}
+    
+          // Set the extract stream value as a label
+          stage.labels {
+            values = {
+              stream  = "",
+            }
+          }
+        }
+    
+        // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
+        // namespace, pod, and container labels. Drop any structured metadata. Also drop the temporary
+        // container runtime label as it is no longer needed.
+        stage.label_drop {
+          values = [
+            "filename",
+            "tmp_container_runtime",
+          ]
+        }
+        // set the structured metadata values
+        stage.structured_metadata {
+          values = {
+            "availability_zone" = "availability_zone",
+            "node_arch" = "architecture",
+            "node_os" = "os",
+            "node_pool" = "nodepool",
+            "node_role" = "node_role",
+            "node_type" = "instance_type",
+            "region" = "region",
+          }
+        }
+    
+        // Only keep the labels that are defined in the `keepLabels` list.
+        stage.label_keep {
+          values = ["app_kubernetes_io_name","container","instance","job","level","namespace","pod","service_name","service_namespace","deployment_environment","deployment_environment_name","k8s_pod_name","k8s_namespace_name","k8s_deployment_name","k8s_statefulset_name","k8s_daemonset_name","k8s_cronjob_name","k8s_job_name","k8s_node_name"]
+        }
+    
+        forward_to = argument.logs_destinations.value
+      }
+    }
+    pod_logs "feature" {
+      logs_destinations = [
+        loki.write.loki.receiver,
+      ]
+    }
+    
+    
+    
+    
+    // Destination: loki (loki)
+    otelcol.exporter.loki "loki" {
+      forward_to = [loki.write.loki.receiver]
+    }
+    
+    loki.write "loki" {
+      endpoint {
+        url = "http://loki.loki.svc:3100/api/push"
+        tls_config {
+          insecure_skip_verify = false
+        }
+        min_backoff_period = "500ms"
+        max_backoff_period = "5m"
+        max_backoff_retries = "10"
+      }
+      external_labels = {
+        "cluster" = "pod-labels-and-annotations",
+        "k8s_cluster_name" = "pod-labels-and-annotations",
+      }
+    }
+---
+# Source: k8s-monitoring/charts/alloy-logs/templates/rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: k8smon-alloy-logs
+  labels:
+    helm.sh/chart: alloy-logs-1.0.2
+    app.kubernetes.io/name: alloy-logs
+    app.kubernetes.io/instance: k8smon
+    app.kubernetes.io/version: "v1.8.2"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: alloy
+    app.kubernetes.io/component: rbac
+rules:
+  # Rules which allow discovery.kubernetes to function.
+  - apiGroups:
+      - ""
+      - "discovery.k8s.io"
+      - "networking.k8s.io"
+    resources:
+      - endpoints
+      - endpointslices
+      - ingresses
+      - nodes
+      - nodes/proxy
+      - nodes/metrics
+      - pods
+      - services
+    verbs:
+      - get
+      - list
+      - watch
+  # Rules which allow loki.source.kubernetes and loki.source.podlogs to work.
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+      - pods/log
+      - namespaces
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - "monitoring.grafana.com"
+    resources:
+      - podlogs
+    verbs:
+      - get
+      - list
+      - watch
+  # Rules which allow mimir.rules.kubernetes to work.
+  - apiGroups: ["monitoring.coreos.com"]
+    resources:
+      - prometheusrules
+    verbs:
+      - get
+      - list
+      - watch
+  - nonResourceURLs:
+      - /metrics
+    verbs:
+      - get
+  # Rules for prometheus.kubernetes.*
+  - apiGroups: ["monitoring.coreos.com"]
+    resources:
+      - podmonitors
+      - servicemonitors
+      - probes
+      - scrapeconfigs
+    verbs:
+      - get
+      - list
+      - watch
+  # Rules which allow eventhandler to work.
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - get
+      - list
+      - watch
+  # needed for remote.kubernetes.*
+  - apiGroups: [""]
+    resources:
+      - "configmaps"
+      - "secrets"
+    verbs:
+      - get
+      - list
+      - watch
+  # needed for otelcol.processor.k8sattributes
+  - apiGroups: ["apps"]
+    resources: ["replicasets"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["extensions"]
+    resources: ["replicasets"]
+    verbs: ["get", "list", "watch"]
+---
+# Source: k8s-monitoring/charts/alloy-metrics/templates/rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: k8smon-alloy-metrics
+  labels:
+    helm.sh/chart: alloy-metrics-1.0.2
+    app.kubernetes.io/name: alloy-metrics
+    app.kubernetes.io/instance: k8smon
+    app.kubernetes.io/version: "v1.8.2"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: alloy
+    app.kubernetes.io/component: rbac
+rules:
+  # Rules which allow discovery.kubernetes to function.
+  - apiGroups:
+      - ""
+      - "discovery.k8s.io"
+      - "networking.k8s.io"
+    resources:
+      - endpoints
+      - endpointslices
+      - ingresses
+      - nodes
+      - nodes/proxy
+      - nodes/metrics
+      - pods
+      - services
+    verbs:
+      - get
+      - list
+      - watch
+  # Rules which allow loki.source.kubernetes and loki.source.podlogs to work.
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+      - pods/log
+      - namespaces
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - "monitoring.grafana.com"
+    resources:
+      - podlogs
+    verbs:
+      - get
+      - list
+      - watch
+  # Rules which allow mimir.rules.kubernetes to work.
+  - apiGroups: ["monitoring.coreos.com"]
+    resources:
+      - prometheusrules
+    verbs:
+      - get
+      - list
+      - watch
+  - nonResourceURLs:
+      - /metrics
+    verbs:
+      - get
+  # Rules for prometheus.kubernetes.*
+  - apiGroups: ["monitoring.coreos.com"]
+    resources:
+      - podmonitors
+      - servicemonitors
+      - probes
+      - scrapeconfigs
+    verbs:
+      - get
+      - list
+      - watch
+  # Rules which allow eventhandler to work.
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - get
+      - list
+      - watch
+  # needed for remote.kubernetes.*
+  - apiGroups: [""]
+    resources:
+      - "configmaps"
+      - "secrets"
+    verbs:
+      - get
+      - list
+      - watch
+  # needed for otelcol.processor.k8sattributes
+  - apiGroups: ["apps"]
+    resources: ["replicasets"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["extensions"]
+    resources: ["replicasets"]
+    verbs: ["get", "list", "watch"]
+---
+# Source: k8s-monitoring/charts/clusterMetrics/charts/kube-state-metrics/templates/role.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:    
+    helm.sh/chart: kube-state-metrics-5.33.0
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: metrics
+    app.kubernetes.io/part-of: kube-state-metrics
+    app.kubernetes.io/name: kube-state-metrics
+    app.kubernetes.io/instance: k8smon
+    app.kubernetes.io/version: "2.15.0"
+    release: k8smon
+  name: k8smon-kube-state-metrics
+rules:
+
+- apiGroups: ["certificates.k8s.io"]
+  resources:
+  - certificatesigningrequests
+  verbs: ["list", "watch"]
+
+- apiGroups: [""]
+  resources:
+  - configmaps
+  verbs: ["list", "watch"]
+
+- apiGroups: ["batch"]
+  resources:
+  - cronjobs
+  verbs: ["list", "watch"]
+
+- apiGroups: ["extensions", "apps"]
+  resources:
+  - daemonsets
+  verbs: ["list", "watch"]
+
+- apiGroups: ["extensions", "apps"]
+  resources:
+  - deployments
+  verbs: ["list", "watch"]
+
+- apiGroups: [""]
+  resources:
+  - endpoints
+  verbs: ["list", "watch"]
+
+- apiGroups: ["autoscaling"]
+  resources:
+  - horizontalpodautoscalers
+  verbs: ["list", "watch"]
+
+- apiGroups: ["extensions", "networking.k8s.io"]
+  resources:
+  - ingresses
+  verbs: ["list", "watch"]
+
+- apiGroups: ["batch"]
+  resources:
+  - jobs
+  verbs: ["list", "watch"]
+
+- apiGroups: ["coordination.k8s.io"]
+  resources:
+  - leases
+  verbs: ["list", "watch"]
+
+- apiGroups: [""]
+  resources:
+  - limitranges
+  verbs: ["list", "watch"]
+
+- apiGroups: ["admissionregistration.k8s.io"]
+  resources:
+    - mutatingwebhookconfigurations
+  verbs: ["list", "watch"]
+
+- apiGroups: [""]
+  resources:
+  - namespaces
+  verbs: ["list", "watch"]
+
+- apiGroups: ["networking.k8s.io"]
+  resources:
+  - networkpolicies
+  verbs: ["list", "watch"]
+
+- apiGroups: [""]
+  resources:
+  - nodes
+  verbs: ["list", "watch"]
+
+- apiGroups: [""]
+  resources:
+  - persistentvolumeclaims
+  verbs: ["list", "watch"]
+
+- apiGroups: [""]
+  resources:
+  - persistentvolumes
+  verbs: ["list", "watch"]
+
+- apiGroups: ["policy"]
+  resources:
+    - poddisruptionbudgets
+  verbs: ["list", "watch"]
+
+- apiGroups: [""]
+  resources:
+  - pods
+  verbs: ["list", "watch"]
+
+- apiGroups: ["extensions", "apps"]
+  resources:
+  - replicasets
+  verbs: ["list", "watch"]
+
+- apiGroups: [""]
+  resources:
+  - replicationcontrollers
+  verbs: ["list", "watch"]
+
+- apiGroups: [""]
+  resources:
+  - resourcequotas
+  verbs: ["list", "watch"]
+
+- apiGroups: [""]
+  resources:
+  - secrets
+  verbs: ["list", "watch"]
+
+- apiGroups: [""]
+  resources:
+  - services
+  verbs: ["list", "watch"]
+
+- apiGroups: ["apps"]
+  resources:
+  - statefulsets
+  verbs: ["list", "watch"]
+
+- apiGroups: ["storage.k8s.io"]
+  resources:
+    - storageclasses
+  verbs: ["list", "watch"]
+
+- apiGroups: ["admissionregistration.k8s.io"]
+  resources:
+    - validatingwebhookconfigurations
+  verbs: ["list", "watch"]
+
+- apiGroups: ["storage.k8s.io"]
+  resources:
+    - volumeattachments
+  verbs: ["list", "watch"]
+---
+# Source: k8s-monitoring/charts/alloy-logs/templates/rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: k8smon-alloy-logs
+  labels:
+    helm.sh/chart: alloy-logs-1.0.2
+    app.kubernetes.io/name: alloy-logs
+    app.kubernetes.io/instance: k8smon
+    app.kubernetes.io/version: "v1.8.2"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: alloy
+    app.kubernetes.io/component: rbac
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: k8smon-alloy-logs
+subjects:
+  - kind: ServiceAccount
+    name: k8smon-alloy-logs
+    namespace: default
+---
+# Source: k8s-monitoring/charts/alloy-metrics/templates/rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: k8smon-alloy-metrics
+  labels:
+    helm.sh/chart: alloy-metrics-1.0.2
+    app.kubernetes.io/name: alloy-metrics
+    app.kubernetes.io/instance: k8smon
+    app.kubernetes.io/version: "v1.8.2"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: alloy
+    app.kubernetes.io/component: rbac
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: k8smon-alloy-metrics
+subjects:
+  - kind: ServiceAccount
+    name: k8smon-alloy-metrics
+    namespace: default
+---
+# Source: k8s-monitoring/charts/clusterMetrics/charts/kube-state-metrics/templates/clusterrolebinding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:    
+    helm.sh/chart: kube-state-metrics-5.33.0
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: metrics
+    app.kubernetes.io/part-of: kube-state-metrics
+    app.kubernetes.io/name: kube-state-metrics
+    app.kubernetes.io/instance: k8smon
+    app.kubernetes.io/version: "2.15.0"
+    release: k8smon
+  name: k8smon-kube-state-metrics
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: k8smon-kube-state-metrics
+subjects:
+- kind: ServiceAccount
+  name: k8smon-kube-state-metrics
+  namespace: default
+---
+# Source: k8s-monitoring/charts/alloy-logs/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: k8smon-alloy-logs
+  namespace: default
+  labels:
+    helm.sh/chart: alloy-logs-1.0.2
+    app.kubernetes.io/name: alloy-logs
+    app.kubernetes.io/instance: k8smon
+    app.kubernetes.io/version: "v1.8.2"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: alloy
+    app.kubernetes.io/component: networking
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: alloy-logs
+    app.kubernetes.io/instance: k8smon
+  internalTrafficPolicy: Cluster
+  ports:
+    - name: http-metrics
+      port: 12345
+      targetPort: 12345
+      protocol: "TCP"
+---
+# Source: k8s-monitoring/charts/alloy-metrics/templates/cluster_service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: k8smon-alloy-metrics-cluster
+  namespace: default
+  labels:
+    helm.sh/chart: alloy-metrics-1.0.2
+    app.kubernetes.io/name: alloy-metrics
+    app.kubernetes.io/instance: k8smon
+    app.kubernetes.io/version: "v1.8.2"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: alloy
+    app.kubernetes.io/component: networking
+spec:
+  type: ClusterIP
+  clusterIP: 'None'
+  publishNotReadyAddresses: true
+  selector:
+    app.kubernetes.io/name: alloy-metrics
+    app.kubernetes.io/instance: k8smon
+  ports:
+    # Do not include the -metrics suffix in the port name, otherwise metrics
+    # can be double-collected with the non-headless Service if it's also
+    # enabled.
+    #
+    # This service should only be used for clustering, and not metric
+    # collection.
+    - name: http
+      port: 12345
+      targetPort: 12345
+      protocol: "TCP"
+---
+# Source: k8s-monitoring/charts/alloy-metrics/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: k8smon-alloy-metrics
+  namespace: default
+  labels:
+    helm.sh/chart: alloy-metrics-1.0.2
+    app.kubernetes.io/name: alloy-metrics
+    app.kubernetes.io/instance: k8smon
+    app.kubernetes.io/version: "v1.8.2"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: alloy
+    app.kubernetes.io/component: networking
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: alloy-metrics
+    app.kubernetes.io/instance: k8smon
+  internalTrafficPolicy: Cluster
+  ports:
+    - name: http-metrics
+      port: 12345
+      targetPort: 12345
+      protocol: "TCP"
+---
+# Source: k8s-monitoring/charts/clusterMetrics/charts/kube-state-metrics/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: k8smon-kube-state-metrics
+  namespace: default
+  labels:    
+    helm.sh/chart: kube-state-metrics-5.33.0
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: metrics
+    app.kubernetes.io/part-of: kube-state-metrics
+    app.kubernetes.io/name: kube-state-metrics
+    app.kubernetes.io/instance: k8smon
+    app.kubernetes.io/version: "2.15.0"
+    release: k8smon
+  annotations:
+spec:
+  type: "ClusterIP"
+  ports:
+  - name: "http"
+    protocol: TCP
+    port: 8080
+    targetPort: 8080
+  
+  selector:    
+    app.kubernetes.io/name: kube-state-metrics
+    app.kubernetes.io/instance: k8smon
+---
+# Source: k8s-monitoring/charts/clusterMetrics/charts/node-exporter/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: k8smon-node-exporter
+  namespace: default
+  labels:
+    helm.sh/chart: node-exporter-4.46.0
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: metrics
+    app.kubernetes.io/part-of: node-exporter
+    app.kubernetes.io/name: node-exporter
+    app.kubernetes.io/instance: k8smon
+    app.kubernetes.io/version: "1.9.1"
+    release: k8smon
+  annotations:
+    prometheus.io/scrape: "false"
+spec:
+  type: ClusterIP
+  ports:
+    - port: 9100
+      targetPort: 9100
+      protocol: TCP
+      name: metrics
+  selector:
+    app.kubernetes.io/name: node-exporter
+    app.kubernetes.io/instance: k8smon
+---
+# Source: k8s-monitoring/charts/clusterMetrics/charts/windows-exporter/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: k8smon-windows-exporter
+  namespace: default
+  labels:
+    helm.sh/chart: windows-exporter-0.10.0
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: metrics
+    app.kubernetes.io/part-of: windows-exporter
+    app.kubernetes.io/name: windows-exporter
+    app.kubernetes.io/instance: k8smon
+    app.kubernetes.io/version: "0.30.6"
+    release: k8smon
+spec:
+  type: ClusterIP
+  ports:
+    - port: 9182
+      targetPort: metrics
+      protocol: TCP
+      appProtocol: http
+      name: metrics
+  selector:
+    app.kubernetes.io/name: windows-exporter
+    app.kubernetes.io/instance: k8smon
+---
+# Source: k8s-monitoring/charts/alloy-logs/templates/controllers/daemonset.yaml
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: k8smon-alloy-logs
+  namespace: default
+  labels:
+    helm.sh/chart: alloy-logs-1.0.2
+    app.kubernetes.io/name: alloy-logs
+    app.kubernetes.io/instance: k8smon
+    app.kubernetes.io/version: "v1.8.2"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: alloy
+spec:
+  minReadySeconds: 10
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: alloy-logs
+      app.kubernetes.io/instance: k8smon
+  template:
+    metadata:
+      annotations:
+        kubectl.kubernetes.io/default-container: alloy
+        k8s.grafana.com/logs.job: integrations/alloy
+      labels:
+        app.kubernetes.io/name: alloy-logs
+        app.kubernetes.io/instance: k8smon
+    spec:
+      serviceAccountName: k8smon-alloy-logs
+      containers:
+        - name: alloy
+          image: docker.io/grafana/alloy:v1.8.2
+          imagePullPolicy: IfNotPresent
+          args:
+            - run
+            - /etc/alloy/config.alloy
+            - --storage.path=/tmp/alloy
+            - --server.http.listen-addr=0.0.0.0:12345
+            - --server.http.ui-path-prefix=/
+            - --stability.level=generally-available
+          env:
+            - name: ALLOY_DEPLOY_MODE
+              value: "helm"
+            - name: HOSTNAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+          ports:
+            - containerPort: 12345
+              name: http-metrics
+          readinessProbe:
+            httpGet:
+              path: /-/ready
+              port: 12345
+              scheme: HTTP
+            initialDelaySeconds: 10
+            timeoutSeconds: 1
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              add:
+              - CHOWN
+              - DAC_OVERRIDE
+              - FOWNER
+              - FSETID
+              - KILL
+              - SETGID
+              - SETUID
+              - SETPCAP
+              - NET_BIND_SERVICE
+              - NET_RAW
+              - SYS_CHROOT
+              - MKNOD
+              - AUDIT_WRITE
+              - SETFCAP
+              drop:
+              - ALL
+            seccompProfile:
+              type: RuntimeDefault
+          volumeMounts:
+            - name: config
+              mountPath: /etc/alloy
+            - name: varlog
+              mountPath: /var/log
+              readOnly: true
+            - name: dockercontainers
+              mountPath: /var/lib/docker/containers
+              readOnly: true
+        - name: config-reloader
+          image: quay.io/prometheus-operator/prometheus-config-reloader:v0.81.0
+          args:
+            - --watched-dir=/etc/alloy
+            - --reload-url=http://localhost:12345/-/reload
+          volumeMounts:
+            - name: config
+              mountPath: /etc/alloy
+          resources:
+            requests:
+              cpu: 10m
+              memory: 50Mi
+      dnsPolicy: ClusterFirst
+      nodeSelector:
+        kubernetes.io/os: linux
+      tolerations:
+        - effect: NoSchedule
+          operator: Exists
+      volumes:
+        - name: config
+          configMap:
+            name: k8smon-alloy-logs
+        - name: varlog
+          hostPath:
+            path: /var/log
+        - name: dockercontainers
+          hostPath:
+            path: /var/lib/docker/containers
+---
+# Source: k8s-monitoring/charts/clusterMetrics/charts/node-exporter/templates/daemonset.yaml
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: k8smon-node-exporter
+  namespace: default
+  labels:
+    helm.sh/chart: node-exporter-4.46.0
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: metrics
+    app.kubernetes.io/part-of: node-exporter
+    app.kubernetes.io/name: node-exporter
+    app.kubernetes.io/instance: k8smon
+    app.kubernetes.io/version: "1.9.1"
+    release: k8smon
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: node-exporter
+      app.kubernetes.io/instance: k8smon
+  revisionHistoryLimit: 10
+  updateStrategy:
+    rollingUpdate:
+      maxUnavailable: 1
+    type: RollingUpdate
+  template:
+    metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
+        k8s.grafana.com/logs.job: integrations/node_exporter
+      labels:
+        helm.sh/chart: node-exporter-4.46.0
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/component: metrics
+        app.kubernetes.io/part-of: node-exporter
+        app.kubernetes.io/name: node-exporter
+        app.kubernetes.io/instance: k8smon
+        app.kubernetes.io/version: "1.9.1"
+        release: k8smon
+    spec:
+      automountServiceAccountToken: false
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+      serviceAccountName: k8smon-node-exporter
+      containers:
+        - name: node-exporter
+          image: quay.io/prometheus/node-exporter:v1.9.1
+          imagePullPolicy: IfNotPresent
+          args:
+            - --path.procfs=/host/proc
+            - --path.sysfs=/host/sys
+            - --path.rootfs=/host/root
+            - --path.udev.data=/host/root/run/udev/data
+            - --web.listen-address=[$(HOST_IP)]:9100
+          securityContext:
+            readOnlyRootFilesystem: true
+          env:
+            - name: HOST_IP
+              value: 0.0.0.0
+          ports:
+            - name: metrics
+              containerPort: 9100
+              protocol: TCP
+          livenessProbe:
+            failureThreshold: 3
+            httpGet:
+              httpHeaders:
+              path: /
+              port: 9100
+              scheme: HTTP
+            initialDelaySeconds: 0
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          readinessProbe:
+            failureThreshold: 3
+            httpGet:
+              httpHeaders:
+              path: /
+              port: 9100
+              scheme: HTTP
+            initialDelaySeconds: 0
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          volumeMounts:
+            - name: proc
+              mountPath: /host/proc
+              readOnly:  true
+            - name: sys
+              mountPath: /host/sys
+              readOnly: true
+            - name: root
+              mountPath: /host/root
+              mountPropagation: HostToContainer
+              readOnly: true
+      hostNetwork: true
+      hostPID: true
+      hostIPC: false
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: eks.amazonaws.com/compute-type
+                operator: NotIn
+                values:
+                - fargate
+      nodeSelector:
+        kubernetes.io/os: linux
+      tolerations:
+        - effect: NoSchedule
+          operator: Exists
+      volumes:
+        - name: proc
+          hostPath:
+            path: /proc
+        - name: sys
+          hostPath:
+            path: /sys
+        - name: root
+          hostPath:
+            path: /
+---
+# Source: k8s-monitoring/charts/clusterMetrics/charts/windows-exporter/templates/daemonset.yaml
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: k8smon-windows-exporter
+  namespace: default
+  labels:
+    helm.sh/chart: windows-exporter-0.10.0
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: metrics
+    app.kubernetes.io/part-of: windows-exporter
+    app.kubernetes.io/name: windows-exporter
+    app.kubernetes.io/instance: k8smon
+    app.kubernetes.io/version: "0.30.6"
+    release: k8smon
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: windows-exporter
+      app.kubernetes.io/instance: k8smon
+  updateStrategy:
+    rollingUpdate:
+      maxUnavailable: 1
+    type: RollingUpdate
+  template:
+    metadata:
+      annotations:
+        cluster-autoscaler.kubernetes.io/safe-to-evict: "true"
+        k8s.grafana.com/logs.job: integrations/windows_exporter
+      labels:
+        helm.sh/chart: windows-exporter-0.10.0
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/component: metrics
+        app.kubernetes.io/part-of: windows-exporter
+        app.kubernetes.io/name: windows-exporter
+        app.kubernetes.io/instance: k8smon
+        app.kubernetes.io/version: "0.30.6"
+        release: k8smon
+    spec:
+      automountServiceAccountToken: false
+      securityContext:
+        windowsOptions:
+          hostProcess: true
+          runAsUserName: NT AUTHORITY\system
+      initContainers:
+        - name: configure-firewall
+          image: ghcr.io/prometheus-community/windows-exporter:0.30.6
+          command: [ "powershell" ]
+          args: [ "New-NetFirewallRule", "-DisplayName", "'windows-exporter'", "-Direction", "inbound", "-Profile", "Any", "-Action", "Allow", "-LocalPort", "9182", "-Protocol", "TCP" ]
+      serviceAccountName: k8smon-windows-exporter
+      containers:
+        - name: windows-exporter
+          image: ghcr.io/prometheus-community/windows-exporter:0.30.6
+          imagePullPolicy: IfNotPresent
+          args:
+            - --config.file=%CONTAINER_SANDBOX_MOUNT_POINT%/config.yml
+            - --collector.textfile.directories=%CONTAINER_SANDBOX_MOUNT_POINT%
+            - --web.listen-address=:9182
+          env:
+          ports:
+            - name: metrics
+              containerPort: 9182
+              protocol: TCP
+          livenessProbe:
+            failureThreshold: 3
+            httpGet:
+              httpHeaders:
+              path: /health
+              port: 9182
+              scheme: HTTP
+            initialDelaySeconds: 0
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          readinessProbe:
+            failureThreshold: 3
+            httpGet:
+              httpHeaders:
+              path: /health
+              port: 9182
+              scheme: HTTP
+            initialDelaySeconds: 0
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+          volumeMounts:
+            - name: config
+              mountPath: /config.yml
+              subPath: config.yml
+      hostNetwork: true
+      hostPID: true
+      nodeSelector:
+        kubernetes.io/os: windows
+      tolerations:
+        - effect: NoSchedule
+          operator: Exists
+      volumes:
+        - name: config
+          configMap:
+            name: k8smon-windows-exporter
+---
+# Source: k8s-monitoring/charts/clusterMetrics/charts/kube-state-metrics/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: k8smon-kube-state-metrics
+  namespace: default
+  labels:    
+    helm.sh/chart: kube-state-metrics-5.33.0
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: metrics
+    app.kubernetes.io/part-of: kube-state-metrics
+    app.kubernetes.io/name: kube-state-metrics
+    app.kubernetes.io/instance: k8smon
+    app.kubernetes.io/version: "2.15.0"
+    release: k8smon
+spec:
+  selector:
+    matchLabels:      
+      app.kubernetes.io/name: kube-state-metrics
+      app.kubernetes.io/instance: k8smon
+  replicas: 1
+  strategy:
+    type: Recreate
+  revisionHistoryLimit: 10
+  template:
+    metadata:
+      labels:        
+        helm.sh/chart: kube-state-metrics-5.33.0
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/component: metrics
+        app.kubernetes.io/part-of: kube-state-metrics
+        app.kubernetes.io/name: kube-state-metrics
+        app.kubernetes.io/instance: k8smon
+        app.kubernetes.io/version: "2.15.0"
+        release: k8smon
+      annotations:
+      
+        k8s.grafana.com/logs.job: integrations/kubernetes/kube-state-metrics
+    spec:
+      automountServiceAccountToken: true
+      hostNetwork: false
+      serviceAccountName: k8smon-kube-state-metrics
+      securityContext:
+        fsGroup: 65534
+        runAsGroup: 65534
+        runAsNonRoot: true
+        runAsUser: 65534
+        seccompProfile:
+          type: RuntimeDefault
+      dnsPolicy: ClusterFirst
+      containers:
+      - name: kube-state-metrics
+        args:
+        - --port=8080
+        - --resources=certificatesigningrequests,configmaps,cronjobs,daemonsets,deployments,endpoints,horizontalpodautoscalers,ingresses,jobs,leases,limitranges,mutatingwebhookconfigurations,namespaces,networkpolicies,nodes,persistentvolumeclaims,persistentvolumes,poddisruptionbudgets,pods,replicasets,replicationcontrollers,resourcequotas,secrets,services,statefulsets,storageclasses,validatingwebhookconfigurations,volumeattachments
+        - --metric-labels-allowlist=nodes=[agentpool,alpha.eksctl.io/cluster-name,alpha.eksctl.io/nodegroup-name,beta.kubernetes.io/instance-type,cloud.google.com/gke-nodepool,cluster-name,ec2.amazonaws.com/Name,ec2.amazonaws.com/aws-autoscaling-groupName,ec2.amazonaws.com/aws-autoscaling-group-name,ec2.amazonaws.com/name,eks.amazonaws.com/nodegroup,k8s.io/cloud-provider-aws,karpenter.sh/nodepool,kubernetes.azure.com/cluster,kubernetes.io/arch,kubernetes.io/hostname,kubernetes.io/os,node.kubernetes.io/instance-type,topology.kubernetes.io/region,topology.kubernetes.io/zone]
+        imagePullPolicy: IfNotPresent
+        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.15.0
+        ports:
+        - containerPort: 8080
+          name: "http"
+        livenessProbe:
+          failureThreshold: 3
+          httpGet:
+            httpHeaders:
+            path: /livez
+            port: 8080
+            scheme: HTTP
+          initialDelaySeconds: 5
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 5
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            httpHeaders:
+            path: /readyz
+            port: 8081
+            scheme: HTTP
+          initialDelaySeconds: 5
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 5
+        resources:
+          {}
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+      nodeSelector:
+        kubernetes.io/os: linux
+---
+# Source: k8s-monitoring/charts/alloy-metrics/templates/controllers/statefulset.yaml
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: k8smon-alloy-metrics
+  namespace: default
+  labels:
+    helm.sh/chart: alloy-metrics-1.0.2
+    app.kubernetes.io/name: alloy-metrics
+    app.kubernetes.io/instance: k8smon
+    app.kubernetes.io/version: "v1.8.2"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: alloy
+spec:
+  replicas: 1
+  podManagementPolicy: Parallel
+  minReadySeconds: 10
+  serviceName: k8smon-alloy-metrics
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: alloy-metrics
+      app.kubernetes.io/instance: k8smon
+  template:
+    metadata:
+      annotations:
+        kubectl.kubernetes.io/default-container: alloy
+        k8s.grafana.com/logs.job: integrations/alloy
+      labels:
+        app.kubernetes.io/name: alloy-metrics
+        app.kubernetes.io/instance: k8smon
+    spec:
+      serviceAccountName: k8smon-alloy-metrics
+      containers:
+        - name: alloy
+          image: docker.io/grafana/alloy:v1.8.2
+          imagePullPolicy: IfNotPresent
+          args:
+            - run
+            - /etc/alloy/config.alloy
+            - --storage.path=/tmp/alloy
+            - --server.http.listen-addr=0.0.0.0:12345
+            - --server.http.ui-path-prefix=/
+            - --cluster.enabled=true
+            - --cluster.join-addresses=k8smon-alloy-metrics-cluster
+            - --cluster.name=alloy-metrics
+            - --stability.level=generally-available
+          env:
+            - name: ALLOY_DEPLOY_MODE
+              value: "helm"
+            - name: HOSTNAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+          ports:
+            - containerPort: 12345
+              name: http-metrics
+          readinessProbe:
+            httpGet:
+              path: /-/ready
+              port: 12345
+              scheme: HTTP
+            initialDelaySeconds: 10
+            timeoutSeconds: 1
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              add:
+              - CHOWN
+              - DAC_OVERRIDE
+              - FOWNER
+              - FSETID
+              - KILL
+              - SETGID
+              - SETUID
+              - SETPCAP
+              - NET_BIND_SERVICE
+              - NET_RAW
+              - SYS_CHROOT
+              - MKNOD
+              - AUDIT_WRITE
+              - SETFCAP
+              drop:
+              - ALL
+            seccompProfile:
+              type: RuntimeDefault
+          volumeMounts:
+            - name: config
+              mountPath: /etc/alloy
+        - name: config-reloader
+          image: quay.io/prometheus-operator/prometheus-config-reloader:v0.81.0
+          args:
+            - --watched-dir=/etc/alloy
+            - --reload-url=http://localhost:12345/-/reload
+          volumeMounts:
+            - name: config
+              mountPath: /etc/alloy
+          resources:
+            requests:
+              cpu: 10m
+              memory: 50Mi
+      dnsPolicy: ClusterFirst
+      nodeSelector:
+        kubernetes.io/os: linux
+      volumes:
+        - name: config
+          configMap:
+            name: k8smon-alloy-metrics

--- a/charts/k8s-monitoring/docs/examples/node-labels/values.yaml
+++ b/charts/k8s-monitoring/docs/examples/node-labels/values.yaml
@@ -1,0 +1,64 @@
+---
+cluster:
+  name: pod-labels-and-annotations
+
+destinations:
+  - name: prometheus
+    type: prometheus
+    url: http://prometheus.prometheus.svc:9090/api/v1/write
+  - name: loki
+    type: loki
+    url: http://loki.loki.svc:3100/api/push
+  - name: tempo
+    type: otlp
+    url: http://tempo.tempo.svc
+    metrics: {enabled: false}
+    logs: {enabled: false}
+    traces: {enabled: true}
+
+clusterMetrics:
+  enabled: true
+  nodeLabels:
+    nodePool: true
+    region: true
+    availabilityZone: true
+    nodeRole: true
+    os: true
+    architecture: true
+    instanceType: true
+
+podLogs:
+  enabled: true
+  nodeLabels:
+    nodepool: true
+    region: true
+    availability_zone: true
+    node_role: true
+    os: true
+    architecture: true
+    instance_type: true
+  structuredMetadata:
+    node_pool: nodepool
+    region:
+    availability_zone:
+    node_role:
+    node_os: os
+    node_arch: architecture
+    node_type: instance_type
+
+annotationAutodiscovery:
+  nodeLabels:
+    nodePool: true
+    region: true
+    availabilityZone: true
+    nodeRole: true
+    os: true
+    architecture: true
+    instanceType: true
+  enabled: true
+
+alloy-metrics:
+  enabled: true
+
+alloy-logs:
+  enabled: true

--- a/charts/k8s-monitoring/docs/examples/platforms/azure-aks/alloy-metrics.alloy
+++ b/charts/k8s-monitoring/docs/examples/platforms/azure-aks/alloy-metrics.alloy
@@ -7,9 +7,23 @@ declare "cluster_metrics" {
     role = "node"
   }
 
+  discovery.relabel "nodes" {
+    targets = discovery.kubernetes.nodes.targets
+    rule {
+      source_labels = ["__meta_kubernetes_node_name"]
+      target_label  = "node"
+    }
+
+    rule {
+      replacement = "kubernetes"
+      target_label = "source"
+    }
+
+  }
+
   // Kubelet
   discovery.relabel "kubelet" {
-    targets = discovery.kubernetes.nodes.targets
+    targets = discovery.relabel.nodes.output
   }
 
   prometheus.scrape "kubelet" {
@@ -45,41 +59,15 @@ declare "cluster_metrics" {
 
   // Kubelet Resources
   discovery.relabel "kubelet_resources" {
-    targets = discovery.kubernetes.nodes.targets
+    targets = discovery.relabel.nodes.output
     rule {
       replacement   = "/metrics/resource"
       target_label  = "__metrics_path__"
     }
-    // set the node label
-    rule {
-      source_labels = ["__meta_kubernetes_node_name"]
-      target_label  = "node"
-    }
-
-    // set the app name if specified as metadata labels "app:" or "app.kubernetes.io/name:" or "k8s-app:"
-    rule {
-      action = "replace"
-      source_labels = [
-        "__meta_kubernetes_node_label_app_kubernetes_io_name",
-        "__meta_kubernetes_node_label_k8s_app",
-        "__meta_kubernetes_node_label_app",
-      ]
-      separator = ";"
-      regex = "^(?:;*)?([^;]+).*$"
-      replacement = "$1"
-      target_label = "app"
-    }
-
-    // set a source label
-    rule {
-      action = "replace"
-      replacement = "kubernetes"
-      target_label = "source"
-    }
   }
 
   prometheus.scrape "kubelet_resources" {
-    targets  = discovery.relabel.kubelet_resources.output
+    targets = discovery.relabel.kubelet_resources.output
     job_name = "integrations/kubernetes/resources"
     scheme   = "https"
     scrape_interval = "60s"
@@ -111,34 +99,10 @@ declare "cluster_metrics" {
 
   // cAdvisor
   discovery.relabel "cadvisor" {
-    targets = discovery.kubernetes.nodes.targets
+    targets = discovery.relabel.nodes.output
     rule {
       replacement   = "/metrics/cadvisor"
       target_label  = "__metrics_path__"
-    }
-    rule {
-      source_labels = ["__meta_kubernetes_node_name"]
-      target_label  = "node"
-    }
-    // set the app name if specified as metadata labels "app:" or "app.kubernetes.io/name:" or "k8s-app:"
-    rule {
-      action = "replace"
-      source_labels = [
-        "__meta_kubernetes_node_label_app_kubernetes_io_name",
-        "__meta_kubernetes_node_label_k8s_app",
-        "__meta_kubernetes_node_label_app",
-      ]
-      separator = ";"
-      regex = "^(?:;*)?([^;]+).*$"
-      replacement = "$1"
-      target_label = "app"
-    }
-
-    // set a source label
-    rule {
-      action = "replace"
-      replacement = "kubernetes"
-      target_label = "source"
     }
   }
 

--- a/charts/k8s-monitoring/docs/examples/platforms/azure-aks/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/platforms/azure-aks/output.yaml
@@ -137,9 +137,23 @@ data:
         role = "node"
       }
     
+      discovery.relabel "nodes" {
+        targets = discovery.kubernetes.nodes.targets
+        rule {
+          source_labels = ["__meta_kubernetes_node_name"]
+          target_label  = "node"
+        }
+    
+        rule {
+          replacement = "kubernetes"
+          target_label = "source"
+        }
+    
+      }
+    
       // Kubelet
       discovery.relabel "kubelet" {
-        targets = discovery.kubernetes.nodes.targets
+        targets = discovery.relabel.nodes.output
       }
     
       prometheus.scrape "kubelet" {
@@ -175,41 +189,15 @@ data:
     
       // Kubelet Resources
       discovery.relabel "kubelet_resources" {
-        targets = discovery.kubernetes.nodes.targets
+        targets = discovery.relabel.nodes.output
         rule {
           replacement   = "/metrics/resource"
           target_label  = "__metrics_path__"
         }
-        // set the node label
-        rule {
-          source_labels = ["__meta_kubernetes_node_name"]
-          target_label  = "node"
-        }
-    
-        // set the app name if specified as metadata labels "app:" or "app.kubernetes.io/name:" or "k8s-app:"
-        rule {
-          action = "replace"
-          source_labels = [
-            "__meta_kubernetes_node_label_app_kubernetes_io_name",
-            "__meta_kubernetes_node_label_k8s_app",
-            "__meta_kubernetes_node_label_app",
-          ]
-          separator = ";"
-          regex = "^(?:;*)?([^;]+).*$"
-          replacement = "$1"
-          target_label = "app"
-        }
-    
-        // set a source label
-        rule {
-          action = "replace"
-          replacement = "kubernetes"
-          target_label = "source"
-        }
       }
     
       prometheus.scrape "kubelet_resources" {
-        targets  = discovery.relabel.kubelet_resources.output
+        targets = discovery.relabel.kubelet_resources.output
         job_name = "integrations/kubernetes/resources"
         scheme   = "https"
         scrape_interval = "60s"
@@ -241,34 +229,10 @@ data:
     
       // cAdvisor
       discovery.relabel "cadvisor" {
-        targets = discovery.kubernetes.nodes.targets
+        targets = discovery.relabel.nodes.output
         rule {
           replacement   = "/metrics/cadvisor"
           target_label  = "__metrics_path__"
-        }
-        rule {
-          source_labels = ["__meta_kubernetes_node_name"]
-          target_label  = "node"
-        }
-        // set the app name if specified as metadata labels "app:" or "app.kubernetes.io/name:" or "k8s-app:"
-        rule {
-          action = "replace"
-          source_labels = [
-            "__meta_kubernetes_node_label_app_kubernetes_io_name",
-            "__meta_kubernetes_node_label_k8s_app",
-            "__meta_kubernetes_node_label_app",
-          ]
-          separator = ";"
-          regex = "^(?:;*)?([^;]+).*$"
-          replacement = "$1"
-          target_label = "app"
-        }
-    
-        // set a source label
-        rule {
-          action = "replace"
-          replacement = "kubernetes"
-          target_label = "source"
         }
       }
     

--- a/charts/k8s-monitoring/docs/examples/platforms/eks-fargate/alloy-metrics.alloy
+++ b/charts/k8s-monitoring/docs/examples/platforms/eks-fargate/alloy-metrics.alloy
@@ -7,9 +7,23 @@ declare "cluster_metrics" {
     role = "node"
   }
 
+  discovery.relabel "nodes" {
+    targets = discovery.kubernetes.nodes.targets
+    rule {
+      source_labels = ["__meta_kubernetes_node_name"]
+      target_label  = "node"
+    }
+
+    rule {
+      replacement = "kubernetes"
+      target_label = "source"
+    }
+
+  }
+
   // Kubelet
   discovery.relabel "kubelet" {
-    targets = discovery.kubernetes.nodes.targets
+    targets = discovery.relabel.nodes.output
   }
 
   prometheus.scrape "kubelet" {
@@ -45,41 +59,15 @@ declare "cluster_metrics" {
 
   // Kubelet Resources
   discovery.relabel "kubelet_resources" {
-    targets = discovery.kubernetes.nodes.targets
+    targets = discovery.relabel.nodes.output
     rule {
       replacement   = "/metrics/resource"
       target_label  = "__metrics_path__"
     }
-    // set the node label
-    rule {
-      source_labels = ["__meta_kubernetes_node_name"]
-      target_label  = "node"
-    }
-
-    // set the app name if specified as metadata labels "app:" or "app.kubernetes.io/name:" or "k8s-app:"
-    rule {
-      action = "replace"
-      source_labels = [
-        "__meta_kubernetes_node_label_app_kubernetes_io_name",
-        "__meta_kubernetes_node_label_k8s_app",
-        "__meta_kubernetes_node_label_app",
-      ]
-      separator = ";"
-      regex = "^(?:;*)?([^;]+).*$"
-      replacement = "$1"
-      target_label = "app"
-    }
-
-    // set a source label
-    rule {
-      action = "replace"
-      replacement = "kubernetes"
-      target_label = "source"
-    }
   }
 
   prometheus.scrape "kubelet_resources" {
-    targets  = discovery.relabel.kubelet_resources.output
+    targets = discovery.relabel.kubelet_resources.output
     job_name = "integrations/kubernetes/resources"
     scheme   = "https"
     scrape_interval = "60s"
@@ -111,34 +99,10 @@ declare "cluster_metrics" {
 
   // cAdvisor
   discovery.relabel "cadvisor" {
-    targets = discovery.kubernetes.nodes.targets
+    targets = discovery.relabel.nodes.output
     rule {
       replacement   = "/metrics/cadvisor"
       target_label  = "__metrics_path__"
-    }
-    rule {
-      source_labels = ["__meta_kubernetes_node_name"]
-      target_label  = "node"
-    }
-    // set the app name if specified as metadata labels "app:" or "app.kubernetes.io/name:" or "k8s-app:"
-    rule {
-      action = "replace"
-      source_labels = [
-        "__meta_kubernetes_node_label_app_kubernetes_io_name",
-        "__meta_kubernetes_node_label_k8s_app",
-        "__meta_kubernetes_node_label_app",
-      ]
-      separator = ";"
-      regex = "^(?:;*)?([^;]+).*$"
-      replacement = "$1"
-      target_label = "app"
-    }
-
-    // set a source label
-    rule {
-      action = "replace"
-      replacement = "kubernetes"
-      target_label = "source"
     }
   }
 

--- a/charts/k8s-monitoring/docs/examples/platforms/eks-fargate/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/platforms/eks-fargate/output.yaml
@@ -120,9 +120,23 @@ data:
         role = "node"
       }
     
+      discovery.relabel "nodes" {
+        targets = discovery.kubernetes.nodes.targets
+        rule {
+          source_labels = ["__meta_kubernetes_node_name"]
+          target_label  = "node"
+        }
+    
+        rule {
+          replacement = "kubernetes"
+          target_label = "source"
+        }
+    
+      }
+    
       // Kubelet
       discovery.relabel "kubelet" {
-        targets = discovery.kubernetes.nodes.targets
+        targets = discovery.relabel.nodes.output
       }
     
       prometheus.scrape "kubelet" {
@@ -158,41 +172,15 @@ data:
     
       // Kubelet Resources
       discovery.relabel "kubelet_resources" {
-        targets = discovery.kubernetes.nodes.targets
+        targets = discovery.relabel.nodes.output
         rule {
           replacement   = "/metrics/resource"
           target_label  = "__metrics_path__"
         }
-        // set the node label
-        rule {
-          source_labels = ["__meta_kubernetes_node_name"]
-          target_label  = "node"
-        }
-    
-        // set the app name if specified as metadata labels "app:" or "app.kubernetes.io/name:" or "k8s-app:"
-        rule {
-          action = "replace"
-          source_labels = [
-            "__meta_kubernetes_node_label_app_kubernetes_io_name",
-            "__meta_kubernetes_node_label_k8s_app",
-            "__meta_kubernetes_node_label_app",
-          ]
-          separator = ";"
-          regex = "^(?:;*)?([^;]+).*$"
-          replacement = "$1"
-          target_label = "app"
-        }
-    
-        // set a source label
-        rule {
-          action = "replace"
-          replacement = "kubernetes"
-          target_label = "source"
-        }
       }
     
       prometheus.scrape "kubelet_resources" {
-        targets  = discovery.relabel.kubelet_resources.output
+        targets = discovery.relabel.kubelet_resources.output
         job_name = "integrations/kubernetes/resources"
         scheme   = "https"
         scrape_interval = "60s"
@@ -224,34 +212,10 @@ data:
     
       // cAdvisor
       discovery.relabel "cadvisor" {
-        targets = discovery.kubernetes.nodes.targets
+        targets = discovery.relabel.nodes.output
         rule {
           replacement   = "/metrics/cadvisor"
           target_label  = "__metrics_path__"
-        }
-        rule {
-          source_labels = ["__meta_kubernetes_node_name"]
-          target_label  = "node"
-        }
-        // set the app name if specified as metadata labels "app:" or "app.kubernetes.io/name:" or "k8s-app:"
-        rule {
-          action = "replace"
-          source_labels = [
-            "__meta_kubernetes_node_label_app_kubernetes_io_name",
-            "__meta_kubernetes_node_label_k8s_app",
-            "__meta_kubernetes_node_label_app",
-          ]
-          separator = ";"
-          regex = "^(?:;*)?([^;]+).*$"
-          replacement = "$1"
-          target_label = "app"
-        }
-    
-        // set a source label
-        rule {
-          action = "replace"
-          replacement = "kubernetes"
-          target_label = "source"
         }
       }
     

--- a/charts/k8s-monitoring/docs/examples/platforms/gke-autopilot/alloy-metrics.alloy
+++ b/charts/k8s-monitoring/docs/examples/platforms/gke-autopilot/alloy-metrics.alloy
@@ -7,9 +7,23 @@ declare "cluster_metrics" {
     role = "node"
   }
 
+  discovery.relabel "nodes" {
+    targets = discovery.kubernetes.nodes.targets
+    rule {
+      source_labels = ["__meta_kubernetes_node_name"]
+      target_label  = "node"
+    }
+
+    rule {
+      replacement = "kubernetes"
+      target_label = "source"
+    }
+
+  }
+
   // Kubelet
   discovery.relabel "kubelet" {
-    targets = discovery.kubernetes.nodes.targets
+    targets = discovery.relabel.nodes.output
   }
 
   prometheus.scrape "kubelet" {
@@ -45,41 +59,15 @@ declare "cluster_metrics" {
 
   // Kubelet Resources
   discovery.relabel "kubelet_resources" {
-    targets = discovery.kubernetes.nodes.targets
+    targets = discovery.relabel.nodes.output
     rule {
       replacement   = "/metrics/resource"
       target_label  = "__metrics_path__"
     }
-    // set the node label
-    rule {
-      source_labels = ["__meta_kubernetes_node_name"]
-      target_label  = "node"
-    }
-
-    // set the app name if specified as metadata labels "app:" or "app.kubernetes.io/name:" or "k8s-app:"
-    rule {
-      action = "replace"
-      source_labels = [
-        "__meta_kubernetes_node_label_app_kubernetes_io_name",
-        "__meta_kubernetes_node_label_k8s_app",
-        "__meta_kubernetes_node_label_app",
-      ]
-      separator = ";"
-      regex = "^(?:;*)?([^;]+).*$"
-      replacement = "$1"
-      target_label = "app"
-    }
-
-    // set a source label
-    rule {
-      action = "replace"
-      replacement = "kubernetes"
-      target_label = "source"
-    }
   }
 
   prometheus.scrape "kubelet_resources" {
-    targets  = discovery.relabel.kubelet_resources.output
+    targets = discovery.relabel.kubelet_resources.output
     job_name = "integrations/kubernetes/resources"
     scheme   = "https"
     scrape_interval = "60s"
@@ -111,34 +99,10 @@ declare "cluster_metrics" {
 
   // cAdvisor
   discovery.relabel "cadvisor" {
-    targets = discovery.kubernetes.nodes.targets
+    targets = discovery.relabel.nodes.output
     rule {
       replacement   = "/metrics/cadvisor"
       target_label  = "__metrics_path__"
-    }
-    rule {
-      source_labels = ["__meta_kubernetes_node_name"]
-      target_label  = "node"
-    }
-    // set the app name if specified as metadata labels "app:" or "app.kubernetes.io/name:" or "k8s-app:"
-    rule {
-      action = "replace"
-      source_labels = [
-        "__meta_kubernetes_node_label_app_kubernetes_io_name",
-        "__meta_kubernetes_node_label_k8s_app",
-        "__meta_kubernetes_node_label_app",
-      ]
-      separator = ";"
-      regex = "^(?:;*)?([^;]+).*$"
-      replacement = "$1"
-      target_label = "app"
-    }
-
-    // set a source label
-    rule {
-      action = "replace"
-      replacement = "kubernetes"
-      target_label = "source"
     }
   }
 

--- a/charts/k8s-monitoring/docs/examples/platforms/gke-autopilot/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/platforms/gke-autopilot/output.yaml
@@ -120,9 +120,23 @@ data:
         role = "node"
       }
     
+      discovery.relabel "nodes" {
+        targets = discovery.kubernetes.nodes.targets
+        rule {
+          source_labels = ["__meta_kubernetes_node_name"]
+          target_label  = "node"
+        }
+    
+        rule {
+          replacement = "kubernetes"
+          target_label = "source"
+        }
+    
+      }
+    
       // Kubelet
       discovery.relabel "kubelet" {
-        targets = discovery.kubernetes.nodes.targets
+        targets = discovery.relabel.nodes.output
       }
     
       prometheus.scrape "kubelet" {
@@ -158,41 +172,15 @@ data:
     
       // Kubelet Resources
       discovery.relabel "kubelet_resources" {
-        targets = discovery.kubernetes.nodes.targets
+        targets = discovery.relabel.nodes.output
         rule {
           replacement   = "/metrics/resource"
           target_label  = "__metrics_path__"
         }
-        // set the node label
-        rule {
-          source_labels = ["__meta_kubernetes_node_name"]
-          target_label  = "node"
-        }
-    
-        // set the app name if specified as metadata labels "app:" or "app.kubernetes.io/name:" or "k8s-app:"
-        rule {
-          action = "replace"
-          source_labels = [
-            "__meta_kubernetes_node_label_app_kubernetes_io_name",
-            "__meta_kubernetes_node_label_k8s_app",
-            "__meta_kubernetes_node_label_app",
-          ]
-          separator = ";"
-          regex = "^(?:;*)?([^;]+).*$"
-          replacement = "$1"
-          target_label = "app"
-        }
-    
-        // set a source label
-        rule {
-          action = "replace"
-          replacement = "kubernetes"
-          target_label = "source"
-        }
       }
     
       prometheus.scrape "kubelet_resources" {
-        targets  = discovery.relabel.kubelet_resources.output
+        targets = discovery.relabel.kubelet_resources.output
         job_name = "integrations/kubernetes/resources"
         scheme   = "https"
         scrape_interval = "60s"
@@ -224,34 +212,10 @@ data:
     
       // cAdvisor
       discovery.relabel "cadvisor" {
-        targets = discovery.kubernetes.nodes.targets
+        targets = discovery.relabel.nodes.output
         rule {
           replacement   = "/metrics/cadvisor"
           target_label  = "__metrics_path__"
-        }
-        rule {
-          source_labels = ["__meta_kubernetes_node_name"]
-          target_label  = "node"
-        }
-        // set the app name if specified as metadata labels "app:" or "app.kubernetes.io/name:" or "k8s-app:"
-        rule {
-          action = "replace"
-          source_labels = [
-            "__meta_kubernetes_node_label_app_kubernetes_io_name",
-            "__meta_kubernetes_node_label_k8s_app",
-            "__meta_kubernetes_node_label_app",
-          ]
-          separator = ";"
-          regex = "^(?:;*)?([^;]+).*$"
-          replacement = "$1"
-          target_label = "app"
-        }
-    
-        // set a source label
-        rule {
-          action = "replace"
-          replacement = "kubernetes"
-          target_label = "source"
         }
       }
     

--- a/charts/k8s-monitoring/docs/examples/platforms/openshift/alloy-metrics.alloy
+++ b/charts/k8s-monitoring/docs/examples/platforms/openshift/alloy-metrics.alloy
@@ -7,9 +7,23 @@ declare "cluster_metrics" {
     role = "node"
   }
 
+  discovery.relabel "nodes" {
+    targets = discovery.kubernetes.nodes.targets
+    rule {
+      source_labels = ["__meta_kubernetes_node_name"]
+      target_label  = "node"
+    }
+
+    rule {
+      replacement = "kubernetes"
+      target_label = "source"
+    }
+
+  }
+
   // Kubelet
   discovery.relabel "kubelet" {
-    targets = discovery.kubernetes.nodes.targets
+    targets = discovery.relabel.nodes.output
   }
 
   prometheus.scrape "kubelet" {
@@ -45,41 +59,15 @@ declare "cluster_metrics" {
 
   // Kubelet Resources
   discovery.relabel "kubelet_resources" {
-    targets = discovery.kubernetes.nodes.targets
+    targets = discovery.relabel.nodes.output
     rule {
       replacement   = "/metrics/resource"
       target_label  = "__metrics_path__"
     }
-    // set the node label
-    rule {
-      source_labels = ["__meta_kubernetes_node_name"]
-      target_label  = "node"
-    }
-
-    // set the app name if specified as metadata labels "app:" or "app.kubernetes.io/name:" or "k8s-app:"
-    rule {
-      action = "replace"
-      source_labels = [
-        "__meta_kubernetes_node_label_app_kubernetes_io_name",
-        "__meta_kubernetes_node_label_k8s_app",
-        "__meta_kubernetes_node_label_app",
-      ]
-      separator = ";"
-      regex = "^(?:;*)?([^;]+).*$"
-      replacement = "$1"
-      target_label = "app"
-    }
-
-    // set a source label
-    rule {
-      action = "replace"
-      replacement = "kubernetes"
-      target_label = "source"
-    }
   }
 
   prometheus.scrape "kubelet_resources" {
-    targets  = discovery.relabel.kubelet_resources.output
+    targets = discovery.relabel.kubelet_resources.output
     job_name = "integrations/kubernetes/resources"
     scheme   = "https"
     scrape_interval = "60s"
@@ -111,34 +99,10 @@ declare "cluster_metrics" {
 
   // cAdvisor
   discovery.relabel "cadvisor" {
-    targets = discovery.kubernetes.nodes.targets
+    targets = discovery.relabel.nodes.output
     rule {
       replacement   = "/metrics/cadvisor"
       target_label  = "__metrics_path__"
-    }
-    rule {
-      source_labels = ["__meta_kubernetes_node_name"]
-      target_label  = "node"
-    }
-    // set the app name if specified as metadata labels "app:" or "app.kubernetes.io/name:" or "k8s-app:"
-    rule {
-      action = "replace"
-      source_labels = [
-        "__meta_kubernetes_node_label_app_kubernetes_io_name",
-        "__meta_kubernetes_node_label_k8s_app",
-        "__meta_kubernetes_node_label_app",
-      ]
-      separator = ";"
-      regex = "^(?:;*)?([^;]+).*$"
-      replacement = "$1"
-      target_label = "app"
-    }
-
-    // set a source label
-    rule {
-      action = "replace"
-      replacement = "kubernetes"
-      target_label = "source"
     }
   }
 
@@ -558,6 +522,7 @@ declare "alloy_integration" {
       namespaces {
         names = coalesce(argument.namespaces.value, [])
       }
+
     }
 
     // alloy relabelings (pre-scrape)
@@ -577,79 +542,78 @@ declare "alloy_integration" {
         action = "keep"
       }
 
+      rule {
+        source_labels = ["__meta_kubernetes_namespace"]
+        target_label  = "namespace"
+      }
 
+      rule {
+        source_labels = ["__meta_kubernetes_pod_name"]
+        target_label  = "pod"
+      }
 
-    rule {
-      source_labels = ["__meta_kubernetes_namespace"]
-      target_label  = "namespace"
-    }
+      rule {
+        source_labels = ["__meta_kubernetes_pod_container_name"]
+        target_label  = "container"
+      }
 
-    rule {
-      source_labels = ["__meta_kubernetes_pod_name"]
-      target_label  = "pod"
-    }
+      // set the workload to the controller kind and name
+      rule {
+        action = "lowercase"
+        source_labels = ["__meta_kubernetes_pod_controller_kind"]
+        target_label  = "workload_type"
+      }
 
-    rule {
-      source_labels = ["__meta_kubernetes_pod_container_name"]
-      target_label  = "container"
-    }
+      rule {
+        source_labels = ["__meta_kubernetes_pod_controller_name"]
+        target_label  = "workload"
+      }
 
-    // set the workload to the controller kind and name
-    rule {
-      action = "lowercase"
-      source_labels = ["__meta_kubernetes_pod_controller_kind"]
-      target_label  = "workload_type"
-    }
+      // remove the hash from the ReplicaSet
+      rule {
+        source_labels = [
+          "workload_type",
+          "workload",
+        ]
+        separator = "/"
+        regex = "replicaset/(.+)-.+$"
+        target_label  = "workload"
+      }
 
-    rule {
-      source_labels = ["__meta_kubernetes_pod_controller_name"]
-      target_label  = "workload"
-    }
+      // set the app name if specified as metadata labels "app:" or "app.kubernetes.io/name:" or "k8s-app:"
+      rule {
+        action = "replace"
+        source_labels = [
+          "__meta_kubernetes_pod_label_app_kubernetes_io_name",
+          "__meta_kubernetes_pod_label_k8s_app",
+          "__meta_kubernetes_pod_label_app",
+        ]
+        separator = ";"
+        regex = "^(?:;*)?([^;]+).*$"
+        replacement = "$1"
+        target_label = "app"
+      }
 
-    // remove the hash from the ReplicaSet
-    rule {
-      source_labels = [
-        "workload_type",
-        "workload",
-      ]
-      separator = "/"
-      regex = "replicaset/(.+)-.+$"
-      target_label  = "workload"
-    }
+      // set the component if specified as metadata labels "component:" or "app.kubernetes.io/component:" or "k8s-component:"
+      rule {
+        action = "replace"
+        source_labels = [
+          "__meta_kubernetes_pod_label_app_kubernetes_io_component",
+          "__meta_kubernetes_pod_label_k8s_component",
+          "__meta_kubernetes_pod_label_component",
+        ]
+        regex = "^(?:;*)?([^;]+).*$"
+        replacement = "$1"
+        target_label = "component"
+      }
 
-    // set the app name if specified as metadata labels "app:" or "app.kubernetes.io/name:" or "k8s-app:"
-    rule {
-      action = "replace"
-      source_labels = [
-        "__meta_kubernetes_pod_label_app_kubernetes_io_name",
-        "__meta_kubernetes_pod_label_k8s_app",
-        "__meta_kubernetes_pod_label_app",
-      ]
-      separator = ";"
-      regex = "^(?:;*)?([^;]+).*$"
-      replacement = "$1"
-      target_label = "app"
-    }
+      // set a source label
+      rule {
+        action = "replace"
+        replacement = "kubernetes"
+        target_label = "source"
+      }
 
-    // set the component if specified as metadata labels "component:" or "app.kubernetes.io/component:" or "k8s-component:"
-    rule {
-      action = "replace"
-      source_labels = [
-        "__meta_kubernetes_pod_label_app_kubernetes_io_component",
-        "__meta_kubernetes_pod_label_k8s_component",
-        "__meta_kubernetes_pod_label_component",
-      ]
-      regex = "^(?:;*)?([^;]+).*$"
-      replacement = "$1"
-      target_label = "component"
-    }
-
-    // set a source label
-    rule {
-      action = "replace"
-      replacement = "kubernetes"
-      target_label = "source"
-    }
     }
 
     export "output" {

--- a/charts/k8s-monitoring/docs/examples/platforms/openshift/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/platforms/openshift/output.yaml
@@ -116,9 +116,23 @@ data:
         role = "node"
       }
     
+      discovery.relabel "nodes" {
+        targets = discovery.kubernetes.nodes.targets
+        rule {
+          source_labels = ["__meta_kubernetes_node_name"]
+          target_label  = "node"
+        }
+    
+        rule {
+          replacement = "kubernetes"
+          target_label = "source"
+        }
+    
+      }
+    
       // Kubelet
       discovery.relabel "kubelet" {
-        targets = discovery.kubernetes.nodes.targets
+        targets = discovery.relabel.nodes.output
       }
     
       prometheus.scrape "kubelet" {
@@ -154,41 +168,15 @@ data:
     
       // Kubelet Resources
       discovery.relabel "kubelet_resources" {
-        targets = discovery.kubernetes.nodes.targets
+        targets = discovery.relabel.nodes.output
         rule {
           replacement   = "/metrics/resource"
           target_label  = "__metrics_path__"
         }
-        // set the node label
-        rule {
-          source_labels = ["__meta_kubernetes_node_name"]
-          target_label  = "node"
-        }
-    
-        // set the app name if specified as metadata labels "app:" or "app.kubernetes.io/name:" or "k8s-app:"
-        rule {
-          action = "replace"
-          source_labels = [
-            "__meta_kubernetes_node_label_app_kubernetes_io_name",
-            "__meta_kubernetes_node_label_k8s_app",
-            "__meta_kubernetes_node_label_app",
-          ]
-          separator = ";"
-          regex = "^(?:;*)?([^;]+).*$"
-          replacement = "$1"
-          target_label = "app"
-        }
-    
-        // set a source label
-        rule {
-          action = "replace"
-          replacement = "kubernetes"
-          target_label = "source"
-        }
       }
     
       prometheus.scrape "kubelet_resources" {
-        targets  = discovery.relabel.kubelet_resources.output
+        targets = discovery.relabel.kubelet_resources.output
         job_name = "integrations/kubernetes/resources"
         scheme   = "https"
         scrape_interval = "60s"
@@ -220,34 +208,10 @@ data:
     
       // cAdvisor
       discovery.relabel "cadvisor" {
-        targets = discovery.kubernetes.nodes.targets
+        targets = discovery.relabel.nodes.output
         rule {
           replacement   = "/metrics/cadvisor"
           target_label  = "__metrics_path__"
-        }
-        rule {
-          source_labels = ["__meta_kubernetes_node_name"]
-          target_label  = "node"
-        }
-        // set the app name if specified as metadata labels "app:" or "app.kubernetes.io/name:" or "k8s-app:"
-        rule {
-          action = "replace"
-          source_labels = [
-            "__meta_kubernetes_node_label_app_kubernetes_io_name",
-            "__meta_kubernetes_node_label_k8s_app",
-            "__meta_kubernetes_node_label_app",
-          ]
-          separator = ";"
-          regex = "^(?:;*)?([^;]+).*$"
-          replacement = "$1"
-          target_label = "app"
-        }
-    
-        // set a source label
-        rule {
-          action = "replace"
-          replacement = "kubernetes"
-          target_label = "source"
         }
       }
     
@@ -667,6 +631,7 @@ data:
           namespaces {
             names = coalesce(argument.namespaces.value, [])
           }
+    
         }
     
         // alloy relabelings (pre-scrape)
@@ -686,79 +651,78 @@ data:
             action = "keep"
           }
     
+          rule {
+            source_labels = ["__meta_kubernetes_namespace"]
+            target_label  = "namespace"
+          }
     
+          rule {
+            source_labels = ["__meta_kubernetes_pod_name"]
+            target_label  = "pod"
+          }
     
-        rule {
-          source_labels = ["__meta_kubernetes_namespace"]
-          target_label  = "namespace"
-        }
+          rule {
+            source_labels = ["__meta_kubernetes_pod_container_name"]
+            target_label  = "container"
+          }
     
-        rule {
-          source_labels = ["__meta_kubernetes_pod_name"]
-          target_label  = "pod"
-        }
+          // set the workload to the controller kind and name
+          rule {
+            action = "lowercase"
+            source_labels = ["__meta_kubernetes_pod_controller_kind"]
+            target_label  = "workload_type"
+          }
     
-        rule {
-          source_labels = ["__meta_kubernetes_pod_container_name"]
-          target_label  = "container"
-        }
+          rule {
+            source_labels = ["__meta_kubernetes_pod_controller_name"]
+            target_label  = "workload"
+          }
     
-        // set the workload to the controller kind and name
-        rule {
-          action = "lowercase"
-          source_labels = ["__meta_kubernetes_pod_controller_kind"]
-          target_label  = "workload_type"
-        }
+          // remove the hash from the ReplicaSet
+          rule {
+            source_labels = [
+              "workload_type",
+              "workload",
+            ]
+            separator = "/"
+            regex = "replicaset/(.+)-.+$"
+            target_label  = "workload"
+          }
     
-        rule {
-          source_labels = ["__meta_kubernetes_pod_controller_name"]
-          target_label  = "workload"
-        }
+          // set the app name if specified as metadata labels "app:" or "app.kubernetes.io/name:" or "k8s-app:"
+          rule {
+            action = "replace"
+            source_labels = [
+              "__meta_kubernetes_pod_label_app_kubernetes_io_name",
+              "__meta_kubernetes_pod_label_k8s_app",
+              "__meta_kubernetes_pod_label_app",
+            ]
+            separator = ";"
+            regex = "^(?:;*)?([^;]+).*$"
+            replacement = "$1"
+            target_label = "app"
+          }
     
-        // remove the hash from the ReplicaSet
-        rule {
-          source_labels = [
-            "workload_type",
-            "workload",
-          ]
-          separator = "/"
-          regex = "replicaset/(.+)-.+$"
-          target_label  = "workload"
-        }
+          // set the component if specified as metadata labels "component:" or "app.kubernetes.io/component:" or "k8s-component:"
+          rule {
+            action = "replace"
+            source_labels = [
+              "__meta_kubernetes_pod_label_app_kubernetes_io_component",
+              "__meta_kubernetes_pod_label_k8s_component",
+              "__meta_kubernetes_pod_label_component",
+            ]
+            regex = "^(?:;*)?([^;]+).*$"
+            replacement = "$1"
+            target_label = "component"
+          }
     
-        // set the app name if specified as metadata labels "app:" or "app.kubernetes.io/name:" or "k8s-app:"
-        rule {
-          action = "replace"
-          source_labels = [
-            "__meta_kubernetes_pod_label_app_kubernetes_io_name",
-            "__meta_kubernetes_pod_label_k8s_app",
-            "__meta_kubernetes_pod_label_app",
-          ]
-          separator = ";"
-          regex = "^(?:;*)?([^;]+).*$"
-          replacement = "$1"
-          target_label = "app"
-        }
+          // set a source label
+          rule {
+            action = "replace"
+            replacement = "kubernetes"
+            target_label = "source"
+          }
     
-        // set the component if specified as metadata labels "component:" or "app.kubernetes.io/component:" or "k8s-component:"
-        rule {
-          action = "replace"
-          source_labels = [
-            "__meta_kubernetes_pod_label_app_kubernetes_io_component",
-            "__meta_kubernetes_pod_label_k8s_component",
-            "__meta_kubernetes_pod_label_component",
-          ]
-          regex = "^(?:;*)?([^;]+).*$"
-          replacement = "$1"
-          target_label = "component"
-        }
-    
-        // set a source label
-        rule {
-          action = "replace"
-          replacement = "kubernetes"
-          target_label = "source"
-        }
         }
     
         export "output" {

--- a/charts/k8s-monitoring/docs/examples/pod-labels-and-annotations/alloy-metrics.alloy
+++ b/charts/k8s-monitoring/docs/examples/pod-labels-and-annotations/alloy-metrics.alloy
@@ -7,9 +7,23 @@ declare "cluster_metrics" {
     role = "node"
   }
 
+  discovery.relabel "nodes" {
+    targets = discovery.kubernetes.nodes.targets
+    rule {
+      source_labels = ["__meta_kubernetes_node_name"]
+      target_label  = "node"
+    }
+
+    rule {
+      replacement = "kubernetes"
+      target_label = "source"
+    }
+
+  }
+
   // Kubelet
   discovery.relabel "kubelet" {
-    targets = discovery.kubernetes.nodes.targets
+    targets = discovery.relabel.nodes.output
   }
 
   prometheus.scrape "kubelet" {
@@ -45,41 +59,15 @@ declare "cluster_metrics" {
 
   // Kubelet Resources
   discovery.relabel "kubelet_resources" {
-    targets = discovery.kubernetes.nodes.targets
+    targets = discovery.relabel.nodes.output
     rule {
       replacement   = "/metrics/resource"
       target_label  = "__metrics_path__"
     }
-    // set the node label
-    rule {
-      source_labels = ["__meta_kubernetes_node_name"]
-      target_label  = "node"
-    }
-
-    // set the app name if specified as metadata labels "app:" or "app.kubernetes.io/name:" or "k8s-app:"
-    rule {
-      action = "replace"
-      source_labels = [
-        "__meta_kubernetes_node_label_app_kubernetes_io_name",
-        "__meta_kubernetes_node_label_k8s_app",
-        "__meta_kubernetes_node_label_app",
-      ]
-      separator = ";"
-      regex = "^(?:;*)?([^;]+).*$"
-      replacement = "$1"
-      target_label = "app"
-    }
-
-    // set a source label
-    rule {
-      action = "replace"
-      replacement = "kubernetes"
-      target_label = "source"
-    }
   }
 
   prometheus.scrape "kubelet_resources" {
-    targets  = discovery.relabel.kubelet_resources.output
+    targets = discovery.relabel.kubelet_resources.output
     job_name = "integrations/kubernetes/resources"
     scheme   = "https"
     scrape_interval = "60s"
@@ -111,34 +99,10 @@ declare "cluster_metrics" {
 
   // cAdvisor
   discovery.relabel "cadvisor" {
-    targets = discovery.kubernetes.nodes.targets
+    targets = discovery.relabel.nodes.output
     rule {
       replacement   = "/metrics/cadvisor"
       target_label  = "__metrics_path__"
-    }
-    rule {
-      source_labels = ["__meta_kubernetes_node_name"]
-      target_label  = "node"
-    }
-    // set the app name if specified as metadata labels "app:" or "app.kubernetes.io/name:" or "k8s-app:"
-    rule {
-      action = "replace"
-      source_labels = [
-        "__meta_kubernetes_node_label_app_kubernetes_io_name",
-        "__meta_kubernetes_node_label_k8s_app",
-        "__meta_kubernetes_node_label_app",
-      ]
-      separator = ";"
-      regex = "^(?:;*)?([^;]+).*$"
-      replacement = "$1"
-      target_label = "app"
-    }
-
-    // set a source label
-    rule {
-      action = "replace"
-      replacement = "kubernetes"
-      target_label = "source"
     }
   }
 

--- a/charts/k8s-monitoring/docs/examples/pod-labels-and-annotations/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/pod-labels-and-annotations/output.yaml
@@ -137,9 +137,23 @@ data:
         role = "node"
       }
     
+      discovery.relabel "nodes" {
+        targets = discovery.kubernetes.nodes.targets
+        rule {
+          source_labels = ["__meta_kubernetes_node_name"]
+          target_label  = "node"
+        }
+    
+        rule {
+          replacement = "kubernetes"
+          target_label = "source"
+        }
+    
+      }
+    
       // Kubelet
       discovery.relabel "kubelet" {
-        targets = discovery.kubernetes.nodes.targets
+        targets = discovery.relabel.nodes.output
       }
     
       prometheus.scrape "kubelet" {
@@ -175,41 +189,15 @@ data:
     
       // Kubelet Resources
       discovery.relabel "kubelet_resources" {
-        targets = discovery.kubernetes.nodes.targets
+        targets = discovery.relabel.nodes.output
         rule {
           replacement   = "/metrics/resource"
           target_label  = "__metrics_path__"
         }
-        // set the node label
-        rule {
-          source_labels = ["__meta_kubernetes_node_name"]
-          target_label  = "node"
-        }
-    
-        // set the app name if specified as metadata labels "app:" or "app.kubernetes.io/name:" or "k8s-app:"
-        rule {
-          action = "replace"
-          source_labels = [
-            "__meta_kubernetes_node_label_app_kubernetes_io_name",
-            "__meta_kubernetes_node_label_k8s_app",
-            "__meta_kubernetes_node_label_app",
-          ]
-          separator = ";"
-          regex = "^(?:;*)?([^;]+).*$"
-          replacement = "$1"
-          target_label = "app"
-        }
-    
-        // set a source label
-        rule {
-          action = "replace"
-          replacement = "kubernetes"
-          target_label = "source"
-        }
       }
     
       prometheus.scrape "kubelet_resources" {
-        targets  = discovery.relabel.kubelet_resources.output
+        targets = discovery.relabel.kubelet_resources.output
         job_name = "integrations/kubernetes/resources"
         scheme   = "https"
         scrape_interval = "60s"
@@ -241,34 +229,10 @@ data:
     
       // cAdvisor
       discovery.relabel "cadvisor" {
-        targets = discovery.kubernetes.nodes.targets
+        targets = discovery.relabel.nodes.output
         rule {
           replacement   = "/metrics/cadvisor"
           target_label  = "__metrics_path__"
-        }
-        rule {
-          source_labels = ["__meta_kubernetes_node_name"]
-          target_label  = "node"
-        }
-        // set the app name if specified as metadata labels "app:" or "app.kubernetes.io/name:" or "k8s-app:"
-        rule {
-          action = "replace"
-          source_labels = [
-            "__meta_kubernetes_node_label_app_kubernetes_io_name",
-            "__meta_kubernetes_node_label_k8s_app",
-            "__meta_kubernetes_node_label_app",
-          ]
-          separator = ";"
-          regex = "^(?:;*)?([^;]+).*$"
-          replacement = "$1"
-          target_label = "app"
-        }
-    
-        // set a source label
-        rule {
-          action = "replace"
-          replacement = "kubernetes"
-          target_label = "source"
         }
       }
     

--- a/charts/k8s-monitoring/docs/examples/private-image-registries/globally/alloy-metrics.alloy
+++ b/charts/k8s-monitoring/docs/examples/private-image-registries/globally/alloy-metrics.alloy
@@ -7,9 +7,23 @@ declare "cluster_metrics" {
     role = "node"
   }
 
+  discovery.relabel "nodes" {
+    targets = discovery.kubernetes.nodes.targets
+    rule {
+      source_labels = ["__meta_kubernetes_node_name"]
+      target_label  = "node"
+    }
+
+    rule {
+      replacement = "kubernetes"
+      target_label = "source"
+    }
+
+  }
+
   // Kubelet
   discovery.relabel "kubelet" {
-    targets = discovery.kubernetes.nodes.targets
+    targets = discovery.relabel.nodes.output
   }
 
   prometheus.scrape "kubelet" {
@@ -45,41 +59,15 @@ declare "cluster_metrics" {
 
   // Kubelet Resources
   discovery.relabel "kubelet_resources" {
-    targets = discovery.kubernetes.nodes.targets
+    targets = discovery.relabel.nodes.output
     rule {
       replacement   = "/metrics/resource"
       target_label  = "__metrics_path__"
     }
-    // set the node label
-    rule {
-      source_labels = ["__meta_kubernetes_node_name"]
-      target_label  = "node"
-    }
-
-    // set the app name if specified as metadata labels "app:" or "app.kubernetes.io/name:" or "k8s-app:"
-    rule {
-      action = "replace"
-      source_labels = [
-        "__meta_kubernetes_node_label_app_kubernetes_io_name",
-        "__meta_kubernetes_node_label_k8s_app",
-        "__meta_kubernetes_node_label_app",
-      ]
-      separator = ";"
-      regex = "^(?:;*)?([^;]+).*$"
-      replacement = "$1"
-      target_label = "app"
-    }
-
-    // set a source label
-    rule {
-      action = "replace"
-      replacement = "kubernetes"
-      target_label = "source"
-    }
   }
 
   prometheus.scrape "kubelet_resources" {
-    targets  = discovery.relabel.kubelet_resources.output
+    targets = discovery.relabel.kubelet_resources.output
     job_name = "integrations/kubernetes/resources"
     scheme   = "https"
     scrape_interval = "60s"
@@ -111,34 +99,10 @@ declare "cluster_metrics" {
 
   // cAdvisor
   discovery.relabel "cadvisor" {
-    targets = discovery.kubernetes.nodes.targets
+    targets = discovery.relabel.nodes.output
     rule {
       replacement   = "/metrics/cadvisor"
       target_label  = "__metrics_path__"
-    }
-    rule {
-      source_labels = ["__meta_kubernetes_node_name"]
-      target_label  = "node"
-    }
-    // set the app name if specified as metadata labels "app:" or "app.kubernetes.io/name:" or "k8s-app:"
-    rule {
-      action = "replace"
-      source_labels = [
-        "__meta_kubernetes_node_label_app_kubernetes_io_name",
-        "__meta_kubernetes_node_label_k8s_app",
-        "__meta_kubernetes_node_label_app",
-      ]
-      separator = ";"
-      regex = "^(?:;*)?([^;]+).*$"
-      replacement = "$1"
-      target_label = "app"
-    }
-
-    // set a source label
-    rule {
-      action = "replace"
-      replacement = "kubernetes"
-      target_label = "source"
     }
   }
 

--- a/charts/k8s-monitoring/docs/examples/private-image-registries/globally/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/private-image-registries/globally/output.yaml
@@ -127,9 +127,23 @@ data:
         role = "node"
       }
     
+      discovery.relabel "nodes" {
+        targets = discovery.kubernetes.nodes.targets
+        rule {
+          source_labels = ["__meta_kubernetes_node_name"]
+          target_label  = "node"
+        }
+    
+        rule {
+          replacement = "kubernetes"
+          target_label = "source"
+        }
+    
+      }
+    
       // Kubelet
       discovery.relabel "kubelet" {
-        targets = discovery.kubernetes.nodes.targets
+        targets = discovery.relabel.nodes.output
       }
     
       prometheus.scrape "kubelet" {
@@ -165,41 +179,15 @@ data:
     
       // Kubelet Resources
       discovery.relabel "kubelet_resources" {
-        targets = discovery.kubernetes.nodes.targets
+        targets = discovery.relabel.nodes.output
         rule {
           replacement   = "/metrics/resource"
           target_label  = "__metrics_path__"
         }
-        // set the node label
-        rule {
-          source_labels = ["__meta_kubernetes_node_name"]
-          target_label  = "node"
-        }
-    
-        // set the app name if specified as metadata labels "app:" or "app.kubernetes.io/name:" or "k8s-app:"
-        rule {
-          action = "replace"
-          source_labels = [
-            "__meta_kubernetes_node_label_app_kubernetes_io_name",
-            "__meta_kubernetes_node_label_k8s_app",
-            "__meta_kubernetes_node_label_app",
-          ]
-          separator = ";"
-          regex = "^(?:;*)?([^;]+).*$"
-          replacement = "$1"
-          target_label = "app"
-        }
-    
-        // set a source label
-        rule {
-          action = "replace"
-          replacement = "kubernetes"
-          target_label = "source"
-        }
       }
     
       prometheus.scrape "kubelet_resources" {
-        targets  = discovery.relabel.kubelet_resources.output
+        targets = discovery.relabel.kubelet_resources.output
         job_name = "integrations/kubernetes/resources"
         scheme   = "https"
         scrape_interval = "60s"
@@ -231,34 +219,10 @@ data:
     
       // cAdvisor
       discovery.relabel "cadvisor" {
-        targets = discovery.kubernetes.nodes.targets
+        targets = discovery.relabel.nodes.output
         rule {
           replacement   = "/metrics/cadvisor"
           target_label  = "__metrics_path__"
-        }
-        rule {
-          source_labels = ["__meta_kubernetes_node_name"]
-          target_label  = "node"
-        }
-        // set the app name if specified as metadata labels "app:" or "app.kubernetes.io/name:" or "k8s-app:"
-        rule {
-          action = "replace"
-          source_labels = [
-            "__meta_kubernetes_node_label_app_kubernetes_io_name",
-            "__meta_kubernetes_node_label_k8s_app",
-            "__meta_kubernetes_node_label_app",
-          ]
-          separator = ";"
-          regex = "^(?:;*)?([^;]+).*$"
-          replacement = "$1"
-          target_label = "app"
-        }
-    
-        // set a source label
-        rule {
-          action = "replace"
-          replacement = "kubernetes"
-          target_label = "source"
         }
       }
     

--- a/charts/k8s-monitoring/docs/examples/private-image-registries/individual/alloy-metrics.alloy
+++ b/charts/k8s-monitoring/docs/examples/private-image-registries/individual/alloy-metrics.alloy
@@ -60,9 +60,23 @@ declare "cluster_metrics" {
     role = "node"
   }
 
+  discovery.relabel "nodes" {
+    targets = discovery.kubernetes.nodes.targets
+    rule {
+      source_labels = ["__meta_kubernetes_node_name"]
+      target_label  = "node"
+    }
+
+    rule {
+      replacement = "kubernetes"
+      target_label = "source"
+    }
+
+  }
+
   // Kubelet
   discovery.relabel "kubelet" {
-    targets = discovery.kubernetes.nodes.targets
+    targets = discovery.relabel.nodes.output
   }
 
   prometheus.scrape "kubelet" {
@@ -98,41 +112,15 @@ declare "cluster_metrics" {
 
   // Kubelet Resources
   discovery.relabel "kubelet_resources" {
-    targets = discovery.kubernetes.nodes.targets
+    targets = discovery.relabel.nodes.output
     rule {
       replacement   = "/metrics/resource"
       target_label  = "__metrics_path__"
     }
-    // set the node label
-    rule {
-      source_labels = ["__meta_kubernetes_node_name"]
-      target_label  = "node"
-    }
-
-    // set the app name if specified as metadata labels "app:" or "app.kubernetes.io/name:" or "k8s-app:"
-    rule {
-      action = "replace"
-      source_labels = [
-        "__meta_kubernetes_node_label_app_kubernetes_io_name",
-        "__meta_kubernetes_node_label_k8s_app",
-        "__meta_kubernetes_node_label_app",
-      ]
-      separator = ";"
-      regex = "^(?:;*)?([^;]+).*$"
-      replacement = "$1"
-      target_label = "app"
-    }
-
-    // set a source label
-    rule {
-      action = "replace"
-      replacement = "kubernetes"
-      target_label = "source"
-    }
   }
 
   prometheus.scrape "kubelet_resources" {
-    targets  = discovery.relabel.kubelet_resources.output
+    targets = discovery.relabel.kubelet_resources.output
     job_name = "integrations/kubernetes/resources"
     scheme   = "https"
     scrape_interval = "60s"
@@ -164,34 +152,10 @@ declare "cluster_metrics" {
 
   // cAdvisor
   discovery.relabel "cadvisor" {
-    targets = discovery.kubernetes.nodes.targets
+    targets = discovery.relabel.nodes.output
     rule {
       replacement   = "/metrics/cadvisor"
       target_label  = "__metrics_path__"
-    }
-    rule {
-      source_labels = ["__meta_kubernetes_node_name"]
-      target_label  = "node"
-    }
-    // set the app name if specified as metadata labels "app:" or "app.kubernetes.io/name:" or "k8s-app:"
-    rule {
-      action = "replace"
-      source_labels = [
-        "__meta_kubernetes_node_label_app_kubernetes_io_name",
-        "__meta_kubernetes_node_label_k8s_app",
-        "__meta_kubernetes_node_label_app",
-      ]
-      separator = ";"
-      regex = "^(?:;*)?([^;]+).*$"
-      replacement = "$1"
-      target_label = "app"
-    }
-
-    // set a source label
-    rule {
-      action = "replace"
-      replacement = "kubernetes"
-      target_label = "source"
     }
   }
 

--- a/charts/k8s-monitoring/docs/examples/private-image-registries/individual/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/private-image-registries/individual/output.yaml
@@ -174,9 +174,23 @@ data:
         role = "node"
       }
     
+      discovery.relabel "nodes" {
+        targets = discovery.kubernetes.nodes.targets
+        rule {
+          source_labels = ["__meta_kubernetes_node_name"]
+          target_label  = "node"
+        }
+    
+        rule {
+          replacement = "kubernetes"
+          target_label = "source"
+        }
+    
+      }
+    
       // Kubelet
       discovery.relabel "kubelet" {
-        targets = discovery.kubernetes.nodes.targets
+        targets = discovery.relabel.nodes.output
       }
     
       prometheus.scrape "kubelet" {
@@ -212,41 +226,15 @@ data:
     
       // Kubelet Resources
       discovery.relabel "kubelet_resources" {
-        targets = discovery.kubernetes.nodes.targets
+        targets = discovery.relabel.nodes.output
         rule {
           replacement   = "/metrics/resource"
           target_label  = "__metrics_path__"
         }
-        // set the node label
-        rule {
-          source_labels = ["__meta_kubernetes_node_name"]
-          target_label  = "node"
-        }
-    
-        // set the app name if specified as metadata labels "app:" or "app.kubernetes.io/name:" or "k8s-app:"
-        rule {
-          action = "replace"
-          source_labels = [
-            "__meta_kubernetes_node_label_app_kubernetes_io_name",
-            "__meta_kubernetes_node_label_k8s_app",
-            "__meta_kubernetes_node_label_app",
-          ]
-          separator = ";"
-          regex = "^(?:;*)?([^;]+).*$"
-          replacement = "$1"
-          target_label = "app"
-        }
-    
-        // set a source label
-        rule {
-          action = "replace"
-          replacement = "kubernetes"
-          target_label = "source"
-        }
       }
     
       prometheus.scrape "kubelet_resources" {
-        targets  = discovery.relabel.kubelet_resources.output
+        targets = discovery.relabel.kubelet_resources.output
         job_name = "integrations/kubernetes/resources"
         scheme   = "https"
         scrape_interval = "60s"
@@ -278,34 +266,10 @@ data:
     
       // cAdvisor
       discovery.relabel "cadvisor" {
-        targets = discovery.kubernetes.nodes.targets
+        targets = discovery.relabel.nodes.output
         rule {
           replacement   = "/metrics/cadvisor"
           target_label  = "__metrics_path__"
-        }
-        rule {
-          source_labels = ["__meta_kubernetes_node_name"]
-          target_label  = "node"
-        }
-        // set the app name if specified as metadata labels "app:" or "app.kubernetes.io/name:" or "k8s-app:"
-        rule {
-          action = "replace"
-          source_labels = [
-            "__meta_kubernetes_node_label_app_kubernetes_io_name",
-            "__meta_kubernetes_node_label_k8s_app",
-            "__meta_kubernetes_node_label_app",
-          ]
-          separator = ";"
-          regex = "^(?:;*)?([^;]+).*$"
-          replacement = "$1"
-          target_label = "app"
-        }
-    
-        // set a source label
-        rule {
-          action = "replace"
-          replacement = "kubernetes"
-          target_label = "source"
         }
       }
     

--- a/charts/k8s-monitoring/docs/examples/proxies/alloy-metrics.alloy
+++ b/charts/k8s-monitoring/docs/examples/proxies/alloy-metrics.alloy
@@ -7,9 +7,23 @@ declare "cluster_metrics" {
     role = "node"
   }
 
+  discovery.relabel "nodes" {
+    targets = discovery.kubernetes.nodes.targets
+    rule {
+      source_labels = ["__meta_kubernetes_node_name"]
+      target_label  = "node"
+    }
+
+    rule {
+      replacement = "kubernetes"
+      target_label = "source"
+    }
+
+  }
+
   // Kubelet
   discovery.relabel "kubelet" {
-    targets = discovery.kubernetes.nodes.targets
+    targets = discovery.relabel.nodes.output
   }
 
   prometheus.scrape "kubelet" {
@@ -45,41 +59,15 @@ declare "cluster_metrics" {
 
   // Kubelet Resources
   discovery.relabel "kubelet_resources" {
-    targets = discovery.kubernetes.nodes.targets
+    targets = discovery.relabel.nodes.output
     rule {
       replacement   = "/metrics/resource"
       target_label  = "__metrics_path__"
     }
-    // set the node label
-    rule {
-      source_labels = ["__meta_kubernetes_node_name"]
-      target_label  = "node"
-    }
-
-    // set the app name if specified as metadata labels "app:" or "app.kubernetes.io/name:" or "k8s-app:"
-    rule {
-      action = "replace"
-      source_labels = [
-        "__meta_kubernetes_node_label_app_kubernetes_io_name",
-        "__meta_kubernetes_node_label_k8s_app",
-        "__meta_kubernetes_node_label_app",
-      ]
-      separator = ";"
-      regex = "^(?:;*)?([^;]+).*$"
-      replacement = "$1"
-      target_label = "app"
-    }
-
-    // set a source label
-    rule {
-      action = "replace"
-      replacement = "kubernetes"
-      target_label = "source"
-    }
   }
 
   prometheus.scrape "kubelet_resources" {
-    targets  = discovery.relabel.kubelet_resources.output
+    targets = discovery.relabel.kubelet_resources.output
     job_name = "integrations/kubernetes/resources"
     scheme   = "https"
     scrape_interval = "60s"
@@ -111,34 +99,10 @@ declare "cluster_metrics" {
 
   // cAdvisor
   discovery.relabel "cadvisor" {
-    targets = discovery.kubernetes.nodes.targets
+    targets = discovery.relabel.nodes.output
     rule {
       replacement   = "/metrics/cadvisor"
       target_label  = "__metrics_path__"
-    }
-    rule {
-      source_labels = ["__meta_kubernetes_node_name"]
-      target_label  = "node"
-    }
-    // set the app name if specified as metadata labels "app:" or "app.kubernetes.io/name:" or "k8s-app:"
-    rule {
-      action = "replace"
-      source_labels = [
-        "__meta_kubernetes_node_label_app_kubernetes_io_name",
-        "__meta_kubernetes_node_label_k8s_app",
-        "__meta_kubernetes_node_label_app",
-      ]
-      separator = ";"
-      regex = "^(?:;*)?([^;]+).*$"
-      replacement = "$1"
-      target_label = "app"
-    }
-
-    // set a source label
-    rule {
-      action = "replace"
-      replacement = "kubernetes"
-      target_label = "source"
     }
   }
 

--- a/charts/k8s-monitoring/docs/examples/proxies/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/proxies/output.yaml
@@ -169,9 +169,23 @@ data:
         role = "node"
       }
     
+      discovery.relabel "nodes" {
+        targets = discovery.kubernetes.nodes.targets
+        rule {
+          source_labels = ["__meta_kubernetes_node_name"]
+          target_label  = "node"
+        }
+    
+        rule {
+          replacement = "kubernetes"
+          target_label = "source"
+        }
+    
+      }
+    
       // Kubelet
       discovery.relabel "kubelet" {
-        targets = discovery.kubernetes.nodes.targets
+        targets = discovery.relabel.nodes.output
       }
     
       prometheus.scrape "kubelet" {
@@ -207,41 +221,15 @@ data:
     
       // Kubelet Resources
       discovery.relabel "kubelet_resources" {
-        targets = discovery.kubernetes.nodes.targets
+        targets = discovery.relabel.nodes.output
         rule {
           replacement   = "/metrics/resource"
           target_label  = "__metrics_path__"
         }
-        // set the node label
-        rule {
-          source_labels = ["__meta_kubernetes_node_name"]
-          target_label  = "node"
-        }
-    
-        // set the app name if specified as metadata labels "app:" or "app.kubernetes.io/name:" or "k8s-app:"
-        rule {
-          action = "replace"
-          source_labels = [
-            "__meta_kubernetes_node_label_app_kubernetes_io_name",
-            "__meta_kubernetes_node_label_k8s_app",
-            "__meta_kubernetes_node_label_app",
-          ]
-          separator = ";"
-          regex = "^(?:;*)?([^;]+).*$"
-          replacement = "$1"
-          target_label = "app"
-        }
-    
-        // set a source label
-        rule {
-          action = "replace"
-          replacement = "kubernetes"
-          target_label = "source"
-        }
       }
     
       prometheus.scrape "kubelet_resources" {
-        targets  = discovery.relabel.kubelet_resources.output
+        targets = discovery.relabel.kubelet_resources.output
         job_name = "integrations/kubernetes/resources"
         scheme   = "https"
         scrape_interval = "60s"
@@ -273,34 +261,10 @@ data:
     
       // cAdvisor
       discovery.relabel "cadvisor" {
-        targets = discovery.kubernetes.nodes.targets
+        targets = discovery.relabel.nodes.output
         rule {
           replacement   = "/metrics/cadvisor"
           target_label  = "__metrics_path__"
-        }
-        rule {
-          source_labels = ["__meta_kubernetes_node_name"]
-          target_label  = "node"
-        }
-        // set the app name if specified as metadata labels "app:" or "app.kubernetes.io/name:" or "k8s-app:"
-        rule {
-          action = "replace"
-          source_labels = [
-            "__meta_kubernetes_node_label_app_kubernetes_io_name",
-            "__meta_kubernetes_node_label_k8s_app",
-            "__meta_kubernetes_node_label_app",
-          ]
-          separator = ";"
-          regex = "^(?:;*)?([^;]+).*$"
-          replacement = "$1"
-          target_label = "app"
-        }
-    
-        // set a source label
-        rule {
-          action = "replace"
-          replacement = "kubernetes"
-          target_label = "source"
         }
       }
     

--- a/charts/k8s-monitoring/docs/examples/scalability/autoscaling/alloy-metrics.alloy
+++ b/charts/k8s-monitoring/docs/examples/scalability/autoscaling/alloy-metrics.alloy
@@ -7,9 +7,23 @@ declare "cluster_metrics" {
     role = "node"
   }
 
+  discovery.relabel "nodes" {
+    targets = discovery.kubernetes.nodes.targets
+    rule {
+      source_labels = ["__meta_kubernetes_node_name"]
+      target_label  = "node"
+    }
+
+    rule {
+      replacement = "kubernetes"
+      target_label = "source"
+    }
+
+  }
+
   // Kubelet
   discovery.relabel "kubelet" {
-    targets = discovery.kubernetes.nodes.targets
+    targets = discovery.relabel.nodes.output
   }
 
   prometheus.scrape "kubelet" {
@@ -45,41 +59,15 @@ declare "cluster_metrics" {
 
   // Kubelet Resources
   discovery.relabel "kubelet_resources" {
-    targets = discovery.kubernetes.nodes.targets
+    targets = discovery.relabel.nodes.output
     rule {
       replacement   = "/metrics/resource"
       target_label  = "__metrics_path__"
     }
-    // set the node label
-    rule {
-      source_labels = ["__meta_kubernetes_node_name"]
-      target_label  = "node"
-    }
-
-    // set the app name if specified as metadata labels "app:" or "app.kubernetes.io/name:" or "k8s-app:"
-    rule {
-      action = "replace"
-      source_labels = [
-        "__meta_kubernetes_node_label_app_kubernetes_io_name",
-        "__meta_kubernetes_node_label_k8s_app",
-        "__meta_kubernetes_node_label_app",
-      ]
-      separator = ";"
-      regex = "^(?:;*)?([^;]+).*$"
-      replacement = "$1"
-      target_label = "app"
-    }
-
-    // set a source label
-    rule {
-      action = "replace"
-      replacement = "kubernetes"
-      target_label = "source"
-    }
   }
 
   prometheus.scrape "kubelet_resources" {
-    targets  = discovery.relabel.kubelet_resources.output
+    targets = discovery.relabel.kubelet_resources.output
     job_name = "integrations/kubernetes/resources"
     scheme   = "https"
     scrape_interval = "60s"
@@ -111,34 +99,10 @@ declare "cluster_metrics" {
 
   // cAdvisor
   discovery.relabel "cadvisor" {
-    targets = discovery.kubernetes.nodes.targets
+    targets = discovery.relabel.nodes.output
     rule {
       replacement   = "/metrics/cadvisor"
       target_label  = "__metrics_path__"
-    }
-    rule {
-      source_labels = ["__meta_kubernetes_node_name"]
-      target_label  = "node"
-    }
-    // set the app name if specified as metadata labels "app:" or "app.kubernetes.io/name:" or "k8s-app:"
-    rule {
-      action = "replace"
-      source_labels = [
-        "__meta_kubernetes_node_label_app_kubernetes_io_name",
-        "__meta_kubernetes_node_label_k8s_app",
-        "__meta_kubernetes_node_label_app",
-      ]
-      separator = ";"
-      regex = "^(?:;*)?([^;]+).*$"
-      replacement = "$1"
-      target_label = "app"
-    }
-
-    // set a source label
-    rule {
-      action = "replace"
-      replacement = "kubernetes"
-      target_label = "source"
     }
   }
 

--- a/charts/k8s-monitoring/docs/examples/scalability/autoscaling/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/scalability/autoscaling/output.yaml
@@ -105,9 +105,23 @@ data:
         role = "node"
       }
     
+      discovery.relabel "nodes" {
+        targets = discovery.kubernetes.nodes.targets
+        rule {
+          source_labels = ["__meta_kubernetes_node_name"]
+          target_label  = "node"
+        }
+    
+        rule {
+          replacement = "kubernetes"
+          target_label = "source"
+        }
+    
+      }
+    
       // Kubelet
       discovery.relabel "kubelet" {
-        targets = discovery.kubernetes.nodes.targets
+        targets = discovery.relabel.nodes.output
       }
     
       prometheus.scrape "kubelet" {
@@ -143,41 +157,15 @@ data:
     
       // Kubelet Resources
       discovery.relabel "kubelet_resources" {
-        targets = discovery.kubernetes.nodes.targets
+        targets = discovery.relabel.nodes.output
         rule {
           replacement   = "/metrics/resource"
           target_label  = "__metrics_path__"
         }
-        // set the node label
-        rule {
-          source_labels = ["__meta_kubernetes_node_name"]
-          target_label  = "node"
-        }
-    
-        // set the app name if specified as metadata labels "app:" or "app.kubernetes.io/name:" or "k8s-app:"
-        rule {
-          action = "replace"
-          source_labels = [
-            "__meta_kubernetes_node_label_app_kubernetes_io_name",
-            "__meta_kubernetes_node_label_k8s_app",
-            "__meta_kubernetes_node_label_app",
-          ]
-          separator = ";"
-          regex = "^(?:;*)?([^;]+).*$"
-          replacement = "$1"
-          target_label = "app"
-        }
-    
-        // set a source label
-        rule {
-          action = "replace"
-          replacement = "kubernetes"
-          target_label = "source"
-        }
       }
     
       prometheus.scrape "kubelet_resources" {
-        targets  = discovery.relabel.kubelet_resources.output
+        targets = discovery.relabel.kubelet_resources.output
         job_name = "integrations/kubernetes/resources"
         scheme   = "https"
         scrape_interval = "60s"
@@ -209,34 +197,10 @@ data:
     
       // cAdvisor
       discovery.relabel "cadvisor" {
-        targets = discovery.kubernetes.nodes.targets
+        targets = discovery.relabel.nodes.output
         rule {
           replacement   = "/metrics/cadvisor"
           target_label  = "__metrics_path__"
-        }
-        rule {
-          source_labels = ["__meta_kubernetes_node_name"]
-          target_label  = "node"
-        }
-        // set the app name if specified as metadata labels "app:" or "app.kubernetes.io/name:" or "k8s-app:"
-        rule {
-          action = "replace"
-          source_labels = [
-            "__meta_kubernetes_node_label_app_kubernetes_io_name",
-            "__meta_kubernetes_node_label_k8s_app",
-            "__meta_kubernetes_node_label_app",
-          ]
-          separator = ";"
-          regex = "^(?:;*)?([^;]+).*$"
-          replacement = "$1"
-          target_label = "app"
-        }
-    
-        // set a source label
-        rule {
-          action = "replace"
-          replacement = "kubernetes"
-          target_label = "source"
         }
       }
     

--- a/charts/k8s-monitoring/docs/examples/scalability/sharded-kube-state-metrics/alloy-metrics.alloy
+++ b/charts/k8s-monitoring/docs/examples/scalability/sharded-kube-state-metrics/alloy-metrics.alloy
@@ -7,9 +7,23 @@ declare "cluster_metrics" {
     role = "node"
   }
 
+  discovery.relabel "nodes" {
+    targets = discovery.kubernetes.nodes.targets
+    rule {
+      source_labels = ["__meta_kubernetes_node_name"]
+      target_label  = "node"
+    }
+
+    rule {
+      replacement = "kubernetes"
+      target_label = "source"
+    }
+
+  }
+
   // Kubelet
   discovery.relabel "kubelet" {
-    targets = discovery.kubernetes.nodes.targets
+    targets = discovery.relabel.nodes.output
   }
 
   prometheus.scrape "kubelet" {
@@ -45,41 +59,15 @@ declare "cluster_metrics" {
 
   // Kubelet Resources
   discovery.relabel "kubelet_resources" {
-    targets = discovery.kubernetes.nodes.targets
+    targets = discovery.relabel.nodes.output
     rule {
       replacement   = "/metrics/resource"
       target_label  = "__metrics_path__"
     }
-    // set the node label
-    rule {
-      source_labels = ["__meta_kubernetes_node_name"]
-      target_label  = "node"
-    }
-
-    // set the app name if specified as metadata labels "app:" or "app.kubernetes.io/name:" or "k8s-app:"
-    rule {
-      action = "replace"
-      source_labels = [
-        "__meta_kubernetes_node_label_app_kubernetes_io_name",
-        "__meta_kubernetes_node_label_k8s_app",
-        "__meta_kubernetes_node_label_app",
-      ]
-      separator = ";"
-      regex = "^(?:;*)?([^;]+).*$"
-      replacement = "$1"
-      target_label = "app"
-    }
-
-    // set a source label
-    rule {
-      action = "replace"
-      replacement = "kubernetes"
-      target_label = "source"
-    }
   }
 
   prometheus.scrape "kubelet_resources" {
-    targets  = discovery.relabel.kubelet_resources.output
+    targets = discovery.relabel.kubelet_resources.output
     job_name = "integrations/kubernetes/resources"
     scheme   = "https"
     scrape_interval = "60s"
@@ -111,34 +99,10 @@ declare "cluster_metrics" {
 
   // cAdvisor
   discovery.relabel "cadvisor" {
-    targets = discovery.kubernetes.nodes.targets
+    targets = discovery.relabel.nodes.output
     rule {
       replacement   = "/metrics/cadvisor"
       target_label  = "__metrics_path__"
-    }
-    rule {
-      source_labels = ["__meta_kubernetes_node_name"]
-      target_label  = "node"
-    }
-    // set the app name if specified as metadata labels "app:" or "app.kubernetes.io/name:" or "k8s-app:"
-    rule {
-      action = "replace"
-      source_labels = [
-        "__meta_kubernetes_node_label_app_kubernetes_io_name",
-        "__meta_kubernetes_node_label_k8s_app",
-        "__meta_kubernetes_node_label_app",
-      ]
-      separator = ";"
-      regex = "^(?:;*)?([^;]+).*$"
-      replacement = "$1"
-      target_label = "app"
-    }
-
-    // set a source label
-    rule {
-      action = "replace"
-      replacement = "kubernetes"
-      target_label = "source"
     }
   }
 

--- a/charts/k8s-monitoring/docs/examples/scalability/sharded-kube-state-metrics/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/scalability/sharded-kube-state-metrics/output.yaml
@@ -105,9 +105,23 @@ data:
         role = "node"
       }
     
+      discovery.relabel "nodes" {
+        targets = discovery.kubernetes.nodes.targets
+        rule {
+          source_labels = ["__meta_kubernetes_node_name"]
+          target_label  = "node"
+        }
+    
+        rule {
+          replacement = "kubernetes"
+          target_label = "source"
+        }
+    
+      }
+    
       // Kubelet
       discovery.relabel "kubelet" {
-        targets = discovery.kubernetes.nodes.targets
+        targets = discovery.relabel.nodes.output
       }
     
       prometheus.scrape "kubelet" {
@@ -143,41 +157,15 @@ data:
     
       // Kubelet Resources
       discovery.relabel "kubelet_resources" {
-        targets = discovery.kubernetes.nodes.targets
+        targets = discovery.relabel.nodes.output
         rule {
           replacement   = "/metrics/resource"
           target_label  = "__metrics_path__"
         }
-        // set the node label
-        rule {
-          source_labels = ["__meta_kubernetes_node_name"]
-          target_label  = "node"
-        }
-    
-        // set the app name if specified as metadata labels "app:" or "app.kubernetes.io/name:" or "k8s-app:"
-        rule {
-          action = "replace"
-          source_labels = [
-            "__meta_kubernetes_node_label_app_kubernetes_io_name",
-            "__meta_kubernetes_node_label_k8s_app",
-            "__meta_kubernetes_node_label_app",
-          ]
-          separator = ";"
-          regex = "^(?:;*)?([^;]+).*$"
-          replacement = "$1"
-          target_label = "app"
-        }
-    
-        // set a source label
-        rule {
-          action = "replace"
-          replacement = "kubernetes"
-          target_label = "source"
-        }
       }
     
       prometheus.scrape "kubelet_resources" {
-        targets  = discovery.relabel.kubelet_resources.output
+        targets = discovery.relabel.kubelet_resources.output
         job_name = "integrations/kubernetes/resources"
         scheme   = "https"
         scrape_interval = "60s"
@@ -209,34 +197,10 @@ data:
     
       // cAdvisor
       discovery.relabel "cadvisor" {
-        targets = discovery.kubernetes.nodes.targets
+        targets = discovery.relabel.nodes.output
         rule {
           replacement   = "/metrics/cadvisor"
           target_label  = "__metrics_path__"
-        }
-        rule {
-          source_labels = ["__meta_kubernetes_node_name"]
-          target_label  = "node"
-        }
-        // set the app name if specified as metadata labels "app:" or "app.kubernetes.io/name:" or "k8s-app:"
-        rule {
-          action = "replace"
-          source_labels = [
-            "__meta_kubernetes_node_label_app_kubernetes_io_name",
-            "__meta_kubernetes_node_label_k8s_app",
-            "__meta_kubernetes_node_label_app",
-          ]
-          separator = ";"
-          regex = "^(?:;*)?([^;]+).*$"
-          replacement = "$1"
-          target_label = "app"
-        }
-    
-        // set a source label
-        rule {
-          action = "replace"
-          replacement = "kubernetes"
-          target_label = "source"
         }
       }
     

--- a/charts/k8s-monitoring/docs/examples/tolerations/alloy-metrics.alloy
+++ b/charts/k8s-monitoring/docs/examples/tolerations/alloy-metrics.alloy
@@ -7,9 +7,23 @@ declare "cluster_metrics" {
     role = "node"
   }
 
+  discovery.relabel "nodes" {
+    targets = discovery.kubernetes.nodes.targets
+    rule {
+      source_labels = ["__meta_kubernetes_node_name"]
+      target_label  = "node"
+    }
+
+    rule {
+      replacement = "kubernetes"
+      target_label = "source"
+    }
+
+  }
+
   // Kubelet
   discovery.relabel "kubelet" {
-    targets = discovery.kubernetes.nodes.targets
+    targets = discovery.relabel.nodes.output
   }
 
   prometheus.scrape "kubelet" {
@@ -45,41 +59,15 @@ declare "cluster_metrics" {
 
   // Kubelet Resources
   discovery.relabel "kubelet_resources" {
-    targets = discovery.kubernetes.nodes.targets
+    targets = discovery.relabel.nodes.output
     rule {
       replacement   = "/metrics/resource"
       target_label  = "__metrics_path__"
     }
-    // set the node label
-    rule {
-      source_labels = ["__meta_kubernetes_node_name"]
-      target_label  = "node"
-    }
-
-    // set the app name if specified as metadata labels "app:" or "app.kubernetes.io/name:" or "k8s-app:"
-    rule {
-      action = "replace"
-      source_labels = [
-        "__meta_kubernetes_node_label_app_kubernetes_io_name",
-        "__meta_kubernetes_node_label_k8s_app",
-        "__meta_kubernetes_node_label_app",
-      ]
-      separator = ";"
-      regex = "^(?:;*)?([^;]+).*$"
-      replacement = "$1"
-      target_label = "app"
-    }
-
-    // set a source label
-    rule {
-      action = "replace"
-      replacement = "kubernetes"
-      target_label = "source"
-    }
   }
 
   prometheus.scrape "kubelet_resources" {
-    targets  = discovery.relabel.kubelet_resources.output
+    targets = discovery.relabel.kubelet_resources.output
     job_name = "integrations/kubernetes/resources"
     scheme   = "https"
     scrape_interval = "60s"
@@ -111,34 +99,10 @@ declare "cluster_metrics" {
 
   // cAdvisor
   discovery.relabel "cadvisor" {
-    targets = discovery.kubernetes.nodes.targets
+    targets = discovery.relabel.nodes.output
     rule {
       replacement   = "/metrics/cadvisor"
       target_label  = "__metrics_path__"
-    }
-    rule {
-      source_labels = ["__meta_kubernetes_node_name"]
-      target_label  = "node"
-    }
-    // set the app name if specified as metadata labels "app:" or "app.kubernetes.io/name:" or "k8s-app:"
-    rule {
-      action = "replace"
-      source_labels = [
-        "__meta_kubernetes_node_label_app_kubernetes_io_name",
-        "__meta_kubernetes_node_label_k8s_app",
-        "__meta_kubernetes_node_label_app",
-      ]
-      separator = ";"
-      regex = "^(?:;*)?([^;]+).*$"
-      replacement = "$1"
-      target_label = "app"
-    }
-
-    // set a source label
-    rule {
-      action = "replace"
-      replacement = "kubernetes"
-      target_label = "source"
     }
   }
 

--- a/charts/k8s-monitoring/docs/examples/tolerations/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/tolerations/output.yaml
@@ -121,9 +121,23 @@ data:
         role = "node"
       }
     
+      discovery.relabel "nodes" {
+        targets = discovery.kubernetes.nodes.targets
+        rule {
+          source_labels = ["__meta_kubernetes_node_name"]
+          target_label  = "node"
+        }
+    
+        rule {
+          replacement = "kubernetes"
+          target_label = "source"
+        }
+    
+      }
+    
       // Kubelet
       discovery.relabel "kubelet" {
-        targets = discovery.kubernetes.nodes.targets
+        targets = discovery.relabel.nodes.output
       }
     
       prometheus.scrape "kubelet" {
@@ -159,41 +173,15 @@ data:
     
       // Kubelet Resources
       discovery.relabel "kubelet_resources" {
-        targets = discovery.kubernetes.nodes.targets
+        targets = discovery.relabel.nodes.output
         rule {
           replacement   = "/metrics/resource"
           target_label  = "__metrics_path__"
         }
-        // set the node label
-        rule {
-          source_labels = ["__meta_kubernetes_node_name"]
-          target_label  = "node"
-        }
-    
-        // set the app name if specified as metadata labels "app:" or "app.kubernetes.io/name:" or "k8s-app:"
-        rule {
-          action = "replace"
-          source_labels = [
-            "__meta_kubernetes_node_label_app_kubernetes_io_name",
-            "__meta_kubernetes_node_label_k8s_app",
-            "__meta_kubernetes_node_label_app",
-          ]
-          separator = ";"
-          regex = "^(?:;*)?([^;]+).*$"
-          replacement = "$1"
-          target_label = "app"
-        }
-    
-        // set a source label
-        rule {
-          action = "replace"
-          replacement = "kubernetes"
-          target_label = "source"
-        }
       }
     
       prometheus.scrape "kubelet_resources" {
-        targets  = discovery.relabel.kubelet_resources.output
+        targets = discovery.relabel.kubelet_resources.output
         job_name = "integrations/kubernetes/resources"
         scheme   = "https"
         scrape_interval = "60s"
@@ -225,34 +213,10 @@ data:
     
       // cAdvisor
       discovery.relabel "cadvisor" {
-        targets = discovery.kubernetes.nodes.targets
+        targets = discovery.relabel.nodes.output
         rule {
           replacement   = "/metrics/cadvisor"
           target_label  = "__metrics_path__"
-        }
-        rule {
-          source_labels = ["__meta_kubernetes_node_name"]
-          target_label  = "node"
-        }
-        // set the app name if specified as metadata labels "app:" or "app.kubernetes.io/name:" or "k8s-app:"
-        rule {
-          action = "replace"
-          source_labels = [
-            "__meta_kubernetes_node_label_app_kubernetes_io_name",
-            "__meta_kubernetes_node_label_k8s_app",
-            "__meta_kubernetes_node_label_app",
-          ]
-          separator = ";"
-          regex = "^(?:;*)?([^;]+).*$"
-          replacement = "$1"
-          target_label = "app"
-        }
-    
-        // set a source label
-        rule {
-          action = "replace"
-          replacement = "kubernetes"
-          target_label = "source"
         }
       }
     

--- a/charts/k8s-monitoring/tests/integration/application-observability/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/integration/application-observability/.rendered/output.yaml
@@ -179,6 +179,7 @@ data:
           namespaces {
             names = coalesce(argument.namespaces.value, [])
           }
+    
         }
     
         // alloy relabelings (pre-scrape)
@@ -198,79 +199,78 @@ data:
             action = "keep"
           }
     
+          rule {
+            source_labels = ["__meta_kubernetes_namespace"]
+            target_label  = "namespace"
+          }
     
+          rule {
+            source_labels = ["__meta_kubernetes_pod_name"]
+            target_label  = "pod"
+          }
     
-        rule {
-          source_labels = ["__meta_kubernetes_namespace"]
-          target_label  = "namespace"
-        }
+          rule {
+            source_labels = ["__meta_kubernetes_pod_container_name"]
+            target_label  = "container"
+          }
     
-        rule {
-          source_labels = ["__meta_kubernetes_pod_name"]
-          target_label  = "pod"
-        }
+          // set the workload to the controller kind and name
+          rule {
+            action = "lowercase"
+            source_labels = ["__meta_kubernetes_pod_controller_kind"]
+            target_label  = "workload_type"
+          }
     
-        rule {
-          source_labels = ["__meta_kubernetes_pod_container_name"]
-          target_label  = "container"
-        }
+          rule {
+            source_labels = ["__meta_kubernetes_pod_controller_name"]
+            target_label  = "workload"
+          }
     
-        // set the workload to the controller kind and name
-        rule {
-          action = "lowercase"
-          source_labels = ["__meta_kubernetes_pod_controller_kind"]
-          target_label  = "workload_type"
-        }
+          // remove the hash from the ReplicaSet
+          rule {
+            source_labels = [
+              "workload_type",
+              "workload",
+            ]
+            separator = "/"
+            regex = "replicaset/(.+)-.+$"
+            target_label  = "workload"
+          }
     
-        rule {
-          source_labels = ["__meta_kubernetes_pod_controller_name"]
-          target_label  = "workload"
-        }
+          // set the app name if specified as metadata labels "app:" or "app.kubernetes.io/name:" or "k8s-app:"
+          rule {
+            action = "replace"
+            source_labels = [
+              "__meta_kubernetes_pod_label_app_kubernetes_io_name",
+              "__meta_kubernetes_pod_label_k8s_app",
+              "__meta_kubernetes_pod_label_app",
+            ]
+            separator = ";"
+            regex = "^(?:;*)?([^;]+).*$"
+            replacement = "$1"
+            target_label = "app"
+          }
     
-        // remove the hash from the ReplicaSet
-        rule {
-          source_labels = [
-            "workload_type",
-            "workload",
-          ]
-          separator = "/"
-          regex = "replicaset/(.+)-.+$"
-          target_label  = "workload"
-        }
+          // set the component if specified as metadata labels "component:" or "app.kubernetes.io/component:" or "k8s-component:"
+          rule {
+            action = "replace"
+            source_labels = [
+              "__meta_kubernetes_pod_label_app_kubernetes_io_component",
+              "__meta_kubernetes_pod_label_k8s_component",
+              "__meta_kubernetes_pod_label_component",
+            ]
+            regex = "^(?:;*)?([^;]+).*$"
+            replacement = "$1"
+            target_label = "component"
+          }
     
-        // set the app name if specified as metadata labels "app:" or "app.kubernetes.io/name:" or "k8s-app:"
-        rule {
-          action = "replace"
-          source_labels = [
-            "__meta_kubernetes_pod_label_app_kubernetes_io_name",
-            "__meta_kubernetes_pod_label_k8s_app",
-            "__meta_kubernetes_pod_label_app",
-          ]
-          separator = ";"
-          regex = "^(?:;*)?([^;]+).*$"
-          replacement = "$1"
-          target_label = "app"
-        }
+          // set a source label
+          rule {
+            action = "replace"
+            replacement = "kubernetes"
+            target_label = "source"
+          }
     
-        // set the component if specified as metadata labels "component:" or "app.kubernetes.io/component:" or "k8s-component:"
-        rule {
-          action = "replace"
-          source_labels = [
-            "__meta_kubernetes_pod_label_app_kubernetes_io_component",
-            "__meta_kubernetes_pod_label_k8s_component",
-            "__meta_kubernetes_pod_label_component",
-          ]
-          regex = "^(?:;*)?([^;]+).*$"
-          replacement = "$1"
-          target_label = "component"
-        }
-    
-        // set a source label
-        rule {
-          action = "replace"
-          replacement = "kubernetes"
-          target_label = "source"
-        }
         }
     
         export "output" {

--- a/charts/k8s-monitoring/tests/integration/auth/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/integration/auth/.rendered/output.yaml
@@ -123,9 +123,23 @@ data:
         role = "node"
       }
     
+      discovery.relabel "nodes" {
+        targets = discovery.kubernetes.nodes.targets
+        rule {
+          source_labels = ["__meta_kubernetes_node_name"]
+          target_label  = "node"
+        }
+    
+        rule {
+          replacement = "kubernetes"
+          target_label = "source"
+        }
+    
+      }
+    
       // Kubelet
       discovery.relabel "kubelet" {
-        targets = discovery.kubernetes.nodes.targets
+        targets = discovery.relabel.nodes.output
       }
     
       prometheus.scrape "kubelet" {

--- a/charts/k8s-monitoring/tests/integration/cluster-monitoring/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/integration/cluster-monitoring/.rendered/output.yaml
@@ -188,9 +188,23 @@ data:
         role = "node"
       }
     
+      discovery.relabel "nodes" {
+        targets = discovery.kubernetes.nodes.targets
+        rule {
+          source_labels = ["__meta_kubernetes_node_name"]
+          target_label  = "node"
+        }
+    
+        rule {
+          replacement = "kubernetes"
+          target_label = "source"
+        }
+    
+      }
+    
       // Kubelet
       discovery.relabel "kubelet" {
-        targets = discovery.kubernetes.nodes.targets
+        targets = discovery.relabel.nodes.output
       }
     
       prometheus.scrape "kubelet" {
@@ -226,41 +240,15 @@ data:
     
       // Kubelet Resources
       discovery.relabel "kubelet_resources" {
-        targets = discovery.kubernetes.nodes.targets
+        targets = discovery.relabel.nodes.output
         rule {
           replacement   = "/metrics/resource"
           target_label  = "__metrics_path__"
         }
-        // set the node label
-        rule {
-          source_labels = ["__meta_kubernetes_node_name"]
-          target_label  = "node"
-        }
-    
-        // set the app name if specified as metadata labels "app:" or "app.kubernetes.io/name:" or "k8s-app:"
-        rule {
-          action = "replace"
-          source_labels = [
-            "__meta_kubernetes_node_label_app_kubernetes_io_name",
-            "__meta_kubernetes_node_label_k8s_app",
-            "__meta_kubernetes_node_label_app",
-          ]
-          separator = ";"
-          regex = "^(?:;*)?([^;]+).*$"
-          replacement = "$1"
-          target_label = "app"
-        }
-    
-        // set a source label
-        rule {
-          action = "replace"
-          replacement = "kubernetes"
-          target_label = "source"
-        }
       }
     
       prometheus.scrape "kubelet_resources" {
-        targets  = discovery.relabel.kubelet_resources.output
+        targets = discovery.relabel.kubelet_resources.output
         job_name = "integrations/kubernetes/resources"
         scheme   = "https"
         scrape_interval = "60s"
@@ -292,34 +280,10 @@ data:
     
       // cAdvisor
       discovery.relabel "cadvisor" {
-        targets = discovery.kubernetes.nodes.targets
+        targets = discovery.relabel.nodes.output
         rule {
           replacement   = "/metrics/cadvisor"
           target_label  = "__metrics_path__"
-        }
-        rule {
-          source_labels = ["__meta_kubernetes_node_name"]
-          target_label  = "node"
-        }
-        // set the app name if specified as metadata labels "app:" or "app.kubernetes.io/name:" or "k8s-app:"
-        rule {
-          action = "replace"
-          source_labels = [
-            "__meta_kubernetes_node_label_app_kubernetes_io_name",
-            "__meta_kubernetes_node_label_k8s_app",
-            "__meta_kubernetes_node_label_app",
-          ]
-          separator = ";"
-          regex = "^(?:;*)?([^;]+).*$"
-          replacement = "$1"
-          target_label = "app"
-        }
-    
-        // set a source label
-        rule {
-          action = "replace"
-          replacement = "kubernetes"
-          target_label = "source"
         }
       }
     

--- a/charts/k8s-monitoring/tests/integration/control-plane-monitoring/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/integration/control-plane-monitoring/.rendered/output.yaml
@@ -149,9 +149,23 @@ data:
         role = "node"
       }
     
+      discovery.relabel "nodes" {
+        targets = discovery.kubernetes.nodes.targets
+        rule {
+          source_labels = ["__meta_kubernetes_node_name"]
+          target_label  = "node"
+        }
+    
+        rule {
+          replacement = "kubernetes"
+          target_label = "source"
+        }
+    
+      }
+    
       // Kubelet
       discovery.relabel "kubelet" {
-        targets = discovery.kubernetes.nodes.targets
+        targets = discovery.relabel.nodes.output
       }
     
       prometheus.scrape "kubelet" {
@@ -187,41 +201,15 @@ data:
     
       // Kubelet Resources
       discovery.relabel "kubelet_resources" {
-        targets = discovery.kubernetes.nodes.targets
+        targets = discovery.relabel.nodes.output
         rule {
           replacement   = "/metrics/resource"
           target_label  = "__metrics_path__"
         }
-        // set the node label
-        rule {
-          source_labels = ["__meta_kubernetes_node_name"]
-          target_label  = "node"
-        }
-    
-        // set the app name if specified as metadata labels "app:" or "app.kubernetes.io/name:" or "k8s-app:"
-        rule {
-          action = "replace"
-          source_labels = [
-            "__meta_kubernetes_node_label_app_kubernetes_io_name",
-            "__meta_kubernetes_node_label_k8s_app",
-            "__meta_kubernetes_node_label_app",
-          ]
-          separator = ";"
-          regex = "^(?:;*)?([^;]+).*$"
-          replacement = "$1"
-          target_label = "app"
-        }
-    
-        // set a source label
-        rule {
-          action = "replace"
-          replacement = "kubernetes"
-          target_label = "source"
-        }
       }
     
       prometheus.scrape "kubelet_resources" {
-        targets  = discovery.relabel.kubelet_resources.output
+        targets = discovery.relabel.kubelet_resources.output
         job_name = "integrations/kubernetes/resources"
         scheme   = "https"
         scrape_interval = "60s"
@@ -253,7 +241,7 @@ data:
     
       // Kubelet Probes
       discovery.relabel "kubelet_probes" {
-        targets = discovery.kubernetes.nodes.targets
+        targets = discovery.relabel.nodes.output
         rule {
           target_label = "__address__"
           replacement  = "kubernetes.default.svc.cluster.local:443"
@@ -265,32 +253,6 @@ data:
           target_label  = "__metrics_path__"
         }
     
-        // set the node label
-        rule {
-          source_labels = ["__meta_kubernetes_node_name"]
-          target_label  = "node"
-        }
-    
-        // set the app name if specified as metadata labels "app:" or "app.kubernetes.io/name:" or "k8s-app:"
-        rule {
-          action = "replace"
-          source_labels = [
-            "__meta_kubernetes_node_label_app_kubernetes_io_name",
-            "__meta_kubernetes_node_label_k8s_app",
-            "__meta_kubernetes_node_label_app",
-          ]
-          separator = ";"
-          regex = "^(?:;*)?([^;]+).*$"
-          replacement = "$1"
-          target_label = "app"
-        }
-    
-        // set a source label
-        rule {
-          action = "replace"
-          replacement = "kubernetes"
-          target_label = "source"
-        }
       }
     
       prometheus.scrape "kubelet_probes" {
@@ -326,34 +288,10 @@ data:
     
       // cAdvisor
       discovery.relabel "cadvisor" {
-        targets = discovery.kubernetes.nodes.targets
+        targets = discovery.relabel.nodes.output
         rule {
           replacement   = "/metrics/cadvisor"
           target_label  = "__metrics_path__"
-        }
-        rule {
-          source_labels = ["__meta_kubernetes_node_name"]
-          target_label  = "node"
-        }
-        // set the app name if specified as metadata labels "app:" or "app.kubernetes.io/name:" or "k8s-app:"
-        rule {
-          action = "replace"
-          source_labels = [
-            "__meta_kubernetes_node_label_app_kubernetes_io_name",
-            "__meta_kubernetes_node_label_k8s_app",
-            "__meta_kubernetes_node_label_app",
-          ]
-          separator = ";"
-          regex = "^(?:;*)?([^;]+).*$"
-          replacement = "$1"
-          target_label = "app"
-        }
-    
-        // set a source label
-        rule {
-          action = "replace"
-          replacement = "kubernetes"
-          target_label = "source"
         }
       }
     

--- a/charts/k8s-monitoring/tests/integration/istio-service-mesh/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/integration/istio-service-mesh/.rendered/output.yaml
@@ -463,9 +463,23 @@ data:
         role = "node"
       }
     
+      discovery.relabel "nodes" {
+        targets = discovery.kubernetes.nodes.targets
+        rule {
+          source_labels = ["__meta_kubernetes_node_name"]
+          target_label  = "node"
+        }
+    
+        rule {
+          replacement = "kubernetes"
+          target_label = "source"
+        }
+    
+      }
+    
       // Kubelet
       discovery.relabel "kubelet" {
-        targets = discovery.kubernetes.nodes.targets
+        targets = discovery.relabel.nodes.output
       }
     
       prometheus.scrape "kubelet" {
@@ -501,41 +515,15 @@ data:
     
       // Kubelet Resources
       discovery.relabel "kubelet_resources" {
-        targets = discovery.kubernetes.nodes.targets
+        targets = discovery.relabel.nodes.output
         rule {
           replacement   = "/metrics/resource"
           target_label  = "__metrics_path__"
         }
-        // set the node label
-        rule {
-          source_labels = ["__meta_kubernetes_node_name"]
-          target_label  = "node"
-        }
-    
-        // set the app name if specified as metadata labels "app:" or "app.kubernetes.io/name:" or "k8s-app:"
-        rule {
-          action = "replace"
-          source_labels = [
-            "__meta_kubernetes_node_label_app_kubernetes_io_name",
-            "__meta_kubernetes_node_label_k8s_app",
-            "__meta_kubernetes_node_label_app",
-          ]
-          separator = ";"
-          regex = "^(?:;*)?([^;]+).*$"
-          replacement = "$1"
-          target_label = "app"
-        }
-    
-        // set a source label
-        rule {
-          action = "replace"
-          replacement = "kubernetes"
-          target_label = "source"
-        }
       }
     
       prometheus.scrape "kubelet_resources" {
-        targets  = discovery.relabel.kubelet_resources.output
+        targets = discovery.relabel.kubelet_resources.output
         job_name = "integrations/kubernetes/resources"
         scheme   = "https"
         scrape_interval = "60s"
@@ -567,34 +555,10 @@ data:
     
       // cAdvisor
       discovery.relabel "cadvisor" {
-        targets = discovery.kubernetes.nodes.targets
+        targets = discovery.relabel.nodes.output
         rule {
           replacement   = "/metrics/cadvisor"
           target_label  = "__metrics_path__"
-        }
-        rule {
-          source_labels = ["__meta_kubernetes_node_name"]
-          target_label  = "node"
-        }
-        // set the app name if specified as metadata labels "app:" or "app.kubernetes.io/name:" or "k8s-app:"
-        rule {
-          action = "replace"
-          source_labels = [
-            "__meta_kubernetes_node_label_app_kubernetes_io_name",
-            "__meta_kubernetes_node_label_k8s_app",
-            "__meta_kubernetes_node_label_app",
-          ]
-          separator = ";"
-          regex = "^(?:;*)?([^;]+).*$"
-          replacement = "$1"
-          target_label = "app"
-        }
-    
-        // set a source label
-        rule {
-          action = "replace"
-          replacement = "kubernetes"
-          target_label = "source"
         }
       }
     

--- a/charts/k8s-monitoring/tests/integration/pod-logs/log-metrics/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/integration/pod-logs/log-metrics/.rendered/output.yaml
@@ -90,6 +90,7 @@ data:
           namespaces {
             names = coalesce(argument.namespaces.value, [])
           }
+    
         }
     
         // alloy relabelings (pre-scrape)
@@ -109,79 +110,78 @@ data:
             action = "keep"
           }
     
+          rule {
+            source_labels = ["__meta_kubernetes_namespace"]
+            target_label  = "namespace"
+          }
     
+          rule {
+            source_labels = ["__meta_kubernetes_pod_name"]
+            target_label  = "pod"
+          }
     
-        rule {
-          source_labels = ["__meta_kubernetes_namespace"]
-          target_label  = "namespace"
-        }
+          rule {
+            source_labels = ["__meta_kubernetes_pod_container_name"]
+            target_label  = "container"
+          }
     
-        rule {
-          source_labels = ["__meta_kubernetes_pod_name"]
-          target_label  = "pod"
-        }
+          // set the workload to the controller kind and name
+          rule {
+            action = "lowercase"
+            source_labels = ["__meta_kubernetes_pod_controller_kind"]
+            target_label  = "workload_type"
+          }
     
-        rule {
-          source_labels = ["__meta_kubernetes_pod_container_name"]
-          target_label  = "container"
-        }
+          rule {
+            source_labels = ["__meta_kubernetes_pod_controller_name"]
+            target_label  = "workload"
+          }
     
-        // set the workload to the controller kind and name
-        rule {
-          action = "lowercase"
-          source_labels = ["__meta_kubernetes_pod_controller_kind"]
-          target_label  = "workload_type"
-        }
+          // remove the hash from the ReplicaSet
+          rule {
+            source_labels = [
+              "workload_type",
+              "workload",
+            ]
+            separator = "/"
+            regex = "replicaset/(.+)-.+$"
+            target_label  = "workload"
+          }
     
-        rule {
-          source_labels = ["__meta_kubernetes_pod_controller_name"]
-          target_label  = "workload"
-        }
+          // set the app name if specified as metadata labels "app:" or "app.kubernetes.io/name:" or "k8s-app:"
+          rule {
+            action = "replace"
+            source_labels = [
+              "__meta_kubernetes_pod_label_app_kubernetes_io_name",
+              "__meta_kubernetes_pod_label_k8s_app",
+              "__meta_kubernetes_pod_label_app",
+            ]
+            separator = ";"
+            regex = "^(?:;*)?([^;]+).*$"
+            replacement = "$1"
+            target_label = "app"
+          }
     
-        // remove the hash from the ReplicaSet
-        rule {
-          source_labels = [
-            "workload_type",
-            "workload",
-          ]
-          separator = "/"
-          regex = "replicaset/(.+)-.+$"
-          target_label  = "workload"
-        }
+          // set the component if specified as metadata labels "component:" or "app.kubernetes.io/component:" or "k8s-component:"
+          rule {
+            action = "replace"
+            source_labels = [
+              "__meta_kubernetes_pod_label_app_kubernetes_io_component",
+              "__meta_kubernetes_pod_label_k8s_component",
+              "__meta_kubernetes_pod_label_component",
+            ]
+            regex = "^(?:;*)?([^;]+).*$"
+            replacement = "$1"
+            target_label = "component"
+          }
     
-        // set the app name if specified as metadata labels "app:" or "app.kubernetes.io/name:" or "k8s-app:"
-        rule {
-          action = "replace"
-          source_labels = [
-            "__meta_kubernetes_pod_label_app_kubernetes_io_name",
-            "__meta_kubernetes_pod_label_k8s_app",
-            "__meta_kubernetes_pod_label_app",
-          ]
-          separator = ";"
-          regex = "^(?:;*)?([^;]+).*$"
-          replacement = "$1"
-          target_label = "app"
-        }
+          // set a source label
+          rule {
+            action = "replace"
+            replacement = "kubernetes"
+            target_label = "source"
+          }
     
-        // set the component if specified as metadata labels "component:" or "app.kubernetes.io/component:" or "k8s-component:"
-        rule {
-          action = "replace"
-          source_labels = [
-            "__meta_kubernetes_pod_label_app_kubernetes_io_component",
-            "__meta_kubernetes_pod_label_k8s_component",
-            "__meta_kubernetes_pod_label_component",
-          ]
-          regex = "^(?:;*)?([^;]+).*$"
-          replacement = "$1"
-          target_label = "component"
-        }
-    
-        // set a source label
-        rule {
-          action = "replace"
-          replacement = "kubernetes"
-          target_label = "source"
-        }
         }
     
         export "output" {

--- a/charts/k8s-monitoring/tests/integration/prom-and-loki-to-otlp/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/integration/prom-and-loki-to-otlp/.rendered/output.yaml
@@ -160,9 +160,23 @@ data:
         role = "node"
       }
     
+      discovery.relabel "nodes" {
+        targets = discovery.kubernetes.nodes.targets
+        rule {
+          source_labels = ["__meta_kubernetes_node_name"]
+          target_label  = "node"
+        }
+    
+        rule {
+          replacement = "kubernetes"
+          target_label = "source"
+        }
+    
+      }
+    
       // Kubelet
       discovery.relabel "kubelet" {
-        targets = discovery.kubernetes.nodes.targets
+        targets = discovery.relabel.nodes.output
       }
     
       prometheus.scrape "kubelet" {
@@ -198,41 +212,15 @@ data:
     
       // Kubelet Resources
       discovery.relabel "kubelet_resources" {
-        targets = discovery.kubernetes.nodes.targets
+        targets = discovery.relabel.nodes.output
         rule {
           replacement   = "/metrics/resource"
           target_label  = "__metrics_path__"
         }
-        // set the node label
-        rule {
-          source_labels = ["__meta_kubernetes_node_name"]
-          target_label  = "node"
-        }
-    
-        // set the app name if specified as metadata labels "app:" or "app.kubernetes.io/name:" or "k8s-app:"
-        rule {
-          action = "replace"
-          source_labels = [
-            "__meta_kubernetes_node_label_app_kubernetes_io_name",
-            "__meta_kubernetes_node_label_k8s_app",
-            "__meta_kubernetes_node_label_app",
-          ]
-          separator = ";"
-          regex = "^(?:;*)?([^;]+).*$"
-          replacement = "$1"
-          target_label = "app"
-        }
-    
-        // set a source label
-        rule {
-          action = "replace"
-          replacement = "kubernetes"
-          target_label = "source"
-        }
       }
     
       prometheus.scrape "kubelet_resources" {
-        targets  = discovery.relabel.kubelet_resources.output
+        targets = discovery.relabel.kubelet_resources.output
         job_name = "integrations/kubernetes/resources"
         scheme   = "https"
         scrape_interval = "60s"
@@ -264,34 +252,10 @@ data:
     
       // cAdvisor
       discovery.relabel "cadvisor" {
-        targets = discovery.kubernetes.nodes.targets
+        targets = discovery.relabel.nodes.output
         rule {
           replacement   = "/metrics/cadvisor"
           target_label  = "__metrics_path__"
-        }
-        rule {
-          source_labels = ["__meta_kubernetes_node_name"]
-          target_label  = "node"
-        }
-        // set the app name if specified as metadata labels "app:" or "app.kubernetes.io/name:" or "k8s-app:"
-        rule {
-          action = "replace"
-          source_labels = [
-            "__meta_kubernetes_node_label_app_kubernetes_io_name",
-            "__meta_kubernetes_node_label_k8s_app",
-            "__meta_kubernetes_node_label_app",
-          ]
-          separator = ";"
-          regex = "^(?:;*)?([^;]+).*$"
-          replacement = "$1"
-          target_label = "app"
-        }
-    
-        // set a source label
-        rule {
-          action = "replace"
-          replacement = "kubernetes"
-          target_label = "source"
         }
       }
     

--- a/charts/k8s-monitoring/tests/integration/prometheus-io-annotations/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/integration/prometheus-io-annotations/.rendered/output.yaml
@@ -408,9 +408,23 @@ data:
         role = "node"
       }
     
+      discovery.relabel "nodes" {
+        targets = discovery.kubernetes.nodes.targets
+        rule {
+          source_labels = ["__meta_kubernetes_node_name"]
+          target_label  = "node"
+        }
+    
+        rule {
+          replacement = "kubernetes"
+          target_label = "source"
+        }
+    
+      }
+    
       // Kubelet
       discovery.relabel "kubelet" {
-        targets = discovery.kubernetes.nodes.targets
+        targets = discovery.relabel.nodes.output
       }
     
       prometheus.scrape "kubelet" {
@@ -446,41 +460,15 @@ data:
     
       // Kubelet Resources
       discovery.relabel "kubelet_resources" {
-        targets = discovery.kubernetes.nodes.targets
+        targets = discovery.relabel.nodes.output
         rule {
           replacement   = "/metrics/resource"
           target_label  = "__metrics_path__"
         }
-        // set the node label
-        rule {
-          source_labels = ["__meta_kubernetes_node_name"]
-          target_label  = "node"
-        }
-    
-        // set the app name if specified as metadata labels "app:" or "app.kubernetes.io/name:" or "k8s-app:"
-        rule {
-          action = "replace"
-          source_labels = [
-            "__meta_kubernetes_node_label_app_kubernetes_io_name",
-            "__meta_kubernetes_node_label_k8s_app",
-            "__meta_kubernetes_node_label_app",
-          ]
-          separator = ";"
-          regex = "^(?:;*)?([^;]+).*$"
-          replacement = "$1"
-          target_label = "app"
-        }
-    
-        // set a source label
-        rule {
-          action = "replace"
-          replacement = "kubernetes"
-          target_label = "source"
-        }
       }
     
       prometheus.scrape "kubelet_resources" {
-        targets  = discovery.relabel.kubelet_resources.output
+        targets = discovery.relabel.kubelet_resources.output
         job_name = "integrations/kubernetes/resources"
         scheme   = "https"
         scrape_interval = "60s"
@@ -512,34 +500,10 @@ data:
     
       // cAdvisor
       discovery.relabel "cadvisor" {
-        targets = discovery.kubernetes.nodes.targets
+        targets = discovery.relabel.nodes.output
         rule {
           replacement   = "/metrics/cadvisor"
           target_label  = "__metrics_path__"
-        }
-        rule {
-          source_labels = ["__meta_kubernetes_node_name"]
-          target_label  = "node"
-        }
-        // set the app name if specified as metadata labels "app:" or "app.kubernetes.io/name:" or "k8s-app:"
-        rule {
-          action = "replace"
-          source_labels = [
-            "__meta_kubernetes_node_label_app_kubernetes_io_name",
-            "__meta_kubernetes_node_label_k8s_app",
-            "__meta_kubernetes_node_label_app",
-          ]
-          separator = ";"
-          regex = "^(?:;*)?([^;]+).*$"
-          replacement = "$1"
-          target_label = "app"
-        }
-    
-        // set a source label
-        rule {
-          action = "replace"
-          replacement = "kubernetes"
-          target_label = "source"
         }
       }
     

--- a/charts/k8s-monitoring/tests/integration/service-integrations/alloy/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/integration/service-integrations/alloy/.rendered/output.yaml
@@ -62,6 +62,7 @@ data:
           namespaces {
             names = coalesce(argument.namespaces.value, [])
           }
+    
         }
     
         // alloy relabelings (pre-scrape)
@@ -81,79 +82,78 @@ data:
             action = "keep"
           }
     
+          rule {
+            source_labels = ["__meta_kubernetes_namespace"]
+            target_label  = "namespace"
+          }
     
+          rule {
+            source_labels = ["__meta_kubernetes_pod_name"]
+            target_label  = "pod"
+          }
     
-        rule {
-          source_labels = ["__meta_kubernetes_namespace"]
-          target_label  = "namespace"
-        }
+          rule {
+            source_labels = ["__meta_kubernetes_pod_container_name"]
+            target_label  = "container"
+          }
     
-        rule {
-          source_labels = ["__meta_kubernetes_pod_name"]
-          target_label  = "pod"
-        }
+          // set the workload to the controller kind and name
+          rule {
+            action = "lowercase"
+            source_labels = ["__meta_kubernetes_pod_controller_kind"]
+            target_label  = "workload_type"
+          }
     
-        rule {
-          source_labels = ["__meta_kubernetes_pod_container_name"]
-          target_label  = "container"
-        }
+          rule {
+            source_labels = ["__meta_kubernetes_pod_controller_name"]
+            target_label  = "workload"
+          }
     
-        // set the workload to the controller kind and name
-        rule {
-          action = "lowercase"
-          source_labels = ["__meta_kubernetes_pod_controller_kind"]
-          target_label  = "workload_type"
-        }
+          // remove the hash from the ReplicaSet
+          rule {
+            source_labels = [
+              "workload_type",
+              "workload",
+            ]
+            separator = "/"
+            regex = "replicaset/(.+)-.+$"
+            target_label  = "workload"
+          }
     
-        rule {
-          source_labels = ["__meta_kubernetes_pod_controller_name"]
-          target_label  = "workload"
-        }
+          // set the app name if specified as metadata labels "app:" or "app.kubernetes.io/name:" or "k8s-app:"
+          rule {
+            action = "replace"
+            source_labels = [
+              "__meta_kubernetes_pod_label_app_kubernetes_io_name",
+              "__meta_kubernetes_pod_label_k8s_app",
+              "__meta_kubernetes_pod_label_app",
+            ]
+            separator = ";"
+            regex = "^(?:;*)?([^;]+).*$"
+            replacement = "$1"
+            target_label = "app"
+          }
     
-        // remove the hash from the ReplicaSet
-        rule {
-          source_labels = [
-            "workload_type",
-            "workload",
-          ]
-          separator = "/"
-          regex = "replicaset/(.+)-.+$"
-          target_label  = "workload"
-        }
+          // set the component if specified as metadata labels "component:" or "app.kubernetes.io/component:" or "k8s-component:"
+          rule {
+            action = "replace"
+            source_labels = [
+              "__meta_kubernetes_pod_label_app_kubernetes_io_component",
+              "__meta_kubernetes_pod_label_k8s_component",
+              "__meta_kubernetes_pod_label_component",
+            ]
+            regex = "^(?:;*)?([^;]+).*$"
+            replacement = "$1"
+            target_label = "component"
+          }
     
-        // set the app name if specified as metadata labels "app:" or "app.kubernetes.io/name:" or "k8s-app:"
-        rule {
-          action = "replace"
-          source_labels = [
-            "__meta_kubernetes_pod_label_app_kubernetes_io_name",
-            "__meta_kubernetes_pod_label_k8s_app",
-            "__meta_kubernetes_pod_label_app",
-          ]
-          separator = ";"
-          regex = "^(?:;*)?([^;]+).*$"
-          replacement = "$1"
-          target_label = "app"
-        }
+          // set a source label
+          rule {
+            action = "replace"
+            replacement = "kubernetes"
+            target_label = "source"
+          }
     
-        // set the component if specified as metadata labels "component:" or "app.kubernetes.io/component:" or "k8s-component:"
-        rule {
-          action = "replace"
-          source_labels = [
-            "__meta_kubernetes_pod_label_app_kubernetes_io_component",
-            "__meta_kubernetes_pod_label_k8s_component",
-            "__meta_kubernetes_pod_label_component",
-          ]
-          regex = "^(?:;*)?([^;]+).*$"
-          replacement = "$1"
-          target_label = "component"
-        }
-    
-        // set a source label
-        rule {
-          action = "replace"
-          replacement = "kubernetes"
-          target_label = "source"
-        }
         }
     
         export "output" {

--- a/charts/k8s-monitoring/tests/integration/service-integrations/coredns/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/integration/service-integrations/coredns/.rendered/output.yaml
@@ -105,9 +105,23 @@ data:
         role = "node"
       }
     
+      discovery.relabel "nodes" {
+        targets = discovery.kubernetes.nodes.targets
+        rule {
+          source_labels = ["__meta_kubernetes_node_name"]
+          target_label  = "node"
+        }
+    
+        rule {
+          replacement = "kubernetes"
+          target_label = "source"
+        }
+    
+      }
+    
       // Kubelet
       discovery.relabel "kubelet" {
-        targets = discovery.kubernetes.nodes.targets
+        targets = discovery.relabel.nodes.output
       }
     
       prometheus.scrape "kubelet" {
@@ -143,41 +157,15 @@ data:
     
       // Kubelet Resources
       discovery.relabel "kubelet_resources" {
-        targets = discovery.kubernetes.nodes.targets
+        targets = discovery.relabel.nodes.output
         rule {
           replacement   = "/metrics/resource"
           target_label  = "__metrics_path__"
         }
-        // set the node label
-        rule {
-          source_labels = ["__meta_kubernetes_node_name"]
-          target_label  = "node"
-        }
-    
-        // set the app name if specified as metadata labels "app:" or "app.kubernetes.io/name:" or "k8s-app:"
-        rule {
-          action = "replace"
-          source_labels = [
-            "__meta_kubernetes_node_label_app_kubernetes_io_name",
-            "__meta_kubernetes_node_label_k8s_app",
-            "__meta_kubernetes_node_label_app",
-          ]
-          separator = ";"
-          regex = "^(?:;*)?([^;]+).*$"
-          replacement = "$1"
-          target_label = "app"
-        }
-    
-        // set a source label
-        rule {
-          action = "replace"
-          replacement = "kubernetes"
-          target_label = "source"
-        }
       }
     
       prometheus.scrape "kubelet_resources" {
-        targets  = discovery.relabel.kubelet_resources.output
+        targets = discovery.relabel.kubelet_resources.output
         job_name = "integrations/kubernetes/resources"
         scheme   = "https"
         scrape_interval = "60s"
@@ -209,34 +197,10 @@ data:
     
       // cAdvisor
       discovery.relabel "cadvisor" {
-        targets = discovery.kubernetes.nodes.targets
+        targets = discovery.relabel.nodes.output
         rule {
           replacement   = "/metrics/cadvisor"
           target_label  = "__metrics_path__"
-        }
-        rule {
-          source_labels = ["__meta_kubernetes_node_name"]
-          target_label  = "node"
-        }
-        // set the app name if specified as metadata labels "app:" or "app.kubernetes.io/name:" or "k8s-app:"
-        rule {
-          action = "replace"
-          source_labels = [
-            "__meta_kubernetes_node_label_app_kubernetes_io_name",
-            "__meta_kubernetes_node_label_k8s_app",
-            "__meta_kubernetes_node_label_app",
-          ]
-          separator = ";"
-          regex = "^(?:;*)?([^;]+).*$"
-          replacement = "$1"
-          target_label = "app"
-        }
-    
-        // set a source label
-        rule {
-          action = "replace"
-          replacement = "kubernetes"
-          target_label = "source"
         }
       }
     

--- a/charts/k8s-monitoring/tests/integration/service-integrations/grafana/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/integration/service-integrations/grafana/.rendered/output.yaml
@@ -160,9 +160,23 @@ data:
         role = "node"
       }
     
+      discovery.relabel "nodes" {
+        targets = discovery.kubernetes.nodes.targets
+        rule {
+          source_labels = ["__meta_kubernetes_node_name"]
+          target_label  = "node"
+        }
+    
+        rule {
+          replacement = "kubernetes"
+          target_label = "source"
+        }
+    
+      }
+    
       // Kubelet
       discovery.relabel "kubelet" {
-        targets = discovery.kubernetes.nodes.targets
+        targets = discovery.relabel.nodes.output
       }
     
       prometheus.scrape "kubelet" {
@@ -198,41 +212,15 @@ data:
     
       // Kubelet Resources
       discovery.relabel "kubelet_resources" {
-        targets = discovery.kubernetes.nodes.targets
+        targets = discovery.relabel.nodes.output
         rule {
           replacement   = "/metrics/resource"
           target_label  = "__metrics_path__"
         }
-        // set the node label
-        rule {
-          source_labels = ["__meta_kubernetes_node_name"]
-          target_label  = "node"
-        }
-    
-        // set the app name if specified as metadata labels "app:" or "app.kubernetes.io/name:" or "k8s-app:"
-        rule {
-          action = "replace"
-          source_labels = [
-            "__meta_kubernetes_node_label_app_kubernetes_io_name",
-            "__meta_kubernetes_node_label_k8s_app",
-            "__meta_kubernetes_node_label_app",
-          ]
-          separator = ";"
-          regex = "^(?:;*)?([^;]+).*$"
-          replacement = "$1"
-          target_label = "app"
-        }
-    
-        // set a source label
-        rule {
-          action = "replace"
-          replacement = "kubernetes"
-          target_label = "source"
-        }
       }
     
       prometheus.scrape "kubelet_resources" {
-        targets  = discovery.relabel.kubelet_resources.output
+        targets = discovery.relabel.kubelet_resources.output
         job_name = "integrations/kubernetes/resources"
         scheme   = "https"
         scrape_interval = "60s"
@@ -264,34 +252,10 @@ data:
     
       // cAdvisor
       discovery.relabel "cadvisor" {
-        targets = discovery.kubernetes.nodes.targets
+        targets = discovery.relabel.nodes.output
         rule {
           replacement   = "/metrics/cadvisor"
           target_label  = "__metrics_path__"
-        }
-        rule {
-          source_labels = ["__meta_kubernetes_node_name"]
-          target_label  = "node"
-        }
-        // set the app name if specified as metadata labels "app:" or "app.kubernetes.io/name:" or "k8s-app:"
-        rule {
-          action = "replace"
-          source_labels = [
-            "__meta_kubernetes_node_label_app_kubernetes_io_name",
-            "__meta_kubernetes_node_label_k8s_app",
-            "__meta_kubernetes_node_label_app",
-          ]
-          separator = ";"
-          regex = "^(?:;*)?([^;]+).*$"
-          replacement = "$1"
-          target_label = "app"
-        }
-    
-        // set a source label
-        rule {
-          action = "replace"
-          replacement = "kubernetes"
-          target_label = "source"
         }
       }
     
@@ -670,6 +634,7 @@ data:
           namespaces {
             names = coalesce(argument.namespaces.value, [])
           }
+    
         }
     
         // grafana relabelings (pre-scrape)
@@ -691,77 +656,78 @@ data:
     
     
     
-        rule {
-          source_labels = ["__meta_kubernetes_namespace"]
-          target_label  = "namespace"
-        }
+          rule {
+            source_labels = ["__meta_kubernetes_namespace"]
+            target_label  = "namespace"
+          }
     
-        rule {
-          source_labels = ["__meta_kubernetes_pod_name"]
-          target_label  = "pod"
-        }
+          rule {
+            source_labels = ["__meta_kubernetes_pod_name"]
+            target_label  = "pod"
+          }
     
-        rule {
-          source_labels = ["__meta_kubernetes_pod_container_name"]
-          target_label  = "container"
-        }
+          rule {
+            source_labels = ["__meta_kubernetes_pod_container_name"]
+            target_label  = "container"
+          }
     
-        // set the workload to the controller kind and name
-        rule {
-          action = "lowercase"
-          source_labels = ["__meta_kubernetes_pod_controller_kind"]
-          target_label  = "workload_type"
-        }
+          // set the workload to the controller kind and name
+          rule {
+            action = "lowercase"
+            source_labels = ["__meta_kubernetes_pod_controller_kind"]
+            target_label  = "workload_type"
+          }
     
-        rule {
-          source_labels = ["__meta_kubernetes_pod_controller_name"]
-          target_label  = "workload"
-        }
+          rule {
+            source_labels = ["__meta_kubernetes_pod_controller_name"]
+            target_label  = "workload"
+          }
     
-        // remove the hash from the ReplicaSet
-        rule {
-          source_labels = [
-            "workload_type",
-            "workload",
-          ]
-          separator = "/"
-          regex = "replicaset/(.+)-.+$"
-          target_label  = "workload"
-        }
+          // remove the hash from the ReplicaSet
+          rule {
+            source_labels = [
+              "workload_type",
+              "workload",
+            ]
+            separator = "/"
+            regex = "replicaset/(.+)-.+$"
+            target_label  = "workload"
+          }
     
-        // set the app name if specified as metadata labels "app:" or "app.kubernetes.io/name:" or "k8s-app:"
-        rule {
-          action = "replace"
-          source_labels = [
-            "__meta_kubernetes_pod_label_app_kubernetes_io_name",
-            "__meta_kubernetes_pod_label_k8s_app",
-            "__meta_kubernetes_pod_label_app",
-          ]
-          separator = ";"
-          regex = "^(?:;*)?([^;]+).*$"
-          replacement = "$1"
-          target_label = "app"
-        }
+          // set the app name if specified as metadata labels "app:" or "app.kubernetes.io/name:" or "k8s-app:"
+          rule {
+            action = "replace"
+            source_labels = [
+              "__meta_kubernetes_pod_label_app_kubernetes_io_name",
+              "__meta_kubernetes_pod_label_k8s_app",
+              "__meta_kubernetes_pod_label_app",
+            ]
+            separator = ";"
+            regex = "^(?:;*)?([^;]+).*$"
+            replacement = "$1"
+            target_label = "app"
+          }
     
-        // set the component if specified as metadata labels "component:" or "app.kubernetes.io/component:" or "k8s-component:"
-        rule {
-          action = "replace"
-          source_labels = [
-            "__meta_kubernetes_pod_label_app_kubernetes_io_component",
-            "__meta_kubernetes_pod_label_k8s_component",
-            "__meta_kubernetes_pod_label_component",
-          ]
-          regex = "^(?:;*)?([^;]+).*$"
-          replacement = "$1"
-          target_label = "component"
-        }
+          // set the component if specified as metadata labels "component:" or "app.kubernetes.io/component:" or "k8s-component:"
+          rule {
+            action = "replace"
+            source_labels = [
+              "__meta_kubernetes_pod_label_app_kubernetes_io_component",
+              "__meta_kubernetes_pod_label_k8s_component",
+              "__meta_kubernetes_pod_label_component",
+            ]
+            regex = "^(?:;*)?([^;]+).*$"
+            replacement = "$1"
+            target_label = "component"
+          }
     
-        // set a source label
-        rule {
-          action = "replace"
-          replacement = "kubernetes"
-          target_label = "source"
-        }
+          // set a source label
+          rule {
+            action = "replace"
+            replacement = "kubernetes"
+            target_label = "source"
+          }
+    
         }
     
         export "output" {

--- a/charts/k8s-monitoring/tests/integration/service-integrations/loki/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/integration/service-integrations/loki/.rendered/output.yaml
@@ -160,9 +160,23 @@ data:
         role = "node"
       }
     
+      discovery.relabel "nodes" {
+        targets = discovery.kubernetes.nodes.targets
+        rule {
+          source_labels = ["__meta_kubernetes_node_name"]
+          target_label  = "node"
+        }
+    
+        rule {
+          replacement = "kubernetes"
+          target_label = "source"
+        }
+    
+      }
+    
       // Kubelet
       discovery.relabel "kubelet" {
-        targets = discovery.kubernetes.nodes.targets
+        targets = discovery.relabel.nodes.output
       }
     
       prometheus.scrape "kubelet" {
@@ -198,41 +212,15 @@ data:
     
       // Kubelet Resources
       discovery.relabel "kubelet_resources" {
-        targets = discovery.kubernetes.nodes.targets
+        targets = discovery.relabel.nodes.output
         rule {
           replacement   = "/metrics/resource"
           target_label  = "__metrics_path__"
         }
-        // set the node label
-        rule {
-          source_labels = ["__meta_kubernetes_node_name"]
-          target_label  = "node"
-        }
-    
-        // set the app name if specified as metadata labels "app:" or "app.kubernetes.io/name:" or "k8s-app:"
-        rule {
-          action = "replace"
-          source_labels = [
-            "__meta_kubernetes_node_label_app_kubernetes_io_name",
-            "__meta_kubernetes_node_label_k8s_app",
-            "__meta_kubernetes_node_label_app",
-          ]
-          separator = ";"
-          regex = "^(?:;*)?([^;]+).*$"
-          replacement = "$1"
-          target_label = "app"
-        }
-    
-        // set a source label
-        rule {
-          action = "replace"
-          replacement = "kubernetes"
-          target_label = "source"
-        }
       }
     
       prometheus.scrape "kubelet_resources" {
-        targets  = discovery.relabel.kubelet_resources.output
+        targets = discovery.relabel.kubelet_resources.output
         job_name = "integrations/kubernetes/resources"
         scheme   = "https"
         scrape_interval = "60s"
@@ -264,34 +252,10 @@ data:
     
       // cAdvisor
       discovery.relabel "cadvisor" {
-        targets = discovery.kubernetes.nodes.targets
+        targets = discovery.relabel.nodes.output
         rule {
           replacement   = "/metrics/cadvisor"
           target_label  = "__metrics_path__"
-        }
-        rule {
-          source_labels = ["__meta_kubernetes_node_name"]
-          target_label  = "node"
-        }
-        // set the app name if specified as metadata labels "app:" or "app.kubernetes.io/name:" or "k8s-app:"
-        rule {
-          action = "replace"
-          source_labels = [
-            "__meta_kubernetes_node_label_app_kubernetes_io_name",
-            "__meta_kubernetes_node_label_k8s_app",
-            "__meta_kubernetes_node_label_app",
-          ]
-          separator = ";"
-          regex = "^(?:;*)?([^;]+).*$"
-          replacement = "$1"
-          target_label = "app"
-        }
-    
-        // set a source label
-        rule {
-          action = "replace"
-          replacement = "kubernetes"
-          target_label = "source"
         }
       }
     
@@ -670,6 +634,7 @@ data:
           namespaces {
             names = coalesce(argument.namespaces.value, [])
           }
+    
         }
     
         // loki relabelings (pre-scrape)
@@ -698,77 +663,78 @@ data:
     
     
     
-        rule {
-          source_labels = ["__meta_kubernetes_namespace"]
-          target_label  = "namespace"
-        }
+          rule {
+            source_labels = ["__meta_kubernetes_namespace"]
+            target_label  = "namespace"
+          }
     
-        rule {
-          source_labels = ["__meta_kubernetes_pod_name"]
-          target_label  = "pod"
-        }
+          rule {
+            source_labels = ["__meta_kubernetes_pod_name"]
+            target_label  = "pod"
+          }
     
-        rule {
-          source_labels = ["__meta_kubernetes_pod_container_name"]
-          target_label  = "container"
-        }
+          rule {
+            source_labels = ["__meta_kubernetes_pod_container_name"]
+            target_label  = "container"
+          }
     
-        // set the workload to the controller kind and name
-        rule {
-          action = "lowercase"
-          source_labels = ["__meta_kubernetes_pod_controller_kind"]
-          target_label  = "workload_type"
-        }
+          // set the workload to the controller kind and name
+          rule {
+            action = "lowercase"
+            source_labels = ["__meta_kubernetes_pod_controller_kind"]
+            target_label  = "workload_type"
+          }
     
-        rule {
-          source_labels = ["__meta_kubernetes_pod_controller_name"]
-          target_label  = "workload"
-        }
+          rule {
+            source_labels = ["__meta_kubernetes_pod_controller_name"]
+            target_label  = "workload"
+          }
     
-        // remove the hash from the ReplicaSet
-        rule {
-          source_labels = [
-            "workload_type",
-            "workload",
-          ]
-          separator = "/"
-          regex = "replicaset/(.+)-.+$"
-          target_label  = "workload"
-        }
+          // remove the hash from the ReplicaSet
+          rule {
+            source_labels = [
+              "workload_type",
+              "workload",
+            ]
+            separator = "/"
+            regex = "replicaset/(.+)-.+$"
+            target_label  = "workload"
+          }
     
-        // set the app name if specified as metadata labels "app:" or "app.kubernetes.io/name:" or "k8s-app:"
-        rule {
-          action = "replace"
-          source_labels = [
-            "__meta_kubernetes_pod_label_app_kubernetes_io_name",
-            "__meta_kubernetes_pod_label_k8s_app",
-            "__meta_kubernetes_pod_label_app",
-          ]
-          separator = ";"
-          regex = "^(?:;*)?([^;]+).*$"
-          replacement = "$1"
-          target_label = "app"
-        }
+          // set the app name if specified as metadata labels "app:" or "app.kubernetes.io/name:" or "k8s-app:"
+          rule {
+            action = "replace"
+            source_labels = [
+              "__meta_kubernetes_pod_label_app_kubernetes_io_name",
+              "__meta_kubernetes_pod_label_k8s_app",
+              "__meta_kubernetes_pod_label_app",
+            ]
+            separator = ";"
+            regex = "^(?:;*)?([^;]+).*$"
+            replacement = "$1"
+            target_label = "app"
+          }
     
-        // set the component if specified as metadata labels "component:" or "app.kubernetes.io/component:" or "k8s-component:"
-        rule {
-          action = "replace"
-          source_labels = [
-            "__meta_kubernetes_pod_label_app_kubernetes_io_component",
-            "__meta_kubernetes_pod_label_k8s_component",
-            "__meta_kubernetes_pod_label_component",
-          ]
-          regex = "^(?:;*)?([^;]+).*$"
-          replacement = "$1"
-          target_label = "component"
-        }
+          // set the component if specified as metadata labels "component:" or "app.kubernetes.io/component:" or "k8s-component:"
+          rule {
+            action = "replace"
+            source_labels = [
+              "__meta_kubernetes_pod_label_app_kubernetes_io_component",
+              "__meta_kubernetes_pod_label_k8s_component",
+              "__meta_kubernetes_pod_label_component",
+            ]
+            regex = "^(?:;*)?([^;]+).*$"
+            replacement = "$1"
+            target_label = "component"
+          }
     
-        // set a source label
-        rule {
-          action = "replace"
-          replacement = "kubernetes"
-          target_label = "source"
-        }
+          // set a source label
+          rule {
+            action = "replace"
+            replacement = "kubernetes"
+            target_label = "source"
+          }
+    
         }
     
         export "output" {

--- a/charts/k8s-monitoring/tests/integration/service-integrations/tempo/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/integration/service-integrations/tempo/.rendered/output.yaml
@@ -160,9 +160,23 @@ data:
         role = "node"
       }
     
+      discovery.relabel "nodes" {
+        targets = discovery.kubernetes.nodes.targets
+        rule {
+          source_labels = ["__meta_kubernetes_node_name"]
+          target_label  = "node"
+        }
+    
+        rule {
+          replacement = "kubernetes"
+          target_label = "source"
+        }
+    
+      }
+    
       // Kubelet
       discovery.relabel "kubelet" {
-        targets = discovery.kubernetes.nodes.targets
+        targets = discovery.relabel.nodes.output
       }
     
       prometheus.scrape "kubelet" {
@@ -198,41 +212,15 @@ data:
     
       // Kubelet Resources
       discovery.relabel "kubelet_resources" {
-        targets = discovery.kubernetes.nodes.targets
+        targets = discovery.relabel.nodes.output
         rule {
           replacement   = "/metrics/resource"
           target_label  = "__metrics_path__"
         }
-        // set the node label
-        rule {
-          source_labels = ["__meta_kubernetes_node_name"]
-          target_label  = "node"
-        }
-    
-        // set the app name if specified as metadata labels "app:" or "app.kubernetes.io/name:" or "k8s-app:"
-        rule {
-          action = "replace"
-          source_labels = [
-            "__meta_kubernetes_node_label_app_kubernetes_io_name",
-            "__meta_kubernetes_node_label_k8s_app",
-            "__meta_kubernetes_node_label_app",
-          ]
-          separator = ";"
-          regex = "^(?:;*)?([^;]+).*$"
-          replacement = "$1"
-          target_label = "app"
-        }
-    
-        // set a source label
-        rule {
-          action = "replace"
-          replacement = "kubernetes"
-          target_label = "source"
-        }
       }
     
       prometheus.scrape "kubelet_resources" {
-        targets  = discovery.relabel.kubelet_resources.output
+        targets = discovery.relabel.kubelet_resources.output
         job_name = "integrations/kubernetes/resources"
         scheme   = "https"
         scrape_interval = "60s"
@@ -264,34 +252,10 @@ data:
     
       // cAdvisor
       discovery.relabel "cadvisor" {
-        targets = discovery.kubernetes.nodes.targets
+        targets = discovery.relabel.nodes.output
         rule {
           replacement   = "/metrics/cadvisor"
           target_label  = "__metrics_path__"
-        }
-        rule {
-          source_labels = ["__meta_kubernetes_node_name"]
-          target_label  = "node"
-        }
-        // set the app name if specified as metadata labels "app:" or "app.kubernetes.io/name:" or "k8s-app:"
-        rule {
-          action = "replace"
-          source_labels = [
-            "__meta_kubernetes_node_label_app_kubernetes_io_name",
-            "__meta_kubernetes_node_label_k8s_app",
-            "__meta_kubernetes_node_label_app",
-          ]
-          separator = ";"
-          regex = "^(?:;*)?([^;]+).*$"
-          replacement = "$1"
-          target_label = "app"
-        }
-    
-        // set a source label
-        rule {
-          action = "replace"
-          replacement = "kubernetes"
-          target_label = "source"
         }
       }
     
@@ -830,6 +794,7 @@ data:
           namespaces {
             names = coalesce(argument.namespaces.value, [])
           }
+    
         }
     
         // tempo relabelings (pre-scrape)
@@ -858,77 +823,78 @@ data:
     
     
     
-        rule {
-          source_labels = ["__meta_kubernetes_namespace"]
-          target_label  = "namespace"
-        }
+          rule {
+            source_labels = ["__meta_kubernetes_namespace"]
+            target_label  = "namespace"
+          }
     
-        rule {
-          source_labels = ["__meta_kubernetes_pod_name"]
-          target_label  = "pod"
-        }
+          rule {
+            source_labels = ["__meta_kubernetes_pod_name"]
+            target_label  = "pod"
+          }
     
-        rule {
-          source_labels = ["__meta_kubernetes_pod_container_name"]
-          target_label  = "container"
-        }
+          rule {
+            source_labels = ["__meta_kubernetes_pod_container_name"]
+            target_label  = "container"
+          }
     
-        // set the workload to the controller kind and name
-        rule {
-          action = "lowercase"
-          source_labels = ["__meta_kubernetes_pod_controller_kind"]
-          target_label  = "workload_type"
-        }
+          // set the workload to the controller kind and name
+          rule {
+            action = "lowercase"
+            source_labels = ["__meta_kubernetes_pod_controller_kind"]
+            target_label  = "workload_type"
+          }
     
-        rule {
-          source_labels = ["__meta_kubernetes_pod_controller_name"]
-          target_label  = "workload"
-        }
+          rule {
+            source_labels = ["__meta_kubernetes_pod_controller_name"]
+            target_label  = "workload"
+          }
     
-        // remove the hash from the ReplicaSet
-        rule {
-          source_labels = [
-            "workload_type",
-            "workload",
-          ]
-          separator = "/"
-          regex = "replicaset/(.+)-.+$"
-          target_label  = "workload"
-        }
+          // remove the hash from the ReplicaSet
+          rule {
+            source_labels = [
+              "workload_type",
+              "workload",
+            ]
+            separator = "/"
+            regex = "replicaset/(.+)-.+$"
+            target_label  = "workload"
+          }
     
-        // set the app name if specified as metadata labels "app:" or "app.kubernetes.io/name:" or "k8s-app:"
-        rule {
-          action = "replace"
-          source_labels = [
-            "__meta_kubernetes_pod_label_app_kubernetes_io_name",
-            "__meta_kubernetes_pod_label_k8s_app",
-            "__meta_kubernetes_pod_label_app",
-          ]
-          separator = ";"
-          regex = "^(?:;*)?([^;]+).*$"
-          replacement = "$1"
-          target_label = "app"
-        }
+          // set the app name if specified as metadata labels "app:" or "app.kubernetes.io/name:" or "k8s-app:"
+          rule {
+            action = "replace"
+            source_labels = [
+              "__meta_kubernetes_pod_label_app_kubernetes_io_name",
+              "__meta_kubernetes_pod_label_k8s_app",
+              "__meta_kubernetes_pod_label_app",
+            ]
+            separator = ";"
+            regex = "^(?:;*)?([^;]+).*$"
+            replacement = "$1"
+            target_label = "app"
+          }
     
-        // set the component if specified as metadata labels "component:" or "app.kubernetes.io/component:" or "k8s-component:"
-        rule {
-          action = "replace"
-          source_labels = [
-            "__meta_kubernetes_pod_label_app_kubernetes_io_component",
-            "__meta_kubernetes_pod_label_k8s_component",
-            "__meta_kubernetes_pod_label_component",
-          ]
-          regex = "^(?:;*)?([^;]+).*$"
-          replacement = "$1"
-          target_label = "component"
-        }
+          // set the component if specified as metadata labels "component:" or "app.kubernetes.io/component:" or "k8s-component:"
+          rule {
+            action = "replace"
+            source_labels = [
+              "__meta_kubernetes_pod_label_app_kubernetes_io_component",
+              "__meta_kubernetes_pod_label_k8s_component",
+              "__meta_kubernetes_pod_label_component",
+            ]
+            regex = "^(?:;*)?([^;]+).*$"
+            replacement = "$1"
+            target_label = "component"
+          }
     
-        // set a source label
-        rule {
-          action = "replace"
-          replacement = "kubernetes"
-          target_label = "source"
-        }
+          // set a source label
+          rule {
+            action = "replace"
+            replacement = "kubernetes"
+            target_label = "source"
+          }
+    
         }
     
         export "output" {

--- a/charts/k8s-monitoring/tests/integration/sharded-kube-state-metrics/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/integration/sharded-kube-state-metrics/.rendered/output.yaml
@@ -408,9 +408,23 @@ data:
         role = "node"
       }
     
+      discovery.relabel "nodes" {
+        targets = discovery.kubernetes.nodes.targets
+        rule {
+          source_labels = ["__meta_kubernetes_node_name"]
+          target_label  = "node"
+        }
+    
+        rule {
+          replacement = "kubernetes"
+          target_label = "source"
+        }
+    
+      }
+    
       // Kubelet
       discovery.relabel "kubelet" {
-        targets = discovery.kubernetes.nodes.targets
+        targets = discovery.relabel.nodes.output
       }
     
       prometheus.scrape "kubelet" {
@@ -446,41 +460,15 @@ data:
     
       // Kubelet Resources
       discovery.relabel "kubelet_resources" {
-        targets = discovery.kubernetes.nodes.targets
+        targets = discovery.relabel.nodes.output
         rule {
           replacement   = "/metrics/resource"
           target_label  = "__metrics_path__"
         }
-        // set the node label
-        rule {
-          source_labels = ["__meta_kubernetes_node_name"]
-          target_label  = "node"
-        }
-    
-        // set the app name if specified as metadata labels "app:" or "app.kubernetes.io/name:" or "k8s-app:"
-        rule {
-          action = "replace"
-          source_labels = [
-            "__meta_kubernetes_node_label_app_kubernetes_io_name",
-            "__meta_kubernetes_node_label_k8s_app",
-            "__meta_kubernetes_node_label_app",
-          ]
-          separator = ";"
-          regex = "^(?:;*)?([^;]+).*$"
-          replacement = "$1"
-          target_label = "app"
-        }
-    
-        // set a source label
-        rule {
-          action = "replace"
-          replacement = "kubernetes"
-          target_label = "source"
-        }
       }
     
       prometheus.scrape "kubelet_resources" {
-        targets  = discovery.relabel.kubelet_resources.output
+        targets = discovery.relabel.kubelet_resources.output
         job_name = "integrations/kubernetes/resources"
         scheme   = "https"
         scrape_interval = "60s"
@@ -512,34 +500,10 @@ data:
     
       // cAdvisor
       discovery.relabel "cadvisor" {
-        targets = discovery.kubernetes.nodes.targets
+        targets = discovery.relabel.nodes.output
         rule {
           replacement   = "/metrics/cadvisor"
           target_label  = "__metrics_path__"
-        }
-        rule {
-          source_labels = ["__meta_kubernetes_node_name"]
-          target_label  = "node"
-        }
-        // set the app name if specified as metadata labels "app:" or "app.kubernetes.io/name:" or "k8s-app:"
-        rule {
-          action = "replace"
-          source_labels = [
-            "__meta_kubernetes_node_label_app_kubernetes_io_name",
-            "__meta_kubernetes_node_label_k8s_app",
-            "__meta_kubernetes_node_label_app",
-          ]
-          separator = ";"
-          regex = "^(?:;*)?([^;]+).*$"
-          replacement = "$1"
-          target_label = "app"
-        }
-    
-        // set a source label
-        rule {
-          action = "replace"
-          replacement = "kubernetes"
-          target_label = "source"
         }
       }
     

--- a/charts/k8s-monitoring/tests/integration/split-destinations/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/integration/split-destinations/.rendered/output.yaml
@@ -253,9 +253,23 @@ data:
         role = "node"
       }
     
+      discovery.relabel "nodes" {
+        targets = discovery.kubernetes.nodes.targets
+        rule {
+          source_labels = ["__meta_kubernetes_node_name"]
+          target_label  = "node"
+        }
+    
+        rule {
+          replacement = "kubernetes"
+          target_label = "source"
+        }
+    
+      }
+    
       // Kubelet
       discovery.relabel "kubelet" {
-        targets = discovery.kubernetes.nodes.targets
+        targets = discovery.relabel.nodes.output
       }
     
       prometheus.scrape "kubelet" {
@@ -291,41 +305,15 @@ data:
     
       // Kubelet Resources
       discovery.relabel "kubelet_resources" {
-        targets = discovery.kubernetes.nodes.targets
+        targets = discovery.relabel.nodes.output
         rule {
           replacement   = "/metrics/resource"
           target_label  = "__metrics_path__"
         }
-        // set the node label
-        rule {
-          source_labels = ["__meta_kubernetes_node_name"]
-          target_label  = "node"
-        }
-    
-        // set the app name if specified as metadata labels "app:" or "app.kubernetes.io/name:" or "k8s-app:"
-        rule {
-          action = "replace"
-          source_labels = [
-            "__meta_kubernetes_node_label_app_kubernetes_io_name",
-            "__meta_kubernetes_node_label_k8s_app",
-            "__meta_kubernetes_node_label_app",
-          ]
-          separator = ";"
-          regex = "^(?:;*)?([^;]+).*$"
-          replacement = "$1"
-          target_label = "app"
-        }
-    
-        // set a source label
-        rule {
-          action = "replace"
-          replacement = "kubernetes"
-          target_label = "source"
-        }
       }
     
       prometheus.scrape "kubelet_resources" {
-        targets  = discovery.relabel.kubelet_resources.output
+        targets = discovery.relabel.kubelet_resources.output
         job_name = "integrations/kubernetes/resources"
         scheme   = "https"
         scrape_interval = "60s"
@@ -357,34 +345,10 @@ data:
     
       // cAdvisor
       discovery.relabel "cadvisor" {
-        targets = discovery.kubernetes.nodes.targets
+        targets = discovery.relabel.nodes.output
         rule {
           replacement   = "/metrics/cadvisor"
           target_label  = "__metrics_path__"
-        }
-        rule {
-          source_labels = ["__meta_kubernetes_node_name"]
-          target_label  = "node"
-        }
-        // set the app name if specified as metadata labels "app:" or "app.kubernetes.io/name:" or "k8s-app:"
-        rule {
-          action = "replace"
-          source_labels = [
-            "__meta_kubernetes_node_label_app_kubernetes_io_name",
-            "__meta_kubernetes_node_label_k8s_app",
-            "__meta_kubernetes_node_label_app",
-          ]
-          separator = ";"
-          regex = "^(?:;*)?([^;]+).*$"
-          replacement = "$1"
-          target_label = "app"
-        }
-    
-        // set a source label
-        rule {
-          action = "replace"
-          replacement = "kubernetes"
-          target_label = "source"
         }
       }
     

--- a/charts/k8s-monitoring/tests/integration/upgrade/patch/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/integration/upgrade/patch/.rendered/output.yaml
@@ -188,9 +188,23 @@ data:
         role = "node"
       }
     
+      discovery.relabel "nodes" {
+        targets = discovery.kubernetes.nodes.targets
+        rule {
+          source_labels = ["__meta_kubernetes_node_name"]
+          target_label  = "node"
+        }
+    
+        rule {
+          replacement = "kubernetes"
+          target_label = "source"
+        }
+    
+      }
+    
       // Kubelet
       discovery.relabel "kubelet" {
-        targets = discovery.kubernetes.nodes.targets
+        targets = discovery.relabel.nodes.output
       }
     
       prometheus.scrape "kubelet" {
@@ -226,41 +240,15 @@ data:
     
       // Kubelet Resources
       discovery.relabel "kubelet_resources" {
-        targets = discovery.kubernetes.nodes.targets
+        targets = discovery.relabel.nodes.output
         rule {
           replacement   = "/metrics/resource"
           target_label  = "__metrics_path__"
         }
-        // set the node label
-        rule {
-          source_labels = ["__meta_kubernetes_node_name"]
-          target_label  = "node"
-        }
-    
-        // set the app name if specified as metadata labels "app:" or "app.kubernetes.io/name:" or "k8s-app:"
-        rule {
-          action = "replace"
-          source_labels = [
-            "__meta_kubernetes_node_label_app_kubernetes_io_name",
-            "__meta_kubernetes_node_label_k8s_app",
-            "__meta_kubernetes_node_label_app",
-          ]
-          separator = ";"
-          regex = "^(?:;*)?([^;]+).*$"
-          replacement = "$1"
-          target_label = "app"
-        }
-    
-        // set a source label
-        rule {
-          action = "replace"
-          replacement = "kubernetes"
-          target_label = "source"
-        }
       }
     
       prometheus.scrape "kubelet_resources" {
-        targets  = discovery.relabel.kubelet_resources.output
+        targets = discovery.relabel.kubelet_resources.output
         job_name = "integrations/kubernetes/resources"
         scheme   = "https"
         scrape_interval = "60s"
@@ -292,34 +280,10 @@ data:
     
       // cAdvisor
       discovery.relabel "cadvisor" {
-        targets = discovery.kubernetes.nodes.targets
+        targets = discovery.relabel.nodes.output
         rule {
           replacement   = "/metrics/cadvisor"
           target_label  = "__metrics_path__"
-        }
-        rule {
-          source_labels = ["__meta_kubernetes_node_name"]
-          target_label  = "node"
-        }
-        // set the app name if specified as metadata labels "app:" or "app.kubernetes.io/name:" or "k8s-app:"
-        rule {
-          action = "replace"
-          source_labels = [
-            "__meta_kubernetes_node_label_app_kubernetes_io_name",
-            "__meta_kubernetes_node_label_k8s_app",
-            "__meta_kubernetes_node_label_app",
-          ]
-          separator = ";"
-          regex = "^(?:;*)?([^;]+).*$"
-          replacement = "$1"
-          target_label = "app"
-        }
-    
-        // set a source label
-        rule {
-          action = "replace"
-          replacement = "kubernetes"
-          target_label = "source"
         }
       }
     

--- a/charts/k8s-monitoring/tests/platform/eks-fargate/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/platform/eks-fargate/.rendered/output.yaml
@@ -137,9 +137,23 @@ data:
         role = "node"
       }
     
+      discovery.relabel "nodes" {
+        targets = discovery.kubernetes.nodes.targets
+        rule {
+          source_labels = ["__meta_kubernetes_node_name"]
+          target_label  = "node"
+        }
+    
+        rule {
+          replacement = "kubernetes"
+          target_label = "source"
+        }
+    
+      }
+    
       // Kubelet
       discovery.relabel "kubelet" {
-        targets = discovery.kubernetes.nodes.targets
+        targets = discovery.relabel.nodes.output
       }
     
       prometheus.scrape "kubelet" {
@@ -175,41 +189,15 @@ data:
     
       // Kubelet Resources
       discovery.relabel "kubelet_resources" {
-        targets = discovery.kubernetes.nodes.targets
+        targets = discovery.relabel.nodes.output
         rule {
           replacement   = "/metrics/resource"
           target_label  = "__metrics_path__"
         }
-        // set the node label
-        rule {
-          source_labels = ["__meta_kubernetes_node_name"]
-          target_label  = "node"
-        }
-    
-        // set the app name if specified as metadata labels "app:" or "app.kubernetes.io/name:" or "k8s-app:"
-        rule {
-          action = "replace"
-          source_labels = [
-            "__meta_kubernetes_node_label_app_kubernetes_io_name",
-            "__meta_kubernetes_node_label_k8s_app",
-            "__meta_kubernetes_node_label_app",
-          ]
-          separator = ";"
-          regex = "^(?:;*)?([^;]+).*$"
-          replacement = "$1"
-          target_label = "app"
-        }
-    
-        // set a source label
-        rule {
-          action = "replace"
-          replacement = "kubernetes"
-          target_label = "source"
-        }
       }
     
       prometheus.scrape "kubelet_resources" {
-        targets  = discovery.relabel.kubelet_resources.output
+        targets = discovery.relabel.kubelet_resources.output
         job_name = "integrations/kubernetes/resources"
         scheme   = "https"
         scrape_interval = "60s"
@@ -241,34 +229,10 @@ data:
     
       // cAdvisor
       discovery.relabel "cadvisor" {
-        targets = discovery.kubernetes.nodes.targets
+        targets = discovery.relabel.nodes.output
         rule {
           replacement   = "/metrics/cadvisor"
           target_label  = "__metrics_path__"
-        }
-        rule {
-          source_labels = ["__meta_kubernetes_node_name"]
-          target_label  = "node"
-        }
-        // set the app name if specified as metadata labels "app:" or "app.kubernetes.io/name:" or "k8s-app:"
-        rule {
-          action = "replace"
-          source_labels = [
-            "__meta_kubernetes_node_label_app_kubernetes_io_name",
-            "__meta_kubernetes_node_label_k8s_app",
-            "__meta_kubernetes_node_label_app",
-          ]
-          separator = ";"
-          regex = "^(?:;*)?([^;]+).*$"
-          replacement = "$1"
-          target_label = "app"
-        }
-    
-        // set a source label
-        rule {
-          action = "replace"
-          replacement = "kubernetes"
-          target_label = "source"
         }
       }
     
@@ -647,6 +611,7 @@ data:
           namespaces {
             names = coalesce(argument.namespaces.value, [])
           }
+    
         }
     
         // alloy relabelings (pre-scrape)
@@ -666,79 +631,78 @@ data:
             action = "keep"
           }
     
+          rule {
+            source_labels = ["__meta_kubernetes_namespace"]
+            target_label  = "namespace"
+          }
     
+          rule {
+            source_labels = ["__meta_kubernetes_pod_name"]
+            target_label  = "pod"
+          }
     
-        rule {
-          source_labels = ["__meta_kubernetes_namespace"]
-          target_label  = "namespace"
-        }
+          rule {
+            source_labels = ["__meta_kubernetes_pod_container_name"]
+            target_label  = "container"
+          }
     
-        rule {
-          source_labels = ["__meta_kubernetes_pod_name"]
-          target_label  = "pod"
-        }
+          // set the workload to the controller kind and name
+          rule {
+            action = "lowercase"
+            source_labels = ["__meta_kubernetes_pod_controller_kind"]
+            target_label  = "workload_type"
+          }
     
-        rule {
-          source_labels = ["__meta_kubernetes_pod_container_name"]
-          target_label  = "container"
-        }
+          rule {
+            source_labels = ["__meta_kubernetes_pod_controller_name"]
+            target_label  = "workload"
+          }
     
-        // set the workload to the controller kind and name
-        rule {
-          action = "lowercase"
-          source_labels = ["__meta_kubernetes_pod_controller_kind"]
-          target_label  = "workload_type"
-        }
+          // remove the hash from the ReplicaSet
+          rule {
+            source_labels = [
+              "workload_type",
+              "workload",
+            ]
+            separator = "/"
+            regex = "replicaset/(.+)-.+$"
+            target_label  = "workload"
+          }
     
-        rule {
-          source_labels = ["__meta_kubernetes_pod_controller_name"]
-          target_label  = "workload"
-        }
+          // set the app name if specified as metadata labels "app:" or "app.kubernetes.io/name:" or "k8s-app:"
+          rule {
+            action = "replace"
+            source_labels = [
+              "__meta_kubernetes_pod_label_app_kubernetes_io_name",
+              "__meta_kubernetes_pod_label_k8s_app",
+              "__meta_kubernetes_pod_label_app",
+            ]
+            separator = ";"
+            regex = "^(?:;*)?([^;]+).*$"
+            replacement = "$1"
+            target_label = "app"
+          }
     
-        // remove the hash from the ReplicaSet
-        rule {
-          source_labels = [
-            "workload_type",
-            "workload",
-          ]
-          separator = "/"
-          regex = "replicaset/(.+)-.+$"
-          target_label  = "workload"
-        }
+          // set the component if specified as metadata labels "component:" or "app.kubernetes.io/component:" or "k8s-component:"
+          rule {
+            action = "replace"
+            source_labels = [
+              "__meta_kubernetes_pod_label_app_kubernetes_io_component",
+              "__meta_kubernetes_pod_label_k8s_component",
+              "__meta_kubernetes_pod_label_component",
+            ]
+            regex = "^(?:;*)?([^;]+).*$"
+            replacement = "$1"
+            target_label = "component"
+          }
     
-        // set the app name if specified as metadata labels "app:" or "app.kubernetes.io/name:" or "k8s-app:"
-        rule {
-          action = "replace"
-          source_labels = [
-            "__meta_kubernetes_pod_label_app_kubernetes_io_name",
-            "__meta_kubernetes_pod_label_k8s_app",
-            "__meta_kubernetes_pod_label_app",
-          ]
-          separator = ";"
-          regex = "^(?:;*)?([^;]+).*$"
-          replacement = "$1"
-          target_label = "app"
-        }
+          // set a source label
+          rule {
+            action = "replace"
+            replacement = "kubernetes"
+            target_label = "source"
+          }
     
-        // set the component if specified as metadata labels "component:" or "app.kubernetes.io/component:" or "k8s-component:"
-        rule {
-          action = "replace"
-          source_labels = [
-            "__meta_kubernetes_pod_label_app_kubernetes_io_component",
-            "__meta_kubernetes_pod_label_k8s_component",
-            "__meta_kubernetes_pod_label_component",
-          ]
-          regex = "^(?:;*)?([^;]+).*$"
-          replacement = "$1"
-          target_label = "component"
-        }
-    
-        // set a source label
-        rule {
-          action = "replace"
-          replacement = "kubernetes"
-          target_label = "source"
-        }
         }
     
         export "output" {

--- a/charts/k8s-monitoring/tests/platform/eks-with-windows/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/platform/eks-with-windows/.rendered/output.yaml
@@ -137,9 +137,23 @@ data:
         role = "node"
       }
     
+      discovery.relabel "nodes" {
+        targets = discovery.kubernetes.nodes.targets
+        rule {
+          source_labels = ["__meta_kubernetes_node_name"]
+          target_label  = "node"
+        }
+    
+        rule {
+          replacement = "kubernetes"
+          target_label = "source"
+        }
+    
+      }
+    
       // Kubelet
       discovery.relabel "kubelet" {
-        targets = discovery.kubernetes.nodes.targets
+        targets = discovery.relabel.nodes.output
       }
     
       prometheus.scrape "kubelet" {
@@ -175,41 +189,15 @@ data:
     
       // Kubelet Resources
       discovery.relabel "kubelet_resources" {
-        targets = discovery.kubernetes.nodes.targets
+        targets = discovery.relabel.nodes.output
         rule {
           replacement   = "/metrics/resource"
           target_label  = "__metrics_path__"
         }
-        // set the node label
-        rule {
-          source_labels = ["__meta_kubernetes_node_name"]
-          target_label  = "node"
-        }
-    
-        // set the app name if specified as metadata labels "app:" or "app.kubernetes.io/name:" or "k8s-app:"
-        rule {
-          action = "replace"
-          source_labels = [
-            "__meta_kubernetes_node_label_app_kubernetes_io_name",
-            "__meta_kubernetes_node_label_k8s_app",
-            "__meta_kubernetes_node_label_app",
-          ]
-          separator = ";"
-          regex = "^(?:;*)?([^;]+).*$"
-          replacement = "$1"
-          target_label = "app"
-        }
-    
-        // set a source label
-        rule {
-          action = "replace"
-          replacement = "kubernetes"
-          target_label = "source"
-        }
       }
     
       prometheus.scrape "kubelet_resources" {
-        targets  = discovery.relabel.kubelet_resources.output
+        targets = discovery.relabel.kubelet_resources.output
         job_name = "integrations/kubernetes/resources"
         scheme   = "https"
         scrape_interval = "60s"
@@ -241,34 +229,10 @@ data:
     
       // cAdvisor
       discovery.relabel "cadvisor" {
-        targets = discovery.kubernetes.nodes.targets
+        targets = discovery.relabel.nodes.output
         rule {
           replacement   = "/metrics/cadvisor"
           target_label  = "__metrics_path__"
-        }
-        rule {
-          source_labels = ["__meta_kubernetes_node_name"]
-          target_label  = "node"
-        }
-        // set the app name if specified as metadata labels "app:" or "app.kubernetes.io/name:" or "k8s-app:"
-        rule {
-          action = "replace"
-          source_labels = [
-            "__meta_kubernetes_node_label_app_kubernetes_io_name",
-            "__meta_kubernetes_node_label_k8s_app",
-            "__meta_kubernetes_node_label_app",
-          ]
-          separator = ";"
-          regex = "^(?:;*)?([^;]+).*$"
-          replacement = "$1"
-          target_label = "app"
-        }
-    
-        // set a source label
-        rule {
-          action = "replace"
-          replacement = "kubernetes"
-          target_label = "source"
         }
       }
     
@@ -647,6 +611,7 @@ data:
           namespaces {
             names = coalesce(argument.namespaces.value, [])
           }
+    
         }
     
         // alloy relabelings (pre-scrape)
@@ -666,79 +631,78 @@ data:
             action = "keep"
           }
     
+          rule {
+            source_labels = ["__meta_kubernetes_namespace"]
+            target_label  = "namespace"
+          }
     
+          rule {
+            source_labels = ["__meta_kubernetes_pod_name"]
+            target_label  = "pod"
+          }
     
-        rule {
-          source_labels = ["__meta_kubernetes_namespace"]
-          target_label  = "namespace"
-        }
+          rule {
+            source_labels = ["__meta_kubernetes_pod_container_name"]
+            target_label  = "container"
+          }
     
-        rule {
-          source_labels = ["__meta_kubernetes_pod_name"]
-          target_label  = "pod"
-        }
+          // set the workload to the controller kind and name
+          rule {
+            action = "lowercase"
+            source_labels = ["__meta_kubernetes_pod_controller_kind"]
+            target_label  = "workload_type"
+          }
     
-        rule {
-          source_labels = ["__meta_kubernetes_pod_container_name"]
-          target_label  = "container"
-        }
+          rule {
+            source_labels = ["__meta_kubernetes_pod_controller_name"]
+            target_label  = "workload"
+          }
     
-        // set the workload to the controller kind and name
-        rule {
-          action = "lowercase"
-          source_labels = ["__meta_kubernetes_pod_controller_kind"]
-          target_label  = "workload_type"
-        }
+          // remove the hash from the ReplicaSet
+          rule {
+            source_labels = [
+              "workload_type",
+              "workload",
+            ]
+            separator = "/"
+            regex = "replicaset/(.+)-.+$"
+            target_label  = "workload"
+          }
     
-        rule {
-          source_labels = ["__meta_kubernetes_pod_controller_name"]
-          target_label  = "workload"
-        }
+          // set the app name if specified as metadata labels "app:" or "app.kubernetes.io/name:" or "k8s-app:"
+          rule {
+            action = "replace"
+            source_labels = [
+              "__meta_kubernetes_pod_label_app_kubernetes_io_name",
+              "__meta_kubernetes_pod_label_k8s_app",
+              "__meta_kubernetes_pod_label_app",
+            ]
+            separator = ";"
+            regex = "^(?:;*)?([^;]+).*$"
+            replacement = "$1"
+            target_label = "app"
+          }
     
-        // remove the hash from the ReplicaSet
-        rule {
-          source_labels = [
-            "workload_type",
-            "workload",
-          ]
-          separator = "/"
-          regex = "replicaset/(.+)-.+$"
-          target_label  = "workload"
-        }
+          // set the component if specified as metadata labels "component:" or "app.kubernetes.io/component:" or "k8s-component:"
+          rule {
+            action = "replace"
+            source_labels = [
+              "__meta_kubernetes_pod_label_app_kubernetes_io_component",
+              "__meta_kubernetes_pod_label_k8s_component",
+              "__meta_kubernetes_pod_label_component",
+            ]
+            regex = "^(?:;*)?([^;]+).*$"
+            replacement = "$1"
+            target_label = "component"
+          }
     
-        // set the app name if specified as metadata labels "app:" or "app.kubernetes.io/name:" or "k8s-app:"
-        rule {
-          action = "replace"
-          source_labels = [
-            "__meta_kubernetes_pod_label_app_kubernetes_io_name",
-            "__meta_kubernetes_pod_label_k8s_app",
-            "__meta_kubernetes_pod_label_app",
-          ]
-          separator = ";"
-          regex = "^(?:;*)?([^;]+).*$"
-          replacement = "$1"
-          target_label = "app"
-        }
+          // set a source label
+          rule {
+            action = "replace"
+            replacement = "kubernetes"
+            target_label = "source"
+          }
     
-        // set the component if specified as metadata labels "component:" or "app.kubernetes.io/component:" or "k8s-component:"
-        rule {
-          action = "replace"
-          source_labels = [
-            "__meta_kubernetes_pod_label_app_kubernetes_io_component",
-            "__meta_kubernetes_pod_label_k8s_component",
-            "__meta_kubernetes_pod_label_component",
-          ]
-          regex = "^(?:;*)?([^;]+).*$"
-          replacement = "$1"
-          target_label = "component"
-        }
-    
-        // set a source label
-        rule {
-          action = "replace"
-          replacement = "kubernetes"
-          target_label = "source"
-        }
         }
     
         export "output" {

--- a/charts/k8s-monitoring/tests/platform/gke-autopilot/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/platform/gke-autopilot/.rendered/output.yaml
@@ -81,9 +81,23 @@ data:
         role = "node"
       }
     
+      discovery.relabel "nodes" {
+        targets = discovery.kubernetes.nodes.targets
+        rule {
+          source_labels = ["__meta_kubernetes_node_name"]
+          target_label  = "node"
+        }
+    
+        rule {
+          replacement = "kubernetes"
+          target_label = "source"
+        }
+    
+      }
+    
       // Kubelet
       discovery.relabel "kubelet" {
-        targets = discovery.kubernetes.nodes.targets
+        targets = discovery.relabel.nodes.output
       }
     
       prometheus.scrape "kubelet" {
@@ -119,41 +133,15 @@ data:
     
       // Kubelet Resources
       discovery.relabel "kubelet_resources" {
-        targets = discovery.kubernetes.nodes.targets
+        targets = discovery.relabel.nodes.output
         rule {
           replacement   = "/metrics/resource"
           target_label  = "__metrics_path__"
         }
-        // set the node label
-        rule {
-          source_labels = ["__meta_kubernetes_node_name"]
-          target_label  = "node"
-        }
-    
-        // set the app name if specified as metadata labels "app:" or "app.kubernetes.io/name:" or "k8s-app:"
-        rule {
-          action = "replace"
-          source_labels = [
-            "__meta_kubernetes_node_label_app_kubernetes_io_name",
-            "__meta_kubernetes_node_label_k8s_app",
-            "__meta_kubernetes_node_label_app",
-          ]
-          separator = ";"
-          regex = "^(?:;*)?([^;]+).*$"
-          replacement = "$1"
-          target_label = "app"
-        }
-    
-        // set a source label
-        rule {
-          action = "replace"
-          replacement = "kubernetes"
-          target_label = "source"
-        }
       }
     
       prometheus.scrape "kubelet_resources" {
-        targets  = discovery.relabel.kubelet_resources.output
+        targets = discovery.relabel.kubelet_resources.output
         job_name = "integrations/kubernetes/resources"
         scheme   = "https"
         scrape_interval = "60s"
@@ -185,34 +173,10 @@ data:
     
       // cAdvisor
       discovery.relabel "cadvisor" {
-        targets = discovery.kubernetes.nodes.targets
+        targets = discovery.relabel.nodes.output
         rule {
           replacement   = "/metrics/cadvisor"
           target_label  = "__metrics_path__"
-        }
-        rule {
-          source_labels = ["__meta_kubernetes_node_name"]
-          target_label  = "node"
-        }
-        // set the app name if specified as metadata labels "app:" or "app.kubernetes.io/name:" or "k8s-app:"
-        rule {
-          action = "replace"
-          source_labels = [
-            "__meta_kubernetes_node_label_app_kubernetes_io_name",
-            "__meta_kubernetes_node_label_k8s_app",
-            "__meta_kubernetes_node_label_app",
-          ]
-          separator = ";"
-          regex = "^(?:;*)?([^;]+).*$"
-          replacement = "$1"
-          target_label = "app"
-        }
-    
-        // set a source label
-        rule {
-          action = "replace"
-          replacement = "kubernetes"
-          target_label = "source"
         }
       }
     
@@ -413,6 +377,7 @@ data:
           namespaces {
             names = coalesce(argument.namespaces.value, [])
           }
+    
         }
     
         // alloy relabelings (pre-scrape)
@@ -432,79 +397,78 @@ data:
             action = "keep"
           }
     
+          rule {
+            source_labels = ["__meta_kubernetes_namespace"]
+            target_label  = "namespace"
+          }
     
+          rule {
+            source_labels = ["__meta_kubernetes_pod_name"]
+            target_label  = "pod"
+          }
     
-        rule {
-          source_labels = ["__meta_kubernetes_namespace"]
-          target_label  = "namespace"
-        }
+          rule {
+            source_labels = ["__meta_kubernetes_pod_container_name"]
+            target_label  = "container"
+          }
     
-        rule {
-          source_labels = ["__meta_kubernetes_pod_name"]
-          target_label  = "pod"
-        }
+          // set the workload to the controller kind and name
+          rule {
+            action = "lowercase"
+            source_labels = ["__meta_kubernetes_pod_controller_kind"]
+            target_label  = "workload_type"
+          }
     
-        rule {
-          source_labels = ["__meta_kubernetes_pod_container_name"]
-          target_label  = "container"
-        }
+          rule {
+            source_labels = ["__meta_kubernetes_pod_controller_name"]
+            target_label  = "workload"
+          }
     
-        // set the workload to the controller kind and name
-        rule {
-          action = "lowercase"
-          source_labels = ["__meta_kubernetes_pod_controller_kind"]
-          target_label  = "workload_type"
-        }
+          // remove the hash from the ReplicaSet
+          rule {
+            source_labels = [
+              "workload_type",
+              "workload",
+            ]
+            separator = "/"
+            regex = "replicaset/(.+)-.+$"
+            target_label  = "workload"
+          }
     
-        rule {
-          source_labels = ["__meta_kubernetes_pod_controller_name"]
-          target_label  = "workload"
-        }
+          // set the app name if specified as metadata labels "app:" or "app.kubernetes.io/name:" or "k8s-app:"
+          rule {
+            action = "replace"
+            source_labels = [
+              "__meta_kubernetes_pod_label_app_kubernetes_io_name",
+              "__meta_kubernetes_pod_label_k8s_app",
+              "__meta_kubernetes_pod_label_app",
+            ]
+            separator = ";"
+            regex = "^(?:;*)?([^;]+).*$"
+            replacement = "$1"
+            target_label = "app"
+          }
     
-        // remove the hash from the ReplicaSet
-        rule {
-          source_labels = [
-            "workload_type",
-            "workload",
-          ]
-          separator = "/"
-          regex = "replicaset/(.+)-.+$"
-          target_label  = "workload"
-        }
+          // set the component if specified as metadata labels "component:" or "app.kubernetes.io/component:" or "k8s-component:"
+          rule {
+            action = "replace"
+            source_labels = [
+              "__meta_kubernetes_pod_label_app_kubernetes_io_component",
+              "__meta_kubernetes_pod_label_k8s_component",
+              "__meta_kubernetes_pod_label_component",
+            ]
+            regex = "^(?:;*)?([^;]+).*$"
+            replacement = "$1"
+            target_label = "component"
+          }
     
-        // set the app name if specified as metadata labels "app:" or "app.kubernetes.io/name:" or "k8s-app:"
-        rule {
-          action = "replace"
-          source_labels = [
-            "__meta_kubernetes_pod_label_app_kubernetes_io_name",
-            "__meta_kubernetes_pod_label_k8s_app",
-            "__meta_kubernetes_pod_label_app",
-          ]
-          separator = ";"
-          regex = "^(?:;*)?([^;]+).*$"
-          replacement = "$1"
-          target_label = "app"
-        }
+          // set a source label
+          rule {
+            action = "replace"
+            replacement = "kubernetes"
+            target_label = "source"
+          }
     
-        // set the component if specified as metadata labels "component:" or "app.kubernetes.io/component:" or "k8s-component:"
-        rule {
-          action = "replace"
-          source_labels = [
-            "__meta_kubernetes_pod_label_app_kubernetes_io_component",
-            "__meta_kubernetes_pod_label_k8s_component",
-            "__meta_kubernetes_pod_label_component",
-          ]
-          regex = "^(?:;*)?([^;]+).*$"
-          replacement = "$1"
-          target_label = "component"
-        }
-    
-        // set a source label
-        rule {
-          action = "replace"
-          replacement = "kubernetes"
-          target_label = "source"
-        }
         }
     
         export "output" {

--- a/charts/k8s-monitoring/tests/platform/gke/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/platform/gke/.rendered/output.yaml
@@ -137,9 +137,23 @@ data:
         role = "node"
       }
     
+      discovery.relabel "nodes" {
+        targets = discovery.kubernetes.nodes.targets
+        rule {
+          source_labels = ["__meta_kubernetes_node_name"]
+          target_label  = "node"
+        }
+    
+        rule {
+          replacement = "kubernetes"
+          target_label = "source"
+        }
+    
+      }
+    
       // Kubelet
       discovery.relabel "kubelet" {
-        targets = discovery.kubernetes.nodes.targets
+        targets = discovery.relabel.nodes.output
       }
     
       prometheus.scrape "kubelet" {
@@ -175,41 +189,15 @@ data:
     
       // Kubelet Resources
       discovery.relabel "kubelet_resources" {
-        targets = discovery.kubernetes.nodes.targets
+        targets = discovery.relabel.nodes.output
         rule {
           replacement   = "/metrics/resource"
           target_label  = "__metrics_path__"
         }
-        // set the node label
-        rule {
-          source_labels = ["__meta_kubernetes_node_name"]
-          target_label  = "node"
-        }
-    
-        // set the app name if specified as metadata labels "app:" or "app.kubernetes.io/name:" or "k8s-app:"
-        rule {
-          action = "replace"
-          source_labels = [
-            "__meta_kubernetes_node_label_app_kubernetes_io_name",
-            "__meta_kubernetes_node_label_k8s_app",
-            "__meta_kubernetes_node_label_app",
-          ]
-          separator = ";"
-          regex = "^(?:;*)?([^;]+).*$"
-          replacement = "$1"
-          target_label = "app"
-        }
-    
-        // set a source label
-        rule {
-          action = "replace"
-          replacement = "kubernetes"
-          target_label = "source"
-        }
       }
     
       prometheus.scrape "kubelet_resources" {
-        targets  = discovery.relabel.kubelet_resources.output
+        targets = discovery.relabel.kubelet_resources.output
         job_name = "integrations/kubernetes/resources"
         scheme   = "https"
         scrape_interval = "60s"
@@ -241,34 +229,10 @@ data:
     
       // cAdvisor
       discovery.relabel "cadvisor" {
-        targets = discovery.kubernetes.nodes.targets
+        targets = discovery.relabel.nodes.output
         rule {
           replacement   = "/metrics/cadvisor"
           target_label  = "__metrics_path__"
-        }
-        rule {
-          source_labels = ["__meta_kubernetes_node_name"]
-          target_label  = "node"
-        }
-        // set the app name if specified as metadata labels "app:" or "app.kubernetes.io/name:" or "k8s-app:"
-        rule {
-          action = "replace"
-          source_labels = [
-            "__meta_kubernetes_node_label_app_kubernetes_io_name",
-            "__meta_kubernetes_node_label_k8s_app",
-            "__meta_kubernetes_node_label_app",
-          ]
-          separator = ";"
-          regex = "^(?:;*)?([^;]+).*$"
-          replacement = "$1"
-          target_label = "app"
-        }
-    
-        // set a source label
-        rule {
-          action = "replace"
-          replacement = "kubernetes"
-          target_label = "source"
         }
       }
     
@@ -647,6 +611,7 @@ data:
           namespaces {
             names = coalesce(argument.namespaces.value, [])
           }
+    
         }
     
         // alloy relabelings (pre-scrape)
@@ -666,79 +631,78 @@ data:
             action = "keep"
           }
     
+          rule {
+            source_labels = ["__meta_kubernetes_namespace"]
+            target_label  = "namespace"
+          }
     
+          rule {
+            source_labels = ["__meta_kubernetes_pod_name"]
+            target_label  = "pod"
+          }
     
-        rule {
-          source_labels = ["__meta_kubernetes_namespace"]
-          target_label  = "namespace"
-        }
+          rule {
+            source_labels = ["__meta_kubernetes_pod_container_name"]
+            target_label  = "container"
+          }
     
-        rule {
-          source_labels = ["__meta_kubernetes_pod_name"]
-          target_label  = "pod"
-        }
+          // set the workload to the controller kind and name
+          rule {
+            action = "lowercase"
+            source_labels = ["__meta_kubernetes_pod_controller_kind"]
+            target_label  = "workload_type"
+          }
     
-        rule {
-          source_labels = ["__meta_kubernetes_pod_container_name"]
-          target_label  = "container"
-        }
+          rule {
+            source_labels = ["__meta_kubernetes_pod_controller_name"]
+            target_label  = "workload"
+          }
     
-        // set the workload to the controller kind and name
-        rule {
-          action = "lowercase"
-          source_labels = ["__meta_kubernetes_pod_controller_kind"]
-          target_label  = "workload_type"
-        }
+          // remove the hash from the ReplicaSet
+          rule {
+            source_labels = [
+              "workload_type",
+              "workload",
+            ]
+            separator = "/"
+            regex = "replicaset/(.+)-.+$"
+            target_label  = "workload"
+          }
     
-        rule {
-          source_labels = ["__meta_kubernetes_pod_controller_name"]
-          target_label  = "workload"
-        }
+          // set the app name if specified as metadata labels "app:" or "app.kubernetes.io/name:" or "k8s-app:"
+          rule {
+            action = "replace"
+            source_labels = [
+              "__meta_kubernetes_pod_label_app_kubernetes_io_name",
+              "__meta_kubernetes_pod_label_k8s_app",
+              "__meta_kubernetes_pod_label_app",
+            ]
+            separator = ";"
+            regex = "^(?:;*)?([^;]+).*$"
+            replacement = "$1"
+            target_label = "app"
+          }
     
-        // remove the hash from the ReplicaSet
-        rule {
-          source_labels = [
-            "workload_type",
-            "workload",
-          ]
-          separator = "/"
-          regex = "replicaset/(.+)-.+$"
-          target_label  = "workload"
-        }
+          // set the component if specified as metadata labels "component:" or "app.kubernetes.io/component:" or "k8s-component:"
+          rule {
+            action = "replace"
+            source_labels = [
+              "__meta_kubernetes_pod_label_app_kubernetes_io_component",
+              "__meta_kubernetes_pod_label_k8s_component",
+              "__meta_kubernetes_pod_label_component",
+            ]
+            regex = "^(?:;*)?([^;]+).*$"
+            replacement = "$1"
+            target_label = "component"
+          }
     
-        // set the app name if specified as metadata labels "app:" or "app.kubernetes.io/name:" or "k8s-app:"
-        rule {
-          action = "replace"
-          source_labels = [
-            "__meta_kubernetes_pod_label_app_kubernetes_io_name",
-            "__meta_kubernetes_pod_label_k8s_app",
-            "__meta_kubernetes_pod_label_app",
-          ]
-          separator = ";"
-          regex = "^(?:;*)?([^;]+).*$"
-          replacement = "$1"
-          target_label = "app"
-        }
+          // set a source label
+          rule {
+            action = "replace"
+            replacement = "kubernetes"
+            target_label = "source"
+          }
     
-        // set the component if specified as metadata labels "component:" or "app.kubernetes.io/component:" or "k8s-component:"
-        rule {
-          action = "replace"
-          source_labels = [
-            "__meta_kubernetes_pod_label_app_kubernetes_io_component",
-            "__meta_kubernetes_pod_label_k8s_component",
-            "__meta_kubernetes_pod_label_component",
-          ]
-          regex = "^(?:;*)?([^;]+).*$"
-          replacement = "$1"
-          target_label = "component"
-        }
-    
-        // set a source label
-        rule {
-          action = "replace"
-          replacement = "kubernetes"
-          target_label = "source"
-        }
         }
     
         export "output" {

--- a/charts/k8s-monitoring/tests/platform/grafana-cloud/k8s-monitoring/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/platform/grafana-cloud/k8s-monitoring/.rendered/output.yaml
@@ -165,9 +165,23 @@ data:
         role = "node"
       }
     
+      discovery.relabel "nodes" {
+        targets = discovery.kubernetes.nodes.targets
+        rule {
+          source_labels = ["__meta_kubernetes_node_name"]
+          target_label  = "node"
+        }
+    
+        rule {
+          replacement = "kubernetes"
+          target_label = "source"
+        }
+    
+      }
+    
       // Kubelet
       discovery.relabel "kubelet" {
-        targets = discovery.kubernetes.nodes.targets
+        targets = discovery.relabel.nodes.output
       }
     
       prometheus.scrape "kubelet" {
@@ -203,41 +217,15 @@ data:
     
       // Kubelet Resources
       discovery.relabel "kubelet_resources" {
-        targets = discovery.kubernetes.nodes.targets
+        targets = discovery.relabel.nodes.output
         rule {
           replacement   = "/metrics/resource"
           target_label  = "__metrics_path__"
         }
-        // set the node label
-        rule {
-          source_labels = ["__meta_kubernetes_node_name"]
-          target_label  = "node"
-        }
-    
-        // set the app name if specified as metadata labels "app:" or "app.kubernetes.io/name:" or "k8s-app:"
-        rule {
-          action = "replace"
-          source_labels = [
-            "__meta_kubernetes_node_label_app_kubernetes_io_name",
-            "__meta_kubernetes_node_label_k8s_app",
-            "__meta_kubernetes_node_label_app",
-          ]
-          separator = ";"
-          regex = "^(?:;*)?([^;]+).*$"
-          replacement = "$1"
-          target_label = "app"
-        }
-    
-        // set a source label
-        rule {
-          action = "replace"
-          replacement = "kubernetes"
-          target_label = "source"
-        }
       }
     
       prometheus.scrape "kubelet_resources" {
-        targets  = discovery.relabel.kubelet_resources.output
+        targets = discovery.relabel.kubelet_resources.output
         job_name = "integrations/kubernetes/resources"
         scheme   = "https"
         scrape_interval = "60s"
@@ -269,34 +257,10 @@ data:
     
       // cAdvisor
       discovery.relabel "cadvisor" {
-        targets = discovery.kubernetes.nodes.targets
+        targets = discovery.relabel.nodes.output
         rule {
           replacement   = "/metrics/cadvisor"
           target_label  = "__metrics_path__"
-        }
-        rule {
-          source_labels = ["__meta_kubernetes_node_name"]
-          target_label  = "node"
-        }
-        // set the app name if specified as metadata labels "app:" or "app.kubernetes.io/name:" or "k8s-app:"
-        rule {
-          action = "replace"
-          source_labels = [
-            "__meta_kubernetes_node_label_app_kubernetes_io_name",
-            "__meta_kubernetes_node_label_k8s_app",
-            "__meta_kubernetes_node_label_app",
-          ]
-          separator = ";"
-          regex = "^(?:;*)?([^;]+).*$"
-          replacement = "$1"
-          target_label = "app"
-        }
-    
-        // set a source label
-        rule {
-          action = "replace"
-          replacement = "kubernetes"
-          target_label = "source"
         }
       }
     
@@ -757,6 +721,7 @@ data:
           namespaces {
             names = coalesce(argument.namespaces.value, [])
           }
+    
         }
     
         // alloy relabelings (pre-scrape)
@@ -776,79 +741,78 @@ data:
             action = "keep"
           }
     
+          rule {
+            source_labels = ["__meta_kubernetes_namespace"]
+            target_label  = "namespace"
+          }
     
+          rule {
+            source_labels = ["__meta_kubernetes_pod_name"]
+            target_label  = "pod"
+          }
     
-        rule {
-          source_labels = ["__meta_kubernetes_namespace"]
-          target_label  = "namespace"
-        }
+          rule {
+            source_labels = ["__meta_kubernetes_pod_container_name"]
+            target_label  = "container"
+          }
     
-        rule {
-          source_labels = ["__meta_kubernetes_pod_name"]
-          target_label  = "pod"
-        }
+          // set the workload to the controller kind and name
+          rule {
+            action = "lowercase"
+            source_labels = ["__meta_kubernetes_pod_controller_kind"]
+            target_label  = "workload_type"
+          }
     
-        rule {
-          source_labels = ["__meta_kubernetes_pod_container_name"]
-          target_label  = "container"
-        }
+          rule {
+            source_labels = ["__meta_kubernetes_pod_controller_name"]
+            target_label  = "workload"
+          }
     
-        // set the workload to the controller kind and name
-        rule {
-          action = "lowercase"
-          source_labels = ["__meta_kubernetes_pod_controller_kind"]
-          target_label  = "workload_type"
-        }
+          // remove the hash from the ReplicaSet
+          rule {
+            source_labels = [
+              "workload_type",
+              "workload",
+            ]
+            separator = "/"
+            regex = "replicaset/(.+)-.+$"
+            target_label  = "workload"
+          }
     
-        rule {
-          source_labels = ["__meta_kubernetes_pod_controller_name"]
-          target_label  = "workload"
-        }
+          // set the app name if specified as metadata labels "app:" or "app.kubernetes.io/name:" or "k8s-app:"
+          rule {
+            action = "replace"
+            source_labels = [
+              "__meta_kubernetes_pod_label_app_kubernetes_io_name",
+              "__meta_kubernetes_pod_label_k8s_app",
+              "__meta_kubernetes_pod_label_app",
+            ]
+            separator = ";"
+            regex = "^(?:;*)?([^;]+).*$"
+            replacement = "$1"
+            target_label = "app"
+          }
     
-        // remove the hash from the ReplicaSet
-        rule {
-          source_labels = [
-            "workload_type",
-            "workload",
-          ]
-          separator = "/"
-          regex = "replicaset/(.+)-.+$"
-          target_label  = "workload"
-        }
+          // set the component if specified as metadata labels "component:" or "app.kubernetes.io/component:" or "k8s-component:"
+          rule {
+            action = "replace"
+            source_labels = [
+              "__meta_kubernetes_pod_label_app_kubernetes_io_component",
+              "__meta_kubernetes_pod_label_k8s_component",
+              "__meta_kubernetes_pod_label_component",
+            ]
+            regex = "^(?:;*)?([^;]+).*$"
+            replacement = "$1"
+            target_label = "component"
+          }
     
-        // set the app name if specified as metadata labels "app:" or "app.kubernetes.io/name:" or "k8s-app:"
-        rule {
-          action = "replace"
-          source_labels = [
-            "__meta_kubernetes_pod_label_app_kubernetes_io_name",
-            "__meta_kubernetes_pod_label_k8s_app",
-            "__meta_kubernetes_pod_label_app",
-          ]
-          separator = ";"
-          regex = "^(?:;*)?([^;]+).*$"
-          replacement = "$1"
-          target_label = "app"
-        }
+          // set a source label
+          rule {
+            action = "replace"
+            replacement = "kubernetes"
+            target_label = "source"
+          }
     
-        // set the component if specified as metadata labels "component:" or "app.kubernetes.io/component:" or "k8s-component:"
-        rule {
-          action = "replace"
-          source_labels = [
-            "__meta_kubernetes_pod_label_app_kubernetes_io_component",
-            "__meta_kubernetes_pod_label_k8s_component",
-            "__meta_kubernetes_pod_label_component",
-          ]
-          regex = "^(?:;*)?([^;]+).*$"
-          replacement = "$1"
-          target_label = "component"
-        }
-    
-        // set a source label
-        rule {
-          action = "replace"
-          replacement = "kubernetes"
-          target_label = "source"
-        }
         }
     
         export "output" {

--- a/charts/k8s-monitoring/tests/platform/openshift/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/platform/openshift/.rendered/output.yaml
@@ -103,9 +103,23 @@ data:
         role = "node"
       }
     
+      discovery.relabel "nodes" {
+        targets = discovery.kubernetes.nodes.targets
+        rule {
+          source_labels = ["__meta_kubernetes_node_name"]
+          target_label  = "node"
+        }
+    
+        rule {
+          replacement = "kubernetes"
+          target_label = "source"
+        }
+    
+      }
+    
       // Kubelet
       discovery.relabel "kubelet" {
-        targets = discovery.kubernetes.nodes.targets
+        targets = discovery.relabel.nodes.output
       }
     
       prometheus.scrape "kubelet" {
@@ -141,41 +155,15 @@ data:
     
       // Kubelet Resources
       discovery.relabel "kubelet_resources" {
-        targets = discovery.kubernetes.nodes.targets
+        targets = discovery.relabel.nodes.output
         rule {
           replacement   = "/metrics/resource"
           target_label  = "__metrics_path__"
         }
-        // set the node label
-        rule {
-          source_labels = ["__meta_kubernetes_node_name"]
-          target_label  = "node"
-        }
-    
-        // set the app name if specified as metadata labels "app:" or "app.kubernetes.io/name:" or "k8s-app:"
-        rule {
-          action = "replace"
-          source_labels = [
-            "__meta_kubernetes_node_label_app_kubernetes_io_name",
-            "__meta_kubernetes_node_label_k8s_app",
-            "__meta_kubernetes_node_label_app",
-          ]
-          separator = ";"
-          regex = "^(?:;*)?([^;]+).*$"
-          replacement = "$1"
-          target_label = "app"
-        }
-    
-        // set a source label
-        rule {
-          action = "replace"
-          replacement = "kubernetes"
-          target_label = "source"
-        }
       }
     
       prometheus.scrape "kubelet_resources" {
-        targets  = discovery.relabel.kubelet_resources.output
+        targets = discovery.relabel.kubelet_resources.output
         job_name = "integrations/kubernetes/resources"
         scheme   = "https"
         scrape_interval = "60s"
@@ -207,34 +195,10 @@ data:
     
       // cAdvisor
       discovery.relabel "cadvisor" {
-        targets = discovery.kubernetes.nodes.targets
+        targets = discovery.relabel.nodes.output
         rule {
           replacement   = "/metrics/cadvisor"
           target_label  = "__metrics_path__"
-        }
-        rule {
-          source_labels = ["__meta_kubernetes_node_name"]
-          target_label  = "node"
-        }
-        // set the app name if specified as metadata labels "app:" or "app.kubernetes.io/name:" or "k8s-app:"
-        rule {
-          action = "replace"
-          source_labels = [
-            "__meta_kubernetes_node_label_app_kubernetes_io_name",
-            "__meta_kubernetes_node_label_k8s_app",
-            "__meta_kubernetes_node_label_app",
-          ]
-          separator = ";"
-          regex = "^(?:;*)?([^;]+).*$"
-          replacement = "$1"
-          target_label = "app"
-        }
-    
-        // set a source label
-        rule {
-          action = "replace"
-          replacement = "kubernetes"
-          target_label = "source"
         }
       }
     
@@ -613,6 +577,7 @@ data:
           namespaces {
             names = coalesce(argument.namespaces.value, [])
           }
+    
         }
     
         // alloy relabelings (pre-scrape)
@@ -632,79 +597,78 @@ data:
             action = "keep"
           }
     
+          rule {
+            source_labels = ["__meta_kubernetes_namespace"]
+            target_label  = "namespace"
+          }
     
+          rule {
+            source_labels = ["__meta_kubernetes_pod_name"]
+            target_label  = "pod"
+          }
     
-        rule {
-          source_labels = ["__meta_kubernetes_namespace"]
-          target_label  = "namespace"
-        }
+          rule {
+            source_labels = ["__meta_kubernetes_pod_container_name"]
+            target_label  = "container"
+          }
     
-        rule {
-          source_labels = ["__meta_kubernetes_pod_name"]
-          target_label  = "pod"
-        }
+          // set the workload to the controller kind and name
+          rule {
+            action = "lowercase"
+            source_labels = ["__meta_kubernetes_pod_controller_kind"]
+            target_label  = "workload_type"
+          }
     
-        rule {
-          source_labels = ["__meta_kubernetes_pod_container_name"]
-          target_label  = "container"
-        }
+          rule {
+            source_labels = ["__meta_kubernetes_pod_controller_name"]
+            target_label  = "workload"
+          }
     
-        // set the workload to the controller kind and name
-        rule {
-          action = "lowercase"
-          source_labels = ["__meta_kubernetes_pod_controller_kind"]
-          target_label  = "workload_type"
-        }
+          // remove the hash from the ReplicaSet
+          rule {
+            source_labels = [
+              "workload_type",
+              "workload",
+            ]
+            separator = "/"
+            regex = "replicaset/(.+)-.+$"
+            target_label  = "workload"
+          }
     
-        rule {
-          source_labels = ["__meta_kubernetes_pod_controller_name"]
-          target_label  = "workload"
-        }
+          // set the app name if specified as metadata labels "app:" or "app.kubernetes.io/name:" or "k8s-app:"
+          rule {
+            action = "replace"
+            source_labels = [
+              "__meta_kubernetes_pod_label_app_kubernetes_io_name",
+              "__meta_kubernetes_pod_label_k8s_app",
+              "__meta_kubernetes_pod_label_app",
+            ]
+            separator = ";"
+            regex = "^(?:;*)?([^;]+).*$"
+            replacement = "$1"
+            target_label = "app"
+          }
     
-        // remove the hash from the ReplicaSet
-        rule {
-          source_labels = [
-            "workload_type",
-            "workload",
-          ]
-          separator = "/"
-          regex = "replicaset/(.+)-.+$"
-          target_label  = "workload"
-        }
+          // set the component if specified as metadata labels "component:" or "app.kubernetes.io/component:" or "k8s-component:"
+          rule {
+            action = "replace"
+            source_labels = [
+              "__meta_kubernetes_pod_label_app_kubernetes_io_component",
+              "__meta_kubernetes_pod_label_k8s_component",
+              "__meta_kubernetes_pod_label_component",
+            ]
+            regex = "^(?:;*)?([^;]+).*$"
+            replacement = "$1"
+            target_label = "component"
+          }
     
-        // set the app name if specified as metadata labels "app:" or "app.kubernetes.io/name:" or "k8s-app:"
-        rule {
-          action = "replace"
-          source_labels = [
-            "__meta_kubernetes_pod_label_app_kubernetes_io_name",
-            "__meta_kubernetes_pod_label_k8s_app",
-            "__meta_kubernetes_pod_label_app",
-          ]
-          separator = ";"
-          regex = "^(?:;*)?([^;]+).*$"
-          replacement = "$1"
-          target_label = "app"
-        }
+          // set a source label
+          rule {
+            action = "replace"
+            replacement = "kubernetes"
+            target_label = "source"
+          }
     
-        // set the component if specified as metadata labels "component:" or "app.kubernetes.io/component:" or "k8s-component:"
-        rule {
-          action = "replace"
-          source_labels = [
-            "__meta_kubernetes_pod_label_app_kubernetes_io_component",
-            "__meta_kubernetes_pod_label_k8s_component",
-            "__meta_kubernetes_pod_label_component",
-          ]
-          regex = "^(?:;*)?([^;]+).*$"
-          replacement = "$1"
-          target_label = "component"
-        }
-    
-        // set a source label
-        rule {
-          action = "replace"
-          replacement = "kubernetes"
-          target_label = "source"
-        }
         }
     
         export "output" {

--- a/charts/k8s-monitoring/tests/platform/otlp-gateway/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/platform/otlp-gateway/.rendered/output.yaml
@@ -94,6 +94,7 @@ data:
           namespaces {
             names = coalesce(argument.namespaces.value, [])
           }
+    
         }
     
         // alloy relabelings (pre-scrape)
@@ -113,79 +114,78 @@ data:
             action = "keep"
           }
     
+          rule {
+            source_labels = ["__meta_kubernetes_namespace"]
+            target_label  = "namespace"
+          }
     
+          rule {
+            source_labels = ["__meta_kubernetes_pod_name"]
+            target_label  = "pod"
+          }
     
-        rule {
-          source_labels = ["__meta_kubernetes_namespace"]
-          target_label  = "namespace"
-        }
+          rule {
+            source_labels = ["__meta_kubernetes_pod_container_name"]
+            target_label  = "container"
+          }
     
-        rule {
-          source_labels = ["__meta_kubernetes_pod_name"]
-          target_label  = "pod"
-        }
+          // set the workload to the controller kind and name
+          rule {
+            action = "lowercase"
+            source_labels = ["__meta_kubernetes_pod_controller_kind"]
+            target_label  = "workload_type"
+          }
     
-        rule {
-          source_labels = ["__meta_kubernetes_pod_container_name"]
-          target_label  = "container"
-        }
+          rule {
+            source_labels = ["__meta_kubernetes_pod_controller_name"]
+            target_label  = "workload"
+          }
     
-        // set the workload to the controller kind and name
-        rule {
-          action = "lowercase"
-          source_labels = ["__meta_kubernetes_pod_controller_kind"]
-          target_label  = "workload_type"
-        }
+          // remove the hash from the ReplicaSet
+          rule {
+            source_labels = [
+              "workload_type",
+              "workload",
+            ]
+            separator = "/"
+            regex = "replicaset/(.+)-.+$"
+            target_label  = "workload"
+          }
     
-        rule {
-          source_labels = ["__meta_kubernetes_pod_controller_name"]
-          target_label  = "workload"
-        }
+          // set the app name if specified as metadata labels "app:" or "app.kubernetes.io/name:" or "k8s-app:"
+          rule {
+            action = "replace"
+            source_labels = [
+              "__meta_kubernetes_pod_label_app_kubernetes_io_name",
+              "__meta_kubernetes_pod_label_k8s_app",
+              "__meta_kubernetes_pod_label_app",
+            ]
+            separator = ";"
+            regex = "^(?:;*)?([^;]+).*$"
+            replacement = "$1"
+            target_label = "app"
+          }
     
-        // remove the hash from the ReplicaSet
-        rule {
-          source_labels = [
-            "workload_type",
-            "workload",
-          ]
-          separator = "/"
-          regex = "replicaset/(.+)-.+$"
-          target_label  = "workload"
-        }
+          // set the component if specified as metadata labels "component:" or "app.kubernetes.io/component:" or "k8s-component:"
+          rule {
+            action = "replace"
+            source_labels = [
+              "__meta_kubernetes_pod_label_app_kubernetes_io_component",
+              "__meta_kubernetes_pod_label_k8s_component",
+              "__meta_kubernetes_pod_label_component",
+            ]
+            regex = "^(?:;*)?([^;]+).*$"
+            replacement = "$1"
+            target_label = "component"
+          }
     
-        // set the app name if specified as metadata labels "app:" or "app.kubernetes.io/name:" or "k8s-app:"
-        rule {
-          action = "replace"
-          source_labels = [
-            "__meta_kubernetes_pod_label_app_kubernetes_io_name",
-            "__meta_kubernetes_pod_label_k8s_app",
-            "__meta_kubernetes_pod_label_app",
-          ]
-          separator = ";"
-          regex = "^(?:;*)?([^;]+).*$"
-          replacement = "$1"
-          target_label = "app"
-        }
+          // set a source label
+          rule {
+            action = "replace"
+            replacement = "kubernetes"
+            target_label = "source"
+          }
     
-        // set the component if specified as metadata labels "component:" or "app.kubernetes.io/component:" or "k8s-component:"
-        rule {
-          action = "replace"
-          source_labels = [
-            "__meta_kubernetes_pod_label_app_kubernetes_io_component",
-            "__meta_kubernetes_pod_label_k8s_component",
-            "__meta_kubernetes_pod_label_component",
-          ]
-          regex = "^(?:;*)?([^;]+).*$"
-          replacement = "$1"
-          target_label = "component"
-        }
-    
-        // set a source label
-        rule {
-          action = "replace"
-          replacement = "kubernetes"
-          target_label = "source"
-        }
         }
     
         export "output" {


### PR DESCRIPTION
Adds support for assigning the following node labels to jobs as a result of service discovery: 

- `nodepool`
- `region`
- `availability_zone` 
- `node_role` 
- `os`
- `architecture` 
- `instance_type` 

The following feature charts have support for this: 

- `feature-cluster-metrics`
- `feature-annotation-autodiscovery` 
- `feature-integrations` 
- `feature-pod-logs` 

For pod logs, while the values can be added to the allowed list of labels, it would be recommended to add the values as structured metadata to reduce the cardinality. 