### PR TITLE
Add validation to warn against enabled: false and deploy: true

### DIFF
--- a/charts/k8s-monitoring/charts/feature-cluster-metrics/templates/_validation.tpl
+++ b/charts/k8s-monitoring/charts/feature-cluster-metrics/templates/_validation.tpl
@@ -1,0 +1,22 @@
+{{- define "feature.clusterMetrics.validate.disabledDeployments" }}
+{{- if and (not (index .Values .key).enabled) (index .Values .key).deploy }}
+  {{- $msg := list "" (printf "For the Cluster Metrics feature, %s is disabled but it will still be deployed." .name) }}
+  {{- $msg = append $msg "If you do not want these metrics, disable the deployment by setting:" }}
+  {{- $msg = append $msg "clusterMetrics:" }}
+  {{- $msg = append $msg (printf "  %s:" .key) }}
+  {{- $msg = append $msg "    enabled: false" }}
+  {{- $msg = append $msg "    deploy: false" }}
+  {{- $msg = append $msg "" }}
+  {{- $msg = append $msg "If you do want these metrics, enable it by setting:" }}
+  {{- $msg = append $msg "clusterMetrics:" }}
+  {{- $msg = append $msg (printf "  %s:" .key) }}
+  {{- $msg = append $msg "    enabled: true" }}
+  {{- fail (join "\n" $msg) }}
+{{- end }}
+{{- end }}
+
+{{- define "feature.clusterMetrics.validate" }}
+  {{- include "feature.clusterMetrics.validate.disabledDeployments" (dict "Values" .Values "key" "kube-state-metrics" "name" "kube-state-metrics" )}}
+  {{- include "feature.clusterMetrics.validate.disabledDeployments" (dict "Values" .Values "key" "node-exporter" "name" "Node Exporter" )}}
+  {{- include "feature.clusterMetrics.validate.disabledDeployments" (dict "Values" .Values "key" "windows-exporter" "name" "Windows Exporter" )}}
+{{- end }}

--- a/charts/k8s-monitoring/charts/feature-cluster-metrics/templates/configmap.yaml
+++ b/charts/k8s-monitoring/charts/feature-cluster-metrics/templates/configmap.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.deployAsConfigMap }}
+{{- include "feature.clusterMetrics.validate" . }}
 {{- $alloyConfig := include "feature.clusterMetrics.module" . }}
 {{- $alloyConfig = regexReplaceAll `[ \t]+(\r?\n)` $alloyConfig "\n" }}
 ---

--- a/charts/k8s-monitoring/charts/feature-cluster-metrics/tests/validation_test.yaml
+++ b/charts/k8s-monitoring/charts/feature-cluster-metrics/tests/validation_test.yaml
@@ -1,0 +1,73 @@
+# yamllint disable rule:document-start rule:line-length rule:trailing-spaces
+suite: Test validation
+templates:
+  - configmap.yaml
+tests:
+  - it: warns about a disabled, but deployed kube-state-metrics
+    set:
+      deployAsConfigMap: true
+      kube-state-metrics:
+        enabled: false
+        deploy: true
+        ddepolot: true
+    asserts:
+      - failedTemplate:
+          errorMessage: |-
+            execution error at (feature-cluster-metrics/templates/configmap.yaml:2:4): 
+            For the Cluster Metrics feature, kube-state-metrics is disabled but it will still be deployed.
+            If you do not want these metrics, disable the deployment by setting:
+            clusterMetrics:
+              kube-state-metrics:
+                enabled: false
+                deploy: false
+
+            If you do want these metrics, enable it by setting:
+            clusterMetrics:
+              kube-state-metrics:
+                enabled: true
+
+  - it: warns about a disabled, but deployed Node Exporter
+    set:
+      deployAsConfigMap: true
+      node-exporter:
+        enabled: false
+        deploy: true
+        ddepolot: true
+    asserts:
+      - failedTemplate:
+          errorMessage: |-
+            execution error at (feature-cluster-metrics/templates/configmap.yaml:2:4): 
+            For the Cluster Metrics feature, Node Exporter is disabled but it will still be deployed.
+            If you do not want these metrics, disable the deployment by setting:
+            clusterMetrics:
+              node-exporter:
+                enabled: false
+                deploy: false
+
+            If you do want these metrics, enable it by setting:
+            clusterMetrics:
+              node-exporter:
+                enabled: true
+
+  - it: warns about a disabled, but deployed Windows Exporter
+    set:
+      deployAsConfigMap: true
+      windows-exporter:
+        enabled: false
+        deploy: true
+        ddepolot: true
+    asserts:
+      - failedTemplate:
+          errorMessage: |-
+            execution error at (feature-cluster-metrics/templates/configmap.yaml:2:4): 
+            For the Cluster Metrics feature, Windows Exporter is disabled but it will still be deployed.
+            If you do not want these metrics, disable the deployment by setting:
+            clusterMetrics:
+              windows-exporter:
+                enabled: false
+                deploy: false
+
+            If you do want these metrics, enable it by setting:
+            clusterMetrics:
+              windows-exporter:
+                enabled: true

--- a/charts/k8s-monitoring/templates/features/_feature_cluster_metrics.tpl
+++ b/charts/k8s-monitoring/templates/features/_feature_cluster_metrics.tpl
@@ -191,5 +191,6 @@ cluster_metrics "feature" {
     {{- end -}}
   {{- end -}}
 {{- end -}}
+{{- include "feature.clusterMetrics.validate" (dict "Values" $.Values.clusterMetrics) }}
 {{- end -}}
 {{- end -}}


### PR DESCRIPTION
If we have something like:

```
clusterMetrics:
  windows-exporter:
    enabled: false
```

but don't know that this will still deploy windows exporter, it can be surprising to see the daemonset still appear.

This adds a validation that checks if you want to add:
```
clusterMetrics:
  windows-exporter:
    enabled: false
    deploy: false
```
