### PR TITLE
Adding usage section to feature docs

### DIFF
--- a/charts/k8s-monitoring/charts/feature-annotation-autodiscovery/README.md
+++ b/charts/k8s-monitoring/charts/feature-annotation-autodiscovery/README.md
@@ -10,6 +10,12 @@ Gathers metrics automatically based on Kubernetes Pod and Service annotations
 
 The annotation-based autodiscovery feature adds scrape targets based on Kubernetes annotations.
 
+## Usage
+
+annotationAutodiscovery:
+  enabled: true
+  ... [values](#values)
+
 ## How it works
 
 With this feature enabled, any Kubernetes Pods or Services with the `k8s.grafana.com/scrape` annotation set to `true` will be automatically discovered

--- a/charts/k8s-monitoring/charts/feature-annotation-autodiscovery/README.md.gotmpl
+++ b/charts/k8s-monitoring/charts/feature-annotation-autodiscovery/README.md.gotmpl
@@ -11,6 +11,12 @@
 
 The annotation-based autodiscovery feature adds scrape targets based on Kubernetes annotations.
 
+## Usage
+
+annotationAutodiscovery:
+  enabled: true
+  ... [values](#values)
+
 ## How it works
 
 With this feature enabled, any Kubernetes Pods or Services with the `k8s.grafana.com/scrape` annotation set to `true` will be automatically discovered

--- a/charts/k8s-monitoring/charts/feature-application-observability/README.md
+++ b/charts/k8s-monitoring/charts/feature-application-observability/README.md
@@ -12,7 +12,13 @@ The Application Observability feature enables the collection of application tele
 
 ## Before enabling
 
-Before you enable this feature, you must enable one or more receivers where data will be sent from the application.
+Before you enable this feature, you must [enable one or more receivers](https://github.com/grafana/k8s-monitoring-helm/blob/main/charts/k8s-monitoring/docs/Collectors.md) where data will be sent from the application.
+
+## Usage
+
+applicationObservability:
+  enabled: true
+  ... [values](#values)
 
 ## Testing
 

--- a/charts/k8s-monitoring/charts/feature-application-observability/README.md.gotmpl
+++ b/charts/k8s-monitoring/charts/feature-application-observability/README.md.gotmpl
@@ -13,7 +13,13 @@ The Application Observability feature enables the collection of application tele
 
 ## Before enabling
 
-Before you enable this feature, you must enable one or more receivers where data will be sent from the application.
+Before you enable this feature, you must [enable one or more receivers](https://github.com/grafana/k8s-monitoring-helm/blob/main/charts/k8s-monitoring/docs/Collectors.md) where data will be sent from the application.
+
+## Usage
+
+applicationObservability:
+  enabled: true
+  ... [values](#values)
 
 ## Testing
 

--- a/charts/k8s-monitoring/charts/feature-auto-instrumentation/README.md
+++ b/charts/k8s-monitoring/charts/feature-auto-instrumentation/README.md
@@ -10,6 +10,12 @@ Gathers telemetry data via automatic instrumentation
 
 The auto-instrumentation feature deploys Grafana Beyla to automatically instrument programs running on this cluster using eBPF.
 
+## Usage
+
+autoInstrumentation:
+  enabled: true
+  ... [values](#values)
+
 ## Testing
 
 This chart contains unit tests to verify the generated configuration. The hidden value `deployAsConfigMap` will render

--- a/charts/k8s-monitoring/charts/feature-auto-instrumentation/README.md.gotmpl
+++ b/charts/k8s-monitoring/charts/feature-auto-instrumentation/README.md.gotmpl
@@ -11,6 +11,12 @@
 
 The auto-instrumentation feature deploys Grafana Beyla to automatically instrument programs running on this cluster using eBPF.
 
+## Usage
+
+autoInstrumentation:
+  enabled: true
+  ... [values](#values)
+
 ## Testing
 
 This chart contains unit tests to verify the generated configuration. The hidden value `deployAsConfigMap` will render

--- a/charts/k8s-monitoring/charts/feature-cluster-events/README.md
+++ b/charts/k8s-monitoring/charts/feature-cluster-events/README.md
@@ -10,6 +10,12 @@ Gathers Kubernetes Events
 
 The Cluster Events feature enables the collection of Kubernetes events from the cluster.
 
+## Usage
+
+clusterEvents:
+  enabled: true
+  ... [values](#values)
+
 ## How it works
 
 Events are captured as logs and are annotated with additional metadata to make them easier to search and filter.

--- a/charts/k8s-monitoring/charts/feature-cluster-events/README.md.gotmpl
+++ b/charts/k8s-monitoring/charts/feature-cluster-events/README.md.gotmpl
@@ -11,6 +11,12 @@
 
 The Cluster Events feature enables the collection of Kubernetes events from the cluster. 
 
+## Usage
+
+clusterEvents:
+  enabled: true
+  ... [values](#values)
+
 ## How it works
 
 Events are captured as logs and are annotated with additional metadata to make them easier to search and filter.

--- a/charts/k8s-monitoring/charts/feature-cluster-metrics/README.md
+++ b/charts/k8s-monitoring/charts/feature-cluster-metrics/README.md
@@ -13,6 +13,12 @@ This chart deploys the Cluster Metrics feature of the Kubernetes Observability H
 lists to limit the metrics needed. An allow list is a set of metric names that will be kept, while any metrics
 not on the list will be dropped. With [metrics tuning](#metrics-tuning--allow-lists), you can further customize which metrics are collected.
 
+## Usage
+
+clusterMetrics:
+  enabled: true
+  ... [values](#values)
+
 ## How it works
 
 This chart includes the ability to collect metrics from the following:

--- a/charts/k8s-monitoring/charts/feature-cluster-metrics/README.md.gotmpl
+++ b/charts/k8s-monitoring/charts/feature-cluster-metrics/README.md.gotmpl
@@ -16,6 +16,12 @@ This chart deploys the Cluster Metrics feature of the Kubernetes Observability H
 lists to limit the metrics needed. An allow list is a set of metric names that will be kept, while any metrics
 not on the list will be dropped. With [metrics tuning](#metrics-tuning--allow-lists), you can further customize which metrics are collected.
 
+## Usage
+
+clusterMetrics:
+  enabled: true
+  ... [values](#values)
+
 ## How it works
 
 This chart includes the ability to collect metrics from the following:

--- a/charts/k8s-monitoring/charts/feature-node-logs/README.md
+++ b/charts/k8s-monitoring/charts/feature-node-logs/README.md
@@ -12,6 +12,12 @@ The Node Logs feature enables the collection of logs from Kubernetes Cluster Nod
 health and performance of the nodes in your cluster. Currently, it gathers logs from the journald service from a
 filterable list of units.
 
+## Usage
+
+nodeLogs:
+  enabled: true
+  ... [values](#values)
+
 ## journald
 
 Gathering logs from journald requires a volume mount to the Node's `/var/log/journal` directory.

--- a/charts/k8s-monitoring/charts/feature-node-logs/README.md.gotmpl
+++ b/charts/k8s-monitoring/charts/feature-node-logs/README.md.gotmpl
@@ -13,6 +13,12 @@ The Node Logs feature enables the collection of logs from Kubernetes Cluster Nod
 health and performance of the nodes in your cluster. Currently, it gathers logs from the journald service from a
 filterable list of units.
 
+## Usage
+
+nodeLogs:
+  enabled: true
+  ... [values](#values)
+
 ## journald
 
 Gathering logs from journald requires a volume mount to the Node's `/var/log/journal` directory.

--- a/charts/k8s-monitoring/charts/feature-pod-logs/README.md
+++ b/charts/k8s-monitoring/charts/feature-pod-logs/README.md
@@ -10,6 +10,12 @@ Kubernetes Observability feature for gathering Pod logs.
 
 The Pod Logs feature enables the collection of logs from Kubernetes Pods on the cluster.
 
+## Usage
+
+podLogs:
+  enabled: true
+  ... [values](#values)
+
 ## Testing
 
 This chart contains unit tests to verify the generated configuration. The hidden value `deployAsConfigMap` will render

--- a/charts/k8s-monitoring/charts/feature-pod-logs/README.md.gotmpl
+++ b/charts/k8s-monitoring/charts/feature-pod-logs/README.md.gotmpl
@@ -11,6 +11,12 @@
 
 The Pod Logs feature enables the collection of logs from Kubernetes Pods on the cluster.
 
+## Usage
+
+podLogs:
+  enabled: true
+  ... [values](#values)
+
 ## Testing
 
 This chart contains unit tests to verify the generated configuration. The hidden value `deployAsConfigMap` will render

--- a/charts/k8s-monitoring/charts/feature-profiling/README.md
+++ b/charts/k8s-monitoring/charts/feature-profiling/README.md
@@ -10,6 +10,12 @@ Gathers profiles from eBPF, Java, and pprof sources.
 
 The Profiling feature enables the collection of profiles from the processes running in the cluster.
 
+## Usage
+
+profiling:
+  enabled: true
+  ... [values](#values)
+
 ## Testing
 
 This chart contains unit tests to verify the generated configuration. The hidden value `deployAsConfigMap` will render

--- a/charts/k8s-monitoring/charts/feature-profiling/README.md.gotmpl
+++ b/charts/k8s-monitoring/charts/feature-profiling/README.md.gotmpl
@@ -11,6 +11,12 @@
 
 The Profiling feature enables the collection of profiles from the processes running in the cluster.
 
+## Usage
+
+profiling:
+  enabled: true
+  ... [values](#values)
+
 ## Testing
 
 This chart contains unit tests to verify the generated configuration. The hidden value `deployAsConfigMap` will render

--- a/charts/k8s-monitoring/charts/feature-prometheus-operator-objects/README.md
+++ b/charts/k8s-monitoring/charts/feature-prometheus-operator-objects/README.md
@@ -17,6 +17,12 @@ Operator objects. Currently, this feature supports the following objects:
 | [PodMonitor](https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api-reference/api.md#podmonitor) | A PodMonitor defines how to scrape metrics from Kubernetes Pods. |
 | [Probe](https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api-reference/api.md#probe) | A Probe defines how to scrape metrics from prober exporters. |
 
+## Usage
+
+prometheusOperatorObjects:
+  enabled: true
+  ... [values](#values)
+
 ## Testing
 
 This chart contains unit tests to verify the generated configuration. The hidden value `deployAsConfigMap` will render

--- a/charts/k8s-monitoring/charts/feature-prometheus-operator-objects/README.md.gotmpl
+++ b/charts/k8s-monitoring/charts/feature-prometheus-operator-objects/README.md.gotmpl
@@ -18,6 +18,12 @@ Operator objects. Currently, this feature supports the following objects:
 | [PodMonitor](https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api-reference/api.md#podmonitor) | A PodMonitor defines how to scrape metrics from Kubernetes Pods. |
 | [Probe](https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api-reference/api.md#probe) | A Probe defines how to scrape metrics from prober exporters. |
 
+## Usage
+
+prometheusOperatorObjects:
+  enabled: true
+  ... [values](#values)
+
 ## Testing
 
 This chart contains unit tests to verify the generated configuration. The hidden value `deployAsConfigMap` will render


### PR DESCRIPTION
Just add the top-level element to the doc so you do't have to go back to the main README