### PR TITLE
feat: Adding in Service Graph Metrics to App O11y Feature

### DIFF
--- a/charts/k8s-monitoring/charts/feature-application-observability/README.md
+++ b/charts/k8s-monitoring/charts/feature-application-observability/README.md
@@ -47,6 +47,20 @@ Be sure perform actual integration testing in a live environment in the main [k8
 |-----|------|---------|-------------|
 | connectors.grafanaCloudMetrics.enabled | bool | `true` | Generate host info metrics from telemetry data. These metrics are required for using Application Observability in Grafana Cloud. Note: Enabling this may incur additional costs. See [Application Observability Pricing](https://grafana.com/docs/grafana-cloud/monitor-applications/application-observability/pricing/) |
 
+### Connectors: Service Graphs
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| connectors.serviceGraphs.cacheLoop | string | `"1m"` | Configures how often to delete series which have not been updated. |
+| connectors.serviceGraphs.databaseNameAttribute | string | `"db.name"` | The attribute name used to identify the database name from span attributes. |
+| connectors.serviceGraphs.dimensions | list | `[]` | Define dimensions to be added. Some are set internally by default: [service.name, span.name, span.kind, status.code] Example: - name: "http.status_code" - name: "http.method"   default: "GET" |
+| connectors.serviceGraphs.enabled | bool | `false` | Use a service graphs connector which creates service graphs from telemetry data. |
+| connectors.serviceGraphs.histogramBuckets | list | `["2ms","4ms","6ms","8ms","10ms","50ms","100ms","200ms","400ms","800ms","1s","1400ms","2s","5s","10s","15s"]` | Buckets for latency histogram metrics. |
+| connectors.serviceGraphs.metricsFlushInterval | string | `"60s"` | The interval at which metrics are flushed to downstream components. |
+| connectors.serviceGraphs.store.maxItems | int | `1000` | The maximum number of items to keep in the in-memory store. |
+| connectors.serviceGraphs.store.ttl | string | `"2s"` | The time to live for spans in the in-memory store. |
+| connectors.serviceGraphs.storeExpirationLoop | string | `"2s"` | The time to expire old entries from the store periodically. |
+
 ### Connectors: Span Logs
 
 | Key | Type | Default | Description |

--- a/charts/k8s-monitoring/charts/feature-application-observability/templates/_connector_service_graphs.tpl
+++ b/charts/k8s-monitoring/charts/feature-application-observability/templates/_connector_service_graphs.tpl
@@ -1,0 +1,31 @@
+{{/* Inputs: Values (values) metricsOutput, name */}}
+{{/* https://grafana.com/docs/alloy/latest/reference/components/otelcol/otelcol.connector.servicegraph/ */}}
+{{- define "feature.applicationObservability.connector.serviceGraphs.alloy.target" }}otelcol.connector.servicegraph.{{ .name | default "default" }}.input{{- end }}
+{{- define "feature.applicationObservability.connector.serviceGraphs.alloy" }}
+otelcol.connector.servicegraph "{{ .name | default "default" }}" {
+{{- range $dimension := .Values.connectors.serviceGraphs.dimensions }}
+  dimension {
+    name = {{ $dimension.name | quote }}
+{{- if $dimension.default }}
+    default = {{ $dimension.default | quote }}
+{{- end }}
+  }
+{{- end }}
+  cache_loop = {{ .Values.connectors.serviceGraphs.cacheLoop | quote }}
+  store_expiration_loop = {{ .Values.connectors.serviceGraphs.storeExpirationLoop | quote }}
+  metrics_flush_interval = {{ .Values.connectors.serviceGraphs.metricsFlushInterval | quote }}
+  database_name_attribute = {{ .Values.connectors.serviceGraphs.databaseNameAttribute | quote }}
+  latency_histogram_buckets = {{ .Values.connectors.serviceGraphs.histogramBuckets | toJson }}
+
+  store {
+    max_items = {{ .Values.connectors.serviceGraphs.store.maxItems }}
+    ttl = {{ .Values.connectors.serviceGraphs.store.ttl | quote }}
+  }
+
+    output {
+{{- if and .metrics .Values.metrics.enabled }}
+      metrics = {{ .metrics }}
+{{- end }}
+    }
+}
+{{- end }}

--- a/charts/k8s-monitoring/charts/feature-application-observability/templates/_pipeline.tpl
+++ b/charts/k8s-monitoring/charts/feature-application-observability/templates/_pipeline.tpl
@@ -97,6 +97,9 @@
 {{- if .Values.connectors.spanMetrics.enabled}}
       - {name: default, component: connector.spanmetrics}
 {{- end }}
+{{- if .Values.connectors.serviceGraphs.enabled}}
+      - {name: default, component: connector.serviceGraphs}
+{{- end }}
 {{- if $filterEnabled }}
       - {name: default, component: processor.filter}
     metrics: [{name: default, component: processor.filter}]
@@ -122,6 +125,18 @@
 - name: default
   description: Span Metrics Connector
   component: connector.spanmetrics
+  targets:
+{{- if $filterEnabled }}
+    metrics: [{name: default, component: processor.filter}]
+{{- else }}
+    metrics: [{name: default, component: processor.batch}]
+{{- end }}
+{{- end }}
+
+{{- if .Values.connectors.serviceGraphs.enabled}}
+- name: default
+  description: Service Graphs Connector
+  component: connector.serviceGraphs
   targets:
 {{- if $filterEnabled }}
     metrics: [{name: default, component: processor.filter}]

--- a/charts/k8s-monitoring/charts/feature-application-observability/values.schema.json
+++ b/charts/k8s-monitoring/charts/feature-application-observability/values.schema.json
@@ -13,6 +13,46 @@
                         }
                     }
                 },
+                "serviceGraphs": {
+                    "type": "object",
+                    "properties": {
+                        "cacheLoop": {
+                            "type": "string"
+                        },
+                        "databaseNameAttribute": {
+                            "type": "string"
+                        },
+                        "dimensions": {
+                            "type": "array"
+                        },
+                        "enabled": {
+                            "type": "boolean"
+                        },
+                        "histogramBuckets": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "metricsFlushInterval": {
+                            "type": "string"
+                        },
+                        "store": {
+                            "type": "object",
+                            "properties": {
+                                "maxItems": {
+                                    "type": "integer"
+                                },
+                                "ttl": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "storeExpirationLoop": {
+                            "type": "string"
+                        }
+                    }
+                },
                 "spanLogs": {
                     "type": "object",
                     "properties": {

--- a/charts/k8s-monitoring/charts/feature-application-observability/values.yaml
+++ b/charts/k8s-monitoring/charts/feature-application-observability/values.yaml
@@ -305,6 +305,50 @@ connectors:
         # @section -- Connectors: Span Metrics
         maxSize: 160
 
+  # Service Graphs connector settings.
+  serviceGraphs:
+    # -- Use a service graphs connector which creates service graphs from telemetry data.
+    # @section -- Connectors: Service Graphs
+    enabled: false
+
+    # -- Define dimensions to be added.
+    # Some are set internally by default: [service.name, span.name, span.kind, status.code]
+    # Example:
+    # - name: "http.status_code"
+    # - name: "http.method"
+    #   default: "GET"
+    # @section -- Connectors: Service Graphs
+    dimensions: []
+
+    # -- Configures how often to delete series which have not been updated.
+    # @section -- Connectors: Service Graphs
+    cacheLoop: "1m"
+
+    # -- The time to expire old entries from the store periodically.
+    # @section -- Connectors: Service Graphs
+    storeExpirationLoop: "2s"
+
+    # -- The interval at which metrics are flushed to downstream components.
+    # @section -- Connectors: Service Graphs
+    metricsFlushInterval: "60s"
+
+    # -- The attribute name used to identify the database name from span attributes.
+    # @section -- Connectors: Service Graphs
+    databaseNameAttribute: "db.name" 
+
+    # -- Buckets for latency histogram metrics.
+    # @section -- Connectors: Service Graphs
+    histogramBuckets: ["2ms", "4ms", "6ms", "8ms", "10ms", "50ms", "100ms", "200ms", "400ms", "800ms", "1s", "1400ms", "2s", "5s", "10s", "15s"]
+    
+    # Settings for the in-memory store for spans.
+    store:
+      # -- The maximum number of items to keep in the in-memory store.
+      # @section -- Connectors: Service Graphs
+      maxItems: 1000
+      # -- The time to live for spans in the in-memory store.
+      # @section -- Connectors: Service Graphs
+      ttl: "2s"
+
 metrics:
   enabled: true
   # -- Apply a filter to metrics received via the OTLP or OTLP HTTP receivers.


### PR DESCRIPTION
Adds in the ability to generate Service Graph Metrics in the Application Observability Feature utilizing the [otelcol.connector.servicegraph](https://grafana.com/docs/alloy/latest/reference/components/otelcol/otelcol.connector.servicegraph) component. 