### PR TITLE
Fix CRD download link 

### DIFF
--- a/charts/k8s-monitoring/templates/_crd-validation.tpl
+++ b/charts/k8s-monitoring/templates/_crd-validation.tpl
@@ -8,7 +8,7 @@
       {{- $msg = append $msg "  crds:" }}
       {{- $msg = append $msg "    deployAlloyCRD: true" }}
       {{- $msg = append $msg "" "Or install the Alloy CRD manually:" }}
-      {{- $msg = append $msg (printf "kubectl apply -f https://github.com/grafana/alloy-operator/releases/download/%s/collectors.grafana.com_alloy.yaml" (index .Subcharts "alloy-operator").Chart.Version) }}
+      {{- $msg = append $msg (printf "kubectl apply -f https://github.com/grafana/alloy-operator/releases/download/v%s/collectors.grafana.com_alloy.yaml" (index .Subcharts "alloy-operator").Chart.Version) }}
       {{- fail (join "\n" $msg) }}
     {{- end }}
   {{- end }}
@@ -18,7 +18,7 @@
   {{- if not (.Capabilities.APIVersions.Has "collectors.grafana.com/v1alpha1/Alloy") }}
     {{- $msg := list "" (printf "The %s Helm chart v2.1 requires the Alloy CRD to be deployed." .Chart.Name) }}
     {{- $msg = append $msg "Before upgrading, please install the Alloy CRD:" }}
-    {{- $msg = append $msg (printf "kubectl apply -f https://github.com/grafana/alloy-operator/releases/download/%s/collectors.grafana.com_alloy.yaml" (index .Subcharts "alloy-operator").Chart.Version) }}
+    {{- $msg = append $msg (printf "kubectl apply -f https://github.com/grafana/alloy-operator/releases/download/v%s/collectors.grafana.com_alloy.yaml" (index .Subcharts "alloy-operator").Chart.Version) }}
     {{- fail (join "\n" $msg) }}
   {{- end }}
 {{- end }}


### PR DESCRIPTION
The links to download the CRD in the validation error responses are invalid. The GitHub releases are prefixed with a `v`, whereas the chart version var does not contain those.