### PR TITLE
Fix the label selectors for the extra receiver service

### DIFF
--- a/charts/k8s-monitoring/docs/examples/auth/bearer-token/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/auth/bearer-token/output.yaml
@@ -1525,10 +1525,6 @@ spec:
   crds:
     create: false
   extraObjects: []
-  extraService:
-    enabled: false
-    fullname: ""
-    name: alloy
   global:
     image:
       pullSecrets: []

--- a/charts/k8s-monitoring/docs/examples/auth/embedded-secrets/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/auth/embedded-secrets/output.yaml
@@ -1502,10 +1502,6 @@ spec:
   crds:
     create: false
   extraObjects: []
-  extraService:
-    enabled: false
-    fullname: ""
-    name: alloy
   global:
     image:
       pullSecrets: []

--- a/charts/k8s-monitoring/docs/examples/auth/external-secrets/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/auth/external-secrets/output.yaml
@@ -1552,10 +1552,6 @@ spec:
   crds:
     create: false
   extraObjects: []
-  extraService:
-    enabled: false
-    fullname: ""
-    name: alloy
   global:
     image:
       pullSecrets: []

--- a/charts/k8s-monitoring/docs/examples/exclude-by-namespace/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/exclude-by-namespace/output.yaml
@@ -4432,10 +4432,6 @@ spec:
   crds:
     create: false
   extraObjects: []
-  extraService:
-    enabled: false
-    fullname: ""
-    name: alloy
   global:
     image:
       pullSecrets: []

--- a/charts/k8s-monitoring/docs/examples/features/application-observability/default/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/features/application-observability/default/output.yaml
@@ -789,10 +789,6 @@ spec:
   crds:
     create: false
   extraObjects: []
-  extraService:
-    enabled: false
-    fullname: ""
-    name: alloy
   global:
     image:
       pullSecrets: []

--- a/charts/k8s-monitoring/docs/examples/features/application-observability/tail-sampling/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/features/application-observability/tail-sampling/output.yaml
@@ -827,10 +827,6 @@ spec:
   crds:
     create: false
   extraObjects: []
-  extraService:
-    enabled: false
-    fullname: ""
-    name: alloy
   global:
     image:
       pullSecrets: []

--- a/charts/k8s-monitoring/docs/examples/features/auto-instrumentation/beyla-metrics-and-traces/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/features/auto-instrumentation/beyla-metrics-and-traces/output.yaml
@@ -1381,10 +1381,6 @@ spec:
   crds:
     create: false
   extraObjects: []
-  extraService:
-    enabled: false
-    fullname: ""
-    name: alloy
   global:
     image:
       pullSecrets: []

--- a/charts/k8s-monitoring/docs/examples/include-by-namespace/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/include-by-namespace/output.yaml
@@ -4402,10 +4402,6 @@ spec:
   crds:
     create: false
   extraObjects: []
-  extraService:
-    enabled: false
-    fullname: ""
-    name: alloy
   global:
     image:
       pullSecrets: []

--- a/charts/k8s-monitoring/docs/examples/meta-monitoring/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/meta-monitoring/output.yaml
@@ -3617,10 +3617,6 @@ spec:
   crds:
     create: false
   extraObjects: []
-  extraService:
-    enabled: false
-    fullname: ""
-    name: alloy
   global:
     image:
       pullSecrets: []

--- a/charts/k8s-monitoring/docs/examples/pod-labels-and-annotations/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/pod-labels-and-annotations/output.yaml
@@ -2557,10 +2557,6 @@ spec:
   crds:
     create: false
   extraObjects: []
-  extraService:
-    enabled: false
-    fullname: ""
-    name: alloy
   global:
     image:
       pullSecrets: []

--- a/charts/k8s-monitoring/docs/examples/proxies/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/proxies/output.yaml
@@ -3861,10 +3861,6 @@ spec:
   crds:
     create: false
   extraObjects: []
-  extraService:
-    enabled: false
-    fullname: ""
-    name: alloy
   global:
     image:
       pullSecrets: []

--- a/charts/k8s-monitoring/templates/alloy.yaml
+++ b/charts/k8s-monitoring/templates/alloy.yaml
@@ -2,10 +2,10 @@
 {{- include "crdValidation" $ }}
 {{- $values := (deepCopy $ | merge (dict "collectorName" $collectorName)) }}
 {{- $alloyValues := (include "collector.alloy.values" $values | fromYaml) | merge (dict "nameOverride" $collectorName) }}
-{{- $excluded := dict "enabled" true "extraConfig" true "includeDestinations" true "remoteConfig" true "logging" true "liveDebugging" true }}
+{{- $fieldsToExclude := include "collector.alloy.extraFields" . | fromYamlArray }}
 {{- $cleanValues := dict }}
 {{- range $key, $val := $alloyValues }}
-  {{- if not (hasKey $excluded $key) }}
+  {{- if not (has $key $fieldsToExclude) }}
     {{- $_ := set $cleanValues $key $val }}
   {{- end }}
 {{- end }}

--- a/charts/k8s-monitoring/templates/collectors/_collector_helpers.tpl
+++ b/charts/k8s-monitoring/templates/collectors/_collector_helpers.tpl
@@ -72,18 +72,13 @@
 
 {{- define "collector.alloy.labels" -}}
 helm.sh/chart: {{ include "helper.chart" . }}
-{{ include "collector.alloy.selectorLabels" . }}
-{{/* substr trims delimeter prefix char from alloy.imageId output
-    e.g. ':' for tags and '@' for digests.
-    For digests, we crop the string to a 7-char (short) sha. */}}
-{{/*app.kubernetes.io/version: {{ (include "alloy.imageId" .) | trunc 15 | trimPrefix "@sha256" | trimPrefix ":" | quote }}*/}}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 app.kubernetes.io/part-of: alloy
 {{- end }}
 
 {{- define "collector.alloy.selectorLabels" -}}
-app.kubernetes.io/name: {{ include "collector.alloy.fullname" . }}
-app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/name: {{ .collectorName }}
+app.kubernetes.io/instance: {{ include "collector.alloy.fullname" . }}
 {{- end }}
 
 {{- /* Gets the Alloy values. Input: $, .collectorName (string, collector name), .collectorValues (object) */ -}}
@@ -99,4 +94,16 @@ app.kubernetes.io/instance: {{ .Release.Name }}
   {{- $userValues = (index $.Values .collectorName) }}
 {{- end }}
 {{ mergeOverwrite $upstreamValues $defaultValues $namedDefaultValues $userValues | toYaml }}
+{{- end }}
+
+{{/* Lists the fields that are not a part of Alloy itself, and should be removed before creating an Alloy instance. */}}
+{{/* Inputs: (none) */}}
+{{- define "collector.alloy.extraFields" }}
+- enabled
+- extraConfig
+- extraService
+- includeDestinations
+- liveDebugging
+- logging
+- remoteConfig
 {{- end }}

--- a/charts/k8s-monitoring/tests/integration/application-observability/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/integration/application-observability/.rendered/output.yaml
@@ -43,6 +43,10 @@ data:
           read_buffer_size = "512KiB"
           write_buffer_size = "32KiB"
         }
+        http {
+          endpoint = "0.0.0.0:4318"
+          max_request_body_size = "20MiB"
+        }
         debug_metrics {
           disable_high_cardinality_metrics = true
         }
@@ -583,7 +587,7 @@ data:
     grafana_kubernetes_monitoring_build_info{version="2.1.1", namespace="default"} 1
     # HELP grafana_kubernetes_monitoring_feature_info A metric to report the enabled features of the Kubernetes Monitoring Helm chart
     # TYPE grafana_kubernetes_monitoring_feature_info gauge
-    grafana_kubernetes_monitoring_feature_info{feature="applicationObservability", protocols="otlpgrpc", version="1.0.0"} 1
+    grafana_kubernetes_monitoring_feature_info{feature="applicationObservability", protocols="otlpgrpc,otlphttp", version="1.0.0"} 1
     grafana_kubernetes_monitoring_feature_info{feature="integrations", sources="alloy", version="1.0.0"} 1
 ---
 # Source: k8s-monitoring/charts/alloy-operator/templates/rbac.yaml
@@ -826,6 +830,36 @@ spec:
     app.kubernetes.io/name: alloy-operator
     app.kubernetes.io/instance: k8smon
 ---
+# Source: k8s-monitoring/templates/receiver-service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: k8smon-extra-receiver
+  labels:
+    helm.sh/chart: k8s-monitoring-2.1.1
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/part-of: alloy
+    app.kubernetes.io/component: networking
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: alloy-receiver
+    app.kubernetes.io/instance: k8smon-alloy-receiver
+  internalTrafficPolicy: Cluster
+  ports:
+    - name: http-metrics
+      port: 12345
+      targetPort: 12345
+      protocol: "TCP"
+    - name: otlp-grpc
+      port: 4317
+      targetPort: 4317
+      protocol: TCP
+    - name: otlp-http
+      port: 4318
+      targetPort: 4318
+      protocol: TCP
+---
 # Source: k8s-monitoring/charts/alloy-operator/templates/deployment.yaml
 apiVersion: apps/v1
 kind: Deployment
@@ -917,6 +951,10 @@ spec:
       port: 4317
       protocol: TCP
       targetPort: 4317
+    - name: otlp-http
+      port: 4318
+      protocol: TCP
+      targetPort: 4318
     hostAliases: []
     lifecycle: {}
     listenAddr: 0.0.0.0
@@ -1041,10 +1079,6 @@ spec:
   crds:
     create: false
   extraObjects: []
-  extraService:
-    enabled: false
-    fullname: ""
-    name: alloy
   global:
     image:
       pullSecrets: []

--- a/charts/k8s-monitoring/tests/integration/application-observability/deployments/alloy-via-extra-service.yaml
+++ b/charts/k8s-monitoring/tests/integration/application-observability/deployments/alloy-via-extra-service.yaml
@@ -1,0 +1,51 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: alloy
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: grafana
+  namespace: alloy
+spec:
+  interval: 1m
+  url: https://grafana.github.io/helm-charts
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: alloy-via-extra-service
+  namespace: alloy
+spec:
+  interval: 1m
+  chart:
+    spec:
+      chart: alloy
+      sourceRef:
+        kind: HelmRepository
+        name: grafana
+        namespace: alloy
+      interval: 1m
+  values:
+    controller:
+      type: deployment
+      replicas: 1
+    alloy:
+      configMap:
+        content: |-
+          tracing {
+            sampling_fraction = 1
+            write_to = [otelcol.exporter.otlphttp.alloy.input]
+          }
+
+          otelcol.exporter.otlphttp "alloy" {
+            client {
+              endpoint = "http://k8smon-extra-receiver.default.svc:4318"
+              tls {
+                insecure = true
+                insecure_skip_verify = true
+              }
+            }
+          }

--- a/charts/k8s-monitoring/tests/integration/application-observability/deployments/query-test.yaml
+++ b/charts/k8s-monitoring/tests/integration/application-observability/deployments/query-test.yaml
@@ -46,6 +46,8 @@ spec:
           # Traces
           - query: "{resource.cluster=\"$CLUSTER\" && resource.k8s.deployment.name=\"alloy-app\"}"
             type: traceql
+          - query: "{resource.cluster=\"$CLUSTER\" && resource.k8s.deployment.name=\"alloy-via-extra-service\"}"
+            type: traceql
 
           # Host Info connector
           - query: traces_host_info{k8s_cluster_name="$CLUSTER", grafana_host_id="$CLUSTER-control-plane"}

--- a/charts/k8s-monitoring/tests/integration/application-observability/values.yaml
+++ b/charts/k8s-monitoring/tests/integration/application-observability/values.yaml
@@ -22,6 +22,8 @@ applicationObservability:
     otlp:
       grpc:
         enabled: true
+      http:
+        enabled: true
   connectors:
     grafanaCloudMetrics:
       enabled: true
@@ -42,9 +44,7 @@ integrations:
 
 alloy-receiver:
   enabled: true
-  alloy:
-    extraPorts:
-      - name: otlp-grpc
-        port: 4317
-        targetPort: 4317
-        protocol: TCP
+  extraService:
+    enabled: true
+    name: extra-receiver
+

--- a/charts/k8s-monitoring/tests/integration/auto-instrumentation/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/integration/auto-instrumentation/.rendered/output.yaml
@@ -1281,10 +1281,6 @@ spec:
   crds:
     create: false
   extraObjects: []
-  extraService:
-    enabled: false
-    fullname: ""
-    name: alloy
   global:
     image:
       pullSecrets: []

--- a/charts/k8s-monitoring/tests/integration/prom-and-loki-to-otlp/deployments/prometheus.yaml
+++ b/charts/k8s-monitoring/tests/integration/prom-and-loki-to-otlp/deployments/prometheus.yaml
@@ -46,6 +46,8 @@ spec:
 
     serverFiles:
       prometheus.yml:
+        otlp:
+          translation_strategy: UnderscoreEscapingWithSuffixes
         scrape_configs: []
       web.yml:
         basic_auth_users:

--- a/charts/k8s-monitoring/tests/integration/proxies/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/integration/proxies/.rendered/output.yaml
@@ -2152,10 +2152,6 @@ spec:
   crds:
     create: false
   extraObjects: []
-  extraService:
-    enabled: false
-    fullname: ""
-    name: alloy
   global:
     image:
       pullSecrets: []

--- a/charts/k8s-monitoring/tests/integration/split-destinations/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/integration/split-destinations/.rendered/output.yaml
@@ -3123,10 +3123,6 @@ spec:
   crds:
     create: false
   extraObjects: []
-  extraService:
-    enabled: false
-    fullname: ""
-    name: alloy
   global:
     image:
       pullSecrets: []

--- a/charts/k8s-monitoring/tests/integration/statsd/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/integration/statsd/.rendered/output.yaml
@@ -611,10 +611,6 @@ spec:
   crds:
     create: false
   extraObjects: []
-  extraService:
-    enabled: false
-    fullname: ""
-    name: alloy
   global:
     image:
       pullSecrets: []

--- a/charts/k8s-monitoring/tests/integration/tail-sampling/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/integration/tail-sampling/.rendered/output.yaml
@@ -1448,10 +1448,6 @@ spec:
   crds:
     create: false
   extraObjects: []
-  extraService:
-    enabled: false
-    fullname: ""
-    name: alloy
   global:
     image:
       pullSecrets: []

--- a/charts/k8s-monitoring/tests/platform/grafana-cloud/app-observability/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/platform/grafana-cloud/app-observability/.rendered/output.yaml
@@ -1354,10 +1354,6 @@ spec:
   crds:
     create: false
   extraObjects: []
-  extraService:
-    enabled: false
-    fullname: ""
-    name: alloy
   global:
     image:
       pullSecrets: []

--- a/charts/k8s-monitoring/tests/receiver-service_test.yaml
+++ b/charts/k8s-monitoring/tests/receiver-service_test.yaml
@@ -105,3 +105,24 @@ tests:
               port: 4317
               targetPort: 4317
               protocol: TCP
+
+  - it: has the right selectors
+    set:
+      cluster: {name: test-cluster}
+      alloy-receiver:
+        enabled: true
+        extraConfig: " "
+        extraService:
+          enabled: true
+          fullname: alloy-ingester
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Service
+      - equal:
+          path: spec.selector["app.kubernetes.io/instance"]
+          value: RELEASE-NAME-alloy-receiver
+      - equal:
+          path: spec.selector["app.kubernetes.io/name"]
+          value: alloy-receiver


### PR DESCRIPTION
Three main changes:
1. Remove `extraService` from `kind: Alloy` objects, since that's defined in the K8s Monitoring Chart, not in Alloy.
2. Fix the label selectors for the extra service so it matches the labels assigned to alloy-receiver.
3. Update the unit and integration tests to validate these changes.