### PR TITLE
Fix k8s-monitoring-v1 templates to use actual stdlib references

### DIFF
--- a/charts/k8s-monitoring-v1/templates/alloy_config/_journal_logs_discovery.alloy.txt
+++ b/charts/k8s-monitoring-v1/templates/alloy_config/_journal_logs_discovery.alloy.txt
@@ -32,7 +32,7 @@ loki.source.journal "worker" {
   relabel_rules = loki.relabel.journal.rules
   labels = {
     job = {{ .Values.logs.journal.jobLabel | default "integrations/kubernetes/journal" | quote }},
-    instance = env("HOSTNAME"),
+    instance = sys.env("HOSTNAME"),
   }
   forward_to = [loki.process.journal_logs.receiver]
 }

--- a/charts/k8s-monitoring-v1/templates/alloy_config/_pod_logs_discovery.alloy.txt
+++ b/charts/k8s-monitoring-v1/templates/alloy_config/_pod_logs_discovery.alloy.txt
@@ -5,7 +5,7 @@ discovery.kubernetes "pods" {
 {{- if eq .Values.logs.pod_logs.gatherMethod "volumes" }}
   selectors {
     role = "pod"
-    field = "spec.nodeName=" + env("HOSTNAME")
+    field = "spec.nodeName=" + sys.env("HOSTNAME")
   }
 {{- end }}
 }

--- a/charts/k8s-monitoring-v1/templates/alloy_config/_profiles_ebpf.alloy.txt
+++ b/charts/k8s-monitoring-v1/templates/alloy_config/_profiles_ebpf.alloy.txt
@@ -4,7 +4,7 @@
 discovery.kubernetes "ebpf_pods" {
   selectors {
     role = "pod"
-    field = "spec.nodeName=" + env("HOSTNAME")
+    field = "spec.nodeName=" + sys.env("HOSTNAME")
   }
 {{- if .Values.profiles.ebpf.namespaces }}
   namespaces {

--- a/charts/k8s-monitoring-v1/templates/alloy_config/_profiles_java.alloy.txt
+++ b/charts/k8s-monitoring-v1/templates/alloy_config/_profiles_java.alloy.txt
@@ -4,7 +4,7 @@
 discovery.kubernetes "java_pods" {
   selectors {
     role = "pod"
-    field = "spec.nodeName=" + env("HOSTNAME")
+    field = "spec.nodeName=" + sys.env("HOSTNAME")
   }
 {{- if .Values.profiles.java.namespaces }}
   namespaces {

--- a/charts/k8s-monitoring-v1/templates/alloy_config/_profiles_pprof.alloy.txt
+++ b/charts/k8s-monitoring-v1/templates/alloy_config/_profiles_pprof.alloy.txt
@@ -5,7 +5,7 @@
 discovery.kubernetes "pprof_pods" {
   selectors {
     role = "pod"
-    field = "spec.nodeName=" + env("HOSTNAME")
+    field = "spec.nodeName=" + sys.env("HOSTNAME")
   }
 {{- if .Values.profiles.pprof.namespaces }}
   namespaces {


### PR DESCRIPTION
Noticed that in the alloy-logs deployment of GKM v1 chart there still are a few warnings about deprecated stdlib references in alloy:

```
level=warn msg="this stdlib function is deprecated; please refer to the documentation for updated usage and alternatives" controller_path=/ controller_id="" function=env
```