### PR TITLE
Add annotation control to the profiling feature

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -64,8 +64,6 @@ jobs:
 
       - name: Set up Helm
         uses: azure/setup-helm@b9e51907a09c216f16ebe8536097933489208112  # v4.3.0
-        with:
-          version: 3.17.3
 
       - name: Setup Kind CLI
         uses: helm/kind-action@a1b0e391336a6ee6713a0583f8c6240d70863de3  # v1.12.0

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -87,6 +87,9 @@ jobs:
         with:
           persist-credentials: 'false'
 
+      - name: Set up Helm
+        uses: azure/setup-helm@b9e51907a09c216f16ebe8536097933489208112  # v4.3.0
+
       - name: Set up chart-testing
         uses: helm/chart-testing-action@0d28d3144d3a25ea2cc349d6e59901c4ff469b3b  # v2.7.0
 
@@ -119,6 +122,9 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
         with:
           persist-credentials: 'false'
+
+      - name: Set up Helm
+        uses: azure/setup-helm@b9e51907a09c216f16ebe8536097933489208112  # v4.3.0
 
       - name: Regenerate files
         env:

--- a/charts/k8s-monitoring-v1/README.md
+++ b/charts/k8s-monitoring-v1/README.md
@@ -6,7 +6,6 @@
 # k8s-monitoring
 
 ![Version: 1.6.38](https://img.shields.io/badge/Version-1.6.38-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.18.0](https://img.shields.io/badge/AppVersion-2.18.0-informational?style=flat-square)
-
 A Helm chart for gathering, scraping, and forwarding Kubernetes telemetry data to a Grafana Stack.
 
 ## Breaking change announcements

--- a/charts/k8s-monitoring-v1/README.md.gotmpl
+++ b/charts/k8s-monitoring-v1/README.md.gotmpl
@@ -5,11 +5,8 @@
 
 {{ template "chart.header" . }}
 {{ template "chart.deprecationWarning" . }}
-
 {{ template "chart.badgesSection" . }}
-
 {{ template "chart.description" . }}
-
 {{ template "chart.homepageLine" . }}
 
 ## Breaking change announcements

--- a/charts/k8s-monitoring/README.md
+++ b/charts/k8s-monitoring/README.md
@@ -5,8 +5,12 @@
 
 # k8s-monitoring
 
+<<<<<<< HEAD
 ![Version: 3.0.0](https://img.shields.io/badge/Version-3.0.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.0.0](https://img.shields.io/badge/AppVersion-3.0.0-informational?style=flat-square)
 
+=======
+![Version: 2.1.4](https://img.shields.io/badge/Version-2.1.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.1.4](https://img.shields.io/badge/AppVersion-2.1.4-informational?style=flat-square)
+>>>>>>> e2cb29e1 (Add an annotations doc)
 Capture all telemetry data from your Kubernetes cluster.
 
 ## Breaking change announcements

--- a/charts/k8s-monitoring/README.md.gotmpl
+++ b/charts/k8s-monitoring/README.md.gotmpl
@@ -5,11 +5,8 @@
 
 {{ template "chart.header" . }}
 {{ template "chart.deprecationWarning" . }}
-
 {{ template "chart.badgesSection" . }}
-
 {{ template "chart.description" . }}
-
 {{ template "chart.homepageLine" . }}
 
 ## Breaking change announcements

--- a/charts/k8s-monitoring/charts/feature-annotation-autodiscovery/README.md
+++ b/charts/k8s-monitoring/charts/feature-annotation-autodiscovery/README.md
@@ -5,7 +5,6 @@
 
 # feature-annotation-autodiscovery
 
-![Version: 1.0.0](https://img.shields.io/badge/Version-1.0.0-informational?style=flat-square) ![AppVersion: 1.0.0](https://img.shields.io/badge/AppVersion-1.0.0-informational?style=flat-square)
 Gathers metrics automatically based on Kubernetes Pod and Service annotations
 
 The annotation-based autodiscovery feature adds scrape targets based on Kubernetes annotations.
@@ -26,11 +25,14 @@ You can use several other annotations to customize the behavior of the scrape co
 
 *   `k8s.grafana.com/job`: The value to use for the `job` label.
 *   `k8s.grafana.com/instance`: The value to use for the `instance` label.
+*   `k8s.grafana.com/metrics.container`: The name of the container within the Pod to scrape for metrics. This is used to target a specific container within a Pod that has multiple containers.
 *   `k8s.grafana.com/metrics.path`: The path to scrape for metrics. Defaults to `/metrics`.
 *   `k8s.grafana.com/metrics.portNumber`: The port on the Pod or Service to scrape for metrics. This is used to target a specific port by its number, rather than all ports.
 *   `k8s.grafana.com/metrics.portName`: The named port on the Pod or Service to scrape for metrics. This is used to target a specific port by its name, rather than all ports.
 *   `k8s.grafana.com/metrics.scheme`: The scheme to use when scraping metrics. Defaults to `http`.
+*   `k8s.grafana.com/metrics.param`: Allows for setting HTTP parameters when calling the scrape endpoint. Use with `k8s.grafana.com/metrics.param_<key>="<value>"`.
 *   `k8s.grafana.com/metrics.scrapeInterval`: The scrape interval to use when scraping metrics. Defaults to `60s`.
+*   `k8s.grafana.com/metrics.scrapeTimeout`: The scrape timeout to use when scraping metrics. Defaults to `10s`.
 
 ## Testing
 

--- a/charts/k8s-monitoring/charts/feature-annotation-autodiscovery/README.md.gotmpl
+++ b/charts/k8s-monitoring/charts/feature-annotation-autodiscovery/README.md.gotmpl
@@ -5,7 +5,6 @@
 
 {{ template "chart.header" . }}
 {{ template "chart.deprecationWarning" . }}
-{{ template "chart.badgesSection" . }}
 {{ template "chart.description" . }}
 {{ template "chart.homepageLine" . }}
 
@@ -27,11 +26,14 @@ You can use several other annotations to customize the behavior of the scrape co
 
 *   `k8s.grafana.com/job`: The value to use for the `job` label.
 *   `k8s.grafana.com/instance`: The value to use for the `instance` label.
+*   `k8s.grafana.com/metrics.container`: The name of the container within the Pod to scrape for metrics. This is used to target a specific container within a Pod that has multiple containers.
 *   `k8s.grafana.com/metrics.path`: The path to scrape for metrics. Defaults to `/metrics`.
 *   `k8s.grafana.com/metrics.portNumber`: The port on the Pod or Service to scrape for metrics. This is used to target a specific port by its number, rather than all ports.
 *   `k8s.grafana.com/metrics.portName`: The named port on the Pod or Service to scrape for metrics. This is used to target a specific port by its name, rather than all ports.
 *   `k8s.grafana.com/metrics.scheme`: The scheme to use when scraping metrics. Defaults to `http`.
+*   `k8s.grafana.com/metrics.param`: Allows for setting HTTP parameters when calling the scrape endpoint. Use with `k8s.grafana.com/metrics.param_<key>="<value>"`.
 *   `k8s.grafana.com/metrics.scrapeInterval`: The scrape interval to use when scraping metrics. Defaults to `60s`.
+*   `k8s.grafana.com/metrics.scrapeTimeout`: The scrape timeout to use when scraping metrics. Defaults to `10s`.
 
 ## Testing
 

--- a/charts/k8s-monitoring/charts/feature-application-observability/README.md
+++ b/charts/k8s-monitoring/charts/feature-application-observability/README.md
@@ -5,7 +5,6 @@
 
 # feature-application-observability
 
-![Version: 1.0.0](https://img.shields.io/badge/Version-1.0.0-informational?style=flat-square) ![AppVersion: 1.0.0](https://img.shields.io/badge/AppVersion-1.0.0-informational?style=flat-square)
 Gathers application data
 
 The Application Observability feature enables the collection of application telemetry data.

--- a/charts/k8s-monitoring/charts/feature-application-observability/README.md.gotmpl
+++ b/charts/k8s-monitoring/charts/feature-application-observability/README.md.gotmpl
@@ -5,7 +5,6 @@
 
 {{ template "chart.header" . }}
 {{ template "chart.deprecationWarning" . }}
-{{ template "chart.badgesSection" . }}
 {{ template "chart.description" . }}
 {{ template "chart.homepageLine" . }}
 

--- a/charts/k8s-monitoring/charts/feature-auto-instrumentation/README.md
+++ b/charts/k8s-monitoring/charts/feature-auto-instrumentation/README.md
@@ -5,7 +5,6 @@
 
 # feature-auto-instrumentation
 
-![Version: 1.0.0](https://img.shields.io/badge/Version-1.0.0-informational?style=flat-square) ![AppVersion: 1.0.0](https://img.shields.io/badge/AppVersion-1.0.0-informational?style=flat-square)
 Gathers telemetry data via automatic instrumentation
 
 The auto-instrumentation feature deploys Grafana Beyla to automatically instrument programs running on this cluster using eBPF.

--- a/charts/k8s-monitoring/charts/feature-auto-instrumentation/README.md.gotmpl
+++ b/charts/k8s-monitoring/charts/feature-auto-instrumentation/README.md.gotmpl
@@ -5,7 +5,6 @@
 
 {{ template "chart.header" . }}
 {{ template "chart.deprecationWarning" . }}
-{{ template "chart.badgesSection" . }}
 {{ template "chart.description" . }}
 {{ template "chart.homepageLine" . }}
 

--- a/charts/k8s-monitoring/charts/feature-cluster-events/README.md
+++ b/charts/k8s-monitoring/charts/feature-cluster-events/README.md
@@ -5,7 +5,6 @@
 
 # feature-cluster-events
 
-![Version: 1.0.0](https://img.shields.io/badge/Version-1.0.0-informational?style=flat-square) ![AppVersion: 1.0.0](https://img.shields.io/badge/AppVersion-1.0.0-informational?style=flat-square)
 Gathers Kubernetes Events
 
 The Cluster Events feature enables the collection of Kubernetes events from the cluster.

--- a/charts/k8s-monitoring/charts/feature-cluster-events/README.md.gotmpl
+++ b/charts/k8s-monitoring/charts/feature-cluster-events/README.md.gotmpl
@@ -5,7 +5,6 @@
 
 {{ template "chart.header" . }}
 {{ template "chart.deprecationWarning" . }}
-{{ template "chart.badgesSection" . }}
 {{ template "chart.description" . }}
 {{ template "chart.homepageLine" . }}
 

--- a/charts/k8s-monitoring/charts/feature-cluster-metrics/README.md
+++ b/charts/k8s-monitoring/charts/feature-cluster-metrics/README.md
@@ -5,8 +5,6 @@
 
 # feature-cluster-metrics
 
-![Version: 1.0.0](https://img.shields.io/badge/Version-1.0.0-informational?style=flat-square) ![AppVersion: 1.0.0](https://img.shields.io/badge/AppVersion-1.0.0-informational?style=flat-square)
-
 Gathers Kubernetes Cluster metrics
 
 This chart deploys the Cluster Metrics feature of the Kubernetes Observability Helm chart, which uses allow

--- a/charts/k8s-monitoring/charts/feature-cluster-metrics/README.md.gotmpl
+++ b/charts/k8s-monitoring/charts/feature-cluster-metrics/README.md.gotmpl
@@ -5,11 +5,7 @@
 
 {{ template "chart.header" . }}
 {{ template "chart.deprecationWarning" . }}
-
-{{ template "chart.badgesSection" . }}
-
 {{ template "chart.description" . }}
-
 {{ template "chart.homepageLine" . }}
 
 This chart deploys the Cluster Metrics feature of the Kubernetes Observability Helm chart, which uses allow 

--- a/charts/k8s-monitoring/charts/feature-integrations/README.md
+++ b/charts/k8s-monitoring/charts/feature-integrations/README.md
@@ -5,7 +5,6 @@
 
 # feature-integrations
 
-![Version: 1.0.0](https://img.shields.io/badge/Version-1.0.0-informational?style=flat-square) ![AppVersion: 1.0.0](https://img.shields.io/badge/AppVersion-1.0.0-informational?style=flat-square)
 Service integrations
 
 The Integrations feature builds in configuration for many common applications and services.

--- a/charts/k8s-monitoring/charts/feature-integrations/README.md.gotmpl
+++ b/charts/k8s-monitoring/charts/feature-integrations/README.md.gotmpl
@@ -5,7 +5,6 @@
 
 {{ template "chart.header" . }}
 {{ template "chart.deprecationWarning" . }}
-{{ template "chart.badgesSection" . }}
 {{ template "chart.description" . }}
 {{ template "chart.homepageLine" . }}
 

--- a/charts/k8s-monitoring/charts/feature-node-logs/README.md
+++ b/charts/k8s-monitoring/charts/feature-node-logs/README.md
@@ -5,7 +5,6 @@
 
 # feature-node-logs
 
-![Version: 1.0.0](https://img.shields.io/badge/Version-1.0.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.0.0](https://img.shields.io/badge/AppVersion-1.0.0-informational?style=flat-square)
 Kubernetes Observability feature for gathering Cluster Node logs.
 
 The Node Logs feature enables the collection of logs from Kubernetes Cluster Nodes. This is useful for understanding the

--- a/charts/k8s-monitoring/charts/feature-node-logs/README.md.gotmpl
+++ b/charts/k8s-monitoring/charts/feature-node-logs/README.md.gotmpl
@@ -5,7 +5,6 @@
 
 {{ template "chart.header" . }}
 {{ template "chart.deprecationWarning" . }}
-{{ template "chart.badgesSection" . }}
 {{ template "chart.description" . }}
 {{ template "chart.homepageLine" . }}
 

--- a/charts/k8s-monitoring/charts/feature-pod-logs/README.md
+++ b/charts/k8s-monitoring/charts/feature-pod-logs/README.md
@@ -5,7 +5,6 @@
 
 # feature-pod-logs
 
-![Version: 1.0.0](https://img.shields.io/badge/Version-1.0.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.0.0](https://img.shields.io/badge/AppVersion-1.0.0-informational?style=flat-square)
 Kubernetes Observability feature for gathering Pod logs.
 
 The Pod Logs feature enables the collection of logs from Kubernetes Pods on the cluster.

--- a/charts/k8s-monitoring/charts/feature-pod-logs/README.md.gotmpl
+++ b/charts/k8s-monitoring/charts/feature-pod-logs/README.md.gotmpl
@@ -5,7 +5,6 @@
 
 {{ template "chart.header" . }}
 {{ template "chart.deprecationWarning" . }}
-{{ template "chart.badgesSection" . }}
 {{ template "chart.description" . }}
 {{ template "chart.homepageLine" . }}
 

--- a/charts/k8s-monitoring/charts/feature-profiling/README.md
+++ b/charts/k8s-monitoring/charts/feature-profiling/README.md
@@ -54,8 +54,8 @@ Be sure perform actual integration testing in a live environment in the main [k8
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| ebpf.annotationSelectors | object | `{}` | Select pods to profile based on pod annotations.  Example with multiple values: `color: ["blue", "green"]` will select pods with the annotation `color="blue"` or `color="green"`. |
-| ebpf.annotations.enable | string | `"enabled"` | The annotation action for enabling or disabling collecting of profiles with eBPF. Default is `profiles.grafana.com/cpu.ebpf.scrape`. |
+| ebpf.annotationSelectors | object | `{}` | Select pods to profile based on pod annotations. Example: `color: "green"` will select pods with the annotation `color="green"`. Example with multiple values: `color: ["blue", "green"]` will select pods with the annotation `color="blue"` or `color="green"`. |
+| ebpf.annotations.enable | string | `"enabled"` | The annotation action for enabling or disabling collecting of profiles with eBPF. Default is `profiles.grafana.com/cpu.ebpf.enabled`. |
 | ebpf.demangle | string | `"none"` | C++ demangle mode. Available options are: none, simplified, templates, full |
 | ebpf.enabled | bool | `true` | Gather profiles using eBPF |
 | ebpf.excludeNamespaces | list | `[]` | Which namespaces to exclude looking for pods. |
@@ -69,20 +69,20 @@ Be sure perform actual integration testing in a live environment in the main [k8
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | java.annotationSelectors | object | `{}` | Select pods to profile based on pod annotations. Example: `color: "green"` will select pods with the annotation `color="green"`. Example with multiple values: `color: ["blue", "green"]` will select pods with the annotation `color="blue"` or `color="green"`. |
-| java.annotations.enable | string | `"enabled"` | The annotation action for enabling or disabling scraping of Java profiles. |
+| java.annotations.enable | string | `"enabled"` | The annotation action for enabling or disabling of Java profile collection. |
 | java.enabled | bool | `true` | Gather profiles by scraping Java HTTP endpoints |
 | java.excludeNamespaces | list | `[]` | Which namespaces to exclude looking for pods. |
 | java.extraDiscoveryRules | string | `""` | Rule blocks to be added to the discovery.relabel component for Java profile sources. ([docs](https://grafana.com/docs/alloy/latest/reference/components/discovery/discovery.relabel/#rule-block)) |
 | java.labelSelectors | object | `{}` | Select pods to profile based on pod labels. Example: `app.kubernetes.io/name: myapp` will select pods with the label `app.kubernetes.io/name=myapp`. Example with multiple values: `app.kubernetes.io/name: [myapp, myapp2]` will select pods with the label `app.kubernetes.io/name=myapp` or `app.kubernetes.io/name=myapp2`. |
 | java.namespaces | list | `[]` | Select pods to profile based on their namespaces. |
 | java.profilingConfig | object | `{"alloc":"512k","cpu":true,"interval":"60s","lock":"10ms","sampleRate":100}` | Configuration for the async-profiler |
-| java.targetingScheme | string | `"annotation"` | How to target pods for finding Java profiles. Options are `all` and `annotation`. If using `all`, all Kubernetes pods will be targeted for Java profiles, and you can exclude certain pods by setting the `profiles.grafana.com/java.scrape="false"` annotation on that pod. If using `annotation`, only pods with the `profiles.grafana.com/java.scrape="true"` annotation will be scraped for Java profiles. |
+| java.targetingScheme | string | `"annotation"` | How to target pods for finding Java profiles. Options are `all` and `annotation`. If using `all`, all Kubernetes pods will be targeted for Java profiles, and you can exclude certain pods by setting the `profiles.grafana.com/java.enabled="false"` annotation on that pod. If using `annotation`, only pods with the `profiles.grafana.com/java.enabled="true"` annotation will collecting Java profiles. |
 
 ### pprof
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| pprof.annotationSelectors | object | `{}` | Select pods to profile based on pod annotations. Example: `k8s.grafana.com/profile: "true"` will select pods with the annotation `k8s.grafana.com/profile="true"`. Example with multiple values: `color: ["blue", "green"]` will select pods with the annotation `color="blue"` or `color="green"`. |
+| pprof.annotationSelectors | object | `{}` | Select pods to profile based on pod annotations. Example: `color: "green"` will select pods with the annotation `color="green"`. Example with multiple values: `color: ["blue", "green"]` will select pods with the annotation `color="blue"` or `color="green"`. |
 | pprof.annotations.enable | string | `"scrape"` | The annotation action for enabling or disabling scraping of profiles of a given type. |
 | pprof.annotations.path | string | `"path"` | The annotation action for choosing the path for scraping profiles of a given type. |
 | pprof.annotations.portName | string | `"port_name"` | The annotation action for choosing the port name for scraping profiles of a given type. |
@@ -91,7 +91,7 @@ Be sure perform actual integration testing in a live environment in the main [k8
 | pprof.enabled | bool | `true` | Gather profiles by scraping pprof HTTP endpoints |
 | pprof.excludeNamespaces | list | `[]` | Which namespaces to exclude looking for pods. |
 | pprof.extraDiscoveryRules | string | `""` | Rule blocks to be added to the discovery.relabel component for eBPF profile sources. These relabeling rules are applied pre-scrape against the targets from service discovery. Before the scrape, any remaining target labels that start with `__` (i.e. `__meta_kubernetes*`) are dropped. ([docs](https://grafana.com/docs/alloy/latest/reference/components/discovery/discovery.relabel/#rule-block)) |
-| pprof.labelSelectors | object | `{}` | Select pods to profile based on pod labels. Example with multiple values: `app.kubernetes.io/name: [myapp, myapp2]` will select pods with the label `app.kubernetes.io/name=myapp` or `app.kubernetes.io/name=myapp2`. |
+| pprof.labelSelectors | object | `{}` | Select pods to profile based on pod labels. Example: `app.kubernetes.io/name: myapp` will select pods with the label `app.kubernetes.io/name=myapp`. Example with multiple values: `app.kubernetes.io/name: [myapp, myapp2]` will select pods with the label `app.kubernetes.io/name=myapp` or `app.kubernetes.io/name=myapp2`. |
 | pprof.namespaces | list | `[]` | Select pods to profile based on their namespaces. |
 | pprof.scrapeInterval | string | `"15s"` | How frequently to collect profiles. |
 | pprof.scrapeTimeout | string | `"18s"` | Timeout for collecting profiles. Must be larger than the scrape interval. |

--- a/charts/k8s-monitoring/charts/feature-profiling/README.md
+++ b/charts/k8s-monitoring/charts/feature-profiling/README.md
@@ -43,48 +43,51 @@ Be sure perform actual integration testing in a live environment in the main [k8
 
 ## Values
 
+### General settings
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| annotations.prefix | string | `"profiles.grafana.com"` | The prefix for all annotations. |
+| fullnameOverride | string | `""` | Full name override |
+| nameOverride | string | `""` | Name override |
+
 ### eBPF
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | ebpf.annotationSelectors | object | `{}` | Select pods to profile based on pod annotations. Example: `k8s.grafana.com/profile: "true"` will select pods with the annotation `k8s.grafana.com/profile="true"`. Example with multiple values: `color: ["blue", "green"]` will select pods with the annotation `color="blue"` or `color="green"`. |
+| ebpf.annotations.enable | string | `"scrape"` | The annotation action for enabling or disabling collecting of profiles with eBPF. Default is `profiles.grafana.com/cpu.ebpf.scrape`. |
 | ebpf.demangle | string | `"none"` | C++ demangle mode. Available options are: none, simplified, templates, full |
 | ebpf.enabled | bool | `true` | Gather profiles using eBPF |
 | ebpf.excludeNamespaces | list | `[]` | Which namespaces to exclude looking for pods. |
 | ebpf.extraDiscoveryRules | string | `""` | Rule blocks to be added to the discovery.relabel component for eBPF profile sources. These relabeling rules are applied pre-scrape against the targets from service discovery. Before the scrape, any remaining target labels that start with `__` (i.e. `__meta_kubernetes*`) are dropped. ([docs](https://grafana.com/docs/alloy/latest/reference/components/discovery/discovery.relabel/#rule-block)) |
 | ebpf.labelSelectors | object | `{}` | Select pods to profile based on pod labels. Example: `app.kubernetes.io/name: myapp` will select pods with the label `app.kubernetes.io/name=myapp`. Example with multiple values: `app.kubernetes.io/name: [myapp, myapp2]` will select pods with the label `app.kubernetes.io/name=myapp` or `app.kubernetes.io/name=myapp2`. |
 | ebpf.namespaces | list | `[]` | Select pods to profile based on their namespaces. |
-
-### General settings
-
-| Key | Type | Default | Description |
-|-----|------|---------|-------------|
-| fullnameOverride | string | `""` | Full name override |
-| nameOverride | string | `""` | Name override |
+| ebpf.targetingScheme | string | `"annotation"` | How to target pods for collecting profiles with eBPF. Options are `all` and `annotation`. If using `all`, all Kubernetes pods will be targeted for collecting profiles, and you can exclude certain pods by setting the `profiles.grafana.com/cpu.ebpf.scrape="false"` annotation on that pod. If using `annotation`, only pods with the `profiles.grafana.com/cpu.ebpf.scrape="true"` annotation will have profiles collected with eBPF. |
 
 ### Java
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| java.annotationSelectors | object | `{}` | Select pods to profile based on pod annotations. Example: `k8s.grafana.com/profile: "true"` will select pods with the annotation `k8s.grafana.com/profile="true"`. Example with multiple values: `color: ["blue", "green"]` will select pods with the annotation `color="blue"` or `color="green"`. |
-| java.enabled | bool | `true` | Gather profiles by scraping java HTTP endpoints |
+| java.annotationSelectors | object | `{}` | Select pods to profile based on pod annotations. Example: `color: "green"` will select pods with the annotation `color="green"`. Example with multiple values: `color: ["blue", "green"]` will select pods with the annotation `color="blue"` or `color="green"`. |
+| java.annotations.enable | string | `"scrape"` | The annotation action for enabling or disabling scraping of Java profiles. |
+| java.enabled | bool | `true` | Gather profiles by scraping Java HTTP endpoints |
 | java.excludeNamespaces | list | `[]` | Which namespaces to exclude looking for pods. |
 | java.extraDiscoveryRules | string | `""` | Rule blocks to be added to the discovery.relabel component for Java profile sources. ([docs](https://grafana.com/docs/alloy/latest/reference/components/discovery/discovery.relabel/#rule-block)) |
 | java.labelSelectors | object | `{}` | Select pods to profile based on pod labels. Example: `app.kubernetes.io/name: myapp` will select pods with the label `app.kubernetes.io/name=myapp`. Example with multiple values: `app.kubernetes.io/name: [myapp, myapp2]` will select pods with the label `app.kubernetes.io/name=myapp` or `app.kubernetes.io/name=myapp2`. |
 | java.namespaces | list | `[]` | Select pods to profile based on their namespaces. |
 | java.profilingConfig | object | `{"alloc":"512k","cpu":true,"interval":"60s","lock":"10ms","sampleRate":100}` | Configuration for the async-profiler |
+| java.targetingScheme | string | `"annotation"` | How to target pods for finding Java profiles. Options are `all` and `annotation`. If using `all`, all Kubernetes pods will be targeted for Java profiles, and you can exclude certain pods by setting the `profiles.grafana.com/java.scrape="false"` annotation on that pod. If using `annotation`, only pods with the `profiles.grafana.com/java.scrape="true"` annotation will be scraped for Java profiles. |
 
 ### pprof
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | pprof.annotationSelectors | object | `{}` | Select pods to profile based on pod annotations. Example: `k8s.grafana.com/profile: "true"` will select pods with the annotation `k8s.grafana.com/profile="true"`. Example with multiple values: `color: ["blue", "green"]` will select pods with the annotation `color="blue"` or `color="green"`. |
-| pprof.annotations | object | `{"enable":"scrape","path":"path","portName":"port_name","portNumber":"port","prefix":"profiles.grafana.com","scheme":"scheme"}` | Configure the annotations that will control how the pprof targets are discovered and how profiles are scraped. All annotations will be `<prefix>/<type>.<action>`, for example, to "enable" scraping of CPU profiles, set the annotation `profiles.grafana.com/cpu.scrape: "true"` on the pod. To set the path for memory profiles, set the annotation `profiles.grafana.com/memory.path: "/debug/pprof/mem"` on the pod. |
 | pprof.annotations.enable | string | `"scrape"` | The annotation action for enabling or disabling scraping of profiles of a given type. |
 | pprof.annotations.path | string | `"path"` | The annotation action for choosing the path for scraping profiles of a given type. |
 | pprof.annotations.portName | string | `"port_name"` | The annotation action for choosing the port name for scraping profiles of a given type. |
 | pprof.annotations.portNumber | string | `"port"` | The annotation action for choosing the port number for scraping profiles of a given type. |
-| pprof.annotations.prefix | string | `"profiles.grafana.com"` | The prefix for all pprof annotations. |
 | pprof.annotations.scheme | string | `"scheme"` | The annotation action for choosing the scheme for scraping profiles of a given type. |
 | pprof.enabled | bool | `true` | Gather profiles by scraping pprof HTTP endpoints |
 | pprof.excludeNamespaces | list | `[]` | Which namespaces to exclude looking for pods. |

--- a/charts/k8s-monitoring/charts/feature-profiling/README.md
+++ b/charts/k8s-monitoring/charts/feature-profiling/README.md
@@ -79,11 +79,18 @@ Be sure perform actual integration testing in a live environment in the main [k8
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | pprof.annotationSelectors | object | `{}` | Select pods to profile based on pod annotations. Example: `k8s.grafana.com/profile: "true"` will select pods with the annotation `k8s.grafana.com/profile="true"`. Example with multiple values: `color: ["blue", "green"]` will select pods with the annotation `color="blue"` or `color="green"`. |
+| pprof.annotations | object | `{"enable":"scrape","path":"path","portName":"port_name","portNumber":"port","prefix":"profiles.grafana.com","scheme":"scheme"}` | Configure the annotations that will control how the pprof targets are discovered and how profiles are scraped. All annotations will be `<prefix>/<type>.<action>`, for example, to "enable" scraping of CPU profiles, set the annotation `profiles.grafana.com/cpu.scrape: "true"` on the pod. To set the path for memory profiles, set the annotation `profiles.grafana.com/memory.path: "/debug/pprof/mem"` on the pod. |
+| pprof.annotations.enable | string | `"scrape"` | The annotation action for enabling or disabling scraping of profiles of a given type. |
+| pprof.annotations.path | string | `"path"` | The annotation action for choosing the path for scraping profiles of a given type. |
+| pprof.annotations.portName | string | `"port_name"` | The annotation action for choosing the port name for scraping profiles of a given type. |
+| pprof.annotations.portNumber | string | `"port"` | The annotation action for choosing the port number for scraping profiles of a given type. |
+| pprof.annotations.prefix | string | `"profiles.grafana.com"` | The prefix for all pprof annotations. |
+| pprof.annotations.scheme | string | `"scheme"` | The annotation action for choosing the scheme for scraping profiles of a given type. |
 | pprof.enabled | bool | `true` | Gather profiles by scraping pprof HTTP endpoints |
 | pprof.excludeNamespaces | list | `[]` | Which namespaces to exclude looking for pods. |
 | pprof.extraDiscoveryRules | string | `""` | Rule blocks to be added to the discovery.relabel component for eBPF profile sources. These relabeling rules are applied pre-scrape against the targets from service discovery. Before the scrape, any remaining target labels that start with `__` (i.e. `__meta_kubernetes*`) are dropped. ([docs](https://grafana.com/docs/alloy/latest/reference/components/discovery/discovery.relabel/#rule-block)) |
 | pprof.labelSelectors | object | `{}` | Select pods to profile based on pod labels. Example: `app.kubernetes.io/name: myapp` will select pods with the label `app.kubernetes.io/name=myapp`. Example with multiple values: `app.kubernetes.io/name: [myapp, myapp2]` will select pods with the label `app.kubernetes.io/name=myapp` or `app.kubernetes.io/name=myapp2`. |
 | pprof.namespaces | list | `[]` | Select pods to profile based on their namespaces. |
 | pprof.scrapeInterval | string | `"15s"` | How frequently to collect profiles. |
-| pprof.scrapeTimeout | string | `"18s"` | Timeout for collecting profiles. Must be larger then the scrape interval. |
+| pprof.scrapeTimeout | string | `"18s"` | Timeout for collecting profiles. Must be larger than the scrape interval. |
 | pprof.types | object | `{"block":true,"cpu":true,"fgprof":true,"godeltaprof_block":false,"godeltaprof_memory":false,"godeltaprof_mutex":false,"goroutine":true,"memory":true,"mutex":true}` | Profile types to gather |

--- a/charts/k8s-monitoring/charts/feature-profiling/README.md
+++ b/charts/k8s-monitoring/charts/feature-profiling/README.md
@@ -54,7 +54,7 @@ Be sure perform actual integration testing in a live environment in the main [k8
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| ebpf.annotationSelectors | object | `{}` | Select pods to profile based on pod annotations. Example: `k8s.grafana.com/profile: "true"` will select pods with the annotation `k8s.grafana.com/profile="true"`. Example with multiple values: `color: ["blue", "green"]` will select pods with the annotation `color="blue"` or `color="green"`. |
+| ebpf.annotationSelectors | object | `{}` | Select pods to profile based on pod annotations.  Example with multiple values: `color: ["blue", "green"]` will select pods with the annotation `color="blue"` or `color="green"`. |
 | ebpf.annotations.enable | string | `"enabled"` | The annotation action for enabling or disabling collecting of profiles with eBPF. Default is `profiles.grafana.com/cpu.ebpf.scrape`. |
 | ebpf.demangle | string | `"none"` | C++ demangle mode. Available options are: none, simplified, templates, full |
 | ebpf.enabled | bool | `true` | Gather profiles using eBPF |

--- a/charts/k8s-monitoring/charts/feature-profiling/README.md
+++ b/charts/k8s-monitoring/charts/feature-profiling/README.md
@@ -5,7 +5,6 @@
 
 # feature-profiling
 
-![Version: 1.0.0](https://img.shields.io/badge/Version-1.0.0-informational?style=flat-square) ![AppVersion: 1.0.0](https://img.shields.io/badge/AppVersion-1.0.0-informational?style=flat-square)
 Gathers profiles from eBPF, Java, and pprof sources.
 
 The Profiling feature enables the collection of profiles from the processes running in the cluster.
@@ -56,7 +55,7 @@ Be sure perform actual integration testing in a live environment in the main [k8
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | ebpf.annotationSelectors | object | `{}` | Select pods to profile based on pod annotations. Example: `k8s.grafana.com/profile: "true"` will select pods with the annotation `k8s.grafana.com/profile="true"`. Example with multiple values: `color: ["blue", "green"]` will select pods with the annotation `color="blue"` or `color="green"`. |
-| ebpf.annotations.enable | string | `"scrape"` | The annotation action for enabling or disabling collecting of profiles with eBPF. Default is `profiles.grafana.com/cpu.ebpf.scrape`. |
+| ebpf.annotations.enable | string | `"enabled"` | The annotation action for enabling or disabling collecting of profiles with eBPF. Default is `profiles.grafana.com/cpu.ebpf.scrape`. |
 | ebpf.demangle | string | `"none"` | C++ demangle mode. Available options are: none, simplified, templates, full |
 | ebpf.enabled | bool | `true` | Gather profiles using eBPF |
 | ebpf.excludeNamespaces | list | `[]` | Which namespaces to exclude looking for pods. |
@@ -70,7 +69,7 @@ Be sure perform actual integration testing in a live environment in the main [k8
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | java.annotationSelectors | object | `{}` | Select pods to profile based on pod annotations. Example: `color: "green"` will select pods with the annotation `color="green"`. Example with multiple values: `color: ["blue", "green"]` will select pods with the annotation `color="blue"` or `color="green"`. |
-| java.annotations.enable | string | `"scrape"` | The annotation action for enabling or disabling scraping of Java profiles. |
+| java.annotations.enable | string | `"enabled"` | The annotation action for enabling or disabling scraping of Java profiles. |
 | java.enabled | bool | `true` | Gather profiles by scraping Java HTTP endpoints |
 | java.excludeNamespaces | list | `[]` | Which namespaces to exclude looking for pods. |
 | java.extraDiscoveryRules | string | `""` | Rule blocks to be added to the discovery.relabel component for Java profile sources. ([docs](https://grafana.com/docs/alloy/latest/reference/components/discovery/discovery.relabel/#rule-block)) |

--- a/charts/k8s-monitoring/charts/feature-profiling/README.md
+++ b/charts/k8s-monitoring/charts/feature-profiling/README.md
@@ -91,7 +91,7 @@ Be sure perform actual integration testing in a live environment in the main [k8
 | pprof.enabled | bool | `true` | Gather profiles by scraping pprof HTTP endpoints |
 | pprof.excludeNamespaces | list | `[]` | Which namespaces to exclude looking for pods. |
 | pprof.extraDiscoveryRules | string | `""` | Rule blocks to be added to the discovery.relabel component for eBPF profile sources. These relabeling rules are applied pre-scrape against the targets from service discovery. Before the scrape, any remaining target labels that start with `__` (i.e. `__meta_kubernetes*`) are dropped. ([docs](https://grafana.com/docs/alloy/latest/reference/components/discovery/discovery.relabel/#rule-block)) |
-| pprof.labelSelectors | object | `{}` | Select pods to profile based on pod labels. Example: `app.kubernetes.io/name: myapp` will select pods with the label `app.kubernetes.io/name=myapp`. Example with multiple values: `app.kubernetes.io/name: [myapp, myapp2]` will select pods with the label `app.kubernetes.io/name=myapp` or `app.kubernetes.io/name=myapp2`. |
+| pprof.labelSelectors | object | `{}` | Select pods to profile based on pod labels. Example with multiple values: `app.kubernetes.io/name: [myapp, myapp2]` will select pods with the label `app.kubernetes.io/name=myapp` or `app.kubernetes.io/name=myapp2`. |
 | pprof.namespaces | list | `[]` | Select pods to profile based on their namespaces. |
 | pprof.scrapeInterval | string | `"15s"` | How frequently to collect profiles. |
 | pprof.scrapeTimeout | string | `"18s"` | Timeout for collecting profiles. Must be larger than the scrape interval. |

--- a/charts/k8s-monitoring/charts/feature-profiling/README.md.gotmpl
+++ b/charts/k8s-monitoring/charts/feature-profiling/README.md.gotmpl
@@ -5,7 +5,6 @@
 
 {{ template "chart.header" . }}
 {{ template "chart.deprecationWarning" . }}
-{{ template "chart.badgesSection" . }}
 {{ template "chart.description" . }}
 {{ template "chart.homepageLine" . }}
 

--- a/charts/k8s-monitoring/charts/feature-profiling/schema-mods/types-and-enums.json
+++ b/charts/k8s-monitoring/charts/feature-profiling/schema-mods/types-and-enums.json
@@ -2,7 +2,13 @@
   "properties": {
     "ebpf": {
       "properties": {
-        "demangle": { "enum": ["none", "simplified", "templates", "full"]}
+        "demangle": { "enum": ["none", "simplified", "templates", "full"]},
+        "targetingScheme": { "enum": ["all", "annotation"] }
+      }
+    },
+    "java": {
+      "properties": {
+        "targetingScheme": { "enum": ["all", "annotation"] }
       }
     }
   }

--- a/charts/k8s-monitoring/charts/feature-profiling/templates/_ebpf.tpl
+++ b/charts/k8s-monitoring/charts/feature-profiling/templates/_ebpf.tpl
@@ -88,6 +88,10 @@ discovery.relabel "ebpf_pods" {
     replacement = "ebpf/${1}/${2}"
     target_label = "service_name"
   }
+  rule {
+    replacement = "alloy/pyroscope.ebpf"
+    target_label = "source"
+  }
 {{- if .Values.ebpf.extraDiscoveryRules }}
 {{ .Values.ebpf.extraDiscoveryRules | indent 2 }}
 {{- end }}

--- a/charts/k8s-monitoring/charts/feature-profiling/templates/_java.tpl
+++ b/charts/k8s-monitoring/charts/feature-profiling/templates/_java.tpl
@@ -49,7 +49,7 @@ discovery.relabel "potential_java_pods" {
 }
 
 discovery.process "java_pods" {
-  join = discovery.kubernetes.potential_java_pods.targets
+  join = discovery.relabel.potential_java_pods.output
 }
 
 discovery.relabel "java_pods" {

--- a/charts/k8s-monitoring/charts/feature-profiling/templates/_java.tpl
+++ b/charts/k8s-monitoring/charts/feature-profiling/templates/_java.tpl
@@ -93,6 +93,10 @@ discovery.relabel "java_pods" {
     source_labels = ["__meta_kubernetes_pod_container_name"]
     target_label = "container"
   }
+  rule {
+    replacement = "alloy/pyroscope.java"
+    target_label = "source"
+  }
 {{- if .Values.java.extraDiscoveryRules }}
 {{ .Values.java.extraDiscoveryRules | indent 2 }}
 {{- end }}

--- a/charts/k8s-monitoring/charts/feature-profiling/templates/_pprof.tpl
+++ b/charts/k8s-monitoring/charts/feature-profiling/templates/_pprof.tpl
@@ -75,35 +75,40 @@ discovery.relabel "pprof_pods" {
 {{- $allProfileTypes := keys .Values.pprof.types | sortAlpha }}
 {{ range $currentType := $allProfileTypes }}
 {{- if get $.Values.pprof.types $currentType }}
+  {{- $scrapeAnnotation := include "pod_annotation" (printf "%s/%s.%s" $.Values.pprof.annotations.prefix $currentType $.Values.pprof.annotations.enable) }}
+  {{- $portNameAnnotation := include "pod_annotation" (printf "%s/%s.%s" $.Values.pprof.annotations.prefix $currentType $.Values.pprof.annotations.portName) }}
+  {{- $portNumberAnnotation := include "pod_annotation" (printf "%s/%s.%s" $.Values.pprof.annotations.prefix $currentType $.Values.pprof.annotations.portNumber) }}
+  {{- $schemeAnnotation := include "pod_annotation" (printf "%s/%s.%s" $.Values.pprof.annotations.prefix $currentType $.Values.pprof.annotations.scheme) }}
+  {{- $pathAnnotation := include "pod_annotation" (printf "%s/%s.%s" $.Values.pprof.annotations.prefix $currentType $.Values.pprof.annotations.path) }}
 discovery.relabel "pprof_pods_{{ $currentType }}_default_name" {
   targets = discovery.relabel.pprof_pods.output
   rule {
-    source_labels = ["__meta_kubernetes_pod_annotation_profiles_grafana_com_{{ $currentType }}_scrape"]
+    source_labels = [{{ $scrapeAnnotation | quote }}]
     regex         = "true"
     action        = "keep"
   }
   rule {
-    source_labels = ["__meta_kubernetes_pod_annotation_profiles_grafana_com_{{ $currentType }}_port_name"]
+    source_labels = [{{ $portNameAnnotation | quote }}]
     regex         = ""
     action        = "keep"
   }
 
   rule {
-    source_labels = ["__meta_kubernetes_pod_annotation_profiles_grafana_com_{{ $currentType }}_scheme"]
+    source_labels = [{{ $schemeAnnotation | quote }}]
     action        = "replace"
     regex         = "(https?)"
     target_label  = "__scheme__"
     replacement   = "$1"
   }
   rule {
-    source_labels = ["__meta_kubernetes_pod_annotation_profiles_grafana_com_{{ $currentType }}_path"]
+    source_labels = [{{ $pathAnnotation | quote }}]
     action        = "replace"
     regex         = "(.+)"
     target_label  = "__profile_path__"
     replacement   = "$1"
   }
   rule {
-    source_labels = ["__address__", "__meta_kubernetes_pod_annotation_profiles_grafana_com_{{ $currentType }}_port"]
+    source_labels = ["__address__", {{ $portNumberAnnotation | quote }}]
     action        = "replace"
     regex         = "(.+?)(?::\\d+)?;(\\d+)"
     target_label  = "__address__"
@@ -114,37 +119,37 @@ discovery.relabel "pprof_pods_{{ $currentType }}_default_name" {
 discovery.relabel "pprof_pods_{{ $currentType }}_custom_name" {
   targets = discovery.relabel.pprof_pods.output
   rule {
-    source_labels = ["__meta_kubernetes_pod_annotation_profiles_grafana_com_{{ $currentType }}_scrape"]
+    source_labels = [{{ $scrapeAnnotation | quote }}]
     regex         = "true"
     action        = "keep"
   }
   rule {
-    source_labels = ["__meta_kubernetes_pod_annotation_profiles_grafana_com_{{ $currentType }}_port_name"]
+    source_labels = [{{ $portNameAnnotation | quote }}]
     regex         = ""
     action        = "drop"
   }
   rule {
     source_labels = ["__meta_kubernetes_pod_container_port_name"]
-    target_label  = "__meta_kubernetes_pod_annotation_profiles_grafana_com_{{ $currentType }}_port_name"
+    target_label  = {{ $portNameAnnotation | quote }}
     action        = "keepequal"
   }
 
   rule {
-    source_labels = ["__meta_kubernetes_pod_annotation_profiles_grafana_com_{{ $currentType }}_scheme"]
+    source_labels = [{{ $schemeAnnotation | quote }}]
     action        = "replace"
     regex         = "(https?)"
     target_label  = "__scheme__"
     replacement   = "$1"
   }
   rule {
-    source_labels = ["__meta_kubernetes_pod_annotation_profiles_grafana_com_{{ $currentType }}_path"]
+    source_labels = [{{ $pathAnnotation | quote }}]
     action        = "replace"
     regex         = "(.+)"
     target_label  = "__profile_path__"
     replacement   = "$1"
   }
   rule {
-    source_labels = ["__address__", "__meta_kubernetes_pod_annotation_profiles_grafana_com_{{ $currentType }}_port"]
+    source_labels = ["__address__", {{ $portNumberAnnotation | quote }}]
     action        = "replace"
     regex         = "(.+?)(?::\\d+)?;(\\d+)"
     target_label  = "__address__"

--- a/charts/k8s-monitoring/charts/feature-profiling/templates/_pprof.tpl
+++ b/charts/k8s-monitoring/charts/feature-profiling/templates/_pprof.tpl
@@ -67,6 +67,10 @@ discovery.relabel "pprof_pods" {
     source_labels = ["__meta_kubernetes_pod_container_name"]
     target_label  = "container"
   }
+  rule {
+    replacement = "alloy/pyroscope.pprof"
+    target_label = "source"
+  }
 {{- if .Values.pprof.extraDiscoveryRules }}
 {{ .Values.pprof.extraDiscoveryRules | indent 2 }}
 {{- end }}

--- a/charts/k8s-monitoring/charts/feature-profiling/templates/_pprof.tpl
+++ b/charts/k8s-monitoring/charts/feature-profiling/templates/_pprof.tpl
@@ -75,11 +75,11 @@ discovery.relabel "pprof_pods" {
 {{- $allProfileTypes := keys .Values.pprof.types | sortAlpha }}
 {{ range $currentType := $allProfileTypes }}
 {{- if get $.Values.pprof.types $currentType }}
-  {{- $scrapeAnnotation := include "pod_annotation" (printf "%s/%s.%s" $.Values.pprof.annotations.prefix $currentType $.Values.pprof.annotations.enable) }}
-  {{- $portNameAnnotation := include "pod_annotation" (printf "%s/%s.%s" $.Values.pprof.annotations.prefix $currentType $.Values.pprof.annotations.portName) }}
-  {{- $portNumberAnnotation := include "pod_annotation" (printf "%s/%s.%s" $.Values.pprof.annotations.prefix $currentType $.Values.pprof.annotations.portNumber) }}
-  {{- $schemeAnnotation := include "pod_annotation" (printf "%s/%s.%s" $.Values.pprof.annotations.prefix $currentType $.Values.pprof.annotations.scheme) }}
-  {{- $pathAnnotation := include "pod_annotation" (printf "%s/%s.%s" $.Values.pprof.annotations.prefix $currentType $.Values.pprof.annotations.path) }}
+  {{- $scrapeAnnotation := include "pod_annotation" (printf "%s/%s.%s" $.Values.annotations.prefix $currentType $.Values.pprof.annotations.enable) }}
+  {{- $portNameAnnotation := include "pod_annotation" (printf "%s/%s.%s" $.Values.annotations.prefix $currentType $.Values.pprof.annotations.portName) }}
+  {{- $portNumberAnnotation := include "pod_annotation" (printf "%s/%s.%s" $.Values.annotations.prefix $currentType $.Values.pprof.annotations.portNumber) }}
+  {{- $schemeAnnotation := include "pod_annotation" (printf "%s/%s.%s" $.Values.annotations.prefix $currentType $.Values.pprof.annotations.scheme) }}
+  {{- $pathAnnotation := include "pod_annotation" (printf "%s/%s.%s" $.Values.annotations.prefix $currentType $.Values.pprof.annotations.path) }}
 discovery.relabel "pprof_pods_{{ $currentType }}_default_name" {
   targets = discovery.relabel.pprof_pods.output
   rule {

--- a/charts/k8s-monitoring/charts/feature-profiling/tests/__snapshot__/ebpf_test.yaml.snap
+++ b/charts/k8s-monitoring/charts/feature-profiling/tests/__snapshot__/ebpf_test.yaml.snap
@@ -23,6 +23,11 @@ should be able to filter by label and annotation:
             action = "drop"
           }
           rule {
+            source_labels = ["__meta_kubernetes_pod_annotation_profiles_grafana_com_cpu_ebpf_scrape"]
+            regex         = "true"
+            action        = "keep"
+          }
+          rule {
             source_labels = ["__meta_kubernetes_namespace"]
             target_label = "namespace"
           }
@@ -86,6 +91,11 @@ should be able to filter by namespace and extra discovery rules:
             action = "drop"
           }
           rule {
+            source_labels = ["__meta_kubernetes_pod_annotation_profiles_grafana_com_cpu_ebpf_scrape"]
+            regex         = "true"
+            action        = "keep"
+          }
+          rule {
             source_labels = ["__meta_kubernetes_namespace"]
             target_label = "namespace"
           }
@@ -144,6 +154,11 @@ should build the eBPF profiling configuration:
             source_labels = ["__meta_kubernetes_pod_phase"]
             regex = "Succeeded|Failed|Completed"
             action = "drop"
+          }
+          rule {
+            source_labels = ["__meta_kubernetes_pod_annotation_profiles_grafana_com_cpu_ebpf_scrape"]
+            regex         = "true"
+            action        = "keep"
           }
           rule {
             source_labels = ["__meta_kubernetes_namespace"]

--- a/charts/k8s-monitoring/charts/feature-profiling/tests/__snapshot__/ebpf_test.yaml.snap
+++ b/charts/k8s-monitoring/charts/feature-profiling/tests/__snapshot__/ebpf_test.yaml.snap
@@ -23,7 +23,7 @@ should be able to filter by label and annotation:
             action = "drop"
           }
           rule {
-            source_labels = ["__meta_kubernetes_pod_annotation_profiles_grafana_com_cpu_ebpf_scrape"]
+            source_labels = ["__meta_kubernetes_pod_annotation_profiles_grafana_com_cpu_ebpf_enabled"]
             regex         = "true"
             action        = "keep"
           }
@@ -91,7 +91,7 @@ should be able to filter by namespace and extra discovery rules:
             action = "drop"
           }
           rule {
-            source_labels = ["__meta_kubernetes_pod_annotation_profiles_grafana_com_cpu_ebpf_scrape"]
+            source_labels = ["__meta_kubernetes_pod_annotation_profiles_grafana_com_cpu_ebpf_enabled"]
             regex         = "true"
             action        = "keep"
           }
@@ -132,6 +132,66 @@ should be able to filter by namespace and extra discovery rules:
           forward_to = argument.profiles_destinations.value
         }
       }
+should be able to target all pods, without requiring the annotation:
+  1: |
+    |-
+      declare "profiling" {
+        argument "profiles_destinations" {
+          comment = "Must be a list of profile destinations where collected profiles should be forwarded to"
+        }
+        // Profiles: eBPF
+        discovery.kubernetes "ebpf_pods" {
+          role = "pod"
+          selectors {
+            role = "pod"
+            field = "spec.nodeName=" + sys.env("HOSTNAME")
+          }
+        }
+
+        discovery.relabel "ebpf_pods" {
+          targets = discovery.kubernetes.ebpf_pods.targets
+          rule {
+            source_labels = ["__meta_kubernetes_pod_phase"]
+            regex = "Succeeded|Failed|Completed"
+            action = "drop"
+          }
+          rule {
+            source_labels = ["__meta_kubernetes_pod_annotation_profiles_grafana_com_cpu_ebpf_enabled"]
+            regex         = "false"
+            action        = "drop"
+          }
+          rule {
+            source_labels = ["__meta_kubernetes_namespace"]
+            target_label = "namespace"
+          }
+          rule {
+            source_labels = ["__meta_kubernetes_pod_name"]
+            target_label = "pod"
+          }
+          rule {
+            source_labels = ["__meta_kubernetes_pod_node_name"]
+            target_label = "node"
+          }
+          rule {
+            source_labels = ["__meta_kubernetes_pod_container_name"]
+            target_label = "container"
+          }
+          // provide arbitrary service_name label, otherwise it will be set to {__meta_kubernetes_namespace}/{__meta_kubernetes_pod_container_name}
+          rule {
+            source_labels = ["__meta_kubernetes_namespace", "__meta_kubernetes_pod_container_name"]
+            separator = "@"
+            regex = "(.*)@(.*)"
+            replacement = "ebpf/${1}/${2}"
+            target_label = "service_name"
+          }
+        }
+
+        pyroscope.ebpf "ebpf_pods" {
+          targets = discovery.relabel.ebpf_pods.output
+          demangle = "none"
+          forward_to = argument.profiles_destinations.value
+        }
+      }
 should build the eBPF profiling configuration:
   1: |
     |-
@@ -156,7 +216,7 @@ should build the eBPF profiling configuration:
             action = "drop"
           }
           rule {
-            source_labels = ["__meta_kubernetes_pod_annotation_profiles_grafana_com_cpu_ebpf_scrape"]
+            source_labels = ["__meta_kubernetes_pod_annotation_profiles_grafana_com_cpu_ebpf_enabled"]
             regex         = "true"
             action        = "keep"
           }

--- a/charts/k8s-monitoring/charts/feature-profiling/tests/__snapshot__/ebpf_test.yaml.snap
+++ b/charts/k8s-monitoring/charts/feature-profiling/tests/__snapshot__/ebpf_test.yaml.snap
@@ -32,8 +32,8 @@ should be able to filter by label and annotation:
             target_label = "namespace"
           }
           rule {
-            source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_profile"]
-            regex = "true"
+            source_labels = ["__meta_kubernetes_pod_annotation_region"]
+            regex = "central"
             action = "keep"
           }
           rule {
@@ -55,6 +55,10 @@ should be able to filter by label and annotation:
             regex = "(.*)@(.*)"
             replacement = "ebpf/${1}/${2}"
             target_label = "service_name"
+          }
+          rule {
+            replacement = "alloy/pyroscope.ebpf"
+            target_label = "source"
           }
         }
 
@@ -118,6 +122,10 @@ should be able to filter by namespace and extra discovery rules:
             regex = "(.*)@(.*)"
             replacement = "ebpf/${1}/${2}"
             target_label = "service_name"
+          }
+          rule {
+            replacement = "alloy/pyroscope.ebpf"
+            target_label = "source"
           }
           rule {
             source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
@@ -184,6 +192,10 @@ should be able to target all pods, without requiring the annotation:
             replacement = "ebpf/${1}/${2}"
             target_label = "service_name"
           }
+          rule {
+            replacement = "alloy/pyroscope.ebpf"
+            target_label = "source"
+          }
         }
 
         pyroscope.ebpf "ebpf_pods" {
@@ -243,6 +255,10 @@ should build the eBPF profiling configuration:
             regex = "(.*)@(.*)"
             replacement = "ebpf/${1}/${2}"
             target_label = "service_name"
+          }
+          rule {
+            replacement = "alloy/pyroscope.ebpf"
+            target_label = "source"
           }
         }
 

--- a/charts/k8s-monitoring/charts/feature-profiling/tests/__snapshot__/java_test.yaml.snap
+++ b/charts/k8s-monitoring/charts/feature-profiling/tests/__snapshot__/java_test.yaml.snap
@@ -15,22 +15,26 @@ should be able to filter by label and annotation:
           }
         }
 
+        discovery.relabel "potential_java_pods" {
+          targets = discovery.kubernetes.java_pods.targets
+          rule {
+            source_labels = ["__meta_kubernetes_pod_phase"]
+            regex         = "Succeeded|Failed|Completed"
+            action        = "drop"
+          }
+          rule {
+            source_labels = ["__meta_kubernetes_pod_annotation_profiles_grafana_com_java_scrape"]
+            regex         = "true"
+            action        = "keep"
+          }
+        }
+
         discovery.process "java_pods" {
-          join = discovery.kubernetes.java_pods.targets
+          join = discovery.kubernetes.potential_java_pods.targets
         }
 
         discovery.relabel "java_pods" {
           targets = discovery.process.java_pods.targets
-          rule {
-            source_labels = ["__meta_kubernetes_pod_phase"]
-            regex = "Succeeded|Failed|Completed"
-            action = "drop"
-          }
-          rule {
-            source_labels = ["__meta_kubernetes_pod_name"]
-            regex = "^$"
-            action = "drop"
-          }
           rule {
             source_labels = ["__meta_process_exe"]
             action = "keep"
@@ -87,22 +91,26 @@ should build the Java profiling configuration:
           }
         }
 
+        discovery.relabel "potential_java_pods" {
+          targets = discovery.kubernetes.java_pods.targets
+          rule {
+            source_labels = ["__meta_kubernetes_pod_phase"]
+            regex         = "Succeeded|Failed|Completed"
+            action        = "drop"
+          }
+          rule {
+            source_labels = ["__meta_kubernetes_pod_annotation_profiles_grafana_com_java_scrape"]
+            regex         = "true"
+            action        = "keep"
+          }
+        }
+
         discovery.process "java_pods" {
-          join = discovery.kubernetes.java_pods.targets
+          join = discovery.kubernetes.potential_java_pods.targets
         }
 
         discovery.relabel "java_pods" {
           targets = discovery.process.java_pods.targets
-          rule {
-            source_labels = ["__meta_kubernetes_pod_phase"]
-            regex = "Succeeded|Failed|Completed"
-            action = "drop"
-          }
-          rule {
-            source_labels = ["__meta_kubernetes_pod_name"]
-            regex = "^$"
-            action = "drop"
-          }
           rule {
             source_labels = ["__meta_process_exe"]
             action = "keep"

--- a/charts/k8s-monitoring/charts/feature-profiling/tests/__snapshot__/java_test.yaml.snap
+++ b/charts/k8s-monitoring/charts/feature-profiling/tests/__snapshot__/java_test.yaml.snap
@@ -30,7 +30,7 @@ should be able to filter by label and annotation:
         }
 
         discovery.process "java_pods" {
-          join = discovery.kubernetes.potential_java_pods.targets
+          join = discovery.relabel.potential_java_pods.output
         }
 
         discovery.relabel "java_pods" {
@@ -106,7 +106,7 @@ should be able to target all pods, without requiring the annotation:
         }
 
         discovery.process "java_pods" {
-          join = discovery.kubernetes.potential_java_pods.targets
+          join = discovery.relabel.potential_java_pods.output
         }
 
         discovery.relabel "java_pods" {
@@ -177,7 +177,7 @@ should build the Java profiling configuration:
         }
 
         discovery.process "java_pods" {
-          join = discovery.kubernetes.potential_java_pods.targets
+          join = discovery.relabel.potential_java_pods.output
         }
 
         discovery.relabel "java_pods" {

--- a/charts/k8s-monitoring/charts/feature-profiling/tests/__snapshot__/java_test.yaml.snap
+++ b/charts/k8s-monitoring/charts/feature-profiling/tests/__snapshot__/java_test.yaml.snap
@@ -45,8 +45,8 @@ should be able to filter by label and annotation:
             target_label = "namespace"
           }
           rule {
-            source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_profile"]
-            regex = "true"
+            source_labels = ["__meta_kubernetes_pod_annotation_region"]
+            regex = "central"
             action = "keep"
           }
           rule {
@@ -60,6 +60,10 @@ should be able to filter by label and annotation:
           rule {
             source_labels = ["__meta_kubernetes_pod_container_name"]
             target_label = "container"
+          }
+          rule {
+            replacement = "alloy/pyroscope.java"
+            target_label = "source"
           }
         }
 
@@ -132,6 +136,10 @@ should be able to target all pods, without requiring the annotation:
             source_labels = ["__meta_kubernetes_pod_container_name"]
             target_label = "container"
           }
+          rule {
+            replacement = "alloy/pyroscope.java"
+            target_label = "source"
+          }
         }
 
         pyroscope.java "java_pods" {
@@ -202,6 +210,10 @@ should build the Java profiling configuration:
           rule {
             source_labels = ["__meta_kubernetes_pod_container_name"]
             target_label = "container"
+          }
+          rule {
+            replacement = "alloy/pyroscope.java"
+            target_label = "source"
           }
         }
 

--- a/charts/k8s-monitoring/charts/feature-profiling/tests/__snapshot__/java_test.yaml.snap
+++ b/charts/k8s-monitoring/charts/feature-profiling/tests/__snapshot__/java_test.yaml.snap
@@ -23,7 +23,7 @@ should be able to filter by label and annotation:
             action        = "drop"
           }
           rule {
-            source_labels = ["__meta_kubernetes_pod_annotation_profiles_grafana_com_java_scrape"]
+            source_labels = ["__meta_kubernetes_pod_annotation_profiles_grafana_com_java_enabled"]
             regex         = "true"
             action        = "keep"
           }
@@ -75,6 +75,77 @@ should be able to filter by label and annotation:
           forward_to = argument.profiles_destinations.value
         }
       }
+should be able to target all pods, without requiring the annotation:
+  1: |
+    |-
+      declare "profiling" {
+        argument "profiles_destinations" {
+          comment = "Must be a list of profile destinations where collected profiles should be forwarded to"
+        }
+        // Profiles: Java
+        discovery.kubernetes "java_pods" {
+          role = "pod"
+          selectors {
+            role = "pod"
+            field = "spec.nodeName=" + sys.env("HOSTNAME")
+          }
+        }
+
+        discovery.relabel "potential_java_pods" {
+          targets = discovery.kubernetes.java_pods.targets
+          rule {
+            source_labels = ["__meta_kubernetes_pod_phase"]
+            regex         = "Succeeded|Failed|Completed"
+            action        = "drop"
+          }
+          rule {
+            source_labels = ["__meta_kubernetes_pod_annotation_profiles_grafana_com_java_enabled"]
+            regex         = "false"
+            action        = "drop"
+          }
+        }
+
+        discovery.process "java_pods" {
+          join = discovery.kubernetes.potential_java_pods.targets
+        }
+
+        discovery.relabel "java_pods" {
+          targets = discovery.process.java_pods.targets
+          rule {
+            source_labels = ["__meta_process_exe"]
+            action = "keep"
+            regex = ".*/java$"
+          }
+          rule {
+            source_labels = ["__meta_kubernetes_namespace"]
+            target_label = "namespace"
+          }
+          rule {
+            source_labels = ["__meta_kubernetes_pod_name"]
+            target_label = "pod"
+          }
+          rule {
+            source_labels = ["__meta_kubernetes_pod_node_name"]
+            target_label = "node"
+          }
+          rule {
+            source_labels = ["__meta_kubernetes_pod_container_name"]
+            target_label = "container"
+          }
+        }
+
+        pyroscope.java "java_pods" {
+          targets = discovery.relabel.java_pods.output
+          profiling_config {
+            interval = "60s"
+            alloc = "512k"
+            cpu = true
+            sample_rate = 100
+            lock = "10ms"
+          }
+          forward_to = argument.profiles_destinations.value
+        }
+      }
 should build the Java profiling configuration:
   1: |
     |-
@@ -99,7 +170,7 @@ should build the Java profiling configuration:
             action        = "drop"
           }
           rule {
-            source_labels = ["__meta_kubernetes_pod_annotation_profiles_grafana_com_java_scrape"]
+            source_labels = ["__meta_kubernetes_pod_annotation_profiles_grafana_com_java_enabled"]
             regex         = "true"
             action        = "keep"
           }

--- a/charts/k8s-monitoring/charts/feature-profiling/tests/__snapshot__/pprof_test.yaml.snap
+++ b/charts/k8s-monitoring/charts/feature-profiling/tests/__snapshot__/pprof_test.yaml.snap
@@ -32,8 +32,8 @@ should be able to filter by label and annotation:
             target_label  = "namespace"
           }
           rule {
-            source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_profile"]
-            regex = "true"
+            source_labels = ["__meta_kubernetes_pod_annotation_region"]
+            regex = "central"
             action = "keep"
           }
           rule {
@@ -43,6 +43,10 @@ should be able to filter by label and annotation:
           rule {
             source_labels = ["__meta_kubernetes_pod_container_name"]
             target_label  = "container"
+          }
+          rule {
+            replacement = "alloy/pyroscope.pprof"
+            target_label = "source"
           }
         }
 
@@ -782,6 +786,10 @@ should build the pprof profiling configuration:
           rule {
             source_labels = ["__meta_kubernetes_pod_container_name"]
             target_label  = "container"
+          }
+          rule {
+            replacement = "alloy/pyroscope.pprof"
+            target_label = "source"
           }
         }
 

--- a/charts/k8s-monitoring/charts/feature-profiling/tests/ebpf_test.yaml
+++ b/charts/k8s-monitoring/charts/feature-profiling/tests/ebpf_test.yaml
@@ -49,7 +49,7 @@ tests:
           app.kubernetes.io/name: secret-program
           colors: [blue, green]
         annotationSelectors:
-          k8s.grafana.com/profile: "true"
+          region: central
       java:
         enabled: false
       pprof:

--- a/charts/k8s-monitoring/charts/feature-profiling/tests/ebpf_test.yaml
+++ b/charts/k8s-monitoring/charts/feature-profiling/tests/ebpf_test.yaml
@@ -1,5 +1,5 @@
 # yamllint disable rule:document-start rule:line-length rule:trailing-spaces
-suite: Test eBPF profiling
+suite: Test - Profiling - eBPF Profiling
 templates:
   - configmap.yaml
 tests:
@@ -50,6 +50,22 @@ tests:
           colors: [blue, green]
         annotationSelectors:
           k8s.grafana.com/profile: "true"
+      java:
+        enabled: false
+      pprof:
+        enabled: false
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - matchSnapshot:
+          path: data["module.alloy"]
+
+  - it: should be able to target all pods, without requiring the annotation
+    set:
+      deployAsConfigMap: true
+      ebpf:
+        enabled: true
+        targetingScheme: all
       java:
         enabled: false
       pprof:

--- a/charts/k8s-monitoring/charts/feature-profiling/tests/java_test.yaml
+++ b/charts/k8s-monitoring/charts/feature-profiling/tests/java_test.yaml
@@ -1,5 +1,5 @@
 # yamllint disable rule:document-start rule:line-length rule:trailing-spaces
-suite: Test Java profiling
+suite: Test - Profiling - Java Profiling
 templates:
   - configmap.yaml
 tests:
@@ -17,6 +17,7 @@ tests:
           of: ConfigMap
       - matchSnapshot:
           path: data["module.alloy"]
+
   - it: should be able to filter by label and annotation
     set:
       deployAsConfigMap: true
@@ -29,6 +30,22 @@ tests:
           colors: [blue, green]
         annotationSelectors:
           k8s.grafana.com/profile: "true"
+      pprof:
+        enabled: false
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - matchSnapshot:
+          path: data["module.alloy"]
+
+  - it: should be able to target all pods, without requiring the annotation
+    set:
+      deployAsConfigMap: true
+      ebpf:
+        enabled: false
+      java:
+        enabled: true
+        targetingScheme: all
       pprof:
         enabled: false
     asserts:

--- a/charts/k8s-monitoring/charts/feature-profiling/tests/java_test.yaml
+++ b/charts/k8s-monitoring/charts/feature-profiling/tests/java_test.yaml
@@ -29,7 +29,7 @@ tests:
           app.kubernetes.io/name: secret-program
           colors: [blue, green]
         annotationSelectors:
-          k8s.grafana.com/profile: "true"
+          region: central
       pprof:
         enabled: false
     asserts:

--- a/charts/k8s-monitoring/charts/feature-profiling/tests/pprof_test.yaml
+++ b/charts/k8s-monitoring/charts/feature-profiling/tests/pprof_test.yaml
@@ -1,5 +1,5 @@
 # yamllint disable rule:document-start rule:line-length rule:trailing-spaces
-suite: Test pprof profiling
+suite: Test - Profiling - pprof Profiling
 templates:
   - configmap.yaml
 tests:

--- a/charts/k8s-monitoring/charts/feature-profiling/tests/pprof_test.yaml
+++ b/charts/k8s-monitoring/charts/feature-profiling/tests/pprof_test.yaml
@@ -30,7 +30,7 @@ tests:
           app.kubernetes.io/name: secret-program
           colors: [blue, green]
         annotationSelectors:
-          k8s.grafana.com/profile: "true"
+          region: central
     asserts:
       - isKind:
           of: ConfigMap

--- a/charts/k8s-monitoring/charts/feature-profiling/values.schema.json
+++ b/charts/k8s-monitoring/charts/feature-profiling/values.schema.json
@@ -2,6 +2,14 @@
     "$schema": "http://json-schema.org/schema#",
     "type": "object",
     "properties": {
+        "annotations": {
+            "type": "object",
+            "properties": {
+                "prefix": {
+                    "type": "string"
+                }
+            }
+        },
         "deployAsConfigMap": {
             "type": "boolean"
         },
@@ -10,6 +18,14 @@
             "properties": {
                 "annotationSelectors": {
                     "type": "object"
+                },
+                "annotations": {
+                    "type": "object",
+                    "properties": {
+                        "enable": {
+                            "type": "string"
+                        }
+                    }
                 },
                 "demangle": {
                     "type": "string",
@@ -34,6 +50,13 @@
                 },
                 "namespaces": {
                     "type": "array"
+                },
+                "targetingScheme": {
+                    "type": "string",
+                    "enum": [
+                        "all",
+                        "annotation"
+                    ]
                 }
             }
         },
@@ -45,6 +68,14 @@
             "properties": {
                 "annotationSelectors": {
                     "type": "object"
+                },
+                "annotations": {
+                    "type": "object",
+                    "properties": {
+                        "enable": {
+                            "type": "string"
+                        }
+                    }
                 },
                 "enabled": {
                     "type": "boolean"
@@ -80,6 +111,13 @@
                             "type": "integer"
                         }
                     }
+                },
+                "targetingScheme": {
+                    "type": "string",
+                    "enum": [
+                        "all",
+                        "annotation"
+                    ]
                 }
             }
         },
@@ -105,9 +143,6 @@
                             "type": "string"
                         },
                         "portNumber": {
-                            "type": "string"
-                        },
-                        "prefix": {
                             "type": "string"
                         },
                         "scheme": {

--- a/charts/k8s-monitoring/charts/feature-profiling/values.schema.json
+++ b/charts/k8s-monitoring/charts/feature-profiling/values.schema.json
@@ -92,6 +92,29 @@
                 "annotationSelectors": {
                     "type": "object"
                 },
+                "annotations": {
+                    "type": "object",
+                    "properties": {
+                        "enable": {
+                            "type": "string"
+                        },
+                        "path": {
+                            "type": "string"
+                        },
+                        "portName": {
+                            "type": "string"
+                        },
+                        "portNumber": {
+                            "type": "string"
+                        },
+                        "prefix": {
+                            "type": "string"
+                        },
+                        "scheme": {
+                            "type": "string"
+                        }
+                    }
+                },
                 "enabled": {
                     "type": "boolean"
                 },

--- a/charts/k8s-monitoring/charts/feature-profiling/values.yaml
+++ b/charts/k8s-monitoring/charts/feature-profiling/values.yaml
@@ -31,7 +31,7 @@ ebpf:
   # the annotation `profiles.grafana.com/cpu.ebpf.scrape: "true"` on the pod.
   annotations:
     # -- The annotation action for enabling or disabling collecting of profiles with eBPF.
-    # Default is `profiles.grafana.com/cpu.ebpf.scrape`.
+    # Default is `profiles.grafana.com/cpu.ebpf.enabled`.
     # @section -- eBPF
     enable: "enabled"
 

--- a/charts/k8s-monitoring/charts/feature-profiling/values.yaml
+++ b/charts/k8s-monitoring/charts/feature-profiling/values.yaml
@@ -33,7 +33,7 @@ ebpf:
     # -- The annotation action for enabling or disabling collecting of profiles with eBPF.
     # Default is `profiles.grafana.com/cpu.ebpf.scrape`.
     # @section -- eBPF
-    enable: "scrape"
+    enable: "enabled"
 
   # -- Select pods to profile based on pod labels.
   # Example: `app.kubernetes.io/name: myapp` will select pods with the label `app.kubernetes.io/name=myapp`.
@@ -86,7 +86,7 @@ java:
   annotations:
     # -- The annotation action for enabling or disabling scraping of Java profiles.
     # @section -- Java
-    enable: "scrape"
+    enable: "enabled"
 
   # -- Select pods to profile based on pod labels.
   # Example: `app.kubernetes.io/name: myapp` will select pods with the label `app.kubernetes.io/name=myapp`.

--- a/charts/k8s-monitoring/charts/feature-profiling/values.yaml
+++ b/charts/k8s-monitoring/charts/feature-profiling/values.yaml
@@ -75,16 +75,16 @@ java:
 
   # -- How to target pods for finding Java profiles. Options are `all` and `annotation`. If using `all`, all Kubernetes
   # pods will be targeted for Java profiles, and you can exclude certain pods by setting the
-  # `profiles.grafana.com/java.scrape="false"` annotation on that pod. If using `annotation`, only pods with the
-  # `profiles.grafana.com/java.scrape="true"` annotation will be scraped for Java profiles.
+  # `profiles.grafana.com/java.enabled="false"` annotation on that pod. If using `annotation`, only pods with the
+  # `profiles.grafana.com/java.enabled="true"` annotation will collecting Java profiles.
   # @section -- Java
   targetingScheme: annotation
 
-  # Configure the annotations that will control how the Java targets are discovered and how profiles are scraped.
+  # Configure the annotations that will control how the Java targets are discovered and how profiles are collected.
   # All annotations will be `<prefix>/java.<action>`, for example, to "enable" scraping of Java profiles, set the
-  # annotation `profiles.grafana.com/java.scrape: "true"` on the pod.
+  # annotation `profiles.grafana.com/java.enabled: "true"` on the pod.
   annotations:
-    # -- The annotation action for enabling or disabling scraping of Java profiles.
+    # -- The annotation action for enabling or disabling of Java profile collection.
     # @section -- Java
     enable: "enabled"
 

--- a/charts/k8s-monitoring/charts/feature-profiling/values.yaml
+++ b/charts/k8s-monitoring/charts/feature-profiling/values.yaml
@@ -7,12 +7,33 @@ nameOverride: ""
 # @section -- General settings
 fullnameOverride: ""
 
+annotations:
+  # -- The prefix for all annotations.
+  # @section -- General settings
+  prefix: "profiles.grafana.com"
+
 # Settings for gathering profiles using eBPF
 # @section -- eBPF
 ebpf:
   # -- Gather profiles using eBPF
   # @section -- eBPF
   enabled: true
+
+  # -- How to target pods for collecting profiles with eBPF. Options are `all` and `annotation`. If using `all`, all
+  # Kubernetes pods will be targeted for collecting profiles, and you can exclude certain pods by setting the
+  # `profiles.grafana.com/cpu.ebpf.scrape="false"` annotation on that pod. If using `annotation`, only pods with the
+  # `profiles.grafana.com/cpu.ebpf.scrape="true"` annotation will have profiles collected with eBPF.
+  # @section -- eBPF
+  targetingScheme: annotation
+
+  # Configure the annotations that will control how the targets are discovered and how profiles are collected.
+  # All annotations will be `<prefix>/cpu.ebpf.<action>`, for example, to "enable" collecting profiles using eBPF, set
+  # the annotation `profiles.grafana.com/cpu.ebpf.scrape: "true"` on the pod.
+  annotations:
+    # -- The annotation action for enabling or disabling collecting of profiles with eBPF.
+    # Default is `profiles.grafana.com/cpu.ebpf.scrape`.
+    # @section -- eBPF
+    enable: "scrape"
 
   # -- Select pods to profile based on pod labels.
   # Example: `app.kubernetes.io/name: myapp` will select pods with the label `app.kubernetes.io/name=myapp`.
@@ -48,9 +69,24 @@ ebpf:
   demangle: none
 
 java:
-  # -- Gather profiles by scraping java HTTP endpoints
+  # -- Gather profiles by scraping Java HTTP endpoints
   # @section -- Java
   enabled: true
+
+  # -- How to target pods for finding Java profiles. Options are `all` and `annotation`. If using `all`, all Kubernetes
+  # pods will be targeted for Java profiles, and you can exclude certain pods by setting the
+  # `profiles.grafana.com/java.scrape="false"` annotation on that pod. If using `annotation`, only pods with the
+  # `profiles.grafana.com/java.scrape="true"` annotation will be scraped for Java profiles.
+  # @section -- Java
+  targetingScheme: annotation
+
+  # Configure the annotations that will control how the Java targets are discovered and how profiles are scraped.
+  # All annotations will be `<prefix>/java.<action>`, for example, to "enable" scraping of Java profiles, set the
+  # annotation `profiles.grafana.com/java.scrape: "true"` on the pod.
+  annotations:
+    # -- The annotation action for enabling or disabling scraping of Java profiles.
+    # @section -- Java
+    enable: "scrape"
 
   # -- Select pods to profile based on pod labels.
   # Example: `app.kubernetes.io/name: myapp` will select pods with the label `app.kubernetes.io/name=myapp`.
@@ -60,7 +96,7 @@ java:
   labelSelectors: {}
 
   # -- Select pods to profile based on pod annotations.
-  # Example: `k8s.grafana.com/profile: "true"` will select pods with the annotation `k8s.grafana.com/profile="true"`.
+  # Example: `color: "green"` will select pods with the annotation `color="green"`.
   # Example with multiple values: `color: ["blue", "green"]` will select pods with the annotation `color="blue"` or
   # `color="green"`.
   # @section -- Java
@@ -106,16 +142,11 @@ pprof:
     godeltaprof_mutex: false
     godeltaprof_block: false
 
-  # -- Configure the annotations that will control how the pprof targets are discovered and how profiles are scraped.
+  # Configure the annotations that will control how the pprof targets are discovered and how profiles are scraped.
   # All annotations will be `<prefix>/<type>.<action>`, for example, to "enable" scraping of CPU profiles, set the
   # annotation `profiles.grafana.com/cpu.scrape: "true"` on the pod. To set the path for memory profiles, set the
   # annotation `profiles.grafana.com/memory.path: "/debug/pprof/mem"` on the pod.
-  # @section -- pprof
   annotations:
-    # -- The prefix for all pprof annotations.
-    # @section -- pprof
-    prefix: "profiles.grafana.com"
-
     # -- The annotation action for enabling or disabling scraping of profiles of a given type.
     # @section -- pprof
     enable: "scrape"

--- a/charts/k8s-monitoring/charts/feature-profiling/values.yaml
+++ b/charts/k8s-monitoring/charts/feature-profiling/values.yaml
@@ -93,6 +93,45 @@ pprof:
   # @section -- pprof
   enabled: true
 
+  # -- Profile types to gather
+  # @section -- pprof
+  types:
+    memory: true
+    block: true
+    goroutine: true
+    mutex: true
+    cpu: true
+    fgprof: true
+    godeltaprof_memory: false
+    godeltaprof_mutex: false
+    godeltaprof_block: false
+
+  # -- Configure the annotations that will control how the pprof targets are discovered and how profiles are scraped.
+  # All annotations will be `<prefix>/<type>.<action>`, for example, to "enable" scraping of CPU profiles, set the
+  # annotation `profiles.grafana.com/cpu.scrape: "true"` on the pod. To set the path for memory profiles, set the
+  # annotation `profiles.grafana.com/memory.path: "/debug/pprof/mem"` on the pod.
+  # @section -- pprof
+  annotations:
+    # -- The prefix for all pprof annotations.
+    # @section -- pprof
+    prefix: "profiles.grafana.com"
+
+    # -- The annotation action for enabling or disabling scraping of profiles of a given type.
+    # @section -- pprof
+    enable: "scrape"
+    # -- The annotation action for choosing the port number for scraping profiles of a given type.
+    # @section -- pprof
+    portNumber: "port"
+    # -- The annotation action for choosing the port name for scraping profiles of a given type.
+    # @section -- pprof
+    portName: "port_name"
+    # -- The annotation action for choosing the path for scraping profiles of a given type.
+    # @section -- pprof
+    path: "path"
+    # -- The annotation action for choosing the scheme for scraping profiles of a given type.
+    # @section -- pprof
+    scheme: "scheme"
+
   # -- Select pods to profile based on pod labels.
   # Example: `app.kubernetes.io/name: myapp` will select pods with the label `app.kubernetes.io/name=myapp`.
   # Example with multiple values: `app.kubernetes.io/name: [myapp, myapp2]` will select pods with the label
@@ -127,22 +166,9 @@ pprof:
   scrapeInterval: "15s"
 
   # -- Timeout for collecting profiles.
-  # Must be larger then the scrape interval.
+  # Must be larger than the scrape interval.
   # @section -- pprof
   scrapeTimeout: "18s"
-
-  # -- Profile types to gather
-  # @section -- pprof
-  types:
-    memory: true
-    block: true
-    goroutine: true
-    mutex: true
-    cpu: true
-    fgprof: true
-    godeltaprof_memory: false
-    godeltaprof_mutex: false
-    godeltaprof_block: false
 
 # @ignore
 deployAsConfigMap: false

--- a/charts/k8s-monitoring/charts/feature-profiling/values.yaml
+++ b/charts/k8s-monitoring/charts/feature-profiling/values.yaml
@@ -43,7 +43,7 @@ ebpf:
   labelSelectors: {}
 
   # -- Select pods to profile based on pod annotations.
-  # Example: `k8s.grafana.com/profile: "true"` will select pods with the annotation `k8s.grafana.com/profile="true"`.
+  # Example: `color: "green"` will select pods with the annotation `color="green"`.
   # Example with multiple values: `color: ["blue", "green"]` will select pods with the annotation `color="blue"` or
   # `color="green"`.
   # @section -- eBPF
@@ -171,7 +171,7 @@ pprof:
   labelSelectors: {}
 
   # -- Select pods to profile based on pod annotations.
-  # Example: `k8s.grafana.com/profile: "true"` will select pods with the annotation `k8s.grafana.com/profile="true"`.
+  # Example: `color: "green"` will select pods with the annotation `color="green"`.
   # Example with multiple values: `color: ["blue", "green"]` will select pods with the annotation `color="blue"` or
   # `color="green"`.
   # @section -- pprof

--- a/charts/k8s-monitoring/charts/feature-prometheus-operator-objects/README.md
+++ b/charts/k8s-monitoring/charts/feature-prometheus-operator-objects/README.md
@@ -5,7 +5,6 @@
 
 # feature-prometheus-operator-objects
 
-![Version: 1.0.0](https://img.shields.io/badge/Version-1.0.0-informational?style=flat-square) ![AppVersion: 1.0.0](https://img.shields.io/badge/AppVersion-1.0.0-informational?style=flat-square)
 Gathers metrics using Prometheus Operator Objects
 
 The Prometheus Operator Objects feature enables the discovery, processing, and utilization of certain Prometheus

--- a/charts/k8s-monitoring/charts/feature-prometheus-operator-objects/README.md.gotmpl
+++ b/charts/k8s-monitoring/charts/feature-prometheus-operator-objects/README.md.gotmpl
@@ -5,7 +5,6 @@
 
 {{ template "chart.header" . }}
 {{ template "chart.deprecationWarning" . }}
-{{ template "chart.badgesSection" . }}
 {{ template "chart.description" . }}
 {{ template "chart.homepageLine" . }}
 

--- a/charts/k8s-monitoring/docs/TargetingDataCollection.md
+++ b/charts/k8s-monitoring/docs/TargetingDataCollection.md
@@ -1,0 +1,58 @@
+# Targeting Data Collection
+
+The Kubernetes Monitoring Helm chart allows you to target specific namespaces or pods for data collection. There are
+many different methods to control this, and the following sections will explain how to use many of them.
+
+## Kubernetes Annotations
+
+Several features within this Helm chart can be controlled using Kubernetes annotations. Often it is for controlling
+service discovery, but often annotations can be used to configure how data is collected.
+
+### Feature: Annotation Autodiscovery
+
+The Annotation Autodiscovery feature allows you to discover and scrape Prometheus-style metrics from Pods and Services
+on your cluster. These are the default annotations that can be applied to a Pod or Service:
+
+*   `k8s.grafana.com/scrape`: This Pod or Service should be scrape for metrics.
+*   `k8s.grafana.com/job`: The value to use for the `job` label.
+*   `k8s.grafana.com/instance`: The value to use for the `instance` label.
+*   `k8s.grafana.com/metrics.container`: The name of the container within the Pod to scrape for metrics. This is used to target a specific container within a Pod that has multiple containers.
+*   `k8s.grafana.com/metrics.path`: The path to scrape for metrics. Defaults to `/metrics`.
+*   `k8s.grafana.com/metrics.portNumber`: The port on the Pod or Service to scrape for metrics. This is used to target a specific port by its number, rather than all ports.
+*   `k8s.grafana.com/metrics.portName`: The named port on the Pod or Service to scrape for metrics. This is used to target a specific port by its name, rather than all ports.
+*   `k8s.grafana.com/metrics.scheme`: The scheme to use when scraping metrics. Defaults to `http`.
+*   `k8s.grafana.com/metrics.param`: Allows for setting HTTP parameters when calling the scrape endpoint. Use with `k8s.grafana.com/metrics.param_<key>="<value>"`.
+*   `k8s.grafana.com/metrics.scrapeInterval`: The scrape interval to use when scraping metrics. Defaults to `60s`.
+*   `k8s.grafana.com/metrics.scrapeTimeout`: The scrape timeout to use when scraping metrics. Defaults to `10s`.
+
+The actual annotations can be configured in the [annotationAutodiscovery feature](https://github.com/grafana/k8s-monitoring-helm/tree/main/charts/k8s-monitoring/charts/feature-annotation-autodiscovery).
+
+### Feature: Profiling
+
+The Profiling feature allows you to collect profiling data from your applications. This feature can collect profiles
+using eBPF, Java, or pprof. The following annotations can be used to control profiling:
+
+#### eBPF Profiling
+
+*   `profiles.grafana.com/cpu.ebpf.enabled`: This Pod should have CPU profiles collected using eBPF.
+
+#### Java Profiling
+
+*   `profiles.grafana.com/java.enabled`: This Pod should have Java profiles collected.
+
+#### pprof Profiling
+
+For each enabled type (`memory`, `block`, `goroutine`, `mutex`, `cpu`, `fgprof`, `godeltaprof_memory`,
+`godeltaprof_mutex`, `godeltaprof_block`), you can use the following annotations to control profiling:
+
+*   `profiles.grafana.com/<type>.scrape`: This Pod should have pprof profiles collected for the specified type.
+*   `profiles.grafana.com/<type>.port`: Profiles for the specified type should be collected from this port number.
+*   `profiles.grafana.com/<type>.port_name`: Profiles for the specified type should be collected from this named port.
+*   `profiles.grafana.com/<type>.path`: Profiles for the specified type should be collected from this path.
+*   `profiles.grafana.com/<type>.scheme`: The scheme to use when scraping profiles for the specified type. Defaults to `http`.
+
+### Feature: Pod Logs
+
+The following annotations can be used to control Pod logs collection:
+
+*   `k8s.grafana.com/logs.job`: The value to use for the `job` label.

--- a/charts/k8s-monitoring/docs/examples/exclude-by-namespace/alloy-profiles.alloy
+++ b/charts/k8s-monitoring/docs/examples/exclude-by-namespace/alloy-profiles.alloy
@@ -20,6 +20,11 @@ declare "profiling" {
       action = "drop"
     }
     rule {
+      source_labels = ["__meta_kubernetes_pod_annotation_profiles_grafana_com_cpu_ebpf_enabled"]
+      regex         = "true"
+      action        = "keep"
+    }
+    rule {
       source_labels = ["__meta_kubernetes_namespace"]
       target_label = "namespace"
     }
@@ -64,22 +69,26 @@ declare "profiling" {
     }
   }
 
+  discovery.relabel "potential_java_pods" {
+    targets = discovery.kubernetes.java_pods.targets
+    rule {
+      source_labels = ["__meta_kubernetes_pod_phase"]
+      regex         = "Succeeded|Failed|Completed"
+      action        = "drop"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_pod_annotation_profiles_grafana_com_java_enabled"]
+      regex         = "true"
+      action        = "keep"
+    }
+  }
+
   discovery.process "java_pods" {
-    join = discovery.kubernetes.java_pods.targets
+    join = discovery.kubernetes.potential_java_pods.targets
   }
 
   discovery.relabel "java_pods" {
     targets = discovery.process.java_pods.targets
-    rule {
-      source_labels = ["__meta_kubernetes_pod_phase"]
-      regex = "Succeeded|Failed|Completed"
-      action = "drop"
-    }
-    rule {
-      source_labels = ["__meta_kubernetes_pod_name"]
-      regex = "^$"
-      action = "drop"
-    }
     rule {
       source_labels = ["__meta_process_exe"]
       action = "keep"

--- a/charts/k8s-monitoring/docs/examples/exclude-by-namespace/alloy-profiles.alloy
+++ b/charts/k8s-monitoring/docs/examples/exclude-by-namespace/alloy-profiles.alloy
@@ -84,7 +84,7 @@ declare "profiling" {
   }
 
   discovery.process "java_pods" {
-    join = discovery.kubernetes.potential_java_pods.targets
+    join = discovery.relabel.potential_java_pods.output
   }
 
   discovery.relabel "java_pods" {

--- a/charts/k8s-monitoring/docs/examples/exclude-by-namespace/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/exclude-by-namespace/output.yaml
@@ -1792,6 +1792,11 @@ data:
           action = "drop"
         }
         rule {
+          source_labels = ["__meta_kubernetes_pod_annotation_profiles_grafana_com_cpu_ebpf_enabled"]
+          regex         = "true"
+          action        = "keep"
+        }
+        rule {
           source_labels = ["__meta_kubernetes_namespace"]
           target_label = "namespace"
         }
@@ -1836,22 +1841,26 @@ data:
         }
       }
     
+      discovery.relabel "potential_java_pods" {
+        targets = discovery.kubernetes.java_pods.targets
+        rule {
+          source_labels = ["__meta_kubernetes_pod_phase"]
+          regex         = "Succeeded|Failed|Completed"
+          action        = "drop"
+        }
+        rule {
+          source_labels = ["__meta_kubernetes_pod_annotation_profiles_grafana_com_java_enabled"]
+          regex         = "true"
+          action        = "keep"
+        }
+      }
+    
       discovery.process "java_pods" {
-        join = discovery.kubernetes.java_pods.targets
+        join = discovery.kubernetes.potential_java_pods.targets
       }
     
       discovery.relabel "java_pods" {
         targets = discovery.process.java_pods.targets
-        rule {
-          source_labels = ["__meta_kubernetes_pod_phase"]
-          regex = "Succeeded|Failed|Completed"
-          action = "drop"
-        }
-        rule {
-          source_labels = ["__meta_kubernetes_pod_name"]
-          regex = "^$"
-          action = "drop"
-        }
         rule {
           source_labels = ["__meta_process_exe"]
           action = "keep"

--- a/charts/k8s-monitoring/docs/examples/exclude-by-namespace/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/exclude-by-namespace/output.yaml
@@ -1856,7 +1856,7 @@ data:
       }
     
       discovery.process "java_pods" {
-        join = discovery.kubernetes.potential_java_pods.targets
+        join = discovery.relabel.potential_java_pods.output
       }
     
       discovery.relabel "java_pods" {

--- a/charts/k8s-monitoring/docs/examples/features/profiling/default/alloy-profiles.alloy
+++ b/charts/k8s-monitoring/docs/examples/features/profiling/default/alloy-profiles.alloy
@@ -79,7 +79,7 @@ declare "profiling" {
   }
 
   discovery.process "java_pods" {
-    join = discovery.kubernetes.potential_java_pods.targets
+    join = discovery.relabel.potential_java_pods.output
   }
 
   discovery.relabel "java_pods" {

--- a/charts/k8s-monitoring/docs/examples/features/profiling/default/alloy-profiles.alloy
+++ b/charts/k8s-monitoring/docs/examples/features/profiling/default/alloy-profiles.alloy
@@ -20,6 +20,11 @@ declare "profiling" {
       action = "drop"
     }
     rule {
+      source_labels = ["__meta_kubernetes_pod_annotation_profiles_grafana_com_cpu_ebpf_enabled"]
+      regex         = "true"
+      action        = "keep"
+    }
+    rule {
       source_labels = ["__meta_kubernetes_namespace"]
       target_label = "namespace"
     }
@@ -59,22 +64,26 @@ declare "profiling" {
     }
   }
 
+  discovery.relabel "potential_java_pods" {
+    targets = discovery.kubernetes.java_pods.targets
+    rule {
+      source_labels = ["__meta_kubernetes_pod_phase"]
+      regex         = "Succeeded|Failed|Completed"
+      action        = "drop"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_pod_annotation_profiles_grafana_com_java_enabled"]
+      regex         = "true"
+      action        = "keep"
+    }
+  }
+
   discovery.process "java_pods" {
-    join = discovery.kubernetes.java_pods.targets
+    join = discovery.kubernetes.potential_java_pods.targets
   }
 
   discovery.relabel "java_pods" {
     targets = discovery.process.java_pods.targets
-    rule {
-      source_labels = ["__meta_kubernetes_pod_phase"]
-      regex = "Succeeded|Failed|Completed"
-      action = "drop"
-    }
-    rule {
-      source_labels = ["__meta_kubernetes_pod_name"]
-      regex = "^$"
-      action = "drop"
-    }
     rule {
       source_labels = ["__meta_process_exe"]
       action = "keep"

--- a/charts/k8s-monitoring/docs/examples/features/profiling/default/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/features/profiling/default/output.yaml
@@ -102,7 +102,7 @@ data:
       }
     
       discovery.process "java_pods" {
-        join = discovery.kubernetes.potential_java_pods.targets
+        join = discovery.relabel.potential_java_pods.output
       }
     
       discovery.relabel "java_pods" {

--- a/charts/k8s-monitoring/docs/examples/features/profiling/default/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/features/profiling/default/output.yaml
@@ -43,6 +43,11 @@ data:
           action = "drop"
         }
         rule {
+          source_labels = ["__meta_kubernetes_pod_annotation_profiles_grafana_com_cpu_ebpf_enabled"]
+          regex         = "true"
+          action        = "keep"
+        }
+        rule {
           source_labels = ["__meta_kubernetes_namespace"]
           target_label = "namespace"
         }
@@ -82,22 +87,26 @@ data:
         }
       }
     
+      discovery.relabel "potential_java_pods" {
+        targets = discovery.kubernetes.java_pods.targets
+        rule {
+          source_labels = ["__meta_kubernetes_pod_phase"]
+          regex         = "Succeeded|Failed|Completed"
+          action        = "drop"
+        }
+        rule {
+          source_labels = ["__meta_kubernetes_pod_annotation_profiles_grafana_com_java_enabled"]
+          regex         = "true"
+          action        = "keep"
+        }
+      }
+    
       discovery.process "java_pods" {
-        join = discovery.kubernetes.java_pods.targets
+        join = discovery.kubernetes.potential_java_pods.targets
       }
     
       discovery.relabel "java_pods" {
         targets = discovery.process.java_pods.targets
-        rule {
-          source_labels = ["__meta_kubernetes_pod_phase"]
-          regex = "Succeeded|Failed|Completed"
-          action = "drop"
-        }
-        rule {
-          source_labels = ["__meta_kubernetes_pod_name"]
-          regex = "^$"
-          action = "drop"
-        }
         rule {
           source_labels = ["__meta_process_exe"]
           action = "keep"

--- a/charts/k8s-monitoring/docs/examples/include-by-namespace/alloy-profiles.alloy
+++ b/charts/k8s-monitoring/docs/examples/include-by-namespace/alloy-profiles.alloy
@@ -23,6 +23,11 @@ declare "profiling" {
       action = "drop"
     }
     rule {
+      source_labels = ["__meta_kubernetes_pod_annotation_profiles_grafana_com_cpu_ebpf_enabled"]
+      regex         = "true"
+      action        = "keep"
+    }
+    rule {
       source_labels = ["__meta_kubernetes_namespace"]
       target_label = "namespace"
     }
@@ -65,22 +70,26 @@ declare "profiling" {
     }
   }
 
+  discovery.relabel "potential_java_pods" {
+    targets = discovery.kubernetes.java_pods.targets
+    rule {
+      source_labels = ["__meta_kubernetes_pod_phase"]
+      regex         = "Succeeded|Failed|Completed"
+      action        = "drop"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_pod_annotation_profiles_grafana_com_java_enabled"]
+      regex         = "true"
+      action        = "keep"
+    }
+  }
+
   discovery.process "java_pods" {
-    join = discovery.kubernetes.java_pods.targets
+    join = discovery.kubernetes.potential_java_pods.targets
   }
 
   discovery.relabel "java_pods" {
     targets = discovery.process.java_pods.targets
-    rule {
-      source_labels = ["__meta_kubernetes_pod_phase"]
-      regex = "Succeeded|Failed|Completed"
-      action = "drop"
-    }
-    rule {
-      source_labels = ["__meta_kubernetes_pod_name"]
-      regex = "^$"
-      action = "drop"
-    }
     rule {
       source_labels = ["__meta_process_exe"]
       action = "keep"

--- a/charts/k8s-monitoring/docs/examples/include-by-namespace/alloy-profiles.alloy
+++ b/charts/k8s-monitoring/docs/examples/include-by-namespace/alloy-profiles.alloy
@@ -85,7 +85,7 @@ declare "profiling" {
   }
 
   discovery.process "java_pods" {
-    join = discovery.kubernetes.potential_java_pods.targets
+    join = discovery.relabel.potential_java_pods.output
   }
 
   discovery.relabel "java_pods" {

--- a/charts/k8s-monitoring/docs/examples/include-by-namespace/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/include-by-namespace/output.yaml
@@ -1773,6 +1773,11 @@ data:
           action = "drop"
         }
         rule {
+          source_labels = ["__meta_kubernetes_pod_annotation_profiles_grafana_com_cpu_ebpf_enabled"]
+          regex         = "true"
+          action        = "keep"
+        }
+        rule {
           source_labels = ["__meta_kubernetes_namespace"]
           target_label = "namespace"
         }
@@ -1815,22 +1820,26 @@ data:
         }
       }
     
+      discovery.relabel "potential_java_pods" {
+        targets = discovery.kubernetes.java_pods.targets
+        rule {
+          source_labels = ["__meta_kubernetes_pod_phase"]
+          regex         = "Succeeded|Failed|Completed"
+          action        = "drop"
+        }
+        rule {
+          source_labels = ["__meta_kubernetes_pod_annotation_profiles_grafana_com_java_enabled"]
+          regex         = "true"
+          action        = "keep"
+        }
+      }
+    
       discovery.process "java_pods" {
-        join = discovery.kubernetes.java_pods.targets
+        join = discovery.kubernetes.potential_java_pods.targets
       }
     
       discovery.relabel "java_pods" {
         targets = discovery.process.java_pods.targets
-        rule {
-          source_labels = ["__meta_kubernetes_pod_phase"]
-          regex = "Succeeded|Failed|Completed"
-          action = "drop"
-        }
-        rule {
-          source_labels = ["__meta_kubernetes_pod_name"]
-          regex = "^$"
-          action = "drop"
-        }
         rule {
           source_labels = ["__meta_process_exe"]
           action = "keep"

--- a/charts/k8s-monitoring/docs/examples/include-by-namespace/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/include-by-namespace/output.yaml
@@ -1835,7 +1835,7 @@ data:
       }
     
       discovery.process "java_pods" {
-        join = discovery.kubernetes.potential_java_pods.targets
+        join = discovery.relabel.potential_java_pods.output
       }
     
       discovery.relabel "java_pods" {

--- a/charts/k8s-monitoring/docs/examples/proxies/alloy-profiles.alloy
+++ b/charts/k8s-monitoring/docs/examples/proxies/alloy-profiles.alloy
@@ -79,7 +79,7 @@ declare "profiling" {
   }
 
   discovery.process "java_pods" {
-    join = discovery.kubernetes.potential_java_pods.targets
+    join = discovery.relabel.potential_java_pods.output
   }
 
   discovery.relabel "java_pods" {

--- a/charts/k8s-monitoring/docs/examples/proxies/alloy-profiles.alloy
+++ b/charts/k8s-monitoring/docs/examples/proxies/alloy-profiles.alloy
@@ -20,6 +20,11 @@ declare "profiling" {
       action = "drop"
     }
     rule {
+      source_labels = ["__meta_kubernetes_pod_annotation_profiles_grafana_com_cpu_ebpf_enabled"]
+      regex         = "true"
+      action        = "keep"
+    }
+    rule {
       source_labels = ["__meta_kubernetes_namespace"]
       target_label = "namespace"
     }
@@ -59,22 +64,26 @@ declare "profiling" {
     }
   }
 
+  discovery.relabel "potential_java_pods" {
+    targets = discovery.kubernetes.java_pods.targets
+    rule {
+      source_labels = ["__meta_kubernetes_pod_phase"]
+      regex         = "Succeeded|Failed|Completed"
+      action        = "drop"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_pod_annotation_profiles_grafana_com_java_enabled"]
+      regex         = "true"
+      action        = "keep"
+    }
+  }
+
   discovery.process "java_pods" {
-    join = discovery.kubernetes.java_pods.targets
+    join = discovery.kubernetes.potential_java_pods.targets
   }
 
   discovery.relabel "java_pods" {
     targets = discovery.process.java_pods.targets
-    rule {
-      source_labels = ["__meta_kubernetes_pod_phase"]
-      regex = "Succeeded|Failed|Completed"
-      action = "drop"
-    }
-    rule {
-      source_labels = ["__meta_kubernetes_pod_name"]
-      regex = "^$"
-      action = "drop"
-    }
     rule {
       source_labels = ["__meta_process_exe"]
       action = "keep"

--- a/charts/k8s-monitoring/docs/examples/proxies/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/proxies/output.yaml
@@ -1445,7 +1445,7 @@ data:
       }
     
       discovery.process "java_pods" {
-        join = discovery.kubernetes.potential_java_pods.targets
+        join = discovery.relabel.potential_java_pods.output
       }
     
       discovery.relabel "java_pods" {

--- a/charts/k8s-monitoring/docs/examples/proxies/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/proxies/output.yaml
@@ -1386,6 +1386,11 @@ data:
           action = "drop"
         }
         rule {
+          source_labels = ["__meta_kubernetes_pod_annotation_profiles_grafana_com_cpu_ebpf_enabled"]
+          regex         = "true"
+          action        = "keep"
+        }
+        rule {
           source_labels = ["__meta_kubernetes_namespace"]
           target_label = "namespace"
         }
@@ -1425,22 +1430,26 @@ data:
         }
       }
     
+      discovery.relabel "potential_java_pods" {
+        targets = discovery.kubernetes.java_pods.targets
+        rule {
+          source_labels = ["__meta_kubernetes_pod_phase"]
+          regex         = "Succeeded|Failed|Completed"
+          action        = "drop"
+        }
+        rule {
+          source_labels = ["__meta_kubernetes_pod_annotation_profiles_grafana_com_java_enabled"]
+          regex         = "true"
+          action        = "keep"
+        }
+      }
+    
       discovery.process "java_pods" {
-        join = discovery.kubernetes.java_pods.targets
+        join = discovery.kubernetes.potential_java_pods.targets
       }
     
       discovery.relabel "java_pods" {
         targets = discovery.process.java_pods.targets
-        rule {
-          source_labels = ["__meta_kubernetes_pod_phase"]
-          regex = "Succeeded|Failed|Completed"
-          action = "drop"
-        }
-        rule {
-          source_labels = ["__meta_kubernetes_pod_name"]
-          regex = "^$"
-          action = "drop"
-        }
         rule {
           source_labels = ["__meta_process_exe"]
           action = "keep"

--- a/charts/k8s-monitoring/tests/integration/profiling/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/integration/profiling/.rendered/output.yaml
@@ -102,7 +102,7 @@ data:
       }
     
       discovery.process "java_pods" {
-        join = discovery.kubernetes.potential_java_pods.targets
+        join = discovery.relabel.potential_java_pods.output
       }
     
       discovery.relabel "java_pods" {

--- a/charts/k8s-monitoring/tests/integration/profiling/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/integration/profiling/.rendered/output.yaml
@@ -43,6 +43,11 @@ data:
           action = "drop"
         }
         rule {
+          source_labels = ["__meta_kubernetes_pod_annotation_profiles_grafana_com_cpu_ebpf_enabled"]
+          regex         = "true"
+          action        = "keep"
+        }
+        rule {
           source_labels = ["__meta_kubernetes_namespace"]
           target_label = "namespace"
         }
@@ -82,22 +87,26 @@ data:
         }
       }
     
+      discovery.relabel "potential_java_pods" {
+        targets = discovery.kubernetes.java_pods.targets
+        rule {
+          source_labels = ["__meta_kubernetes_pod_phase"]
+          regex         = "Succeeded|Failed|Completed"
+          action        = "drop"
+        }
+        rule {
+          source_labels = ["__meta_kubernetes_pod_annotation_profiles_grafana_com_java_enabled"]
+          regex         = "true"
+          action        = "keep"
+        }
+      }
+    
       discovery.process "java_pods" {
-        join = discovery.kubernetes.java_pods.targets
+        join = discovery.kubernetes.potential_java_pods.targets
       }
     
       discovery.relabel "java_pods" {
         targets = discovery.process.java_pods.targets
-        rule {
-          source_labels = ["__meta_kubernetes_pod_phase"]
-          regex = "Succeeded|Failed|Completed"
-          action = "drop"
-        }
-        rule {
-          source_labels = ["__meta_kubernetes_pod_name"]
-          regex = "^$"
-          action = "drop"
-        }
         rule {
           source_labels = ["__meta_process_exe"]
           action = "keep"

--- a/charts/k8s-monitoring/tests/integration/profiling/deployments/grafana.yaml
+++ b/charts/k8s-monitoring/tests/integration/profiling/deployments/grafana.yaml
@@ -29,6 +29,8 @@ spec:
         namespace: grafana
       interval: 1m
   values:
+    podAnnotations:
+      profiles.grafana.com/cpu.ebpf.enabled: "true"
     grafana.ini:
       auth.anonymous:
         enabled: true


### PR DESCRIPTION
Now, the following annotations can be used and are on by default:

*   `profiles.grafana.com/cpu.ebpf.enabled`: This Pod should have CPU profiles collected using eBPF.
*   `profiles.grafana.com/java.enabled`: This Pod should have Java profiles collected.

For each enabled type (`memory`, `block`, `goroutine`, `mutex`, `cpu`, `fgprof`, `godeltaprof_memory`,
`godeltaprof_mutex`, `godeltaprof_block`), you can use the following annotations to control profiling:

*   `profiles.grafana.com/<type>.scrape`: This Pod should have pprof profiles collected for the specified type.
*   `profiles.grafana.com/<type>.port`: Profiles for the specified type should be collected from this port number.
*   `profiles.grafana.com/<type>.port_name`: Profiles for the specified type should be collected from this named port.
*   `profiles.grafana.com/<type>.path`: Profiles for the specified type should be collected from this path.
*   `profiles.grafana.com/<type>.scheme`: The scheme to use when scraping profiles for the specified type. Defaults to `http`.

Also create the start of a "Targeting Data Collection" document that shows the various features that can be controlled and configured with annotations.

Finally, some clean up for other readme and tests.
* Remove white space
* Remove "helm badges" from feature charts, where they are not necessary.
* Update the Annotation Autodiscovery feature's list of annotations to include some that weren't there before.