### PR TITLE
Skip upgrade tests if not applicable.

### DIFF
--- a/charts/k8s-monitoring/tests/integration/alternative-deployments/argocd/Makefile
+++ b/charts/k8s-monitoring/tests/integration/alternative-deployments/argocd/Makefile
@@ -1,7 +1,17 @@
-all: deployments/alloy-crd.yaml
+.PHONY: check
+check: ;
+
+.PHONY: clean
 clean:
 	rm -f deployments/alloy-crd.yaml
+
+.PHONY: all
+all: deployments/alloy-crd.yaml
 
 ALLOY_OPERATOR_VERSION=$(shell yq '.dependencies[] | select(.name == "alloy-operator") | .version' ../../../../Chart.yaml)
 deployments/alloy-crd.yaml:
 	wget -O deployments/alloy-crd.yaml https://github.com/grafana/alloy-operator/releases/download/alloy-operator-$(ALLOY_OPERATOR_VERSION)/collectors.grafana.com_alloy.yaml
+
+.PHONY: run-test
+run-test:
+	../../../../../../scripts/run-cluster-test.sh .

--- a/charts/k8s-monitoring/tests/integration/auth/Makefile
+++ b/charts/k8s-monitoring/tests/integration/auth/Makefile
@@ -1,4 +1,7 @@
-all: deployments/passwords.yaml
+.PHONY: check
+check: ;
+
+.PHONY: clean
 clean:
 	rm -f deployments/passwords.yaml
 
@@ -10,3 +13,10 @@ ifdef HAS_HTPASSWD
 else
 	kubectl create secret generic passwords --from-literal=htpasswd='$(shell docker run --platform linux/amd64 --rm xmartlabs/htpasswd basicuser basicpassword)' -o yaml --dry-run=client >> deployments/passwords.yaml
 endif
+
+.PHONY: all
+all: deployments/passwords.yaml
+
+.PHONY: run-test
+run-test:
+	../../../../../../scripts/run-cluster-test.sh .

--- a/charts/k8s-monitoring/tests/integration/upgrade/minor/Makefile
+++ b/charts/k8s-monitoring/tests/integration/upgrade/minor/Makefile
@@ -1,3 +1,10 @@
+.PHONY: check
+check:
+	if yq eval '.version' ../../../../Chart.yaml | grep -q "[[:digit:]]\+\.0\.[[:digit:]]\+"; then \
+		echo "Minor version is 0."; \
+		exit 2; \
+	fi
+
 .PHONY: clean
 clean:
 	rm -f collectors.grafana.com_alloy.yaml

--- a/charts/k8s-monitoring/tests/integration/upgrade/minor/deploy.sh
+++ b/charts/k8s-monitoring/tests/integration/upgrade/minor/deploy.sh
@@ -9,8 +9,8 @@ CLUSTER_NAME=$(yq eval '.cluster.name' values.yaml)
 CURRENT_VERSION="$(yq eval '.version' ../../../../Chart.yaml)"
 IFS='.' read -r major minor patch <<< "${CURRENT_VERSION}"
 if [ "${minor}" -eq 0 ]; then
-  echo "Minor version is 0. Testing an in-place upgrade."
-  PREVIOUS_MINOR_RELEASE="${major}.${minor}"
+  echo "Minor version is 0. This test is not applicable."
+  exit 1
 else
   PREVIOUS_MINOR_RELEASE="${major}.$((minor - 1))"
 fi

--- a/charts/k8s-monitoring/tests/integration/upgrade/patch/Makefile
+++ b/charts/k8s-monitoring/tests/integration/upgrade/patch/Makefile
@@ -1,6 +1,6 @@
 .PHONY: check
 check:
-	if yq eval '.version' ../../../../Chart.yaml | grep -q "[[:digit:]]\+\.[[:digit:]]\.0\+"; then \
+	if yq eval '.version' ../../../../Chart.yaml | grep -q "[[:digit:]]\+\.[[:digit:]]\+\.0"; then \
 		echo "Patch version is 0."; \
 		exit 2; \
 	fi

--- a/charts/k8s-monitoring/tests/integration/upgrade/patch/Makefile
+++ b/charts/k8s-monitoring/tests/integration/upgrade/patch/Makefile
@@ -1,0 +1,16 @@
+.PHONY: check
+check:
+	if yq eval '.version' ../../../../Chart.yaml | grep -q "[[:digit:]]\+\.[[:digit:]]\.0\+"; then \
+		echo "Patch version is 0."; \
+		exit 2; \
+	fi
+
+.PHONY: clean
+clean: ;
+
+.PHONY: all
+all: ;
+
+.PHONY: run-test
+run-test:
+	../../../../../../scripts/run-cluster-test.sh .

--- a/charts/k8s-monitoring/tests/integration/upgrade/patch/deploy.sh
+++ b/charts/k8s-monitoring/tests/integration/upgrade/patch/deploy.sh
@@ -9,8 +9,8 @@ CLUSTER_NAME=$(yq eval '.cluster.name' values.yaml)
 CURRENT_VERSION="$(yq eval '.version' ../../../../Chart.yaml)"
 IFS='.' read -r major minor patch <<< "${CURRENT_VERSION}"
 if [ "${patch}" -eq 0 ]; then
-  echo "Patch version is 0. Testing an in-place upgrade."
-  PREVIOUS_PATCH_RELEASE="${major}.${minor}.${patch}"
+  echo "Patch version is 0. This test is not applicable."
+  exit 1
 else
   PREVIOUS_PATCH_RELEASE="${major}.${minor}.$((patch - 1))"
 fi

--- a/charts/k8s-monitoring/tests/platform/aks/Makefile
+++ b/charts/k8s-monitoring/tests/platform/aks/Makefile
@@ -1,6 +1,12 @@
-all: deployments/test-variables.yaml deployments/grafana-cloud-credentials.yaml
+.PHONY: check
+check: ;
+
+.PHONY: clean
 clean:
 	rm -f deployments/test-variables.yaml deployments/grafana-cloud-credentials.yaml
+
+.PHONY: all
+all: deployments/test-variables.yaml deployments/grafana-cloud-credentials.yaml
 
 deployments/test-variables.yaml:
 	echo "---" > $@
@@ -18,5 +24,6 @@ deployments/grafana-cloud-credentials.yaml:
   		--from-literal=LOKI_PASS="$$GRAFANA_CLOUD_RW_POLICY_TOKEN" \
 		-o yaml --dry-run=client >> $@
 
+.PHONY: run-test
 run-test:
 	../../../../../scripts/run-cluster-test.sh .

--- a/charts/k8s-monitoring/tests/platform/eks-addon-with-terraform/Makefile
+++ b/charts/k8s-monitoring/tests/platform/eks-addon-with-terraform/Makefile
@@ -1,6 +1,12 @@
-all: deployments/test-variables.yaml deployments/grafana-cloud.yaml deployments/grafana-cloud-credentials.yaml vars.tf
+.PHONY: check
+check: ;
+
+.PHONY: clean
 clean:
 	rm -f deployments/test-variables.yaml deployments/grafana-cloud.yaml deployments/grafana-cloud-credentials.yaml vars.tf
+
+.PHONY: all
+all: deployments/test-variables.yaml deployments/grafana-cloud.yaml deployments/grafana-cloud-credentials.yaml vars.tf
 
 deployments/test-variables.yaml:
 	echo "---" > $@
@@ -57,6 +63,6 @@ vars.tf:
 	echo "  sensitive = true" >> $@
 	echo "}" >> $@
 
-
+.PHONY: run-test
 run-test:
 	../../../../../scripts/run-cluster-test.sh .

--- a/charts/k8s-monitoring/tests/platform/eks-addon/Makefile
+++ b/charts/k8s-monitoring/tests/platform/eks-addon/Makefile
@@ -1,6 +1,12 @@
-all: values.json deployments/test-variables.yaml deployments/grafana-cloud.yaml deployments/grafana-cloud-credentials.yaml
+.PHONY: check
+check: ;
+
+.PHONY: clean
 clean:
 	rm -f deployments/test-variables.yaml deployments/grafana-cloud.yaml deployments/grafana-cloud-credentials.yaml
+
+.PHONY: all
+all: values.json deployments/test-variables.yaml deployments/grafana-cloud.yaml deployments/grafana-cloud-credentials.yaml
 
 values.json: values.yaml
 	yq eval --output-format json '. | del(.cluster.name)' values.yaml > $@
@@ -40,5 +46,6 @@ deployments/grafana-cloud-credentials.yaml:
   		--from-literal=LOKI_PASS="$$GRAFANA_CLOUD_RW_POLICY_TOKEN" \
 		-o yaml --dry-run=client >> $@
 
+.PHONY: run-test
 run-test:
 	../../../../../scripts/run-cluster-test.sh .

--- a/charts/k8s-monitoring/tests/platform/eks-fargate/Makefile
+++ b/charts/k8s-monitoring/tests/platform/eks-fargate/Makefile
@@ -1,6 +1,12 @@
-all: deployments/test-variables.yaml deployments/grafana-cloud-credentials.yaml
+.PHONY: check
+check: ;
+
+.PHONY: clean
 clean:
 	rm -f deployments/test-variables.yaml deployments/grafana-cloud-credentials.yaml
+
+.PHONY: all
+all: deployments/test-variables.yaml deployments/grafana-cloud-credentials.yaml
 
 deployments/test-variables.yaml:
 	echo "---" > $@
@@ -19,5 +25,6 @@ deployments/grafana-cloud-credentials.yaml:
   		--from-literal=LOKI_PASS="$$GRAFANA_CLOUD_RW_POLICY_TOKEN" \
 		-o yaml --dry-run=client >> $@
 
+.PHONY: run-test
 run-test:
 	../../../../../scripts/run-cluster-test.sh .

--- a/charts/k8s-monitoring/tests/platform/eks-with-windows/Makefile
+++ b/charts/k8s-monitoring/tests/platform/eks-with-windows/Makefile
@@ -1,6 +1,12 @@
-all: deployments/test-variables.yaml deployments/grafana-cloud-credentials.yaml
+.PHONY: check
+check: ;
+
+.PHONY: clean
 clean:
 	rm -f deployments/test-variables.yaml deployments/grafana-cloud-credentials.yaml
+
+.PHONY: all
+all: deployments/test-variables.yaml deployments/grafana-cloud-credentials.yaml
 
 deployments/test-variables.yaml:
 	echo "---" > $@
@@ -19,5 +25,6 @@ deployments/grafana-cloud-credentials.yaml:
   		--from-literal=LOKI_PASS="$$GRAFANA_CLOUD_RW_POLICY_TOKEN" \
 		-o yaml --dry-run=client >> $@
 
+.PHONY: run-test
 run-test:
 	../../../../../scripts/run-cluster-test.sh .

--- a/charts/k8s-monitoring/tests/platform/gke-autopilot/Makefile
+++ b/charts/k8s-monitoring/tests/platform/gke-autopilot/Makefile
@@ -1,6 +1,12 @@
-all: deployments/test-variables.yaml deployments/grafana-cloud-credentials.yaml
+.PHONY: check
+check: ;
+
+.PHONY: clean
 clean:
 	rm -f deployments/test-variables.yaml deployments/grafana-cloud-credentials.yaml
+
+.PHONY: all
+all: deployments/test-variables.yaml deployments/grafana-cloud-credentials.yaml
 
 deployments/test-variables.yaml:
 	echo "---" > $@
@@ -19,5 +25,6 @@ deployments/grafana-cloud-credentials.yaml:
   		--from-literal=LOKI_PASS="$$GRAFANA_CLOUD_RW_POLICY_TOKEN" \
 		-o yaml --dry-run=client >> $@
 
+.PHONY: run-test
 run-test:
 	../../../../../scripts/run-cluster-test.sh .

--- a/charts/k8s-monitoring/tests/platform/gke/Makefile
+++ b/charts/k8s-monitoring/tests/platform/gke/Makefile
@@ -1,6 +1,12 @@
-all: deployments/test-variables.yaml deployments/grafana-cloud-credentials.yaml
+.PHONY: check
+check: ;
+
+.PHONY: clean
 clean:
 	rm -f deployments/test-variables.yaml deployments/grafana-cloud-credentials.yaml
+
+.PHONY: all
+all: deployments/test-variables.yaml deployments/grafana-cloud-credentials.yaml
 
 deployments/test-variables.yaml:
 	echo "---" > $@
@@ -19,5 +25,6 @@ deployments/grafana-cloud-credentials.yaml:
   		--from-literal=LOKI_PASS="$$GRAFANA_CLOUD_RW_POLICY_TOKEN" \
 		-o yaml --dry-run=client >> $@
 
+.PHONY: run-test
 run-test:
 	../../../../../scripts/run-cluster-test.sh .

--- a/charts/k8s-monitoring/tests/platform/grafana-cloud/app-observability/Makefile
+++ b/charts/k8s-monitoring/tests/platform/grafana-cloud/app-observability/Makefile
@@ -1,6 +1,12 @@
-all: deployments/test-variables.yaml deployments/grafana-cloud-credentials.yaml
+.PHONY: check
+check: ;
+
+.PHONY: clean
 clean:
 	rm -f deployments/test-variables.yaml deployments/grafana-cloud-credentials.yaml
+
+.PHONY: all
+all: deployments/test-variables.yaml deployments/grafana-cloud-credentials.yaml
 
 deployments/test-variables.yaml:
 	echo "---" > $@
@@ -26,5 +32,6 @@ deployments/grafana-cloud-credentials.yaml:
 		--from-literal=PROMETHEUS_PASS="$$GRAFANA_CLOUD_RW_POLICY_TOKEN" \
 		-o yaml --dry-run=client >> $@
 
+.PHONY: run-test
 run-test:
 	../../../../../../scripts/run-cluster-test.sh .

--- a/charts/k8s-monitoring/tests/platform/grafana-cloud/k8s-monitoring/Makefile
+++ b/charts/k8s-monitoring/tests/platform/grafana-cloud/k8s-monitoring/Makefile
@@ -1,6 +1,12 @@
-all: deployments/test-variables.yaml deployments/grafana-cloud-credentials.yaml
+.PHONY: check
+check: ;
+
+.PHONY: clean
 clean:
 	rm -f deployments/test-variables.yaml deployments/grafana-cloud-credentials.yaml
+
+.PHONY: all
+all: deployments/test-variables.yaml deployments/grafana-cloud-credentials.yaml
 
 deployments/test-variables.yaml:
 	echo "---" > $@
@@ -21,5 +27,6 @@ deployments/grafana-cloud-credentials.yaml:
   		--from-literal=LOKI_PASS="$$GRAFANA_CLOUD_RW_POLICY_TOKEN" \
 		-o yaml --dry-run=client >> $@
 
+.PHONY: run-test
 run-test:
 	../../../../../../scripts/run-cluster-test.sh .

--- a/charts/k8s-monitoring/tests/platform/openshift/Makefile
+++ b/charts/k8s-monitoring/tests/platform/openshift/Makefile
@@ -1,7 +1,12 @@
-.PHONY: all clean run-test
-all: deployments/test-variables.yaml deployments/grafana-cloud-credentials.yaml flux-manifest.yaml
+.PHONY: check
+check: ;
+
+.PHONY: clean
 clean:
 	rm -f deployments/test-variables.yaml deployments/grafana-cloud-credentials.yaml flux-manifest.yaml
+
+.PHONY: all
+all: deployments/test-variables.yaml deployments/grafana-cloud-credentials.yaml flux-manifest.yaml
 
 deployments/test-variables.yaml:
 	echo "---" > $@
@@ -29,5 +34,6 @@ flux-manifest.yaml:
 	kustomize build . > $@
 	rm flux-temp.yaml
 
+.PHONY: run-test
 run-test:
 	../../../../../scripts/run-cluster-test.sh .

--- a/charts/k8s-monitoring/tests/platform/otlp-gateway/Makefile
+++ b/charts/k8s-monitoring/tests/platform/otlp-gateway/Makefile
@@ -1,6 +1,12 @@
-all: deployments/test-variables.yaml deployments/grafana-cloud-credentials.yaml
+.PHONY: check
+check: ;
+
+.PHONY: clean
 clean:
 	rm -f deployments/test-variables.yaml deployments/grafana-cloud-credentials.yaml
+
+.PHONY: all
+all: deployments/test-variables.yaml deployments/grafana-cloud-credentials.yaml
 
 deployments/test-variables.yaml:
 	echo "---" > $@
@@ -21,5 +27,6 @@ deployments/grafana-cloud-credentials.yaml:
   		--from-literal=LOKI_PASS="$$GRAFANA_CLOUD_RW_POLICY_TOKEN" \
 		-o yaml --dry-run=client >> $@
 
+.PHONY: run-test
 run-test:
 	../../../../../scripts/run-cluster-test.sh .

--- a/charts/k8s-monitoring/tests/platform/remote-config/Makefile
+++ b/charts/k8s-monitoring/tests/platform/remote-config/Makefile
@@ -1,6 +1,12 @@
-all: deployments/test-variables.yaml deployments/grafana-cloud-credentials.yaml
+.PHONY: check
+check: ;
+
+.PHONY: clean
 clean:
 	rm -f deployments/test-variables.yaml deployments/grafana-cloud-credentials.yaml
+
+.PHONY: all
+all: deployments/test-variables.yaml deployments/grafana-cloud-credentials.yaml
 
 deployments/test-variables.yaml:
 	echo "---" > $@
@@ -19,5 +25,6 @@ deployments/grafana-cloud-credentials.yaml:
   		--from-literal=PROMETHEUS_PASS="$$GRAFANA_CLOUD_RW_POLICY_TOKEN" \
 		-o yaml --dry-run=client >> $@
 
+.PHONY: run-test
 run-test:
 	../../../../../scripts/run-cluster-test.sh .

--- a/scripts/run-cluster-test.sh
+++ b/scripts/run-cluster-test.sh
@@ -101,6 +101,18 @@ kubectl get nodes
 
 # Build any pre-requisite files
 if [ -f "${TEST_DIRECTORY}/Makefile" ]; then
+  set +e
+  make check
+  RETURN_CODE=$?
+  if [ "${RETURN_CODE}" -eq 1 ]; then
+    echo "Failed to check if the test can run."
+    exit 1
+  elif [ "${RETURN_CODE}" -eq 2 ]; then
+    echo "Skipping test."
+    exit 0
+  fi
+  set -e
+
   make -C "${TEST_DIRECTORY}" clean all
 fi
 


### PR DESCRIPTION
Introduce a 'make check' for integration and platform tests that contain Makefiles. This target checks if the test is capable of running. A return code of 0 means the test can run. 1 means the test cannot run and is a failure. 2 means the test should be skipped.