### PR TITLE
K8s Helm chart docs update

### DIFF
--- a/charts/k8s-monitoring/docs/Collectors.md
+++ b/charts/k8s-monitoring/docs/Collectors.md
@@ -22,9 +22,10 @@ This creates a Kubernetes workload as either a DaemonSet, StatefulSet, or Deploy
 containers.
 
 Because collectors are deployed using the Alloy Operator, you can use any of the
-standard [Alloy helm chart values](https://raw.githubusercontent.com/grafana/alloy/refs/heads/main/operations/helm/charts/alloy/values.yaml). Those values will be used when creating the Alloy instance.
+standard [Alloy helm chart values](https://raw.githubusercontent.com/grafana/alloy/refs/heads/main/operations/helm/charts/alloy/values.yaml). 
+These values will be used when creating the Alloy instance.
 
-Options specific to the Kubernetes Mnitoring Helm chart are described in the subsequent reference section.
+Options specific to the Kubernetes Mpnitoring Helm chart are described in the following reference section.
 
 ## Alloy Receiver
 

--- a/charts/k8s-monitoring/docs/Collectors.md
+++ b/charts/k8s-monitoring/docs/Collectors.md
@@ -1,6 +1,6 @@
 # Collectors
 
-Collectors are Alloy instances deployed by Alloy Operator as Kubernetes workloads. Each collector uses a
+Collectors are Alloy instances deployed by the Alloy Operator as Kubernetes workloads. Each collector uses a
 workload type appropriate for the telemetry type it collects.
 
 ## General configuration

--- a/charts/k8s-monitoring/docs/Collectors.md
+++ b/charts/k8s-monitoring/docs/Collectors.md
@@ -137,7 +137,7 @@ Make sure your receiver Pods are up and running. To do so, use this command to s
 `kubectl get pods -n <helm_release_namespace>`
 
 While you may have meta monitoring turned on (which would expose the Alloy Pod logs in Loki), this is not helpful when
-the alloy-log receiver itself is faulty.
+the alloy-logs receiver itself is faulty.
 
 To troubleshoot receiver startup problems, you can inspect the Pod
 logs [just like you would any Kubernetes workload](https://kubernetes.io/docs/reference/kubectl/generated/kubectl_logs/) to to watch the alloy-logs receiver Pods:

--- a/charts/k8s-monitoring/docs/Collectors.md
+++ b/charts/k8s-monitoring/docs/Collectors.md
@@ -25,7 +25,7 @@ Because collectors are deployed using the Alloy Operator, you can use any of the
 standard [Alloy helm chart values](https://raw.githubusercontent.com/grafana/alloy/refs/heads/main/operations/helm/charts/alloy/values.yaml). 
 These values will be used when creating the Alloy instance.
 
-Options specific to the Kubernetes Mpnitoring Helm chart are described in the following reference section.
+Options specific to the Kubernetes Monitoring Helm chart are described in the following reference section.
 
 ## Alloy Receiver
 

--- a/charts/k8s-monitoring/docs/Features.md
+++ b/charts/k8s-monitoring/docs/Features.md
@@ -1,5 +1,6 @@
 # Features
 
+<!-- Features are...???need to define what this means -->
 These are the current features supported in this Helm chart:
 
 -   [Cluster Metrics](#cluster-metrics)
@@ -13,59 +14,52 @@ These are the current features supported in this Helm chart:
 -   [Profiling](#profiling)
 -   [Frontend Observability](#frontend-observability)
 
+
 ## Cluster Metrics
 
-[Documentation](https://github.com/grafana/k8s-monitoring-helm/tree/main/charts/k8s-monitoring/charts/feature-cluster-metrics)
-
-Collects metrics about the Kubernetes cluster.
+Collects metrics about the Kubernetes Cluster, including the control plane if configured to do so. 
+Refer to the [documentation](https://github.com/grafana/k8s-monitoring-helm/tree/main/charts/k8s-monitoring/charts/feature-cluster-metrics) for more information.
 
 ## Cluster Events
 
-[Documentation](https://github.com/grafana/k8s-monitoring-helm/tree/main/charts/k8s-monitoring/charts/feature-cluster-events)
-
-Collects Kubernetes Cluster events.
+Collects Kubernetes Cluster events from the Kubernetes API server.
+Refer to the [documentation](https://github.com/grafana/k8s-monitoring-helm/tree/main/charts/k8s-monitoring/charts/feature-cluster-events) for more information.
 
 ## Application Observability
 
-[Documentation](https://github.com/grafana/k8s-monitoring-helm/tree/main/charts/k8s-monitoring/charts/feature-application-observability)
-
-Open receivers to collect telemetry data from instrumented applications.
+Open receivers to collect telemetry data from instrumented applications, including tail sampling when configured to do so.
+Refer to [documentation](https://github.com/grafana/k8s-monitoring-helm/tree/main/charts/k8s-monitoring/charts/feature-application-observability) for more information.
 
 ## Annotation Autodiscovery
 
-[Documentation](https://github.com/grafana/k8s-monitoring-helm/tree/main/charts/k8s-monitoring/charts/feature-annotation-autodiscovery)
-
-Collects metrics from Pods and Services that use a specific annotation.
+Collects metrics from any Pod or Service that uses a specific annotation.
+Refer to [documentation](https://github.com/grafana/k8s-monitoring-helm/tree/main/charts/k8s-monitoring/charts/feature-annotation-autodiscovery) for more information.
 
 ## Prometheus Operator Objects
 
-[Documentation](https://github.com/grafana/k8s-monitoring-helm/tree/main/charts/k8s-monitoring/charts/feature-prometheus-operator-objects)
-
-Collects metrics from Prometheus Operator objects, like PodMonitors and ServiceMonitors.
+Collects metrics from Prometheus Operator objects, such as PodMonitors and ServiceMonitors.
+Refer to [documentation](https://github.com/grafana/k8s-monitoring-helm/tree/main/charts/k8s-monitoring/charts/feature-prometheus-operator-objects) for more information.
 
 ## Node Logs
 
-[Documentation](https://github.com/grafana/k8s-monitoring-helm/tree/main/charts/k8s-monitoring/charts/feature-node-logs)
-
 Collects logs from Kubernetes Cluster Nodes.
+Refer to [documentation](https://github.com/grafana/k8s-monitoring-helm/tree/main/charts/k8s-monitoring/charts/feature-node-logs) for more information.
 
 ## Pod Logs
 
-[Documentation](https://github.com/grafana/k8s-monitoring-helm/tree/main/charts/k8s-monitoring/charts/feature-pod-logs)
-
 Collects logs from Kubernetes Pods.
+Refer to [documentation](https://github.com/grafana/k8s-monitoring-helm/tree/main/charts/k8s-monitoring/charts/feature-pod-logs) for more information.
+
 
 ## Service Integrations
 
-[Documentation](https://github.com/grafana/k8s-monitoring-helm/tree/main/charts/k8s-monitoring/charts/feature-integrations)
-
 Collects metrics and logs from a variety of popular services and integrations.
+Refer to [documentation](https://github.com/grafana/k8s-monitoring-helm/tree/main/charts/k8s-monitoring/charts/feature-integrations) for more information.
 
 ## Profiling
 
-[Documentation](https://github.com/grafana/k8s-monitoring-helm/tree/main/charts/k8s-monitoring/charts/feature-profiling)
-
 Collect profiles using Pyroscope.
+Refer to [documentation](https://github.com/grafana/k8s-monitoring-helm/tree/main/charts/k8s-monitoring/charts/feature-profiling) for more information.
 
 ## Contributing
 
@@ -76,17 +70,17 @@ To add a new feature, create a new Helm chart in the `charts` directory. The cha
 its name. The following files are required for a feature chart:
 
 -   `templates/_module.alloy.tpl` - This file should contain a template function named
-    `feature.<feature-slug>.module` which should create an [Alloy module](https://grafana.com/docs/alloy/latest/get-started/modules/)
-    that wraps the configuration for your feature. It should expose any of these arguments as appropriate:
-    -   `metrics_destination` - An argument that defines where scrape metrics should be delivered.
-    -   `logs_destination` - An argument that defines where logs should be delivered.
-    -   `traces_destination` - An argument that defines where traces should be delivered.
-    -   `profiles_destination` - An argument that defines where profiles should be delivered.
+    `feature.<feature-slug>.module` Creates an [Alloy module](https://grafana.com/docs/alloy/latest/get-started/modules/)
+    that wraps the configuration for your feature, and exposes any of these arguments as appropriate:
+    -   `metrics_destination` - Defines where scrape metrics should be delivered
+    -   `logs_destination` - Defines where logs should be delivered
+    -   `traces_destination` - Defines where traces should be delivered
+    -   `profiles_destination` - Defines where profiles should be delivered
 
 -   `templates/_notes.alloy.tpl` - This file should contain these template functions:
-    -   `feature.<feature-slug>.notes.deployments` - This function returns a list of workloads that will be
-    deployed to the Kubernetes Cluster by the feature.
-    -   `feature.<feature-slug>.notes.task` - This function returns a 1-line summary of what this feature will do.
-    -   `feature.<feature-slug>.notes.actions` - This function returns any prompts for the user to take additional
-        action after deployment.
-    -   `feature.<feature-slug>.summary` - This function a dictionary of settings, used for self-reporting metrics.
+    -   `feature.<feature-slug>.notes.deployments` - Returns a list of workloads that will be
+    deployed to the Kubernetes Cluster by the feature
+    -   `feature.<feature-slug>.notes.task` - Returns a one-line summary of what this feature will do
+    -   `feature.<feature-slug>.notes.actions` - Returns any prompts for the user to take additional
+        action after deployment
+    -   `feature.<feature-slug>.summary` - Returns a dictionary of settings that is used for self-reporting metrics

--- a/charts/k8s-monitoring/docs/Features.md
+++ b/charts/k8s-monitoring/docs/Features.md
@@ -28,7 +28,7 @@ Refer to the [documentation](https://github.com/grafana/k8s-monitoring-helm/tree
 
 ## Application Observability
 
-Open receivers to collect telemetry data from instrumented applications, including tail sampling when configured to do so.
+Opens receivers to collect telemetry data from instrumented applications, including tail sampling when configured to do so.
 Refer to [documentation](https://github.com/grafana/k8s-monitoring-helm/tree/main/charts/k8s-monitoring/charts/feature-application-observability) for more information.
 
 ## Annotation Autodiscovery

--- a/charts/k8s-monitoring/docs/Features.md
+++ b/charts/k8s-monitoring/docs/Features.md
@@ -1,6 +1,7 @@
 # Features
 
-<!-- Features are...???need to define what this means -->
+The Kubernetes Monitoring Helm chart contains multiple features to group common monitoring tasks into  sections within the chart. Any feature contains the Alloy configuration used to discover, gather, process, and deliver the appropriate telemetry data, as well as some additional Kubernetes workloads to supplement Alloy's functionality. Features can be enabled or disabled with the enabled flag, and each contain multiple configuration options described in the feature's documentation.
+
 These are the current features supported in this Helm chart:
 
 -   [Cluster Metrics](#cluster-metrics)

--- a/charts/k8s-monitoring/docs/Migration.md
+++ b/charts/k8s-monitoring/docs/Migration.md
@@ -16,7 +16,7 @@ been rearranged to be organized around features rather than data types (such as 
 explain how the settings have changed, feature by feature, and how to migrate your v1 values.yaml file.
 
 In v1, many features were enabled by default. Cluster metrics, pod logs, cluster events, and so on. In v2, all features
-are turned off by default, which leads your values file to better reflect your desired feature set.
+are turned off by default. This means your values file better reflects your desired feature set.
 
 A migration tool is available
 at [https://grafana.github.io/k8s-monitoring-helm-migrator/](https://grafana.github.io/k8s-monitoring-helm-migrator/).

--- a/charts/k8s-monitoring/docs/Migration.md
+++ b/charts/k8s-monitoring/docs/Migration.md
@@ -1,20 +1,21 @@
 # Migration guide
 
-## Migrating from version 2.0 to 3.0
+## Migrate from version 2.0 to 3.0
 
 The 3.0 release of the k8s-monitoring Helm chart no longer utilizes the
-[Alloy Helm chart](https://github.com/grafana/alloy/tree/main/operations/helm/charts/alloy) as a subchart dependency,
-but instead utilizes the new [Alloy Operator](https://github.com/grafana/alloy-operator) to deploy the Alloy instances.
+[Alloy Helm chart](https://github.com/grafana/alloy/tree/main/operations/helm/charts/alloy) as a subchart dependency.
+Instead the chart uses the new [Alloy Operator](https://github.com/grafana/alloy-operator) to deploy Alloy instances.
 This allows for a more flexible and powerful deployment of Alloy, as well as the ability of your chosen features to
 appropriately configure those Alloy instances.
 
-## Migrating from version 1.x to 2.0
+## Migrate from version 1.x to 2.0
+<!-- question: should this now be titled 1. to 3.0? -->
 
-The 2.0 release of the k8s-monitoring Helm chart includes major changes from the 1.x version. Many of the features have
-been re-arranged to be organized around features, rather than data types (e.g. metrics, logs, etc.). This document will
-explain how the settings have changed, feature-by-feature, and how to migrate your v1 values.yaml file.
+The 2.0 release of the Kubernetes Monitoring Helm chart includes major changes from the 1.x version. Many of the features have
+been rearranged to be organized around features rather than data types (such as metrics, logs, and so on). This document will
+explain how the settings have changed, feature by feature, and how to migrate your v1 values.yaml file.
 
-In v1, many features were enabled by default. Cluster metrics, pod logs, cluster events, etc... In v2, all features
+In v1, many features were enabled by default. Cluster metrics, pod logs, cluster events, and so on. In v2, all features
 are turned off by default, which leads your values file to better reflect your desired feature set.
 
 A migration tool is available
@@ -25,17 +26,17 @@ at [https://grafana.github.io/k8s-monitoring-helm-migrator/](https://grafana.git
 The definition of where data is delivered has changed from `externalServices`, an object of four types, to
 `destinations`, an array of any number of types. Before the `externalServices` object had four types of destinations:
 
--   `prometheus` - Where all metrics are delivered. It could refer to a true Prometheus server, or an OTLP destination
+-   `prometheus` - Where all metrics are delivered. It could refer to a true Prometheus server or an OTLP destination
     that handles metrics.
--   `loki` - Where all logs are delivered. It could refer to a true Loki server, or an OTLP destination that handles logs.
--   `tempo` - Where all traces are delivered. It could refer to a true Tempo server, or an OTLP destination that handles
+-   `loki` - Where all logs are delivered. It could refer to a true Loki server or an OTLP destination that handles logs.
+-   `tempo` - Where all traces are delivered. It could refer to a true Tempo server or an OTLP destination that handles
     traces.
 -   `pyroscope` - Where all profiles are delivered.
 
-So, the service essentially referred to the destination for the data type. In v2, the destination refers to the protocol
+In v1, the service essentially referred to the destination for the data type. In v2, the destination refers to the protocol
 used to deliver the data type.
 
-See [Destinations](destinations/README.md) for more information.
+Refer to [Destinations](destinations/README.md) for more information.
 
 Here's how to map from v1 `externalServices` to v2 `destinations`:
 
@@ -62,7 +63,7 @@ Here's how to map from v1 `externalServices` to v2 `destinations`:
 
 ### Collectors
 
-The Alloy instances has been further split from the original to allow for more flexibility in the configuration and
+The Alloy instances have been further split from the original to allow for more flexibility in the configuration and
 predictability in their resource requirements. Each feature allows for setting the collector, but the defaults have been
 chosen carefully, so you should only need to change these if you have specific requirements.
 
@@ -84,9 +85,9 @@ chosen carefully, so you should only need to change these if you have specific r
 
 Gathering of Cluster Events has been moved into its own feature called `clusterEvents`.
 
-| Feature        | v1.x setting          | v2.0 setting    | Notes |
-|----------------|-----------------------|-----------------|-------|
-| Cluster Events | `logs.cluster_events` | `clusterEvents` |       |
+| Feature        | v1.x setting          | v2.0 setting    |
+|----------------|-----------------------|-----------------|
+| Cluster Events | `logs.cluster_events` | `clusterEvents` |
 
 #### Steps to take
 
@@ -109,7 +110,7 @@ If using cluster events, `logs.cluster_events.enabled`:
 Cluster metrics refers to any metric data source that scrapes metrics about the cluster itself. This includes the
 following data sources:
 
--   Cluster metrics (Kubelet, API Server, etc.)
+-   Cluster metrics (Kubelet, API Server, and so on)
 -   Node metrics (Node Exporter & Windows Exporter)
 -   kube-state-metrics
 -   Energy metrics via Kepler
@@ -223,9 +224,9 @@ If using application observability, `traces.enabled`, `receivers.*.enabled`:
 9.  Move trace filters from `traces.receiver.filters` to `applicationObservability.traces.filters`
 10.  Move trace transforms from `traces.receiver.transforms` to `applicationObservability.traces.transforms`
 
-### Auto-Instrumentation (Grafana Beyla)
+### Zero code instrumentation (Grafana Beyla)
 
-Deployment and handling of the auto instrumentation feature, using Grafana Beyla, has been moved into its own feature
+Deployment and handling of the zero-code instrumentation feature, using Grafana Beyla, has been moved into its own feature
 called `autoInstrumentation`.
 
 | Feature                      | v1.x setting    | v2.0 setting                | Notes |
@@ -250,7 +251,7 @@ If using Beyla, `beyla.enabled`:
 
 ### Pod Logs
 
-Gathering of pods logs has been moved into its own feature called `podLogs`.
+Gathering of Pods logs has been moved into its own feature called `podLogs`.
 
 | Feature  | v1.x setting    | v2.0 setting | Notes |
 |----------|-----------------|--------------|-------|
@@ -258,7 +259,7 @@ Gathering of pods logs has been moved into its own feature called `podLogs`.
 
 #### Steps to take
 
-If using pod logs, `logs.pod_logs.enabled`:
+If using Pod logs `logs.pod_logs.enabled`:
 
 1.  Enable `podLogs` and `alloy-logs` in your values file:
 
@@ -309,9 +310,10 @@ Integrations are a new feature in v2.0 that allow you to enable and configure ad
 includes the Alloy metrics that were previously part of `v1`. Some service integrations that previously needed to be
 defined in the `extraConfig` and `logs.extraConfig` sections can now be used in the integration feature.
 
-If you are using the `metrics.alloy` setting for getting Alloy metrics, or if you are using `extraConfig` to add config
-to get data from any of the new build-in integrations, you should replace your `extraConfig` to the new `integrations`
-feature.
+Replace your `extraConfig` to the new `integrations`feature if either of these are true:
+
+- You are using the `metrics.alloy` setting for getting Alloy metrics.
+- You are using `extraConfig` to add config to get data from any of the new build-in integrations.
 
 #### Built-in integrations
 
@@ -326,7 +328,7 @@ feature.
 
 If using the Alloy integration `metrics.alloy.enabled`, or if using `extraConfig` for cert-manager, etcd, or MySQL:
 
-1.  Create instances of the integration that you want and enable `alloy-metrics` in your values file:
+1.  Create instances of the integration that you want, and enable `alloy-metrics` in your values file:
 
     ```yaml
     integrations:
@@ -344,12 +346,12 @@ If using the Alloy integration `metrics.alloy.enabled`, or if using `extraConfig
 For service integrations that are not available in the built-in integrations feature, you can continue to use them
 in the `extraConfig` sections. See the [Extra Configs](#extra-configs) section below for guidance.
 
-### Extra Configs
+### Extra configs
 
-The variables for adding arbitrary configuration to the Alloy instances has been moved inside the respective Alloy
+The variables for adding arbitrary configuration to the Alloy instances have been moved inside the respective Alloy
 instance. If you are using `extraConfig` to add configuration for scraping metrics from an integration built-in with the
 [integrations](https://github.com/grafana/k8s-monitoring-helm/tree/main/charts/k8s-monitoring/charts/feature-integrations)
-feature (e.g. cert-manager, etcd, MySQL), you can move that configuration to the new `integrations` feature.
+feature (such as cert-manager, etcd, or MySQL), you can move that configuration to the new `integrations` feature.
 
 For other uses of `extraConfig`, continue with this section.
 
@@ -368,7 +370,7 @@ For other uses of `extraConfig`, continue with this section.
 3.  Move `logs.cluster_events.extraConfig` to `alloy-singleton.extraConfig`
 4.  Move `logs.extraConfig` to `alloy-logs.extraConfig`
 5.  Move `profiles.extraConfig` to `alloy-profiles.extraConfig`
-6.  Rename destinations for telemetry data to the appropriate destination component:
+6.  Rename destinations for telemetry data to the appropriate destination component. Refer to the following section.
 
 #### Destination names
 
@@ -379,7 +381,7 @@ For other uses of `extraConfig`, continue with this section.
 | Traces    | `otelcol.exporter.otlp.traces_service.input`  | `otelcol.exporter.otlp.<destination_name>.input`      |
 | Profiles  | `pyroscope.write.profiles_service.receiver`   | `pyroscope.write.<destination_name>.receiver`         |
 
-Note that the `<destination_name>` in the component reference is the name of the destination, set to lower-case and
+Note that the `<destination_name>` in the component reference is the name of the destination, set to lowercase and
 with any non-alphanumeric characters replaced with an underscore. For example, if your destination is named
 `Grafana Cloud Metrics`, then the destination name would be `grafana_cloud_metrics`.
 
@@ -388,10 +390,10 @@ with any non-alphanumeric characters replaced with an underscore. For example, i
 The following features have been removed from the 2.0 release:
 <!--alex ignore hooks-->
 
--   **Pre-install hooks**: The pre-install and pre-upgrade hooks that did config validation have been removed. The Alloy
-    pods will now validate the configuration at runtime and log any issues and without these pods, this greatly
+-   **Pre-install hooks**: The pre-install and pre-upgrade hooks that performed config validation have been removed. The Alloy
+    Pods will now validate the configuration at runtime and log any issues and without these Pods. This greatly
     decreases startup time.
 -   **`helm test` functionality**: The `helm test` functionality that ran a config analysis and attempted to query the
-    databases for expected metrics and logs has been removed. This functionality was either not fully developed, or not
+    databases for expected metrics and logs has been removed. This functionality was either not fully developed or not
     useful in production environments. The query testing was mainly for CI/CD testing in development and has been
     replaced by more effective and comprehensive methods.

--- a/charts/k8s-monitoring/docs/Migration.md
+++ b/charts/k8s-monitoring/docs/Migration.md
@@ -9,7 +9,6 @@ This allows for a more flexible and powerful deployment of Alloy, as well as the
 appropriately configure those Alloy instances.
 
 ## Migrate from version 1.x to 2.0
-<!-- question: should this now be titled 1. to 3.0? -->
 
 The 2.0 release of the Kubernetes Monitoring Helm chart includes major changes from the 1.x version. Many of the features have
 been reorganized around features rather than data types (such as metrics, logs, and so on). This document 
@@ -224,9 +223,9 @@ If using application observability, `traces.enabled`, `receivers.*.enabled`:
 9.  Move trace filters from `traces.receiver.filters` to `applicationObservability.traces.filters`
 10.  Move trace transforms from `traces.receiver.transforms` to `applicationObservability.traces.transforms`
 
-### Zero code instrumentation (Grafana Beyla)
+### Zero-code instrumentation with Grafana Beyla
 
-Deployment and handling of the zero-code instrumentation feature, using Grafana Beyla, has been moved into its own feature
+Deployment and handling of the zero-code instrumentation feature (using Grafana Beyla) has been moved into its own feature
 called `autoInstrumentation`.
 
 | Feature                      | v1.x setting    | v2.0 setting                | Notes |
@@ -249,7 +248,7 @@ If using Beyla, `beyla.enabled`:
 
 2.  Combine `beyla` and `metrics.beyla` and copy to `autoInstrumentation.beyla`
 
-### Pod Logs
+### Pod logs
 
 Gathering of Pods logs has been moved into its own feature called `podLogs`.
 
@@ -274,7 +273,7 @@ If using Pod logs `logs.pod_logs.enabled`:
 3.  Rename any `extraRelabelingRules` to `extraDiscoveryRules`
 4.  Rename any `extraStageBlocks` to `extraLogProcessingStages`
 
-### Prometheus Operator Objects
+### Prometheus Operator objects
 
 Handling for Prometheus Operator objects, such as `ServiceMonitors`, `PodMonitors`, and `Probes` has been moved to the
 `prometheusOperatorObjects` feature. This feature also includes the option to deploy the Prometheus Operator CRDs.

--- a/charts/k8s-monitoring/docs/Migration.md
+++ b/charts/k8s-monitoring/docs/Migration.md
@@ -51,9 +51,9 @@ Here's how to map from v1 `externalServices` to v2 `destinations`:
 #### Steps to take
 
 1.  Create a destination for each external service you are using.
-2.  Provide a `name` and a `type` for the destination
-3.  Provide the URL for the destination. *NOTE* this is a full data writing/pushing URL, not only the hostname!
-4.  Map the other settings from the original service to the new destination
+2.  Provide a `name` and a `type` for the destination.
+3.  Provide the URL for the destination. *NOTE* this is a full data writing/pushing URL, not only the hostname.
+4.  Map the other settings from the original service to the new destination:
 
 -   `authMode` --> `auth.type`
 -   Auth definitions (e.g. `basicAuth`) --> `auth`
@@ -254,7 +254,7 @@ Gathering of Pods logs has been moved into its own feature called `podLogs`.
 
 | Feature  | v1.x setting    | v2.0 setting | Notes |
 |----------|-----------------|--------------|-------|
-| Pod Logs | `logs.pod_logs` | `podLogs`    |       |
+| Pod logs | `logs.pod_logs` | `podLogs`    |       |
 
 #### Steps to take
 
@@ -352,7 +352,7 @@ instance. If you are using `extraConfig` to add configuration for scraping metri
 [integrations](https://github.com/grafana/k8s-monitoring-helm/tree/main/charts/k8s-monitoring/charts/feature-integrations)
 feature (such as cert-manager, etcd, or MySQL), you can move that configuration to the new `integrations` feature.
 
-For other uses of `extraConfig`, continue with this section.
+For other uses of `extraConfig`, refer to the following table:
 
 | extraConfig        | v1.x setting                      | v2.0 setting                  | Notes |
 |--------------------|-----------------------------------|-------------------------------|-------|
@@ -373,6 +373,10 @@ For other uses of `extraConfig`, continue with this section.
 
 #### Destination names
 
+Note that the `<destination_name>` in the component reference is the name of the destination, set to lowercase and
+with any non-alphanumeric characters replaced with an underscore. For example, if your destination is named
+`Grafana Cloud Metrics`, then the destination name would be `grafana_cloud_metrics`.
+
 | Data type | v1.x setting                                  | v2.0 setting                                          |
 |-----------|-----------------------------------------------|-------------------------------------------------------|
 | Metrics   | `prometheus.relabel.metrics_service.receiver` | `prometheus.remote_write.<destination_name>.receiver` |
@@ -380,17 +384,13 @@ For other uses of `extraConfig`, continue with this section.
 | Traces    | `otelcol.exporter.otlp.traces_service.input`  | `otelcol.exporter.otlp.<destination_name>.input`      |
 | Profiles  | `pyroscope.write.profiles_service.receiver`   | `pyroscope.write.<destination_name>.receiver`         |
 
-Note that the `<destination_name>` in the component reference is the name of the destination, set to lowercase and
-with any non-alphanumeric characters replaced with an underscore. For example, if your destination is named
-`Grafana Cloud Metrics`, then the destination name would be `grafana_cloud_metrics`.
-
 ### Dropped features
 
 The following features have been removed from the 2.0 release:
 <!--alex ignore hooks-->
 
 -   **Pre-install hooks**: The pre-install and pre-upgrade hooks that performed config validation have been removed. The Alloy
-    Pods will now validate the configuration at runtime and log any issues and without these Pods. This greatly
+    Pods now validate the configuration at runtime and log any issues and without these Pods. This greatly
     decreases startup time.
 -   **`helm test` functionality**: The `helm test` functionality that ran a config analysis and attempted to query the
     databases for expected metrics and logs has been removed. This functionality was either not fully developed or not

--- a/charts/k8s-monitoring/docs/Migration.md
+++ b/charts/k8s-monitoring/docs/Migration.md
@@ -82,7 +82,7 @@ chosen carefully, so you should only need to change these if you have specific r
 
 ### Cluster Events
 
-Gathering of Cluster Events has been moved into its own feature called `clusterEvents`.
+Gathering of Cluster events has been moved into its own feature called `clusterEvents`.
 
 | Feature        | v1.x setting          | v2.0 setting    |
 |----------------|-----------------------|-----------------|
@@ -90,7 +90,7 @@ Gathering of Cluster Events has been moved into its own feature called `clusterE
 
 #### Steps to take
 
-If using cluster events, `logs.cluster_events.enabled`:
+If using Cluster events, `logs.cluster_events.enabled`:
 
 1.  Enable `clusterEvents` and `alloy-singleton` in your values file:
 
@@ -134,7 +134,7 @@ These have all been combined into a single feature called `clusterMetrics`.
 
 #### Steps to take
 
-If using cluster metrics, `metrics.enabled`:
+If using Cluster metrics, `metrics.enabled`:
 
 1.  Enable `clusterMetrics` and `alloy-metrics` in your values file:
 

--- a/charts/k8s-monitoring/docs/Migration.md
+++ b/charts/k8s-monitoring/docs/Migration.md
@@ -26,10 +26,10 @@ at [https://grafana.github.io/k8s-monitoring-helm-migrator/](https://grafana.git
 The definition of where data is delivered has changed from `externalServices`, an object of four types, to
 `destinations`, an array of any number of types. Before the `externalServices` object had four types of destinations:
 
--   `prometheus` - Where all metrics are delivered. It could refer to a true Prometheus server or an OTLP destination
+-   `prometheus` - Where all metrics are delivered. This could refer to a true Prometheus server or an OTLP destination
     that handles metrics.
--   `loki` - Where all logs are delivered. It could refer to a true Loki server or an OTLP destination that handles logs.
--   `tempo` - Where all traces are delivered. It could refer to a true Tempo server or an OTLP destination that handles
+-   `loki` - Where all logs are delivered. This could refer to a true Loki server or an OTLP destination that handles logs.
+-   `tempo` - Where all traces are delivered. This could refer to a true Tempo server or an OTLP destination that handles
     traces.
 -   `pyroscope` - Where all profiles are delivered.
 

--- a/charts/k8s-monitoring/docs/Migration.md
+++ b/charts/k8s-monitoring/docs/Migration.md
@@ -12,8 +12,8 @@ appropriately configure those Alloy instances.
 <!-- question: should this now be titled 1. to 3.0? -->
 
 The 2.0 release of the Kubernetes Monitoring Helm chart includes major changes from the 1.x version. Many of the features have
-been rearranged to be organized around features rather than data types (such as metrics, logs, and so on). This document will
-explain how the settings have changed, feature by feature, and how to migrate your v1 values.yaml file.
+been reorganized around features rather than data types (such as metrics, logs, and so on). This document 
+explains how the settings have changed feature by feature, and how to migrate your v1 values.yaml file.
 
 In v1, many features were enabled by default. Cluster metrics, pod logs, cluster events, and so on. In v2, all features
 are turned off by default. This means your values file better reflects your desired feature set.

--- a/charts/k8s-monitoring/docs/Structure.md
+++ b/charts/k8s-monitoring/docs/Structure.md
@@ -3,9 +3,9 @@
 The Kubernetes Monitoring Helm chart contains many software packages, and builds a comprehensive set of configuration
 and secrets for those packages.
 
-![Kubernetes Monitoring inside of a Cluster](https://grafana.com/media/docs/grafana-cloud/k8s/helm-chart-diagram-2024-dec.png)
+![Kubernetes Monitoring inside of a Cluster](https://grafana.com/media/docs/grafana-cloud/k8s/helm-diagram-v3.png)
 
-## Software Deployed
+## Software deployed
 
 This Helm chart deploys several packages to generate and capture the telemetry data on the cluster. This list
 corresponds to the list of dependencies in this chart's Chart.yaml file. For each package, there is an associated
@@ -13,42 +13,48 @@ section inside the Helm chart's values.yaml file that controls how it is configu
 
 | Name                                                                                   | Type                      | Associated values             | Description                                                                                                                                                                                                                      |
 |----------------------------------------------------------------------------------------|---------------------------|-------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| [Grafana Alloy](https://grafana.com/oss/alloy/) for Metrics                            | StatefulSet               | `alloy-metrics`               | The Grafana Alloy instance that is responsible for scraping metrics, and accepting metrics, logs, and traces via receivers.                                                                                                      |
-| Grafana Alloy Singleton                                                                | Deployment                | `alloy-singleton`             | The Grafana Alloy instance that is responsible for anything that must be done on a single instance, such as gathering Cluster events from the API server. This does not support clustering, so only one instance should be used. |
-| Grafana Alloy for Logs                                                                 | DaemonSet                 | `alloy-logs`                  | The Grafana Alloy instance that gathers Pod logs. By default, it uses HostPath volume mounts to read Pod log files directly from the nodes. It can alternatively get logs via the API server and be deployed as a Deployment.    |
-| Grafana Alloy for Application Data                                                     | DaemonSet                 | `alloy-receiver`              | The Grafana Alloy instance that opens receiver ports to process data delivered directly to Alloy. For example, applications instrumented with OpenTelemetry SDKs                                                                 |
-| Grafana Alloy for Profiles                                                             | DaemonSet                 | `alloy-events`                | The Grafana Alloy instance that is responsible for gathering profiles.                                                                                                                                                           |
+| [Grafana Alloy](https://grafana.com/oss/alloy/) for Metrics                            | StatefulSet               | `alloy-metrics`               | The Alloy instance responsible for scraping metrics, and accepting metrics, logs, and traces via receivers.                                                                                                      |
+| Grafana Alloy Singleton                                                                | Deployment                | `alloy-singleton`             | The Alloy instance responsible for anything that must be done on a single instance, such as gathering Cluster events from the API server. This instance does not support clustering, so only one instance should be used. |
+| Grafana Alloy for Logs                                                                 | DaemonSet                 | `alloy-logs`                  | The Alloy instance that gathers Pod logs. By default, it uses HostPath volume mounts to read Pod log files directly from the Nodes. It can alternatively get logs via the API server, and be deployed as a Deployment.    |
+| Grafana Alloy for Application Data                                                     | DaemonSet                 | `alloy-receiver`              | The Alloy instance that opens receiver ports to process data delivered directly to Alloy (for example, applications instrumented with OpenTelemetry). SDKs                                                                 |
+| Grafana Alloy for Profiles                                                             | DaemonSet                 | `alloy-events`                | The Alloy instance responsible for gathering profiles.                                                                                                                                                           |
 | [kube-state-metrics](https://github.com/kubernetes/kube-state-metrics)                 | Deployment                | `kube-state-metrics`          | A service for generating metrics about the state of the objects inside the Cluster.                                                                                                                                              |
-| [Node Exporter](https://github.com/prometheus/node_exporter)                           | DaemonSet                 | `prometheus-node-exporter`    | An exporter used for gathering hardware and OS metrics for *NIX nodes of the Cluster.                                                                                                                                            |
-| [Windows Exporter](https://github.com/prometheus-community/windows_exporter)           | DaemonSet                 | `prometheus-windows-exporter` | An exporter used for gathering hardware and OS metrics for Windows nodes of the Cluster. Not deployed by default.                                                                                                                |
+| [Node Exporter](https://github.com/prometheus/node_exporter)                           | DaemonSet                 | `prometheus-node-exporter`    | An exporter for gathering hardware and OS metrics for *NIX nodes of the Cluster.                                                                                                                                            |
+| [Windows Exporter](https://github.com/prometheus-community/windows_exporter)           | DaemonSet                 | `prometheus-windows-exporter` | An exporter for gathering hardware and OS metrics for Windows nodes of the Cluster. Not deployed by default.                                                                                                                |
 | [OpenCost](https://www.opencost.io/)                                                   | Deployment                | `opencost`                    | Used for gathering cost metrics for the Cluster.                                                                                                                                                                                 |
 | [Prometheus Operator CRDs](https://github.com/prometheus-operator/prometheus-operator) | CustomResourceDefinitions | `prometheus-operator-crds`    | The custom resources for the Prometheus Operator. Use if you want to deploy PodMonitors, ServiceMonitors, or Probes.                                                                                                             |
-| [Grafana Beyla](https://grafana.com/oss/beyla-ebpf/)                                   | DaemonSet                 | `beyla`                       | Used for automatically instrumenting applications and gathering network metrics.                                                                                                                                                 |
+| [Grafana Beyla](https://grafana.com/oss/beyla-ebpf/)                                   | DaemonSet                 | `beyla`                       | Used for zero-code instrumentation of applications and gathering network metrics.                                                                                                                                                 |
 | [Kepler](https://sustainable-computing.io/)                                            | DaemonSet                 | `kepler`                      | Used for gathering energy consumption metrics.                                                                                                                                                                                   |
 
 ### Grafana Alloy instances
 
-There are five instances of Grafana Alloy instead of one that includes all functions due to the need for:
+There are multiple instances of Grafana Alloy instead of one instance that includes all functions. This design is required for:
 
 *   Balance between functionality and scalability
 *   Security
 
-#### Functionality/Scalability balance
+#### Functionality/scalability balance
 
 Without multiple instances, scalability can be hindered. For example, the default functionality of the Grafana Alloy for Logs is to gather
-logs via HostPath volume mounts. This requires this instance to be deployed as a DaemonSet. The Grafana Alloy for Metrics is
-deployed as a StatefulSet, which allows it to be scaled (optionally with a HorizontalPodAutoscaler) based on load. If it would lose its ability to scale. Also, the Grafana Alloy Singleton cannot be
+logs via HostPath volume mounts. 
+This functionality requires the instance to be deployed as a DaemonSet. 
+The Grafana Alloy for Metrics is
+deployed as a StatefulSet, which allows it to be scaled (optionally with a HorizontalPodAutoscaler) based on load. 
+Otherwise, it would lose its ability to scale. 
+The Grafana Alloy Singleton cannot be
 scaled beyond one replica, because that would result in duplicate data being sent.
 
 #### Security
 
-Another reason for using distinct instances is to minimize the security footprint required. While the Alloy for logs
-may require a HostPath volume mount, the other instances do not. That means they can be deployed with a more restrictive
-security context. This is similarly why we use a distinct Grafana Beyla and Node Exporter deployments to gather
-auto instrumented data and node metrics respectively, rather than using the
+Another reason for using distinct instances is to minimize the security footprint required. While the Alloy for Logs
+may require a HostPath volume mount, the other instances do not. 
+That means they can be deployed with a more restrictive
+security context. 
+This is similarly why we use a distinct Grafana Beyla and Node Exporter deployments to gather zero-code instrumented data and Node metrics respectively, rather than using the
 [beyla.ebpf](https://grafana.com/docs/alloy/latest/reference/components/beyla/beyla.ebpf/) or
 [prometheus.exporter.unix](https://grafana.com/docs/alloy/latest/reference/components/prometheus/prometheus.exporter.unix/)
-Alloy components. This allows Beyla and Node Exporter to be deployed with the permissions they require to gather their
+Alloy components. 
+Separate instances allow Beyla and Node Exporter to be deployed with the permissions they require to gather their
 data, while limiting Grafana Alloy to only act as a collector of that data.
 
 ## Configuration created
@@ -71,20 +77,20 @@ Here is the list of features, their section within the values file, and the defa
 | [Node Logs](https://github.com/grafana/k8s-monitoring-helm/tree/main/charts/k8s-monitoring/charts/feature-node-logs)                                     | `nodeLogs`                  | `alloy-logs`                   | Gathers logs from the Kubernetes Nodes.                                                                                                                                           |
 | [Pod Logs](https://github.com/grafana/k8s-monitoring-helm/tree/main/charts/k8s-monitoring/charts/feature-pod-logs)                                       | `podLogs`                   | `alloy-logs`                   | Gathers logs from the Kubernetes Pods.                                                                                                                                            |
 | [Application Observability](https://github.com/grafana/k8s-monitoring-helm/tree/main/charts/k8s-monitoring/charts/feature-application-observability)     | `applicationObservability`  | `alloy-receiver`               | Receives and processes application data from instrumented services.                                                                                                               |
-| [Auto Instrumentation](https://github.com/grafana/k8s-monitoring-helm/tree/main/charts/k8s-monitoring/charts/feature-auto-instrumentation)               | `autoInstrumentation`       | `alloy-metrics`                | Deploys Grafana Beyla and gathers auto-instrumented application metrics. If Application Observability is also enabled, auto-instrumented application traces are captured as well. |
+| [Auto Instrumentation](https://github.com/grafana/k8s-monitoring-helm/tree/main/charts/k8s-monitoring/charts/feature-auto-instrumentation)               | `autoInstrumentation`       | `alloy-metrics`                | Deploys Grafana Beyla and gathers zero-code instrumented application metrics. If Application Observability is also enabled, zero-code instrumented application traces are captured as well. |
 | [Annotation Autodiscovery](https://github.com/grafana/k8s-monitoring-helm/tree/main/charts/k8s-monitoring/charts/feature-annotation-autodiscovery)       | `annotationAutodiscovery`   | `alloy-metrics`                | Automatically discovers and scrapes metrics from specially annotated Pods and Services.                                                                                           |
 | [Prometheus Operator Objects](https://github.com/grafana/k8s-monitoring-helm/tree/main/charts/k8s-monitoring/charts/feature-prometheus-operator-objects) | `prometheusOperatorObjects` | `alloy-metrics`                | Discovers and scrapes metrics from Probes, PodMonitors, and ServiceMonitors.                                                                                                      |
 | [Profiling](https://github.com/grafana/k8s-monitoring-helm/tree/main/charts/k8s-monitoring/charts/feature-profiling)                                     | `profiling`                 | `alloy-profiles`               | Gathers application profiles from processes running within the Kubernetes Cluster.                                                                                                |
 | [Integrations](https://github.com/grafana/k8s-monitoring-helm/tree/main/charts/k8s-monitoring/charts/feature-integrations)                               | `integrations`              | `alloy-metrics` & `alloy-logs` | Gathers metrics and logs from common services.                                                                                                                                    |
 
-### Additional Configuration sources
+### Additional configuration sources
 
 Each collector also has the ability to specify additional configuration sources. These are specified within the Alloy
 instance's own section in the values file:
 
 | Name                 | Associated values         | Description                                                                                                                                                                                         |
 |----------------------|---------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| Extra Configuration  | `alloy-___.extraConfig`   | Additional configuration to added to the configuration file. This is used for adding custom configuration, but cannot be used to modify existing configuration.                                     |
-| Remote Configuration | `alloy-___.remoteConfig`  | Configuration for fetching remotely-defined configuration. This is how to connect this collector to [Grafana Fleet Management](https://grafana.com/docs/grafana-cloud/send-data/fleet-management/). |
+| Extra configuration  | `alloy-___.extraConfig`   | Additional configuration to be added to the configuration file. Use this for adding custom configuration, but do not use it to modify existing configuration.                                     |
+| Remote configuration | `alloy-___.remoteConfig`  | Configuration for fetching remotely defined configuration. To configure, refer to [Grafana Fleet Management](https://grafana.com/docs/grafana-cloud/send-data/fleet-management/). |
 | Logging              | `alloy-___.logging`       | Configuration for [logging](https://grafana.com/docs/alloy/latest/reference/config-blocks/logging/).                                                                                                |
-| Live Debugging       | `alloy-___.liveDebugging` | Configuration for enabling the [Alloy Live Debugging feature](https://grafana.com/docs/alloy/latest/troubleshoot/debug/#live-debugging-page).                                                       |
+| Live debugging       | `alloy-___.liveDebugging` | Configuration for enabling the [Alloy Live Debugging feature](https://grafana.com/docs/alloy/latest/troubleshoot/debug/#live-debugging-page).                                                       |

--- a/charts/k8s-monitoring/docs/TargetingDataCollection.md
+++ b/charts/k8s-monitoring/docs/TargetingDataCollection.md
@@ -1,19 +1,20 @@
 # Targeting Data Collection
 
-The Kubernetes Monitoring Helm chart allows you to target specific namespaces or pods for data collection. There are
+The Kubernetes Monitoring Helm chart allows you to target specific namespaces or Pods for data collection. There are
 many different methods to control this, and the following sections will explain how to use many of them.
 
 ## Kubernetes Annotations
 
-Several features within this Helm chart can be controlled using Kubernetes annotations. Often it is for controlling
-service discovery, but often annotations can be used to configure how data is collected.
+Often annotations are used for controlling
+service discovery, but you can also use them to configure how data is collected. 
+Several features within this Helm chart can be controlled using Kubernetes annotations. 
 
 ### Feature: Annotation Autodiscovery
 
-The Annotation Autodiscovery feature allows you to discover and scrape Prometheus-style metrics from Pods and Services
-on your cluster. These are the default annotations that can be applied to a Pod or Service:
+Use the [Annotation Autodiscovery feature](https://github.com/grafana/k8s-monitoring-helm/tree/main/charts/k8s-monitoring/charts/feature-annotation-autodiscovery) to discover and scrape Prometheus-style metrics from Pods and Services
+on your Cluster. You can apply these default annotations to a Pod or Service:
 
-*   `k8s.grafana.com/scrape`: This Pod or Service should be scrape for metrics.
+*   `k8s.grafana.com/scrape`: Scrape this Pod or Service for metrics.
 *   `k8s.grafana.com/job`: The value to use for the `job` label.
 *   `k8s.grafana.com/instance`: The value to use for the `instance` label.
 *   `k8s.grafana.com/metrics.container`: The name of the container within the Pod to scrape for metrics. This is used to target a specific container within a Pod that has multiple containers.
@@ -25,20 +26,18 @@ on your cluster. These are the default annotations that can be applied to a Pod 
 *   `k8s.grafana.com/metrics.scrapeInterval`: The scrape interval to use when scraping metrics. Defaults to `60s`.
 *   `k8s.grafana.com/metrics.scrapeTimeout`: The scrape timeout to use when scraping metrics. Defaults to `10s`.
 
-The actual annotations can be configured in the [annotationAutodiscovery feature](https://github.com/grafana/k8s-monitoring-helm/tree/main/charts/k8s-monitoring/charts/feature-annotation-autodiscovery).
-
 ### Feature: Profiling
 
-The Profiling feature allows you to collect profiling data from your applications. This feature can collect profiles
-using eBPF, Java, or pprof. The following annotations can be used to control profiling:
+The [Profiling feature](https://github.com/grafana/k8s-monitoring-helm/tree/main/charts/k8s-monitoring/charts/feature-profiling) allows you to collect profiling data from your applications. This feature can collect profiles
+using eBPF, Java, or pprof.
 
 #### eBPF Profiling
 
-*   `profiles.grafana.com/cpu.ebpf.enabled`: This Pod should have CPU profiles collected using eBPF.
+`profiles.grafana.com/cpu.ebpf.enabled`: Using eBPF, collect CPU profiles from this Pod.
 
 #### Java Profiling
 
-*   `profiles.grafana.com/java.enabled`: This Pod should have Java profiles collected.
+`profiles.grafana.com/java.enabled`: Collect Java profiles from this Pod.
 
 #### pprof Profiling
 
@@ -53,6 +52,6 @@ For each enabled type (`memory`, `block`, `goroutine`, `mutex`, `cpu`, `fgprof`,
 
 ### Feature: Pod Logs
 
-The following annotations can be used to control Pod logs collection:
+Use the following annotation to control [Pod logs](https://github.com/grafana/k8s-monitoring-helm/tree/main/charts/k8s-monitoring/charts/feature-pod-logs) collection:
 
-*   `k8s.grafana.com/logs.job`: The value to use for the `job` label.
+`k8s.grafana.com/logs.job`: The value to use for the `job` label.

--- a/charts/k8s-monitoring/docs/TargetingDataCollection.md
+++ b/charts/k8s-monitoring/docs/TargetingDataCollection.md
@@ -1,4 +1,4 @@
-# Targeting Data Collection
+# Targeted data collection
 
 The Kubernetes Monitoring Helm chart allows you to target specific namespaces or Pods for data collection. There are
 many different methods to control this, and the following sections will explain how to use many of them.


### PR DESCRIPTION
Performed following updates:
- Style and format changes in prep for moving HC docs into public docs
- Edits for clarity or any errors
- Updates due to Alloy Operator addition, including diagram (Please verify all changes related to this.  For example "Because collectors are deployed using the Alloy Operator, you can use any of the
standard [Alloy helm chart values](https://raw.githubusercontent.com/grafana/alloy/refs/heads/main/operations/helm/charts/alloy/values.yaml). These values will be used when creating the Alloy instance.")

Comments/questions for reviewers:
- Should the migration guide now be from 1x+ to 3? I was under the understanding that there are no incremental upgrades.
- Some content removed that referred to singleton not being automatically created since no instances are auto created now.
- We should probably put the definition of a "feature" in Features.md - i think Pete told me, but I forgot.