### PR TITLE
Add ability to convert OTel resource attributes to Prometheus labels

### DIFF
--- a/charts/k8s-monitoring/destinations/prometheus-values.yaml
+++ b/charts/k8s-monitoring/destinations/prometheus-values.yaml
@@ -285,8 +285,7 @@ writeAheadLog:
   # @section -- Write-Ahead Log
   maxKeepaliveTime: 8h
 
-# -- Settings for converting OpenTelemetry ecosystem metrics to Prometheus ecosystem metrics.
-# @section -- OpenTelemetry Conversion
+# Settings for converting OpenTelemetry ecosystem metrics to Prometheus ecosystem metrics.
 openTelemetryConversion:
   # -- Whether to add type and unit suffixes to metrics names.
   # @section -- OpenTelemetry Conversion

--- a/charts/k8s-monitoring/destinations/prometheus-values.yaml
+++ b/charts/k8s-monitoring/destinations/prometheus-values.yaml
@@ -291,3 +291,6 @@ openTelemetryConversion:
   # -- Whether to add type and unit suffixes to metrics names.
   # @section -- OpenTelemetry Conversion
   addMetricSuffixes: true
+  # -- Whether to convert OTel resource attributes to Prometheus labels.
+  # @section -- OpenTelemetry Conversion
+  resourceToTelemetryConversion: false

--- a/charts/k8s-monitoring/docs/destinations/prometheus.md
+++ b/charts/k8s-monitoring/docs/destinations/prometheus.md
@@ -94,9 +94,8 @@ This defines the options for defining a destination for metrics that use the Pro
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| openTelemetryConversion | object | `{"addMetricSuffixes":true}` | Settings for converting OpenTelemetry ecosystem metrics to Prometheus ecosystem metrics. |
 | openTelemetryConversion.addMetricSuffixes | bool | `true` | Whether to add type and unit suffixes to metrics names. |
-| openTelemetryConversion.resourceToTelemetryConversion | bool | `true` | Whether to convert OTel resource attributes to Prometheus labels. |
+| openTelemetryConversion.resourceToTelemetryConversion | bool | `false` | Whether to convert OTel resource attributes to Prometheus labels. |
 
 ### Queue Configuration
 

--- a/charts/k8s-monitoring/docs/destinations/prometheus.md
+++ b/charts/k8s-monitoring/docs/destinations/prometheus.md
@@ -96,6 +96,7 @@ This defines the options for defining a destination for metrics that use the Pro
 |-----|------|---------|-------------|
 | openTelemetryConversion | object | `{"addMetricSuffixes":true}` | Settings for converting OpenTelemetry ecosystem metrics to Prometheus ecosystem metrics. |
 | openTelemetryConversion.addMetricSuffixes | bool | `true` | Whether to add type and unit suffixes to metrics names. |
+| openTelemetryConversion.resourceToTelemetryConversion | bool | `true` | Whether to convert OTel resource attributes to Prometheus labels. |
 
 ### Queue Configuration
 

--- a/charts/k8s-monitoring/docs/examples/auth/bearer-token/alloy-metrics.alloy
+++ b/charts/k8s-monitoring/docs/examples/auth/bearer-token/alloy-metrics.alloy
@@ -91,6 +91,7 @@ prometheus.relabel "kubernetes_monitoring_telemetry" {
 // Destination: prometheus (prometheus)
 otelcol.exporter.prometheus "prometheus" {
   add_metric_suffixes = true
+  resource_to_telemetry_conversion = false
   forward_to = [prometheus.remote_write.prometheus.receiver]
 }
 

--- a/charts/k8s-monitoring/docs/examples/auth/bearer-token/alloy-receiver.alloy
+++ b/charts/k8s-monitoring/docs/examples/auth/bearer-token/alloy-receiver.alloy
@@ -133,6 +133,7 @@ application_observability "feature" {
 // Destination: prometheus (prometheus)
 otelcol.exporter.prometheus "prometheus" {
   add_metric_suffixes = true
+  resource_to_telemetry_conversion = false
   forward_to = [prometheus.remote_write.prometheus.receiver]
 }
 

--- a/charts/k8s-monitoring/docs/examples/auth/bearer-token/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/auth/bearer-token/output.yaml
@@ -124,6 +124,7 @@ data:
     // Destination: prometheus (prometheus)
     otelcol.exporter.prometheus "prometheus" {
       add_metric_suffixes = true
+      resource_to_telemetry_conversion = false
       forward_to = [prometheus.remote_write.prometheus.receiver]
     }
     
@@ -542,6 +543,7 @@ data:
     // Destination: prometheus (prometheus)
     otelcol.exporter.prometheus "prometheus" {
       add_metric_suffixes = true
+      resource_to_telemetry_conversion = false
       forward_to = [prometheus.remote_write.prometheus.receiver]
     }
     

--- a/charts/k8s-monitoring/docs/examples/auth/embedded-secrets/alloy-metrics.alloy
+++ b/charts/k8s-monitoring/docs/examples/auth/embedded-secrets/alloy-metrics.alloy
@@ -91,6 +91,7 @@ prometheus.relabel "kubernetes_monitoring_telemetry" {
 // Destination: prometheus (prometheus)
 otelcol.exporter.prometheus "prometheus" {
   add_metric_suffixes = true
+  resource_to_telemetry_conversion = false
   forward_to = [prometheus.remote_write.prometheus.receiver]
 }
 

--- a/charts/k8s-monitoring/docs/examples/auth/embedded-secrets/alloy-receiver.alloy
+++ b/charts/k8s-monitoring/docs/examples/auth/embedded-secrets/alloy-receiver.alloy
@@ -136,6 +136,7 @@ application_observability "feature" {
 // Destination: prometheus (prometheus)
 otelcol.exporter.prometheus "prometheus" {
   add_metric_suffixes = true
+  resource_to_telemetry_conversion = false
   forward_to = [prometheus.remote_write.prometheus.receiver]
 }
 

--- a/charts/k8s-monitoring/docs/examples/auth/embedded-secrets/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/auth/embedded-secrets/output.yaml
@@ -114,6 +114,7 @@ data:
     // Destination: prometheus (prometheus)
     otelcol.exporter.prometheus "prometheus" {
       add_metric_suffixes = true
+      resource_to_telemetry_conversion = false
       forward_to = [prometheus.remote_write.prometheus.receiver]
     }
     
@@ -534,6 +535,7 @@ data:
     // Destination: prometheus (prometheus)
     otelcol.exporter.prometheus "prometheus" {
       add_metric_suffixes = true
+      resource_to_telemetry_conversion = false
       forward_to = [prometheus.remote_write.prometheus.receiver]
     }
     

--- a/charts/k8s-monitoring/docs/examples/auth/external-secrets/alloy-metrics.alloy
+++ b/charts/k8s-monitoring/docs/examples/auth/external-secrets/alloy-metrics.alloy
@@ -91,6 +91,7 @@ prometheus.relabel "kubernetes_monitoring_telemetry" {
 // Destination: prometheus (prometheus)
 otelcol.exporter.prometheus "prometheus" {
   add_metric_suffixes = true
+  resource_to_telemetry_conversion = false
   forward_to = [prometheus.remote_write.prometheus.receiver]
 }
 

--- a/charts/k8s-monitoring/docs/examples/auth/external-secrets/alloy-receiver.alloy
+++ b/charts/k8s-monitoring/docs/examples/auth/external-secrets/alloy-receiver.alloy
@@ -133,6 +133,7 @@ application_observability "feature" {
 // Destination: prometheus (prometheus)
 otelcol.exporter.prometheus "prometheus" {
   add_metric_suffixes = true
+  resource_to_telemetry_conversion = false
   forward_to = [prometheus.remote_write.prometheus.receiver]
 }
 

--- a/charts/k8s-monitoring/docs/examples/auth/external-secrets/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/auth/external-secrets/output.yaml
@@ -114,6 +114,7 @@ data:
     // Destination: prometheus (prometheus)
     otelcol.exporter.prometheus "prometheus" {
       add_metric_suffixes = true
+      resource_to_telemetry_conversion = false
       forward_to = [prometheus.remote_write.prometheus.receiver]
     }
     
@@ -551,6 +552,7 @@ data:
     // Destination: prometheus (prometheus)
     otelcol.exporter.prometheus "prometheus" {
       add_metric_suffixes = true
+      resource_to_telemetry_conversion = false
       forward_to = [prometheus.remote_write.prometheus.receiver]
     }
     

--- a/charts/k8s-monitoring/docs/examples/auth/sigv4/alloy-metrics.alloy
+++ b/charts/k8s-monitoring/docs/examples/auth/sigv4/alloy-metrics.alloy
@@ -491,6 +491,7 @@ prometheus.relabel "kubernetes_monitoring_telemetry" {
 // Destination: prometheus (prometheus)
 otelcol.exporter.prometheus "prometheus" {
   add_metric_suffixes = true
+  resource_to_telemetry_conversion = false
   forward_to = [prometheus.remote_write.prometheus.receiver]
 }
 

--- a/charts/k8s-monitoring/docs/examples/auth/sigv4/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/auth/sigv4/output.yaml
@@ -598,6 +598,7 @@ data:
     // Destination: prometheus (prometheus)
     otelcol.exporter.prometheus "prometheus" {
       add_metric_suffixes = true
+      resource_to_telemetry_conversion = false
       forward_to = [prometheus.remote_write.prometheus.receiver]
     }
     

--- a/charts/k8s-monitoring/docs/examples/collector-storage/alloy-metrics.alloy
+++ b/charts/k8s-monitoring/docs/examples/collector-storage/alloy-metrics.alloy
@@ -491,6 +491,7 @@ prometheus.relabel "kubernetes_monitoring_telemetry" {
 // Destination: prometheus (prometheus)
 otelcol.exporter.prometheus "prometheus" {
   add_metric_suffixes = true
+  resource_to_telemetry_conversion = false
   forward_to = [prometheus.remote_write.prometheus.receiver]
 }
 

--- a/charts/k8s-monitoring/docs/examples/collector-storage/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/collector-storage/output.yaml
@@ -587,6 +587,7 @@ data:
     // Destination: prometheus (prometheus)
     otelcol.exporter.prometheus "prometheus" {
       add_metric_suffixes = true
+      resource_to_telemetry_conversion = false
       forward_to = [prometheus.remote_write.prometheus.receiver]
     }
     

--- a/charts/k8s-monitoring/docs/examples/exclude-by-namespace/alloy-metrics.alloy
+++ b/charts/k8s-monitoring/docs/examples/exclude-by-namespace/alloy-metrics.alloy
@@ -879,6 +879,7 @@ prometheus_operator_objects "feature" {
 // Destination: prometheus (prometheus)
 otelcol.exporter.prometheus "prometheus" {
   add_metric_suffixes = true
+  resource_to_telemetry_conversion = false
   forward_to = [prometheus.remote_write.prometheus.receiver]
 }
 

--- a/charts/k8s-monitoring/docs/examples/exclude-by-namespace/alloy-receiver.alloy
+++ b/charts/k8s-monitoring/docs/examples/exclude-by-namespace/alloy-receiver.alloy
@@ -150,6 +150,7 @@ application_observability "feature" {
 // Destination: prometheus (prometheus)
 otelcol.exporter.prometheus "prometheus" {
   add_metric_suffixes = true
+  resource_to_telemetry_conversion = false
   forward_to = [prometheus.remote_write.prometheus.receiver]
 }
 

--- a/charts/k8s-monitoring/docs/examples/exclude-by-namespace/alloy-singleton.alloy
+++ b/charts/k8s-monitoring/docs/examples/exclude-by-namespace/alloy-singleton.alloy
@@ -142,6 +142,7 @@ prometheus.relabel "kubernetes_monitoring_telemetry" {
 // Destination: prometheus (prometheus)
 otelcol.exporter.prometheus "prometheus" {
   add_metric_suffixes = true
+  resource_to_telemetry_conversion = false
   forward_to = [prometheus.remote_write.prometheus.receiver]
 }
 

--- a/charts/k8s-monitoring/docs/examples/exclude-by-namespace/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/exclude-by-namespace/output.yaml
@@ -991,6 +991,7 @@ data:
     // Destination: prometheus (prometheus)
     otelcol.exporter.prometheus "prometheus" {
       add_metric_suffixes = true
+      resource_to_telemetry_conversion = false
       forward_to = [prometheus.remote_write.prometheus.receiver]
     }
     
@@ -1189,6 +1190,7 @@ data:
     // Destination: prometheus (prometheus)
     otelcol.exporter.prometheus "prometheus" {
       add_metric_suffixes = true
+      resource_to_telemetry_conversion = false
       forward_to = [prometheus.remote_write.prometheus.receiver]
     }
     
@@ -1647,6 +1649,7 @@ data:
     // Destination: prometheus (prometheus)
     otelcol.exporter.prometheus "prometheus" {
       add_metric_suffixes = true
+      resource_to_telemetry_conversion = false
       forward_to = [prometheus.remote_write.prometheus.receiver]
     }
     

--- a/charts/k8s-monitoring/docs/examples/extra-configuration/alloy-metrics.alloy
+++ b/charts/k8s-monitoring/docs/examples/extra-configuration/alloy-metrics.alloy
@@ -16,6 +16,7 @@ prometheus.scrape "animal_service" {
 // Destination: prometheus-kubernetes (prometheus)
 otelcol.exporter.prometheus "prometheus_kubernetes" {
   add_metric_suffixes = true
+  resource_to_telemetry_conversion = false
   forward_to = [prometheus.remote_write.prometheus_kubernetes.receiver]
 }
 

--- a/charts/k8s-monitoring/docs/examples/extra-configuration/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/extra-configuration/output.yaml
@@ -39,6 +39,7 @@ data:
     // Destination: prometheus-kubernetes (prometheus)
     otelcol.exporter.prometheus "prometheus_kubernetes" {
       add_metric_suffixes = true
+      resource_to_telemetry_conversion = false
       forward_to = [prometheus.remote_write.prometheus_kubernetes.receiver]
     }
     

--- a/charts/k8s-monitoring/docs/examples/extra-rules/alloy-metrics.alloy
+++ b/charts/k8s-monitoring/docs/examples/extra-rules/alloy-metrics.alloy
@@ -455,6 +455,7 @@ cluster_metrics "feature" {
 // Destination: prometheus (prometheus)
 otelcol.exporter.prometheus "prometheus" {
   add_metric_suffixes = true
+  resource_to_telemetry_conversion = false
   forward_to = [prometheus.remote_write.prometheus.receiver]
 }
 

--- a/charts/k8s-monitoring/docs/examples/extra-rules/alloy-singleton.alloy
+++ b/charts/k8s-monitoring/docs/examples/extra-rules/alloy-singleton.alloy
@@ -138,6 +138,7 @@ prometheus.relabel "kubernetes_monitoring_telemetry" {
 // Destination: prometheus (prometheus)
 otelcol.exporter.prometheus "prometheus" {
   add_metric_suffixes = true
+  resource_to_telemetry_conversion = false
   forward_to = [prometheus.remote_write.prometheus.receiver]
 }
 

--- a/charts/k8s-monitoring/docs/examples/extra-rules/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/extra-rules/output.yaml
@@ -551,6 +551,7 @@ data:
     // Destination: prometheus (prometheus)
     otelcol.exporter.prometheus "prometheus" {
       add_metric_suffixes = true
+      resource_to_telemetry_conversion = false
       forward_to = [prometheus.remote_write.prometheus.receiver]
     }
     
@@ -754,6 +755,7 @@ data:
     // Destination: prometheus (prometheus)
     otelcol.exporter.prometheus "prometheus" {
       add_metric_suffixes = true
+      resource_to_telemetry_conversion = false
       forward_to = [prometheus.remote_write.prometheus.receiver]
     }
     

--- a/charts/k8s-monitoring/docs/examples/features/annotation-autodiscovery/default/alloy-metrics.alloy
+++ b/charts/k8s-monitoring/docs/examples/features/annotation-autodiscovery/default/alloy-metrics.alloy
@@ -350,6 +350,7 @@ prometheus.relabel "kubernetes_monitoring_telemetry" {
 // Destination: prometheus (prometheus)
 otelcol.exporter.prometheus "prometheus" {
   add_metric_suffixes = true
+  resource_to_telemetry_conversion = false
   forward_to = [prometheus.remote_write.prometheus.receiver]
 }
 

--- a/charts/k8s-monitoring/docs/examples/features/annotation-autodiscovery/default/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/features/annotation-autodiscovery/default/output.yaml
@@ -373,6 +373,7 @@ data:
     // Destination: prometheus (prometheus)
     otelcol.exporter.prometheus "prometheus" {
       add_metric_suffixes = true
+      resource_to_telemetry_conversion = false
       forward_to = [prometheus.remote_write.prometheus.receiver]
     }
     

--- a/charts/k8s-monitoring/docs/examples/features/annotation-autodiscovery/prom-annotations/alloy-metrics.alloy
+++ b/charts/k8s-monitoring/docs/examples/features/annotation-autodiscovery/prom-annotations/alloy-metrics.alloy
@@ -350,6 +350,7 @@ prometheus.relabel "kubernetes_monitoring_telemetry" {
 // Destination: prometheus (prometheus)
 otelcol.exporter.prometheus "prometheus" {
   add_metric_suffixes = true
+  resource_to_telemetry_conversion = false
   forward_to = [prometheus.remote_write.prometheus.receiver]
 }
 

--- a/charts/k8s-monitoring/docs/examples/features/annotation-autodiscovery/prom-annotations/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/features/annotation-autodiscovery/prom-annotations/output.yaml
@@ -373,6 +373,7 @@ data:
     // Destination: prometheus (prometheus)
     otelcol.exporter.prometheus "prometheus" {
       add_metric_suffixes = true
+      resource_to_telemetry_conversion = false
       forward_to = [prometheus.remote_write.prometheus.receiver]
     }
     

--- a/charts/k8s-monitoring/docs/examples/features/auto-instrumentation/beyla-metrics/alloy-metrics.alloy
+++ b/charts/k8s-monitoring/docs/examples/features/auto-instrumentation/beyla-metrics/alloy-metrics.alloy
@@ -100,6 +100,7 @@ prometheus.relabel "kubernetes_monitoring_telemetry" {
 // Destination: prometheus (prometheus)
 otelcol.exporter.prometheus "prometheus" {
   add_metric_suffixes = true
+  resource_to_telemetry_conversion = false
   forward_to = [prometheus.remote_write.prometheus.receiver]
 }
 

--- a/charts/k8s-monitoring/docs/examples/features/auto-instrumentation/beyla-metrics/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/features/auto-instrumentation/beyla-metrics/output.yaml
@@ -139,6 +139,7 @@ data:
     // Destination: prometheus (prometheus)
     otelcol.exporter.prometheus "prometheus" {
       add_metric_suffixes = true
+      resource_to_telemetry_conversion = false
       forward_to = [prometheus.remote_write.prometheus.receiver]
     }
     

--- a/charts/k8s-monitoring/docs/examples/features/auto-instrumentation/discovery-rules/alloy-metrics.alloy
+++ b/charts/k8s-monitoring/docs/examples/features/auto-instrumentation/discovery-rules/alloy-metrics.alloy
@@ -100,6 +100,7 @@ prometheus.relabel "kubernetes_monitoring_telemetry" {
 // Destination: prometheus (prometheus)
 otelcol.exporter.prometheus "prometheus" {
   add_metric_suffixes = true
+  resource_to_telemetry_conversion = false
   forward_to = [prometheus.remote_write.prometheus.receiver]
 }
 

--- a/charts/k8s-monitoring/docs/examples/features/auto-instrumentation/discovery-rules/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/features/auto-instrumentation/discovery-rules/output.yaml
@@ -139,6 +139,7 @@ data:
     // Destination: prometheus (prometheus)
     otelcol.exporter.prometheus "prometheus" {
       add_metric_suffixes = true
+      resource_to_telemetry_conversion = false
       forward_to = [prometheus.remote_write.prometheus.receiver]
     }
     

--- a/charts/k8s-monitoring/docs/examples/features/cluster-metrics/control-plane-monitoring/alloy-metrics.alloy
+++ b/charts/k8s-monitoring/docs/examples/features/cluster-metrics/control-plane-monitoring/alloy-metrics.alloy
@@ -834,6 +834,7 @@ etcd_integration "integration" {
 // Destination: prometheus (prometheus)
 otelcol.exporter.prometheus "prometheus" {
   add_metric_suffixes = true
+  resource_to_telemetry_conversion = false
   forward_to = [prometheus.remote_write.prometheus.receiver]
 }
 

--- a/charts/k8s-monitoring/docs/examples/features/cluster-metrics/control-plane-monitoring/alloy-singleton.alloy
+++ b/charts/k8s-monitoring/docs/examples/features/cluster-metrics/control-plane-monitoring/alloy-singleton.alloy
@@ -137,6 +137,7 @@ prometheus.relabel "kubernetes_monitoring_telemetry" {
 // Destination: prometheus (prometheus)
 otelcol.exporter.prometheus "prometheus" {
   add_metric_suffixes = true
+  resource_to_telemetry_conversion = false
   forward_to = [prometheus.remote_write.prometheus.receiver]
 }
 

--- a/charts/k8s-monitoring/docs/examples/features/cluster-metrics/control-plane-monitoring/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/features/cluster-metrics/control-plane-monitoring/output.yaml
@@ -930,6 +930,7 @@ data:
     // Destination: prometheus (prometheus)
     otelcol.exporter.prometheus "prometheus" {
       add_metric_suffixes = true
+      resource_to_telemetry_conversion = false
       forward_to = [prometheus.remote_write.prometheus.receiver]
     }
     
@@ -1123,6 +1124,7 @@ data:
     // Destination: prometheus (prometheus)
     otelcol.exporter.prometheus "prometheus" {
       add_metric_suffixes = true
+      resource_to_telemetry_conversion = false
       forward_to = [prometheus.remote_write.prometheus.receiver]
     }
     

--- a/charts/k8s-monitoring/docs/examples/features/cluster-metrics/default/alloy-metrics.alloy
+++ b/charts/k8s-monitoring/docs/examples/features/cluster-metrics/default/alloy-metrics.alloy
@@ -573,6 +573,7 @@ prometheus.relabel "kubernetes_monitoring_telemetry" {
 // Destination: prometheus (prometheus)
 otelcol.exporter.prometheus "prometheus" {
   add_metric_suffixes = true
+  resource_to_telemetry_conversion = false
   forward_to = [prometheus.remote_write.prometheus.receiver]
 }
 

--- a/charts/k8s-monitoring/docs/examples/features/cluster-metrics/default/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/features/cluster-metrics/default/output.yaml
@@ -697,6 +697,7 @@ data:
     // Destination: prometheus (prometheus)
     otelcol.exporter.prometheus "prometheus" {
       add_metric_suffixes = true
+      resource_to_telemetry_conversion = false
       forward_to = [prometheus.remote_write.prometheus.receiver]
     }
     

--- a/charts/k8s-monitoring/docs/examples/features/integrations/alloy/alloy-metrics.alloy
+++ b/charts/k8s-monitoring/docs/examples/features/integrations/alloy/alloy-metrics.alloy
@@ -341,6 +341,7 @@ prometheus.relabel "kubernetes_monitoring_telemetry" {
 // Destination: prometheus (prometheus)
 otelcol.exporter.prometheus "prometheus" {
   add_metric_suffixes = true
+  resource_to_telemetry_conversion = false
   forward_to = [prometheus.remote_write.prometheus.receiver]
 }
 

--- a/charts/k8s-monitoring/docs/examples/features/integrations/alloy/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/features/integrations/alloy/output.yaml
@@ -364,6 +364,7 @@ data:
     // Destination: prometheus (prometheus)
     otelcol.exporter.prometheus "prometheus" {
       add_metric_suffixes = true
+      resource_to_telemetry_conversion = false
       forward_to = [prometheus.remote_write.prometheus.receiver]
     }
     

--- a/charts/k8s-monitoring/docs/examples/features/integrations/cert-manager/alloy-metrics.alloy
+++ b/charts/k8s-monitoring/docs/examples/features/integrations/cert-manager/alloy-metrics.alloy
@@ -167,6 +167,7 @@ prometheus.relabel "kubernetes_monitoring_telemetry" {
 // Destination: prometheus (prometheus)
 otelcol.exporter.prometheus "prometheus" {
   add_metric_suffixes = true
+  resource_to_telemetry_conversion = false
   forward_to = [prometheus.remote_write.prometheus.receiver]
 }
 

--- a/charts/k8s-monitoring/docs/examples/features/integrations/cert-manager/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/features/integrations/cert-manager/output.yaml
@@ -190,6 +190,7 @@ data:
     // Destination: prometheus (prometheus)
     otelcol.exporter.prometheus "prometheus" {
       add_metric_suffixes = true
+      resource_to_telemetry_conversion = false
       forward_to = [prometheus.remote_write.prometheus.receiver]
     }
     

--- a/charts/k8s-monitoring/docs/examples/features/integrations/etcd/alloy-metrics.alloy
+++ b/charts/k8s-monitoring/docs/examples/features/integrations/etcd/alloy-metrics.alloy
@@ -167,6 +167,7 @@ prometheus.relabel "kubernetes_monitoring_telemetry" {
 // Destination: prometheus (prometheus)
 otelcol.exporter.prometheus "prometheus" {
   add_metric_suffixes = true
+  resource_to_telemetry_conversion = false
   forward_to = [prometheus.remote_write.prometheus.receiver]
 }
 

--- a/charts/k8s-monitoring/docs/examples/features/integrations/etcd/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/features/integrations/etcd/output.yaml
@@ -190,6 +190,7 @@ data:
     // Destination: prometheus (prometheus)
     otelcol.exporter.prometheus "prometheus" {
       add_metric_suffixes = true
+      resource_to_telemetry_conversion = false
       forward_to = [prometheus.remote_write.prometheus.receiver]
     }
     

--- a/charts/k8s-monitoring/docs/examples/features/integrations/grafana/alloy-metrics.alloy
+++ b/charts/k8s-monitoring/docs/examples/features/integrations/grafana/alloy-metrics.alloy
@@ -289,6 +289,7 @@ prometheus.relabel "kubernetes_monitoring_telemetry" {
 // Destination: prometheus (prometheus)
 otelcol.exporter.prometheus "prometheus" {
   add_metric_suffixes = true
+  resource_to_telemetry_conversion = false
   forward_to = [prometheus.remote_write.prometheus.receiver]
 }
 

--- a/charts/k8s-monitoring/docs/examples/features/integrations/grafana/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/features/integrations/grafana/output.yaml
@@ -312,6 +312,7 @@ data:
     // Destination: prometheus (prometheus)
     otelcol.exporter.prometheus "prometheus" {
       add_metric_suffixes = true
+      resource_to_telemetry_conversion = false
       forward_to = [prometheus.remote_write.prometheus.receiver]
     }
     

--- a/charts/k8s-monitoring/docs/examples/features/integrations/loki/alloy-metrics.alloy
+++ b/charts/k8s-monitoring/docs/examples/features/integrations/loki/alloy-metrics.alloy
@@ -306,6 +306,7 @@ prometheus.relabel "kubernetes_monitoring_telemetry" {
 // Destination: prometheus (prometheus)
 otelcol.exporter.prometheus "prometheus" {
   add_metric_suffixes = true
+  resource_to_telemetry_conversion = false
   forward_to = [prometheus.remote_write.prometheus.receiver]
 }
 

--- a/charts/k8s-monitoring/docs/examples/features/integrations/loki/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/features/integrations/loki/output.yaml
@@ -329,6 +329,7 @@ data:
     // Destination: prometheus (prometheus)
     otelcol.exporter.prometheus "prometheus" {
       add_metric_suffixes = true
+      resource_to_telemetry_conversion = false
       forward_to = [prometheus.remote_write.prometheus.receiver]
     }
     

--- a/charts/k8s-monitoring/docs/examples/features/integrations/mimir/alloy-metrics.alloy
+++ b/charts/k8s-monitoring/docs/examples/features/integrations/mimir/alloy-metrics.alloy
@@ -304,6 +304,7 @@ prometheus.relabel "kubernetes_monitoring_telemetry" {
 // Destination: prometheus (prometheus)
 otelcol.exporter.prometheus "prometheus" {
   add_metric_suffixes = true
+  resource_to_telemetry_conversion = false
   forward_to = [prometheus.remote_write.prometheus.receiver]
 }
 

--- a/charts/k8s-monitoring/docs/examples/features/integrations/mimir/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/features/integrations/mimir/output.yaml
@@ -327,6 +327,7 @@ data:
     // Destination: prometheus (prometheus)
     otelcol.exporter.prometheus "prometheus" {
       add_metric_suffixes = true
+      resource_to_telemetry_conversion = false
       forward_to = [prometheus.remote_write.prometheus.receiver]
     }
     

--- a/charts/k8s-monitoring/docs/examples/features/integrations/multiple/alloy-metrics.alloy
+++ b/charts/k8s-monitoring/docs/examples/features/integrations/multiple/alloy-metrics.alloy
@@ -201,6 +201,7 @@ prometheus.relabel "kubernetes_monitoring_telemetry" {
 // Destination: prometheus (prometheus)
 otelcol.exporter.prometheus "prometheus" {
   add_metric_suffixes = true
+  resource_to_telemetry_conversion = false
   forward_to = [prometheus.remote_write.prometheus.receiver]
 }
 

--- a/charts/k8s-monitoring/docs/examples/features/integrations/multiple/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/features/integrations/multiple/output.yaml
@@ -224,6 +224,7 @@ data:
     // Destination: prometheus (prometheus)
     otelcol.exporter.prometheus "prometheus" {
       add_metric_suffixes = true
+      resource_to_telemetry_conversion = false
       forward_to = [prometheus.remote_write.prometheus.receiver]
     }
     

--- a/charts/k8s-monitoring/docs/examples/features/integrations/mysql/alloy-metrics.alloy
+++ b/charts/k8s-monitoring/docs/examples/features/integrations/mysql/alloy-metrics.alloy
@@ -106,6 +106,7 @@ prometheus.relabel "kubernetes_monitoring_telemetry" {
 // Destination: prometheus (prometheus)
 otelcol.exporter.prometheus "prometheus" {
   add_metric_suffixes = true
+  resource_to_telemetry_conversion = false
   forward_to = [prometheus.remote_write.prometheus.receiver]
 }
 

--- a/charts/k8s-monitoring/docs/examples/features/integrations/mysql/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/features/integrations/mysql/output.yaml
@@ -139,6 +139,7 @@ data:
     // Destination: prometheus (prometheus)
     otelcol.exporter.prometheus "prometheus" {
       add_metric_suffixes = true
+      resource_to_telemetry_conversion = false
       forward_to = [prometheus.remote_write.prometheus.receiver]
     }
     

--- a/charts/k8s-monitoring/docs/examples/features/prometheus-operator-objects/default/alloy-metrics.alloy
+++ b/charts/k8s-monitoring/docs/examples/features/prometheus-operator-objects/default/alloy-metrics.alloy
@@ -109,6 +109,7 @@ prometheus.relabel "kubernetes_monitoring_telemetry" {
 // Destination: prometheus (prometheus)
 otelcol.exporter.prometheus "prometheus" {
   add_metric_suffixes = true
+  resource_to_telemetry_conversion = false
   forward_to = [prometheus.remote_write.prometheus.receiver]
 }
 

--- a/charts/k8s-monitoring/docs/examples/features/prometheus-operator-objects/default/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/features/prometheus-operator-objects/default/output.yaml
@@ -132,6 +132,7 @@ data:
     // Destination: prometheus (prometheus)
     otelcol.exporter.prometheus "prometheus" {
       add_metric_suffixes = true
+      resource_to_telemetry_conversion = false
       forward_to = [prometheus.remote_write.prometheus.receiver]
     }
     

--- a/charts/k8s-monitoring/docs/examples/include-by-namespace/alloy-metrics.alloy
+++ b/charts/k8s-monitoring/docs/examples/include-by-namespace/alloy-metrics.alloy
@@ -863,6 +863,7 @@ prometheus_operator_objects "feature" {
 // Destination: prometheus (prometheus)
 otelcol.exporter.prometheus "prometheus" {
   add_metric_suffixes = true
+  resource_to_telemetry_conversion = false
   forward_to = [prometheus.remote_write.prometheus.receiver]
 }
 

--- a/charts/k8s-monitoring/docs/examples/include-by-namespace/alloy-receiver.alloy
+++ b/charts/k8s-monitoring/docs/examples/include-by-namespace/alloy-receiver.alloy
@@ -150,6 +150,7 @@ application_observability "feature" {
 // Destination: prometheus (prometheus)
 otelcol.exporter.prometheus "prometheus" {
   add_metric_suffixes = true
+  resource_to_telemetry_conversion = false
   forward_to = [prometheus.remote_write.prometheus.receiver]
 }
 

--- a/charts/k8s-monitoring/docs/examples/include-by-namespace/alloy-singleton.alloy
+++ b/charts/k8s-monitoring/docs/examples/include-by-namespace/alloy-singleton.alloy
@@ -138,6 +138,7 @@ prometheus.relabel "kubernetes_monitoring_telemetry" {
 // Destination: prometheus (prometheus)
 otelcol.exporter.prometheus "prometheus" {
   add_metric_suffixes = true
+  resource_to_telemetry_conversion = false
   forward_to = [prometheus.remote_write.prometheus.receiver]
 }
 

--- a/charts/k8s-monitoring/docs/examples/include-by-namespace/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/include-by-namespace/output.yaml
@@ -975,6 +975,7 @@ data:
     // Destination: prometheus (prometheus)
     otelcol.exporter.prometheus "prometheus" {
       add_metric_suffixes = true
+      resource_to_telemetry_conversion = false
       forward_to = [prometheus.remote_write.prometheus.receiver]
     }
     
@@ -1169,6 +1170,7 @@ data:
     // Destination: prometheus (prometheus)
     otelcol.exporter.prometheus "prometheus" {
       add_metric_suffixes = true
+      resource_to_telemetry_conversion = false
       forward_to = [prometheus.remote_write.prometheus.receiver]
     }
     
@@ -1625,6 +1627,7 @@ data:
     // Destination: prometheus (prometheus)
     otelcol.exporter.prometheus "prometheus" {
       add_metric_suffixes = true
+      resource_to_telemetry_conversion = false
       forward_to = [prometheus.remote_write.prometheus.receiver]
     }
     

--- a/charts/k8s-monitoring/docs/examples/istio-service-mesh/alloy-metrics.alloy
+++ b/charts/k8s-monitoring/docs/examples/istio-service-mesh/alloy-metrics.alloy
@@ -794,6 +794,7 @@ prometheus.relabel "kubernetes_monitoring_telemetry" {
 // Destination: localPrometheus (prometheus)
 otelcol.exporter.prometheus "localprometheus" {
   add_metric_suffixes = true
+  resource_to_telemetry_conversion = false
   forward_to = [prometheus.remote_write.localprometheus.receiver]
 }
 

--- a/charts/k8s-monitoring/docs/examples/istio-service-mesh/alloy-receiver.alloy
+++ b/charts/k8s-monitoring/docs/examples/istio-service-mesh/alloy-receiver.alloy
@@ -130,6 +130,7 @@ enabled = true
 // Destination: localPrometheus (prometheus)
 otelcol.exporter.prometheus "localprometheus" {
   add_metric_suffixes = true
+  resource_to_telemetry_conversion = false
   forward_to = [prometheus.remote_write.localprometheus.receiver]
 }
 

--- a/charts/k8s-monitoring/docs/examples/istio-service-mesh/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/istio-service-mesh/output.yaml
@@ -890,6 +890,7 @@ data:
     // Destination: localPrometheus (prometheus)
     otelcol.exporter.prometheus "localprometheus" {
       add_metric_suffixes = true
+      resource_to_telemetry_conversion = false
       forward_to = [prometheus.remote_write.localprometheus.receiver]
     }
     
@@ -1087,6 +1088,7 @@ data:
     // Destination: localPrometheus (prometheus)
     otelcol.exporter.prometheus "localprometheus" {
       add_metric_suffixes = true
+      resource_to_telemetry_conversion = false
       forward_to = [prometheus.remote_write.localprometheus.receiver]
     }
     

--- a/charts/k8s-monitoring/docs/examples/log-metrics/alloy-metrics.alloy
+++ b/charts/k8s-monitoring/docs/examples/log-metrics/alloy-metrics.alloy
@@ -341,6 +341,7 @@ prometheus.relabel "kubernetes_monitoring_telemetry" {
 // Destination: prometheus (prometheus)
 otelcol.exporter.prometheus "prometheus" {
   add_metric_suffixes = true
+  resource_to_telemetry_conversion = false
   forward_to = [prometheus.remote_write.prometheus.receiver]
 }
 

--- a/charts/k8s-monitoring/docs/examples/log-metrics/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/log-metrics/output.yaml
@@ -364,6 +364,7 @@ data:
     // Destination: prometheus (prometheus)
     otelcol.exporter.prometheus "prometheus" {
       add_metric_suffixes = true
+      resource_to_telemetry_conversion = false
       forward_to = [prometheus.remote_write.prometheus.receiver]
     }
     

--- a/charts/k8s-monitoring/docs/examples/meta-monitoring/alloy-receiver.alloy
+++ b/charts/k8s-monitoring/docs/examples/meta-monitoring/alloy-receiver.alloy
@@ -133,6 +133,7 @@ application_observability "feature" {
 // Destination: prometheus (prometheus)
 otelcol.exporter.prometheus "prometheus" {
   add_metric_suffixes = true
+  resource_to_telemetry_conversion = false
   forward_to = [prometheus.remote_write.prometheus.receiver]
 }
 

--- a/charts/k8s-monitoring/docs/examples/meta-monitoring/alloy-singleton.alloy
+++ b/charts/k8s-monitoring/docs/examples/meta-monitoring/alloy-singleton.alloy
@@ -2121,6 +2121,7 @@ prometheus.relabel "kubernetes_monitoring_telemetry" {
 // Destination: prometheus (prometheus)
 otelcol.exporter.prometheus "prometheus" {
   add_metric_suffixes = true
+  resource_to_telemetry_conversion = false
   forward_to = [prometheus.remote_write.prometheus.receiver]
 }
 

--- a/charts/k8s-monitoring/docs/examples/meta-monitoring/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/meta-monitoring/output.yaml
@@ -2178,6 +2178,7 @@ data:
     // Destination: prometheus (prometheus)
     otelcol.exporter.prometheus "prometheus" {
       add_metric_suffixes = true
+      resource_to_telemetry_conversion = false
       forward_to = [prometheus.remote_write.prometheus.receiver]
     }
     
@@ -2400,6 +2401,7 @@ data:
     // Destination: prometheus (prometheus)
     otelcol.exporter.prometheus "prometheus" {
       add_metric_suffixes = true
+      resource_to_telemetry_conversion = false
       forward_to = [prometheus.remote_write.prometheus.receiver]
     }
     

--- a/charts/k8s-monitoring/docs/examples/metrics-tuning/alloy-metrics.alloy
+++ b/charts/k8s-monitoring/docs/examples/metrics-tuning/alloy-metrics.alloy
@@ -798,6 +798,7 @@ prometheus.relabel "kubernetes_monitoring_telemetry" {
 // Destination: prometheus (prometheus)
 otelcol.exporter.prometheus "prometheus" {
   add_metric_suffixes = true
+  resource_to_telemetry_conversion = false
   forward_to = [prometheus.remote_write.prometheus.receiver]
 }
 

--- a/charts/k8s-monitoring/docs/examples/metrics-tuning/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/metrics-tuning/output.yaml
@@ -894,6 +894,7 @@ data:
     // Destination: prometheus (prometheus)
     otelcol.exporter.prometheus "prometheus" {
       add_metric_suffixes = true
+      resource_to_telemetry_conversion = false
       forward_to = [prometheus.remote_write.prometheus.receiver]
     }
     

--- a/charts/k8s-monitoring/docs/examples/namespace-labels-and-annotations/alloy-metrics.alloy
+++ b/charts/k8s-monitoring/docs/examples/namespace-labels-and-annotations/alloy-metrics.alloy
@@ -491,6 +491,7 @@ prometheus.relabel "kubernetes_monitoring_telemetry" {
 // Destination: prometheus (prometheus)
 otelcol.exporter.prometheus "prometheus" {
   add_metric_suffixes = true
+  resource_to_telemetry_conversion = false
   forward_to = [prometheus.remote_write.prometheus.receiver]
 }
 

--- a/charts/k8s-monitoring/docs/examples/namespace-labels-and-annotations/alloy-receiver.alloy
+++ b/charts/k8s-monitoring/docs/examples/namespace-labels-and-annotations/alloy-receiver.alloy
@@ -151,6 +151,7 @@ application_observability "feature" {
 // Destination: prometheus (prometheus)
 otelcol.exporter.prometheus "prometheus" {
   add_metric_suffixes = true
+  resource_to_telemetry_conversion = false
   forward_to = [prometheus.remote_write.prometheus.receiver]
 }
 

--- a/charts/k8s-monitoring/docs/examples/namespace-labels-and-annotations/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/namespace-labels-and-annotations/output.yaml
@@ -587,6 +587,7 @@ data:
     // Destination: prometheus (prometheus)
     otelcol.exporter.prometheus "prometheus" {
       add_metric_suffixes = true
+      resource_to_telemetry_conversion = false
       forward_to = [prometheus.remote_write.prometheus.receiver]
     }
     
@@ -1016,6 +1017,7 @@ data:
     // Destination: prometheus (prometheus)
     otelcol.exporter.prometheus "prometheus" {
       add_metric_suffixes = true
+      resource_to_telemetry_conversion = false
       forward_to = [prometheus.remote_write.prometheus.receiver]
     }
     

--- a/charts/k8s-monitoring/docs/examples/node-labels/alloy-metrics.alloy
+++ b/charts/k8s-monitoring/docs/examples/node-labels/alloy-metrics.alloy
@@ -1007,6 +1007,7 @@ prometheus.relabel "kubernetes_monitoring_telemetry" {
 // Destination: prometheus (prometheus)
 otelcol.exporter.prometheus "prometheus" {
   add_metric_suffixes = true
+  resource_to_telemetry_conversion = false
   forward_to = [prometheus.remote_write.prometheus.receiver]
 }
 

--- a/charts/k8s-monitoring/docs/examples/node-labels/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/node-labels/output.yaml
@@ -1103,6 +1103,7 @@ data:
     // Destination: prometheus (prometheus)
     otelcol.exporter.prometheus "prometheus" {
       add_metric_suffixes = true
+      resource_to_telemetry_conversion = false
       forward_to = [prometheus.remote_write.prometheus.receiver]
     }
     

--- a/charts/k8s-monitoring/docs/examples/platforms/azure-aks/alloy-metrics.alloy
+++ b/charts/k8s-monitoring/docs/examples/platforms/azure-aks/alloy-metrics.alloy
@@ -449,6 +449,7 @@ cluster_metrics "feature" {
 // Destination: prometheus (prometheus)
 otelcol.exporter.prometheus "prometheus" {
   add_metric_suffixes = true
+  resource_to_telemetry_conversion = false
   forward_to = [prometheus.remote_write.prometheus.receiver]
 }
 

--- a/charts/k8s-monitoring/docs/examples/platforms/azure-aks/alloy-singleton.alloy
+++ b/charts/k8s-monitoring/docs/examples/platforms/azure-aks/alloy-singleton.alloy
@@ -137,6 +137,7 @@ prometheus.relabel "kubernetes_monitoring_telemetry" {
 // Destination: prometheus (prometheus)
 otelcol.exporter.prometheus "prometheus" {
   add_metric_suffixes = true
+  resource_to_telemetry_conversion = false
   forward_to = [prometheus.remote_write.prometheus.receiver]
 }
 

--- a/charts/k8s-monitoring/docs/examples/platforms/azure-aks/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/platforms/azure-aks/output.yaml
@@ -545,6 +545,7 @@ data:
     // Destination: prometheus (prometheus)
     otelcol.exporter.prometheus "prometheus" {
       add_metric_suffixes = true
+      resource_to_telemetry_conversion = false
       forward_to = [prometheus.remote_write.prometheus.receiver]
     }
     
@@ -738,6 +739,7 @@ data:
     // Destination: prometheus (prometheus)
     otelcol.exporter.prometheus "prometheus" {
       add_metric_suffixes = true
+      resource_to_telemetry_conversion = false
       forward_to = [prometheus.remote_write.prometheus.receiver]
     }
     

--- a/charts/k8s-monitoring/docs/examples/platforms/eks-fargate/alloy-metrics.alloy
+++ b/charts/k8s-monitoring/docs/examples/platforms/eks-fargate/alloy-metrics.alloy
@@ -311,6 +311,7 @@ cluster_metrics "feature" {
 // Destination: prometheus (prometheus)
 otelcol.exporter.prometheus "prometheus" {
   add_metric_suffixes = true
+  resource_to_telemetry_conversion = false
   forward_to = [prometheus.remote_write.prometheus.receiver]
 }
 

--- a/charts/k8s-monitoring/docs/examples/platforms/eks-fargate/alloy-singleton.alloy
+++ b/charts/k8s-monitoring/docs/examples/platforms/eks-fargate/alloy-singleton.alloy
@@ -137,6 +137,7 @@ prometheus.relabel "kubernetes_monitoring_telemetry" {
 // Destination: prometheus (prometheus)
 otelcol.exporter.prometheus "prometheus" {
   add_metric_suffixes = true
+  resource_to_telemetry_conversion = false
   forward_to = [prometheus.remote_write.prometheus.receiver]
 }
 

--- a/charts/k8s-monitoring/docs/examples/platforms/eks-fargate/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/platforms/eks-fargate/output.yaml
@@ -390,6 +390,7 @@ data:
     // Destination: prometheus (prometheus)
     otelcol.exporter.prometheus "prometheus" {
       add_metric_suffixes = true
+      resource_to_telemetry_conversion = false
       forward_to = [prometheus.remote_write.prometheus.receiver]
     }
     
@@ -583,6 +584,7 @@ data:
     // Destination: prometheus (prometheus)
     otelcol.exporter.prometheus "prometheus" {
       add_metric_suffixes = true
+      resource_to_telemetry_conversion = false
       forward_to = [prometheus.remote_write.prometheus.receiver]
     }
     

--- a/charts/k8s-monitoring/docs/examples/platforms/gke-autopilot/alloy-metrics.alloy
+++ b/charts/k8s-monitoring/docs/examples/platforms/gke-autopilot/alloy-metrics.alloy
@@ -311,6 +311,7 @@ cluster_metrics "feature" {
 // Destination: prometheus (prometheus)
 otelcol.exporter.prometheus "prometheus" {
   add_metric_suffixes = true
+  resource_to_telemetry_conversion = false
   forward_to = [prometheus.remote_write.prometheus.receiver]
 }
 

--- a/charts/k8s-monitoring/docs/examples/platforms/gke-autopilot/alloy-singleton.alloy
+++ b/charts/k8s-monitoring/docs/examples/platforms/gke-autopilot/alloy-singleton.alloy
@@ -137,6 +137,7 @@ prometheus.relabel "kubernetes_monitoring_telemetry" {
 // Destination: prometheus (prometheus)
 otelcol.exporter.prometheus "prometheus" {
   add_metric_suffixes = true
+  resource_to_telemetry_conversion = false
   forward_to = [prometheus.remote_write.prometheus.receiver]
 }
 

--- a/charts/k8s-monitoring/docs/examples/platforms/gke-autopilot/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/platforms/gke-autopilot/output.yaml
@@ -390,6 +390,7 @@ data:
     // Destination: prometheus (prometheus)
     otelcol.exporter.prometheus "prometheus" {
       add_metric_suffixes = true
+      resource_to_telemetry_conversion = false
       forward_to = [prometheus.remote_write.prometheus.receiver]
     }
     
@@ -583,6 +584,7 @@ data:
     // Destination: prometheus (prometheus)
     otelcol.exporter.prometheus "prometheus" {
       add_metric_suffixes = true
+      resource_to_telemetry_conversion = false
       forward_to = [prometheus.remote_write.prometheus.receiver]
     }
     

--- a/charts/k8s-monitoring/docs/examples/platforms/openshift/alloy-metrics.alloy
+++ b/charts/k8s-monitoring/docs/examples/platforms/openshift/alloy-metrics.alloy
@@ -784,6 +784,7 @@ alloy_integration "integration" {
 // Destination: prometheus (prometheus)
 otelcol.exporter.prometheus "prometheus" {
   add_metric_suffixes = true
+  resource_to_telemetry_conversion = false
   forward_to = [prometheus.remote_write.prometheus.receiver]
 }
 

--- a/charts/k8s-monitoring/docs/examples/platforms/openshift/alloy-singleton.alloy
+++ b/charts/k8s-monitoring/docs/examples/platforms/openshift/alloy-singleton.alloy
@@ -137,6 +137,7 @@ prometheus.relabel "kubernetes_monitoring_telemetry" {
 // Destination: prometheus (prometheus)
 otelcol.exporter.prometheus "prometheus" {
   add_metric_suffixes = true
+  resource_to_telemetry_conversion = false
   forward_to = [prometheus.remote_write.prometheus.receiver]
 }
 

--- a/charts/k8s-monitoring/docs/examples/platforms/openshift/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/platforms/openshift/output.yaml
@@ -859,6 +859,7 @@ data:
     // Destination: prometheus (prometheus)
     otelcol.exporter.prometheus "prometheus" {
       add_metric_suffixes = true
+      resource_to_telemetry_conversion = false
       forward_to = [prometheus.remote_write.prometheus.receiver]
     }
     
@@ -1052,6 +1053,7 @@ data:
     // Destination: prometheus (prometheus)
     otelcol.exporter.prometheus "prometheus" {
       add_metric_suffixes = true
+      resource_to_telemetry_conversion = false
       forward_to = [prometheus.remote_write.prometheus.receiver]
     }
     

--- a/charts/k8s-monitoring/docs/examples/pod-labels-and-annotations/alloy-metrics.alloy
+++ b/charts/k8s-monitoring/docs/examples/pod-labels-and-annotations/alloy-metrics.alloy
@@ -491,6 +491,7 @@ prometheus.relabel "kubernetes_monitoring_telemetry" {
 // Destination: prometheus (prometheus)
 otelcol.exporter.prometheus "prometheus" {
   add_metric_suffixes = true
+  resource_to_telemetry_conversion = false
   forward_to = [prometheus.remote_write.prometheus.receiver]
 }
 

--- a/charts/k8s-monitoring/docs/examples/pod-labels-and-annotations/alloy-receiver.alloy
+++ b/charts/k8s-monitoring/docs/examples/pod-labels-and-annotations/alloy-receiver.alloy
@@ -141,6 +141,7 @@ application_observability "feature" {
 // Destination: prometheus (prometheus)
 otelcol.exporter.prometheus "prometheus" {
   add_metric_suffixes = true
+  resource_to_telemetry_conversion = false
   forward_to = [prometheus.remote_write.prometheus.receiver]
 }
 

--- a/charts/k8s-monitoring/docs/examples/pod-labels-and-annotations/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/pod-labels-and-annotations/output.yaml
@@ -587,6 +587,7 @@ data:
     // Destination: prometheus (prometheus)
     otelcol.exporter.prometheus "prometheus" {
       add_metric_suffixes = true
+      resource_to_telemetry_conversion = false
       forward_to = [prometheus.remote_write.prometheus.receiver]
     }
     
@@ -1016,6 +1017,7 @@ data:
     // Destination: prometheus (prometheus)
     otelcol.exporter.prometheus "prometheus" {
       add_metric_suffixes = true
+      resource_to_telemetry_conversion = false
       forward_to = [prometheus.remote_write.prometheus.receiver]
     }
     

--- a/charts/k8s-monitoring/docs/examples/private-image-registries/globally/alloy-metrics.alloy
+++ b/charts/k8s-monitoring/docs/examples/private-image-registries/globally/alloy-metrics.alloy
@@ -491,6 +491,7 @@ prometheus.relabel "kubernetes_monitoring_telemetry" {
 // Destination: prometheus (prometheus)
 otelcol.exporter.prometheus "prometheus" {
   add_metric_suffixes = true
+  resource_to_telemetry_conversion = false
   forward_to = [prometheus.remote_write.prometheus.receiver]
 }
 

--- a/charts/k8s-monitoring/docs/examples/private-image-registries/globally/alloy-receiver.alloy
+++ b/charts/k8s-monitoring/docs/examples/private-image-registries/globally/alloy-receiver.alloy
@@ -134,6 +134,7 @@ application_observability "feature" {
 // Destination: prometheus (prometheus)
 otelcol.exporter.prometheus "prometheus" {
   add_metric_suffixes = true
+  resource_to_telemetry_conversion = false
   forward_to = [prometheus.remote_write.prometheus.receiver]
 }
 

--- a/charts/k8s-monitoring/docs/examples/private-image-registries/globally/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/private-image-registries/globally/output.yaml
@@ -593,6 +593,7 @@ data:
     // Destination: prometheus (prometheus)
     otelcol.exporter.prometheus "prometheus" {
       add_metric_suffixes = true
+      resource_to_telemetry_conversion = false
       forward_to = [prometheus.remote_write.prometheus.receiver]
     }
     
@@ -1005,6 +1006,7 @@ data:
     // Destination: prometheus (prometheus)
     otelcol.exporter.prometheus "prometheus" {
       add_metric_suffixes = true
+      resource_to_telemetry_conversion = false
       forward_to = [prometheus.remote_write.prometheus.receiver]
     }
     

--- a/charts/k8s-monitoring/docs/examples/private-image-registries/individual/alloy-metrics.alloy
+++ b/charts/k8s-monitoring/docs/examples/private-image-registries/individual/alloy-metrics.alloy
@@ -544,6 +544,7 @@ prometheus.relabel "kubernetes_monitoring_telemetry" {
 // Destination: prometheus (prometheus)
 otelcol.exporter.prometheus "prometheus" {
   add_metric_suffixes = true
+  resource_to_telemetry_conversion = false
   forward_to = [prometheus.remote_write.prometheus.receiver]
 }
 

--- a/charts/k8s-monitoring/docs/examples/private-image-registries/individual/alloy-receiver.alloy
+++ b/charts/k8s-monitoring/docs/examples/private-image-registries/individual/alloy-receiver.alloy
@@ -134,6 +134,7 @@ application_observability "feature" {
 // Destination: prometheus (prometheus)
 otelcol.exporter.prometheus "prometheus" {
   add_metric_suffixes = true
+  resource_to_telemetry_conversion = false
   forward_to = [prometheus.remote_write.prometheus.receiver]
 }
 

--- a/charts/k8s-monitoring/docs/examples/private-image-registries/individual/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/private-image-registries/individual/output.yaml
@@ -656,6 +656,7 @@ data:
     // Destination: prometheus (prometheus)
     otelcol.exporter.prometheus "prometheus" {
       add_metric_suffixes = true
+      resource_to_telemetry_conversion = false
       forward_to = [prometheus.remote_write.prometheus.receiver]
     }
     
@@ -857,6 +858,7 @@ data:
     // Destination: prometheus (prometheus)
     otelcol.exporter.prometheus "prometheus" {
       add_metric_suffixes = true
+      resource_to_telemetry_conversion = false
       forward_to = [prometheus.remote_write.prometheus.receiver]
     }
     

--- a/charts/k8s-monitoring/docs/examples/proxies/alloy-metrics.alloy
+++ b/charts/k8s-monitoring/docs/examples/proxies/alloy-metrics.alloy
@@ -449,6 +449,7 @@ cluster_metrics "feature" {
 // Destination: prometheus (prometheus)
 otelcol.exporter.prometheus "prometheus" {
   add_metric_suffixes = true
+  resource_to_telemetry_conversion = false
   forward_to = [prometheus.remote_write.prometheus.receiver]
 }
 

--- a/charts/k8s-monitoring/docs/examples/proxies/alloy-singleton.alloy
+++ b/charts/k8s-monitoring/docs/examples/proxies/alloy-singleton.alloy
@@ -137,6 +137,7 @@ prometheus.relabel "kubernetes_monitoring_telemetry" {
 // Destination: prometheus (prometheus)
 otelcol.exporter.prometheus "prometheus" {
   add_metric_suffixes = true
+  resource_to_telemetry_conversion = false
   forward_to = [prometheus.remote_write.prometheus.receiver]
 }
 

--- a/charts/k8s-monitoring/docs/examples/proxies/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/proxies/output.yaml
@@ -545,6 +545,7 @@ data:
     // Destination: prometheus (prometheus)
     otelcol.exporter.prometheus "prometheus" {
       add_metric_suffixes = true
+      resource_to_telemetry_conversion = false
       forward_to = [prometheus.remote_write.prometheus.receiver]
     }
     
@@ -743,6 +744,7 @@ data:
     // Destination: prometheus (prometheus)
     otelcol.exporter.prometheus "prometheus" {
       add_metric_suffixes = true
+      resource_to_telemetry_conversion = false
       forward_to = [prometheus.remote_write.prometheus.receiver]
     }
     

--- a/charts/k8s-monitoring/docs/examples/scalability/autoscaling/alloy-metrics.alloy
+++ b/charts/k8s-monitoring/docs/examples/scalability/autoscaling/alloy-metrics.alloy
@@ -491,6 +491,7 @@ prometheus.relabel "kubernetes_monitoring_telemetry" {
 // Destination: prometheus (prometheus)
 otelcol.exporter.prometheus "prometheus" {
   add_metric_suffixes = true
+  resource_to_telemetry_conversion = false
   forward_to = [prometheus.remote_write.prometheus.receiver]
 }
 

--- a/charts/k8s-monitoring/docs/examples/scalability/autoscaling/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/scalability/autoscaling/output.yaml
@@ -587,6 +587,7 @@ data:
     // Destination: prometheus (prometheus)
     otelcol.exporter.prometheus "prometheus" {
       add_metric_suffixes = true
+      resource_to_telemetry_conversion = false
       forward_to = [prometheus.remote_write.prometheus.receiver]
     }
     

--- a/charts/k8s-monitoring/docs/examples/scalability/high-availability-kube-state-metrics/alloy-metrics.alloy
+++ b/charts/k8s-monitoring/docs/examples/scalability/high-availability-kube-state-metrics/alloy-metrics.alloy
@@ -491,6 +491,7 @@ prometheus.relabel "kubernetes_monitoring_telemetry" {
 // Destination: prometheus (prometheus)
 otelcol.exporter.prometheus "prometheus" {
   add_metric_suffixes = true
+  resource_to_telemetry_conversion = false
   forward_to = [prometheus.remote_write.prometheus.receiver]
 }
 

--- a/charts/k8s-monitoring/docs/examples/scalability/high-availability-kube-state-metrics/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/scalability/high-availability-kube-state-metrics/output.yaml
@@ -587,6 +587,7 @@ data:
     // Destination: prometheus (prometheus)
     otelcol.exporter.prometheus "prometheus" {
       add_metric_suffixes = true
+      resource_to_telemetry_conversion = false
       forward_to = [prometheus.remote_write.prometheus.receiver]
     }
     

--- a/charts/k8s-monitoring/docs/examples/scalability/sharded-kube-state-metrics/alloy-metrics.alloy
+++ b/charts/k8s-monitoring/docs/examples/scalability/sharded-kube-state-metrics/alloy-metrics.alloy
@@ -491,6 +491,7 @@ prometheus.relabel "kubernetes_monitoring_telemetry" {
 // Destination: prometheus (prometheus)
 otelcol.exporter.prometheus "prometheus" {
   add_metric_suffixes = true
+  resource_to_telemetry_conversion = false
   forward_to = [prometheus.remote_write.prometheus.receiver]
 }
 

--- a/charts/k8s-monitoring/docs/examples/scalability/sharded-kube-state-metrics/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/scalability/sharded-kube-state-metrics/output.yaml
@@ -587,6 +587,7 @@ data:
     // Destination: prometheus (prometheus)
     otelcol.exporter.prometheus "prometheus" {
       add_metric_suffixes = true
+      resource_to_telemetry_conversion = false
       forward_to = [prometheus.remote_write.prometheus.receiver]
     }
     

--- a/charts/k8s-monitoring/docs/examples/service-integrations/mongodb-atlas/alloy-metrics.alloy
+++ b/charts/k8s-monitoring/docs/examples/service-integrations/mongodb-atlas/alloy-metrics.alloy
@@ -73,6 +73,7 @@ prometheus.scrape "mongodb_atlas" {
 // Destination: prometheus (prometheus)
 otelcol.exporter.prometheus "prometheus" {
   add_metric_suffixes = true
+  resource_to_telemetry_conversion = false
   forward_to = [prometheus.remote_write.prometheus.receiver]
 }
 

--- a/charts/k8s-monitoring/docs/examples/service-integrations/mongodb-atlas/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/service-integrations/mongodb-atlas/output.yaml
@@ -96,6 +96,7 @@ data:
     // Destination: prometheus (prometheus)
     otelcol.exporter.prometheus "prometheus" {
       add_metric_suffixes = true
+      resource_to_telemetry_conversion = false
       forward_to = [prometheus.remote_write.prometheus.receiver]
     }
     

--- a/charts/k8s-monitoring/docs/examples/tolerations/alloy-metrics.alloy
+++ b/charts/k8s-monitoring/docs/examples/tolerations/alloy-metrics.alloy
@@ -585,6 +585,7 @@ prometheus.relabel "kubernetes_monitoring_telemetry" {
 // Destination: prometheus (prometheus)
 otelcol.exporter.prometheus "prometheus" {
   add_metric_suffixes = true
+  resource_to_telemetry_conversion = false
   forward_to = [prometheus.remote_write.prometheus.receiver]
 }
 

--- a/charts/k8s-monitoring/docs/examples/tolerations/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/tolerations/output.yaml
@@ -710,6 +710,7 @@ data:
     // Destination: prometheus (prometheus)
     otelcol.exporter.prometheus "prometheus" {
       add_metric_suffixes = true
+      resource_to_telemetry_conversion = false
       forward_to = [prometheus.remote_write.prometheus.receiver]
     }
     

--- a/charts/k8s-monitoring/schema-mods/definitions/prometheus-destination.schema.json
+++ b/charts/k8s-monitoring/schema-mods/definitions/prometheus-destination.schema.json
@@ -150,6 +150,9 @@
             "properties": {
                 "addMetricSuffixes": {
                     "type": "boolean"
+                },
+                "resourceToTelemetryConversion": {
+                    "type": "boolean"
                 }
             }
         },

--- a/charts/k8s-monitoring/templates/destinations/_destination_prometheus.tpl
+++ b/charts/k8s-monitoring/templates/destinations/_destination_prometheus.tpl
@@ -2,6 +2,7 @@
 {{- with .destination }}
 otelcol.exporter.prometheus {{ include "helper.alloy_name" .name | quote }} {
   add_metric_suffixes = {{ .openTelemetryConversion.addMetricSuffixes }}
+  resource_to_telemetry_conversion = {{ .openTelemetryConversion.resourceToTelemetryConversion }}
   forward_to = [prometheus.remote_write.{{ include "helper.alloy_name" .name }}.receiver]
 }
 

--- a/charts/k8s-monitoring/tests/integration/annotation-autodiscovery/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/integration/annotation-autodiscovery/.rendered/output.yaml
@@ -409,6 +409,7 @@ data:
     // Destination: prometheus (prometheus)
     otelcol.exporter.prometheus "prometheus" {
       add_metric_suffixes = true
+      resource_to_telemetry_conversion = false
       forward_to = [prometheus.remote_write.prometheus.receiver]
     }
     

--- a/charts/k8s-monitoring/tests/integration/application-observability/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/integration/application-observability/.rendered/output.yaml
@@ -487,6 +487,7 @@ data:
     // Destination: localPrometheus (prometheus)
     otelcol.exporter.prometheus "localprometheus" {
       add_metric_suffixes = true
+      resource_to_telemetry_conversion = false
       forward_to = [prometheus.remote_write.localprometheus.receiver]
     }
     

--- a/charts/k8s-monitoring/tests/integration/auth/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/integration/auth/.rendered/output.yaml
@@ -220,6 +220,7 @@ data:
     // Destination: prometheus-noauth (prometheus)
     otelcol.exporter.prometheus "prometheus_noauth" {
       add_metric_suffixes = true
+      resource_to_telemetry_conversion = false
       forward_to = [prometheus.remote_write.prometheus_noauth.receiver]
     }
     
@@ -271,6 +272,7 @@ data:
     // Destination: prometheus-basicauth (prometheus)
     otelcol.exporter.prometheus "prometheus_basicauth" {
       add_metric_suffixes = true
+      resource_to_telemetry_conversion = false
       forward_to = [prometheus.remote_write.prometheus_basicauth.receiver]
     }
     
@@ -332,6 +334,7 @@ data:
     // Destination: prometheus-basicauth-external-secret-1 (prometheus)
     otelcol.exporter.prometheus "prometheus_basicauth_external_secret_1" {
       add_metric_suffixes = true
+      resource_to_telemetry_conversion = false
       forward_to = [prometheus.remote_write.prometheus_basicauth_external_secret_1.receiver]
     }
     
@@ -397,6 +400,7 @@ data:
     // Destination: prometheus-basicauth-external-secret-2 (prometheus)
     otelcol.exporter.prometheus "prometheus_basicauth_external_secret_2" {
       add_metric_suffixes = true
+      resource_to_telemetry_conversion = false
       forward_to = [prometheus.remote_write.prometheus_basicauth_external_secret_2.receiver]
     }
     
@@ -462,6 +466,7 @@ data:
     // Destination: prometheus-bearer-token (prometheus)
     otelcol.exporter.prometheus "prometheus_bearer_token" {
       add_metric_suffixes = true
+      resource_to_telemetry_conversion = false
       forward_to = [prometheus.remote_write.prometheus_bearer_token.receiver]
     }
     

--- a/charts/k8s-monitoring/tests/integration/auto-instrumentation/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/integration/auto-instrumentation/.rendered/output.yaml
@@ -153,6 +153,7 @@ data:
     // Destination: localPrometheus (prometheus)
     otelcol.exporter.prometheus "localprometheus" {
       add_metric_suffixes = true
+      resource_to_telemetry_conversion = false
       forward_to = [prometheus.remote_write.localprometheus.receiver]
     }
     
@@ -355,6 +356,7 @@ data:
     // Destination: localPrometheus (prometheus)
     otelcol.exporter.prometheus "localprometheus" {
       add_metric_suffixes = true
+      resource_to_telemetry_conversion = false
       forward_to = [prometheus.remote_write.localprometheus.receiver]
     }
     

--- a/charts/k8s-monitoring/tests/integration/cluster-monitoring/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/integration/cluster-monitoring/.rendered/output.yaml
@@ -678,6 +678,7 @@ data:
     // Destination: localPrometheus (prometheus)
     otelcol.exporter.prometheus "localprometheus" {
       add_metric_suffixes = true
+      resource_to_telemetry_conversion = false
       forward_to = [prometheus.remote_write.localprometheus.receiver]
     }
     
@@ -880,6 +881,7 @@ data:
     // Destination: localPrometheus (prometheus)
     otelcol.exporter.prometheus "localprometheus" {
       add_metric_suffixes = true
+      resource_to_telemetry_conversion = false
       forward_to = [prometheus.remote_write.localprometheus.receiver]
     }
     

--- a/charts/k8s-monitoring/tests/integration/control-plane-monitoring/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/integration/control-plane-monitoring/.rendered/output.yaml
@@ -869,6 +869,7 @@ data:
     // Destination: prometheus (prometheus)
     otelcol.exporter.prometheus "prometheus" {
       add_metric_suffixes = true
+      resource_to_telemetry_conversion = false
       forward_to = [prometheus.remote_write.prometheus.receiver]
     }
     
@@ -1062,6 +1063,7 @@ data:
     // Destination: prometheus (prometheus)
     otelcol.exporter.prometheus "prometheus" {
       add_metric_suffixes = true
+      resource_to_telemetry_conversion = false
       forward_to = [prometheus.remote_write.prometheus.receiver]
     }
     

--- a/charts/k8s-monitoring/tests/integration/istio-service-mesh/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/integration/istio-service-mesh/.rendered/output.yaml
@@ -871,6 +871,7 @@ data:
     // Destination: localPrometheus (prometheus)
     otelcol.exporter.prometheus "localprometheus" {
       add_metric_suffixes = true
+      resource_to_telemetry_conversion = false
       forward_to = [prometheus.remote_write.localprometheus.receiver]
     }
     
@@ -1073,6 +1074,7 @@ data:
     // Destination: localPrometheus (prometheus)
     otelcol.exporter.prometheus "localprometheus" {
       add_metric_suffixes = true
+      resource_to_telemetry_conversion = false
       forward_to = [prometheus.remote_write.localprometheus.receiver]
     }
     
@@ -1533,6 +1535,7 @@ data:
     // Destination: localPrometheus (prometheus)
     otelcol.exporter.prometheus "localprometheus" {
       add_metric_suffixes = true
+      resource_to_telemetry_conversion = false
       forward_to = [prometheus.remote_write.localprometheus.receiver]
     }
     

--- a/charts/k8s-monitoring/tests/integration/pod-logs/log-metrics/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/integration/pod-logs/log-metrics/.rendered/output.yaml
@@ -376,6 +376,7 @@ data:
     // Destination: localPrometheus (prometheus)
     otelcol.exporter.prometheus "localprometheus" {
       add_metric_suffixes = true
+      resource_to_telemetry_conversion = false
       forward_to = [prometheus.remote_write.localprometheus.receiver]
     }
     

--- a/charts/k8s-monitoring/tests/integration/prom-and-loki-to-otlp/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/integration/prom-and-loki-to-otlp/.rendered/output.yaml
@@ -1145,6 +1145,12 @@ data:
             "tmp_container_runtime",
           ]
         }
+        stage.structured_metadata {
+          values = {
+            "k8s_pod_name" = "k8s_pod_name",
+            "pod" = "pod",
+          }
+        }
     
         // Only keep the labels that are defined in the `keepLabels` list.
         stage.label_keep {

--- a/charts/k8s-monitoring/tests/integration/prometheus-io-annotations/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/integration/prometheus-io-annotations/.rendered/output.yaml
@@ -890,6 +890,7 @@ data:
     // Destination: prometheus (prometheus)
     otelcol.exporter.prometheus "prometheus" {
       add_metric_suffixes = true
+      resource_to_telemetry_conversion = false
       forward_to = [prometheus.remote_write.prometheus.receiver]
     }
     

--- a/charts/k8s-monitoring/tests/integration/prometheus-operator-objects/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/integration/prometheus-operator-objects/.rendered/output.yaml
@@ -119,6 +119,7 @@ data:
     // Destination: localPrometheus (prometheus)
     otelcol.exporter.prometheus "localprometheus" {
       add_metric_suffixes = true
+      resource_to_telemetry_conversion = false
       forward_to = [prometheus.remote_write.localprometheus.receiver]
     }
     

--- a/charts/k8s-monitoring/tests/integration/proxies/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/integration/proxies/.rendered/output.yaml
@@ -334,6 +334,7 @@ data:
     // Destination: localPrometheus (prometheus)
     otelcol.exporter.prometheus "localprometheus" {
       add_metric_suffixes = true
+      resource_to_telemetry_conversion = false
       forward_to = [prometheus.remote_write.localprometheus.receiver]
     }
     
@@ -528,6 +529,7 @@ data:
     // Destination: localPrometheus (prometheus)
     otelcol.exporter.prometheus "localprometheus" {
       add_metric_suffixes = true
+      resource_to_telemetry_conversion = false
       forward_to = [prometheus.remote_write.localprometheus.receiver]
     }
     
@@ -988,6 +990,7 @@ data:
     // Destination: localPrometheus (prometheus)
     otelcol.exporter.prometheus "localprometheus" {
       add_metric_suffixes = true
+      resource_to_telemetry_conversion = false
       forward_to = [prometheus.remote_write.localprometheus.receiver]
     }
     

--- a/charts/k8s-monitoring/tests/integration/service-integrations/alloy/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/integration/service-integrations/alloy/.rendered/output.yaml
@@ -364,6 +364,7 @@ data:
     // Destination: localPrometheus (prometheus)
     otelcol.exporter.prometheus "localprometheus" {
       add_metric_suffixes = true
+      resource_to_telemetry_conversion = false
       forward_to = [prometheus.remote_write.localprometheus.receiver]
     }
     

--- a/charts/k8s-monitoring/tests/integration/service-integrations/cert-manager/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/integration/service-integrations/cert-manager/.rendered/output.yaml
@@ -200,6 +200,7 @@ data:
     // Destination: localPrometheus (prometheus)
     otelcol.exporter.prometheus "localprometheus" {
       add_metric_suffixes = true
+      resource_to_telemetry_conversion = false
       forward_to = [prometheus.remote_write.localprometheus.receiver]
     }
     

--- a/charts/k8s-monitoring/tests/integration/service-integrations/coredns/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/integration/service-integrations/coredns/.rendered/output.yaml
@@ -694,6 +694,7 @@ data:
     // Destination: localPrometheus (prometheus)
     otelcol.exporter.prometheus "localprometheus" {
       add_metric_suffixes = true
+      resource_to_telemetry_conversion = false
       forward_to = [prometheus.remote_write.localprometheus.receiver]
     }
     

--- a/charts/k8s-monitoring/tests/integration/service-integrations/etcd/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/integration/service-integrations/etcd/.rendered/output.yaml
@@ -193,6 +193,7 @@ data:
     // Destination: localPrometheus (prometheus)
     otelcol.exporter.prometheus "localprometheus" {
       add_metric_suffixes = true
+      resource_to_telemetry_conversion = false
       forward_to = [prometheus.remote_write.localprometheus.receiver]
     }
     

--- a/charts/k8s-monitoring/tests/integration/service-integrations/grafana/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/integration/service-integrations/grafana/.rendered/output.yaml
@@ -810,6 +810,7 @@ data:
     // Destination: localPrometheus (prometheus)
     otelcol.exporter.prometheus "localprometheus" {
       add_metric_suffixes = true
+      resource_to_telemetry_conversion = false
       forward_to = [prometheus.remote_write.localprometheus.receiver]
     }
     
@@ -1012,6 +1013,7 @@ data:
     // Destination: localPrometheus (prometheus)
     otelcol.exporter.prometheus "localprometheus" {
       add_metric_suffixes = true
+      resource_to_telemetry_conversion = false
       forward_to = [prometheus.remote_write.localprometheus.receiver]
     }
     

--- a/charts/k8s-monitoring/tests/integration/service-integrations/loki/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/integration/service-integrations/loki/.rendered/output.yaml
@@ -827,6 +827,7 @@ data:
     // Destination: localPrometheus (prometheus)
     otelcol.exporter.prometheus "localprometheus" {
       add_metric_suffixes = true
+      resource_to_telemetry_conversion = false
       forward_to = [prometheus.remote_write.localprometheus.receiver]
     }
     
@@ -1029,6 +1030,7 @@ data:
     // Destination: localPrometheus (prometheus)
     otelcol.exporter.prometheus "localprometheus" {
       add_metric_suffixes = true
+      resource_to_telemetry_conversion = false
       forward_to = [prometheus.remote_write.localprometheus.receiver]
     }
     

--- a/charts/k8s-monitoring/tests/integration/service-integrations/mysql/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/integration/service-integrations/mysql/.rendered/output.yaml
@@ -122,6 +122,7 @@ data:
     // Destination: localPrometheus (prometheus)
     otelcol.exporter.prometheus "localprometheus" {
       add_metric_suffixes = true
+      resource_to_telemetry_conversion = false
       forward_to = [prometheus.remote_write.localprometheus.receiver]
     }
     

--- a/charts/k8s-monitoring/tests/integration/service-integrations/tempo/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/integration/service-integrations/tempo/.rendered/output.yaml
@@ -568,6 +568,7 @@ data:
     // Destination: localPrometheus (prometheus)
     otelcol.exporter.prometheus "localprometheus" {
       add_metric_suffixes = true
+      resource_to_telemetry_conversion = false
       forward_to = [prometheus.remote_write.localprometheus.receiver]
     }
     
@@ -1029,6 +1030,7 @@ data:
     // Destination: localPrometheus (prometheus)
     otelcol.exporter.prometheus "localprometheus" {
       add_metric_suffixes = true
+      resource_to_telemetry_conversion = false
       forward_to = [prometheus.remote_write.localprometheus.receiver]
     }
     

--- a/charts/k8s-monitoring/tests/integration/sharded-kube-state-metrics/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/integration/sharded-kube-state-metrics/.rendered/output.yaml
@@ -890,6 +890,7 @@ data:
     // Destination: prometheus (prometheus)
     otelcol.exporter.prometheus "prometheus" {
       add_metric_suffixes = true
+      resource_to_telemetry_conversion = false
       forward_to = [prometheus.remote_write.prometheus.receiver]
     }
     

--- a/charts/k8s-monitoring/tests/integration/split-destinations/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/integration/split-destinations/.rendered/output.yaml
@@ -705,6 +705,7 @@ data:
     // Destination: allMetrics (prometheus)
     otelcol.exporter.prometheus "allmetrics" {
       add_metric_suffixes = true
+      resource_to_telemetry_conversion = false
       forward_to = [prometheus.remote_write.allmetrics.receiver]
     }
     
@@ -763,6 +764,7 @@ data:
     // Destination: productionMetrics (prometheus)
     otelcol.exporter.prometheus "productionmetrics" {
       add_metric_suffixes = true
+      resource_to_telemetry_conversion = false
       forward_to = [prometheus.remote_write.productionmetrics.receiver]
     }
     
@@ -1245,6 +1247,7 @@ data:
     // Destination: allMetrics (prometheus)
     otelcol.exporter.prometheus "allmetrics" {
       add_metric_suffixes = true
+      resource_to_telemetry_conversion = false
       forward_to = [prometheus.remote_write.allmetrics.receiver]
     }
     
@@ -1303,6 +1306,7 @@ data:
     // Destination: productionMetrics (prometheus)
     otelcol.exporter.prometheus "productionmetrics" {
       add_metric_suffixes = true
+      resource_to_telemetry_conversion = false
       forward_to = [prometheus.remote_write.productionmetrics.receiver]
     }
     

--- a/charts/k8s-monitoring/tests/integration/statsd/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/integration/statsd/.rendered/output.yaml
@@ -89,6 +89,7 @@ data:
     // Destination: localPrometheus (prometheus)
     otelcol.exporter.prometheus "localprometheus" {
       add_metric_suffixes = true
+      resource_to_telemetry_conversion = false
       forward_to = [prometheus.remote_write.localprometheus.receiver]
     }
     

--- a/charts/k8s-monitoring/tests/integration/tail-sampling/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/integration/tail-sampling/.rendered/output.yaml
@@ -391,6 +391,7 @@ data:
     // Destination: localPrometheus (prometheus)
     otelcol.exporter.prometheus "localprometheus" {
       add_metric_suffixes = true
+      resource_to_telemetry_conversion = false
       forward_to = [prometheus.remote_write.localprometheus.receiver]
     }
     
@@ -593,6 +594,7 @@ data:
     // Destination: localPrometheus (prometheus)
     otelcol.exporter.prometheus "localprometheus" {
       add_metric_suffixes = true
+      resource_to_telemetry_conversion = false
       forward_to = [prometheus.remote_write.localprometheus.receiver]
     }
     

--- a/charts/k8s-monitoring/tests/integration/upgrade/minor/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/integration/upgrade/minor/.rendered/output.yaml
@@ -681,6 +681,7 @@ data:
     // Destination: localPrometheus (prometheus)
     otelcol.exporter.prometheus "localprometheus" {
       add_metric_suffixes = true
+      resource_to_telemetry_conversion = false
       forward_to = [prometheus.remote_write.localprometheus.receiver]
     }
     
@@ -889,6 +890,7 @@ data:
     // Destination: localPrometheus (prometheus)
     otelcol.exporter.prometheus "localprometheus" {
       add_metric_suffixes = true
+      resource_to_telemetry_conversion = false
       forward_to = [prometheus.remote_write.localprometheus.receiver]
     }
     

--- a/charts/k8s-monitoring/tests/integration/upgrade/patch/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/integration/upgrade/patch/.rendered/output.yaml
@@ -681,6 +681,7 @@ data:
     // Destination: localPrometheus (prometheus)
     otelcol.exporter.prometheus "localprometheus" {
       add_metric_suffixes = true
+      resource_to_telemetry_conversion = false
       forward_to = [prometheus.remote_write.localprometheus.receiver]
     }
     
@@ -889,6 +890,7 @@ data:
     // Destination: localPrometheus (prometheus)
     otelcol.exporter.prometheus "localprometheus" {
       add_metric_suffixes = true
+      resource_to_telemetry_conversion = false
       forward_to = [prometheus.remote_write.localprometheus.receiver]
     }
     

--- a/charts/k8s-monitoring/tests/platform/aks/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/platform/aks/.rendered/output.yaml
@@ -839,6 +839,7 @@ data:
     // Destination: grafana-cloud-metrics (prometheus)
     otelcol.exporter.prometheus "grafana_cloud_metrics" {
       add_metric_suffixes = true
+      resource_to_telemetry_conversion = false
       forward_to = [prometheus.remote_write.grafana_cloud_metrics.receiver]
     }
     
@@ -1045,6 +1046,7 @@ data:
     // Destination: grafana-cloud-metrics (prometheus)
     otelcol.exporter.prometheus "grafana_cloud_metrics" {
       add_metric_suffixes = true
+      resource_to_telemetry_conversion = false
       forward_to = [prometheus.remote_write.grafana_cloud_metrics.receiver]
     }
     

--- a/charts/k8s-monitoring/tests/platform/eks-fargate/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/platform/eks-fargate/.rendered/output.yaml
@@ -839,6 +839,7 @@ data:
     // Destination: grafana-cloud-metrics (prometheus)
     otelcol.exporter.prometheus "grafana_cloud_metrics" {
       add_metric_suffixes = true
+      resource_to_telemetry_conversion = false
       forward_to = [prometheus.remote_write.grafana_cloud_metrics.receiver]
     }
     
@@ -1045,6 +1046,7 @@ data:
     // Destination: grafana-cloud-metrics (prometheus)
     otelcol.exporter.prometheus "grafana_cloud_metrics" {
       add_metric_suffixes = true
+      resource_to_telemetry_conversion = false
       forward_to = [prometheus.remote_write.grafana_cloud_metrics.receiver]
     }
     

--- a/charts/k8s-monitoring/tests/platform/eks-with-windows/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/platform/eks-with-windows/.rendered/output.yaml
@@ -839,6 +839,7 @@ data:
     // Destination: grafana-cloud-metrics (prometheus)
     otelcol.exporter.prometheus "grafana_cloud_metrics" {
       add_metric_suffixes = true
+      resource_to_telemetry_conversion = false
       forward_to = [prometheus.remote_write.grafana_cloud_metrics.receiver]
     }
     
@@ -1045,6 +1046,7 @@ data:
     // Destination: grafana-cloud-metrics (prometheus)
     otelcol.exporter.prometheus "grafana_cloud_metrics" {
       add_metric_suffixes = true
+      resource_to_telemetry_conversion = false
       forward_to = [prometheus.remote_write.grafana_cloud_metrics.receiver]
     }
     

--- a/charts/k8s-monitoring/tests/platform/gke-autopilot/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/platform/gke-autopilot/.rendered/output.yaml
@@ -605,6 +605,7 @@ data:
     // Destination: grafana-cloud-metrics (prometheus)
     otelcol.exporter.prometheus "grafana_cloud_metrics" {
       add_metric_suffixes = true
+      resource_to_telemetry_conversion = false
       forward_to = [prometheus.remote_write.grafana_cloud_metrics.receiver]
     }
     
@@ -811,6 +812,7 @@ data:
     // Destination: grafana-cloud-metrics (prometheus)
     otelcol.exporter.prometheus "grafana_cloud_metrics" {
       add_metric_suffixes = true
+      resource_to_telemetry_conversion = false
       forward_to = [prometheus.remote_write.grafana_cloud_metrics.receiver]
     }
     

--- a/charts/k8s-monitoring/tests/platform/gke/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/platform/gke/.rendered/output.yaml
@@ -839,6 +839,7 @@ data:
     // Destination: grafana-cloud-metrics (prometheus)
     otelcol.exporter.prometheus "grafana_cloud_metrics" {
       add_metric_suffixes = true
+      resource_to_telemetry_conversion = false
       forward_to = [prometheus.remote_write.grafana_cloud_metrics.receiver]
     }
     
@@ -1045,6 +1046,7 @@ data:
     // Destination: grafana-cloud-metrics (prometheus)
     otelcol.exporter.prometheus "grafana_cloud_metrics" {
       add_metric_suffixes = true
+      resource_to_telemetry_conversion = false
       forward_to = [prometheus.remote_write.grafana_cloud_metrics.receiver]
     }
     

--- a/charts/k8s-monitoring/tests/platform/grafana-cloud/k8s-monitoring/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/platform/grafana-cloud/k8s-monitoring/.rendered/output.yaml
@@ -949,6 +949,7 @@ data:
     // Destination: grafanaCloudMetrics (prometheus)
     otelcol.exporter.prometheus "grafanacloudmetrics" {
       add_metric_suffixes = true
+      resource_to_telemetry_conversion = false
       forward_to = [prometheus.remote_write.grafanacloudmetrics.receiver]
     }
     
@@ -1155,6 +1156,7 @@ data:
     // Destination: grafanaCloudMetrics (prometheus)
     otelcol.exporter.prometheus "grafanacloudmetrics" {
       add_metric_suffixes = true
+      resource_to_telemetry_conversion = false
       forward_to = [prometheus.remote_write.grafanacloudmetrics.receiver]
     }
     

--- a/charts/k8s-monitoring/tests/platform/openshift/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/platform/openshift/.rendered/output.yaml
@@ -805,6 +805,7 @@ data:
     // Destination: grafanaCloudMetrics (prometheus)
     otelcol.exporter.prometheus "grafanacloudmetrics" {
       add_metric_suffixes = true
+      resource_to_telemetry_conversion = false
       forward_to = [prometheus.remote_write.grafanacloudmetrics.receiver]
     }
     
@@ -1011,6 +1012,7 @@ data:
     // Destination: grafanaCloudMetrics (prometheus)
     otelcol.exporter.prometheus "grafanacloudmetrics" {
       add_metric_suffixes = true
+      resource_to_telemetry_conversion = false
       forward_to = [prometheus.remote_write.grafanacloudmetrics.receiver]
     }
     

--- a/charts/k8s-monitoring/tests/platform/otlp-gateway/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/platform/otlp-gateway/.rendered/output.yaml
@@ -934,6 +934,12 @@ data:
             "tmp_container_runtime",
           ]
         }
+        stage.structured_metadata {
+          values = {
+            "k8s_pod_name" = "k8s_pod_name",
+            "pod" = "pod",
+          }
+        }
     
         // Only keep the labels that are defined in the `keepLabels` list.
         stage.label_keep {

--- a/charts/k8s-monitoring/values.schema.json
+++ b/charts/k8s-monitoring/values.schema.json
@@ -1354,6 +1354,9 @@
                     "properties": {
                         "addMetricSuffixes": {
                             "type": "boolean"
+                        },
+                        "resourceToTelemetryConversion": {
+                            "type": "boolean"
                         }
                     }
                 },


### PR DESCRIPTION
This solves https://github.com/grafana/k8s-monitoring-helm/issues/648 and allows users to convert OTel resource attributes to Prometheus labels