### PR TITLE
fix: can't disable retry on failure otlp destination

### DIFF
--- a/charts/k8s-monitoring/docs/examples/destinations/otlp-endpoint/README.md
+++ b/charts/k8s-monitoring/docs/examples/destinations/otlp-endpoint/README.md
@@ -35,6 +35,8 @@ destinations:
           - set(resource.attributes["quoted"], "quted")
           resourceFrom:
           - string.format(`set(attributes["from_env"], %q)`, coalesce(sys.env("MY_ENV"), "undefined"))
+    retryOnFailure:
+      enabled: false
 
 clusterMetrics:
   enabled: true

--- a/charts/k8s-monitoring/docs/examples/destinations/otlp-endpoint/alloy-logs.alloy
+++ b/charts/k8s-monitoring/docs/examples/destinations/otlp-endpoint/alloy-logs.alloy
@@ -306,7 +306,7 @@ otelcol.exporter.otlphttp "otlp_gateway" {
   }
 
   retry_on_failure {
-    enabled = true
+    enabled = false
     initial_interval = "5s"
     max_interval = "30s"
     max_elapsed_time = "5m"

--- a/charts/k8s-monitoring/docs/examples/destinations/otlp-endpoint/alloy-metrics.alloy
+++ b/charts/k8s-monitoring/docs/examples/destinations/otlp-endpoint/alloy-metrics.alloy
@@ -614,7 +614,7 @@ otelcol.exporter.otlphttp "otlp_gateway" {
   }
 
   retry_on_failure {
-    enabled = true
+    enabled = false
     initial_interval = "5s"
     max_interval = "30s"
     max_elapsed_time = "5m"

--- a/charts/k8s-monitoring/docs/examples/destinations/otlp-endpoint/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/destinations/otlp-endpoint/output.yaml
@@ -721,7 +721,7 @@ data:
       }
     
       retry_on_failure {
-        enabled = true
+        enabled = false
         initial_interval = "5s"
         max_interval = "30s"
         max_elapsed_time = "5m"
@@ -1064,7 +1064,7 @@ data:
       }
     
       retry_on_failure {
-        enabled = true
+        enabled = false
         initial_interval = "5s"
         max_interval = "30s"
         max_elapsed_time = "5m"

--- a/charts/k8s-monitoring/docs/examples/destinations/otlp-endpoint/values.yaml
+++ b/charts/k8s-monitoring/docs/examples/destinations/otlp-endpoint/values.yaml
@@ -21,6 +21,8 @@ destinations:
           - set(resource.attributes["quoted"], "quted")
           resourceFrom:
           - string.format(`set(attributes["from_env"], %q)`, coalesce(sys.env("MY_ENV"), "undefined"))
+    retryOnFailure:
+      enabled: false
 
 clusterMetrics:
   enabled: true

--- a/charts/k8s-monitoring/templates/destinations/_destination_otlp.tpl
+++ b/charts/k8s-monitoring/templates/destinations/_destination_otlp.tpl
@@ -435,7 +435,7 @@ otelcol.exporter.otlphttp {{ include "helper.alloy_name" .name | quote }} {
   }
 
   retry_on_failure {
-    enabled = {{ .retryOnFailure.enabled | default true }}
+    enabled = {{ .retryOnFailure.enabled | default false }}
     initial_interval = {{ .retryOnFailure.initialInterval | quote }}
     max_interval = {{ .retryOnFailure.maxInterval | quote }}
     max_elapsed_time = {{ .retryOnFailure.maxElapsedTime | quote }}


### PR DESCRIPTION
Due to the default value in the template being set to true, when we input the attribute with false (bool) in `values.yaml` it will drop that attribute and cause it to use default values from the template (true).