### PR TITLE
update tempo datasource port in integration tests

### DIFF
--- a/charts/k8s-monitoring/tests/integration/application-observability/deployments/grafana.yaml
+++ b/charts/k8s-monitoring/tests/integration/application-observability/deployments/grafana.yaml
@@ -43,4 +43,4 @@ spec:
             isDefault: true
           - name: Tempo
             type: tempo
-            url: http://tempo.tempo.svc:3100
+            url: http://tempo.tempo.svc:3200

--- a/charts/k8s-monitoring/tests/integration/auto-instrumentation/deployments/grafana.yaml
+++ b/charts/k8s-monitoring/tests/integration/auto-instrumentation/deployments/grafana.yaml
@@ -43,4 +43,4 @@ spec:
             isDefault: true
           - name: Tempo
             type: tempo
-            url: http://tempo.tempo.svc:3100
+            url: http://tempo.tempo.svc:3200

--- a/charts/k8s-monitoring/tests/integration/istio-service-mesh/deployments/grafana.yaml
+++ b/charts/k8s-monitoring/tests/integration/istio-service-mesh/deployments/grafana.yaml
@@ -61,4 +61,4 @@ spec:
 
           - name: Tempo
             type: tempo
-            url: http://tempo.tempo.svc:3100
+            url: http://tempo.tempo.svc:3200

--- a/charts/k8s-monitoring/tests/integration/proxies/deployments/grafana.yaml
+++ b/charts/k8s-monitoring/tests/integration/proxies/deployments/grafana.yaml
@@ -53,4 +53,4 @@ spec:
               httpHeaderValue1: "1"
           - name: Tempo
             type: tempo
-            url: http://tempo.tempo.svc:3100
+            url: http://tempo.tempo.svc:3200

--- a/charts/k8s-monitoring/tests/integration/service-graph-metrics/deployments/grafana.yaml
+++ b/charts/k8s-monitoring/tests/integration/service-graph-metrics/deployments/grafana.yaml
@@ -44,7 +44,7 @@ spec:
             isDefault: true
           - name: Tempo
             type: tempo
-            url: http://tempo.tempo.svc:3100
+            url: http://tempo.tempo.svc:3200
             jsonData:
               serviceMap:
                 datasourceUid: prometheus

--- a/charts/k8s-monitoring/tests/integration/service-graph-metrics/deployments/query-test.yaml
+++ b/charts/k8s-monitoring/tests/integration/service-graph-metrics/deployments/query-test.yaml
@@ -33,7 +33,7 @@ spec:
       - env:
           CLUSTER: service-graph-metrics-test
           PROMETHEUS_URL: http://prometheus-server.prometheus.svc:9090/api/v1/query
-          TEMPO_URL: http://tempo.tempo.svc:3100/api/search
+          TEMPO_URL: http://tempo.tempo.svc:3200/api/search
         queries:
           # query load balancer backends
           - query: otelcol_loadbalancer_num_backends{component_id="otelcol.exporter.loadbalancing.localtempo_servicegraph", cluster="$CLUSTER"}

--- a/charts/k8s-monitoring/tests/integration/split-destinations/deployments/grafana.yaml
+++ b/charts/k8s-monitoring/tests/integration/split-destinations/deployments/grafana.yaml
@@ -79,7 +79,7 @@ spec:
               httpHeaderValue1: "1"
           - name: All Traces
             type: tempo
-            url: http://all-traces-tempo.all-dbs.svc:3100
+            url: http://all-traces-tempo.all-dbs.svc:3200
           - name: Production Traces
             type: tempo
-            url: http://prod-traces-tempo.prod-dbs.svc:3100
+            url: http://prod-traces-tempo.prod-dbs.svc:3200

--- a/charts/k8s-monitoring/tests/integration/tail-sampling/deployments/grafana.yaml
+++ b/charts/k8s-monitoring/tests/integration/tail-sampling/deployments/grafana.yaml
@@ -43,4 +43,4 @@ spec:
             isDefault: true
           - name: Tempo
             type: tempo
-            url: http://tempo.tempo.svc:3100
+            url: http://tempo.tempo.svc:3200


### PR DESCRIPTION
Default port for tempo helm chart changed from 3100 to 3200. Pulling the latest broke datasource connectivity in my test environment.

See https://github.com/grafana/helm-charts/pull/3745