### PR TITLE
Set the job label for annotation discoverered metric sources

### DIFF
--- a/charts/k8s-monitoring/Makefile
+++ b/charts/k8s-monitoring/Makefile
@@ -242,3 +242,15 @@ ifdef HAS_HELM_UNITTEST
 else
 	docker run --rm --volume $(shell pwd):/apps helmunittest/helm-unittest:3.17.0-0.7.1 --failfast --with-subchart=false .
 endif
+
+.PHONY: update-test-snapshots
+update-test-snapshots:
+ifdef HAS_HELM_UNITTEST
+	helm unittest --with-subchart=false . --update-snapshot
+else
+	docker run --rm --volume $(shell pwd):/apps helmunittest/helm-unittest:3.17.0-0.7.1 --with-subchart=false . --update-snapshot
+endif
+	set -e && \
+	for chart in $(FEATURE_CHARTS); do \
+		make -C charts/$$chart update-test-snapshots; \
+	done

--- a/charts/k8s-monitoring/charts/feature-annotation-autodiscovery/Makefile
+++ b/charts/k8s-monitoring/charts/feature-annotation-autodiscovery/Makefile
@@ -32,3 +32,11 @@ ifdef HAS_HELM_UNITTEST
 else
 	docker run --rm --volume $(shell pwd):/apps helmunittest/helm-unittest:3.17.0-0.7.1 .
 endif
+
+.PHONY: update-test-snapshots
+update-test-snapshots:
+ifdef HAS_HELM_UNITTEST
+	helm unittest . --update-snapshot
+else
+	docker run --rm --volume $(shell pwd):/apps helmunittest/helm-unittest:3.17.0-0.7.1 . --update-snapshot
+endif

--- a/charts/k8s-monitoring/charts/feature-annotation-autodiscovery/templates/_pods.alloy.tpl
+++ b/charts/k8s-monitoring/charts/feature-annotation-autodiscovery/templates/_pods.alloy.tpl
@@ -72,6 +72,21 @@ discovery.relabel "annotation_autodiscovery_pods" {
     target_label = "job"
   }
   rule {
+    source_labels = ["job", "{{ include "pod_label" "app.kubernetes.io/name" }}"]
+    regex = ";(.+)"
+    target_label = "job"
+  }
+  rule {
+    source_labels = ["job", "{{ include "pod_label" "app" }}"]
+    regex = ";(.+)"
+    target_label = "job"
+  }
+  rule {
+    source_labels = ["job", "container"]
+    regex = ";(.+)"
+    target_label = "job"
+  }
+  rule {
     source_labels = ["{{ include "pod_annotation" .Values.annotations.instance }}"]
     target_label = "instance"
   }

--- a/charts/k8s-monitoring/charts/feature-annotation-autodiscovery/templates/_services.alloy.tpl
+++ b/charts/k8s-monitoring/charts/feature-annotation-autodiscovery/templates/_services.alloy.tpl
@@ -57,6 +57,21 @@ discovery.relabel "annotation_autodiscovery_services" {
     target_label = "job"
   }
   rule {
+    source_labels = ["job", "{{ include "service_label" "app.kubernetes.io/name" }}"]
+    regex = ";(.+)"
+    target_label = "job"
+  }
+  rule {
+    source_labels = ["job", "{{ include "service_label" "app" }}"]
+    regex = ";(.+)"
+    target_label = "job"
+  }
+  rule {
+    source_labels = ["job", "service"]
+    regex = ";(.+)"
+    target_label = "job"
+  }
+  rule {
     source_labels = ["{{ include "service_annotation" .Values.annotations.instance }}"]
     target_label = "instance"
   }

--- a/charts/k8s-monitoring/charts/feature-annotation-autodiscovery/tests/__snapshot__/default_test.yaml.snap
+++ b/charts/k8s-monitoring/charts/feature-annotation-autodiscovery/tests/__snapshot__/default_test.yaml.snap
@@ -44,6 +44,21 @@ creates a module with default discovery, scraping, and processing configurations
             target_label = "job"
           }
           rule {
+            source_labels = ["job", "__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+            regex = ";(.+)"
+            target_label = "job"
+          }
+          rule {
+            source_labels = ["job", "__meta_kubernetes_pod_label_app"]
+            regex = ";(.+)"
+            target_label = "job"
+          }
+          rule {
+            source_labels = ["job", "container"]
+            regex = ";(.+)"
+            target_label = "job"
+          }
+          rule {
             source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_instance"]
             target_label = "instance"
           }
@@ -170,6 +185,21 @@ creates a module with default discovery, scraping, and processing configurations
           }
           rule {
             source_labels = ["__meta_kubernetes_service_annotation_k8s_grafana_com_job"]
+            target_label = "job"
+          }
+          rule {
+            source_labels = ["job", "__meta_kubernetes_service_label_app_kubernetes_io_name"]
+            regex = ";(.+)"
+            target_label = "job"
+          }
+          rule {
+            source_labels = ["job", "__meta_kubernetes_service_label_app"]
+            regex = ";(.+)"
+            target_label = "job"
+          }
+          rule {
+            source_labels = ["job", "service"]
+            regex = ";(.+)"
             target_label = "job"
           }
           rule {

--- a/charts/k8s-monitoring/charts/feature-annotation-autodiscovery/tests/__snapshot__/namespaced_test.yaml.snap
+++ b/charts/k8s-monitoring/charts/feature-annotation-autodiscovery/tests/__snapshot__/namespaced_test.yaml.snap
@@ -49,6 +49,21 @@ can exclude a specified list of namespaces:
             target_label = "job"
           }
           rule {
+            source_labels = ["job", "__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+            regex = ";(.+)"
+            target_label = "job"
+          }
+          rule {
+            source_labels = ["job", "__meta_kubernetes_pod_label_app"]
+            regex = ";(.+)"
+            target_label = "job"
+          }
+          rule {
+            source_labels = ["job", "container"]
+            regex = ";(.+)"
+            target_label = "job"
+          }
+          rule {
             source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_instance"]
             target_label = "instance"
           }
@@ -180,6 +195,21 @@ can exclude a specified list of namespaces:
           }
           rule {
             source_labels = ["__meta_kubernetes_service_annotation_k8s_grafana_com_job"]
+            target_label = "job"
+          }
+          rule {
+            source_labels = ["job", "__meta_kubernetes_service_label_app_kubernetes_io_name"]
+            regex = ";(.+)"
+            target_label = "job"
+          }
+          rule {
+            source_labels = ["job", "__meta_kubernetes_service_label_app"]
+            regex = ";(.+)"
+            target_label = "job"
+          }
+          rule {
+            source_labels = ["job", "service"]
+            regex = ";(.+)"
             target_label = "job"
           }
           rule {
@@ -357,6 +387,21 @@ can use a specified list of namespaces:
             target_label = "job"
           }
           rule {
+            source_labels = ["job", "__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+            regex = ";(.+)"
+            target_label = "job"
+          }
+          rule {
+            source_labels = ["job", "__meta_kubernetes_pod_label_app"]
+            regex = ";(.+)"
+            target_label = "job"
+          }
+          rule {
+            source_labels = ["job", "container"]
+            regex = ";(.+)"
+            target_label = "job"
+          }
+          rule {
             source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_instance"]
             target_label = "instance"
           }
@@ -486,6 +531,21 @@ can use a specified list of namespaces:
           }
           rule {
             source_labels = ["__meta_kubernetes_service_annotation_k8s_grafana_com_job"]
+            target_label = "job"
+          }
+          rule {
+            source_labels = ["job", "__meta_kubernetes_service_label_app_kubernetes_io_name"]
+            regex = ";(.+)"
+            target_label = "job"
+          }
+          rule {
+            source_labels = ["job", "__meta_kubernetes_service_label_app"]
+            regex = ";(.+)"
+            target_label = "job"
+          }
+          rule {
+            source_labels = ["job", "service"]
+            regex = ";(.+)"
             target_label = "job"
           }
           rule {

--- a/charts/k8s-monitoring/charts/feature-annotation-autodiscovery/tests/__snapshot__/pods_only_test.yaml.snap
+++ b/charts/k8s-monitoring/charts/feature-annotation-autodiscovery/tests/__snapshot__/pods_only_test.yaml.snap
@@ -48,6 +48,21 @@ will only discover pods:
             target_label = "job"
           }
           rule {
+            source_labels = ["job", "__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+            regex = ";(.+)"
+            target_label = "job"
+          }
+          rule {
+            source_labels = ["job", "__meta_kubernetes_pod_label_app"]
+            regex = ";(.+)"
+            target_label = "job"
+          }
+          rule {
+            source_labels = ["job", "container"]
+            regex = ";(.+)"
+            target_label = "job"
+          }
+          rule {
             source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_instance"]
             target_label = "instance"
           }

--- a/charts/k8s-monitoring/charts/feature-annotation-autodiscovery/tests/__snapshot__/prometheus_annotation_test.yaml.snap
+++ b/charts/k8s-monitoring/charts/feature-annotation-autodiscovery/tests/__snapshot__/prometheus_annotation_test.yaml.snap
@@ -44,6 +44,21 @@ creates a module with default discovery, scraping, and processing configurations
             target_label = "job"
           }
           rule {
+            source_labels = ["job", "__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+            regex = ";(.+)"
+            target_label = "job"
+          }
+          rule {
+            source_labels = ["job", "__meta_kubernetes_pod_label_app"]
+            regex = ";(.+)"
+            target_label = "job"
+          }
+          rule {
+            source_labels = ["job", "container"]
+            regex = ";(.+)"
+            target_label = "job"
+          }
+          rule {
             source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_instance"]
             target_label = "instance"
           }
@@ -170,6 +185,21 @@ creates a module with default discovery, scraping, and processing configurations
           }
           rule {
             source_labels = ["__meta_kubernetes_service_annotation_k8s_grafana_com_job"]
+            target_label = "job"
+          }
+          rule {
+            source_labels = ["job", "__meta_kubernetes_service_label_app_kubernetes_io_name"]
+            regex = ";(.+)"
+            target_label = "job"
+          }
+          rule {
+            source_labels = ["job", "__meta_kubernetes_service_label_app"]
+            regex = ";(.+)"
+            target_label = "job"
+          }
+          rule {
+            source_labels = ["job", "service"]
+            regex = ";(.+)"
             target_label = "job"
           }
           rule {

--- a/charts/k8s-monitoring/charts/feature-annotation-autodiscovery/tests/__snapshot__/selectors_test.yaml.snap
+++ b/charts/k8s-monitoring/charts/feature-annotation-autodiscovery/tests/__snapshot__/selectors_test.yaml.snap
@@ -48,6 +48,21 @@ will set appropriate selectors:
             target_label = "job"
           }
           rule {
+            source_labels = ["job", "__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+            regex = ";(.+)"
+            target_label = "job"
+          }
+          rule {
+            source_labels = ["job", "__meta_kubernetes_pod_label_app"]
+            regex = ";(.+)"
+            target_label = "job"
+          }
+          rule {
+            source_labels = ["job", "container"]
+            regex = ";(.+)"
+            target_label = "job"
+          }
+          rule {
             source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_instance"]
             target_label = "instance"
           }
@@ -178,6 +193,21 @@ will set appropriate selectors:
           }
           rule {
             source_labels = ["__meta_kubernetes_service_annotation_k8s_grafana_com_job"]
+            target_label = "job"
+          }
+          rule {
+            source_labels = ["job", "__meta_kubernetes_service_label_app_kubernetes_io_name"]
+            regex = ";(.+)"
+            target_label = "job"
+          }
+          rule {
+            source_labels = ["job", "__meta_kubernetes_service_label_app"]
+            regex = ";(.+)"
+            target_label = "job"
+          }
+          rule {
+            source_labels = ["job", "service"]
+            regex = ";(.+)"
             target_label = "job"
           }
           rule {

--- a/charts/k8s-monitoring/charts/feature-application-observability/Makefile
+++ b/charts/k8s-monitoring/charts/feature-application-observability/Makefile
@@ -32,3 +32,11 @@ ifdef HAS_HELM_UNITTEST
 else
 	docker run --rm --volume $(shell pwd):/apps helmunittest/helm-unittest:3.17.0-0.7.1 .
 endif
+
+.PHONY: update-test-snapshots
+update-test-snapshots:
+ifdef HAS_HELM_UNITTEST
+	helm unittest . --update-snapshot
+else
+	docker run --rm --volume $(shell pwd):/apps helmunittest/helm-unittest:3.17.0-0.7.1 . --update-snapshot
+endif

--- a/charts/k8s-monitoring/charts/feature-auto-instrumentation/Makefile
+++ b/charts/k8s-monitoring/charts/feature-auto-instrumentation/Makefile
@@ -34,3 +34,11 @@ ifdef HAS_HELM_UNITTEST
 else
 	docker run --rm --volume $(shell pwd):/apps helmunittest/helm-unittest:3.17.0-0.7.1 .
 endif
+
+.PHONY: update-test-snapshots
+update-test-snapshots:
+ifdef HAS_HELM_UNITTEST
+	helm unittest . --update-snapshot
+else
+	docker run --rm --volume $(shell pwd):/apps helmunittest/helm-unittest:3.17.0-0.7.1 . --update-snapshot
+endif

--- a/charts/k8s-monitoring/charts/feature-cluster-events/Makefile
+++ b/charts/k8s-monitoring/charts/feature-cluster-events/Makefile
@@ -32,3 +32,11 @@ ifdef HAS_HELM_UNITTEST
 else
 	docker run --rm --volume $(shell pwd):/apps helmunittest/helm-unittest:3.17.0-0.7.1 .
 endif
+
+.PHONY: update-test-snapshots
+update-test-snapshots:
+ifdef HAS_HELM_UNITTEST
+	helm unittest . --update-snapshot
+else
+	docker run --rm --volume $(shell pwd):/apps helmunittest/helm-unittest:3.17.0-0.7.1 . --update-snapshot
+endif

--- a/charts/k8s-monitoring/charts/feature-cluster-metrics/Makefile
+++ b/charts/k8s-monitoring/charts/feature-cluster-metrics/Makefile
@@ -40,3 +40,11 @@ ifdef HAS_HELM_UNITTEST
 else
 	docker run --rm --volume $(shell pwd):/apps helmunittest/helm-unittest:3.17.0-0.7.1 .
 endif
+
+.PHONY: update-test-snapshots
+update-test-snapshots:
+ifdef HAS_HELM_UNITTEST
+	helm unittest . --update-snapshot
+else
+	docker run --rm --volume $(shell pwd):/apps helmunittest/helm-unittest:3.17.0-0.7.1 . --update-snapshot
+endif

--- a/charts/k8s-monitoring/charts/feature-integrations/Makefile
+++ b/charts/k8s-monitoring/charts/feature-integrations/Makefile
@@ -85,3 +85,10 @@ else
 	docker run --rm --volume $(shell pwd):/apps helmunittest/helm-unittest:3.17.0-0.7.1 .
 endif
 
+.PHONY: update-test-snapshots
+update-test-snapshots:
+ifdef HAS_HELM_UNITTEST
+	helm unittest . --update-snapshot
+else
+	docker run --rm --volume $(shell pwd):/apps helmunittest/helm-unittest:3.17.0-0.7.1 . --update-snapshot
+endif

--- a/charts/k8s-monitoring/charts/feature-node-logs/Makefile
+++ b/charts/k8s-monitoring/charts/feature-node-logs/Makefile
@@ -32,3 +32,11 @@ ifdef HAS_HELM_UNITTEST
 else
 	docker run --rm --volume $(shell pwd):/apps helmunittest/helm-unittest:3.17.0-0.7.1 .
 endif
+
+.PHONY: update-test-snapshots
+update-test-snapshots:
+ifdef HAS_HELM_UNITTEST
+	helm unittest . --update-snapshot
+else
+	docker run --rm --volume $(shell pwd):/apps helmunittest/helm-unittest:3.17.0-0.7.1 . --update-snapshot
+endif

--- a/charts/k8s-monitoring/charts/feature-pod-logs/Makefile
+++ b/charts/k8s-monitoring/charts/feature-pod-logs/Makefile
@@ -32,3 +32,11 @@ ifdef HAS_HELM_UNITTEST
 else
 	docker run --rm --volume $(shell pwd):/apps helmunittest/helm-unittest:3.17.0-0.7.1 .
 endif
+
+.PHONY: update-test-snapshots
+update-test-snapshots:
+ifdef HAS_HELM_UNITTEST
+	helm unittest . --update-snapshot
+else
+	docker run --rm --volume $(shell pwd):/apps helmunittest/helm-unittest:3.17.0-0.7.1 . --update-snapshot
+endif

--- a/charts/k8s-monitoring/charts/feature-profiling/Makefile
+++ b/charts/k8s-monitoring/charts/feature-profiling/Makefile
@@ -32,3 +32,11 @@ ifdef HAS_HELM_UNITTEST
 else
 	docker run --rm --volume $(shell pwd):/apps helmunittest/helm-unittest:3.17.0-0.7.1 .
 endif
+
+.PHONY: update-test-snapshots
+update-test-snapshots:
+ifdef HAS_HELM_UNITTEST
+	helm unittest . --update-snapshot
+else
+	docker run --rm --volume $(shell pwd):/apps helmunittest/helm-unittest:3.17.0-0.7.1 . --update-snapshot
+endif

--- a/charts/k8s-monitoring/charts/feature-prometheus-operator-objects/Makefile
+++ b/charts/k8s-monitoring/charts/feature-prometheus-operator-objects/Makefile
@@ -33,3 +33,11 @@ ifdef HAS_HELM_UNITTEST
 else
 	docker run --rm --volume $(shell pwd):/apps helmunittest/helm-unittest:3.17.0-0.7.1 .
 endif
+
+.PHONY: update-test-snapshots
+update-test-snapshots:
+ifdef HAS_HELM_UNITTEST
+	helm unittest . --update-snapshot
+else
+	docker run --rm --volume $(shell pwd):/apps helmunittest/helm-unittest:3.17.0-0.7.1 . --update-snapshot
+endif

--- a/charts/k8s-monitoring/docs/examples/auth/oauth2/alloy-metrics.alloy
+++ b/charts/k8s-monitoring/docs/examples/auth/oauth2/alloy-metrics.alloy
@@ -42,6 +42,21 @@ declare "annotation_autodiscovery" {
       target_label = "job"
     }
     rule {
+      source_labels = ["job", "__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+      regex = ";(.+)"
+      target_label = "job"
+    }
+    rule {
+      source_labels = ["job", "__meta_kubernetes_pod_label_app"]
+      regex = ";(.+)"
+      target_label = "job"
+    }
+    rule {
+      source_labels = ["job", "container"]
+      regex = ";(.+)"
+      target_label = "job"
+    }
+    rule {
       source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_instance"]
       target_label = "instance"
     }
@@ -168,6 +183,21 @@ declare "annotation_autodiscovery" {
     }
     rule {
       source_labels = ["__meta_kubernetes_service_annotation_k8s_grafana_com_job"]
+      target_label = "job"
+    }
+    rule {
+      source_labels = ["job", "__meta_kubernetes_service_label_app_kubernetes_io_name"]
+      regex = ";(.+)"
+      target_label = "job"
+    }
+    rule {
+      source_labels = ["job", "__meta_kubernetes_service_label_app"]
+      regex = ";(.+)"
+      target_label = "job"
+    }
+    rule {
+      source_labels = ["job", "service"]
+      regex = ";(.+)"
       target_label = "job"
     }
     rule {

--- a/charts/k8s-monitoring/docs/examples/auth/oauth2/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/auth/oauth2/output.yaml
@@ -148,6 +148,21 @@ data:
           target_label = "job"
         }
         rule {
+          source_labels = ["job", "__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+          regex = ";(.+)"
+          target_label = "job"
+        }
+        rule {
+          source_labels = ["job", "__meta_kubernetes_pod_label_app"]
+          regex = ";(.+)"
+          target_label = "job"
+        }
+        rule {
+          source_labels = ["job", "container"]
+          regex = ";(.+)"
+          target_label = "job"
+        }
+        rule {
           source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_instance"]
           target_label = "instance"
         }
@@ -274,6 +289,21 @@ data:
         }
         rule {
           source_labels = ["__meta_kubernetes_service_annotation_k8s_grafana_com_job"]
+          target_label = "job"
+        }
+        rule {
+          source_labels = ["job", "__meta_kubernetes_service_label_app_kubernetes_io_name"]
+          regex = ";(.+)"
+          target_label = "job"
+        }
+        rule {
+          source_labels = ["job", "__meta_kubernetes_service_label_app"]
+          regex = ";(.+)"
+          target_label = "job"
+        }
+        rule {
+          source_labels = ["job", "service"]
+          regex = ";(.+)"
           target_label = "job"
         }
         rule {

--- a/charts/k8s-monitoring/docs/examples/exclude-by-namespace/alloy-metrics.alloy
+++ b/charts/k8s-monitoring/docs/examples/exclude-by-namespace/alloy-metrics.alloy
@@ -47,6 +47,21 @@ declare "annotation_autodiscovery" {
       target_label = "job"
     }
     rule {
+      source_labels = ["job", "__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+      regex = ";(.+)"
+      target_label = "job"
+    }
+    rule {
+      source_labels = ["job", "__meta_kubernetes_pod_label_app"]
+      regex = ";(.+)"
+      target_label = "job"
+    }
+    rule {
+      source_labels = ["job", "container"]
+      regex = ";(.+)"
+      target_label = "job"
+    }
+    rule {
       source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_instance"]
       target_label = "instance"
     }
@@ -178,6 +193,21 @@ declare "annotation_autodiscovery" {
     }
     rule {
       source_labels = ["__meta_kubernetes_service_annotation_k8s_grafana_com_job"]
+      target_label = "job"
+    }
+    rule {
+      source_labels = ["job", "__meta_kubernetes_service_label_app_kubernetes_io_name"]
+      regex = ";(.+)"
+      target_label = "job"
+    }
+    rule {
+      source_labels = ["job", "__meta_kubernetes_service_label_app"]
+      regex = ";(.+)"
+      target_label = "job"
+    }
+    rule {
+      source_labels = ["job", "service"]
+      regex = ";(.+)"
       target_label = "job"
     }
     rule {

--- a/charts/k8s-monitoring/docs/examples/exclude-by-namespace/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/exclude-by-namespace/output.yaml
@@ -159,6 +159,21 @@ data:
           target_label = "job"
         }
         rule {
+          source_labels = ["job", "__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+          regex = ";(.+)"
+          target_label = "job"
+        }
+        rule {
+          source_labels = ["job", "__meta_kubernetes_pod_label_app"]
+          regex = ";(.+)"
+          target_label = "job"
+        }
+        rule {
+          source_labels = ["job", "container"]
+          regex = ";(.+)"
+          target_label = "job"
+        }
+        rule {
           source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_instance"]
           target_label = "instance"
         }
@@ -290,6 +305,21 @@ data:
         }
         rule {
           source_labels = ["__meta_kubernetes_service_annotation_k8s_grafana_com_job"]
+          target_label = "job"
+        }
+        rule {
+          source_labels = ["job", "__meta_kubernetes_service_label_app_kubernetes_io_name"]
+          regex = ";(.+)"
+          target_label = "job"
+        }
+        rule {
+          source_labels = ["job", "__meta_kubernetes_service_label_app"]
+          regex = ";(.+)"
+          target_label = "job"
+        }
+        rule {
+          source_labels = ["job", "service"]
+          regex = ";(.+)"
           target_label = "job"
         }
         rule {

--- a/charts/k8s-monitoring/docs/examples/features/annotation-autodiscovery/default/alloy-metrics.alloy
+++ b/charts/k8s-monitoring/docs/examples/features/annotation-autodiscovery/default/alloy-metrics.alloy
@@ -42,6 +42,21 @@ declare "annotation_autodiscovery" {
       target_label = "job"
     }
     rule {
+      source_labels = ["job", "__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+      regex = ";(.+)"
+      target_label = "job"
+    }
+    rule {
+      source_labels = ["job", "__meta_kubernetes_pod_label_app"]
+      regex = ";(.+)"
+      target_label = "job"
+    }
+    rule {
+      source_labels = ["job", "container"]
+      regex = ";(.+)"
+      target_label = "job"
+    }
+    rule {
       source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_instance"]
       target_label = "instance"
     }
@@ -168,6 +183,21 @@ declare "annotation_autodiscovery" {
     }
     rule {
       source_labels = ["__meta_kubernetes_service_annotation_k8s_grafana_com_job"]
+      target_label = "job"
+    }
+    rule {
+      source_labels = ["job", "__meta_kubernetes_service_label_app_kubernetes_io_name"]
+      regex = ";(.+)"
+      target_label = "job"
+    }
+    rule {
+      source_labels = ["job", "__meta_kubernetes_service_label_app"]
+      regex = ";(.+)"
+      target_label = "job"
+    }
+    rule {
+      source_labels = ["job", "service"]
+      regex = ";(.+)"
       target_label = "job"
     }
     rule {

--- a/charts/k8s-monitoring/docs/examples/features/annotation-autodiscovery/default/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/features/annotation-autodiscovery/default/output.yaml
@@ -65,6 +65,21 @@ data:
           target_label = "job"
         }
         rule {
+          source_labels = ["job", "__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+          regex = ";(.+)"
+          target_label = "job"
+        }
+        rule {
+          source_labels = ["job", "__meta_kubernetes_pod_label_app"]
+          regex = ";(.+)"
+          target_label = "job"
+        }
+        rule {
+          source_labels = ["job", "container"]
+          regex = ";(.+)"
+          target_label = "job"
+        }
+        rule {
           source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_instance"]
           target_label = "instance"
         }
@@ -191,6 +206,21 @@ data:
         }
         rule {
           source_labels = ["__meta_kubernetes_service_annotation_k8s_grafana_com_job"]
+          target_label = "job"
+        }
+        rule {
+          source_labels = ["job", "__meta_kubernetes_service_label_app_kubernetes_io_name"]
+          regex = ";(.+)"
+          target_label = "job"
+        }
+        rule {
+          source_labels = ["job", "__meta_kubernetes_service_label_app"]
+          regex = ";(.+)"
+          target_label = "job"
+        }
+        rule {
+          source_labels = ["job", "service"]
+          regex = ";(.+)"
           target_label = "job"
         }
         rule {

--- a/charts/k8s-monitoring/docs/examples/features/annotation-autodiscovery/prom-annotations/alloy-metrics.alloy
+++ b/charts/k8s-monitoring/docs/examples/features/annotation-autodiscovery/prom-annotations/alloy-metrics.alloy
@@ -42,6 +42,21 @@ declare "annotation_autodiscovery" {
       target_label = "job"
     }
     rule {
+      source_labels = ["job", "__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+      regex = ";(.+)"
+      target_label = "job"
+    }
+    rule {
+      source_labels = ["job", "__meta_kubernetes_pod_label_app"]
+      regex = ";(.+)"
+      target_label = "job"
+    }
+    rule {
+      source_labels = ["job", "container"]
+      regex = ";(.+)"
+      target_label = "job"
+    }
+    rule {
       source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_instance"]
       target_label = "instance"
     }
@@ -168,6 +183,21 @@ declare "annotation_autodiscovery" {
     }
     rule {
       source_labels = ["__meta_kubernetes_service_annotation_k8s_grafana_com_job"]
+      target_label = "job"
+    }
+    rule {
+      source_labels = ["job", "__meta_kubernetes_service_label_app_kubernetes_io_name"]
+      regex = ";(.+)"
+      target_label = "job"
+    }
+    rule {
+      source_labels = ["job", "__meta_kubernetes_service_label_app"]
+      regex = ";(.+)"
+      target_label = "job"
+    }
+    rule {
+      source_labels = ["job", "service"]
+      regex = ";(.+)"
       target_label = "job"
     }
     rule {

--- a/charts/k8s-monitoring/docs/examples/features/annotation-autodiscovery/prom-annotations/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/features/annotation-autodiscovery/prom-annotations/output.yaml
@@ -65,6 +65,21 @@ data:
           target_label = "job"
         }
         rule {
+          source_labels = ["job", "__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+          regex = ";(.+)"
+          target_label = "job"
+        }
+        rule {
+          source_labels = ["job", "__meta_kubernetes_pod_label_app"]
+          regex = ";(.+)"
+          target_label = "job"
+        }
+        rule {
+          source_labels = ["job", "container"]
+          regex = ";(.+)"
+          target_label = "job"
+        }
+        rule {
           source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_instance"]
           target_label = "instance"
         }
@@ -191,6 +206,21 @@ data:
         }
         rule {
           source_labels = ["__meta_kubernetes_service_annotation_k8s_grafana_com_job"]
+          target_label = "job"
+        }
+        rule {
+          source_labels = ["job", "__meta_kubernetes_service_label_app_kubernetes_io_name"]
+          regex = ";(.+)"
+          target_label = "job"
+        }
+        rule {
+          source_labels = ["job", "__meta_kubernetes_service_label_app"]
+          regex = ";(.+)"
+          target_label = "job"
+        }
+        rule {
+          source_labels = ["job", "service"]
+          regex = ";(.+)"
           target_label = "job"
         }
         rule {

--- a/charts/k8s-monitoring/docs/examples/include-by-namespace/alloy-metrics.alloy
+++ b/charts/k8s-monitoring/docs/examples/include-by-namespace/alloy-metrics.alloy
@@ -45,6 +45,21 @@ declare "annotation_autodiscovery" {
       target_label = "job"
     }
     rule {
+      source_labels = ["job", "__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+      regex = ";(.+)"
+      target_label = "job"
+    }
+    rule {
+      source_labels = ["job", "__meta_kubernetes_pod_label_app"]
+      regex = ";(.+)"
+      target_label = "job"
+    }
+    rule {
+      source_labels = ["job", "container"]
+      regex = ";(.+)"
+      target_label = "job"
+    }
+    rule {
       source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_instance"]
       target_label = "instance"
     }
@@ -174,6 +189,21 @@ declare "annotation_autodiscovery" {
     }
     rule {
       source_labels = ["__meta_kubernetes_service_annotation_k8s_grafana_com_job"]
+      target_label = "job"
+    }
+    rule {
+      source_labels = ["job", "__meta_kubernetes_service_label_app_kubernetes_io_name"]
+      regex = ";(.+)"
+      target_label = "job"
+    }
+    rule {
+      source_labels = ["job", "__meta_kubernetes_service_label_app"]
+      regex = ";(.+)"
+      target_label = "job"
+    }
+    rule {
+      source_labels = ["job", "service"]
+      regex = ";(.+)"
       target_label = "job"
     }
     rule {

--- a/charts/k8s-monitoring/docs/examples/include-by-namespace/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/include-by-namespace/output.yaml
@@ -157,6 +157,21 @@ data:
           target_label = "job"
         }
         rule {
+          source_labels = ["job", "__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+          regex = ";(.+)"
+          target_label = "job"
+        }
+        rule {
+          source_labels = ["job", "__meta_kubernetes_pod_label_app"]
+          regex = ";(.+)"
+          target_label = "job"
+        }
+        rule {
+          source_labels = ["job", "container"]
+          regex = ";(.+)"
+          target_label = "job"
+        }
+        rule {
           source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_instance"]
           target_label = "instance"
         }
@@ -286,6 +301,21 @@ data:
         }
         rule {
           source_labels = ["__meta_kubernetes_service_annotation_k8s_grafana_com_job"]
+          target_label = "job"
+        }
+        rule {
+          source_labels = ["job", "__meta_kubernetes_service_label_app_kubernetes_io_name"]
+          regex = ";(.+)"
+          target_label = "job"
+        }
+        rule {
+          source_labels = ["job", "__meta_kubernetes_service_label_app"]
+          regex = ";(.+)"
+          target_label = "job"
+        }
+        rule {
+          source_labels = ["job", "service"]
+          regex = ";(.+)"
           target_label = "job"
         }
         rule {

--- a/charts/k8s-monitoring/docs/examples/istio-service-mesh/alloy-metrics.alloy
+++ b/charts/k8s-monitoring/docs/examples/istio-service-mesh/alloy-metrics.alloy
@@ -42,6 +42,21 @@ declare "annotation_autodiscovery" {
       target_label = "job"
     }
     rule {
+      source_labels = ["job", "__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+      regex = ";(.+)"
+      target_label = "job"
+    }
+    rule {
+      source_labels = ["job", "__meta_kubernetes_pod_label_app"]
+      regex = ";(.+)"
+      target_label = "job"
+    }
+    rule {
+      source_labels = ["job", "container"]
+      regex = ";(.+)"
+      target_label = "job"
+    }
+    rule {
       source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_instance"]
       target_label = "instance"
     }
@@ -168,6 +183,21 @@ declare "annotation_autodiscovery" {
     }
     rule {
       source_labels = ["__meta_kubernetes_service_annotation_k8s_grafana_com_job"]
+      target_label = "job"
+    }
+    rule {
+      source_labels = ["job", "__meta_kubernetes_service_label_app_kubernetes_io_name"]
+      regex = ";(.+)"
+      target_label = "job"
+    }
+    rule {
+      source_labels = ["job", "__meta_kubernetes_service_label_app"]
+      regex = ";(.+)"
+      target_label = "job"
+    }
+    rule {
+      source_labels = ["job", "service"]
+      regex = ";(.+)"
       target_label = "job"
     }
     rule {

--- a/charts/k8s-monitoring/docs/examples/istio-service-mesh/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/istio-service-mesh/output.yaml
@@ -138,6 +138,21 @@ data:
           target_label = "job"
         }
         rule {
+          source_labels = ["job", "__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+          regex = ";(.+)"
+          target_label = "job"
+        }
+        rule {
+          source_labels = ["job", "__meta_kubernetes_pod_label_app"]
+          regex = ";(.+)"
+          target_label = "job"
+        }
+        rule {
+          source_labels = ["job", "container"]
+          regex = ";(.+)"
+          target_label = "job"
+        }
+        rule {
           source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_instance"]
           target_label = "instance"
         }
@@ -264,6 +279,21 @@ data:
         }
         rule {
           source_labels = ["__meta_kubernetes_service_annotation_k8s_grafana_com_job"]
+          target_label = "job"
+        }
+        rule {
+          source_labels = ["job", "__meta_kubernetes_service_label_app_kubernetes_io_name"]
+          regex = ";(.+)"
+          target_label = "job"
+        }
+        rule {
+          source_labels = ["job", "__meta_kubernetes_service_label_app"]
+          regex = ";(.+)"
+          target_label = "job"
+        }
+        rule {
+          source_labels = ["job", "service"]
+          regex = ";(.+)"
           target_label = "job"
         }
         rule {

--- a/charts/k8s-monitoring/docs/examples/metrics-tuning/alloy-metrics.alloy
+++ b/charts/k8s-monitoring/docs/examples/metrics-tuning/alloy-metrics.alloy
@@ -42,6 +42,21 @@ declare "annotation_autodiscovery" {
       target_label = "job"
     }
     rule {
+      source_labels = ["job", "__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+      regex = ";(.+)"
+      target_label = "job"
+    }
+    rule {
+      source_labels = ["job", "__meta_kubernetes_pod_label_app"]
+      regex = ";(.+)"
+      target_label = "job"
+    }
+    rule {
+      source_labels = ["job", "container"]
+      regex = ";(.+)"
+      target_label = "job"
+    }
+    rule {
       source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_instance"]
       target_label = "instance"
     }
@@ -168,6 +183,21 @@ declare "annotation_autodiscovery" {
     }
     rule {
       source_labels = ["__meta_kubernetes_service_annotation_k8s_grafana_com_job"]
+      target_label = "job"
+    }
+    rule {
+      source_labels = ["job", "__meta_kubernetes_service_label_app_kubernetes_io_name"]
+      regex = ";(.+)"
+      target_label = "job"
+    }
+    rule {
+      source_labels = ["job", "__meta_kubernetes_service_label_app"]
+      regex = ";(.+)"
+      target_label = "job"
+    }
+    rule {
+      source_labels = ["job", "service"]
+      regex = ";(.+)"
       target_label = "job"
     }
     rule {

--- a/charts/k8s-monitoring/docs/examples/metrics-tuning/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/metrics-tuning/output.yaml
@@ -138,6 +138,21 @@ data:
           target_label = "job"
         }
         rule {
+          source_labels = ["job", "__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+          regex = ";(.+)"
+          target_label = "job"
+        }
+        rule {
+          source_labels = ["job", "__meta_kubernetes_pod_label_app"]
+          regex = ";(.+)"
+          target_label = "job"
+        }
+        rule {
+          source_labels = ["job", "container"]
+          regex = ";(.+)"
+          target_label = "job"
+        }
+        rule {
           source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_instance"]
           target_label = "instance"
         }
@@ -264,6 +279,21 @@ data:
         }
         rule {
           source_labels = ["__meta_kubernetes_service_annotation_k8s_grafana_com_job"]
+          target_label = "job"
+        }
+        rule {
+          source_labels = ["job", "__meta_kubernetes_service_label_app_kubernetes_io_name"]
+          regex = ";(.+)"
+          target_label = "job"
+        }
+        rule {
+          source_labels = ["job", "__meta_kubernetes_service_label_app"]
+          regex = ";(.+)"
+          target_label = "job"
+        }
+        rule {
+          source_labels = ["job", "service"]
+          regex = ";(.+)"
           target_label = "job"
         }
         rule {

--- a/charts/k8s-monitoring/docs/examples/node-labels/alloy-metrics.alloy
+++ b/charts/k8s-monitoring/docs/examples/node-labels/alloy-metrics.alloy
@@ -45,6 +45,21 @@ declare "annotation_autodiscovery" {
       target_label = "job"
     }
     rule {
+      source_labels = ["job", "__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+      regex = ";(.+)"
+      target_label = "job"
+    }
+    rule {
+      source_labels = ["job", "__meta_kubernetes_pod_label_app"]
+      regex = ";(.+)"
+      target_label = "job"
+    }
+    rule {
+      source_labels = ["job", "container"]
+      regex = ";(.+)"
+      target_label = "job"
+    }
+    rule {
       source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_instance"]
       target_label = "instance"
     }
@@ -222,6 +237,21 @@ declare "annotation_autodiscovery" {
     }
     rule {
       source_labels = ["__meta_kubernetes_service_annotation_k8s_grafana_com_job"]
+      target_label = "job"
+    }
+    rule {
+      source_labels = ["job", "__meta_kubernetes_service_label_app_kubernetes_io_name"]
+      regex = ";(.+)"
+      target_label = "job"
+    }
+    rule {
+      source_labels = ["job", "__meta_kubernetes_service_label_app"]
+      regex = ";(.+)"
+      target_label = "job"
+    }
+    rule {
+      source_labels = ["job", "service"]
+      regex = ";(.+)"
       target_label = "job"
     }
     rule {

--- a/charts/k8s-monitoring/docs/examples/node-labels/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/node-labels/output.yaml
@@ -141,6 +141,21 @@ data:
           target_label = "job"
         }
         rule {
+          source_labels = ["job", "__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+          regex = ";(.+)"
+          target_label = "job"
+        }
+        rule {
+          source_labels = ["job", "__meta_kubernetes_pod_label_app"]
+          regex = ";(.+)"
+          target_label = "job"
+        }
+        rule {
+          source_labels = ["job", "container"]
+          regex = ";(.+)"
+          target_label = "job"
+        }
+        rule {
           source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_instance"]
           target_label = "instance"
         }
@@ -318,6 +333,21 @@ data:
         }
         rule {
           source_labels = ["__meta_kubernetes_service_annotation_k8s_grafana_com_job"]
+          target_label = "job"
+        }
+        rule {
+          source_labels = ["job", "__meta_kubernetes_service_label_app_kubernetes_io_name"]
+          regex = ";(.+)"
+          target_label = "job"
+        }
+        rule {
+          source_labels = ["job", "__meta_kubernetes_service_label_app"]
+          regex = ";(.+)"
+          target_label = "job"
+        }
+        rule {
+          source_labels = ["job", "service"]
+          regex = ";(.+)"
           target_label = "job"
         }
         rule {

--- a/charts/k8s-monitoring/tests/integration/annotation-autodiscovery/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/integration/annotation-autodiscovery/.rendered/output.yaml
@@ -81,6 +81,21 @@ data:
           target_label = "job"
         }
         rule {
+          source_labels = ["job", "__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+          regex = ";(.+)"
+          target_label = "job"
+        }
+        rule {
+          source_labels = ["job", "__meta_kubernetes_pod_label_app"]
+          regex = ";(.+)"
+          target_label = "job"
+        }
+        rule {
+          source_labels = ["job", "container"]
+          regex = ";(.+)"
+          target_label = "job"
+        }
+        rule {
           source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_instance"]
           target_label = "instance"
         }
@@ -219,6 +234,21 @@ data:
         }
         rule {
           source_labels = ["__meta_kubernetes_service_annotation_k8s_grafana_com_job"]
+          target_label = "job"
+        }
+        rule {
+          source_labels = ["job", "__meta_kubernetes_service_label_app_kubernetes_io_name"]
+          regex = ";(.+)"
+          target_label = "job"
+        }
+        rule {
+          source_labels = ["job", "__meta_kubernetes_service_label_app"]
+          regex = ";(.+)"
+          target_label = "job"
+        }
+        rule {
+          source_labels = ["job", "service"]
+          regex = ";(.+)"
           target_label = "job"
         }
         rule {

--- a/charts/k8s-monitoring/tests/integration/annotation-autodiscovery/deployments/nginx-static-metrics.yaml
+++ b/charts/k8s-monitoring/tests/integration/annotation-autodiscovery/deployments/nginx-static-metrics.yaml
@@ -31,7 +31,6 @@ spec:
   values:
     podAnnotations:
       k8s.grafana.com/scrape: "true"
-      k8s.grafana.com/job: "nginx-static-metrics"
       k8s.grafana.com/metrics.portNumber: "8080"
       k8s.grafana.com/metrics.scrapeInterval: "30s"
       k8s.grafana.com/metrics.scrapeTimeout: "15s"
@@ -74,7 +73,6 @@ spec:
   values:
     podAnnotations:
       k8s.grafana.com/scrape: "true"
-      k8s.grafana.com/job: "nginx-static-metrics"
       k8s.grafana.com/metrics.portNumber: "8080"
       k8s.grafana.com/metrics.scrapeInterval: "30s"
       k8s.grafana.com/metrics.scrapeTimeout: "15s"

--- a/charts/k8s-monitoring/tests/integration/annotation-autodiscovery/deployments/query-test.yaml
+++ b/charts/k8s-monitoring/tests/integration/annotation-autodiscovery/deployments/query-test.yaml
@@ -51,15 +51,15 @@ spec:
             type: promql
 
           # Annotation Autodiscovery from a Pod Annotation
-          - query: static_metric{cluster="$CLUSTER", job="nginx-static-metrics", scrape_interval="30s", scrape_timeout="15s", namespace="default", color="blue"}
+          - query: static_metric{cluster="$CLUSTER", job="nginx", scrape_interval="30s", scrape_timeout="15s", namespace="default", color="blue"}
             type: promql
           # Gets metrics from both replicas
-          - query: count(static_metric{cluster="$CLUSTER", job="nginx-static-metrics", color="blue"})
+          - query: count(static_metric{cluster="$CLUSTER", job="nginx", color="blue"})
             type: promql
             expect:
               value: 2
           # Label selector did not select the green deployment
-          - query: count(static_metric{cluster="$CLUSTER", job="nginx-static-metrics", color="green"}) or vector(0)
+          - query: count(static_metric{cluster="$CLUSTER", job="nginx", color="green"}) or vector(0)
             type: promql
             expect:
               value: 0
@@ -69,12 +69,12 @@ spec:
             type: logql
 
           # DPM check
-          - query: avg(count_over_time(scrape_samples_scraped{cluster="$CLUSTER", job="nginx-static-metrics"}[1m]))
+          - query: avg(count_over_time(scrape_samples_scraped{cluster="$CLUSTER", job="nginx"}[1m]))
             type: promql
             expect:
               value: 2  # 30s scrape interval for nginx-static-metrics
               operator: ==
-          - query: avg(count_over_time(scrape_samples_scraped{cluster="$CLUSTER", job!="nginx-static-metrics"}[1m]))
+          - query: avg(count_over_time(scrape_samples_scraped{cluster="$CLUSTER", job!="nginx"}[1m]))
             type: promql
             expect:
               value: 1  # 60s scrape interval for everything else

--- a/charts/k8s-monitoring/tests/integration/istio-service-mesh/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/integration/istio-service-mesh/.rendered/output.yaml
@@ -161,6 +161,21 @@ data:
           target_label = "job"
         }
         rule {
+          source_labels = ["job", "__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+          regex = ";(.+)"
+          target_label = "job"
+        }
+        rule {
+          source_labels = ["job", "__meta_kubernetes_pod_label_app"]
+          regex = ";(.+)"
+          target_label = "job"
+        }
+        rule {
+          source_labels = ["job", "container"]
+          regex = ";(.+)"
+          target_label = "job"
+        }
+        rule {
           source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_instance"]
           target_label = "instance"
         }
@@ -287,6 +302,21 @@ data:
         }
         rule {
           source_labels = ["__meta_kubernetes_service_annotation_k8s_grafana_com_job"]
+          target_label = "job"
+        }
+        rule {
+          source_labels = ["job", "__meta_kubernetes_service_label_app_kubernetes_io_name"]
+          regex = ";(.+)"
+          target_label = "job"
+        }
+        rule {
+          source_labels = ["job", "__meta_kubernetes_service_label_app"]
+          regex = ";(.+)"
+          target_label = "job"
+        }
+        rule {
+          source_labels = ["job", "service"]
+          regex = ";(.+)"
           target_label = "job"
         }
         rule {

--- a/charts/k8s-monitoring/tests/integration/prometheus-io-annotations/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/integration/prometheus-io-annotations/.rendered/output.yaml
@@ -138,6 +138,21 @@ data:
           target_label = "job"
         }
         rule {
+          source_labels = ["job", "__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+          regex = ";(.+)"
+          target_label = "job"
+        }
+        rule {
+          source_labels = ["job", "__meta_kubernetes_pod_label_app"]
+          regex = ";(.+)"
+          target_label = "job"
+        }
+        rule {
+          source_labels = ["job", "container"]
+          regex = ";(.+)"
+          target_label = "job"
+        }
+        rule {
           source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_instance"]
           target_label = "instance"
         }
@@ -264,6 +279,21 @@ data:
         }
         rule {
           source_labels = ["__meta_kubernetes_service_annotation_k8s_grafana_com_job"]
+          target_label = "job"
+        }
+        rule {
+          source_labels = ["job", "__meta_kubernetes_service_label_app_kubernetes_io_name"]
+          regex = ";(.+)"
+          target_label = "job"
+        }
+        rule {
+          source_labels = ["job", "__meta_kubernetes_service_label_app"]
+          regex = ";(.+)"
+          target_label = "job"
+        }
+        rule {
+          source_labels = ["job", "service"]
+          regex = ";(.+)"
           target_label = "job"
         }
         rule {

--- a/charts/k8s-monitoring/tests/integration/sharded-kube-state-metrics/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/integration/sharded-kube-state-metrics/.rendered/output.yaml
@@ -138,6 +138,21 @@ data:
           target_label = "job"
         }
         rule {
+          source_labels = ["job", "__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+          regex = ";(.+)"
+          target_label = "job"
+        }
+        rule {
+          source_labels = ["job", "__meta_kubernetes_pod_label_app"]
+          regex = ";(.+)"
+          target_label = "job"
+        }
+        rule {
+          source_labels = ["job", "container"]
+          regex = ";(.+)"
+          target_label = "job"
+        }
+        rule {
           source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_instance"]
           target_label = "instance"
         }
@@ -264,6 +279,21 @@ data:
         }
         rule {
           source_labels = ["__meta_kubernetes_service_annotation_k8s_grafana_com_job"]
+          target_label = "job"
+        }
+        rule {
+          source_labels = ["job", "__meta_kubernetes_service_label_app_kubernetes_io_name"]
+          regex = ";(.+)"
+          target_label = "job"
+        }
+        rule {
+          source_labels = ["job", "__meta_kubernetes_service_label_app"]
+          regex = ";(.+)"
+          target_label = "job"
+        }
+        rule {
+          source_labels = ["job", "service"]
+          regex = ";(.+)"
           target_label = "job"
         }
         rule {


### PR DESCRIPTION
The order:
  * `k8s.grafana.com/job` (annotation)
  * `app.kubernetes.io/name` (label)
  * `app` (label)
  * container or service name