### PR TITLE
Handle cluster events structured metadata the same as podlogs

### DIFF
--- a/charts/k8s-monitoring/charts/feature-cluster-events/templates/_module.alloy.tpl
+++ b/charts/k8s-monitoring/charts/feature-cluster-events/templates/_module.alloy.tpl
@@ -156,8 +156,7 @@ declare "cluster_events" {
     {{- /* the stage.structured_metadata block needs to be conditionalized because the support for enabling structured metadata can be disabled */ -}}
     {{- /* through the loki limits_conifg on a per-tenant basis, even if there are no values defined or there are values defined but it is disabled */ -}}
     {{- /* in Loki, the write will fail. */ -}}
-    {{- if gt (len (keys .Values.structuredMetadata)) 0 }}
-    // set the structured metadata values
+    {{- if .Values.structuredMetadata }}
     stage.structured_metadata {
       values = {
         {{- range $key, $value := .Values.structuredMetadata }}

--- a/charts/k8s-monitoring/charts/feature-cluster-events/tests/__snapshot__/default_test.yaml.snap
+++ b/charts/k8s-monitoring/charts/feature-cluster-events/tests/__snapshot__/default_test.yaml.snap
@@ -66,7 +66,6 @@ should create a ConfigMap:
               }
             }
           }
-          // set the structured metadata values
           stage.structured_metadata {
             values = {
               "name" = "name",

--- a/charts/k8s-monitoring/charts/feature-cluster-events/tests/__snapshot__/extra_processing_stages_test.yaml.snap
+++ b/charts/k8s-monitoring/charts/feature-cluster-events/tests/__snapshot__/extra_processing_stages_test.yaml.snap
@@ -79,7 +79,6 @@ should create a ConfigMap with extra processing stages:
             }
           }
 
-          // set the structured metadata values
           stage.structured_metadata {
             values = {
               "name" = "name",

--- a/charts/k8s-monitoring/charts/feature-cluster-events/tests/__snapshot__/labels_test.yaml.snap
+++ b/charts/k8s-monitoring/charts/feature-cluster-events/tests/__snapshot__/labels_test.yaml.snap
@@ -66,7 +66,6 @@ should create a ConfigMap that sets custom labels to keep:
               }
             }
           }
-          // set the structured metadata values
           stage.structured_metadata {
             values = {
               "name" = "name",

--- a/charts/k8s-monitoring/charts/feature-cluster-events/tests/__snapshot__/levels_test.yaml.snap
+++ b/charts/k8s-monitoring/charts/feature-cluster-events/tests/__snapshot__/levels_test.yaml.snap
@@ -71,7 +71,6 @@ can restrict events from a given list of levels:
               }
             }
           }
-          // set the structured metadata values
           stage.structured_metadata {
             values = {
               "name" = "name",
@@ -179,7 +178,6 @@ can restrict events to a given list of levels:
               }
             }
           }
-          // set the structured metadata values
           stage.structured_metadata {
             values = {
               "name" = "name",

--- a/charts/k8s-monitoring/charts/feature-cluster-events/tests/__snapshot__/namespace_test.yaml.snap
+++ b/charts/k8s-monitoring/charts/feature-cluster-events/tests/__snapshot__/namespace_test.yaml.snap
@@ -71,7 +71,6 @@ can restrict events from a given list of namespaces:
               }
             }
           }
-          // set the structured metadata values
           stage.structured_metadata {
             values = {
               "name" = "name",
@@ -159,7 +158,6 @@ can restrict events to a given list of namespaces:
               }
             }
           }
-          // set the structured metadata values
           stage.structured_metadata {
             values = {
               "name" = "name",

--- a/charts/k8s-monitoring/charts/feature-cluster-events/tests/__snapshot__/reasons_test.yaml.snap
+++ b/charts/k8s-monitoring/charts/feature-cluster-events/tests/__snapshot__/reasons_test.yaml.snap
@@ -71,7 +71,6 @@ can restrict events from a given list of reasons:
               }
             }
           }
-          // set the structured metadata values
           stage.structured_metadata {
             values = {
               "name" = "name",
@@ -179,7 +178,6 @@ can restrict events to a given list of reasons:
               }
             }
           }
-          // set the structured metadata values
           stage.structured_metadata {
             values = {
               "name" = "name",

--- a/charts/k8s-monitoring/charts/feature-cluster-events/tests/__snapshot__/structured_metadata_test.yaml.snap
+++ b/charts/k8s-monitoring/charts/feature-cluster-events/tests/__snapshot__/structured_metadata_test.yaml.snap
@@ -66,7 +66,6 @@ should create a ConfigMap that sets structured metadata k/v pairs:
               }
             }
           }
-          // set the structured metadata values
           stage.structured_metadata {
             values = {
               "component" = "component",

--- a/charts/k8s-monitoring/docs/examples/auth/oauth2/alloy-singleton.alloy
+++ b/charts/k8s-monitoring/docs/examples/auth/oauth2/alloy-singleton.alloy
@@ -64,7 +64,6 @@ declare "cluster_events" {
         }
       }
     }
-    // set the structured metadata values
     stage.structured_metadata {
       values = {
         "name" = "name",

--- a/charts/k8s-monitoring/docs/examples/auth/oauth2/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/auth/oauth2/output.yaml
@@ -1119,7 +1119,6 @@ data:
             }
           }
         }
-        // set the structured metadata values
         stage.structured_metadata {
           values = {
             "name" = "name",

--- a/charts/k8s-monitoring/docs/examples/exclude-by-namespace/alloy-singleton.alloy
+++ b/charts/k8s-monitoring/docs/examples/exclude-by-namespace/alloy-singleton.alloy
@@ -69,7 +69,6 @@ declare "cluster_events" {
         }
       }
     }
-    // set the structured metadata values
     stage.structured_metadata {
       values = {
         "name" = "name",

--- a/charts/k8s-monitoring/docs/examples/exclude-by-namespace/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/exclude-by-namespace/output.yaml
@@ -1117,7 +1117,6 @@ data:
             }
           }
         }
-        // set the structured metadata values
         stage.structured_metadata {
           values = {
             "name" = "name",

--- a/charts/k8s-monitoring/docs/examples/extra-rules/alloy-singleton.alloy
+++ b/charts/k8s-monitoring/docs/examples/extra-rules/alloy-singleton.alloy
@@ -65,7 +65,6 @@ declare "cluster_events" {
         }
       }
     }
-    // set the structured metadata values
     stage.structured_metadata {
       values = {
         "name" = "name",

--- a/charts/k8s-monitoring/docs/examples/extra-rules/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/extra-rules/output.yaml
@@ -682,7 +682,6 @@ data:
             }
           }
         }
-        // set the structured metadata values
         stage.structured_metadata {
           values = {
             "name" = "name",

--- a/charts/k8s-monitoring/docs/examples/features/cluster-events/default/alloy-singleton.alloy
+++ b/charts/k8s-monitoring/docs/examples/features/cluster-events/default/alloy-singleton.alloy
@@ -64,7 +64,6 @@ declare "cluster_events" {
         }
       }
     }
-    // set the structured metadata values
     stage.structured_metadata {
       values = {
         "name" = "name",

--- a/charts/k8s-monitoring/docs/examples/features/cluster-events/default/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/features/cluster-events/default/output.yaml
@@ -87,7 +87,6 @@ data:
             }
           }
         }
-        // set the structured metadata values
         stage.structured_metadata {
           values = {
             "name" = "name",

--- a/charts/k8s-monitoring/docs/examples/features/cluster-metrics/control-plane-monitoring/alloy-singleton.alloy
+++ b/charts/k8s-monitoring/docs/examples/features/cluster-metrics/control-plane-monitoring/alloy-singleton.alloy
@@ -64,7 +64,6 @@ declare "cluster_events" {
         }
       }
     }
-    // set the structured metadata values
     stage.structured_metadata {
       values = {
         "name" = "name",

--- a/charts/k8s-monitoring/docs/examples/features/cluster-metrics/control-plane-monitoring/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/features/cluster-metrics/control-plane-monitoring/output.yaml
@@ -1051,7 +1051,6 @@ data:
             }
           }
         }
-        // set the structured metadata values
         stage.structured_metadata {
           values = {
             "name" = "name",

--- a/charts/k8s-monitoring/docs/examples/include-by-namespace/alloy-singleton.alloy
+++ b/charts/k8s-monitoring/docs/examples/include-by-namespace/alloy-singleton.alloy
@@ -65,7 +65,6 @@ declare "cluster_events" {
         }
       }
     }
-    // set the structured metadata values
     stage.structured_metadata {
       values = {
         "name" = "name",

--- a/charts/k8s-monitoring/docs/examples/include-by-namespace/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/include-by-namespace/output.yaml
@@ -1097,7 +1097,6 @@ data:
             }
           }
         }
-        // set the structured metadata values
         stage.structured_metadata {
           values = {
             "name" = "name",

--- a/charts/k8s-monitoring/docs/examples/meta-monitoring/alloy-singleton.alloy
+++ b/charts/k8s-monitoring/docs/examples/meta-monitoring/alloy-singleton.alloy
@@ -503,7 +503,6 @@ declare "cluster_events" {
         }
       }
     }
-    // set the structured metadata values
     stage.structured_metadata {
       values = {
         "name" = "name",

--- a/charts/k8s-monitoring/docs/examples/meta-monitoring/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/meta-monitoring/output.yaml
@@ -560,7 +560,6 @@ data:
             }
           }
         }
-        // set the structured metadata values
         stage.structured_metadata {
           values = {
             "name" = "name",

--- a/charts/k8s-monitoring/docs/examples/platforms/azure-aks/alloy-singleton.alloy
+++ b/charts/k8s-monitoring/docs/examples/platforms/azure-aks/alloy-singleton.alloy
@@ -64,7 +64,6 @@ declare "cluster_events" {
         }
       }
     }
-    // set the structured metadata values
     stage.structured_metadata {
       values = {
         "name" = "name",

--- a/charts/k8s-monitoring/docs/examples/platforms/azure-aks/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/platforms/azure-aks/output.yaml
@@ -666,7 +666,6 @@ data:
             }
           }
         }
-        // set the structured metadata values
         stage.structured_metadata {
           values = {
             "name" = "name",

--- a/charts/k8s-monitoring/docs/examples/platforms/eks-fargate/alloy-singleton.alloy
+++ b/charts/k8s-monitoring/docs/examples/platforms/eks-fargate/alloy-singleton.alloy
@@ -64,7 +64,6 @@ declare "cluster_events" {
         }
       }
     }
-    // set the structured metadata values
     stage.structured_metadata {
       values = {
         "name" = "name",

--- a/charts/k8s-monitoring/docs/examples/platforms/eks-fargate/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/platforms/eks-fargate/output.yaml
@@ -511,7 +511,6 @@ data:
             }
           }
         }
-        // set the structured metadata values
         stage.structured_metadata {
           values = {
             "name" = "name",

--- a/charts/k8s-monitoring/docs/examples/platforms/gke-autopilot/alloy-singleton.alloy
+++ b/charts/k8s-monitoring/docs/examples/platforms/gke-autopilot/alloy-singleton.alloy
@@ -64,7 +64,6 @@ declare "cluster_events" {
         }
       }
     }
-    // set the structured metadata values
     stage.structured_metadata {
       values = {
         "name" = "name",

--- a/charts/k8s-monitoring/docs/examples/platforms/gke-autopilot/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/platforms/gke-autopilot/output.yaml
@@ -511,7 +511,6 @@ data:
             }
           }
         }
-        // set the structured metadata values
         stage.structured_metadata {
           values = {
             "name" = "name",

--- a/charts/k8s-monitoring/docs/examples/platforms/openshift/alloy-singleton.alloy
+++ b/charts/k8s-monitoring/docs/examples/platforms/openshift/alloy-singleton.alloy
@@ -64,7 +64,6 @@ declare "cluster_events" {
         }
       }
     }
-    // set the structured metadata values
     stage.structured_metadata {
       values = {
         "name" = "name",

--- a/charts/k8s-monitoring/docs/examples/platforms/openshift/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/platforms/openshift/output.yaml
@@ -980,7 +980,6 @@ data:
             }
           }
         }
-        // set the structured metadata values
         stage.structured_metadata {
           values = {
             "name" = "name",

--- a/charts/k8s-monitoring/docs/examples/proxies/alloy-singleton.alloy
+++ b/charts/k8s-monitoring/docs/examples/proxies/alloy-singleton.alloy
@@ -64,7 +64,6 @@ declare "cluster_events" {
         }
       }
     }
-    // set the structured metadata values
     stage.structured_metadata {
       values = {
         "name" = "name",

--- a/charts/k8s-monitoring/docs/examples/proxies/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/proxies/output.yaml
@@ -727,7 +727,6 @@ data:
             }
           }
         }
-        // set the structured metadata values
         stage.structured_metadata {
           values = {
             "name" = "name",

--- a/charts/k8s-monitoring/tests/__snapshot__/cluster_events_test.yaml.snap
+++ b/charts/k8s-monitoring/tests/__snapshot__/cluster_events_test.yaml.snap
@@ -67,7 +67,6 @@ renders the config to gather Kubernetes Cluster Events:
               }
             }
           }
-          // set the structured metadata values
           stage.structured_metadata {
             values = {
               "name" = "name",

--- a/charts/k8s-monitoring/tests/integration/cluster-monitoring/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/integration/cluster-monitoring/.rendered/output.yaml
@@ -808,7 +808,6 @@ data:
             }
           }
         }
-        // set the structured metadata values
         stage.structured_metadata {
           values = {
             "name" = "name",

--- a/charts/k8s-monitoring/tests/integration/control-plane-monitoring/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/integration/control-plane-monitoring/.rendered/output.yaml
@@ -990,7 +990,6 @@ data:
             }
           }
         }
-        // set the structured metadata values
         stage.structured_metadata {
           values = {
             "name" = "name",

--- a/charts/k8s-monitoring/tests/integration/istio-service-mesh/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/integration/istio-service-mesh/.rendered/output.yaml
@@ -1001,7 +1001,6 @@ data:
             }
           }
         }
-        // set the structured metadata values
         stage.structured_metadata {
           values = {
             "name" = "name",

--- a/charts/k8s-monitoring/tests/integration/prom-and-loki-to-otlp/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/integration/prom-and-loki-to-otlp/.rendered/output.yaml
@@ -718,7 +718,6 @@ data:
             }
           }
         }
-        // set the structured metadata values
         stage.structured_metadata {
           values = {
             "name" = "name",

--- a/charts/k8s-monitoring/tests/integration/proxies/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/integration/proxies/.rendered/output.yaml
@@ -456,7 +456,6 @@ data:
             }
           }
         }
-        // set the structured metadata values
         stage.structured_metadata {
           values = {
             "name" = "name",

--- a/charts/k8s-monitoring/tests/integration/service-integrations/grafana/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/integration/service-integrations/grafana/.rendered/output.yaml
@@ -940,7 +940,6 @@ data:
             }
           }
         }
-        // set the structured metadata values
         stage.structured_metadata {
           values = {
             "name" = "name",

--- a/charts/k8s-monitoring/tests/integration/service-integrations/loki/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/integration/service-integrations/loki/.rendered/output.yaml
@@ -957,7 +957,6 @@ data:
             }
           }
         }
-        // set the structured metadata values
         stage.structured_metadata {
           values = {
             "name" = "name",

--- a/charts/k8s-monitoring/tests/integration/service-integrations/tempo/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/integration/service-integrations/tempo/.rendered/output.yaml
@@ -698,7 +698,6 @@ data:
             }
           }
         }
-        // set the structured metadata values
         stage.structured_metadata {
           values = {
             "name" = "name",

--- a/charts/k8s-monitoring/tests/integration/upgrade/minor/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/integration/upgrade/minor/.rendered/output.yaml
@@ -814,7 +814,6 @@ data:
             }
           }
         }
-        // set the structured metadata values
         stage.structured_metadata {
           values = {
             "name" = "name",

--- a/charts/k8s-monitoring/tests/integration/upgrade/patch/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/integration/upgrade/patch/.rendered/output.yaml
@@ -814,7 +814,6 @@ data:
             }
           }
         }
-        // set the structured metadata values
         stage.structured_metadata {
           values = {
             "name" = "name",

--- a/charts/k8s-monitoring/tests/platform/aks/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/platform/aks/.rendered/output.yaml
@@ -973,7 +973,6 @@ data:
             }
           }
         }
-        // set the structured metadata values
         stage.structured_metadata {
           values = {
             "name" = "name",

--- a/charts/k8s-monitoring/tests/platform/eks-fargate/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/platform/eks-fargate/.rendered/output.yaml
@@ -973,7 +973,6 @@ data:
             }
           }
         }
-        // set the structured metadata values
         stage.structured_metadata {
           values = {
             "name" = "name",

--- a/charts/k8s-monitoring/tests/platform/eks-with-windows/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/platform/eks-with-windows/.rendered/output.yaml
@@ -973,7 +973,6 @@ data:
             }
           }
         }
-        // set the structured metadata values
         stage.structured_metadata {
           values = {
             "name" = "name",

--- a/charts/k8s-monitoring/tests/platform/gke-autopilot/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/platform/gke-autopilot/.rendered/output.yaml
@@ -739,7 +739,6 @@ data:
             }
           }
         }
-        // set the structured metadata values
         stage.structured_metadata {
           values = {
             "name" = "name",

--- a/charts/k8s-monitoring/tests/platform/gke/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/platform/gke/.rendered/output.yaml
@@ -973,7 +973,6 @@ data:
             }
           }
         }
-        // set the structured metadata values
         stage.structured_metadata {
           values = {
             "name" = "name",

--- a/charts/k8s-monitoring/tests/platform/grafana-cloud/k8s-monitoring/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/platform/grafana-cloud/k8s-monitoring/.rendered/output.yaml
@@ -1083,7 +1083,6 @@ data:
             }
           }
         }
-        // set the structured metadata values
         stage.structured_metadata {
           values = {
             "name" = "name",

--- a/charts/k8s-monitoring/tests/platform/openshift/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/platform/openshift/.rendered/output.yaml
@@ -939,7 +939,6 @@ data:
             }
           }
         }
-        // set the structured metadata values
         stage.structured_metadata {
           values = {
             "name" = "name",

--- a/charts/k8s-monitoring/tests/platform/otlp-gateway/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/platform/otlp-gateway/.rendered/output.yaml
@@ -540,7 +540,6 @@ data:
             }
           }
         }
-        // set the structured metadata values
         stage.structured_metadata {
           values = {
             "name" = "name",


### PR DESCRIPTION
This allows users to disable structured metadata with:
```yaml
structuredMetadata: null
```