### PR TITLE
Improve how tail sampling and service graph metrics components are wired together

### DIFF
--- a/charts/k8s-monitoring/docs/examples/images/images-by-digest/alloy-receiver.alloy
+++ b/charts/k8s-monitoring/docs/examples/images/images-by-digest/alloy-receiver.alloy
@@ -220,11 +220,10 @@ otelcol.processor.transform "tempo" {
   }
 
   output {
-    traces = [
-      otelcol.exporter.loadbalancing.tempo_sampler.input,
-    ]
+    traces = [otelcol.exporter.loadbalancing.tempo_sampler.input]
   }
 }
+
 otelcol.exporter.loadbalancing "tempo_sampler" {
   resolver {
     kubernetes {

--- a/charts/k8s-monitoring/docs/examples/images/images-by-digest/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/images/images-by-digest/output.yaml
@@ -943,11 +943,10 @@ data:
       }
     
       output {
-        traces = [
-          otelcol.exporter.loadbalancing.tempo_sampler.input,
-        ]
+        traces = [otelcol.exporter.loadbalancing.tempo_sampler.input]
       }
     }
+    
     otelcol.exporter.loadbalancing "tempo_sampler" {
       resolver {
         kubernetes {

--- a/charts/k8s-monitoring/docs/examples/private-image-registries/globally/alloy-receiver.alloy
+++ b/charts/k8s-monitoring/docs/examples/private-image-registries/globally/alloy-receiver.alloy
@@ -220,11 +220,10 @@ otelcol.processor.transform "tempo" {
   }
 
   output {
-    traces = [
-      otelcol.exporter.loadbalancing.tempo_sampler.input,
-    ]
+    traces = [otelcol.exporter.loadbalancing.tempo_sampler.input]
   }
 }
+
 otelcol.exporter.loadbalancing "tempo_sampler" {
   resolver {
     kubernetes {

--- a/charts/k8s-monitoring/docs/examples/private-image-registries/globally/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/private-image-registries/globally/output.yaml
@@ -1091,11 +1091,10 @@ data:
       }
     
       output {
-        traces = [
-          otelcol.exporter.loadbalancing.tempo_sampler.input,
-        ]
+        traces = [otelcol.exporter.loadbalancing.tempo_sampler.input]
       }
     }
+    
     otelcol.exporter.loadbalancing "tempo_sampler" {
       resolver {
         kubernetes {

--- a/charts/k8s-monitoring/docs/examples/private-image-registries/individual/alloy-receiver.alloy
+++ b/charts/k8s-monitoring/docs/examples/private-image-registries/individual/alloy-receiver.alloy
@@ -220,11 +220,10 @@ otelcol.processor.transform "tempo" {
   }
 
   output {
-    traces = [
-      otelcol.exporter.loadbalancing.tempo_sampler.input,
-    ]
+    traces = [otelcol.exporter.loadbalancing.tempo_sampler.input]
   }
 }
+
 otelcol.exporter.loadbalancing "tempo_sampler" {
   resolver {
     kubernetes {

--- a/charts/k8s-monitoring/docs/examples/private-image-registries/individual/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/private-image-registries/individual/output.yaml
@@ -943,11 +943,10 @@ data:
       }
     
       output {
-        traces = [
-          otelcol.exporter.loadbalancing.tempo_sampler.input,
-        ]
+        traces = [otelcol.exporter.loadbalancing.tempo_sampler.input]
       }
     }
+    
     otelcol.exporter.loadbalancing "tempo_sampler" {
       resolver {
         kubernetes {

--- a/charts/k8s-monitoring/docs/examples/tail-sampling/alloy-receiver.alloy
+++ b/charts/k8s-monitoring/docs/examples/tail-sampling/alloy-receiver.alloy
@@ -220,11 +220,10 @@ otelcol.processor.transform "tempo" {
   }
 
   output {
-    traces = [
-      otelcol.exporter.loadbalancing.tempo_sampler.input,
-    ]
+    traces = [otelcol.exporter.loadbalancing.tempo_sampler.input]
   }
 }
+
 otelcol.exporter.loadbalancing "tempo_sampler" {
   resolver {
     kubernetes {

--- a/charts/k8s-monitoring/docs/examples/tail-sampling/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/tail-sampling/output.yaml
@@ -1085,11 +1085,10 @@ data:
       }
     
       output {
-        traces = [
-          otelcol.exporter.loadbalancing.tempo_sampler.input,
-        ]
+        traces = [otelcol.exporter.loadbalancing.tempo_sampler.input]
       }
     }
+    
     otelcol.exporter.loadbalancing "tempo_sampler" {
       resolver {
         kubernetes {

--- a/charts/k8s-monitoring/tests/integration/service-graph-metrics/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/integration/service-graph-metrics/.rendered/output.yaml
@@ -932,6 +932,7 @@ data:
         ]
       }
     }
+    
     otelcol.exporter.loadbalancing "localtempo_servicegraph" {
       resolver {
         kubernetes {

--- a/charts/k8s-monitoring/tests/integration/tail-sampling/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/integration/tail-sampling/.rendered/output.yaml
@@ -690,11 +690,10 @@ data:
       }
     
       output {
-        traces = [
-          otelcol.exporter.loadbalancing.localtempo_sampler.input,
-        ]
+        traces = [otelcol.exporter.loadbalancing.localtempo_sampler.input]
       }
     }
+    
     otelcol.exporter.loadbalancing "localtempo_sampler" {
       resolver {
         kubernetes {


### PR DESCRIPTION
This fixes the issue where using both service graph metrics and tail sampling together would break.