### PR TITLE
Allow exclude dimensions on spanmetrics

### DIFF
--- a/charts/k8s-monitoring/charts/feature-application-observability/README.md
+++ b/charts/k8s-monitoring/charts/feature-application-observability/README.md
@@ -75,6 +75,7 @@ Be sure perform actual integration testing in a live environment in the main [k8
 | connectors.spanMetrics.dimensionsCacheSize | int | `1000` | How many dimensions to cache |
 | connectors.spanMetrics.enabled | bool | `false` | Use a span metrics connector which creates metrics from spans. |
 | connectors.spanMetrics.events.enabled | bool | `false` | Capture events metrics, which track span events. |
+| connectors.spanMetrics.excludeDimensions | list | `[]` | List of dimensions to be excluded from the default set of dimensions. |
 | connectors.spanMetrics.exemplars.enabled | bool | `false` | Attach exemplars to histograms. |
 | connectors.spanMetrics.exemplars.maxPerDataPoint | number | `nil` | Limits the number of exemplars that can be added to a unique dimension set. |
 | connectors.spanMetrics.histogram.enabled | bool | `true` | Capture histogram metrics, derived from spans’ durations. |

--- a/charts/k8s-monitoring/charts/feature-application-observability/templates/_connector_span_metrics.tpl
+++ b/charts/k8s-monitoring/charts/feature-application-observability/templates/_connector_span_metrics.tpl
@@ -11,6 +11,7 @@ otelcol.connector.spanmetrics "{{ .name | default "default" }}" {
 {{- end }}
   }
 {{- end }}
+  exclude_dimensions = {{ .Values.connectors.spanMetrics.excludeDimensions }}
   dimensions_cache_size = {{ .Values.connectors.spanMetrics.dimensionsCacheSize }}
   namespace = {{ .Values.connectors.spanMetrics.namespace | quote }}
 {{- if .Values.connectors.spanMetrics.events.enabled }}

--- a/charts/k8s-monitoring/charts/feature-application-observability/values.schema.json
+++ b/charts/k8s-monitoring/charts/feature-application-observability/values.schema.json
@@ -59,6 +59,9 @@
                                 }
                             }
                         },
+                        "excludeDimensions": {
+                            "type": "array"
+                        },
                         "exemplars": {
                             "type": "object",
                             "properties": {

--- a/charts/k8s-monitoring/charts/feature-application-observability/values.yaml
+++ b/charts/k8s-monitoring/charts/feature-application-observability/values.yaml
@@ -289,7 +289,10 @@ connectors:
     # -- How many dimensions to cache
     # @section -- Connectors: Span Metrics
     dimensionsCacheSize: 1000
-
+  
+    # -- List of dimensions to be excluded from the default set of dimensions.
+    # @section -- Connectors: Span Metrics
+    excludeDimensions: []
     # -- The Metric namespace.
     # @section -- Connectors: Span Metrics
     namespace: traces.span.metrics


### PR DESCRIPTION
Expose `exclude_dimensions` on the spanmetrics to help with cardinality management ([docs](https://grafana.com/docs/alloy/latest/reference/components/otelcol/otelcol.connector.spanmetrics/#arguments))