### PR TITLE
Prevent Node Exporter from even generating metrics about ramfs and tmpfs

### DIFF
--- a/charts/k8s-monitoring/charts/feature-cluster-metrics/values.schema.json
+++ b/charts/k8s-monitoring/charts/feature-cluster-metrics/values.schema.json
@@ -752,6 +752,12 @@
                 "enabled": {
                     "type": "boolean"
                 },
+                "extraArgs": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
                 "extraDiscoveryRules": {
                     "type": "string"
                 },

--- a/charts/k8s-monitoring/charts/feature-cluster-metrics/values.yaml
+++ b/charts/k8s-monitoring/charts/feature-cluster-metrics/values.yaml
@@ -763,6 +763,10 @@ node-exporter:
   deploy: true
 
   # @ignored
+  extraArgs:
+    - --collector.filesystem.fs-types-exclude=^(ramfs|tmpfs)$
+
+  # @ignored
   nodeSelector:
     kubernetes.io/os: linux
 

--- a/charts/k8s-monitoring/docs/examples/auth/oauth2/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/auth/oauth2/output.yaml
@@ -2345,6 +2345,7 @@ spec:
             - --path.rootfs=/host/root
             - --path.udev.data=/host/root/run/udev/data
             - --web.listen-address=[$(HOST_IP)]:9100
+            - --collector.filesystem.fs-types-exclude=^(ramfs|tmpfs)$
           securityContext:
             readOnlyRootFilesystem: true
           env:

--- a/charts/k8s-monitoring/docs/examples/auth/sigv4/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/auth/sigv4/output.yaml
@@ -1173,6 +1173,7 @@ spec:
             - --path.rootfs=/host/root
             - --path.udev.data=/host/root/run/udev/data
             - --web.listen-address=[$(HOST_IP)]:9100
+            - --collector.filesystem.fs-types-exclude=^(ramfs|tmpfs)$
           securityContext:
             readOnlyRootFilesystem: true
           env:

--- a/charts/k8s-monitoring/docs/examples/collector-storage/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/collector-storage/output.yaml
@@ -1364,6 +1364,7 @@ spec:
             - --path.rootfs=/host/root
             - --path.udev.data=/host/root/run/udev/data
             - --web.listen-address=[$(HOST_IP)]:9100
+            - --collector.filesystem.fs-types-exclude=^(ramfs|tmpfs)$
           securityContext:
             readOnlyRootFilesystem: true
           env:

--- a/charts/k8s-monitoring/docs/examples/destinations/otlp-endpoint/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/destinations/otlp-endpoint/output.yaml
@@ -1590,6 +1590,7 @@ spec:
             - --path.rootfs=/host/root
             - --path.udev.data=/host/root/run/udev/data
             - --web.listen-address=[$(HOST_IP)]:9100
+            - --collector.filesystem.fs-types-exclude=^(ramfs|tmpfs)$
           securityContext:
             readOnlyRootFilesystem: true
           env:

--- a/charts/k8s-monitoring/docs/examples/exclude-by-namespace/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/exclude-by-namespace/output.yaml
@@ -3345,6 +3345,7 @@ spec:
             - --path.rootfs=/host/root
             - --path.udev.data=/host/root/run/udev/data
             - --web.listen-address=[$(HOST_IP)]:9100
+            - --collector.filesystem.fs-types-exclude=^(ramfs|tmpfs)$
           securityContext:
             readOnlyRootFilesystem: true
           env:

--- a/charts/k8s-monitoring/docs/examples/extra-rules/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/extra-rules/output.yaml
@@ -1591,6 +1591,7 @@ spec:
             - --path.rootfs=/host/root
             - --path.udev.data=/host/root/run/udev/data
             - --web.listen-address=[$(HOST_IP)]:9100
+            - --collector.filesystem.fs-types-exclude=^(ramfs|tmpfs)$
           securityContext:
             readOnlyRootFilesystem: true
           env:

--- a/charts/k8s-monitoring/docs/examples/features/cluster-metrics/control-plane-monitoring/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/features/cluster-metrics/control-plane-monitoring/output.yaml
@@ -1922,6 +1922,7 @@ spec:
             - --path.rootfs=/host/root
             - --path.udev.data=/host/root/run/udev/data
             - --web.listen-address=[$(HOST_IP)]:9100
+            - --collector.filesystem.fs-types-exclude=^(ramfs|tmpfs)$
           securityContext:
             readOnlyRootFilesystem: true
           env:

--- a/charts/k8s-monitoring/docs/examples/features/cluster-metrics/default/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/features/cluster-metrics/default/output.yaml
@@ -1583,6 +1583,7 @@ spec:
             - --path.rootfs=/host/root
             - --path.udev.data=/host/root/run/udev/data
             - --web.listen-address=[$(HOST_IP)]:9100
+            - --collector.filesystem.fs-types-exclude=^(ramfs|tmpfs)$
           securityContext:
             readOnlyRootFilesystem: true
           env:

--- a/charts/k8s-monitoring/docs/examples/images/images-by-digest/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/images/images-by-digest/output.yaml
@@ -1654,6 +1654,7 @@ spec:
             - --path.rootfs=/host/root
             - --path.udev.data=/host/root/run/udev/data
             - --web.listen-address=[$(HOST_IP)]:9100
+            - --collector.filesystem.fs-types-exclude=^(ramfs|tmpfs)$
           securityContext:
             readOnlyRootFilesystem: true
           env:

--- a/charts/k8s-monitoring/docs/examples/include-by-namespace/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/include-by-namespace/output.yaml
@@ -3315,6 +3315,7 @@ spec:
             - --path.rootfs=/host/root
             - --path.udev.data=/host/root/run/udev/data
             - --web.listen-address=[$(HOST_IP)]:9100
+            - --collector.filesystem.fs-types-exclude=^(ramfs|tmpfs)$
           securityContext:
             readOnlyRootFilesystem: true
           env:

--- a/charts/k8s-monitoring/docs/examples/istio-service-mesh/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/istio-service-mesh/output.yaml
@@ -1693,6 +1693,7 @@ spec:
             - --path.rootfs=/host/root
             - --path.udev.data=/host/root/run/udev/data
             - --web.listen-address=[$(HOST_IP)]:9100
+            - --collector.filesystem.fs-types-exclude=^(ramfs|tmpfs)$
           securityContext:
             readOnlyRootFilesystem: true
           env:

--- a/charts/k8s-monitoring/docs/examples/meta-monitoring/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/meta-monitoring/output.yaml
@@ -2998,6 +2998,7 @@ spec:
             - --path.rootfs=/host/root
             - --path.udev.data=/host/root/run/udev/data
             - --web.listen-address=[$(HOST_IP)]:9100
+            - --collector.filesystem.fs-types-exclude=^(ramfs|tmpfs)$
           securityContext:
             readOnlyRootFilesystem: true
           env:

--- a/charts/k8s-monitoring/docs/examples/metrics-tuning/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/metrics-tuning/output.yaml
@@ -1460,6 +1460,7 @@ spec:
             - --path.rootfs=/host/root
             - --path.udev.data=/host/root/run/udev/data
             - --web.listen-address=[$(HOST_IP)]:9100
+            - --collector.filesystem.fs-types-exclude=^(ramfs|tmpfs)$
           securityContext:
             readOnlyRootFilesystem: true
           env:

--- a/charts/k8s-monitoring/docs/examples/namespace-labels-and-annotations/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/namespace-labels-and-annotations/output.yaml
@@ -1642,6 +1642,7 @@ spec:
             - --path.rootfs=/host/root
             - --path.udev.data=/host/root/run/udev/data
             - --web.listen-address=[$(HOST_IP)]:9100
+            - --collector.filesystem.fs-types-exclude=^(ramfs|tmpfs)$
           securityContext:
             readOnlyRootFilesystem: true
           env:

--- a/charts/k8s-monitoring/docs/examples/node-labels/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/node-labels/output.yaml
@@ -1897,6 +1897,7 @@ spec:
             - --path.rootfs=/host/root
             - --path.udev.data=/host/root/run/udev/data
             - --web.listen-address=[$(HOST_IP)]:9100
+            - --collector.filesystem.fs-types-exclude=^(ramfs|tmpfs)$
           securityContext:
             readOnlyRootFilesystem: true
           env:

--- a/charts/k8s-monitoring/docs/examples/platforms/azure-aks/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/platforms/azure-aks/output.yaml
@@ -1536,6 +1536,7 @@ spec:
             - --path.rootfs=/host/root
             - --path.udev.data=/host/root/run/udev/data
             - --web.listen-address=[$(HOST_IP)]:9100
+            - --collector.filesystem.fs-types-exclude=^(ramfs|tmpfs)$
           securityContext:
             readOnlyRootFilesystem: true
           env:

--- a/charts/k8s-monitoring/docs/examples/pod-labels-and-annotations/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/pod-labels-and-annotations/output.yaml
@@ -1642,6 +1642,7 @@ spec:
             - --path.rootfs=/host/root
             - --path.udev.data=/host/root/run/udev/data
             - --web.listen-address=[$(HOST_IP)]:9100
+            - --collector.filesystem.fs-types-exclude=^(ramfs|tmpfs)$
           securityContext:
             readOnlyRootFilesystem: true
           env:

--- a/charts/k8s-monitoring/docs/examples/private-image-registries/globally/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/private-image-registries/globally/output.yaml
@@ -1648,6 +1648,7 @@ spec:
             - --path.rootfs=/host/root
             - --path.udev.data=/host/root/run/udev/data
             - --web.listen-address=[$(HOST_IP)]:9100
+            - --collector.filesystem.fs-types-exclude=^(ramfs|tmpfs)$
           securityContext:
             readOnlyRootFilesystem: true
           env:

--- a/charts/k8s-monitoring/docs/examples/private-image-registries/individual/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/private-image-registries/individual/output.yaml
@@ -1656,6 +1656,7 @@ spec:
             - --path.rootfs=/host/root
             - --path.udev.data=/host/root/run/udev/data
             - --web.listen-address=[$(HOST_IP)]:9100
+            - --collector.filesystem.fs-types-exclude=^(ramfs|tmpfs)$
           securityContext:
             readOnlyRootFilesystem: true
           env:

--- a/charts/k8s-monitoring/docs/examples/proxies/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/proxies/output.yaml
@@ -2955,6 +2955,7 @@ spec:
             - --path.rootfs=/host/root
             - --path.udev.data=/host/root/run/udev/data
             - --web.listen-address=[$(HOST_IP)]:9100
+            - --collector.filesystem.fs-types-exclude=^(ramfs|tmpfs)$
           securityContext:
             readOnlyRootFilesystem: true
           env:

--- a/charts/k8s-monitoring/docs/examples/resource-requests-and-limits/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/resource-requests-and-limits/output.yaml
@@ -1632,6 +1632,7 @@ spec:
             - --path.rootfs=/host/root
             - --path.udev.data=/host/root/run/udev/data
             - --web.listen-address=[$(HOST_IP)]:9100
+            - --collector.filesystem.fs-types-exclude=^(ramfs|tmpfs)$
           securityContext:
             readOnlyRootFilesystem: true
           env:

--- a/charts/k8s-monitoring/docs/examples/scalability/autoscaling/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/scalability/autoscaling/output.yaml
@@ -1152,6 +1152,7 @@ spec:
             - --path.rootfs=/host/root
             - --path.udev.data=/host/root/run/udev/data
             - --web.listen-address=[$(HOST_IP)]:9100
+            - --collector.filesystem.fs-types-exclude=^(ramfs|tmpfs)$
           securityContext:
             readOnlyRootFilesystem: true
           env:

--- a/charts/k8s-monitoring/docs/examples/scalability/high-availability-kube-state-metrics/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/scalability/high-availability-kube-state-metrics/output.yaml
@@ -1152,6 +1152,7 @@ spec:
             - --path.rootfs=/host/root
             - --path.udev.data=/host/root/run/udev/data
             - --web.listen-address=[$(HOST_IP)]:9100
+            - --collector.filesystem.fs-types-exclude=^(ramfs|tmpfs)$
           securityContext:
             readOnlyRootFilesystem: true
           env:

--- a/charts/k8s-monitoring/docs/examples/scalability/sharded-kube-state-metrics/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/scalability/sharded-kube-state-metrics/output.yaml
@@ -1210,6 +1210,7 @@ spec:
             - --path.rootfs=/host/root
             - --path.udev.data=/host/root/run/udev/data
             - --web.listen-address=[$(HOST_IP)]:9100
+            - --collector.filesystem.fs-types-exclude=^(ramfs|tmpfs)$
           securityContext:
             readOnlyRootFilesystem: true
           env:

--- a/charts/k8s-monitoring/docs/examples/tail-sampling/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/tail-sampling/output.yaml
@@ -1642,6 +1642,7 @@ spec:
             - --path.rootfs=/host/root
             - --path.udev.data=/host/root/run/udev/data
             - --web.listen-address=[$(HOST_IP)]:9100
+            - --collector.filesystem.fs-types-exclude=^(ramfs|tmpfs)$
           securityContext:
             readOnlyRootFilesystem: true
           env:

--- a/charts/k8s-monitoring/docs/examples/tolerations/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/tolerations/output.yaml
@@ -1832,6 +1832,7 @@ spec:
             - --path.rootfs=/host/root
             - --path.udev.data=/host/root/run/udev/data
             - --web.listen-address=[$(HOST_IP)]:9100
+            - --collector.filesystem.fs-types-exclude=^(ramfs|tmpfs)$
           securityContext:
             readOnlyRootFilesystem: true
           env:

--- a/charts/k8s-monitoring/tests/integration/cluster-monitoring/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/integration/cluster-monitoring/.rendered/output.yaml
@@ -2029,6 +2029,7 @@ spec:
             - --path.rootfs=/host/root
             - --path.udev.data=/host/root/run/udev/data
             - --web.listen-address=[$(HOST_IP)]:9100
+            - --collector.filesystem.fs-types-exclude=^(ramfs|tmpfs)$
           securityContext:
             readOnlyRootFilesystem: true
           env:

--- a/charts/k8s-monitoring/tests/integration/control-plane-monitoring/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/integration/control-plane-monitoring/.rendered/output.yaml
@@ -1880,6 +1880,7 @@ spec:
             - --path.rootfs=/host/root
             - --path.udev.data=/host/root/run/udev/data
             - --web.listen-address=[$(HOST_IP)]:9100
+            - --collector.filesystem.fs-types-exclude=^(ramfs|tmpfs)$
           securityContext:
             readOnlyRootFilesystem: true
           env:

--- a/charts/k8s-monitoring/tests/integration/istio-service-mesh/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/integration/istio-service-mesh/.rendered/output.yaml
@@ -2180,6 +2180,7 @@ spec:
             - --path.rootfs=/host/root
             - --path.udev.data=/host/root/run/udev/data
             - --web.listen-address=[$(HOST_IP)]:9100
+            - --collector.filesystem.fs-types-exclude=^(ramfs|tmpfs)$
           securityContext:
             readOnlyRootFilesystem: true
           env:

--- a/charts/k8s-monitoring/tests/integration/prom-and-loki-to-otlp/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/integration/prom-and-loki-to-otlp/.rendered/output.yaml
@@ -1774,6 +1774,7 @@ spec:
             - --path.rootfs=/host/root
             - --path.udev.data=/host/root/run/udev/data
             - --web.listen-address=[$(HOST_IP)]:9100
+            - --collector.filesystem.fs-types-exclude=^(ramfs|tmpfs)$
           securityContext:
             readOnlyRootFilesystem: true
           env:

--- a/charts/k8s-monitoring/tests/integration/prometheus-io-annotations/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/integration/prometheus-io-annotations/.rendered/output.yaml
@@ -1456,6 +1456,7 @@ spec:
             - --path.rootfs=/host/root
             - --path.udev.data=/host/root/run/udev/data
             - --web.listen-address=[$(HOST_IP)]:9100
+            - --collector.filesystem.fs-types-exclude=^(ramfs|tmpfs)$
           securityContext:
             readOnlyRootFilesystem: true
           env:

--- a/charts/k8s-monitoring/tests/integration/service-integrations/coredns/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/integration/service-integrations/coredns/.rendered/output.yaml
@@ -1259,6 +1259,7 @@ spec:
             - --path.rootfs=/host/root
             - --path.udev.data=/host/root/run/udev/data
             - --web.listen-address=[$(HOST_IP)]:9100
+            - --collector.filesystem.fs-types-exclude=^(ramfs|tmpfs)$
           securityContext:
             readOnlyRootFilesystem: true
           env:

--- a/charts/k8s-monitoring/tests/integration/service-integrations/grafana/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/integration/service-integrations/grafana/.rendered/output.yaml
@@ -1891,6 +1891,7 @@ spec:
             - --path.rootfs=/host/root
             - --path.udev.data=/host/root/run/udev/data
             - --web.listen-address=[$(HOST_IP)]:9100
+            - --collector.filesystem.fs-types-exclude=^(ramfs|tmpfs)$
           securityContext:
             readOnlyRootFilesystem: true
           env:

--- a/charts/k8s-monitoring/tests/integration/service-integrations/loki/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/integration/service-integrations/loki/.rendered/output.yaml
@@ -1917,6 +1917,7 @@ spec:
             - --path.rootfs=/host/root
             - --path.udev.data=/host/root/run/udev/data
             - --web.listen-address=[$(HOST_IP)]:9100
+            - --collector.filesystem.fs-types-exclude=^(ramfs|tmpfs)$
           securityContext:
             readOnlyRootFilesystem: true
           env:

--- a/charts/k8s-monitoring/tests/integration/service-integrations/tempo/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/integration/service-integrations/tempo/.rendered/output.yaml
@@ -1917,6 +1917,7 @@ spec:
             - --path.rootfs=/host/root
             - --path.udev.data=/host/root/run/udev/data
             - --web.listen-address=[$(HOST_IP)]:9100
+            - --collector.filesystem.fs-types-exclude=^(ramfs|tmpfs)$
           securityContext:
             readOnlyRootFilesystem: true
           env:

--- a/charts/k8s-monitoring/tests/integration/sharded-kube-state-metrics/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/integration/sharded-kube-state-metrics/.rendered/output.yaml
@@ -1514,6 +1514,7 @@ spec:
             - --path.rootfs=/host/root
             - --path.udev.data=/host/root/run/udev/data
             - --web.listen-address=[$(HOST_IP)]:9100
+            - --collector.filesystem.fs-types-exclude=^(ramfs|tmpfs)$
           securityContext:
             readOnlyRootFilesystem: true
           env:

--- a/charts/k8s-monitoring/tests/integration/split-destinations/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/integration/split-destinations/.rendered/output.yaml
@@ -2211,6 +2211,7 @@ spec:
             - --path.rootfs=/host/root
             - --path.udev.data=/host/root/run/udev/data
             - --web.listen-address=[$(HOST_IP)]:9100
+            - --collector.filesystem.fs-types-exclude=^(ramfs|tmpfs)$
           securityContext:
             readOnlyRootFilesystem: true
           env:

--- a/charts/k8s-monitoring/tests/integration/upgrade/minor/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/integration/upgrade/minor/.rendered/output.yaml
@@ -2055,6 +2055,7 @@ spec:
             - --path.rootfs=/host/root
             - --path.udev.data=/host/root/run/udev/data
             - --web.listen-address=[$(HOST_IP)]:9100
+            - --collector.filesystem.fs-types-exclude=^(ramfs|tmpfs)$
           securityContext:
             readOnlyRootFilesystem: true
           env:

--- a/charts/k8s-monitoring/tests/integration/upgrade/patch/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/integration/upgrade/patch/.rendered/output.yaml
@@ -2055,6 +2055,7 @@ spec:
             - --path.rootfs=/host/root
             - --path.udev.data=/host/root/run/udev/data
             - --web.listen-address=[$(HOST_IP)]:9100
+            - --collector.filesystem.fs-types-exclude=^(ramfs|tmpfs)$
           securityContext:
             readOnlyRootFilesystem: true
           env:

--- a/charts/k8s-monitoring/tests/platform/aks/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/platform/aks/.rendered/output.yaml
@@ -1884,6 +1884,7 @@ spec:
             - --path.rootfs=/host/root
             - --path.udev.data=/host/root/run/udev/data
             - --web.listen-address=[$(HOST_IP)]:9100
+            - --collector.filesystem.fs-types-exclude=^(ramfs|tmpfs)$
           securityContext:
             readOnlyRootFilesystem: true
           env:

--- a/charts/k8s-monitoring/tests/platform/eks-fargate/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/platform/eks-fargate/.rendered/output.yaml
@@ -1867,6 +1867,7 @@ spec:
             - --path.rootfs=/host/root
             - --path.udev.data=/host/root/run/udev/data
             - --web.listen-address=[$(HOST_IP)]:9100
+            - --collector.filesystem.fs-types-exclude=^(ramfs|tmpfs)$
           securityContext:
             readOnlyRootFilesystem: true
           env:

--- a/charts/k8s-monitoring/tests/platform/eks-with-windows/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/platform/eks-with-windows/.rendered/output.yaml
@@ -2037,6 +2037,7 @@ spec:
             - --path.rootfs=/host/root
             - --path.udev.data=/host/root/run/udev/data
             - --web.listen-address=[$(HOST_IP)]:9100
+            - --collector.filesystem.fs-types-exclude=^(ramfs|tmpfs)$
           securityContext:
             readOnlyRootFilesystem: true
           env:

--- a/charts/k8s-monitoring/tests/platform/gke/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/platform/gke/.rendered/output.yaml
@@ -1884,6 +1884,7 @@ spec:
             - --path.rootfs=/host/root
             - --path.udev.data=/host/root/run/udev/data
             - --web.listen-address=[$(HOST_IP)]:9100
+            - --collector.filesystem.fs-types-exclude=^(ramfs|tmpfs)$
           securityContext:
             readOnlyRootFilesystem: true
           env:

--- a/charts/k8s-monitoring/tests/platform/grafana-cloud/k8s-monitoring/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/platform/grafana-cloud/k8s-monitoring/.rendered/output.yaml
@@ -2315,6 +2315,7 @@ spec:
             - --path.rootfs=/host/root
             - --path.udev.data=/host/root/run/udev/data
             - --web.listen-address=[$(HOST_IP)]:9100
+            - --collector.filesystem.fs-types-exclude=^(ramfs|tmpfs)$
           securityContext:
             readOnlyRootFilesystem: true
           env:


### PR DESCRIPTION
Thanks Bryce:
https://grafana.slack.com/archives/CAGMZG3GB/p1749273784731179