### PR TITLE
Allow for modifying alloy settings in one place.

### DIFF
--- a/charts/k8s-monitoring/README.md
+++ b/charts/k8s-monitoring/README.md
@@ -227,6 +227,12 @@ details:
 |-----|------|---------|-------------|
 | alloy-metrics.enabled | bool | `false` | Deploy the Alloy instance for collecting metrics. |
 
+### Alloy Operator
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| alloy-operator.deploy | bool | `true` | Deploy the Alloy Operator. |
+
 ### Collectors - Alloy Profiles
 
 | Key | Type | Default | Description |
@@ -370,5 +376,5 @@ details:
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| alloy-operator.deploy | bool | `true` |  |
+| alloyTemplate | object | `{}` |  |
 | extraObjects | list | `[]` | Deploy additional manifest objects |

--- a/charts/k8s-monitoring/docs/collectors/.doc_templates/alloy.gotmpl
+++ b/charts/k8s-monitoring/docs/collectors/.doc_templates/alloy.gotmpl
@@ -1,0 +1,36 @@
+# Grafana Alloy
+
+Grafana Alloy combines the strengths of the leading collectors into one place. Whether observing applications,
+infrastructure, or both, Grafana Alloy can collect, process, and export telemetry signals to scale and future-proof your
+observability approach.
+
+The Kubernetes Monitoring Helm chart uses the Alloy Operator to deploy Grafana Alloy in your cluster. Each instance is
+defined in its own section in the Kubernetes Monitoring Helm chart values file. Here is an example of the general format
+to enable and configure a collector:
+
+```yaml
+alloy-<collector name>:
+  enabled: true  # Enable deploying this collector
+
+  alloy:  # Settings related to the Alloy instance
+    ...
+  controller:  # Settings related to the Alloy controller
+    ...
+```
+
+This creates a Kubernetes workload as either a DaemonSet, StatefulSet, or Deployment, with its own set of Pods running
+Alloy containers.
+
+## Alloy settings
+
+Settings for each primary Alloy instance come from several potential sources, in order of precedence:
+
+1.   The settings for each Alloy instance in the values.yaml file.
+2.   The settings in the `alloyTemplate` section of the values.yaml file.
+3.   The settings for the named alloy instance in [named defaults](https://github.com/grafana/k8s-monitoring-helm/tree/main/charts/k8s-monitoring/collectors/named-defaults).
+4.   The settings common for all Alloy instances deployed by this chart, defined in [alloy-values.yaml](https://github.com/grafana/k8s-monitoring-helm/blob/main/charts/k8s-monitoring/collectors/alloy-values.yaml).
+5.   The default settings defined by the Alloy project, defined in [alloy-values.yaml)[https://github.com/grafana/k8s-monitoring-helm/blob/main/charts/k8s-monitoring/collectors/upstream/alloy-values.yaml).
+
+<!-- textlint-disable terminology -->
+{{ template "chart.valuesSection" . }}
+<!-- textlint-enable terminology -->

--- a/charts/k8s-monitoring/docs/collectors/alloy.md
+++ b/charts/k8s-monitoring/docs/collectors/alloy.md
@@ -1,5 +1,37 @@
-# alloy
+# Grafana Alloy
 
+Grafana Alloy combines the strengths of the leading collectors into one place. Whether observing applications,
+infrastructure, or both, Grafana Alloy can collect, process, and export telemetry signals to scale and future-proof your
+observability approach.
+
+The Kubernetes Monitoring Helm chart uses the Alloy Operator to deploy Grafana Alloy in your cluster. Each instance is
+defined in its own section in the Kubernetes Monitoring Helm chart values file. Here is an example of the general format
+to enable and configure a collector:
+
+```yaml
+alloy-<collector name>:
+  enabled: true  # Enable deploying this collector
+
+  alloy:  # Settings related to the Alloy instance
+    ...
+  controller:  # Settings related to the Alloy controller
+    ...
+```
+
+This creates a Kubernetes workload as either a DaemonSet, StatefulSet, or Deployment, with its own set of Pods running
+Alloy containers.
+
+## Alloy settings
+
+Settings for each primary Alloy instance come from several potential sources, in order of precedence:
+
+1.   The settings for each Alloy instance in the values.yaml file.
+2.   The settings in the `alloyTemplate` section of the values.yaml file.
+3.   The settings for the named alloy instance in [named defaults](https://github.com/grafana/k8s-monitoring-helm/tree/main/charts/k8s-monitoring/collectors/named-defaults).
+4.   The settings common for all Alloy instances deployed by this chart, defined in [alloy-values.yaml](https://github.com/grafana/k8s-monitoring-helm/blob/main/charts/k8s-monitoring/collectors/alloy-values.yaml).
+5.   The default settings defined by the Alloy project, defined in [alloy-values.yaml)[https://github.com/grafana/k8s-monitoring-helm/blob/main/charts/k8s-monitoring/collectors/upstream/alloy-values.yaml).
+
+<!-- textlint-disable terminology -->
 ## Values
 
 ### General
@@ -46,3 +78,4 @@
 | remoteConfig.proxyFromEnvironment | bool | `false` | Use the proxy URL indicated by environment variables. |
 | remoteConfig.proxyURL | string | `""` | The proxy URL to use of the remote config server. |
 | remoteConfig.url | string | `""` | The URL of the remote config server. |
+<!-- textlint-enable terminology -->

--- a/charts/k8s-monitoring/docs/examples/auth/bearer-token/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/auth/bearer-token/output.yaml
@@ -977,7 +977,7 @@ kind: Alloy
 metadata:
   name: k8smon-alloy-metrics
   namespace: default
-spec: 
+spec:
   alloy:
     clustering:
       enabled: true
@@ -1168,7 +1168,7 @@ kind: Alloy
 metadata:
   name: k8smon-alloy-logs
   namespace: default
-spec: 
+spec:
   alloy:
     clustering:
       enabled: false
@@ -1363,7 +1363,7 @@ kind: Alloy
 metadata:
   name: k8smon-alloy-receiver
   namespace: default
-spec: 
+spec:
   alloy:
     clustering:
       enabled: false

--- a/charts/k8s-monitoring/docs/examples/auth/embedded-secrets/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/auth/embedded-secrets/output.yaml
@@ -957,7 +957,7 @@ kind: Alloy
 metadata:
   name: k8smon-alloy-metrics
   namespace: default
-spec: 
+spec:
   alloy:
     clustering:
       enabled: true
@@ -1148,7 +1148,7 @@ kind: Alloy
 metadata:
   name: k8smon-alloy-logs
   namespace: default
-spec: 
+spec:
   alloy:
     clustering:
       enabled: false
@@ -1341,7 +1341,7 @@ kind: Alloy
 metadata:
   name: k8smon-alloy-receiver
   namespace: default
-spec: 
+spec:
   alloy:
     clustering:
       enabled: false

--- a/charts/k8s-monitoring/docs/examples/auth/external-secrets/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/auth/external-secrets/output.yaml
@@ -1006,7 +1006,7 @@ kind: Alloy
 metadata:
   name: k8smon-alloy-metrics
   namespace: default
-spec: 
+spec:
   alloy:
     clustering:
       enabled: true
@@ -1197,7 +1197,7 @@ kind: Alloy
 metadata:
   name: k8smon-alloy-logs
   namespace: default
-spec: 
+spec:
   alloy:
     clustering:
       enabled: false
@@ -1390,7 +1390,7 @@ kind: Alloy
 metadata:
   name: k8smon-alloy-receiver
   namespace: default
-spec: 
+spec:
   alloy:
     clustering:
       enabled: false

--- a/charts/k8s-monitoring/docs/examples/auth/oauth2/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/auth/oauth2/output.yaml
@@ -2745,7 +2745,7 @@ kind: Alloy
 metadata:
   name: k8smon-alloy-metrics
   namespace: default
-spec: 
+spec:
   alloy:
     clustering:
       enabled: true
@@ -2936,7 +2936,7 @@ kind: Alloy
 metadata:
   name: k8smon-alloy-singleton
   namespace: default
-spec: 
+spec:
   alloy:
     clustering:
       enabled: false
@@ -3127,7 +3127,7 @@ kind: Alloy
 metadata:
   name: k8smon-alloy-logs
   namespace: default
-spec: 
+spec:
   alloy:
     clustering:
       enabled: false

--- a/charts/k8s-monitoring/docs/examples/auth/sigv4/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/auth/sigv4/output.yaml
@@ -1509,7 +1509,7 @@ kind: Alloy
 metadata:
   name: k8smon-alloy-metrics
   namespace: default
-spec: 
+spec:
   alloy:
     clustering:
       enabled: true

--- a/charts/k8s-monitoring/docs/examples/collector-storage/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/collector-storage/output.yaml
@@ -1734,7 +1734,7 @@ kind: Alloy
 metadata:
   name: k8smon-alloy-metrics
   namespace: default
-spec: 
+spec:
   alloy:
     clustering:
       enabled: true
@@ -1936,7 +1936,7 @@ kind: Alloy
 metadata:
   name: k8smon-alloy-logs
   namespace: default
-spec: 
+spec:
   alloy:
     clustering:
       enabled: false

--- a/charts/k8s-monitoring/docs/examples/destinations/otlp-endpoint/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/destinations/otlp-endpoint/output.yaml
@@ -1960,7 +1960,7 @@ kind: Alloy
 metadata:
   name: k8smon-alloy-metrics
   namespace: default
-spec: 
+spec:
   alloy:
     clustering:
       enabled: true
@@ -2151,7 +2151,7 @@ kind: Alloy
 metadata:
   name: k8smon-alloy-logs
   namespace: default
-spec: 
+spec:
   alloy:
     clustering:
       enabled: false

--- a/charts/k8s-monitoring/docs/examples/exclude-by-namespace/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/exclude-by-namespace/output.yaml
@@ -3746,7 +3746,7 @@ kind: Alloy
 metadata:
   name: k8smon-alloy-metrics
   namespace: default
-spec: 
+spec:
   alloy:
     clustering:
       enabled: true
@@ -3937,7 +3937,7 @@ kind: Alloy
 metadata:
   name: k8smon-alloy-singleton
   namespace: default
-spec: 
+spec:
   alloy:
     clustering:
       enabled: false
@@ -4128,7 +4128,7 @@ kind: Alloy
 metadata:
   name: k8smon-alloy-logs
   namespace: default
-spec: 
+spec:
   alloy:
     clustering:
       enabled: false
@@ -4321,7 +4321,7 @@ kind: Alloy
 metadata:
   name: k8smon-alloy-receiver
   namespace: default
-spec: 
+spec:
   alloy:
     clustering:
       enabled: false
@@ -4516,7 +4516,7 @@ kind: Alloy
 metadata:
   name: k8smon-alloy-profiles
   namespace: default
-spec: 
+spec:
   alloy:
     clustering:
       enabled: false

--- a/charts/k8s-monitoring/docs/examples/extra-configuration/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/extra-configuration/output.yaml
@@ -347,7 +347,7 @@ kind: Alloy
 metadata:
   name: k8smon-alloy-metrics
   namespace: default
-spec: 
+spec:
   alloy:
     clustering:
       enabled: true

--- a/charts/k8s-monitoring/docs/examples/extra-rules/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/extra-rules/output.yaml
@@ -1961,7 +1961,7 @@ kind: Alloy
 metadata:
   name: k8smon-alloy-metrics
   namespace: default
-spec: 
+spec:
   alloy:
     clustering:
       enabled: true
@@ -2154,7 +2154,7 @@ kind: Alloy
 metadata:
   name: k8smon-alloy-singleton
   namespace: default
-spec: 
+spec:
   alloy:
     clustering:
       enabled: false
@@ -2347,7 +2347,7 @@ kind: Alloy
 metadata:
   name: k8smon-alloy-logs
   namespace: default
-spec: 
+spec:
   alloy:
     clustering:
       enabled: false

--- a/charts/k8s-monitoring/docs/examples/features/annotation-autodiscovery/default/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/features/annotation-autodiscovery/default/output.yaml
@@ -719,7 +719,7 @@ kind: Alloy
 metadata:
   name: k8smon-alloy-metrics
   namespace: default
-spec: 
+spec:
   alloy:
     clustering:
       enabled: true

--- a/charts/k8s-monitoring/docs/examples/features/annotation-autodiscovery/prom-annotations/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/features/annotation-autodiscovery/prom-annotations/output.yaml
@@ -719,7 +719,7 @@ kind: Alloy
 metadata:
   name: k8smon-alloy-metrics
   namespace: default
-spec: 
+spec:
   alloy:
     clustering:
       enabled: true

--- a/charts/k8s-monitoring/docs/examples/features/application-observability/default/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/features/application-observability/default/output.yaml
@@ -595,7 +595,7 @@ kind: Alloy
 metadata:
   name: k8smon-alloy-receiver
   namespace: default
-spec: 
+spec:
   alloy:
     clustering:
       enabled: false

--- a/charts/k8s-monitoring/docs/examples/features/application-observability/tail-sampling/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/features/application-observability/tail-sampling/output.yaml
@@ -633,7 +633,7 @@ kind: Alloy
 metadata:
   name: k8smon-alloy-receiver
   namespace: default
-spec: 
+spec:
   alloy:
     clustering:
       enabled: false

--- a/charts/k8s-monitoring/docs/examples/features/auto-instrumentation/beyla-metrics-and-traces/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/features/auto-instrumentation/beyla-metrics-and-traces/output.yaml
@@ -994,7 +994,7 @@ kind: Alloy
 metadata:
   name: k8smon-alloy-metrics
   namespace: default
-spec: 
+spec:
   alloy:
     clustering:
       enabled: true
@@ -1185,7 +1185,7 @@ kind: Alloy
 metadata:
   name: k8smon-alloy-receiver
   namespace: default
-spec: 
+spec:
   alloy:
     clustering:
       enabled: false

--- a/charts/k8s-monitoring/docs/examples/features/auto-instrumentation/beyla-metrics/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/features/auto-instrumentation/beyla-metrics/output.yaml
@@ -607,7 +607,7 @@ kind: Alloy
 metadata:
   name: k8smon-alloy-metrics
   namespace: default
-spec: 
+spec:
   alloy:
     clustering:
       enabled: true

--- a/charts/k8s-monitoring/docs/examples/features/auto-instrumentation/discovery-rules/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/features/auto-instrumentation/discovery-rules/output.yaml
@@ -608,7 +608,7 @@ kind: Alloy
 metadata:
   name: k8smon-alloy-metrics
   namespace: default
-spec: 
+spec:
   alloy:
     clustering:
       enabled: true

--- a/charts/k8s-monitoring/docs/examples/features/cluster-events/default/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/features/cluster-events/default/output.yaml
@@ -396,7 +396,7 @@ kind: Alloy
 metadata:
   name: k8smon-alloy-singleton
   namespace: default
-spec: 
+spec:
   alloy:
     clustering:
       enabled: false

--- a/charts/k8s-monitoring/docs/examples/features/cluster-metrics/control-plane-monitoring/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/features/cluster-metrics/control-plane-monitoring/output.yaml
@@ -2292,7 +2292,7 @@ kind: Alloy
 metadata:
   name: k8smon-alloy-metrics
   namespace: default
-spec: 
+spec:
   alloy:
     clustering:
       enabled: true
@@ -2483,7 +2483,7 @@ kind: Alloy
 metadata:
   name: k8smon-alloy-singleton
   namespace: default
-spec: 
+spec:
   alloy:
     clustering:
       enabled: false
@@ -2674,7 +2674,7 @@ kind: Alloy
 metadata:
   name: k8smon-alloy-logs
   namespace: default
-spec: 
+spec:
   alloy:
     clustering:
       enabled: false

--- a/charts/k8s-monitoring/docs/examples/features/cluster-metrics/default/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/features/cluster-metrics/default/output.yaml
@@ -2030,7 +2030,7 @@ kind: Alloy
 metadata:
   name: k8smon-alloy-metrics
   namespace: default
-spec: 
+spec:
   alloy:
     clustering:
       enabled: true

--- a/charts/k8s-monitoring/docs/examples/features/integrations/alloy/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/features/integrations/alloy/output.yaml
@@ -680,7 +680,7 @@ kind: Alloy
 metadata:
   name: k8smon-alloy-metrics
   namespace: default
-spec: 
+spec:
   alloy:
     clustering:
       enabled: true

--- a/charts/k8s-monitoring/docs/examples/features/integrations/cert-manager/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/features/integrations/cert-manager/output.yaml
@@ -506,7 +506,7 @@ kind: Alloy
 metadata:
   name: k8smon-alloy-metrics
   namespace: default
-spec: 
+spec:
   alloy:
     clustering:
       enabled: true

--- a/charts/k8s-monitoring/docs/examples/features/integrations/etcd/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/features/integrations/etcd/output.yaml
@@ -506,7 +506,7 @@ kind: Alloy
 metadata:
   name: k8smon-alloy-metrics
   namespace: default
-spec: 
+spec:
   alloy:
     clustering:
       enabled: true

--- a/charts/k8s-monitoring/docs/examples/features/integrations/grafana/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/features/integrations/grafana/output.yaml
@@ -924,7 +924,7 @@ kind: Alloy
 metadata:
   name: k8smon-alloy-metrics
   namespace: default
-spec: 
+spec:
   alloy:
     clustering:
       enabled: true
@@ -1115,7 +1115,7 @@ kind: Alloy
 metadata:
   name: k8smon-alloy-logs
   namespace: default
-spec: 
+spec:
   alloy:
     clustering:
       enabled: false

--- a/charts/k8s-monitoring/docs/examples/features/integrations/loki/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/features/integrations/loki/output.yaml
@@ -950,7 +950,7 @@ kind: Alloy
 metadata:
   name: k8smon-alloy-metrics
   namespace: default
-spec: 
+spec:
   alloy:
     clustering:
       enabled: true
@@ -1141,7 +1141,7 @@ kind: Alloy
 metadata:
   name: k8smon-alloy-logs
   namespace: default
-spec: 
+spec:
   alloy:
     clustering:
       enabled: false

--- a/charts/k8s-monitoring/docs/examples/features/integrations/mimir/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/features/integrations/mimir/output.yaml
@@ -948,7 +948,7 @@ kind: Alloy
 metadata:
   name: k8smon-alloy-metrics
   namespace: default
-spec: 
+spec:
   alloy:
     clustering:
       enabled: true
@@ -1139,7 +1139,7 @@ kind: Alloy
 metadata:
   name: k8smon-alloy-logs
   namespace: default
-spec: 
+spec:
   alloy:
     clustering:
       enabled: false

--- a/charts/k8s-monitoring/docs/examples/features/integrations/multiple/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/features/integrations/multiple/output.yaml
@@ -831,7 +831,7 @@ kind: Alloy
 metadata:
   name: k8smon-alloy-metrics
   namespace: default
-spec: 
+spec:
   alloy:
     clustering:
       enabled: true
@@ -1022,7 +1022,7 @@ kind: Alloy
 metadata:
   name: k8smon-alloy-logs
   namespace: default
-spec: 
+spec:
   alloy:
     clustering:
       enabled: false

--- a/charts/k8s-monitoring/docs/examples/features/integrations/mysql/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/features/integrations/mysql/output.yaml
@@ -746,7 +746,7 @@ kind: Alloy
 metadata:
   name: k8smon-alloy-metrics
   namespace: default
-spec: 
+spec:
   alloy:
     clustering:
       enabled: true
@@ -937,7 +937,7 @@ kind: Alloy
 metadata:
   name: k8smon-alloy-logs
   namespace: default
-spec: 
+spec:
   alloy:
     clustering:
       enabled: false

--- a/charts/k8s-monitoring/docs/examples/features/node-logs/default/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/features/node-logs/default/output.yaml
@@ -464,7 +464,7 @@ kind: Alloy
 metadata:
   name: k8smon-alloy-logs
   namespace: default
-spec: 
+spec:
   alloy:
     clustering:
       enabled: false

--- a/charts/k8s-monitoring/docs/examples/features/pod-logs/default/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/features/pod-logs/default/output.yaml
@@ -519,7 +519,7 @@ kind: Alloy
 metadata:
   name: k8smon-alloy-logs
   namespace: default
-spec: 
+spec:
   alloy:
     clustering:
       enabled: false

--- a/charts/k8s-monitoring/docs/examples/features/pod-logs/kubernetes-api/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/features/pod-logs/kubernetes-api/output.yaml
@@ -502,7 +502,7 @@ kind: Alloy
 metadata:
   name: k8smon-alloy-logs
   namespace: default
-spec: 
+spec:
   alloy:
     clustering:
       enabled: true

--- a/charts/k8s-monitoring/docs/examples/features/profiles-receiver/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/features/profiles-receiver/output.yaml
@@ -326,7 +326,7 @@ kind: Alloy
 metadata:
   name: k8smon-alloy-receiver
   namespace: default
-spec: 
+spec:
   alloy:
     clustering:
       enabled: false

--- a/charts/k8s-monitoring/docs/examples/features/profiling/default/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/features/profiling/default/output.yaml
@@ -1175,7 +1175,7 @@ kind: Alloy
 metadata:
   name: k8smon-alloy-profiles
   namespace: default
-spec: 
+spec:
   alloy:
     clustering:
       enabled: false

--- a/charts/k8s-monitoring/docs/examples/features/prometheus-operator-objects/default/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/features/prometheus-operator-objects/default/output.yaml
@@ -448,7 +448,7 @@ kind: Alloy
 metadata:
   name: k8smon-alloy-metrics
   namespace: default
-spec: 
+spec:
   alloy:
     clustering:
       enabled: true

--- a/charts/k8s-monitoring/docs/examples/images/images-by-digest/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/images/images-by-digest/output.yaml
@@ -1992,6 +1992,10 @@ metadata:
   namespace: default
 spec:
   alloy:
+    clustering:
+      enabled: false
+      name: ""
+      portName: http
     configMap:
       content: |-
         otelcol.receiver.otlp "sampler_receiver" {
@@ -2050,15 +2054,183 @@ spec:
           }
         }
       create: true
+      key: null
+      name: null
+    enableReporting: true
+    envFrom: []
+    extraArgs: []
+    extraEnv: []
+    extraPorts: []
+    hostAliases: []
+    lifecycle: {}
+    listenAddr: 0.0.0.0
+    listenPort: 12345
+    listenScheme: HTTP
+    livenessProbe: {}
+    mounts:
+      dockercontainers: false
+      extra: []
+      varlog: false
+    resources: {}
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        add:
+        - CHOWN
+        - DAC_OVERRIDE
+        - FOWNER
+        - FSETID
+        - KILL
+        - SETGID
+        - SETUID
+        - SETPCAP
+        - NET_BIND_SERVICE
+        - NET_RAW
+        - SYS_CHROOT
+        - MKNOD
+        - AUDIT_WRITE
+        - SETFCAP
+        drop:
+        - ALL
+      seccompProfile:
+        type: RuntimeDefault
+    stabilityLevel: generally-available
+    storagePath: /tmp/alloy
+    uiPathPrefix: /
   configReloader:
+    customArgs: []
+    enabled: true
     image:
       digest: sha256:1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef
+      registry: quay.io
+      repository: prometheus-operator/prometheus-config-reloader
+      tag: v0.81.0
+    resources:
+      requests:
+        cpu: 10m
+        memory: 50Mi
+    securityContext: {}
   controller:
+    affinity: {}
+    autoscaling:
+      enabled: false
+      horizontal:
+        enabled: false
+        maxReplicas: 5
+        minReplicas: 1
+        scaleDown:
+          policies: []
+          selectPolicy: Max
+          stabilizationWindowSeconds: 300
+        scaleUp:
+          policies: []
+          selectPolicy: Max
+          stabilizationWindowSeconds: 0
+        targetCPUUtilizationPercentage: 0
+        targetMemoryUtilizationPercentage: 80
+      maxReplicas: 5
+      minReplicas: 1
+      scaleDown:
+        policies: []
+        selectPolicy: Max
+        stabilizationWindowSeconds: 300
+      scaleUp:
+        policies: []
+        selectPolicy: Max
+        stabilizationWindowSeconds: 0
+      targetCPUUtilizationPercentage: 0
+      targetMemoryUtilizationPercentage: 80
+      vertical:
+        enabled: false
+        recommenders: []
+        resourcePolicy:
+          containerPolicies:
+          - containerName: alloy
+            controlledResources:
+            - cpu
+            - memory
+            controlledValues: RequestsAndLimits
+            maxAllowed: {}
+            minAllowed: {}
+        updatePolicy: null
+    dnsPolicy: ClusterFirst
+    enableStatefulSetAutoDeletePVC: false
+    extraAnnotations: {}
+    extraContainers: []
+    hostNetwork: false
+    hostPID: false
+    initContainers: []
+    nodeSelector:
+      kubernetes.io/os: linux
+    parallelRollout: true
+    podAnnotations:
+      k8s.grafana.com/logs.job: integrations/alloy
+    podDisruptionBudget:
+      enabled: false
+      maxUnavailable: null
+      minAvailable: null
+    podLabels: {}
+    priorityClassName: ""
     replicas: 2
+    terminationGracePeriodSeconds: null
+    tolerations: []
+    topologySpreadConstraints: []
     type: statefulset
+    updateStrategy: {}
+    volumeClaimTemplates: []
+    volumes:
+      extra: []
+  crds:
+    create: false
+  extraObjects: []
+  fullnameOverride: null
+  global:
+    image:
+      pullSecrets: []
+      registry: ""
+    podSecurityContext: {}
   image:
     digest: sha256:1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef
+    pullPolicy: IfNotPresent
+    pullSecrets: []
+    registry: docker.io
+    repository: grafana/alloy
+    tag: null
+  ingress:
+    annotations: {}
+    enabled: false
+    extraPaths: []
+    faroPort: 12347
+    hosts:
+    - chart-example.local
+    labels: {}
+    path: /
+    pathType: Prefix
+    tls: []
   nameOverride: tempo-sampler
+  namespaceOverride: null
+  rbac:
+    create: true
+  service:
+    annotations: {}
+    clusterIP: ""
+    enabled: true
+    internalTrafficPolicy: Cluster
+    nodePort: 31128
+    type: ClusterIP
+  serviceAccount:
+    additionalLabels: {}
+    annotations: {}
+    automountServiceAccountToken: true
+    create: true
+    name: null
+  serviceMonitor:
+    additionalLabels: {}
+    enabled: false
+    interval: ""
+    metricRelabelings: []
+    relabelings: []
+    tlsConfig: {}
 ---
 # Source: k8s-monitoring/templates/alloy.yaml
 apiVersion: collectors.grafana.com/v1alpha1
@@ -2066,7 +2238,7 @@ kind: Alloy
 metadata:
   name: k8smon-alloy-metrics
   namespace: default
-spec: 
+spec:
   alloy:
     clustering:
       enabled: true
@@ -2257,7 +2429,7 @@ kind: Alloy
 metadata:
   name: k8smon-alloy-receiver
   namespace: default
-spec: 
+spec:
   alloy:
     clustering:
       enabled: false

--- a/charts/k8s-monitoring/docs/examples/include-by-namespace/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/include-by-namespace/output.yaml
@@ -3716,7 +3716,7 @@ kind: Alloy
 metadata:
   name: k8smon-alloy-metrics
   namespace: default
-spec: 
+spec:
   alloy:
     clustering:
       enabled: true
@@ -3907,7 +3907,7 @@ kind: Alloy
 metadata:
   name: k8smon-alloy-singleton
   namespace: default
-spec: 
+spec:
   alloy:
     clustering:
       enabled: false
@@ -4098,7 +4098,7 @@ kind: Alloy
 metadata:
   name: k8smon-alloy-logs
   namespace: default
-spec: 
+spec:
   alloy:
     clustering:
       enabled: false
@@ -4291,7 +4291,7 @@ kind: Alloy
 metadata:
   name: k8smon-alloy-receiver
   namespace: default
-spec: 
+spec:
   alloy:
     clustering:
       enabled: false
@@ -4486,7 +4486,7 @@ kind: Alloy
 metadata:
   name: k8smon-alloy-profiles
   namespace: default
-spec: 
+spec:
   alloy:
     clustering:
       enabled: false

--- a/charts/k8s-monitoring/docs/examples/istio-service-mesh/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/istio-service-mesh/output.yaml
@@ -2059,7 +2059,7 @@ kind: Alloy
 metadata:
   name: k8smon-alloy-metrics
   namespace: default
-spec: 
+spec:
   alloy:
     clustering:
       enabled: true
@@ -2250,7 +2250,7 @@ kind: Alloy
 metadata:
   name: k8smon-alloy-receiver
   namespace: default
-spec: 
+spec:
   alloy:
     clustering:
       enabled: false

--- a/charts/k8s-monitoring/docs/examples/log-metrics/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/log-metrics/output.yaml
@@ -937,7 +937,7 @@ kind: Alloy
 metadata:
   name: k8smon-alloy-metrics
   namespace: default
-spec: 
+spec:
   alloy:
     clustering:
       enabled: true
@@ -1128,7 +1128,7 @@ kind: Alloy
 metadata:
   name: k8smon-alloy-logs
   namespace: default
-spec: 
+spec:
   alloy:
     clustering:
       enabled: false

--- a/charts/k8s-monitoring/docs/examples/meta-monitoring/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/meta-monitoring/output.yaml
@@ -3268,7 +3268,7 @@ kind: Alloy
 metadata:
   name: k8smon-alloy-singleton
   namespace: default
-spec: 
+spec:
   alloy:
     clustering:
       enabled: false
@@ -3459,7 +3459,7 @@ kind: Alloy
 metadata:
   name: k8smon-alloy-receiver
   namespace: default
-spec: 
+spec:
   alloy:
     clustering:
       enabled: false

--- a/charts/k8s-monitoring/docs/examples/metrics-tuning/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/metrics-tuning/output.yaml
@@ -1826,7 +1826,7 @@ kind: Alloy
 metadata:
   name: k8smon-alloy-metrics
   namespace: default
-spec: 
+spec:
   alloy:
     clustering:
       enabled: true

--- a/charts/k8s-monitoring/docs/examples/namespace-labels-and-annotations/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/namespace-labels-and-annotations/output.yaml
@@ -2012,7 +2012,7 @@ kind: Alloy
 metadata:
   name: k8smon-alloy-metrics
   namespace: default
-spec: 
+spec:
   alloy:
     clustering:
       enabled: true
@@ -2203,7 +2203,7 @@ kind: Alloy
 metadata:
   name: k8smon-alloy-logs
   namespace: default
-spec: 
+spec:
   alloy:
     clustering:
       enabled: false
@@ -2396,7 +2396,7 @@ kind: Alloy
 metadata:
   name: k8smon-alloy-receiver
   namespace: default
-spec: 
+spec:
   alloy:
     clustering:
       enabled: false

--- a/charts/k8s-monitoring/docs/examples/node-labels/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/node-labels/output.yaml
@@ -2297,7 +2297,7 @@ kind: Alloy
 metadata:
   name: k8smon-alloy-metrics
   namespace: default
-spec: 
+spec:
   alloy:
     clustering:
       enabled: true
@@ -2488,7 +2488,7 @@ kind: Alloy
 metadata:
   name: k8smon-alloy-logs
   namespace: default
-spec: 
+spec:
   alloy:
     clustering:
       enabled: false

--- a/charts/k8s-monitoring/docs/examples/platforms/azure-aks/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/platforms/azure-aks/output.yaml
@@ -1907,7 +1907,7 @@ kind: Alloy
 metadata:
   name: k8smon-alloy-metrics
   namespace: default
-spec: 
+spec:
   alloy:
     clustering:
       enabled: true
@@ -2099,7 +2099,7 @@ kind: Alloy
 metadata:
   name: k8smon-alloy-singleton
   namespace: default
-spec: 
+spec:
   alloy:
     clustering:
       enabled: false
@@ -2291,7 +2291,7 @@ kind: Alloy
 metadata:
   name: k8smon-alloy-logs
   namespace: default
-spec: 
+spec:
   alloy:
     clustering:
       enabled: false

--- a/charts/k8s-monitoring/docs/examples/platforms/eks-fargate/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/platforms/eks-fargate/output.yaml
@@ -1578,7 +1578,7 @@ kind: Alloy
 metadata:
   name: k8smon-alloy-metrics
   namespace: default
-spec: 
+spec:
   alloy:
     clustering:
       enabled: true
@@ -1769,7 +1769,7 @@ kind: Alloy
 metadata:
   name: k8smon-alloy-singleton
   namespace: default
-spec: 
+spec:
   alloy:
     clustering:
       enabled: false
@@ -1960,7 +1960,7 @@ kind: Alloy
 metadata:
   name: k8smon-alloy-logs
   namespace: default
-spec: 
+spec:
   alloy:
     clustering:
       enabled: true

--- a/charts/k8s-monitoring/docs/examples/platforms/gke-autopilot/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/platforms/gke-autopilot/output.yaml
@@ -1595,7 +1595,7 @@ kind: Alloy
 metadata:
   name: k8smon-alloy-metrics
   namespace: default
-spec: 
+spec:
   alloy:
     clustering:
       enabled: true
@@ -1786,7 +1786,7 @@ kind: Alloy
 metadata:
   name: k8smon-alloy-singleton
   namespace: default
-spec: 
+spec:
   alloy:
     clustering:
       enabled: false
@@ -1977,7 +1977,7 @@ kind: Alloy
 metadata:
   name: k8smon-alloy-logs
   namespace: default
-spec: 
+spec:
   alloy:
     clustering:
       enabled: false

--- a/charts/k8s-monitoring/docs/examples/platforms/openshift/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/platforms/openshift/output.yaml
@@ -2070,7 +2070,7 @@ kind: Alloy
 metadata:
   name: k8smon-alloy-metrics
   namespace: default
-spec: 
+spec:
   alloy:
     clustering:
       enabled: true
@@ -2261,7 +2261,7 @@ kind: Alloy
 metadata:
   name: k8smon-alloy-singleton
   namespace: default
-spec: 
+spec:
   alloy:
     clustering:
       enabled: false
@@ -2452,7 +2452,7 @@ kind: Alloy
 metadata:
   name: k8smon-alloy-logs
   namespace: default
-spec: 
+spec:
   alloy:
     clustering:
       enabled: false

--- a/charts/k8s-monitoring/docs/examples/pod-labels-and-annotations/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/pod-labels-and-annotations/output.yaml
@@ -2012,7 +2012,7 @@ kind: Alloy
 metadata:
   name: k8smon-alloy-metrics
   namespace: default
-spec: 
+spec:
   alloy:
     clustering:
       enabled: true
@@ -2203,7 +2203,7 @@ kind: Alloy
 metadata:
   name: k8smon-alloy-logs
   namespace: default
-spec: 
+spec:
   alloy:
     clustering:
       enabled: false
@@ -2396,7 +2396,7 @@ kind: Alloy
 metadata:
   name: k8smon-alloy-receiver
   namespace: default
-spec: 
+spec:
   alloy:
     clustering:
       enabled: false

--- a/charts/k8s-monitoring/docs/examples/private-image-registries/globally/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/private-image-registries/globally/output.yaml
@@ -2029,6 +2029,10 @@ metadata:
   namespace: default
 spec:
   alloy:
+    clustering:
+      enabled: false
+      name: ""
+      portName: http
     configMap:
       content: |-
         otelcol.receiver.otlp "sampler_receiver" {
@@ -2087,15 +2091,184 @@ spec:
           }
         }
       create: true
+      key: null
+      name: null
+    enableReporting: true
+    envFrom: []
+    extraArgs: []
+    extraEnv: []
+    extraPorts: []
+    hostAliases: []
+    lifecycle: {}
+    listenAddr: 0.0.0.0
+    listenPort: 12345
+    listenScheme: HTTP
+    livenessProbe: {}
+    mounts:
+      dockercontainers: false
+      extra: []
+      varlog: false
+    resources: {}
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        add:
+        - CHOWN
+        - DAC_OVERRIDE
+        - FOWNER
+        - FSETID
+        - KILL
+        - SETGID
+        - SETUID
+        - SETPCAP
+        - NET_BIND_SERVICE
+        - NET_RAW
+        - SYS_CHROOT
+        - MKNOD
+        - AUDIT_WRITE
+        - SETFCAP
+        drop:
+        - ALL
+      seccompProfile:
+        type: RuntimeDefault
+    stabilityLevel: generally-available
+    storagePath: /tmp/alloy
+    uiPathPrefix: /
+  configReloader:
+    customArgs: []
+    enabled: true
+    image:
+      digest: ""
+      registry: quay.io
+      repository: prometheus-operator/prometheus-config-reloader
+      tag: v0.81.0
+    resources:
+      requests:
+        cpu: 10m
+        memory: 50Mi
+    securityContext: {}
   controller:
+    affinity: {}
+    autoscaling:
+      enabled: false
+      horizontal:
+        enabled: false
+        maxReplicas: 5
+        minReplicas: 1
+        scaleDown:
+          policies: []
+          selectPolicy: Max
+          stabilizationWindowSeconds: 300
+        scaleUp:
+          policies: []
+          selectPolicy: Max
+          stabilizationWindowSeconds: 0
+        targetCPUUtilizationPercentage: 0
+        targetMemoryUtilizationPercentage: 80
+      maxReplicas: 5
+      minReplicas: 1
+      scaleDown:
+        policies: []
+        selectPolicy: Max
+        stabilizationWindowSeconds: 300
+      scaleUp:
+        policies: []
+        selectPolicy: Max
+        stabilizationWindowSeconds: 0
+      targetCPUUtilizationPercentage: 0
+      targetMemoryUtilizationPercentage: 80
+      vertical:
+        enabled: false
+        recommenders: []
+        resourcePolicy:
+          containerPolicies:
+          - containerName: alloy
+            controlledResources:
+            - cpu
+            - memory
+            controlledValues: RequestsAndLimits
+            maxAllowed: {}
+            minAllowed: {}
+        updatePolicy: null
+    dnsPolicy: ClusterFirst
+    enableStatefulSetAutoDeletePVC: false
+    extraAnnotations: {}
+    extraContainers: []
+    hostNetwork: false
+    hostPID: false
+    initContainers: []
+    nodeSelector:
+      kubernetes.io/os: linux
+    parallelRollout: true
+    podAnnotations:
+      k8s.grafana.com/logs.job: integrations/alloy
+    podDisruptionBudget:
+      enabled: false
+      maxUnavailable: null
+      minAvailable: null
+    podLabels: {}
+    priorityClassName: ""
     replicas: 2
+    terminationGracePeriodSeconds: null
+    tolerations: []
+    topologySpreadConstraints: []
     type: statefulset
+    updateStrategy: {}
+    volumeClaimTemplates: []
+    volumes:
+      extra: []
+  crds:
+    create: false
+  extraObjects: []
+  fullnameOverride: null
   global:
     image:
       pullSecrets:
       - name: my-registry-creds
       registry: my.registry.com
+    podSecurityContext: {}
+  image:
+    digest: null
+    pullPolicy: IfNotPresent
+    pullSecrets: []
+    registry: docker.io
+    repository: grafana/alloy
+    tag: null
+  ingress:
+    annotations: {}
+    enabled: false
+    extraPaths: []
+    faroPort: 12347
+    hosts:
+    - chart-example.local
+    labels: {}
+    path: /
+    pathType: Prefix
+    tls: []
   nameOverride: tempo-sampler
+  namespaceOverride: null
+  rbac:
+    create: true
+  service:
+    annotations: {}
+    clusterIP: ""
+    enabled: true
+    internalTrafficPolicy: Cluster
+    nodePort: 31128
+    type: ClusterIP
+  serviceAccount:
+    additionalLabels: {}
+    annotations: {}
+    automountServiceAccountToken: true
+    create: true
+    name: null
+  serviceMonitor:
+    additionalLabels: {}
+    enabled: false
+    interval: ""
+    metricRelabelings: []
+    relabelings: []
+    tlsConfig: {}
 ---
 # Source: k8s-monitoring/templates/alloy.yaml
 apiVersion: collectors.grafana.com/v1alpha1
@@ -2103,7 +2276,7 @@ kind: Alloy
 metadata:
   name: k8smon-alloy-metrics
   namespace: default
-spec: 
+spec:
   alloy:
     clustering:
       enabled: true
@@ -2295,7 +2468,7 @@ kind: Alloy
 metadata:
   name: k8smon-alloy-logs
   namespace: default
-spec: 
+spec:
   alloy:
     clustering:
       enabled: false
@@ -2489,7 +2662,7 @@ kind: Alloy
 metadata:
   name: k8smon-alloy-receiver
   namespace: default
-spec: 
+spec:
   alloy:
     clustering:
       enabled: false

--- a/charts/k8s-monitoring/docs/examples/private-image-registries/individual/README.md
+++ b/charts/k8s-monitoring/docs/examples/private-image-registries/individual/README.md
@@ -39,17 +39,6 @@ destinations:
         policies:
           - name: always_sample-policy
             type: always_sample
-        collector:
-          image:
-            registry: my.registry.com
-            repository: grafana/alloy
-            pullSecrets:
-              - name: my-registry-creds
-          configReloader:
-            image:
-              registry: my.registry.com
-              repository: prometheus-operator/prometheus-config-reloader
-
 
 clusterMetrics:
   enabled: true
@@ -116,18 +105,11 @@ alloy-operator:
 
 alloy-metrics:
   enabled: true
-  image:
-    registry: my.registry.com
-    repository: grafana/alloy
-    pullSecrets:
-      - name: my-registry-creds
-  configReloader:
-    image:
-      registry: my.registry.com
-      repository: prometheus-operator/prometheus-config-reloader
 
 alloy-receiver:
   enabled: true
+
+alloyTemplate:
   image:
     registry: my.registry.com
     repository: grafana/alloy

--- a/charts/k8s-monitoring/docs/examples/private-image-registries/individual/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/private-image-registries/individual/output.yaml
@@ -2003,6 +2003,10 @@ metadata:
   namespace: default
 spec:
   alloy:
+    clustering:
+      enabled: false
+      name: ""
+      portName: http
     configMap:
       content: |-
         otelcol.receiver.otlp "sampler_receiver" {
@@ -2061,19 +2065,184 @@ spec:
           }
         }
       create: true
+      key: null
+      name: null
+    enableReporting: true
+    envFrom: []
+    extraArgs: []
+    extraEnv: []
+    extraPorts: []
+    hostAliases: []
+    lifecycle: {}
+    listenAddr: 0.0.0.0
+    listenPort: 12345
+    listenScheme: HTTP
+    livenessProbe: {}
+    mounts:
+      dockercontainers: false
+      extra: []
+      varlog: false
+    resources: {}
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        add:
+        - CHOWN
+        - DAC_OVERRIDE
+        - FOWNER
+        - FSETID
+        - KILL
+        - SETGID
+        - SETUID
+        - SETPCAP
+        - NET_BIND_SERVICE
+        - NET_RAW
+        - SYS_CHROOT
+        - MKNOD
+        - AUDIT_WRITE
+        - SETFCAP
+        drop:
+        - ALL
+      seccompProfile:
+        type: RuntimeDefault
+    stabilityLevel: generally-available
+    storagePath: /tmp/alloy
+    uiPathPrefix: /
   configReloader:
+    customArgs: []
+    enabled: true
     image:
+      digest: ""
       registry: my.registry.com
       repository: prometheus-operator/prometheus-config-reloader
+      tag: v0.81.0
+    resources:
+      requests:
+        cpu: 10m
+        memory: 50Mi
+    securityContext: {}
   controller:
+    affinity: {}
+    autoscaling:
+      enabled: false
+      horizontal:
+        enabled: false
+        maxReplicas: 5
+        minReplicas: 1
+        scaleDown:
+          policies: []
+          selectPolicy: Max
+          stabilizationWindowSeconds: 300
+        scaleUp:
+          policies: []
+          selectPolicy: Max
+          stabilizationWindowSeconds: 0
+        targetCPUUtilizationPercentage: 0
+        targetMemoryUtilizationPercentage: 80
+      maxReplicas: 5
+      minReplicas: 1
+      scaleDown:
+        policies: []
+        selectPolicy: Max
+        stabilizationWindowSeconds: 300
+      scaleUp:
+        policies: []
+        selectPolicy: Max
+        stabilizationWindowSeconds: 0
+      targetCPUUtilizationPercentage: 0
+      targetMemoryUtilizationPercentage: 80
+      vertical:
+        enabled: false
+        recommenders: []
+        resourcePolicy:
+          containerPolicies:
+          - containerName: alloy
+            controlledResources:
+            - cpu
+            - memory
+            controlledValues: RequestsAndLimits
+            maxAllowed: {}
+            minAllowed: {}
+        updatePolicy: null
+    dnsPolicy: ClusterFirst
+    enableStatefulSetAutoDeletePVC: false
+    extraAnnotations: {}
+    extraContainers: []
+    hostNetwork: false
+    hostPID: false
+    initContainers: []
+    nodeSelector:
+      kubernetes.io/os: linux
+    parallelRollout: true
+    podAnnotations:
+      k8s.grafana.com/logs.job: integrations/alloy
+    podDisruptionBudget:
+      enabled: false
+      maxUnavailable: null
+      minAvailable: null
+    podLabels: {}
+    priorityClassName: ""
     replicas: 2
+    terminationGracePeriodSeconds: null
+    tolerations: []
+    topologySpreadConstraints: []
     type: statefulset
+    updateStrategy: {}
+    volumeClaimTemplates: []
+    volumes:
+      extra: []
+  crds:
+    create: false
+  extraObjects: []
+  fullnameOverride: null
+  global:
+    image:
+      pullSecrets: []
+      registry: ""
+    podSecurityContext: {}
   image:
+    digest: null
+    pullPolicy: IfNotPresent
     pullSecrets:
     - name: my-registry-creds
     registry: my.registry.com
     repository: grafana/alloy
+    tag: null
+  ingress:
+    annotations: {}
+    enabled: false
+    extraPaths: []
+    faroPort: 12347
+    hosts:
+    - chart-example.local
+    labels: {}
+    path: /
+    pathType: Prefix
+    tls: []
   nameOverride: tempo-sampler
+  namespaceOverride: null
+  rbac:
+    create: true
+  service:
+    annotations: {}
+    clusterIP: ""
+    enabled: true
+    internalTrafficPolicy: Cluster
+    nodePort: 31128
+    type: ClusterIP
+  serviceAccount:
+    additionalLabels: {}
+    annotations: {}
+    automountServiceAccountToken: true
+    create: true
+    name: null
+  serviceMonitor:
+    additionalLabels: {}
+    enabled: false
+    interval: ""
+    metricRelabelings: []
+    relabelings: []
+    tlsConfig: {}
 ---
 # Source: k8s-monitoring/templates/alloy.yaml
 apiVersion: collectors.grafana.com/v1alpha1
@@ -2081,7 +2250,7 @@ kind: Alloy
 metadata:
   name: k8smon-alloy-metrics
   namespace: default
-spec: 
+spec:
   alloy:
     clustering:
       enabled: true
@@ -2273,7 +2442,7 @@ kind: Alloy
 metadata:
   name: k8smon-alloy-receiver
   namespace: default
-spec: 
+spec:
   alloy:
     clustering:
       enabled: false

--- a/charts/k8s-monitoring/docs/examples/private-image-registries/individual/values.yaml
+++ b/charts/k8s-monitoring/docs/examples/private-image-registries/individual/values.yaml
@@ -23,17 +23,6 @@ destinations:
         policies:
           - name: always_sample-policy
             type: always_sample
-        collector:
-          image:
-            registry: my.registry.com
-            repository: grafana/alloy
-            pullSecrets:
-              - name: my-registry-creds
-          configReloader:
-            image:
-              registry: my.registry.com
-              repository: prometheus-operator/prometheus-config-reloader
-
 
 clusterMetrics:
   enabled: true
@@ -100,18 +89,11 @@ alloy-operator:
 
 alloy-metrics:
   enabled: true
-  image:
-    registry: my.registry.com
-    repository: grafana/alloy
-    pullSecrets:
-      - name: my-registry-creds
-  configReloader:
-    image:
-      registry: my.registry.com
-      repository: prometheus-operator/prometheus-config-reloader
 
 alloy-receiver:
   enabled: true
+
+alloyTemplate:
   image:
     registry: my.registry.com
     repository: grafana/alloy

--- a/charts/k8s-monitoring/docs/examples/proxies/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/proxies/output.yaml
@@ -3440,7 +3440,7 @@ kind: Alloy
 metadata:
   name: k8smon-alloy-metrics
   namespace: default
-spec: 
+spec:
   alloy:
     clustering:
       enabled: true
@@ -3631,7 +3631,7 @@ kind: Alloy
 metadata:
   name: k8smon-alloy-singleton
   namespace: default
-spec: 
+spec:
   alloy:
     clustering:
       enabled: false
@@ -3822,7 +3822,7 @@ kind: Alloy
 metadata:
   name: k8smon-alloy-logs
   namespace: default
-spec: 
+spec:
   alloy:
     clustering:
       enabled: false
@@ -4015,7 +4015,7 @@ kind: Alloy
 metadata:
   name: k8smon-alloy-receiver
   namespace: default
-spec: 
+spec:
   alloy:
     clustering:
       enabled: false
@@ -4214,7 +4214,7 @@ kind: Alloy
 metadata:
   name: k8smon-alloy-profiles
   namespace: default
-spec: 
+spec:
   alloy:
     clustering:
       enabled: false

--- a/charts/k8s-monitoring/docs/examples/remote-config/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/remote-config/output.yaml
@@ -366,7 +366,7 @@ kind: Alloy
 metadata:
   name: k8smon-alloy-metrics
   namespace: default
-spec: 
+spec:
   alloy:
     clustering:
       enabled: true
@@ -574,7 +574,7 @@ kind: Alloy
 metadata:
   name: k8smon-alloy-logs
   namespace: default
-spec: 
+spec:
   alloy:
     clustering:
       enabled: false

--- a/charts/k8s-monitoring/docs/examples/resource-requests-and-limits/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/resource-requests-and-limits/output.yaml
@@ -1998,7 +1998,7 @@ kind: Alloy
 metadata:
   name: k8smon-alloy-metrics
   namespace: default
-spec: 
+spec:
   alloy:
     clustering:
       enabled: true

--- a/charts/k8s-monitoring/docs/examples/scalability/autoscaling/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/scalability/autoscaling/output.yaml
@@ -1488,7 +1488,7 @@ kind: Alloy
 metadata:
   name: k8smon-alloy-metrics
   namespace: default
-spec: 
+spec:
   alloy:
     clustering:
       enabled: true

--- a/charts/k8s-monitoring/docs/examples/scalability/high-availability-kube-state-metrics/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/scalability/high-availability-kube-state-metrics/output.yaml
@@ -1488,7 +1488,7 @@ kind: Alloy
 metadata:
   name: k8smon-alloy-metrics
   namespace: default
-spec: 
+spec:
   alloy:
     clustering:
       enabled: true

--- a/charts/k8s-monitoring/docs/examples/scalability/sharded-kube-state-metrics/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/scalability/sharded-kube-state-metrics/output.yaml
@@ -1558,7 +1558,7 @@ kind: Alloy
 metadata:
   name: k8smon-alloy-metrics
   namespace: default
-spec: 
+spec:
   alloy:
     clustering:
       enabled: true

--- a/charts/k8s-monitoring/docs/examples/service-integrations/mongodb-atlas/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/service-integrations/mongodb-atlas/output.yaml
@@ -411,7 +411,7 @@ kind: Alloy
 metadata:
   name: k8smon-alloy-metrics
   namespace: default
-spec: 
+spec:
   alloy:
     clustering:
       enabled: true

--- a/charts/k8s-monitoring/docs/examples/service-integrations/timescaledb/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/service-integrations/timescaledb/output.yaml
@@ -415,7 +415,7 @@ kind: Alloy
 metadata:
   name: k8smon-alloy-metrics
   namespace: default
-spec: 
+spec:
   alloy:
     clustering:
       enabled: true

--- a/charts/k8s-monitoring/docs/examples/tail-sampling/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/tail-sampling/output.yaml
@@ -2014,6 +2014,10 @@ metadata:
   namespace: default
 spec:
   alloy:
+    clustering:
+      enabled: false
+      name: ""
+      portName: http
     configMap:
       content: |-
         otelcol.receiver.otlp "sampler_receiver" {
@@ -2116,10 +2120,183 @@ spec:
           }
         }
       create: true
+      key: null
+      name: null
+    enableReporting: true
+    envFrom: []
+    extraArgs: []
+    extraEnv: []
+    extraPorts: []
+    hostAliases: []
+    lifecycle: {}
+    listenAddr: 0.0.0.0
+    listenPort: 12345
+    listenScheme: HTTP
+    livenessProbe: {}
+    mounts:
+      dockercontainers: false
+      extra: []
+      varlog: false
+    resources: {}
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        add:
+        - CHOWN
+        - DAC_OVERRIDE
+        - FOWNER
+        - FSETID
+        - KILL
+        - SETGID
+        - SETUID
+        - SETPCAP
+        - NET_BIND_SERVICE
+        - NET_RAW
+        - SYS_CHROOT
+        - MKNOD
+        - AUDIT_WRITE
+        - SETFCAP
+        drop:
+        - ALL
+      seccompProfile:
+        type: RuntimeDefault
+    stabilityLevel: generally-available
+    storagePath: /tmp/alloy
+    uiPathPrefix: /
+  configReloader:
+    customArgs: []
+    enabled: true
+    image:
+      digest: ""
+      registry: quay.io
+      repository: prometheus-operator/prometheus-config-reloader
+      tag: v0.81.0
+    resources:
+      requests:
+        cpu: 10m
+        memory: 50Mi
+    securityContext: {}
   controller:
+    affinity: {}
+    autoscaling:
+      enabled: false
+      horizontal:
+        enabled: false
+        maxReplicas: 5
+        minReplicas: 1
+        scaleDown:
+          policies: []
+          selectPolicy: Max
+          stabilizationWindowSeconds: 300
+        scaleUp:
+          policies: []
+          selectPolicy: Max
+          stabilizationWindowSeconds: 0
+        targetCPUUtilizationPercentage: 0
+        targetMemoryUtilizationPercentage: 80
+      maxReplicas: 5
+      minReplicas: 1
+      scaleDown:
+        policies: []
+        selectPolicy: Max
+        stabilizationWindowSeconds: 300
+      scaleUp:
+        policies: []
+        selectPolicy: Max
+        stabilizationWindowSeconds: 0
+      targetCPUUtilizationPercentage: 0
+      targetMemoryUtilizationPercentage: 80
+      vertical:
+        enabled: false
+        recommenders: []
+        resourcePolicy:
+          containerPolicies:
+          - containerName: alloy
+            controlledResources:
+            - cpu
+            - memory
+            controlledValues: RequestsAndLimits
+            maxAllowed: {}
+            minAllowed: {}
+        updatePolicy: null
+    dnsPolicy: ClusterFirst
+    enableStatefulSetAutoDeletePVC: false
+    extraAnnotations: {}
+    extraContainers: []
+    hostNetwork: false
+    hostPID: false
+    initContainers: []
+    nodeSelector:
+      kubernetes.io/os: linux
+    parallelRollout: true
+    podAnnotations:
+      k8s.grafana.com/logs.job: integrations/alloy
+    podDisruptionBudget:
+      enabled: false
+      maxUnavailable: null
+      minAvailable: null
+    podLabels: {}
+    priorityClassName: ""
     replicas: 2
+    terminationGracePeriodSeconds: null
+    tolerations: []
+    topologySpreadConstraints: []
     type: statefulset
+    updateStrategy: {}
+    volumeClaimTemplates: []
+    volumes:
+      extra: []
+  crds:
+    create: false
+  extraObjects: []
+  fullnameOverride: null
+  global:
+    image:
+      pullSecrets: []
+      registry: ""
+    podSecurityContext: {}
+  image:
+    digest: null
+    pullPolicy: IfNotPresent
+    pullSecrets: []
+    registry: docker.io
+    repository: grafana/alloy
+    tag: null
+  ingress:
+    annotations: {}
+    enabled: false
+    extraPaths: []
+    faroPort: 12347
+    hosts:
+    - chart-example.local
+    labels: {}
+    path: /
+    pathType: Prefix
+    tls: []
   nameOverride: tempo-sampler
+  namespaceOverride: null
+  rbac:
+    create: true
+  service:
+    annotations: {}
+    clusterIP: ""
+    enabled: true
+    internalTrafficPolicy: Cluster
+    nodePort: 31128
+    type: ClusterIP
+  serviceAccount:
+    additionalLabels: {}
+    annotations: {}
+    automountServiceAccountToken: true
+    create: true
+    name: null
+  serviceMonitor:
+    additionalLabels: {}
+    enabled: false
+    interval: ""
+    metricRelabelings: []
+    relabelings: []
+    tlsConfig: {}
 ---
 # Source: k8s-monitoring/templates/alloy.yaml
 apiVersion: collectors.grafana.com/v1alpha1
@@ -2127,7 +2304,7 @@ kind: Alloy
 metadata:
   name: k8smon-alloy-metrics
   namespace: default
-spec: 
+spec:
   alloy:
     clustering:
       enabled: true
@@ -2318,7 +2495,7 @@ kind: Alloy
 metadata:
   name: k8smon-alloy-logs
   namespace: default
-spec: 
+spec:
   alloy:
     clustering:
       enabled: false
@@ -2511,7 +2688,7 @@ kind: Alloy
 metadata:
   name: k8smon-alloy-receiver
   namespace: default
-spec: 
+spec:
   alloy:
     clustering:
       enabled: false

--- a/charts/k8s-monitoring/docs/examples/tolerations/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/tolerations/output.yaml
@@ -2212,7 +2212,7 @@ kind: Alloy
 metadata:
   name: k8smon-alloy-metrics
   namespace: default
-spec: 
+spec:
   alloy:
     clustering:
       enabled: true
@@ -2406,7 +2406,7 @@ kind: Alloy
 metadata:
   name: k8smon-alloy-logs
   namespace: default
-spec: 
+spec:
   alloy:
     clustering:
       enabled: false

--- a/charts/k8s-monitoring/templates/alloy-sampler.yaml
+++ b/charts/k8s-monitoring/templates/alloy-sampler.yaml
@@ -3,6 +3,7 @@
   {{- $isSamplingEnabled := include "destinations.otlp.isTailSamplingEnabled" $destination }}
   {{- if eq $isSamplingEnabled "true" }}
 
+    {{- /* Build Alloy configuration for Tail Sampling */}}
     {{- $defaultValues := "destinations/otlp-values.yaml" | $.Files.Get | fromYaml }}
     {{- $destination = mergeOverwrite $defaultValues $destination }}
     {{- $destinationTarget := include "destinations.otlp.alloy.exporter.target" $destination }}
@@ -22,19 +23,19 @@
     {{- end }}
     {{- $alloyConfig = regexReplaceAll `[ \t]+(\r?\n)` $alloyConfig "\n" | trim }}
 
+    {{- /* Build Alloy spec */}}
     {{- $collectorName := include "helper.k8s_name" (printf "%s-sampler" $destination.name) }}
-    {{- $alloySpec := dict "alloy" (dict "configMap" (dict "create" true "content" $alloyConfig)) }}
-    {{- $globalValues := include "collector.alloy.values.global" $ | fromYaml }}
-    {{- $alloyName := dict "nameOverride" $collectorName}}
-    {{- $alloy := mergeOverwrite $alloySpec $globalValues $alloyName $destination.processors.tailSampling.collector }}
+    {{- $collectorValues := merge (dict "nameOverride" $collectorName "alloy" (dict "configMap" (dict "create" true "content" $alloyConfig))) $destination.processors.tailSampling.collector }}
+    {{- $values := (deepCopy $ | merge (dict "collectorName" $collectorName "collectorValues" $collectorValues)) }}
+    {{- $alloyValues := include "collector.alloy.values" $values | fromYaml }}
+    {{- $alloySpec := include "collector.alloy.valuesToSpec" $alloyValues }}
 ---
 apiVersion: collectors.grafana.com/v1alpha1
 kind: Alloy
 metadata:
-  name: {{ include "collector.alloy.fullname" (deepCopy $ | merge (dict "collectorName" $collectorName "collectorValues" $alloy)) }}
+  name: {{ include "collector.alloy.fullname" $values }}
   namespace: {{ $.Release.Namespace }}
-spec:
-  {{- $alloy | toYaml | nindent 2 }}
+spec:{{ $alloySpec | trim | nindent 2 }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/k8s-monitoring/templates/alloy-servicegraph.yaml
+++ b/charts/k8s-monitoring/templates/alloy-servicegraph.yaml
@@ -3,33 +3,25 @@
   {{- $isServiceGraphsEnabled := include "destinations.otlp.isServiceGraphsEnabled" $destination }}
   {{- if eq $isServiceGraphsEnabled "true" }}
 
+    {{- /* Build Alloy configuration for Service Graph Metrics */}}
     {{- $defaultValues := "destinations/otlp-values.yaml" | $.Files.Get | fromYaml }}
     {{- $destination = mergeOverwrite $defaultValues $destination }}
     {{- $metricsDestinationNames := include "destinations.get" (dict "destinations" $.Values.destinations "type" "metrics" "ecosystem" "otlp" "filter" $destination.processors.serviceGraphMetrics.destinations) | fromYamlArray -}}
 
+    {{- $alloyConfig := "" }}
     {{- $destinations := list }}
     {{- $destinationTargets := list }}
     {{- range $metricsDestinationName := $metricsDestinationNames }}
-      {{- $myDestination := include "destination.getDestinationByName" (deepCopy $ | merge (dict "destination" $metricsDestinationName )) | fromYaml }}
-      {{- $destinations = append $destinations $myDestination }}
-      {{- if ne $myDestination.type "prometheus" -}}
-        {{- $destinationTarget := include "destinations.otlp.alloy.exporter.target" $myDestination }}
+      {{- $dest := include "destination.getDestinationByName" (deepCopy $ | merge (dict "destination" $metricsDestinationName )) | fromYaml }}
+      {{- $destinations = append $destinations $dest }}
+      {{- if ne $dest.type "prometheus" -}}
+        {{- $destinationTarget := include "destinations.otlp.alloy.exporter.target" $dest }}
         {{- $destinationTargets = append $destinationTargets (printf "%s" $destinationTarget) }}
       {{- else }}
-        {{- $destinationTarget := include "destinations.prometheus.alloy.otlp.metrics.target" $myDestination }}
+        {{- $destinationTarget := include "destinations.prometheus.alloy.otlp.metrics.target" $dest }}
         {{- $destinationTargets = append $destinationTargets (printf "%s" $destinationTarget) }}
       {{- end }}
-    {{- end }}
 
-    {{- $serviceGraphConfig := merge (dict "traces" $destination "metrics" $destinationTargets "name" "service_graph_metrics") $destination.processors.serviceGraphMetrics }}
-    {{- $serviceGraphTarget := include "servicegraph.connector.serviceGraphMetrics.alloy.target" $serviceGraphConfig }}
-    {{- $receiverConfig := merge (dict "traces" $serviceGraphTarget "name" "service_graph_receiver") $destination.processors.serviceGraphMetrics }}
-
-    {{- $alloyConfig := "" }}
-    {{- $alloyConfig = cat $alloyConfig ((include "receiver.otlp.alloy" $receiverConfig) | trim | nindent 0) }}
-    {{- $alloyConfig = cat $alloyConfig ((include "servicegraph.connector.serviceGraphMetrics.alloy" $serviceGraphConfig) | trim | nindent 0) }}
-
-    {{- range $dest := $destinations }} 
       {{- $alloyConfig = cat $alloyConfig (printf "\n\n// Destination: %s (%s)" $dest.name $dest.type) }}
       {{- if eq (include "secrets.usesKubernetesSecret" $dest) "true" }}
         {{- $alloyConfig = cat $alloyConfig (include "secret.alloy" (deepCopy $ | merge (dict "object" $dest)) | nindent 0) }}
@@ -46,21 +38,27 @@
       {{- end }}
     {{- end }}
 
+    {{- $serviceGraphConfig := merge (dict "traces" $destination "metrics" $destinationTargets "name" "service_graph_metrics") $destination.processors.serviceGraphMetrics }}
+    {{- $serviceGraphTarget := include "servicegraph.connector.serviceGraphMetrics.alloy.target" $serviceGraphConfig }}
+    {{- $receiverConfig := merge (dict "traces" $serviceGraphTarget "name" "service_graph_receiver") $destination.processors.serviceGraphMetrics }}
+
+    {{- $alloyConfig = cat $alloyConfig ((include "receiver.otlp.alloy" $receiverConfig) | trim | nindent 0) }}
+    {{- $alloyConfig = cat $alloyConfig ((include "servicegraph.connector.serviceGraphMetrics.alloy" $serviceGraphConfig) | trim | nindent 0) }}
     {{- $alloyConfig = regexReplaceAll `[ \t]+(\r?\n)` $alloyConfig "\n" | trim }}
 
+    {{- /* Build Alloy spec */}}
     {{- $collectorName := include "helper.k8s_name" (printf "%s-servicegraph" $destination.name) }}
-    {{- $alloySpec := dict "alloy" (dict "configMap" (dict "create" true "content" $alloyConfig) "extraEnv" (list (dict "name" "POD_NAME" "valueFrom" (dict "fieldRef" (dict "apiVersion" "v1" "fieldPath" "metadata.name"))))) }}
-    {{- $globalValues := include "collector.alloy.values.global" $ | fromYaml }}
-    {{- $alloyName := dict "nameOverride" $collectorName}}
-    {{- $alloy := mergeOverwrite $alloySpec $globalValues $alloyName $destination.processors.serviceGraphMetrics.collector }}
+    {{- $collectorValues := merge (dict "nameOverride" $collectorName "alloy" (dict "configMap" (dict "create" true "content" $alloyConfig))) $destination.processors.tailSampling.collector }}
+    {{- $values := (deepCopy $ | merge (dict "collectorName" $collectorName "collectorValues" $collectorValues)) }}
+    {{- $alloyValues := include "collector.alloy.values" $values | fromYaml }}
+    {{- $alloySpec := include "collector.alloy.valuesToSpec" $alloyValues }}
 ---
 apiVersion: collectors.grafana.com/v1alpha1
 kind: Alloy
 metadata:
-  name: {{ include "collector.alloy.fullname" (deepCopy $ | merge (dict "collectorName" $collectorName "collectorValues" $alloy)) }}
+  name: {{ include "collector.alloy.fullname" $values }}
   namespace: {{ $.Release.Namespace }}
-spec:
-  {{- $alloy | toYaml | nindent 2 }}
+spec:{{ $alloySpec | trim | nindent 2 }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/k8s-monitoring/templates/alloy.yaml
+++ b/charts/k8s-monitoring/templates/alloy.yaml
@@ -2,18 +2,12 @@
 {{- include "crdValidation" $ }}
 {{- $values := (deepCopy $ | merge (dict "collectorName" $collectorName)) }}
 {{- $alloyValues := (include "collector.alloy.values" $values | fromYaml) | merge (dict "nameOverride" $collectorName) }}
-{{- $fieldsToExclude := include "collector.alloy.extraFields" . | fromYamlArray }}
-{{- $cleanValues := dict }}
-{{- range $key, $val := $alloyValues }}
-  {{- if not (has $key $fieldsToExclude) }}
-    {{- $_ := set $cleanValues $key $val }}
-  {{- end }}
-{{- end }}
+{{- $alloySpec := include "collector.alloy.valuesToSpec" $alloyValues }}
 ---
 apiVersion: collectors.grafana.com/v1alpha1
 kind: Alloy
 metadata:
   name: {{ include "collector.alloy.fullname" $values }}
   namespace: {{ $.Release.Namespace }}
-spec: {{ $cleanValues | toYaml | nindent 2 }}
+spec:{{ $alloySpec | trim | nindent 2 }}
 {{- end }}

--- a/charts/k8s-monitoring/tests/integration/annotation-autodiscovery/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/integration/annotation-autodiscovery/.rendered/output.yaml
@@ -1011,7 +1011,7 @@ kind: Alloy
 metadata:
   name: k8smon-alloy-metrics
   namespace: default
-spec: 
+spec:
   alloy:
     clustering:
       enabled: true
@@ -1202,7 +1202,7 @@ kind: Alloy
 metadata:
   name: k8smon-alloy-logs
   namespace: default
-spec: 
+spec:
   alloy:
     clustering:
       enabled: false

--- a/charts/k8s-monitoring/tests/integration/application-observability/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/integration/application-observability/.rendered/output.yaml
@@ -892,7 +892,7 @@ kind: Alloy
 metadata:
   name: k8smon-alloy-receiver
   namespace: default
-spec: 
+spec:
   alloy:
     clustering:
       enabled: false

--- a/charts/k8s-monitoring/tests/integration/auth/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/integration/auth/.rendered/output.yaml
@@ -1391,7 +1391,7 @@ kind: Alloy
 metadata:
   name: k8smon-alloy-metrics
   namespace: default
-spec: 
+spec:
   alloy:
     clustering:
       enabled: true
@@ -1582,7 +1582,7 @@ kind: Alloy
 metadata:
   name: k8smon-alloy-logs
   namespace: default
-spec: 
+spec:
   alloy:
     clustering:
       enabled: false

--- a/charts/k8s-monitoring/tests/integration/auto-instrumentation/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/integration/auto-instrumentation/.rendered/output.yaml
@@ -897,7 +897,7 @@ kind: Alloy
 metadata:
   name: k8smon-alloy-metrics
   namespace: default
-spec: 
+spec:
   alloy:
     clustering:
       enabled: true
@@ -1088,7 +1088,7 @@ kind: Alloy
 metadata:
   name: k8smon-alloy-receiver
   namespace: default
-spec: 
+spec:
   alloy:
     clustering:
       enabled: false

--- a/charts/k8s-monitoring/tests/integration/cluster-monitoring/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/integration/cluster-monitoring/.rendered/output.yaml
@@ -2520,7 +2520,7 @@ kind: Alloy
 metadata:
   name: k8smon-alloy-metrics
   namespace: default
-spec: 
+spec:
   alloy:
     clustering:
       enabled: true
@@ -2711,7 +2711,7 @@ kind: Alloy
 metadata:
   name: k8smon-alloy-singleton
   namespace: default
-spec: 
+spec:
   alloy:
     clustering:
       enabled: false
@@ -2902,7 +2902,7 @@ kind: Alloy
 metadata:
   name: k8smon-alloy-logs
   namespace: default
-spec: 
+spec:
   alloy:
     clustering:
       enabled: false

--- a/charts/k8s-monitoring/tests/integration/control-plane-monitoring/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/integration/control-plane-monitoring/.rendered/output.yaml
@@ -2250,7 +2250,7 @@ kind: Alloy
 metadata:
   name: k8smon-alloy-metrics
   namespace: default
-spec: 
+spec:
   alloy:
     clustering:
       enabled: true
@@ -2441,7 +2441,7 @@ kind: Alloy
 metadata:
   name: k8smon-alloy-singleton
   namespace: default
-spec: 
+spec:
   alloy:
     clustering:
       enabled: false
@@ -2632,7 +2632,7 @@ kind: Alloy
 metadata:
   name: k8smon-alloy-logs
   namespace: default
-spec: 
+spec:
   alloy:
     clustering:
       enabled: false

--- a/charts/k8s-monitoring/tests/integration/istio-service-mesh/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/integration/istio-service-mesh/.rendered/output.yaml
@@ -2580,7 +2580,7 @@ kind: Alloy
 metadata:
   name: k8smon-alloy-metrics
   namespace: default
-spec: 
+spec:
   alloy:
     clustering:
       enabled: true
@@ -2771,7 +2771,7 @@ kind: Alloy
 metadata:
   name: k8smon-alloy-singleton
   namespace: default
-spec: 
+spec:
   alloy:
     clustering:
       enabled: false
@@ -2962,7 +2962,7 @@ kind: Alloy
 metadata:
   name: k8smon-alloy-logs
   namespace: default
-spec: 
+spec:
   alloy:
     clustering:
       enabled: false
@@ -3155,7 +3155,7 @@ kind: Alloy
 metadata:
   name: k8smon-alloy-receiver
   namespace: default
-spec: 
+spec:
   alloy:
     clustering:
       enabled: false

--- a/charts/k8s-monitoring/tests/integration/pod-logs/default/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/integration/pod-logs/default/.rendered/output.yaml
@@ -543,7 +543,7 @@ kind: Alloy
 metadata:
   name: k8smon-alloy-logs
   namespace: default
-spec: 
+spec:
   alloy:
     clustering:
       enabled: false

--- a/charts/k8s-monitoring/tests/integration/pod-logs/filelog/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/integration/pod-logs/filelog/.rendered/output.yaml
@@ -513,7 +513,7 @@ kind: Alloy
 metadata:
   name: k8smon-alloy-logs
   namespace: default
-spec: 
+spec:
   alloy:
     clustering:
       enabled: false

--- a/charts/k8s-monitoring/tests/integration/pod-logs/log-metrics/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/integration/pod-logs/log-metrics/.rendered/output.yaml
@@ -959,7 +959,7 @@ kind: Alloy
 metadata:
   name: k8smon-alloy-metrics
   namespace: default
-spec: 
+spec:
   alloy:
     clustering:
       enabled: true
@@ -1150,7 +1150,7 @@ kind: Alloy
 metadata:
   name: k8smon-alloy-logs
   namespace: default
-spec: 
+spec:
   alloy:
     clustering:
       enabled: false

--- a/charts/k8s-monitoring/tests/integration/pod-logs/secret-filter/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/integration/pod-logs/secret-filter/.rendered/output.yaml
@@ -547,7 +547,7 @@ kind: Alloy
 metadata:
   name: k8smon-alloy-logs
   namespace: default
-spec: 
+spec:
   alloy:
     clustering:
       enabled: false

--- a/charts/k8s-monitoring/tests/integration/profiles-receiver/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/integration/profiles-receiver/.rendered/output.yaml
@@ -335,7 +335,7 @@ kind: Alloy
 metadata:
   name: k8smon-alloy-receiver
   namespace: default
-spec: 
+spec:
   alloy:
     clustering:
       enabled: false

--- a/charts/k8s-monitoring/tests/integration/profiling/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/integration/profiling/.rendered/output.yaml
@@ -1175,7 +1175,7 @@ kind: Alloy
 metadata:
   name: k8smon-alloy-profiles
   namespace: default
-spec: 
+spec:
   alloy:
     clustering:
       enabled: false

--- a/charts/k8s-monitoring/tests/integration/prom-and-loki-to-otlp/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/integration/prom-and-loki-to-otlp/.rendered/output.yaml
@@ -2148,7 +2148,7 @@ kind: Alloy
 metadata:
   name: k8smon-alloy-metrics
   namespace: default
-spec: 
+spec:
   alloy:
     clustering:
       enabled: true
@@ -2339,7 +2339,7 @@ kind: Alloy
 metadata:
   name: k8smon-alloy-singleton
   namespace: default
-spec: 
+spec:
   alloy:
     clustering:
       enabled: false
@@ -2530,7 +2530,7 @@ kind: Alloy
 metadata:
   name: k8smon-alloy-logs
   namespace: default
-spec: 
+spec:
   alloy:
     clustering:
       enabled: false

--- a/charts/k8s-monitoring/tests/integration/prometheus-io-annotations/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/integration/prometheus-io-annotations/.rendered/output.yaml
@@ -1822,7 +1822,7 @@ kind: Alloy
 metadata:
   name: k8smon-alloy-metrics
   namespace: default
-spec: 
+spec:
   alloy:
     clustering:
       enabled: true

--- a/charts/k8s-monitoring/tests/integration/prometheus-operator-objects/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/integration/prometheus-operator-objects/.rendered/output.yaml
@@ -435,7 +435,7 @@ kind: Alloy
 metadata:
   name: k8smon-alloy-metrics
   namespace: default
-spec: 
+spec:
   alloy:
     clustering:
       enabled: true

--- a/charts/k8s-monitoring/tests/integration/proxies/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/integration/proxies/.rendered/output.yaml
@@ -1413,7 +1413,7 @@ kind: Alloy
 metadata:
   name: k8smon-alloy-metrics
   namespace: default
-spec: 
+spec:
   alloy:
     clustering:
       enabled: true
@@ -1604,7 +1604,7 @@ kind: Alloy
 metadata:
   name: k8smon-alloy-singleton
   namespace: default
-spec: 
+spec:
   alloy:
     clustering:
       enabled: false
@@ -1795,7 +1795,7 @@ kind: Alloy
 metadata:
   name: k8smon-alloy-logs
   namespace: default
-spec: 
+spec:
   alloy:
     clustering:
       enabled: false
@@ -1988,7 +1988,7 @@ kind: Alloy
 metadata:
   name: k8smon-alloy-receiver
   namespace: default
-spec: 
+spec:
   alloy:
     clustering:
       enabled: false

--- a/charts/k8s-monitoring/tests/integration/service-graph-metrics/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/integration/service-graph-metrics/.rendered/output.yaml
@@ -1240,8 +1240,64 @@ metadata:
   namespace: default
 spec:
   alloy:
+    clustering:
+      enabled: false
+      name: ""
+      portName: http
     configMap:
       content: |-
+        // Destination: localPrometheus (prometheus)
+        otelcol.exporter.prometheus "localprometheus" {
+          add_metric_suffixes = true
+          resource_to_telemetry_conversion = false
+          forward_to = [prometheus.remote_write.localprometheus.receiver]
+        }
+  
+        prometheus.remote_write "localprometheus" {
+          endpoint {
+            url = "http://prometheus-server.prometheus.svc:9090/api/v1/write"
+            headers = {
+            }
+            tls_config {
+              insecure_skip_verify = false
+            }
+            send_native_histograms = false
+  
+            queue_config {
+              capacity = 10000
+              min_shards = 1
+              max_shards = 50
+              max_samples_per_send = 2000
+              batch_send_deadline = "5s"
+              min_backoff = "30ms"
+              max_backoff = "5s"
+              retry_on_http_429 = true
+              sample_age_limit = "0s"
+            }
+  
+            write_relabel_config {
+              source_labels = ["cluster"]
+              regex = ""
+              replacement = "service-graph-metrics-test"
+              target_label = "cluster"
+            }
+            write_relabel_config {
+              source_labels = ["k8s_cluster_name"]
+              regex = ""
+              replacement = "service-graph-metrics-test"
+              target_label = "k8s_cluster_name"
+            }
+          }
+  
+          wal {
+            truncate_frequency = "2h"
+            min_keepalive_time = "5m"
+            max_keepalive_time = "8h"
+          }
+          external_labels = {
+            collector_id = env("POD_NAME"),
+          }
+        }
         otelcol.receiver.otlp "service_graph_receiver" {
           grpc {
             max_recv_msg_size = "8MB"
@@ -1295,70 +1351,184 @@ spec:
               ]
           }
         }
-  
-        // Destination: localPrometheus (prometheus)
-        otelcol.exporter.prometheus "localprometheus" {
-          add_metric_suffixes = true
-          resource_to_telemetry_conversion = false
-          forward_to = [prometheus.remote_write.localprometheus.receiver]
-        }
-  
-        prometheus.remote_write "localprometheus" {
-          endpoint {
-            url = "http://prometheus-server.prometheus.svc:9090/api/v1/write"
-            headers = {
-            }
-            tls_config {
-              insecure_skip_verify = false
-            }
-            send_native_histograms = false
-  
-            queue_config {
-              capacity = 10000
-              min_shards = 1
-              max_shards = 50
-              max_samples_per_send = 2000
-              batch_send_deadline = "5s"
-              min_backoff = "30ms"
-              max_backoff = "5s"
-              retry_on_http_429 = true
-              sample_age_limit = "0s"
-            }
-  
-            write_relabel_config {
-              source_labels = ["cluster"]
-              regex = ""
-              replacement = "service-graph-metrics-test"
-              target_label = "cluster"
-            }
-            write_relabel_config {
-              source_labels = ["k8s_cluster_name"]
-              regex = ""
-              replacement = "service-graph-metrics-test"
-              target_label = "k8s_cluster_name"
-            }
-          }
-  
-          wal {
-            truncate_frequency = "2h"
-            min_keepalive_time = "5m"
-            max_keepalive_time = "8h"
-          }
-          external_labels = {
-            collector_id = env("POD_NAME"),
-          }
-        }
       create: true
-    extraEnv:
-    - name: POD_NAME
-      valueFrom:
-        fieldRef:
-          apiVersion: v1
-          fieldPath: metadata.name
+      key: null
+      name: null
+    enableReporting: true
+    envFrom: []
+    extraArgs: []
+    extraEnv: []
+    extraPorts: []
+    hostAliases: []
+    lifecycle: {}
+    listenAddr: 0.0.0.0
+    listenPort: 12345
+    listenScheme: HTTP
+    livenessProbe: {}
+    mounts:
+      dockercontainers: false
+      extra: []
+      varlog: false
+    resources: {}
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        add:
+        - CHOWN
+        - DAC_OVERRIDE
+        - FOWNER
+        - FSETID
+        - KILL
+        - SETGID
+        - SETUID
+        - SETPCAP
+        - NET_BIND_SERVICE
+        - NET_RAW
+        - SYS_CHROOT
+        - MKNOD
+        - AUDIT_WRITE
+        - SETFCAP
+        drop:
+        - ALL
+      seccompProfile:
+        type: RuntimeDefault
+    stabilityLevel: generally-available
+    storagePath: /tmp/alloy
+    uiPathPrefix: /
+  configReloader:
+    customArgs: []
+    enabled: true
+    image:
+      digest: ""
+      registry: quay.io
+      repository: prometheus-operator/prometheus-config-reloader
+      tag: v0.81.0
+    resources:
+      requests:
+        cpu: 10m
+        memory: 50Mi
+    securityContext: {}
   controller:
-    replicas: 3
+    affinity: {}
+    autoscaling:
+      enabled: false
+      horizontal:
+        enabled: false
+        maxReplicas: 5
+        minReplicas: 1
+        scaleDown:
+          policies: []
+          selectPolicy: Max
+          stabilizationWindowSeconds: 300
+        scaleUp:
+          policies: []
+          selectPolicy: Max
+          stabilizationWindowSeconds: 0
+        targetCPUUtilizationPercentage: 0
+        targetMemoryUtilizationPercentage: 80
+      maxReplicas: 5
+      minReplicas: 1
+      scaleDown:
+        policies: []
+        selectPolicy: Max
+        stabilizationWindowSeconds: 300
+      scaleUp:
+        policies: []
+        selectPolicy: Max
+        stabilizationWindowSeconds: 0
+      targetCPUUtilizationPercentage: 0
+      targetMemoryUtilizationPercentage: 80
+      vertical:
+        enabled: false
+        recommenders: []
+        resourcePolicy:
+          containerPolicies:
+          - containerName: alloy
+            controlledResources:
+            - cpu
+            - memory
+            controlledValues: RequestsAndLimits
+            maxAllowed: {}
+            minAllowed: {}
+        updatePolicy: null
+    dnsPolicy: ClusterFirst
+    enableStatefulSetAutoDeletePVC: false
+    extraAnnotations: {}
+    extraContainers: []
+    hostNetwork: false
+    hostPID: false
+    initContainers: []
+    nodeSelector:
+      kubernetes.io/os: linux
+    parallelRollout: true
+    podAnnotations:
+      k8s.grafana.com/logs.job: integrations/alloy
+    podDisruptionBudget:
+      enabled: false
+      maxUnavailable: null
+      minAvailable: null
+    podLabels: {}
+    priorityClassName: ""
+    replicas: 2
+    terminationGracePeriodSeconds: null
+    tolerations: []
+    topologySpreadConstraints: []
     type: statefulset
+    updateStrategy: {}
+    volumeClaimTemplates: []
+    volumes:
+      extra: []
+  crds:
+    create: false
+  extraObjects: []
+  fullnameOverride: null
+  global:
+    image:
+      pullSecrets: []
+      registry: ""
+    podSecurityContext: {}
+  image:
+    digest: null
+    pullPolicy: IfNotPresent
+    pullSecrets: []
+    registry: docker.io
+    repository: grafana/alloy
+    tag: null
+  ingress:
+    annotations: {}
+    enabled: false
+    extraPaths: []
+    faroPort: 12347
+    hosts:
+    - chart-example.local
+    labels: {}
+    path: /
+    pathType: Prefix
+    tls: []
   nameOverride: localtempo-servicegraph
+  namespaceOverride: null
+  rbac:
+    create: true
+  service:
+    annotations: {}
+    clusterIP: ""
+    enabled: true
+    internalTrafficPolicy: Cluster
+    nodePort: 31128
+    type: ClusterIP
+  serviceAccount:
+    additionalLabels: {}
+    annotations: {}
+    automountServiceAccountToken: true
+    create: true
+    name: null
+  serviceMonitor:
+    additionalLabels: {}
+    enabled: false
+    interval: ""
+    metricRelabelings: []
+    relabelings: []
+    tlsConfig: {}
 ---
 # Source: k8s-monitoring/templates/alloy.yaml
 apiVersion: collectors.grafana.com/v1alpha1
@@ -1366,7 +1536,7 @@ kind: Alloy
 metadata:
   name: k8smon-alloy-metrics
   namespace: default
-spec: 
+spec:
   alloy:
     clustering:
       enabled: true
@@ -1557,7 +1727,7 @@ kind: Alloy
 metadata:
   name: k8smon-alloy-logs
   namespace: default
-spec: 
+spec:
   alloy:
     clustering:
       enabled: false
@@ -1750,7 +1920,7 @@ kind: Alloy
 metadata:
   name: k8smon-alloy-receiver
   namespace: default
-spec: 
+spec:
   alloy:
     clustering:
       enabled: false

--- a/charts/k8s-monitoring/tests/integration/service-integrations/alloy/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/integration/service-integrations/alloy/.rendered/output.yaml
@@ -680,7 +680,7 @@ kind: Alloy
 metadata:
   name: k8smon-alloy-metrics
   namespace: default
-spec: 
+spec:
   alloy:
     clustering:
       enabled: true

--- a/charts/k8s-monitoring/tests/integration/service-integrations/cert-manager/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/integration/service-integrations/cert-manager/.rendered/output.yaml
@@ -516,7 +516,7 @@ kind: Alloy
 metadata:
   name: k8smon-alloy-metrics
   namespace: default
-spec: 
+spec:
   alloy:
     clustering:
       enabled: true

--- a/charts/k8s-monitoring/tests/integration/service-integrations/coredns/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/integration/service-integrations/coredns/.rendered/output.yaml
@@ -1595,7 +1595,7 @@ kind: Alloy
 metadata:
   name: k8smon-alloy-metrics
   namespace: default
-spec: 
+spec:
   alloy:
     clustering:
       enabled: true

--- a/charts/k8s-monitoring/tests/integration/service-integrations/etcd/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/integration/service-integrations/etcd/.rendered/output.yaml
@@ -509,7 +509,7 @@ kind: Alloy
 metadata:
   name: k8smon-alloy-metrics
   namespace: default
-spec: 
+spec:
   alloy:
     clustering:
       enabled: true

--- a/charts/k8s-monitoring/tests/integration/service-integrations/grafana/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/integration/service-integrations/grafana/.rendered/output.yaml
@@ -2261,7 +2261,7 @@ kind: Alloy
 metadata:
   name: k8smon-alloy-metrics
   namespace: default
-spec: 
+spec:
   alloy:
     clustering:
       enabled: true
@@ -2452,7 +2452,7 @@ kind: Alloy
 metadata:
   name: k8smon-alloy-singleton
   namespace: default
-spec: 
+spec:
   alloy:
     clustering:
       enabled: false
@@ -2643,7 +2643,7 @@ kind: Alloy
 metadata:
   name: k8smon-alloy-logs
   namespace: default
-spec: 
+spec:
   alloy:
     clustering:
       enabled: false

--- a/charts/k8s-monitoring/tests/integration/service-integrations/loki/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/integration/service-integrations/loki/.rendered/output.yaml
@@ -2287,7 +2287,7 @@ kind: Alloy
 metadata:
   name: k8smon-alloy-metrics
   namespace: default
-spec: 
+spec:
   alloy:
     clustering:
       enabled: true
@@ -2478,7 +2478,7 @@ kind: Alloy
 metadata:
   name: k8smon-alloy-singleton
   namespace: default
-spec: 
+spec:
   alloy:
     clustering:
       enabled: false
@@ -2669,7 +2669,7 @@ kind: Alloy
 metadata:
   name: k8smon-alloy-logs
   namespace: default
-spec: 
+spec:
   alloy:
     clustering:
       enabled: false

--- a/charts/k8s-monitoring/tests/integration/service-integrations/mysql/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/integration/service-integrations/mysql/.rendered/output.yaml
@@ -739,7 +739,7 @@ kind: Alloy
 metadata:
   name: k8smon-alloy-metrics
   namespace: default
-spec: 
+spec:
   alloy:
     clustering:
       enabled: true
@@ -930,7 +930,7 @@ kind: Alloy
 metadata:
   name: k8smon-alloy-logs
   namespace: default
-spec: 
+spec:
   alloy:
     clustering:
       enabled: false

--- a/charts/k8s-monitoring/tests/integration/service-integrations/tempo/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/integration/service-integrations/tempo/.rendered/output.yaml
@@ -2287,7 +2287,7 @@ kind: Alloy
 metadata:
   name: k8smon-alloy-metrics
   namespace: default
-spec: 
+spec:
   alloy:
     clustering:
       enabled: true
@@ -2478,7 +2478,7 @@ kind: Alloy
 metadata:
   name: k8smon-alloy-singleton
   namespace: default
-spec: 
+spec:
   alloy:
     clustering:
       enabled: false
@@ -2669,7 +2669,7 @@ kind: Alloy
 metadata:
   name: k8smon-alloy-logs
   namespace: default
-spec: 
+spec:
   alloy:
     clustering:
       enabled: false

--- a/charts/k8s-monitoring/tests/integration/sharded-kube-state-metrics/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/integration/sharded-kube-state-metrics/.rendered/output.yaml
@@ -1895,7 +1895,7 @@ kind: Alloy
 metadata:
   name: k8smon-alloy-metrics
   namespace: default
-spec: 
+spec:
   alloy:
     clustering:
       enabled: true

--- a/charts/k8s-monitoring/tests/integration/split-destinations/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/integration/split-destinations/.rendered/output.yaml
@@ -2581,7 +2581,7 @@ kind: Alloy
 metadata:
   name: k8smon-alloy-metrics
   namespace: default
-spec: 
+spec:
   alloy:
     clustering:
       enabled: true
@@ -2772,7 +2772,7 @@ kind: Alloy
 metadata:
   name: k8smon-alloy-logs
   namespace: default
-spec: 
+spec:
   alloy:
     clustering:
       enabled: false
@@ -2965,7 +2965,7 @@ kind: Alloy
 metadata:
   name: k8smon-alloy-receiver
   namespace: default
-spec: 
+spec:
   alloy:
     clustering:
       enabled: false

--- a/charts/k8s-monitoring/tests/integration/statsd/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/integration/statsd/.rendered/output.yaml
@@ -413,7 +413,7 @@ kind: Alloy
 metadata:
   name: k8smon-alloy-receiver
   namespace: default
-spec: 
+spec:
   alloy:
     clustering:
       enabled: false

--- a/charts/k8s-monitoring/tests/integration/tail-sampling/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/integration/tail-sampling/.rendered/output.yaml
@@ -1000,6 +1000,10 @@ metadata:
   namespace: default
 spec:
   alloy:
+    clustering:
+      enabled: false
+      name: ""
+      portName: http
     configMap:
       content: |-
         otelcol.receiver.otlp "sampler_receiver" {
@@ -1058,10 +1062,183 @@ spec:
           }
         }
       create: true
+      key: null
+      name: null
+    enableReporting: true
+    envFrom: []
+    extraArgs: []
+    extraEnv: []
+    extraPorts: []
+    hostAliases: []
+    lifecycle: {}
+    listenAddr: 0.0.0.0
+    listenPort: 12345
+    listenScheme: HTTP
+    livenessProbe: {}
+    mounts:
+      dockercontainers: false
+      extra: []
+      varlog: false
+    resources: {}
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        add:
+        - CHOWN
+        - DAC_OVERRIDE
+        - FOWNER
+        - FSETID
+        - KILL
+        - SETGID
+        - SETUID
+        - SETPCAP
+        - NET_BIND_SERVICE
+        - NET_RAW
+        - SYS_CHROOT
+        - MKNOD
+        - AUDIT_WRITE
+        - SETFCAP
+        drop:
+        - ALL
+      seccompProfile:
+        type: RuntimeDefault
+    stabilityLevel: generally-available
+    storagePath: /tmp/alloy
+    uiPathPrefix: /
+  configReloader:
+    customArgs: []
+    enabled: true
+    image:
+      digest: ""
+      registry: quay.io
+      repository: prometheus-operator/prometheus-config-reloader
+      tag: v0.81.0
+    resources:
+      requests:
+        cpu: 10m
+        memory: 50Mi
+    securityContext: {}
   controller:
+    affinity: {}
+    autoscaling:
+      enabled: false
+      horizontal:
+        enabled: false
+        maxReplicas: 5
+        minReplicas: 1
+        scaleDown:
+          policies: []
+          selectPolicy: Max
+          stabilizationWindowSeconds: 300
+        scaleUp:
+          policies: []
+          selectPolicy: Max
+          stabilizationWindowSeconds: 0
+        targetCPUUtilizationPercentage: 0
+        targetMemoryUtilizationPercentage: 80
+      maxReplicas: 5
+      minReplicas: 1
+      scaleDown:
+        policies: []
+        selectPolicy: Max
+        stabilizationWindowSeconds: 300
+      scaleUp:
+        policies: []
+        selectPolicy: Max
+        stabilizationWindowSeconds: 0
+      targetCPUUtilizationPercentage: 0
+      targetMemoryUtilizationPercentage: 80
+      vertical:
+        enabled: false
+        recommenders: []
+        resourcePolicy:
+          containerPolicies:
+          - containerName: alloy
+            controlledResources:
+            - cpu
+            - memory
+            controlledValues: RequestsAndLimits
+            maxAllowed: {}
+            minAllowed: {}
+        updatePolicy: null
+    dnsPolicy: ClusterFirst
+    enableStatefulSetAutoDeletePVC: false
+    extraAnnotations: {}
+    extraContainers: []
+    hostNetwork: false
+    hostPID: false
+    initContainers: []
+    nodeSelector:
+      kubernetes.io/os: linux
+    parallelRollout: true
+    podAnnotations:
+      k8s.grafana.com/logs.job: integrations/alloy
+    podDisruptionBudget:
+      enabled: false
+      maxUnavailable: null
+      minAvailable: null
+    podLabels: {}
+    priorityClassName: ""
     replicas: 3
+    terminationGracePeriodSeconds: null
+    tolerations: []
+    topologySpreadConstraints: []
     type: statefulset
+    updateStrategy: {}
+    volumeClaimTemplates: []
+    volumes:
+      extra: []
+  crds:
+    create: false
+  extraObjects: []
+  fullnameOverride: null
+  global:
+    image:
+      pullSecrets: []
+      registry: ""
+    podSecurityContext: {}
+  image:
+    digest: null
+    pullPolicy: IfNotPresent
+    pullSecrets: []
+    registry: docker.io
+    repository: grafana/alloy
+    tag: null
+  ingress:
+    annotations: {}
+    enabled: false
+    extraPaths: []
+    faroPort: 12347
+    hosts:
+    - chart-example.local
+    labels: {}
+    path: /
+    pathType: Prefix
+    tls: []
   nameOverride: localtempo-sampler
+  namespaceOverride: null
+  rbac:
+    create: true
+  service:
+    annotations: {}
+    clusterIP: ""
+    enabled: true
+    internalTrafficPolicy: Cluster
+    nodePort: 31128
+    type: ClusterIP
+  serviceAccount:
+    additionalLabels: {}
+    annotations: {}
+    automountServiceAccountToken: true
+    create: true
+    name: null
+  serviceMonitor:
+    additionalLabels: {}
+    enabled: false
+    interval: ""
+    metricRelabelings: []
+    relabelings: []
+    tlsConfig: {}
 ---
 # Source: k8s-monitoring/templates/alloy.yaml
 apiVersion: collectors.grafana.com/v1alpha1
@@ -1069,7 +1246,7 @@ kind: Alloy
 metadata:
   name: k8smon-alloy-metrics
   namespace: default
-spec: 
+spec:
   alloy:
     clustering:
       enabled: true
@@ -1260,7 +1437,7 @@ kind: Alloy
 metadata:
   name: k8smon-alloy-receiver
   namespace: default
-spec: 
+spec:
   alloy:
     clustering:
       enabled: false

--- a/charts/k8s-monitoring/tests/integration/upgrade/minor/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/integration/upgrade/minor/.rendered/output.yaml
@@ -2546,7 +2546,7 @@ kind: Alloy
 metadata:
   name: k8smon-alloy-metrics
   namespace: default
-spec: 
+spec:
   alloy:
     clustering:
       enabled: true
@@ -2737,7 +2737,7 @@ kind: Alloy
 metadata:
   name: k8smon-alloy-singleton
   namespace: default
-spec: 
+spec:
   alloy:
     clustering:
       enabled: false
@@ -2928,7 +2928,7 @@ kind: Alloy
 metadata:
   name: k8smon-alloy-logs
   namespace: default
-spec: 
+spec:
   alloy:
     clustering:
       enabled: false

--- a/charts/k8s-monitoring/tests/integration/upgrade/patch/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/integration/upgrade/patch/.rendered/output.yaml
@@ -2546,7 +2546,7 @@ kind: Alloy
 metadata:
   name: k8smon-alloy-metrics
   namespace: default
-spec: 
+spec:
   alloy:
     clustering:
       enabled: true
@@ -2737,7 +2737,7 @@ kind: Alloy
 metadata:
   name: k8smon-alloy-singleton
   namespace: default
-spec: 
+spec:
   alloy:
     clustering:
       enabled: false
@@ -2928,7 +2928,7 @@ kind: Alloy
 metadata:
   name: k8smon-alloy-logs
   namespace: default
-spec: 
+spec:
   alloy:
     clustering:
       enabled: false

--- a/charts/k8s-monitoring/tests/platform/aks/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/platform/aks/.rendered/output.yaml
@@ -2255,7 +2255,7 @@ kind: Alloy
 metadata:
   name: k8smon-alloy-metrics
   namespace: default
-spec: 
+spec:
   alloy:
     clustering:
       enabled: true
@@ -2447,7 +2447,7 @@ kind: Alloy
 metadata:
   name: k8smon-alloy-singleton
   namespace: default
-spec: 
+spec:
   alloy:
     clustering:
       enabled: false
@@ -2639,7 +2639,7 @@ kind: Alloy
 metadata:
   name: k8smon-alloy-logs
   namespace: default
-spec: 
+spec:
   alloy:
     clustering:
       enabled: false

--- a/charts/k8s-monitoring/tests/platform/eks-fargate/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/platform/eks-fargate/.rendered/output.yaml
@@ -2237,7 +2237,7 @@ kind: Alloy
 metadata:
   name: k8smon-alloy-metrics
   namespace: default
-spec: 
+spec:
   alloy:
     clustering:
       enabled: true
@@ -2428,7 +2428,7 @@ kind: Alloy
 metadata:
   name: k8smon-alloy-singleton
   namespace: default
-spec: 
+spec:
   alloy:
     clustering:
       enabled: false
@@ -2619,7 +2619,7 @@ kind: Alloy
 metadata:
   name: k8smon-alloy-logs
   namespace: default
-spec: 
+spec:
   alloy:
     clustering:
       enabled: true

--- a/charts/k8s-monitoring/tests/platform/eks-with-windows/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/platform/eks-with-windows/.rendered/output.yaml
@@ -2407,7 +2407,7 @@ kind: Alloy
 metadata:
   name: k8smon-alloy-metrics
   namespace: default
-spec: 
+spec:
   alloy:
     clustering:
       enabled: true
@@ -2598,7 +2598,7 @@ kind: Alloy
 metadata:
   name: k8smon-alloy-singleton
   namespace: default
-spec: 
+spec:
   alloy:
     clustering:
       enabled: false
@@ -2789,7 +2789,7 @@ kind: Alloy
 metadata:
   name: k8smon-alloy-logs
   namespace: default
-spec: 
+spec:
   alloy:
     clustering:
       enabled: false

--- a/charts/k8s-monitoring/tests/platform/gke-autopilot/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/platform/gke-autopilot/.rendered/output.yaml
@@ -1736,7 +1736,7 @@ kind: Alloy
 metadata:
   name: k8smon-alloy-metrics
   namespace: default
-spec: 
+spec:
   alloy:
     clustering:
       enabled: true
@@ -1927,7 +1927,7 @@ kind: Alloy
 metadata:
   name: k8smon-alloy-singleton
   namespace: default
-spec: 
+spec:
   alloy:
     clustering:
       enabled: false
@@ -2118,7 +2118,7 @@ kind: Alloy
 metadata:
   name: k8smon-alloy-logs
   namespace: default
-spec: 
+spec:
   alloy:
     clustering:
       enabled: false

--- a/charts/k8s-monitoring/tests/platform/gke/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/platform/gke/.rendered/output.yaml
@@ -2254,7 +2254,7 @@ kind: Alloy
 metadata:
   name: k8smon-alloy-metrics
   namespace: default
-spec: 
+spec:
   alloy:
     clustering:
       enabled: true
@@ -2445,7 +2445,7 @@ kind: Alloy
 metadata:
   name: k8smon-alloy-singleton
   namespace: default
-spec: 
+spec:
   alloy:
     clustering:
       enabled: false
@@ -2636,7 +2636,7 @@ kind: Alloy
 metadata:
   name: k8smon-alloy-logs
   namespace: default
-spec: 
+spec:
   alloy:
     clustering:
       enabled: false

--- a/charts/k8s-monitoring/tests/platform/grafana-cloud/app-observability/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/platform/grafana-cloud/app-observability/.rendered/output.yaml
@@ -998,7 +998,7 @@ kind: Alloy
 metadata:
   name: k8smon-alloy-logs
   namespace: default
-spec: 
+spec:
   alloy:
     clustering:
       enabled: false
@@ -1191,7 +1191,7 @@ kind: Alloy
 metadata:
   name: k8smon-alloy-receiver
   namespace: default
-spec: 
+spec:
   alloy:
     clustering:
       enabled: false

--- a/charts/k8s-monitoring/tests/platform/grafana-cloud/k8s-monitoring/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/platform/grafana-cloud/k8s-monitoring/.rendered/output.yaml
@@ -2806,7 +2806,7 @@ kind: Alloy
 metadata:
   name: k8smon-alloy-metrics
   namespace: default
-spec: 
+spec:
   alloy:
     clustering:
       enabled: true
@@ -2997,7 +2997,7 @@ kind: Alloy
 metadata:
   name: k8smon-alloy-singleton
   namespace: default
-spec: 
+spec:
   alloy:
     clustering:
       enabled: false
@@ -3188,7 +3188,7 @@ kind: Alloy
 metadata:
   name: k8smon-alloy-logs
   namespace: default
-spec: 
+spec:
   alloy:
     clustering:
       enabled: false

--- a/charts/k8s-monitoring/tests/platform/openshift/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/platform/openshift/.rendered/output.yaml
@@ -1850,7 +1850,7 @@ kind: Alloy
 metadata:
   name: k8smon-alloy-metrics
   namespace: default
-spec: 
+spec:
   alloy:
     clustering:
       enabled: true
@@ -2041,7 +2041,7 @@ kind: Alloy
 metadata:
   name: k8smon-alloy-singleton
   namespace: default
-spec: 
+spec:
   alloy:
     clustering:
       enabled: false
@@ -2232,7 +2232,7 @@ kind: Alloy
 metadata:
   name: k8smon-alloy-logs
   namespace: default
-spec: 
+spec:
   alloy:
     clustering:
       enabled: false

--- a/charts/k8s-monitoring/tests/platform/otlp-gateway/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/platform/otlp-gateway/.rendered/output.yaml
@@ -1396,7 +1396,7 @@ kind: Alloy
 metadata:
   name: k8smon-alloy-metrics
   namespace: default
-spec: 
+spec:
   alloy:
     clustering:
       enabled: true
@@ -1587,7 +1587,7 @@ kind: Alloy
 metadata:
   name: k8smon-alloy-singleton
   namespace: default
-spec: 
+spec:
   alloy:
     clustering:
       enabled: false
@@ -1778,7 +1778,7 @@ kind: Alloy
 metadata:
   name: k8smon-alloy-logs
   namespace: default
-spec: 
+spec:
   alloy:
     clustering:
       enabled: false

--- a/charts/k8s-monitoring/tests/platform/remote-config/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/platform/remote-config/.rendered/output.yaml
@@ -344,7 +344,7 @@ kind: Alloy
 metadata:
   name: k8smon-alloy-metrics
   namespace: default
-spec: 
+spec:
   alloy:
     clustering:
       enabled: true
@@ -555,7 +555,7 @@ kind: Alloy
 metadata:
   name: k8smon-alloy-logs
   namespace: default
-spec: 
+spec:
   alloy:
     clustering:
       enabled: false

--- a/charts/k8s-monitoring/values.schema.json
+++ b/charts/k8s-monitoring/values.schema.json
@@ -10,6 +10,9 @@
                 }
             }
         },
+        "alloyTemplate": {
+            "type": "object"
+        },
         "annotationAutodiscovery": {
             "type": "object",
             "properties": {

--- a/charts/k8s-monitoring/values.yaml
+++ b/charts/k8s-monitoring/values.yaml
@@ -293,14 +293,14 @@ selfReporting:
 #
 
 # An Alloy instance for collecting metrics.
-# To see additional valid options, please see the [Alloy Helm chart documentation](https://github.com/grafana/alloy/tree/main/operations/helm/charts/alloy).
+# To see all valid settings, please see the [Alloy Collector documentation](https://github.com/grafana/k8s-monitoring-helm/blob/main/charts/k8s-monitoring/docs/collectors/alloy.md).
 alloy-metrics:
   # -- Deploy the Alloy instance for collecting metrics.
   # @section -- Collectors - Alloy Metrics
   enabled: false
 
 # An Alloy instance for data sources required to be deployed on a single replica.
-# To see additional valid options, please see the [Alloy Helm chart documentation](https://github.com/grafana/alloy/tree/main/operations/helm/charts/alloy).
+# To see all valid settings, please see the [Alloy Collector documentation](https://github.com/grafana/k8s-monitoring-helm/blob/main/charts/k8s-monitoring/docs/collectors/alloy.md).
 alloy-singleton:
   # -- Deploy the Alloy instance for data sources required to be deployed on a single replica.
   # @section -- Collectors - Alloy Singleton
@@ -308,14 +308,14 @@ alloy-singleton:
 
 
 # An Alloy instance for collecting log data.
-# To see additional valid options, please see the [Alloy Helm chart documentation](https://github.com/grafana/alloy/tree/main/operations/helm/charts/alloy).
+# To see all valid settings, please see the [Alloy Collector documentation](https://github.com/grafana/k8s-monitoring-helm/blob/main/charts/k8s-monitoring/docs/collectors/alloy.md).
 alloy-logs:
   # -- Deploy the Alloy instance for collecting log data.
   # @section -- Collectors - Alloy Logs
   enabled: false
 
 # An Alloy instance for opening receivers to collect application data.
-# To see additional valid options, please see the [Alloy Helm chart documentation](https://github.com/grafana/alloy/tree/main/operations/helm/charts/alloy).
+# To see all valid settings, please see the [Alloy Collector documentation](https://github.com/grafana/k8s-monitoring-helm/blob/main/charts/k8s-monitoring/docs/collectors/alloy.md).
 alloy-receiver:
   # -- Deploy the Alloy instance for opening receivers to collect application data.
   # @section -- Collectors - Alloy Receiver
@@ -339,13 +339,21 @@ alloy-receiver:
     fullname: ""
 
 # An Alloy instance for gathering profiles.
-# To see additional valid options, please see the [Alloy Helm chart documentation](https://github.com/grafana/alloy/tree/main/operations/helm/charts/alloy).
+# To see all valid settings, please see the [Alloy Collector documentation](https://github.com/grafana/k8s-monitoring-helm/blob/main/charts/k8s-monitoring/docs/collectors/alloy.md).
 alloy-profiles:
   # -- Deploy the Alloy instance for gathering profiles.
   # @section -- Collectors - Alloy Profiles
   enabled: false
 
+# Settings to apply to all Alloy instances created by this Helm chart. This includes Alloy instances created by
+# enabling Tail Sampling or Service Graph Metrics.
+# @section -- Collectors - Alloy Common
+alloyTemplate: {}
+
+# The Alloy Operator is a Kubernetes Operator that manages Alloy instances and their lifecycle.
 alloy-operator:
+  # -- Deploy the Alloy Operator.
+  # @section -- Alloy Operator
   deploy: true
 
 # -- Deploy additional manifest objects


### PR DESCRIPTION
```yaml
alloyTemplate: {}
```

Allows for setting things for all Alloy instances at once, an no longer requires bulk applying the same change 5 different times.

Also update tail sampling and service graph metrics alloy configs to use the same config functions that the main alloy spec generator does.