### PR TITLE
fix(crd-validation): 🐛 remove bad double quote in crd validation

### DIFF
--- a/charts/k8s-monitoring/templates/_crd-validation.tpl
+++ b/charts/k8s-monitoring/templates/_crd-validation.tpl
@@ -2,7 +2,7 @@
 {{- $crdURL := printf "https://github.com/grafana/alloy-operator/releases/download/alloy-operator-%s/collectors.grafana.com_alloy.yaml" (index .Subcharts "alloy-operator").Chart.Version }}
 {{- if .Release.IsInstall }}
   {{- if not (.Capabilities.APIVersions.Has "collectors.grafana.com/v1alpha1/Alloy") }}
-    {{- if not (index .Values "alloy-operator").crds.deployAlloyCRD }}
+    {{- if not (dig "alloy-operator" "crds" "deployAlloyCRD" true .Values.AsMap) }}
       {{- $msg := list "" (printf "The %s Helm chart v3.0 requires the Alloy CRD to be deployed." .Chart.Name) }}
       {{- $msg = append $msg "Please set:" }}
       {{- $msg = append $msg "alloy-operator:" }}

--- a/charts/k8s-monitoring/templates/_crd-validation.tpl
+++ b/charts/k8s-monitoring/templates/_crd-validation.tpl
@@ -8,7 +8,7 @@
       {{- $msg = append $msg "alloy-operator:" }}
       {{- $msg = append $msg "  crds:" }}
       {{- $msg = append $msg "    deployAlloyCRD: true" }}
-      {{- $msg = append $msg "" "Or install the Alloy CRD manually:" }}
+      {{- $msg = append $msg "Or install the Alloy CRD manually:" }}
       {{- $msg = append $msg (printf "kubectl apply -f %s" $crdURL) }}
       {{- fail (join "\n" $msg) }}
     {{- end }}


### PR DESCRIPTION
Removes the empty double quote that breaks the Helm chart when `alloy-operator.deploy` is set to `false` to avoid error

```
 executing "crdValidation" at <append>: wrong number of args for append: want 2 got 3
```
