### PR TITLE
fix(spanmetrics): add span attribute support for skip metrics generation

### DIFF
--- a/charts/k8s-monitoring/charts/feature-application-observability/templates/_connector_span_metrics.tpl
+++ b/charts/k8s-monitoring/charts/feature-application-observability/templates/_connector_span_metrics.tpl
@@ -7,7 +7,7 @@ otelcol.processor.filter "span_metrics_prefilter" {
 {{- if .Values.connectors.spanMetrics.skipBeyla }}
   traces {
     span = [
-      `resource.attributes["span.metrics.skip"] != nil`,
+      `resource.attributes["span.metrics.skip"] != nil or attributes["span.metrics.skip"] != nil`,
     ]
   }
 {{- end }}

--- a/charts/k8s-monitoring/tests/integration/application-observability/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/integration/application-observability/.rendered/output.yaml
@@ -135,7 +135,7 @@ data:
         error_mode = "silent"
         traces {
           span = [
-            `resource.attributes["span.metrics.skip"] != nil`,
+            `resource.attributes["span.metrics.skip"] != nil or attributes["span.metrics.skip"] != nil`,
           ]
         }
         output {


### PR DESCRIPTION
Beyla adds `span.metrics.skip` as span attribute, but for any changes supporting both resource and span attributes would make sense