### PR TITLE
chore: allow settings `passthrough` for k8sattributes processor

### DIFF
--- a/charts/k8s-monitoring/charts/feature-application-observability/README.md
+++ b/charts/k8s-monitoring/charts/feature-application-observability/README.md
@@ -117,6 +117,7 @@ Be sure perform actual integration testing in a live environment in the main [k8
 | processors.k8sattributes.annotations | list | `[]` | Kubernetes annotations to extract and add to the attributes of the received telemetry data. |
 | processors.k8sattributes.labels | list | `[]` | Kubernetes labels to extract and add to the attributes of the received telemetry data. |
 | processors.k8sattributes.metadata | list | `["k8s.namespace.name","k8s.pod.name","k8s.deployment.name","k8s.statefulset.name","k8s.daemonset.name","k8s.cronjob.name","k8s.job.name","k8s.node.name","k8s.pod.uid","k8s.pod.start_time"]` | Kubernetes metadata to extract and add to the attributes of the received telemetry data. |
+| processors.k8sattributes.passthrough | bool | `false` | Pass through signals as-is, only adding a `k8s.pod.ip` resource attribute. |
 
 ### Processors: Memory Limiter
 

--- a/charts/k8s-monitoring/charts/feature-application-observability/templates/_processor_k8sattributes.tpl
+++ b/charts/k8s-monitoring/charts/feature-application-observability/templates/_processor_k8sattributes.tpl
@@ -3,6 +3,7 @@
 {{- define "feature.applicationObservability.processor.k8sattributes.alloy.target" }}otelcol.processor.k8sattributes.{{ .name | default "default" }}.input{{ end }}
 {{- define "feature.applicationObservability.processor.k8sattributes.alloy" }}
 otelcol.processor.k8sattributes "{{ .name | default "default" }}" {
+  passthrough = {{ .Values.processors.k8sattributes.passthrough }}
   extract {
 {{- if .Values.processors.k8sattributes.metadata }}
     metadata = {{ .Values.processors.k8sattributes.metadata | toJson }}

--- a/charts/k8s-monitoring/charts/feature-application-observability/tests/__snapshot__/default_test.yaml.snap
+++ b/charts/k8s-monitoring/charts/feature-application-observability/tests/__snapshot__/default_test.yaml.snap
@@ -92,6 +92,7 @@ creates the default pipeline:
 
         // K8s Attributes Processor
         otelcol.processor.k8sattributes "default" {
+          passthrough = false
           extract {
             metadata = ["k8s.namespace.name","k8s.pod.name","k8s.deployment.name","k8s.statefulset.name","k8s.daemonset.name","k8s.cronjob.name","k8s.job.name","k8s.node.name","k8s.pod.uid","k8s.pod.start_time"]
           }

--- a/charts/k8s-monitoring/charts/feature-application-observability/tests/__snapshot__/interval_test.yaml.snap
+++ b/charts/k8s-monitoring/charts/feature-application-observability/tests/__snapshot__/interval_test.yaml.snap
@@ -92,6 +92,7 @@ creates the pipeline with the interval processor:
 
         // K8s Attributes Processor
         otelcol.processor.k8sattributes "default" {
+          passthrough = false
           extract {
             metadata = ["k8s.namespace.name","k8s.pod.name","k8s.deployment.name","k8s.statefulset.name","k8s.daemonset.name","k8s.cronjob.name","k8s.job.name","k8s.node.name","k8s.pod.uid","k8s.pod.start_time"]
           }

--- a/charts/k8s-monitoring/charts/feature-application-observability/tests/__snapshot__/jaeger_test.yaml.snap
+++ b/charts/k8s-monitoring/charts/feature-application-observability/tests/__snapshot__/jaeger_test.yaml.snap
@@ -48,6 +48,7 @@ should allow you to enable just the jaeger grpc receiver:
 
         // K8s Attributes Processor
         otelcol.processor.k8sattributes "default" {
+          passthrough = false
           extract {
             metadata = ["k8s.namespace.name","k8s.pod.name","k8s.deployment.name","k8s.statefulset.name","k8s.daemonset.name","k8s.cronjob.name","k8s.job.name","k8s.node.name","k8s.pod.uid","k8s.pod.start_time"]
           }
@@ -167,6 +168,7 @@ should allow you to enable just the jaeger thrift binary receiver:
 
         // K8s Attributes Processor
         otelcol.processor.k8sattributes "default" {
+          passthrough = false
           extract {
             metadata = ["k8s.namespace.name","k8s.pod.name","k8s.deployment.name","k8s.statefulset.name","k8s.daemonset.name","k8s.cronjob.name","k8s.job.name","k8s.node.name","k8s.pod.uid","k8s.pod.start_time"]
           }
@@ -286,6 +288,7 @@ should allow you to enable just the jaeger thrift compact receiver:
 
         // K8s Attributes Processor
         otelcol.processor.k8sattributes "default" {
+          passthrough = false
           extract {
             metadata = ["k8s.namespace.name","k8s.pod.name","k8s.deployment.name","k8s.statefulset.name","k8s.daemonset.name","k8s.cronjob.name","k8s.job.name","k8s.node.name","k8s.pod.uid","k8s.pod.start_time"]
           }
@@ -405,6 +408,7 @@ should allow you to enable just the jaeger thrift http receiver:
 
         // K8s Attributes Processor
         otelcol.processor.k8sattributes "default" {
+          passthrough = false
           extract {
             metadata = ["k8s.namespace.name","k8s.pod.name","k8s.deployment.name","k8s.statefulset.name","k8s.daemonset.name","k8s.cronjob.name","k8s.job.name","k8s.node.name","k8s.pod.uid","k8s.pod.start_time"]
           }

--- a/charts/k8s-monitoring/charts/feature-application-observability/tests/__snapshot__/keepalive-settings_test.yaml.snap
+++ b/charts/k8s-monitoring/charts/feature-application-observability/tests/__snapshot__/keepalive-settings_test.yaml.snap
@@ -60,6 +60,7 @@ creates the default pipeline:
 
         // K8s Attributes Processor
         otelcol.processor.k8sattributes "default" {
+          passthrough = false
           extract {
             metadata = ["k8s.namespace.name","k8s.pod.name","k8s.deployment.name","k8s.statefulset.name","k8s.daemonset.name","k8s.cronjob.name","k8s.job.name","k8s.node.name","k8s.pod.uid","k8s.pod.start_time"]
           }

--- a/charts/k8s-monitoring/charts/feature-application-observability/tests/__snapshot__/memorylimiter_test.yaml.snap
+++ b/charts/k8s-monitoring/charts/feature-application-observability/tests/__snapshot__/memorylimiter_test.yaml.snap
@@ -55,6 +55,7 @@ creates the pipeline with the interval processor:
 
         // K8s Attributes Processor
         otelcol.processor.k8sattributes "default" {
+          passthrough = false
           extract {
             metadata = ["k8s.namespace.name","k8s.pod.name","k8s.deployment.name","k8s.statefulset.name","k8s.daemonset.name","k8s.cronjob.name","k8s.job.name","k8s.node.name","k8s.pod.uid","k8s.pod.start_time"]
           }

--- a/charts/k8s-monitoring/charts/feature-application-observability/tests/__snapshot__/resourcedetection_test.yaml.snap
+++ b/charts/k8s-monitoring/charts/feature-application-observability/tests/__snapshot__/resourcedetection_test.yaml.snap
@@ -43,6 +43,7 @@ creates the pipeline with the default resource detection processor:
 
         // K8s Attributes Processor
         otelcol.processor.k8sattributes "default" {
+          passthrough = false
           extract {
             metadata = ["k8s.namespace.name","k8s.pod.name","k8s.deployment.name","k8s.statefulset.name","k8s.daemonset.name","k8s.cronjob.name","k8s.job.name","k8s.node.name","k8s.pod.uid","k8s.pod.start_time"]
           }
@@ -163,6 +164,7 @@ creates the resource detection processor with EKS info:
 
         // K8s Attributes Processor
         otelcol.processor.k8sattributes "default" {
+          passthrough = false
           extract {
             metadata = ["k8s.namespace.name","k8s.pod.name","k8s.deployment.name","k8s.statefulset.name","k8s.daemonset.name","k8s.cronjob.name","k8s.job.name","k8s.node.name","k8s.pod.uid","k8s.pod.start_time"]
           }
@@ -282,6 +284,7 @@ creates the resource detection processor with Kubernetes node info:
 
         // K8s Attributes Processor
         otelcol.processor.k8sattributes "default" {
+          passthrough = false
           extract {
             metadata = ["k8s.namespace.name","k8s.pod.name","k8s.deployment.name","k8s.statefulset.name","k8s.daemonset.name","k8s.cronjob.name","k8s.job.name","k8s.node.name","k8s.pod.uid","k8s.pod.start_time"]
           }

--- a/charts/k8s-monitoring/charts/feature-application-observability/tests/__snapshot__/spanlogs_test.yaml.snap
+++ b/charts/k8s-monitoring/charts/feature-application-observability/tests/__snapshot__/spanlogs_test.yaml.snap
@@ -51,6 +51,7 @@ creates the pipeline with the spanlogs connector:
 
         // K8s Attributes Processor
         otelcol.processor.k8sattributes "default" {
+          passthrough = false
           extract {
             metadata = ["k8s.namespace.name","k8s.pod.name","k8s.deployment.name","k8s.statefulset.name","k8s.daemonset.name","k8s.cronjob.name","k8s.job.name","k8s.node.name","k8s.pod.uid","k8s.pod.start_time"]
           }

--- a/charts/k8s-monitoring/charts/feature-application-observability/tests/__snapshot__/spanmetrics_test.yaml.snap
+++ b/charts/k8s-monitoring/charts/feature-application-observability/tests/__snapshot__/spanmetrics_test.yaml.snap
@@ -51,6 +51,7 @@ creates the pipeline with the spanmetrics connector:
 
         // K8s Attributes Processor
         otelcol.processor.k8sattributes "default" {
+          passthrough = false
           extract {
             metadata = ["k8s.namespace.name","k8s.pod.name","k8s.deployment.name","k8s.statefulset.name","k8s.daemonset.name","k8s.cronjob.name","k8s.job.name","k8s.node.name","k8s.pod.uid","k8s.pod.start_time"]
           }

--- a/charts/k8s-monitoring/charts/feature-application-observability/values.schema.json
+++ b/charts/k8s-monitoring/charts/feature-application-observability/values.schema.json
@@ -258,6 +258,9 @@
                             "items": {
                                 "type": "string"
                             }
+                        },
+                        "passthrough": {
+                            "type": "boolean"
                         }
                     }
                 },

--- a/charts/k8s-monitoring/charts/feature-application-observability/values.yaml
+++ b/charts/k8s-monitoring/charts/feature-application-observability/values.yaml
@@ -200,6 +200,10 @@ processors:
       nodeFromEnvVar: K8S_NODE_NAME
 
   k8sattributes:
+    # -- Pass through signals as-is, only adding a `k8s.pod.ip` resource attribute.
+    # @section -- Processors: K8s Attributes
+    passthrough: false
+
     # -- Kubernetes metadata to extract and add to the attributes of the received telemetry data.
     # @section -- Processors: K8s Attributes
     metadata:


### PR DESCRIPTION
Allow setting `passthrough` for the `k8sattributes` processor.

Refs: #1884