### PR TITLE
feat(spanmetrics): add service.instance.id resilience to span metrics

### DIFF
--- a/charts/k8s-monitoring/charts/feature-application-observability/templates/_connector_span_metrics.tpl
+++ b/charts/k8s-monitoring/charts/feature-application-observability/templates/_connector_span_metrics.tpl
@@ -88,6 +88,8 @@ otelcol.processor.transform "span_metrics_transform" {
     context = "datapoint"
     statements = [
       `set(attributes["collector.id"], "` + constants.hostname + `")`,
+      `set(attributes["service.instance.id"], resource.attributes["k8s.pod.name"]) where resource.attributes["service.instance.id"] == nil and resource.attributes["k8s.pod.name"] != nil`,
+      `set(attributes["service.instance.id"], resource.attributes["k8s.pod.uid"]) where resource.attributes["service.instance.id"] == nil and resource.attributes["k8s.pod.uid"] != nil`,
 {{- if .Values.connectors.spanMetrics.transforms.datapoint }}
 {{- range $transform := .Values.connectors.spanMetrics.transforms.datapoint }}
 {{ $transform | quote | indent 6 }},

--- a/charts/k8s-monitoring/tests/integration/application-observability/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/integration/application-observability/.rendered/output.yaml
@@ -168,6 +168,8 @@ data:
           context = "datapoint"
           statements = [
             `set(attributes["collector.id"], "` + constants.hostname + `")`,
+            `set(attributes["service.instance.id"], resource.attributes["k8s.pod.name"]) where resource.attributes["service.instance.id"] == nil and resource.attributes["k8s.pod.name"] != nil`,
+            `set(attributes["service.instance.id"], resource.attributes["k8s.pod.uid"]) where resource.attributes["service.instance.id"] == nil and resource.attributes["k8s.pod.uid"] != nil`,
           ]
         }
     

--- a/charts/k8s-monitoring/tests/integration/prom-and-loki-to-otlp/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/integration/prom-and-loki-to-otlp/.rendered/output.yaml
@@ -1205,6 +1205,8 @@ data:
         }
         stage.structured_metadata {
           values = {
+            "k8s_pod_name" = "k8s_pod_name",
+            "pod" = "pod",
             "service_instance_id" = "service_instance_id",
           }
         }

--- a/charts/k8s-monitoring/tests/platform/otlp-gateway/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/platform/otlp-gateway/.rendered/output.yaml
@@ -981,6 +981,8 @@ data:
         }
         stage.structured_metadata {
           values = {
+            "k8s_pod_name" = "k8s_pod_name",
+            "pod" = "pod",
             "service_instance_id" = "service_instance_id",
           }
         }


### PR DESCRIPTION
This out-of-the-box support would align well with the k8s-monitoring best practices.