### PR TITLE
support extraObjects type string

### DIFF
--- a/charts/k8s-monitoring/templates/extra-objects.yaml
+++ b/charts/k8s-monitoring/templates/extra-objects.yaml
@@ -1,4 +1,8 @@
 {{ range .Values.extraObjects }}
 ---
-{{ tpl (toYaml .) $ }}
+{{- if typeIs "string" . }}
+  {{ tpl . $ }}
+{{ else }}
+  {{ tpl (. | toYaml) $ }}
+{{- end }}
 {{ end }}

--- a/charts/k8s-monitoring/values.yaml
+++ b/charts/k8s-monitoring/values.yaml
@@ -442,3 +442,22 @@ extraObjects: []
 #     dataFrom:
 #     - extract:
 #         key: mysecret
+# - |-
+#   apiVersion: external-secrets.io/v1beta1
+#   kind: ExternalSecret
+#   metadata:
+#     name: prometheus-secret
+#   spec:
+#     refreshInterval: 1h
+#     secretStoreRef:
+#       kind: SecretStore
+#       name: example
+#     target:
+#       template:
+#         data:
+#           prometheus_host: "{{ .Values.externalServices.prometheus.host }}"
+#           username: "{{`{{ .username }}`}}"
+#           password: "{{`{{ .password }}`}}"
+#     dataFrom:
+#     - extract:
+#         key: mysecret


### PR DESCRIPTION
Add support for type string in extraObjects 
This needs because ArgoCD cannot unmarshal manifests in values.yaml 