### PR TITLE
Fix job label issue and add the ability to set rules

### DIFF
--- a/charts/k8s-monitoring/charts/feature-integrations/docs/integrations/mysql.md
+++ b/charts/k8s-monitoring/charts/feature-integrations/docs/integrations/mysql.md
@@ -48,6 +48,7 @@
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
+| metrics.extraMetricProcessingRules | string | `""` | Rule blocks to be added to the prometheus.relabel component for MySQL metrics. These relabeling rules are applied post-scrape against the metrics returned from the scraped target, no `__meta*` labels are present. ([docs](https://grafana.com/docs/alloy/latest/reference/components/prometheus/prometheus.relabel/#rule-block)) |
 | metrics.maxCacheSize | string | `100000` | Sets the max_cache_size for prometheus.relabel component. This should be at least 2x-5x your largest scrape target or samples appended rate. ([docs](https://grafana.com/docs/alloy/latest/reference/components/prometheus.relabel/#arguments)) Overrides global.maxCacheSize |
 | metrics.tuning.excludeMetrics | list | `[]` | Metrics to drop. Can use regular expressions. |
 | metrics.tuning.includeMetrics | list | `[]` | Metrics to keep. Can use regular expressions. |

--- a/charts/k8s-monitoring/charts/feature-integrations/integrations/mysql-values.yaml
+++ b/charts/k8s-monitoring/charts/feature-integrations/integrations/mysql-values.yaml
@@ -35,6 +35,12 @@ metrics:
     # @section -- Metric Processing Settings
     excludeMetrics: []
 
+  # -- Rule blocks to be added to the prometheus.relabel component for MySQL metrics.
+  # These relabeling rules are applied post-scrape against the metrics returned from the scraped target, no `__meta*` labels are present.
+  # ([docs](https://grafana.com/docs/alloy/latest/reference/components/prometheus/prometheus.relabel/#rule-block))
+  # @section -- Metric Processing Settings
+  extraMetricProcessingRules: ""
+
 # Settings for log gathering using the Pod Logs feature
 logs:
   # -- Whether to enable special processing of MySQL pod logs.

--- a/charts/k8s-monitoring/charts/feature-integrations/schema-mods/definitions/mysql-integration.schema.json
+++ b/charts/k8s-monitoring/charts/feature-integrations/schema-mods/definitions/mysql-integration.schema.json
@@ -72,6 +72,9 @@
                 "enabled": {
                     "type": "boolean"
                 },
+                "extraMetricProcessingRules": {
+                    "type": "string"
+                },
                 "maxCacheSize": {
                     "type": "null"
                 },

--- a/charts/k8s-monitoring/charts/feature-integrations/templates/_integration_mysql_metrics.tpl
+++ b/charts/k8s-monitoring/charts/feature-integrations/templates/_integration_mysql_metrics.tpl
@@ -55,7 +55,6 @@ prometheus.exporter.mysql {{ include "helper.alloy_name" .name | quote }} {
 {{- $metricDenyList := .metrics.tuning.excludeMetrics }}
 prometheus.scrape {{ include "helper.alloy_name" .name | quote }} {
   targets    = prometheus.exporter.mysql.{{ include "helper.alloy_name" .name }}.targets
-  job_name   = {{ .jobLabel | quote }}
   scrape_interval = {{ .scrapeInterval | default $.Values.global.scrapeInterval | quote }}
   scrape_protocols = {{ $.Values.global.scrapeProtocols | toJson }}
   scrape_classic_histograms = {{ $.Values.global.scrapeClassicHistograms }}
@@ -67,6 +66,10 @@ prometheus.relabel {{ include "helper.alloy_name" .name | quote }} {
   rule {
     target_label = "instance"
     replacement = {{ .name | quote }}
+  }
+  rule {
+    target_label = "job"
+    replacement = {{ .jobLabel | quote }}
   }
 {{- if $metricAllowList }}
   rule {
@@ -81,6 +84,9 @@ prometheus.relabel {{ include "helper.alloy_name" .name | quote }} {
     regex = {{ $metricDenyList | join "|" | quote }}
     action = "drop"
   }
+{{- end }}
+{{- if .extraMetricProcessingRules }}
+{{ .extraMetricProcessingRules | indent 2 }}
 {{- end }}
   forward_to = argument.metrics_destinations.value
 }

--- a/charts/k8s-monitoring/charts/feature-integrations/values.schema.json
+++ b/charts/k8s-monitoring/charts/feature-integrations/values.schema.json
@@ -733,6 +733,9 @@
                         "enabled": {
                             "type": "boolean"
                         },
+                        "extraMetricProcessingRules": {
+                            "type": "string"
+                        },
                         "maxCacheSize": {
                             "type": "null"
                         },

--- a/charts/k8s-monitoring/docs/examples/features/integrations/multiple/alloy-metrics.alloy
+++ b/charts/k8s-monitoring/docs/examples/features/integrations/multiple/alloy-metrics.alloy
@@ -142,7 +142,6 @@ declare "mysql_integration" {
   }
   prometheus.scrape "mysql_cluster" {
     targets    = prometheus.exporter.mysql.mysql_cluster.targets
-    job_name   = "integration/mysql"
     scrape_interval = "60s"
     scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
     scrape_classic_histograms = false
@@ -154,6 +153,10 @@ declare "mysql_integration" {
     rule {
       target_label = "instance"
       replacement = "mysql-cluster"
+    }
+    rule {
+      target_label = "job"
+      replacement = "integration/mysql"
     }
     rule {
       source_labels = ["__name__"]

--- a/charts/k8s-monitoring/docs/examples/features/integrations/multiple/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/features/integrations/multiple/output.yaml
@@ -175,7 +175,6 @@ data:
       }
       prometheus.scrape "mysql_cluster" {
         targets    = prometheus.exporter.mysql.mysql_cluster.targets
-        job_name   = "integration/mysql"
         scrape_interval = "60s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
@@ -187,6 +186,10 @@ data:
         rule {
           target_label = "instance"
           replacement = "mysql-cluster"
+        }
+        rule {
+          target_label = "job"
+          replacement = "integration/mysql"
         }
         rule {
           source_labels = ["__name__"]

--- a/charts/k8s-monitoring/docs/examples/features/integrations/mysql/alloy-metrics.alloy
+++ b/charts/k8s-monitoring/docs/examples/features/integrations/mysql/alloy-metrics.alloy
@@ -9,7 +9,6 @@ declare "mysql_integration" {
   }
   prometheus.scrape "staging_db" {
     targets    = prometheus.exporter.mysql.staging_db.targets
-    job_name   = "integration/mysql"
     scrape_interval = "60s"
     scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
     scrape_classic_histograms = false
@@ -21,6 +20,10 @@ declare "mysql_integration" {
     rule {
       target_label = "instance"
       replacement = "staging-db"
+    }
+    rule {
+      target_label = "job"
+      replacement = "integration/mysql"
     }
     forward_to = argument.metrics_destinations.value
   }
@@ -42,7 +45,6 @@ declare "mysql_integration" {
   }
   prometheus.scrape "prod_db" {
     targets    = prometheus.exporter.mysql.prod_db.targets
-    job_name   = "integration/mysql"
     scrape_interval = "60s"
     scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
     scrape_classic_histograms = false
@@ -54,6 +56,10 @@ declare "mysql_integration" {
     rule {
       target_label = "instance"
       replacement = "prod-db"
+    }
+    rule {
+      target_label = "job"
+      replacement = "integration/mysql"
     }
     forward_to = argument.metrics_destinations.value
   }

--- a/charts/k8s-monitoring/docs/examples/features/integrations/mysql/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/features/integrations/mysql/output.yaml
@@ -42,7 +42,6 @@ data:
       }
       prometheus.scrape "staging_db" {
         targets    = prometheus.exporter.mysql.staging_db.targets
-        job_name   = "integration/mysql"
         scrape_interval = "60s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
@@ -54,6 +53,10 @@ data:
         rule {
           target_label = "instance"
           replacement = "staging-db"
+        }
+        rule {
+          target_label = "job"
+          replacement = "integration/mysql"
         }
         forward_to = argument.metrics_destinations.value
       }
@@ -75,7 +78,6 @@ data:
       }
       prometheus.scrape "prod_db" {
         targets    = prometheus.exporter.mysql.prod_db.targets
-        job_name   = "integration/mysql"
         scrape_interval = "60s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
@@ -87,6 +89,10 @@ data:
         rule {
           target_label = "instance"
           replacement = "prod-db"
+        }
+        rule {
+          target_label = "job"
+          replacement = "integration/mysql"
         }
         forward_to = argument.metrics_destinations.value
       }

--- a/charts/k8s-monitoring/tests/integration/service-integrations/mysql/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/integration/service-integrations/mysql/.rendered/output.yaml
@@ -55,7 +55,6 @@ data:
       }
       prometheus.scrape "test_database" {
         targets    = prometheus.exporter.mysql.test_database.targets
-        job_name   = "integration/mysql"
         scrape_interval = "60s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
@@ -67,6 +66,10 @@ data:
         rule {
           target_label = "instance"
           replacement = "test-database"
+        }
+        rule {
+          target_label = "job"
+          replacement = "integration/mysql"
         }
         forward_to = argument.metrics_destinations.value
       }


### PR DESCRIPTION
The issue is that `prometheus.exporter.mysql` already sets the `job` label.
`prometheus.scrape`'s `job_label` field will only set the label if it's not already set, which means we can't overwrite the label. We need to move that into the `prometheus.relabel` component.