### PR TITLE
Fix flaky integration test

### DIFF
--- a/charts/k8s-monitoring/tests/integration/prometheus-operator-objects/dependencies/probe.yaml
+++ b/charts/k8s-monitoring/tests/integration/prometheus-operator-objects/dependencies/probe.yaml
@@ -5,7 +5,7 @@ metadata:
   name: grafana-probe
   namespace: grafana
 spec:
-  interval: 30s
+  interval: 60s
   module: http_2xx
   prober:
     path: /probe


### PR DESCRIPTION
Turns out, the failure was "correct"? But we want it to stick to 1 DPM, so fix the scrape interval to be 60s.