### PR TITLE
Add Global Values Toggle for `scrape_native_histograms` in `prometheus.scrape` Components

### DIFF
--- a/charts/k8s-monitoring/README.md
+++ b/charts/k8s-monitoring/README.md
@@ -380,6 +380,8 @@ details:
 | global.platform | string | `""` | The specific platform for this cluster. Will enable compatibility for some platforms. Supported options: (empty) or "openshift". |
 | global.scrapeClassicHistograms | bool | `false` | Whether to scrape a classic histogram that’s also exposed as a native histogram. |
 | global.scrapeInterval | string | `"60s"` | How frequently to scrape metrics. |
+| global.scrapeNativeHistograms | bool | `false` | Whether to scrape native histograms. |
+| global.scrapeNativeHistograms | bool | `false` | Whether to scrape native histograms. |
 | global.scrapeProtocols | list | `["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]` | The protocols to negotiate during a Prometheus metrics scrape, in order of preference. |
 | global.scrapeTimeout | string | `"10s"` | The timeout for scraping metrics. |
 

--- a/charts/k8s-monitoring/charts/feature-annotation-autodiscovery/README.md
+++ b/charts/k8s-monitoring/charts/feature-annotation-autodiscovery/README.md
@@ -109,6 +109,7 @@ Be sure perform actual integration testing in a live environment in the main [k8
 | global.maxCacheSize | int | `100000` | Sets the max_cache_size for every prometheus.relabel component. ([docs](https://grafana.com/docs/alloy/latest/reference/components/prometheus/prometheus.relabel/#arguments)) This should be at least 2x-5x your largest scrape target or samples appended rate. |
 | global.scrapeClassicHistograms | bool | `false` | Whether to scrape a classic histogram that’s also exposed as a native histogram. |
 | global.scrapeInterval | string | `"60s"` | How frequently to scrape metrics. |
+| global.scrapeNativeHistograms | bool | `false` | Whether to scrape native histograms. |
 | global.scrapeProtocols | list | `["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]` | The protocols to negotiate during a Prometheus metrics scrape, in order of preference. |
 | global.scrapeTimeout | string | `"10s"` | The timeout for scraping metrics. |
 

--- a/charts/k8s-monitoring/charts/feature-annotation-autodiscovery/templates/_module.alloy.tpl
+++ b/charts/k8s-monitoring/charts/feature-annotation-autodiscovery/templates/_module.alloy.tpl
@@ -44,6 +44,7 @@ declare "annotation_autodiscovery" {
 {{- end }}
     scrape_protocols = {{ .Values.global.scrapeProtocols | toJson }}
     scrape_classic_histograms = {{ .Values.global.scrapeClassicHistograms }}
+    scrape_native_histograms = {{ .Values.global.scrapeNativeHistograms }}
     clustering {
       enabled = true
     }
@@ -68,6 +69,7 @@ declare "annotation_autodiscovery" {
     }
     scrape_protocols = {{ .Values.global.scrapeProtocols | toJson }}
     scrape_classic_histograms = {{ .Values.global.scrapeClassicHistograms }}
+    scrape_native_histograms = {{ .Values.global.scrapeNativeHistograms }}
     clustering {
       enabled = true
     }

--- a/charts/k8s-monitoring/charts/feature-annotation-autodiscovery/tests/__snapshot__/default_test.yaml.snap
+++ b/charts/k8s-monitoring/charts/feature-annotation-autodiscovery/tests/__snapshot__/default_test.yaml.snap
@@ -309,6 +309,7 @@ creates a module with default discovery, scraping, and processing configurations
           bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
           scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
           scrape_classic_histograms = false
+          scrape_native_histograms = false
           clustering {
             enabled = true
           }
@@ -325,6 +326,7 @@ creates a module with default discovery, scraping, and processing configurations
           }
           scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
           scrape_classic_histograms = false
+          scrape_native_histograms = false
           clustering {
             enabled = true
           }

--- a/charts/k8s-monitoring/charts/feature-annotation-autodiscovery/tests/__snapshot__/namespaced_test.yaml.snap
+++ b/charts/k8s-monitoring/charts/feature-annotation-autodiscovery/tests/__snapshot__/namespaced_test.yaml.snap
@@ -319,6 +319,7 @@ can exclude a specified list of namespaces:
           bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
           scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
           scrape_classic_histograms = false
+          scrape_native_histograms = false
           clustering {
             enabled = true
           }
@@ -335,6 +336,7 @@ can exclude a specified list of namespaces:
           }
           scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
           scrape_classic_histograms = false
+          scrape_native_histograms = false
           clustering {
             enabled = true
           }
@@ -659,6 +661,7 @@ can use a specified list of namespaces:
           bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
           scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
           scrape_classic_histograms = false
+          scrape_native_histograms = false
           clustering {
             enabled = true
           }
@@ -675,6 +678,7 @@ can use a specified list of namespaces:
           }
           scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
           scrape_classic_histograms = false
+          scrape_native_histograms = false
           clustering {
             enabled = true
           }

--- a/charts/k8s-monitoring/charts/feature-annotation-autodiscovery/tests/__snapshot__/pods_only_test.yaml.snap
+++ b/charts/k8s-monitoring/charts/feature-annotation-autodiscovery/tests/__snapshot__/pods_only_test.yaml.snap
@@ -200,6 +200,7 @@ will only discover pods:
           bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
           scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
           scrape_classic_histograms = false
+          scrape_native_histograms = false
           clustering {
             enabled = true
           }
@@ -216,6 +217,7 @@ will only discover pods:
           }
           scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
           scrape_classic_histograms = false
+          scrape_native_histograms = false
           clustering {
             enabled = true
           }

--- a/charts/k8s-monitoring/charts/feature-annotation-autodiscovery/tests/__snapshot__/prometheus_annotation_test.yaml.snap
+++ b/charts/k8s-monitoring/charts/feature-annotation-autodiscovery/tests/__snapshot__/prometheus_annotation_test.yaml.snap
@@ -309,6 +309,7 @@ creates a module with default discovery, scraping, and processing configurations
           bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
           scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
           scrape_classic_histograms = false
+          scrape_native_histograms = false
           clustering {
             enabled = true
           }
@@ -325,6 +326,7 @@ creates a module with default discovery, scraping, and processing configurations
           }
           scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
           scrape_classic_histograms = false
+          scrape_native_histograms = false
           clustering {
             enabled = true
           }

--- a/charts/k8s-monitoring/charts/feature-annotation-autodiscovery/tests/__snapshot__/selectors_test.yaml.snap
+++ b/charts/k8s-monitoring/charts/feature-annotation-autodiscovery/tests/__snapshot__/selectors_test.yaml.snap
@@ -317,6 +317,7 @@ will set appropriate selectors:
           bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
           scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
           scrape_classic_histograms = false
+          scrape_native_histograms = false
           clustering {
             enabled = true
           }
@@ -333,6 +334,7 @@ will set appropriate selectors:
           }
           scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
           scrape_classic_histograms = false
+          scrape_native_histograms = false
           clustering {
             enabled = true
           }

--- a/charts/k8s-monitoring/charts/feature-annotation-autodiscovery/values.schema.json
+++ b/charts/k8s-monitoring/charts/feature-annotation-autodiscovery/values.schema.json
@@ -75,6 +75,9 @@
                 "scrapeInterval": {
                     "type": "string"
                 },
+                "scrapeNativeHistograms": {
+                    "type": "boolean"
+                },
                 "scrapeProtocols": {
                     "type": "array",
                     "items": {

--- a/charts/k8s-monitoring/charts/feature-annotation-autodiscovery/values.yaml
+++ b/charts/k8s-monitoring/charts/feature-annotation-autodiscovery/values.yaml
@@ -16,6 +16,10 @@ global:
   # @section -- Global Settings
   scrapeClassicHistograms: false
 
+  # -- Whether to scrape native histograms.
+  # @section -- Global Settings
+  scrapeNativeHistograms: false
+
   # -- Sets the max_cache_size for every prometheus.relabel component. ([docs](https://grafana.com/docs/alloy/latest/reference/components/prometheus/prometheus.relabel/#arguments))
   # This should be at least 2x-5x your largest scrape target or samples appended rate.
   # @section -- Global Settings

--- a/charts/k8s-monitoring/charts/feature-auto-instrumentation/README.md
+++ b/charts/k8s-monitoring/charts/feature-auto-instrumentation/README.md
@@ -71,5 +71,6 @@ Be sure perform actual integration testing in a live environment in the main [k8
 | global.platform | string | `""` | The specific platform for this cluster. Will enable compatibility for some platforms. Supported options: (empty) or "openshift". |
 | global.scrapeClassicHistograms | bool | `false` | Whether to scrape a classic histogram that’s also exposed as a native histogram. |
 | global.scrapeInterval | string | `"60s"` | How frequently to scrape metrics. |
+| global.scrapeNativeHistograms | bool | `false` | Whether to scrape native histograms. |
 | global.scrapeProtocols | list | `["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]` | The protocols to negotiate during a Prometheus metrics scrape, in order of preference. |
 <!-- markdownlint-enable no-space-in-emphasis -->

--- a/charts/k8s-monitoring/charts/feature-auto-instrumentation/templates/_module.alloy.tpl
+++ b/charts/k8s-monitoring/charts/feature-auto-instrumentation/templates/_module.alloy.tpl
@@ -40,6 +40,7 @@ declare "auto_instrumentation" {
     scrape_interval = {{ .Values.beyla.scrapeInterval | default .Values.global.scrapeInterval | quote }}
     scrape_protocols = {{ .Values.global.scrapeProtocols | toJson }}
     scrape_classic_histograms = {{ .Values.global.scrapeClassicHistograms }}
+    scrape_native_histograms = {{ .Values.global.scrapeNativeHistograms }}
     clustering {
       enabled = true
     }
@@ -58,6 +59,7 @@ declare "auto_instrumentation" {
     scrape_interval = {{ .Values.beyla.scrapeInterval | default .Values.global.scrapeInterval | quote }}
     scrape_protocols = {{ .Values.global.scrapeProtocols | toJson }}
     scrape_classic_histograms = {{ .Values.global.scrapeClassicHistograms }}
+    scrape_native_histograms = {{ .Values.global.scrapeNativeHistograms }}
     clustering {
       enabled = true
     }

--- a/charts/k8s-monitoring/charts/feature-auto-instrumentation/tests/__snapshot__/default_test.yaml.snap
+++ b/charts/k8s-monitoring/charts/feature-auto-instrumentation/tests/__snapshot__/default_test.yaml.snap
@@ -32,6 +32,7 @@ creates a module with default Beyla configuration:
           scrape_interval = "60s"
           scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
           scrape_classic_histograms = false
+          scrape_native_histograms = false
           clustering {
             enabled = true
           }
@@ -46,6 +47,7 @@ creates a module with default Beyla configuration:
           scrape_interval = "60s"
           scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
           scrape_classic_histograms = false
+          scrape_native_histograms = false
           clustering {
             enabled = true
           }

--- a/charts/k8s-monitoring/charts/feature-auto-instrumentation/values.schema.json
+++ b/charts/k8s-monitoring/charts/feature-auto-instrumentation/values.schema.json
@@ -118,6 +118,9 @@
                 "scrapeInterval": {
                     "type": "string"
                 },
+                "scrapeNativeHistograms": {
+                    "type": "boolean"
+                },
                 "scrapeProtocols": {
                     "type": "array",
                     "items": {

--- a/charts/k8s-monitoring/charts/feature-cluster-metrics/README.md
+++ b/charts/k8s-monitoring/charts/feature-cluster-metrics/README.md
@@ -175,6 +175,7 @@ Be sure perform actual integration testing in a live environment in the main [k8
 | global.platform | string | `""` | The specific platform for this cluster. Will enable compatibility for some platforms. Supported options: (empty) or "openshift". |
 | global.scrapeClassicHistograms | bool | `false` | Whether to scrape a classic histogram that’s also exposed as a native histogram. |
 | global.scrapeInterval | string | `"60s"` | How frequently to scrape metrics. |
+| global.scrapeNativeHistograms | bool | `false` | Whether to scrape native histograms. |
 | global.scrapeProtocols | list | `["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]` | The protocols to negotiate during a Prometheus metrics scrape, in order of preference. |
 | global.scrapeTimeout | string | `"10s"` | The timeout for scraping metrics. |
 

--- a/charts/k8s-monitoring/charts/feature-cluster-metrics/templates/_api_server.alloy.tpl
+++ b/charts/k8s-monitoring/charts/feature-cluster-metrics/templates/_api_server.alloy.tpl
@@ -55,6 +55,7 @@ prometheus.scrape "apiserver" {
   scrape_timeout = {{ .Values.apiServer.scrapeTimeout | default .Values.global.scrapeTimeout | quote }}
   scrape_protocols = {{ .Values.global.scrapeProtocols | toJson }}
   scrape_classic_histograms = {{ .Values.global.scrapeClassicHistograms }}
+  scrape_native_histograms = {{ .Values.global.scrapeNativeHistograms }}
   bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
 
   tls_config {

--- a/charts/k8s-monitoring/charts/feature-cluster-metrics/templates/_cadvisor.alloy.tpl
+++ b/charts/k8s-monitoring/charts/feature-cluster-metrics/templates/_cadvisor.alloy.tpl
@@ -47,6 +47,7 @@ prometheus.scrape "cadvisor" {
   scrape_timeout = {{ .Values.cadvisor.scrapeTimeout | default .Values.global.scrapeTimeout | quote }}
   scrape_protocols = {{ .Values.global.scrapeProtocols | toJson }}
   scrape_classic_histograms = {{ .Values.global.scrapeClassicHistograms }}
+  scrape_native_histograms = {{ .Values.global.scrapeNativeHistograms }}
   bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
 
   tls_config {

--- a/charts/k8s-monitoring/charts/feature-cluster-metrics/templates/_kepler.alloy.tpl
+++ b/charts/k8s-monitoring/charts/feature-cluster-metrics/templates/_kepler.alloy.tpl
@@ -51,6 +51,7 @@ prometheus.scrape "kepler" {
   scrape_timeout = {{ .Values.kepler.scrapeTimeout | default .Values.global.scrapeTimeout | quote }}
   scrape_protocols = {{ .Values.global.scrapeProtocols | toJson }}
   scrape_classic_histograms = {{ .Values.global.scrapeClassicHistograms }}
+  scrape_native_histograms = {{ .Values.global.scrapeNativeHistograms }}
   clustering {
     enabled = true
   }

--- a/charts/k8s-monitoring/charts/feature-cluster-metrics/templates/_kube_controller_manager.alloy.tpl
+++ b/charts/k8s-monitoring/charts/feature-cluster-metrics/templates/_kube_controller_manager.alloy.tpl
@@ -36,6 +36,7 @@ prometheus.scrape "kube_controller_manager" {
   scrape_timeout = {{ .Values.kubeControllerManager.scrapeTimeout | default .Values.global.scrapeTimeout | quote }}
   scrape_protocols = {{ .Values.global.scrapeProtocols | toJson }}
   scrape_classic_histograms = {{ .Values.global.scrapeClassicHistograms }}
+  scrape_native_histograms = {{ .Values.global.scrapeNativeHistograms }}
   bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
   tls_config {
     insecure_skip_verify = true

--- a/charts/k8s-monitoring/charts/feature-cluster-metrics/templates/_kube_dns.alloy.tpl
+++ b/charts/k8s-monitoring/charts/feature-cluster-metrics/templates/_kube_dns.alloy.tpl
@@ -112,6 +112,7 @@ prometheus.scrape "kube_dns" {
   scrape_timeout = {{ .Values.kubeDNS.scrapeTimeout | default .Values.global.scrapeTimeout | quote }}
   scrape_protocols = {{ .Values.global.scrapeProtocols | toJson }}
   scrape_classic_histograms = {{ .Values.global.scrapeClassicHistograms }}
+  scrape_native_histograms = {{ .Values.global.scrapeNativeHistograms }}
   clustering {
     enabled = true
   }

--- a/charts/k8s-monitoring/charts/feature-cluster-metrics/templates/_kube_proxy.alloy.tpl
+++ b/charts/k8s-monitoring/charts/feature-cluster-metrics/templates/_kube_proxy.alloy.tpl
@@ -36,6 +36,7 @@ prometheus.scrape "kube_proxy" {
   scrape_timeout = {{ .Values.kubeProxy.scrapeTimeout | default .Values.global.scrapeTimeout | quote }}
   scrape_protocols = {{ .Values.global.scrapeProtocols | toJson }}
   scrape_classic_histograms = {{ .Values.global.scrapeClassicHistograms }}
+  scrape_native_histograms = {{ .Values.global.scrapeNativeHistograms }}
   clustering {
     enabled = true
   }

--- a/charts/k8s-monitoring/charts/feature-cluster-metrics/templates/_kube_scheduler.alloy.tpl
+++ b/charts/k8s-monitoring/charts/feature-cluster-metrics/templates/_kube_scheduler.alloy.tpl
@@ -36,6 +36,7 @@ prometheus.scrape "kube_scheduler" {
   scrape_timeout = {{ .Values.kubeScheduler.scrapeTimeout | default .Values.global.scrapeTimeout | quote }}
   scrape_protocols = {{ .Values.global.scrapeProtocols | toJson }}
   scrape_classic_histograms = {{ .Values.global.scrapeClassicHistograms }}
+  scrape_native_histograms = {{ .Values.global.scrapeNativeHistograms }}
   bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
   tls_config {
     insecure_skip_verify = true

--- a/charts/k8s-monitoring/charts/feature-cluster-metrics/templates/_kube_state_metrics.alloy.tpl
+++ b/charts/k8s-monitoring/charts/feature-cluster-metrics/templates/_kube_state_metrics.alloy.tpl
@@ -67,6 +67,7 @@ prometheus.scrape "kube_state_metrics" {
   scrape_timeout = {{ (index .Values "kube-state-metrics").scrapeTimeout | default .Values.global.scrapeTimeout | quote }}
   scrape_protocols = {{ .Values.global.scrapeProtocols | toJson }}
   scrape_classic_histograms = {{ .Values.global.scrapeClassicHistograms }}
+  scrape_native_histograms = {{ .Values.global.scrapeNativeHistograms }}
   scheme = {{ (index .Values "kube-state-metrics").service.scheme | quote }}
   bearer_token_file = {{ (index .Values "kube-state-metrics").bearerTokenFile | quote }}
   tls_config {

--- a/charts/k8s-monitoring/charts/feature-cluster-metrics/templates/_kubelet.alloy.tpl
+++ b/charts/k8s-monitoring/charts/feature-cluster-metrics/templates/_kubelet.alloy.tpl
@@ -42,6 +42,7 @@ prometheus.scrape "kubelet" {
   scrape_timeout = {{ .Values.kubelet.scrapeTimeout | default .Values.global.scrapeTimeout | quote }}
   scrape_protocols = {{ .Values.global.scrapeProtocols | toJson }}
   scrape_classic_histograms = {{ .Values.global.scrapeClassicHistograms }}
+  scrape_native_histograms = {{ .Values.global.scrapeNativeHistograms }}
   bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
 
   tls_config {

--- a/charts/k8s-monitoring/charts/feature-cluster-metrics/templates/_kubelet_probes.alloy.tpl
+++ b/charts/k8s-monitoring/charts/feature-cluster-metrics/templates/_kubelet_probes.alloy.tpl
@@ -47,6 +47,7 @@ prometheus.scrape "kubelet_probes" {
   scrape_timeout = {{ .Values.kubeletProbes.scrapeTimeout | default .Values.global.scrapeTimeout | quote }}
   scrape_protocols = {{ .Values.global.scrapeProtocols | toJson }}
   scrape_classic_histograms = {{ .Values.global.scrapeClassicHistograms }}
+  scrape_native_histograms = {{ .Values.global.scrapeNativeHistograms }}
   bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
 
   tls_config {

--- a/charts/k8s-monitoring/charts/feature-cluster-metrics/templates/_kubelet_resource.alloy.tpl
+++ b/charts/k8s-monitoring/charts/feature-cluster-metrics/templates/_kubelet_resource.alloy.tpl
@@ -47,6 +47,7 @@ prometheus.scrape "kubelet_resources" {
   scrape_timeout = {{ .Values.kubeletResource.scrapeTimeout | default .Values.global.scrapeTimeout | quote }}
   scrape_protocols = {{ .Values.global.scrapeProtocols | toJson }}
   scrape_classic_histograms = {{ .Values.global.scrapeClassicHistograms }}
+  scrape_native_histograms = {{ .Values.global.scrapeNativeHistograms }}
   bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
 
   tls_config {

--- a/charts/k8s-monitoring/charts/feature-cluster-metrics/templates/_node_exporter.alloy.tpl
+++ b/charts/k8s-monitoring/charts/feature-cluster-metrics/templates/_node_exporter.alloy.tpl
@@ -149,6 +149,7 @@ prometheus.scrape "node_exporter" {
   scrape_timeout = {{ (index .Values "node-exporter").scrapeTimeout | default .Values.global.scrapeTimeout | quote }}
   scrape_protocols = {{ .Values.global.scrapeProtocols | toJson }}
   scrape_classic_histograms = {{ .Values.global.scrapeClassicHistograms }}
+  scrape_native_histograms = {{ .Values.global.scrapeNativeHistograms }}
   scheme = {{ (index .Values "node-exporter").service.scheme | quote }}
   bearer_token_file = {{ (index .Values "node-exporter").bearerTokenFile | quote }}
   tls_config {

--- a/charts/k8s-monitoring/charts/feature-cluster-metrics/templates/_opencost.alloy.tpl
+++ b/charts/k8s-monitoring/charts/feature-cluster-metrics/templates/_opencost.alloy.tpl
@@ -51,6 +51,7 @@ prometheus.scrape "opencost" {
   scrape_timeout = {{ .Values.opencost.scrapeTimeout | default .Values.global.scrapeTimeout | quote }}
   scrape_protocols = {{ .Values.global.scrapeProtocols | toJson }}
   scrape_classic_histograms = {{ .Values.global.scrapeClassicHistograms }}
+  scrape_native_histograms = {{ .Values.global.scrapeNativeHistograms }}
   clustering {
     enabled = true
   }

--- a/charts/k8s-monitoring/charts/feature-cluster-metrics/templates/_windows_exporter.alloy.tpl
+++ b/charts/k8s-monitoring/charts/feature-cluster-metrics/templates/_windows_exporter.alloy.tpl
@@ -78,6 +78,7 @@ prometheus.scrape "windows_exporter" {
   scrape_timeout = {{ (index .Values "windows-exporter").scrapeTimeout | default .Values.global.scrapeTimeout | quote }}
   scrape_protocols = {{ .Values.global.scrapeProtocols | toJson }}
   scrape_classic_histograms = {{ .Values.global.scrapeClassicHistograms }}
+  scrape_native_histograms = {{ .Values.global.scrapeNativeHistograms }}
   clustering {
     enabled = true
   }

--- a/charts/k8s-monitoring/charts/feature-cluster-metrics/tests/__snapshot__/alternative-discovery_test.yaml.snap
+++ b/charts/k8s-monitoring/charts/feature-cluster-metrics/tests/__snapshot__/alternative-discovery_test.yaml.snap
@@ -46,6 +46,7 @@ should be able to find the Kubelet and cAdvisor via the API server proxy:
           scrape_timeout = "10s"
           scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
           scrape_classic_histograms = false
+          scrape_native_histograms = false
           bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
 
           tls_config {
@@ -96,6 +97,7 @@ should be able to find the Kubelet and cAdvisor via the API server proxy:
           scrape_timeout = "10s"
           scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
           scrape_classic_histograms = false
+          scrape_native_histograms = false
           bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
 
           tls_config {
@@ -146,6 +148,7 @@ should be able to find the Kubelet and cAdvisor via the API server proxy:
           scrape_timeout = "10s"
           scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
           scrape_classic_histograms = false
+          scrape_native_histograms = false
           bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
 
           tls_config {
@@ -196,6 +199,7 @@ should be able to find the Kubelet and cAdvisor via the API server proxy:
           scrape_timeout = "10s"
           scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
           scrape_classic_histograms = false
+          scrape_native_histograms = false
           bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
 
           tls_config {
@@ -325,6 +329,7 @@ should be able to find the Kubelet and cAdvisor via the API server proxy:
           scrape_timeout = "10s"
           scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
           scrape_classic_histograms = false
+          scrape_native_histograms = false
           scheme = "http"
           bearer_token_file = ""
           tls_config {
@@ -459,6 +464,7 @@ should be able to find the Kubelet and cAdvisor via the API server proxy:
           scrape_timeout = "10s"
           scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
           scrape_classic_histograms = false
+          scrape_native_histograms = false
           scheme = "http"
           bearer_token_file = ""
           tls_config {
@@ -530,6 +536,7 @@ should be able to find the Kubelet and cAdvisor via the API server proxy:
           scrape_timeout = "10s"
           scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
           scrape_classic_histograms = false
+          scrape_native_histograms = false
           clustering {
             enabled = true
           }
@@ -584,6 +591,7 @@ should be able to look for kube-state-metrics via pods, rather than endpoints:
           scrape_timeout = "10s"
           scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
           scrape_classic_histograms = false
+          scrape_native_histograms = false
           bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
 
           tls_config {
@@ -627,6 +635,7 @@ should be able to look for kube-state-metrics via pods, rather than endpoints:
           scrape_timeout = "10s"
           scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
           scrape_classic_histograms = false
+          scrape_native_histograms = false
           bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
 
           tls_config {
@@ -670,6 +679,7 @@ should be able to look for kube-state-metrics via pods, rather than endpoints:
           scrape_timeout = "10s"
           scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
           scrape_classic_histograms = false
+          scrape_native_histograms = false
           bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
 
           tls_config {
@@ -799,6 +809,7 @@ should be able to look for kube-state-metrics via pods, rather than endpoints:
           scrape_timeout = "10s"
           scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
           scrape_classic_histograms = false
+          scrape_native_histograms = false
           scheme = "http"
           bearer_token_file = ""
           tls_config {
@@ -933,6 +944,7 @@ should be able to look for kube-state-metrics via pods, rather than endpoints:
           scrape_timeout = "10s"
           scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
           scrape_classic_histograms = false
+          scrape_native_histograms = false
           scheme = "http"
           bearer_token_file = ""
           tls_config {
@@ -1004,6 +1016,7 @@ should be able to look for kube-state-metrics via pods, rather than endpoints:
           scrape_timeout = "10s"
           scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
           scrape_classic_histograms = false
+          scrape_native_histograms = false
           clustering {
             enabled = true
           }

--- a/charts/k8s-monitoring/charts/feature-cluster-metrics/tests/__snapshot__/control_plane_test.yaml.snap
+++ b/charts/k8s-monitoring/charts/feature-cluster-metrics/tests/__snapshot__/control_plane_test.yaml.snap
@@ -36,6 +36,7 @@ should render the configuration with control plane components included:
           scrape_timeout = "10s"
           scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
           scrape_classic_histograms = false
+          scrape_native_histograms = false
           bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
 
           tls_config {
@@ -79,6 +80,7 @@ should render the configuration with control plane components included:
           scrape_timeout = "10s"
           scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
           scrape_classic_histograms = false
+          scrape_native_histograms = false
           bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
 
           tls_config {
@@ -122,6 +124,7 @@ should render the configuration with control plane components included:
           scrape_timeout = "10s"
           scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
           scrape_classic_histograms = false
+          scrape_native_histograms = false
           bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
 
           tls_config {
@@ -261,6 +264,7 @@ should render the configuration with control plane components included:
           scrape_timeout = "10s"
           scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
           scrape_classic_histograms = false
+          scrape_native_histograms = false
           bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
 
           tls_config {
@@ -303,6 +307,7 @@ should render the configuration with control plane components included:
           scrape_timeout = "10s"
           scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
           scrape_classic_histograms = false
+          scrape_native_histograms = false
           bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
           tls_config {
             insecure_skip_verify = true
@@ -417,6 +422,7 @@ should render the configuration with control plane components included:
           scrape_timeout = "10s"
           scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
           scrape_classic_histograms = false
+          scrape_native_histograms = false
           clustering {
             enabled = true
           }
@@ -451,6 +457,7 @@ should render the configuration with control plane components included:
           scrape_timeout = "10s"
           scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
           scrape_classic_histograms = false
+          scrape_native_histograms = false
           clustering {
             enabled = true
           }
@@ -485,6 +492,7 @@ should render the configuration with control plane components included:
           scrape_timeout = "10s"
           scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
           scrape_classic_histograms = false
+          scrape_native_histograms = false
           bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
           tls_config {
             insecure_skip_verify = true
@@ -531,6 +539,7 @@ should render the configuration with control plane components included:
           scrape_timeout = "10s"
           scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
           scrape_classic_histograms = false
+          scrape_native_histograms = false
           scheme = "http"
           bearer_token_file = ""
           tls_config {
@@ -665,6 +674,7 @@ should render the configuration with control plane components included:
           scrape_timeout = "10s"
           scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
           scrape_classic_histograms = false
+          scrape_native_histograms = false
           scheme = "http"
           bearer_token_file = ""
           tls_config {
@@ -736,6 +746,7 @@ should render the configuration with control plane components included:
           scrape_timeout = "10s"
           scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
           scrape_classic_histograms = false
+          scrape_native_histograms = false
           clustering {
             enabled = true
           }

--- a/charts/k8s-monitoring/charts/feature-cluster-metrics/tests/__snapshot__/custom_rules_test.yaml.snap
+++ b/charts/k8s-monitoring/charts/feature-cluster-metrics/tests/__snapshot__/custom_rules_test.yaml.snap
@@ -40,6 +40,7 @@ should render the default configuration:
           scrape_timeout = "10s"
           scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
           scrape_classic_histograms = false
+          scrape_native_histograms = false
           bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
 
           tls_config {
@@ -83,6 +84,7 @@ should render the default configuration:
           scrape_timeout = "10s"
           scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
           scrape_classic_histograms = false
+          scrape_native_histograms = false
           bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
 
           tls_config {
@@ -126,6 +128,7 @@ should render the default configuration:
           scrape_timeout = "10s"
           scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
           scrape_classic_histograms = false
+          scrape_native_histograms = false
           bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
 
           tls_config {
@@ -258,6 +261,7 @@ should render the default configuration:
           scrape_timeout = "10s"
           scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
           scrape_classic_histograms = false
+          scrape_native_histograms = false
           scheme = "http"
           bearer_token_file = ""
           tls_config {
@@ -403,6 +407,7 @@ should render the default configuration:
           scrape_timeout = "10s"
           scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
           scrape_classic_histograms = false
+          scrape_native_histograms = false
           scheme = "http"
           bearer_token_file = ""
           tls_config {
@@ -474,6 +479,7 @@ should render the default configuration:
           scrape_timeout = "10s"
           scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
           scrape_classic_histograms = false
+          scrape_native_histograms = false
           clustering {
             enabled = true
           }

--- a/charts/k8s-monitoring/charts/feature-cluster-metrics/tests/__snapshot__/default_test.yaml.snap
+++ b/charts/k8s-monitoring/charts/feature-cluster-metrics/tests/__snapshot__/default_test.yaml.snap
@@ -36,6 +36,7 @@ should render the default configuration:
           scrape_timeout = "10s"
           scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
           scrape_classic_histograms = false
+          scrape_native_histograms = false
           bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
 
           tls_config {
@@ -79,6 +80,7 @@ should render the default configuration:
           scrape_timeout = "10s"
           scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
           scrape_classic_histograms = false
+          scrape_native_histograms = false
           bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
 
           tls_config {
@@ -122,6 +124,7 @@ should render the default configuration:
           scrape_timeout = "10s"
           scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
           scrape_classic_histograms = false
+          scrape_native_histograms = false
           bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
 
           tls_config {
@@ -251,6 +254,7 @@ should render the default configuration:
           scrape_timeout = "10s"
           scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
           scrape_classic_histograms = false
+          scrape_native_histograms = false
           scheme = "http"
           bearer_token_file = ""
           tls_config {
@@ -385,6 +389,7 @@ should render the default configuration:
           scrape_timeout = "10s"
           scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
           scrape_classic_histograms = false
+          scrape_native_histograms = false
           scheme = "http"
           bearer_token_file = ""
           tls_config {
@@ -456,6 +461,7 @@ should render the default configuration:
           scrape_timeout = "10s"
           scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
           scrape_classic_histograms = false
+          scrape_native_histograms = false
           clustering {
             enabled = true
           }

--- a/charts/k8s-monitoring/charts/feature-cluster-metrics/tests/__snapshot__/kepler_test.yaml.snap
+++ b/charts/k8s-monitoring/charts/feature-cluster-metrics/tests/__snapshot__/kepler_test.yaml.snap
@@ -36,6 +36,7 @@ should render the configuration with Kepler:
           scrape_timeout = "10s"
           scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
           scrape_classic_histograms = false
+          scrape_native_histograms = false
           bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
 
           tls_config {
@@ -79,6 +80,7 @@ should render the configuration with Kepler:
           scrape_timeout = "10s"
           scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
           scrape_classic_histograms = false
+          scrape_native_histograms = false
           bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
 
           tls_config {
@@ -122,6 +124,7 @@ should render the configuration with Kepler:
           scrape_timeout = "10s"
           scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
           scrape_classic_histograms = false
+          scrape_native_histograms = false
           bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
 
           tls_config {
@@ -251,6 +254,7 @@ should render the configuration with Kepler:
           scrape_timeout = "10s"
           scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
           scrape_classic_histograms = false
+          scrape_native_histograms = false
           scheme = "http"
           bearer_token_file = ""
           tls_config {
@@ -385,6 +389,7 @@ should render the configuration with Kepler:
           scrape_timeout = "10s"
           scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
           scrape_classic_histograms = false
+          scrape_native_histograms = false
           scheme = "http"
           bearer_token_file = ""
           tls_config {
@@ -456,6 +461,7 @@ should render the configuration with Kepler:
           scrape_timeout = "10s"
           scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
           scrape_classic_histograms = false
+          scrape_native_histograms = false
           clustering {
             enabled = true
           }
@@ -500,6 +506,7 @@ should render the configuration with Kepler:
           scrape_timeout = "10s"
           scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
           scrape_classic_histograms = false
+          scrape_native_histograms = false
           clustering {
             enabled = true
           }

--- a/charts/k8s-monitoring/charts/feature-cluster-metrics/tests/__snapshot__/kube-state-metrics_test.yaml.snap
+++ b/charts/k8s-monitoring/charts/feature-cluster-metrics/tests/__snapshot__/kube-state-metrics_test.yaml.snap
@@ -42,6 +42,7 @@ can discover kube-state-metrics via pods:
           scrape_timeout = "10s"
           scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
           scrape_classic_histograms = false
+          scrape_native_histograms = false
           scheme = "http"
           bearer_token_file = ""
           tls_config {
@@ -108,6 +109,7 @@ can discover kube-state-metrics via service:
           scrape_timeout = "10s"
           scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
           scrape_classic_histograms = false
+          scrape_native_histograms = false
           scheme = "http"
           bearer_token_file = ""
           tls_config {

--- a/charts/k8s-monitoring/charts/feature-cluster-metrics/tests/__snapshot__/metrics_tuning_test.yaml.snap
+++ b/charts/k8s-monitoring/charts/feature-cluster-metrics/tests/__snapshot__/metrics_tuning_test.yaml.snap
@@ -36,6 +36,7 @@ should render with modified metrics tuning settings:
           scrape_timeout = "10s"
           scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
           scrape_classic_histograms = false
+          scrape_native_histograms = false
           bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
 
           tls_config {
@@ -79,6 +80,7 @@ should render with modified metrics tuning settings:
           scrape_timeout = "10s"
           scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
           scrape_classic_histograms = false
+          scrape_native_histograms = false
           bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
 
           tls_config {
@@ -122,6 +124,7 @@ should render with modified metrics tuning settings:
           scrape_timeout = "10s"
           scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
           scrape_classic_histograms = false
+          scrape_native_histograms = false
           bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
 
           tls_config {
@@ -246,6 +249,7 @@ should render with modified metrics tuning settings:
           scrape_timeout = "10s"
           scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
           scrape_classic_histograms = false
+          scrape_native_histograms = false
           scheme = "http"
           bearer_token_file = ""
           tls_config {
@@ -385,6 +389,7 @@ should render with modified metrics tuning settings:
           scrape_timeout = "10s"
           scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
           scrape_classic_histograms = false
+          scrape_native_histograms = false
           scheme = "http"
           bearer_token_file = ""
           tls_config {
@@ -456,6 +461,7 @@ should render with modified metrics tuning settings:
           scrape_timeout = "10s"
           scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
           scrape_classic_histograms = false
+          scrape_native_histograms = false
           clustering {
             enabled = true
           }

--- a/charts/k8s-monitoring/charts/feature-cluster-metrics/tests/__snapshot__/opencost_test.yaml.snap
+++ b/charts/k8s-monitoring/charts/feature-cluster-metrics/tests/__snapshot__/opencost_test.yaml.snap
@@ -36,6 +36,7 @@ should render the configuration with OpenCost:
           scrape_timeout = "10s"
           scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
           scrape_classic_histograms = false
+          scrape_native_histograms = false
           bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
 
           tls_config {
@@ -79,6 +80,7 @@ should render the configuration with OpenCost:
           scrape_timeout = "10s"
           scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
           scrape_classic_histograms = false
+          scrape_native_histograms = false
           bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
 
           tls_config {
@@ -122,6 +124,7 @@ should render the configuration with OpenCost:
           scrape_timeout = "10s"
           scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
           scrape_classic_histograms = false
+          scrape_native_histograms = false
           bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
 
           tls_config {
@@ -251,6 +254,7 @@ should render the configuration with OpenCost:
           scrape_timeout = "10s"
           scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
           scrape_classic_histograms = false
+          scrape_native_histograms = false
           scheme = "http"
           bearer_token_file = ""
           tls_config {
@@ -385,6 +389,7 @@ should render the configuration with OpenCost:
           scrape_timeout = "10s"
           scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
           scrape_classic_histograms = false
+          scrape_native_histograms = false
           scheme = "http"
           bearer_token_file = ""
           tls_config {
@@ -456,6 +461,7 @@ should render the configuration with OpenCost:
           scrape_timeout = "10s"
           scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
           scrape_classic_histograms = false
+          scrape_native_histograms = false
           clustering {
             enabled = true
           }
@@ -500,6 +506,7 @@ should render the configuration with OpenCost:
           scrape_timeout = "10s"
           scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
           scrape_classic_histograms = false
+          scrape_native_histograms = false
           clustering {
             enabled = true
           }

--- a/charts/k8s-monitoring/charts/feature-cluster-metrics/tests/__snapshot__/openshift_test.yaml.snap
+++ b/charts/k8s-monitoring/charts/feature-cluster-metrics/tests/__snapshot__/openshift_test.yaml.snap
@@ -36,6 +36,7 @@ can adapt to locally deployed kube-state-metrics and Node Exporter instances:
           scrape_timeout = "10s"
           scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
           scrape_classic_histograms = false
+          scrape_native_histograms = false
           bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
 
           tls_config {
@@ -79,6 +80,7 @@ can adapt to locally deployed kube-state-metrics and Node Exporter instances:
           scrape_timeout = "10s"
           scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
           scrape_classic_histograms = false
+          scrape_native_histograms = false
           bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
 
           tls_config {
@@ -122,6 +124,7 @@ can adapt to locally deployed kube-state-metrics and Node Exporter instances:
           scrape_timeout = "10s"
           scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
           scrape_classic_histograms = false
+          scrape_native_histograms = false
           bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
 
           tls_config {
@@ -251,6 +254,7 @@ can adapt to locally deployed kube-state-metrics and Node Exporter instances:
           scrape_timeout = "10s"
           scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
           scrape_classic_histograms = false
+          scrape_native_histograms = false
           scheme = "https"
           bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
           tls_config {
@@ -385,6 +389,7 @@ can adapt to locally deployed kube-state-metrics and Node Exporter instances:
           scrape_timeout = "10s"
           scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
           scrape_classic_histograms = false
+          scrape_native_histograms = false
           scheme = "https"
           bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
           tls_config {
@@ -456,6 +461,7 @@ can adapt to locally deployed kube-state-metrics and Node Exporter instances:
           scrape_timeout = "10s"
           scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
           scrape_classic_histograms = false
+          scrape_native_histograms = false
           clustering {
             enabled = true
           }

--- a/charts/k8s-monitoring/charts/feature-cluster-metrics/values.schema.json
+++ b/charts/k8s-monitoring/charts/feature-cluster-metrics/values.schema.json
@@ -163,6 +163,9 @@
                 "scrapeInterval": {
                     "type": "string"
                 },
+                "scrapeNativeHistograms": {
+                    "type": "boolean"
+                },
                 "scrapeProtocols": {
                     "type": "array",
                     "items": {

--- a/charts/k8s-monitoring/charts/feature-cluster-metrics/values.yaml
+++ b/charts/k8s-monitoring/charts/feature-cluster-metrics/values.yaml
@@ -24,6 +24,10 @@ global:
   # @section -- Global Settings
   scrapeClassicHistograms: false
 
+  # -- Whether to scrape native histograms.
+  # @section -- Global Settings
+  scrapeNativeHistograms: false
+
   # -- Sets the max_cache_size for every prometheus.relabel component. ([docs](https://grafana.com/docs/alloy/latest/reference/components/prometheus/prometheus.relabel/#arguments))
   # This should be at least 2x-5x your largest scrape target or samples appended rate.
   # @section -- Global Settings

--- a/charts/k8s-monitoring/charts/feature-integrations/README.md
+++ b/charts/k8s-monitoring/charts/feature-integrations/README.md
@@ -104,6 +104,7 @@ Be sure perform actual integration testing in a live environment in the main [k8
 | global.maxCacheSize | int | `100000` | Sets the max_cache_size for every prometheus.relabel component. ([docs](https://grafana.com/docs/alloy/latest/reference/components/prometheus/prometheus.relabel/#arguments)) This should be at least 2x-5x your largest scrape target or samples appended rate. |
 | global.scrapeClassicHistograms | bool | `false` | Whether to scrape a classic histogram that’s also exposed as a native histogram. |
 | global.scrapeInterval | string | `"60s"` | How frequently to scrape metrics. |
+| global.scrapeNativeHistograms | bool | `false` | Whether to scrape native histograms. |
 | global.scrapeProtocols | list | `["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]` | The protocols to negotiate during a Prometheus metrics scrape, in order of preference. |
 | global.scrapeTimeout | string | `"10s"` | The timeout for scraping metrics. |
 

--- a/charts/k8s-monitoring/charts/feature-integrations/templates/_integration_alloy.tpl
+++ b/charts/k8s-monitoring/charts/feature-integrations/templates/_integration_alloy.tpl
@@ -146,6 +146,7 @@ declare "alloy_integration" {
       scrape_timeout = coalesce(argument.scrape_timeout.value, "10s")
       scrape_protocols = argument.scrape_protocols.value
       scrape_classic_histograms = argument.scrape_classic_histograms.value
+      scrape_native_histograms = argument.scrape_native_histograms.value
 
       clustering {
         enabled = coalesce(argument.clustering.value, false)
@@ -283,6 +284,7 @@ alloy_integration_scrape  {{ include "helper.alloy_name" .name | quote }} {
   scrape_timeout = {{ .scrapeTimeout | default $.Values.global.scrapeTimeout | quote }}
   scrape_protocols = {{ $.Values.global.scrapeProtocols | toJson }}
   scrape_classic_histograms = {{ $.Values.global.scrapeClassicHistograms }}
+  scrape_native_histograms = {{ $.Values.global.scrapeNativeHistograms }}
   max_cache_size = {{ .metrics.maxCacheSize | default $.Values.global.maxCacheSize | int }}
   forward_to = argument.metrics_destinations.value
 }

--- a/charts/k8s-monitoring/charts/feature-integrations/templates/_integration_cert-manager.tpl
+++ b/charts/k8s-monitoring/charts/feature-integrations/templates/_integration_cert-manager.tpl
@@ -146,6 +146,7 @@ prometheus.scrape {{ include "helper.alloy_name" .name | quote }} {
   scrape_timeout = {{ .scrapeTimeout | default $.Values.global.scrapeTimeout | quote }}
   scrape_protocols = {{ $.Values.global.scrapeProtocols | toJson }}
   scrape_classic_histograms = {{ $.Values.global.scrapeClassicHistograms }}
+  scrape_native_histograms = {{ $.Values.global.scrapeNativeHistograms }}
   clustering {
     enabled = true
   }

--- a/charts/k8s-monitoring/charts/feature-integrations/templates/_integration_dcgm-exporter.tpl
+++ b/charts/k8s-monitoring/charts/feature-integrations/templates/_integration_dcgm-exporter.tpl
@@ -142,6 +142,7 @@ declare "dcgm_exporter_integration" {
       scrape_timeout = coalesce(argument.scrape_timeout.value, "10s")
       scrape_protocols = argument.scrape_protocols.value
       scrape_classic_histograms = argument.scrape_classic_histograms.value
+      scrape_native_histograms = argument.scrape_native_histograms.value
 
       clustering {
         enabled = coalesce(argument.clustering.value, false)
@@ -281,6 +282,7 @@ dcgm_exporter_integration_scrape  {{ include "helper.alloy_name" .name | quote }
   scrape_timeout = {{ .scrapeTimeout | default $.Values.global.scrapeTimeout | quote }}
   scrape_protocols = {{ $.Values.global.scrapeProtocols | toJson }}
   scrape_classic_histograms = {{ $.Values.global.scrapeClassicHistograms }}
+  scrape_native_histograms = {{ $.Values.global.scrapeNativeHistograms }}
   max_cache_size = {{ .metrics.maxCacheSize | default $.Values.global.maxCacheSize | int }}
   forward_to = argument.metrics_destinations.value
 }

--- a/charts/k8s-monitoring/charts/feature-integrations/templates/_integration_etcd.tpl
+++ b/charts/k8s-monitoring/charts/feature-integrations/templates/_integration_etcd.tpl
@@ -141,6 +141,7 @@ prometheus.scrape {{ include "helper.alloy_name" .name | quote }} {
   scrape_timeout = {{ .scrapeTimeout | default $.Values.global.scrapeTimeout | quote }}
   scrape_protocols = {{ $.Values.global.scrapeProtocols | toJson }}
   scrape_classic_histograms = {{ $.Values.global.scrapeClassicHistograms }}
+  scrape_native_histograms = {{ $.Values.global.scrapeNativeHistograms }}
   clustering {
     enabled = true
   }

--- a/charts/k8s-monitoring/charts/feature-integrations/templates/_integration_grafana_metrics.tpl
+++ b/charts/k8s-monitoring/charts/feature-integrations/templates/_integration_grafana_metrics.tpl
@@ -156,6 +156,7 @@ declare "grafana_integration" {
       scrape_timeout = coalesce(argument.scrape_timeout.value, "10s")
       scrape_protocols = argument.scrape_protocols.value
       scrape_classic_histograms = argument.scrape_classic_histograms.value
+      scrape_native_histograms = argument.scrape_native_histograms.value
 
       clustering {
         enabled = coalesce(argument.clustering.value, false)
@@ -237,6 +238,7 @@ grafana_integration_scrape  {{ include "helper.alloy_name" .name | quote }} {
   scrape_timeout = {{ .scrapeTimeout | default $.Values.global.scrapeTimeout | quote }}
   scrape_protocols = {{ $.Values.global.scrapeProtocols | toJson }}
   scrape_classic_histograms = {{ $.Values.global.scrapeClassicHistograms }}
+  scrape_native_histograms = {{ $.Values.global.scrapeNativeHistograms }}
   max_cache_size = {{ .metrics.maxCacheSize | default $.Values.global.maxCacheSize | int }}
   forward_to = argument.metrics_destinations.value
 }

--- a/charts/k8s-monitoring/charts/feature-integrations/templates/_integration_loki_metrics.tpl
+++ b/charts/k8s-monitoring/charts/feature-integrations/templates/_integration_loki_metrics.tpl
@@ -163,6 +163,7 @@ declare "loki_integration" {
       scrape_timeout = coalesce(argument.scrape_timeout.value, "10s")
       scrape_protocols = argument.scrape_protocols.value
       scrape_classic_histograms = argument.scrape_classic_histograms.value
+      scrape_native_histograms = argument.scrape_native_histograms.value
 
       clustering {
         enabled = coalesce(argument.clustering.value, false)
@@ -253,6 +254,7 @@ loki_integration_scrape  {{ include "helper.alloy_name" .name | quote }} {
   scrape_timeout = {{ .scrapeTimeout | default $.Values.global.scrapeTimeout | quote }}
   scrape_protocols = {{ $.Values.global.scrapeProtocols | toJson }}
   scrape_classic_histograms = {{ $.Values.global.scrapeClassicHistograms }}
+  scrape_native_histograms = {{ $.Values.global.scrapeNativeHistograms }}
   max_cache_size = {{ .metrics.maxCacheSize | default $.Values.global.maxCacheSize | int }}
   forward_to = argument.metrics_destinations.value
 }

--- a/charts/k8s-monitoring/charts/feature-integrations/templates/_integration_mimir_metrics.tpl
+++ b/charts/k8s-monitoring/charts/feature-integrations/templates/_integration_mimir_metrics.tpl
@@ -163,6 +163,7 @@ declare "mimir_integration" {
       scrape_timeout = coalesce(argument.scrape_timeout.value, "10s")
       scrape_protocols = argument.scrape_protocols.value
       scrape_classic_histograms = argument.scrape_classic_histograms.value
+      scrape_native_histograms = argument.scrape_native_histograms.value
 
       clustering {
         enabled = coalesce(argument.clustering.value, false)
@@ -253,6 +254,7 @@ mimir_integration_scrape  {{ include "helper.alloy_name" .name | quote }} {
   scrape_timeout = {{ .scrapeTimeout | default $.Values.global.scrapeTimeout | quote }}
   scrape_protocols = {{ $.Values.global.scrapeProtocols | toJson }}
   scrape_classic_histograms = {{ $.Values.global.scrapeClassicHistograms }}
+  scrape_native_histograms = {{ $.Values.global.scrapeNativeHistograms }}
   max_cache_size = {{ .metrics.maxCacheSize | default $.Values.global.maxCacheSize | int }}
   forward_to = argument.metrics_destinations.value
 }

--- a/charts/k8s-monitoring/charts/feature-integrations/templates/_integration_mysql_metrics.tpl
+++ b/charts/k8s-monitoring/charts/feature-integrations/templates/_integration_mysql_metrics.tpl
@@ -63,6 +63,7 @@ prometheus.scrape {{ include "helper.alloy_name" .name | quote }} {
   scrape_timeout = {{ .scrapeTimeout | default $.Values.global.scrapeTimeout | quote }}
   scrape_protocols = {{ $.Values.global.scrapeProtocols | toJson }}
   scrape_classic_histograms = {{ $.Values.global.scrapeClassicHistograms }}
+  scrape_native_histograms = {{ $.Values.global.scrapeNativeHistograms }}
   forward_to = [prometheus.relabel.{{ include "helper.alloy_name" .name }}.receiver]
 }
 

--- a/charts/k8s-monitoring/charts/feature-integrations/templates/_integration_tempo_metrics.tpl
+++ b/charts/k8s-monitoring/charts/feature-integrations/templates/_integration_tempo_metrics.tpl
@@ -163,6 +163,7 @@ declare "tempo_integration" {
       scrape_timeout = coalesce(argument.scrape_timeout.value, "10s")
       scrape_protocols = argument.scrape_protocols.value
       scrape_classic_histograms = argument.scrape_classic_histograms.value
+      scrape_native_histograms = argument.scrape_native_histograms.value
 
       clustering {
         enabled = coalesce(argument.clustering.value, false)
@@ -253,6 +254,7 @@ tempo_integration_scrape  {{ include "helper.alloy_name" .name | quote }} {
   scrape_timeout = {{ .scrapeTimeout | default $.Values.global.scrapeTimeout | quote }}
   scrape_protocols = {{ $.Values.global.scrapeProtocols | toJson }}
   scrape_classic_histograms = {{ $.Values.global.scrapeClassicHistograms }}
+  scrape_native_histograms = {{ $.Values.global.scrapeNativeHistograms }}
   max_cache_size = {{ .metrics.maxCacheSize | default $.Values.global.maxCacheSize | int }}
   forward_to = argument.metrics_destinations.value
 }

--- a/charts/k8s-monitoring/charts/feature-integrations/tests/__snapshot__/alloy_test.yaml.snap
+++ b/charts/k8s-monitoring/charts/feature-integrations/tests/__snapshot__/alloy_test.yaml.snap
@@ -183,6 +183,11 @@ should create the Alloy config:
             optional = true
           }
 
+          argument "scrape_native_histograms" {
+            comment = "Whether to scrape native histograms (default: false)."
+            optional = true
+          }
+
           argument "max_cache_size" {
             comment = "The maximum number of elements to hold in the relabeling cache (default: 100000).  This should be at least 2x-5x your largest scrape target or samples appended rate."
             optional = true
@@ -201,6 +206,7 @@ should create the Alloy config:
             scrape_timeout = coalesce(argument.scrape_timeout.value, "10s")
             scrape_protocols = argument.scrape_protocols.value
             scrape_classic_histograms = argument.scrape_classic_histograms.value
+      scrape_native_histograms = argument.scrape_native_histograms.value
 
             clustering {
               enabled = coalesce(argument.clustering.value, false)
@@ -307,6 +313,7 @@ should create the Alloy config:
           scrape_timeout = "10s"
           scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
           scrape_classic_histograms = false
+          scrape_native_histograms = false
           max_cache_size = 100000
           forward_to = argument.metrics_destinations.value
         }

--- a/charts/k8s-monitoring/charts/feature-integrations/tests/__snapshot__/cert-manager_test.yaml.snap
+++ b/charts/k8s-monitoring/charts/feature-integrations/tests/__snapshot__/cert-manager_test.yaml.snap
@@ -116,6 +116,7 @@ can be restricted to a namespace:
           scrape_timeout = "10s"
           scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
           scrape_classic_histograms = false
+          scrape_native_histograms = false
           clustering {
             enabled = true
           }
@@ -237,6 +238,7 @@ should create the cert-manager config:
           scrape_timeout = "10s"
           scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
           scrape_classic_histograms = false
+          scrape_native_histograms = false
           clustering {
             enabled = true
           }

--- a/charts/k8s-monitoring/charts/feature-integrations/tests/__snapshot__/dcgm-exporter_test.yaml.snap
+++ b/charts/k8s-monitoring/charts/feature-integrations/tests/__snapshot__/dcgm-exporter_test.yaml.snap
@@ -183,6 +183,11 @@ should create the DCGM Exporter config:
             optional = true
           }
 
+          argument "scrape_native_histograms" {
+            comment = "Whether to scrape native histograms (default: false)."
+            optional = true
+          }
+
           argument "max_cache_size" {
             comment = "The maximum number of elements to hold in the relabeling cache (default: 100000).  This should be at least 2x-5x your largest scrape target or samples appended rate."
             optional = true
@@ -200,6 +205,7 @@ should create the DCGM Exporter config:
             scrape_timeout = coalesce(argument.scrape_timeout.value, "10s")
             scrape_protocols = argument.scrape_protocols.value
             scrape_classic_histograms = argument.scrape_classic_histograms.value
+      scrape_native_histograms = argument.scrape_native_histograms.value
 
             clustering {
               enabled = coalesce(argument.clustering.value, false)
@@ -307,6 +313,7 @@ should create the DCGM Exporter config:
           scrape_timeout = "10s"
           scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
           scrape_classic_histograms = false
+          scrape_native_histograms = false
           max_cache_size = 100000
           forward_to = argument.metrics_destinations.value
         }

--- a/charts/k8s-monitoring/charts/feature-integrations/tests/__snapshot__/etcd_test.yaml.snap
+++ b/charts/k8s-monitoring/charts/feature-integrations/tests/__snapshot__/etcd_test.yaml.snap
@@ -111,6 +111,7 @@ can be restricted to a namespace:
           scrape_timeout = "10s"
           scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
           scrape_classic_histograms = false
+          scrape_native_histograms = false
           clustering {
             enabled = true
           }
@@ -232,6 +233,7 @@ should create the etcd config:
           scrape_timeout = "10s"
           scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
           scrape_classic_histograms = false
+          scrape_native_histograms = false
           clustering {
             enabled = true
           }

--- a/charts/k8s-monitoring/charts/feature-integrations/tests/__snapshot__/grafana_logs_test.yaml.snap
+++ b/charts/k8s-monitoring/charts/feature-integrations/tests/__snapshot__/grafana_logs_test.yaml.snap
@@ -185,6 +185,11 @@ should add the grafana processing stage to the logs config:
             optional = true
           }
 
+          argument "scrape_native_histograms" {
+            comment = "Whether to scrape native histograms (default: false)."
+            optional = true
+          }
+
           argument "max_cache_size" {
             comment = "The maximum number of elements to hold in the relabeling cache (default: 100000).  This should be at least 2x-5x your largest scrape target or samples appended rate."
             optional = true
@@ -203,6 +208,7 @@ should add the grafana processing stage to the logs config:
             scrape_timeout = coalesce(argument.scrape_timeout.value, "10s")
             scrape_protocols = argument.scrape_protocols.value
             scrape_classic_histograms = argument.scrape_classic_histograms.value
+      scrape_native_histograms = argument.scrape_native_histograms.value
 
             clustering {
               enabled = coalesce(argument.clustering.value, false)
@@ -255,6 +261,7 @@ should add the grafana processing stage to the logs config:
           scrape_timeout = "10s"
           scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
           scrape_classic_histograms = false
+          scrape_native_histograms = false
           max_cache_size = 100000
           forward_to = argument.metrics_destinations.value
         }

--- a/charts/k8s-monitoring/charts/feature-integrations/tests/__snapshot__/grafana_metrics_test.yaml.snap
+++ b/charts/k8s-monitoring/charts/feature-integrations/tests/__snapshot__/grafana_metrics_test.yaml.snap
@@ -185,6 +185,11 @@ should create the grafana metrics config:
             optional = true
           }
 
+          argument "scrape_native_histograms" {
+            comment = "Whether to scrape native histograms (default: false)."
+            optional = true
+          }
+
           argument "max_cache_size" {
             comment = "The maximum number of elements to hold in the relabeling cache (default: 100000).  This should be at least 2x-5x your largest scrape target or samples appended rate."
             optional = true
@@ -203,6 +208,7 @@ should create the grafana metrics config:
             scrape_timeout = coalesce(argument.scrape_timeout.value, "10s")
             scrape_protocols = argument.scrape_protocols.value
             scrape_classic_histograms = argument.scrape_classic_histograms.value
+      scrape_native_histograms = argument.scrape_native_histograms.value
 
             clustering {
               enabled = coalesce(argument.clustering.value, false)
@@ -255,6 +261,7 @@ should create the grafana metrics config:
           scrape_timeout = "10s"
           scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
           scrape_classic_histograms = false
+          scrape_native_histograms = false
           max_cache_size = 100000
           forward_to = argument.metrics_destinations.value
         }

--- a/charts/k8s-monitoring/charts/feature-integrations/tests/__snapshot__/loki_logs_test.yaml.snap
+++ b/charts/k8s-monitoring/charts/feature-integrations/tests/__snapshot__/loki_logs_test.yaml.snap
@@ -192,6 +192,11 @@ should add the Loki processing stage to the logs config:
             optional = true
           }
 
+          argument "scrape_native_histograms" {
+            comment = "Whether to scrape native histograms (default: false)."
+            optional = true
+          }
+
           argument "max_cache_size" {
             comment = "The maximum number of elements to hold in the relabeling cache (default: 100000).  This should be at least 2x-5x your largest scrape target or samples appended rate."
             optional = true
@@ -210,6 +215,7 @@ should add the Loki processing stage to the logs config:
             scrape_timeout = coalesce(argument.scrape_timeout.value, "10s")
             scrape_protocols = argument.scrape_protocols.value
             scrape_classic_histograms = argument.scrape_classic_histograms.value
+      scrape_native_histograms = argument.scrape_native_histograms.value
 
             clustering {
               enabled = coalesce(argument.clustering.value, false)
@@ -272,6 +278,7 @@ should add the Loki processing stage to the logs config:
           scrape_timeout = "10s"
           scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
           scrape_classic_histograms = false
+          scrape_native_histograms = false
           max_cache_size = 100000
           forward_to = argument.metrics_destinations.value
         }

--- a/charts/k8s-monitoring/charts/feature-integrations/tests/__snapshot__/loki_metrics_test.yaml.snap
+++ b/charts/k8s-monitoring/charts/feature-integrations/tests/__snapshot__/loki_metrics_test.yaml.snap
@@ -192,6 +192,11 @@ should create the loki metrics config:
             optional = true
           }
 
+          argument "scrape_native_histograms" {
+            comment = "Whether to scrape native histograms (default: false)."
+            optional = true
+          }
+
           argument "max_cache_size" {
             comment = "The maximum number of elements to hold in the relabeling cache (default: 100000).  This should be at least 2x-5x your largest scrape target or samples appended rate."
             optional = true
@@ -210,6 +215,7 @@ should create the loki metrics config:
             scrape_timeout = coalesce(argument.scrape_timeout.value, "10s")
             scrape_protocols = argument.scrape_protocols.value
             scrape_classic_histograms = argument.scrape_classic_histograms.value
+      scrape_native_histograms = argument.scrape_native_histograms.value
 
             clustering {
               enabled = coalesce(argument.clustering.value, false)
@@ -272,6 +278,7 @@ should create the loki metrics config:
           scrape_timeout = "10s"
           scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
           scrape_classic_histograms = false
+          scrape_native_histograms = false
           max_cache_size = 100000
           forward_to = argument.metrics_destinations.value
         }

--- a/charts/k8s-monitoring/charts/feature-integrations/tests/__snapshot__/mimir_logs_test.yaml.snap
+++ b/charts/k8s-monitoring/charts/feature-integrations/tests/__snapshot__/mimir_logs_test.yaml.snap
@@ -190,6 +190,11 @@ should add the Mimir processing stage to the logs config:
             optional = true
           }
 
+          argument "scrape_native_histograms" {
+            comment = "Whether to scrape native histograms (default: false)."
+            optional = true
+          }
+
           argument "max_cache_size" {
             comment = "The maximum number of elements to hold in the relabeling cache (default: 100000).  This should be at least 2x-5x your largest scrape target or samples appended rate."
             optional = true
@@ -208,6 +213,7 @@ should add the Mimir processing stage to the logs config:
             scrape_timeout = coalesce(argument.scrape_timeout.value, "10s")
             scrape_protocols = argument.scrape_protocols.value
             scrape_classic_histograms = argument.scrape_classic_histograms.value
+      scrape_native_histograms = argument.scrape_native_histograms.value
 
             clustering {
               enabled = coalesce(argument.clustering.value, false)
@@ -270,6 +276,7 @@ should add the Mimir processing stage to the logs config:
           scrape_timeout = "10s"
           scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
           scrape_classic_histograms = false
+          scrape_native_histograms = false
           max_cache_size = 100000
           forward_to = argument.metrics_destinations.value
         }

--- a/charts/k8s-monitoring/charts/feature-integrations/tests/__snapshot__/mimir_metrics_test.yaml.snap
+++ b/charts/k8s-monitoring/charts/feature-integrations/tests/__snapshot__/mimir_metrics_test.yaml.snap
@@ -190,6 +190,11 @@ should create the mimir metrics config:
             optional = true
           }
 
+          argument "scrape_native_histograms" {
+            comment = "Whether to scrape native histograms (default: false)."
+            optional = true
+          }
+
           argument "max_cache_size" {
             comment = "The maximum number of elements to hold in the relabeling cache (default: 100000).  This should be at least 2x-5x your largest scrape target or samples appended rate."
             optional = true
@@ -208,6 +213,7 @@ should create the mimir metrics config:
             scrape_timeout = coalesce(argument.scrape_timeout.value, "10s")
             scrape_protocols = argument.scrape_protocols.value
             scrape_classic_histograms = argument.scrape_classic_histograms.value
+      scrape_native_histograms = argument.scrape_native_histograms.value
 
             clustering {
               enabled = coalesce(argument.clustering.value, false)
@@ -270,6 +276,7 @@ should create the mimir metrics config:
           scrape_timeout = "10s"
           scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
           scrape_classic_histograms = false
+          scrape_native_histograms = false
           max_cache_size = 100000
           forward_to = argument.metrics_destinations.value
         }

--- a/charts/k8s-monitoring/charts/feature-integrations/tests/__snapshot__/mysql_metrics_test.yaml.snap
+++ b/charts/k8s-monitoring/charts/feature-integrations/tests/__snapshot__/mysql_metrics_test.yaml.snap
@@ -27,6 +27,7 @@ allows you to set the network protocol:
           scrape_timeout = "10s"
           scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
           scrape_classic_histograms = false
+          scrape_native_histograms = false
           forward_to = [prometheus.relabel.test_database.receiver]
         }
 
@@ -72,6 +73,7 @@ should create the MySQL config:
           scrape_timeout = "10s"
           scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
           scrape_classic_histograms = false
+          scrape_native_histograms = false
           forward_to = [prometheus.relabel.my_database.receiver]
         }
 
@@ -117,6 +119,7 @@ works when referencing the MySQL Secret:
           scrape_timeout = "10s"
           scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
           scrape_classic_histograms = false
+          scrape_native_histograms = false
           forward_to = [prometheus.relabel.test_database.receiver]
         }
 
@@ -151,6 +154,7 @@ works with multiple MySQL Instances:
           scrape_timeout = "10s"
           scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
           scrape_classic_histograms = false
+          scrape_native_histograms = false
           forward_to = [prometheus.relabel.test_db.receiver]
         }
 
@@ -177,6 +181,7 @@ works with multiple MySQL Instances:
           scrape_timeout = "10s"
           scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
           scrape_classic_histograms = false
+          scrape_native_histograms = false
           forward_to = [prometheus.relabel.staging_db.receiver]
         }
 
@@ -214,6 +219,7 @@ works with multiple MySQL Instances:
           scrape_timeout = "10s"
           scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
           scrape_classic_histograms = false
+          scrape_native_histograms = false
           forward_to = [prometheus.relabel.prod_db.receiver]
         }
 

--- a/charts/k8s-monitoring/charts/feature-integrations/tests/__snapshot__/tempo_logs_test.yaml.snap
+++ b/charts/k8s-monitoring/charts/feature-integrations/tests/__snapshot__/tempo_logs_test.yaml.snap
@@ -192,6 +192,11 @@ should add the Tempo processing stage to the logs config:
             optional = true
           }
 
+          argument "scrape_native_histograms" {
+            comment = "Whether to scrape native histograms (default: false)."
+            optional = true
+          }
+
           argument "max_cache_size" {
             comment = "The maximum number of elements to hold in the relabeling cache (default: 100000).  This should be at least 2x-5x your largest scrape target or samples appended rate."
             optional = true
@@ -210,6 +215,7 @@ should add the Tempo processing stage to the logs config:
             scrape_timeout = coalesce(argument.scrape_timeout.value, "10s")
             scrape_protocols = argument.scrape_protocols.value
             scrape_classic_histograms = argument.scrape_classic_histograms.value
+      scrape_native_histograms = argument.scrape_native_histograms.value
 
             clustering {
               enabled = coalesce(argument.clustering.value, false)
@@ -272,6 +278,7 @@ should add the Tempo processing stage to the logs config:
           scrape_timeout = "10s"
           scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
           scrape_classic_histograms = false
+          scrape_native_histograms = false
           max_cache_size = 100000
           forward_to = argument.metrics_destinations.value
         }

--- a/charts/k8s-monitoring/charts/feature-integrations/tests/__snapshot__/tempo_metrics_test.yaml.snap
+++ b/charts/k8s-monitoring/charts/feature-integrations/tests/__snapshot__/tempo_metrics_test.yaml.snap
@@ -192,6 +192,11 @@ should allow you to disable the default allow list:
             optional = true
           }
 
+          argument "scrape_native_histograms" {
+            comment = "Whether to scrape native histograms (default: false)."
+            optional = true
+          }
+
           argument "max_cache_size" {
             comment = "The maximum number of elements to hold in the relabeling cache (default: 100000).  This should be at least 2x-5x your largest scrape target or samples appended rate."
             optional = true
@@ -210,6 +215,7 @@ should allow you to disable the default allow list:
             scrape_timeout = coalesce(argument.scrape_timeout.value, "10s")
             scrape_protocols = argument.scrape_protocols.value
             scrape_classic_histograms = argument.scrape_classic_histograms.value
+      scrape_native_histograms = argument.scrape_native_histograms.value
 
             clustering {
               enabled = coalesce(argument.clustering.value, false)
@@ -271,6 +277,7 @@ should allow you to disable the default allow list:
           scrape_timeout = "10s"
           scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
           scrape_classic_histograms = false
+          scrape_native_histograms = false
           max_cache_size = 100000
           forward_to = argument.metrics_destinations.value
         }
@@ -469,6 +476,11 @@ should create the tempo metrics config:
             optional = true
           }
 
+          argument "scrape_native_histograms" {
+            comment = "Whether to scrape native histograms (default: false)."
+            optional = true
+          }
+
           argument "max_cache_size" {
             comment = "The maximum number of elements to hold in the relabeling cache (default: 100000).  This should be at least 2x-5x your largest scrape target or samples appended rate."
             optional = true
@@ -487,6 +499,7 @@ should create the tempo metrics config:
             scrape_timeout = coalesce(argument.scrape_timeout.value, "10s")
             scrape_protocols = argument.scrape_protocols.value
             scrape_classic_histograms = argument.scrape_classic_histograms.value
+      scrape_native_histograms = argument.scrape_native_histograms.value
 
             clustering {
               enabled = coalesce(argument.clustering.value, false)
@@ -549,6 +562,7 @@ should create the tempo metrics config:
           scrape_timeout = "10s"
           scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
           scrape_classic_histograms = false
+          scrape_native_histograms = false
           max_cache_size = 100000
           forward_to = argument.metrics_destinations.value
         }

--- a/charts/k8s-monitoring/charts/feature-integrations/values.schema.json
+++ b/charts/k8s-monitoring/charts/feature-integrations/values.schema.json
@@ -49,6 +49,9 @@
                 "scrapeInterval": {
                     "type": "string"
                 },
+                "scrapeNativeHistograms": {
+                    "type": "boolean"
+                },
                 "scrapeProtocols": {
                     "type": "array",
                     "items": {

--- a/charts/k8s-monitoring/charts/feature-integrations/values.yaml
+++ b/charts/k8s-monitoring/charts/feature-integrations/values.yaml
@@ -16,6 +16,10 @@ global:
   # @section -- Global Settings
   scrapeClassicHistograms: false
 
+  # -- Whether to scrape native histograms.
+  # @section -- Global Settings
+  scrapeNativeHistograms: false
+
   # -- Sets the max_cache_size for every prometheus.relabel component. ([docs](https://grafana.com/docs/alloy/latest/reference/components/prometheus/prometheus.relabel/#arguments))
   # This should be at least 2x-5x your largest scrape target or samples appended rate.
   # @section -- Global Settings

--- a/charts/k8s-monitoring/docs/examples/auth/oauth2/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/auth/oauth2/output.yaml
@@ -413,6 +413,7 @@ data:
         bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         clustering {
           enabled = true
         }
@@ -429,6 +430,7 @@ data:
         }
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         clustering {
           enabled = true
         }
@@ -477,6 +479,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
     
         tls_config {
@@ -520,6 +523,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
     
         tls_config {
@@ -563,6 +567,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
     
         tls_config {
@@ -692,6 +697,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         scheme = "http"
         bearer_token_file = ""
         tls_config {
@@ -826,6 +832,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         scheme = "http"
         bearer_token_file = ""
         tls_config {
@@ -897,6 +904,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         clustering {
           enabled = true
         }

--- a/charts/k8s-monitoring/docs/examples/auth/sigv4/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/auth/sigv4/output.yaml
@@ -141,6 +141,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
     
         tls_config {
@@ -184,6 +185,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
     
         tls_config {
@@ -227,6 +229,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
     
         tls_config {
@@ -356,6 +359,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         scheme = "http"
         bearer_token_file = ""
         tls_config {
@@ -490,6 +494,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         scheme = "http"
         bearer_token_file = ""
         tls_config {
@@ -561,6 +566,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         clustering {
           enabled = true
         }

--- a/charts/k8s-monitoring/docs/examples/collector-storage/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/collector-storage/output.yaml
@@ -130,6 +130,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
     
         tls_config {
@@ -173,6 +174,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
     
         tls_config {
@@ -216,6 +218,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
     
         tls_config {
@@ -345,6 +348,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         scheme = "http"
         bearer_token_file = ""
         tls_config {
@@ -479,6 +483,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         scheme = "http"
         bearer_token_file = ""
         tls_config {
@@ -550,6 +555,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         clustering {
           enabled = true
         }

--- a/charts/k8s-monitoring/docs/examples/custom-destinations/debug/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/custom-destinations/debug/output.yaml
@@ -330,6 +330,7 @@ data:
         bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         clustering {
           enabled = true
         }
@@ -346,6 +347,7 @@ data:
         }
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         clustering {
           enabled = true
         }

--- a/charts/k8s-monitoring/docs/examples/destinations/otlp-endpoint/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/destinations/otlp-endpoint/output.yaml
@@ -141,6 +141,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
     
         tls_config {
@@ -184,6 +185,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
     
         tls_config {
@@ -227,6 +229,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
     
         tls_config {
@@ -356,6 +359,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         scheme = "http"
         bearer_token_file = ""
         tls_config {
@@ -490,6 +494,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         scheme = "http"
         bearer_token_file = ""
         tls_config {
@@ -561,6 +566,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         clustering {
           enabled = true
         }

--- a/charts/k8s-monitoring/docs/examples/exclude-by-namespace/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/exclude-by-namespace/output.yaml
@@ -429,6 +429,7 @@ data:
         bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         clustering {
           enabled = true
         }
@@ -445,6 +446,7 @@ data:
         }
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         clustering {
           enabled = true
         }
@@ -489,6 +491,7 @@ data:
         scrape_interval = "60s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         clustering {
           enabled = true
         }
@@ -503,6 +506,7 @@ data:
         scrape_interval = "60s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         clustering {
           enabled = true
         }
@@ -550,6 +554,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
     
         tls_config {
@@ -593,6 +598,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
     
         tls_config {
@@ -636,6 +642,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
     
         tls_config {
@@ -770,6 +777,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         scheme = "http"
         bearer_token_file = ""
         tls_config {
@@ -904,6 +912,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         scheme = "http"
         bearer_token_file = ""
         tls_config {
@@ -975,6 +984,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         clustering {
           enabled = true
         }

--- a/charts/k8s-monitoring/docs/examples/extra-rules/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/extra-rules/output.yaml
@@ -130,6 +130,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
     
         tls_config {
@@ -173,6 +174,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
     
         tls_config {
@@ -216,6 +218,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
     
         tls_config {
@@ -345,6 +348,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         scheme = "http"
         bearer_token_file = ""
         tls_config {
@@ -485,6 +489,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         scheme = "http"
         bearer_token_file = ""
         tls_config {
@@ -556,6 +561,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         clustering {
           enabled = true
         }

--- a/charts/k8s-monitoring/docs/examples/features/annotation-autodiscovery/default/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/features/annotation-autodiscovery/default/output.yaml
@@ -330,6 +330,7 @@ data:
         bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         clustering {
           enabled = true
         }
@@ -346,6 +347,7 @@ data:
         }
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         clustering {
           enabled = true
         }

--- a/charts/k8s-monitoring/docs/examples/features/annotation-autodiscovery/prom-annotations/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/features/annotation-autodiscovery/prom-annotations/output.yaml
@@ -330,6 +330,7 @@ data:
         bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         clustering {
           enabled = true
         }
@@ -346,6 +347,7 @@ data:
         }
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         clustering {
           enabled = true
         }

--- a/charts/k8s-monitoring/docs/examples/features/auto-instrumentation/beyla-metrics-and-traces/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/features/auto-instrumentation/beyla-metrics-and-traces/output.yaml
@@ -69,6 +69,7 @@ data:
         scrape_interval = "60s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         clustering {
           enabled = true
         }
@@ -83,6 +84,7 @@ data:
         scrape_interval = "60s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         clustering {
           enabled = true
         }

--- a/charts/k8s-monitoring/docs/examples/features/auto-instrumentation/beyla-metrics/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/features/auto-instrumentation/beyla-metrics/output.yaml
@@ -69,6 +69,7 @@ data:
         scrape_interval = "60s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         clustering {
           enabled = true
         }
@@ -83,6 +84,7 @@ data:
         scrape_interval = "60s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         clustering {
           enabled = true
         }

--- a/charts/k8s-monitoring/docs/examples/features/auto-instrumentation/discovery-rules/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/features/auto-instrumentation/discovery-rules/output.yaml
@@ -69,6 +69,7 @@ data:
         scrape_interval = "60s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         clustering {
           enabled = true
         }
@@ -83,6 +84,7 @@ data:
         scrape_interval = "60s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         clustering {
           enabled = true
         }

--- a/charts/k8s-monitoring/docs/examples/features/cluster-metrics/control-plane-monitoring/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/features/cluster-metrics/control-plane-monitoring/output.yaml
@@ -130,6 +130,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
     
         tls_config {
@@ -173,6 +174,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
     
         tls_config {
@@ -216,6 +218,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
     
         tls_config {
@@ -355,6 +358,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
     
         tls_config {
@@ -397,6 +401,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
         tls_config {
           insecure_skip_verify = true
@@ -511,6 +516,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         clustering {
           enabled = true
         }
@@ -545,6 +551,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         clustering {
           enabled = true
         }
@@ -579,6 +586,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
         tls_config {
           insecure_skip_verify = true
@@ -625,6 +633,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         scheme = "http"
         bearer_token_file = ""
         tls_config {
@@ -759,6 +768,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         scheme = "http"
         bearer_token_file = ""
         tls_config {
@@ -830,6 +840,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         clustering {
           enabled = true
         }
@@ -958,6 +969,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         clustering {
           enabled = true
         }

--- a/charts/k8s-monitoring/docs/examples/features/cluster-metrics/default/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/features/cluster-metrics/default/output.yaml
@@ -158,6 +158,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
     
         tls_config {
@@ -201,6 +202,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
     
         tls_config {
@@ -244,6 +246,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
     
         tls_config {
@@ -373,6 +376,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         scheme = "http"
         bearer_token_file = ""
         tls_config {
@@ -507,6 +511,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         scheme = "http"
         bearer_token_file = ""
         tls_config {
@@ -578,6 +583,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         clustering {
           enabled = true
         }
@@ -622,6 +628,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         clustering {
           enabled = true
         }
@@ -666,6 +673,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         clustering {
           enabled = true
         }

--- a/charts/k8s-monitoring/docs/examples/features/integrations/alloy/alloy-metrics.alloy
+++ b/charts/k8s-monitoring/docs/examples/features/integrations/alloy/alloy-metrics.alloy
@@ -198,6 +198,7 @@ declare "alloy_integration" {
       scrape_timeout = coalesce(argument.scrape_timeout.value, "10s")
       scrape_protocols = argument.scrape_protocols.value
       scrape_classic_histograms = argument.scrape_classic_histograms.value
+      scrape_native_histograms = argument.scrape_native_histograms.value
 
       clustering {
         enabled = coalesce(argument.clustering.value, false)

--- a/charts/k8s-monitoring/docs/examples/features/integrations/alloy/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/features/integrations/alloy/output.yaml
@@ -221,6 +221,7 @@ data:
           scrape_timeout = coalesce(argument.scrape_timeout.value, "10s")
           scrape_protocols = argument.scrape_protocols.value
           scrape_classic_histograms = argument.scrape_classic_histograms.value
+          scrape_native_histograms = argument.scrape_native_histograms.value
     
           clustering {
             enabled = coalesce(argument.clustering.value, false)
@@ -327,6 +328,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         max_cache_size = 100000
         forward_to = argument.metrics_destinations.value
       }

--- a/charts/k8s-monitoring/docs/examples/features/integrations/cert-manager/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/features/integrations/cert-manager/output.yaml
@@ -133,6 +133,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         clustering {
           enabled = true
         }

--- a/charts/k8s-monitoring/docs/examples/features/integrations/dcgm-exporter/alloy-metrics.alloy
+++ b/charts/k8s-monitoring/docs/examples/features/integrations/dcgm-exporter/alloy-metrics.alloy
@@ -197,6 +197,7 @@ declare "dcgm_exporter_integration" {
       scrape_timeout = coalesce(argument.scrape_timeout.value, "10s")
       scrape_protocols = argument.scrape_protocols.value
       scrape_classic_histograms = argument.scrape_classic_histograms.value
+      scrape_native_histograms = argument.scrape_native_histograms.value
 
       clustering {
         enabled = coalesce(argument.clustering.value, false)

--- a/charts/k8s-monitoring/docs/examples/features/integrations/dcgm-exporter/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/features/integrations/dcgm-exporter/output.yaml
@@ -220,6 +220,7 @@ data:
           scrape_timeout = coalesce(argument.scrape_timeout.value, "10s")
           scrape_protocols = argument.scrape_protocols.value
           scrape_classic_histograms = argument.scrape_classic_histograms.value
+          scrape_native_histograms = argument.scrape_native_histograms.value
     
           clustering {
             enabled = coalesce(argument.clustering.value, false)
@@ -327,6 +328,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         max_cache_size = 100000
         forward_to = argument.metrics_destinations.value
       }

--- a/charts/k8s-monitoring/docs/examples/features/integrations/etcd/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/features/integrations/etcd/output.yaml
@@ -128,6 +128,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         clustering {
           enabled = true
         }

--- a/charts/k8s-monitoring/docs/examples/features/integrations/grafana/alloy-metrics.alloy
+++ b/charts/k8s-monitoring/docs/examples/features/integrations/grafana/alloy-metrics.alloy
@@ -200,6 +200,7 @@ declare "grafana_integration" {
       scrape_timeout = coalesce(argument.scrape_timeout.value, "10s")
       scrape_protocols = argument.scrape_protocols.value
       scrape_classic_histograms = argument.scrape_classic_histograms.value
+      scrape_native_histograms = argument.scrape_native_histograms.value
 
       clustering {
         enabled = coalesce(argument.clustering.value, false)

--- a/charts/k8s-monitoring/docs/examples/features/integrations/grafana/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/features/integrations/grafana/output.yaml
@@ -223,6 +223,7 @@ data:
           scrape_timeout = coalesce(argument.scrape_timeout.value, "10s")
           scrape_protocols = argument.scrape_protocols.value
           scrape_classic_histograms = argument.scrape_classic_histograms.value
+          scrape_native_histograms = argument.scrape_native_histograms.value
     
           clustering {
             enabled = coalesce(argument.clustering.value, false)
@@ -275,6 +276,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         max_cache_size = 100000
         forward_to = argument.metrics_destinations.value
       }

--- a/charts/k8s-monitoring/docs/examples/features/integrations/loki/alloy-metrics.alloy
+++ b/charts/k8s-monitoring/docs/examples/features/integrations/loki/alloy-metrics.alloy
@@ -207,6 +207,7 @@ declare "loki_integration" {
       scrape_timeout = coalesce(argument.scrape_timeout.value, "10s")
       scrape_protocols = argument.scrape_protocols.value
       scrape_classic_histograms = argument.scrape_classic_histograms.value
+      scrape_native_histograms = argument.scrape_native_histograms.value
 
       clustering {
         enabled = coalesce(argument.clustering.value, false)

--- a/charts/k8s-monitoring/docs/examples/features/integrations/loki/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/features/integrations/loki/output.yaml
@@ -230,6 +230,7 @@ data:
           scrape_timeout = coalesce(argument.scrape_timeout.value, "10s")
           scrape_protocols = argument.scrape_protocols.value
           scrape_classic_histograms = argument.scrape_classic_histograms.value
+          scrape_native_histograms = argument.scrape_native_histograms.value
     
           clustering {
             enabled = coalesce(argument.clustering.value, false)
@@ -292,6 +293,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         max_cache_size = 100000
         forward_to = argument.metrics_destinations.value
       }

--- a/charts/k8s-monitoring/docs/examples/features/integrations/mimir/alloy-metrics.alloy
+++ b/charts/k8s-monitoring/docs/examples/features/integrations/mimir/alloy-metrics.alloy
@@ -205,6 +205,7 @@ declare "mimir_integration" {
       scrape_timeout = coalesce(argument.scrape_timeout.value, "10s")
       scrape_protocols = argument.scrape_protocols.value
       scrape_classic_histograms = argument.scrape_classic_histograms.value
+      scrape_native_histograms = argument.scrape_native_histograms.value
 
       clustering {
         enabled = coalesce(argument.clustering.value, false)

--- a/charts/k8s-monitoring/docs/examples/features/integrations/mimir/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/features/integrations/mimir/output.yaml
@@ -228,6 +228,7 @@ data:
           scrape_timeout = coalesce(argument.scrape_timeout.value, "10s")
           scrape_protocols = argument.scrape_protocols.value
           scrape_classic_histograms = argument.scrape_classic_histograms.value
+          scrape_native_histograms = argument.scrape_native_histograms.value
     
           clustering {
             enabled = coalesce(argument.clustering.value, false)
@@ -290,6 +291,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         max_cache_size = 100000
         forward_to = argument.metrics_destinations.value
       }

--- a/charts/k8s-monitoring/docs/examples/features/integrations/multiple/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/features/integrations/multiple/output.yaml
@@ -143,6 +143,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         clustering {
           enabled = true
         }
@@ -180,6 +181,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         forward_to = [prometheus.relabel.mysql_cluster.receiver]
       }
     

--- a/charts/k8s-monitoring/docs/examples/features/integrations/mysql/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/features/integrations/mysql/output.yaml
@@ -46,6 +46,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         forward_to = [prometheus.relabel.staging_db.receiver]
       }
     
@@ -83,6 +84,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         forward_to = [prometheus.relabel.staging_db.receiver]
       }
     
@@ -120,6 +122,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         forward_to = [prometheus.relabel.prod_db.receiver]
       }
     

--- a/charts/k8s-monitoring/docs/examples/images/images-by-digest/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/images/images-by-digest/output.yaml
@@ -142,6 +142,7 @@ data:
         scrape_interval = "60s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         clustering {
           enabled = true
         }
@@ -156,6 +157,7 @@ data:
         scrape_interval = "60s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         clustering {
           enabled = true
         }
@@ -203,6 +205,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
     
         tls_config {
@@ -246,6 +249,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
     
         tls_config {
@@ -289,6 +293,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
     
         tls_config {
@@ -418,6 +423,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         scheme = "http"
         bearer_token_file = ""
         tls_config {
@@ -552,6 +558,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         scheme = "http"
         bearer_token_file = ""
         tls_config {
@@ -623,6 +630,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         clustering {
           enabled = true
         }

--- a/charts/k8s-monitoring/docs/examples/include-by-namespace/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/include-by-namespace/output.yaml
@@ -425,6 +425,7 @@ data:
         bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         clustering {
           enabled = true
         }
@@ -441,6 +442,7 @@ data:
         }
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         clustering {
           enabled = true
         }
@@ -485,6 +487,7 @@ data:
         scrape_interval = "60s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         clustering {
           enabled = true
         }
@@ -499,6 +502,7 @@ data:
         scrape_interval = "60s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         clustering {
           enabled = true
         }
@@ -546,6 +550,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
     
         tls_config {
@@ -589,6 +594,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
     
         tls_config {
@@ -632,6 +638,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
     
         tls_config {
@@ -766,6 +773,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         scheme = "http"
         bearer_token_file = ""
         tls_config {
@@ -900,6 +908,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         scheme = "http"
         bearer_token_file = ""
         tls_config {
@@ -971,6 +980,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         clustering {
           enabled = true
         }

--- a/charts/k8s-monitoring/docs/examples/istio-service-mesh/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/istio-service-mesh/output.yaml
@@ -403,6 +403,7 @@ data:
         bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         clustering {
           enabled = true
         }
@@ -419,6 +420,7 @@ data:
         }
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         clustering {
           enabled = true
         }
@@ -467,6 +469,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
     
         tls_config {
@@ -510,6 +513,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
     
         tls_config {
@@ -553,6 +557,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
     
         tls_config {
@@ -682,6 +687,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         scheme = "http"
         bearer_token_file = ""
         tls_config {
@@ -816,6 +822,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         scheme = "http"
         bearer_token_file = ""
         tls_config {
@@ -887,6 +894,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         clustering {
           enabled = true
         }

--- a/charts/k8s-monitoring/docs/examples/log-metrics/alloy-metrics.alloy
+++ b/charts/k8s-monitoring/docs/examples/log-metrics/alloy-metrics.alloy
@@ -198,6 +198,7 @@ declare "alloy_integration" {
       scrape_timeout = coalesce(argument.scrape_timeout.value, "10s")
       scrape_protocols = argument.scrape_protocols.value
       scrape_classic_histograms = argument.scrape_classic_histograms.value
+      scrape_native_histograms = argument.scrape_native_histograms.value
 
       clustering {
         enabled = coalesce(argument.clustering.value, false)

--- a/charts/k8s-monitoring/docs/examples/log-metrics/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/log-metrics/output.yaml
@@ -221,6 +221,7 @@ data:
           scrape_timeout = coalesce(argument.scrape_timeout.value, "10s")
           scrape_protocols = argument.scrape_protocols.value
           scrape_classic_histograms = argument.scrape_classic_histograms.value
+          scrape_native_histograms = argument.scrape_native_histograms.value
     
           clustering {
             enabled = coalesce(argument.clustering.value, false)
@@ -327,6 +328,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         max_cache_size = 100000
         forward_to = argument.metrics_destinations.value
       }

--- a/charts/k8s-monitoring/docs/examples/meta-monitoring/alloy-singleton.alloy
+++ b/charts/k8s-monitoring/docs/examples/meta-monitoring/alloy-singleton.alloy
@@ -1208,6 +1208,7 @@ declare "alloy_integration" {
       scrape_timeout = coalesce(argument.scrape_timeout.value, "10s")
       scrape_protocols = argument.scrape_protocols.value
       scrape_classic_histograms = argument.scrape_classic_histograms.value
+      scrape_native_histograms = argument.scrape_native_histograms.value
 
       clustering {
         enabled = coalesce(argument.clustering.value, false)
@@ -1557,6 +1558,7 @@ declare "grafana_integration" {
       scrape_timeout = coalesce(argument.scrape_timeout.value, "10s")
       scrape_protocols = argument.scrape_protocols.value
       scrape_classic_histograms = argument.scrape_classic_histograms.value
+      scrape_native_histograms = argument.scrape_native_histograms.value
 
       clustering {
         enabled = coalesce(argument.clustering.value, false)
@@ -1839,6 +1841,7 @@ declare "loki_integration" {
       scrape_timeout = coalesce(argument.scrape_timeout.value, "10s")
       scrape_protocols = argument.scrape_protocols.value
       scrape_classic_histograms = argument.scrape_classic_histograms.value
+      scrape_native_histograms = argument.scrape_native_histograms.value
 
       clustering {
         enabled = coalesce(argument.clustering.value, false)
@@ -2129,6 +2132,7 @@ declare "mimir_integration" {
       scrape_timeout = coalesce(argument.scrape_timeout.value, "10s")
       scrape_protocols = argument.scrape_protocols.value
       scrape_classic_histograms = argument.scrape_classic_histograms.value
+      scrape_native_histograms = argument.scrape_native_histograms.value
 
       clustering {
         enabled = coalesce(argument.clustering.value, false)

--- a/charts/k8s-monitoring/docs/examples/meta-monitoring/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/meta-monitoring/output.yaml
@@ -146,6 +146,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
     
         tls_config {
@@ -280,6 +281,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         scheme = "http"
         bearer_token_file = ""
         tls_config {
@@ -468,6 +470,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         scheme = "http"
         bearer_token_file = ""
         tls_config {
@@ -1265,6 +1268,7 @@ data:
           scrape_timeout = coalesce(argument.scrape_timeout.value, "10s")
           scrape_protocols = argument.scrape_protocols.value
           scrape_classic_histograms = argument.scrape_classic_histograms.value
+          scrape_native_histograms = argument.scrape_native_histograms.value
     
           clustering {
             enabled = coalesce(argument.clustering.value, false)
@@ -1372,6 +1376,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         max_cache_size = 100000
         forward_to = argument.metrics_destinations.value
       }
@@ -1391,6 +1396,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         max_cache_size = 100000
         forward_to = argument.metrics_destinations.value
       }
@@ -1614,6 +1620,7 @@ data:
           scrape_timeout = coalesce(argument.scrape_timeout.value, "10s")
           scrape_protocols = argument.scrape_protocols.value
           scrape_classic_histograms = argument.scrape_classic_histograms.value
+          scrape_native_histograms = argument.scrape_native_histograms.value
     
           clustering {
             enabled = coalesce(argument.clustering.value, false)
@@ -1666,6 +1673,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         max_cache_size = 100000
         forward_to = argument.metrics_destinations.value
       }
@@ -1896,6 +1904,7 @@ data:
           scrape_timeout = coalesce(argument.scrape_timeout.value, "10s")
           scrape_protocols = argument.scrape_protocols.value
           scrape_classic_histograms = argument.scrape_classic_histograms.value
+          scrape_native_histograms = argument.scrape_native_histograms.value
     
           clustering {
             enabled = coalesce(argument.clustering.value, false)
@@ -1958,6 +1967,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         max_cache_size = 100000
         forward_to = argument.metrics_destinations.value
       }
@@ -2186,6 +2196,7 @@ data:
           scrape_timeout = coalesce(argument.scrape_timeout.value, "10s")
           scrape_protocols = argument.scrape_protocols.value
           scrape_classic_histograms = argument.scrape_classic_histograms.value
+          scrape_native_histograms = argument.scrape_native_histograms.value
     
           clustering {
             enabled = coalesce(argument.clustering.value, false)
@@ -2248,6 +2259,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         max_cache_size = 100000
         forward_to = argument.metrics_destinations.value
       }

--- a/charts/k8s-monitoring/docs/examples/metrics-tuning/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/metrics-tuning/output.yaml
@@ -403,6 +403,7 @@ data:
         bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         clustering {
           enabled = true
         }
@@ -419,6 +420,7 @@ data:
         }
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         clustering {
           enabled = true
         }
@@ -481,6 +483,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
     
         tls_config {
@@ -524,6 +527,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
     
         tls_config {
@@ -567,6 +571,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
     
         tls_config {
@@ -696,6 +701,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         scheme = "http"
         bearer_token_file = ""
         tls_config {
@@ -820,6 +826,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         scheme = "http"
         bearer_token_file = ""
         tls_config {
@@ -891,6 +898,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         clustering {
           enabled = true
         }

--- a/charts/k8s-monitoring/docs/examples/name-overrides/fullname-overrides/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/name-overrides/fullname-overrides/output.yaml
@@ -158,6 +158,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
     
         tls_config {
@@ -201,6 +202,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
     
         tls_config {
@@ -244,6 +246,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
     
         tls_config {
@@ -373,6 +376,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         scheme = "http"
         bearer_token_file = ""
         tls_config {
@@ -507,6 +511,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         scheme = "http"
         bearer_token_file = ""
         tls_config {
@@ -578,6 +583,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         clustering {
           enabled = true
         }
@@ -622,6 +628,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         clustering {
           enabled = true
         }
@@ -666,6 +673,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         clustering {
           enabled = true
         }

--- a/charts/k8s-monitoring/docs/examples/name-overrides/name-overrides/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/name-overrides/name-overrides/output.yaml
@@ -158,6 +158,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
     
         tls_config {
@@ -201,6 +202,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
     
         tls_config {
@@ -244,6 +246,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
     
         tls_config {
@@ -373,6 +376,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         scheme = "http"
         bearer_token_file = ""
         tls_config {
@@ -507,6 +511,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         scheme = "http"
         bearer_token_file = ""
         tls_config {
@@ -578,6 +583,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         clustering {
           enabled = true
         }
@@ -622,6 +628,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         clustering {
           enabled = true
         }
@@ -666,6 +673,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         clustering {
           enabled = true
         }

--- a/charts/k8s-monitoring/docs/examples/namespace-labels-and-annotations/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/namespace-labels-and-annotations/output.yaml
@@ -130,6 +130,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
     
         tls_config {
@@ -173,6 +174,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
     
         tls_config {
@@ -216,6 +218,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
     
         tls_config {
@@ -345,6 +348,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         scheme = "http"
         bearer_token_file = ""
         tls_config {
@@ -479,6 +483,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         scheme = "http"
         bearer_token_file = ""
         tls_config {
@@ -550,6 +555,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         clustering {
           enabled = true
         }

--- a/charts/k8s-monitoring/docs/examples/node-labels/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/node-labels/output.yaml
@@ -457,6 +457,7 @@ data:
         bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         clustering {
           enabled = true
         }
@@ -473,6 +474,7 @@ data:
         }
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         clustering {
           enabled = true
         }
@@ -572,6 +574,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
     
         tls_config {
@@ -615,6 +618,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
     
         tls_config {
@@ -658,6 +662,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
     
         tls_config {
@@ -787,6 +792,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         scheme = "http"
         bearer_token_file = ""
         tls_config {
@@ -975,6 +981,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         scheme = "http"
         bearer_token_file = ""
         tls_config {
@@ -1100,6 +1107,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         clustering {
           enabled = true
         }

--- a/charts/k8s-monitoring/docs/examples/platforms/azure-aks/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/platforms/azure-aks/output.yaml
@@ -130,6 +130,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
     
         tls_config {
@@ -173,6 +174,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
     
         tls_config {
@@ -216,6 +218,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
     
         tls_config {
@@ -345,6 +348,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         scheme = "http"
         bearer_token_file = ""
         tls_config {
@@ -479,6 +483,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         scheme = "http"
         bearer_token_file = ""
         tls_config {
@@ -550,6 +555,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         clustering {
           enabled = true
         }

--- a/charts/k8s-monitoring/docs/examples/platforms/eks-fargate/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/platforms/eks-fargate/output.yaml
@@ -113,6 +113,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
     
         tls_config {
@@ -156,6 +157,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
     
         tls_config {
@@ -199,6 +201,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
     
         tls_config {
@@ -328,6 +331,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         scheme = "http"
         bearer_token_file = ""
         tls_config {
@@ -392,6 +396,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         clustering {
           enabled = true
         }

--- a/charts/k8s-monitoring/docs/examples/platforms/gke-autopilot/alloy-metrics.alloy
+++ b/charts/k8s-monitoring/docs/examples/platforms/gke-autopilot/alloy-metrics.alloy
@@ -476,6 +476,7 @@ declare "alloy_integration" {
       scrape_timeout = coalesce(argument.scrape_timeout.value, "10s")
       scrape_protocols = argument.scrape_protocols.value
       scrape_classic_histograms = argument.scrape_classic_histograms.value
+      scrape_native_histograms = argument.scrape_native_histograms.value
 
       clustering {
         enabled = coalesce(argument.clustering.value, false)

--- a/charts/k8s-monitoring/docs/examples/platforms/gke-autopilot/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/platforms/gke-autopilot/output.yaml
@@ -74,6 +74,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
     
         tls_config {
@@ -117,6 +118,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
     
         tls_config {
@@ -160,6 +162,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
     
         tls_config {
@@ -289,6 +292,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         scheme = "http"
         bearer_token_file = ""
         tls_config {
@@ -516,6 +520,7 @@ data:
           scrape_timeout = coalesce(argument.scrape_timeout.value, "10s")
           scrape_protocols = argument.scrape_protocols.value
           scrape_classic_histograms = argument.scrape_classic_histograms.value
+          scrape_native_histograms = argument.scrape_native_histograms.value
     
           clustering {
             enabled = coalesce(argument.clustering.value, false)
@@ -622,6 +627,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         max_cache_size = 100000
         forward_to = argument.metrics_destinations.value
       }

--- a/charts/k8s-monitoring/docs/examples/platforms/openshift/alloy-metrics.alloy
+++ b/charts/k8s-monitoring/docs/examples/platforms/openshift/alloy-metrics.alloy
@@ -719,6 +719,7 @@ declare "alloy_integration" {
       scrape_timeout = coalesce(argument.scrape_timeout.value, "10s")
       scrape_protocols = argument.scrape_protocols.value
       scrape_classic_histograms = argument.scrape_classic_histograms.value
+      scrape_native_histograms = argument.scrape_native_histograms.value
 
       clustering {
         enabled = coalesce(argument.clustering.value, false)

--- a/charts/k8s-monitoring/docs/examples/platforms/openshift/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/platforms/openshift/output.yaml
@@ -109,6 +109,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
     
         tls_config {
@@ -152,6 +153,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
     
         tls_config {
@@ -195,6 +197,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
     
         tls_config {
@@ -324,6 +327,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         scheme = "https"
         bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
         tls_config {
@@ -458,6 +462,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         scheme = "https"
         bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
         tls_config {
@@ -529,6 +534,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         clustering {
           enabled = true
         }
@@ -573,6 +579,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         clustering {
           enabled = true
         }
@@ -794,6 +801,7 @@ data:
           scrape_timeout = coalesce(argument.scrape_timeout.value, "10s")
           scrape_protocols = argument.scrape_protocols.value
           scrape_classic_histograms = argument.scrape_classic_histograms.value
+          scrape_native_histograms = argument.scrape_native_histograms.value
     
           clustering {
             enabled = coalesce(argument.clustering.value, false)
@@ -900,6 +908,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         max_cache_size = 100000
         forward_to = argument.metrics_destinations.value
       }

--- a/charts/k8s-monitoring/docs/examples/pod-labels-and-annotations/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/pod-labels-and-annotations/output.yaml
@@ -130,6 +130,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
     
         tls_config {
@@ -173,6 +174,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
     
         tls_config {
@@ -216,6 +218,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
     
         tls_config {
@@ -345,6 +348,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         scheme = "http"
         bearer_token_file = ""
         tls_config {
@@ -479,6 +483,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         scheme = "http"
         bearer_token_file = ""
         tls_config {
@@ -550,6 +555,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         clustering {
           enabled = true
         }

--- a/charts/k8s-monitoring/docs/examples/private-image-registries/globally/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/private-image-registries/globally/output.yaml
@@ -136,6 +136,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
     
         tls_config {
@@ -179,6 +180,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
     
         tls_config {
@@ -222,6 +224,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
     
         tls_config {
@@ -351,6 +354,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         scheme = "http"
         bearer_token_file = ""
         tls_config {
@@ -485,6 +489,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         scheme = "http"
         bearer_token_file = ""
         tls_config {
@@ -556,6 +561,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         clustering {
           enabled = true
         }

--- a/charts/k8s-monitoring/docs/examples/private-image-registries/individual/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/private-image-registries/individual/output.yaml
@@ -142,6 +142,7 @@ data:
         scrape_interval = "60s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         clustering {
           enabled = true
         }
@@ -156,6 +157,7 @@ data:
         scrape_interval = "60s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         clustering {
           enabled = true
         }
@@ -203,6 +205,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
     
         tls_config {
@@ -246,6 +249,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
     
         tls_config {
@@ -289,6 +293,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
     
         tls_config {
@@ -418,6 +423,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         scheme = "http"
         bearer_token_file = ""
         tls_config {
@@ -552,6 +558,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         scheme = "http"
         bearer_token_file = ""
         tls_config {
@@ -623,6 +630,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         clustering {
           enabled = true
         }

--- a/charts/k8s-monitoring/docs/examples/proxies/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/proxies/output.yaml
@@ -145,6 +145,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
     
         tls_config {
@@ -188,6 +189,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
     
         tls_config {
@@ -231,6 +233,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
     
         tls_config {
@@ -360,6 +363,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         scheme = "http"
         bearer_token_file = ""
         tls_config {
@@ -494,6 +498,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         scheme = "http"
         bearer_token_file = ""
         tls_config {
@@ -565,6 +570,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         clustering {
           enabled = true
         }
@@ -609,6 +615,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         clustering {
           enabled = true
         }

--- a/charts/k8s-monitoring/docs/examples/resource-requests-and-limits/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/resource-requests-and-limits/output.yaml
@@ -155,6 +155,7 @@ data:
         scrape_interval = "60s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         clustering {
           enabled = true
         }
@@ -169,6 +170,7 @@ data:
         scrape_interval = "60s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         clustering {
           enabled = true
         }
@@ -216,6 +218,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
     
         tls_config {
@@ -259,6 +262,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
     
         tls_config {
@@ -302,6 +306,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
     
         tls_config {
@@ -431,6 +436,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         scheme = "http"
         bearer_token_file = ""
         tls_config {
@@ -565,6 +571,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         scheme = "http"
         bearer_token_file = ""
         tls_config {
@@ -636,6 +643,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         clustering {
           enabled = true
         }
@@ -680,6 +688,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         clustering {
           enabled = true
         }

--- a/charts/k8s-monitoring/docs/examples/scalability/autoscaling/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/scalability/autoscaling/output.yaml
@@ -130,6 +130,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
     
         tls_config {
@@ -173,6 +174,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
     
         tls_config {
@@ -216,6 +218,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
     
         tls_config {
@@ -345,6 +348,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         scheme = "http"
         bearer_token_file = ""
         tls_config {
@@ -479,6 +483,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         scheme = "http"
         bearer_token_file = ""
         tls_config {
@@ -550,6 +555,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         clustering {
           enabled = true
         }

--- a/charts/k8s-monitoring/docs/examples/scalability/high-availability-kube-state-metrics/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/scalability/high-availability-kube-state-metrics/output.yaml
@@ -130,6 +130,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
     
         tls_config {
@@ -173,6 +174,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
     
         tls_config {
@@ -216,6 +218,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
     
         tls_config {
@@ -345,6 +348,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         scheme = "http"
         bearer_token_file = ""
         tls_config {
@@ -479,6 +483,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         scheme = "http"
         bearer_token_file = ""
         tls_config {
@@ -550,6 +555,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         clustering {
           enabled = true
         }

--- a/charts/k8s-monitoring/docs/examples/scalability/sharded-kube-state-metrics/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/scalability/sharded-kube-state-metrics/output.yaml
@@ -130,6 +130,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
     
         tls_config {
@@ -173,6 +174,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
     
         tls_config {
@@ -216,6 +218,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
     
         tls_config {
@@ -345,6 +348,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         scheme = "http"
         bearer_token_file = ""
         tls_config {
@@ -479,6 +483,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         scheme = "http"
         bearer_token_file = ""
         tls_config {
@@ -550,6 +555,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         clustering {
           enabled = true
         }

--- a/charts/k8s-monitoring/docs/examples/tail-sampling/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/tail-sampling/output.yaml
@@ -130,6 +130,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
     
         tls_config {
@@ -173,6 +174,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
     
         tls_config {
@@ -216,6 +218,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
     
         tls_config {
@@ -345,6 +348,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         scheme = "http"
         bearer_token_file = ""
         tls_config {
@@ -479,6 +483,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         scheme = "http"
         bearer_token_file = ""
         tls_config {
@@ -550,6 +555,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         clustering {
           enabled = true
         }

--- a/charts/k8s-monitoring/docs/examples/tolerations/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/tolerations/output.yaml
@@ -155,6 +155,7 @@ data:
         scrape_interval = "60s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         clustering {
           enabled = true
         }
@@ -169,6 +170,7 @@ data:
         scrape_interval = "60s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         clustering {
           enabled = true
         }
@@ -216,6 +218,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
     
         tls_config {
@@ -259,6 +262,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
     
         tls_config {
@@ -302,6 +306,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
     
         tls_config {
@@ -431,6 +436,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         scheme = "http"
         bearer_token_file = ""
         tls_config {
@@ -565,6 +571,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         scheme = "http"
         bearer_token_file = ""
         tls_config {
@@ -636,6 +643,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         clustering {
           enabled = true
         }
@@ -680,6 +688,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         clustering {
           enabled = true
         }

--- a/charts/k8s-monitoring/tests/__snapshot__/feature_integrations_test.yaml.snap
+++ b/charts/k8s-monitoring/tests/__snapshot__/feature_integrations_test.yaml.snap
@@ -481,6 +481,11 @@ works with a metrics-only integration:
             optional = true
           }
 
+          argument "scrape_native_histograms" {
+            comment = "Whether to scrape native histograms (default: false)."
+            optional = true
+          }
+
           argument "max_cache_size" {
             comment = "The maximum number of elements to hold in the relabeling cache (default: 100000).  This should be at least 2x-5x your largest scrape target or samples appended rate."
             optional = true
@@ -499,6 +504,7 @@ works with a metrics-only integration:
             scrape_timeout = coalesce(argument.scrape_timeout.value, "10s")
             scrape_protocols = argument.scrape_protocols.value
             scrape_classic_histograms = argument.scrape_classic_histograms.value
+      scrape_native_histograms = argument.scrape_native_histograms.value
 
             clustering {
               enabled = coalesce(argument.clustering.value, false)
@@ -605,6 +611,7 @@ works with a metrics-only integration:
           scrape_timeout = "10s"
           scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
           scrape_classic_histograms = false
+          scrape_native_histograms = false
           max_cache_size = 100000
           forward_to = argument.metrics_destinations.value
         }
@@ -1307,6 +1314,11 @@ works with multiple metrics-only integrations:
             optional = true
           }
 
+          argument "scrape_native_histograms" {
+            comment = "Whether to scrape native histograms (default: false)."
+            optional = true
+          }
+
           argument "max_cache_size" {
             comment = "The maximum number of elements to hold in the relabeling cache (default: 100000).  This should be at least 2x-5x your largest scrape target or samples appended rate."
             optional = true
@@ -1325,6 +1337,7 @@ works with multiple metrics-only integrations:
             scrape_timeout = coalesce(argument.scrape_timeout.value, "10s")
             scrape_protocols = argument.scrape_protocols.value
             scrape_classic_histograms = argument.scrape_classic_histograms.value
+      scrape_native_histograms = argument.scrape_native_histograms.value
 
             clustering {
               enabled = coalesce(argument.clustering.value, false)
@@ -1377,6 +1390,7 @@ works with multiple metrics-only integrations:
           scrape_timeout = "10s"
           scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
           scrape_classic_histograms = false
+          scrape_native_histograms = false
           max_cache_size = 100000
           forward_to = argument.metrics_destinations.value
         }
@@ -1577,6 +1591,11 @@ works with multiple metrics-only integrations:
             optional = true
           }
 
+          argument "scrape_native_histograms" {
+            comment = "Whether to scrape native histograms (default: false)."
+            optional = true
+          }
+
           argument "max_cache_size" {
             comment = "The maximum number of elements to hold in the relabeling cache (default: 100000).  This should be at least 2x-5x your largest scrape target or samples appended rate."
             optional = true
@@ -1595,6 +1614,7 @@ works with multiple metrics-only integrations:
             scrape_timeout = coalesce(argument.scrape_timeout.value, "10s")
             scrape_protocols = argument.scrape_protocols.value
             scrape_classic_histograms = argument.scrape_classic_histograms.value
+      scrape_native_histograms = argument.scrape_native_histograms.value
 
             clustering {
               enabled = coalesce(argument.clustering.value, false)
@@ -1657,6 +1677,7 @@ works with multiple metrics-only integrations:
           scrape_timeout = "10s"
           scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
           scrape_classic_histograms = false
+          scrape_native_histograms = false
           max_cache_size = 100000
           forward_to = argument.metrics_destinations.value
         }
@@ -1855,6 +1876,11 @@ works with multiple metrics-only integrations:
             optional = true
           }
 
+          argument "scrape_native_histograms" {
+            comment = "Whether to scrape native histograms (default: false)."
+            optional = true
+          }
+
           argument "max_cache_size" {
             comment = "The maximum number of elements to hold in the relabeling cache (default: 100000).  This should be at least 2x-5x your largest scrape target or samples appended rate."
             optional = true
@@ -1873,6 +1899,7 @@ works with multiple metrics-only integrations:
             scrape_timeout = coalesce(argument.scrape_timeout.value, "10s")
             scrape_protocols = argument.scrape_protocols.value
             scrape_classic_histograms = argument.scrape_classic_histograms.value
+      scrape_native_histograms = argument.scrape_native_histograms.value
 
             clustering {
               enabled = coalesce(argument.clustering.value, false)
@@ -1935,6 +1962,7 @@ works with multiple metrics-only integrations:
           scrape_timeout = "10s"
           scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
           scrape_classic_histograms = false
+          scrape_native_histograms = false
           max_cache_size = 100000
           forward_to = argument.metrics_destinations.value
         }

--- a/charts/k8s-monitoring/tests/integration/annotation-autodiscovery/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/integration/annotation-autodiscovery/.rendered/output.yaml
@@ -366,6 +366,7 @@ data:
         bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         clustering {
           enabled = true
         }
@@ -382,6 +383,7 @@ data:
         }
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         clustering {
           enabled = true
         }

--- a/charts/k8s-monitoring/tests/integration/application-observability/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/integration/application-observability/.rendered/output.yaml
@@ -402,6 +402,7 @@ data:
           scrape_timeout = coalesce(argument.scrape_timeout.value, "10s")
           scrape_protocols = argument.scrape_protocols.value
           scrape_classic_histograms = argument.scrape_classic_histograms.value
+          scrape_native_histograms = argument.scrape_native_histograms.value
     
           clustering {
             enabled = coalesce(argument.clustering.value, false)
@@ -508,6 +509,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         max_cache_size = 100000
         forward_to = argument.metrics_destinations.value
       }

--- a/charts/k8s-monitoring/tests/integration/auth/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/integration/auth/.rendered/output.yaml
@@ -132,6 +132,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
     
         tls_config {

--- a/charts/k8s-monitoring/tests/integration/auto-instrumentation/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/integration/auto-instrumentation/.rendered/output.yaml
@@ -81,6 +81,7 @@ data:
         scrape_interval = "60s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         clustering {
           enabled = true
         }
@@ -95,6 +96,7 @@ data:
         scrape_interval = "60s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         clustering {
           enabled = true
         }

--- a/charts/k8s-monitoring/tests/integration/cluster-monitoring/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/integration/cluster-monitoring/.rendered/output.yaml
@@ -181,6 +181,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
     
         tls_config {
@@ -224,6 +225,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
     
         tls_config {
@@ -267,6 +269,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
     
         tls_config {
@@ -396,6 +399,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         scheme = "http"
         bearer_token_file = ""
         tls_config {
@@ -530,6 +534,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         scheme = "http"
         bearer_token_file = ""
         tls_config {
@@ -601,6 +606,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         clustering {
           enabled = true
         }
@@ -645,6 +651,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         clustering {
           enabled = true
         }
@@ -689,6 +696,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         clustering {
           enabled = true
         }

--- a/charts/k8s-monitoring/tests/integration/control-plane-monitoring/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/integration/control-plane-monitoring/.rendered/output.yaml
@@ -142,6 +142,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
     
         tls_config {
@@ -185,6 +186,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
     
         tls_config {
@@ -235,6 +237,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
     
         tls_config {
@@ -278,6 +281,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
     
         tls_config {
@@ -417,6 +421,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
     
         tls_config {
@@ -459,6 +464,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
         tls_config {
           insecure_skip_verify = true
@@ -573,6 +579,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         clustering {
           enabled = true
         }
@@ -607,6 +614,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         clustering {
           enabled = true
         }
@@ -641,6 +649,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
         tls_config {
           insecure_skip_verify = true
@@ -687,6 +696,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         scheme = "http"
         bearer_token_file = ""
         tls_config {
@@ -821,6 +831,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         scheme = "http"
         bearer_token_file = ""
         tls_config {
@@ -892,6 +903,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         clustering {
           enabled = true
         }

--- a/charts/k8s-monitoring/tests/integration/istio-service-mesh/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/integration/istio-service-mesh/.rendered/output.yaml
@@ -426,6 +426,7 @@ data:
         bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         clustering {
           enabled = true
         }
@@ -442,6 +443,7 @@ data:
         }
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         clustering {
           enabled = true
         }
@@ -490,6 +492,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
     
         tls_config {
@@ -533,6 +536,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
     
         tls_config {
@@ -576,6 +580,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
     
         tls_config {
@@ -705,6 +710,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         scheme = "http"
         bearer_token_file = ""
         tls_config {
@@ -839,6 +845,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         scheme = "http"
         bearer_token_file = ""
         tls_config {
@@ -910,6 +917,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         clustering {
           enabled = true
         }

--- a/charts/k8s-monitoring/tests/integration/pod-logs/log-metrics/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/integration/pod-logs/log-metrics/.rendered/output.yaml
@@ -233,6 +233,7 @@ data:
           scrape_timeout = coalesce(argument.scrape_timeout.value, "10s")
           scrape_protocols = argument.scrape_protocols.value
           scrape_classic_histograms = argument.scrape_classic_histograms.value
+          scrape_native_histograms = argument.scrape_native_histograms.value
     
           clustering {
             enabled = coalesce(argument.clustering.value, false)
@@ -339,6 +340,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         max_cache_size = 100000
         forward_to = argument.metrics_destinations.value
       }

--- a/charts/k8s-monitoring/tests/integration/prom-and-loki-to-otlp/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/integration/prom-and-loki-to-otlp/.rendered/output.yaml
@@ -153,6 +153,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
     
         tls_config {
@@ -196,6 +197,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
     
         tls_config {
@@ -239,6 +241,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
     
         tls_config {
@@ -368,6 +371,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         scheme = "http"
         bearer_token_file = ""
         tls_config {
@@ -502,6 +506,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         scheme = "http"
         bearer_token_file = ""
         tls_config {
@@ -573,6 +578,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         clustering {
           enabled = true
         }

--- a/charts/k8s-monitoring/tests/integration/prometheus-io-annotations/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/integration/prometheus-io-annotations/.rendered/output.yaml
@@ -403,6 +403,7 @@ data:
         bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         clustering {
           enabled = true
         }
@@ -419,6 +420,7 @@ data:
         }
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         clustering {
           enabled = true
         }
@@ -467,6 +469,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
     
         tls_config {
@@ -510,6 +513,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
     
         tls_config {
@@ -553,6 +557,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
     
         tls_config {
@@ -682,6 +687,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         scheme = "http"
         bearer_token_file = ""
         tls_config {
@@ -816,6 +822,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         scheme = "http"
         bearer_token_file = ""
         tls_config {
@@ -887,6 +894,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         clustering {
           enabled = true
         }

--- a/charts/k8s-monitoring/tests/integration/proxies/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/integration/proxies/.rendered/output.yaml
@@ -233,6 +233,7 @@ data:
           scrape_timeout = coalesce(argument.scrape_timeout.value, "10s")
           scrape_protocols = argument.scrape_protocols.value
           scrape_classic_histograms = argument.scrape_classic_histograms.value
+          scrape_native_histograms = argument.scrape_native_histograms.value
     
           clustering {
             enabled = coalesce(argument.clustering.value, false)
@@ -339,6 +340,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         max_cache_size = 100000
         forward_to = argument.metrics_destinations.value
       }

--- a/charts/k8s-monitoring/tests/integration/service-graph-metrics/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/integration/service-graph-metrics/.rendered/output.yaml
@@ -233,6 +233,7 @@ data:
           scrape_timeout = coalesce(argument.scrape_timeout.value, "10s")
           scrape_protocols = argument.scrape_protocols.value
           scrape_classic_histograms = argument.scrape_classic_histograms.value
+          scrape_native_histograms = argument.scrape_native_histograms.value
     
           clustering {
             enabled = coalesce(argument.clustering.value, false)
@@ -339,6 +340,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         max_cache_size = 100000
         forward_to = argument.metrics_destinations.value
       }
@@ -357,6 +359,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         max_cache_size = 100000
         forward_to = argument.metrics_destinations.value
       }

--- a/charts/k8s-monitoring/tests/integration/service-integrations/alloy/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/integration/service-integrations/alloy/.rendered/output.yaml
@@ -221,6 +221,7 @@ data:
           scrape_timeout = coalesce(argument.scrape_timeout.value, "10s")
           scrape_protocols = argument.scrape_protocols.value
           scrape_classic_histograms = argument.scrape_classic_histograms.value
+          scrape_native_histograms = argument.scrape_native_histograms.value
     
           clustering {
             enabled = coalesce(argument.clustering.value, false)
@@ -327,6 +328,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         max_cache_size = 100000
         forward_to = argument.metrics_destinations.value
       }

--- a/charts/k8s-monitoring/tests/integration/service-integrations/cert-manager/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/integration/service-integrations/cert-manager/.rendered/output.yaml
@@ -133,6 +133,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         clustering {
           enabled = true
         }

--- a/charts/k8s-monitoring/tests/integration/service-integrations/coredns/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/integration/service-integrations/coredns/.rendered/output.yaml
@@ -130,6 +130,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
     
         tls_config {
@@ -173,6 +174,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
     
         tls_config {
@@ -216,6 +218,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
     
         tls_config {
@@ -413,6 +416,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         clustering {
           enabled = true
         }
@@ -455,6 +459,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         scheme = "http"
         bearer_token_file = ""
         tls_config {
@@ -589,6 +594,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         scheme = "http"
         bearer_token_file = ""
         tls_config {
@@ -660,6 +666,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         clustering {
           enabled = true
         }

--- a/charts/k8s-monitoring/tests/integration/service-integrations/etcd/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/integration/service-integrations/etcd/.rendered/output.yaml
@@ -131,6 +131,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         clustering {
           enabled = true
         }

--- a/charts/k8s-monitoring/tests/integration/service-integrations/grafana/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/integration/service-integrations/grafana/.rendered/output.yaml
@@ -153,6 +153,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
     
         tls_config {
@@ -196,6 +197,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
     
         tls_config {
@@ -239,6 +241,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
     
         tls_config {
@@ -368,6 +371,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         scheme = "http"
         bearer_token_file = ""
         tls_config {
@@ -502,6 +506,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         scheme = "http"
         bearer_token_file = ""
         tls_config {
@@ -573,6 +578,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         clustering {
           enabled = true
         }
@@ -796,6 +802,7 @@ data:
           scrape_timeout = coalesce(argument.scrape_timeout.value, "10s")
           scrape_protocols = argument.scrape_protocols.value
           scrape_classic_histograms = argument.scrape_classic_histograms.value
+          scrape_native_histograms = argument.scrape_native_histograms.value
     
           clustering {
             enabled = coalesce(argument.clustering.value, false)
@@ -848,6 +855,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         max_cache_size = 100000
         forward_to = argument.metrics_destinations.value
       }

--- a/charts/k8s-monitoring/tests/integration/service-integrations/loki/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/integration/service-integrations/loki/.rendered/output.yaml
@@ -153,6 +153,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
     
         tls_config {
@@ -196,6 +197,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
     
         tls_config {
@@ -239,6 +241,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
     
         tls_config {
@@ -368,6 +371,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         scheme = "http"
         bearer_token_file = ""
         tls_config {
@@ -502,6 +506,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         scheme = "http"
         bearer_token_file = ""
         tls_config {
@@ -573,6 +578,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         clustering {
           enabled = true
         }
@@ -803,6 +809,7 @@ data:
           scrape_timeout = coalesce(argument.scrape_timeout.value, "10s")
           scrape_protocols = argument.scrape_protocols.value
           scrape_classic_histograms = argument.scrape_classic_histograms.value
+          scrape_native_histograms = argument.scrape_native_histograms.value
     
           clustering {
             enabled = coalesce(argument.clustering.value, false)
@@ -865,6 +872,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         max_cache_size = 100000
         forward_to = argument.metrics_destinations.value
       }

--- a/charts/k8s-monitoring/tests/integration/service-integrations/mysql/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/integration/service-integrations/mysql/.rendered/output.yaml
@@ -59,6 +59,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         forward_to = [prometheus.relabel.test_database.receiver]
       }
     

--- a/charts/k8s-monitoring/tests/integration/service-integrations/tempo/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/integration/service-integrations/tempo/.rendered/output.yaml
@@ -153,6 +153,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
     
         tls_config {
@@ -196,6 +197,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
     
         tls_config {
@@ -239,6 +241,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
     
         tls_config {
@@ -368,6 +371,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         scheme = "http"
         bearer_token_file = ""
         tls_config {
@@ -502,6 +506,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         scheme = "http"
         bearer_token_file = ""
         tls_config {
@@ -573,6 +578,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         clustering {
           enabled = true
         }
@@ -963,6 +969,7 @@ data:
           scrape_timeout = coalesce(argument.scrape_timeout.value, "10s")
           scrape_protocols = argument.scrape_protocols.value
           scrape_classic_histograms = argument.scrape_classic_histograms.value
+          scrape_native_histograms = argument.scrape_native_histograms.value
     
           clustering {
             enabled = coalesce(argument.clustering.value, false)
@@ -1025,6 +1032,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         max_cache_size = 100000
         forward_to = argument.metrics_destinations.value
       }

--- a/charts/k8s-monitoring/tests/integration/sharded-kube-state-metrics/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/integration/sharded-kube-state-metrics/.rendered/output.yaml
@@ -403,6 +403,7 @@ data:
         bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         clustering {
           enabled = true
         }
@@ -419,6 +420,7 @@ data:
         }
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         clustering {
           enabled = true
         }
@@ -467,6 +469,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
     
         tls_config {
@@ -510,6 +513,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
     
         tls_config {
@@ -553,6 +557,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
     
         tls_config {
@@ -682,6 +687,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         scheme = "http"
         bearer_token_file = ""
         tls_config {
@@ -816,6 +822,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         scheme = "http"
         bearer_token_file = ""
         tls_config {
@@ -887,6 +894,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         clustering {
           enabled = true
         }

--- a/charts/k8s-monitoring/tests/integration/split-destinations/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/integration/split-destinations/.rendered/output.yaml
@@ -188,6 +188,7 @@ data:
         scrape_interval = "60s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         clustering {
           enabled = true
         }
@@ -202,6 +203,7 @@ data:
         scrape_interval = "60s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         clustering {
           enabled = true
         }
@@ -250,6 +252,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
     
         tls_config {
@@ -293,6 +296,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
     
         tls_config {
@@ -336,6 +340,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
     
         tls_config {
@@ -465,6 +470,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         scheme = "http"
         bearer_token_file = ""
         tls_config {
@@ -599,6 +605,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         scheme = "http"
         bearer_token_file = ""
         tls_config {
@@ -670,6 +677,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         clustering {
           enabled = true
         }

--- a/charts/k8s-monitoring/tests/integration/tail-sampling/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/integration/tail-sampling/.rendered/output.yaml
@@ -233,6 +233,7 @@ data:
           scrape_timeout = coalesce(argument.scrape_timeout.value, "10s")
           scrape_protocols = argument.scrape_protocols.value
           scrape_classic_histograms = argument.scrape_classic_histograms.value
+          scrape_native_histograms = argument.scrape_native_histograms.value
     
           clustering {
             enabled = coalesce(argument.clustering.value, false)
@@ -339,6 +340,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         max_cache_size = 100000
         forward_to = argument.metrics_destinations.value
       }
@@ -357,6 +359,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         max_cache_size = 100000
         forward_to = argument.metrics_destinations.value
       }

--- a/charts/k8s-monitoring/tests/integration/uninstall/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/integration/uninstall/.rendered/output.yaml
@@ -181,6 +181,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
     
         tls_config {
@@ -224,6 +225,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
     
         tls_config {
@@ -267,6 +269,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
     
         tls_config {
@@ -396,6 +399,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         scheme = "http"
         bearer_token_file = ""
         tls_config {
@@ -530,6 +534,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         scheme = "http"
         bearer_token_file = ""
         tls_config {
@@ -601,6 +606,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         clustering {
           enabled = true
         }
@@ -645,6 +651,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         clustering {
           enabled = true
         }
@@ -689,6 +696,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         clustering {
           enabled = true
         }

--- a/charts/k8s-monitoring/tests/integration/upgrade/major/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/integration/upgrade/major/.rendered/output.yaml
@@ -181,6 +181,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
     
         tls_config {
@@ -224,6 +225,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
     
         tls_config {
@@ -267,6 +269,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
     
         tls_config {
@@ -396,6 +399,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         scheme = "http"
         bearer_token_file = ""
         tls_config {
@@ -530,6 +534,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         scheme = "http"
         bearer_token_file = ""
         tls_config {
@@ -601,6 +606,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         clustering {
           enabled = true
         }
@@ -645,6 +651,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         clustering {
           enabled = true
         }
@@ -689,6 +696,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         clustering {
           enabled = true
         }

--- a/charts/k8s-monitoring/tests/integration/upgrade/minor/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/integration/upgrade/minor/.rendered/output.yaml
@@ -181,6 +181,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
     
         tls_config {
@@ -224,6 +225,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
     
         tls_config {
@@ -267,6 +269,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
     
         tls_config {
@@ -396,6 +399,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         scheme = "http"
         bearer_token_file = ""
         tls_config {
@@ -530,6 +534,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         scheme = "http"
         bearer_token_file = ""
         tls_config {
@@ -601,6 +606,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         clustering {
           enabled = true
         }
@@ -645,6 +651,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         clustering {
           enabled = true
         }
@@ -689,6 +696,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         clustering {
           enabled = true
         }

--- a/charts/k8s-monitoring/tests/integration/upgrade/patch/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/integration/upgrade/patch/.rendered/output.yaml
@@ -181,6 +181,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
     
         tls_config {
@@ -224,6 +225,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
     
         tls_config {
@@ -267,6 +269,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
     
         tls_config {
@@ -396,6 +399,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         scheme = "http"
         bearer_token_file = ""
         tls_config {
@@ -530,6 +534,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         scheme = "http"
         bearer_token_file = ""
         tls_config {
@@ -601,6 +606,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         clustering {
           enabled = true
         }
@@ -645,6 +651,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         clustering {
           enabled = true
         }
@@ -689,6 +696,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         clustering {
           enabled = true
         }

--- a/charts/k8s-monitoring/tests/platform/aks/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/platform/aks/.rendered/output.yaml
@@ -130,6 +130,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
     
         tls_config {
@@ -173,6 +174,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
     
         tls_config {
@@ -216,6 +218,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
     
         tls_config {
@@ -345,6 +348,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         scheme = "http"
         bearer_token_file = ""
         tls_config {
@@ -479,6 +483,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         scheme = "http"
         bearer_token_file = ""
         tls_config {
@@ -550,6 +555,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         clustering {
           enabled = true
         }
@@ -771,6 +777,7 @@ data:
           scrape_timeout = coalesce(argument.scrape_timeout.value, "10s")
           scrape_protocols = argument.scrape_protocols.value
           scrape_classic_histograms = argument.scrape_classic_histograms.value
+          scrape_native_histograms = argument.scrape_native_histograms.value
     
           clustering {
             enabled = coalesce(argument.clustering.value, false)
@@ -877,6 +884,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         max_cache_size = 100000
         forward_to = argument.metrics_destinations.value
       }

--- a/charts/k8s-monitoring/tests/platform/eks-fargate/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/platform/eks-fargate/.rendered/output.yaml
@@ -130,6 +130,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
     
         tls_config {
@@ -173,6 +174,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
     
         tls_config {
@@ -216,6 +218,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
     
         tls_config {
@@ -345,6 +348,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         scheme = "http"
         bearer_token_file = ""
         tls_config {
@@ -479,6 +483,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         scheme = "http"
         bearer_token_file = ""
         tls_config {
@@ -550,6 +555,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         clustering {
           enabled = true
         }
@@ -771,6 +777,7 @@ data:
           scrape_timeout = coalesce(argument.scrape_timeout.value, "10s")
           scrape_protocols = argument.scrape_protocols.value
           scrape_classic_histograms = argument.scrape_classic_histograms.value
+          scrape_native_histograms = argument.scrape_native_histograms.value
     
           clustering {
             enabled = coalesce(argument.clustering.value, false)
@@ -877,6 +884,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         max_cache_size = 100000
         forward_to = argument.metrics_destinations.value
       }

--- a/charts/k8s-monitoring/tests/platform/eks-with-windows/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/platform/eks-with-windows/.rendered/output.yaml
@@ -130,6 +130,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
     
         tls_config {
@@ -173,6 +174,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
     
         tls_config {
@@ -216,6 +218,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
     
         tls_config {
@@ -345,6 +348,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         scheme = "http"
         bearer_token_file = ""
         tls_config {
@@ -479,6 +483,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         scheme = "http"
         bearer_token_file = ""
         tls_config {
@@ -550,6 +555,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         clustering {
           enabled = true
         }
@@ -771,6 +777,7 @@ data:
           scrape_timeout = coalesce(argument.scrape_timeout.value, "10s")
           scrape_protocols = argument.scrape_protocols.value
           scrape_classic_histograms = argument.scrape_classic_histograms.value
+          scrape_native_histograms = argument.scrape_native_histograms.value
     
           clustering {
             enabled = coalesce(argument.clustering.value, false)
@@ -877,6 +884,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         max_cache_size = 100000
         forward_to = argument.metrics_destinations.value
       }

--- a/charts/k8s-monitoring/tests/platform/gke-autopilot/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/platform/gke-autopilot/.rendered/output.yaml
@@ -74,6 +74,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
     
         tls_config {
@@ -117,6 +118,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
     
         tls_config {
@@ -160,6 +162,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
     
         tls_config {
@@ -289,6 +292,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         scheme = "http"
         bearer_token_file = ""
         tls_config {
@@ -516,6 +520,7 @@ data:
           scrape_timeout = coalesce(argument.scrape_timeout.value, "10s")
           scrape_protocols = argument.scrape_protocols.value
           scrape_classic_histograms = argument.scrape_classic_histograms.value
+          scrape_native_histograms = argument.scrape_native_histograms.value
     
           clustering {
             enabled = coalesce(argument.clustering.value, false)
@@ -622,6 +627,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         max_cache_size = 100000
         forward_to = argument.metrics_destinations.value
       }

--- a/charts/k8s-monitoring/tests/platform/gke/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/platform/gke/.rendered/output.yaml
@@ -130,6 +130,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
     
         tls_config {
@@ -173,6 +174,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
     
         tls_config {
@@ -216,6 +218,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
     
         tls_config {
@@ -345,6 +348,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         scheme = "http"
         bearer_token_file = ""
         tls_config {
@@ -479,6 +483,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         scheme = "http"
         bearer_token_file = ""
         tls_config {
@@ -550,6 +555,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         clustering {
           enabled = true
         }
@@ -771,6 +777,7 @@ data:
           scrape_timeout = coalesce(argument.scrape_timeout.value, "10s")
           scrape_protocols = argument.scrape_protocols.value
           scrape_classic_histograms = argument.scrape_classic_histograms.value
+          scrape_native_histograms = argument.scrape_native_histograms.value
     
           clustering {
             enabled = coalesce(argument.clustering.value, false)
@@ -877,6 +884,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         max_cache_size = 100000
         forward_to = argument.metrics_destinations.value
       }

--- a/charts/k8s-monitoring/tests/platform/gpu/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/platform/gpu/.rendered/output.yaml
@@ -220,6 +220,7 @@ data:
           scrape_timeout = coalesce(argument.scrape_timeout.value, "10s")
           scrape_protocols = argument.scrape_protocols.value
           scrape_classic_histograms = argument.scrape_classic_histograms.value
+          scrape_native_histograms = argument.scrape_native_histograms.value
     
           clustering {
             enabled = coalesce(argument.clustering.value, false)
@@ -327,6 +328,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         max_cache_size = 100000
         forward_to = argument.metrics_destinations.value
       }

--- a/charts/k8s-monitoring/tests/platform/grafana-cloud/k8s-monitoring/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/platform/grafana-cloud/k8s-monitoring/.rendered/output.yaml
@@ -170,6 +170,7 @@ data:
         scrape_interval = "60s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         clustering {
           enabled = true
         }
@@ -184,6 +185,7 @@ data:
         scrape_interval = "60s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         clustering {
           enabled = true
         }
@@ -231,6 +233,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
     
         tls_config {
@@ -274,6 +277,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
     
         tls_config {
@@ -317,6 +321,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
     
         tls_config {
@@ -446,6 +451,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         scheme = "http"
         bearer_token_file = ""
         tls_config {
@@ -580,6 +586,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         scheme = "http"
         bearer_token_file = ""
         tls_config {
@@ -651,6 +658,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         clustering {
           enabled = true
         }
@@ -695,6 +703,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         clustering {
           enabled = true
         }
@@ -739,6 +748,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         clustering {
           enabled = true
         }
@@ -960,6 +970,7 @@ data:
           scrape_timeout = coalesce(argument.scrape_timeout.value, "10s")
           scrape_protocols = argument.scrape_protocols.value
           scrape_classic_histograms = argument.scrape_classic_histograms.value
+          scrape_native_histograms = argument.scrape_native_histograms.value
     
           clustering {
             enabled = coalesce(argument.clustering.value, false)
@@ -1066,6 +1077,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         max_cache_size = 100000
         forward_to = argument.metrics_destinations.value
       }

--- a/charts/k8s-monitoring/tests/platform/openshift/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/platform/openshift/.rendered/output.yaml
@@ -96,6 +96,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
     
         tls_config {
@@ -139,6 +140,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
     
         tls_config {
@@ -182,6 +184,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
     
         tls_config {
@@ -311,6 +314,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         scheme = "https"
         bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
         tls_config {
@@ -445,6 +449,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         scheme = "https"
         bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
         tls_config {
@@ -516,6 +521,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         clustering {
           enabled = true
         }
@@ -737,6 +743,7 @@ data:
           scrape_timeout = coalesce(argument.scrape_timeout.value, "10s")
           scrape_protocols = argument.scrape_protocols.value
           scrape_classic_histograms = argument.scrape_classic_histograms.value
+          scrape_native_histograms = argument.scrape_native_histograms.value
     
           clustering {
             enabled = coalesce(argument.clustering.value, false)
@@ -843,6 +850,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         max_cache_size = 100000
         forward_to = argument.metrics_destinations.value
       }

--- a/charts/k8s-monitoring/tests/platform/otlp-gateway/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/platform/otlp-gateway/.rendered/output.yaml
@@ -221,6 +221,7 @@ data:
           scrape_timeout = coalesce(argument.scrape_timeout.value, "10s")
           scrape_protocols = argument.scrape_protocols.value
           scrape_classic_histograms = argument.scrape_classic_histograms.value
+          scrape_native_histograms = argument.scrape_native_histograms.value
     
           clustering {
             enabled = coalesce(argument.clustering.value, false)
@@ -327,6 +328,7 @@ data:
         scrape_timeout = "10s"
         scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
         scrape_classic_histograms = false
+        scrape_native_histograms = false
         max_cache_size = 100000
         forward_to = argument.metrics_destinations.value
       }

--- a/charts/k8s-monitoring/values.schema.json
+++ b/charts/k8s-monitoring/values.schema.json
@@ -207,6 +207,9 @@
                 "scrapeInterval": {
                     "type": "string"
                 },
+                "scrapeNativeHistograms": {
+                    "type": "boolean"
+                },
                 "scrapeProtocols": {
                     "type": "array",
                     "items": {

--- a/charts/k8s-monitoring/values.yaml
+++ b/charts/k8s-monitoring/values.yaml
@@ -33,6 +33,10 @@ global:
   # @section -- Global Settings
   scrapeClassicHistograms: false
 
+  # -- Whether to scrape native histograms.
+  # @section -- Global Settings
+  scrapeNativeHistograms: false
+
   # -- Sets the max_cache_size for every prometheus.relabel component. ([docs](https://grafana.com/docs/alloy/latest/reference/components/prometheus/prometheus.relabel/#arguments))
   # This should be at least 2x-5x your largest scrape target or samples appended rate.
   # @section -- Global Settings


### PR DESCRIPTION
In Alloy v1.11 there is a Breaking Change for `prometheus.scrape` where the `scrape_native_histograms` default value changes from `true` to `false`.

Ref: <https://grafana.com/docs/alloy/latest/release-notes/#breaking-changes-in-prometheusscrape>

> scrape_native_histograms attribute for prometheus.scrape is now set to false, whereas in previous versions of Alloy it would default to true. This means that it is no longer enough to just configure scrape_protocols to start with PrometheusProto to scrape native histograms - scrape_native_histograms has to be enabled. If scrape_native_histograms is enabled, scrape_protocols will automatically be configured correctly for you to include PrometheusProto. If you configure it explicitly, Alloy will validate that PrometheusProto is in the scrape_protocols list.

This PR attempts to add a Global Values Setting (similar to `scrapeClassicHistograms` where the `scrape_native_histograms` setting can be toggled.