### PR TITLE
Escape Sequence quotation marks _common_log_processing.alloy.tpl

### DIFF
--- a/charts/k8s-monitoring/charts/feature-pod-logs/templates/_common_log_processing.alloy.tpl
+++ b/charts/k8s-monitoring/charts/feature-pod-logs/templates/_common_log_processing.alloy.tpl
@@ -1,7 +1,7 @@
 {{- define "feature.podLogs.processing.alloy" }}
 loki.process "pod_logs" {
   stage.match {
-    selector = "{tmp_container_runtime=~\"containerd|cri-o\"}"
+    selector = "{tmp_container_runtime=~\\\"containerd|cri-o\\\"}"
     // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
     stage.cri {}
 
@@ -15,7 +15,7 @@ loki.process "pod_logs" {
   }
 
   stage.match {
-    selector = "{tmp_container_runtime=\"docker\"}"
+    selector = "{tmp_container_runtime=\\\"docker\\\"}"
     // the docker processing stage extracts the following k/v pairs: log, stream, time
     stage.docker {}
 


### PR DESCRIPTION
Wrong escape sequence causing error in ConfigMap:

Error contexts

```txt
Error: /etc/alloy/config.alloy:134:41: expected TERMINATOR, got IDENT

133 |         stage.match {
134 |             selector = "{tmp_container_runtime=~"containerd|cri-o"}"
    |                                                  ^
135 |             //          the cri processing stage extracts the following k/v pairs: log, stream,    time,       flags

Error: /etc/alloy/config.alloy:134:52: missing second | in ||

133 |         stage.match {
134 |             selector = "{tmp_container_runtime=~"containerd|cri-o"}"
    |                                                             ^
135 |             //          the cri processing stage extracts the following k/v pairs: log, stream,    time,       flags

Error: /etc/alloy/config.alloy:146:40: expected TERMINATOR, got IDENT

145 |         stage.match    {
146 |             selector = "{tmp_container_runtime="docker"}"
    |                                                 ^
147 |             //       the    docker processing stage extracts the following k/v pairs: log, stream,    time
interrupt received
Error: could not perform the initial load successfully
```

Debugging:

```sh
kubectl exec -it Pod/k8s-monitoring-alloy-logs-xxxxx-xxxx --container config-reloader -- sh
cat /etc/alloy/congfig.alloy
```

```config.alloy
...
loki.process          "pod_logs" {
                stage.match {
                        selector = "{tmp_container_runtime=~"containerd|cri-o"}"
                        //          the cri processing stage extracts the following k/v pairs: log, stream,    time,       flags
                        stage.cri { }
                        // Set the extract flags and stream    values       as labels
                        stage.labels {
                                values = {
                                        flags     = "",
                                        stream       = "",
                                }
                        }
                }
                stage.match    {
                        selector = "{tmp_container_runtime="docker"}"
                        //       the    docker processing stage extracts the following k/v pairs: log, stream,    time
                        stage.docker       { }
                        // Set the extract stream value as a label
                        stage.labels       {
                                values    = {
                                        stream = "",
                                }
                        }
                }
...
```
