### PR TITLE
Fix profiles receiver test

### DIFF
--- a/charts/k8s-monitoring/tests/integration/profiles-receiver/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/integration/profiles-receiver/.rendered/output.yaml
@@ -555,7 +555,7 @@ spec:
           }
         }
 
-        pyroscope.ebpf "alloy" {
+        pyroscope.scrape "alloy" {
           targets = discovery.kubernetes.alloy.targets
           forward_to = [pyroscope.write.chart.receiver]
         }

--- a/charts/k8s-monitoring/tests/integration/profiles-receiver/values.yaml
+++ b/charts/k8s-monitoring/tests/integration/profiles-receiver/values.yaml
@@ -45,7 +45,7 @@ extraObjects:
               }
             }
 
-            pyroscope.ebpf "alloy" {
+            pyroscope.scrape "alloy" {
               targets = discovery.kubernetes.alloy.targets
               forward_to = [pyroscope.write.chart.receiver]
             }


### PR DESCRIPTION
Using pyroscope.scrape (pprof) is more regular and reliable than pyroscope.ebpf (ebpf, obvs).