### PR TITLE
Ensure that service graph generator utilizes destination defaults

### DIFF
--- a/charts/k8s-monitoring/templates/alloy-servicegraph.yaml
+++ b/charts/k8s-monitoring/templates/alloy-servicegraph.yaml
@@ -14,32 +14,34 @@
 
     {{- /* Destination components*/}}
     {{- $metricsDestinationNames := include "destinations.get" (dict "destinations" $.Values.destinations "type" "metrics" "ecosystem" "otlp" "filter" $destination.processors.serviceGraphMetrics.destinations) | fromYamlArray -}}
-    {{- $destinations := list }}
     {{- $destinationTargets := list }}
     {{- $destinationConfigComponents := "" }}
     {{- range $metricsDestinationName := $metricsDestinationNames }}
       {{- $dest := include "destination.getDestinationByName" (deepCopy $ | merge (dict "destination" $metricsDestinationName )) | fromYaml }}
-      {{- $destinations = append $destinations $dest }}
-      {{- if ne $dest.type "prometheus" -}}
-        {{- $destinationTarget := include "destinations.otlp.alloy.exporter.target" $dest }}
+      {{- if eq $dest.type "prometheus" -}}
+        {{- $defaultValues := "destinations/prometheus-values.yaml" | $.Files.Get | fromYaml }}
+        {{- $destWithDefaults := mergeOverwrite (deepCopy $defaultValues) $dest }}
+        {{- $destinationTarget := include "destinations.prometheus.alloy.otlp.metrics.target" $destWithDefaults }}
         {{- $destinationTargets = append $destinationTargets (printf "%s" $destinationTarget) }}
       {{- else }}
-        {{- $destinationTarget := include "destinations.prometheus.alloy.otlp.metrics.target" $dest }}
+        {{- $defaultValues := "destinations/otlp-values.yaml" | $.Files.Get | fromYaml }}
+        {{- $destWithDefaults := mergeOverwrite (deepCopy $defaultValues) $dest }}
+        {{- $destinationTarget := include "destinations.otlp.alloy.exporter.target" $destWithDefaults }}
         {{- $destinationTargets = append $destinationTargets (printf "%s" $destinationTarget) }}
       {{- end }}
       {{- $destinationConfigComponents = cat $destinationConfigComponents (printf "\n\n// Destination: %s (%s)" $dest.name $dest.type) }}
       {{- if eq (include "secrets.usesKubernetesSecret" $dest) "true" }}
         {{- $destinationConfigComponents = cat $destinationConfigComponents (include "secret.alloy" (deepCopy $ | merge (dict "object" $dest)) | nindent 0) }}
       {{- end }}
-      {{- if ne $dest.type "prometheus" -}}
-        {{- $defaultValues := "destinations/otlp-values.yaml" | $.Files.Get | fromYaml }}
-        {{- $dest = mergeOverwrite $defaultValues $dest }}
-        {{- $destinationConfigComponents = cat $destinationConfigComponents ((include "destinations.otlp.alloy.exporter" $dest) | trim | nindent 0) }}
-      {{- else -}}
+      {{- if eq $dest.type "prometheus" -}}
         {{- $defaultValues := "destinations/prometheus-values.yaml" | $.Files.Get | fromYaml }}
-        {{- $dest = mergeOverwrite $defaultValues $dest }}
-        {{- $dest = set $dest "extraLabelsFrom" (dict "collector_id" "env(\"POD_NAME\")") }}
-        {{- $destinationConfigComponents = cat $destinationConfigComponents ((include "destinations.prometheus.alloy" (deepCopy $ | merge (dict "destination" $dest))) | trim | nindent 0) }}
+        {{- $destWithDefaults := mergeOverwrite (deepCopy $defaultValues) $dest }}
+        {{- $destWithDefaults = set $destWithDefaults "extraLabelsFrom" (dict "collector_id" "env(\"POD_NAME\")") }}
+        {{- $destinationConfigComponents = cat $destinationConfigComponents ((include "destinations.prometheus.alloy" (deepCopy $ | merge (dict "destination" $destWithDefaults))) | trim | nindent 0) }}
+      {{- else -}}
+        {{- $defaultValues := "destinations/otlp-values.yaml" | $.Files.Get | fromYaml }}
+        {{- $destWithDefaults := mergeOverwrite (deepCopy $defaultValues) $dest }}
+        {{- $destinationConfigComponents = cat $destinationConfigComponents ((include "destinations.otlp.alloy.exporter" $destWithDefaults) | trim | nindent 0) }}
       {{- end }}
     {{- end }}
 

--- a/charts/k8s-monitoring/tests/integration/alternative-deployments/argocd/.gitignore
+++ b/charts/k8s-monitoring/tests/integration/alternative-deployments/argocd/.gitignore
@@ -1,0 +1,2 @@
+output.yaml
+values.yaml

--- a/charts/k8s-monitoring/tests/integration/alternative-deployments/argocd/Makefile
+++ b/charts/k8s-monitoring/tests/integration/alternative-deployments/argocd/Makefile
@@ -13,3 +13,9 @@ k8s-monitoring-application.yaml:
 	@yq eval '.spec.source.targetRevision = "$(BRANCH_NAME)"' k8s-monitoring-application.yaml > temp.yaml
 	@cp temp.yaml k8s-monitoring-application.yaml
 	@rm temp.yaml
+
+values.yaml: k8s-monitoring-application.yaml
+	yq eval '.spec.source.helm.valuesObject' $< > $@
+
+output.yaml: values.yaml
+	helm template k8smon ../../../.. -f $< > $@


### PR DESCRIPTION
Without this, the default values in the OTLP and Prometheus destinations, like:
```
processors:
  batch:
    enabled: true
```

Was undefined. So we ran into null issues unless the default was re-defined.