### PR TITLE
Add the node label

### DIFF
--- a/charts/k8s-monitoring/charts/feature-integrations/templates/_integration_grafana_metrics.tpl
+++ b/charts/k8s-monitoring/charts/feature-integrations/templates/_integration_grafana_metrics.tpl
@@ -86,6 +86,11 @@ declare "grafana_integration" {
         action = "keep"
       }
 
+      rule {
+        source_labels = ["__meta_kubernetes_pod_node_name"]
+        target_label = "node"
+      }
+
       {{ include "feature.integrations.commonDiscoveryRules" . | nindent 6 }}
     }
 

--- a/charts/k8s-monitoring/charts/feature-integrations/templates/_integration_loki_metrics.tpl
+++ b/charts/k8s-monitoring/charts/feature-integrations/templates/_integration_loki_metrics.tpl
@@ -86,6 +86,11 @@ declare "loki_integration" {
         action = "keep"
       }
 
+      rule {
+        source_labels = ["__meta_kubernetes_pod_node_name"]
+        target_label = "node"
+      }
+
       // the loki-mixin expects the job label to be namespace/component
       rule {
         source_labels = ["__meta_kubernetes_namespace","__meta_kubernetes_pod_label_app_kubernetes_io_component"]

--- a/charts/k8s-monitoring/charts/feature-integrations/templates/_integration_mimir_metrics.tpl
+++ b/charts/k8s-monitoring/charts/feature-integrations/templates/_integration_mimir_metrics.tpl
@@ -86,6 +86,11 @@ declare "mimir_integration" {
         action = "keep"
       }
 
+      rule {
+        source_labels = ["__meta_kubernetes_pod_node_name"]
+        target_label = "node"
+      }
+
       // the mimir-mixin expects the job label to be namespace/component
       rule {
         source_labels = ["__meta_kubernetes_namespace","__meta_kubernetes_pod_label_app_kubernetes_io_component"]

--- a/charts/k8s-monitoring/docs/examples/features/integrations/grafana/alloy-metrics.alloy
+++ b/charts/k8s-monitoring/docs/examples/features/integrations/grafana/alloy-metrics.alloy
@@ -57,6 +57,11 @@ declare "grafana_integration" {
         action = "keep"
       }
 
+      rule {
+        source_labels = ["__meta_kubernetes_pod_node_name"]
+        target_label = "node"
+      }
+
 
 
       rule {

--- a/charts/k8s-monitoring/docs/examples/features/integrations/grafana/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/features/integrations/grafana/output.yaml
@@ -80,6 +80,11 @@ data:
             action = "keep"
           }
     
+          rule {
+            source_labels = ["__meta_kubernetes_pod_node_name"]
+            target_label = "node"
+          }
+    
     
     
           rule {

--- a/charts/k8s-monitoring/docs/examples/features/integrations/loki/alloy-metrics.alloy
+++ b/charts/k8s-monitoring/docs/examples/features/integrations/loki/alloy-metrics.alloy
@@ -57,6 +57,11 @@ declare "loki_integration" {
         action = "keep"
       }
 
+      rule {
+        source_labels = ["__meta_kubernetes_pod_node_name"]
+        target_label = "node"
+      }
+
       // the loki-mixin expects the job label to be namespace/component
       rule {
         source_labels = ["__meta_kubernetes_namespace","__meta_kubernetes_pod_label_app_kubernetes_io_component"]

--- a/charts/k8s-monitoring/docs/examples/features/integrations/loki/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/features/integrations/loki/output.yaml
@@ -80,6 +80,11 @@ data:
             action = "keep"
           }
     
+          rule {
+            source_labels = ["__meta_kubernetes_pod_node_name"]
+            target_label = "node"
+          }
+    
           // the loki-mixin expects the job label to be namespace/component
           rule {
             source_labels = ["__meta_kubernetes_namespace","__meta_kubernetes_pod_label_app_kubernetes_io_component"]

--- a/charts/k8s-monitoring/docs/examples/features/integrations/mimir/alloy-metrics.alloy
+++ b/charts/k8s-monitoring/docs/examples/features/integrations/mimir/alloy-metrics.alloy
@@ -57,6 +57,11 @@ declare "mimir_integration" {
         action = "keep"
       }
 
+      rule {
+        source_labels = ["__meta_kubernetes_pod_node_name"]
+        target_label = "node"
+      }
+
       // the mimir-mixin expects the job label to be namespace/component
       rule {
         source_labels = ["__meta_kubernetes_namespace","__meta_kubernetes_pod_label_app_kubernetes_io_component"]

--- a/charts/k8s-monitoring/docs/examples/features/integrations/mimir/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/features/integrations/mimir/output.yaml
@@ -80,6 +80,11 @@ data:
             action = "keep"
           }
     
+          rule {
+            source_labels = ["__meta_kubernetes_pod_node_name"]
+            target_label = "node"
+          }
+    
           // the mimir-mixin expects the job label to be namespace/component
           rule {
             source_labels = ["__meta_kubernetes_namespace","__meta_kubernetes_pod_label_app_kubernetes_io_component"]

--- a/charts/k8s-monitoring/docs/examples/meta-monitoring/alloy-singleton.alloy
+++ b/charts/k8s-monitoring/docs/examples/meta-monitoring/alloy-singleton.alloy
@@ -1405,6 +1405,11 @@ declare "grafana_integration" {
         action = "keep"
       }
 
+      rule {
+        source_labels = ["__meta_kubernetes_pod_node_name"]
+        target_label = "node"
+      }
+
 
 
       rule {
@@ -1678,6 +1683,11 @@ declare "loki_integration" {
         separator = "@"
         regex = coalesce(argument.port_name.value, "http-metrics") + "@Running@true@false"
         action = "keep"
+      }
+
+      rule {
+        source_labels = ["__meta_kubernetes_pod_node_name"]
+        target_label = "node"
       }
 
       // the loki-mixin expects the job label to be namespace/component
@@ -1970,6 +1980,11 @@ declare "mimir_integration" {
         separator = "@"
         regex = coalesce(argument.port_name.value, "http-metrics") + "@Running@true@false"
         action = "keep"
+      }
+
+      rule {
+        source_labels = ["__meta_kubernetes_pod_node_name"]
+        target_label = "node"
       }
 
       // the mimir-mixin expects the job label to be namespace/component

--- a/charts/k8s-monitoring/docs/examples/meta-monitoring/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/meta-monitoring/output.yaml
@@ -1462,6 +1462,11 @@ data:
             action = "keep"
           }
     
+          rule {
+            source_labels = ["__meta_kubernetes_pod_node_name"]
+            target_label = "node"
+          }
+    
     
     
           rule {
@@ -1735,6 +1740,11 @@ data:
             separator = "@"
             regex = coalesce(argument.port_name.value, "http-metrics") + "@Running@true@false"
             action = "keep"
+          }
+    
+          rule {
+            source_labels = ["__meta_kubernetes_pod_node_name"]
+            target_label = "node"
           }
     
           // the loki-mixin expects the job label to be namespace/component
@@ -2027,6 +2037,11 @@ data:
             separator = "@"
             regex = coalesce(argument.port_name.value, "http-metrics") + "@Running@true@false"
             action = "keep"
+          }
+    
+          rule {
+            source_labels = ["__meta_kubernetes_pod_node_name"]
+            target_label = "node"
           }
     
           // the mimir-mixin expects the job label to be namespace/component

--- a/charts/k8s-monitoring/tests/integration/service-integrations/grafana/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/integration/service-integrations/grafana/.rendered/output.yaml
@@ -653,6 +653,11 @@ data:
             action = "keep"
           }
     
+          rule {
+            source_labels = ["__meta_kubernetes_pod_node_name"]
+            target_label = "node"
+          }
+    
     
     
           rule {

--- a/charts/k8s-monitoring/tests/integration/service-integrations/loki/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/integration/service-integrations/loki/.rendered/output.yaml
@@ -653,6 +653,11 @@ data:
             action = "keep"
           }
     
+          rule {
+            source_labels = ["__meta_kubernetes_pod_node_name"]
+            target_label = "node"
+          }
+    
           // the loki-mixin expects the job label to be namespace/component
           rule {
             source_labels = ["__meta_kubernetes_namespace","__meta_kubernetes_pod_label_app_kubernetes_io_component"]

--- a/charts/k8s-monitoring/tests/integration/service-integrations/loki/test-plan.yaml
+++ b/charts/k8s-monitoring/tests/integration/service-integrations/loki/test-plan.yaml
@@ -13,6 +13,48 @@ cluster:
 
 dependencies:
   - preset: prometheus
+    overrides:
+      serverFiles:
+        recording_rules.yml:
+          groups:
+            - name: loki_rules
+              rules:
+                - expr: histogram_quantile(0.99, sum(rate(loki_request_duration_seconds_bucket[1m])) by (le, cluster, job))
+                  record: cluster_job:loki_request_duration_seconds:99quantile
+                - expr: histogram_quantile(0.50, sum(rate(loki_request_duration_seconds_bucket[1m])) by (le, cluster, job))
+                  record: cluster_job:loki_request_duration_seconds:50quantile
+                - expr: sum(rate(loki_request_duration_seconds_sum[1m])) by (cluster, job) / sum(rate(loki_request_duration_seconds_count[1m])) by (cluster, job)
+                  record: cluster_job:loki_request_duration_seconds:avg
+                - expr: sum(rate(loki_request_duration_seconds_bucket[1m])) by (le, cluster, job)
+                  record: cluster_job:loki_request_duration_seconds_bucket:sum_rate
+                - expr: sum(rate(loki_request_duration_seconds_sum[1m])) by (cluster, job)
+                  record: cluster_job:loki_request_duration_seconds_sum:sum_rate
+                - expr: sum(rate(loki_request_duration_seconds_count[1m])) by (cluster, job)
+                  record: cluster_job:loki_request_duration_seconds_count:sum_rate
+                - expr: histogram_quantile(0.99, sum(rate(loki_request_duration_seconds_bucket[1m])) by (le, cluster, job, route))
+                  record: cluster_job_route:loki_request_duration_seconds:99quantile
+                - expr: histogram_quantile(0.50, sum(rate(loki_request_duration_seconds_bucket[1m])) by (le, cluster, job, route))
+                  record: cluster_job_route:loki_request_duration_seconds:50quantile
+                - expr: sum(rate(loki_request_duration_seconds_sum[1m])) by (cluster, job, route) / sum(rate(loki_request_duration_seconds_count[1m])) by (cluster, job, route)
+                  record: cluster_job_route:loki_request_duration_seconds:avg
+                - expr: sum(rate(loki_request_duration_seconds_bucket[1m])) by (le, cluster, job, route)
+                  record: cluster_job_route:loki_request_duration_seconds_bucket:sum_rate
+                - expr: sum(rate(loki_request_duration_seconds_sum[1m])) by (cluster, job, route)
+                  record: cluster_job_route:loki_request_duration_seconds_sum:sum_rate
+                - expr: sum(rate(loki_request_duration_seconds_count[1m])) by (cluster, job, route)
+                  record: cluster_job_route:loki_request_duration_seconds_count:sum_rate
+                - expr: histogram_quantile(0.99, sum(rate(loki_request_duration_seconds_bucket[1m])) by (le, cluster, namespace, job, route))
+                  record: cluster_namespace_job_route:loki_request_duration_seconds:99quantile
+                - expr: histogram_quantile(0.50, sum(rate(loki_request_duration_seconds_bucket[1m])) by (le, cluster, namespace, job, route))
+                  record: cluster_namespace_job_route:loki_request_duration_seconds:50quantile
+                - expr: sum(rate(loki_request_duration_seconds_sum[1m])) by (cluster, namespace, job, route) / sum(rate(loki_request_duration_seconds_count[1m])) by (cluster, namespace, job, route)
+                  record: cluster_namespace_job_route:loki_request_duration_seconds:avg
+                - expr: sum(rate(loki_request_duration_seconds_bucket[1m])) by (le, cluster, namespace, job, route)
+                  record: cluster_namespace_job_route:loki_request_duration_seconds_bucket:sum_rate
+                - expr: sum(rate(loki_request_duration_seconds_sum[1m])) by (cluster, namespace, job, route)
+                  record: cluster_namespace_job_route:loki_request_duration_seconds_sum:sum_rate
+                - expr: sum(rate(loki_request_duration_seconds_count[1m])) by (cluster, namespace, job, route)
+                  record: cluster_namespace_job_route:loki_request_duration_seconds_count:sum_rate
   - preset: loki
   - preset: grafana
     overrides:
@@ -34,7 +76,46 @@ dependencies:
               secureJsonData:
                 basicAuthPassword: lokipassword
                 httpHeaderValue1: "1"
-
+      dashboardProviders:
+        dashboardproviders.yaml:
+          apiVersion: 1
+          providers:
+            - name: 'default'
+              orgId: 1
+              folder: ''
+              type: file
+              disableDeletion: false
+              editable: true
+              options:
+                path: /var/lib/grafana/dashboards/default
+      dashboards:
+        default:
+          loki-bloom-build:
+            url: http://raw.githubusercontent.com/grafana/loki/refs/heads/main/production/loki-mixin-compiled/dashboards/loki-bloom-build.json
+          loki-bloom-gateway:
+            url: https://raw.githubusercontent.com/grafana/loki/refs/heads/main/production/loki-mixin-compiled/dashboards/loki-bloom-gateway.json
+          loki-chunks:
+            url: https://raw.githubusercontent.com/grafana/loki/refs/heads/main/production/loki-mixin-compiled/dashboards/loki-chunks.json
+          loki-deletion:
+            url: https://raw.githubusercontent.com/grafana/loki/refs/heads/main/production/loki-mixin-compiled/dashboards/loki-deletion.json
+          loki-logs:
+            url: https://raw.githubusercontent.com/grafana/loki/refs/heads/main/production/loki-mixin-compiled/dashboards/loki-logs.json
+          loki-mixin-recording-rules:
+            url: https://raw.githubusercontent.com/grafana/loki/refs/heads/main/production/loki-mixin-compiled/dashboards/loki-mixin-recording-rules.json
+          loki-operational:
+            url: https://raw.githubusercontent.com/grafana/loki/refs/heads/main/production/loki-mixin-compiled/dashboards/loki-operational.json
+          loki-reads:
+            url: https://raw.githubusercontent.com/grafana/loki/refs/heads/main/production/loki-mixin-compiled/dashboards/loki-reads.json
+          loki-reads-resources:
+            url: https://raw.githubusercontent.com/grafana/loki/refs/heads/main/production/loki-mixin-compiled/dashboards/loki-reads-resources.json
+          loki-retention:
+            url: https://raw.githubusercontent.com/grafana/loki/refs/heads/main/production/loki-mixin-compiled/dashboards/loki-retention.json
+          loki-thanos-object-storage:
+            url: https://raw.githubusercontent.com/grafana/loki/refs/heads/main/production/loki-mixin-compiled/dashboards/loki-thanos-object-storage.json
+          loki-writes:
+            url: https://raw.githubusercontent.com/grafana/loki/refs/heads/main/production/loki-mixin-compiled/dashboards/loki-writes.json
+          loki-writes-resources:
+            url: https://raw.githubusercontent.com/grafana/loki/refs/heads/main/production/loki-mixin-compiled/dashboards/loki-writes-resources.json
 tests:
   - type: query-test
     values:


### PR DESCRIPTION
The Grafana, Loki, and Mimir integrations use node as the instance label, but we never set `node`.