### PR TITLE
Update Examples Documentation to Include `v3` in Examples

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -3,4 +3,4 @@
 Examples have been moved into their own chart directories.
 
 *   K8s Monitoring Helm chart v1.x: [v1 chart examples](../charts/k8s-monitoring-v1/docs/examples)
-*   K8s Monitoring Helm chart v2.x: [v2 chart examples](../charts/k8s-monitoring/docs/examples)
+*   K8s Monitoring Helm chart v2.x and v3.x: [v2 and v3 chart examples](../charts/k8s-monitoring/docs/examples)


### PR DESCRIPTION
This PR updates the `README.md` file in the `examples` directory to indicate that `v2.x` examples are also examples for `v3.x`