### PR TITLE
Fix Indentation Issues for Beyla Relabel Component

### DIFF
--- a/charts/k8s-monitoring/charts/feature-auto-instrumentation/templates/_module.alloy.tpl
+++ b/charts/k8s-monitoring/charts/feature-auto-instrumentation/templates/_module.alloy.tpl
@@ -67,21 +67,21 @@ declare "auto_instrumentation" {
     forward_to = [prometheus.relabel.beyla.receiver]
   }
 
-prometheus.relabel "beyla" {
-  max_cache_size = {{ .Values.beyla.maxCacheSize | default .Values.global.maxCacheSize | int }}
+  prometheus.relabel "beyla" {
+    max_cache_size = {{ .Values.beyla.maxCacheSize | default .Values.global.maxCacheSize | int }}
 {{- if $metricAllowList }}
-  rule {
-    source_labels = ["__name__"]
-    regex = "up|scrape_samples_scraped|{{ $metricAllowList | join "|" }}"
-    action = "keep"
-  }
+    rule {
+      source_labels = ["__name__"]
+      regex = "up|scrape_samples_scraped|{{ $metricAllowList | join "|" }}"
+      action = "keep"
+    }
 {{- end }}
 {{- if $metricDenyList }}
-  rule {
-    source_labels = ["__name__"]
-    regex = {{ $metricDenyList | join "|" | quote }}
-    action = "drop"
-  }
+    rule {
+      source_labels = ["__name__"]
+      regex = {{ $metricDenyList | join "|" | quote }}
+      action = "drop"
+    }
 {{- end }}
 {{- if .Values.beyla.extraMetricProcessingRules }}
 {{ .Values.beyla.extraMetricProcessingRules | indent 4 }}


### PR DESCRIPTION
Fix Indentation Issues for Beyla Relabel Component

Currently, the config renders like this in the Config Map;

```
prometheus.relabel "beyla" {
  max_cache_size = 100000
    // Custom Rule to add a "source_component" Label, with a Static Value of "beyla_application_metrics".
    rule {
      source_labels = ["job"]
      regex         = "auto_instrumentation.+"
      target_label  = "source_component"
      replacement   = "beyla_application_metrics"
    }
    forward_to = argument.metrics_destinations.value
  }
}
```

Which causes Alloy Validation errors of `component evaluation failed: decoding configuration: /etc/alloy/config.alloy:1324:5: unrecognized block name "rule"`

This should now correctly indent the Configuration to prevent that error.