### PR TITLE
Correct some Span Logs Component Argument Names

### DIFF
--- a/charts/k8s-monitoring/charts/feature-application-observability/templates/_connector_span_logs.tpl
+++ b/charts/k8s-monitoring/charts/feature-application-observability/templates/_connector_span_logs.tpl
@@ -7,13 +7,13 @@ otelcol.connector.spanlogs "{{ .name | default "default" }}" {
   spans = true
 {{- end }}
 {{- if .Values.connectors.spanLogs.spansAttributes }}
-  spans_attributes = {{ .Values.connectors.spanLogs.spansAttributes | toJson }}
+  span_attributes = {{ .Values.connectors.spanLogs.spansAttributes | toJson }}
 {{- end }}
 {{- if .Values.connectors.spanLogs.roots }}
   roots = true
 {{- end }}
 {{- if .Values.connectors.spanLogs.process }}
-  process = true
+  processes = true
 {{- end }}
 {{- if .Values.connectors.spanLogs.processAttributes }}
   process_attributes = {{ .Values.connectors.spanLogs.processAttributes | toJson }}


### PR DESCRIPTION
Some of the Argument Names are incorrect which caused them not to get set correctly, this addresses that.

Argument Names taken from: https://grafana.com/docs/alloy/latest/reference/components/otelcol/otelcol.connector.spanlogs/#arguments

Testing with below HELM Values, results in the correct config;

```yaml
  connectors:
    spanLogs:
      enabled: true
      spans: false
      spansAttributes: ["http.method", "http.status_code", "http.target"]
      roots: true
      process: true
      processAttributes: ["service.name", "service.namespace"]
      labels: ["service.name", "service.namespace"]
      overrides:
        service_key: "service.name"
        trace_id_key: "traceID"
```
Alloy Config;

```hcl
  // Span Logs Connector
  otelcol.connector.spanlogs "default" {
    span_attributes = ["http.method","http.status_code","http.target"]
    roots = true
    processes = true
    process_attributes = ["service.name","service.namespace"]
    labels = ["service.name","service.namespace"]
    overrides {
        service_key = "service.name"
        trace_id_key = "traceID"
    }

    output {
      logs = [otelcol.processor.batch.default.input]
    }
  }
```

Alloy Debug UI;

<img width="746" height="854" alt="image" src="https://github.com/user-attachments/assets/22f1f4f9-d1e7-4784-8540-aa6cb976ca38" />
