### PR TITLE
Add support for write-ahead-log (wal) setting for loki destination

### DIFF
--- a/charts/k8s-monitoring/destinations/loki-values.yaml
+++ b/charts/k8s-monitoring/destinations/loki-values.yaml
@@ -93,6 +93,24 @@ batchSize: ""
 # @section -- General
 batchWait: ""
 
+# Write-Ahead Log (WAL) settings. Only applies when protocol is "remote_write"
+writeAheadLog:
+  # -- Whether to enable the WAL.
+  # @section -- Write-Ahead Log
+  enabled: false
+  # -- Maximum time the WAL drain procedure can take, before being forcefully stopped.
+  # @section -- Write-Ahead Log
+  drainTimeout: 30s
+  # -- Minimum backoff time in the backup read mechanism.
+  # @section -- Write-Ahead Log
+  minReadFrequency: 250ms
+  # -- Maximum backoff time in the backup read mechanism.
+  # @section -- Write-Ahead Log
+  maxReadFrequency: 1s
+  # -- Maximum time a WAL segment should be allowed to live. Segments older than this setting are eventually deleted.
+  # @section -- Write-Ahead Log
+  maxSegmentAge: 1h
+
 auth:
   # -- The type of authentication to do.
   # Options are "none" (default), "basic", "bearerToken", "oauth2".

--- a/charts/k8s-monitoring/docs/destinations/loki.md
+++ b/charts/k8s-monitoring/docs/destinations/loki.md
@@ -101,6 +101,16 @@ This defines the options for defining a destination for logs that use the Loki p
 | tls.key | string | `""` | The client key for the server (as a string). |
 | tls.keyFile | string | `""` | The client key for the server (as a path to a file). |
 | tls.keyFrom | string | `""` | Raw config for accessing the client key. |
+
+### Write-Ahead Log
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| writeAheadLog.drainTimeout | string | `"30s"` | Maximum time the WAL drain procedure can take, before being forcefully stopped. |
+| writeAheadLog.enabled | bool | `false` | Whether to enable the WAL. |
+| writeAheadLog.maxReadFrequency | string | `"1s"` | Maximum backoff time in the backup read mechanism. |
+| writeAheadLog.maxSegmentAge | string | `"1h"` | Maximum time a WAL segment should be allowed to live. Segments older than this setting are eventually deleted. |
+| writeAheadLog.minReadFrequency | string | `"250ms"` | Minimum backoff time in the backup read mechanism. |
 <!-- textlint-enable terminology -->
 
 ## Examples

--- a/charts/k8s-monitoring/schema-mods/definitions/loki-destination.schema.json
+++ b/charts/k8s-monitoring/schema-mods/definitions/loki-destination.schema.json
@@ -210,6 +210,26 @@
         },
         "urlFrom": {
             "type": "string"
+        },
+        "writeAheadLog": {
+            "type": "object",
+            "properties": {
+                "drainTimeout": {
+                    "type": "string"
+                },
+                "enabled": {
+                    "type": "boolean"
+                },
+                "maxReadFrequency": {
+                    "type": "string"
+                },
+                "maxSegmentAge": {
+                    "type": "string"
+                },
+                "minReadFrequency": {
+                    "type": "string"
+                }
+            }
         }
     }
 }

--- a/charts/k8s-monitoring/templates/destinations/_destination_loki.tpl
+++ b/charts/k8s-monitoring/templates/destinations/_destination_loki.tpl
@@ -13,10 +13,10 @@ loki.process {{ include "helper.alloy_name" .name | quote }} {
 
 loki.write {{ include "helper.alloy_name" .name | quote }} {
   endpoint {
-{{- if .urlFrom }} 
+{{- if .urlFrom }}
     url = {{ .urlFrom }}
 {{- else }}
-    url = {{ .url | quote }} 
+    url = {{ .url | quote }}
 {{- end }}
 {{- if .timeout }}
     remote_timeout = {{ .timeout | quote }}
@@ -146,6 +146,23 @@ loki.write {{ include "helper.alloy_name" .name | quote }} {
   {{- end }}
 {{- end }}
   }
+{{- if .writeAheadLog.enabled }}
+  wal {
+    enabled = true
+{{- if .writeAheadLog.minReadFrequency }}
+    min_read_frequency = {{ .writeAheadLog.minReadFrequency | quote }}
+{{- end }}
+{{- if .writeAheadLog.maxReadFrequency }}
+    max_read_frequency = {{ .writeAheadLog.maxReadFrequency | quote }}
+{{- end }}
+{{- if .writeAheadLog.drainTimeout }}
+    drain_timeout = {{ .writeAheadLog.drainTimeout | quote }}
+{{- end }}
+{{- if .writeAheadLog.maxSegmentAge }}
+    max_segment_age = {{ .writeAheadLog.maxSegmentAge | quote }}
+{{- end }}
+  }
+{{- end }}
 }
 {{- end }}
 {{- end }}

--- a/charts/k8s-monitoring/values.schema.json
+++ b/charts/k8s-monitoring/values.schema.json
@@ -953,6 +953,26 @@
                 "urlFrom": {
                     "type": "string"
                 },
+                "writeAheadLog": {
+                    "type": "object",
+                    "properties": {
+                        "drainTimeout": {
+                            "type": "string"
+                        },
+                        "enabled": {
+                            "type": "boolean"
+                        },
+                        "maxReadFrequency": {
+                            "type": "string"
+                        },
+                        "maxSegmentAge": {
+                            "type": "string"
+                        },
+                        "minReadFrequency": {
+                            "type": "string"
+                        }
+                    }
+                },
                 "type": {
                     "type": "string",
                     "const": "loki"


### PR DESCRIPTION
In our workflow we want to enable the wal (write-ahead-log) in loki.wrote component. 
With this small improvement you can enable it in the loki destination by proposed values changes.

```yaml
writeAheadLog:
  enabled: false
  drainTimeout: 30s
  minReadFrequency: 250ms
  maxReadFrequency: 1s
  maxSegmentAge: 1h
``` 