### PR TITLE
feat: Pyroscope enrich configuration on profiles receiver

### DIFF
--- a/charts/k8s-monitoring/charts/feature-profiles-receiver/templates/_helpers.tpl
+++ b/charts/k8s-monitoring/charts/feature-profiles-receiver/templates/_helpers.tpl
@@ -1,0 +1,11 @@
+{{- define "feature.profilesReceiver.escape_label" -}}
+{{ . | replace "-" "_" | replace "." "_" | replace "/" "_" }}
+{{- end }}
+
+{{- define "feature.profilesReceiver.pod_annotation" -}}
+{{ printf "__meta_kubernetes_pod_annotation_%s" (include "feature.profilesReceiver.escape_label" .) }}
+{{- end }}
+
+{{- define "feature.profilesReceiver.pod_label" -}}
+{{ printf "__meta_kubernetes_pod_label_%s" (include "feature.profilesReceiver.escape_label" .) }}
+{{- end }}

--- a/charts/k8s-monitoring/charts/feature-profiles-receiver/templates/_module.alloy.tpl
+++ b/charts/k8s-monitoring/charts/feature-profiles-receiver/templates/_module.alloy.tpl
@@ -3,20 +3,173 @@ declare "profiles_receiver" {
   argument "profiles_destinations" {
     comment = "Must be a list of profile destinations where collected profiles should be forwarded to"
   }
+{{- if .Values.enrich.enabled }}
+{{- $labelSelectors := list }}
+{{- range $k, $v := .Values.enrich.kubernetes.labelSelectors }}
+  {{- if kindIs "slice" $v }}
+    {{- $labelSelectors = append $labelSelectors (printf "%s in (%s)" $k (join "," $v)) }}
+  {{- else }}
+    {{- $labelSelectors = append $labelSelectors (printf "%s=%s" $k $v) }}
+  {{- end }}
+{{- end }}
+
+  // Profiles: Kubernetes pod discovery for enrichment
+  discovery.kubernetes "kubernetes_pods" {
+    role = "pod"
+{{- if $labelSelectors }}
+    selectors {
+      role = "pod"
+      label = {{ $labelSelectors | join "," | quote }}
+    }
+{{- end }}
+{{- if .Values.enrich.kubernetes.namespaces }}
+    namespaces {
+      names = {{ .Values.enrich.kubernetes.namespaces | toJson }}
+    }
+{{- end }}
+  }
+
+  discovery.relabel "kubernetes_pods" {
+    targets = discovery.kubernetes.kubernetes_pods.targets
+    rule {
+      source_labels = ["__meta_kubernetes_pod_phase"]
+      regex = "Succeeded|Failed|Completed"
+      action = "drop"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_namespace"]
+      target_label = "namespace"
+    }
+{{- if .Values.enrich.kubernetes.excludeNamespaces }}
+    rule {
+      source_labels = ["namespace"]
+      regex = "{{ .Values.enrich.kubernetes.excludeNamespaces | join "|" }}"
+      action = "drop"
+    }
+{{- end }}
+{{- range $k, $v := .Values.enrich.kubernetes.annotationSelectors }}
+    rule {
+      source_labels = [{{ include "feature.profilesReceiver.pod_annotation" $k | quote }}]
+    {{- if kindIs "slice" $v }}
+      regex = {{ $v | join "|" | quote }}
+    {{- else }}
+      regex = {{ $v | quote }}
+    {{- end }}
+      action = "keep"
+    }
+{{- end }}
+    rule {
+      source_labels = ["__meta_kubernetes_pod_name"]
+      target_label = "pod"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_pod_node_name"]
+      target_label = "node"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_pod_container_name"]
+      target_label = "container"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_pod_ip"]
+      target_label = "pod_ip"
+    }
+
+    // Set service_name by choosing the first value found from the following ordered list:
+    // - pod.annotation[resource.opentelemetry.io/service.name]
+    // - pod.label[app.kubernetes.io/instance]
+    // - pod.label[app.kubernetes.io/name]
+    // - k8s.container.name
+    rule {
+      action = "replace"
+      source_labels = [
+        {{ include "feature.profilesReceiver.pod_annotation" "resource.opentelemetry.io/service.name" | quote }},
+        {{ include "feature.profilesReceiver.pod_label" "app.kubernetes.io/instance" | quote }},
+        {{ include "feature.profilesReceiver.pod_label" "app.kubernetes.io/name" | quote }},
+        "container",
+      ]
+      separator = ";"
+      regex = "^(?:;*)?([^;]+).*$"
+      replacement = "$1"
+      target_label = "service_name"
+    }
+
+    // Set service_namespace by choosing the first value found from the following ordered list:
+    // - pod.annotation[resource.opentelemetry.io/service.namespace]
+    // - pod.namespace
+    rule {
+      action = "replace"
+      source_labels = [
+        {{ include "feature.profilesReceiver.pod_annotation" "resource.opentelemetry.io/service.namespace" | quote }},
+        "namespace",
+      ]
+      separator = ";"
+      regex = "^(?:;*)?([^;]+).*$"
+      replacement = "$1"
+      target_label = "service_namespace"
+    }
+
+    // Set service_instance_id by choosing the first value found from the following ordered list:
+    // - pod.annotation[resource.opentelemetry.io/service.instance.id]
+    // - concat([k8s.namespace.name, k8s.pod.name, k8s.container.name], '.')
+    rule {
+      source_labels = [{{ include "feature.profilesReceiver.pod_annotation" "resource.opentelemetry.io/service.instance.id" | quote }}]
+      target_label = "service_instance_id"
+    }
+    rule {
+      source_labels = ["service_instance_id", "namespace", "pod", "container"]
+      separator = "."
+      regex = "^\\.([^.]+\\.[^.]+\\.[^.]+)$"
+      target_label = "service_instance_id"
+    }
+
+    rule {
+      replacement = "alloy/pyroscope.receive_http"
+      target_label = "source"
+    }
+{{- if .Values.enrich.kubernetes.extraDiscoveryRules }}
+{{ .Values.enrich.kubernetes.extraDiscoveryRules | indent 4 }}
+{{- end }}
+  }
+{{- end }}
 
   pyroscope.receive_http "default" {
     http {
       listen_address = "0.0.0.0"
       listen_port = {{ .Values.port | quote }}
     }
-{{ if .Values.profileProcessingRules }}
+{{- if .Values.enrich.enabled }}
+    forward_to = [pyroscope.enrich.metadata.receiver]
+{{- else if .Values.profileProcessingRules }}
     forward_to = [pyroscope.relabel.default.receiver]
+{{- else }}
+    forward_to = argument.profiles_destinations.value
+{{- end }}
   }
+{{- if .Values.enrich.enabled }}
+
+  pyroscope.enrich "metadata" {
+    targets = discovery.relabel.kubernetes_pods.output
+    target_match_label = {{ .Values.enrich.targetMatchLabel | quote }}
+{{- if .Values.enrich.profilesMatchLabel }}
+    profiles_match_label = {{ .Values.enrich.profilesMatchLabel | quote }}
+{{- end }}
+{{- if .Values.enrich.labelsToCopy }}
+    labels_to_copy = {{ .Values.enrich.labelsToCopy | toJson }}
+{{- end }}
+{{- if .Values.profileProcessingRules }}
+    forward_to = [pyroscope.relabel.default.receiver]
+{{- else }}
+    forward_to = argument.profiles_destinations.value
+{{- end }}
+  }
+{{- end }}
+{{- if .Values.profileProcessingRules }}
 
   pyroscope.relabel "default" {
 {{ .Values.profileProcessingRules | indent 4 }}
-{{- end }}
     forward_to = argument.profiles_destinations.value
   }
+{{- end }}
 }
 {{- end }}

--- a/charts/k8s-monitoring/charts/feature-profiles-receiver/tests/__snapshot__/enrich_test.yaml.snap
+++ b/charts/k8s-monitoring/charts/feature-profiles-receiver/tests/__snapshot__/enrich_test.yaml.snap
@@ -1,0 +1,694 @@
+should render enrichment combined with profile processing rules:
+  1: |
+    |-
+      declare "profiles_receiver" {
+        argument "profiles_destinations" {
+          comment = "Must be a list of profile destinations where collected profiles should be forwarded to"
+        }
+
+        // Profiles: Kubernetes pod discovery for enrichment
+        discovery.kubernetes "pods" {
+          role = "pod"
+        }
+
+        discovery.relabel "pods" {
+          targets = discovery.kubernetes.pods.targets
+          rule {
+            source_labels = ["__meta_kubernetes_pod_phase"]
+            regex = "Succeeded|Failed|Completed"
+            action = "drop"
+          }
+          rule {
+            source_labels = ["__meta_kubernetes_namespace"]
+            target_label = "namespace"
+          }
+          rule {
+            source_labels = ["__meta_kubernetes_pod_name"]
+            target_label = "pod"
+          }
+          rule {
+            source_labels = ["__meta_kubernetes_pod_node_name"]
+            target_label = "node"
+          }
+          rule {
+            source_labels = ["__meta_kubernetes_pod_container_name"]
+            target_label = "container"
+          }
+          rule {
+            source_labels = ["__meta_kubernetes_pod_ip"]
+            target_label = "pod_ip"
+          }
+
+          // Set service_name by choosing the first value found from the following ordered list:
+          // - pod.annotation[resource.opentelemetry.io/service.name]
+          // - pod.label[app.kubernetes.io/instance]
+          // - pod.label[app.kubernetes.io/name]
+          // - k8s.container.name
+          rule {
+            action = "replace"
+            source_labels = [
+              "__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_name",
+              "__meta_kubernetes_pod_label_app_kubernetes_io_instance",
+              "__meta_kubernetes_pod_label_app_kubernetes_io_name",
+              "container",
+            ]
+            separator = ";"
+            regex = "^(?:;*)?([^;]+).*$"
+            replacement = "$1"
+            target_label = "service_name"
+          }
+
+          // Set service_namespace by choosing the first value found from the following ordered list:
+          // - pod.annotation[resource.opentelemetry.io/service.namespace]
+          // - pod.namespace
+          rule {
+            action = "replace"
+            source_labels = [
+              "__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_namespace",
+              "namespace",
+            ]
+            separator = ";"
+            regex = "^(?:;*)?([^;]+).*$"
+            replacement = "$1"
+            target_label = "service_namespace"
+          }
+
+          // Set service_instance_id by choosing the first value found from the following ordered list:
+          // - pod.annotation[resource.opentelemetry.io/service.instance.id]
+          // - concat([k8s.namespace.name, k8s.pod.name, k8s.container.name], '.')
+          rule {
+            source_labels = ["__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_instance_id"]
+            target_label = "service_instance_id"
+          }
+          rule {
+            source_labels = ["service_instance_id", "namespace", "pod", "container"]
+            separator = "."
+            regex = "^\\.([^.]+\\.[^.]+\\.[^.]+)$"
+            target_label = "service_instance_id"
+          }
+
+          rule {
+            replacement = "alloy/pyroscope.receive_http"
+            target_label = "source"
+          }
+        }
+
+        pyroscope.receive_http "default" {
+          http {
+            listen_address = "0.0.0.0"
+            listen_port = "4040"
+          }
+          forward_to = [pyroscope.enrich.metadata.receiver]
+        }
+
+        pyroscope.enrich "metadata" {
+          targets = discovery.relabel.pods.output
+          target_match_label = "service_name"
+          forward_to = [pyroscope.relabel.default.receiver]
+        }
+
+        pyroscope.relabel "default" {
+          rule {
+            source_labels = ["env"]
+            target_label = "__tmp_hash"
+            action = "hashmod"
+            modulus = 2
+          }
+          rule {
+            source_labels = ["__tmp_hash"]
+            action       = "drop"
+            regex        = "^1$"
+          }
+
+          forward_to = argument.profiles_destinations.value
+        }
+      }
+should render enrichment with custom match labels:
+  1: |
+    |-
+      declare "profiles_receiver" {
+        argument "profiles_destinations" {
+          comment = "Must be a list of profile destinations where collected profiles should be forwarded to"
+        }
+
+        // Profiles: Kubernetes pod discovery for enrichment
+        discovery.kubernetes "pods" {
+          role = "pod"
+        }
+
+        discovery.relabel "pods" {
+          targets = discovery.kubernetes.pods.targets
+          rule {
+            source_labels = ["__meta_kubernetes_pod_phase"]
+            regex = "Succeeded|Failed|Completed"
+            action = "drop"
+          }
+          rule {
+            source_labels = ["__meta_kubernetes_namespace"]
+            target_label = "namespace"
+          }
+          rule {
+            source_labels = ["__meta_kubernetes_pod_name"]
+            target_label = "pod"
+          }
+          rule {
+            source_labels = ["__meta_kubernetes_pod_node_name"]
+            target_label = "node"
+          }
+          rule {
+            source_labels = ["__meta_kubernetes_pod_container_name"]
+            target_label = "container"
+          }
+          rule {
+            source_labels = ["__meta_kubernetes_pod_ip"]
+            target_label = "pod_ip"
+          }
+
+          // Set service_name by choosing the first value found from the following ordered list:
+          // - pod.annotation[resource.opentelemetry.io/service.name]
+          // - pod.label[app.kubernetes.io/instance]
+          // - pod.label[app.kubernetes.io/name]
+          // - k8s.container.name
+          rule {
+            action = "replace"
+            source_labels = [
+              "__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_name",
+              "__meta_kubernetes_pod_label_app_kubernetes_io_instance",
+              "__meta_kubernetes_pod_label_app_kubernetes_io_name",
+              "container",
+            ]
+            separator = ";"
+            regex = "^(?:;*)?([^;]+).*$"
+            replacement = "$1"
+            target_label = "service_name"
+          }
+
+          // Set service_namespace by choosing the first value found from the following ordered list:
+          // - pod.annotation[resource.opentelemetry.io/service.namespace]
+          // - pod.namespace
+          rule {
+            action = "replace"
+            source_labels = [
+              "__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_namespace",
+              "namespace",
+            ]
+            separator = ";"
+            regex = "^(?:;*)?([^;]+).*$"
+            replacement = "$1"
+            target_label = "service_namespace"
+          }
+
+          // Set service_instance_id by choosing the first value found from the following ordered list:
+          // - pod.annotation[resource.opentelemetry.io/service.instance.id]
+          // - concat([k8s.namespace.name, k8s.pod.name, k8s.container.name], '.')
+          rule {
+            source_labels = ["__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_instance_id"]
+            target_label = "service_instance_id"
+          }
+          rule {
+            source_labels = ["service_instance_id", "namespace", "pod", "container"]
+            separator = "."
+            regex = "^\\.([^.]+\\.[^.]+\\.[^.]+)$"
+            target_label = "service_instance_id"
+          }
+
+          rule {
+            replacement = "alloy/pyroscope.receive_http"
+            target_label = "source"
+          }
+        }
+
+        pyroscope.receive_http "default" {
+          http {
+            listen_address = "0.0.0.0"
+            listen_port = "4040"
+          }
+          forward_to = [pyroscope.enrich.metadata.receiver]
+        }
+
+        pyroscope.enrich "metadata" {
+          targets = discovery.relabel.pods.output
+          target_match_label = "pod_ip"
+          profiles_match_label = "service_name"
+          labels_to_copy = ["namespace","pod","node"]
+          forward_to = argument.profiles_destinations.value
+        }
+      }
+should render enrichment with default settings:
+  1: |
+    |-
+      declare "profiles_receiver" {
+        argument "profiles_destinations" {
+          comment = "Must be a list of profile destinations where collected profiles should be forwarded to"
+        }
+
+        // Profiles: Kubernetes pod discovery for enrichment
+        discovery.kubernetes "pods" {
+          role = "pod"
+        }
+
+        discovery.relabel "pods" {
+          targets = discovery.kubernetes.pods.targets
+          rule {
+            source_labels = ["__meta_kubernetes_pod_phase"]
+            regex = "Succeeded|Failed|Completed"
+            action = "drop"
+          }
+          rule {
+            source_labels = ["__meta_kubernetes_namespace"]
+            target_label = "namespace"
+          }
+          rule {
+            source_labels = ["__meta_kubernetes_pod_name"]
+            target_label = "pod"
+          }
+          rule {
+            source_labels = ["__meta_kubernetes_pod_node_name"]
+            target_label = "node"
+          }
+          rule {
+            source_labels = ["__meta_kubernetes_pod_container_name"]
+            target_label = "container"
+          }
+          rule {
+            source_labels = ["__meta_kubernetes_pod_ip"]
+            target_label = "pod_ip"
+          }
+
+          // Set service_name by choosing the first value found from the following ordered list:
+          // - pod.annotation[resource.opentelemetry.io/service.name]
+          // - pod.label[app.kubernetes.io/instance]
+          // - pod.label[app.kubernetes.io/name]
+          // - k8s.container.name
+          rule {
+            action = "replace"
+            source_labels = [
+              "__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_name",
+              "__meta_kubernetes_pod_label_app_kubernetes_io_instance",
+              "__meta_kubernetes_pod_label_app_kubernetes_io_name",
+              "container",
+            ]
+            separator = ";"
+            regex = "^(?:;*)?([^;]+).*$"
+            replacement = "$1"
+            target_label = "service_name"
+          }
+
+          // Set service_namespace by choosing the first value found from the following ordered list:
+          // - pod.annotation[resource.opentelemetry.io/service.namespace]
+          // - pod.namespace
+          rule {
+            action = "replace"
+            source_labels = [
+              "__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_namespace",
+              "namespace",
+            ]
+            separator = ";"
+            regex = "^(?:;*)?([^;]+).*$"
+            replacement = "$1"
+            target_label = "service_namespace"
+          }
+
+          // Set service_instance_id by choosing the first value found from the following ordered list:
+          // - pod.annotation[resource.opentelemetry.io/service.instance.id]
+          // - concat([k8s.namespace.name, k8s.pod.name, k8s.container.name], '.')
+          rule {
+            source_labels = ["__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_instance_id"]
+            target_label = "service_instance_id"
+          }
+          rule {
+            source_labels = ["service_instance_id", "namespace", "pod", "container"]
+            separator = "."
+            regex = "^\\.([^.]+\\.[^.]+\\.[^.]+)$"
+            target_label = "service_instance_id"
+          }
+
+          rule {
+            replacement = "alloy/pyroscope.receive_http"
+            target_label = "source"
+          }
+        }
+
+        pyroscope.receive_http "default" {
+          http {
+            listen_address = "0.0.0.0"
+            listen_port = "4040"
+          }
+          forward_to = [pyroscope.enrich.metadata.receiver]
+        }
+
+        pyroscope.enrich "metadata" {
+          targets = discovery.relabel.pods.output
+          target_match_label = "service_name"
+          forward_to = argument.profiles_destinations.value
+        }
+      }
+should render enrichment with extra discovery rules:
+  1: |
+    |-
+      declare "profiles_receiver" {
+        argument "profiles_destinations" {
+          comment = "Must be a list of profile destinations where collected profiles should be forwarded to"
+        }
+
+        // Profiles: Kubernetes pod discovery for enrichment
+        discovery.kubernetes "pods" {
+          role = "pod"
+        }
+
+        discovery.relabel "pods" {
+          targets = discovery.kubernetes.pods.targets
+          rule {
+            source_labels = ["__meta_kubernetes_pod_phase"]
+            regex = "Succeeded|Failed|Completed"
+            action = "drop"
+          }
+          rule {
+            source_labels = ["__meta_kubernetes_namespace"]
+            target_label = "namespace"
+          }
+          rule {
+            source_labels = ["__meta_kubernetes_pod_name"]
+            target_label = "pod"
+          }
+          rule {
+            source_labels = ["__meta_kubernetes_pod_node_name"]
+            target_label = "node"
+          }
+          rule {
+            source_labels = ["__meta_kubernetes_pod_container_name"]
+            target_label = "container"
+          }
+          rule {
+            source_labels = ["__meta_kubernetes_pod_ip"]
+            target_label = "pod_ip"
+          }
+
+          // Set service_name by choosing the first value found from the following ordered list:
+          // - pod.annotation[resource.opentelemetry.io/service.name]
+          // - pod.label[app.kubernetes.io/instance]
+          // - pod.label[app.kubernetes.io/name]
+          // - k8s.container.name
+          rule {
+            action = "replace"
+            source_labels = [
+              "__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_name",
+              "__meta_kubernetes_pod_label_app_kubernetes_io_instance",
+              "__meta_kubernetes_pod_label_app_kubernetes_io_name",
+              "container",
+            ]
+            separator = ";"
+            regex = "^(?:;*)?([^;]+).*$"
+            replacement = "$1"
+            target_label = "service_name"
+          }
+
+          // Set service_namespace by choosing the first value found from the following ordered list:
+          // - pod.annotation[resource.opentelemetry.io/service.namespace]
+          // - pod.namespace
+          rule {
+            action = "replace"
+            source_labels = [
+              "__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_namespace",
+              "namespace",
+            ]
+            separator = ";"
+            regex = "^(?:;*)?([^;]+).*$"
+            replacement = "$1"
+            target_label = "service_namespace"
+          }
+
+          // Set service_instance_id by choosing the first value found from the following ordered list:
+          // - pod.annotation[resource.opentelemetry.io/service.instance.id]
+          // - concat([k8s.namespace.name, k8s.pod.name, k8s.container.name], '.')
+          rule {
+            source_labels = ["__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_instance_id"]
+            target_label = "service_instance_id"
+          }
+          rule {
+            source_labels = ["service_instance_id", "namespace", "pod", "container"]
+            separator = "."
+            regex = "^\\.([^.]+\\.[^.]+\\.[^.]+)$"
+            target_label = "service_instance_id"
+          }
+
+          rule {
+            replacement = "alloy/pyroscope.receive_http"
+            target_label = "source"
+          }
+          rule {
+            source_labels = ["__meta_kubernetes_pod_label_team"]
+            target_label = "team"
+          }
+
+        }
+
+        pyroscope.receive_http "default" {
+          http {
+            listen_address = "0.0.0.0"
+            listen_port = "4040"
+          }
+          forward_to = [pyroscope.enrich.metadata.receiver]
+        }
+
+        pyroscope.enrich "metadata" {
+          targets = discovery.relabel.pods.output
+          target_match_label = "service_name"
+          forward_to = argument.profiles_destinations.value
+        }
+      }
+should render enrichment with label and annotation selectors:
+  1: |
+    |-
+      declare "profiles_receiver" {
+        argument "profiles_destinations" {
+          comment = "Must be a list of profile destinations where collected profiles should be forwarded to"
+        }
+
+        // Profiles: Kubernetes pod discovery for enrichment
+        discovery.kubernetes "pods" {
+          role = "pod"
+          selectors {
+            role = "pod"
+            label = "app.kubernetes.io/name=myapp"
+          }
+        }
+
+        discovery.relabel "pods" {
+          targets = discovery.kubernetes.pods.targets
+          rule {
+            source_labels = ["__meta_kubernetes_pod_phase"]
+            regex = "Succeeded|Failed|Completed"
+            action = "drop"
+          }
+          rule {
+            source_labels = ["__meta_kubernetes_namespace"]
+            target_label = "namespace"
+          }
+          rule {
+            source_labels = ["__meta_kubernetes_pod_annotation_color"]
+            regex = "green"
+            action = "keep"
+          }
+          rule {
+            source_labels = ["__meta_kubernetes_pod_name"]
+            target_label = "pod"
+          }
+          rule {
+            source_labels = ["__meta_kubernetes_pod_node_name"]
+            target_label = "node"
+          }
+          rule {
+            source_labels = ["__meta_kubernetes_pod_container_name"]
+            target_label = "container"
+          }
+          rule {
+            source_labels = ["__meta_kubernetes_pod_ip"]
+            target_label = "pod_ip"
+          }
+
+          // Set service_name by choosing the first value found from the following ordered list:
+          // - pod.annotation[resource.opentelemetry.io/service.name]
+          // - pod.label[app.kubernetes.io/instance]
+          // - pod.label[app.kubernetes.io/name]
+          // - k8s.container.name
+          rule {
+            action = "replace"
+            source_labels = [
+              "__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_name",
+              "__meta_kubernetes_pod_label_app_kubernetes_io_instance",
+              "__meta_kubernetes_pod_label_app_kubernetes_io_name",
+              "container",
+            ]
+            separator = ";"
+            regex = "^(?:;*)?([^;]+).*$"
+            replacement = "$1"
+            target_label = "service_name"
+          }
+
+          // Set service_namespace by choosing the first value found from the following ordered list:
+          // - pod.annotation[resource.opentelemetry.io/service.namespace]
+          // - pod.namespace
+          rule {
+            action = "replace"
+            source_labels = [
+              "__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_namespace",
+              "namespace",
+            ]
+            separator = ";"
+            regex = "^(?:;*)?([^;]+).*$"
+            replacement = "$1"
+            target_label = "service_namespace"
+          }
+
+          // Set service_instance_id by choosing the first value found from the following ordered list:
+          // - pod.annotation[resource.opentelemetry.io/service.instance.id]
+          // - concat([k8s.namespace.name, k8s.pod.name, k8s.container.name], '.')
+          rule {
+            source_labels = ["__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_instance_id"]
+            target_label = "service_instance_id"
+          }
+          rule {
+            source_labels = ["service_instance_id", "namespace", "pod", "container"]
+            separator = "."
+            regex = "^\\.([^.]+\\.[^.]+\\.[^.]+)$"
+            target_label = "service_instance_id"
+          }
+
+          rule {
+            replacement = "alloy/pyroscope.receive_http"
+            target_label = "source"
+          }
+        }
+
+        pyroscope.receive_http "default" {
+          http {
+            listen_address = "0.0.0.0"
+            listen_port = "4040"
+          }
+          forward_to = [pyroscope.enrich.metadata.receiver]
+        }
+
+        pyroscope.enrich "metadata" {
+          targets = discovery.relabel.pods.output
+          target_match_label = "service_name"
+          forward_to = argument.profiles_destinations.value
+        }
+      }
+should render enrichment with namespace filtering:
+  1: |
+    |-
+      declare "profiles_receiver" {
+        argument "profiles_destinations" {
+          comment = "Must be a list of profile destinations where collected profiles should be forwarded to"
+        }
+
+        // Profiles: Kubernetes pod discovery for enrichment
+        discovery.kubernetes "pods" {
+          role = "pod"
+          namespaces {
+            names = ["production","staging"]
+          }
+        }
+
+        discovery.relabel "pods" {
+          targets = discovery.kubernetes.pods.targets
+          rule {
+            source_labels = ["__meta_kubernetes_pod_phase"]
+            regex = "Succeeded|Failed|Completed"
+            action = "drop"
+          }
+          rule {
+            source_labels = ["__meta_kubernetes_namespace"]
+            target_label = "namespace"
+          }
+          rule {
+            source_labels = ["namespace"]
+            regex = "kube-system|kube-public"
+            action = "drop"
+          }
+          rule {
+            source_labels = ["__meta_kubernetes_pod_name"]
+            target_label = "pod"
+          }
+          rule {
+            source_labels = ["__meta_kubernetes_pod_node_name"]
+            target_label = "node"
+          }
+          rule {
+            source_labels = ["__meta_kubernetes_pod_container_name"]
+            target_label = "container"
+          }
+          rule {
+            source_labels = ["__meta_kubernetes_pod_ip"]
+            target_label = "pod_ip"
+          }
+
+          // Set service_name by choosing the first value found from the following ordered list:
+          // - pod.annotation[resource.opentelemetry.io/service.name]
+          // - pod.label[app.kubernetes.io/instance]
+          // - pod.label[app.kubernetes.io/name]
+          // - k8s.container.name
+          rule {
+            action = "replace"
+            source_labels = [
+              "__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_name",
+              "__meta_kubernetes_pod_label_app_kubernetes_io_instance",
+              "__meta_kubernetes_pod_label_app_kubernetes_io_name",
+              "container",
+            ]
+            separator = ";"
+            regex = "^(?:;*)?([^;]+).*$"
+            replacement = "$1"
+            target_label = "service_name"
+          }
+
+          // Set service_namespace by choosing the first value found from the following ordered list:
+          // - pod.annotation[resource.opentelemetry.io/service.namespace]
+          // - pod.namespace
+          rule {
+            action = "replace"
+            source_labels = [
+              "__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_namespace",
+              "namespace",
+            ]
+            separator = ";"
+            regex = "^(?:;*)?([^;]+).*$"
+            replacement = "$1"
+            target_label = "service_namespace"
+          }
+
+          // Set service_instance_id by choosing the first value found from the following ordered list:
+          // - pod.annotation[resource.opentelemetry.io/service.instance.id]
+          // - concat([k8s.namespace.name, k8s.pod.name, k8s.container.name], '.')
+          rule {
+            source_labels = ["__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_instance_id"]
+            target_label = "service_instance_id"
+          }
+          rule {
+            source_labels = ["service_instance_id", "namespace", "pod", "container"]
+            separator = "."
+            regex = "^\\.([^.]+\\.[^.]+\\.[^.]+)$"
+            target_label = "service_instance_id"
+          }
+
+          rule {
+            replacement = "alloy/pyroscope.receive_http"
+            target_label = "source"
+          }
+        }
+
+        pyroscope.receive_http "default" {
+          http {
+            listen_address = "0.0.0.0"
+            listen_port = "4040"
+          }
+          forward_to = [pyroscope.enrich.metadata.receiver]
+        }
+
+        pyroscope.enrich "metadata" {
+          targets = discovery.relabel.pods.output
+          target_match_label = "service_name"
+          forward_to = argument.profiles_destinations.value
+        }
+      }

--- a/charts/k8s-monitoring/charts/feature-profiles-receiver/tests/enrich_test.yaml
+++ b/charts/k8s-monitoring/charts/feature-profiles-receiver/tests/enrich_test.yaml
@@ -1,0 +1,106 @@
+# yamllint disable rule:document-start rule:line-length rule:trailing-spaces
+suite: Test enrichment configuration
+templates:
+  - configmap.yaml
+tests:
+  - it: should render enrichment with default settings
+    set:
+      deployAsConfigMap: true
+      enrich:
+        enabled: true
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - matchSnapshot:
+          path: data["module.alloy"]
+
+  - it: should render enrichment with custom match labels
+    set:
+      deployAsConfigMap: true
+      enrich:
+        enabled: true
+        targetMatchLabel: "pod_ip"
+        profilesMatchLabel: "service_name"
+        labelsToCopy:
+          - namespace
+          - pod
+          - node
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - matchSnapshot:
+          path: data["module.alloy"]
+
+  - it: should render enrichment with namespace filtering
+    set:
+      deployAsConfigMap: true
+      enrich:
+        enabled: true
+        kubernetes:
+          namespaces:
+            - production
+            - staging
+          excludeNamespaces:
+            - kube-system
+            - kube-public
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - matchSnapshot:
+          path: data["module.alloy"]
+
+  - it: should render enrichment with label and annotation selectors
+    set:
+      deployAsConfigMap: true
+      enrich:
+        enabled: true
+        kubernetes:
+          labelSelectors:
+            app.kubernetes.io/name: myapp
+          annotationSelectors:
+            color: green
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - matchSnapshot:
+          path: data["module.alloy"]
+
+  - it: should render enrichment with extra discovery rules
+    set:
+      deployAsConfigMap: true
+      enrich:
+        enabled: true
+        kubernetes:
+          extraDiscoveryRules: |
+            rule {
+              source_labels = ["__meta_kubernetes_pod_label_team"]
+              target_label = "team"
+            }
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - matchSnapshot:
+          path: data["module.alloy"]
+
+  - it: should render enrichment combined with profile processing rules
+    set:
+      deployAsConfigMap: true
+      enrich:
+        enabled: true
+      profileProcessingRules: |
+        rule {
+          source_labels = ["env"]
+          target_label = "__tmp_hash"
+          action = "hashmod"
+          modulus = 2
+        }
+        rule {
+          source_labels = ["__tmp_hash"]
+          action       = "drop"
+          regex        = "^1$"
+        }
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - matchSnapshot:
+          path: data["module.alloy"]

--- a/charts/k8s-monitoring/charts/feature-profiles-receiver/values.schema.json
+++ b/charts/k8s-monitoring/charts/feature-profiles-receiver/values.schema.json
@@ -5,6 +5,52 @@
         "port": {
             "type": "integer"
         },
+        "enrich": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean"
+                },
+                "targetMatchLabel": {
+                    "type": "string"
+                },
+                "profilesMatchLabel": {
+                    "type": "string"
+                },
+                "labelsToCopy": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "kubernetes": {
+                    "type": "object",
+                    "properties": {
+                        "namespaces": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "excludeNamespaces": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "labelSelectors": {
+                            "type": "object"
+                        },
+                        "annotationSelectors": {
+                            "type": "object"
+                        },
+                        "extraDiscoveryRules": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
         "profileProcessingRules": {
             "type": "string"
         }

--- a/charts/k8s-monitoring/charts/feature-profiles-receiver/values.yaml
+++ b/charts/k8s-monitoring/charts/feature-profiles-receiver/values.yaml
@@ -4,8 +4,66 @@
 # @section -- Listener Configuration
 port: 4040
 
+# Settings for enriching received profiles with Kubernetes metadata using
+# [pyroscope.enrich](https://grafana.com/docs/alloy/latest/reference/components/pyroscope/pyroscope.enrich/).
+# When enabled, this discovers Kubernetes pods and enriches incoming profiles with metadata
+# labels like namespace, pod, node, container, service_name, service_namespace, and service_instance_id.
+# @section -- Enrichment
+enrich:
+  # -- Enable enrichment of received profiles with Kubernetes metadata.
+  # @section -- Enrichment
+  enabled: false
+
+  # -- The label from discovered targets to match against incoming profiles.
+  # @section -- Enrichment
+  targetMatchLabel: "service_name"
+
+  # -- The label from incoming profiles to match against discovered targets.
+  # If not set, targetMatchLabel is used for both sides.
+  # @section -- Enrichment
+  profilesMatchLabel: ""
+
+  # -- List of labels to copy from discovered targets to profiles.
+  # If empty, all labels from the discovered target are copied.
+  # @section -- Enrichment
+  labelsToCopy: []
+
+  # Settings for the Kubernetes discovery module used to find pods for enrichment.
+  # Uses [discovery.kubernetes](https://grafana.com/docs/alloy/latest/reference/components/discovery/discovery.kubernetes/)
+  # and [discovery.relabel](https://grafana.com/docs/alloy/latest/reference/components/discovery/discovery.relabel/) to
+  # discover and relabel Kubernetes pod targets.
+  # @section -- Enrichment (Kubernetes Discovery)
+  kubernetes:
+    # -- Select pods for enrichment based on their namespaces.
+    # @section -- Enrichment (Kubernetes Discovery)
+    namespaces: []
+
+    # -- Which namespaces to exclude from pod discovery.
+    # @section -- Enrichment (Kubernetes Discovery)
+    excludeNamespaces: []
+
+    # -- Select pods for enrichment based on pod labels.
+    # Example: `app.kubernetes.io/name: myapp` will select pods with the label `app.kubernetes.io/name=myapp`.
+    # Example with multiple values: `app.kubernetes.io/name: [myapp, myapp2]` will select pods with the label
+    # `app.kubernetes.io/name=myapp` or `app.kubernetes.io/name=myapp2`.
+    # @section -- Enrichment (Kubernetes Discovery)
+    labelSelectors: {}
+
+    # -- Select pods for enrichment based on pod annotations.
+    # Example: `color: "green"` will select pods with the annotation `color="green"`.
+    # Example with multiple values: `color: ["blue", "green"]` will select pods with the annotation `color="blue"` or
+    # `color="green"`.
+    # @section -- Enrichment (Kubernetes Discovery)
+    annotationSelectors: {}
+
+    # -- Rule blocks to be added to the discovery.relabel component for enrichment pod discovery.
+    # These relabeling rules are applied to discovered targets before they are used for enrichment.
+    # ([docs](https://grafana.com/docs/alloy/latest/reference/components/discovery/discovery.relabel/#rule-block))
+    # @section -- Enrichment (Kubernetes Discovery)
+    extraDiscoveryRules: ""
+
 # -- Rule blocks to be added to the pyroscope.relabel component for received profiles.
-# These relabeling rules are applied to profiles received by this feature.
+# These relabeling rules are applied post-enrichment to profiles received by this feature.
 # ([docs](https://grafana.com/docs/alloy/latest/reference/components/pyroscope/pyroscope.relabel/#rule))
 # @section -- Profile Processing
 profileProcessingRules: ""


### PR DESCRIPTION
Add support for [pyroscope.enrich](https://grafana.com/docs/alloy/latest/reference/components/pyroscope/pyroscope.enrich/) in profiles-receiver

The relabeling section was based on the [ebpf template](https://github.com/grafana/k8s-monitoring-helm/blob/main/charts/k8s-monitoring/charts/feature-profiling/templates/_ebpf.tpl)