### PR TITLE
feat: enrich pod logs with namespace and pod labels

### DIFF
--- a/charts/k8s-monitoring/destinations/loki-values.yaml
+++ b/charts/k8s-monitoring/destinations/loki-values.yaml
@@ -73,6 +73,19 @@ clusterLabels: [cluster, k8s.cluster.name]
 # @section -- General
 logProcessingStages: ""
 
+logEnrichment:
+  # -- Finds kubernetes namespace labels and adds them as labels to matching logs.
+  # Applies to logs that contain the following labels: `namespace`. Note that this can greatly increase the resource
+  # utilization of Alloy.
+  # @section -- Log Enrichment
+  namespaceLabels: []
+
+  # -- Finds kubernetes pod labels and adds them as labels to matching pod logs.
+  # Applies to logs that contain the following labels: `namespace`, `pod`. Note that this can greatly increase the
+  # resource utilization of Alloy.
+  # @section -- Log Enrichment
+  podLabels: []
+
 # -- The minimum backoff period for the Loki destination.
 # @section -- General
 minBackoffPeriod: 500ms

--- a/charts/k8s-monitoring/docs/destinations/loki.md
+++ b/charts/k8s-monitoring/docs/destinations/loki.md
@@ -78,6 +78,13 @@ This defines the options for defining a destination for logs that use the Loki p
 | url | string | `""` | The URL for the Loki destination. |
 | urlFrom | string | `""` | Raw config for accessing the URL. |
 
+### Log Enrichment
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| logEnrichment.namespaceLabels | list | `[]` | Finds kubernetes namespace labels and adds them as labels to matching logs. Applies to logs that contain the following labels: `namespace`. Note that this can greatly increase the resource utilization of Alloy. |
+| logEnrichment.podLabels | list | `[]` | Finds kubernetes pod labels and adds them as labels to matching pod logs. Applies to logs that contain the following labels: `namespace`, `pod`. Note that this can greatly increase the resource utilization of Alloy. |
+
 ### Secret
 
 | Key | Type | Default | Description |

--- a/charts/k8s-monitoring/schema-mods/definitions/loki-destination.schema.json
+++ b/charts/k8s-monitoring/schema-mods/definitions/loki-destination.schema.json
@@ -111,6 +111,17 @@
         "extraLabelsFrom": {
             "type": "object"
         },
+        "logEnrichment": {
+            "type": "object",
+            "properties": {
+                "namespaceLabels": {
+                    "type": "array"
+                },
+                "podLabels": {
+                    "type": "array"
+                }
+            }
+        },
         "logProcessingStages": {
             "type": "string"
         },

--- a/charts/k8s-monitoring/schema-mods/destination-loki-types-and-enums.json
+++ b/charts/k8s-monitoring/schema-mods/destination-loki-types-and-enums.json
@@ -1,0 +1,14 @@
+{
+  "definitions": {
+    "loki-destination": {"properties": {
+      "logEnrichment": {"properties": {
+        "namespaceLabels": {
+          "items": {"type": "string"}
+        },
+        "podLabels": {
+          "items": {"type": "string"}
+        }
+      }}
+    }}
+  }
+}

--- a/charts/k8s-monitoring/tests/__snapshot__/destination_loki_test.yaml.snap
+++ b/charts/k8s-monitoring/tests/__snapshot__/destination_loki_test.yaml.snap
@@ -1,0 +1,324 @@
+creates enrichment components combined with logProcessingStages:
+  1: |
+    |
+      // Destination: test (loki)
+      otelcol.exporter.loki "test" {
+        forward_to = [loki.process.test.receiver]
+      }
+
+      loki.process "test" {
+        stage.drop {
+          source = "level"
+          value = "debug"
+        }
+
+        forward_to = [loki.relabel.test.receiver]
+      }
+
+      discovery.kubernetes "test" {
+        role = "pod"
+        attach_metadata {
+          namespace = true
+        }
+      }
+      discovery.relabel "test" {
+        targets = discovery.kubernetes.test.targets
+        rule {
+          source_labels = ["__meta_kubernetes_namespace", "__meta_kubernetes_pod_name"]
+          regex = "(.+;.+)"
+          target_label = "__meta_kubernetes_namespace_pod"
+        }
+        rule {
+          source_labels = ["__meta_kubernetes_pod_label_app"]
+          target_label = "app"
+        }
+        rule {
+          source_labels = ["__meta_kubernetes_namespace_label_team"]
+          target_label = "team"
+        }
+      }
+
+      loki.relabel "test" {
+        rule {
+          source_labels = ["namespace", "pod"]
+          regex = "(.+;.+)"
+          target_label = "__meta_kubernetes_namespace_pod"
+        }
+        forward_to = [loki.enrich.test_ns.receiver]
+      }
+      loki.enrich "test_ns" {
+        targets = discovery.relabel.test.output
+        target_match_label = "__meta_kubernetes_namespace"
+        logs_match_label = "namespace"
+        labels_to_copy = ["team"]
+        forward_to = [loki.enrich.test_pod.receiver]
+      }
+      loki.enrich "test_pod" {
+        targets = discovery.relabel.test.output
+        target_match_label = "__meta_kubernetes_namespace_pod"
+        labels_to_copy = ["app"]
+        forward_to = [loki.relabel.test_cleanup.receiver]
+      }
+
+      loki.relabel "test_cleanup" {
+        rule {
+          regex = "__meta_kubernetes_namespace_pod"
+          action = "labeldrop"
+        }
+        forward_to = [loki.write.test.receiver]
+      }
+
+      loki.write "test" {
+        endpoint {
+          url = "https://loki.example.com"
+          retry_on_http_429 = true
+          tls_config {
+            insecure_skip_verify = false
+          }
+          min_backoff_period = "500ms"
+          max_backoff_period = "5m"
+          max_backoff_retries = "10"
+        }
+        external_labels = {
+          "cluster" = "test-cluster",
+          "k8s_cluster_name" = "test-cluster",
+        }
+      }
+creates enrichment components for both namespace and pod labels:
+  1: |
+    |
+      // Destination: test (loki)
+      otelcol.exporter.loki "test" {
+        forward_to = [loki.relabel.test.receiver]
+      }
+
+      discovery.kubernetes "test" {
+        role = "pod"
+        attach_metadata {
+          namespace = true
+        }
+      }
+      discovery.relabel "test" {
+        targets = discovery.kubernetes.test.targets
+        rule {
+          source_labels = ["__meta_kubernetes_namespace", "__meta_kubernetes_pod_name"]
+          regex = "(.+;.+)"
+          target_label = "__meta_kubernetes_namespace_pod"
+        }
+        rule {
+          source_labels = ["__meta_kubernetes_pod_label_app"]
+          target_label = "app"
+        }
+        rule {
+          source_labels = ["__meta_kubernetes_namespace_label_team"]
+          target_label = "team"
+        }
+      }
+
+      loki.relabel "test" {
+        rule {
+          source_labels = ["namespace", "pod"]
+          regex = "(.+;.+)"
+          target_label = "__meta_kubernetes_namespace_pod"
+        }
+        forward_to = [loki.enrich.test_ns.receiver]
+      }
+      loki.enrich "test_ns" {
+        targets = discovery.relabel.test.output
+        target_match_label = "__meta_kubernetes_namespace"
+        logs_match_label = "namespace"
+        labels_to_copy = ["team"]
+        forward_to = [loki.enrich.test_pod.receiver]
+      }
+      loki.enrich "test_pod" {
+        targets = discovery.relabel.test.output
+        target_match_label = "__meta_kubernetes_namespace_pod"
+        labels_to_copy = ["app"]
+        forward_to = [loki.relabel.test_cleanup.receiver]
+      }
+
+      loki.relabel "test_cleanup" {
+        rule {
+          regex = "__meta_kubernetes_namespace_pod"
+          action = "labeldrop"
+        }
+        forward_to = [loki.write.test.receiver]
+      }
+
+      loki.write "test" {
+        endpoint {
+          url = "https://loki.example.com"
+          retry_on_http_429 = true
+          tls_config {
+            insecure_skip_verify = false
+          }
+          min_backoff_period = "500ms"
+          max_backoff_period = "5m"
+          max_backoff_retries = "10"
+        }
+        external_labels = {
+          "cluster" = "test-cluster",
+          "k8s_cluster_name" = "test-cluster",
+        }
+      }
+creates enrichment components for namespace labels only:
+  1: |
+    |
+      // Destination: test (loki)
+      otelcol.exporter.loki "test" {
+        forward_to = [loki.relabel.test.receiver]
+      }
+
+      discovery.kubernetes "test" {
+        role = "pod"
+        attach_metadata {
+          namespace = true
+        }
+      }
+      discovery.relabel "test" {
+        targets = discovery.kubernetes.test.targets
+        rule {
+          source_labels = ["__meta_kubernetes_namespace_label_team"]
+          target_label = "team"
+        }
+        rule {
+          source_labels = ["__meta_kubernetes_namespace_label_environment"]
+          target_label = "environment"
+        }
+      }
+
+      loki.relabel "test" {
+        rule {
+          source_labels = ["namespace", "pod"]
+          regex = "(.+;.+)"
+          target_label = "__meta_kubernetes_namespace_pod"
+        }
+        forward_to = [loki.enrich.test_ns.receiver]
+      }
+      loki.enrich "test_ns" {
+        targets = discovery.relabel.test.output
+        target_match_label = "__meta_kubernetes_namespace"
+        logs_match_label = "namespace"
+        labels_to_copy = ["team","environment"]
+        forward_to = [loki.relabel.test_cleanup.receiver]
+      }
+
+      loki.relabel "test_cleanup" {
+        rule {
+          regex = "__meta_kubernetes_namespace_pod"
+          action = "labeldrop"
+        }
+        forward_to = [loki.write.test.receiver]
+      }
+
+      loki.write "test" {
+        endpoint {
+          url = "https://loki.example.com"
+          retry_on_http_429 = true
+          tls_config {
+            insecure_skip_verify = false
+          }
+          min_backoff_period = "500ms"
+          max_backoff_period = "5m"
+          max_backoff_retries = "10"
+        }
+        external_labels = {
+          "cluster" = "test-cluster",
+          "k8s_cluster_name" = "test-cluster",
+        }
+      }
+creates enrichment components for pod labels only:
+  1: |
+    |
+      // Destination: test (loki)
+      otelcol.exporter.loki "test" {
+        forward_to = [loki.relabel.test.receiver]
+      }
+
+      discovery.kubernetes "test" {
+        role = "pod"
+        selectors {
+          role = "pod"
+          label = "app,version"
+        }
+      }
+      discovery.relabel "test" {
+        targets = discovery.kubernetes.test.targets
+        rule {
+          source_labels = ["__meta_kubernetes_namespace", "__meta_kubernetes_pod_name"]
+          regex = "(.+;.+)"
+          target_label = "__meta_kubernetes_namespace_pod"
+        }
+        rule {
+          source_labels = ["__meta_kubernetes_pod_label_app"]
+          target_label = "app"
+        }
+        rule {
+          source_labels = ["__meta_kubernetes_pod_label_version"]
+          target_label = "version"
+        }
+      }
+
+      loki.relabel "test" {
+        rule {
+          source_labels = ["namespace", "pod"]
+          regex = "(.+;.+)"
+          target_label = "__meta_kubernetes_namespace_pod"
+        }
+        forward_to = [loki.enrich.test_pod.receiver]
+      }
+      loki.enrich "test_pod" {
+        targets = discovery.relabel.test.output
+        target_match_label = "__meta_kubernetes_namespace_pod"
+        labels_to_copy = ["app","version"]
+        forward_to = [loki.relabel.test_cleanup.receiver]
+      }
+
+      loki.relabel "test_cleanup" {
+        rule {
+          regex = "__meta_kubernetes_namespace_pod"
+          action = "labeldrop"
+        }
+        forward_to = [loki.write.test.receiver]
+      }
+
+      loki.write "test" {
+        endpoint {
+          url = "https://loki.example.com"
+          retry_on_http_429 = true
+          tls_config {
+            insecure_skip_verify = false
+          }
+          min_backoff_period = "500ms"
+          max_backoff_period = "5m"
+          max_backoff_retries = "10"
+        }
+        external_labels = {
+          "cluster" = "test-cluster",
+          "k8s_cluster_name" = "test-cluster",
+        }
+      }
+creates the Alloy components for a Loki destination:
+  1: |
+    |
+      // Destination: test (loki)
+      otelcol.exporter.loki "test" {
+        forward_to = [loki.write.test.receiver]
+      }
+
+      loki.write "test" {
+        endpoint {
+          url = "https://loki.example.com"
+          retry_on_http_429 = true
+          tls_config {
+            insecure_skip_verify = false
+          }
+          min_backoff_period = "500ms"
+          max_backoff_period = "5m"
+          max_backoff_retries = "10"
+        }
+        external_labels = {
+          "cluster" = "test-cluster",
+          "k8s_cluster_name" = "test-cluster",
+        }
+      }

--- a/charts/k8s-monitoring/tests/destination_loki_test.yaml
+++ b/charts/k8s-monitoring/tests/destination_loki_test.yaml
@@ -1,0 +1,102 @@
+# yamllint disable rule:document-start rule:line-length rule:trailing-spaces
+suite: Destinations - Loki
+templates:
+  - alloy-config.yaml
+tests:
+  - it: creates the Alloy components for a Loki destination
+    set:
+      cluster: {name: test-cluster}
+      alloy-singleton: {enabled: true, extraConfig: " ", includeDestinations: ["test"]}
+      selfReporting: {enabled: false}
+      destinations:
+        - name: test
+          type: loki
+          url: https://loki.example.com
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - matchSnapshot:
+          path: data["config.alloy"]
+
+  - it: creates enrichment components for namespace labels only
+    set:
+      cluster: {name: test-cluster}
+      alloy-singleton: {enabled: true, extraConfig: " ", includeDestinations: ["test"]}
+      selfReporting: {enabled: false}
+      destinations:
+        - name: test
+          type: loki
+          url: https://loki.example.com
+          logEnrichment:
+            namespaceLabels:
+              - team
+              - environment
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - matchSnapshot:
+          path: data["config.alloy"]
+
+  - it: creates enrichment components for pod labels only
+    set:
+      cluster: {name: test-cluster}
+      alloy-singleton: {enabled: true, extraConfig: " ", includeDestinations: ["test"]}
+      selfReporting: {enabled: false}
+      destinations:
+        - name: test
+          type: loki
+          url: https://loki.example.com
+          logEnrichment:
+            podLabels:
+              - app
+              - version
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - matchSnapshot:
+          path: data["config.alloy"]
+
+  - it: creates enrichment components for both namespace and pod labels
+    set:
+      cluster: {name: test-cluster}
+      alloy-singleton: {enabled: true, extraConfig: " ", includeDestinations: ["test"]}
+      selfReporting: {enabled: false}
+      destinations:
+        - name: test
+          type: loki
+          url: https://loki.example.com
+          logEnrichment:
+            namespaceLabels:
+              - team
+            podLabels:
+              - app
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - matchSnapshot:
+          path: data["config.alloy"]
+
+  - it: creates enrichment components combined with logProcessingStages
+    set:
+      cluster: {name: test-cluster}
+      alloy-singleton: {enabled: true, extraConfig: " ", includeDestinations: ["test"]}
+      selfReporting: {enabled: false}
+      destinations:
+        - name: test
+          type: loki
+          url: https://loki.example.com
+          logProcessingStages: |
+            stage.drop {
+              source = "level"
+              value = "debug"
+            }
+          logEnrichment:
+            namespaceLabels:
+              - team
+            podLabels:
+              - app
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - matchSnapshot:
+          path: data["config.alloy"]

--- a/charts/k8s-monitoring/values.schema.json
+++ b/charts/k8s-monitoring/values.schema.json
@@ -861,6 +861,23 @@
                 "extraLabelsFrom": {
                     "type": "object"
                 },
+                "logEnrichment": {
+                    "type": "object",
+                    "properties": {
+                        "namespaceLabels": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "podLabels": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                },
                 "logProcessingStages": {
                     "type": "string"
                 },
@@ -966,20 +983,6 @@
                 },
                 "urlFrom": {
                     "type": "string"
-                },
-                "logEnrichment": {
-                    "properties": {
-                        "namespaceLabels": {
-                            "items": {
-                                "type": "string"
-                            }
-                        },
-                        "podLabels": {
-                            "items": {
-                                "type": "string"
-                            }
-                        }
-                    }
                 },
                 "type": {
                     "type": "string",

--- a/charts/k8s-monitoring/values.schema.json
+++ b/charts/k8s-monitoring/values.schema.json
@@ -967,6 +967,20 @@
                 "urlFrom": {
                     "type": "string"
                 },
+                "logEnrichment": {
+                    "properties": {
+                        "namespaceLabels": {
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "podLabels": {
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                },
                 "type": {
                     "type": "string",
                     "const": "loki"


### PR DESCRIPTION
Similar to metricEnrichment feature, following the same pattern using [loki.enrich](https://grafana.com/docs/alloy/latest/reference/components/loki/loki.enrich/)
allows to add dynamic labels without changing the gatherMethod