### PR TITLE
Find Pod logs for static pods using the config.mirror annotation

### DIFF
--- a/charts/k8s-monitoring/CHANGELOG.md
+++ b/charts/k8s-monitoring/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+*   Find Pod logs for static pods using the config.mirror annotation (@sebastian-de)
+
 ## 3.8.1
 
 *   Add an option to set the semantic convention version for Application Observability span names (@petewall)

--- a/charts/k8s-monitoring/charts/feature-pod-logs/templates/_volumes.alloy.tpl
+++ b/charts/k8s-monitoring/charts/feature-pod-logs/templates/_volumes.alloy.tpl
@@ -51,6 +51,17 @@ discovery.relabel "filtered_pods_with_paths" {
     replacement = "/var/log/pods/*$1/*.log"
     target_label = "__path__"
   }
+
+  // If kubernetes.io/config.mirror is set, this is a static pod, created by the kubelet.
+  // It's logs live on a different path.
+  rule {
+    source_labels = ["__meta_kubernetes_pod_annotation_kubernetes_io_config_mirror", "__meta_kubernetes_pod_container_name"]
+    separator = "/"
+    regex = "(.+/.+)"
+    action = "replace"
+    replacement = "/var/log/pods/*$1/*.log"
+    target_label = "__path__"
+  }
 }
 
 local.file_match "pod_logs" {

--- a/charts/k8s-monitoring/docs/examples/auth/bearer-token/alloy-logs.alloy
+++ b/charts/k8s-monitoring/docs/examples/auth/bearer-token/alloy-logs.alloy
@@ -140,6 +140,17 @@ declare "pod_logs" {
       replacement = "/var/log/pods/*$1/*.log"
       target_label = "__path__"
     }
+
+    // If kubernetes.io/config.mirror is set, this is a static pod, created by the kubelet.
+    // It's logs live on a different path.
+    rule {
+      source_labels = ["__meta_kubernetes_pod_annotation_kubernetes_io_config_mirror", "__meta_kubernetes_pod_container_name"]
+      separator = "/"
+      regex = "(.+/.+)"
+      action = "replace"
+      replacement = "/var/log/pods/*$1/*.log"
+      target_label = "__path__"
+    }
   }
 
   local.file_match "pod_logs" {

--- a/charts/k8s-monitoring/docs/examples/auth/bearer-token/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/auth/bearer-token/output.yaml
@@ -340,6 +340,17 @@ data:
           replacement = "/var/log/pods/*$1/*.log"
           target_label = "__path__"
         }
+    
+        // If kubernetes.io/config.mirror is set, this is a static pod, created by the kubelet.
+        // It's logs live on a different path.
+        rule {
+          source_labels = ["__meta_kubernetes_pod_annotation_kubernetes_io_config_mirror", "__meta_kubernetes_pod_container_name"]
+          separator = "/"
+          regex = "(.+/.+)"
+          action = "replace"
+          replacement = "/var/log/pods/*$1/*.log"
+          target_label = "__path__"
+        }
       }
     
       local.file_match "pod_logs" {

--- a/charts/k8s-monitoring/docs/examples/auth/embedded-secrets/alloy-logs.alloy
+++ b/charts/k8s-monitoring/docs/examples/auth/embedded-secrets/alloy-logs.alloy
@@ -140,6 +140,17 @@ declare "pod_logs" {
       replacement = "/var/log/pods/*$1/*.log"
       target_label = "__path__"
     }
+
+    // If kubernetes.io/config.mirror is set, this is a static pod, created by the kubelet.
+    // It's logs live on a different path.
+    rule {
+      source_labels = ["__meta_kubernetes_pod_annotation_kubernetes_io_config_mirror", "__meta_kubernetes_pod_container_name"]
+      separator = "/"
+      regex = "(.+/.+)"
+      action = "replace"
+      replacement = "/var/log/pods/*$1/*.log"
+      target_label = "__path__"
+    }
   }
 
   local.file_match "pod_logs" {

--- a/charts/k8s-monitoring/docs/examples/auth/embedded-secrets/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/auth/embedded-secrets/output.yaml
@@ -329,6 +329,17 @@ data:
           replacement = "/var/log/pods/*$1/*.log"
           target_label = "__path__"
         }
+    
+        // If kubernetes.io/config.mirror is set, this is a static pod, created by the kubelet.
+        // It's logs live on a different path.
+        rule {
+          source_labels = ["__meta_kubernetes_pod_annotation_kubernetes_io_config_mirror", "__meta_kubernetes_pod_container_name"]
+          separator = "/"
+          regex = "(.+/.+)"
+          action = "replace"
+          replacement = "/var/log/pods/*$1/*.log"
+          target_label = "__path__"
+        }
       }
     
       local.file_match "pod_logs" {

--- a/charts/k8s-monitoring/docs/examples/auth/external-secrets/alloy-logs.alloy
+++ b/charts/k8s-monitoring/docs/examples/auth/external-secrets/alloy-logs.alloy
@@ -140,6 +140,17 @@ declare "pod_logs" {
       replacement = "/var/log/pods/*$1/*.log"
       target_label = "__path__"
     }
+
+    // If kubernetes.io/config.mirror is set, this is a static pod, created by the kubelet.
+    // It's logs live on a different path.
+    rule {
+      source_labels = ["__meta_kubernetes_pod_annotation_kubernetes_io_config_mirror", "__meta_kubernetes_pod_container_name"]
+      separator = "/"
+      regex = "(.+/.+)"
+      action = "replace"
+      replacement = "/var/log/pods/*$1/*.log"
+      target_label = "__path__"
+    }
   }
 
   local.file_match "pod_logs" {

--- a/charts/k8s-monitoring/docs/examples/auth/external-secrets/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/auth/external-secrets/output.yaml
@@ -366,6 +366,17 @@ data:
           replacement = "/var/log/pods/*$1/*.log"
           target_label = "__path__"
         }
+    
+        // If kubernetes.io/config.mirror is set, this is a static pod, created by the kubelet.
+        // It's logs live on a different path.
+        rule {
+          source_labels = ["__meta_kubernetes_pod_annotation_kubernetes_io_config_mirror", "__meta_kubernetes_pod_container_name"]
+          separator = "/"
+          regex = "(.+/.+)"
+          action = "replace"
+          replacement = "/var/log/pods/*$1/*.log"
+          target_label = "__path__"
+        }
       }
     
       local.file_match "pod_logs" {

--- a/charts/k8s-monitoring/docs/examples/auth/oauth2/alloy-logs.alloy
+++ b/charts/k8s-monitoring/docs/examples/auth/oauth2/alloy-logs.alloy
@@ -292,6 +292,17 @@ declare "pod_logs" {
       replacement = "/var/log/pods/*$1/*.log"
       target_label = "__path__"
     }
+
+    // If kubernetes.io/config.mirror is set, this is a static pod, created by the kubelet.
+    // It's logs live on a different path.
+    rule {
+      source_labels = ["__meta_kubernetes_pod_annotation_kubernetes_io_config_mirror", "__meta_kubernetes_pod_container_name"]
+      separator = "/"
+      regex = "(.+/.+)"
+      action = "replace"
+      replacement = "/var/log/pods/*$1/*.log"
+      target_label = "__path__"
+    }
   }
 
   local.file_match "pod_logs" {

--- a/charts/k8s-monitoring/docs/examples/auth/oauth2/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/auth/oauth2/output.yaml
@@ -1831,6 +1831,17 @@ data:
           replacement = "/var/log/pods/*$1/*.log"
           target_label = "__path__"
         }
+    
+        // If kubernetes.io/config.mirror is set, this is a static pod, created by the kubelet.
+        // It's logs live on a different path.
+        rule {
+          source_labels = ["__meta_kubernetes_pod_annotation_kubernetes_io_config_mirror", "__meta_kubernetes_pod_container_name"]
+          separator = "/"
+          regex = "(.+/.+)"
+          action = "replace"
+          replacement = "/var/log/pods/*$1/*.log"
+          target_label = "__path__"
+        }
       }
     
       local.file_match "pod_logs" {

--- a/charts/k8s-monitoring/docs/examples/collector-storage/alloy-logs.alloy
+++ b/charts/k8s-monitoring/docs/examples/collector-storage/alloy-logs.alloy
@@ -140,6 +140,17 @@ declare "pod_logs" {
       replacement = "/var/log/pods/*$1/*.log"
       target_label = "__path__"
     }
+
+    // If kubernetes.io/config.mirror is set, this is a static pod, created by the kubelet.
+    // It's logs live on a different path.
+    rule {
+      source_labels = ["__meta_kubernetes_pod_annotation_kubernetes_io_config_mirror", "__meta_kubernetes_pod_container_name"]
+      separator = "/"
+      regex = "(.+/.+)"
+      action = "replace"
+      replacement = "/var/log/pods/*$1/*.log"
+      target_label = "__path__"
+    }
   }
 
   local.file_match "pod_logs" {

--- a/charts/k8s-monitoring/docs/examples/collector-storage/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/collector-storage/output.yaml
@@ -832,6 +832,17 @@ data:
           replacement = "/var/log/pods/*$1/*.log"
           target_label = "__path__"
         }
+    
+        // If kubernetes.io/config.mirror is set, this is a static pod, created by the kubelet.
+        // It's logs live on a different path.
+        rule {
+          source_labels = ["__meta_kubernetes_pod_annotation_kubernetes_io_config_mirror", "__meta_kubernetes_pod_container_name"]
+          separator = "/"
+          regex = "(.+/.+)"
+          action = "replace"
+          replacement = "/var/log/pods/*$1/*.log"
+          target_label = "__path__"
+        }
       }
     
       local.file_match "pod_logs" {

--- a/charts/k8s-monitoring/docs/examples/destinations/custom/debug/alloy-logs.alloy
+++ b/charts/k8s-monitoring/docs/examples/destinations/custom/debug/alloy-logs.alloy
@@ -147,6 +147,17 @@ declare "pod_logs" {
       replacement = "/var/log/pods/*$1/*.log"
       target_label = "__path__"
     }
+
+    // If kubernetes.io/config.mirror is set, this is a static pod, created by the kubelet.
+    // It's logs live on a different path.
+    rule {
+      source_labels = ["__meta_kubernetes_pod_annotation_kubernetes_io_config_mirror", "__meta_kubernetes_pod_container_name"]
+      separator = "/"
+      regex = "(.+/.+)"
+      action = "replace"
+      replacement = "/var/log/pods/*$1/*.log"
+      target_label = "__path__"
+    }
   }
 
   local.file_match "pod_logs" {

--- a/charts/k8s-monitoring/docs/examples/destinations/custom/debug/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/destinations/custom/debug/output.yaml
@@ -644,6 +644,17 @@ data:
           replacement = "/var/log/pods/*$1/*.log"
           target_label = "__path__"
         }
+    
+        // If kubernetes.io/config.mirror is set, this is a static pod, created by the kubelet.
+        // It's logs live on a different path.
+        rule {
+          source_labels = ["__meta_kubernetes_pod_annotation_kubernetes_io_config_mirror", "__meta_kubernetes_pod_container_name"]
+          separator = "/"
+          regex = "(.+/.+)"
+          action = "replace"
+          replacement = "/var/log/pods/*$1/*.log"
+          target_label = "__path__"
+        }
       }
     
       local.file_match "pod_logs" {

--- a/charts/k8s-monitoring/docs/examples/destinations/loki-stdout/alloy-logs.alloy
+++ b/charts/k8s-monitoring/docs/examples/destinations/loki-stdout/alloy-logs.alloy
@@ -140,6 +140,17 @@ declare "pod_logs" {
       replacement = "/var/log/pods/*$1/*.log"
       target_label = "__path__"
     }
+
+    // If kubernetes.io/config.mirror is set, this is a static pod, created by the kubelet.
+    // It's logs live on a different path.
+    rule {
+      source_labels = ["__meta_kubernetes_pod_annotation_kubernetes_io_config_mirror", "__meta_kubernetes_pod_container_name"]
+      separator = "/"
+      regex = "(.+/.+)"
+      action = "replace"
+      replacement = "/var/log/pods/*$1/*.log"
+      target_label = "__path__"
+    }
   }
 
   local.file_match "pod_logs" {

--- a/charts/k8s-monitoring/docs/examples/destinations/loki-stdout/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/destinations/loki-stdout/output.yaml
@@ -175,6 +175,17 @@ data:
           replacement = "/var/log/pods/*$1/*.log"
           target_label = "__path__"
         }
+    
+        // If kubernetes.io/config.mirror is set, this is a static pod, created by the kubelet.
+        // It's logs live on a different path.
+        rule {
+          source_labels = ["__meta_kubernetes_pod_annotation_kubernetes_io_config_mirror", "__meta_kubernetes_pod_container_name"]
+          separator = "/"
+          regex = "(.+/.+)"
+          action = "replace"
+          replacement = "/var/log/pods/*$1/*.log"
+          target_label = "__path__"
+        }
       }
     
       local.file_match "pod_logs" {

--- a/charts/k8s-monitoring/docs/examples/destinations/otlp-endpoint/alloy-logs.alloy
+++ b/charts/k8s-monitoring/docs/examples/destinations/otlp-endpoint/alloy-logs.alloy
@@ -140,6 +140,17 @@ declare "pod_logs" {
       replacement = "/var/log/pods/*$1/*.log"
       target_label = "__path__"
     }
+
+    // If kubernetes.io/config.mirror is set, this is a static pod, created by the kubelet.
+    // It's logs live on a different path.
+    rule {
+      source_labels = ["__meta_kubernetes_pod_annotation_kubernetes_io_config_mirror", "__meta_kubernetes_pod_container_name"]
+      separator = "/"
+      regex = "(.+/.+)"
+      action = "replace"
+      replacement = "/var/log/pods/*$1/*.log"
+      target_label = "__path__"
+    }
   }
 
   local.file_match "pod_logs" {

--- a/charts/k8s-monitoring/docs/examples/destinations/otlp-endpoint/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/destinations/otlp-endpoint/output.yaml
@@ -999,6 +999,17 @@ data:
           replacement = "/var/log/pods/*$1/*.log"
           target_label = "__path__"
         }
+    
+        // If kubernetes.io/config.mirror is set, this is a static pod, created by the kubelet.
+        // It's logs live on a different path.
+        rule {
+          source_labels = ["__meta_kubernetes_pod_annotation_kubernetes_io_config_mirror", "__meta_kubernetes_pod_container_name"]
+          separator = "/"
+          regex = "(.+/.+)"
+          action = "replace"
+          replacement = "/var/log/pods/*$1/*.log"
+          target_label = "__path__"
+        }
       }
     
       local.file_match "pod_logs" {

--- a/charts/k8s-monitoring/docs/examples/exclude-by-namespace/alloy-logs.alloy
+++ b/charts/k8s-monitoring/docs/examples/exclude-by-namespace/alloy-logs.alloy
@@ -145,6 +145,17 @@ declare "pod_logs" {
       replacement = "/var/log/pods/*$1/*.log"
       target_label = "__path__"
     }
+
+    // If kubernetes.io/config.mirror is set, this is a static pod, created by the kubelet.
+    // It's logs live on a different path.
+    rule {
+      source_labels = ["__meta_kubernetes_pod_annotation_kubernetes_io_config_mirror", "__meta_kubernetes_pod_container_name"]
+      separator = "/"
+      regex = "(.+/.+)"
+      action = "replace"
+      replacement = "/var/log/pods/*$1/*.log"
+      target_label = "__path__"
+    }
   }
 
   local.file_match "pod_logs" {

--- a/charts/k8s-monitoring/docs/examples/exclude-by-namespace/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/exclude-by-namespace/output.yaml
@@ -1511,6 +1511,17 @@ data:
           replacement = "/var/log/pods/*$1/*.log"
           target_label = "__path__"
         }
+    
+        // If kubernetes.io/config.mirror is set, this is a static pod, created by the kubelet.
+        // It's logs live on a different path.
+        rule {
+          source_labels = ["__meta_kubernetes_pod_annotation_kubernetes_io_config_mirror", "__meta_kubernetes_pod_container_name"]
+          separator = "/"
+          regex = "(.+/.+)"
+          action = "replace"
+          replacement = "/var/log/pods/*$1/*.log"
+          target_label = "__path__"
+        }
       }
     
       local.file_match "pod_logs" {

--- a/charts/k8s-monitoring/docs/examples/extra-rules/alloy-logs.alloy
+++ b/charts/k8s-monitoring/docs/examples/extra-rules/alloy-logs.alloy
@@ -145,6 +145,17 @@ declare "pod_logs" {
       replacement = "/var/log/pods/*$1/*.log"
       target_label = "__path__"
     }
+
+    // If kubernetes.io/config.mirror is set, this is a static pod, created by the kubelet.
+    // It's logs live on a different path.
+    rule {
+      source_labels = ["__meta_kubernetes_pod_annotation_kubernetes_io_config_mirror", "__meta_kubernetes_pod_container_name"]
+      separator = "/"
+      regex = "(.+/.+)"
+      action = "replace"
+      replacement = "/var/log/pods/*$1/*.log"
+      target_label = "__path__"
+    }
   }
 
   local.file_match "pod_logs" {

--- a/charts/k8s-monitoring/docs/examples/extra-rules/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/extra-rules/output.yaml
@@ -1037,6 +1037,17 @@ data:
           replacement = "/var/log/pods/*$1/*.log"
           target_label = "__path__"
         }
+    
+        // If kubernetes.io/config.mirror is set, this is a static pod, created by the kubelet.
+        // It's logs live on a different path.
+        rule {
+          source_labels = ["__meta_kubernetes_pod_annotation_kubernetes_io_config_mirror", "__meta_kubernetes_pod_container_name"]
+          separator = "/"
+          regex = "(.+/.+)"
+          action = "replace"
+          replacement = "/var/log/pods/*$1/*.log"
+          target_label = "__path__"
+        }
       }
     
       local.file_match "pod_logs" {

--- a/charts/k8s-monitoring/docs/examples/features/cluster-metrics/control-plane-monitoring/alloy-logs.alloy
+++ b/charts/k8s-monitoring/docs/examples/features/cluster-metrics/control-plane-monitoring/alloy-logs.alloy
@@ -140,6 +140,17 @@ declare "pod_logs" {
       replacement = "/var/log/pods/*$1/*.log"
       target_label = "__path__"
     }
+
+    // If kubernetes.io/config.mirror is set, this is a static pod, created by the kubelet.
+    // It's logs live on a different path.
+    rule {
+      source_labels = ["__meta_kubernetes_pod_annotation_kubernetes_io_config_mirror", "__meta_kubernetes_pod_container_name"]
+      separator = "/"
+      regex = "(.+/.+)"
+      action = "replace"
+      replacement = "/var/log/pods/*$1/*.log"
+      target_label = "__path__"
+    }
   }
 
   local.file_match "pod_logs" {

--- a/charts/k8s-monitoring/docs/examples/features/cluster-metrics/control-plane-monitoring/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/features/cluster-metrics/control-plane-monitoring/output.yaml
@@ -1415,6 +1415,17 @@ data:
           replacement = "/var/log/pods/*$1/*.log"
           target_label = "__path__"
         }
+    
+        // If kubernetes.io/config.mirror is set, this is a static pod, created by the kubelet.
+        // It's logs live on a different path.
+        rule {
+          source_labels = ["__meta_kubernetes_pod_annotation_kubernetes_io_config_mirror", "__meta_kubernetes_pod_container_name"]
+          separator = "/"
+          regex = "(.+/.+)"
+          action = "replace"
+          replacement = "/var/log/pods/*$1/*.log"
+          target_label = "__path__"
+        }
       }
     
       local.file_match "pod_logs" {

--- a/charts/k8s-monitoring/docs/examples/features/database-observability/mysql/alloy-logs.alloy
+++ b/charts/k8s-monitoring/docs/examples/features/database-observability/mysql/alloy-logs.alloy
@@ -154,6 +154,17 @@ declare "pod_logs" {
       replacement = "/var/log/pods/*$1/*.log"
       target_label = "__path__"
     }
+
+    // If kubernetes.io/config.mirror is set, this is a static pod, created by the kubelet.
+    // It's logs live on a different path.
+    rule {
+      source_labels = ["__meta_kubernetes_pod_annotation_kubernetes_io_config_mirror", "__meta_kubernetes_pod_container_name"]
+      separator = "/"
+      regex = "(.+/.+)"
+      action = "replace"
+      replacement = "/var/log/pods/*$1/*.log"
+      target_label = "__path__"
+    }
   }
 
   local.file_match "pod_logs" {

--- a/charts/k8s-monitoring/docs/examples/features/database-observability/mysql/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/features/database-observability/mysql/output.yaml
@@ -422,6 +422,17 @@ data:
           replacement = "/var/log/pods/*$1/*.log"
           target_label = "__path__"
         }
+    
+        // If kubernetes.io/config.mirror is set, this is a static pod, created by the kubelet.
+        // It's logs live on a different path.
+        rule {
+          source_labels = ["__meta_kubernetes_pod_annotation_kubernetes_io_config_mirror", "__meta_kubernetes_pod_container_name"]
+          separator = "/"
+          regex = "(.+/.+)"
+          action = "replace"
+          replacement = "/var/log/pods/*$1/*.log"
+          target_label = "__path__"
+        }
       }
     
       local.file_match "pod_logs" {

--- a/charts/k8s-monitoring/docs/examples/features/database-observability/postgresql/alloy-logs.alloy
+++ b/charts/k8s-monitoring/docs/examples/features/database-observability/postgresql/alloy-logs.alloy
@@ -154,6 +154,17 @@ declare "pod_logs" {
       replacement = "/var/log/pods/*$1/*.log"
       target_label = "__path__"
     }
+
+    // If kubernetes.io/config.mirror is set, this is a static pod, created by the kubelet.
+    // It's logs live on a different path.
+    rule {
+      source_labels = ["__meta_kubernetes_pod_annotation_kubernetes_io_config_mirror", "__meta_kubernetes_pod_container_name"]
+      separator = "/"
+      regex = "(.+/.+)"
+      action = "replace"
+      replacement = "/var/log/pods/*$1/*.log"
+      target_label = "__path__"
+    }
   }
 
   local.file_match "pod_logs" {

--- a/charts/k8s-monitoring/docs/examples/features/database-observability/postgresql/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/features/database-observability/postgresql/output.yaml
@@ -425,6 +425,17 @@ data:
           replacement = "/var/log/pods/*$1/*.log"
           target_label = "__path__"
         }
+    
+        // If kubernetes.io/config.mirror is set, this is a static pod, created by the kubelet.
+        // It's logs live on a different path.
+        rule {
+          source_labels = ["__meta_kubernetes_pod_annotation_kubernetes_io_config_mirror", "__meta_kubernetes_pod_container_name"]
+          separator = "/"
+          regex = "(.+/.+)"
+          action = "replace"
+          replacement = "/var/log/pods/*$1/*.log"
+          target_label = "__path__"
+        }
       }
     
       local.file_match "pod_logs" {

--- a/charts/k8s-monitoring/docs/examples/features/integrations/grafana/alloy-logs.alloy
+++ b/charts/k8s-monitoring/docs/examples/features/integrations/grafana/alloy-logs.alloy
@@ -154,6 +154,17 @@ declare "pod_logs" {
       replacement = "/var/log/pods/*$1/*.log"
       target_label = "__path__"
     }
+
+    // If kubernetes.io/config.mirror is set, this is a static pod, created by the kubelet.
+    // It's logs live on a different path.
+    rule {
+      source_labels = ["__meta_kubernetes_pod_annotation_kubernetes_io_config_mirror", "__meta_kubernetes_pod_container_name"]
+      separator = "/"
+      regex = "(.+/.+)"
+      action = "replace"
+      replacement = "/var/log/pods/*$1/*.log"
+      target_label = "__path__"
+    }
   }
 
   local.file_match "pod_logs" {

--- a/charts/k8s-monitoring/docs/examples/features/integrations/grafana/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/features/integrations/grafana/output.yaml
@@ -565,6 +565,17 @@ data:
           replacement = "/var/log/pods/*$1/*.log"
           target_label = "__path__"
         }
+    
+        // If kubernetes.io/config.mirror is set, this is a static pod, created by the kubelet.
+        // It's logs live on a different path.
+        rule {
+          source_labels = ["__meta_kubernetes_pod_annotation_kubernetes_io_config_mirror", "__meta_kubernetes_pod_container_name"]
+          separator = "/"
+          regex = "(.+/.+)"
+          action = "replace"
+          replacement = "/var/log/pods/*$1/*.log"
+          target_label = "__path__"
+        }
       }
     
       local.file_match "pod_logs" {

--- a/charts/k8s-monitoring/docs/examples/features/integrations/loki/alloy-logs.alloy
+++ b/charts/k8s-monitoring/docs/examples/features/integrations/loki/alloy-logs.alloy
@@ -163,6 +163,17 @@ declare "pod_logs" {
       replacement = "/var/log/pods/*$1/*.log"
       target_label = "__path__"
     }
+
+    // If kubernetes.io/config.mirror is set, this is a static pod, created by the kubelet.
+    // It's logs live on a different path.
+    rule {
+      source_labels = ["__meta_kubernetes_pod_annotation_kubernetes_io_config_mirror", "__meta_kubernetes_pod_container_name"]
+      separator = "/"
+      regex = "(.+/.+)"
+      action = "replace"
+      replacement = "/var/log/pods/*$1/*.log"
+      target_label = "__path__"
+    }
   }
 
   local.file_match "pod_logs" {

--- a/charts/k8s-monitoring/docs/examples/features/integrations/loki/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/features/integrations/loki/output.yaml
@@ -591,6 +591,17 @@ data:
           replacement = "/var/log/pods/*$1/*.log"
           target_label = "__path__"
         }
+    
+        // If kubernetes.io/config.mirror is set, this is a static pod, created by the kubelet.
+        // It's logs live on a different path.
+        rule {
+          source_labels = ["__meta_kubernetes_pod_annotation_kubernetes_io_config_mirror", "__meta_kubernetes_pod_container_name"]
+          separator = "/"
+          regex = "(.+/.+)"
+          action = "replace"
+          replacement = "/var/log/pods/*$1/*.log"
+          target_label = "__path__"
+        }
       }
     
       local.file_match "pod_logs" {

--- a/charts/k8s-monitoring/docs/examples/features/integrations/mimir/alloy-logs.alloy
+++ b/charts/k8s-monitoring/docs/examples/features/integrations/mimir/alloy-logs.alloy
@@ -163,6 +163,17 @@ declare "pod_logs" {
       replacement = "/var/log/pods/*$1/*.log"
       target_label = "__path__"
     }
+
+    // If kubernetes.io/config.mirror is set, this is a static pod, created by the kubelet.
+    // It's logs live on a different path.
+    rule {
+      source_labels = ["__meta_kubernetes_pod_annotation_kubernetes_io_config_mirror", "__meta_kubernetes_pod_container_name"]
+      separator = "/"
+      regex = "(.+/.+)"
+      action = "replace"
+      replacement = "/var/log/pods/*$1/*.log"
+      target_label = "__path__"
+    }
   }
 
   local.file_match "pod_logs" {

--- a/charts/k8s-monitoring/docs/examples/features/integrations/mimir/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/features/integrations/mimir/output.yaml
@@ -589,6 +589,17 @@ data:
           replacement = "/var/log/pods/*$1/*.log"
           target_label = "__path__"
         }
+    
+        // If kubernetes.io/config.mirror is set, this is a static pod, created by the kubelet.
+        // It's logs live on a different path.
+        rule {
+          source_labels = ["__meta_kubernetes_pod_annotation_kubernetes_io_config_mirror", "__meta_kubernetes_pod_container_name"]
+          separator = "/"
+          regex = "(.+/.+)"
+          action = "replace"
+          replacement = "/var/log/pods/*$1/*.log"
+          target_label = "__path__"
+        }
       }
     
       local.file_match "pod_logs" {

--- a/charts/k8s-monitoring/docs/examples/features/integrations/multiple/alloy-logs.alloy
+++ b/charts/k8s-monitoring/docs/examples/features/integrations/multiple/alloy-logs.alloy
@@ -154,6 +154,17 @@ declare "pod_logs" {
       replacement = "/var/log/pods/*$1/*.log"
       target_label = "__path__"
     }
+
+    // If kubernetes.io/config.mirror is set, this is a static pod, created by the kubelet.
+    // It's logs live on a different path.
+    rule {
+      source_labels = ["__meta_kubernetes_pod_annotation_kubernetes_io_config_mirror", "__meta_kubernetes_pod_container_name"]
+      separator = "/"
+      regex = "(.+/.+)"
+      action = "replace"
+      replacement = "/var/log/pods/*$1/*.log"
+      target_label = "__path__"
+    }
   }
 
   local.file_match "pod_logs" {

--- a/charts/k8s-monitoring/docs/examples/features/integrations/multiple/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/features/integrations/multiple/output.yaml
@@ -480,6 +480,17 @@ data:
           replacement = "/var/log/pods/*$1/*.log"
           target_label = "__path__"
         }
+    
+        // If kubernetes.io/config.mirror is set, this is a static pod, created by the kubelet.
+        // It's logs live on a different path.
+        rule {
+          source_labels = ["__meta_kubernetes_pod_annotation_kubernetes_io_config_mirror", "__meta_kubernetes_pod_container_name"]
+          separator = "/"
+          regex = "(.+/.+)"
+          action = "replace"
+          replacement = "/var/log/pods/*$1/*.log"
+          target_label = "__path__"
+        }
       }
     
       local.file_match "pod_logs" {

--- a/charts/k8s-monitoring/docs/examples/features/integrations/mysql/alloy-logs.alloy
+++ b/charts/k8s-monitoring/docs/examples/features/integrations/mysql/alloy-logs.alloy
@@ -154,6 +154,17 @@ declare "pod_logs" {
       replacement = "/var/log/pods/*$1/*.log"
       target_label = "__path__"
     }
+
+    // If kubernetes.io/config.mirror is set, this is a static pod, created by the kubelet.
+    // It's logs live on a different path.
+    rule {
+      source_labels = ["__meta_kubernetes_pod_annotation_kubernetes_io_config_mirror", "__meta_kubernetes_pod_container_name"]
+      separator = "/"
+      regex = "(.+/.+)"
+      action = "replace"
+      replacement = "/var/log/pods/*$1/*.log"
+      target_label = "__path__"
+    }
   }
 
   local.file_match "pod_logs" {

--- a/charts/k8s-monitoring/docs/examples/features/integrations/mysql/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/features/integrations/mysql/output.yaml
@@ -423,6 +423,17 @@ data:
           replacement = "/var/log/pods/*$1/*.log"
           target_label = "__path__"
         }
+    
+        // If kubernetes.io/config.mirror is set, this is a static pod, created by the kubelet.
+        // It's logs live on a different path.
+        rule {
+          source_labels = ["__meta_kubernetes_pod_annotation_kubernetes_io_config_mirror", "__meta_kubernetes_pod_container_name"]
+          separator = "/"
+          regex = "(.+/.+)"
+          action = "replace"
+          replacement = "/var/log/pods/*$1/*.log"
+          target_label = "__path__"
+        }
       }
     
       local.file_match "pod_logs" {

--- a/charts/k8s-monitoring/docs/examples/features/integrations/postgresql/alloy-logs.alloy
+++ b/charts/k8s-monitoring/docs/examples/features/integrations/postgresql/alloy-logs.alloy
@@ -154,6 +154,17 @@ declare "pod_logs" {
       replacement = "/var/log/pods/*$1/*.log"
       target_label = "__path__"
     }
+
+    // If kubernetes.io/config.mirror is set, this is a static pod, created by the kubelet.
+    // It's logs live on a different path.
+    rule {
+      source_labels = ["__meta_kubernetes_pod_annotation_kubernetes_io_config_mirror", "__meta_kubernetes_pod_container_name"]
+      separator = "/"
+      regex = "(.+/.+)"
+      action = "replace"
+      replacement = "/var/log/pods/*$1/*.log"
+      target_label = "__path__"
+    }
   }
 
   local.file_match "pod_logs" {

--- a/charts/k8s-monitoring/docs/examples/features/integrations/postgresql/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/features/integrations/postgresql/output.yaml
@@ -355,6 +355,17 @@ data:
           replacement = "/var/log/pods/*$1/*.log"
           target_label = "__path__"
         }
+    
+        // If kubernetes.io/config.mirror is set, this is a static pod, created by the kubelet.
+        // It's logs live on a different path.
+        rule {
+          source_labels = ["__meta_kubernetes_pod_annotation_kubernetes_io_config_mirror", "__meta_kubernetes_pod_container_name"]
+          separator = "/"
+          regex = "(.+/.+)"
+          action = "replace"
+          replacement = "/var/log/pods/*$1/*.log"
+          target_label = "__path__"
+        }
       }
     
       local.file_match "pod_logs" {

--- a/charts/k8s-monitoring/docs/examples/features/pod-logs/default/alloy-logs.alloy
+++ b/charts/k8s-monitoring/docs/examples/features/pod-logs/default/alloy-logs.alloy
@@ -140,6 +140,17 @@ declare "pod_logs" {
       replacement = "/var/log/pods/*$1/*.log"
       target_label = "__path__"
     }
+
+    // If kubernetes.io/config.mirror is set, this is a static pod, created by the kubelet.
+    // It's logs live on a different path.
+    rule {
+      source_labels = ["__meta_kubernetes_pod_annotation_kubernetes_io_config_mirror", "__meta_kubernetes_pod_container_name"]
+      separator = "/"
+      regex = "(.+/.+)"
+      action = "replace"
+      replacement = "/var/log/pods/*$1/*.log"
+      target_label = "__path__"
+    }
   }
 
   local.file_match "pod_logs" {

--- a/charts/k8s-monitoring/docs/examples/features/pod-logs/default/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/features/pod-logs/default/output.yaml
@@ -163,6 +163,17 @@ data:
           replacement = "/var/log/pods/*$1/*.log"
           target_label = "__path__"
         }
+    
+        // If kubernetes.io/config.mirror is set, this is a static pod, created by the kubelet.
+        // It's logs live on a different path.
+        rule {
+          source_labels = ["__meta_kubernetes_pod_annotation_kubernetes_io_config_mirror", "__meta_kubernetes_pod_container_name"]
+          separator = "/"
+          regex = "(.+/.+)"
+          action = "replace"
+          replacement = "/var/log/pods/*$1/*.log"
+          target_label = "__path__"
+        }
       }
     
       local.file_match "pod_logs" {

--- a/charts/k8s-monitoring/docs/examples/features/pod-logs/multiline/alloy-logs.alloy
+++ b/charts/k8s-monitoring/docs/examples/features/pod-logs/multiline/alloy-logs.alloy
@@ -140,6 +140,17 @@ declare "pod_logs" {
       replacement = "/var/log/pods/*$1/*.log"
       target_label = "__path__"
     }
+
+    // If kubernetes.io/config.mirror is set, this is a static pod, created by the kubelet.
+    // It's logs live on a different path.
+    rule {
+      source_labels = ["__meta_kubernetes_pod_annotation_kubernetes_io_config_mirror", "__meta_kubernetes_pod_container_name"]
+      separator = "/"
+      regex = "(.+/.+)"
+      action = "replace"
+      replacement = "/var/log/pods/*$1/*.log"
+      target_label = "__path__"
+    }
   }
 
   local.file_match "pod_logs" {

--- a/charts/k8s-monitoring/docs/examples/features/pod-logs/multiline/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/features/pod-logs/multiline/output.yaml
@@ -175,6 +175,17 @@ data:
           replacement = "/var/log/pods/*$1/*.log"
           target_label = "__path__"
         }
+    
+        // If kubernetes.io/config.mirror is set, this is a static pod, created by the kubelet.
+        // It's logs live on a different path.
+        rule {
+          source_labels = ["__meta_kubernetes_pod_annotation_kubernetes_io_config_mirror", "__meta_kubernetes_pod_container_name"]
+          separator = "/"
+          regex = "(.+/.+)"
+          action = "replace"
+          replacement = "/var/log/pods/*$1/*.log"
+          target_label = "__path__"
+        }
       }
     
       local.file_match "pod_logs" {

--- a/charts/k8s-monitoring/docs/examples/include-by-namespace/alloy-logs.alloy
+++ b/charts/k8s-monitoring/docs/examples/include-by-namespace/alloy-logs.alloy
@@ -143,6 +143,17 @@ declare "pod_logs" {
       replacement = "/var/log/pods/*$1/*.log"
       target_label = "__path__"
     }
+
+    // If kubernetes.io/config.mirror is set, this is a static pod, created by the kubelet.
+    // It's logs live on a different path.
+    rule {
+      source_labels = ["__meta_kubernetes_pod_annotation_kubernetes_io_config_mirror", "__meta_kubernetes_pod_container_name"]
+      separator = "/"
+      regex = "(.+/.+)"
+      action = "replace"
+      replacement = "/var/log/pods/*$1/*.log"
+      target_label = "__path__"
+    }
   }
 
   local.file_match "pod_logs" {

--- a/charts/k8s-monitoring/docs/examples/include-by-namespace/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/include-by-namespace/output.yaml
@@ -1489,6 +1489,17 @@ data:
           replacement = "/var/log/pods/*$1/*.log"
           target_label = "__path__"
         }
+    
+        // If kubernetes.io/config.mirror is set, this is a static pod, created by the kubelet.
+        // It's logs live on a different path.
+        rule {
+          source_labels = ["__meta_kubernetes_pod_annotation_kubernetes_io_config_mirror", "__meta_kubernetes_pod_container_name"]
+          separator = "/"
+          regex = "(.+/.+)"
+          action = "replace"
+          replacement = "/var/log/pods/*$1/*.log"
+          target_label = "__path__"
+        }
       }
     
       local.file_match "pod_logs" {

--- a/charts/k8s-monitoring/docs/examples/istio-service-mesh/alloy-logs.alloy
+++ b/charts/k8s-monitoring/docs/examples/istio-service-mesh/alloy-logs.alloy
@@ -140,6 +140,17 @@ declare "pod_logs" {
       replacement = "/var/log/pods/*$1/*.log"
       target_label = "__path__"
     }
+
+    // If kubernetes.io/config.mirror is set, this is a static pod, created by the kubelet.
+    // It's logs live on a different path.
+    rule {
+      source_labels = ["__meta_kubernetes_pod_annotation_kubernetes_io_config_mirror", "__meta_kubernetes_pod_container_name"]
+      separator = "/"
+      regex = "(.+/.+)"
+      action = "replace"
+      replacement = "/var/log/pods/*$1/*.log"
+      target_label = "__path__"
+    }
   }
 
   local.file_match "pod_logs" {

--- a/charts/k8s-monitoring/docs/examples/istio-service-mesh/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/istio-service-mesh/output.yaml
@@ -1188,6 +1188,17 @@ data:
           replacement = "/var/log/pods/*$1/*.log"
           target_label = "__path__"
         }
+    
+        // If kubernetes.io/config.mirror is set, this is a static pod, created by the kubelet.
+        // It's logs live on a different path.
+        rule {
+          source_labels = ["__meta_kubernetes_pod_annotation_kubernetes_io_config_mirror", "__meta_kubernetes_pod_container_name"]
+          separator = "/"
+          regex = "(.+/.+)"
+          action = "replace"
+          replacement = "/var/log/pods/*$1/*.log"
+          target_label = "__path__"
+        }
       }
     
       local.file_match "pod_logs" {

--- a/charts/k8s-monitoring/docs/examples/log-metrics/alloy-logs.alloy
+++ b/charts/k8s-monitoring/docs/examples/log-metrics/alloy-logs.alloy
@@ -140,6 +140,17 @@ declare "pod_logs" {
       replacement = "/var/log/pods/*$1/*.log"
       target_label = "__path__"
     }
+
+    // If kubernetes.io/config.mirror is set, this is a static pod, created by the kubelet.
+    // It's logs live on a different path.
+    rule {
+      source_labels = ["__meta_kubernetes_pod_annotation_kubernetes_io_config_mirror", "__meta_kubernetes_pod_container_name"]
+      separator = "/"
+      regex = "(.+/.+)"
+      action = "replace"
+      replacement = "/var/log/pods/*$1/*.log"
+      target_label = "__path__"
+    }
   }
 
   local.file_match "pod_logs" {

--- a/charts/k8s-monitoring/docs/examples/log-metrics/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/log-metrics/output.yaml
@@ -598,6 +598,17 @@ data:
           replacement = "/var/log/pods/*$1/*.log"
           target_label = "__path__"
         }
+    
+        // If kubernetes.io/config.mirror is set, this is a static pod, created by the kubelet.
+        // It's logs live on a different path.
+        rule {
+          source_labels = ["__meta_kubernetes_pod_annotation_kubernetes_io_config_mirror", "__meta_kubernetes_pod_container_name"]
+          separator = "/"
+          regex = "(.+/.+)"
+          action = "replace"
+          replacement = "/var/log/pods/*$1/*.log"
+          target_label = "__path__"
+        }
       }
     
       local.file_match "pod_logs" {

--- a/charts/k8s-monitoring/docs/examples/namespace-labels-and-annotations/alloy-logs.alloy
+++ b/charts/k8s-monitoring/docs/examples/namespace-labels-and-annotations/alloy-logs.alloy
@@ -140,6 +140,17 @@ declare "pod_logs" {
       replacement = "/var/log/pods/*$1/*.log"
       target_label = "__path__"
     }
+
+    // If kubernetes.io/config.mirror is set, this is a static pod, created by the kubelet.
+    // It's logs live on a different path.
+    rule {
+      source_labels = ["__meta_kubernetes_pod_annotation_kubernetes_io_config_mirror", "__meta_kubernetes_pod_container_name"]
+      separator = "/"
+      regex = "(.+/.+)"
+      action = "replace"
+      replacement = "/var/log/pods/*$1/*.log"
+      target_label = "__path__"
+    }
   }
 
   local.file_match "pod_logs" {

--- a/charts/k8s-monitoring/docs/examples/namespace-labels-and-annotations/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/namespace-labels-and-annotations/output.yaml
@@ -833,6 +833,17 @@ data:
           replacement = "/var/log/pods/*$1/*.log"
           target_label = "__path__"
         }
+    
+        // If kubernetes.io/config.mirror is set, this is a static pod, created by the kubelet.
+        // It's logs live on a different path.
+        rule {
+          source_labels = ["__meta_kubernetes_pod_annotation_kubernetes_io_config_mirror", "__meta_kubernetes_pod_container_name"]
+          separator = "/"
+          regex = "(.+/.+)"
+          action = "replace"
+          replacement = "/var/log/pods/*$1/*.log"
+          target_label = "__path__"
+        }
       }
     
       local.file_match "pod_logs" {

--- a/charts/k8s-monitoring/docs/examples/node-labels/alloy-logs.alloy
+++ b/charts/k8s-monitoring/docs/examples/node-labels/alloy-logs.alloy
@@ -152,6 +152,17 @@ declare "pod_logs" {
       replacement = "/var/log/pods/*$1/*.log"
       target_label = "__path__"
     }
+
+    // If kubernetes.io/config.mirror is set, this is a static pod, created by the kubelet.
+    // It's logs live on a different path.
+    rule {
+      source_labels = ["__meta_kubernetes_pod_annotation_kubernetes_io_config_mirror", "__meta_kubernetes_pod_container_name"]
+      separator = "/"
+      regex = "(.+/.+)"
+      action = "replace"
+      replacement = "/var/log/pods/*$1/*.log"
+      target_label = "__path__"
+    }
   }
 
   local.file_match "pod_logs" {

--- a/charts/k8s-monitoring/docs/examples/node-labels/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/node-labels/output.yaml
@@ -1397,6 +1397,17 @@ data:
           replacement = "/var/log/pods/*$1/*.log"
           target_label = "__path__"
         }
+    
+        // If kubernetes.io/config.mirror is set, this is a static pod, created by the kubelet.
+        // It's logs live on a different path.
+        rule {
+          source_labels = ["__meta_kubernetes_pod_annotation_kubernetes_io_config_mirror", "__meta_kubernetes_pod_container_name"]
+          separator = "/"
+          regex = "(.+/.+)"
+          action = "replace"
+          replacement = "/var/log/pods/*$1/*.log"
+          target_label = "__path__"
+        }
       }
     
       local.file_match "pod_logs" {

--- a/charts/k8s-monitoring/docs/examples/platforms/azure-aks/alloy-logs.alloy
+++ b/charts/k8s-monitoring/docs/examples/platforms/azure-aks/alloy-logs.alloy
@@ -140,6 +140,17 @@ declare "pod_logs" {
       replacement = "/var/log/pods/*$1/*.log"
       target_label = "__path__"
     }
+
+    // If kubernetes.io/config.mirror is set, this is a static pod, created by the kubelet.
+    // It's logs live on a different path.
+    rule {
+      source_labels = ["__meta_kubernetes_pod_annotation_kubernetes_io_config_mirror", "__meta_kubernetes_pod_container_name"]
+      separator = "/"
+      regex = "(.+/.+)"
+      action = "replace"
+      replacement = "/var/log/pods/*$1/*.log"
+      target_label = "__path__"
+    }
   }
 
   local.file_match "pod_logs" {

--- a/charts/k8s-monitoring/docs/examples/platforms/azure-aks/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/platforms/azure-aks/output.yaml
@@ -1005,6 +1005,17 @@ data:
           replacement = "/var/log/pods/*$1/*.log"
           target_label = "__path__"
         }
+    
+        // If kubernetes.io/config.mirror is set, this is a static pod, created by the kubelet.
+        // It's logs live on a different path.
+        rule {
+          source_labels = ["__meta_kubernetes_pod_annotation_kubernetes_io_config_mirror", "__meta_kubernetes_pod_container_name"]
+          separator = "/"
+          regex = "(.+/.+)"
+          action = "replace"
+          replacement = "/var/log/pods/*$1/*.log"
+          target_label = "__path__"
+        }
       }
     
       local.file_match "pod_logs" {

--- a/charts/k8s-monitoring/docs/examples/platforms/gke-autopilot/alloy-logs.alloy
+++ b/charts/k8s-monitoring/docs/examples/platforms/gke-autopilot/alloy-logs.alloy
@@ -140,6 +140,17 @@ declare "pod_logs" {
       replacement = "/var/log/pods/*$1/*.log"
       target_label = "__path__"
     }
+
+    // If kubernetes.io/config.mirror is set, this is a static pod, created by the kubelet.
+    // It's logs live on a different path.
+    rule {
+      source_labels = ["__meta_kubernetes_pod_annotation_kubernetes_io_config_mirror", "__meta_kubernetes_pod_container_name"]
+      separator = "/"
+      regex = "(.+/.+)"
+      action = "replace"
+      replacement = "/var/log/pods/*$1/*.log"
+      target_label = "__path__"
+    }
   }
 
   local.file_match "pod_logs" {

--- a/charts/k8s-monitoring/docs/examples/platforms/gke-autopilot/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/platforms/gke-autopilot/output.yaml
@@ -1071,6 +1071,17 @@ data:
           replacement = "/var/log/pods/*$1/*.log"
           target_label = "__path__"
         }
+    
+        // If kubernetes.io/config.mirror is set, this is a static pod, created by the kubelet.
+        // It's logs live on a different path.
+        rule {
+          source_labels = ["__meta_kubernetes_pod_annotation_kubernetes_io_config_mirror", "__meta_kubernetes_pod_container_name"]
+          separator = "/"
+          regex = "(.+/.+)"
+          action = "replace"
+          replacement = "/var/log/pods/*$1/*.log"
+          target_label = "__path__"
+        }
       }
     
       local.file_match "pod_logs" {

--- a/charts/k8s-monitoring/docs/examples/platforms/openshift/alloy-logs.alloy
+++ b/charts/k8s-monitoring/docs/examples/platforms/openshift/alloy-logs.alloy
@@ -140,6 +140,17 @@ declare "pod_logs" {
       replacement = "/var/log/pods/*$1/*.log"
       target_label = "__path__"
     }
+
+    // If kubernetes.io/config.mirror is set, this is a static pod, created by the kubelet.
+    // It's logs live on a different path.
+    rule {
+      source_labels = ["__meta_kubernetes_pod_annotation_kubernetes_io_config_mirror", "__meta_kubernetes_pod_container_name"]
+      separator = "/"
+      regex = "(.+/.+)"
+      action = "replace"
+      replacement = "/var/log/pods/*$1/*.log"
+      target_label = "__path__"
+    }
   }
 
   local.file_match "pod_logs" {

--- a/charts/k8s-monitoring/docs/examples/platforms/openshift/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/platforms/openshift/output.yaml
@@ -1352,6 +1352,17 @@ data:
           replacement = "/var/log/pods/*$1/*.log"
           target_label = "__path__"
         }
+    
+        // If kubernetes.io/config.mirror is set, this is a static pod, created by the kubelet.
+        // It's logs live on a different path.
+        rule {
+          source_labels = ["__meta_kubernetes_pod_annotation_kubernetes_io_config_mirror", "__meta_kubernetes_pod_container_name"]
+          separator = "/"
+          regex = "(.+/.+)"
+          action = "replace"
+          replacement = "/var/log/pods/*$1/*.log"
+          target_label = "__path__"
+        }
       }
     
       local.file_match "pod_logs" {

--- a/charts/k8s-monitoring/docs/examples/pod-labels-and-annotations/alloy-logs.alloy
+++ b/charts/k8s-monitoring/docs/examples/pod-labels-and-annotations/alloy-logs.alloy
@@ -150,6 +150,17 @@ declare "pod_logs" {
       replacement = "/var/log/pods/*$1/*.log"
       target_label = "__path__"
     }
+
+    // If kubernetes.io/config.mirror is set, this is a static pod, created by the kubelet.
+    // It's logs live on a different path.
+    rule {
+      source_labels = ["__meta_kubernetes_pod_annotation_kubernetes_io_config_mirror", "__meta_kubernetes_pod_container_name"]
+      separator = "/"
+      regex = "(.+/.+)"
+      action = "replace"
+      replacement = "/var/log/pods/*$1/*.log"
+      target_label = "__path__"
+    }
   }
 
   local.file_match "pod_logs" {

--- a/charts/k8s-monitoring/docs/examples/pod-labels-and-annotations/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/pod-labels-and-annotations/output.yaml
@@ -843,6 +843,17 @@ data:
           replacement = "/var/log/pods/*$1/*.log"
           target_label = "__path__"
         }
+    
+        // If kubernetes.io/config.mirror is set, this is a static pod, created by the kubelet.
+        // It's logs live on a different path.
+        rule {
+          source_labels = ["__meta_kubernetes_pod_annotation_kubernetes_io_config_mirror", "__meta_kubernetes_pod_container_name"]
+          separator = "/"
+          regex = "(.+/.+)"
+          action = "replace"
+          replacement = "/var/log/pods/*$1/*.log"
+          target_label = "__path__"
+        }
       }
     
       local.file_match "pod_logs" {

--- a/charts/k8s-monitoring/docs/examples/private-image-registries/globally/alloy-logs.alloy
+++ b/charts/k8s-monitoring/docs/examples/private-image-registries/globally/alloy-logs.alloy
@@ -140,6 +140,17 @@ declare "pod_logs" {
       replacement = "/var/log/pods/*$1/*.log"
       target_label = "__path__"
     }
+
+    // If kubernetes.io/config.mirror is set, this is a static pod, created by the kubelet.
+    // It's logs live on a different path.
+    rule {
+      source_labels = ["__meta_kubernetes_pod_annotation_kubernetes_io_config_mirror", "__meta_kubernetes_pod_container_name"]
+      separator = "/"
+      regex = "(.+/.+)"
+      action = "replace"
+      replacement = "/var/log/pods/*$1/*.log"
+      target_label = "__path__"
+    }
   }
 
   local.file_match "pod_logs" {

--- a/charts/k8s-monitoring/docs/examples/private-image-registries/globally/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/private-image-registries/globally/output.yaml
@@ -897,6 +897,17 @@ data:
           replacement = "/var/log/pods/*$1/*.log"
           target_label = "__path__"
         }
+    
+        // If kubernetes.io/config.mirror is set, this is a static pod, created by the kubelet.
+        // It's logs live on a different path.
+        rule {
+          source_labels = ["__meta_kubernetes_pod_annotation_kubernetes_io_config_mirror", "__meta_kubernetes_pod_container_name"]
+          separator = "/"
+          regex = "(.+/.+)"
+          action = "replace"
+          replacement = "/var/log/pods/*$1/*.log"
+          target_label = "__path__"
+        }
       }
     
       local.file_match "pod_logs" {

--- a/charts/k8s-monitoring/docs/examples/proxies/alloy-logs.alloy
+++ b/charts/k8s-monitoring/docs/examples/proxies/alloy-logs.alloy
@@ -140,6 +140,17 @@ declare "pod_logs" {
       replacement = "/var/log/pods/*$1/*.log"
       target_label = "__path__"
     }
+
+    // If kubernetes.io/config.mirror is set, this is a static pod, created by the kubelet.
+    // It's logs live on a different path.
+    rule {
+      source_labels = ["__meta_kubernetes_pod_annotation_kubernetes_io_config_mirror", "__meta_kubernetes_pod_container_name"]
+      separator = "/"
+      regex = "(.+/.+)"
+      action = "replace"
+      replacement = "/var/log/pods/*$1/*.log"
+      target_label = "__path__"
+    }
   }
 
   local.file_match "pod_logs" {

--- a/charts/k8s-monitoring/docs/examples/proxies/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/proxies/output.yaml
@@ -1078,6 +1078,17 @@ data:
           replacement = "/var/log/pods/*$1/*.log"
           target_label = "__path__"
         }
+    
+        // If kubernetes.io/config.mirror is set, this is a static pod, created by the kubelet.
+        // It's logs live on a different path.
+        rule {
+          source_labels = ["__meta_kubernetes_pod_annotation_kubernetes_io_config_mirror", "__meta_kubernetes_pod_container_name"]
+          separator = "/"
+          regex = "(.+/.+)"
+          action = "replace"
+          replacement = "/var/log/pods/*$1/*.log"
+          target_label = "__path__"
+        }
       }
     
       local.file_match "pod_logs" {

--- a/charts/k8s-monitoring/docs/examples/rbac-no-cluster-roles/alloy-logs.alloy
+++ b/charts/k8s-monitoring/docs/examples/rbac-no-cluster-roles/alloy-logs.alloy
@@ -143,6 +143,17 @@ declare "pod_logs" {
       replacement = "/var/log/pods/*$1/*.log"
       target_label = "__path__"
     }
+
+    // If kubernetes.io/config.mirror is set, this is a static pod, created by the kubelet.
+    // It's logs live on a different path.
+    rule {
+      source_labels = ["__meta_kubernetes_pod_annotation_kubernetes_io_config_mirror", "__meta_kubernetes_pod_container_name"]
+      separator = "/"
+      regex = "(.+/.+)"
+      action = "replace"
+      replacement = "/var/log/pods/*$1/*.log"
+      target_label = "__path__"
+    }
   }
 
   local.file_match "pod_logs" {

--- a/charts/k8s-monitoring/docs/examples/rbac-no-cluster-roles/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/rbac-no-cluster-roles/output.yaml
@@ -819,6 +819,17 @@ data:
           replacement = "/var/log/pods/*$1/*.log"
           target_label = "__path__"
         }
+    
+        // If kubernetes.io/config.mirror is set, this is a static pod, created by the kubelet.
+        // It's logs live on a different path.
+        rule {
+          source_labels = ["__meta_kubernetes_pod_annotation_kubernetes_io_config_mirror", "__meta_kubernetes_pod_container_name"]
+          separator = "/"
+          regex = "(.+/.+)"
+          action = "replace"
+          replacement = "/var/log/pods/*$1/*.log"
+          target_label = "__path__"
+        }
       }
     
       local.file_match "pod_logs" {

--- a/charts/k8s-monitoring/docs/examples/tail-sampling/alloy-logs.alloy
+++ b/charts/k8s-monitoring/docs/examples/tail-sampling/alloy-logs.alloy
@@ -140,6 +140,17 @@ declare "pod_logs" {
       replacement = "/var/log/pods/*$1/*.log"
       target_label = "__path__"
     }
+
+    // If kubernetes.io/config.mirror is set, this is a static pod, created by the kubelet.
+    // It's logs live on a different path.
+    rule {
+      source_labels = ["__meta_kubernetes_pod_annotation_kubernetes_io_config_mirror", "__meta_kubernetes_pod_container_name"]
+      separator = "/"
+      regex = "(.+/.+)"
+      action = "replace"
+      replacement = "/var/log/pods/*$1/*.log"
+      target_label = "__path__"
+    }
   }
 
   local.file_match "pod_logs" {

--- a/charts/k8s-monitoring/docs/examples/tail-sampling/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/tail-sampling/output.yaml
@@ -833,6 +833,17 @@ data:
           replacement = "/var/log/pods/*$1/*.log"
           target_label = "__path__"
         }
+    
+        // If kubernetes.io/config.mirror is set, this is a static pod, created by the kubelet.
+        // It's logs live on a different path.
+        rule {
+          source_labels = ["__meta_kubernetes_pod_annotation_kubernetes_io_config_mirror", "__meta_kubernetes_pod_container_name"]
+          separator = "/"
+          regex = "(.+/.+)"
+          action = "replace"
+          replacement = "/var/log/pods/*$1/*.log"
+          target_label = "__path__"
+        }
       }
     
       local.file_match "pod_logs" {

--- a/charts/k8s-monitoring/docs/examples/tolerations/alloy-logs.alloy
+++ b/charts/k8s-monitoring/docs/examples/tolerations/alloy-logs.alloy
@@ -140,6 +140,17 @@ declare "pod_logs" {
       replacement = "/var/log/pods/*$1/*.log"
       target_label = "__path__"
     }
+
+    // If kubernetes.io/config.mirror is set, this is a static pod, created by the kubelet.
+    // It's logs live on a different path.
+    rule {
+      source_labels = ["__meta_kubernetes_pod_annotation_kubernetes_io_config_mirror", "__meta_kubernetes_pod_container_name"]
+      separator = "/"
+      regex = "(.+/.+)"
+      action = "replace"
+      replacement = "/var/log/pods/*$1/*.log"
+      target_label = "__path__"
+    }
   }
 
   local.file_match "pod_logs" {

--- a/charts/k8s-monitoring/docs/examples/tolerations/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/tolerations/output.yaml
@@ -966,6 +966,17 @@ data:
           replacement = "/var/log/pods/*$1/*.log"
           target_label = "__path__"
         }
+    
+        // If kubernetes.io/config.mirror is set, this is a static pod, created by the kubelet.
+        // It's logs live on a different path.
+        rule {
+          source_labels = ["__meta_kubernetes_pod_annotation_kubernetes_io_config_mirror", "__meta_kubernetes_pod_container_name"]
+          separator = "/"
+          regex = "(.+/.+)"
+          action = "replace"
+          replacement = "/var/log/pods/*$1/*.log"
+          target_label = "__path__"
+        }
       }
     
       local.file_match "pod_logs" {

--- a/charts/k8s-monitoring/tests/integration/annotation-autodiscovery/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/integration/annotation-autodiscovery/.rendered/output.yaml
@@ -651,6 +651,17 @@ data:
           replacement = "/var/log/pods/*$1/*.log"
           target_label = "__path__"
         }
+    
+        // If kubernetes.io/config.mirror is set, this is a static pod, created by the kubelet.
+        // It's logs live on a different path.
+        rule {
+          source_labels = ["__meta_kubernetes_pod_annotation_kubernetes_io_config_mirror", "__meta_kubernetes_pod_container_name"]
+          separator = "/"
+          regex = "(.+/.+)"
+          action = "replace"
+          replacement = "/var/log/pods/*$1/*.log"
+          target_label = "__path__"
+        }
       }
     
       local.file_match "pod_logs" {

--- a/charts/k8s-monitoring/tests/integration/auth/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/integration/auth/.rendered/output.yaml
@@ -993,6 +993,17 @@ data:
           replacement = "/var/log/pods/*$1/*.log"
           target_label = "__path__"
         }
+    
+        // If kubernetes.io/config.mirror is set, this is a static pod, created by the kubelet.
+        // It's logs live on a different path.
+        rule {
+          source_labels = ["__meta_kubernetes_pod_annotation_kubernetes_io_config_mirror", "__meta_kubernetes_pod_container_name"]
+          separator = "/"
+          regex = "(.+/.+)"
+          action = "replace"
+          replacement = "/var/log/pods/*$1/*.log"
+          target_label = "__path__"
+        }
       }
     
       local.file_match "pod_logs" {

--- a/charts/k8s-monitoring/tests/integration/cluster-monitoring/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/integration/cluster-monitoring/.rendered/output.yaml
@@ -1175,6 +1175,17 @@ data:
           replacement = "/var/log/pods/*$1/*.log"
           target_label = "__path__"
         }
+    
+        // If kubernetes.io/config.mirror is set, this is a static pod, created by the kubelet.
+        // It's logs live on a different path.
+        rule {
+          source_labels = ["__meta_kubernetes_pod_annotation_kubernetes_io_config_mirror", "__meta_kubernetes_pod_container_name"]
+          separator = "/"
+          regex = "(.+/.+)"
+          action = "replace"
+          replacement = "/var/log/pods/*$1/*.log"
+          target_label = "__path__"
+        }
       }
     
       local.file_match "pod_logs" {

--- a/charts/k8s-monitoring/tests/integration/control-plane-monitoring/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/integration/control-plane-monitoring/.rendered/output.yaml
@@ -1356,6 +1356,17 @@ data:
           replacement = "/var/log/pods/*$1/*.log"
           target_label = "__path__"
         }
+    
+        // If kubernetes.io/config.mirror is set, this is a static pod, created by the kubelet.
+        // It's logs live on a different path.
+        rule {
+          source_labels = ["__meta_kubernetes_pod_annotation_kubernetes_io_config_mirror", "__meta_kubernetes_pod_container_name"]
+          separator = "/"
+          regex = "(.+/.+)"
+          action = "replace"
+          replacement = "/var/log/pods/*$1/*.log"
+          target_label = "__path__"
+        }
       }
     
       local.file_match "pod_logs" {

--- a/charts/k8s-monitoring/tests/integration/pod-logs/default/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/integration/pod-logs/default/.rendered/output.yaml
@@ -175,6 +175,17 @@ data:
           replacement = "/var/log/pods/*$1/*.log"
           target_label = "__path__"
         }
+    
+        // If kubernetes.io/config.mirror is set, this is a static pod, created by the kubelet.
+        // It's logs live on a different path.
+        rule {
+          source_labels = ["__meta_kubernetes_pod_annotation_kubernetes_io_config_mirror", "__meta_kubernetes_pod_container_name"]
+          separator = "/"
+          regex = "(.+/.+)"
+          action = "replace"
+          replacement = "/var/log/pods/*$1/*.log"
+          target_label = "__path__"
+        }
       }
     
       local.file_match "pod_logs" {

--- a/charts/k8s-monitoring/tests/integration/pod-logs/log-metrics/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/integration/pod-logs/log-metrics/.rendered/output.yaml
@@ -610,6 +610,17 @@ data:
           replacement = "/var/log/pods/*$1/*.log"
           target_label = "__path__"
         }
+    
+        // If kubernetes.io/config.mirror is set, this is a static pod, created by the kubelet.
+        // It's logs live on a different path.
+        rule {
+          source_labels = ["__meta_kubernetes_pod_annotation_kubernetes_io_config_mirror", "__meta_kubernetes_pod_container_name"]
+          separator = "/"
+          regex = "(.+/.+)"
+          action = "replace"
+          replacement = "/var/log/pods/*$1/*.log"
+          target_label = "__path__"
+        }
       }
     
       local.file_match "pod_logs" {

--- a/charts/k8s-monitoring/tests/integration/pod-logs/secret-filter/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/integration/pod-logs/secret-filter/.rendered/output.yaml
@@ -175,6 +175,17 @@ data:
           replacement = "/var/log/pods/*$1/*.log"
           target_label = "__path__"
         }
+    
+        // If kubernetes.io/config.mirror is set, this is a static pod, created by the kubelet.
+        // It's logs live on a different path.
+        rule {
+          source_labels = ["__meta_kubernetes_pod_annotation_kubernetes_io_config_mirror", "__meta_kubernetes_pod_container_name"]
+          separator = "/"
+          regex = "(.+/.+)"
+          action = "replace"
+          replacement = "/var/log/pods/*$1/*.log"
+          target_label = "__path__"
+        }
       }
     
       local.file_match "pod_logs" {

--- a/charts/k8s-monitoring/tests/integration/prom-and-loki-to-otlp/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/integration/prom-and-loki-to-otlp/.rendered/output.yaml
@@ -1226,6 +1226,17 @@ data:
           replacement = "/var/log/pods/*$1/*.log"
           target_label = "__path__"
         }
+    
+        // If kubernetes.io/config.mirror is set, this is a static pod, created by the kubelet.
+        // It's logs live on a different path.
+        rule {
+          source_labels = ["__meta_kubernetes_pod_annotation_kubernetes_io_config_mirror", "__meta_kubernetes_pod_container_name"]
+          separator = "/"
+          regex = "(.+/.+)"
+          action = "replace"
+          replacement = "/var/log/pods/*$1/*.log"
+          target_label = "__path__"
+        }
       }
     
       local.file_match "pod_logs" {

--- a/charts/k8s-monitoring/tests/integration/proxies/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/integration/proxies/.rendered/output.yaml
@@ -797,6 +797,17 @@ data:
           replacement = "/var/log/pods/*$1/*.log"
           target_label = "__path__"
         }
+    
+        // If kubernetes.io/config.mirror is set, this is a static pod, created by the kubelet.
+        // It's logs live on a different path.
+        rule {
+          source_labels = ["__meta_kubernetes_pod_annotation_kubernetes_io_config_mirror", "__meta_kubernetes_pod_container_name"]
+          separator = "/"
+          regex = "(.+/.+)"
+          action = "replace"
+          replacement = "/var/log/pods/*$1/*.log"
+          target_label = "__path__"
+        }
       }
     
       local.file_match "pod_logs" {

--- a/charts/k8s-monitoring/tests/integration/service-integrations/grafana/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/integration/service-integrations/grafana/.rendered/output.yaml
@@ -1347,6 +1347,17 @@ data:
           replacement = "/var/log/pods/*$1/*.log"
           target_label = "__path__"
         }
+    
+        // If kubernetes.io/config.mirror is set, this is a static pod, created by the kubelet.
+        // It's logs live on a different path.
+        rule {
+          source_labels = ["__meta_kubernetes_pod_annotation_kubernetes_io_config_mirror", "__meta_kubernetes_pod_container_name"]
+          separator = "/"
+          regex = "(.+/.+)"
+          action = "replace"
+          replacement = "/var/log/pods/*$1/*.log"
+          target_label = "__path__"
+        }
       }
     
       local.file_match "pod_logs" {

--- a/charts/k8s-monitoring/tests/integration/service-integrations/loki/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/integration/service-integrations/loki/.rendered/output.yaml
@@ -1373,6 +1373,17 @@ data:
           replacement = "/var/log/pods/*$1/*.log"
           target_label = "__path__"
         }
+    
+        // If kubernetes.io/config.mirror is set, this is a static pod, created by the kubelet.
+        // It's logs live on a different path.
+        rule {
+          source_labels = ["__meta_kubernetes_pod_annotation_kubernetes_io_config_mirror", "__meta_kubernetes_pod_container_name"]
+          separator = "/"
+          regex = "(.+/.+)"
+          action = "replace"
+          replacement = "/var/log/pods/*$1/*.log"
+          target_label = "__path__"
+        }
       }
     
       local.file_match "pod_logs" {

--- a/charts/k8s-monitoring/tests/integration/service-integrations/mysql/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/integration/service-integrations/mysql/.rendered/output.yaml
@@ -356,6 +356,17 @@ data:
           replacement = "/var/log/pods/*$1/*.log"
           target_label = "__path__"
         }
+    
+        // If kubernetes.io/config.mirror is set, this is a static pod, created by the kubelet.
+        // It's logs live on a different path.
+        rule {
+          source_labels = ["__meta_kubernetes_pod_annotation_kubernetes_io_config_mirror", "__meta_kubernetes_pod_container_name"]
+          separator = "/"
+          regex = "(.+/.+)"
+          action = "replace"
+          replacement = "/var/log/pods/*$1/*.log"
+          target_label = "__path__"
+        }
       }
     
       local.file_match "pod_logs" {

--- a/charts/k8s-monitoring/tests/integration/service-integrations/tempo/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/integration/service-integrations/tempo/.rendered/output.yaml
@@ -1373,6 +1373,17 @@ data:
           replacement = "/var/log/pods/*$1/*.log"
           target_label = "__path__"
         }
+    
+        // If kubernetes.io/config.mirror is set, this is a static pod, created by the kubelet.
+        // It's logs live on a different path.
+        rule {
+          source_labels = ["__meta_kubernetes_pod_annotation_kubernetes_io_config_mirror", "__meta_kubernetes_pod_container_name"]
+          separator = "/"
+          regex = "(.+/.+)"
+          action = "replace"
+          replacement = "/var/log/pods/*$1/*.log"
+          target_label = "__path__"
+        }
       }
     
       local.file_match "pod_logs" {

--- a/charts/k8s-monitoring/tests/integration/split-destinations/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/integration/split-destinations/.rendered/output.yaml
@@ -1031,6 +1031,17 @@ data:
           replacement = "/var/log/pods/*$1/*.log"
           target_label = "__path__"
         }
+    
+        // If kubernetes.io/config.mirror is set, this is a static pod, created by the kubelet.
+        // It's logs live on a different path.
+        rule {
+          source_labels = ["__meta_kubernetes_pod_annotation_kubernetes_io_config_mirror", "__meta_kubernetes_pod_container_name"]
+          separator = "/"
+          regex = "(.+/.+)"
+          action = "replace"
+          replacement = "/var/log/pods/*$1/*.log"
+          target_label = "__path__"
+        }
       }
     
       local.file_match "pod_logs" {

--- a/charts/k8s-monitoring/tests/integration/uninstall/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/integration/uninstall/.rendered/output.yaml
@@ -1175,6 +1175,17 @@ data:
           replacement = "/var/log/pods/*$1/*.log"
           target_label = "__path__"
         }
+    
+        // If kubernetes.io/config.mirror is set, this is a static pod, created by the kubelet.
+        // It's logs live on a different path.
+        rule {
+          source_labels = ["__meta_kubernetes_pod_annotation_kubernetes_io_config_mirror", "__meta_kubernetes_pod_container_name"]
+          separator = "/"
+          regex = "(.+/.+)"
+          action = "replace"
+          replacement = "/var/log/pods/*$1/*.log"
+          target_label = "__path__"
+        }
       }
     
       local.file_match "pod_logs" {

--- a/charts/k8s-monitoring/tests/integration/upgrade/major/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/integration/upgrade/major/.rendered/output.yaml
@@ -1188,6 +1188,17 @@ data:
           replacement = "/var/log/pods/*$1/*.log"
           target_label = "__path__"
         }
+    
+        // If kubernetes.io/config.mirror is set, this is a static pod, created by the kubelet.
+        // It's logs live on a different path.
+        rule {
+          source_labels = ["__meta_kubernetes_pod_annotation_kubernetes_io_config_mirror", "__meta_kubernetes_pod_container_name"]
+          separator = "/"
+          regex = "(.+/.+)"
+          action = "replace"
+          replacement = "/var/log/pods/*$1/*.log"
+          target_label = "__path__"
+        }
       }
     
       local.file_match "pod_logs" {

--- a/charts/k8s-monitoring/tests/integration/upgrade/minor/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/integration/upgrade/minor/.rendered/output.yaml
@@ -1188,6 +1188,17 @@ data:
           replacement = "/var/log/pods/*$1/*.log"
           target_label = "__path__"
         }
+    
+        // If kubernetes.io/config.mirror is set, this is a static pod, created by the kubelet.
+        // It's logs live on a different path.
+        rule {
+          source_labels = ["__meta_kubernetes_pod_annotation_kubernetes_io_config_mirror", "__meta_kubernetes_pod_container_name"]
+          separator = "/"
+          regex = "(.+/.+)"
+          action = "replace"
+          replacement = "/var/log/pods/*$1/*.log"
+          target_label = "__path__"
+        }
       }
     
       local.file_match "pod_logs" {

--- a/charts/k8s-monitoring/tests/integration/upgrade/patch/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/integration/upgrade/patch/.rendered/output.yaml
@@ -1188,6 +1188,17 @@ data:
           replacement = "/var/log/pods/*$1/*.log"
           target_label = "__path__"
         }
+    
+        // If kubernetes.io/config.mirror is set, this is a static pod, created by the kubelet.
+        // It's logs live on a different path.
+        rule {
+          source_labels = ["__meta_kubernetes_pod_annotation_kubernetes_io_config_mirror", "__meta_kubernetes_pod_container_name"]
+          separator = "/"
+          regex = "(.+/.+)"
+          action = "replace"
+          replacement = "/var/log/pods/*$1/*.log"
+          target_label = "__path__"
+        }
       }
     
       local.file_match "pod_logs" {

--- a/charts/k8s-monitoring/tests/platform/aks/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/platform/aks/.rendered/output.yaml
@@ -1368,6 +1368,17 @@ data:
           replacement = "/var/log/pods/*$1/*.log"
           target_label = "__path__"
         }
+    
+        // If kubernetes.io/config.mirror is set, this is a static pod, created by the kubelet.
+        // It's logs live on a different path.
+        rule {
+          source_labels = ["__meta_kubernetes_pod_annotation_kubernetes_io_config_mirror", "__meta_kubernetes_pod_container_name"]
+          separator = "/"
+          regex = "(.+/.+)"
+          action = "replace"
+          replacement = "/var/log/pods/*$1/*.log"
+          target_label = "__path__"
+        }
       }
     
       local.file_match "pod_logs" {

--- a/charts/k8s-monitoring/tests/platform/eks-fargate/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/platform/eks-fargate/.rendered/output.yaml
@@ -1369,6 +1369,17 @@ data:
           replacement = "/var/log/pods/*$1/*.log"
           target_label = "__path__"
         }
+    
+        // If kubernetes.io/config.mirror is set, this is a static pod, created by the kubelet.
+        // It's logs live on a different path.
+        rule {
+          source_labels = ["__meta_kubernetes_pod_annotation_kubernetes_io_config_mirror", "__meta_kubernetes_pod_container_name"]
+          separator = "/"
+          regex = "(.+/.+)"
+          action = "replace"
+          replacement = "/var/log/pods/*$1/*.log"
+          target_label = "__path__"
+        }
       }
     
       local.file_match "pod_logs" {

--- a/charts/k8s-monitoring/tests/platform/eks-with-windows/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/platform/eks-with-windows/.rendered/output.yaml
@@ -1522,6 +1522,17 @@ data:
           replacement = "/var/log/pods/*$1/*.log"
           target_label = "__path__"
         }
+    
+        // If kubernetes.io/config.mirror is set, this is a static pod, created by the kubelet.
+        // It's logs live on a different path.
+        rule {
+          source_labels = ["__meta_kubernetes_pod_annotation_kubernetes_io_config_mirror", "__meta_kubernetes_pod_container_name"]
+          separator = "/"
+          regex = "(.+/.+)"
+          action = "replace"
+          replacement = "/var/log/pods/*$1/*.log"
+          target_label = "__path__"
+        }
       }
     
       local.file_match "pod_logs" {

--- a/charts/k8s-monitoring/tests/platform/gke-autopilot/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/platform/gke-autopilot/.rendered/output.yaml
@@ -1111,6 +1111,17 @@ data:
           replacement = "/var/log/pods/*$1/*.log"
           target_label = "__path__"
         }
+    
+        // If kubernetes.io/config.mirror is set, this is a static pod, created by the kubelet.
+        // It's logs live on a different path.
+        rule {
+          source_labels = ["__meta_kubernetes_pod_annotation_kubernetes_io_config_mirror", "__meta_kubernetes_pod_container_name"]
+          separator = "/"
+          regex = "(.+/.+)"
+          action = "replace"
+          replacement = "/var/log/pods/*$1/*.log"
+          target_label = "__path__"
+        }
       }
     
       local.file_match "pod_logs" {

--- a/charts/k8s-monitoring/tests/platform/gke/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/platform/gke/.rendered/output.yaml
@@ -1428,6 +1428,17 @@ data:
           replacement = "/var/log/pods/*$1/*.log"
           target_label = "__path__"
         }
+    
+        // If kubernetes.io/config.mirror is set, this is a static pod, created by the kubelet.
+        // It's logs live on a different path.
+        rule {
+          source_labels = ["__meta_kubernetes_pod_annotation_kubernetes_io_config_mirror", "__meta_kubernetes_pod_container_name"]
+          separator = "/"
+          regex = "(.+/.+)"
+          action = "replace"
+          replacement = "/var/log/pods/*$1/*.log"
+          target_label = "__path__"
+        }
       }
     
       local.file_match "pod_logs" {

--- a/charts/k8s-monitoring/tests/platform/grafana-cloud/app-observability/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/platform/grafana-cloud/app-observability/.rendered/output.yaml
@@ -163,6 +163,17 @@ data:
           replacement = "/var/log/pods/*$1/*.log"
           target_label = "__path__"
         }
+    
+        // If kubernetes.io/config.mirror is set, this is a static pod, created by the kubelet.
+        // It's logs live on a different path.
+        rule {
+          source_labels = ["__meta_kubernetes_pod_annotation_kubernetes_io_config_mirror", "__meta_kubernetes_pod_container_name"]
+          separator = "/"
+          regex = "(.+/.+)"
+          action = "replace"
+          replacement = "/var/log/pods/*$1/*.log"
+          target_label = "__path__"
+        }
       }
     
       local.file_match "pod_logs" {

--- a/charts/k8s-monitoring/tests/platform/grafana-cloud/database-observability/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/platform/grafana-cloud/database-observability/.rendered/output.yaml
@@ -537,6 +537,17 @@ data:
           replacement = "/var/log/pods/*$1/*.log"
           target_label = "__path__"
         }
+    
+        // If kubernetes.io/config.mirror is set, this is a static pod, created by the kubelet.
+        // It's logs live on a different path.
+        rule {
+          source_labels = ["__meta_kubernetes_pod_annotation_kubernetes_io_config_mirror", "__meta_kubernetes_pod_container_name"]
+          separator = "/"
+          regex = "(.+/.+)"
+          action = "replace"
+          replacement = "/var/log/pods/*$1/*.log"
+          target_label = "__path__"
+        }
       }
     
       local.file_match "pod_logs" {

--- a/charts/k8s-monitoring/tests/platform/grafana-cloud/k8s-monitoring/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/platform/grafana-cloud/k8s-monitoring/.rendered/output.yaml
@@ -1569,6 +1569,17 @@ data:
           replacement = "/var/log/pods/*$1/*.log"
           target_label = "__path__"
         }
+    
+        // If kubernetes.io/config.mirror is set, this is a static pod, created by the kubelet.
+        // It's logs live on a different path.
+        rule {
+          source_labels = ["__meta_kubernetes_pod_annotation_kubernetes_io_config_mirror", "__meta_kubernetes_pod_container_name"]
+          separator = "/"
+          regex = "(.+/.+)"
+          action = "replace"
+          replacement = "/var/log/pods/*$1/*.log"
+          target_label = "__path__"
+        }
       }
     
       local.file_match "pod_logs" {

--- a/charts/k8s-monitoring/tests/platform/openshift/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/platform/openshift/.rendered/output.yaml
@@ -1410,6 +1410,17 @@ data:
           replacement = "/var/log/pods/*$1/*.log"
           target_label = "__path__"
         }
+    
+        // If kubernetes.io/config.mirror is set, this is a static pod, created by the kubelet.
+        // It's logs live on a different path.
+        rule {
+          source_labels = ["__meta_kubernetes_pod_annotation_kubernetes_io_config_mirror", "__meta_kubernetes_pod_container_name"]
+          separator = "/"
+          regex = "(.+/.+)"
+          action = "replace"
+          replacement = "/var/log/pods/*$1/*.log"
+          target_label = "__path__"
+        }
       }
     
       local.file_match "pod_logs" {

--- a/charts/k8s-monitoring/tests/platform/otlp-gateway/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/platform/otlp-gateway/.rendered/output.yaml
@@ -1048,6 +1048,17 @@ data:
           replacement = "/var/log/pods/*$1/*.log"
           target_label = "__path__"
         }
+    
+        // If kubernetes.io/config.mirror is set, this is a static pod, created by the kubelet.
+        // It's logs live on a different path.
+        rule {
+          source_labels = ["__meta_kubernetes_pod_annotation_kubernetes_io_config_mirror", "__meta_kubernetes_pod_container_name"]
+          separator = "/"
+          regex = "(.+/.+)"
+          action = "replace"
+          replacement = "/var/log/pods/*$1/*.log"
+          target_label = "__path__"
+        }
       }
     
       local.file_match "pod_logs" {


### PR DESCRIPTION
Static pods (created directly by the kubelet, often on a kubeadm-based cluster) don't show up on the regular pod logs path. The reason is that the pod that shows from the API server is a "mirror" of the one actually running on the kubelet. There's an annotation, [kubernetes.io/config.mirror](https://kubernetes.io/docs/reference/labels-annotations-taints/#kubernetes-io-config-mirror), that is added that links the API server's mirror pod to the actual pod id. So, to find the pod logs for those pods, we use the value in the annotation, rather than the pod UID.

cc @sebastian-de