### PR TITLE
fix(servicegraph): preserve user extraEnv in service graph collector

### DIFF
--- a/charts/k8s-monitoring/templates/alloy-servicegraph.yaml
+++ b/charts/k8s-monitoring/templates/alloy-servicegraph.yaml
@@ -7,10 +7,9 @@
 
     {{- $maxLength := 51 }}{{/* This limit is from the `controller-revision-hash` pod label value*/}}
     {{- $collectorName := printf "%s-%s" $.Release.Name (include "helper.k8s_name" (printf "%s-servicegraph" $destination.name)) | trunc $maxLength | trimSuffix "-" | lower }}
-    {{- $extraEnvContent := list (dict "name" "POD_NAME" "valueFrom" (dict "fieldRef" (dict "apiVersion" "v1" "fieldPath" "metadata.name"))) }}
-    {{- $userExtraEnv := dig "alloy" "extraEnv" list ($destination.processors.serviceGraphMetrics.collector | default dict) }}
-    {{- $combinedExtraEnv := concat $extraEnvContent $userExtraEnv }}
-    {{- $collectorValues := mergeOverwrite (dict "fullnameOverride" $collectorName "alloy" (dict "extraEnv" $combinedExtraEnv)) ($destination.processors.serviceGraphMetrics.collector | default dict) }}
+    {{- $extraEnv := dig "alloy" "extraEnv" list ($destination.processors.serviceGraphMetrics.collector | default dict) }}
+    {{- $extraEnv = (include "collectors.set_extra_env" (dict "envList" $extraEnv "name" "POD_NAME" "valueFrom" (dict "fieldRef" (dict "fieldPath" "metadata.name")))) | fromYamlArray }}
+    {{- $collectorValues := mergeOverwrite (dict "fullnameOverride" $collectorName) ($destination.processors.serviceGraphMetrics.collector | default dict) (dict "alloy" (dict "extraEnv" $extraEnv)) }}
     {{- $values := (deepCopy $ | merge (dict "collectorName" $collectorName "collectorValues" $collectorValues)) }}
     {{- $alloyValues := include "collector.alloy.values" $values | fromYaml }}
 

--- a/charts/k8s-monitoring/templates/collectors/_collector_helpers.tpl
+++ b/charts/k8s-monitoring/templates/collectors/_collector_helpers.tpl
@@ -49,6 +49,36 @@
 {{- $found -}}
 {{- end }}
 
+{{/* Inputs: envList (existing environment var list), name (environrment var name), value (), overwrite */}}
+{{- define "collectors.set_extra_env" -}}
+{{- $found := false -}}
+{{- $newList := list -}}
+{{- range .envList -}}
+  {{- if eq .name $.name -}}
+    {{- $found = true -}}
+    {{- if $.overwrite -}}
+      {{- if $.value -}}
+        {{- $newList = append $newList (dict "name" $.name "value" $.value) -}}
+      {{- else if $.valueFrom -}}
+        {{- $newList = append $newList (dict "name" $.name "valueFrom" $.valueFrom) -}}
+      {{- end -}}
+    {{- else -}}
+      {{- $newList = append $newList . -}}
+    {{- end -}}
+  {{- else -}}
+    {{- $newList = append $newList . -}}
+  {{- end -}}
+{{- end -}}
+{{- if not $found -}}
+  {{- if $.value -}}
+    {{- $newList = append $newList (dict "name" $.name "value" $.value) -}}
+  {{- else if $.valueFrom -}}
+    {{- $newList = append $newList (dict "name" $.name "valueFrom" $.valueFrom) -}}
+  {{- end -}}
+{{- end -}}
+{{- $newList | toYaml -}}
+{{- end }}
+
 {{/* Inputs: Values (all values), name (collector name), feature (feature name), portNumber, portName, portProtocol */}}
 {{- define "collectors.require_extra_port" -}}
 {{- if eq (include "collectors.has_extra_port" .) "false" }}

--- a/charts/k8s-monitoring/templates/collectors/_collector_remoteConfig.tpl
+++ b/charts/k8s-monitoring/templates/collectors/_collector_remoteConfig.tpl
@@ -7,24 +7,14 @@
   {{- if (dig "remoteConfig" "enabled" false $collectorValues) }}
     {{- $extraEnv := deepCopy (dig "alloy" "extraEnv" list $collectorValues) }}
     {{- if eq (include "collectors.has_extra_env" (deepCopy $ | merge (dict "name" $collectorName "envVar" "GCLOUD_FM_COLLECTOR_ID"))) "false" }}
-      {{- if eq (include "collectors.has_extra_env" (deepCopy $ | merge (dict "name" $collectorName "envVar" "CLUSTER_NAME"))) "false" }}
-        {{- $extraEnv = append $extraEnv (dict "name" "CLUSTER_NAME" "value" $.Values.cluster.name) }}
-      {{- end }}
-      {{- if eq (include "collectors.has_extra_env" (deepCopy $ | merge (dict "name" $collectorName "envVar" "NAMESPACE"))) "false" }}
-        {{- $extraEnv = append $extraEnv (dict "name" "NAMESPACE" "valueFrom" (dict "fieldRef" (dict "fieldPath" "metadata.namespace"))) }}
-      {{- end }}
+      {{- $extraEnv = (include "collectors.set_extra_env" (dict "envList" $extraEnv "name" "CLUSTER_NAME" "value" $.Values.cluster.name)) | fromYamlArray }}
+      {{- $extraEnv = (include "collectors.set_extra_env" (dict "envList" $extraEnv "name" "NAMESPACE" "valueFrom" (dict "fieldRef" (dict "fieldPath" "metadata.namespace")))) | fromYamlArray }}
       {{- if eq $collectorType "daemonset" }}
-        {{- if eq (include "collectors.has_extra_env" (deepCopy $ | merge (dict "name" $collectorName "envVar" "NODE_NAME"))) "false" }}
-          {{- $extraEnv = append $extraEnv (dict "name" "NODE_NAME" "valueFrom" (dict "fieldRef" (dict "fieldPath" "spec.nodeName"))) }}
-        {{- end }}
-        {{- if eq (include "collectors.has_extra_env" (deepCopy $ | merge (dict "name" $collectorName "envVar" "GCLOUD_FM_COLLECTOR_ID"))) "false" }}
-          {{- $extraEnv = append $extraEnv (dict "name" "GCLOUD_FM_COLLECTOR_ID" "value" (printf "%s-$(CLUSTER_NAME)-$(NAMESPACE)-%s-$(NODE_NAME)" $.Release.Name $collectorName)) }}
-        {{- end }}
+        {{- $extraEnv = (include "collectors.set_extra_env" (dict "envList" $extraEnv "name" "NODE_NAME" "valueFrom" (dict "fieldRef" (dict "fieldPath" "spec.nodeName")))) | fromYamlArray }}
+        {{- $extraEnv = (include "collectors.set_extra_env" (dict "envList" $extraEnv "name" "GCLOUD_FM_COLLECTOR_ID" "value" (printf "%s-$(CLUSTER_NAME)-$(NAMESPACE)-%s-$(NODE_NAME)" $.Release.Name $collectorName))) | fromYamlArray }}
       {{- else }}
-        {{- if eq (include "collectors.has_extra_env" (deepCopy $ | merge (dict "name" $collectorName "envVar" "POD_NAME"))) "false" }}
-          {{- $extraEnv = append $extraEnv (dict "name" "POD_NAME" "valueFrom" (dict "fieldRef" (dict "fieldPath" "metadata.name"))) }}
-        {{- end }}
-        {{- $extraEnv = append $extraEnv (dict "name" "GCLOUD_FM_COLLECTOR_ID" "value" (printf "%s-$(CLUSTER_NAME)-$(NAMESPACE)-$(POD_NAME)" $.Release.Name)) }}
+        {{- $extraEnv = (include "collectors.set_extra_env" (dict "envList" $extraEnv "name" "POD_NAME" "valueFrom" (dict "fieldRef" (dict "fieldPath" "metadata.name")))) | fromYamlArray }}
+        {{- $extraEnv = (include "collectors.set_extra_env" (dict "envList" $extraEnv "name" "GCLOUD_FM_COLLECTOR_ID" "value" (printf "%s-$(CLUSTER_NAME)-$(NAMESPACE)-$(POD_NAME)" $.Release.Name))) | fromYamlArray }}
       {{- end }}
     {{- end }}
 

--- a/charts/k8s-monitoring/templates/features/_feature_pod_logs_objects.tpl
+++ b/charts/k8s-monitoring/templates/features/_feature_pod_logs_objects.tpl
@@ -44,9 +44,7 @@ pod_logs_objects "feature" {
       {{- $values := dict }}
       {{- range $collectorName := include "features.podLogsObjects.collectors" . | fromYamlArray }}
         {{- $extraEnv := deepCopy (dig "alloy" "extraEnv" list (index $.Values $collectorName)) }}
-        {{- if eq (include "collectors.has_extra_env" (deepCopy $ | merge (dict "name" $collectorName "envVar" "NODE_NAME"))) "false" }}
-          {{- $extraEnv = append $extraEnv (dict "name" "NODE_NAME" "valueFrom" (dict "fieldRef" (dict "fieldPath" "spec.nodeName"))) }}
-        {{- end }}
+        {{- $extraEnv = (include "collectors.set_extra_env" (dict "envList" $extraEnv "name" "NODE_NAME" "valueFrom" (dict "fieldRef" (dict "fieldPath" "spec.nodeName")))) | fromYamlArray }}
         {{- $values = $values | merge (dict $collectorName (dict "alloy" (dict "extraEnv" $extraEnv))) }}
       {{- end }}
       {{- $values | toYaml }}

--- a/charts/k8s-monitoring/templates/test/helpers.yaml
+++ b/charts/k8s-monitoring/templates/test/helpers.yaml
@@ -8,4 +8,14 @@ data:
   regular: {{ include "helper.kubernetesName" "valid-kubernetes-name" | quote }}
   nameWithSpacesAndCapitals: {{ include "helper.kubernetesName" "This is my name" | quote }}
   nameWithUnderscores: {{ include "helper.kubernetesName" "i_am_a_snake" | quote }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: test-collectors-set-extra-env
+data:
+  insertNew: {{ include "collectors.set_extra_env" (dict "envList" (list (dict "name" "PORT" "value" "8080")) "name" "HOST" "value" "localhost" "overwrite" false) | fromYamlArray | toJson | quote }}
+  overwriteExisting: {{ include "collectors.set_extra_env" (dict "envList" (list (dict "name" "PORT" "value" "8080")) "name" "PORT" "value" "9090" "overwrite" true) | fromYamlArray | toJson | quote }}
+  noOverwriteExisting: {{ include "collectors.set_extra_env" (dict "envList" (list (dict "name" "PORT" "value" "8080")) "name" "PORT" "value" "9090" "overwrite" false) | fromYamlArray | toJson | quote }}
+  insertIntoEmpty: {{ include "collectors.set_extra_env" (dict "envList" (list) "name" "PORT" "value" "8080" "overwrite" false) | fromYamlArray | toJson | quote }}
 {{- end }}

--- a/charts/k8s-monitoring/tests/integration/service-graph-metrics/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/integration/service-graph-metrics/.rendered/output.yaml
@@ -1434,7 +1434,6 @@ spec:
     - name: POD_NAME
       valueFrom:
         fieldRef:
-          apiVersion: v1
           fieldPath: metadata.name
     extraPorts: []
     hostAliases: []

--- a/charts/k8s-monitoring/tests/unittest_helpers_test.yaml
+++ b/charts/k8s-monitoring/tests/unittest_helpers_test.yaml
@@ -10,3 +10,27 @@ tests:
       - {equal: {path: "data.regular",                   value: "valid-kubernetes-name" }, documentIndex: 0 }
       - {equal: {path: "data.nameWithSpacesAndCapitals", value: "this-is-my-name"       }, documentIndex: 0 }
       - {equal: {path: "data.nameWithUnderscores",       value: "i-am-a-snake"          }, documentIndex: 0 }
+
+  - it: collectors.set_extra_env inserts a new entry when name is not found
+    set:
+      testing: true
+    asserts:
+      - {equal: {path: "data.insertNew", value: '[{"name":"PORT","value":"8080"},{"name":"HOST","value":"localhost"}]'}, documentIndex: 1}
+
+  - it: collectors.set_extra_env overwrites an existing entry when overwrite is true
+    set:
+      testing: true
+    asserts:
+      - {equal: {path: "data.overwriteExisting", value: '[{"name":"PORT","value":"9090"}]'}, documentIndex: 1}
+
+  - it: collectors.set_extra_env does not overwrite an existing entry when overwrite is false
+    set:
+      testing: true
+    asserts:
+      - {equal: {path: "data.noOverwriteExisting", value: '[{"name":"PORT","value":"8080"}]'}, documentIndex: 1}
+
+  - it: collectors.set_extra_env inserts into an empty list
+    set:
+      testing: true
+    asserts:
+      - {equal: {path: "data.insertIntoEmpty", value: '[{"name":"PORT","value":"8080"}]'}, documentIndex: 1}


### PR DESCRIPTION
## Problem

The service graph template (`alloy-servicegraph.yaml`, line 11) uses Helm's `merge` to build collector values:

```go
$collectorValues := merge (dict "fullnameOverride" $collectorName "alloy" (dict "extraEnv" $extraEnvContent)) ($destination.processors.serviceGraphMetrics.collector | default dict)
```

Helm's `merge` gives priority to the **first** dict. Since the template hard-codes `alloy.extraEnv` with just `POD_NAME`, any user-provided `extraEnv` entries via `collector.alloy.extraEnv` are silently dropped.

This means users cannot inject custom environment variables into the service graph Alloy pod — which breaks auth when the Prometheus destination uses `passwordFrom: env("...")` since the env var doesn't exist in the service graph pod.

## Fix

1. **`concat`** the required `POD_NAME` env var with user-provided `extraEnv` entries (so both are preserved)
2. Switch from **`merge`** to **`mergeOverwrite`** so user collector values take priority over template defaults

```go
$userExtraEnv := dig "alloy" "extraEnv" list ($destination.processors.serviceGraphMetrics.collector | default dict)
$combinedExtraEnv := concat $extraEnvContent $userExtraEnv
$collectorValues := mergeOverwrite (dict "fullnameOverride" $collectorName "alloy" (dict "extraEnv" $combinedExtraEnv)) ($destination.processors.serviceGraphMetrics.collector | default dict)
```

## Reproduction

Configure a service graph with a custom env var:

```yaml
destinations:
  - name: my-otlp
    type: otlp
    auth:
      type: basic
      username: "12345"
      passwordFrom: env("MY_API_KEY")
    processors:
      serviceGraphMetrics:
        enabled: true
        collector:
          alloy:
            extraEnv:
              - name: MY_API_KEY
                valueFrom:
                  secretKeyRef:
                    name: my-secret
                    key: api-key
```

**Before fix:** The `MY_API_KEY` env var is dropped; only `POD_NAME` exists in the pod. Auth fails with 401.  
**After fix:** Both `POD_NAME` and `MY_API_KEY` are present. Auth works correctly.