### PR TITLE
feat(mysql): add perf_schema.eventsstatements collector options

### DIFF
--- a/charts/k8s-monitoring/charts/feature-integrations/docs/integrations/mysql.md
+++ b/charts/k8s-monitoring/charts/feature-integrations/docs/integrations/mysql.md
@@ -132,7 +132,7 @@ integrations:
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| exporter.collectors | object | `{"heartbeat":{"database":"","enabled":true,"table":""},"mysqlUser":{"enabled":true,"privileges":false},"perfSchemaEventsStatements":{"enabled":false}}` | The list of collectors to enable for the MySQL Exporter ([Documentation](https://grafana.com/docs/alloy/latest/reference/components/prometheus/prometheus.exporter.mysql/#supported-collectors)). This used to be a list of collector names. This format is still supported, but the new format will allow for customization. collectors: ["heartbeat", "mysql.user"] |
+| exporter.collectors | object | `{"heartbeat":{"database":"","enabled":true,"table":""},"mysqlUser":{"enabled":true,"privileges":false},"perfSchemaEventsStatements":{"enabled":false,"limit":null,"textLimit":null,"timeLimit":null}}` | The list of collectors to enable for the MySQL Exporter ([Documentation](https://grafana.com/docs/alloy/latest/reference/components/prometheus/prometheus.exporter.mysql/#supported-collectors)). This used to be a list of collector names. This format is still supported, but the new format will allow for customization. collectors: ["heartbeat", "mysql.user"] |
 | exporter.dataSource.allowFallbackToPlaintext | bool | `false` | The TLS setting to use. Options are none, "true", "false", "skip-verify", "preferred". See the [driver documentation](https://github.com/go-sql-driver/mysql#tls) for details. |
 | exporter.dataSource.auth.password | string | `""` | The password to use for the MySQL connection. |
 | exporter.dataSource.auth.passwordFrom | string | `""` | Raw config for accessing the password. |
@@ -157,6 +157,9 @@ integrations:
 | exporter.collectors.mysqlUser.enabled | bool | `true` | Enable mysql.user collector. |
 | exporter.collectors.mysqlUser.privileges | bool | `false` | Enable collecting user privileges from mysql.user. |
 | exporter.collectors.perfSchemaEventsStatements.enabled | bool | `false` | Enable perf_schema.eventsstatements collector. |
+| exporter.collectors.perfSchemaEventsStatements.limit | string | `250` | Limit the number of events statements digests, in descending order by last_seen. |
+| exporter.collectors.perfSchemaEventsStatements.textLimit | string | `120` (`0` when databaseObservability is enabled) | Maximum length of the normalized statement text. |
+| exporter.collectors.perfSchemaEventsStatements.timeLimit | string | `86400` | Limit how old, in seconds, the last_seen events statements can be. |
 
 ### General Settings
 

--- a/charts/k8s-monitoring/charts/feature-integrations/integrations/mysql-values.yaml
+++ b/charts/k8s-monitoring/charts/feature-integrations/integrations/mysql-values.yaml
@@ -148,6 +148,21 @@ exporter:
       # @section -- Exporter Collectors
       enabled: false
 
+      # -- Limit the number of events statements digests, in descending order by last_seen.
+      # @default -- `250`
+      # @section -- Exporter Collectors
+      limit:
+
+      # -- Maximum length of the normalized statement text.
+      # @default -- `120` (`0` when databaseObservability is enabled)
+      # @section -- Exporter Collectors
+      textLimit:
+
+      # -- Limit how old, in seconds, the last_seen events statements can be.
+      # @default -- `86400`
+      # @section -- Exporter Collectors
+      timeLimit:
+
 # Capture table, schema, and query information for the Database Observability feature in Grafana Cloud.
 databaseObservability:
   # -- Whether to gather table, schema, and query information from the database. Requires exporter to be enabled.

--- a/charts/k8s-monitoring/charts/feature-integrations/schema-mods/definitions/mysql-integration.schema.json
+++ b/charts/k8s-monitoring/charts/feature-integrations/schema-mods/definitions/mysql-integration.schema.json
@@ -163,6 +163,15 @@
                             "properties": {
                                 "enabled": {
                                     "type": "boolean"
+                                },
+                                "limit": {
+                                    "type": "integer"
+                                },
+                                "textLimit": {
+                                    "type": "integer"
+                                },
+                                "timeLimit": {
+                                    "type": "integer"
                                 }
                             }
                         }

--- a/charts/k8s-monitoring/charts/feature-integrations/templates/_integration_mysql_metrics.tpl
+++ b/charts/k8s-monitoring/charts/feature-integrations/templates/_integration_mysql_metrics.tpl
@@ -102,6 +102,22 @@ prometheus.exporter.mysql {{ include "helper.alloy_name" .name | quote }} {
     {{- end }}
     {{- if .exporter.collectors.perfSchemaEventsStatements.enabled }}
       {{- $enabledCollectors = append $enabledCollectors "perf_schema.eventsstatements" }}
+      {{- $opts := .exporter.collectors.perfSchemaEventsStatements }}
+      {{- if or $opts.limit $opts.textLimit $opts.timeLimit .databaseObservability.enabled }}
+  perf_schema.eventsstatements {
+        {{- if $opts.limit }}
+    limit = {{ $opts.limit | int }}
+        {{- end }}
+        {{- if not (kindIs "invalid" $opts.textLimit) }}
+    text_limit = {{ $opts.textLimit | int }}
+        {{- else if .databaseObservability.enabled }}
+    text_limit = 0
+        {{- end }}
+        {{- if $opts.timeLimit }}
+    time_limit = {{ $opts.timeLimit | int }}
+        {{- end }}
+  }
+      {{- end }}
     {{- end }}
   {{- end }}
   enable_collectors = {{ $enabledCollectors | toJson }}

--- a/charts/k8s-monitoring/charts/feature-integrations/tests/__snapshot__/mysql_db_o11y_metrics_test.yaml.snap
+++ b/charts/k8s-monitoring/charts/feature-integrations/tests/__snapshot__/mysql_db_o11y_metrics_test.yaml.snap
@@ -1,3 +1,90 @@
+defaults text_limit to 0 for perf_schema.eventsstatements when db o11y is enabled:
+  1: |
+    |-
+      declare "mysql_integration" {
+        argument "metrics_destinations" {
+          comment = "Must be a list of metric destinations where collected metrics should be forwarded to"
+        }
+        argument "logs_destinations" {
+          comment = "Must be a list of log destinations where collected logs should be forwarded to"
+        }
+
+        remote.kubernetes.secret "my_database" {
+          name      = "my-database-release-name-feature-integrations"
+          namespace = "NAMESPACE"
+        }
+
+        prometheus.exporter.mysql "my_database" {
+          data_source_name = string.format("%s:%s@(%s:%d)/",
+            convert.nonsensitive(remote.kubernetes.secret.my_database.data["username"]),
+            convert.nonsensitive(remote.kubernetes.secret.my_database.data["password"]),
+            "my-db.mysql.svc",
+            3306,
+          )
+          perf_schema.eventsstatements {
+            text_limit = 0
+          }
+          enable_collectors = ["heartbeat","mysql.user","perf_schema.eventsstatements"]
+        }
+
+        database_observability.mysql "my_database" {
+          targets = prometheus.exporter.mysql.my_database.targets
+          data_source_name = string.format("%s:%s@(%s:%d)/",
+            convert.nonsensitive(remote.kubernetes.secret.my_database.data["username"]),
+            convert.nonsensitive(remote.kubernetes.secret.my_database.data["password"]),
+            "my-db.mysql.svc",
+            3306,
+          )
+          allow_update_performance_schema_settings = false
+          query_details {
+            collect_interval = "1m"
+          }
+          query_samples {
+            collect_interval = "1m"
+            disable_query_redaction = false
+            auto_enable_setup_consumers = false
+            setup_consumers_check_interval = "1h"
+          }
+          schema_details {
+            collect_interval = "1m"
+            cache_enabled = false
+            cache_size = 256
+            cache_ttl = "10m"
+          }
+          setup_consumers {
+            collect_interval = "1m"
+          }
+          enable_collectors = ["query_details","query_samples","schema_details","setup_consumers"]
+
+          forward_to = argument.logs_destinations.value
+        }
+        prometheus.scrape "my_database" {
+          targets = database_observability.mysql.my_database.targets
+          clustering {
+            enabled = true
+          }
+
+          scrape_interval = "60s"
+          scrape_timeout = "10s"
+          scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
+          scrape_classic_histograms = false
+          scrape_native_histograms = false
+          forward_to = [prometheus.relabel.my_database.receiver]
+        }
+
+        prometheus.relabel "my_database" {
+          max_cache_size = 100000
+          rule {
+            target_label = "instance"
+            replacement = "my-database"
+          }
+          rule {
+            target_label = "job"
+            replacement = "integration/mysql"
+          }
+          forward_to = argument.metrics_destinations.value
+        }
+      }
 should create the MySQL config:
   1: |
     |-

--- a/charts/k8s-monitoring/charts/feature-integrations/tests/__snapshot__/mysql_metrics_test.yaml.snap
+++ b/charts/k8s-monitoring/charts/feature-integrations/tests/__snapshot__/mysql_metrics_test.yaml.snap
@@ -47,6 +47,60 @@ allows you to set the network protocol:
           forward_to = argument.metrics_destinations.value
         }
       }
+allows configuring perf_schema.eventsstatements options:
+  1: |
+    |-
+      declare "mysql_integration" {
+        argument "metrics_destinations" {
+          comment = "Must be a list of metric destinations where collected metrics should be forwarded to"
+        }
+
+        remote.kubernetes.secret "test_database" {
+          name      = "test-database-release-name-feature-integrations"
+          namespace = "NAMESPACE"
+        }
+
+        prometheus.exporter.mysql "test_database" {
+          data_source_name = string.format("%s:%s@(%s:%d)/",
+            convert.nonsensitive(remote.kubernetes.secret.test_database.data["username"]),
+            convert.nonsensitive(remote.kubernetes.secret.test_database.data["password"]),
+            "test-database-mysql.mysql.svc",
+            3306,
+          )
+          perf_schema.eventsstatements {
+            limit = 500
+            text_limit = 0
+            time_limit = 43200
+          }
+          enable_collectors = ["heartbeat","mysql.user","perf_schema.eventsstatements"]
+        }
+        prometheus.scrape "test_database" {
+          targets = prometheus.exporter.mysql.test_database.targets
+          clustering {
+            enabled = true
+          }
+
+          scrape_interval = "60s"
+          scrape_timeout = "10s"
+          scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
+          scrape_classic_histograms = false
+          scrape_native_histograms = false
+          forward_to = [prometheus.relabel.test_database.receiver]
+        }
+
+        prometheus.relabel "test_database" {
+          max_cache_size = 100000
+          rule {
+            target_label = "instance"
+            replacement = "test-database"
+          }
+          rule {
+            target_label = "job"
+            replacement = "integration/mysql"
+          }
+          forward_to = argument.metrics_destinations.value
+        }
+      }
 allows you to set the tls:
   1: |
     |-

--- a/charts/k8s-monitoring/charts/feature-integrations/tests/mysql_db_o11y_metrics_test.yaml
+++ b/charts/k8s-monitoring/charts/feature-integrations/tests/mysql_db_o11y_metrics_test.yaml
@@ -92,6 +92,29 @@ tests:
           path: stringData.password
           value: db-password
 
+  - it: defaults text_limit to 0 for perf_schema.eventsstatements when db o11y is enabled
+    set:
+      deployAsConfigMap: true
+      mysql:
+        instances:
+          - name: my-database
+            exporter:
+              dataSource:
+                host: my-db.mysql.svc
+                auth:
+                  username: db-admin
+                  password: db-password
+              collectors:
+                perfSchemaEventsStatements:
+                  enabled: true
+            databaseObservability:
+              enabled: true
+            logs: {enabled: false}
+    asserts:
+      - template: configmap.yaml
+        matchSnapshot:
+          path: data["metrics.alloy"]
+
   - it: requires metrics
     set:
       deployAsConfigMap: true

--- a/charts/k8s-monitoring/charts/feature-integrations/tests/mysql_metrics_test.yaml
+++ b/charts/k8s-monitoring/charts/feature-integrations/tests/mysql_metrics_test.yaml
@@ -148,3 +148,27 @@ tests:
       - template: configmap.yaml
         matchSnapshot:
           path: data["metrics.alloy"]
+
+  - it: allows configuring perf_schema.eventsstatements options
+    set:
+      deployAsConfigMap: true
+      mysql:
+        instances:
+          - name: test-database
+            exporter:
+              dataSource:
+                host: test-database-mysql.mysql.svc
+                auth:
+                  username: db-admin
+                  password: db-password
+              collectors:
+                perfSchemaEventsStatements:
+                  enabled: true
+                  limit: 500
+                  textLimit: 0
+                  timeLimit: 43200
+            logs: {enabled: false}
+    asserts:
+      - template: configmap.yaml
+        matchSnapshot:
+          path: data["metrics.alloy"]

--- a/charts/k8s-monitoring/charts/feature-integrations/values.schema.json
+++ b/charts/k8s-monitoring/charts/feature-integrations/values.schema.json
@@ -974,6 +974,15 @@
                                     "properties": {
                                         "enabled": {
                                             "type": "boolean"
+                                        },
+                                        "limit": {
+                                            "type": "integer"
+                                        },
+                                        "textLimit": {
+                                            "type": "integer"
+                                        },
+                                        "timeLimit": {
+                                            "type": "integer"
                                         }
                                     }
                                 }

--- a/charts/k8s-monitoring/docs/examples/features/database-observability/mysql/alloy-singleton.alloy
+++ b/charts/k8s-monitoring/docs/examples/features/database-observability/mysql/alloy-singleton.alloy
@@ -18,6 +18,9 @@ declare "mysql_integration" {
       "test-database-mysql.mysql.svc",
       3306,
     )
+    perf_schema.eventsstatements {
+      text_limit = 0
+    }
     enable_collectors = ["heartbeat","mysql.user","perf_schema.eventsstatements"]
   }
 

--- a/charts/k8s-monitoring/docs/examples/features/database-observability/mysql/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/features/database-observability/mysql/output.yaml
@@ -53,6 +53,9 @@ data:
           "test-database-mysql.mysql.svc",
           3306,
         )
+        perf_schema.eventsstatements {
+          text_limit = 0
+        }
         enable_collectors = ["heartbeat","mysql.user","perf_schema.eventsstatements"]
       }
     

--- a/charts/k8s-monitoring/tests/platform/grafana-cloud/database-observability/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/platform/grafana-cloud/database-observability/.rendered/output.yaml
@@ -41,6 +41,9 @@ data:
           "test-mysql-db.mysql.svc",
           3306,
         )
+        perf_schema.eventsstatements {
+          text_limit = 0
+        }
         enable_collectors = ["heartbeat","mysql.user","perf_schema.eventsstatements"]
       }
     


### PR DESCRIPTION
## Summary

- Expose `limit`, `textLimit`, and `timeLimit` options for the `perfSchemaEventsStatements` exporter collector in the MySQL integration, matching the [upstream Alloy options](https://grafana.com/docs/alloy/latest/reference/components/prometheus/prometheus.exporter.mysql/#perf_schemaeventsstatements).
- When `databaseObservability` is enabled and no explicit `textLimit` is set, default `text_limit` to `0` so query text is not captured.
- When `databaseObservability` is not enabled, unset options are omitted and Alloy applies its built-in defaults (`limit=250`, `text_limit=120`, `time_limit=86400`).

## Details

Previously the `perfSchemaEventsStatements` collector only had an `enabled` toggle with no way to configure its sub-options. This follows the existing pattern used by the `heartbeat` and `mysqlUser` collectors.

Example usage:

```yaml
integrations:
  mysql:
    instances:
      - name: my-db
        exporter:
          collectors:
            perfSchemaEventsStatements:
              enabled: true
              textLimit: 0
              limit: 500
          dataSource:
            host: mysql.default.svc
```

## Test plan

- [x] New helm-unittest cases added for both standard metrics and DB O11y scenarios
- [x] All 117 existing tests pass with 32 matching snapshots
- [x] `helm lint` passes
- [x] Rendered outputs for database-observability examples/tests regenerated and verified to contain `perf_schema.eventsstatements { text_limit = 0 }`
- [x] Non-DB-O11y rendered outputs confirmed unchanged (no spurious block rendered)