### PR TITLE
feat(pod-logs): add attachNamespaceMetadata option for volumes gather method

### DIFF
--- a/charts/k8s-monitoring/charts/feature-pod-logs/templates/_common_pod_discovery.alloy.tpl
+++ b/charts/k8s-monitoring/charts/feature-pod-logs/templates/_common_pod_discovery.alloy.tpl
@@ -127,6 +127,14 @@ discovery.relabel "filtered_pods" {
     target_label = {{ $label | quote }}
   }
 {{- end }}
+{{- if .Values.attachNamespaceMetadata }}
+  // make all labels on the namespace available to the pipeline as labels,
+  // they are omitted before write to loki via stage.label_keep unless explicitly set
+  rule {
+    action = "labelmap"
+    regex = "__meta_kubernetes_namespace_label_(.+)"
+  }
+{{- end }}
 {{- include "feature.podLogs.nodeDiscoveryRules" . | indent 2 }}
 
 {{- if .Values.extraDiscoveryRules }}

--- a/charts/k8s-monitoring/charts/feature-pod-logs/templates/_nodes_common.tpl
+++ b/charts/k8s-monitoring/charts/feature-pod-logs/templates/_nodes_common.tpl
@@ -1,16 +1,21 @@
 {{- define "feature.podLogs.attachNodeMetadata" }}
-{{- $attachMetadata := false -}}
-{{- $attachMetadata = or $attachMetadata (not (empty .Values.nodeSelectors)) -}}
-{{- $attachMetadata = or $attachMetadata .Values.nodeLabels.nodePool -}}
-{{- $attachMetadata = or $attachMetadata .Values.nodeLabels.region -}}
-{{- $attachMetadata = or $attachMetadata .Values.nodeLabels.availabilityZone -}}
-{{- $attachMetadata = or $attachMetadata .Values.nodeLabels.nodeRole -}}
-{{- $attachMetadata = or $attachMetadata .Values.nodeLabels.nodeOS -}}
-{{- $attachMetadata = or $attachMetadata .Values.nodeLabels.nodeArchitecture -}}
-{{- $attachMetadata = or $attachMetadata .Values.nodeLabels.instanceType -}}
-{{- if eq $attachMetadata true }}
+{{- $attachNodeMetadata := false -}}
+{{- $attachNodeMetadata = or $attachNodeMetadata (not (empty .Values.nodeSelectors)) -}}
+{{- $attachNodeMetadata = or $attachNodeMetadata .Values.nodeLabels.nodePool -}}
+{{- $attachNodeMetadata = or $attachNodeMetadata .Values.nodeLabels.region -}}
+{{- $attachNodeMetadata = or $attachNodeMetadata .Values.nodeLabels.availabilityZone -}}
+{{- $attachNodeMetadata = or $attachNodeMetadata .Values.nodeLabels.nodeRole -}}
+{{- $attachNodeMetadata = or $attachNodeMetadata .Values.nodeLabels.nodeOS -}}
+{{- $attachNodeMetadata = or $attachNodeMetadata .Values.nodeLabels.nodeArchitecture -}}
+{{- $attachNodeMetadata = or $attachNodeMetadata .Values.nodeLabels.instanceType -}}
+{{- if or $attachNodeMetadata .Values.attachNamespaceMetadata }}
 attach_metadata {
+{{- if eq $attachNodeMetadata true }}
   node = true
+{{- end }}
+{{- if .Values.attachNamespaceMetadata }}
+  namespace = true
+{{- end }}
 }
 {{- end }}
 {{- end }}

--- a/charts/k8s-monitoring/charts/feature-pod-logs/values.yaml
+++ b/charts/k8s-monitoring/charts/feature-pod-logs/values.yaml
@@ -41,6 +41,11 @@ nodeSelectors: {}
 # @section -- Pod Discovery
 labelSelectors: {}
 
+# -- Attach namespace metadata to pod discovery targets. When enabled, all namespace labels
+# are available as log labels via `__meta_kubernetes_namespace_label_*`. Only for the "volumes" gather method.
+# @section -- Pod Discovery
+attachNamespaceMetadata: false
+
 # -- Rules to filter pods for log gathering. Only used for "volumes" or "kubernetesApi" gather methods.
 # @section -- Pod Discovery
 extraDiscoveryRules: ""


### PR DESCRIPTION
## Description

Add `attachNamespaceMetadata` option to the pod logs feature for the `volumes` gather method.

When using the default `volumes` gather method, namespace labels are not available on pod log targets because `discovery.kubernetes "pods"` does not set `attach_metadata { namespace = true }`. This prevents users from enriching logs with namespace-level metadata (e.g., `team`, `environment`, `cost-center`) — a common requirement in multi-tenant clusters for log routing, access control, or cost attribution.

The `filelog` gather method already supports namespace labels via `otelcol.processor.k8sattributes`, but there is no equivalent for `volumes`.

This PR adds a single boolean option `attachNamespaceMetadata` (default: `false`) that:

1. Sets `attach_metadata { namespace = true }` in `discovery.kubernetes "pods"`, making `__meta_kubernetes_namespace_label_*` targets available.
2. Adds a `labelmap` rule in `discovery.relabel "filtered_pods"` to expose all namespace labels as pipeline labels.

### Changes

- **`values.yaml`**: Add `attachNamespaceMetadata: false` under Pod Discovery.
- **`_nodes_common.tpl`**: Extend `attachNodeMetadata` helper to include `namespace = true` when enabled.
- **`_common_pod_discovery.alloy.tpl`**: Add `labelmap` rule for `__meta_kubernetes_namespace_label_(.+)` when enabled.

## How to test

```yaml
podLogs:
  enabled: true
  gatherMethod: volumes
  attachNamespaceMetadata: true
  extraDiscoveryRules: |-
    rule {
      source_labels = ["my_namespace_label"]
      regex = "(.+)"
      target_label = "my_label"
    }
  labelsToKeep:
    - my_label
    - namespace
    - container
    - pod
```

1. Label a namespace: `kubectl label namespace default team=my-team`
2. Deploy a pod in that namespace
3. Verify `team` label appears on pod logs in Loki

## Related Issue(s)

None — feature request via PR.

