### PR TITLE
Fix Pod Logs documentation links in values.yaml

### DIFF
--- a/charts/k8s-monitoring/values.yaml
+++ b/charts/k8s-monitoring/values.yaml
@@ -162,7 +162,7 @@ nodeLogs:
 
 # -- Pod logs in Loki format.
 # Requires a destination that supports logs.
-# To see the valid options, please see the [Pod Logs feature documentation](https://github.com/grafana/k8s-monitoring-helm/tree/main/charts/k8s-monitoring/charts/feature-pod-logs).
+# To see the valid options, please see the [Pod Logs feature documentation](https://github.com/grafana/k8s-monitoring-helm/tree/main/charts/k8s-monitoring/charts/feature-pod-logs-via-loki).
 # @default -- Disabled
 # @section -- Features - Pod Logs via Loki
 podLogsViaLoki:
@@ -179,11 +179,11 @@ podLogsViaLoki:
   # @ignored
   collector: ""
 
-  # To see additional options, please see the [Pod Logs feature documentation](https://github.com/grafana/k8s-monitoring-helm/tree/main/charts/k8s-monitoring/charts/feature-pod-logs).
+  # To see additional options, please see the [Pod Logs feature documentation](https://github.com/grafana/k8s-monitoring-helm/tree/main/charts/k8s-monitoring/charts/feature-pod-logs-via-loki).
 
 # -- Pod logs in OpenTelemetry format.
 # Requires a destination that supports logs.
-# To see the valid options, please see the [Pod Logs feature documentation](https://github.com/grafana/k8s-monitoring-helm/tree/main/charts/k8s-monitoring/charts/feature-pod-logs).
+# To see the valid options, please see the [Pod Logs feature documentation](https://github.com/grafana/k8s-monitoring-helm/tree/main/charts/k8s-monitoring/charts/feature-pod-logs-via-opentelemetry).
 # @default -- Disabled
 # @section -- Features - Pod Logs via OpenTelemetry
 podLogsViaOpenTelemetry:
@@ -200,7 +200,7 @@ podLogsViaOpenTelemetry:
   # @ignored
   collector: ""
 
-  # To see additional options, please see the [Pod Logs feature documentation](https://github.com/grafana/k8s-monitoring-helm/tree/main/charts/k8s-monitoring/charts/feature-pod-logs).
+  # To see additional options, please see the [Pod Logs feature documentation](https://github.com/grafana/k8s-monitoring-helm/tree/main/charts/k8s-monitoring/charts/feature-pod-log-via-opentelemetrys).
 
 # -- Pod logs via Kubernetes API.
 # Requires a destination that supports logs.


### PR DESCRIPTION
Updated Pod Logs feature documentation links to reflect changes in the Loki and OpenTelemetry sections.