### PR TITLE
Fix node log level parsing broken since v4.0

### DIFF
--- a/charts/k8s-monitoring/CHANGELOG.md
+++ b/charts/k8s-monitoring/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+*   Fix node log level parsing broken since v4.0 due to case mismatch in selectors (@petewall)
+
 ## 4.0.1
 
 *   Remove extra `/var/configs` volume mount from OpenCost (@petewall)

--- a/charts/k8s-monitoring/charts/feature-node-logs/templates/_module.alloy.tpl
+++ b/charts/k8s-monitoring/charts/feature-node-logs/templates/_module.alloy.tpl
@@ -83,7 +83,7 @@ declare "node_logs" {
     // check to see if the log line matches the klog format (https://github.com/kubernetes/klog)
     stage.match {
       // unescaped regex: ([IWED][0-9]{4}\s+[0-9]{2}:[0-9]{2}:[0-9]{2}\.[0-9]+)
-      selector = "{level=\"unknown\"} |~ \"([IWED][0-9]{4}\\\\s+[0-9]{2}:[0-9]{2}:[0-9]{2}\\\\.[0-9]+)\""
+      selector = "{level=\"UNKNOWN\"} |~ \"([IWED][0-9]{4}\\\\s+[0-9]{2}:[0-9]{2}:[0-9]{2}\\\\.[0-9]+)\""
 
       // extract log level, klog uses a single letter code for the level followed by the month and day i.e. I0119
       stage.regex {
@@ -134,7 +134,7 @@ declare "node_logs" {
 
     // if the level is still unknown, do one last attempt at detecting it based on common levels
     stage.match {
-      selector = "{level=\"unknown\"}"
+      selector = "{level=\"UNKNOWN\"}"
 
       // unescaped regex: (?i)(?:"(?:level|loglevel|levelname|lvl|levelText|SeverityText)":\s*"|\s*(?:level|loglevel|levelText|lvl)="?|\s+\[?)(?P<level>(DEBUG?|DBG|INFO?(RMATION)?|WA?RN(ING)?|ERR(OR)?|CRI?T(ICAL)?|FATAL|FTL|NOTICE|TRACE|TRC|PANIC|PNC|ALERT|EMERGENCY))("|\s+|-|\s*\])
       stage.regex {

--- a/charts/k8s-monitoring/charts/feature-node-logs/tests/__snapshot__/default_test.yaml.snap
+++ b/charts/k8s-monitoring/charts/feature-node-logs/tests/__snapshot__/default_test.yaml.snap
@@ -53,7 +53,7 @@ should render the default configuration:
           // check to see if the log line matches the klog format (https://github.com/kubernetes/klog)
           stage.match {
             // unescaped regex: ([IWED][0-9]{4}\s+[0-9]{2}:[0-9]{2}:[0-9]{2}\.[0-9]+)
-            selector = "{level=\"unknown\"} |~ \"([IWED][0-9]{4}\\\\s+[0-9]{2}:[0-9]{2}:[0-9]{2}\\\\.[0-9]+)\""
+            selector = "{level=\"UNKNOWN\"} |~ \"([IWED][0-9]{4}\\\\s+[0-9]{2}:[0-9]{2}:[0-9]{2}\\\\.[0-9]+)\""
 
             // extract log level, klog uses a single letter code for the level followed by the month and day i.e. I0119
             stage.regex {
@@ -104,7 +104,7 @@ should render the default configuration:
 
           // if the level is still unknown, do one last attempt at detecting it based on common levels
           stage.match {
-            selector = "{level=\"unknown\"}"
+            selector = "{level=\"UNKNOWN\"}"
 
             // unescaped regex: (?i)(?:"(?:level|loglevel|levelname|lvl|levelText|SeverityText)":\s*"|\s*(?:level|loglevel|levelText|lvl)="?|\s+\[?)(?P<level>(DEBUG?|DBG|INFO?(RMATION)?|WA?RN(ING)?|ERR(OR)?|CRI?T(ICAL)?|FATAL|FTL|NOTICE|TRACE|TRC|PANIC|PNC|ALERT|EMERGENCY))("|\s+|-|\s*\])
             stage.regex {

--- a/charts/k8s-monitoring/charts/feature-node-logs/tests/__snapshot__/filter_units_test.yaml.snap
+++ b/charts/k8s-monitoring/charts/feature-node-logs/tests/__snapshot__/filter_units_test.yaml.snap
@@ -58,7 +58,7 @@ should create a ConfigMap that only includes certain units:
           // check to see if the log line matches the klog format (https://github.com/kubernetes/klog)
           stage.match {
             // unescaped regex: ([IWED][0-9]{4}\s+[0-9]{2}:[0-9]{2}:[0-9]{2}\.[0-9]+)
-            selector = "{level=\"unknown\"} |~ \"([IWED][0-9]{4}\\\\s+[0-9]{2}:[0-9]{2}:[0-9]{2}\\\\.[0-9]+)\""
+            selector = "{level=\"UNKNOWN\"} |~ \"([IWED][0-9]{4}\\\\s+[0-9]{2}:[0-9]{2}:[0-9]{2}\\\\.[0-9]+)\""
 
             // extract log level, klog uses a single letter code for the level followed by the month and day i.e. I0119
             stage.regex {
@@ -109,7 +109,7 @@ should create a ConfigMap that only includes certain units:
 
           // if the level is still unknown, do one last attempt at detecting it based on common levels
           stage.match {
-            selector = "{level=\"unknown\"}"
+            selector = "{level=\"UNKNOWN\"}"
 
             // unescaped regex: (?i)(?:"(?:level|loglevel|levelname|lvl|levelText|SeverityText)":\s*"|\s*(?:level|loglevel|levelText|lvl)="?|\s+\[?)(?P<level>(DEBUG?|DBG|INFO?(RMATION)?|WA?RN(ING)?|ERR(OR)?|CRI?T(ICAL)?|FATAL|FTL|NOTICE|TRACE|TRC|PANIC|PNC|ALERT|EMERGENCY))("|\s+|-|\s*\])
             stage.regex {

--- a/charts/k8s-monitoring/charts/feature-node-logs/tests/__snapshot__/labels_test.yaml.snap
+++ b/charts/k8s-monitoring/charts/feature-node-logs/tests/__snapshot__/labels_test.yaml.snap
@@ -65,7 +65,7 @@ should create a ConfigMap that sets custom journal labels:
           // check to see if the log line matches the klog format (https://github.com/kubernetes/klog)
           stage.match {
             // unescaped regex: ([IWED][0-9]{4}\s+[0-9]{2}:[0-9]{2}:[0-9]{2}\.[0-9]+)
-            selector = "{level=\"unknown\"} |~ \"([IWED][0-9]{4}\\\\s+[0-9]{2}:[0-9]{2}:[0-9]{2}\\\\.[0-9]+)\""
+            selector = "{level=\"UNKNOWN\"} |~ \"([IWED][0-9]{4}\\\\s+[0-9]{2}:[0-9]{2}:[0-9]{2}\\\\.[0-9]+)\""
 
             // extract log level, klog uses a single letter code for the level followed by the month and day i.e. I0119
             stage.regex {
@@ -116,7 +116,7 @@ should create a ConfigMap that sets custom journal labels:
 
           // if the level is still unknown, do one last attempt at detecting it based on common levels
           stage.match {
-            selector = "{level=\"unknown\"}"
+            selector = "{level=\"UNKNOWN\"}"
 
             // unescaped regex: (?i)(?:"(?:level|loglevel|levelname|lvl|levelText|SeverityText)":\s*"|\s*(?:level|loglevel|levelText|lvl)="?|\s+\[?)(?P<level>(DEBUG?|DBG|INFO?(RMATION)?|WA?RN(ING)?|ERR(OR)?|CRI?T(ICAL)?|FATAL|FTL|NOTICE|TRACE|TRC|PANIC|PNC|ALERT|EMERGENCY))("|\s+|-|\s*\])
             stage.regex {

--- a/charts/k8s-monitoring/charts/feature-node-logs/tests/__snapshot__/structured_metadata_test.yaml.snap
+++ b/charts/k8s-monitoring/charts/feature-node-logs/tests/__snapshot__/structured_metadata_test.yaml.snap
@@ -83,7 +83,7 @@ should create a ConfigMap that sets structured metadata k/v pairs:
           // check to see if the log line matches the klog format (https://github.com/kubernetes/klog)
           stage.match {
             // unescaped regex: ([IWED][0-9]{4}\s+[0-9]{2}:[0-9]{2}:[0-9]{2}\.[0-9]+)
-            selector = "{level=\"unknown\"} |~ \"([IWED][0-9]{4}\\\\s+[0-9]{2}:[0-9]{2}:[0-9]{2}\\\\.[0-9]+)\""
+            selector = "{level=\"UNKNOWN\"} |~ \"([IWED][0-9]{4}\\\\s+[0-9]{2}:[0-9]{2}:[0-9]{2}\\\\.[0-9]+)\""
 
             // extract log level, klog uses a single letter code for the level followed by the month and day i.e. I0119
             stage.regex {
@@ -134,7 +134,7 @@ should create a ConfigMap that sets structured metadata k/v pairs:
 
           // if the level is still unknown, do one last attempt at detecting it based on common levels
           stage.match {
-            selector = "{level=\"unknown\"}"
+            selector = "{level=\"UNKNOWN\"}"
 
             // unescaped regex: (?i)(?:"(?:level|loglevel|levelname|lvl|levelText|SeverityText)":\s*"|\s*(?:level|loglevel|levelText|lvl)="?|\s+\[?)(?P<level>(DEBUG?|DBG|INFO?(RMATION)?|WA?RN(ING)?|ERR(OR)?|CRI?T(ICAL)?|FATAL|FTL|NOTICE|TRACE|TRC|PANIC|PNC|ALERT|EMERGENCY))("|\s+|-|\s*\])
             stage.regex {

--- a/charts/k8s-monitoring/docs/examples/auth/oauth2/alloy-logs.alloy
+++ b/charts/k8s-monitoring/docs/examples/auth/oauth2/alloy-logs.alloy
@@ -51,7 +51,7 @@ declare "node_logs" {
     // check to see if the log line matches the klog format (https://github.com/kubernetes/klog)
     stage.match {
       // unescaped regex: ([IWED][0-9]{4}\s+[0-9]{2}:[0-9]{2}:[0-9]{2}\.[0-9]+)
-      selector = "{level=\"unknown\"} |~ \"([IWED][0-9]{4}\\\\s+[0-9]{2}:[0-9]{2}:[0-9]{2}\\\\.[0-9]+)\""
+      selector = "{level=\"UNKNOWN\"} |~ \"([IWED][0-9]{4}\\\\s+[0-9]{2}:[0-9]{2}:[0-9]{2}\\\\.[0-9]+)\""
 
       // extract log level, klog uses a single letter code for the level followed by the month and day i.e. I0119
       stage.regex {
@@ -102,7 +102,7 @@ declare "node_logs" {
 
     // if the level is still unknown, do one last attempt at detecting it based on common levels
     stage.match {
-      selector = "{level=\"unknown\"}"
+      selector = "{level=\"UNKNOWN\"}"
 
       // unescaped regex: (?i)(?:"(?:level|loglevel|levelname|lvl|levelText|SeverityText)":\s*"|\s*(?:level|loglevel|levelText|lvl)="?|\s+\[?)(?P<level>(DEBUG?|DBG|INFO?(RMATION)?|WA?RN(ING)?|ERR(OR)?|CRI?T(ICAL)?|FATAL|FTL|NOTICE|TRACE|TRC|PANIC|PNC|ALERT|EMERGENCY))("|\s+|-|\s*\])
       stage.regex {

--- a/charts/k8s-monitoring/docs/examples/auth/oauth2/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/auth/oauth2/output.yaml
@@ -157,7 +157,7 @@ data:
         // check to see if the log line matches the klog format (https://github.com/kubernetes/klog)
         stage.match {
           // unescaped regex: ([IWED][0-9]{4}\s+[0-9]{2}:[0-9]{2}:[0-9]{2}\.[0-9]+)
-          selector = "{level=\"unknown\"} |~ \"([IWED][0-9]{4}\\\\s+[0-9]{2}:[0-9]{2}:[0-9]{2}\\\\.[0-9]+)\""
+          selector = "{level=\"UNKNOWN\"} |~ \"([IWED][0-9]{4}\\\\s+[0-9]{2}:[0-9]{2}:[0-9]{2}\\\\.[0-9]+)\""
     
           // extract log level, klog uses a single letter code for the level followed by the month and day i.e. I0119
           stage.regex {
@@ -208,7 +208,7 @@ data:
     
         // if the level is still unknown, do one last attempt at detecting it based on common levels
         stage.match {
-          selector = "{level=\"unknown\"}"
+          selector = "{level=\"UNKNOWN\"}"
     
           // unescaped regex: (?i)(?:"(?:level|loglevel|levelname|lvl|levelText|SeverityText)":\s*"|\s*(?:level|loglevel|levelText|lvl)="?|\s+\[?)(?P<level>(DEBUG?|DBG|INFO?(RMATION)?|WA?RN(ING)?|ERR(OR)?|CRI?T(ICAL)?|FATAL|FTL|NOTICE|TRACE|TRC|PANIC|PNC|ALERT|EMERGENCY))("|\s+|-|\s*\])
           stage.regex {

--- a/charts/k8s-monitoring/docs/examples/features/node-logs/default/alloy-logs.alloy
+++ b/charts/k8s-monitoring/docs/examples/features/node-logs/default/alloy-logs.alloy
@@ -56,7 +56,7 @@ declare "node_logs" {
     // check to see if the log line matches the klog format (https://github.com/kubernetes/klog)
     stage.match {
       // unescaped regex: ([IWED][0-9]{4}\s+[0-9]{2}:[0-9]{2}:[0-9]{2}\.[0-9]+)
-      selector = "{level=\"unknown\"} |~ \"([IWED][0-9]{4}\\\\s+[0-9]{2}:[0-9]{2}:[0-9]{2}\\\\.[0-9]+)\""
+      selector = "{level=\"UNKNOWN\"} |~ \"([IWED][0-9]{4}\\\\s+[0-9]{2}:[0-9]{2}:[0-9]{2}\\\\.[0-9]+)\""
 
       // extract log level, klog uses a single letter code for the level followed by the month and day i.e. I0119
       stage.regex {
@@ -107,7 +107,7 @@ declare "node_logs" {
 
     // if the level is still unknown, do one last attempt at detecting it based on common levels
     stage.match {
-      selector = "{level=\"unknown\"}"
+      selector = "{level=\"UNKNOWN\"}"
 
       // unescaped regex: (?i)(?:"(?:level|loglevel|levelname|lvl|levelText|SeverityText)":\s*"|\s*(?:level|loglevel|levelText|lvl)="?|\s+\[?)(?P<level>(DEBUG?|DBG|INFO?(RMATION)?|WA?RN(ING)?|ERR(OR)?|CRI?T(ICAL)?|FATAL|FTL|NOTICE|TRACE|TRC|PANIC|PNC|ALERT|EMERGENCY))("|\s+|-|\s*\])
       stage.regex {

--- a/charts/k8s-monitoring/docs/examples/features/node-logs/default/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/features/node-logs/default/output.yaml
@@ -91,7 +91,7 @@ data:
         // check to see if the log line matches the klog format (https://github.com/kubernetes/klog)
         stage.match {
           // unescaped regex: ([IWED][0-9]{4}\s+[0-9]{2}:[0-9]{2}:[0-9]{2}\.[0-9]+)
-          selector = "{level=\"unknown\"} |~ \"([IWED][0-9]{4}\\\\s+[0-9]{2}:[0-9]{2}:[0-9]{2}\\\\.[0-9]+)\""
+          selector = "{level=\"UNKNOWN\"} |~ \"([IWED][0-9]{4}\\\\s+[0-9]{2}:[0-9]{2}:[0-9]{2}\\\\.[0-9]+)\""
     
           // extract log level, klog uses a single letter code for the level followed by the month and day i.e. I0119
           stage.regex {
@@ -142,7 +142,7 @@ data:
     
         // if the level is still unknown, do one last attempt at detecting it based on common levels
         stage.match {
-          selector = "{level=\"unknown\"}"
+          selector = "{level=\"UNKNOWN\"}"
     
           // unescaped regex: (?i)(?:"(?:level|loglevel|levelname|lvl|levelText|SeverityText)":\s*"|\s*(?:level|loglevel|levelText|lvl)="?|\s+\[?)(?P<level>(DEBUG?|DBG|INFO?(RMATION)?|WA?RN(ING)?|ERR(OR)?|CRI?T(ICAL)?|FATAL|FTL|NOTICE|TRACE|TRC|PANIC|PNC|ALERT|EMERGENCY))("|\s+|-|\s*\])
           stage.regex {

--- a/charts/k8s-monitoring/tests/platform/eks-with-windows/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/platform/eks-with-windows/.rendered/output.yaml
@@ -147,7 +147,7 @@ data:
         // check to see if the log line matches the klog format (https://github.com/kubernetes/klog)
         stage.match {
           // unescaped regex: ([IWED][0-9]{4}\s+[0-9]{2}:[0-9]{2}:[0-9]{2}\.[0-9]+)
-          selector = "{level=\"unknown\"} |~ \"([IWED][0-9]{4}\\\\s+[0-9]{2}:[0-9]{2}:[0-9]{2}\\\\.[0-9]+)\""
+          selector = "{level=\"UNKNOWN\"} |~ \"([IWED][0-9]{4}\\\\s+[0-9]{2}:[0-9]{2}:[0-9]{2}\\\\.[0-9]+)\""
     
           // extract log level, klog uses a single letter code for the level followed by the month and day i.e. I0119
           stage.regex {
@@ -198,7 +198,7 @@ data:
     
         // if the level is still unknown, do one last attempt at detecting it based on common levels
         stage.match {
-          selector = "{level=\"unknown\"}"
+          selector = "{level=\"UNKNOWN\"}"
     
           // unescaped regex: (?i)(?:"(?:level|loglevel|levelname|lvl|levelText|SeverityText)":\s*"|\s*(?:level|loglevel|levelText|lvl)="?|\s+\[?)(?P<level>(DEBUG?|DBG|INFO?(RMATION)?|WA?RN(ING)?|ERR(OR)?|CRI?T(ICAL)?|FATAL|FTL|NOTICE|TRACE|TRC|PANIC|PNC|ALERT|EMERGENCY))("|\s+|-|\s*\])
           stage.regex {


### PR DESCRIPTION
## Summary

Fixes #2435. The v4.0 refactor changed the initial log level from `"unknown"` to `"UNKNOWN"` (uppercase) to match the `ToUpper` normalization at the end of the pipeline, but the two `stage.match` selectors were not updated. Since Alloy selectors are case-sensitive, the level-parsing stages were never entered and all node logs kept `UNKNOWN` as their level.

This PR updates both selectors in `_module.alloy.tpl` to match `UNKNOWN` (uppercase).

## Test plan

- [x] `helm unittest` passes for feature-node-logs
- [x] `make build` and `make examples` regenerated all outputs
- [ ] Deploy and verify node logs get proper level labels (INFO, WARN, ERROR, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)