### PR TITLE
[codex] Support templated destination values

### DIFF
--- a/charts/k8s-monitoring/destinations/loki-values.yaml
+++ b/charts/k8s-monitoring/destinations/loki-values.yaml
@@ -4,10 +4,12 @@
 name: ""
 
 # -- The URL for the Loki destination.
+# Supports Helm templating and is rendered as a quoted string in the generated Alloy config.
 # @section -- General
 url: ""
 
 # -- Raw config for accessing the URL.
+# Use this when you need to insert a raw Alloy expression instead of a quoted string.
 # @section -- General
 urlFrom: ""
 
@@ -47,11 +49,11 @@ tenantIdKey: tenantId
 tenantIdFrom: ""
 
 # -- Extra headers to be set when sending data.
-# All values are treated as strings and automatically quoted.
+# All values are treated as strings, support Helm templating, and are automatically quoted.
 # @section -- General
 extraHeaders: {}
 # -- Extra headers to be set when sending data through a dynamic reference.
-# All values are treated as raw strings and not quoted.
+# All values are treated as raw Alloy expressions and not quoted.
 # @section -- General
 extraHeadersFrom: {}
 

--- a/charts/k8s-monitoring/destinations/otlp-values.yaml
+++ b/charts/k8s-monitoring/destinations/otlp-values.yaml
@@ -28,10 +28,12 @@ traces:
   enabled: true
 
 # -- The URL for the OTLP destination.
+# Supports Helm templating and is rendered as a quoted string in the generated Alloy config.
 # @section -- General
 url: ""
 
 # -- Raw config for accessing the URL.
+# Use this when you need to insert a raw Alloy expression instead of a quoted string.
 # @section -- General
 urlFrom: ""
 
@@ -50,11 +52,11 @@ tenantIdKey: "tenantId"
 tenantIdFrom: ""
 
 # -- Extra headers to be set when sending data.
-# All values are treated as strings and automatically quoted.
+# All values are treated as strings, support Helm templating, and are automatically quoted.
 # @section -- General
 extraHeaders: {}
 # -- Extra headers to be set when sending data through a dynamic reference.
-# All values are treated as raw strings and not quoted.
+# All values are treated as raw Alloy expressions and not quoted.
 # @section -- General
 extraHeadersFrom: {}
 

--- a/charts/k8s-monitoring/destinations/prometheus-values.yaml
+++ b/charts/k8s-monitoring/destinations/prometheus-values.yaml
@@ -4,11 +4,13 @@
 name: ""
 
 # -- The URL for the Prometheus destination.
+# Supports Helm templating and is rendered as a quoted string in the generated Alloy config.
 # @section -- General
 url: ""
 
 # -- Raw config for accessing the URL. Lets you insert raw Alloy references so you can load the URL from any number of
-# places, such as loading values from config maps to HTTP calls. For example: `urlFrom: sys.env("PROMETHEUS_URL")`
+# places, such as loading values from config maps to HTTP calls. Use this when you need a raw Alloy expression instead
+# of a quoted string. For example: `urlFrom: sys.env("PROMETHEUS_URL")`
 # @section -- General
 urlFrom: ""
 
@@ -39,11 +41,11 @@ tenantIdKey: tenantId
 tenantIdFrom: ""
 
 # -- Extra headers to be set when sending data.
-# All values are treated as strings and automatically quoted.
+# All values are treated as strings, support Helm templating, and are automatically quoted.
 # @section -- General
 extraHeaders: {}
 # -- Extra headers to be set when sending data using a dynamic reference.
-# All values are treated as raw strings and not quoted.
+# All values are treated as raw Alloy expressions and not quoted.
 # @section -- General
 extraHeadersFrom: {}
 

--- a/charts/k8s-monitoring/destinations/pyroscope-values.yaml
+++ b/charts/k8s-monitoring/destinations/pyroscope-values.yaml
@@ -4,10 +4,12 @@
 name: ""
 
 # -- The URL for the Pyroscope destination.
+# Supports Helm templating and is rendered as a quoted string in the generated Alloy config.
 # @section -- General
 url: ""
 
 # -- Raw config for accessing the URL.
+# Use this when you need to insert a raw Alloy expression instead of a quoted string.
 # @section -- General
 urlFrom: ""
 
@@ -38,11 +40,11 @@ tenantIdKey: tenantId
 tenantIdFrom: ""
 
 # -- Extra headers to be set when sending data.
-# All values are treated as strings and automatically quoted.
+# All values are treated as strings, support Helm templating, and are automatically quoted.
 # @section -- General
 extraHeaders: {}
 # -- Extra headers to be set when sending data through a dynamic reference.
-# All values are treated as raw strings and not quoted.
+# All values are treated as raw Alloy expressions and not quoted.
 # @section -- General
 extraHeadersFrom: {}
 

--- a/charts/k8s-monitoring/docs/destinations/loki.md
+++ b/charts/k8s-monitoring/docs/destinations/loki.md
@@ -75,8 +75,8 @@ This defines the options for defining a destination for logs that use the Loki p
 | batchSize | string | `""` | Maximum batch size of logs to accumulate before sending. |
 | batchWait | string | `""` | Maximum amount of time to wait before sending a batch. |
 | clusterLabels | list | `["cluster","k8s.cluster.name"]` | Labels to be set with the cluster name as the value. |
-| extraHeaders | object | `{}` | Extra headers to be set when sending data. All values are treated as strings and automatically quoted. |
-| extraHeadersFrom | object | `{}` | Extra headers to be set when sending data through a dynamic reference. All values are treated as raw strings and not quoted. |
+| extraHeaders | object | `{}` | Extra headers to be set when sending data. All values are treated as strings, support Helm templating, and are automatically quoted. |
+| extraHeadersFrom | object | `{}` | Extra headers to be set when sending data through a dynamic reference. All values are treated as raw Alloy expressions and not quoted. |
 | extraLabels | object | `{}` | Custom labels to be added to all logs and events. All values are treated as strings and automatically quoted. |
 | extraLabelsFrom | object | `{}` | Custom labels to be added to all logs and events through a dynamic reference. All values are treated as raw strings and not quoted. |
 | logProcessingStages | string | `""` | Stage blocks to be evaluated before delivering to the Loki destination. See ([docs](https://grafana.com/docs/alloy/latest/reference/components/loki/loki.process/#blocks)) for more information. |
@@ -93,8 +93,8 @@ This defines the options for defining a destination for logs that use the Loki p
 | tenantIdFrom | string | `""` | Raw config for accessing the tenant ID. |
 | tenantIdKey | string | `"tenantId"` | The key for storing the tenant ID in the secret. |
 | timeout | string | `10s` | Timeout for requests made to the URL. |
-| url | string | `""` | The URL for the Loki destination. |
-| urlFrom | string | `""` | Raw config for accessing the URL. |
+| url | string | `""` | The URL for the Loki destination. Supports Helm templating and is rendered as a quoted string in the generated Alloy config. |
+| urlFrom | string | `""` | Raw config for accessing the URL. Use this when you need to insert a raw Alloy expression instead of a quoted string. |
 
 ### Secret
 

--- a/charts/k8s-monitoring/docs/destinations/otlp.md
+++ b/charts/k8s-monitoring/docs/destinations/otlp.md
@@ -73,8 +73,8 @@ This defines the options for defining a destination for OpenTelemetry data that 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | clusterLabels | list | `["cluster","k8s.cluster.name"]` | Labels to be set with the cluster name as the value. |
-| extraHeaders | object | `{}` | Extra headers to be set when sending data. All values are treated as strings and automatically quoted. |
-| extraHeadersFrom | object | `{}` | Extra headers to be set when sending data through a dynamic reference. All values are treated as raw strings and not quoted. |
+| extraHeaders | object | `{}` | Extra headers to be set when sending data. All values are treated as strings, support Helm templating, and are automatically quoted. |
+| extraHeadersFrom | object | `{}` | Extra headers to be set when sending data through a dynamic reference. All values are treated as raw Alloy expressions and not quoted. |
 | name | string | `""` | The name for this OTLP destination. |
 | protocol | string | `"grpc"` | The protocol for the OTLP destination. Options are "grpc" (default), "http". |
 | protocolValidation | bool | `true` | Validate that the protocol matches known OTLP destinations, like Grafana Cloud's OTLP Gateway or Tempo endpoints. |
@@ -87,8 +87,8 @@ This defines the options for defining a destination for OpenTelemetry data that 
 | tenantId | string | `""` | The tenant ID for the OTLP destination. |
 | tenantIdFrom | string | `""` | Raw config for accessing the tenant ID. |
 | tenantIdKey | string | `"tenantId"` | The key for storing the tenant ID in the secret. |
-| url | string | `""` | The URL for the OTLP destination. |
-| urlFrom | string | `""` | Raw config for accessing the URL. |
+| url | string | `""` | The URL for the OTLP destination. Supports Helm templating and is rendered as a quoted string in the generated Alloy config. |
+| urlFrom | string | `""` | Raw config for accessing the URL. Use this when you need to insert a raw Alloy expression instead of a quoted string. |
 | writeBufferSize | string | `""` | Size of the write buffer the gRPC client to use for writing requests. |
 
 ### Telemetry

--- a/charts/k8s-monitoring/docs/destinations/prometheus.md
+++ b/charts/k8s-monitoring/docs/destinations/prometheus.md
@@ -92,8 +92,8 @@ This defines the options for defining a destination for metrics that use the Pro
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | clusterLabels | list | `["cluster","k8s.cluster.name"]` | Labels to be set with the cluster name as the value. |
-| extraHeaders | object | `{}` | Extra headers to be set when sending data. All values are treated as strings and automatically quoted. |
-| extraHeadersFrom | object | `{}` | Extra headers to be set when sending data using a dynamic reference. All values are treated as raw strings and not quoted. |
+| extraHeaders | object | `{}` | Extra headers to be set when sending data. All values are treated as strings, support Helm templating, and are automatically quoted. |
+| extraHeadersFrom | object | `{}` | Extra headers to be set when sending data using a dynamic reference. All values are treated as raw Alloy expressions and not quoted. |
 | extraLabels | object | `{}` | Extra labels to be added to all metrics before delivering to the destination. All values are treated as strings and automatically quoted. |
 | extraLabelsFrom | object | `{}` | Extra labels to be added to all metrics using a dynamic reference before delivering to the destination. All values are treated as raw strings and not quoted. |
 | metricProcessingRules | string | `""` | Rule blocks to apply to all metrics. Uses the [write_relabel_config block](https://grafana.com/docs/alloy/latest/reference/components/prometheus/prometheus.remote_write/#write_relabel_config-block) of the prometheus.remote_write component. Format: write_relabel_config {   source_labels = ["..."]   action = "..."   ... } |
@@ -108,8 +108,8 @@ This defines the options for defining a destination for metrics that use the Pro
 | tenantId | string | `""` | The tenant ID for the Prometheus destination. |
 | tenantIdFrom | string | `""` | Raw config for accessing the tenant ID. |
 | tenantIdKey | string | `"tenantId"` | The key for storing the tenant ID in the secret. |
-| url | string | `""` | The URL for the Prometheus destination. |
-| urlFrom | string | `""` | Raw config for accessing the URL. Lets you insert raw Alloy references so you can load the URL from any number of places, such as loading values from config maps to HTTP calls. For example: `urlFrom: sys.env("PROMETHEUS_URL")` |
+| url | string | `""` | The URL for the Prometheus destination. Supports Helm templating and is rendered as a quoted string in the generated Alloy config. |
+| urlFrom | string | `""` | Raw config for accessing the URL. Lets you insert raw Alloy references so you can load the URL from any number of places, such as loading values from config maps to HTTP calls. Use this when you need a raw Alloy expression instead of a quoted string. For example: `urlFrom: sys.env("PROMETHEUS_URL")` |
 
 ### Metric Enrichment
 

--- a/charts/k8s-monitoring/docs/destinations/pyroscope.md
+++ b/charts/k8s-monitoring/docs/destinations/pyroscope.md
@@ -72,8 +72,8 @@ This defines the options for defining a destination for profiles that use the Py
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | clusterLabels | list | `["cluster","k8s.cluster.name"]` | Labels to be set with the cluster name as the value. |
-| extraHeaders | object | `{}` | Extra headers to be set when sending data. All values are treated as strings and automatically quoted. |
-| extraHeadersFrom | object | `{}` | Extra headers to be set when sending data through a dynamic reference. All values are treated as raw strings and not quoted. |
+| extraHeaders | object | `{}` | Extra headers to be set when sending data. All values are treated as strings, support Helm templating, and are automatically quoted. |
+| extraHeadersFrom | object | `{}` | Extra headers to be set when sending data through a dynamic reference. All values are treated as raw Alloy expressions and not quoted. |
 | extraLabels | object | `{}` | Extra labels to be added to all profiles before delivering to the destination. All values are treated as strings and automatically quoted. |
 | extraLabelsFrom | object | `{}` | Extra labels to be added to all profiles using a dynamic reference before delivering to the destination. All values are treated as raw strings and not quoted. |
 | maxBackoffPeriod | string | `"5m"` | The maximum backoff period for the Pyroscope destination. |
@@ -87,8 +87,8 @@ This defines the options for defining a destination for profiles that use the Py
 | tenantId | string | `""` | The tenant ID for the Pyroscope destination. |
 | tenantIdFrom | string | `""` | Raw config for accessing the tenant ID. |
 | tenantIdKey | string | `"tenantId"` | The key for storing the tenant ID in the secret. |
-| url | string | `""` | The URL for the Pyroscope destination. |
-| urlFrom | string | `""` | Raw config for accessing the URL. |
+| url | string | `""` | The URL for the Pyroscope destination. Supports Helm templating and is rendered as a quoted string in the generated Alloy config. |
+| urlFrom | string | `""` | Raw config for accessing the URL. Use this when you need to insert a raw Alloy expression instead of a quoted string. |
 
 ### Secret
 

--- a/charts/k8s-monitoring/docs/examples/destinations/otlp-endpoint/README.md
+++ b/charts/k8s-monitoring/docs/examples/destinations/otlp-endpoint/README.md
@@ -9,6 +9,10 @@ the appropriate backend databases for storage. In this Helm chart, the
 [OTLP Destination](https://grafana.com/docs/grafana-cloud/send-data/otlp/send-data-otlp/) makes this possible. This
 means that you can define a single destination for all of your telemetry data.
 
+This example also shows how standard destination fields such as `url` and `extraHeaders`
+can be templated from other Helm values without switching to the raw `urlFrom` or
+`extraHeadersFrom` forms.
+
 ## Values
 
 <!-- textlint-disable terminology -->
@@ -20,8 +24,10 @@ cluster:
 destinations:
   otlp-gateway:
     type: otlp
-    url: https://otlp-gateway-my-region.grafana.net/otlp
+    url: https://{{ .Values.cluster.name }}.otlp-gateway-my-region.grafana.net/otlp
     protocol: http
+    extraHeaders:
+      x-cluster: "{{ .Values.cluster.name }}"
     auth:
       type: basic
       username: my-gateway-username

--- a/charts/k8s-monitoring/docs/examples/destinations/otlp-endpoint/alloy-logs.alloy
+++ b/charts/k8s-monitoring/docs/examples/destinations/otlp-endpoint/alloy-logs.alloy
@@ -372,8 +372,11 @@ otelcol.processor.batch "otlp_gateway" {
 }
 otelcol.exporter.otlphttp "otlp_gateway" {
   client {
-    endpoint = "https://otlp-gateway-my-region.grafana.net/otlp"
+    endpoint = "https://otlp-gateway-test.otlp-gateway-my-region.grafana.net/otlp"
     auth = otelcol.auth.basic.otlp_gateway.handler
+    headers = {
+      "x-cluster" = "otlp-gateway-test",
+    }
     tls {
       insecure = false
       insecure_skip_verify = false
@@ -409,4 +412,3 @@ remote.kubernetes.secret "otlp_gateway" {
   name      = "otlp-gateway-k8smon-k8s-monitoring"
   namespace = "default"
 }
-

--- a/charts/k8s-monitoring/docs/examples/destinations/otlp-endpoint/alloy-metrics.alloy
+++ b/charts/k8s-monitoring/docs/examples/destinations/otlp-endpoint/alloy-metrics.alloy
@@ -698,8 +698,11 @@ otelcol.processor.batch "otlp_gateway" {
 }
 otelcol.exporter.otlphttp "otlp_gateway" {
   client {
-    endpoint = "https://otlp-gateway-my-region.grafana.net/otlp"
+    endpoint = "https://otlp-gateway-test.otlp-gateway-my-region.grafana.net/otlp"
     auth = otelcol.auth.basic.otlp_gateway.handler
+    headers = {
+      "x-cluster" = "otlp-gateway-test",
+    }
     tls {
       insecure = false
       insecure_skip_verify = false
@@ -735,4 +738,3 @@ remote.kubernetes.secret "otlp_gateway" {
   name      = "otlp-gateway-k8smon-k8s-monitoring"
   namespace = "default"
 }
-

--- a/charts/k8s-monitoring/docs/examples/destinations/otlp-endpoint/description.txt
+++ b/charts/k8s-monitoring/docs/examples/destinations/otlp-endpoint/description.txt
@@ -4,3 +4,7 @@ Some cloud services allow for sending all telemetry data to a single endpoint, w
 the appropriate backend databases for storage. In this Helm chart, the
 [OTLP Destination](https://grafana.com/docs/grafana-cloud/send-data/otlp/send-data-otlp/) makes this possible. This
 means that you can define a single destination for all of your telemetry data.
+
+This example also shows how standard destination fields such as `url` and `extraHeaders`
+can be templated from other Helm values without switching to the raw `urlFrom` or
+`extraHeadersFrom` forms.

--- a/charts/k8s-monitoring/docs/examples/destinations/otlp-endpoint/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/destinations/otlp-endpoint/output.yaml
@@ -479,8 +479,11 @@ data:
     }
     otelcol.exporter.otlphttp "otlp_gateway" {
       client {
-        endpoint = "https://otlp-gateway-my-region.grafana.net/otlp"
+        endpoint = "https://otlp-gateway-test.otlp-gateway-my-region.grafana.net/otlp"
         auth = otelcol.auth.basic.otlp_gateway.handler
+        headers = {
+          "x-cluster" = "otlp-gateway-test",
+        }
         tls {
           insecure = false
           insecure_skip_verify = false
@@ -1225,8 +1228,11 @@ data:
     }
     otelcol.exporter.otlphttp "otlp_gateway" {
       client {
-        endpoint = "https://otlp-gateway-my-region.grafana.net/otlp"
+        endpoint = "https://otlp-gateway-test.otlp-gateway-my-region.grafana.net/otlp"
         auth = otelcol.auth.basic.otlp_gateway.handler
+        headers = {
+          "x-cluster" = "otlp-gateway-test",
+        }
         tls {
           insecure = false
           insecure_skip_verify = false

--- a/charts/k8s-monitoring/docs/examples/destinations/otlp-endpoint/values.yaml
+++ b/charts/k8s-monitoring/docs/examples/destinations/otlp-endpoint/values.yaml
@@ -5,8 +5,10 @@ cluster:
 destinations:
   otlp-gateway:
     type: otlp
-    url: https://otlp-gateway-my-region.grafana.net/otlp
+    url: https://{{ .Values.cluster.name }}.otlp-gateway-my-region.grafana.net/otlp
     protocol: http
+    extraHeaders:
+      x-cluster: "{{ .Values.cluster.name }}"
     auth:
       type: basic
       username: my-gateway-username

--- a/charts/k8s-monitoring/templates/destinations/_config.alloy.tpl
+++ b/charts/k8s-monitoring/templates/destinations/_config.alloy.tpl
@@ -21,6 +21,7 @@
     {{- $destination := get $.Values.destinations $destinationName }}
     {{- $defaultValues := (printf "destinations/%s-values.yaml" $destination.type) | $.Files.Get | fromYaml }}
     {{- $destinationWithDefaults := mergeOverwrite $defaultValues $destination }}
+    {{- $_ := set $destinationWithDefaults "tplRoot" $ }}
 // Destination: {{ $destinationName }} ({{ $destination.type }})
 {{- include (printf "destinations.%s.alloy" $destination.type) (deepCopy $ | merge (dict "destination" $destinationWithDefaults "destinationName" $destinationName)) | indent 0 }}
 

--- a/charts/k8s-monitoring/templates/destinations/_destination_loki.tpl
+++ b/charts/k8s-monitoring/templates/destinations/_destination_loki.tpl
@@ -18,7 +18,7 @@ loki.write {{ include "helper.alloy_name" $.destinationName | quote }} {
 {{- if .urlFrom }} 
     url = {{ .urlFrom }}
 {{- else }}
-    url = {{ .url | quote }} 
+    url = {{ tpl (toString .url) .tplRoot | quote }} 
 {{- end }}
 {{- if .timeout }}
     remote_timeout = {{ .timeout | quote }}
@@ -34,9 +34,10 @@ loki.write {{ include "helper.alloy_name" $.destinationName | quote }} {
     tenant_id = {{ include "secrets.read" (dict "object" . "name" $.destinationName "key" "tenantId" "nonsensitive" true) }}
 {{- end }}
 {{- if or .extraHeaders .extraHeadersFrom }}
+  {{- $tplRoot := .tplRoot }}
     headers = {
 {{- range $key, $value := .extraHeaders }}
-      {{ $key | quote }} = {{ $value | quote }},
+      {{ $key | quote }} = {{ tpl (toString $value) $tplRoot | quote }},
 {{- end }}
 {{- range $key, $value := .extraHeadersFrom }}
       {{ $key | quote }} = {{ $value }},

--- a/charts/k8s-monitoring/templates/destinations/_destination_otlp.tpl
+++ b/charts/k8s-monitoring/templates/destinations/_destination_otlp.tpl
@@ -440,7 +440,7 @@ otelcol.exporter.otlphttp {{ include "helper.alloy_name" $.destinationName | quo
 {{- if .urlFrom }}
     endpoint = {{ .urlFrom }}
 {{- else }}
-    endpoint = {{ .url | quote }}
+    endpoint = {{ tpl (toString .url) .tplRoot | quote }}
 {{- end }}
 {{- if .proxyURL }}
     proxy_url = {{ .proxyURL | quote }}
@@ -455,12 +455,13 @@ otelcol.exporter.otlphttp {{ include "helper.alloy_name" $.destinationName | quo
     auth = otelcol.auth.sigv4.{{ include "helper.alloy_name" $.destinationName }}.handler
 {{- end }}
 {{- if or (eq (include "secrets.usesSecret" (dict "object" . "name" $.destinationName "key" "tenantId")) "true") .extraHeaders .extraHeadersFrom }}
+  {{- $tplRoot := .tplRoot }}
     headers = {
 {{- if eq (include "secrets.usesSecret" (dict "object" . "name" $.destinationName "key" "tenantId")) "true" }}
       "X-Scope-OrgID" = {{ include "secrets.read" (dict "object" . "name" $.destinationName "key" "tenantId" "nonsensitive" true) }},
 {{- end }}
 {{- range $key, $value := .extraHeaders }}
-      {{ $key | quote }} = {{ $value | quote }},
+      {{ $key | quote }} = {{ tpl (toString $value) $tplRoot | quote }},
 {{- end }}
 {{- range $key, $value := .extraHeadersFrom }}
       {{ $key | quote }} = {{ $value }},

--- a/charts/k8s-monitoring/templates/destinations/_destination_prometheus.tpl
+++ b/charts/k8s-monitoring/templates/destinations/_destination_prometheus.tpl
@@ -91,7 +91,7 @@ prometheus.remote_write {{ include "helper.alloy_name" $.destinationName | quote
 {{- if .urlFrom }} 
     url = {{ .urlFrom }}
 {{- else }}
-    url = {{ .url | quote }} 
+    url = {{ tpl (toString .url) .tplRoot | quote }} 
 {{- end }}
 {{- if .protobufMessage }}
     protobuf_message = {{ .protobufMessage | quote }}
@@ -99,13 +99,14 @@ prometheus.remote_write {{ include "helper.alloy_name" $.destinationName | quote
     protobuf_message = "io.prometheus.write.v2.Request"
 {{- end }}
     headers = {
+{{- $tplRoot := .tplRoot }}
 {{- if ne (include "secrets.authType" .) "sigv4" }}
   {{- if eq (include "secrets.usesSecret" (dict "object" . "name" $.destinationName "key" "tenantId")) "true" }}
       "X-Scope-OrgID" = {{ include "secrets.read" (dict "object" . "name" $.destinationName "key" "tenantId" "nonsensitive" true) }},
   {{- end }}
 {{- end }}
 {{- range $key, $value := .extraHeaders }}
-      {{ $key | quote }} = {{ $value | quote }},
+      {{ $key | quote }} = {{ tpl (toString $value) $tplRoot | quote }},
 {{- end }}
 {{- range $key, $value := .extraHeadersFrom }}
       {{ $key | quote }} = {{ $value }},

--- a/charts/k8s-monitoring/templates/destinations/_destination_pyroscope.tpl
+++ b/charts/k8s-monitoring/templates/destinations/_destination_pyroscope.tpl
@@ -7,14 +7,15 @@ pyroscope.write {{ include "helper.alloy_name" $.destinationName | quote }} {
 {{- if .urlFrom }} 
     url = {{ .urlFrom }}
 {{- else }}
-    url = {{ .url | quote }} 
+    url = {{ tpl (toString .url) .tplRoot | quote }} 
 {{- end }}
     headers = {
+{{- $tplRoot := .tplRoot }}
 {{- if eq (include "secrets.usesSecret" (dict "object" . "name" $.destinationName "key" "tenantId")) "true" }}
       "X-Scope-OrgID" = {{ include "secrets.read" (dict "object" . "name" $.destinationName "key" "tenantId" "nonsensitive" true) }},
 {{- end }}
 {{- range $key, $value := .extraHeaders }}
-      {{ $key | quote }} = {{ $value | quote }},
+      {{ $key | quote }} = {{ tpl (toString $value) $tplRoot | quote }},
 {{- end }}
 {{- range $key, $value := .extraHeadersFrom }}
       {{ $key | quote }} = {{ $value }},

--- a/charts/k8s-monitoring/tests/destination_templated_values_test.yaml
+++ b/charts/k8s-monitoring/tests/destination_templated_values_test.yaml
@@ -1,0 +1,80 @@
+# yamllint disable rule:document-start rule:line-length rule:trailing-spaces
+suite: Destinations - Templated Values
+templates:
+  - alloy-config.yaml
+tests:
+  - it: evaluates templated OTLP destination URLs and headers
+    set:
+      cluster: {name: test-cluster}
+      collectors: {alloy-singleton: {extraConfig: " ", includeDestinations: ["test"]}}
+      selfReporting: {enabled: false}
+      destinations:
+        test:
+          type: otlp
+          url: https://{{ .Values.cluster.name }}.example.com
+          extraHeaders:
+            x-test-cluster: "{{ .Values.cluster.name }}"
+    asserts:
+      - matchRegex:
+          path: data["config.alloy"]
+          pattern: 'endpoint = "https://test-cluster\.example\.com"'
+      - matchRegex:
+          path: data["config.alloy"]
+          pattern: '"x-test-cluster" = "test-cluster"'
+
+  - it: evaluates templated Prometheus destination URLs and headers
+    set:
+      cluster: {name: test-cluster}
+      collectors: {alloy-singleton: {extraConfig: " ", includeDestinations: ["test"]}}
+      selfReporting: {enabled: false}
+      destinations:
+        test:
+          type: prometheus
+          url: https://{{ .Values.cluster.name }}.example.com/api/v1/write
+          extraHeaders:
+            x-test-cluster: "{{ .Values.cluster.name }}"
+    asserts:
+      - matchRegex:
+          path: data["config.alloy"]
+          pattern: 'url = "https://test-cluster\.example\.com/api/v1/write"'
+      - matchRegex:
+          path: data["config.alloy"]
+          pattern: '"x-test-cluster" = "test-cluster"'
+
+  - it: evaluates templated Loki destination URLs and headers
+    set:
+      cluster: {name: test-cluster}
+      collectors: {alloy-singleton: {extraConfig: " ", includeDestinations: ["test"]}}
+      selfReporting: {enabled: false}
+      destinations:
+        test:
+          type: loki
+          url: https://{{ .Values.cluster.name }}.example.com/loki/api/v1/push
+          extraHeaders:
+            x-test-cluster: "{{ .Values.cluster.name }}"
+    asserts:
+      - matchRegex:
+          path: data["config.alloy"]
+          pattern: 'url = "https://test-cluster\.example\.com/loki/api/v1/push"'
+      - matchRegex:
+          path: data["config.alloy"]
+          pattern: '"x-test-cluster" = "test-cluster"'
+
+  - it: evaluates templated Pyroscope destination URLs and headers
+    set:
+      cluster: {name: test-cluster}
+      collectors: {alloy-singleton: {extraConfig: " ", includeDestinations: ["test"]}}
+      selfReporting: {enabled: false}
+      destinations:
+        test:
+          type: pyroscope
+          url: https://{{ .Values.cluster.name }}.example.com
+          extraHeaders:
+            x-test-cluster: "{{ .Values.cluster.name }}"
+    asserts:
+      - matchRegex:
+          path: data["config.alloy"]
+          pattern: 'url = "https://test-cluster\.example\.com"'
+      - matchRegex:
+          path: data["config.alloy"]
+          pattern: '"x-test-cluster" = "test-cluster"'


### PR DESCRIPTION
## What changed

This change allows destination `url` and `extraHeaders` values to be templated with Helm before they are rendered into Alloy config.

The implementation keeps the existing `urlFrom` and `extraHeadersFrom` behavior intact, and adds templating support for the string-valued counterparts across the destination types that already expose both forms:

- OTLP
- Prometheus
- Loki
- Pyroscope

## Why

Today, plain `url` and `extraHeaders` values are treated as literal strings, while `urlFrom` and `extraHeadersFrom` are emitted as raw Alloy expressions. That makes it awkward for wrapper charts to define a shared destination endpoint or header once and reuse it from standard Helm values.

With this change, charts can keep using the regular string fields when they want a value derived from other Helm values, for example a cluster name or shared endpoint, without needing to switch to raw Alloy expressions.

## Implementation notes

- Pass the chart root through destination rendering so destination templates can evaluate Helm templates with the correct `.Values` context.
- Evaluate `url` through `tpl` for OTLP, Prometheus, Loki, and Pyroscope destinations.
- Evaluate string-valued `extraHeaders` entries through `tpl` for the same destination types.
- Preserve current behavior for `urlFrom` and `extraHeadersFrom`.
- Use `toString` before `tpl` so existing non-string YAML scalars in `extraHeaders` continue to render safely as quoted strings.

## Validation

- `helm unittest --with-subchart=false -f tests/destination_otlp_test.yaml -f tests/destination_prometheus_test.yaml -f tests/destination_templated_values_test.yaml .`
- Manual `helm template` render checks for OTLP and Loki templated URLs/headers.
