### PR TITLE
Fix validation messages to reference labelMatchers

### DIFF
--- a/charts/k8s-monitoring/CHANGELOG.md
+++ b/charts/k8s-monitoring/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 *   Add validators to require clustering on collectors that are assigned cluster-enabled features (@petewall)
 *   Add validators to warn when deployment-level settings are placed under feature configs instead of telemetryServices (@petewall)
+*   Fix validation error messages referencing `labelSelectors` instead of the correct `labelMatchers` field (@petewall)
 *   Fix node log level parsing broken since v4.0 due to case mismatch in selectors (@petewall)
 *   Switch from deprecated Endpoints discovery to EndpointSlice for Kubernetes 1.33+ compatibility (@petewall)
 *   Use glob syntax instead of regular expressions in Beyla discovery config (@petewall)

--- a/charts/k8s-monitoring/charts/feature-cluster-metrics/templates/_validation.tpl
+++ b/charts/k8s-monitoring/charts/feature-cluster-metrics/templates/_validation.tpl
@@ -8,11 +8,11 @@
       {{- $msg = append $msg "telemetryServices:" }}
       {{- $msg = append $msg "  kube-state-metrics:" }}
       {{- $msg = append $msg "    deploy: true" }}
-      {{- $msg = append $msg "Or, set the namespace and label selectors for an existing kube-state-metrics:" }}
+      {{- $msg = append $msg "Or, set the namespace and label matchers for an existing kube-state-metrics:" }}
       {{- $msg = append $msg "clusterMetrics:" }}
       {{- $msg = append $msg "  kube-state-metrics:" }}
       {{- $msg = append $msg "    namespace: kube-state-metrics-namespace" }}
-      {{- $msg = append $msg "    labelSelectors:" }}
+      {{- $msg = append $msg "    labelMatchers:" }}
       {{- $msg = append $msg "      app.kubernetes.io/name: kube-state-metrics" }}
       {{- fail (join "\n" $msg) }}
     {{- end }}

--- a/charts/k8s-monitoring/charts/feature-cluster-metrics/tests/validation_test.yaml
+++ b/charts/k8s-monitoring/charts/feature-cluster-metrics/tests/validation_test.yaml
@@ -16,11 +16,11 @@ tests:
             telemetryServices:
               kube-state-metrics:
                 deploy: true
-            Or, set the namespace and label selectors for an existing kube-state-metrics:
+            Or, set the namespace and label matchers for an existing kube-state-metrics:
             clusterMetrics:
               kube-state-metrics:
                 namespace: kube-state-metrics-namespace
-                labelSelectors:
+                labelMatchers:
                   app.kubernetes.io/name: kube-state-metrics
 
   - it: should fail when node-exporter is set under clusterMetrics

--- a/charts/k8s-monitoring/charts/feature-cost-metrics/templates/_validation.tpl
+++ b/charts/k8s-monitoring/charts/feature-cost-metrics/templates/_validation.tpl
@@ -6,11 +6,11 @@
       {{- $msg = append $msg "telemetryServices:" }}
       {{- $msg = append $msg "  opencost:" }}
       {{- $msg = append $msg "    deploy: true" }}
-      {{- $msg = append $msg "Or, set the namespace and label selectors for an existing OpenCost:" }}
+      {{- $msg = append $msg "Or, set the namespace and label matchers for an existing OpenCost:" }}
       {{- $msg = append $msg "costMetrics:" }}
       {{- $msg = append $msg "  opencost:" }}
       {{- $msg = append $msg "    namespace: opencost-namespace" }}
-      {{- $msg = append $msg "    labelSelectors:" }}
+      {{- $msg = append $msg "    labelMatchers:" }}
       {{- $msg = append $msg "      app.kubernetes.io/name: opencost" }}
       {{- fail (join "\n" $msg) }}
     {{- end }}

--- a/charts/k8s-monitoring/charts/feature-cost-metrics/tests/validation_test.yaml
+++ b/charts/k8s-monitoring/charts/feature-cost-metrics/tests/validation_test.yaml
@@ -14,9 +14,9 @@ tests:
             telemetryServices:
               opencost:
                 deploy: true
-            Or, set the namespace and label selectors for an existing OpenCost:
+            Or, set the namespace and label matchers for an existing OpenCost:
             costMetrics:
               opencost:
                 namespace: opencost-namespace
-                labelSelectors:
+                labelMatchers:
                   app.kubernetes.io/name: opencost

--- a/charts/k8s-monitoring/charts/feature-host-metrics/templates/_validation.tpl
+++ b/charts/k8s-monitoring/charts/feature-host-metrics/templates/_validation.tpl
@@ -7,11 +7,11 @@
       {{- $msg = append $msg "telemetryServices:" }}
       {{- $msg = append $msg "  node-exporter:" }}
       {{- $msg = append $msg "    deploy: true" }}
-      {{- $msg = append $msg "Or, set the namespace and label selectors for an existing Node Exporter:" }}
+      {{- $msg = append $msg "Or, set the namespace and label matchers for an existing Node Exporter:" }}
       {{- $msg = append $msg "hostMetrics:" }}
       {{- $msg = append $msg "  linuxHosts:" }}
       {{- $msg = append $msg "    namespace: node-exporter-namespace" }}
-      {{- $msg = append $msg "    labelSelectors:" }}
+      {{- $msg = append $msg "    labelMatchers:" }}
       {{- $msg = append $msg "      app.kubernetes.io/name: prometheus-node-exporter" }}
       {{- fail (join "\n" $msg) }}
     {{- end }}
@@ -25,11 +25,11 @@
       {{- $msg = append $msg "telemetryServices:" }}
       {{- $msg = append $msg "  windows-exporter:" }}
       {{- $msg = append $msg "    deploy: true" }}
-      {{- $msg = append $msg "Or, set the namespace and label selectors for an existing Windows Exporter:" }}
+      {{- $msg = append $msg "Or, set the namespace and label matchers for an existing Windows Exporter:" }}
       {{- $msg = append $msg "hostMetrics:" }}
       {{- $msg = append $msg "  windowsHosts:" }}
       {{- $msg = append $msg "    namespace: windows-exporter-namespace" }}
-      {{- $msg = append $msg "    labelSelectors:" }}
+      {{- $msg = append $msg "    labelMatchers:" }}
       {{- $msg = append $msg "      app.kubernetes.io/name: prometheus-windows-exporter" }}
       {{- fail (join "\n" $msg) }}
     {{- end }}
@@ -43,11 +43,11 @@
       {{- $msg = append $msg "telemetryServices:" }}
       {{- $msg = append $msg "  kepler:" }}
       {{- $msg = append $msg "    deploy: true" }}
-      {{- $msg = append $msg "Or, set the namespace and label selectors for an existing Kepler:" }}
+      {{- $msg = append $msg "Or, set the namespace and label matchers for an existing Kepler:" }}
       {{- $msg = append $msg "hostMetrics:" }}
       {{- $msg = append $msg "  energyMetrics:" }}
       {{- $msg = append $msg "    namespace: kepler-namespace" }}
-      {{- $msg = append $msg "    labelSelectors:" }}
+      {{- $msg = append $msg "    labelMatchers:" }}
       {{- $msg = append $msg "      app.kubernetes.io/name: kepler" }}
       {{- fail (join "\n" $msg) }}
     {{- end }}

--- a/charts/k8s-monitoring/charts/feature-host-metrics/tests/validation_test.yaml
+++ b/charts/k8s-monitoring/charts/feature-host-metrics/tests/validation_test.yaml
@@ -20,11 +20,11 @@ tests:
             telemetryServices:
               node-exporter:
                 deploy: true
-            Or, set the namespace and label selectors for an existing Node Exporter:
+            Or, set the namespace and label matchers for an existing Node Exporter:
             hostMetrics:
               linuxHosts:
                 namespace: node-exporter-namespace
-                labelSelectors:
+                labelMatchers:
                   app.kubernetes.io/name: prometheus-node-exporter
 
   - it: should fail when Windows hosts do not specify Windows Exporter selectors
@@ -44,11 +44,11 @@ tests:
             telemetryServices:
               windows-exporter:
                 deploy: true
-            Or, set the namespace and label selectors for an existing Windows Exporter:
+            Or, set the namespace and label matchers for an existing Windows Exporter:
             hostMetrics:
               windowsHosts:
                 namespace: windows-exporter-namespace
-                labelSelectors:
+                labelMatchers:
                   app.kubernetes.io/name: prometheus-windows-exporter
 
   - it: should fail when host energy metrics do not specify Kepler selectors
@@ -68,11 +68,11 @@ tests:
             telemetryServices:
               kepler:
                 deploy: true
-            Or, set the namespace and label selectors for an existing Kepler:
+            Or, set the namespace and label matchers for an existing Kepler:
             hostMetrics:
               energyMetrics:
                 namespace: kepler-namespace
-                labelSelectors:
+                labelMatchers:
                   app.kubernetes.io/name: kepler
 
   - it: should fail when deployment-level setting is under hostMetrics.linuxHosts


### PR DESCRIPTION
## Summary
- Validation error messages for host metrics, cost metrics, and cluster metrics referred to `labelSelectors`, but the actual values schema field is `labelMatchers`
- Fixed the validation templates and corresponding unit tests

Fixes #2504

## Test plan
- [x] `helm unittest` passes for feature-host-metrics, feature-cost-metrics, and feature-cluster-metrics

🤖 Generated with [Claude Code](https://claude.com/claude-code)