### PR TITLE
Fix annotations and labels for Alloy CRs

### DIFF
--- a/charts/k8s-monitoring/CHANGELOG.md
+++ b/charts/k8s-monitoring/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+*   Change Alloy collector `labels` and `annotations` defaults from arrays to maps, and accept either type in the schema for backwards compatibility (@petewall)
 *   Warn in NOTES.txt when installing into an Istio-enabled namespace with Alloy clustering using the default "http" port name, which breaks clustering peer discovery and causes duplicate metrics (@petewall)
 *   PostgreSQL: Add `statementsLimit` option to the Database Observability `queryDetails` collector (@petewall)
 *   Normalize collector and destination names to DNS-1123 resource names so mixed-case or underscore-containing keys (e.g. `alloyMetrics`, `my_dest`) render valid Kubernetes resources, and fail when two keys collapse to the same normalized name (@petewall)

--- a/charts/k8s-monitoring/collectors/alloy-values.yaml
+++ b/charts/k8s-monitoring/collectors/alloy-values.yaml
@@ -13,11 +13,11 @@ presets: []
 
 # -- Labels to add to the Alloy Custom Resource. These labels are not added to the workload or Pod.
 # @section -- General
-labels: []
+labels: {}
 
 # -- Annotations to add to the Alloy Custom Resource. These annotations are not added to the workload or Pod.
 # @section -- General
-annotations: []
+annotations: {}
 
 # -- Extra Alloy configuration to be added to the configuration file.
 # @section -- General

--- a/charts/k8s-monitoring/docs/collectors/alloy.md
+++ b/charts/k8s-monitoring/docs/collectors/alloy.md
@@ -39,11 +39,11 @@ Settings for each primary Alloy instance come from several potential sources, in
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| annotations | list | `[]` | Annotations to add to the Alloy Custom Resource. These annotations are not added to the workload or Pod. |
+| annotations | object | `{}` | Annotations to add to the Alloy Custom Resource. These annotations are not added to the workload or Pod. |
 | enabled | bool | `true` | Deploy this collector. Set to `false` to skip creating the collector's resources without removing the collector from the values file. |
 | extraConfig | string | `""` | Extra Alloy configuration to be added to the configuration file. |
 | includeDestinations | list | `[]` | Include the configuration components for these destinations. Configuration is already added for destinations used By enabled features on this collector. This is useful when referencing destinations in the extraConfig. |
-| labels | list | `[]` | Labels to add to the Alloy Custom Resource. These labels are not added to the workload or Pod. |
+| labels | object | `{}` | Labels to add to the Alloy Custom Resource. These labels are not added to the workload or Pod. |
 | liveDebugging.enabled | bool | `false` | Enable live debugging for the Alloy instance. Requires stability level to be set to "experimental". |
 | presets | list | `[]` | The list of Alloy configuration presets, which sets common Alloy configurations. Multiple presets can be set, with the latter ones overwriting former ones. See https://github.com/grafana/k8s-monitoring-helm/tree/main/charts/k8s-monitoring/docs/collectors/presets/ for the list of available presets. |
 

--- a/charts/k8s-monitoring/schema-mods/definitions/alloy-collector.schema.json
+++ b/charts/k8s-monitoring/schema-mods/definitions/alloy-collector.schema.json
@@ -52,7 +52,7 @@
             }
         },
         "annotations": {
-            "type": "array"
+            "type": "object"
         },
         "controller": {
             "type": "object",
@@ -93,7 +93,7 @@
             "type": "array"
         },
         "labels": {
-            "type": "array"
+            "type": "object"
         },
         "liveDebugging": {
             "type": "object",

--- a/charts/k8s-monitoring/schema-mods/types-and-enums.json
+++ b/charts/k8s-monitoring/schema-mods/types-and-enums.json
@@ -33,6 +33,8 @@
   "definitions": {
     "alloy-collector": {"properties":  {
       "includeDestinations": { "uniqueItems": true, "items": { "type": "string" }},
+      "labels": {"type": ["array", "object"]},
+      "annotations": {"type": ["array", "object"]},
       "remoteConfig": {"properties": {"auth": {"properties": {"username": {"type": ["number", "string"]}}}}}
     }},
     "loki-destination": {"properties": {

--- a/charts/k8s-monitoring/tests/collector_labels_annotations_test.yaml
+++ b/charts/k8s-monitoring/tests/collector_labels_annotations_test.yaml
@@ -1,0 +1,58 @@
+# yamllint disable rule:document-start rule:line-length rule:trailing-spaces
+suite: Collectors - Labels and Annotations
+templates:
+  - alloy.yaml
+tests:
+  - it: applies labels and annotations to the Alloy Custom Resource when set as maps
+    set:
+      cluster: {name: test-cluster}
+      collectors:
+        alloy-metrics:
+          extraConfig: "// Giving this Alloy something to do"
+          labels:
+            team: observability
+            tier: platform
+          annotations:
+            owner: o11y-team
+    asserts:
+      - containsDocument:
+          kind: Alloy
+          apiVersion: collectors.grafana.com/v1alpha1
+          name: RELEASE-NAME-alloy-metrics
+      - equal:
+          path: metadata.labels.team
+          value: observability
+      - equal:
+          path: metadata.labels.tier
+          value: platform
+      - equal:
+          path: metadata.annotations.owner
+          value: o11y-team
+
+  - it: accepts labels and annotations as empty maps
+    set:
+      cluster: {name: test-cluster}
+      collectors:
+        alloy-metrics:
+          extraConfig: "// Giving this Alloy something to do"
+          labels: {}
+          annotations: {}
+    asserts:
+      - containsDocument:
+          kind: Alloy
+          apiVersion: collectors.grafana.com/v1alpha1
+          name: RELEASE-NAME-alloy-metrics
+
+  - it: accepts labels and annotations as empty arrays for backwards compatibility
+    set:
+      cluster: {name: test-cluster}
+      collectors:
+        alloy-metrics:
+          extraConfig: "// Giving this Alloy something to do"
+          labels: []
+          annotations: []
+    asserts:
+      - containsDocument:
+          kind: Alloy
+          apiVersion: collectors.grafana.com/v1alpha1
+          name: RELEASE-NAME-alloy-metrics

--- a/charts/k8s-monitoring/values.schema.json
+++ b/charts/k8s-monitoring/values.schema.json
@@ -575,7 +575,10 @@
                     }
                 },
                 "annotations": {
-                    "type": "array"
+                    "type": [
+                        "array",
+                        "object"
+                    ]
                 },
                 "controller": {
                     "type": "object",
@@ -620,7 +623,10 @@
                     }
                 },
                 "labels": {
-                    "type": "array"
+                    "type": [
+                        "array",
+                        "object"
+                    ]
                 },
                 "liveDebugging": {
                     "type": "object",


### PR DESCRIPTION
They were defined as arrays, but really should be maps.