### PR TITLE
feat: update databaseObservability settings to match Alloy v1.16.0

### DIFF
--- a/charts/k8s-monitoring/CHANGELOG.md
+++ b/charts/k8s-monitoring/CHANGELOG.md
@@ -10,6 +10,11 @@
 *   Database Observability: emit proper relabeling for MySQL and PostgreSQL so both metrics and logs carry `job=integrations/db-o11y`, the configured `instance` name,
     and a `dsn` label for Knowledge Graph integration. Breaking change for users on `databaseObservability.enabled: true`: the default `job` label is now `integrations/db-o11y`
     (was `integration/mysql` for MySQL and `integration/postgresql` for PostgreSQL), and the `instance` label on db o11y logs is the instance name (was the raw DSN, which now lives on the `dsn` label) (@cristiangreco)
+*   Database Observability: add `databaseObservability.cloudProvider.gcp` for MySQL and PostgreSQL to label metrics with GCP Cloud SQL instance metadata (@cristiangreco)
+*   Database Observability: add `databaseObservability.collectors.querySamples.sampleMinDuration` and `waitEventMinDuration` for MySQL (@cristiangreco)
+*   Database Observability: emit `disable_collectors` for any MySQL or PostgreSQL collector explicitly turned off via `databaseObservability.collectors.<name>.enabled: false` (@cristiangreco)
+*   Database Observability: realign some default `databaseObservability.collectors` values with Alloy upstream defaults (@cristiangreco)
+*   Database Observability: remove the unused `databaseObservability.collectors.explainPlans.excludeSchemas` value from the PostgreSQL settings (@cristiangreco)
 
 ## 4.0.4
 

--- a/charts/k8s-monitoring/charts/feature-integrations/docs/integrations/mysql.md
+++ b/charts/k8s-monitoring/charts/feature-integrations/docs/integrations/mysql.md
@@ -102,6 +102,7 @@ integrations:
 | databaseObservability.cloudProvider.azure.resourceGroup | string | `""` | The Resource Group that holds the database resource. |
 | databaseObservability.cloudProvider.azure.serverName | string | `""` | The database server name. |
 | databaseObservability.cloudProvider.azure.subscriptionId | string | `""` | The Subscription ID for your Azure account. |
+| databaseObservability.cloudProvider.gcp.connectionName | string | `""` | The Cloud SQL instance connection name in the format `project:region:instance`, for example `my-project:us-central1:my-db`. |
 
 ### Database Observability - Collectors
 
@@ -118,11 +119,13 @@ integrations:
 | databaseObservability.collectors.queryDetails.enabled | bool | `true` | Enable collection of query information. |
 | databaseObservability.collectors.queryDetails.statementsLimit | number | `250` | Max number of recent queries to collect details for. |
 | databaseObservability.collectors.querySamples.autoEnableSetupConsumers | bool | `false` | Whether to enable some specific performance_schema.setup_consumers settings. |
-| databaseObservability.collectors.querySamples.collectInterval | string | `"1m"` | How frequently to collect query samples from the database. |
+| databaseObservability.collectors.querySamples.collectInterval | string | `"10s"` | How frequently to collect query samples from the database. |
 | databaseObservability.collectors.querySamples.disableQueryRedaction | bool | `false` | Collect unredacted SQL query text including parameters. |
 | databaseObservability.collectors.querySamples.enabled | bool | `true` | Enable collection of query samples. |
+| databaseObservability.collectors.querySamples.sampleMinDuration | string | `"0s"` | Minimum duration for query samples to be collected. Set to "0s" to disable filtering and collect all samples regardless of their duration. |
 | databaseObservability.collectors.querySamples.setupConsumersCheckInterval | string | `"1h"` | How frequently to check if setup_consumers are correctly enabled. |
-| databaseObservability.collectors.schemaDetails.cacheEnabled | bool | `false` | Whether to enable caching of table definitions. |
+| databaseObservability.collectors.querySamples.waitEventMinDuration | string | `"1us"` | Minimum duration for a wait event to be collected. Set to "0s" to disable filtering and collect all wait events regardless of their duration. |
+| databaseObservability.collectors.schemaDetails.cacheEnabled | bool | `true` | Whether to enable caching of table definitions. |
 | databaseObservability.collectors.schemaDetails.cacheSize | int | `256` | Table definitions cache size. |
 | databaseObservability.collectors.schemaDetails.cacheTTL | string | `"10m"` | Table definitions cache TTL. |
 | databaseObservability.collectors.schemaDetails.collectInterval | string | `"1m"` | How frequently to collect schemas and tables from information_schema. |
@@ -130,7 +133,7 @@ integrations:
 | databaseObservability.collectors.setupActors.autoUpdateSetupActors | bool | `false` | Whether to enable updates to performance_schema.setup_actors settings. Requires allowUpdatePerformanceSchemaSettings to also be enabled. |
 | databaseObservability.collectors.setupActors.collectInterval | string | `"1h"` | How frequently to check if setup_actors are configured correctly. |
 | databaseObservability.collectors.setupActors.enabled | bool | `true` | Enable the setup_actors collector. |
-| databaseObservability.collectors.setupConsumers.collectInterval | string | `"1m"` | How frequently to collect performance_schema.setup_consumers information from the database. |
+| databaseObservability.collectors.setupConsumers.collectInterval | string | `"1h"` | How frequently to collect performance_schema.setup_consumers information from the database. |
 | databaseObservability.collectors.setupConsumers.enabled | bool | `true` | Enable collection of performance_schema.setup_consumers information. |
 
 ### Exporter Settings

--- a/charts/k8s-monitoring/charts/feature-integrations/docs/integrations/postgresql.md
+++ b/charts/k8s-monitoring/charts/feature-integrations/docs/integrations/postgresql.md
@@ -82,6 +82,7 @@ integrations:
 | databaseObservability.cloudProvider.azure.resourceGroup | string | `""` | The Resource Group that holds the database resource. |
 | databaseObservability.cloudProvider.azure.serverName | string | `""` | The database server name. |
 | databaseObservability.cloudProvider.azure.subscriptionId | string | `""` | The Subscription ID for your Azure account. |
+| databaseObservability.cloudProvider.gcp.connectionName | string | `""` | The Cloud SQL instance connection name in the format `project:region:instance`, for example `my-project:us-central1:my-db`. |
 
 ### Database Observability - Collectors
 
@@ -89,12 +90,11 @@ integrations:
 |-----|------|---------|-------------|
 | databaseObservability.collectors.explainPlans.collectInterval | string | `"1m"` | How frequently to collect explain plans information from the database. |
 | databaseObservability.collectors.explainPlans.enabled | bool | `true` | Enable collection of explain plans information. |
-| databaseObservability.collectors.explainPlans.excludeSchemas | list | `[]` | List of schemas to exclude from explain plan collection. |
 | databaseObservability.collectors.explainPlans.perCollectRatio | float | `1` | Ratio of explain plan queries to collect per collect interval. |
 | databaseObservability.collectors.queryDetails.collectInterval | string | `"1m"` | How frequently to collect query information from the database. |
 | databaseObservability.collectors.queryDetails.enabled | bool | `true` | Enable collection of query information. |
 | databaseObservability.collectors.queryDetails.statementsLimit | number | `100` | Max number of recent queries to collect details for. |
-| databaseObservability.collectors.querySamples.collectInterval | string | `"1m"` | How frequently to collect query samples from the database. |
+| databaseObservability.collectors.querySamples.collectInterval | string | `"15s"` | How frequently to collect query samples from the database. |
 | databaseObservability.collectors.querySamples.disableQueryRedaction | bool | `false` | Collect unredacted SQL query text including parameters. |
 | databaseObservability.collectors.querySamples.enabled | bool | `true` | Enable collection of query samples. |
 | databaseObservability.collectors.querySamples.excludeCurrentUser | bool | `true` | Do not collect query samples for the current database user. |

--- a/charts/k8s-monitoring/charts/feature-integrations/integrations/mysql-values.yaml
+++ b/charts/k8s-monitoring/charts/feature-integrations/integrations/mysql-values.yaml
@@ -196,6 +196,12 @@ databaseObservability:
       # -- The database server name.
       # @section -- Database Observability - Cloud Provider
       serverName: ""
+    # GCP configuration.
+    gcp:
+      # -- The Cloud SQL instance connection name in the format `project:region:instance`,
+      # for example `my-project:us-central1:my-db`.
+      # @section -- Database Observability - Cloud Provider
+      connectionName: ""
 
   collectors:
     # Collect explain plans information.
@@ -243,7 +249,7 @@ databaseObservability:
       enabled: true
       # -- How frequently to collect query samples from the database.
       # @section -- Database Observability - Collectors
-      collectInterval: 1m
+      collectInterval: 10s
       # -- Collect unredacted SQL query text including parameters.
       # @section -- Database Observability - Collectors
       disableQueryRedaction: false
@@ -253,6 +259,14 @@ databaseObservability:
       # -- How frequently to check if setup_consumers are correctly enabled.
       # @section -- Database Observability - Collectors
       setupConsumersCheckInterval: 1h
+      # -- Minimum duration for query samples to be collected. Set to "0s" to disable
+      # filtering and collect all samples regardless of their duration.
+      # @section -- Database Observability - Collectors
+      sampleMinDuration: 0s
+      # -- Minimum duration for a wait event to be collected. Set to "0s" to disable
+      # filtering and collect all wait events regardless of their duration.
+      # @section -- Database Observability - Collectors
+      waitEventMinDuration: 1us
 
     # Collect schemas and tables from information_schema.
     schemaDetails:
@@ -264,7 +278,7 @@ databaseObservability:
       collectInterval: 1m
       # -- Whether to enable caching of table definitions.
       # @section -- Database Observability - Collectors
-      cacheEnabled: false
+      cacheEnabled: true
       # -- Table definitions cache size.
       # @section -- Database Observability - Collectors
       cacheSize: 256
@@ -279,7 +293,7 @@ databaseObservability:
       enabled: true
       # -- How frequently to collect performance_schema.setup_consumers information from the database.
       # @section -- Database Observability - Collectors
-      collectInterval: 1m
+      collectInterval: 1h
 
     # Check and update performance_schema.setup_actors settings.
     setupActors:

--- a/charts/k8s-monitoring/charts/feature-integrations/integrations/postgresql-values.yaml
+++ b/charts/k8s-monitoring/charts/feature-integrations/integrations/postgresql-values.yaml
@@ -279,6 +279,12 @@ databaseObservability:
       # -- The database server name.
       # @section -- Database Observability - Cloud Provider
       serverName: ""
+    # GCP configuration.
+    gcp:
+      # -- The Cloud SQL instance connection name in the format `project:region:instance`,
+      # for example `my-project:us-central1:my-db`.
+      # @section -- Database Observability - Cloud Provider
+      connectionName: ""
 
   collectors:
     # Collect explain plans information.
@@ -289,9 +295,6 @@ databaseObservability:
       # -- How frequently to collect explain plans information from the database.
       # @section -- Database Observability - Collectors
       collectInterval: 1m
-      # -- List of schemas to exclude from explain plan collection.
-      # @section -- Database Observability - Collectors
-      excludeSchemas: []
       # -- Ratio of explain plan queries to collect per collect interval.
       # @section -- Database Observability - Collectors
       perCollectRatio: 1.0
@@ -316,7 +319,7 @@ databaseObservability:
       enabled: true
       # -- How frequently to collect query samples from the database.
       # @section -- Database Observability - Collectors
-      collectInterval: 1m
+      collectInterval: 15s
       # -- Collect unredacted SQL query text including parameters.
       # @section -- Database Observability - Collectors
       disableQueryRedaction: false

--- a/charts/k8s-monitoring/charts/feature-integrations/schema-mods/definitions/mysql-integration.schema.json
+++ b/charts/k8s-monitoring/charts/feature-integrations/schema-mods/definitions/mysql-integration.schema.json
@@ -32,6 +32,14 @@
                                     "type": "string"
                                 }
                             }
+                        },
+                        "gcp": {
+                            "type": "object",
+                            "properties": {
+                                "connectionName": {
+                                    "type": "string"
+                                }
+                            }
                         }
                     }
                 },
@@ -98,7 +106,13 @@
                                 "enabled": {
                                     "type": "boolean"
                                 },
+                                "sampleMinDuration": {
+                                    "type": "string"
+                                },
                                 "setupConsumersCheckInterval": {
+                                    "type": "string"
+                                },
+                                "waitEventMinDuration": {
                                     "type": "string"
                                 }
                             }

--- a/charts/k8s-monitoring/charts/feature-integrations/schema-mods/definitions/postgresql-integration.schema.json
+++ b/charts/k8s-monitoring/charts/feature-integrations/schema-mods/definitions/postgresql-integration.schema.json
@@ -29,6 +29,14 @@
                                     "type": "string"
                                 }
                             }
+                        },
+                        "gcp": {
+                            "type": "object",
+                            "properties": {
+                                "connectionName": {
+                                    "type": "string"
+                                }
+                            }
                         }
                     }
                 },
@@ -43,9 +51,6 @@
                                 },
                                 "enabled": {
                                     "type": "boolean"
-                                },
-                                "excludeSchemas": {
-                                    "type": "array"
                                 },
                                 "perCollectRatio": {
                                     "type": "number"

--- a/charts/k8s-monitoring/charts/feature-integrations/templates/_integration_mysql_metrics.tpl
+++ b/charts/k8s-monitoring/charts/feature-integrations/templates/_integration_mysql_metrics.tpl
@@ -145,7 +145,8 @@ database_observability.mysql {{ include "helper.alloy_name" .name | quote }} {
   {{- with .databaseObservability.cloudProvider }}
   {{- $hasAws := and .aws .aws.arn }}
   {{- $hasAzure := and .azure .azure.subscriptionId .azure.resourceGroup }}
-  {{- if or $hasAws $hasAzure }}
+  {{- $hasGcp := and .gcp .gcp.connectionName }}
+  {{- if or $hasAws $hasAzure $hasGcp }}
   cloud_provider {
     {{- if $hasAws }}
     aws {
@@ -161,11 +162,17 @@ database_observability.mysql {{ include "helper.alloy_name" .name | quote }} {
       {{- end }}
     }
     {{- end }}
+    {{- if $hasGcp }}
+    gcp {
+      connection_name = {{ .gcp.connectionName | quote }}
+    }
+    {{- end }}
   }
   {{- end }}
   {{- end }}
 
   {{- $enabledCollectors := list }}
+  {{- $disabledCollectors := list }}
   {{- if .databaseObservability.collectors.explainPlans.enabled }}
     {{- $enabledCollectors = append $enabledCollectors "explain_plans" }}
     {{- with .databaseObservability.collectors.explainPlans }}
@@ -175,6 +182,8 @@ database_observability.mysql {{ include "helper.alloy_name" .name | quote }} {
     per_collect_ratio = {{ .perCollectRatio | quote }}
   }
     {{- end }}
+  {{- else }}
+    {{- $disabledCollectors = append $disabledCollectors "explain_plans" }}
   {{- end }}
   {{- if .databaseObservability.collectors.locks.enabled }}
     {{- $enabledCollectors = append $enabledCollectors "locks" }}
@@ -184,6 +193,8 @@ database_observability.mysql {{ include "helper.alloy_name" .name | quote }} {
     threshold = {{ .threshold | quote }}
   }
     {{- end }}
+  {{- else }}
+    {{- $disabledCollectors = append $disabledCollectors "locks" }}
   {{- end }}
   {{- if .databaseObservability.collectors.queryDetails.enabled }}
     {{- $enabledCollectors = append $enabledCollectors "query_details" }}
@@ -195,6 +206,8 @@ database_observability.mysql {{ include "helper.alloy_name" .name | quote }} {
     {{- end }}
   }
     {{- end }}
+  {{- else }}
+    {{- $disabledCollectors = append $disabledCollectors "query_details" }}
   {{- end }}
   {{- if .databaseObservability.collectors.querySamples.enabled }}
     {{- $enabledCollectors = append $enabledCollectors "query_samples" }}
@@ -204,8 +217,12 @@ database_observability.mysql {{ include "helper.alloy_name" .name | quote }} {
     disable_query_redaction = {{ .disableQueryRedaction }}
     auto_enable_setup_consumers = {{ .autoEnableSetupConsumers }}
     setup_consumers_check_interval = {{ .setupConsumersCheckInterval | quote }}
+    sample_min_duration = {{ .sampleMinDuration | quote }}
+    wait_event_min_duration = {{ .waitEventMinDuration | quote }}
   }
     {{- end }}
+  {{- else }}
+    {{- $disabledCollectors = append $disabledCollectors "query_samples" }}
   {{- end }}
   {{- if .databaseObservability.collectors.schemaDetails.enabled }}
     {{- $enabledCollectors = append $enabledCollectors "schema_details" }}
@@ -217,6 +234,8 @@ database_observability.mysql {{ include "helper.alloy_name" .name | quote }} {
     cache_ttl = {{ .cacheTTL | quote }}
   }
     {{- end }}
+  {{- else }}
+    {{- $disabledCollectors = append $disabledCollectors "schema_details" }}
   {{- end }}
   {{- if .databaseObservability.collectors.setupConsumers.enabled }}
     {{- $enabledCollectors = append $enabledCollectors "setup_consumers" }}
@@ -225,6 +244,8 @@ database_observability.mysql {{ include "helper.alloy_name" .name | quote }} {
     collect_interval = {{ .collectInterval | quote }}
   }
     {{- end }}
+  {{- else }}
+    {{- $disabledCollectors = append $disabledCollectors "setup_consumers" }}
   {{- end }}
   {{- if .databaseObservability.collectors.setupActors.enabled }}
     {{- $enabledCollectors = append $enabledCollectors "setup_actors" }}
@@ -234,8 +255,13 @@ database_observability.mysql {{ include "helper.alloy_name" .name | quote }} {
     collect_interval = {{ .collectInterval | quote }}
   }
     {{- end }}
+  {{- else }}
+    {{- $disabledCollectors = append $disabledCollectors "setup_actors" }}
   {{- end }}
   enable_collectors = {{ $enabledCollectors | toJson }}
+  {{- if $disabledCollectors }}
+  disable_collectors = {{ $disabledCollectors | toJson }}
+  {{- end }}
 
   forward_to = [loki.relabel.{{ $dbRelabelName }}.receiver]
 }

--- a/charts/k8s-monitoring/charts/feature-integrations/templates/_integration_postgresql_metrics.tpl
+++ b/charts/k8s-monitoring/charts/feature-integrations/templates/_integration_postgresql_metrics.tpl
@@ -156,7 +156,8 @@ database_observability.postgres {{ include "helper.alloy_name" .name | quote }} 
   {{- with .databaseObservability.cloudProvider }}
   {{- $hasAws := and .aws .aws.arn }}
   {{- $hasAzure := and .azure .azure.subscriptionId .azure.resourceGroup }}
-  {{- if or $hasAws $hasAzure }}
+  {{- $hasGcp := and .gcp .gcp.connectionName }}
+  {{- if or $hasAws $hasAzure $hasGcp }}
   cloud_provider {
     {{- if $hasAws }}
     aws {
@@ -172,6 +173,11 @@ database_observability.postgres {{ include "helper.alloy_name" .name | quote }} 
       {{- end }}
     }
     {{- end }}
+    {{- if $hasGcp }}
+    gcp {
+      connection_name = {{ .gcp.connectionName | quote }}
+    }
+    {{- end }}
   }
   {{- end }}
   {{- end }}
@@ -183,17 +189,17 @@ database_observability.postgres {{ include "helper.alloy_name" .name | quote }} 
   {{- end }}
 
   {{- $enabledCollectors := list }}
+  {{- $disabledCollectors := list }}
   {{- if .databaseObservability.collectors.explainPlans.enabled }}
     {{- $enabledCollectors = append $enabledCollectors "explain_plans" }}
     {{- with .databaseObservability.collectors.explainPlans }}
   explain_plans {
     collect_interval = {{ .collectInterval | quote }}
-    {{- if .excludeSchemas }}
-    exclude_schemas = {{ .excludeSchemas | toJson }}
-    {{- end }}
     per_collect_ratio = {{ .perCollectRatio | quote }}
   }
     {{- end }}
+  {{- else }}
+    {{- $disabledCollectors = append $disabledCollectors "explain_plans" }}
   {{- end }}
   {{- if .databaseObservability.collectors.queryDetails.enabled }}
     {{- $enabledCollectors = append $enabledCollectors "query_details" }}
@@ -205,6 +211,8 @@ database_observability.postgres {{ include "helper.alloy_name" .name | quote }} 
     {{- end }}
   }
     {{- end }}
+  {{- else }}
+    {{- $disabledCollectors = append $disabledCollectors "query_details" }}
   {{- end }}
   {{- if .databaseObservability.collectors.querySamples.enabled }}
     {{- $enabledCollectors = append $enabledCollectors "query_samples" }}
@@ -215,6 +223,8 @@ database_observability.postgres {{ include "helper.alloy_name" .name | quote }} 
     exclude_current_user = {{ .excludeCurrentUser }}
   }
     {{- end }}
+  {{- else }}
+    {{- $disabledCollectors = append $disabledCollectors "query_samples" }}
   {{- end }}
   {{- if .databaseObservability.collectors.schemaDetails.enabled }}
     {{- $enabledCollectors = append $enabledCollectors "schema_details" }}
@@ -226,8 +236,13 @@ database_observability.postgres {{ include "helper.alloy_name" .name | quote }} 
     cache_ttl = {{ .cacheTTL | quote }}
   }
     {{- end }}
+  {{- else }}
+    {{- $disabledCollectors = append $disabledCollectors "schema_details" }}
   {{- end }}
   enable_collectors = {{ $enabledCollectors | toJson }}
+  {{- if $disabledCollectors }}
+  disable_collectors = {{ $disabledCollectors | toJson }}
+  {{- end }}
 
   forward_to = [loki.relabel.{{ $dbRelabelName }}.receiver]
 }

--- a/charts/k8s-monitoring/charts/feature-integrations/tests/__snapshot__/mysql_db_o11y_metrics_test.yaml.snap
+++ b/charts/k8s-monitoring/charts/feature-integrations/tests/__snapshot__/mysql_db_o11y_metrics_test.yaml.snap
@@ -45,25 +45,28 @@ defaults text_limit to 0 for perf_schema.eventsstatements when db o11y is enable
             collect_interval = "1m"
           }
           query_samples {
-            collect_interval = "1m"
+            collect_interval = "10s"
             disable_query_redaction = false
             auto_enable_setup_consumers = false
             setup_consumers_check_interval = "1h"
+            sample_min_duration = "0s"
+            wait_event_min_duration = "1us"
           }
           schema_details {
             collect_interval = "1m"
-            cache_enabled = false
+            cache_enabled = true
             cache_size = 256
             cache_ttl = "10m"
           }
           setup_consumers {
-            collect_interval = "1m"
+            collect_interval = "1h"
           }
           setup_actors {
             auto_update_setup_actors = false
             collect_interval = "1h"
           }
           enable_collectors = ["explain_plans","query_details","query_samples","schema_details","setup_consumers","setup_actors"]
+          disable_collectors = ["locks"]
 
           forward_to = [loki.relabel.database_observability_mysql_my_database.receiver]
         }
@@ -157,25 +160,28 @@ keeps prometheus.relabel when metrics tuning is set under db o11y:
             collect_interval = "1m"
           }
           query_samples {
-            collect_interval = "1m"
+            collect_interval = "10s"
             disable_query_redaction = false
             auto_enable_setup_consumers = false
             setup_consumers_check_interval = "1h"
+            sample_min_duration = "0s"
+            wait_event_min_duration = "1us"
           }
           schema_details {
             collect_interval = "1m"
-            cache_enabled = false
+            cache_enabled = true
             cache_size = 256
             cache_ttl = "10m"
           }
           setup_consumers {
-            collect_interval = "1m"
+            collect_interval = "1h"
           }
           setup_actors {
             auto_update_setup_actors = false
             collect_interval = "1h"
           }
           enable_collectors = ["explain_plans","query_details","query_samples","schema_details","setup_consumers","setup_actors"]
+          disable_collectors = ["locks"]
 
           forward_to = [loki.relabel.database_observability_mysql_my_database.receiver]
         }
@@ -235,6 +241,113 @@ keeps prometheus.relabel when metrics tuning is set under db o11y:
           forward_to = argument.metrics_destinations.value
         }
       }
+renders gcp cloud_provider, query_samples min durations, and disable_collectors:
+  1: |
+    |-
+      declare "mysql_integration" {
+        argument "metrics_destinations" {
+          comment = "Must be a list of metric destinations where collected metrics should be forwarded to"
+        }
+        argument "logs_destinations" {
+          comment = "Must be a list of log destinations where collected logs should be forwarded to"
+        }
+
+        remote.kubernetes.secret "gcp_db" {
+          name      = "gcp-db-release-name-feature-integrations"
+          namespace = "NAMESPACE"
+        } // remote.kubernetes.secret "gcp_db"
+
+        prometheus.exporter.mysql "gcp_db" {
+          data_source_name = string.format("%s:%s@(%s:%d)/",
+            convert.nonsensitive(remote.kubernetes.secret.gcp_db.data["username"]),
+            convert.nonsensitive(remote.kubernetes.secret.gcp_db.data["password"]),
+            "gcp-db.mysql.svc",
+            3306,
+          )
+          enable_collectors = ["heartbeat","mysql.user"]
+        }
+
+        database_observability.mysql "gcp_db" {
+          targets = prometheus.exporter.mysql.gcp_db.targets
+          data_source_name = string.format("%s:%s@(%s:%d)/",
+            convert.nonsensitive(remote.kubernetes.secret.gcp_db.data["username"]),
+            convert.nonsensitive(remote.kubernetes.secret.gcp_db.data["password"]),
+            "gcp-db.mysql.svc",
+            3306,
+          )
+          allow_update_performance_schema_settings = false
+          cloud_provider {
+            gcp {
+              connection_name = "my-project:us-central1:my-db"
+            }
+          }
+          explain_plans {
+            collect_interval = "1m"
+            initial_lookback = "24h"
+            per_collect_ratio = "1"
+          }
+          query_details {
+            collect_interval = "1m"
+          }
+          query_samples {
+            collect_interval = "10s"
+            disable_query_redaction = false
+            auto_enable_setup_consumers = false
+            setup_consumers_check_interval = "1h"
+            sample_min_duration = "100ms"
+            wait_event_min_duration = "5ms"
+          }
+          enable_collectors = ["explain_plans","query_details","query_samples"]
+          disable_collectors = ["locks","schema_details","setup_consumers","setup_actors"]
+
+          forward_to = [loki.relabel.database_observability_mysql_gcp_db.receiver]
+        }
+
+        loki.relabel "database_observability_mysql_gcp_db" {
+          forward_to = argument.logs_destinations.value
+          rule {
+            target_label = "job"
+            replacement = "integrations/db-o11y"
+          }
+          rule {
+            source_labels = ["instance"]
+            target_label = "dsn"
+          }
+          rule {
+            target_label = "instance"
+            replacement = "gcp-db"
+          }
+        }
+
+        discovery.relabel "database_observability_mysql_gcp_db" {
+          targets = database_observability.mysql.gcp_db.targets
+          rule {
+            target_label = "job"
+            replacement = "integrations/db-o11y"
+          }
+          rule {
+            source_labels = ["instance"]
+            target_label = "dsn"
+          }
+          rule {
+            target_label = "instance"
+            replacement = "gcp-db"
+          }
+        }
+        prometheus.scrape "gcp_db" {
+          targets = discovery.relabel.database_observability_mysql_gcp_db.output
+          clustering {
+            enabled = true
+          }
+
+          scrape_interval = "60s"
+          scrape_timeout = "10s"
+          scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
+          scrape_classic_histograms = false
+          scrape_native_histograms = false
+          forward_to = argument.metrics_destinations.value
+        }
+      }
 renders new db o11y options (azure, setup_actors, statements_limit, exclude_schemas):
   1: |
     |-
@@ -288,25 +401,28 @@ renders new db o11y options (azure, setup_actors, statements_limit, exclude_sche
             statements_limit = 500
           }
           query_samples {
-            collect_interval = "1m"
+            collect_interval = "10s"
             disable_query_redaction = false
             auto_enable_setup_consumers = false
             setup_consumers_check_interval = "1h"
+            sample_min_duration = "0s"
+            wait_event_min_duration = "1us"
           }
           schema_details {
             collect_interval = "1m"
-            cache_enabled = false
+            cache_enabled = true
             cache_size = 256
             cache_ttl = "10m"
           }
           setup_consumers {
-            collect_interval = "1m"
+            collect_interval = "1h"
           }
           setup_actors {
             auto_update_setup_actors = true
             collect_interval = "30m"
           }
           enable_collectors = ["explain_plans","query_details","query_samples","schema_details","setup_consumers","setup_actors"]
+          disable_collectors = ["locks"]
 
           forward_to = [loki.relabel.database_observability_mysql_azure_db.receiver]
         }
@@ -400,25 +516,28 @@ respects an explicit jobLabel override under db o11y:
             collect_interval = "1m"
           }
           query_samples {
-            collect_interval = "1m"
+            collect_interval = "10s"
             disable_query_redaction = false
             auto_enable_setup_consumers = false
             setup_consumers_check_interval = "1h"
+            sample_min_duration = "0s"
+            wait_event_min_duration = "1us"
           }
           schema_details {
             collect_interval = "1m"
-            cache_enabled = false
+            cache_enabled = true
             cache_size = 256
             cache_ttl = "10m"
           }
           setup_consumers {
-            collect_interval = "1m"
+            collect_interval = "1h"
           }
           setup_actors {
             auto_update_setup_actors = false
             collect_interval = "1h"
           }
           enable_collectors = ["explain_plans","query_details","query_samples","schema_details","setup_consumers","setup_actors"]
+          disable_collectors = ["locks"]
 
           forward_to = [loki.relabel.database_observability_mysql_my_database.receiver]
         }
@@ -512,25 +631,28 @@ should create the MySQL config:
             collect_interval = "1m"
           }
           query_samples {
-            collect_interval = "1m"
+            collect_interval = "10s"
             disable_query_redaction = false
             auto_enable_setup_consumers = false
             setup_consumers_check_interval = "1h"
+            sample_min_duration = "0s"
+            wait_event_min_duration = "1us"
           }
           schema_details {
             collect_interval = "1m"
-            cache_enabled = false
+            cache_enabled = true
             cache_size = 256
             cache_ttl = "10m"
           }
           setup_consumers {
-            collect_interval = "1m"
+            collect_interval = "1h"
           }
           setup_actors {
             auto_update_setup_actors = false
             collect_interval = "1h"
           }
           enable_collectors = ["explain_plans","query_details","query_samples","schema_details","setup_consumers","setup_actors"]
+          disable_collectors = ["locks"]
 
           forward_to = [loki.relabel.database_observability_mysql_my_database.receiver]
         }
@@ -609,25 +731,28 @@ works with multiple MySQL Instances:
             collect_interval = "1m"
           }
           query_samples {
-            collect_interval = "1m"
+            collect_interval = "10s"
             disable_query_redaction = false
             auto_enable_setup_consumers = false
             setup_consumers_check_interval = "1h"
+            sample_min_duration = "0s"
+            wait_event_min_duration = "1us"
           }
           schema_details {
             collect_interval = "1m"
-            cache_enabled = false
+            cache_enabled = true
             cache_size = 256
             cache_ttl = "10m"
           }
           setup_consumers {
-            collect_interval = "1m"
+            collect_interval = "1h"
           }
           setup_actors {
             auto_update_setup_actors = false
             collect_interval = "1h"
           }
           enable_collectors = ["explain_plans","query_details","query_samples","schema_details","setup_consumers","setup_actors"]
+          disable_collectors = ["locks"]
 
           forward_to = [loki.relabel.database_observability_mysql_test_db.receiver]
         }
@@ -695,25 +820,28 @@ works with multiple MySQL Instances:
             collect_interval = "1m"
           }
           query_samples {
-            collect_interval = "1m"
+            collect_interval = "10s"
             disable_query_redaction = false
             auto_enable_setup_consumers = false
             setup_consumers_check_interval = "1h"
+            sample_min_duration = "0s"
+            wait_event_min_duration = "1us"
           }
           schema_details {
             collect_interval = "1m"
-            cache_enabled = false
+            cache_enabled = true
             cache_size = 256
             cache_ttl = "10m"
           }
           setup_consumers {
-            collect_interval = "1m"
+            collect_interval = "1h"
           }
           setup_actors {
             auto_update_setup_actors = false
             collect_interval = "1h"
           }
           enable_collectors = ["explain_plans","query_details","query_samples","schema_details","setup_consumers","setup_actors"]
+          disable_collectors = ["locks"]
 
           forward_to = [loki.relabel.database_observability_mysql_staging_db.receiver]
         }
@@ -796,25 +924,28 @@ works with multiple MySQL Instances:
             collect_interval = "1m"
           }
           query_samples {
-            collect_interval = "1m"
+            collect_interval = "10s"
             disable_query_redaction = false
             auto_enable_setup_consumers = false
             setup_consumers_check_interval = "1h"
+            sample_min_duration = "0s"
+            wait_event_min_duration = "1us"
           }
           schema_details {
             collect_interval = "1m"
-            cache_enabled = false
+            cache_enabled = true
             cache_size = 256
             cache_ttl = "10m"
           }
           setup_consumers {
-            collect_interval = "1m"
+            collect_interval = "1h"
           }
           setup_actors {
             auto_update_setup_actors = false
             collect_interval = "1h"
           }
           enable_collectors = ["explain_plans","query_details","query_samples","schema_details","setup_consumers","setup_actors"]
+          disable_collectors = ["locks"]
 
           forward_to = [loki.relabel.database_observability_mysql_prod_db.receiver]
         }

--- a/charts/k8s-monitoring/charts/feature-integrations/tests/__snapshot__/postgresql_db_o11y_metrics_test.yaml.snap
+++ b/charts/k8s-monitoring/charts/feature-integrations/tests/__snapshot__/postgresql_db_o11y_metrics_test.yaml.snap
@@ -42,7 +42,7 @@ keeps prometheus.relabel when metrics tuning is set under db o11y:
             collect_interval = "1m"
           }
           query_samples {
-            collect_interval = "1m"
+            collect_interval = "15s"
             disable_query_redaction = false
             exclude_current_user = true
           }
@@ -109,6 +109,106 @@ keeps prometheus.relabel when metrics tuning is set under db o11y:
             regex = "pg_stat_activity_.*"
             action = "drop"
           }
+          forward_to = argument.metrics_destinations.value
+        }
+      }
+renders gcp cloud_provider and disable_collectors:
+  1: |
+    |-
+      declare "postgresql_integration" {
+        argument "metrics_destinations" {
+          comment = "Must be a list of metric destinations where collected metrics should be forwarded to"
+        }
+        argument "logs_destinations" {
+          comment = "Must be a list of log destinations where collected logs should be forwarded to"
+        }
+
+        remote.kubernetes.secret "gcp_db" {
+          name      = "gcp-db-release-name-feature-integrations"
+          namespace = "NAMESPACE"
+        } // remote.kubernetes.secret "gcp_db"
+
+        prometheus.exporter.postgres "gcp_db" {
+          data_source_names = [string.format("postgresql://%s:%s@%s:%d/",
+            encoding.url_encode(convert.nonsensitive(remote.kubernetes.secret.gcp_db.data["username"])),
+            encoding.url_encode(convert.nonsensitive(remote.kubernetes.secret.gcp_db.data["password"])),
+            "gcp-db.postgresql.svc",
+            5432,
+          )]
+          enabled_collectors = ["database","locks","replication","replication_slot","stat_bgwriter","stat_database","stat_progress_vacuum","stat_user_tables","statio_user_tables","wal"]
+          disable_default_metrics = false
+          disable_settings_metrics = false
+        }
+
+        database_observability.postgres "gcp_db" {
+          targets = prometheus.exporter.postgres.gcp_db.targets
+          data_source_name = string.format("postgresql://%s:%s@%s:%d/",
+            encoding.url_encode(convert.nonsensitive(remote.kubernetes.secret.gcp_db.data["username"])),
+            encoding.url_encode(convert.nonsensitive(remote.kubernetes.secret.gcp_db.data["password"])),
+            "gcp-db.postgresql.svc",
+            5432,
+          )
+          cloud_provider {
+            gcp {
+              connection_name = "my-project:us-central1:my-db"
+            }
+          }
+          query_details {
+            collect_interval = "1m"
+          }
+          query_samples {
+            collect_interval = "15s"
+            disable_query_redaction = false
+            exclude_current_user = true
+          }
+          enable_collectors = ["query_details","query_samples"]
+          disable_collectors = ["explain_plans","schema_details"]
+
+          forward_to = [loki.relabel.database_observability_postgres_gcp_db.receiver]
+        }
+
+        loki.relabel "database_observability_postgres_gcp_db" {
+          forward_to = argument.logs_destinations.value
+          rule {
+            target_label = "job"
+            replacement = "integrations/db-o11y"
+          }
+          rule {
+            source_labels = ["instance"]
+            target_label = "dsn"
+          }
+          rule {
+            target_label = "instance"
+            replacement = "gcp-db"
+          }
+        }
+
+        discovery.relabel "database_observability_postgres_gcp_db" {
+          targets = database_observability.postgres.gcp_db.targets
+          rule {
+            target_label = "job"
+            replacement = "integrations/db-o11y"
+          }
+          rule {
+            source_labels = ["instance"]
+            target_label = "dsn"
+          }
+          rule {
+            target_label = "instance"
+            replacement = "gcp-db"
+          }
+        }
+        prometheus.scrape "gcp_db" {
+          targets = discovery.relabel.database_observability_postgres_gcp_db.output
+          clustering {
+            enabled = true
+          }
+
+          scrape_interval = "60s"
+          scrape_timeout = "10s"
+          scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
+          scrape_classic_histograms = false
+          scrape_native_histograms = false
           forward_to = argument.metrics_destinations.value
         }
       }
@@ -269,7 +369,7 @@ renders new db o11y options (exclude_users):
             collect_interval = "1m"
           }
           query_samples {
-            collect_interval = "1m"
+            collect_interval = "15s"
             disable_query_redaction = false
             exclude_current_user = true
           }
@@ -374,7 +474,7 @@ renders new db o11y options (statements_limit):
             statements_limit = 50
           }
           query_samples {
-            collect_interval = "1m"
+            collect_interval = "15s"
             disable_query_redaction = false
             exclude_current_user = true
           }
@@ -478,7 +578,7 @@ respects an explicit jobLabel override under db o11y:
             collect_interval = "1m"
           }
           query_samples {
-            collect_interval = "1m"
+            collect_interval = "15s"
             disable_query_redaction = false
             exclude_current_user = true
           }
@@ -582,7 +682,7 @@ should create the PostgreSQL config:
             collect_interval = "1m"
           }
           query_samples {
-            collect_interval = "1m"
+            collect_interval = "15s"
             disable_query_redaction = false
             exclude_current_user = true
           }
@@ -671,7 +771,7 @@ works with multiple PostgreSQL Instances:
             collect_interval = "1m"
           }
           query_samples {
-            collect_interval = "1m"
+            collect_interval = "15s"
             disable_query_redaction = false
             exclude_current_user = true
           }
@@ -749,7 +849,7 @@ works with multiple PostgreSQL Instances:
             collect_interval = "1m"
           }
           query_samples {
-            collect_interval = "1m"
+            collect_interval = "15s"
             disable_query_redaction = false
             exclude_current_user = true
           }
@@ -842,7 +942,7 @@ works with multiple PostgreSQL Instances:
             collect_interval = "1m"
           }
           query_samples {
-            collect_interval = "1m"
+            collect_interval = "15s"
             disable_query_redaction = false
             exclude_current_user = true
           }

--- a/charts/k8s-monitoring/charts/feature-integrations/tests/mysql_db_o11y_metrics_test.yaml
+++ b/charts/k8s-monitoring/charts/feature-integrations/tests/mysql_db_o11y_metrics_test.yaml
@@ -149,6 +149,40 @@ tests:
         matchSnapshot:
           path: data["metrics.alloy"]
 
+  - it: renders gcp cloud_provider, query_samples min durations, and disable_collectors
+    set:
+      testing: {enabled: true}
+      mysql:
+        instances:
+          - name: gcp-db
+            exporter:
+              dataSource:
+                host: gcp-db.mysql.svc
+                auth:
+                  username: db-admin
+                  password: db-password
+            databaseObservability:
+              enabled: true
+              cloudProvider:
+                gcp:
+                  connectionName: "my-project:us-central1:my-db"
+              collectors:
+                querySamples:
+                  enabled: true
+                  sampleMinDuration: 100ms
+                  waitEventMinDuration: 5ms
+                schemaDetails:
+                  enabled: false
+                setupActors:
+                  enabled: false
+                setupConsumers:
+                  enabled: false
+            logs: {enabled: false}
+    asserts:
+      - template: test/configmap.yaml
+        matchSnapshot:
+          path: data["metrics.alloy"]
+
   - it: keeps prometheus.relabel when metrics tuning is set under db o11y
     set:
       testing: {enabled: true}

--- a/charts/k8s-monitoring/charts/feature-integrations/tests/postgresql_db_o11y_metrics_test.yaml
+++ b/charts/k8s-monitoring/charts/feature-integrations/tests/postgresql_db_o11y_metrics_test.yaml
@@ -169,6 +169,34 @@ tests:
         matchSnapshot:
           path: data["metrics.alloy"]
 
+  - it: renders gcp cloud_provider and disable_collectors
+    set:
+      testing: {enabled: true}
+      postgresql:
+        instances:
+          - name: gcp-db
+            exporter:
+              dataSource:
+                host: gcp-db.postgresql.svc
+                auth:
+                  username: db-admin
+                  password: db-password
+            databaseObservability:
+              enabled: true
+              cloudProvider:
+                gcp:
+                  connectionName: "my-project:us-central1:my-db"
+              collectors:
+                explainPlans:
+                  enabled: false
+                schemaDetails:
+                  enabled: false
+            logs: {enabled: false}
+    asserts:
+      - template: test/configmap.yaml
+        matchSnapshot:
+          path: data["metrics.alloy"]
+
   - it: keeps prometheus.relabel when metrics tuning is set under db o11y
     set:
       testing: {enabled: true}

--- a/charts/k8s-monitoring/charts/feature-integrations/values.schema.json
+++ b/charts/k8s-monitoring/charts/feature-integrations/values.schema.json
@@ -843,6 +843,14 @@
                                             "type": "string"
                                         }
                                     }
+                                },
+                                "gcp": {
+                                    "type": "object",
+                                    "properties": {
+                                        "connectionName": {
+                                            "type": "string"
+                                        }
+                                    }
                                 }
                             }
                         },
@@ -909,7 +917,13 @@
                                         "enabled": {
                                             "type": "boolean"
                                         },
+                                        "sampleMinDuration": {
+                                            "type": "string"
+                                        },
                                         "setupConsumersCheckInterval": {
+                                            "type": "string"
+                                        },
+                                        "waitEventMinDuration": {
                                             "type": "string"
                                         }
                                     }
@@ -1187,6 +1201,14 @@
                                             "type": "string"
                                         }
                                     }
+                                },
+                                "gcp": {
+                                    "type": "object",
+                                    "properties": {
+                                        "connectionName": {
+                                            "type": "string"
+                                        }
+                                    }
                                 }
                             }
                         },
@@ -1201,9 +1223,6 @@
                                         },
                                         "enabled": {
                                             "type": "boolean"
-                                        },
-                                        "excludeSchemas": {
-                                            "type": "array"
                                         },
                                         "perCollectRatio": {
                                             "type": "number"

--- a/charts/k8s-monitoring/docs/examples/features/database-observability/mysql/alloy-singleton.alloy
+++ b/charts/k8s-monitoring/docs/examples/features/database-observability/mysql/alloy-singleton.alloy
@@ -42,25 +42,28 @@ declare "mysql_integration" {
       collect_interval = "1m"
     }
     query_samples {
-      collect_interval = "1m"
+      collect_interval = "10s"
       disable_query_redaction = false
       auto_enable_setup_consumers = false
       setup_consumers_check_interval = "1h"
+      sample_min_duration = "0s"
+      wait_event_min_duration = "1us"
     }
     schema_details {
       collect_interval = "1m"
-      cache_enabled = false
+      cache_enabled = true
       cache_size = 256
       cache_ttl = "10m"
     }
     setup_consumers {
-      collect_interval = "1m"
+      collect_interval = "1h"
     }
     setup_actors {
       auto_update_setup_actors = false
       collect_interval = "1h"
     }
     enable_collectors = ["explain_plans","query_details","query_samples","schema_details","setup_consumers","setup_actors"]
+    disable_collectors = ["locks"]
 
     forward_to = [loki.relabel.database_observability_mysql_test_db.receiver]
   }

--- a/charts/k8s-monitoring/docs/examples/features/database-observability/mysql/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/features/database-observability/mysql/output.yaml
@@ -370,25 +370,28 @@ data:
           collect_interval = "1m"
         }
         query_samples {
-          collect_interval = "1m"
+          collect_interval = "10s"
           disable_query_redaction = false
           auto_enable_setup_consumers = false
           setup_consumers_check_interval = "1h"
+          sample_min_duration = "0s"
+          wait_event_min_duration = "1us"
         }
         schema_details {
           collect_interval = "1m"
-          cache_enabled = false
+          cache_enabled = true
           cache_size = 256
           cache_ttl = "10m"
         }
         setup_consumers {
-          collect_interval = "1m"
+          collect_interval = "1h"
         }
         setup_actors {
           auto_update_setup_actors = false
           collect_interval = "1h"
         }
         enable_collectors = ["explain_plans","query_details","query_samples","schema_details","setup_consumers","setup_actors"]
+        disable_collectors = ["locks"]
     
         forward_to = [loki.relabel.database_observability_mysql_test_db.receiver]
       }

--- a/charts/k8s-monitoring/docs/examples/features/database-observability/postgresql/alloy-singleton.alloy
+++ b/charts/k8s-monitoring/docs/examples/features/database-observability/postgresql/alloy-singleton.alloy
@@ -42,7 +42,7 @@ declare "postgresql_integration" {
       collect_interval = "1m"
     }
     query_samples {
-      collect_interval = "1m"
+      collect_interval = "15s"
       disable_query_redaction = false
       exclude_current_user = true
     }

--- a/charts/k8s-monitoring/docs/examples/features/database-observability/postgresql/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/features/database-observability/postgresql/output.yaml
@@ -353,7 +353,7 @@ data:
           collect_interval = "1m"
         }
         query_samples {
-          collect_interval = "1m"
+          collect_interval = "15s"
           disable_query_redaction = false
           exclude_current_user = true
         }

--- a/charts/k8s-monitoring/tests/platform/grafana-cloud/database-observability/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/platform/grafana-cloud/database-observability/.rendered/output.yaml
@@ -391,25 +391,28 @@ data:
           collect_interval = "1m"
         }
         query_samples {
-          collect_interval = "1m"
+          collect_interval = "10s"
           disable_query_redaction = false
           auto_enable_setup_consumers = false
           setup_consumers_check_interval = "1h"
+          sample_min_duration = "0s"
+          wait_event_min_duration = "1us"
         }
         schema_details {
           collect_interval = "1m"
-          cache_enabled = false
+          cache_enabled = true
           cache_size = 256
           cache_ttl = "10m"
         }
         setup_consumers {
-          collect_interval = "1m"
+          collect_interval = "1h"
         }
         setup_actors {
           auto_update_setup_actors = false
           collect_interval = "1h"
         }
         enable_collectors = ["explain_plans","query_details","query_samples","schema_details","setup_consumers","setup_actors"]
+        disable_collectors = ["locks"]
     
         forward_to = [loki.relabel.database_observability_mysql_test_mysql_db.receiver]
       }
@@ -511,7 +514,7 @@ data:
           collect_interval = "1m"
         }
         query_samples {
-          collect_interval = "1m"
+          collect_interval = "15s"
           disable_query_redaction = false
           exclude_current_user = true
         }


### PR DESCRIPTION
- Add `databaseObservability.cloudProvider.gcp` for GCP metadata
- Add new `databaseObservability.collectors.querySamples` settings for samples and wait events duration
- Emit `disable_collectors` for any collector explicitly turned off
- Align default `databaseObservability.collectors` collect interval values
- Remove the unused `databaseObservability.collectors.explainPlans.excludeSchemas` postgres attribute