### PR TITLE
Add Argo CD external-secrets and ApplicationSet examples

### DIFF
--- a/charts/k8s-monitoring/docs/examples/deployment-alternatives/argocd/README.md
+++ b/charts/k8s-monitoring/docs/examples/deployment-alternatives/argocd/README.md
@@ -20,7 +20,10 @@ Three variants are provided:
 - [`k8s-monitoring-applicationset.yaml`](./k8s-monitoring-applicationset.yaml): an `ApplicationSet` using the
   [cluster generator](https://argo-cd.readthedocs.io/en/stable/operator-manual/applicationset/Generators-Cluster/) to
   fan the same configuration out to every Argo CD cluster carrying the `kubernetes-monitoring: enabled` label.
-  Combine with the external-secrets variant when each managed cluster has its own credentials Secret.
+  Combine with the external-secrets variant when each managed cluster has its own credentials Secret. The template
+  uses `{{ .nameNormalized }}` for the generated `Application.metadata.name`; ensure your Argo CD cluster names are
+  unique after normalization (lowercase + non-DNS characters replaced with `-`), since names like `prod_us` and
+  `prod-us` both normalize to `prod-us` and would generate colliding Applications.
 
 ## Setting `null` values
 

--- a/charts/k8s-monitoring/docs/examples/deployment-alternatives/argocd/README.md
+++ b/charts/k8s-monitoring/docs/examples/deployment-alternatives/argocd/README.md
@@ -5,14 +5,31 @@ the application using ArgoCD's [Helm application spec](https://argo-cd.readthedo
 does not install the Helm chart directly, but instead utilizes `helm template` to render the chart manifests and deploys
 them to the cluster.
 
+For a step-by-step Grafana Cloud guide built on top of these manifests, refer to
+[Send Kubernetes metrics, logs, and events with Helm and Argo CD to Grafana Cloud](https://grafana.com/docs/grafana-cloud/monitor-infrastructure/kubernetes-monitoring/configuration/config-other-methods/argocd-config/).
+
+Three variants are provided:
+
+- [`k8s-monitoring-application.yaml`](./k8s-monitoring-application.yaml): a single-cluster `Application` with
+  credentials embedded in `valuesObject`. Easiest to read; convenient for getting started.
+- [`k8s-monitoring-application-external-secrets.yaml`](./k8s-monitoring-application-external-secrets.yaml): the same
+  single-cluster `Application`, but credentials are read from a pre-existing Kubernetes `Secret` using the
+  [external secrets pattern](../../auth/external-secrets). Endpoint URLs stay inline in the manifest; only credentials
+  live in the Secret. Recommended for any environment where credentials should not live in the manifest checked into
+  git.
+- [`k8s-monitoring-applicationset.yaml`](./k8s-monitoring-applicationset.yaml): an `ApplicationSet` using the
+  [cluster generator](https://argo-cd.readthedocs.io/en/stable/operator-manual/applicationset/Generators-Cluster/) to
+  fan the same configuration out to every Argo CD cluster carrying the `kubernetes-monitoring: enabled` label.
+  Combine with the external-secrets variant when each managed cluster has its own credentials Secret.
+
 ## Setting `null` values
 
-This example uses the `valuesObject` field to define Helm values inline within the Application manifest as YAML object.
-If you need to remove a value that is set by default in the Helm chart, you will need to explicitly set it to `null`.
-However, this currently [does not work](https://github.com/argoproj/argo-cd/issues/16312) when using `valuesObject`, so
-instead utilize the multiline string `values` field to define your Helm chart values. Note you cannot combine both
-`valuesObject` and `values` in the same Application manifest, as the `valuesObject` field takes precedence and the
-result will not be a merged object.
+These examples use the `valuesObject` field to define Helm values inline within the Application manifest as YAML
+object. If you need to remove a value that is set by default in the Helm chart, you will need to explicitly set it to
+`null`. However, this currently [does not work](https://github.com/argoproj/argo-cd/issues/16312) when using
+`valuesObject`, so instead utilize the multiline string `values` field to define your Helm chart values. Note you
+cannot combine both `valuesObject` and `values` in the same Application manifest, as the `valuesObject` field takes
+precedence and the result will not be a merged object.
 
 ## Application manifest
 

--- a/charts/k8s-monitoring/docs/examples/deployment-alternatives/argocd/README.md
+++ b/charts/k8s-monitoring/docs/examples/deployment-alternatives/argocd/README.md
@@ -10,20 +10,20 @@ For a step-by-step Grafana Cloud guide built on top of these manifests, refer to
 
 Three variants are provided:
 
-- [`k8s-monitoring-application.yaml`](./k8s-monitoring-application.yaml): a single-cluster `Application` with
-  credentials embedded in `valuesObject`. Easiest to read; convenient for getting started.
-- [`k8s-monitoring-application-external-secrets.yaml`](./k8s-monitoring-application-external-secrets.yaml): the same
-  single-cluster `Application`, but credentials are read from a pre-existing Kubernetes `Secret` using the
-  [external secrets pattern](../../auth/external-secrets). Endpoint URLs stay inline in the manifest; only credentials
-  live in the Secret. Recommended for any environment where credentials should not live in the manifest checked into
-  git.
-- [`k8s-monitoring-applicationset.yaml`](./k8s-monitoring-applicationset.yaml): an `ApplicationSet` using the
-  [cluster generator](https://argo-cd.readthedocs.io/en/stable/operator-manual/applicationset/Generators-Cluster/) to
-  fan the same configuration out to every Argo CD cluster carrying the `kubernetes-monitoring: enabled` label.
-  Combine with the external-secrets variant when each managed cluster has its own credentials Secret. The template
-  uses `{{ .nameNormalized }}` for the generated `Application.metadata.name`; ensure your Argo CD cluster names are
-  unique after normalization (lowercase + non-DNS characters replaced with `-`), since names like `prod_us` and
-  `prod-us` both normalize to `prod-us` and would generate colliding Applications.
+-   [`k8s-monitoring-application.yaml`](./k8s-monitoring-application.yaml): a single-cluster `Application` with
+    credentials embedded in `valuesObject`. Easiest to read; convenient for getting started.
+-   [`k8s-monitoring-application-external-secrets.yaml`](./k8s-monitoring-application-external-secrets.yaml): the same
+    single-cluster `Application`, but credentials are read from a pre-existing Kubernetes `Secret` using the
+    [external secrets pattern](../../auth/external-secrets). Endpoint URLs stay inline in the manifest; only
+    credentials live in the Secret. Recommended for any environment where credentials should not live in the
+    manifest checked into git.
+-   [`k8s-monitoring-applicationset.yaml`](./k8s-monitoring-applicationset.yaml): an `ApplicationSet` using the
+    [cluster generator](https://argo-cd.readthedocs.io/en/stable/operator-manual/applicationset/Generators-Cluster/)
+    to fan the same configuration out to every Argo CD cluster carrying the `kubernetes-monitoring: enabled` label.
+    Combine with the external-secrets variant when each managed cluster has its own credentials Secret. The template
+    uses `{{ .nameNormalized }}` for the generated `Application.metadata.name`; ensure your Argo CD cluster names
+    are unique after normalization (lowercase + non-DNS characters replaced with `-`), since names like `prod_us` and
+    `prod-us` both normalize to `prod-us` and would generate colliding Applications.
 
 ## Setting `null` values
 

--- a/charts/k8s-monitoring/docs/examples/deployment-alternatives/argocd/k8s-monitoring-application-external-secrets.yaml
+++ b/charts/k8s-monitoring/docs/examples/deployment-alternatives/argocd/k8s-monitoring-application-external-secrets.yaml
@@ -1,0 +1,140 @@
+---
+# Pre-existing Kubernetes Secret consumed by the Application below.
+# In a real deployment this Secret is provisioned by your secret-store integration
+# (External Secrets Operator, Sealed Secrets, SOPS, Vault, ...) rather than committed
+# alongside the Application manifest. Only credentials live in the Secret; endpoint
+# URLs stay inline in the manifest below where they are easier to review and update.
+apiVersion: v1
+kind: Secret
+metadata:
+  name: grafana-cloud-credentials
+  namespace: default
+type: Opaque
+stringData:
+  prometheus-username: promuser
+  loki-username: loki
+  access-token: testpassword
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: k8s-monitoring-application
+  namespace: argocd
+operation:
+  sync:
+    syncStrategy:
+      hook: {}
+spec:
+  project: default
+  syncPolicy:
+    automated:
+      selfHeal: true
+      enabled: true
+    syncOptions:
+      - Retry=true
+    retry:
+      limit: 5
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 1m
+  destination:
+    server: "https://kubernetes.default.svc"
+    namespace: default
+  source:
+    repoURL: https://github.com/grafana/k8s-monitoring-helm.git
+    path: charts/k8s-monitoring
+    targetRevision: "main"
+    helm:
+      releaseName: k8smon
+      valuesObject:
+        cluster:
+          name: argocd-external-secrets-test
+        destinations:
+          localPrometheus:
+            type: prometheus
+            url: http://prometheus-server.prometheus.svc:9090/api/v1/write
+            auth:
+              type: basic
+              usernameKey: prometheus-username
+              passwordKey: access-token
+            secret:
+              create: false
+              name: grafana-cloud-credentials
+              namespace: default
+          localLoki:
+            type: loki
+            url: http://loki.loki.svc:3100/loki/api/v1/push
+            tenantId: "1"
+            auth:
+              type: basic
+              usernameKey: loki-username
+              passwordKey: access-token
+            secret:
+              create: false
+              name: grafana-cloud-credentials
+              namespace: default
+        clusterMetrics:
+          enabled: true
+          collector: alloy-metrics
+
+        costMetrics:
+          enabled: true
+          collector: alloy-metrics
+
+        hostMetrics:
+          enabled: true
+          collector: alloy-metrics
+          linuxHosts:
+            enabled: true
+          windowsHosts:
+            enabled: true
+          energyMetrics:
+            enabled: true
+
+        clusterEvents:
+          enabled: true
+          collector: alloy-singleton
+
+        podLogsViaLoki:
+          enabled: true
+          collector: alloy-logs
+          structuredMetadata:
+            pod: ""
+
+        collectors:
+          alloy-metrics:
+            presets: [clustered, statefulset]
+          alloy-logs:
+            presets: [filesystem-log-reader, daemonset]
+          alloy-singleton:
+            presets: [singleton]
+
+        collectorCommon:
+          alloy:
+            annotations:
+              argocd.argoproj.io/sync-wave: "1"
+
+        telemetryServices:
+          kube-state-metrics:
+            deploy: true
+          node-exporter:
+            deploy: true
+          windows-exporter:
+            deploy: true
+          kepler:
+            deploy: true
+          opencost:
+            deploy: true
+            metricsSource: localPrometheus
+            annotations:
+              argocd.argoproj.io/sync-wave: "1"
+            opencost:
+              exporter:
+                defaultClusterId: argocd-external-secrets-test
+              prometheus:
+                existingSecretName: grafana-cloud-credentials
+                username_key: prometheus-username
+                password_key: access-token
+                external:
+                  url: http://prometheus-server.prometheus.svc:9090

--- a/charts/k8s-monitoring/docs/examples/deployment-alternatives/argocd/k8s-monitoring-applicationset.yaml
+++ b/charts/k8s-monitoring/docs/examples/deployment-alternatives/argocd/k8s-monitoring-applicationset.yaml
@@ -1,0 +1,141 @@
+---
+# Multi-cluster fan-out using Argo CD's cluster generator. The generator iterates
+# over every Argo CD `Cluster` secret carrying the label below and produces one
+# Application per cluster from the template. {{ .name }} and {{ .nameNormalized }}
+# are substituted by Argo CD itself, not by Helm or the chart.
+#
+# Each managed cluster must already have a `grafana-cloud-credentials` Secret
+# (see k8s-monitoring-application-external-secrets.yaml) in the destination
+# namespace before the generated Applications sync. Endpoint URLs stay inline
+# below; only credentials live in the Secret.
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: k8s-monitoring
+  namespace: argocd
+spec:
+  goTemplate: true
+  goTemplateOptions: ["missingkey=error"]
+  generators:
+    - clusters:
+        selector:
+          matchLabels:
+            kubernetes-monitoring: enabled
+  template:
+    metadata:
+      name: 'k8s-monitoring-{{ .nameNormalized }}'
+      finalizers:
+        - resources-finalizer.argocd.argoproj.io
+    spec:
+      project: default
+      syncPolicy:
+        automated:
+          selfHeal: true
+        syncOptions:
+          - Retry=true
+        retry:
+          limit: 5
+          backoff:
+            duration: 5s
+            factor: 2
+            maxDuration: 1m
+      destination:
+        name: '{{ .name }}'
+        namespace: default
+      source:
+        repoURL: https://github.com/grafana/k8s-monitoring-helm.git
+        path: charts/k8s-monitoring
+        targetRevision: "main"
+        helm:
+          releaseName: k8smon
+          valuesObject:
+            cluster:
+              name: '{{ .name }}'
+            destinations:
+              localPrometheus:
+                type: prometheus
+                url: http://prometheus-server.prometheus.svc:9090/api/v1/write
+                auth:
+                  type: basic
+                  usernameKey: prometheus-username
+                  passwordKey: access-token
+                secret:
+                  create: false
+                  name: grafana-cloud-credentials
+                  namespace: default
+              localLoki:
+                type: loki
+                url: http://loki.loki.svc:3100/loki/api/v1/push
+                tenantId: "1"
+                auth:
+                  type: basic
+                  usernameKey: loki-username
+                  passwordKey: access-token
+                secret:
+                  create: false
+                  name: grafana-cloud-credentials
+                  namespace: default
+            clusterMetrics:
+              enabled: true
+              collector: alloy-metrics
+
+            costMetrics:
+              enabled: true
+              collector: alloy-metrics
+
+            hostMetrics:
+              enabled: true
+              collector: alloy-metrics
+              linuxHosts:
+                enabled: true
+              windowsHosts:
+                enabled: true
+              energyMetrics:
+                enabled: true
+
+            clusterEvents:
+              enabled: true
+              collector: alloy-singleton
+
+            podLogsViaLoki:
+              enabled: true
+              collector: alloy-logs
+              structuredMetadata:
+                pod: ""
+
+            collectors:
+              alloy-metrics:
+                presets: [clustered, statefulset]
+              alloy-logs:
+                presets: [filesystem-log-reader, daemonset]
+              alloy-singleton:
+                presets: [singleton]
+
+            collectorCommon:
+              alloy:
+                annotations:
+                  argocd.argoproj.io/sync-wave: "1"
+
+            telemetryServices:
+              kube-state-metrics:
+                deploy: true
+              node-exporter:
+                deploy: true
+              windows-exporter:
+                deploy: true
+              kepler:
+                deploy: true
+              opencost:
+                deploy: true
+                metricsSource: localPrometheus
+                annotations:
+                  argocd.argoproj.io/sync-wave: "1"
+                opencost:
+                  exporter:
+                    defaultClusterId: '{{ .name }}'
+                  prometheus:
+                    existingSecretName: grafana-cloud-credentials
+                    username_key: prometheus-username
+                    password_key: access-token
+                    external:
+                      url: http://prometheus-server.prometheus.svc:9090


### PR DESCRIPTION
Adds two new Argo CD deployment-alternative manifests alongside the existing `k8s-monitoring-application.yaml`, so users who already use External Secrets Operator, Sealed Secrets, SOPS, Vault, or similar have a complete starting point that doesn't put credentials in the Application manifest, and users running Argo CD across many clusters have an `ApplicationSet` example with the cluster generator.

The new manifests intentionally mirror the existing example's full feature set (clusterMetrics, costMetrics, hostMetrics with Linux/Windows/energy, clusterEvents, podLogsViaLoki, full telemetryServices including OpenCost) so the only diff between them and the existing example is credential sourcing. Validated locally via `helm template`: both new manifests produce a 2952-line render byte-identical to the existing example modulo `cluster.name`. The README cross-links to the [Grafana Cloud Argo CD configuration page](https://grafana.com/docs/grafana-cloud/monitor-infrastructure/kubernetes-monitoring/configuration/config-other-methods/argocd-config/) that walks users through these manifests step by step; that docs page is being updated in parallel to match the new shape.

The `ApplicationSet` uses `{{ .nameNormalized }}` for `metadata.name` so cluster names containing underscores or uppercase characters don't produce DNS-1123-invalid Application names, with a README caveat that `nameNormalized` is not injective (`prod_us` and `prod-us` both normalize to `prod-us`) and users should ensure their cluster names are unique after normalization.

Question for maintainers: the existing `argocd/test/` rig only covers `k8s-monitoring-application.yaml`. Worth extending it (or adding a sibling `test/` directory) to exercise the two new manifests in CI? The external-secrets variant would need its `Secret` applied as a test dependency; the `ApplicationSet` variant would need a labelled Cluster secret on the kind node so the generator has something to iterate over. Happy to add either as a follow-up commit on this PR if you want it before merge.