### PR TITLE
Fix hook templates failing when waitForAlloyRemoval.securityContext is null

### DIFF
--- a/charts/k8s-monitoring/CHANGELOG.md
+++ b/charts/k8s-monitoring/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 *   Fix `cluster.nameFrom` rendering in OTLP destinations so the expression is interpolated into the OTTL transform statements via `string.format`, instead of being inlined as raw OTTL where it failed to parse (@petewall)
+*   Fix the pre-delete and post-install Alloy-finalizer hook templates failing to render when `alloy-operator.waitForAlloyRemoval.securityContext` is set to `null` (#2569) (@petewall)
 
 ## 4.1
 

--- a/charts/k8s-monitoring/templates/hooks/post-install_add-finalizer.yaml
+++ b/charts/k8s-monitoring/templates/hooks/post-install_add-finalizer.yaml
@@ -1,9 +1,11 @@
 {{- if and (index .Values "alloy-operator").deploy (index .Values "alloy-operator").waitForAlloyRemoval.enabled }}
 {{- $jobName := (printf "%s-add-finalizer" (include "helper.fullname" .)) | trunc 63 | trimSuffix "-" }}
 {{- $jobSettings := (index .Values "alloy-operator").waitForAlloyRemoval -}}
+{{- if $jobSettings.securityContext }}
 {{- if eq $jobSettings.securityContext.runAsUser nil }}
   {{- /* Fixes an issue where this wouldn't remove, but instead set it to `null` */}}
   {{- $jobSettings = mergeOverwrite $jobSettings (dict "securityContext" (unset $jobSettings.securityContext "runAsUser")) }}
+{{- end }}
 {{- end }}
 {{- $imagePullSecrets := $jobSettings.image.pullSecrets }}
 {{- if ((index .Values.global "image") | default dict).pullSecrets }}

--- a/charts/k8s-monitoring/templates/hooks/pre-delete_remove-alloy-and-finalizer.yaml
+++ b/charts/k8s-monitoring/templates/hooks/pre-delete_remove-alloy-and-finalizer.yaml
@@ -1,9 +1,11 @@
 {{- if and (index .Values "alloy-operator").deploy (index .Values "alloy-operator").waitForAlloyRemoval.enabled }}
 {{- $jobName := (printf "%s-remove-alloy-and-finalizer" (include "helper.fullname" .)) | trunc 63 | trimSuffix "-" }}
 {{- $jobSettings := (index .Values "alloy-operator").waitForAlloyRemoval -}}
+{{- if $jobSettings.securityContext }}
 {{- if eq $jobSettings.securityContext.runAsUser nil }}
   {{- /* Fixes an issue where this wouldn't remove, but instead set it to `null` */}}
   {{- $jobSettings = mergeOverwrite $jobSettings (dict "securityContext" (unset $jobSettings.securityContext "runAsUser")) }}
+{{- end }}
 {{- end }}
 {{- $imagePullSecrets := $jobSettings.image.pullSecrets }}
 {{- if ((index .Values.global "image") | default dict).pullSecrets }}

--- a/charts/k8s-monitoring/tests/hook_post-install_add-finalizer_test.yaml
+++ b/charts/k8s-monitoring/tests/hook_post-install_add-finalizer_test.yaml
@@ -104,3 +104,17 @@ tests:
         equal:
           path: "subjects[0].namespace"
           value: observability
+
+  - it: should render when securityContext is null
+    set:
+      alloy-operator:
+        deploy: true
+        waitForAlloyRemoval:
+          enabled: true
+          securityContext: null
+    asserts:
+      - hasDocuments:
+          count: 4
+      - documentIndex: 0
+        notExists:
+          path: "spec.template.spec.containers[0].securityContext"

--- a/charts/k8s-monitoring/tests/hook_pre-delete_remove-alloy-and-finalizer_test.yaml
+++ b/charts/k8s-monitoring/tests/hook_pre-delete_remove-alloy-and-finalizer_test.yaml
@@ -71,3 +71,17 @@ tests:
         equal:
           path: "spec.template.spec.containers[0].resources.limits.memory"
           value: 128Mi
+
+  - it: should render when securityContext is null
+    set:
+      alloy-operator:
+        deploy: true
+        waitForAlloyRemoval:
+          enabled: true
+          securityContext: null
+    asserts:
+      - hasDocuments:
+          count: 4
+      - documentIndex: 0
+        notExists:
+          path: "spec.template.spec.containers[0].securityContext"


### PR DESCRIPTION
Setting `alloy-operator.waitForAlloyRemoval.securityContext` to `null` caused helm template/install to fail with a nil-pointer dereference on .runAsUser. Guard the runAsUser cleanup block with a nil check on securityContext itself, in both the post-install and pre-delete hooks.

Fixes #2569.