### PR TITLE
Propagate Template into feature module includes for tpl compatibility

### DIFF
--- a/charts/k8s-monitoring/CHANGELOG.md
+++ b/charts/k8s-monitoring/CHANGELOG.md
@@ -2,9 +2,9 @@
 
 ## Unreleased
 
-*   Fix `cluster.nameFrom` rendering in OTLP destinations so the expression is interpolated into the OTTL transform statements via `string.format`, instead of being inlined as raw OTTL where it failed to parse (@petewall)
 *   Fix the pre-delete and post-install Alloy-finalizer hook templates failing to render when `alloy-operator.waitForAlloyRemoval.securityContext` is set to `null` (#2569) (@petewall)
 *   Update Alloy Operator to 0.5.7, Beyla to 1.16.6, and k8s-manifest-tail to 0.1.4 (@petewall)
+*   Fix `extraLogProcessingStages` (and `extraLogProcessingRules` on `podLogsObjects`) failing to render under older Helm versions (e.g. those bundled with the Terraform Helm provider) with `cannot retrieve Template.Basepath from values inside tpl function`, by propagating `Template` through to the feature module includes that call `tpl` (@petewall)
 
 ## 4.1
 

--- a/charts/k8s-monitoring/templates/alloy-config.yaml
+++ b/charts/k8s-monitoring/templates/alloy-config.yaml
@@ -8,7 +8,7 @@
 {{- end }}
 
 {{/* Save the top level object and add the collector name */}}
-{{- $values := dict "Values" $.Values "Chart" $.Chart "Files" $.Files "Release" $.Release "Subcharts" $.Subcharts "collectorName" $collectorName }}
+{{- $values := dict "Values" $.Values "Chart" $.Chart "Files" $.Files "Release" $.Release "Subcharts" $.Subcharts "Template" $.Template "collectorName" $collectorName }}
 {{- $collectorValues := include "collector.alloy.values" $values | fromYaml }}
 {{- $alloyConfig := "" }}
 {{- range $featureKey := include "features.list" . | fromYamlArray }}

--- a/charts/k8s-monitoring/templates/features/_feature_cluster_events.tpl
+++ b/charts/k8s-monitoring/templates/features/_feature_cluster_events.tpl
@@ -4,7 +4,7 @@
 {{- if .Values.clusterEvents.enabled -}}
 {{- $destinations := include "features.clusterEvents.destinations" . | fromYamlArray }}
 // Feature: Cluster Events
-{{- include "feature.clusterEvents.module" (dict "Values" $.Values.clusterEvents "Files" $.Subcharts.clusterEvents.Files) }}
+{{- include "feature.clusterEvents.module" (dict "Values" $.Values.clusterEvents "Files" $.Subcharts.clusterEvents.Files "Template" $.Template) }}
 cluster_events "feature" {
   logs_destinations = [
     {{ include "destinations.alloy.targets" (dict "destinations" $.Values.destinations "destinationNames" $destinations "type" "logs" "ecosystem" "loki") | indent 4 | trim }}

--- a/charts/k8s-monitoring/templates/features/_feature_node_logs.tpl
+++ b/charts/k8s-monitoring/templates/features/_feature_node_logs.tpl
@@ -5,7 +5,7 @@
 {{- $destinations := include "features.nodeLogs.destinations" . | fromYamlArray }}
 
 // Feature: Node Logs
-{{- include "feature.nodeLogs.module" (dict "Values" .Values.nodeLogs "Files" $.Subcharts.nodeLogs.Files) }}
+{{- include "feature.nodeLogs.module" (dict "Values" .Values.nodeLogs "Files" $.Subcharts.nodeLogs.Files "Template" $.Template) }}
 node_logs "feature" {
   logs_destinations = [
     {{ include "destinations.alloy.targets" (dict "destinations" $.Values.destinations "destinationNames" $destinations "type" "logs" "ecosystem" "loki") | indent 4 | trim }}

--- a/charts/k8s-monitoring/templates/features/_feature_pod_logs_objects.tpl
+++ b/charts/k8s-monitoring/templates/features/_feature_pod_logs_objects.tpl
@@ -5,7 +5,7 @@
 {{- $destinations := include "features.podLogsObjects.destinations" . | fromYamlArray }}
 
 // Feature: PodLogs Objects
-{{- include "feature.podLogsObjects.module" (dict "Values" .Values.podLogsObjects "Files" $.Subcharts.podLogsObjects.Files) }}
+{{- include "feature.podLogsObjects.module" (dict "Values" .Values.podLogsObjects "Files" $.Subcharts.podLogsObjects.Files "Template" $.Template) }}
 pod_logs_objects "feature" {
   logs_destinations = [
     {{ include "destinations.alloy.targets" (dict "destinations" $.Values.destinations "destinationNames" $destinations "type" "logs" "ecosystem" "loki") | indent 4 | trim }}

--- a/charts/k8s-monitoring/templates/features/_feature_pod_logs_via_kubernetes_api.tpl
+++ b/charts/k8s-monitoring/templates/features/_feature_pod_logs_via_kubernetes_api.tpl
@@ -5,7 +5,7 @@
 {{- $destinations := include "features.podLogsViaKubernetesApi.destinations" . | fromYamlArray }}
 
 // Feature: Pod Logs via Kubernetes API
-{{- include "feature.podLogsViaKubernetesApi.module" (dict "Values" .Values.podLogsViaKubernetesApi "Files" $.Subcharts.podLogsViaKubernetesApi.Files) }}
+{{- include "feature.podLogsViaKubernetesApi.module" (dict "Values" .Values.podLogsViaKubernetesApi "Files" $.Subcharts.podLogsViaKubernetesApi.Files "Template" $.Template) }}
 pod_logs_via_kubernetes_api "feature" {
   logs_destinations = [
     {{ include "destinations.alloy.targets" (dict "destinations" $.Values.destinations "destinationNames" $destinations "type" "logs" "ecosystem" "loki") | indent 4 | trim }}

--- a/charts/k8s-monitoring/templates/features/_feature_pod_logs_via_loki.tpl
+++ b/charts/k8s-monitoring/templates/features/_feature_pod_logs_via_loki.tpl
@@ -8,7 +8,7 @@
 {{- $destinations := include "features.podLogsViaLoki.destinations" . | fromYamlArray }}
 
 // Feature: Pod Logs (Loki)
-{{- include "feature.podLogsViaLoki.module" (dict "Values" $values "Files" $.Subcharts.podLogsViaLoki.Files) }}
+{{- include "feature.podLogsViaLoki.module" (dict "Values" $values "Files" $.Subcharts.podLogsViaLoki.Files "Template" $.Template) }}
 pod_logs_via_loki "feature" {
   logs_destinations = [
     {{ include "destinations.alloy.targets" (dict "destinations" $.Values.destinations "destinationNames" $destinations "type" "logs" "ecosystem" "loki") | indent 4 | trim }}


### PR DESCRIPTION
Older Helm versions (e.g. those bundled with older terraform-provider-helm releases) require .Template.BasePath on the value passed to the tpl function, so `tpl .Values.extraLogProcessingStages $` failed inside feature module includes whose `$` was a custom dict lacking Template. Add Template to the dict at each call site so the lookup succeeds across helm versions.

Fixes #2549
Fixes #2577