### PR TITLE
feat(prometheus-operator-objects): support scraping native histograms

### DIFF
--- a/charts/k8s-monitoring/charts/feature-prometheus-operator-objects/README.md
+++ b/charts/k8s-monitoring/charts/feature-prometheus-operator-objects/README.md
@@ -56,6 +56,7 @@ Be sure perform actual integration testing in a live environment in the main [k8
 | global.maxCacheSize | int | `100000` | Sets the max_cache_size for every prometheus.relabel component. ([docs](https://grafana.com/docs/alloy/latest/reference/components/prometheus/prometheus.relabel/#arguments)) This should be at least 2x-5x your largest scrape target or samples appended rate. |
 | global.namespaceOverride | string | `""` | Override the namespace for namespaced resources created by this chart. |
 | global.scrapeInterval | string | `"60s"` | How frequently to scrape metrics. |
+| global.scrapeNativeHistograms | bool | `false` | Whether to scrape native histograms from targets. Used as the default if a section does not override it. |
 | global.scrapeTimeout | string | `"10s"` | The timeout for scraping metrics. |
 
 ### PodMonitors

--- a/charts/k8s-monitoring/charts/feature-prometheus-operator-objects/templates/_pod_monitors.alloy.tpl
+++ b/charts/k8s-monitoring/charts/feature-prometheus-operator-objects/templates/_pod_monitors.alloy.tpl
@@ -31,6 +31,7 @@ prometheus.operator.podmonitors "pod_monitors" {
   scrape {
     default_scrape_interval = {{ .Values.podMonitors.scrapeInterval | default .Values.global.scrapeInterval | quote }}
     default_scrape_timeout = {{ .Values.podMonitors.scrapeTimeout | default .Values.global.scrapeTimeout | quote }}
+    scrape_native_histograms = {{ .Values.global.scrapeNativeHistograms }}
   }
 
 {{- with .Values.podMonitors.excludeNamespaces }}

--- a/charts/k8s-monitoring/charts/feature-prometheus-operator-objects/templates/_probes.alloy.tpl
+++ b/charts/k8s-monitoring/charts/feature-prometheus-operator-objects/templates/_probes.alloy.tpl
@@ -31,6 +31,7 @@ prometheus.operator.probes "probes" {
   scrape {
     default_scrape_interval = {{ .Values.probes.scrapeInterval | default .Values.global.scrapeInterval | quote }}
     default_scrape_timeout = {{ .Values.probes.scrapeTimeout | default .Values.global.scrapeTimeout | quote }}
+    scrape_native_histograms = {{ .Values.global.scrapeNativeHistograms }}
   }
 
 {{- with .Values.probes.excludeNamespaces }}

--- a/charts/k8s-monitoring/charts/feature-prometheus-operator-objects/templates/_scrape_configs.alloy.tpl
+++ b/charts/k8s-monitoring/charts/feature-prometheus-operator-objects/templates/_scrape_configs.alloy.tpl
@@ -31,6 +31,7 @@ prometheus.operator.scrapeconfigs "scrapeConfigs" {
   scrape {
     default_scrape_interval = {{ .Values.scrapeConfigs.scrapeInterval | default .Values.global.scrapeInterval | quote }}
     default_scrape_timeout = {{ .Values.scrapeConfigs.scrapeTimeout | default .Values.global.scrapeTimeout | quote }}
+    scrape_native_histograms = {{ .Values.global.scrapeNativeHistograms }}
   }
 
 {{- with .Values.scrapeConfigs.excludeNamespaces }}

--- a/charts/k8s-monitoring/charts/feature-prometheus-operator-objects/templates/_service_monitors.alloy.tpl
+++ b/charts/k8s-monitoring/charts/feature-prometheus-operator-objects/templates/_service_monitors.alloy.tpl
@@ -32,6 +32,7 @@ prometheus.operator.servicemonitors "service_monitors" {
   scrape {
     default_scrape_interval = {{ .Values.serviceMonitors.scrapeInterval | default .Values.global.scrapeInterval | quote }}
     default_scrape_timeout = {{ .Values.serviceMonitors.scrapeTimeout | default .Values.global.scrapeTimeout | quote }}
+    scrape_native_histograms = {{ .Values.global.scrapeNativeHistograms }}
   }
 
 {{- with .Values.serviceMonitors.excludeNamespaces }}

--- a/charts/k8s-monitoring/charts/feature-prometheus-operator-objects/tests/__snapshot__/default_test.yaml.snap
+++ b/charts/k8s-monitoring/charts/feature-prometheus-operator-objects/tests/__snapshot__/default_test.yaml.snap
@@ -14,6 +14,7 @@ should generate the default configuration:
           scrape {
             default_scrape_interval = "60s"
             default_scrape_timeout = "10s"
+            scrape_native_histograms = false
           }
           forward_to = argument.metrics_destinations.value
         } // prometheus.relabel "podmonitors"
@@ -26,6 +27,7 @@ should generate the default configuration:
           scrape {
             default_scrape_interval = "60s"
             default_scrape_timeout = "10s"
+            scrape_native_histograms = false
           }
           forward_to = argument.metrics_destinations.value
         } // prometheus.relabel "probes"
@@ -39,6 +41,7 @@ should generate the default configuration:
           scrape {
             default_scrape_interval = "60s"
             default_scrape_timeout = "10s"
+            scrape_native_histograms = false
           }
           forward_to = argument.metrics_destinations.value
         } // prometheus.relabel "servicemonitors"

--- a/charts/k8s-monitoring/charts/feature-prometheus-operator-objects/tests/__snapshot__/labels-and-expressions_test.yaml.snap
+++ b/charts/k8s-monitoring/charts/feature-prometheus-operator-objects/tests/__snapshot__/labels-and-expressions_test.yaml.snap
@@ -19,6 +19,7 @@ should generate the correct configuration:
           scrape {
             default_scrape_interval = "60s"
             default_scrape_timeout = "10s"
+            scrape_native_histograms = false
           }
           forward_to = argument.metrics_destinations.value
         } // prometheus.relabel "podmonitors"
@@ -48,6 +49,7 @@ should generate the correct configuration:
           scrape {
             default_scrape_interval = "60s"
             default_scrape_timeout = "10s"
+            scrape_native_histograms = false
           }
           forward_to = argument.metrics_destinations.value
         } // prometheus.relabel "probes"
@@ -71,6 +73,7 @@ should generate the correct configuration:
           scrape {
             default_scrape_interval = "60s"
             default_scrape_timeout = "10s"
+            scrape_native_histograms = false
           }
           forward_to = argument.metrics_destinations.value
         } // prometheus.relabel "servicemonitors"

--- a/charts/k8s-monitoring/charts/feature-prometheus-operator-objects/tests/__snapshot__/scrape-intervals-and-timeouts_test.yaml.snap
+++ b/charts/k8s-monitoring/charts/feature-prometheus-operator-objects/tests/__snapshot__/scrape-intervals-and-timeouts_test.yaml.snap
@@ -14,6 +14,7 @@ should generate the default configuration:
           scrape {
             default_scrape_interval = "10s"
             default_scrape_timeout = "5s"
+            scrape_native_histograms = false
           }
           forward_to = argument.metrics_destinations.value
         } // prometheus.relabel "podmonitors"
@@ -26,6 +27,7 @@ should generate the default configuration:
           scrape {
             default_scrape_interval = "60s"
             default_scrape_timeout = "10s"
+            scrape_native_histograms = false
           }
           forward_to = argument.metrics_destinations.value
         } // prometheus.relabel "probes"
@@ -39,6 +41,7 @@ should generate the default configuration:
           scrape {
             default_scrape_interval = "30s"
             default_scrape_timeout = "10s"
+            scrape_native_histograms = false
           }
           forward_to = argument.metrics_destinations.value
         } // prometheus.relabel "servicemonitors"

--- a/charts/k8s-monitoring/charts/feature-prometheus-operator-objects/values.schema.json
+++ b/charts/k8s-monitoring/charts/feature-prometheus-operator-objects/values.schema.json
@@ -14,6 +14,9 @@
                 "scrapeInterval": {
                     "type": "string"
                 },
+                "scrapeNativeHistograms": {
+                    "type": "boolean"
+                },
                 "scrapeTimeout": {
                     "type": "string"
                 }

--- a/charts/k8s-monitoring/charts/feature-prometheus-operator-objects/values.yaml
+++ b/charts/k8s-monitoring/charts/feature-prometheus-operator-objects/values.yaml
@@ -20,6 +20,10 @@ global:
   # @section -- Global Settings
   maxCacheSize: 100000
 
+  # -- Whether to scrape native histograms from targets. Used as the default if a section does not override it.
+  # @section -- Global Settings
+  scrapeNativeHistograms: false
+
 # Prometheus Operator PodMonitors
 podMonitors:
   # -- Enable discovery of Prometheus Operator PodMonitor objects.

--- a/charts/k8s-monitoring/docs/examples/auth/bearer-token/alloy-metrics.alloy
+++ b/charts/k8s-monitoring/docs/examples/auth/bearer-token/alloy-metrics.alloy
@@ -12,6 +12,7 @@ declare "prometheus_operator_objects" {
     scrape {
       default_scrape_interval = "60s"
       default_scrape_timeout = "10s"
+      scrape_native_histograms = false
     }
     forward_to = argument.metrics_destinations.value
   } // prometheus.relabel "podmonitors"
@@ -24,6 +25,7 @@ declare "prometheus_operator_objects" {
     scrape {
       default_scrape_interval = "60s"
       default_scrape_timeout = "10s"
+      scrape_native_histograms = false
     }
     forward_to = argument.metrics_destinations.value
   } // prometheus.relabel "probes"
@@ -37,6 +39,7 @@ declare "prometheus_operator_objects" {
     scrape {
       default_scrape_interval = "60s"
       default_scrape_timeout = "10s"
+      scrape_native_histograms = false
     }
     forward_to = argument.metrics_destinations.value
   } // prometheus.relabel "servicemonitors"

--- a/charts/k8s-monitoring/docs/examples/auth/bearer-token/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/auth/bearer-token/output.yaml
@@ -281,6 +281,7 @@ data:
         scrape {
           default_scrape_interval = "60s"
           default_scrape_timeout = "10s"
+          scrape_native_histograms = false
         }
         forward_to = argument.metrics_destinations.value
       } // prometheus.relabel "podmonitors"
@@ -293,6 +294,7 @@ data:
         scrape {
           default_scrape_interval = "60s"
           default_scrape_timeout = "10s"
+          scrape_native_histograms = false
         }
         forward_to = argument.metrics_destinations.value
       } // prometheus.relabel "probes"
@@ -306,6 +308,7 @@ data:
         scrape {
           default_scrape_interval = "60s"
           default_scrape_timeout = "10s"
+          scrape_native_histograms = false
         }
         forward_to = argument.metrics_destinations.value
       } // prometheus.relabel "servicemonitors"

--- a/charts/k8s-monitoring/docs/examples/auth/embedded-secrets/alloy-metrics.alloy
+++ b/charts/k8s-monitoring/docs/examples/auth/embedded-secrets/alloy-metrics.alloy
@@ -12,6 +12,7 @@ declare "prometheus_operator_objects" {
     scrape {
       default_scrape_interval = "60s"
       default_scrape_timeout = "10s"
+      scrape_native_histograms = false
     }
     forward_to = argument.metrics_destinations.value
   } // prometheus.relabel "podmonitors"
@@ -24,6 +25,7 @@ declare "prometheus_operator_objects" {
     scrape {
       default_scrape_interval = "60s"
       default_scrape_timeout = "10s"
+      scrape_native_histograms = false
     }
     forward_to = argument.metrics_destinations.value
   } // prometheus.relabel "probes"
@@ -37,6 +39,7 @@ declare "prometheus_operator_objects" {
     scrape {
       default_scrape_interval = "60s"
       default_scrape_timeout = "10s"
+      scrape_native_histograms = false
     }
     forward_to = argument.metrics_destinations.value
   } // prometheus.relabel "servicemonitors"

--- a/charts/k8s-monitoring/docs/examples/auth/embedded-secrets/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/auth/embedded-secrets/output.yaml
@@ -271,6 +271,7 @@ data:
         scrape {
           default_scrape_interval = "60s"
           default_scrape_timeout = "10s"
+          scrape_native_histograms = false
         }
         forward_to = argument.metrics_destinations.value
       } // prometheus.relabel "podmonitors"
@@ -283,6 +284,7 @@ data:
         scrape {
           default_scrape_interval = "60s"
           default_scrape_timeout = "10s"
+          scrape_native_histograms = false
         }
         forward_to = argument.metrics_destinations.value
       } // prometheus.relabel "probes"
@@ -296,6 +298,7 @@ data:
         scrape {
           default_scrape_interval = "60s"
           default_scrape_timeout = "10s"
+          scrape_native_histograms = false
         }
         forward_to = argument.metrics_destinations.value
       } // prometheus.relabel "servicemonitors"

--- a/charts/k8s-monitoring/docs/examples/auth/external-secrets/alloy-metrics.alloy
+++ b/charts/k8s-monitoring/docs/examples/auth/external-secrets/alloy-metrics.alloy
@@ -12,6 +12,7 @@ declare "prometheus_operator_objects" {
     scrape {
       default_scrape_interval = "60s"
       default_scrape_timeout = "10s"
+      scrape_native_histograms = false
     }
     forward_to = argument.metrics_destinations.value
   } // prometheus.relabel "podmonitors"
@@ -24,6 +25,7 @@ declare "prometheus_operator_objects" {
     scrape {
       default_scrape_interval = "60s"
       default_scrape_timeout = "10s"
+      scrape_native_histograms = false
     }
     forward_to = argument.metrics_destinations.value
   } // prometheus.relabel "probes"
@@ -37,6 +39,7 @@ declare "prometheus_operator_objects" {
     scrape {
       default_scrape_interval = "60s"
       default_scrape_timeout = "10s"
+      scrape_native_histograms = false
     }
     forward_to = argument.metrics_destinations.value
   } // prometheus.relabel "servicemonitors"

--- a/charts/k8s-monitoring/docs/examples/auth/external-secrets/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/auth/external-secrets/output.yaml
@@ -283,6 +283,7 @@ data:
         scrape {
           default_scrape_interval = "60s"
           default_scrape_timeout = "10s"
+          scrape_native_histograms = false
         }
         forward_to = argument.metrics_destinations.value
       } // prometheus.relabel "podmonitors"
@@ -295,6 +296,7 @@ data:
         scrape {
           default_scrape_interval = "60s"
           default_scrape_timeout = "10s"
+          scrape_native_histograms = false
         }
         forward_to = argument.metrics_destinations.value
       } // prometheus.relabel "probes"
@@ -308,6 +310,7 @@ data:
         scrape {
           default_scrape_interval = "60s"
           default_scrape_timeout = "10s"
+          scrape_native_histograms = false
         }
         forward_to = argument.metrics_destinations.value
       } // prometheus.relabel "servicemonitors"

--- a/charts/k8s-monitoring/docs/examples/auth/oauth2/alloy-metrics.alloy
+++ b/charts/k8s-monitoring/docs/examples/auth/oauth2/alloy-metrics.alloy
@@ -837,6 +837,7 @@ declare "prometheus_operator_objects" {
     scrape {
       default_scrape_interval = "60s"
       default_scrape_timeout = "10s"
+      scrape_native_histograms = false
     }
     forward_to = argument.metrics_destinations.value
   } // prometheus.relabel "podmonitors"
@@ -849,6 +850,7 @@ declare "prometheus_operator_objects" {
     scrape {
       default_scrape_interval = "60s"
       default_scrape_timeout = "10s"
+      scrape_native_histograms = false
     }
     forward_to = argument.metrics_destinations.value
   } // prometheus.relabel "probes"
@@ -862,6 +864,7 @@ declare "prometheus_operator_objects" {
     scrape {
       default_scrape_interval = "60s"
       default_scrape_timeout = "10s"
+      scrape_native_histograms = false
     }
     forward_to = argument.metrics_destinations.value
   } // prometheus.relabel "servicemonitors"

--- a/charts/k8s-monitoring/docs/examples/auth/oauth2/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/auth/oauth2/output.yaml
@@ -1489,6 +1489,7 @@ data:
         scrape {
           default_scrape_interval = "60s"
           default_scrape_timeout = "10s"
+          scrape_native_histograms = false
         }
         forward_to = argument.metrics_destinations.value
       } // prometheus.relabel "podmonitors"
@@ -1501,6 +1502,7 @@ data:
         scrape {
           default_scrape_interval = "60s"
           default_scrape_timeout = "10s"
+          scrape_native_histograms = false
         }
         forward_to = argument.metrics_destinations.value
       } // prometheus.relabel "probes"
@@ -1514,6 +1516,7 @@ data:
         scrape {
           default_scrape_interval = "60s"
           default_scrape_timeout = "10s"
+          scrape_native_histograms = false
         }
         forward_to = argument.metrics_destinations.value
       } // prometheus.relabel "servicemonitors"

--- a/charts/k8s-monitoring/docs/examples/exclude-by-namespace/alloy-metrics.alloy
+++ b/charts/k8s-monitoring/docs/examples/exclude-by-namespace/alloy-metrics.alloy
@@ -851,6 +851,7 @@ declare "prometheus_operator_objects" {
     scrape {
       default_scrape_interval = "60s"
       default_scrape_timeout = "10s"
+      scrape_native_histograms = false
     }
     rule {
       source_labels = ["job"]
@@ -868,6 +869,7 @@ declare "prometheus_operator_objects" {
     scrape {
       default_scrape_interval = "60s"
       default_scrape_timeout = "10s"
+      scrape_native_histograms = false
     }
     rule {
       source_labels = ["job"]
@@ -886,6 +888,7 @@ declare "prometheus_operator_objects" {
     scrape {
       default_scrape_interval = "60s"
       default_scrape_timeout = "10s"
+      scrape_native_histograms = false
     }
     rule {
       source_labels = ["job"]

--- a/charts/k8s-monitoring/docs/examples/exclude-by-namespace/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/exclude-by-namespace/output.yaml
@@ -2233,6 +2233,7 @@ data:
         scrape {
           default_scrape_interval = "60s"
           default_scrape_timeout = "10s"
+          scrape_native_histograms = false
         }
         rule {
           source_labels = ["job"]
@@ -2250,6 +2251,7 @@ data:
         scrape {
           default_scrape_interval = "60s"
           default_scrape_timeout = "10s"
+          scrape_native_histograms = false
         }
         rule {
           source_labels = ["job"]
@@ -2268,6 +2270,7 @@ data:
         scrape {
           default_scrape_interval = "60s"
           default_scrape_timeout = "10s"
+          scrape_native_histograms = false
         }
         rule {
           source_labels = ["job"]

--- a/charts/k8s-monitoring/docs/examples/features/prometheus-operator-objects/default/alloy-metrics.alloy
+++ b/charts/k8s-monitoring/docs/examples/features/prometheus-operator-objects/default/alloy-metrics.alloy
@@ -17,6 +17,7 @@ declare "prometheus_operator_objects" {
     scrape {
       default_scrape_interval = "60s"
       default_scrape_timeout = "10s"
+      scrape_native_histograms = false
     }
     forward_to = argument.metrics_destinations.value
   } // prometheus.relabel "podmonitors"
@@ -29,6 +30,7 @@ declare "prometheus_operator_objects" {
     scrape {
       default_scrape_interval = "60s"
       default_scrape_timeout = "10s"
+      scrape_native_histograms = false
     }
     forward_to = argument.metrics_destinations.value
   } // prometheus.relabel "probes"
@@ -55,6 +57,7 @@ declare "prometheus_operator_objects" {
     scrape {
       default_scrape_interval = "60s"
       default_scrape_timeout = "10s"
+      scrape_native_histograms = false
     }
     forward_to = argument.metrics_destinations.value
   } // prometheus.relabel "servicemonitors"

--- a/charts/k8s-monitoring/docs/examples/features/prometheus-operator-objects/default/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/features/prometheus-operator-objects/default/output.yaml
@@ -40,6 +40,7 @@ data:
         scrape {
           default_scrape_interval = "60s"
           default_scrape_timeout = "10s"
+          scrape_native_histograms = false
         }
         forward_to = argument.metrics_destinations.value
       } // prometheus.relabel "podmonitors"
@@ -52,6 +53,7 @@ data:
         scrape {
           default_scrape_interval = "60s"
           default_scrape_timeout = "10s"
+          scrape_native_histograms = false
         }
         forward_to = argument.metrics_destinations.value
       } // prometheus.relabel "probes"
@@ -78,6 +80,7 @@ data:
         scrape {
           default_scrape_interval = "60s"
           default_scrape_timeout = "10s"
+          scrape_native_histograms = false
         }
         forward_to = argument.metrics_destinations.value
       } // prometheus.relabel "servicemonitors"

--- a/charts/k8s-monitoring/docs/examples/include-by-namespace/alloy-metrics.alloy
+++ b/charts/k8s-monitoring/docs/examples/include-by-namespace/alloy-metrics.alloy
@@ -908,6 +908,7 @@ declare "prometheus_operator_objects" {
     scrape {
       default_scrape_interval = "60s"
       default_scrape_timeout = "10s"
+      scrape_native_histograms = false
     }
     forward_to = argument.metrics_destinations.value
   } // prometheus.relabel "podmonitors"
@@ -921,6 +922,7 @@ declare "prometheus_operator_objects" {
     scrape {
       default_scrape_interval = "60s"
       default_scrape_timeout = "10s"
+      scrape_native_histograms = false
     }
     forward_to = argument.metrics_destinations.value
   } // prometheus.relabel "probes"
@@ -935,6 +937,7 @@ declare "prometheus_operator_objects" {
     scrape {
       default_scrape_interval = "60s"
       default_scrape_timeout = "10s"
+      scrape_native_histograms = false
     }
     forward_to = argument.metrics_destinations.value
   } // prometheus.relabel "servicemonitors"

--- a/charts/k8s-monitoring/docs/examples/include-by-namespace/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/include-by-namespace/output.yaml
@@ -1280,6 +1280,7 @@ data:
         scrape {
           default_scrape_interval = "60s"
           default_scrape_timeout = "10s"
+          scrape_native_histograms = false
         }
         forward_to = argument.metrics_destinations.value
       } // prometheus.relabel "podmonitors"
@@ -1293,6 +1294,7 @@ data:
         scrape {
           default_scrape_interval = "60s"
           default_scrape_timeout = "10s"
+          scrape_native_histograms = false
         }
         forward_to = argument.metrics_destinations.value
       } // prometheus.relabel "probes"
@@ -1307,6 +1309,7 @@ data:
         scrape {
           default_scrape_interval = "60s"
           default_scrape_timeout = "10s"
+          scrape_native_histograms = false
         }
         forward_to = argument.metrics_destinations.value
       } // prometheus.relabel "servicemonitors"

--- a/charts/k8s-monitoring/tests/integration/prometheus-operator-objects/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/integration/prometheus-operator-objects/.rendered/output.yaml
@@ -35,6 +35,7 @@ data:
         scrape {
           default_scrape_interval = "60s"
           default_scrape_timeout = "10s"
+          scrape_native_histograms = false
         }
         rule {
           source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
@@ -52,6 +53,7 @@ data:
         scrape {
           default_scrape_interval = "60s"
           default_scrape_timeout = "10s"
+          scrape_native_histograms = false
         }
         forward_to = argument.metrics_destinations.value
       } // prometheus.relabel "probes"
@@ -64,6 +66,7 @@ data:
         scrape {
           default_scrape_interval = "60s"
           default_scrape_timeout = "10s"
+          scrape_native_histograms = false
         }
         forward_to = argument.metrics_destinations.value
       } // prometheus.relabel "scrapeConfigs"
@@ -82,6 +85,7 @@ data:
         scrape {
           default_scrape_interval = "60s"
           default_scrape_timeout = "10s"
+          scrape_native_histograms = false
         }
         rule {
           source_labels = ["job"]


### PR DESCRIPTION
Enables native histograms for PrometheusObjects, I only did in `global` settings, though we could set it separately ServiceMonitor/PodMonitor and Probe if we wanted to, so open for feedback.