### PR TITLE
fix(spanmetrics): quote exclude_dimensions in rendered config

### DIFF
--- a/charts/k8s-monitoring/CHANGELOG.md
+++ b/charts/k8s-monitoring/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+*   Fix `spanMetrics.excludeDimensions` rendering: list values are now properly quoted as strings instead of unquoted bareword identifiers, which caused Alloy to fail to parse the rendered config. (#2596) (@savannahostrowski)
+
 ## 4.1.2
 
 *   Add convertClassicHistogramsToNhcb setting to global (@MattiasSegerdahl)

--- a/charts/k8s-monitoring/charts/feature-application-observability/templates/_connector_span_metrics.tpl
+++ b/charts/k8s-monitoring/charts/feature-application-observability/templates/_connector_span_metrics.tpl
@@ -34,7 +34,7 @@ otelcol.connector.spanmetrics "{{ .name | default "default" }}" {
 {{- end }}
   }
 {{- end }}
-  exclude_dimensions = {{ .Values.connectors.spanMetrics.excludeDimensions }}
+  exclude_dimensions = {{ .Values.connectors.spanMetrics.excludeDimensions | toJson }}
   dimensions_cache_size = {{ .Values.connectors.spanMetrics.dimensionsCacheSize }}
   aggregation_cardinality_limit = {{ .Values.connectors.spanMetrics.aggregationCardinalityLimit }}
   namespace = {{ .Values.connectors.spanMetrics.namespace | quote }}

--- a/charts/k8s-monitoring/charts/feature-application-observability/tests/__snapshot__/spanmetrics_test.yaml.snap
+++ b/charts/k8s-monitoring/charts/feature-application-observability/tests/__snapshot__/spanmetrics_test.yaml.snap
@@ -182,3 +182,180 @@ creates the pipeline with the spanmetrics connector:
           }
         }
       } // declare "application_observability"
+excludes dimensions when configured:
+  1: |
+    |-
+      declare "application_observability" {
+        argument "metrics_destinations" {
+          comment = "Must be a list of metrics destinations where collected metrics should be forwarded to"
+        }
+
+        argument "logs_destinations" {
+          comment = "Must be a list of log destinations where collected logs should be forwarded to"
+        }
+
+        argument "traces_destinations" {
+          comment = "Must be a list of trace destinations where collected trace should be forwarded to"
+        }
+
+        // OTLP Receiver
+        otelcol.receiver.otlp "receiver" {
+          grpc {
+            endpoint = "0.0.0.0:4317"
+            include_metadata = false
+            max_recv_msg_size = "4MiB"
+            read_buffer_size = "512KiB"
+            write_buffer_size = "32KiB"
+          }
+          debug_metrics {
+            disable_high_cardinality_metrics = true
+          }
+          output {
+            metrics = [otelcol.processor.resourcedetection.default.input]
+            logs = [otelcol.processor.resourcedetection.default.input]
+            traces = [otelcol.processor.resourcedetection.default.input]
+          }
+        } // otelcol.receiver.otlp "receiver"
+
+        // Resource Detection Processor
+        otelcol.processor.resourcedetection "default" {
+          detectors = ["env","system"]
+          override = true
+
+          system {
+            hostname_sources = ["os"]
+          }
+
+          output {
+            metrics = [otelcol.processor.k8sattributes.default.input]
+            logs = [otelcol.processor.k8sattributes.default.input]
+            traces = [otelcol.processor.k8sattributes.default.input]
+          }
+        }
+
+        // K8s Attributes Processor
+        otelcol.processor.k8sattributes "default" {
+          passthrough = false
+          extract {
+            metadata = ["k8s.namespace.name","k8s.pod.name","k8s.deployment.name","k8s.statefulset.name","k8s.daemonset.name","k8s.cronjob.name","k8s.job.name","k8s.node.name","k8s.pod.uid","k8s.pod.start_time"]
+          }
+          pod_association {
+            source {
+              from = "resource_attribute"
+              name = "k8s.pod.ip"
+            }
+          }
+          pod_association {
+            source {
+              from = "resource_attribute"
+              name = "k8s.pod.uid"
+            }
+          }
+          pod_association {
+            source {
+              from = "connection"
+            }
+          }
+
+          output {
+            metrics = [otelcol.processor.transform.default.input]
+            logs = [otelcol.processor.transform.default.input]
+            traces = [otelcol.processor.transform.default.input, otelcol.connector.host_info.default.input]
+          }
+        }
+
+        // Host Info Connector
+        otelcol.connector.host_info "default" {
+          host_identifiers = [ "k8s.node.name" ]
+
+          output {
+            metrics = [otelcol.processor.batch.default.input]
+          }
+        }
+
+        // Transform Processor
+        otelcol.processor.transform "default" {
+          error_mode = "ignore"
+          log_statements {
+            context = "resource"
+            statements = [
+              "set(attributes[\"pod\"], attributes[\"k8s.pod.name\"])",
+              "set(attributes[\"namespace\"], attributes[\"k8s.namespace.name\"])",
+              "set(attributes[\"loki.resource.labels\"], \"cluster, namespace, job, pod\")",
+            ]
+          }
+          trace_statements {
+            context = "span"
+            statements = [
+             "set_semconv_span_name(\"1.37.0\", \"original_span_name\")",
+            ]
+          }
+
+          output {
+            metrics = [otelcol.processor.batch.default.input]
+            logs = [otelcol.processor.batch.default.input]
+            traces = [otelcol.processor.filter.span_metrics_prefilter.input, otelcol.processor.batch.default.input]
+          }
+        }
+
+        // Span Metrics Connector
+        otelcol.processor.filter "span_metrics_prefilter" {
+          error_mode = "silent"
+          traces {
+            span = [
+              `resource.attributes["span.metrics.skip"] != nil or attributes["span.metrics.skip"] != nil`,
+              `kind == 1`,
+            ]
+          }
+          output {
+            traces = [otelcol.connector.spanmetrics.default.input]
+          }
+        } // otelcol.processor.filter "span_metrics_prefilter"
+
+        otelcol.connector.spanmetrics "default" {
+          exclude_dimensions = ["status.code","span.name"]
+          dimensions_cache_size = 1000
+          aggregation_cardinality_limit = 1000
+          namespace = "traces.span.metrics"
+
+          histogram {
+            disable = false
+            unit = "s"
+            explicit {
+              buckets = ["2ms","4ms","6ms","8ms","10ms","50ms","100ms","200ms","400ms","800ms","1s","1400ms","2s","5s","10s","15s"]
+            }
+          }
+
+          output {
+            metrics = [otelcol.processor.transform.span_metrics_transform.input]
+          }
+        }
+
+        otelcol.processor.transform "span_metrics_transform" {
+           metric_statements {
+            context = "datapoint"
+            statements = [
+              `set(attributes["collector.id"], "` + constants.hostname + `")`,
+              `set(resource.attributes["service.instance.id"], resource.attributes["k8s.pod.name"]) where resource.attributes["service.instance.id"] == nil and resource.attributes["k8s.pod.name"] != nil`,
+              `set(resource.attributes["service.instance.id"], resource.attributes["k8s.pod.uid"]) where resource.attributes["service.instance.id"] == nil and resource.attributes["k8s.pod.uid"] != nil`,
+            ]
+          }
+
+          output {
+            metrics = [otelcol.processor.batch.default.input]
+          }
+        } // otelcol.processor.transform "span_metrics_transform"
+
+        // Batch Processor
+        otelcol.processor.batch "default" {
+          send_batch_size = 8192
+          send_batch_max_size = 0
+          timeout = "2s"
+
+          output {
+            metrics = argument.metrics_destinations.value
+            logs = argument.logs_destinations.value
+            traces = argument.traces_destinations.value
+          }
+        }
+      } // declare "application_observability"

--- a/charts/k8s-monitoring/charts/feature-application-observability/tests/spanmetrics_test.yaml
+++ b/charts/k8s-monitoring/charts/feature-application-observability/tests/spanmetrics_test.yaml
@@ -22,3 +22,22 @@ tests:
           of: ConfigMap
       - matchSnapshot:
           path: data["module.alloy"]
+
+  - it: excludes dimensions when configured
+    set:
+      testing: {enabled: true}
+      connectors:
+        spanMetrics:
+          enabled: true
+          excludeDimensions:
+            - status.code
+            - span.name
+      receivers:
+        otlp:
+          grpc:
+            enabled: true
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - matchSnapshot:
+          path: data["module.alloy"]


### PR DESCRIPTION
Apologies if I missed some repo conventions here and should have opened an issue first! Seemed like a simple enough fix to just put up the PR 🙂 

Right now, setting `connectors.spanMetrics.excludeDimensions` to a non-empty list causes Alloy to fail to parse the rendered config:

```
Error: component "status.code" does not exist or is out of scope
```

The values are rendered as unquoted bareword identifiers; Alloy interprets dotted names like `status.code` as component references instead of string literals.

Seems like we just need to serialize the list properly via `| toJson`. I've added that as well as a test to exercise the path.