### PR TITLE
fix(prometheus-operator-objects): remove unsupported scrape_protocols attribute

### DIFF
--- a/charts/k8s-monitoring/CHANGELOG.md
+++ b/charts/k8s-monitoring/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 *   Add global pull policy support for the hooks and collectors (@petewall)
 *   Fix `spanMetrics.excludeDimensions` rendering: list values are now properly quoted as strings instead of unquoted bareword identifiers, which caused Alloy to fail to parse the rendered config. (#2596) (@savannahostrowski)
+*   Remove scrape protocols from the four `prometheus.operator.*` components, which do not support setting them. (@MattiasSegerdahl)
 
 ## 4.1.2
 

--- a/charts/k8s-monitoring/charts/feature-prometheus-operator-objects/templates/_pod_monitors.alloy.tpl
+++ b/charts/k8s-monitoring/charts/feature-prometheus-operator-objects/templates/_pod_monitors.alloy.tpl
@@ -31,9 +31,6 @@ prometheus.operator.podmonitors "pod_monitors" {
   scrape {
     default_scrape_interval = {{ .Values.podMonitors.scrapeInterval | default .Values.global.scrapeInterval | quote }}
     default_scrape_timeout = {{ .Values.podMonitors.scrapeTimeout | default .Values.global.scrapeTimeout | quote }}
-    {{- if .Values.global.scrapeNativeHistograms }}
-    scrape_protocols = {{ include "helper.scrapeProtocols" . }}
-    {{- end }}
     scrape_native_histograms = {{ .Values.global.scrapeNativeHistograms }}
   }
 

--- a/charts/k8s-monitoring/charts/feature-prometheus-operator-objects/templates/_probes.alloy.tpl
+++ b/charts/k8s-monitoring/charts/feature-prometheus-operator-objects/templates/_probes.alloy.tpl
@@ -31,9 +31,6 @@ prometheus.operator.probes "probes" {
   scrape {
     default_scrape_interval = {{ .Values.probes.scrapeInterval | default .Values.global.scrapeInterval | quote }}
     default_scrape_timeout = {{ .Values.probes.scrapeTimeout | default .Values.global.scrapeTimeout | quote }}
-    {{- if .Values.global.scrapeNativeHistograms }}
-    scrape_protocols = {{ include "helper.scrapeProtocols" . }}
-    {{- end }}
     scrape_native_histograms = {{ .Values.global.scrapeNativeHistograms }}
   }
 

--- a/charts/k8s-monitoring/charts/feature-prometheus-operator-objects/templates/_scrape_configs.alloy.tpl
+++ b/charts/k8s-monitoring/charts/feature-prometheus-operator-objects/templates/_scrape_configs.alloy.tpl
@@ -31,9 +31,6 @@ prometheus.operator.scrapeconfigs "scrapeConfigs" {
   scrape {
     default_scrape_interval = {{ .Values.scrapeConfigs.scrapeInterval | default .Values.global.scrapeInterval | quote }}
     default_scrape_timeout = {{ .Values.scrapeConfigs.scrapeTimeout | default .Values.global.scrapeTimeout | quote }}
-    {{- if .Values.global.scrapeNativeHistograms }}
-    scrape_protocols = {{ include "helper.scrapeProtocols" . }}
-    {{- end }}
     scrape_native_histograms = {{ .Values.global.scrapeNativeHistograms }}
   }
 

--- a/charts/k8s-monitoring/charts/feature-prometheus-operator-objects/templates/_service_monitors.alloy.tpl
+++ b/charts/k8s-monitoring/charts/feature-prometheus-operator-objects/templates/_service_monitors.alloy.tpl
@@ -32,9 +32,6 @@ prometheus.operator.servicemonitors "service_monitors" {
   scrape {
     default_scrape_interval = {{ .Values.serviceMonitors.scrapeInterval | default .Values.global.scrapeInterval | quote }}
     default_scrape_timeout = {{ .Values.serviceMonitors.scrapeTimeout | default .Values.global.scrapeTimeout | quote }}
-    {{- if .Values.global.scrapeNativeHistograms }}
-    scrape_protocols = {{ include "helper.scrapeProtocols" . }}
-    {{- end }}
     scrape_native_histograms = {{ .Values.global.scrapeNativeHistograms }}
   }
 

--- a/charts/k8s-monitoring/charts/feature-prometheus-operator-objects/tests/scrape_native_histograms_test.yaml
+++ b/charts/k8s-monitoring/charts/feature-prometheus-operator-objects/tests/scrape_native_histograms_test.yaml
@@ -3,7 +3,7 @@ suite: Feature - Prometheus Operator Objects - Native Histogram Scraping
 templates:
   - test/configmap.yaml
 tests:
-  - it: emits scrape_protocols with PrometheusProto prepended when scrapeNativeHistograms is enabled
+  - it: emits scrape_native_histograms but not scrape_protocols when scrapeNativeHistograms is enabled
     set:
       testing: {enabled: true}
       global:
@@ -13,10 +13,13 @@ tests:
           of: ConfigMap
       - matchRegex:
           path: data["module.alloy"]
-          pattern: scrape_protocols = \["PrometheusProto","OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"\]
-      - matchRegex:
-          path: data["module.alloy"]
           pattern: scrape_native_histograms = true
+      # scrape_protocols is not a valid argument on the prometheus.operator.* components in Alloy
+      # (only on prometheus.scrape), so the chart must never render it inside their `scrape { }` block,
+      # even when scrapeNativeHistograms is on.
+      - notMatchRegex:
+          path: data["module.alloy"]
+          pattern: scrape_protocols =
 
   - it: does not emit scrape_protocols when scrapeNativeHistograms is disabled
     set:


### PR DESCRIPTION
## What does this PR do?

The four `prometheus.operator.*` templates — `_pod_monitors.alloy.tpl`, `_probes.alloy.tpl`, `_service_monitors.alloy.tpl`, `_scrape_configs.alloy.tpl` — emit a `scrape_protocols = ...` attribute inside their `scrape { }` block whenever `global.scrapeNativeHistograms: true`:

```alloy
scrape {
  default_scrape_interval = "60s"
  default_scrape_timeout  = "10s"
  scrape_protocols = ["PrometheusProto","OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]   // <- not a valid arg here
  scrape_native_histograms = true
}
```

That attribute is **not** a field on the `prometheus.operator.*` components in Alloy — it only exists on `prometheus.scrape`. The valid `ScrapeOptions` struct is in [`internal/component/prometheus/operator/types.go`](https://github.com/grafana/alloy/blob/v1.16.1/internal/component/prometheus/operator/types.go) (v1.16.1):

```go
type ScrapeOptions struct {
    DefaultScrapeInterval   time.Duration                `alloy:"default_scrape_interval,attr,optional"`
    DefaultScrapeTimeout    time.Duration                `alloy:"default_scrape_timeout,attr,optional"`
    DefaultSampleLimit      uint                         `alloy:"default_sample_limit,attr,optional"`
    ScrapeNativeHistograms  bool                         `alloy:"scrape_native_histograms,attr,optional"`
    HonorMetadata           bool                         `alloy:"honor_metadata,attr,optional"`
    EnableTypeAndUnitLabels bool                         `alloy:"enable_type_and_unit_labels,attr,optional"`
}
```

No `scrape_protocols` field. The same shape is on `main`.

This PR removes those four blocks. `scrape_native_histograms` is unaffected.

## Repro

Stock chart 4.1.x install with the two flags both enabled crash-loops `grafana-k8s-monitoring-alloy-metrics-0`:

```yaml
global:
  scrapeNativeHistograms: true
prometheusOperatorObjects:
  enabled: true
```

```
level=error msg="failed to evaluate config" controller_id=prometheus_operator_objects.feature
    node=prometheus.operator.podmonitors.pod_monitors
    err="decoding configuration: /etc/alloy/config.alloy:1029:7: unrecognized attribute name \"scrape_protocols\""

Error: /etc/alloy/config.alloy:1029:7: unrecognized attribute name "scrape_protocols"
Error: /etc/alloy/config.alloy:1053:7: unrecognized attribute name "scrape_protocols"
Error: /etc/alloy/config.alloy:1078:7: unrecognized attribute name "scrape_protocols"
Error: could not perform the initial load successfully
```

(The fourth template, `_scrape_configs`, fails the same way on installs that have the upstream ScrapeConfig CRD installed.)

## Why this is the right fix

This is the exact same fix as commit [`158db9d106`](https://github.com/grafana/k8s-monitoring-helm/commit/158db9d106) ("Fix indentation and remove `convert_classic_histograms_to_nhcb` from unsupported components"), applied to the sibling line that was missed. That commit removed `convert_classic_histograms_to_nhcb` from the same four templates because, like `scrape_protocols`, it isn't a field on the operator components.

The `scrape_protocols` line was added by [`5e22927e18`](https://github.com/grafana/k8s-monitoring-helm/commit/5e22927e18) / #2582 ("Automatically set the scrape protocol when scrape native histograms is enabled"), which intended to make every place that sets `scrape_native_histograms` also prepend `PrometheusProto` to `scrape_protocols`. That's the correct fix on `prometheus.scrape` (the only component where `scrape_protocols` is a valid argument), but it incidentally also added the attribute to the four `prometheus.operator.*` templates where it doesn't compile.

## Diff size

5 files, 1 insertion, 12 deletions:

```
charts/k8s-monitoring/CHANGELOG.md                                                                  | 1 +
charts/k8s-monitoring/charts/feature-prometheus-operator-objects/templates/_pod_monitors.alloy.tpl  | 3 ---
charts/k8s-monitoring/charts/feature-prometheus-operator-objects/templates/_probes.alloy.tpl       | 3 ---
charts/k8s-monitoring/charts/feature-prometheus-operator-objects/templates/_scrape_configs.alloy.tpl| 3 ---
charts/k8s-monitoring/charts/feature-prometheus-operator-objects/templates/_service_monitors.alloy.tpl | 3 ---
```

## Test plan

- [x] `helm lint` passes
- [x] `make build` regenerates all rendered fixtures without other diffs
- [x] Confirmed the crashloop happens on chart 4.1.2 before the fix, and is gone after the fix, on a real cluster
- [x] Confirmed `scrape_native_histograms = true` still renders correctly inside the `scrape { }` block after the fix

