### PR TITLE
feat(validations): fail loudly when stabilityLevel is too low for experimental Alloy components

### DIFF
--- a/charts/k8s-monitoring/CHANGELOG.md
+++ b/charts/k8s-monitoring/CHANGELOG.md
@@ -5,6 +5,14 @@
 *   Add global pull policy support for the hooks and collectors (@petewall)
 *   Fix `spanMetrics.excludeDimensions` rendering: list values are now properly quoted as strings instead of unquoted bareword identifiers, which caused Alloy to fail to parse the rendered config. (#2596) (@savannahostrowski)
 *   Remove scrape protocols from the four `prometheus.operator.*` components, which do not support setting them. (@MattiasSegerdahl)
+*   Fail with a helpful message when the chart will render Alloy components that require
+    `stabilityLevel: experimental` (e.g. `global.convertClassicHistogramsToNhcb: true` or a
+    Prometheus destination on `remoteWriteProtocol: 2`) but a collector hosting those components
+    has a lower stabilityLevel, instead of crash-looping the collector at startup. Per-trigger
+    minimum stabilityLevel is declared in the `collectors.experimentalStabilityRequirements`
+    helper, so when Alloy graduates a component
+    (`experimental` → `public-preview` → `generally-available`) the validation is updated by
+    changing a single value. (@MattiasSegerdahl)
 
 ## 4.1.2
 

--- a/charts/k8s-monitoring/templates/_validations.tpl
+++ b/charts/k8s-monitoring/templates/_validations.tpl
@@ -6,6 +6,8 @@
   {{- include "destinations.validate" . -}}
   {{- include "collectors.validate.atLeastOneEnabled" . }}
   {{- include "collectors.validate.uniqueNames" . }}
+  {{- include "collectors.validate.experimentalStabilityLevel" . }}
+  {{- include "collectors.validate.experimentalStabilityLevel" . }}
 
   {{- /* Feature Config Influence */}}
   {{- $updatedValues := $.Values }}

--- a/charts/k8s-monitoring/templates/collectors/_collector_validations.tpl
+++ b/charts/k8s-monitoring/templates/collectors/_collector_validations.tpl
@@ -67,6 +67,102 @@
 {{- end }}
 {{- end }}
 
+{{/* Fails when the chart will render Alloy components that require a higher stability.level
+     than the collector hosting them is configured for. Walks enabled features, looks up each
+     feature's assigned collector and the destinations it forwards to, and -- for each trigger
+     declared in collectors.experimentalStabilityRequirements -- raises the minimum required
+     stabilityLevel on the affected collector. Inputs: Values, Files. */}}
+{{- define "collectors.validate.experimentalStabilityLevel" }}
+{{- $root := . }}
+{{- $requirements := include "collectors.experimentalStabilityRequirements" . | fromYaml }}
+{{- $rank := dict "generally-available" 0 "public-preview" 1 "experimental" 2 }}
+{{- $nhcbRequired := dig "nhcbConversion" "stabilityLevel" "" $requirements }}
+{{- $rwv2Required := dig "remoteWriteV2" "stabilityLevel" "" $requirements }}
+{{- $convertNhcb := and $root.Values.global $root.Values.global.convertClassicHistogramsToNhcb }}
+{{- $collectorReasons := dict }}
+{{- $collectorMaxRequired := dict }}
+{{- range $featureKey := include "features.list.enabled" . | fromYamlArray }}
+  {{- /* selfReporting is a chart-internal feature whose collector is chosen by the chart, not the user.
+         Skip it here so the validation only fires on collectors wired through a user-facing feature. */}}
+  {{- $collectorName := "" }}
+  {{- if ne $featureKey "selfReporting" }}
+    {{- $collectorName = include "collectors.getCollectorForFeature" (dict "Values" $root.Values "Files" $root.Files "Subcharts" $root.Subcharts "featureKey" $featureKey) }}
+  {{- end }}
+  {{- if $collectorName }}
+    {{- $featureDestinations := include (printf "features.%s.destinations" $featureKey) $root | fromYamlArray }}
+    {{- range $destinationName := $featureDestinations }}
+      {{- $destination := get $root.Values.destinations $destinationName }}
+      {{- if eq (default "" $destination.type) "prometheus" }}
+        {{- /* Trigger: prometheus.remote_write protobuf v2 message */}}
+        {{- if and $rwv2Required (eq (int (default 1 $destination.remoteWriteProtocol)) 2) }}
+          {{- $reason := printf "feature %q forwards to destinations.%s, which uses remoteWriteProtocol: 2 and renders `protobuf_message = \"io.prometheus.write.v2.Request\"` on prometheus.remote_write (Alloy exposes this only at stability.level=%s)" $featureKey $destinationName $rwv2Required }}
+          {{- $existing := default list (get $collectorReasons $collectorName) }}
+          {{- if not (has $reason $existing) }}
+            {{- $_ := set $collectorReasons $collectorName (append $existing $reason) }}
+          {{- end }}
+          {{- $curMax := default "generally-available" (get $collectorMaxRequired $collectorName) }}
+          {{- if gt (int (get $rank $rwv2Required)) (int (get $rank $curMax)) }}
+            {{- $_ := set $collectorMaxRequired $collectorName $rwv2Required }}
+          {{- end }}
+        {{- end }}
+        {{- /* Trigger: convert_classic_histograms_to_nhcb on prometheus.scrape */}}
+        {{- if and $convertNhcb $nhcbRequired }}
+          {{- $reason := printf "feature %q forwards to a prometheus destination (%s) and global.convertClassicHistogramsToNhcb: true renders `convert_classic_histograms_to_nhcb = true` on its scrape components (Alloy exposes this only at stability.level=%s)" $featureKey $destinationName $nhcbRequired }}
+          {{- $existing := default list (get $collectorReasons $collectorName) }}
+          {{- if not (has $reason $existing) }}
+            {{- $_ := set $collectorReasons $collectorName (append $existing $reason) }}
+          {{- end }}
+          {{- $curMax := default "generally-available" (get $collectorMaxRequired $collectorName) }}
+          {{- if gt (int (get $rank $nhcbRequired)) (int (get $rank $curMax)) }}
+            {{- $_ := set $collectorMaxRequired $collectorName $nhcbRequired }}
+          {{- end }}
+        {{- end }}
+      {{- end }}
+    {{- end }}
+  {{- end }}
+{{- end }}
+{{- range $collectorName, $reasons := $collectorReasons }}
+  {{- $required := get $collectorMaxRequired $collectorName }}
+  {{- $collectorValues := include "collector.alloy.values" (dict "Values" $root.Values "Files" $root.Files "collectorName" $collectorName) | fromYaml }}
+  {{- /* collectorCommon.alloy.<k> currently lands at the top level of collectorValues rather than under
+         collectorValues.alloy, so look in both places before deciding the user hasn't set it. */}}
+  {{- $stability := dig "alloy" "stabilityLevel" (dig "stabilityLevel" "generally-available" $collectorValues) $collectorValues }}
+  {{- $actualRank := int (default 0 (get $rank $stability)) }}
+  {{- $requiredRank := int (get $rank $required) }}
+  {{- if lt $actualRank $requiredRank }}
+    {{- $msg := list "" }}
+    {{- $msg = append $msg (printf "Collector %q has stabilityLevel=%q but the chart will render Alloy components that require stabilityLevel=%s:" $collectorName $stability $required) }}
+    {{- range $r := $reasons }}
+      {{- $msg = append $msg (printf "  - %s" $r) }}
+    {{- end }}
+    {{- $msg = append $msg "" }}
+    {{- $msg = append $msg "Please set:" }}
+    {{- $msg = append $msg "collectors:" }}
+    {{- $msg = append $msg (printf "  %s:" $collectorName) }}
+    {{- $msg = append $msg "    alloy:" }}
+    {{- $msg = append $msg (printf "      stabilityLevel: %s" $required) }}
+    {{- fail (join "\n" $msg) }}
+  {{- end }}
+{{- end }}
+{{- end }}
+
+{{/* The set of Alloy components / arguments the chart can render today that are not yet
+     generally-available, mapped to the minimum stability.level Alloy currently exposes them at.
+     Update an entry when Alloy graduates the component
+     (`experimental` → `public-preview` → `generally-available`). Set the level to
+     `generally-available` (or delete the entry) to remove the requirement entirely. */}}
+{{- define "collectors.experimentalStabilityRequirements" }}
+# Triggered by global.convertClassicHistogramsToNhcb: true on any feature that forwards to a
+# prometheus destination. Renders `convert_classic_histograms_to_nhcb = true` on the
+# prometheus.scrape components the feature emits.
+nhcbConversion:
+  stabilityLevel: experimental
+# Triggered by any prometheus destination with remoteWriteProtocol: 2. Renders
+# `protobuf_message = "io.prometheus.write.v2.Request"` on prometheus.remote_write.
+remoteWriteV2:
+  stabilityLevel: experimental
+{{- end }}
+
 {{- define "collectors.validate.atLeastOneEnabled" }}
   {{- $enabledCollectors := include "collectors.list.enabled" . | fromYamlArray }}
   {{- if eq (len $enabledCollectors) 0 }}

--- a/charts/k8s-monitoring/tests/collector_stability_level_test.yaml
+++ b/charts/k8s-monitoring/tests/collector_stability_level_test.yaml
@@ -1,0 +1,142 @@
+# yamllint disable rule:document-start rule:line-length rule:trailing-spaces
+suite: Collector - Stability Level for Experimental Features
+templates:
+  - validations.yaml
+tests:
+  - it: fails when convertClassicHistogramsToNhcb is enabled but the metrics collector lacks experimental stability
+    set:
+      cluster:
+        name: ci-test-cluster
+      destinations:
+        prom:
+          type: prometheus
+          url: http://prom.monitoring.svc:9090/api/v1/write
+      global:
+        convertClassicHistogramsToNhcb: true
+      clusterMetrics:
+        enabled: true
+      telemetryServices:
+        kube-state-metrics: {deploy: true}
+        node-exporter: {deploy: true}
+      collectors:
+        alloy-metrics:
+          presets: [clustered]
+    asserts:
+      - failedTemplate:
+          errorMessage: |-
+            Collector "alloy-metrics" has stabilityLevel="generally-available" but the chart will render Alloy components that require stabilityLevel=experimental:
+              - feature "clusterMetrics" forwards to a prometheus destination (prom) and global.convertClassicHistogramsToNhcb: true renders `convert_classic_histograms_to_nhcb = true` on its scrape components (Alloy exposes this only at stability.level=experimental)
+
+            Please set:
+            collectors:
+              alloy-metrics:
+                alloy:
+                  stabilityLevel: experimental
+
+  - it: fails when a prometheus destination uses remoteWriteProtocol=2 but the metrics collector lacks experimental stability
+    set:
+      cluster:
+        name: ci-test-cluster
+      destinations:
+        prom:
+          type: prometheus
+          url: http://prom.monitoring.svc:9090/api/v1/write
+          remoteWriteProtocol: 2
+      clusterMetrics:
+        enabled: true
+      telemetryServices:
+        kube-state-metrics: {deploy: true}
+        node-exporter: {deploy: true}
+      collectors:
+        alloy-metrics:
+          presets: [clustered]
+    asserts:
+      - failedTemplate:
+          errorMessage: |-
+            Collector "alloy-metrics" has stabilityLevel="generally-available" but the chart will render Alloy components that require stabilityLevel=experimental:
+              - feature "clusterMetrics" forwards to destinations.prom, which uses remoteWriteProtocol: 2 and renders `protobuf_message = "io.prometheus.write.v2.Request"` on prometheus.remote_write (Alloy exposes this only at stability.level=experimental)
+
+            Please set:
+            collectors:
+              alloy-metrics:
+                alloy:
+                  stabilityLevel: experimental
+
+  - it: passes when stabilityLevel is experimental on the per-collector key
+    set:
+      cluster:
+        name: ci-test-cluster
+      destinations:
+        prom:
+          type: prometheus
+          url: http://prom.monitoring.svc:9090/api/v1/write
+          remoteWriteProtocol: 2
+      global:
+        convertClassicHistogramsToNhcb: true
+      clusterMetrics:
+        enabled: true
+      telemetryServices:
+        kube-state-metrics: {deploy: true}
+        node-exporter: {deploy: true}
+      collectors:
+        alloy-metrics:
+          presets: [clustered]
+          alloy:
+            stabilityLevel: experimental
+    asserts:
+      - notFailedTemplate: {}
+
+  - it: does not fail collectors that do not forward to a prometheus destination, even if convertClassicHistogramsToNhcb or remoteWriteProtocol=2 are set elsewhere
+    # Repro for the bug originally found in tests/platform/grafana-cloud/database-observability:
+    # alloy-logs was failing validation because a *separate* prometheus destination had RWv2 enabled,
+    # even though alloy-logs only forwards to Loki and never renders prometheus.remote_write.
+    set:
+      cluster:
+        name: ci-test-cluster
+      destinations:
+        prom:
+          type: prometheus
+          url: http://prom.monitoring.svc:9090/api/v1/write
+          remoteWriteProtocol: 2
+        loki:
+          type: loki
+          url: http://loki.monitoring.svc:3100/loki/api/v1/push
+      global:
+        convertClassicHistogramsToNhcb: true
+      podLogsViaLoki:
+        enabled: true
+        collector: alloy-logs
+      clusterMetrics:
+        enabled: true
+        collector: alloy-metrics
+      telemetryServices:
+        kube-state-metrics: {deploy: true}
+        node-exporter: {deploy: true}
+      collectors:
+        alloy-logs:
+          presets: [filesystem-log-reader, daemonset]
+        alloy-metrics:
+          presets: [clustered]
+          alloy:
+            stabilityLevel: experimental
+    asserts:
+      - notFailedTemplate: {}
+
+  - it: passes when neither convertClassicHistogramsToNhcb nor remoteWriteProtocol=2 are set
+    set:
+      cluster:
+        name: ci-test-cluster
+      destinations:
+        prom:
+          type: prometheus
+          url: http://prom.monitoring.svc:9090/api/v1/write
+      clusterMetrics:
+        enabled: true
+      telemetryServices:
+        kube-state-metrics: {deploy: true}
+        node-exporter: {deploy: true}
+      collectors:
+        alloy-metrics:
+          presets: [clustered]
+    asserts:
+      - notFailedTemplate: {}


### PR DESCRIPTION
## What does this PR do?

The chart writes Alloy config that requires `stabilityLevel: experimental` whenever either of these is set:

- `global.convertClassicHistogramsToNhcb: true` (renders `convert_classic_histograms_to_nhcb = true` on prometheus.scrape components)
- a prometheus destination on `remoteWriteProtocol: 2` (renders `protobuf_message = \"io.prometheus.write.v2.Request\"` on prometheus.remote_write)

Without `stabilityLevel: experimental` on the affected collector the Alloy operator schedules the collector and then it crash-loops at init:

```
building component: using remote write v2 (protobuf_message=io.prometheus.write.v2.Request)
with endpoint <url> requires setting the stability.level flag to experimental
```

or, for NHCB:

```
... convert_classic_histograms_to_nhcb = true ... requires setting the stability.level flag to experimental
```

This is the natural follow-on to #2586 (`convertClassicHistogramsToNhcb`) and #2582 (auto-prepend `PrometheusProto`): the chart now invites users down a config path it knows needs experimental, but doesn't surface that to them until the collector is in CrashLoopBackOff.

This PR adds a chart-level validation that runs at `helm template` time:

- walks `features.list.enabled`,
- for each feature looks up the assigned collector (`collectors.getCollectorForFeature`) and the destinations it forwards to (`features.<feature>.destinations`),
- and if any (feature, destination) pair would render an experimental-only Alloy component, fails the render with the exact `collectors.<name>.alloy.stabilityLevel: experimental` snippet to set, plus a list of which feature+destination combinations triggered the requirement.

## Example

Stock 4.1.x values from a Grafana Cloud onboarding wizard (omitting destination credentials) plus the two recommended knobs from #2586 / #2582 / chart docs:

```yaml
cluster:
  name: production
destinations:
  grafana-cloud-metrics:
    type: prometheus
    url: https://prometheus-prod-X-prod-us-central-0.grafana.net/api/prom/push
    remoteWriteProtocol: 2
global:
  convertClassicHistogramsToNhcb: true
clusterMetrics:
  enabled: true
collectors:
  alloy-metrics:
    presets: [clustered]
```

Before this PR: \`helm install\` succeeds, alloy-metrics-0 starts and immediately enters CrashLoopBackOff. \`kubectl logs\` shows the \`requires setting the stability.level flag to experimental\` line.

After this PR:

```text
Collector \"alloy-metrics\" has stabilityLevel=\"generally-available\" but the chart will render Alloy components that require stabilityLevel=experimental:
  - feature \"clusterMetrics\" forwards to destinations.grafana-cloud-metrics, which uses remoteWriteProtocol: 2 and renders \`protobuf_message = \"io.prometheus.write.v2.Request\"\` (Alloy exposes this only at stability.level=experimental)
  - feature \"clusterMetrics\" forwards to a prometheus destination (grafana-cloud-metrics) and global.convertClassicHistogramsToNhcb: true renders \`convert_classic_histograms_to_nhcb = true\` on its scrape components (Alloy exposes this only at stability.level=experimental)

Please set:
collectors:
  alloy-metrics:
    alloy:
      stabilityLevel: experimental
```

## Why per-feature scoping

Earlier in development I tried a chart-wide check (\"if NHCB or RWv2 is set anywhere, every enabled collector needs experimental\"). That broke the existing \`tests/platform/grafana-cloud/database-observability\` fixture, where alloy-logs is enabled alongside a Prometheus destination on RWv2 but alloy-logs only forwards to Loki and never renders \`prometheus.remote_write\`. Walking features and only flagging the collector(s) actually hosting an experimental component avoids the false positive — there's a dedicated test for that scenario.

## Tests

\`charts/k8s-monitoring/tests/collector_stability_level_test.yaml\` adds five cases:

1. \`global.convertClassicHistogramsToNhcb: true\` with no override → fails with the right message
2. Prometheus destination on \`remoteWriteProtocol: 2\` with no override → fails with the right message
3. Both of the above + \`collectors.alloy-metrics.alloy.stabilityLevel: experimental\` → passes
4. Mixed Loki+Prometheus install with NHCB and RWv2, alloy-logs without experimental, alloy-metrics with experimental → passes (no false positive on the logs collector)
5. Neither flag set → passes

Full chart suite (\`make build && make test ALLOY_OPERATOR_VERSION=...\`): 175/175 unit tests pass, all integration fixtures still render unchanged.

## Notes for reviewers

- \`selfReporting\` is intentionally skipped because its collector assignment is chart-internal and not directly tied to a user-facing feature. If we wanted to lock it in too we'd want to do it on the chosen collector after \`features.selfReporting.chooseCollector\` resolves.
- The lookup checks both \`collectorValues.alloy.stabilityLevel\` and a top-level \`collectorValues.stabilityLevel\`, because \`collectorCommon.alloy.<key>\` currently lands at the top of the merged values rather than under \`.alloy\`. That's a separate chart bug (the rendered Alloy CR ends up with \`spec.stabilityLevel\` instead of \`spec.alloy.stabilityLevel\`), not addressed here — I'll send a follow-up if you want.
- The two new templates change \~110 lines; the rest of the PR diff is the test fixture.

