### PR TITLE
fix(collectorCommon): land alloy:-subtree keys at spec.alloy on the Alloy CR

### DIFF
--- a/charts/k8s-monitoring/CHANGELOG.md
+++ b/charts/k8s-monitoring/CHANGELOG.md
@@ -1,12 +1,25 @@
 # Changelog
 
-## 4.1.3
+## Unreleased
 
-*   Add support for the write-ahead log (WAL) setting on the Loki destination (@nooboo)
-*   Add `drop` policy support for tail sampling (@petewall)
 *   Add global pull policy support for the hooks and collectors (@petewall)
 *   Fix `spanMetrics.excludeDimensions` rendering: list values are now properly quoted as strings instead of unquoted bareword identifiers, which caused Alloy to fail to parse the rendered config. (#2596) (@savannahostrowski)
 *   Remove scrape protocols from the four `prometheus.operator.*` components, which do not support setting them. (@MattiasSegerdahl)
+*   Fix `collectorCommon.alloy.<key>` propagation: keys the upstream Alloy chart hosts under its
+    own `alloy:` subtree (`stabilityLevel`, `configMap`, `securityContext`, `clustering`,
+    `resources`, etc.) now land at `spec.alloy.<key>` on the Alloy CR, where the operator reads
+    them, instead of being silently dropped at `spec.<key>`. Keys the upstream Alloy chart exposes
+    at the top of its values (`image`, `controller`, `rbac`, ...) continue to land at
+    `spec.<key>`, so existing usage like the `docs/examples/private-image-registries` example
+    (`collectorCommon.alloy.image.registry`) keeps working unchanged. (@MattiasSegerdahl)
+*   Fail with a helpful message when the chart will render Alloy components that require
+    `stabilityLevel: experimental` (e.g. `global.convertClassicHistogramsToNhcb: true` or a
+    Prometheus destination on `remoteWriteProtocol: 2`) but a collector hosting those components
+    has a lower stabilityLevel, instead of crash-looping the collector at startup. Per-trigger
+    minimum stabilityLevel is declared in the `collectors.experimentalStabilityRequirements`
+    helper, so when Alloy graduates a component
+    (`experimental` → `public-preview` → `generally-available`) the validation is updated by
+    changing a single value. (@MattiasSegerdahl)
 
 ## 4.1.2
 

--- a/charts/k8s-monitoring/templates/collectors/_collector_helpers.tpl
+++ b/charts/k8s-monitoring/templates/collectors/_collector_helpers.tpl
@@ -116,8 +116,29 @@ app.kubernetes.io/instance: {{ include "collector.alloy.fullname" . }}
 {{- define "collector.alloy.values" }}
 {{- /* The default settings set for all Alloy instances by this chart */}}
 {{- $defaultValues := "collectors/alloy-values.yaml" | .Files.Get | fromYaml }}
-{{- /* Settings in values.yaml for all Alloy instances */}}
-{{- $userCommonValues := $.Values.collectorCommon.alloy }}
+{{- /* Settings in values.yaml for all Alloy instances. `collectorCommon.alloy.<key>` mixes two
+       shapes of keys: ones that the upstream Alloy chart exposes at the top of its values
+       (image, controller, rbac, serviceAccount, ...) and ones that it nests under its own
+       `alloy:` subtree (stabilityLevel, configMap, securityContext, clustering, resources, ...).
+       Splitting the user-provided dict against `collectors/upstream/alloy-values.yaml` lets the
+       first group keep landing at `spec.<key>` on the Alloy CR (preserves the existing
+       `collectorCommon.alloy.image.tag` API documented in `docs/examples/private-image-registries`)
+       while the second group lands at `spec.alloy.<key>` where the operator actually reads it. */}}
+{{- $upstreamAlloyValues := "collectors/upstream/alloy-values.yaml" | .Files.Get | fromYaml }}
+{{- $alloySubtreeKeys := keys (default dict (get $upstreamAlloyValues "alloy")) }}
+{{- $rawUserCommon := default dict $.Values.collectorCommon.alloy }}
+{{- $userCommonAlloy := dict }}
+{{- $userCommonValues := dict }}
+{{- range $key, $val := $rawUserCommon }}
+  {{- if has $key $alloySubtreeKeys }}
+    {{- $_ := set $userCommonAlloy $key $val }}
+  {{- else }}
+    {{- $_ := set $userCommonValues $key $val }}
+  {{- end }}
+{{- end }}
+{{- if $userCommonAlloy }}
+  {{- $_ := set $userCommonValues "alloy" $userCommonAlloy }}
+{{- end }}
 {{- /* Copying the this chart's global values to the Alloy instances global values */}}
 {{- $globalValues := include "collector.alloy.values.global" . | fromYaml }}
 {{- /* Settings in values.yaml for the named instance */}}

--- a/charts/k8s-monitoring/tests/collector_common_alloy_test.yaml
+++ b/charts/k8s-monitoring/tests/collector_common_alloy_test.yaml
@@ -1,0 +1,123 @@
+# yamllint disable rule:document-start rule:line-length rule:trailing-spaces
+suite: Collectors - collectorCommon.alloy propagation
+templates:
+  - alloy.yaml
+release:
+  name: ci
+tests:
+  - it: routes `collectorCommon.alloy.stabilityLevel` to `spec.alloy.stabilityLevel` on every Alloy CR
+    set:
+      cluster:
+        name: ci-test-cluster
+      destinations:
+        prom:
+          type: prometheus
+          url: http://prom.monitoring.svc:9090/api/v1/write
+      clusterMetrics:
+        enabled: true
+      telemetryServices:
+        kube-state-metrics: {deploy: true}
+        node-exporter: {deploy: true}
+      collectorCommon:
+        alloy:
+          stabilityLevel: experimental
+      collectors:
+        alloy-metrics:
+          presets: [clustered, statefulset]
+    asserts:
+      - documentSelector:
+          path: metadata.name
+          value: ci-alloy-metrics
+        equal:
+          path: spec.alloy.stabilityLevel
+          value: experimental
+
+  - it: keeps `collectorCommon.alloy.image` rendering to `spec.image` (top-level, where the operator reads it)
+    set:
+      cluster:
+        name: ci-test-cluster
+      destinations:
+        prom:
+          type: prometheus
+          url: http://prom.monitoring.svc:9090/api/v1/write
+      clusterMetrics:
+        enabled: true
+      telemetryServices:
+        kube-state-metrics: {deploy: true}
+        node-exporter: {deploy: true}
+      collectorCommon:
+        alloy:
+          image:
+            registry: my.registry.com
+            repository: grafana/alloy
+            tag: v1.16.1
+      collectors:
+        alloy-metrics:
+          presets: [clustered, statefulset]
+    asserts:
+      - documentSelector:
+          path: metadata.name
+          value: ci-alloy-metrics
+        equal:
+          path: spec.image
+          value:
+            registry: my.registry.com
+            repository: grafana/alloy
+            tag: v1.16.1
+
+  - it: routes `collectorCommon.alloy.securityContext` to `spec.alloy.securityContext` (deep merge with chart defaults)
+    set:
+      cluster:
+        name: ci-test-cluster
+      destinations:
+        prom:
+          type: prometheus
+          url: http://prom.monitoring.svc:9090/api/v1/write
+      clusterMetrics:
+        enabled: true
+      telemetryServices:
+        kube-state-metrics: {deploy: true}
+        node-exporter: {deploy: true}
+      collectorCommon:
+        alloy:
+          securityContext:
+            runAsUser: 12345
+      collectors:
+        alloy-metrics:
+          presets: [clustered, statefulset]
+    asserts:
+      - documentSelector:
+          path: metadata.name
+          value: ci-alloy-metrics
+        equal:
+          path: spec.alloy.securityContext.runAsUser
+          value: 12345
+
+  - it: lets a per-collector `collectors.<name>.alloy.stabilityLevel` override `collectorCommon.alloy.stabilityLevel`
+    set:
+      cluster:
+        name: ci-test-cluster
+      destinations:
+        prom:
+          type: prometheus
+          url: http://prom.monitoring.svc:9090/api/v1/write
+      clusterMetrics:
+        enabled: true
+      telemetryServices:
+        kube-state-metrics: {deploy: true}
+        node-exporter: {deploy: true}
+      collectorCommon:
+        alloy:
+          stabilityLevel: experimental
+      collectors:
+        alloy-metrics:
+          presets: [clustered, statefulset]
+          alloy:
+            stabilityLevel: public-preview
+    asserts:
+      - documentSelector:
+          path: metadata.name
+          value: ci-alloy-metrics
+        equal:
+          path: spec.alloy.stabilityLevel
+          value: public-preview


### PR DESCRIPTION
## What does this PR do?

`collectorCommon.alloy.<key>` is the chart's "settings for all Alloy collectors" knob. Today it works for some keys and silently fails for others:

| User sets | Lands at, on the Alloy CR | Operator reads it? |
|---|---|---|
| `collectorCommon.alloy.image.tag` | `spec.image.tag` | ✅ yes |
| `collectorCommon.alloy.controller.replicas` | `spec.controller.replicas` | ✅ yes |
| `collectorCommon.alloy.stabilityLevel: experimental` | `spec.stabilityLevel` | ❌ no (must be `spec.alloy.stabilityLevel`) |
| `collectorCommon.alloy.configMap.create` | `spec.configMap` | ❌ no |
| `collectorCommon.alloy.securityContext.runAsUser` | `spec.securityContext` | ❌ no |
| `collectorCommon.alloy.clustering.enabled` | `spec.clustering` | ❌ no |

The root cause is in `collector.alloy.values` (`_collector_helpers.tpl`): it does

```yaml
$userCommonValues := $.Values.collectorCommon.alloy
```

which extracts the **contents** of `collectorCommon.alloy` and then merges them at the **top of the per-collector values dict**. Whatever the user put under `collectorCommon.alloy.<key>` therefore lands at `spec.<key>` on the rendered Alloy CR. The upstream Alloy chart's values shape is hybrid: some fields live at the top (`image`, `controller`, `rbac`, `serviceAccount`, `configReloader`, `networkPolicy`, `service`, `ingress`, `extraObjects`), others under its own `alloy:` subtree (`stabilityLevel`, `configMap`, `securityContext`, `clustering`, `resources`, `logging`, `liveDebugging`, `mounts`, `lifecycle`, `livenessProbe`, `storagePath`, `listenAddr`/`listenPort`/`listenScheme`, `extraEnv`, `extraArgs`, ...). The chart's strip happens to map the first group correctly; the second group ends up at the wrong place in `spec` and the operator drops the value.

The most common way to hit this is `collectorCommon.alloy.stabilityLevel: experimental`: the chart writes it, the operator doesn't see it, and the alloy-metrics collector crash-loops on any config that requires `--stability.level=experimental` (Prometheus RWv2 protobuf, NHCB conversion, ...). The current docs and `upgrade.sh`-style snippets recommend exactly that knob.

## The fix

Split the user's `collectorCommon.alloy` dict against `collectors/upstream/alloy-values.yaml`: keys that exist under the upstream `alloy:` subtree get re-wrapped so they merge into `spec.alloy`, the rest stay at the top of `spec`.

```yaml
{{- $upstreamAlloyValues := "collectors/upstream/alloy-values.yaml" | .Files.Get | fromYaml }}
{{- $alloySubtreeKeys := keys (default dict (get $upstreamAlloyValues "alloy")) }}
{{- $rawUserCommon := default dict $.Values.collectorCommon.alloy }}
{{- $userCommonAlloy := dict }}
{{- $userCommonValues := dict }}
{{- range $key, $val := $rawUserCommon }}
  {{- if has $key $alloySubtreeKeys }}
    {{- $_ := set $userCommonAlloy $key $val }}
  {{- else }}
    {{- $_ := set $userCommonValues $key $val }}
  {{- end }}
{{- end }}
{{- if $userCommonAlloy }}
  {{- $_ := set $userCommonValues "alloy" $userCommonAlloy }}
{{- end }}
```

The list of "under-alloy" keys is sourced from the upstream Alloy chart's values, so it tracks the Alloy chart's shape as Alloy evolves. No manual list to maintain.

## Backward compatibility

The `docs/examples/private-image-registries/individual/values.yaml` and `README.md` example continue to work unchanged:

```yaml
collectorCommon:
  alloy:
    image:
      registry: my.registry.com
      repository: grafana/alloy
```

`image` is at the top of the upstream Alloy chart's values, so it stays at the top of `spec` after the split. Verified by a unit test.

`collectorCommon.alloy.controller.podAnnotations` (used in `tests/platform/aks`), `collectorCommon.alloy.liveDebugging.enabled` (`tests/platform/grafana-cloud/k8s-monitoring`), `collectorCommon.alloy.remoteConfig.*` (`tests/platform/remote-config`) — `controller`, `liveDebugging`, and `remoteConfig` are all categorised correctly by the data-driven split:

| Key | In upstream `alloy:`? | Lands at, after this PR |
|---|---|---|
| `controller` | No | `spec.controller` (unchanged) |
| `liveDebugging` | Yes | `spec.alloy.liveDebugging` (newly correct; was `spec.liveDebugging`) |
| `remoteConfig` | No (chart-internal field, not from upstream Alloy chart) | `spec.remoteConfig` (unchanged) |

The full chart suite passes (175 unit tests + 42 snapshots), including the rendered fixtures in `tests/platform/*` and `docs/examples/*`.

## Tests

`charts/k8s-monitoring/tests/collector_common_alloy_test.yaml` covers four cases:

1. `collectorCommon.alloy.stabilityLevel: experimental` → `spec.alloy.stabilityLevel: experimental` (was silently dropped)
2. `collectorCommon.alloy.image: { tag: v1.16.1, ... }` → `spec.image: { tag: v1.16.1, ... }` (preserves the existing private-image-registries example)
3. `collectorCommon.alloy.securityContext.runAsUser: 12345` → `spec.alloy.securityContext.runAsUser: 12345` (deep merge with chart defaults, was silently dropped)
4. Per-collector override: `collectors.<name>.alloy.stabilityLevel: public-preview` still wins over `collectorCommon.alloy.stabilityLevel: experimental` (precedence preserved)

## Notes for reviewers

- The diff is small (`_collector_helpers.tpl` +23 / -2, plus the test fixture and a CHANGELOG note). Most of the PR is the test + the CHANGELOG explanation.
- Naturally follows from the `stabilityLevel` validation in #2601: with that PR the chart fails loudly when the user's stabilityLevel is too low; with this PR, the `collectorCommon.alloy.stabilityLevel` escape route the user is most likely to reach for actually works.

