### PR TITLE
Repoint argocd README to new Grafana Cloud docs URL

### DIFF
--- a/charts/k8s-monitoring/docs/examples/deployment-alternatives/argocd/README.md
+++ b/charts/k8s-monitoring/docs/examples/deployment-alternatives/argocd/README.md
@@ -6,7 +6,7 @@ does not install the Helm chart directly, but instead utilizes `helm template` t
 them to the cluster.
 
 For a step-by-step Grafana Cloud guide built on top of these manifests, refer to
-[Send Kubernetes metrics, logs, and events with Helm and Argo CD to Grafana Cloud](https://grafana.com/docs/grafana-cloud/monitor-infrastructure/kubernetes-monitoring/configuration/config-other-methods/argocd-config/).
+[Send Kubernetes metrics, logs, and events with Helm and Argo CD to Grafana Cloud](https://grafana.com/docs/grafana-cloud/monitor-infrastructure/kubernetes-monitoring/configuration/helm-chart-config/hc-config-steps/#argocd).
 
 Three variants are provided:
 


### PR DESCRIPTION
## Summary

The `charts/k8s-monitoring/docs/examples/deployment-alternatives/argocd/README.md` links to a Grafana Cloud docs page that was retired during a recent docs reorganization, so the link now 404s:

- old: `https://grafana.com/docs/grafana-cloud/monitor-infrastructure/kubernetes-monitoring/configuration/config-other-methods/argocd-config/` (404)
- new: `https://grafana.com/docs/grafana-cloud/monitor-infrastructure/kubernetes-monitoring/configuration/helm-chart-config/hc-config-steps/#argocd` (200)

The new section documents the wizard-driven Argo CD deployment flow, which is now the canonical Grafana Cloud guide on top of these manifests.

## Test plan

- [x] `curl -o /dev/null -s -w "%{http_code}\n" "<new-url>"` returns `200`
- [x] Confirmed the original URL returns `404` (no alias / redirect)
- [x] `git diff` shows only the URL change, no other content modified