### PR TITLE
feat(k8s-monitoring-v1): add configurable Prometheus OTLP timeout

### DIFF
--- a/charts/k8s-monitoring-v1/README.md
+++ b/charts/k8s-monitoring-v1/README.md
@@ -311,6 +311,7 @@ The Prometheus and Loki services may be hosted on the same cluster, or remotely 
 | externalServices.prometheus.oauth2.proxyURL | string | `""` | HTTP proxy to send requests through. |
 | externalServices.prometheus.oauth2.scopes | list | `[]` | List of scopes to authenticate with. |
 | externalServices.prometheus.oauth2.tokenURL | string | `""` | URL to fetch the token from. |
+| externalServices.prometheus.otlpTimeout | string | `""` | Time to wait before marking an OTLP metrics export request as failed. Only applies when protocol is "otlp". When unset, Alloy uses its default timeout. |
 | externalServices.prometheus.processors.batch.maxSize | int | `0` | Maximum number of spans, metric data points, or log records to send in a single batch. This number must be greater than or equal to the `size` setting. If set to 0, the batch processor will not enforce a maximum size. |
 | externalServices.prometheus.processors.batch.size | int | `8192` | Number of spans, metric data points, or log records after which a batch will be sent regardless of the timeout. This setting acts as a trigger and does not affect the size of the batch. If you need to enforce batch size, limit use `maxSize`. |
 | externalServices.prometheus.processors.batch.timeout | string | `"2s"` | How long to wait before flushing the batch. |

--- a/charts/k8s-monitoring-v1/templates/alloy_config/_metrics_service_otlp.alloy.txt
+++ b/charts/k8s-monitoring-v1/templates/alloy_config/_metrics_service_otlp.alloy.txt
@@ -106,6 +106,9 @@ otelcol.auth.oauth2 "metrics_service" {
 {{- end }}
 {{ if eq .protocol "otlp" }}
 otelcol.exporter.otlp "metrics_service" {
+  {{- if .otlpTimeout }}
+  timeout = {{ .otlpTimeout | quote }}
+  {{- end }}
 {{- end }}
 {{- if eq .protocol "otlphttp" }}
 otelcol.exporter.otlphttp "metrics_service" {

--- a/charts/k8s-monitoring-v1/values.schema.json
+++ b/charts/k8s-monitoring-v1/values.schema.json
@@ -592,6 +592,9 @@
                                 }
                             }
                         },
+                        "otlpTimeout": {
+                            "type": "string"
+                        },
                         "processors": {
                             "type": "object",
                             "properties": {

--- a/charts/k8s-monitoring-v1/values.yaml
+++ b/charts/k8s-monitoring-v1/values.yaml
@@ -30,6 +30,10 @@ externalServices:
     #  "otlphttp" will use OTLP HTTP
     # @section -- External Services (Prometheus)
     protocol: "remote_write"
+    # -- Time to wait before marking an OTLP metrics export request as failed.
+    # Only applies when protocol is "otlp". When unset, Alloy uses its default timeout.
+    # @section -- External Services (Prometheus)
+    otlpTimeout: ""
     # -- HTTP proxy to proxy requests to Prometheus through.
     # @section -- External Services (Prometheus)
     proxyURL: ""


### PR DESCRIPTION
feat(k8s-monitoring-v1): add configurable Prometheus OTLP timeout

Add externalServices.prometheus.otlpTimeout to configure the otelcol.exporter.otlp metrics_service timeout when Prometheus uses the otlp protocol.
When unset, the chart keeps the current behavior and lets Alloy use its default timeout.