### PR TITLE
feat(prometheus-operator-objects): add convert classic histograms to Prometheus Operator objects

### DIFF
--- a/charts/k8s-monitoring/CHANGELOG.md
+++ b/charts/k8s-monitoring/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+*   Adds the native histogram scrape options to all Prometheus Operator object types (PodMonitors, Probes, ServiceMonitors) (@nlamirault)
 *   Fix control-plane (Kube Proxy, Kube Controller Manager, Kube Scheduler) and etcd integration scraping on IPv6/dual-stack clusters by using bracket notation for IPv6 pod addresses. (#2999) (@petewall)
 
 ## 4.5.1

--- a/charts/k8s-monitoring/README.md
+++ b/charts/k8s-monitoring/README.md
@@ -315,6 +315,8 @@ details:
 | global.kubernetesAPIService | string | `""` | The Kubernetes service. Change this if your cluster DNS is configured differently than the default. |
 | global.maxCacheSize | int | `100000` | Sets the max_cache_size for every prometheus.relabel component. ([docs](https://grafana.com/docs/alloy/latest/reference/components/prometheus/prometheus.relabel/#arguments)) This should be at least 2x-5x your largest scrape target or samples appended rate. |
 | global.namespaceOverride | string | `""` | Override the namespace for namespaced resources created by this chart and its feature subcharts. |
+| global.nativeHistogramBucketLimit | int | `0` | If a native histogram has more buckets than this, buckets will be merged to stay within the limit. Disabled when set to zero. |
+| global.nativeHistogramMinBucketFactor | float | `0` | If the growth factor from one native histogram bucket to the next is smaller than this, buckets will be merged. Disabled when set to zero. |
 | global.platform | string | `""` | The specific platform for this cluster. Will enable compatibility for some platforms. Supported options: (empty) or "openshift". |
 | global.scrapeClassicHistograms | bool | `false` | Whether to scrape a classic histogram that’s also exposed as a native histogram. |
 | global.scrapeInterval | string | `"60s"` | How frequently to scrape metrics. |

--- a/charts/k8s-monitoring/charts/feature-prometheus-operator-objects/README.md
+++ b/charts/k8s-monitoring/charts/feature-prometheus-operator-objects/README.md
@@ -57,6 +57,9 @@ Be sure perform actual integration testing in a live environment in the main [k8
 | global.convertClassicHistogramsToNhcb | bool | `false` | Whether to convert classic histograms to native histograms with custom buckets (NHCB) at scrape time. |
 | global.maxCacheSize | int | `100000` | Sets the max_cache_size for every prometheus.relabel component. ([docs](https://grafana.com/docs/alloy/latest/reference/components/prometheus/prometheus.relabel/#arguments)) This should be at least 2x-5x your largest scrape target or samples appended rate. |
 | global.namespaceOverride | string | `""` | Override the namespace for namespaced resources created by this chart. |
+| global.nativeHistogramBucketLimit | int | `0` | If a native histogram has more buckets than this, buckets will be merged to stay within the limit. Disabled when set to zero. |
+| global.nativeHistogramMinBucketFactor | float | `0` | If the growth factor from one native histogram bucket to the next is smaller than this, buckets will be merged. Disabled when set to zero. |
+| global.scrapeClassicHistograms | bool | `false` | Whether to scrape a classic histogram that’s also exposed as a native histogram. |
 | global.scrapeInterval | string | `"60s"` | How frequently to scrape metrics. |
 | global.scrapeNativeHistograms | bool | `false` | Whether to scrape native histograms from targets. Used as the default if a section does not override it. |
 | global.scrapeProtocols | list | `["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]` | The protocols to negotiate during a Prometheus metrics scrape, in order of preference. When `scrapeNativeHistograms` is enabled, `PrometheusProto` is automatically prepended to this list because it is the only protocol that supports native histograms. |

--- a/charts/k8s-monitoring/charts/feature-prometheus-operator-objects/templates/_pod_monitors.alloy.tpl
+++ b/charts/k8s-monitoring/charts/feature-prometheus-operator-objects/templates/_pod_monitors.alloy.tpl
@@ -32,6 +32,7 @@ prometheus.operator.podmonitors "pod_monitors" {
     default_scrape_interval = {{ .Values.podMonitors.scrapeInterval | default .Values.global.scrapeInterval | quote }}
     default_scrape_timeout = {{ .Values.podMonitors.scrapeTimeout | default .Values.global.scrapeTimeout | quote }}
     scrape_native_histograms = {{ .Values.global.scrapeNativeHistograms }}
+    convert_classic_histograms_to_nhcb = {{ .Values.global.convertClassicHistogramsToNhcb }}
   }
 
 {{- with .Values.podMonitors.excludeNamespaces }}

--- a/charts/k8s-monitoring/charts/feature-prometheus-operator-objects/templates/_pod_monitors.alloy.tpl
+++ b/charts/k8s-monitoring/charts/feature-prometheus-operator-objects/templates/_pod_monitors.alloy.tpl
@@ -31,8 +31,11 @@ prometheus.operator.podmonitors "pod_monitors" {
   scrape {
     default_scrape_interval = {{ .Values.podMonitors.scrapeInterval | default .Values.global.scrapeInterval | quote }}
     default_scrape_timeout = {{ .Values.podMonitors.scrapeTimeout | default .Values.global.scrapeTimeout | quote }}
+    scrape_classic_histograms = {{ .Values.global.scrapeClassicHistograms }}
     scrape_native_histograms = {{ .Values.global.scrapeNativeHistograms }}
     convert_classic_histograms_to_nhcb = {{ .Values.global.convertClassicHistogramsToNhcb }}
+    native_histogram_bucket_limit = {{ .Values.global.nativeHistogramBucketLimit | int }}
+    native_histogram_min_bucket_factor = {{ .Values.global.nativeHistogramMinBucketFactor | float64 }}
   }
 
 {{- with .Values.podMonitors.excludeNamespaces }}

--- a/charts/k8s-monitoring/charts/feature-prometheus-operator-objects/templates/_probes.alloy.tpl
+++ b/charts/k8s-monitoring/charts/feature-prometheus-operator-objects/templates/_probes.alloy.tpl
@@ -32,6 +32,7 @@ prometheus.operator.probes "probes" {
     default_scrape_interval = {{ .Values.probes.scrapeInterval | default .Values.global.scrapeInterval | quote }}
     default_scrape_timeout = {{ .Values.probes.scrapeTimeout | default .Values.global.scrapeTimeout | quote }}
     scrape_native_histograms = {{ .Values.global.scrapeNativeHistograms }}
+    convert_classic_histograms_to_nhcb = {{ .Values.global.convertClassicHistogramsToNhcb }}
   }
 
 {{- with .Values.probes.excludeNamespaces }}

--- a/charts/k8s-monitoring/charts/feature-prometheus-operator-objects/templates/_probes.alloy.tpl
+++ b/charts/k8s-monitoring/charts/feature-prometheus-operator-objects/templates/_probes.alloy.tpl
@@ -31,8 +31,11 @@ prometheus.operator.probes "probes" {
   scrape {
     default_scrape_interval = {{ .Values.probes.scrapeInterval | default .Values.global.scrapeInterval | quote }}
     default_scrape_timeout = {{ .Values.probes.scrapeTimeout | default .Values.global.scrapeTimeout | quote }}
+    scrape_classic_histograms = {{ .Values.global.scrapeClassicHistograms }}
     scrape_native_histograms = {{ .Values.global.scrapeNativeHistograms }}
     convert_classic_histograms_to_nhcb = {{ .Values.global.convertClassicHistogramsToNhcb }}
+    native_histogram_bucket_limit = {{ .Values.global.nativeHistogramBucketLimit | int }}
+    native_histogram_min_bucket_factor = {{ .Values.global.nativeHistogramMinBucketFactor | float64 }}
   }
 
 {{- with .Values.probes.excludeNamespaces }}

--- a/charts/k8s-monitoring/charts/feature-prometheus-operator-objects/templates/_service_monitors.alloy.tpl
+++ b/charts/k8s-monitoring/charts/feature-prometheus-operator-objects/templates/_service_monitors.alloy.tpl
@@ -33,6 +33,7 @@ prometheus.operator.servicemonitors "service_monitors" {
     default_scrape_interval = {{ .Values.serviceMonitors.scrapeInterval | default .Values.global.scrapeInterval | quote }}
     default_scrape_timeout = {{ .Values.serviceMonitors.scrapeTimeout | default .Values.global.scrapeTimeout | quote }}
     scrape_native_histograms = {{ .Values.global.scrapeNativeHistograms }}
+    convert_classic_histograms_to_nhcb = {{ .Values.global.convertClassicHistogramsToNhcb }}
   }
 
 {{- with .Values.serviceMonitors.excludeNamespaces }}

--- a/charts/k8s-monitoring/charts/feature-prometheus-operator-objects/templates/_service_monitors.alloy.tpl
+++ b/charts/k8s-monitoring/charts/feature-prometheus-operator-objects/templates/_service_monitors.alloy.tpl
@@ -32,8 +32,11 @@ prometheus.operator.servicemonitors "service_monitors" {
   scrape {
     default_scrape_interval = {{ .Values.serviceMonitors.scrapeInterval | default .Values.global.scrapeInterval | quote }}
     default_scrape_timeout = {{ .Values.serviceMonitors.scrapeTimeout | default .Values.global.scrapeTimeout | quote }}
+    scrape_classic_histograms = {{ .Values.global.scrapeClassicHistograms }}
     scrape_native_histograms = {{ .Values.global.scrapeNativeHistograms }}
     convert_classic_histograms_to_nhcb = {{ .Values.global.convertClassicHistogramsToNhcb }}
+    native_histogram_bucket_limit = {{ .Values.global.nativeHistogramBucketLimit | int }}
+    native_histogram_min_bucket_factor = {{ .Values.global.nativeHistogramMinBucketFactor | float64 }}
   }
 
 {{- with .Values.serviceMonitors.excludeNamespaces }}

--- a/charts/k8s-monitoring/charts/feature-prometheus-operator-objects/tests/__snapshot__/default_test.yaml.snap
+++ b/charts/k8s-monitoring/charts/feature-prometheus-operator-objects/tests/__snapshot__/default_test.yaml.snap
@@ -14,7 +14,11 @@ should generate the default configuration:
           scrape {
             default_scrape_interval = "60s"
             default_scrape_timeout = "10s"
+            scrape_classic_histograms = false
             scrape_native_histograms = false
+            convert_classic_histograms_to_nhcb = false
+            native_histogram_bucket_limit = 0
+            native_histogram_min_bucket_factor = 0
           }
           forward_to = argument.metrics_destinations.value
         } // prometheus.operator.podmonitors "pod_monitors"
@@ -27,7 +31,11 @@ should generate the default configuration:
           scrape {
             default_scrape_interval = "60s"
             default_scrape_timeout = "10s"
+            scrape_classic_histograms = false
             scrape_native_histograms = false
+            convert_classic_histograms_to_nhcb = false
+            native_histogram_bucket_limit = 0
+            native_histogram_min_bucket_factor = 0
           }
           forward_to = argument.metrics_destinations.value
         } // prometheus.operator.probes "probes"
@@ -41,7 +49,11 @@ should generate the default configuration:
           scrape {
             default_scrape_interval = "60s"
             default_scrape_timeout = "10s"
+            scrape_classic_histograms = false
             scrape_native_histograms = false
+            convert_classic_histograms_to_nhcb = false
+            native_histogram_bucket_limit = 0
+            native_histogram_min_bucket_factor = 0
           }
           forward_to = argument.metrics_destinations.value
         } // prometheus.operator.servicemonitors "service_monitors"

--- a/charts/k8s-monitoring/charts/feature-prometheus-operator-objects/tests/__snapshot__/labels-and-expressions_test.yaml.snap
+++ b/charts/k8s-monitoring/charts/feature-prometheus-operator-objects/tests/__snapshot__/labels-and-expressions_test.yaml.snap
@@ -19,7 +19,11 @@ should generate the correct configuration:
           scrape {
             default_scrape_interval = "60s"
             default_scrape_timeout = "10s"
+            scrape_classic_histograms = false
             scrape_native_histograms = false
+            convert_classic_histograms_to_nhcb = false
+            native_histogram_bucket_limit = 0
+            native_histogram_min_bucket_factor = 0
           }
           forward_to = argument.metrics_destinations.value
         } // prometheus.operator.podmonitors "pod_monitors"
@@ -49,7 +53,11 @@ should generate the correct configuration:
           scrape {
             default_scrape_interval = "60s"
             default_scrape_timeout = "10s"
+            scrape_classic_histograms = false
             scrape_native_histograms = false
+            convert_classic_histograms_to_nhcb = false
+            native_histogram_bucket_limit = 0
+            native_histogram_min_bucket_factor = 0
           }
           forward_to = argument.metrics_destinations.value
         } // prometheus.operator.probes "probes"
@@ -73,7 +81,11 @@ should generate the correct configuration:
           scrape {
             default_scrape_interval = "60s"
             default_scrape_timeout = "10s"
+            scrape_classic_histograms = false
             scrape_native_histograms = false
+            convert_classic_histograms_to_nhcb = false
+            native_histogram_bucket_limit = 0
+            native_histogram_min_bucket_factor = 0
           }
           forward_to = argument.metrics_destinations.value
         } // prometheus.operator.servicemonitors "service_monitors"

--- a/charts/k8s-monitoring/charts/feature-prometheus-operator-objects/tests/__snapshot__/scrape-intervals-and-timeouts_test.yaml.snap
+++ b/charts/k8s-monitoring/charts/feature-prometheus-operator-objects/tests/__snapshot__/scrape-intervals-and-timeouts_test.yaml.snap
@@ -14,7 +14,11 @@ should generate the default configuration:
           scrape {
             default_scrape_interval = "10s"
             default_scrape_timeout = "5s"
+            scrape_classic_histograms = false
             scrape_native_histograms = false
+            convert_classic_histograms_to_nhcb = false
+            native_histogram_bucket_limit = 0
+            native_histogram_min_bucket_factor = 0
           }
           forward_to = argument.metrics_destinations.value
         } // prometheus.operator.podmonitors "pod_monitors"
@@ -27,7 +31,11 @@ should generate the default configuration:
           scrape {
             default_scrape_interval = "60s"
             default_scrape_timeout = "10s"
+            scrape_classic_histograms = false
             scrape_native_histograms = false
+            convert_classic_histograms_to_nhcb = false
+            native_histogram_bucket_limit = 0
+            native_histogram_min_bucket_factor = 0
           }
           forward_to = argument.metrics_destinations.value
         } // prometheus.operator.probes "probes"
@@ -41,7 +49,11 @@ should generate the default configuration:
           scrape {
             default_scrape_interval = "30s"
             default_scrape_timeout = "10s"
+            scrape_classic_histograms = false
             scrape_native_histograms = false
+            convert_classic_histograms_to_nhcb = false
+            native_histogram_bucket_limit = 0
+            native_histogram_min_bucket_factor = 0
           }
           forward_to = argument.metrics_destinations.value
         } // prometheus.operator.servicemonitors "service_monitors"

--- a/charts/k8s-monitoring/charts/feature-prometheus-operator-objects/tests/scrape_native_histograms_test.yaml
+++ b/charts/k8s-monitoring/charts/feature-prometheus-operator-objects/tests/scrape_native_histograms_test.yaml
@@ -30,3 +30,50 @@ tests:
       - notMatchRegex:
           path: data["module.alloy"]
           pattern: scrape_protocols =
+
+  - it: emits all histogram scrape options when configured
+    set:
+      testing: {enabled: true}
+      global:
+        scrapeClassicHistograms: true
+        scrapeNativeHistograms: true
+        convertClassicHistogramsToNhcb: true
+        nativeHistogramBucketLimit: 100
+        nativeHistogramMinBucketFactor: 1.1
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - matchRegex:
+          path: data["module.alloy"]
+          pattern: scrape_classic_histograms = true
+      - matchRegex:
+          path: data["module.alloy"]
+          pattern: scrape_native_histograms = true
+      - matchRegex:
+          path: data["module.alloy"]
+          pattern: convert_classic_histograms_to_nhcb = true
+      - matchRegex:
+          path: data["module.alloy"]
+          pattern: native_histogram_bucket_limit = 100
+      - matchRegex:
+          path: data["module.alloy"]
+          pattern: native_histogram_min_bucket_factor = 1\.1
+
+  - it: disables histogram bucket merging options by default
+    set:
+      testing: {enabled: true}
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - matchRegex:
+          path: data["module.alloy"]
+          pattern: scrape_classic_histograms = false
+      - matchRegex:
+          path: data["module.alloy"]
+          pattern: convert_classic_histograms_to_nhcb = false
+      - matchRegex:
+          path: data["module.alloy"]
+          pattern: native_histogram_bucket_limit = 0
+      - matchRegex:
+          path: data["module.alloy"]
+          pattern: native_histogram_min_bucket_factor = 0

--- a/charts/k8s-monitoring/charts/feature-prometheus-operator-objects/values.schema.json
+++ b/charts/k8s-monitoring/charts/feature-prometheus-operator-objects/values.schema.json
@@ -14,6 +14,15 @@
                 "namespaceOverride": {
                     "type": "string"
                 },
+                "nativeHistogramBucketLimit": {
+                    "type": "integer"
+                },
+                "nativeHistogramMinBucketFactor": {
+                    "type": "number"
+                },
+                "scrapeClassicHistograms": {
+                    "type": "boolean"
+                },
                 "scrapeInterval": {
                     "type": "string"
                 },

--- a/charts/k8s-monitoring/charts/feature-prometheus-operator-objects/values.yaml
+++ b/charts/k8s-monitoring/charts/feature-prometheus-operator-objects/values.yaml
@@ -20,6 +20,10 @@ global:
   # @section -- Global Settings
   maxCacheSize: 100000
 
+  # -- Whether to scrape a classic histogram that’s also exposed as a native histogram.
+  # @section -- Global Settings
+  scrapeClassicHistograms: false
+
   # -- Whether to scrape native histograms from targets. Used as the default if a section does not override it.
   # @section -- Global Settings
   scrapeNativeHistograms: false
@@ -33,6 +37,16 @@ global:
   # -- Whether to convert classic histograms to native histograms with custom buckets (NHCB) at scrape time.
   # @section -- Global Settings
   convertClassicHistogramsToNhcb: false
+
+  # -- If a native histogram has more buckets than this, buckets will be merged to stay within the limit.
+  # Disabled when set to zero.
+  # @section -- Global Settings
+  nativeHistogramBucketLimit: 0
+
+  # -- If the growth factor from one native histogram bucket to the next is smaller than this, buckets will be
+  # merged. Disabled when set to zero.
+  # @section -- Global Settings
+  nativeHistogramMinBucketFactor: 0.0
 
 # Prometheus Operator PodMonitors
 podMonitors:

--- a/charts/k8s-monitoring/docs/examples/auth/bearer-token/alloy-metrics.alloy
+++ b/charts/k8s-monitoring/docs/examples/auth/bearer-token/alloy-metrics.alloy
@@ -12,7 +12,11 @@ declare "prometheus_operator_objects" {
     scrape {
       default_scrape_interval = "60s"
       default_scrape_timeout = "10s"
+      scrape_classic_histograms = false
       scrape_native_histograms = false
+      convert_classic_histograms_to_nhcb = false
+      native_histogram_bucket_limit = 0
+      native_histogram_min_bucket_factor = 0
     }
     forward_to = argument.metrics_destinations.value
   } // prometheus.operator.podmonitors "pod_monitors"
@@ -25,7 +29,11 @@ declare "prometheus_operator_objects" {
     scrape {
       default_scrape_interval = "60s"
       default_scrape_timeout = "10s"
+      scrape_classic_histograms = false
       scrape_native_histograms = false
+      convert_classic_histograms_to_nhcb = false
+      native_histogram_bucket_limit = 0
+      native_histogram_min_bucket_factor = 0
     }
     forward_to = argument.metrics_destinations.value
   } // prometheus.operator.probes "probes"
@@ -39,7 +47,11 @@ declare "prometheus_operator_objects" {
     scrape {
       default_scrape_interval = "60s"
       default_scrape_timeout = "10s"
+      scrape_classic_histograms = false
       scrape_native_histograms = false
+      convert_classic_histograms_to_nhcb = false
+      native_histogram_bucket_limit = 0
+      native_histogram_min_bucket_factor = 0
     }
     forward_to = argument.metrics_destinations.value
   } // prometheus.operator.servicemonitors "service_monitors"

--- a/charts/k8s-monitoring/docs/examples/auth/bearer-token/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/auth/bearer-token/output.yaml
@@ -280,7 +280,11 @@ data:
         scrape {
           default_scrape_interval = "60s"
           default_scrape_timeout = "10s"
+          scrape_classic_histograms = false
           scrape_native_histograms = false
+          convert_classic_histograms_to_nhcb = false
+          native_histogram_bucket_limit = 0
+          native_histogram_min_bucket_factor = 0
         }
         forward_to = argument.metrics_destinations.value
       } // prometheus.operator.podmonitors "pod_monitors"
@@ -293,7 +297,11 @@ data:
         scrape {
           default_scrape_interval = "60s"
           default_scrape_timeout = "10s"
+          scrape_classic_histograms = false
           scrape_native_histograms = false
+          convert_classic_histograms_to_nhcb = false
+          native_histogram_bucket_limit = 0
+          native_histogram_min_bucket_factor = 0
         }
         forward_to = argument.metrics_destinations.value
       } // prometheus.operator.probes "probes"
@@ -307,7 +315,11 @@ data:
         scrape {
           default_scrape_interval = "60s"
           default_scrape_timeout = "10s"
+          scrape_classic_histograms = false
           scrape_native_histograms = false
+          convert_classic_histograms_to_nhcb = false
+          native_histogram_bucket_limit = 0
+          native_histogram_min_bucket_factor = 0
         }
         forward_to = argument.metrics_destinations.value
       } // prometheus.operator.servicemonitors "service_monitors"

--- a/charts/k8s-monitoring/docs/examples/auth/embedded-secrets/alloy-metrics.alloy
+++ b/charts/k8s-monitoring/docs/examples/auth/embedded-secrets/alloy-metrics.alloy
@@ -12,7 +12,11 @@ declare "prometheus_operator_objects" {
     scrape {
       default_scrape_interval = "60s"
       default_scrape_timeout = "10s"
+      scrape_classic_histograms = false
       scrape_native_histograms = false
+      convert_classic_histograms_to_nhcb = false
+      native_histogram_bucket_limit = 0
+      native_histogram_min_bucket_factor = 0
     }
     forward_to = argument.metrics_destinations.value
   } // prometheus.operator.podmonitors "pod_monitors"
@@ -25,7 +29,11 @@ declare "prometheus_operator_objects" {
     scrape {
       default_scrape_interval = "60s"
       default_scrape_timeout = "10s"
+      scrape_classic_histograms = false
       scrape_native_histograms = false
+      convert_classic_histograms_to_nhcb = false
+      native_histogram_bucket_limit = 0
+      native_histogram_min_bucket_factor = 0
     }
     forward_to = argument.metrics_destinations.value
   } // prometheus.operator.probes "probes"
@@ -39,7 +47,11 @@ declare "prometheus_operator_objects" {
     scrape {
       default_scrape_interval = "60s"
       default_scrape_timeout = "10s"
+      scrape_classic_histograms = false
       scrape_native_histograms = false
+      convert_classic_histograms_to_nhcb = false
+      native_histogram_bucket_limit = 0
+      native_histogram_min_bucket_factor = 0
     }
     forward_to = argument.metrics_destinations.value
   } // prometheus.operator.servicemonitors "service_monitors"

--- a/charts/k8s-monitoring/docs/examples/auth/embedded-secrets/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/auth/embedded-secrets/output.yaml
@@ -270,7 +270,11 @@ data:
         scrape {
           default_scrape_interval = "60s"
           default_scrape_timeout = "10s"
+          scrape_classic_histograms = false
           scrape_native_histograms = false
+          convert_classic_histograms_to_nhcb = false
+          native_histogram_bucket_limit = 0
+          native_histogram_min_bucket_factor = 0
         }
         forward_to = argument.metrics_destinations.value
       } // prometheus.operator.podmonitors "pod_monitors"
@@ -283,7 +287,11 @@ data:
         scrape {
           default_scrape_interval = "60s"
           default_scrape_timeout = "10s"
+          scrape_classic_histograms = false
           scrape_native_histograms = false
+          convert_classic_histograms_to_nhcb = false
+          native_histogram_bucket_limit = 0
+          native_histogram_min_bucket_factor = 0
         }
         forward_to = argument.metrics_destinations.value
       } // prometheus.operator.probes "probes"
@@ -297,7 +305,11 @@ data:
         scrape {
           default_scrape_interval = "60s"
           default_scrape_timeout = "10s"
+          scrape_classic_histograms = false
           scrape_native_histograms = false
+          convert_classic_histograms_to_nhcb = false
+          native_histogram_bucket_limit = 0
+          native_histogram_min_bucket_factor = 0
         }
         forward_to = argument.metrics_destinations.value
       } // prometheus.operator.servicemonitors "service_monitors"

--- a/charts/k8s-monitoring/docs/examples/auth/external-secrets/alloy-metrics.alloy
+++ b/charts/k8s-monitoring/docs/examples/auth/external-secrets/alloy-metrics.alloy
@@ -12,7 +12,11 @@ declare "prometheus_operator_objects" {
     scrape {
       default_scrape_interval = "60s"
       default_scrape_timeout = "10s"
+      scrape_classic_histograms = false
       scrape_native_histograms = false
+      convert_classic_histograms_to_nhcb = false
+      native_histogram_bucket_limit = 0
+      native_histogram_min_bucket_factor = 0
     }
     forward_to = argument.metrics_destinations.value
   } // prometheus.operator.podmonitors "pod_monitors"
@@ -25,7 +29,11 @@ declare "prometheus_operator_objects" {
     scrape {
       default_scrape_interval = "60s"
       default_scrape_timeout = "10s"
+      scrape_classic_histograms = false
       scrape_native_histograms = false
+      convert_classic_histograms_to_nhcb = false
+      native_histogram_bucket_limit = 0
+      native_histogram_min_bucket_factor = 0
     }
     forward_to = argument.metrics_destinations.value
   } // prometheus.operator.probes "probes"
@@ -39,7 +47,11 @@ declare "prometheus_operator_objects" {
     scrape {
       default_scrape_interval = "60s"
       default_scrape_timeout = "10s"
+      scrape_classic_histograms = false
       scrape_native_histograms = false
+      convert_classic_histograms_to_nhcb = false
+      native_histogram_bucket_limit = 0
+      native_histogram_min_bucket_factor = 0
     }
     forward_to = argument.metrics_destinations.value
   } // prometheus.operator.servicemonitors "service_monitors"

--- a/charts/k8s-monitoring/docs/examples/auth/external-secrets/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/auth/external-secrets/output.yaml
@@ -282,7 +282,11 @@ data:
         scrape {
           default_scrape_interval = "60s"
           default_scrape_timeout = "10s"
+          scrape_classic_histograms = false
           scrape_native_histograms = false
+          convert_classic_histograms_to_nhcb = false
+          native_histogram_bucket_limit = 0
+          native_histogram_min_bucket_factor = 0
         }
         forward_to = argument.metrics_destinations.value
       } // prometheus.operator.podmonitors "pod_monitors"
@@ -295,7 +299,11 @@ data:
         scrape {
           default_scrape_interval = "60s"
           default_scrape_timeout = "10s"
+          scrape_classic_histograms = false
           scrape_native_histograms = false
+          convert_classic_histograms_to_nhcb = false
+          native_histogram_bucket_limit = 0
+          native_histogram_min_bucket_factor = 0
         }
         forward_to = argument.metrics_destinations.value
       } // prometheus.operator.probes "probes"
@@ -309,7 +317,11 @@ data:
         scrape {
           default_scrape_interval = "60s"
           default_scrape_timeout = "10s"
+          scrape_classic_histograms = false
           scrape_native_histograms = false
+          convert_classic_histograms_to_nhcb = false
+          native_histogram_bucket_limit = 0
+          native_histogram_min_bucket_factor = 0
         }
         forward_to = argument.metrics_destinations.value
       } // prometheus.operator.servicemonitors "service_monitors"

--- a/charts/k8s-monitoring/docs/examples/auth/oauth2/alloy-metrics.alloy
+++ b/charts/k8s-monitoring/docs/examples/auth/oauth2/alloy-metrics.alloy
@@ -863,7 +863,11 @@ declare "prometheus_operator_objects" {
     scrape {
       default_scrape_interval = "60s"
       default_scrape_timeout = "10s"
+      scrape_classic_histograms = false
       scrape_native_histograms = false
+      convert_classic_histograms_to_nhcb = false
+      native_histogram_bucket_limit = 0
+      native_histogram_min_bucket_factor = 0
     }
     forward_to = argument.metrics_destinations.value
   } // prometheus.operator.podmonitors "pod_monitors"
@@ -876,7 +880,11 @@ declare "prometheus_operator_objects" {
     scrape {
       default_scrape_interval = "60s"
       default_scrape_timeout = "10s"
+      scrape_classic_histograms = false
       scrape_native_histograms = false
+      convert_classic_histograms_to_nhcb = false
+      native_histogram_bucket_limit = 0
+      native_histogram_min_bucket_factor = 0
     }
     forward_to = argument.metrics_destinations.value
   } // prometheus.operator.probes "probes"
@@ -890,7 +898,11 @@ declare "prometheus_operator_objects" {
     scrape {
       default_scrape_interval = "60s"
       default_scrape_timeout = "10s"
+      scrape_classic_histograms = false
       scrape_native_histograms = false
+      convert_classic_histograms_to_nhcb = false
+      native_histogram_bucket_limit = 0
+      native_histogram_min_bucket_factor = 0
     }
     forward_to = argument.metrics_destinations.value
   } // prometheus.operator.servicemonitors "service_monitors"

--- a/charts/k8s-monitoring/docs/examples/auth/oauth2/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/auth/oauth2/output.yaml
@@ -1618,7 +1618,11 @@ data:
         scrape {
           default_scrape_interval = "60s"
           default_scrape_timeout = "10s"
+          scrape_classic_histograms = false
           scrape_native_histograms = false
+          convert_classic_histograms_to_nhcb = false
+          native_histogram_bucket_limit = 0
+          native_histogram_min_bucket_factor = 0
         }
         forward_to = argument.metrics_destinations.value
       } // prometheus.operator.podmonitors "pod_monitors"
@@ -1631,7 +1635,11 @@ data:
         scrape {
           default_scrape_interval = "60s"
           default_scrape_timeout = "10s"
+          scrape_classic_histograms = false
           scrape_native_histograms = false
+          convert_classic_histograms_to_nhcb = false
+          native_histogram_bucket_limit = 0
+          native_histogram_min_bucket_factor = 0
         }
         forward_to = argument.metrics_destinations.value
       } // prometheus.operator.probes "probes"
@@ -1645,7 +1653,11 @@ data:
         scrape {
           default_scrape_interval = "60s"
           default_scrape_timeout = "10s"
+          scrape_classic_histograms = false
           scrape_native_histograms = false
+          convert_classic_histograms_to_nhcb = false
+          native_histogram_bucket_limit = 0
+          native_histogram_min_bucket_factor = 0
         }
         forward_to = argument.metrics_destinations.value
       } // prometheus.operator.servicemonitors "service_monitors"

--- a/charts/k8s-monitoring/docs/examples/exclude-by-namespace/alloy-metrics.alloy
+++ b/charts/k8s-monitoring/docs/examples/exclude-by-namespace/alloy-metrics.alloy
@@ -862,7 +862,11 @@ declare "prometheus_operator_objects" {
     scrape {
       default_scrape_interval = "60s"
       default_scrape_timeout = "10s"
+      scrape_classic_histograms = false
       scrape_native_histograms = false
+      convert_classic_histograms_to_nhcb = false
+      native_histogram_bucket_limit = 0
+      native_histogram_min_bucket_factor = 0
     }
     rule {
       source_labels = ["job"]
@@ -880,7 +884,11 @@ declare "prometheus_operator_objects" {
     scrape {
       default_scrape_interval = "60s"
       default_scrape_timeout = "10s"
+      scrape_classic_histograms = false
       scrape_native_histograms = false
+      convert_classic_histograms_to_nhcb = false
+      native_histogram_bucket_limit = 0
+      native_histogram_min_bucket_factor = 0
     }
     rule {
       source_labels = ["job"]
@@ -899,7 +907,11 @@ declare "prometheus_operator_objects" {
     scrape {
       default_scrape_interval = "60s"
       default_scrape_timeout = "10s"
+      scrape_classic_histograms = false
       scrape_native_histograms = false
+      convert_classic_histograms_to_nhcb = false
+      native_histogram_bucket_limit = 0
+      native_histogram_min_bucket_factor = 0
     }
     rule {
       source_labels = ["job"]

--- a/charts/k8s-monitoring/docs/examples/exclude-by-namespace/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/exclude-by-namespace/output.yaml
@@ -2301,7 +2301,11 @@ data:
         scrape {
           default_scrape_interval = "60s"
           default_scrape_timeout = "10s"
+          scrape_classic_histograms = false
           scrape_native_histograms = false
+          convert_classic_histograms_to_nhcb = false
+          native_histogram_bucket_limit = 0
+          native_histogram_min_bucket_factor = 0
         }
         rule {
           source_labels = ["job"]
@@ -2319,7 +2323,11 @@ data:
         scrape {
           default_scrape_interval = "60s"
           default_scrape_timeout = "10s"
+          scrape_classic_histograms = false
           scrape_native_histograms = false
+          convert_classic_histograms_to_nhcb = false
+          native_histogram_bucket_limit = 0
+          native_histogram_min_bucket_factor = 0
         }
         rule {
           source_labels = ["job"]
@@ -2338,7 +2346,11 @@ data:
         scrape {
           default_scrape_interval = "60s"
           default_scrape_timeout = "10s"
+          scrape_classic_histograms = false
           scrape_native_histograms = false
+          convert_classic_histograms_to_nhcb = false
+          native_histogram_bucket_limit = 0
+          native_histogram_min_bucket_factor = 0
         }
         rule {
           source_labels = ["job"]

--- a/charts/k8s-monitoring/docs/examples/features/prometheus-operator-objects/default/alloy-metrics.alloy
+++ b/charts/k8s-monitoring/docs/examples/features/prometheus-operator-objects/default/alloy-metrics.alloy
@@ -17,7 +17,11 @@ declare "prometheus_operator_objects" {
     scrape {
       default_scrape_interval = "60s"
       default_scrape_timeout = "10s"
+      scrape_classic_histograms = false
       scrape_native_histograms = false
+      convert_classic_histograms_to_nhcb = false
+      native_histogram_bucket_limit = 0
+      native_histogram_min_bucket_factor = 0
     }
     forward_to = argument.metrics_destinations.value
   } // prometheus.operator.podmonitors "pod_monitors"
@@ -30,7 +34,11 @@ declare "prometheus_operator_objects" {
     scrape {
       default_scrape_interval = "60s"
       default_scrape_timeout = "10s"
+      scrape_classic_histograms = false
       scrape_native_histograms = false
+      convert_classic_histograms_to_nhcb = false
+      native_histogram_bucket_limit = 0
+      native_histogram_min_bucket_factor = 0
     }
     forward_to = argument.metrics_destinations.value
   } // prometheus.operator.probes "probes"
@@ -57,7 +65,11 @@ declare "prometheus_operator_objects" {
     scrape {
       default_scrape_interval = "60s"
       default_scrape_timeout = "10s"
+      scrape_classic_histograms = false
       scrape_native_histograms = false
+      convert_classic_histograms_to_nhcb = false
+      native_histogram_bucket_limit = 0
+      native_histogram_min_bucket_factor = 0
     }
     forward_to = argument.metrics_destinations.value
   } // prometheus.operator.servicemonitors "service_monitors"

--- a/charts/k8s-monitoring/docs/examples/features/prometheus-operator-objects/default/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/features/prometheus-operator-objects/default/output.yaml
@@ -40,7 +40,11 @@ data:
         scrape {
           default_scrape_interval = "60s"
           default_scrape_timeout = "10s"
+          scrape_classic_histograms = false
           scrape_native_histograms = false
+          convert_classic_histograms_to_nhcb = false
+          native_histogram_bucket_limit = 0
+          native_histogram_min_bucket_factor = 0
         }
         forward_to = argument.metrics_destinations.value
       } // prometheus.operator.podmonitors "pod_monitors"
@@ -53,7 +57,11 @@ data:
         scrape {
           default_scrape_interval = "60s"
           default_scrape_timeout = "10s"
+          scrape_classic_histograms = false
           scrape_native_histograms = false
+          convert_classic_histograms_to_nhcb = false
+          native_histogram_bucket_limit = 0
+          native_histogram_min_bucket_factor = 0
         }
         forward_to = argument.metrics_destinations.value
       } // prometheus.operator.probes "probes"
@@ -80,7 +88,11 @@ data:
         scrape {
           default_scrape_interval = "60s"
           default_scrape_timeout = "10s"
+          scrape_classic_histograms = false
           scrape_native_histograms = false
+          convert_classic_histograms_to_nhcb = false
+          native_histogram_bucket_limit = 0
+          native_histogram_min_bucket_factor = 0
         }
         forward_to = argument.metrics_destinations.value
       } // prometheus.operator.servicemonitors "service_monitors"

--- a/charts/k8s-monitoring/docs/examples/include-by-namespace/alloy-metrics.alloy
+++ b/charts/k8s-monitoring/docs/examples/include-by-namespace/alloy-metrics.alloy
@@ -936,7 +936,11 @@ declare "prometheus_operator_objects" {
     scrape {
       default_scrape_interval = "60s"
       default_scrape_timeout = "10s"
+      scrape_classic_histograms = false
       scrape_native_histograms = false
+      convert_classic_histograms_to_nhcb = false
+      native_histogram_bucket_limit = 0
+      native_histogram_min_bucket_factor = 0
     }
     forward_to = argument.metrics_destinations.value
   } // prometheus.operator.podmonitors "pod_monitors"
@@ -950,7 +954,11 @@ declare "prometheus_operator_objects" {
     scrape {
       default_scrape_interval = "60s"
       default_scrape_timeout = "10s"
+      scrape_classic_histograms = false
       scrape_native_histograms = false
+      convert_classic_histograms_to_nhcb = false
+      native_histogram_bucket_limit = 0
+      native_histogram_min_bucket_factor = 0
     }
     forward_to = argument.metrics_destinations.value
   } // prometheus.operator.probes "probes"
@@ -965,7 +973,11 @@ declare "prometheus_operator_objects" {
     scrape {
       default_scrape_interval = "60s"
       default_scrape_timeout = "10s"
+      scrape_classic_histograms = false
       scrape_native_histograms = false
+      convert_classic_histograms_to_nhcb = false
+      native_histogram_bucket_limit = 0
+      native_histogram_min_bucket_factor = 0
     }
     forward_to = argument.metrics_destinations.value
   } // prometheus.operator.servicemonitors "service_monitors"

--- a/charts/k8s-monitoring/docs/examples/include-by-namespace/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/include-by-namespace/output.yaml
@@ -1307,7 +1307,11 @@ data:
         scrape {
           default_scrape_interval = "60s"
           default_scrape_timeout = "10s"
+          scrape_classic_histograms = false
           scrape_native_histograms = false
+          convert_classic_histograms_to_nhcb = false
+          native_histogram_bucket_limit = 0
+          native_histogram_min_bucket_factor = 0
         }
         forward_to = argument.metrics_destinations.value
       } // prometheus.operator.podmonitors "pod_monitors"
@@ -1321,7 +1325,11 @@ data:
         scrape {
           default_scrape_interval = "60s"
           default_scrape_timeout = "10s"
+          scrape_classic_histograms = false
           scrape_native_histograms = false
+          convert_classic_histograms_to_nhcb = false
+          native_histogram_bucket_limit = 0
+          native_histogram_min_bucket_factor = 0
         }
         forward_to = argument.metrics_destinations.value
       } // prometheus.operator.probes "probes"
@@ -1336,7 +1344,11 @@ data:
         scrape {
           default_scrape_interval = "60s"
           default_scrape_timeout = "10s"
+          scrape_classic_histograms = false
           scrape_native_histograms = false
+          convert_classic_histograms_to_nhcb = false
+          native_histogram_bucket_limit = 0
+          native_histogram_min_bucket_factor = 0
         }
         forward_to = argument.metrics_destinations.value
       } // prometheus.operator.servicemonitors "service_monitors"

--- a/charts/k8s-monitoring/tests/integration/prometheus-operator-objects/.rendered/alloy-metrics.alloy
+++ b/charts/k8s-monitoring/tests/integration/prometheus-operator-objects/.rendered/alloy-metrics.alloy
@@ -12,7 +12,11 @@ declare "prometheus_operator_objects" {
     scrape {
       default_scrape_interval = "60s"
       default_scrape_timeout = "10s"
+      scrape_classic_histograms = false
       scrape_native_histograms = false
+      convert_classic_histograms_to_nhcb = false
+      native_histogram_bucket_limit = 0
+      native_histogram_min_bucket_factor = 0
     }
     rule {
       source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
@@ -30,7 +34,11 @@ declare "prometheus_operator_objects" {
     scrape {
       default_scrape_interval = "60s"
       default_scrape_timeout = "10s"
+      scrape_classic_histograms = false
       scrape_native_histograms = false
+      convert_classic_histograms_to_nhcb = false
+      native_histogram_bucket_limit = 0
+      native_histogram_min_bucket_factor = 0
     }
     forward_to = argument.metrics_destinations.value
   } // prometheus.operator.probes "probes"
@@ -62,7 +70,11 @@ declare "prometheus_operator_objects" {
     scrape {
       default_scrape_interval = "60s"
       default_scrape_timeout = "10s"
+      scrape_classic_histograms = false
       scrape_native_histograms = false
+      convert_classic_histograms_to_nhcb = false
+      native_histogram_bucket_limit = 0
+      native_histogram_min_bucket_factor = 0
     }
     rule {
       source_labels = ["job"]

--- a/charts/k8s-monitoring/tests/integration/prometheus-operator-objects/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/integration/prometheus-operator-objects/.rendered/output.yaml
@@ -35,7 +35,11 @@ data:
         scrape {
           default_scrape_interval = "60s"
           default_scrape_timeout = "10s"
+          scrape_classic_histograms = false
           scrape_native_histograms = false
+          convert_classic_histograms_to_nhcb = false
+          native_histogram_bucket_limit = 0
+          native_histogram_min_bucket_factor = 0
         }
         rule {
           source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
@@ -53,7 +57,11 @@ data:
         scrape {
           default_scrape_interval = "60s"
           default_scrape_timeout = "10s"
+          scrape_classic_histograms = false
           scrape_native_histograms = false
+          convert_classic_histograms_to_nhcb = false
+          native_histogram_bucket_limit = 0
+          native_histogram_min_bucket_factor = 0
         }
         forward_to = argument.metrics_destinations.value
       } // prometheus.operator.probes "probes"
@@ -85,7 +93,11 @@ data:
         scrape {
           default_scrape_interval = "60s"
           default_scrape_timeout = "10s"
+          scrape_classic_histograms = false
           scrape_native_histograms = false
+          convert_classic_histograms_to_nhcb = false
+          native_histogram_bucket_limit = 0
+          native_histogram_min_bucket_factor = 0
         }
         rule {
           source_labels = ["job"]

--- a/charts/k8s-monitoring/values.schema.json
+++ b/charts/k8s-monitoring/values.schema.json
@@ -349,6 +349,12 @@
                 "namespaceOverride": {
                     "type": "string"
                 },
+                "nativeHistogramBucketLimit": {
+                    "type": "integer"
+                },
+                "nativeHistogramMinBucketFactor": {
+                    "type": "number"
+                },
                 "platform": {
                     "type": "string",
                     "enum": [

--- a/charts/k8s-monitoring/values.yaml
+++ b/charts/k8s-monitoring/values.yaml
@@ -52,6 +52,16 @@ global:
   # @section -- Global Settings
   convertClassicHistogramsToNhcb: false
 
+  # -- If a native histogram has more buckets than this, buckets will be merged to stay within the limit.
+  # Disabled when set to zero.
+  # @section -- Global Settings
+  nativeHistogramBucketLimit: 0
+
+  # -- If the growth factor from one native histogram bucket to the next is smaller than this, buckets will be
+  # merged. Disabled when set to zero.
+  # @section -- Global Settings
+  nativeHistogramMinBucketFactor: 0.0
+
   # -- Sets the max_cache_size for every prometheus.relabel component. ([docs](https://grafana.com/docs/alloy/latest/reference/components/prometheus/prometheus.relabel/#arguments))
   # This should be at least 2x-5x your largest scrape target or samples appended rate.
   # @section -- Global Settings


### PR DESCRIPTION
Adds the native histogram scrape options introduced in grafana/alloy#6406 (scrape_classic_histograms, convert_classic_histograms_to_nhcb, native_histogram_bucket_limit, native_histogram_min_bucket_factor) to all Prometheus Operator object types (PodMonitors, Probes, ServiceMonitors), so native histogram behavior is consistent with the other metrics features.

Adds global.nativeHistogramBucketLimit and global.nativeHistogramMinBucketFactor values.

Depends on: https://github.com/grafana/alloy/pull/6406