### PR TITLE
Fix cost-metrics feature README

### DIFF
--- a/charts/k8s-monitoring/charts/feature-cost-metrics/README.md
+++ b/charts/k8s-monitoring/charts/feature-cost-metrics/README.md
@@ -3,47 +3,51 @@
 (      To make changes, please modify README.md.gotmpl and run `helm-docs`)
 -->
 
-# Feature: Cluster Metrics
+# Feature: Cost Metrics
 
-This chart deploys the Cluster Metrics feature of the Kubernetes Monitoring Helm Chart, which uses allow
-lists to limit the metrics needed. An allow list is a set of metric names that will be kept, while any metrics
-not on the list will be dropped. With [metrics tuning](#metrics-tuning--allow-lists), you can further customize which metrics are collected.
+This chart deploys the Cost Metrics feature of the Kubernetes Monitoring Helm Chart. It gathers cost metrics for the
+Kubernetes cluster and the objects running inside it from [OpenCost](https://www.opencost.io/), and uses an allow list
+to limit the metrics needed. An allow list is a set of metric names that will be kept, while any metrics not on the list
+will be dropped. With [metrics tuning](#metrics-tuning--allow-lists), you can further customize which metrics are collected.
 
 ## Usage
 
 ```yaml
-clusterMetrics:
+costMetrics:
   enabled: true
 ```
 
+This feature scrapes metrics from an OpenCost instance, but does not deploy OpenCost itself. The simplest way to deploy
+OpenCost alongside this feature is to use the `telemetryServices` section of the parent chart, which also wires up the
+required metrics source for you:
+
+```yaml
+costMetrics:
+  enabled: true
+
+telemetryServices:
+  opencost:
+    deploy: true
+    metricsSource: <destination name>  # The metric destination OpenCost queries for required metrics
+```
+
+If you are deploying OpenCost some other way, set `costMetrics.opencost.labelMatchers` and `costMetrics.opencost.namespace`
+so the feature can discover the OpenCost pods to scrape.
+
 ## How it works
 
-This chart includes the ability to collect metrics from the following:
-
-*   The Kubernetes cluster itself
-*   Sources like the Kubelet and cAdvisor
-*   Common supporting services like [kube-state-metrics](https://github.com/kubernetes/kube-state-metrics) and
-    [Node Exporter](https://github.com/prometheus/node_exporter)
-*   Systems to capture additional data like Kepler
+This chart scrapes cost metrics from [OpenCost](https://www.opencost.io/). OpenCost monitors the cost of the Kubernetes
+cluster and the objects running inside it, and exposes those costs as Prometheus metrics. This feature discovers the
+OpenCost pods, scrapes their metrics, and applies an allow list to limit the metrics delivered to your destinations.
 
 ### Metrics sources
 
-The Cluster Metrics feature of the Kubernetes Monitoring Helm Chart includes the following metric systems and
-their default allow lists:
+The Cost Metrics feature of the Kubernetes Monitoring Helm Chart includes the following metric system and its default
+allow list:
 
-| Metric source                                                                | Gathers information about                                                                    | Allow list                                                                                                                                                                                     |
-|------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| API Server                                                                   | Kubernetes API Server                                                                        | NA                                                                                                                                                                                             |
-| [cAdvisor](https://github.com/google/cadvisor)                               | Containers on each node                                                                      | [default-allow-lists/cadvisor.yaml](./default-allow-lists/cadvisor.yaml)                                                                                                                       |
-| [Kepler](https://sustainable-computing.io/)                                  | Kubernetes cluster                                                                           | [default-allow-lists/kepler.yaml](./default-allow-lists/kepler.yaml)                                                                                                                           |
-| Kube Controller Manager                                                      | Kubernetes Controller Manager                                                                | NA                                                                                                                                                                                             |
-| Kube Proxy                                                                   | Kube Proxy                                                                                   | NA                                                                                                                                                                                             |
-| Kube Scheduler                                                               | Kube Scheduler                                                                               | NA                                                                                                                                                                                             |
-| Kubelet                                                                      | Kubernetes information on each node                                                          | [default-allow-lists/kubelet.yaml](./default-allow-lists/kubelet.yaml)                                                                                                                         |
-| [kube-state-metrics](https://github.com/kubernetes/kube-state-metrics)       | Kubernetes                                                                                   |                                                                                                                                                                                                |
-| resources inside the cluster                                                 | [default-allow-lists/kube-state-metrics.yaml](./default-allow-lists/kube-state-metrics.yaml) |                                                                                                                                                                                                |
-| [Node Exporter](https://github.com/prometheus/node_exporter)                 | Linux Kubernetes nodes                                                                       | [default-allow-lists/node-exporter.yaml](./default-allow-lists/node-exporter.yaml), [default-allow-lists/node-exporter-integration.yaml](./default-allow-lists/node-exporter-integration.yaml) |
-| [Windows Exporter](https://github.com/prometheus-community/windows_exporter) | Windows Kubernetes nodes                                                                     | [default-allow-lists/windows-exporter.yaml](./default-allow-lists/windows-exporter.yaml)                                                                                                       |
+| Metric source                            | Gathers information about                                          | Allow list                                                              |
+|------------------------------------------|-------------------------------------------------------------------|-------------------------------------------------------------------------|
+| [OpenCost](https://www.opencost.io/)     | The cost of the Kubernetes cluster and the objects running inside | [default-allow-lists/opencost.yaml](./default-allow-lists/opencost.yaml) |
 
 ## Metrics tuning and allow lists
 

--- a/charts/k8s-monitoring/charts/feature-cost-metrics/README.md.gotmpl
+++ b/charts/k8s-monitoring/charts/feature-cost-metrics/README.md.gotmpl
@@ -3,49 +3,53 @@
 (      To make changes, please modify README.md.gotmpl and run `helm-docs`)
 -->
 
-# Feature: Cluster Metrics
+# Feature: Cost Metrics
 
 {{ template "chart.deprecationWarning" . }}
 
-This chart deploys the Cluster Metrics feature of the Kubernetes Monitoring Helm Chart, which uses allow
-lists to limit the metrics needed. An allow list is a set of metric names that will be kept, while any metrics
-not on the list will be dropped. With [metrics tuning](#metrics-tuning--allow-lists), you can further customize which metrics are collected.
+This chart deploys the Cost Metrics feature of the Kubernetes Monitoring Helm Chart. It gathers cost metrics for the
+Kubernetes cluster and the objects running inside it from [OpenCost](https://www.opencost.io/), and uses an allow list
+to limit the metrics needed. An allow list is a set of metric names that will be kept, while any metrics not on the list
+will be dropped. With [metrics tuning](#metrics-tuning--allow-lists), you can further customize which metrics are collected.
 
 ## Usage
 
 ```yaml
-clusterMetrics:
+costMetrics:
   enabled: true
 ```
 
+This feature scrapes metrics from an OpenCost instance, but does not deploy OpenCost itself. The simplest way to deploy
+OpenCost alongside this feature is to use the `telemetryServices` section of the parent chart, which also wires up the
+required metrics source for you:
+
+```yaml
+costMetrics:
+  enabled: true
+
+telemetryServices:
+  opencost:
+    deploy: true
+    metricsSource: <destination name>  # The metric destination OpenCost queries for required metrics
+```
+
+If you are deploying OpenCost some other way, set `costMetrics.opencost.labelMatchers` and `costMetrics.opencost.namespace`
+so the feature can discover the OpenCost pods to scrape.
+
 ## How it works
 
-This chart includes the ability to collect metrics from the following:
-
-*   The Kubernetes cluster itself
-*   Sources like the Kubelet and cAdvisor
-*   Common supporting services like [kube-state-metrics](https://github.com/kubernetes/kube-state-metrics) and
-    [Node Exporter](https://github.com/prometheus/node_exporter)
-*   Systems to capture additional data like Kepler
+This chart scrapes cost metrics from [OpenCost](https://www.opencost.io/). OpenCost monitors the cost of the Kubernetes
+cluster and the objects running inside it, and exposes those costs as Prometheus metrics. This feature discovers the
+OpenCost pods, scrapes their metrics, and applies an allow list to limit the metrics delivered to your destinations.
 
 ### Metrics sources
 
-The Cluster Metrics feature of the Kubernetes Monitoring Helm Chart includes the following metric systems and
-their default allow lists:
+The Cost Metrics feature of the Kubernetes Monitoring Helm Chart includes the following metric system and its default
+allow list:
 
-| Metric source                                                                | Gathers information about                                                                    | Allow list                                                                                                                                                                                     |
-|------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| API Server                                                                   | Kubernetes API Server                                                                        | NA                                                                                                                                                                                             |
-| [cAdvisor](https://github.com/google/cadvisor)                               | Containers on each node                                                                      | [default-allow-lists/cadvisor.yaml](./default-allow-lists/cadvisor.yaml)                                                                                                                       |
-| [Kepler](https://sustainable-computing.io/)                                  | Kubernetes cluster                                                                           | [default-allow-lists/kepler.yaml](./default-allow-lists/kepler.yaml)                                                                                                                           |
-| Kube Controller Manager                                                      | Kubernetes Controller Manager                                                                | NA                                                                                                                                                                                             |
-| Kube Proxy                                                                   | Kube Proxy                                                                                   | NA                                                                                                                                                                                             |
-| Kube Scheduler                                                               | Kube Scheduler                                                                               | NA                                                                                                                                                                                             |
-| Kubelet                                                                      | Kubernetes information on each node                                                          | [default-allow-lists/kubelet.yaml](./default-allow-lists/kubelet.yaml)                                                                                                                         |
-| [kube-state-metrics](https://github.com/kubernetes/kube-state-metrics)       | Kubernetes                                                                                   |                                                                                                                                                                                                |
-| resources inside the cluster                                                 | [default-allow-lists/kube-state-metrics.yaml](./default-allow-lists/kube-state-metrics.yaml) |                                                                                                                                                                                                |
-| [Node Exporter](https://github.com/prometheus/node_exporter)                 | Linux Kubernetes nodes                                                                       | [default-allow-lists/node-exporter.yaml](./default-allow-lists/node-exporter.yaml), [default-allow-lists/node-exporter-integration.yaml](./default-allow-lists/node-exporter-integration.yaml) |
-| [Windows Exporter](https://github.com/prometheus-community/windows_exporter) | Windows Kubernetes nodes                                                                     | [default-allow-lists/windows-exporter.yaml](./default-allow-lists/windows-exporter.yaml)                                                                                                       |
+| Metric source                            | Gathers information about                                          | Allow list                                                              |
+|------------------------------------------|-------------------------------------------------------------------|-------------------------------------------------------------------------|
+| [OpenCost](https://www.opencost.io/)     | The cost of the Kubernetes cluster and the objects running inside | [default-allow-lists/opencost.yaml](./default-allow-lists/opencost.yaml) |
 
 ## Metrics tuning and allow lists
 
@@ -78,7 +82,7 @@ The behavior of the combination of these settings is shown in this table:
 ## Relabeling rules
 
 You can also use relabeling rules to take any action on the metrics allow list, such as to filter based on a label.
-To do so, use `extraMetricProcessingRules` section in the values file to add arbitrary relabeling rules. 
+To do so, use `extraMetricProcessingRules` section in the values file to add arbitrary relabeling rules.
 
 ## Testing
 


### PR DESCRIPTION
The `feature-cost-metrics` README was a copy of the cluster-metrics README. Rewrote it to document the Cost Metrics (OpenCost) feature and regenerated `README.md`.

Fixes #2563