### PR TITLE
Use an emptyDir volume mount for OpenCost config

### DIFF
--- a/charts/k8s-monitoring/CHANGELOG.md
+++ b/charts/k8s-monitoring/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+*   Fix OpenCost failing to deploy with `duplicate entries for key [name="CONFIG_PATH"]` when `customPricing` is enabled. The GKE GCP-provider workaround no longer sets `CONFIG_PATH` via `extraEnv` (which collided with the `CONFIG_PATH` the OpenCost chart sets for custom pricing); instead it mounts a writable `emptyDir` at OpenCost's default config path (`/var/configs`). (#2692) (@petewall)
 *   Require `labelMatchers` (rather than accepting a `namespace` alone) when connecting Cluster Metrics (kube-state-metrics), Host Metrics (Node Exporter, Windows Exporter, Kepler), or Cost Metrics (OpenCost) to an existing service that is not deployed via `telemetryServices`. Previously a namespace-only configuration rendered an empty `label = ""` selector that matched every pod in the namespace. (@petewall)
 *   Add a best-effort validator that uses Helm `lookup` to confirm the configured `labelMatchers` actually select running pods in the specified `namespace` for an existing kube-state-metrics, Node Exporter, Windows Exporter, Kepler, or OpenCost. The check is skipped during `helm template`/`--dry-run` (no cluster connection) and only runs when a namespace is set. (@petewall)
 *   Add a best-effort validator that checks (via Helm `lookup`) for an existing Node Exporter using the same port when deploying the bundled `telemetryServices.node-exporter`. If a port conflict is detected, the install fails with guidance to either skip the deployment and point Host Metrics at the existing Node Exporter, or deploy on a unique port. (@petewall)

--- a/charts/k8s-monitoring/charts/telemetry-services/README.md
+++ b/charts/k8s-monitoring/charts/telemetry-services/README.md
@@ -55,6 +55,7 @@ telemetryServices:
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | k8s-manifest-tail.deploy | bool | `false` | Deploy k8s-manifest-tail to watch and log Kubernetes manifest changes. |
+| k8s-manifest-tail.extraEnv | list | `[]` | Extra environment variables, required for setting the OTLP destination for the manifests. |
 
 ### Kepler
 
@@ -81,6 +82,7 @@ telemetryServices:
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | opencost.deploy | bool | `false` | Deploy OpenCost. |
+| opencost.extraVolumes | list | `[{"emptyDir":{},"name":"configs"}]` | On GCP/GKE, OpenCost's GCP provider writes ${CONFIG_PATH}/gcp.json on startup. CONFIG_PATH defaults to /var/configs, which is not writable by the non-root container user, causing the pod to panic. Mount an emptyDir there so the default path is writable. This is preferred over setting CONFIG_PATH via extraEnv, which collides with the CONFIG_PATH the OpenCost chart sets when customPricing is enabled (duplicate env var). The upstream chart only mounts at /var/configs when cloud integration is enabled, so this does not conflict by default. |
 | opencost.metricsSource | string | `""` | The name of the metric destination where OpenCost will query for required metrics. Setting this will enable guided setup for required OpenCost parameters. To skip guided setup, set this to "custom". |
 | opencost.opencost.prometheus.existingSecretName | string | `""` | The name of the secret containing the username and password for the metrics service. This must be in the same namespace as the OpenCost deployment. |
 | opencost.opencost.prometheus.external.url | string | `""` | The URL for Prometheus queries. It should match externalServices.prometheus.host + "/api/prom" |
@@ -92,9 +94,3 @@ telemetryServices:
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | windows-exporter.deploy | bool | `true` | Deploy Windows Exporter. Set to false if your cluster already has Windows Exporter deployed. |
-
-### Other Values
-
-| Key | Type | Default | Description |
-|-----|------|---------|-------------|
-| k8s-manifest-tail.extraEnv | list | `[]` | Extra environment variables, required for setting the OTLP destination for the manifests. @secton -- k8s-manifest-tail |

--- a/charts/k8s-monitoring/charts/telemetry-services/templates/_validate.tpl
+++ b/charts/k8s-monitoring/charts/telemetry-services/templates/_validate.tpl
@@ -79,6 +79,35 @@ If a conflict is found, recommend either using the existing Node Exporter or dep
 {{- define "telemetryServices.validate.opencost" }}
 {{- if .Values.telemetryServices.opencost.deploy }}
   {{- $featureDestinations := include "features.costMetrics.destinations" . | fromYamlArray }}
+
+  {{/*
+  The chart mounts an emptyDir at /var/configs (OpenCost's default CONFIG_PATH) so the GCP provider
+  can write gcp.json on GKE. When cloud integration is enabled, the OpenCost chart already mounts its
+  own writable volume at /var/configs, so our extra mount collides (duplicate mountPath). In that case
+  the chart-managed volume is unnecessary and must be removed.
+  */}}
+  {{- $cloudIntegration := or (dig "opencost" "cloudIntegrationSecret" "" .Values.telemetryServices.opencost) (dig "opencost" "cloudIntegrationJSON" "" .Values.telemetryServices.opencost) }}
+  {{- if $cloudIntegration }}
+    {{- $varConfigsMount := false }}
+    {{- range $mount := (dig "opencost" "exporter" "extraVolumeMounts" (list) .Values.telemetryServices.opencost) }}
+      {{- if eq (dig "mountPath" "" $mount) "/var/configs" }}
+        {{- $varConfigsMount = true }}
+      {{- end }}
+    {{- end }}
+    {{- if $varConfigsMount }}
+      {{- $msg := list "" "OpenCost cloud integration is enabled, which mounts a writable volume at /var/configs." }}
+      {{- $msg = append $msg "This conflicts with the chart-managed /var/configs volume used to work around the GKE GCP provider." }}
+      {{- $msg = append $msg "Since cloud integration already makes /var/configs writable, remove the chart-managed volume:" }}
+      {{- $msg = append $msg "telemetryServices:" }}
+      {{- $msg = append $msg "  opencost:" }}
+      {{- $msg = append $msg "    extraVolumes: []" }}
+      {{- $msg = append $msg "    opencost:" }}
+      {{- $msg = append $msg "      exporter:" }}
+      {{- $msg = append $msg "        extraVolumeMounts: []" }}
+      {{- fail (join "\n" $msg) }}
+    {{- end }}
+  {{- end }}
+
   {{- if ne .Values.cluster.name .Values.telemetryServices.opencost.opencost.exporter.defaultClusterId }}
     {{- $msg := list "" "The OpenCost default cluster id should match the cluster name." }}
     {{- $msg = append $msg "Please set:" }}

--- a/charts/k8s-monitoring/charts/telemetry-services/values.schema.json
+++ b/charts/k8s-monitoring/charts/telemetry-services/values.schema.json
@@ -249,6 +249,20 @@
                 "deploy": {
                     "type": "boolean"
                 },
+                "extraVolumes": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "emptyDir": {
+                                "type": "object"
+                            },
+                            "name": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                },
                 "metricsSource": {
                     "type": "string"
                 },
@@ -283,14 +297,28 @@
                                         "CLOUD_PROVIDER_API_KEY": {
                                             "type": "string"
                                         },
-                                        "CONFIG_PATH": {
-                                            "type": "string"
-                                        },
                                         "CURRENT_CLUSTER_ID_FILTER_ENABLED": {
                                             "type": "string"
                                         },
                                         "PROM_CLUSTER_ID_LABEL": {
                                             "type": "string"
+                                        }
+                                    }
+                                },
+                                "extraVolumeMounts": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "object",
+                                        "properties": {
+                                            "mountPath": {
+                                                "type": "string"
+                                            },
+                                            "name": {
+                                                "type": "string"
+                                            },
+                                            "readOnly": {
+                                                "type": "boolean"
+                                            }
                                         }
                                     }
                                 }

--- a/charts/k8s-monitoring/charts/telemetry-services/values.yaml
+++ b/charts/k8s-monitoring/charts/telemetry-services/values.yaml
@@ -139,6 +139,17 @@ opencost:
   # @section -- OpenCost
   metricsSource: ""
 
+  # -- On GCP/GKE, OpenCost's GCP provider writes ${CONFIG_PATH}/gcp.json on startup. CONFIG_PATH
+  # defaults to /var/configs, which is not writable by the non-root container user, causing the
+  # pod to panic. Mount an emptyDir there so the default path is writable. This is preferred over
+  # setting CONFIG_PATH via extraEnv, which collides with the CONFIG_PATH the OpenCost chart sets
+  # when customPricing is enabled (duplicate env var). The upstream chart only mounts at
+  # /var/configs when cloud integration is enabled, so this does not conflict by default.
+  # @section -- OpenCost
+  extraVolumes:
+    - name: configs
+      emptyDir: {}
+
   opencost:
     # @ignored -- This skips including these values in README.md
     exporter:
@@ -147,16 +158,17 @@ opencost:
       defaultClusterId: "default-cluster"
 
       extraEnv:
-        # On GCP/GKE, OpenCost's GCP provider writes ${CONFIG_PATH}/gcp.json on startup. The
-        # default of /var/configs is not writable by the non-root container user, which causes
-        # the pod to panic. Point CONFIG_PATH at the always-writable /tmp instead.
-        CONFIG_PATH: /tmp
         # CLOUD_PROVIDER_API_KEY must be non-empty so OpenCost's NewProvider() does not refuse
         # to construct the GCP provider on GKE; the value itself is unused (pricing falls back
         # to defaults).
         CLOUD_PROVIDER_API_KEY: disabled
         CURRENT_CLUSTER_ID_FILTER_ENABLED: "true"
         PROM_CLUSTER_ID_LABEL: cluster
+
+      extraVolumeMounts:
+        - mountPath: /var/configs
+          name: configs
+          readOnly: false
 
     # @ignored -- This skips including these values in README.md
     carbonCost:
@@ -220,7 +232,7 @@ k8s-manifest-tail:
     logs.grafana.com/pods.enabled: "false"
 
   # -- Extra environment variables, required for setting the OTLP destination for the manifests.
-  # @secton -- k8s-manifest-tail
+  # @section -- k8s-manifest-tail
   extraEnv: []
   #  - name: OTEL_EXPORTER_OTLP_LOGS_ENDPOINT
   #    value: http://k8smon-alloy-receiver.default.svc:4317

--- a/charts/k8s-monitoring/docs/examples/features/cost-metrics/default/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/features/cost-metrics/default/output.yaml
@@ -1326,14 +1326,19 @@ spec:
             # Add any additional provided variables
             - name: CLOUD_PROVIDER_API_KEY
               value: "disabled"
-            - name: CONFIG_PATH
-              value: "/tmp"
             - name: CURRENT_CLUSTER_ID_FILTER_ENABLED
               value: "true"
             - name: PROM_CLUSTER_ID_LABEL
               value: "cluster"
             - name: MCP_SERVER_ENABLED
               value: "false"
+          volumeMounts:
+            - mountPath: /var/configs
+              name: configs
+              readOnly: false
+      volumes:
+        - emptyDir: {}
+          name: configs
 ---
 # Source: k8s-monitoring/templates/alloy.yaml
 apiVersion: collectors.grafana.com/v1alpha1

--- a/charts/k8s-monitoring/docs/examples/images/images-by-digest/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/images/images-by-digest/output.yaml
@@ -2737,14 +2737,19 @@ spec:
             # Add any additional provided variables
             - name: CLOUD_PROVIDER_API_KEY
               value: "disabled"
-            - name: CONFIG_PATH
-              value: "/tmp"
             - name: CURRENT_CLUSTER_ID_FILTER_ENABLED
               value: "true"
             - name: PROM_CLUSTER_ID_LABEL
               value: "cluster"
             - name: MCP_SERVER_ENABLED
               value: "false"
+          volumeMounts:
+            - mountPath: /var/configs
+              name: configs
+              readOnly: false
+      volumes:
+        - emptyDir: {}
+          name: configs
 ---
 # Source: k8s-monitoring/templates/alloy-sampler.yaml
 apiVersion: collectors.grafana.com/v1alpha1

--- a/charts/k8s-monitoring/docs/examples/name-overrides/fullname-overrides/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/name-overrides/fullname-overrides/output.yaml
@@ -1904,14 +1904,19 @@ spec:
             # Add any additional provided variables
             - name: CLOUD_PROVIDER_API_KEY
               value: "disabled"
-            - name: CONFIG_PATH
-              value: "/tmp"
             - name: CURRENT_CLUSTER_ID_FILTER_ENABLED
               value: "true"
             - name: PROM_CLUSTER_ID_LABEL
               value: "cluster"
             - name: MCP_SERVER_ENABLED
               value: "false"
+          volumeMounts:
+            - mountPath: /var/configs
+              name: configs
+              readOnly: false
+      volumes:
+        - emptyDir: {}
+          name: configs
 ---
 # Source: k8s-monitoring/templates/alloy.yaml
 apiVersion: collectors.grafana.com/v1alpha1

--- a/charts/k8s-monitoring/docs/examples/name-overrides/name-overrides/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/name-overrides/name-overrides/output.yaml
@@ -1762,14 +1762,19 @@ spec:
             # Add any additional provided variables
             - name: CLOUD_PROVIDER_API_KEY
               value: "disabled"
-            - name: CONFIG_PATH
-              value: "/tmp"
             - name: CURRENT_CLUSTER_ID_FILTER_ENABLED
               value: "true"
             - name: PROM_CLUSTER_ID_LABEL
               value: "cluster"
             - name: MCP_SERVER_ENABLED
               value: "false"
+          volumeMounts:
+            - mountPath: /var/configs
+              name: configs
+              readOnly: false
+      volumes:
+        - emptyDir: {}
+          name: configs
 ---
 # Source: k8s-monitoring/templates/alloy.yaml
 apiVersion: collectors.grafana.com/v1alpha1

--- a/charts/k8s-monitoring/docs/examples/private-image-registries/globally/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/private-image-registries/globally/output.yaml
@@ -2677,14 +2677,19 @@ spec:
             # Add any additional provided variables
             - name: CLOUD_PROVIDER_API_KEY
               value: "disabled"
-            - name: CONFIG_PATH
-              value: "/tmp"
             - name: CURRENT_CLUSTER_ID_FILTER_ENABLED
               value: "true"
             - name: PROM_CLUSTER_ID_LABEL
               value: "cluster"
             - name: MCP_SERVER_ENABLED
               value: "false"
+          volumeMounts:
+            - mountPath: /var/configs
+              name: configs
+              readOnly: false
+      volumes:
+        - emptyDir: {}
+          name: configs
 ---
 # Source: k8s-monitoring/templates/alloy-sampler.yaml
 apiVersion: collectors.grafana.com/v1alpha1

--- a/charts/k8s-monitoring/docs/examples/private-image-registries/individual/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/private-image-registries/individual/output.yaml
@@ -2752,14 +2752,19 @@ spec:
             # Add any additional provided variables
             - name: CLOUD_PROVIDER_API_KEY
               value: "disabled"
-            - name: CONFIG_PATH
-              value: "/tmp"
             - name: CURRENT_CLUSTER_ID_FILTER_ENABLED
               value: "true"
             - name: PROM_CLUSTER_ID_LABEL
               value: "cluster"
             - name: MCP_SERVER_ENABLED
               value: "false"
+          volumeMounts:
+            - mountPath: /var/configs
+              name: configs
+              readOnly: false
+      volumes:
+        - emptyDir: {}
+          name: configs
 ---
 # Source: k8s-monitoring/templates/alloy-sampler.yaml
 apiVersion: collectors.grafana.com/v1alpha1

--- a/charts/k8s-monitoring/docs/examples/proxies/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/proxies/output.yaml
@@ -3746,8 +3746,6 @@ spec:
             # Add any additional provided variables
             - name: CLOUD_PROVIDER_API_KEY
               value: "disabled"
-            - name: CONFIG_PATH
-              value: "/tmp"
             - name: CURRENT_CLUSTER_ID_FILTER_ENABLED
               value: "true"
             - name: HTTPS_PROXY
@@ -3758,6 +3756,13 @@ spec:
               value: "cluster"
             - name: MCP_SERVER_ENABLED
               value: "false"
+          volumeMounts:
+            - mountPath: /var/configs
+              name: configs
+              readOnly: false
+      volumes:
+        - emptyDir: {}
+          name: configs
 ---
 # Source: k8s-monitoring/templates/alloy.yaml
 apiVersion: collectors.grafana.com/v1alpha1

--- a/charts/k8s-monitoring/docs/examples/resource-requests-and-limits/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/resource-requests-and-limits/output.yaml
@@ -2488,14 +2488,19 @@ spec:
             # Add any additional provided variables
             - name: CLOUD_PROVIDER_API_KEY
               value: "disabled"
-            - name: CONFIG_PATH
-              value: "/tmp"
             - name: CURRENT_CLUSTER_ID_FILTER_ENABLED
               value: "true"
             - name: PROM_CLUSTER_ID_LABEL
               value: "cluster"
             - name: MCP_SERVER_ENABLED
               value: "false"
+          volumeMounts:
+            - mountPath: /var/configs
+              name: configs
+              readOnly: false
+      volumes:
+        - emptyDir: {}
+          name: configs
 ---
 # Source: k8s-monitoring/templates/alloy.yaml
 apiVersion: collectors.grafana.com/v1alpha1

--- a/charts/k8s-monitoring/docs/examples/tolerations/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/tolerations/output.yaml
@@ -2682,14 +2682,19 @@ spec:
             # Add any additional provided variables
             - name: CLOUD_PROVIDER_API_KEY
               value: "disabled"
-            - name: CONFIG_PATH
-              value: "/tmp"
             - name: CURRENT_CLUSTER_ID_FILTER_ENABLED
               value: "true"
             - name: PROM_CLUSTER_ID_LABEL
               value: "cluster"
             - name: MCP_SERVER_ENABLED
               value: "false"
+          volumeMounts:
+            - mountPath: /var/configs
+              name: configs
+              readOnly: false
+      volumes:
+        - emptyDir: {}
+          name: configs
 ---
 # Source: k8s-monitoring/templates/alloy.yaml
 apiVersion: collectors.grafana.com/v1alpha1

--- a/charts/k8s-monitoring/tests/integration/cluster-monitoring/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/integration/cluster-monitoring/.rendered/output.yaml
@@ -2383,14 +2383,19 @@ spec:
             # Add any additional provided variables
             - name: CLOUD_PROVIDER_API_KEY
               value: "disabled"
-            - name: CONFIG_PATH
-              value: "/tmp"
             - name: CURRENT_CLUSTER_ID_FILTER_ENABLED
               value: "true"
             - name: PROM_CLUSTER_ID_LABEL
               value: "cluster"
             - name: MCP_SERVER_ENABLED
               value: "false"
+          volumeMounts:
+            - mountPath: /var/configs
+              name: configs
+              readOnly: false
+      volumes:
+        - emptyDir: {}
+          name: configs
 ---
 # Source: k8s-monitoring/templates/alloy.yaml
 apiVersion: collectors.grafana.com/v1alpha1

--- a/charts/k8s-monitoring/tests/integration/uninstall/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/integration/uninstall/.rendered/output.yaml
@@ -2591,14 +2591,19 @@ spec:
             # Add any additional provided variables
             - name: CLOUD_PROVIDER_API_KEY
               value: "disabled"
-            - name: CONFIG_PATH
-              value: "/tmp"
             - name: CURRENT_CLUSTER_ID_FILTER_ENABLED
               value: "true"
             - name: PROM_CLUSTER_ID_LABEL
               value: "cluster"
             - name: MCP_SERVER_ENABLED
               value: "false"
+          volumeMounts:
+            - mountPath: /var/configs
+              name: configs
+              readOnly: false
+      volumes:
+        - emptyDir: {}
+          name: configs
 ---
 # Source: k8s-monitoring/templates/alloy.yaml
 apiVersion: collectors.grafana.com/v1alpha1

--- a/charts/k8s-monitoring/tests/integration/upgrade/minor/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/integration/upgrade/minor/.rendered/output.yaml
@@ -2613,14 +2613,19 @@ spec:
             # Add any additional provided variables
             - name: CLOUD_PROVIDER_API_KEY
               value: "disabled"
-            - name: CONFIG_PATH
-              value: "/tmp"
             - name: CURRENT_CLUSTER_ID_FILTER_ENABLED
               value: "true"
             - name: PROM_CLUSTER_ID_LABEL
               value: "cluster"
             - name: MCP_SERVER_ENABLED
               value: "false"
+          volumeMounts:
+            - mountPath: /var/configs
+              name: configs
+              readOnly: false
+      volumes:
+        - emptyDir: {}
+          name: configs
 ---
 # Source: k8s-monitoring/templates/alloy.yaml
 apiVersion: collectors.grafana.com/v1alpha1

--- a/charts/k8s-monitoring/tests/integration/upgrade/patch/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/integration/upgrade/patch/.rendered/output.yaml
@@ -2613,14 +2613,19 @@ spec:
             # Add any additional provided variables
             - name: CLOUD_PROVIDER_API_KEY
               value: "disabled"
-            - name: CONFIG_PATH
-              value: "/tmp"
             - name: CURRENT_CLUSTER_ID_FILTER_ENABLED
               value: "true"
             - name: PROM_CLUSTER_ID_LABEL
               value: "cluster"
             - name: MCP_SERVER_ENABLED
               value: "false"
+          volumeMounts:
+            - mountPath: /var/configs
+              name: configs
+              readOnly: false
+      volumes:
+        - emptyDir: {}
+          name: configs
 ---
 # Source: k8s-monitoring/templates/alloy.yaml
 apiVersion: collectors.grafana.com/v1alpha1

--- a/charts/k8s-monitoring/tests/platform/gke/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/platform/gke/.rendered/output.yaml
@@ -2425,14 +2425,19 @@ spec:
             # Add any additional provided variables
             - name: CLOUD_PROVIDER_API_KEY
               value: "disabled"
-            - name: CONFIG_PATH
-              value: "/tmp"
             - name: CURRENT_CLUSTER_ID_FILTER_ENABLED
               value: "true"
             - name: PROM_CLUSTER_ID_LABEL
               value: "cluster"
             - name: MCP_SERVER_ENABLED
               value: "false"
+          volumeMounts:
+            - mountPath: /var/configs
+              name: configs
+              readOnly: false
+      volumes:
+        - emptyDir: {}
+          name: configs
 ---
 # Source: k8s-monitoring/templates/alloy.yaml
 apiVersion: collectors.grafana.com/v1alpha1

--- a/charts/k8s-monitoring/tests/platform/grafana-cloud/k8s-monitoring/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/platform/grafana-cloud/k8s-monitoring/.rendered/output.yaml
@@ -3597,14 +3597,19 @@ spec:
             # Add any additional provided variables
             - name: CLOUD_PROVIDER_API_KEY
               value: "disabled"
-            - name: CONFIG_PATH
-              value: "/tmp"
             - name: CURRENT_CLUSTER_ID_FILTER_ENABLED
               value: "true"
             - name: PROM_CLUSTER_ID_LABEL
               value: "cluster"
             - name: MCP_SERVER_ENABLED
               value: "false"
+          volumeMounts:
+            - mountPath: /var/configs
+              name: configs
+              readOnly: false
+      volumes:
+        - emptyDir: {}
+          name: configs
 ---
 # Source: k8s-monitoring/templates/alloy-sampler.yaml
 apiVersion: collectors.grafana.com/v1alpha1

--- a/charts/k8s-monitoring/tests/validations_opencost_cloud_integration_test.yaml
+++ b/charts/k8s-monitoring/tests/validations_opencost_cloud_integration_test.yaml
@@ -1,0 +1,146 @@
+# yamllint disable rule:document-start rule:line-length rule:trailing-spaces
+suite: Validations - OpenCost cloud integration /var/configs conflict
+templates:
+  - validations.yaml
+tests:
+  - it: fails when cloud integration (secret) is enabled alongside the chart-managed /var/configs volume
+    set:
+      cluster:
+        name: ci-test-cluster
+      destinations:
+        prometheus:
+          type: prometheus
+          url: http://prometheus.prometheus.svc:9090/api/v1/write
+      collectors:
+        alloy-metrics:
+          presets: [clustered]
+      costMetrics:
+        enabled: true
+        collector: alloy-metrics
+      telemetryServices:
+        kube-state-metrics:
+          deploy: true
+        opencost:
+          deploy: true
+          metricsSource: prometheus
+          opencost:
+            exporter:
+              defaultClusterId: ci-test-cluster
+            prometheus:
+              external:
+                url: http://prometheus.prometheus.svc:9090/api/v1/query
+            cloudIntegrationSecret: my-cloud-integration
+    asserts:
+      - failedTemplate:
+          errorMessage: |-
+            OpenCost cloud integration is enabled, which mounts a writable volume at /var/configs.
+            This conflicts with the chart-managed /var/configs volume used to work around the GKE GCP provider.
+            Since cloud integration already makes /var/configs writable, remove the chart-managed volume:
+            telemetryServices:
+              opencost:
+                extraVolumes: []
+                opencost:
+                  exporter:
+                    extraVolumeMounts: []
+
+  - it: fails when cloud integration (raw JSON) is enabled alongside the chart-managed /var/configs volume
+    set:
+      cluster:
+        name: ci-test-cluster
+      destinations:
+        prometheus:
+          type: prometheus
+          url: http://prometheus.prometheus.svc:9090/api/v1/write
+      collectors:
+        alloy-metrics:
+          presets: [clustered]
+      costMetrics:
+        enabled: true
+        collector: alloy-metrics
+      telemetryServices:
+        kube-state-metrics:
+          deploy: true
+        opencost:
+          deploy: true
+          metricsSource: prometheus
+          opencost:
+            exporter:
+              defaultClusterId: ci-test-cluster
+            prometheus:
+              external:
+                url: http://prometheus.prometheus.svc:9090/api/v1/query
+            cloudIntegrationJSON: |-
+              {"gcp": []}
+    asserts:
+      - failedTemplate:
+          errorMessage: |-
+            OpenCost cloud integration is enabled, which mounts a writable volume at /var/configs.
+            This conflicts with the chart-managed /var/configs volume used to work around the GKE GCP provider.
+            Since cloud integration already makes /var/configs writable, remove the chart-managed volume:
+            telemetryServices:
+              opencost:
+                extraVolumes: []
+                opencost:
+                  exporter:
+                    extraVolumeMounts: []
+
+  - it: does not fail when cloud integration is enabled and the chart-managed volume is removed
+    set:
+      cluster:
+        name: ci-test-cluster
+      destinations:
+        prometheus:
+          type: prometheus
+          url: http://prometheus.prometheus.svc:9090/api/v1/write
+      collectors:
+        alloy-metrics:
+          presets: [clustered]
+      costMetrics:
+        enabled: true
+        collector: alloy-metrics
+      telemetryServices:
+        kube-state-metrics:
+          deploy: true
+        opencost:
+          deploy: true
+          metricsSource: prometheus
+          extraVolumes: []
+          opencost:
+            exporter:
+              defaultClusterId: ci-test-cluster
+              extraVolumeMounts: []
+            prometheus:
+              external:
+                url: http://prometheus.prometheus.svc:9090/api/v1/query
+            cloudIntegrationSecret: my-cloud-integration
+    asserts:
+      - notFailedTemplate: {}
+
+  - it: does not fail in the default case without cloud integration
+    set:
+      cluster:
+        name: ci-test-cluster
+      destinations:
+        prometheus:
+          type: prometheus
+          url: http://prometheus.prometheus.svc:9090/api/v1/write
+      collectors:
+        alloy-metrics:
+          presets: [clustered]
+      costMetrics:
+        enabled: true
+        collector: alloy-metrics
+      telemetryServices:
+        kube-state-metrics:
+          deploy: true
+        opencost:
+          deploy: true
+          metricsSource: prometheus
+          opencost:
+            exporter:
+              defaultClusterId: ci-test-cluster
+            prometheus:
+              external:
+                url: http://prometheus.prometheus.svc:9090/api/v1/query
+    asserts:
+      - notFailedTemplate: {}


### PR DESCRIPTION
This is instead of setting the `CONFIG_PATH` environment variable, which runs into trouble when the user is using custom pricing.

Fixes #2692