### PR TITLE
Detect and report platform

### DIFF
--- a/charts/k8s-monitoring/CHANGELOG.md
+++ b/charts/k8s-monitoring/CHANGELOG.md
@@ -5,6 +5,9 @@
 *   Fix the deployment notes printing an empty "It will:" section when no local features are enabled (e.g. when only using remote configuration or only deploying telemetry services) (#2711) (@petewall)
 *   Fix the OTLP destination `timeout` setting rendering `timeout` at the top level of the `otelcol.exporter.otlp`/`otelcol.exporter.otlphttp` component instead of inside the `client` block. Alloy 1.16.3+ rejects the misplaced attribute (`unrecognized attribute name "timeout"`), causing the collector to fail to start. (#2710) (@petewall)
 *   Update Alloy Operator to 0.5.10 and kube-state-metrics to 7.5.1 (@petewall)
+*   Expand the platform detection template to recognize Azure AKS, Google GKE, and Amazon EKS (in addition to OpenShift) by inspecting node labels and cloud provider IDs, and expose the detection result through a reusable `validations.platform.detect` template. (@petewall)
+*   Set the `provider` attribute reported by the Remote Configuration (`remotecfg`) feature to the configured or detected platform (`openshift`, `aks`, `gke`, `eks`) when it can be determined. (@petewall)
+*   Report the detected platform in the `platform` label of the `grafana_kubernetes_monitoring_build_info` self-reporting metric when `global.platform` is not set explicitly. (@petewall)
 
 ## 4.1.5
 

--- a/charts/k8s-monitoring/templates/_platform_validations.tpl
+++ b/charts/k8s-monitoring/templates/_platform_validations.tpl
@@ -1,19 +1,69 @@
-{{ define "validations.platform" -}}
+{{- /*
+Detects the platform this cluster is running on by inspecting the available API
+versions and the metadata of the cluster's nodes. Returns the detected platform
+name ("openshift", "aks", "gke", or "eks"), or an empty string if the platform
+could not be determined. Input: . (root context)
+*/ -}}
+{{ define "validations.platform.detect" -}}
   {{- $platform := "" }}
-  {{- if (.Capabilities.APIVersions.Has "security.openshift.io/v1/SecurityContextConstraints") }}
+  {{- if ((.Capabilities).APIVersions.Has "security.openshift.io/v1/SecurityContextConstraints") }}
     {{- $platform = "openshift" }}
-    {{- include "validations.platform.openshift" . }}
   {{- end }}
 
-  {{- range $node := (lookup "v1" "Node" "" "").items }}
+  {{- $nodes := list }}
+  {{- if eq $platform "" }}
+    {{- $nodes = (dig "items" list (lookup "v1" "Node" "" "" | default dict)) }}
+  {{- end }}
+
+  {{- range $node := $nodes }}
     {{- if eq $platform "" }}
+      {{- /* Inspect well-known node labels added by the managed Kubernetes providers. */ -}}
       {{- range $label, $value := $node.metadata.labels }}
-        {{- if regexMatch "kubernetes.azure.com.*" $label }}
+        {{- if eq $platform "" }}
+          {{- if regexMatch "^kubernetes\\.azure\\.com/" $label }}
+            {{- $platform = "aks" }}
+          {{- else if regexMatch "^cloud\\.google\\.com/gke" $label }}
+            {{- $platform = "gke" }}
+          {{- else if regexMatch "^eks\\.amazonaws\\.com/" $label }}
+            {{- $platform = "eks" }}
+          {{- end }}
+        {{- end }}
+      {{- end }}
+      {{- /* Fall back to the node's cloud provider ID when the labels are inconclusive. */ -}}
+      {{- if eq $platform "" }}
+        {{- $providerID := (dig "spec" "providerID" "" $node) }}
+        {{- if hasPrefix "azure://" $providerID }}
           {{- $platform = "aks" }}
-          {{- include "validations.platform.aks" $ }}
+        {{- else if hasPrefix "gce://" $providerID }}
+          {{- $platform = "gke" }}
+        {{- else if hasPrefix "aws://" $providerID }}
+          {{- $platform = "eks" }}
         {{- end }}
       {{- end }}
     {{- end }}
+  {{- end }}
+  {{- $platform }}
+{{- end }}
+
+{{- /*
+Resolves the platform for this cluster: returns the explicitly configured
+`global.platform` if set, otherwise the auto-detected platform, or an empty
+string if neither is available. Input: . (root context)
+*/ -}}
+{{ define "validations.platform.resolve" -}}
+  {{- if .Values.global.platform -}}
+    {{- .Values.global.platform -}}
+  {{- else -}}
+    {{- include "validations.platform.detect" . | trim -}}
+  {{- end -}}
+{{- end }}
+
+{{ define "validations.platform" -}}
+  {{- $platform := include "validations.platform.detect" . | trim }}
+  {{- if eq $platform "openshift" }}
+    {{- include "validations.platform.openshift" . }}
+  {{- else if eq $platform "aks" }}
+    {{- include "validations.platform.aks" . }}
   {{- end }}
 {{- end }}
 

--- a/charts/k8s-monitoring/templates/alloy-config.yaml
+++ b/charts/k8s-monitoring/templates/alloy-config.yaml
@@ -8,7 +8,7 @@
 {{- end }}
 
 {{/* Save the top level object and add the collector name */}}
-{{- $values := dict "Values" $.Values "Chart" $.Chart "Files" $.Files "Release" $.Release "Subcharts" $.Subcharts "Template" $.Template "collectorName" $collectorName }}
+{{- $values := dict "Values" $.Values "Chart" $.Chart "Files" $.Files "Release" $.Release "Subcharts" $.Subcharts "Template" $.Template "Capabilities" $.Capabilities "collectorName" $collectorName }}
 {{- $collectorValues := include "collector.alloy.values" $values | fromYaml }}
 {{- $alloyConfig := "" }}
 {{- range $featureKey := include "features.list" . | fromYamlArray }}

--- a/charts/k8s-monitoring/templates/alloy-sampler.yaml
+++ b/charts/k8s-monitoring/templates/alloy-sampler.yaml
@@ -8,7 +8,7 @@
     {{- $maxLength := 51 }}{{/* This limit is from the `controller-revision-hash` pod label value*/}}
     {{- $collectorName := printf "%s-%s" $.Release.Name (include "helper.k8s_name" (printf "%s-sampler" $destinationName)) | trunc $maxLength | trimSuffix "-" | lower }}
     {{- $collectorValues := merge (dict "fullnameOverride" $collectorName) ($destination.processors.tailSampling.collector | default dict) }}
-    {{- $values := (dict "Values" $.Values "Files" $.Files "collectorName" $collectorName "collectorValues" $collectorValues) }}
+    {{- $values := (dict "Values" $.Values "Files" $.Files "Capabilities" $.Capabilities "collectorName" $collectorName "collectorValues" $collectorValues) }}
     {{- $alloyValues := include "collector.alloy.values" $values | fromYaml }}
 
     {{- /* Sampler config components */}}

--- a/charts/k8s-monitoring/templates/alloy-servicegraph.yaml
+++ b/charts/k8s-monitoring/templates/alloy-servicegraph.yaml
@@ -10,7 +10,7 @@
     {{- $extraEnv := dig "alloy" "extraEnv" list ($destination.processors.serviceGraphMetrics.collector | default dict) }}
     {{- $extraEnv = (include "collectors.set_extra_env" (dict "envList" $extraEnv "name" "POD_NAME" "valueFrom" (dict "fieldRef" (dict "fieldPath" "metadata.name")))) | fromYamlArray }}
     {{- $collectorValues := mergeOverwrite (dict "fullnameOverride" $collectorName) ($destination.processors.serviceGraphMetrics.collector | default dict) (dict "alloy" (dict "extraEnv" $extraEnv)) }}
-    {{- $values := dict "Values" $.Values "Files" $.Files "collectorName" $collectorName "collectorValues" $collectorValues }}
+    {{- $values := dict "Values" $.Values "Files" $.Files "Capabilities" $.Capabilities "collectorName" $collectorName "collectorValues" $collectorValues }}
     {{- $alloyValues := include "collector.alloy.values" $values | fromYaml }}
 
     {{- /* Destination components*/}}

--- a/charts/k8s-monitoring/templates/collectors/_collector_remoteConfig.tpl
+++ b/charts/k8s-monitoring/templates/collectors/_collector_remoteConfig.tpl
@@ -89,6 +89,10 @@ remotecfg {
 {{- end }}
   poll_frequency = {{ .pollFrequency | quote }}
 {{- $attributes := dict "platform" "kubernetes" }}
+{{- $provider := include "validations.platform.resolve" $ | trim }}
+{{- if $provider }}
+  {{- $attributes = merge $attributes (dict "provider" $provider) }}
+{{- end }}
 {{- $attributes = merge $attributes (dict "source" $.Chart.Name) }}
 {{- $attributes = merge $attributes (dict "sourceVersion" $.Chart.Version) }}
 {{- $attributes = merge $attributes (dict "release" $.Release.Name) }}

--- a/charts/k8s-monitoring/templates/features/_feature_self_reporting.tpl
+++ b/charts/k8s-monitoring/templates/features/_feature_self_reporting.tpl
@@ -111,7 +111,8 @@ prometheus.relabel "kubernetes_monitoring_telemetry" {
 {{- if eq (include "features.selfReporting.enabled" .) "true" }}
 # HELP grafana_kubernetes_monitoring_build_info A metric to report the version of the Kubernetes Monitoring Helm chart
 # TYPE grafana_kubernetes_monitoring_build_info gauge
-grafana_kubernetes_monitoring_build_info{version="{{ .Chart.Version }}", namespace="{{ include "helper.namespace" . }}"{{- if .Values.global.platform }}, platform="{{ .Values.global.platform }}"{{ end }}} 1
+{{- $platform := include "validations.platform.resolve" . | trim }}
+grafana_kubernetes_monitoring_build_info{version="{{ .Chart.Version }}", namespace="{{ include "helper.namespace" . }}"{{- if $platform }}, platform="{{ $platform }}"{{ end }}} 1
 # HELP grafana_kubernetes_monitoring_feature_info A metric to report the enabled features of the Kubernetes Monitoring Helm chart
 # TYPE grafana_kubernetes_monitoring_feature_info gauge
 {{- range $feature := include "features.list.enabled" . | fromYamlArray }}

--- a/charts/k8s-monitoring/tests/feature_remoteConfig_test.yaml
+++ b/charts/k8s-monitoring/tests/feature_remoteConfig_test.yaml
@@ -23,6 +23,29 @@ tests:
       - matchSnapshot:
           path: data["config.alloy"]
 
+  - it: sets the provider attribute from the configured platform
+    template: alloy-config.yaml
+    set:
+      cluster:
+        name: ci-test-cluster
+      global:
+        platform: openshift
+      collectors:
+        alloy-metrics:
+          remoteConfig:
+            enabled: true
+            url: https://fleet-management-prod-001.grafana.net
+            auth:
+              type: basic
+              username: 123456
+              password: "It's a secret to everyone"
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - matchRegex:
+          path: data["config.alloy"]
+          pattern: '"provider" = "openshift",'
+
   - it: allows for overriding the default attributes
     template: alloy-config.yaml
     set:

--- a/charts/k8s-monitoring/tests/feature_self_reporting_test.yaml
+++ b/charts/k8s-monitoring/tests/feature_self_reporting_test.yaml
@@ -36,3 +36,19 @@ tests:
           of: ConfigMap
       - matchSnapshot:
           path: data["self-reporting-metric.prom"]
+
+  - it: reports the configured platform in the build info metric
+    set:
+      cluster: {name: test-cluster}
+      global: {platform: openshift}
+      collectors: {alloy-singleton: {presets: [singleton]}}
+      destinations:
+        prometheus:
+          type: prometheus
+          url: http://prometheus:9090/api/v1/write
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - matchRegex:
+          path: data["self-reporting-metric.prom"]
+          pattern: 'grafana_kubernetes_monitoring_build_info\{version="[^"]+", namespace="[^"]+", platform="openshift"\} 1'

--- a/charts/k8s-monitoring/tests/platform/aks/test-plan.yaml
+++ b/charts/k8s-monitoring/tests/platform/aks/test-plan.yaml
@@ -37,7 +37,7 @@ tests:
             - configMapRef: {name: test-parameters}
           queries:
             # Features
-            - query: grafana_kubernetes_monitoring_build_info{cluster="$clusterName"}
+            - query: grafana_kubernetes_monitoring_build_info{cluster="$clusterName", platform="aks"}
               type: promql
             - query: grafana_kubernetes_monitoring_feature_info{cluster="$clusterName", feature="clusterMetrics"}
               type: promql

--- a/charts/k8s-monitoring/tests/platform/eks-fargate/test-plan.yaml
+++ b/charts/k8s-monitoring/tests/platform/eks-fargate/test-plan.yaml
@@ -36,7 +36,7 @@ tests:
             - configMapRef: {name: test-parameters}
           queries:
             # Features
-            - query: grafana_kubernetes_monitoring_build_info{cluster="$clusterName"}
+            - query: grafana_kubernetes_monitoring_build_info{cluster="$clusterName", platform="eks"}
               type: promql
             - query: grafana_kubernetes_monitoring_feature_info{cluster="$clusterName", feature="clusterMetrics"}
               type: promql

--- a/charts/k8s-monitoring/tests/platform/eks-with-windows/test-plan.yaml
+++ b/charts/k8s-monitoring/tests/platform/eks-with-windows/test-plan.yaml
@@ -33,7 +33,7 @@ tests:
             - configMapRef: {name: test-parameters}
           queries:
             # Features
-            - query: grafana_kubernetes_monitoring_build_info{cluster="$clusterName"}
+            - query: grafana_kubernetes_monitoring_build_info{cluster="$clusterName", platform="eks"}
               type: promql
             - query: grafana_kubernetes_monitoring_feature_info{cluster="$clusterName", feature="clusterMetrics"}
               type: promql

--- a/charts/k8s-monitoring/tests/platform/gke-autopilot/test-plan.yaml
+++ b/charts/k8s-monitoring/tests/platform/gke-autopilot/test-plan.yaml
@@ -35,7 +35,7 @@ tests:
             - configMapRef: {name: test-parameters}
           queries:
             # Features
-            - query: grafana_kubernetes_monitoring_build_info{cluster="$clusterName"}
+            - query: grafana_kubernetes_monitoring_build_info{cluster="$clusterName", platform="gke"}
               type: promql
             - query: grafana_kubernetes_monitoring_feature_info{cluster="$clusterName", feature="clusterMetrics"}
               type: promql

--- a/charts/k8s-monitoring/tests/platform/gke/test-plan.yaml
+++ b/charts/k8s-monitoring/tests/platform/gke/test-plan.yaml
@@ -38,7 +38,7 @@ tests:
             - configMapRef: {name: test-parameters}
           queries:
             # Features
-            - query: grafana_kubernetes_monitoring_build_info{cluster="$clusterName"}
+            - query: grafana_kubernetes_monitoring_build_info{cluster="$clusterName", platform="gke"}
               type: promql
             - query: grafana_kubernetes_monitoring_feature_info{cluster="$clusterName", feature="clusterMetrics"}
               type: promql

--- a/charts/k8s-monitoring/tests/platform/gpu/test-plan.yaml
+++ b/charts/k8s-monitoring/tests/platform/gpu/test-plan.yaml
@@ -42,7 +42,7 @@ tests:
             - configMapRef: {name: test-parameters}
           queries:
             # Features
-            - query: grafana_kubernetes_monitoring_build_info{cluster="$clusterName"}
+            - query: grafana_kubernetes_monitoring_build_info{cluster="$clusterName", platform="eks"}
               type: promql
             - query: grafana_kubernetes_monitoring_feature_info{cluster="$clusterName", feature="integrations", sources="dcgm-exporter"}
               type: promql

--- a/charts/k8s-monitoring/tests/platform/openshift/test-plan.yaml
+++ b/charts/k8s-monitoring/tests/platform/openshift/test-plan.yaml
@@ -34,7 +34,7 @@ tests:
             - configMapRef: {name: test-parameters}
           queries:
             # Self reporting metrics
-            - query: grafana_kubernetes_monitoring_build_info{cluster="$clusterName"}
+            - query: grafana_kubernetes_monitoring_build_info{cluster="$clusterName", platform="openshift"}
               type: promql
             - query: grafana_kubernetes_monitoring_feature_info{cluster="$clusterName", feature="clusterMetrics"}
               type: promql


### PR DESCRIPTION
Previously, we had some platform detection, but it was for checking for invalid configurations. For example, if your cluster is OpenShift, but we're not declaring the `openshift` platform, we error and tell them to fix it.

Now, we're going to try and detect any platform that we're deploying to, then use that in the self-reporting metric and as an attribute to remote config settings.