### PR TITLE
The timeout placement is different between otlp and otlp http

### DIFF
--- a/charts/k8s-monitoring/CHANGELOG.md
+++ b/charts/k8s-monitoring/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+*   Fix the OTLP destination `timeout` setting rendering inside the `client` block for `protocol: grpc`, which Alloy rejects. It now renders as a top-level argument for gRPC and inside `client` for HTTP. (#2710) (@petewall)
 *   Add `openTelemetryConversion.keepIdentifyingResourceAttributes` option to `otelcol.exporter.prometheus` component to optionally preserve `service.name`, `service.namespace`, and `service.instance.id` attributes as labels on `target_info` metric during OTLP to Prometheus conversion. (#2718) (@rlankfo)
 
 ## 4.1.6

--- a/charts/k8s-monitoring/templates/destinations/_destination_otlp.tpl
+++ b/charts/k8s-monitoring/templates/destinations/_destination_otlp.tpl
@@ -459,6 +459,9 @@ otelcol.processor.memory_limiter {{ include "helper.alloy_name" $.destinationNam
 
 {{- if eq .protocol "grpc" }}
 otelcol.exporter.otlp {{ include "helper.alloy_name" $.destinationName | quote }} {
+{{- if .timeout }}
+  timeout = {{ .timeout | quote }}
+{{- end }}
 {{- else if eq .protocol "http" }}
 otelcol.exporter.otlphttp {{ include "helper.alloy_name" $.destinationName | quote }} {
 {{- if and (ne .metrics.enabled false) .metrics.path }}
@@ -487,7 +490,7 @@ otelcol.exporter.otlphttp {{ include "helper.alloy_name" $.destinationName | quo
 {{- end }}
 {{- end }}
   client {
-{{- if .timeout }}
+{{- if and .timeout (eq .protocol "http") }}
     timeout = {{ .timeout | quote }}
 {{- end }}
 {{- if .urlFrom }}

--- a/charts/k8s-monitoring/tests/__snapshot__/destination_otlp_test.yaml.snap
+++ b/charts/k8s-monitoring/tests/__snapshot__/destination_otlp_test.yaml.snap
@@ -345,6 +345,190 @@ allows you to set a timeout:
         }
       } // otelcol.processor.batch "test"
       otelcol.exporter.otlp "test" {
+        timeout = "30s"
+        client {
+          endpoint = "https://otlp.example.com"
+          tls {
+            insecure = false
+            insecure_skip_verify = false
+          }
+        }
+
+        retry_on_failure {
+          enabled = true
+          initial_interval = "5s"
+          max_interval = "30s"
+          max_elapsed_time = "5m"
+        }
+
+        sending_queue {
+          enabled = true
+        }
+      } // otelcol.exporter.otlp "test"
+allows you to set a timeout when using http:
+  1: |
+    |
+      // Destination: test (otlp)
+      otelcol.receiver.prometheus "test" {
+        output {
+          metrics = [otelcol.processor.attributes.test.input]
+        }
+      } // otelcol.receiver.prometheus "test"
+      otelcol.receiver.loki "test" {
+        output {
+          logs = [otelcol.processor.attributes.test.input]
+        }
+      } // otelcol.receiver.loki "test"
+      otelcol.processor.attributes "test" {
+        output {
+          metrics = [otelcol.processor.transform.test.input]
+          logs = [otelcol.processor.transform.test.input]
+          traces = [otelcol.processor.transform.test.input]
+        }
+      } // otelcol.processor.attributes "test"
+
+      otelcol.processor.transform "test" {
+        error_mode = "ignore"
+        metric_statements {
+          context = "resource"
+          statements = [
+            `set(attributes["cluster"], "test-cluster")`,
+            `set(attributes["k8s.cluster.name"], "test-cluster")`,
+            `delete_key(attributes, "process.pid")`,
+            `delete_key(attributes, "process.parent_pid")`,
+            `delete_key(attributes, "process.executable.path")`,
+            `delete_key(attributes, "process.command_line")`,
+            `delete_key(attributes, "process.command_args")`,
+            `delete_key(attributes, "process.owner")`,
+            `delete_key(attributes, "process.runtime.version")`,
+            `delete_key(attributes, "process.runtime.description")`,
+            `delete_key(attributes, "host.ip")`,
+            `delete_key(attributes, "host.mac")`,
+            `delete_key(attributes, "k8s.pod.start_time")`,
+            `delete_key(attributes, "k8s.pod.uid")`,
+            `delete_key(attributes, "container.image.id")`,
+            `delete_key(attributes, "container.image.repo_digests")`,
+            `delete_key(attributes, "os.description")`,
+            `delete_key(attributes, "os.build_id")`,
+          ]
+        }
+
+        metric_statements {
+          context = "datapoint"
+          statements = [
+            `set(attributes["cluster"], "test-cluster")`,
+            `set(attributes["k8s.cluster.name"], "test-cluster")`,
+            `set(resource.attributes["deployment.environment"], attributes["deployment_environment"] ) where resource.attributes["deployment.environment"] == nil and attributes["deployment_environment"] != nil`,
+            `delete_key(attributes, "deployment_environment") where attributes["deployment_environment"] == resource.attributes["deployment.environment"]`,
+            `set(resource.attributes["deployment.environment.name"], attributes["deployment_environment_name"] ) where resource.attributes["deployment.environment.name"] == nil and attributes["deployment_environment_name"] != nil`,
+            `delete_key(attributes, "deployment_environment_name") where attributes["deployment_environment_name"] == resource.attributes["deployment.environment.name"]`,
+            `set(resource.attributes["service.name"], attributes["service_name"] ) where (resource.attributes["service.name"] == nil or resource.attributes["service.name"] == "") and attributes["service_name"] != nil and attributes["service_name"] != ""`,
+            `delete_key(attributes, "service_name") where attributes["service_name"] == resource.attributes["service.name"]`,
+            `set(resource.attributes["service.namespace"], attributes["service_namespace"] ) where (resource.attributes["service.namespace"] == nil or resource.attributes["service.namespace"] == "") and attributes["service_namespace"] != nil and attributes["service_namespace"] != ""`,
+            `delete_key(attributes, "service_namespace") where attributes["service_namespace"] == resource.attributes["service.namespace"]`,
+          ]
+        }
+        log_statements {
+          context = "resource"
+          statements = [
+            `set(attributes["cluster"], "test-cluster")`,
+            `set(attributes["k8s.cluster.name"], "test-cluster")`,
+            `delete_key(attributes, "process.pid")`,
+            `delete_key(attributes, "process.parent_pid")`,
+            `delete_key(attributes, "process.executable.path")`,
+            `delete_key(attributes, "process.command_line")`,
+            `delete_key(attributes, "process.command_args")`,
+            `delete_key(attributes, "process.owner")`,
+            `delete_key(attributes, "process.runtime.version")`,
+            `delete_key(attributes, "process.runtime.description")`,
+            `delete_key(attributes, "host.ip")`,
+            `delete_key(attributes, "host.mac")`,
+            `delete_key(attributes, "k8s.pod.start_time")`,
+            `delete_key(attributes, "k8s.pod.uid")`,
+            `delete_key(attributes, "container.image.id")`,
+            `delete_key(attributes, "container.image.repo_digests")`,
+            `delete_key(attributes, "os.description")`,
+            `delete_key(attributes, "os.build_id")`,
+          ]
+        }
+
+        log_statements {
+          context = "log"
+          statements = [
+            `delete_key(attributes, "loki.attribute.labels")`,
+            `delete_key(attributes, "loki.resource.labels")`,
+            `set(resource.attributes["k8s.container.name"], attributes["container"] ) where resource.attributes["k8s.container.name"] == nil and attributes["container"] != nil`,
+            `delete_key(attributes, "container") where attributes["container"] == resource.attributes["k8s.container.name"]`,
+            `set(resource.attributes["k8s.cronjob.name"], attributes["cronjob"] ) where resource.attributes["k8s.cronjob.name"] == nil and attributes["cronjob"] != nil`,
+            `delete_key(attributes, "cronjob") where attributes["cronjob"] == resource.attributes["k8s.cronjob.name"]`,
+            `set(resource.attributes["k8s.daemonset.name"], attributes["daemonset"] ) where resource.attributes["k8s.daemonset.name"] == nil and attributes["daemonset"] != nil`,
+            `delete_key(attributes, "daemonset") where attributes["daemonset"] == resource.attributes["k8s.daemonset.name"]`,
+            `set(resource.attributes["k8s.deployment.name"], attributes["deployment"] ) where resource.attributes["k8s.deployment.name"] == nil and attributes["deployment"] != nil`,
+            `delete_key(attributes, "deployment") where attributes["deployment"] == resource.attributes["k8s.deployment.name"]`,
+            `set(resource.attributes["deployment.environment"], attributes["deployment_environment"] ) where resource.attributes["deployment.environment"] == nil and attributes["deployment_environment"] != nil`,
+            `delete_key(attributes, "deployment_environment") where attributes["deployment_environment"] == resource.attributes["deployment.environment"]`,
+            `set(resource.attributes["deployment.environment.name"], attributes["deployment_environment_name"] ) where resource.attributes["deployment.environment.name"] == nil and attributes["deployment_environment_name"] != nil`,
+            `delete_key(attributes, "deployment_environment_name") where attributes["deployment_environment_name"] == resource.attributes["deployment.environment.name"]`,
+            `set(resource.attributes["k8s.job.name"], attributes["job_name"] ) where resource.attributes["k8s.job.name"] == nil and attributes["job_name"] != nil`,
+            `delete_key(attributes, "job_name") where attributes["job_name"] == resource.attributes["k8s.job.name"]`,
+            `set(resource.attributes["k8s.namespace.name"], attributes["namespace"] ) where resource.attributes["k8s.namespace.name"] == nil and attributes["namespace"] != nil`,
+            `delete_key(attributes, "namespace") where attributes["namespace"] == resource.attributes["k8s.namespace.name"]`,
+            `set(resource.attributes["k8s.pod.name"], attributes["pod"] ) where resource.attributes["k8s.pod.name"] == nil and attributes["pod"] != nil`,
+            `delete_key(attributes, "pod") where attributes["pod"] == resource.attributes["k8s.pod.name"]`,
+            `set(resource.attributes["k8s.replicaset.name"], attributes["replicaset"] ) where resource.attributes["k8s.replicaset.name"] == nil and attributes["replicaset"] != nil`,
+            `delete_key(attributes, "replicaset") where attributes["replicaset"] == resource.attributes["k8s.replicaset.name"]`,
+            `set(resource.attributes["service.name"], attributes["service_name"] ) where (resource.attributes["service.name"] == nil or resource.attributes["service.name"] == "") and attributes["service_name"] != nil and attributes["service_name"] != ""`,
+            `delete_key(attributes, "service_name") where attributes["service_name"] == resource.attributes["service.name"]`,
+            `set(resource.attributes["service.namespace"], attributes["service_namespace"] ) where (resource.attributes["service.namespace"] == nil or resource.attributes["service.namespace"] == "") and attributes["service_namespace"] != nil and attributes["service_namespace"] != ""`,
+            `delete_key(attributes, "service_namespace") where attributes["service_namespace"] == resource.attributes["service.namespace"]`,
+            `set(resource.attributes["k8s.statefulset.name"], attributes["statefulset"] ) where resource.attributes["k8s.statefulset.name"] == nil and attributes["statefulset"] != nil`,
+            `delete_key(attributes, "statefulset") where attributes["statefulset"] == resource.attributes["k8s.statefulset.name"]`,
+          ]
+        }
+
+        trace_statements {
+          context = "resource"
+          statements = [
+            `set(attributes["cluster"], "test-cluster")`,
+            `set(attributes["k8s.cluster.name"], "test-cluster")`,
+            `delete_key(attributes, "process.pid")`,
+            `delete_key(attributes, "process.parent_pid")`,
+            `delete_key(attributes, "process.executable.path")`,
+            `delete_key(attributes, "process.command_line")`,
+            `delete_key(attributes, "process.command_args")`,
+            `delete_key(attributes, "process.owner")`,
+            `delete_key(attributes, "process.runtime.version")`,
+            `delete_key(attributes, "process.runtime.description")`,
+            `delete_key(attributes, "host.ip")`,
+            `delete_key(attributes, "host.mac")`,
+            `delete_key(attributes, "k8s.pod.start_time")`,
+            `delete_key(attributes, "k8s.pod.uid")`,
+            `delete_key(attributes, "container.image.id")`,
+            `delete_key(attributes, "container.image.repo_digests")`,
+            `delete_key(attributes, "os.description")`,
+            `delete_key(attributes, "os.build_id")`,
+          ]
+        }
+
+        output {
+          metrics = [otelcol.processor.batch.test.input]
+          logs = [otelcol.processor.batch.test.input]
+          traces = [otelcol.processor.batch.test.input]
+        }
+      } // otelcol.processor.transform "test"
+
+      otelcol.processor.batch "test" {
+        timeout = "2s"
+        send_batch_size = 8192
+        send_batch_max_size = 0
+
+        output {
+          metrics = [otelcol.exporter.otlphttp.test.input]
+          logs = [otelcol.exporter.otlphttp.test.input]
+          traces = [otelcol.exporter.otlphttp.test.input]
+        }
+      } // otelcol.processor.batch "test"
+      otelcol.exporter.otlphttp "test" {
         client {
           timeout = "30s"
           endpoint = "https://otlp.example.com"
@@ -364,7 +548,7 @@ allows you to set a timeout:
         sending_queue {
           enabled = true
         }
-      } // otelcol.exporter.otlp "test"
+      } // otelcol.exporter.otlphttp "test"
 allows you to set per-signal paths when using http:
   1: |
     |

--- a/charts/k8s-monitoring/tests/destination_otlp_test.yaml
+++ b/charts/k8s-monitoring/tests/destination_otlp_test.yaml
@@ -105,6 +105,23 @@ tests:
       - matchSnapshot:
           path: data["config.alloy"]
 
+  - it: allows you to set a timeout when using http
+    set:
+      cluster: {name: test-cluster}
+      collectors: {alloy-singleton: {extraConfig: " ", includeDestinations: ["test"]}}
+      selfReporting: {enabled: false}
+      destinations:
+        test:
+          type: otlp
+          protocol: http
+          url: https://otlp.example.com
+          timeout: 30s
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - matchSnapshot:
+          path: data["config.alloy"]
+
   - it: allows you to set per-signal paths when using http
     set:
       cluster: {name: test-cluster}


### PR DESCRIPTION
Unfortunately, due to inconsistencies, we need another fix for the OTLP destination timeout placement...

In `otelcol.exporter.otlp` ([docs](https://grafana.com/docs/alloy/latest/reference/components/otelcol/otelcol.exporter.otlp/)):
```
otelcol.exporter.otlp "<LABEL>" {
  timeout = "60s"
  client {
    ...
  }
}
```

In `otelcol.exporter.otlphttp` ([docs](https://grafana.com/docs/alloy/latest/reference/components/otelcol/otelcol.exporter.otlphttp/)):
```
otelcol.exporter.otlphttp "<LABEL>" {
  client {
    timeout = "60s"
    ...
  }
}
```