### PR TITLE
Fix docs for integrations

### DIFF
--- a/charts/k8s-monitoring/docs/destinations/.doc_templates/custom.gotmpl
+++ b/charts/k8s-monitoring/docs/destinations/.doc_templates/custom.gotmpl
@@ -40,7 +40,7 @@ logs, and traces, but in this definition, we only choose to send logs. We are al
 
 ```yaml
 destinations:
-  - name: kafka
+  kafka:
     type: custom
     config: |
       otelcol.processor.batch "kafka" {

--- a/charts/k8s-monitoring/docs/destinations/.doc_templates/loki.gotmpl
+++ b/charts/k8s-monitoring/docs/destinations/.doc_templates/loki.gotmpl
@@ -12,34 +12,34 @@ This defines the options for defining a destination for logs that use the Loki p
 
 ```yaml
 destinations:
-- name: localLoki
-  type: loki
-  url: http://loki.monitoring.svc.cluster.local:3100
+  localLoki:
+    type: loki
+    url: http://loki.monitoring.svc.cluster.local:3100
 ```
 
 ### Loki with Basic Auth
 
 ```yaml
 destinations:
-- name: CloudHostedLogs
-  type: loki
-  url: https://prometheus.example.com/loki/api/v1/push
-  auth:
-    type: basic
-    username: "my-username"
-    password: "my-password"
+  CloudHostedLogs:
+    type: loki
+    url: https://prometheus.example.com/loki/api/v1/push
+    auth:
+      type: basic
+      username: "my-username"
+      password: "my-password"
 ```
 
 ### Loki with embedded Bearer Token
 
 ```yaml
 destinations:
-- name: lokiWithBearerToken
-  type: loki
-  url: https://loki.example.com/loki/api/v1/push
-  auth:
-    type: bearerToken
-    bearerToken: my-token
-  secret:
-    embed: true
+  lokiWithBearerToken:
+    type: loki
+    url: https://loki.example.com/loki/api/v1/push
+    auth:
+      type: bearerToken
+      bearerToken: my-token
+    secret:
+      embed: true
 ```

--- a/charts/k8s-monitoring/docs/destinations/.doc_templates/prometheus.gotmpl
+++ b/charts/k8s-monitoring/docs/destinations/.doc_templates/prometheus.gotmpl
@@ -12,34 +12,34 @@ This defines the options for defining a destination for metrics that use the Pro
 
 ```yaml
 destinations:
-- name: localPrometheus
-  type: prometheus
-  url: http://prometheus.monitoring.svc.cluster.local:9090
+  localPrometheus:
+    type: prometheus
+    url: http://prometheus.monitoring.svc.cluster.local:9090
 ```
 
 ### Prometheus with Basic Auth
 
 ```yaml
 destinations:
-- name: CloudHostedMetrics
-  type: prometheus
-  url: https://prometheus.example.com/api/prom/push
-  auth:
-    type: basic
-    username: "my-username"
-    password: "my-password"
+  CloudHostedMetrics:
+    type: prometheus
+    url: https://prometheus.example.com/api/prom/push
+    auth:
+      type: basic
+      username: "my-username"
+      password: "my-password"
 ```
 
 ### Prometheus with embedded Bearer Token
 
 ```yaml
 destinations:
-- name: promWithBearerToken
-  type: prometheus
-  url: https://prometheus.example.com/api/prom/push
-  auth:
-    type: bearerToken
-    bearerToken: my-token
-  secret:
-    embed: true
+  promWithBearerToken:
+    type: prometheus
+    url: https://prometheus.example.com/api/prom/push
+    auth:
+      type: bearerToken
+      bearerToken: my-token
+    secret:
+      embed: true
 ```

--- a/charts/k8s-monitoring/docs/destinations/custom.md
+++ b/charts/k8s-monitoring/docs/destinations/custom.md
@@ -61,7 +61,7 @@ logs, and traces, but in this definition, we only choose to send logs. We are al
 
 ```yaml
 destinations:
-  - name: kafka
+  kafka:
     type: custom
     config: |
       otelcol.processor.batch "kafka" {

--- a/charts/k8s-monitoring/docs/destinations/loki.md
+++ b/charts/k8s-monitoring/docs/destinations/loki.md
@@ -137,34 +137,34 @@ This defines the options for defining a destination for logs that use the Loki p
 
 ```yaml
 destinations:
-- name: localLoki
-  type: loki
-  url: http://loki.monitoring.svc.cluster.local:3100
+  localLoki:
+    type: loki
+    url: http://loki.monitoring.svc.cluster.local:3100
 ```
 
 ### Loki with Basic Auth
 
 ```yaml
 destinations:
-- name: CloudHostedLogs
-  type: loki
-  url: https://prometheus.example.com/loki/api/v1/push
-  auth:
-    type: basic
-    username: "my-username"
-    password: "my-password"
+  CloudHostedLogs:
+    type: loki
+    url: https://prometheus.example.com/loki/api/v1/push
+    auth:
+      type: basic
+      username: "my-username"
+      password: "my-password"
 ```
 
 ### Loki with embedded Bearer Token
 
 ```yaml
 destinations:
-- name: lokiWithBearerToken
-  type: loki
-  url: https://loki.example.com/loki/api/v1/push
-  auth:
-    type: bearerToken
-    bearerToken: my-token
-  secret:
-    embed: true
+  lokiWithBearerToken:
+    type: loki
+    url: https://loki.example.com/loki/api/v1/push
+    auth:
+      type: bearerToken
+      bearerToken: my-token
+    secret:
+      embed: true
 ```

--- a/charts/k8s-monitoring/docs/destinations/prometheus.md
+++ b/charts/k8s-monitoring/docs/destinations/prometheus.md
@@ -198,34 +198,34 @@ This defines the options for defining a destination for metrics that use the Pro
 
 ```yaml
 destinations:
-- name: localPrometheus
-  type: prometheus
-  url: http://prometheus.monitoring.svc.cluster.local:9090
+  localPrometheus:
+    type: prometheus
+    url: http://prometheus.monitoring.svc.cluster.local:9090
 ```
 
 ### Prometheus with Basic Auth
 
 ```yaml
 destinations:
-- name: CloudHostedMetrics
-  type: prometheus
-  url: https://prometheus.example.com/api/prom/push
-  auth:
-    type: basic
-    username: "my-username"
-    password: "my-password"
+  CloudHostedMetrics:
+    type: prometheus
+    url: https://prometheus.example.com/api/prom/push
+    auth:
+      type: basic
+      username: "my-username"
+      password: "my-password"
 ```
 
 ### Prometheus with embedded Bearer Token
 
 ```yaml
 destinations:
-- name: promWithBearerToken
-  type: prometheus
-  url: https://prometheus.example.com/api/prom/push
-  auth:
-    type: bearerToken
-    bearerToken: my-token
-  secret:
-    embed: true
+  promWithBearerToken:
+    type: prometheus
+    url: https://prometheus.example.com/api/prom/push
+    auth:
+      type: bearerToken
+      bearerToken: my-token
+    secret:
+      embed: true
 ```


### PR DESCRIPTION
Still used the v3 version where `destinations` was an array and not an object.

Fixes #2719