### PR TITLE
maint: add local folder to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,9 @@
 data-alloy
 daily-triage/
 
+# Place to put untracked stuff
+local/
+
 # MacOS
 # ---------------------------------------------------
 # General


### PR DESCRIPTION
I often find myself doing `helm template .... --output-dir` when developing helm charts locally. Its nice to put this output somewhere git doesn't see, especially now with robots looking through the changed git files for analysis. Also nice for store test values.yaml files. I went with `local` because its the name we use in collector contrib/core