### PR TITLE
feat: verify opencost via cosign and depend on its signed OCI package

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,9 @@ jobs:
         with:
           version: v4.1.4
 
+      - name: Set up Cosign
+        uses: sigstore/cosign-installer@59acb6260d9c0ba8f4a2f9d9b48431a222b68e20  # v3.5.0
+
       - name: Verify signed chart dependencies
         run: make -C charts/k8s-monitoring verify-signatures
 

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -130,6 +130,9 @@ jobs:
         with:
           version: v4.1.4  # pin to 4.1.x; 4.2.x changes template output formatting (helm/helm#32132)
 
+      - name: Set up Cosign
+        uses: sigstore/cosign-installer@59acb6260d9c0ba8f4a2f9d9b48431a222b68e20  # v3.5.0
+
       - name: Regenerate files
         env:
           CHART: ${{ matrix.dir }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -133,6 +133,7 @@ required to work on this repository:
 -   [Helm](https://helm.sh/docs/intro/install/) - Minimum required version is 3.14.
 -   [Docker](https://docs.docker.com/get-started/get-docker/) - Used for running some tools in containers and required for `kind`.
 -   [chart-testing](https://github.com/helm/chart-testing) - Used for linting Helm charts.
+-   [Cosign](https://docs.sigstore.dev/cosign/system_config/installation/) - Used to verify the signature of the OpenCost chart dependency when building.
 -   [kind](https://kind.sigs.k8s.io/) - Used for creating local Kubernetes clusters for integration testing.
 -   [Grafana Alloy](https://github.com/grafana/alloy) - Used for linting the generated config files.
 -   [yamllint](https://yamllint.readthedocs.io/en/stable/index.html) - Used for linting YAML files.

--- a/charts/k8s-monitoring/.ct.yaml
+++ b/charts/k8s-monitoring/.ct.yaml
@@ -7,7 +7,6 @@ chart-dirs:
 chart-repos:
   - grafana=https://grafana.github.io/helm-charts
   - kepler=https://sustainable-computing-io.github.io/kepler-helm-chart
-  - opencost=https://opencost.github.io/opencost-helm-chart
   - prometheus-community=https://prometheus-community.github.io/helm-charts
 helm-dependency-extra-args:
   - --skip-refresh

--- a/charts/k8s-monitoring/.ct.yaml
+++ b/charts/k8s-monitoring/.ct.yaml
@@ -7,6 +7,7 @@ chart-dirs:
 chart-repos:
   - grafana=https://grafana.github.io/helm-charts
   - kepler=https://sustainable-computing-io.github.io/kepler-helm-chart
+  - opencost=https://opencost.github.io/opencost-helm-chart
   - prometheus-community=https://prometheus-community.github.io/helm-charts
 helm-dependency-extra-args:
   - --skip-refresh

--- a/charts/k8s-monitoring/charts/telemetry-services/Chart.lock
+++ b/charts/k8s-monitoring/charts/telemetry-services/Chart.lock
@@ -12,10 +12,10 @@ dependencies:
   repository: https://prometheus-community.github.io/helm-charts
   version: 7.5.1
 - name: opencost
-  repository: https://opencost.github.io/opencost-helm-chart
+  repository: oci://ghcr.io/opencost/charts
   version: 2.5.23
 - name: k8s-manifest-tail
   repository: https://grafana.github.io/helm-charts
   version: 0.1.5
-digest: sha256:db919004fbac4ec689a26a28f380fc97828cefc5726b97fcc6523f235f9d1251
-generated: "2026-06-24T11:17:43.077795-06:00"
+digest: sha256:6ba50e3d57f5541084cbb73242d50d288585de79c46b70a4fe0a0f5b09281d11
+generated: "2026-06-25T09:44:42.082128-06:00"

--- a/charts/k8s-monitoring/charts/telemetry-services/Chart.yaml
+++ b/charts/k8s-monitoring/charts/telemetry-services/Chart.yaml
@@ -33,7 +33,7 @@ dependencies:
     condition: kube-state-metrics.deploy
   - name: opencost
     version: 2.5.23
-    repository: https://opencost.github.io/opencost-helm-chart
+    repository: oci://ghcr.io/opencost/charts
     condition: opencost.deploy
   - alias: k8s-manifest-tail
     name: k8s-manifest-tail

--- a/charts/k8s-monitoring/charts/telemetry-services/Makefile
+++ b/charts/k8s-monitoring/charts/telemetry-services/Makefile
@@ -14,6 +14,15 @@ WINDOWS_EXPORTER_VERSION := $(shell yq '.dependencies[] | select(.name == "prome
 GRAFANA_HELM_CHARTS_KEYRING := ../../../../keys/grafana-helm-charts-pubkey.gpg
 PROMETHEUS_COMMUNITY_KEYRING := ../../../../keys/prometheus-community-pubkey.gpg
 
+# OpenCost signs its chart with keyless cosign rather than a GPG provenance file,
+# so it is verified against the signing workflow's certificate identity instead of
+# a keyring. This chart depends on the signed OCI artifact directly (see Chart.yaml).
+COSIGN ?= cosign
+OPENCOST_VERSION := $(shell yq '.dependencies[] | select(.name == "opencost") | .version' Chart.yaml)
+OPENCOST_OCI_CHART := ghcr.io/opencost/charts/opencost
+OPENCOST_COSIGN_IDENTITY := https://github.com/opencost/opencost-helm-chart/.github/workflows/publish.yml@refs/heads/main
+OPENCOST_COSIGN_ISSUER := https://token.actions.githubusercontent.com
+
 .SECONDEXPANSION:
 README.md: values.yaml Chart.yaml $$(wildcard README.md.gotmpl)
 	docker run --rm --platform linux/amd64 --volume $(shell pwd):/chart ghcr.io/grafana/helm-chart-toolbox-doc-generator --chart /chart > $@
@@ -54,12 +63,15 @@ verify-signatures: ## Verify the signatures of the signed chart dependencies
 		--version $(WINDOWS_EXPORTER_VERSION) \
 		--verify --keyring $(PROMETHEUS_COMMUNITY_KEYRING) \
 		--destination "$$(mktemp -d)"
+	$(COSIGN) verify $(OPENCOST_OCI_CHART):$(OPENCOST_VERSION) \
+		--certificate-identity $(OPENCOST_COSIGN_IDENTITY) \
+		--certificate-oidc-issuer $(OPENCOST_COSIGN_ISSUER) \
+		> /dev/null
 
 .PHONY: test
 test: build
 	$(HELM) repo add prometheus-community https://prometheus-community.github.io/helm-charts
 	$(HELM) repo add kepler https://sustainable-computing-io.github.io/kepler-helm-chart
-	$(HELM) repo add opencost https://opencost.github.io/opencost-helm-chart
 
 	$(HELM) lint .
 	ct lint --lint-conf ../../.lintconf.yaml --helm-dependency-extra-args=--skip-refresh --charts .

--- a/charts/k8s-monitoring/charts/telemetry-services/Makefile
+++ b/charts/k8s-monitoring/charts/telemetry-services/Makefile
@@ -72,6 +72,7 @@ verify-signatures: ## Verify the signatures of the signed chart dependencies
 test: build
 	$(HELM) repo add prometheus-community https://prometheus-community.github.io/helm-charts
 	$(HELM) repo add kepler https://sustainable-computing-io.github.io/kepler-helm-chart
+	$(HELM) repo add opencost https://opencost.github.io/opencost-helm-chart
 
 	$(HELM) lint .
 	ct lint --lint-conf ../../.lintconf.yaml --helm-dependency-extra-args=--skip-refresh --charts .

--- a/charts/k8s-monitoring/charts/telemetry-services/README.md
+++ b/charts/k8s-monitoring/charts/telemetry-services/README.md
@@ -37,11 +37,11 @@ telemetryServices:
 | Repository | Name | Version |
 |------------|------|---------|
 | https://grafana.github.io/helm-charts | k8s-manifest-tail(k8s-manifest-tail) | 0.1.5 |
-| https://opencost.github.io/opencost-helm-chart | opencost | 2.5.23 |
 | https://prometheus-community.github.io/helm-charts | kube-state-metrics | 7.5.1 |
 | https://prometheus-community.github.io/helm-charts | node-exporter(prometheus-node-exporter) | 4.55.0 |
 | https://prometheus-community.github.io/helm-charts | windows-exporter(prometheus-windows-exporter) | 0.12.7 |
 | https://sustainable-computing-io.github.io/kepler-helm-chart | kepler | 0.6.1 |
+| oci://ghcr.io/opencost/charts | opencost | 2.5.23 |
 <!-- markdownlint-enable no-bare-urls -->
 ## Values
 

--- a/charts/k8s-monitoring/docs/examples/deployment-alternatives/helmfile/README.md
+++ b/charts/k8s-monitoring/docs/examples/deployment-alternatives/helmfile/README.md
@@ -13,6 +13,9 @@ repositories:
     url: https://prometheus-community.github.io/helm-charts
   - name: kepler
     url: https://sustainable-computing-io.github.io/kepler-helm-chart
+  - name: opencost
+    url: ghcr.io/opencost/charts
+    oci: true
 
 helmDefaults:
   diffArgs:

--- a/charts/k8s-monitoring/docs/examples/deployment-alternatives/helmfile/README.md
+++ b/charts/k8s-monitoring/docs/examples/deployment-alternatives/helmfile/README.md
@@ -13,8 +13,6 @@ repositories:
     url: https://prometheus-community.github.io/helm-charts
   - name: kepler
     url: https://sustainable-computing-io.github.io/kepler-helm-chart
-  - name: opencost
-    url: https://opencost.github.io/opencost-helm-chart
 
 helmDefaults:
   diffArgs:

--- a/charts/k8s-monitoring/docs/examples/deployment-alternatives/helmfile/helmfile.yaml
+++ b/charts/k8s-monitoring/docs/examples/deployment-alternatives/helmfile/helmfile.yaml
@@ -6,6 +6,9 @@ repositories:
     url: https://prometheus-community.github.io/helm-charts
   - name: kepler
     url: https://sustainable-computing-io.github.io/kepler-helm-chart
+  - name: opencost
+    url: ghcr.io/opencost/charts
+    oci: true
 
 helmDefaults:
   diffArgs:

--- a/charts/k8s-monitoring/docs/examples/deployment-alternatives/helmfile/helmfile.yaml
+++ b/charts/k8s-monitoring/docs/examples/deployment-alternatives/helmfile/helmfile.yaml
@@ -6,8 +6,6 @@ repositories:
     url: https://prometheus-community.github.io/helm-charts
   - name: kepler
     url: https://sustainable-computing-io.github.io/kepler-helm-chart
-  - name: opencost
-    url: https://opencost.github.io/opencost-helm-chart
 
 helmDefaults:
   diffArgs:

--- a/keys/README.md
+++ b/keys/README.md
@@ -24,3 +24,15 @@ Published at <https://prometheus-community.github.io/helm-charts/pubkey.gpg>.
 Key fingerprint `E2F1 02EF A9AC D882 585B FE1A 2725 2B16 8248 743B`. The key
 does not expire. Confirm this fingerprint from a trusted, independent source
 before you replace the key.
+
+## Charts verified without a key file
+
+Some dependencies are not signed with a GPG provenance file and therefore have
+no keyring here:
+
+- **opencost** is signed with keyless [cosign](https://docs.sigstore.dev/).
+  It is verified against the signing workflow's certificate identity rather
+  than a key, in the `verify-signatures` target of
+  `charts/k8s-monitoring/charts/telemetry-services/Makefile`. That chart depends
+  on the signed OCI artifact (`oci://ghcr.io/opencost/charts`) directly, so the
+  cosign check covers exactly the artifact that is pulled.

--- a/keys/README.md
+++ b/keys/README.md
@@ -30,9 +30,9 @@ before you replace the key.
 Some dependencies are not signed with a GPG provenance file and therefore have
 no keyring here:
 
-- **opencost** is signed with keyless [cosign](https://docs.sigstore.dev/).
-  It is verified against the signing workflow's certificate identity rather
-  than a key, in the `verify-signatures` target of
-  `charts/k8s-monitoring/charts/telemetry-services/Makefile`. That chart depends
-  on the signed OCI artifact (`oci://ghcr.io/opencost/charts`) directly, so the
-  cosign check covers exactly the artifact that is pulled.
+-   **opencost** is signed with keyless [cosign](https://docs.sigstore.dev/).
+    It is verified against the signing workflow's certificate identity rather
+    than a key, in the `verify-signatures` target of
+    `charts/k8s-monitoring/charts/telemetry-services/Makefile`. That chart depends
+    on the signed OCI artifact (`oci://ghcr.io/opencost/charts`) directly, so the
+    cosign check covers exactly the artifact that is pulled.


### PR DESCRIPTION
Add support for verifying opencost via cosign. Switch to using the oci package since it is what we can verify.