### PR TITLE
fix: honor extraDiscoveryRules for kubeletResource and kubeletProbes

### DIFF
--- a/charts/k8s-monitoring/CHANGELOG.md
+++ b/charts/k8s-monitoring/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+*   Fix `kubeletResource.extraDiscoveryRules` and `kubeletProbes.extraDiscoveryRules` being silently dropped. (#2743) (@bradleypettit)
 *   Surface `deploy: false` defaults for `telemetryServices.beyla` and `telemetryServices.sdkInjector` in the top-level values, matching the other telemetry services. This prevents them from deploying unintentionally on Helm versions affected by a subchart value coalescing regression (helm/helm#32132). (#2781, #2782) (@petewall)
 *   Change the default remote configuration `pollFrequency` from `5m` to `30s`. (@TylerHelmuth)
 *   Add `CLUSTER_NAME` environment variable to remote-config-enabled collectors alongside `NAMESPACE` and `POD_NAME`. (#2775) (@petewall)

--- a/charts/k8s-monitoring/charts/feature-cluster-metrics/templates/_kubelet_probes.alloy.tpl
+++ b/charts/k8s-monitoring/charts/feature-cluster-metrics/templates/_kubelet_probes.alloy.tpl
@@ -34,8 +34,8 @@ discovery.relabel "kubelet_probes" {
     target_label  = "__metrics_path__"
   }
 {{- end }}
-{{- if .Values.kubeletProbes.extraRelabelingRules }}
-{{ .Values.kubeletProbes.extraRelabelingRules | indent 2 }}
+{{- if .Values.kubeletProbes.extraDiscoveryRules }}
+{{ .Values.kubeletProbes.extraDiscoveryRules | indent 2 }}
 {{- end }}
 } // discovery.relabel "kubelet_probes"
 

--- a/charts/k8s-monitoring/charts/feature-cluster-metrics/templates/_kubelet_resource.alloy.tpl
+++ b/charts/k8s-monitoring/charts/feature-cluster-metrics/templates/_kubelet_resource.alloy.tpl
@@ -34,8 +34,8 @@ discovery.relabel "kubelet_resources" {
     target_label  = "__metrics_path__"
   }
 {{- end }}
-{{- if .Values.kubeletResource.extraRelabelingRules }}
-{{ .Values.kubeletResource.extraRelabelingRules | indent 2 }}
+{{- if .Values.kubeletResource.extraDiscoveryRules }}
+{{ .Values.kubeletResource.extraDiscoveryRules | indent 2 }}
 {{- end }}
 } // discovery.relabel "kubelet_resources"
 

--- a/charts/k8s-monitoring/charts/feature-cluster-metrics/tests/__snapshot__/custom_rules_test.yaml.snap
+++ b/charts/k8s-monitoring/charts/feature-cluster-metrics/tests/__snapshot__/custom_rules_test.yaml.snap
@@ -74,6 +74,10 @@ should render the default configuration:
             replacement   = "/metrics/resource"
             target_label  = "__metrics_path__"
           }
+          rule {
+            target_label = "color"
+            replacement = "green"
+          }
         } // discovery.relabel "kubelet_resources"
 
         prometheus.scrape "kubelet_resources" {
@@ -111,6 +115,55 @@ should render the default configuration:
 
           forward_to = argument.metrics_destinations.value
         } // prometheus.relabel "kubelet_resources"
+
+        // Kubelet Probes
+        discovery.relabel "kubelet_probes" {
+          targets = discovery.relabel.nodes.output
+          rule {
+            replacement   = "/metrics/probes"
+            target_label  = "__metrics_path__"
+          }
+          rule {
+            target_label = "color"
+            replacement = "blue"
+          }
+        } // discovery.relabel "kubelet_probes"
+
+        prometheus.scrape "kubelet_probes" {
+          targets  = discovery.relabel.kubelet_probes.output
+          job_name = "integrations/kubernetes/probes"
+          scheme   = "https"
+          scrape_interval = "60s"
+          scrape_timeout = "10s"
+          scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
+          scrape_classic_histograms = false
+          scrape_native_histograms = false
+          convert_classic_histograms_to_nhcb = false
+          bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+
+          tls_config {
+            ca_file = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+            insecure_skip_verify = true
+            server_name = "kubernetes"
+          }
+
+          clustering {
+            enabled = true
+          }
+
+          forward_to = [prometheus.relabel.kubelet_probes.receiver]
+        } // prometheus.scrape "kubelet_probes"
+
+        prometheus.relabel "kubelet_probes" {
+          max_cache_size = 100000
+          rule {
+            source_labels = ["__name__"]
+            regex = "up|scrape_samples_scraped|prober_.*"
+            action = "keep"
+          }
+
+          forward_to = argument.metrics_destinations.value
+        } // prometheus.relabel "kubelet_probes"
 
         // cAdvisor
         discovery.relabel "cadvisor" {

--- a/charts/k8s-monitoring/charts/feature-cluster-metrics/tests/custom_rules_test.yaml
+++ b/charts/k8s-monitoring/charts/feature-cluster-metrics/tests/custom_rules_test.yaml
@@ -16,6 +16,19 @@ tests:
             target_label = "color"
             replacement = "red"
           }
+      kubeletResource:
+        extraDiscoveryRules: |-
+          rule {
+            target_label = "color"
+            replacement = "green"
+          }
+      kubeletProbes:
+        enabled: true
+        extraDiscoveryRules: |-
+          rule {
+            target_label = "color"
+            replacement = "blue"
+          }
       kube-state-metrics:
         extraDiscoveryRules: |-
           rule {


### PR DESCRIPTION
## What this does

Fixes a typo that caused `kubeletResource.extraDiscoveryRules` and
`kubeletProbes.extraDiscoveryRules` to be silently ignored.

Both templates referenced a values key that does not exist
(`extraRelabelingRules`) inside their `discovery.relabel` blocks, so the
`{{- if }}` guard was always false and user-supplied rules were dropped. This
renames the reference to the documented key `extraDiscoveryRules`, matching
every sibling cluster-metrics component (`kubelet`, `cadvisor`, `apiServer`,
`kubeProxy`, `kubeScheduler`, `kubeControllerManager`, `kubeDNS`,
`kube-state-metrics`).

This is the same typo as #1268, which was fixed for the `kubelet` template but
never propagated to these two siblings.

## Affected files

- `charts/k8s-monitoring/charts/feature-cluster-metrics/templates/_kubelet_resource.alloy.tpl`
- `charts/k8s-monitoring/charts/feature-cluster-metrics/templates/_kubelet_probes.alloy.tpl`

The `extraMetricProcessingRules` reference in the `prometheus.relabel` block was
already correct and is unchanged. The README already documents the correct key,
so no docs regeneration is needed.

Fixes #2743

🤖 Generated with [Claude Code](https://claude.com/claude-code)
