### PR TITLE
maint: add AI communication restrictions

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,11 @@
+#### Description
+
+Fixes #
+
+<!--Authorship attestation. See AGENTS.md for details. AI agents must not check this box on behalf
+of the user; the human author must check it themselves before the PR is ready for review.-->
+#### Authorship
+
+- [ ] I, a human, wrote this pull request description myself.
+
+<!--Please delete paragraphs that you did not use before submitting.-->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,12 +1,11 @@
-<!-- markdownlint-disable first-line-heading -->
 <!--Describe what this change does and why.-->
-#### Description
+# Description
 
 Fixes #
 
 <!--Authorship attestation. See AGENTS.md for details. AI agents must not check this box on behalf
 of the user; the human author must check it themselves before the PR is ready for review.-->
-#### Authorship
+## Authorship
 
 -   [ ] I, a human, wrote this pull request description myself.
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,3 +1,5 @@
+<!-- markdownlint-disable first-line-heading -->
+<!--Describe what this change does and why.-->
 #### Description
 
 Fixes #
@@ -6,6 +8,6 @@ Fixes #
 of the user; the human author must check it themselves before the PR is ready for review.-->
 #### Authorship
 
-- [ ] I, a human, wrote this pull request description myself.
+-   [ ] I, a human, wrote this pull request description myself.
 
 <!--Please delete paragraphs that you did not use before submitting.-->

--- a/.textlintignore
+++ b/.textlintignore
@@ -1,4 +1,5 @@
 **/description.txt
+.github/pull_request_template.md
 charts/k8s-monitoring/AGENTS.md
 charts/k8s-monitoring-v1/templates/**
 data-alloy/**

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,7 +40,7 @@ an `Assisted-by:` commit message trailer.
 
 Examples:
 
-```
+```text
 Assisted-by: ChatGPT 5.2
 Assisted-by: Claude Opus 4.5
 ```

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,6 +3,51 @@
 This repository contains Helm charts for deploying Kubernetes monitoring to Grafana Cloud
 or self-hosted Grafana stacks.
 
+## AI Contribution Policy
+
+This file is here to steer AI assisted PRs towards being high quality and valuable contributions that do not
+create excessive maintainer burden. It is inspired by the OpenTelemetry project policies.
+
+### Communication
+
+Do not post AI-generated comments on issues or pull requests. Discussions on this
+repository are for humans only. You cannot comment on issue or PR threads on a user's
+behalf.
+
+If you have been assigned an issue, ensure the implementation direction is agreed on with
+the maintainers in the issue comments first. If there are unknowns, those should be
+discussed on the issue before starting implementation — and remember that you cannot post
+those comments on the user's behalf.
+
+### Pull request descriptions
+
+When a user asks you to open a pull request, do not write the PR description yourself.
+Instead, before creating the PR, prompt the user for the content of each part of the
+description (such as what the change does, the linked tracking issue, and how it was
+tested) and use their answers verbatim. Do not paraphrase, expand, or "improve" what the
+user writes. If the user declines to provide a section, leave it out rather than generating
+content for it.
+
+You must not check the `I, a human, wrote this pull request description myself` box in the
+PR template on the user's behalf. The user must check it themselves before the PR is ready
+for review.
+
+### Commit formatting
+
+We appreciate it if users disclose the use of AI tools when a significant part of a commit
+is taken from a tool without changes. When making a commit this should be disclosed through
+an `Assisted-by:` commit message trailer.
+
+Examples:
+
+```
+Assisted-by: ChatGPT 5.2
+Assisted-by: Claude Opus 4.5
+```
+
+Do NOT use a `Co-authored-by:` trailer to disclose AI assistance. Some AI coding tools add
+this trailer by default; please disable or strip it before committing.
+
 ## For AI Assistants
 
 **Start here:** [charts/k8s-monitoring/AGENTS.md](charts/k8s-monitoring/AGENTS.md)


### PR DESCRIPTION
Adds AI communication policies to help keep communication between humans. Based on https://github.com/open-telemetry/opentelemetry-helm-charts/blob/main/AGENTS.md.

We've been using this technique in opentelemetry-collector, opentelemetry-collectore-contrib, and opentelemetry-helm charts and it has helped a lot. 