### PR TITLE
feat: update database_observability values for Alloy 1.17.0

### DIFF
--- a/charts/k8s-monitoring/CHANGELOG.md
+++ b/charts/k8s-monitoring/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+*   Database Observability: add top-level `databaseObservability.excludeCurrentUser` for PostgreSQL (Alloy 1.17.0). The per-collector `databaseObservability.collectors.querySamples.excludeCurrentUser` is now deprecated but still honored when explicitly set. (@cristiangreco)
+*   Database Observability: stop rendering the now-deprecated `schema_details.cache_enabled` / `cache_size` / `cache_ttl` arguments for MySQL and PostgreSQL (Alloy 1.17.0 ignores them). The `cacheEnabled` / `cacheSize` / `cacheTTL` values keys are kept for backwards compatibility but documented as no-op. (@cristiangreco)
 *   Fix the Beyla `SecurityContextConstraints` on OpenShift to set `allowHostPorts: true`. Beyla runs with host networking when context propagation or the `network` preset is enabled, which OpenShift treats as host-port usage. Without it, the Beyla DaemonSet pods fail SCC admission with `Host ports are not allowed to be used`. (#2734) (@petewall)
 *   Fix the OTLP destination `timeout` setting rendering inside the `client` block for `protocol: grpc`, which Alloy rejects. It now renders as a top-level argument for gRPC and inside `client` for HTTP. (#2710) (@petewall)
 *   Add `openTelemetryConversion.keepIdentifyingResourceAttributes` option to `otelcol.exporter.prometheus` component to optionally preserve `service.name`, `service.namespace`, and `service.instance.id` attributes as labels on `target_info` metric during OTLP to Prometheus conversion. (#2718) (@rlankfo)

--- a/charts/k8s-monitoring/charts/feature-integrations/docs/integrations/mysql.md
+++ b/charts/k8s-monitoring/charts/feature-integrations/docs/integrations/mysql.md
@@ -125,9 +125,9 @@ integrations:
 | databaseObservability.collectors.querySamples.sampleMinDuration | string | `"0s"` | Minimum duration for query samples to be collected. Set to "0s" to disable filtering and collect all samples regardless of their duration. |
 | databaseObservability.collectors.querySamples.setupConsumersCheckInterval | string | `"1h"` | How frequently to check if setup_consumers are correctly enabled. |
 | databaseObservability.collectors.querySamples.waitEventMinDuration | string | `"1us"` | Minimum duration for a wait event to be collected. Set to "0s" to disable filtering and collect all wait events regardless of their duration. |
-| databaseObservability.collectors.schemaDetails.cacheEnabled | bool | `true` | Whether to enable caching of table definitions. |
-| databaseObservability.collectors.schemaDetails.cacheSize | int | `256` | Table definitions cache size. |
-| databaseObservability.collectors.schemaDetails.cacheTTL | string | `"10m"` | Table definitions cache TTL. |
+| databaseObservability.collectors.schemaDetails.cacheEnabled | bool | `true` | Deprecated. Kept for backwards compatibility. |
+| databaseObservability.collectors.schemaDetails.cacheSize | int | `256` | Deprecated. Kept for backwards compatibility. |
+| databaseObservability.collectors.schemaDetails.cacheTTL | string | `"10m"` | Deprecated. Kept for backwards compatibility. |
 | databaseObservability.collectors.schemaDetails.collectInterval | string | `"1m"` | How frequently to collect schemas and tables from information_schema. |
 | databaseObservability.collectors.schemaDetails.enabled | bool | `true` | Enable collection of schemas and tables from information_schema. |
 | databaseObservability.collectors.setupActors.autoUpdateSetupActors | bool | `false` | Whether to enable updates to performance_schema.setup_actors settings. Requires allowUpdatePerformanceSchemaSettings to also be enabled. |

--- a/charts/k8s-monitoring/charts/feature-integrations/docs/integrations/postgresql.md
+++ b/charts/k8s-monitoring/charts/feature-integrations/docs/integrations/postgresql.md
@@ -97,10 +97,10 @@ integrations:
 | databaseObservability.collectors.querySamples.collectInterval | string | `"15s"` | How frequently to collect query samples from the database. |
 | databaseObservability.collectors.querySamples.disableQueryRedaction | bool | `false` | Collect unredacted SQL query text including parameters. |
 | databaseObservability.collectors.querySamples.enabled | bool | `true` | Enable collection of query samples. |
-| databaseObservability.collectors.querySamples.excludeCurrentUser | bool | `true` | Do not collect query samples for the current database user. |
-| databaseObservability.collectors.schemaDetails.cacheEnabled | bool | `true` | Whether to enable caching of table definitions. |
-| databaseObservability.collectors.schemaDetails.cacheSize | int | `256` | Table definitions cache size. |
-| databaseObservability.collectors.schemaDetails.cacheTTL | string | `"10m"` | Table definitions cache TTL. |
+| databaseObservability.collectors.querySamples.excludeCurrentUser | bool | `true` | Deprecated. Use the top-level `databaseObservability.excludeCurrentUser` instead. When set, this takes precedence over the top-level setting. |
+| databaseObservability.collectors.schemaDetails.cacheEnabled | bool | `true` | Deprecated. Kept for backwards compatibility. |
+| databaseObservability.collectors.schemaDetails.cacheSize | int | `256` | Deprecated. Kept for backwards compatibility. |
+| databaseObservability.collectors.schemaDetails.cacheTTL | string | `"10m"` | Deprecated. Kept for backwards compatibility. |
 | databaseObservability.collectors.schemaDetails.collectInterval | string | `"1m"` | How frequently to collect schemas and tables from information_schema. |
 | databaseObservability.collectors.schemaDetails.enabled | bool | `true` | Enable collection of schemas and tables from information_schema. |
 
@@ -109,6 +109,7 @@ integrations:
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | databaseObservability.enabled | bool | `false` | Whether to gather table, schema, and query information from the database. Requires exporter to be enabled. |
+| databaseObservability.excludeCurrentUser | bool | `true` | Exclude the user that Alloy uses to connect to the database from monitoring. The resolved username is automatically appended to `excludeUsers`, if not already present. |
 | databaseObservability.excludeDatabases | list | `[]` | A list of databases to exclude from monitoring. |
 | databaseObservability.excludeUsers | list | `[]` | A list of users to exclude from monitoring. |
 

--- a/charts/k8s-monitoring/charts/feature-integrations/integrations/mysql-values.yaml
+++ b/charts/k8s-monitoring/charts/feature-integrations/integrations/mysql-values.yaml
@@ -276,13 +276,13 @@ databaseObservability:
       # -- How frequently to collect schemas and tables from information_schema.
       # @section -- Database Observability - Collectors
       collectInterval: 1m
-      # -- Whether to enable caching of table definitions.
+      # -- Deprecated. Kept for backwards compatibility.
       # @section -- Database Observability - Collectors
       cacheEnabled: true
-      # -- Table definitions cache size.
+      # -- Deprecated. Kept for backwards compatibility.
       # @section -- Database Observability - Collectors
       cacheSize: 256
-      # -- Table definitions cache TTL.
+      # -- Deprecated. Kept for backwards compatibility.
       # @section -- Database Observability - Collectors
       cacheTTL: 10m
 

--- a/charts/k8s-monitoring/charts/feature-integrations/integrations/postgresql-values.yaml
+++ b/charts/k8s-monitoring/charts/feature-integrations/integrations/postgresql-values.yaml
@@ -260,6 +260,11 @@ databaseObservability:
   # @section -- Database Observability
   excludeUsers: []
 
+  # -- Exclude the user that Alloy uses to connect to the database from monitoring. The resolved username is
+  # automatically appended to `excludeUsers`, if not already present.
+  # @section -- Database Observability
+  excludeCurrentUser: true
+
   # Cloud provider configuration for the database.
   # @section -- Database Observability
   cloudProvider:
@@ -323,9 +328,11 @@ databaseObservability:
       # -- Collect unredacted SQL query text including parameters.
       # @section -- Database Observability - Collectors
       disableQueryRedaction: false
-      # -- Do not collect query samples for the current database user.
+      # -- (bool) Deprecated. Use the top-level `databaseObservability.excludeCurrentUser` instead. When set, this
+      # takes precedence over the top-level setting.
+      # @default -- `true`
       # @section -- Database Observability - Collectors
-      excludeCurrentUser: true
+      excludeCurrentUser:
 
     # Collect schemas and tables from information_schema.
     schemaDetails:
@@ -335,13 +342,13 @@ databaseObservability:
       # -- How frequently to collect schemas and tables from information_schema.
       # @section -- Database Observability - Collectors
       collectInterval: 1m
-      # -- Whether to enable caching of table definitions.
+      # -- Deprecated. Kept for backwards compatibility.
       # @section -- Database Observability - Collectors
       cacheEnabled: true
-      # -- Table definitions cache size.
+      # -- Deprecated. Kept for backwards compatibility.
       # @section -- Database Observability - Collectors
       cacheSize: 256
-      # -- Table definitions cache TTL.
+      # -- Deprecated. Kept for backwards compatibility.
       # @section -- Database Observability - Collectors
       cacheTTL: 10m
 

--- a/charts/k8s-monitoring/charts/feature-integrations/schema-mods/definitions/postgresql-integration.schema.json
+++ b/charts/k8s-monitoring/charts/feature-integrations/schema-mods/definitions/postgresql-integration.schema.json
@@ -84,7 +84,7 @@
                                     "type": "boolean"
                                 },
                                 "excludeCurrentUser": {
-                                    "type": "boolean"
+                                    "type": "null"
                                 }
                             }
                         },
@@ -111,6 +111,9 @@
                     }
                 },
                 "enabled": {
+                    "type": "boolean"
+                },
+                "excludeCurrentUser": {
                     "type": "boolean"
                 },
                 "excludeDatabases": {

--- a/charts/k8s-monitoring/charts/feature-integrations/schema-mods/type-overrides.json
+++ b/charts/k8s-monitoring/charts/feature-integrations/schema-mods/type-overrides.json
@@ -52,6 +52,11 @@
                   "properties": {
                     "statementsLimit": {"type": "integer"}
                   }
+                },
+                "querySamples": {
+                  "properties": {
+                    "excludeCurrentUser": {"type": "boolean"}
+                  }
                 }
               }
             }

--- a/charts/k8s-monitoring/charts/feature-integrations/templates/_integration_mysql_metrics.tpl
+++ b/charts/k8s-monitoring/charts/feature-integrations/templates/_integration_mysql_metrics.tpl
@@ -229,9 +229,6 @@ database_observability.mysql {{ include "helper.alloy_name" .name | quote }} {
     {{- with .databaseObservability.collectors.schemaDetails }}
   schema_details {
     collect_interval = {{ .collectInterval | quote }}
-    cache_enabled = {{ .cacheEnabled }}
-    cache_size = {{ .cacheSize }}
-    cache_ttl = {{ .cacheTTL | quote }}
   }
     {{- end }}
   {{- else }}

--- a/charts/k8s-monitoring/charts/feature-integrations/templates/_integration_postgresql_metrics.tpl
+++ b/charts/k8s-monitoring/charts/feature-integrations/templates/_integration_postgresql_metrics.tpl
@@ -187,6 +187,7 @@ database_observability.postgres {{ include "helper.alloy_name" .name | quote }} 
   {{- if .databaseObservability.excludeUsers }}
   exclude_users = {{ .databaseObservability.excludeUsers | toJson }}
   {{- end }}
+  exclude_current_user = {{ .databaseObservability.excludeCurrentUser }}
 
   {{- $enabledCollectors := list }}
   {{- $disabledCollectors := list }}
@@ -220,7 +221,9 @@ database_observability.postgres {{ include "helper.alloy_name" .name | quote }} 
   query_samples {
     collect_interval = {{ .collectInterval | quote }}
     disable_query_redaction = {{ .disableQueryRedaction }}
+    {{- if not (kindIs "invalid" .excludeCurrentUser) }}
     exclude_current_user = {{ .excludeCurrentUser }}
+    {{- end }}
   }
     {{- end }}
   {{- else }}
@@ -231,9 +234,6 @@ database_observability.postgres {{ include "helper.alloy_name" .name | quote }} 
     {{- with .databaseObservability.collectors.schemaDetails }}
   schema_details {
     collect_interval = {{ .collectInterval | quote }}
-    cache_enabled = {{ .cacheEnabled }}
-    cache_size = {{ .cacheSize }}
-    cache_ttl = {{ .cacheTTL | quote }}
   }
     {{- end }}
   {{- else }}

--- a/charts/k8s-monitoring/charts/feature-integrations/tests/__snapshot__/mysql_db_o11y_metrics_test.yaml.snap
+++ b/charts/k8s-monitoring/charts/feature-integrations/tests/__snapshot__/mysql_db_o11y_metrics_test.yaml.snap
@@ -54,9 +54,6 @@ defaults text_limit to 0 for perf_schema.eventsstatements when db o11y is enable
           }
           schema_details {
             collect_interval = "1m"
-            cache_enabled = true
-            cache_size = 256
-            cache_ttl = "10m"
           }
           setup_consumers {
             collect_interval = "1h"
@@ -169,9 +166,6 @@ keeps prometheus.relabel when metrics tuning is set under db o11y:
           }
           schema_details {
             collect_interval = "1m"
-            cache_enabled = true
-            cache_size = 256
-            cache_ttl = "10m"
           }
           setup_consumers {
             collect_interval = "1h"
@@ -410,9 +404,6 @@ renders new db o11y options (azure, setup_actors, statements_limit, exclude_sche
           }
           schema_details {
             collect_interval = "1m"
-            cache_enabled = true
-            cache_size = 256
-            cache_ttl = "10m"
           }
           setup_consumers {
             collect_interval = "1h"
@@ -525,9 +516,6 @@ respects an explicit jobLabel override under db o11y:
           }
           schema_details {
             collect_interval = "1m"
-            cache_enabled = true
-            cache_size = 256
-            cache_ttl = "10m"
           }
           setup_consumers {
             collect_interval = "1h"
@@ -640,9 +628,6 @@ should create the MySQL config:
           }
           schema_details {
             collect_interval = "1m"
-            cache_enabled = true
-            cache_size = 256
-            cache_ttl = "10m"
           }
           setup_consumers {
             collect_interval = "1h"
@@ -740,9 +725,6 @@ works with multiple MySQL Instances:
           }
           schema_details {
             collect_interval = "1m"
-            cache_enabled = true
-            cache_size = 256
-            cache_ttl = "10m"
           }
           setup_consumers {
             collect_interval = "1h"
@@ -829,9 +811,6 @@ works with multiple MySQL Instances:
           }
           schema_details {
             collect_interval = "1m"
-            cache_enabled = true
-            cache_size = 256
-            cache_ttl = "10m"
           }
           setup_consumers {
             collect_interval = "1h"
@@ -933,9 +912,6 @@ works with multiple MySQL Instances:
           }
           schema_details {
             collect_interval = "1m"
-            cache_enabled = true
-            cache_size = 256
-            cache_ttl = "10m"
           }
           setup_consumers {
             collect_interval = "1h"

--- a/charts/k8s-monitoring/charts/feature-integrations/tests/__snapshot__/postgresql_db_o11y_metrics_test.yaml.snap
+++ b/charts/k8s-monitoring/charts/feature-integrations/tests/__snapshot__/postgresql_db_o11y_metrics_test.yaml.snap
@@ -34,6 +34,7 @@ keeps prometheus.relabel when metrics tuning is set under db o11y:
             "my-db.postgresql.svc",
             5432,
           )
+          exclude_current_user = true
           explain_plans {
             collect_interval = "1m"
             per_collect_ratio = "1"
@@ -44,13 +45,9 @@ keeps prometheus.relabel when metrics tuning is set under db o11y:
           query_samples {
             collect_interval = "15s"
             disable_query_redaction = false
-            exclude_current_user = true
           }
           schema_details {
             collect_interval = "1m"
-            cache_enabled = true
-            cache_size = 256
-            cache_ttl = "10m"
           }
           enable_collectors = ["explain_plans","query_details","query_samples","schema_details"]
 
@@ -153,13 +150,13 @@ renders gcp cloud_provider and disable_collectors:
               connection_name = "my-project:us-central1:my-db"
             }
           }
+          exclude_current_user = true
           query_details {
             collect_interval = "1m"
           }
           query_samples {
             collect_interval = "15s"
             disable_query_redaction = false
-            exclude_current_user = true
           }
           enable_collectors = ["query_details","query_samples"]
           disable_collectors = ["explain_plans","schema_details"]
@@ -256,6 +253,7 @@ renders new db o11y options (azure, exclude_databases, exclude_current_user):
             }
           }
           exclude_databases = ["employees","departments"]
+          exclude_current_user = true
           explain_plans {
             collect_interval = "1m"
             per_collect_ratio = "1"
@@ -270,9 +268,6 @@ renders new db o11y options (azure, exclude_databases, exclude_current_user):
           }
           schema_details {
             collect_interval = "1m"
-            cache_enabled = true
-            cache_size = 256
-            cache_ttl = "10m"
           }
           enable_collectors = ["explain_plans","query_details","query_samples","schema_details"]
 
@@ -361,6 +356,7 @@ renders new db o11y options (exclude_users):
             5432,
           )
           exclude_users = ["monitoring_user"]
+          exclude_current_user = true
           explain_plans {
             collect_interval = "1m"
             per_collect_ratio = "1"
@@ -371,13 +367,9 @@ renders new db o11y options (exclude_users):
           query_samples {
             collect_interval = "15s"
             disable_query_redaction = false
-            exclude_current_user = true
           }
           schema_details {
             collect_interval = "1m"
-            cache_enabled = true
-            cache_size = 256
-            cache_ttl = "10m"
           }
           enable_collectors = ["explain_plans","query_details","query_samples","schema_details"]
 
@@ -465,6 +457,7 @@ renders new db o11y options (statements_limit):
             "limited-db.postgresql.svc",
             5432,
           )
+          exclude_current_user = true
           explain_plans {
             collect_interval = "1m"
             per_collect_ratio = "1"
@@ -476,13 +469,9 @@ renders new db o11y options (statements_limit):
           query_samples {
             collect_interval = "15s"
             disable_query_redaction = false
-            exclude_current_user = true
           }
           schema_details {
             collect_interval = "1m"
-            cache_enabled = true
-            cache_size = 256
-            cache_ttl = "10m"
           }
           enable_collectors = ["explain_plans","query_details","query_samples","schema_details"]
 
@@ -534,6 +523,107 @@ renders new db o11y options (statements_limit):
           forward_to = argument.metrics_destinations.value
         }
       }
+honors top-level exclude_current_user:
+  1: |
+    |-
+      declare "postgresql_integration" {
+        argument "metrics_destinations" {
+          comment = "Must be a list of metric destinations where collected metrics should be forwarded to"
+        }
+        argument "logs_destinations" {
+          comment = "Must be a list of log destinations where collected logs should be forwarded to"
+        }
+
+        remote.kubernetes.secret "top_level_excl_db" {
+          name      = "top-level-excl-db-release-name-feature-integrations"
+          namespace = "NAMESPACE"
+        } // remote.kubernetes.secret "top_level_excl_db"
+
+        prometheus.exporter.postgres "top_level_excl_db" {
+          data_source_names = [string.format("postgresql://%s:%s@%s:%d/",
+            encoding.url_encode(convert.nonsensitive(remote.kubernetes.secret.top_level_excl_db.data["username"])),
+            encoding.url_encode(convert.nonsensitive(remote.kubernetes.secret.top_level_excl_db.data["password"])),
+            "top-level-excl-db.postgresql.svc",
+            5432,
+          )]
+          enabled_collectors = ["database","locks","replication","replication_slot","stat_bgwriter","stat_database","stat_progress_vacuum","stat_user_tables","statio_user_tables","wal"]
+          disable_default_metrics = false
+          disable_settings_metrics = false
+        }
+
+        database_observability.postgres "top_level_excl_db" {
+          targets = prometheus.exporter.postgres.top_level_excl_db.targets
+          data_source_name = string.format("postgresql://%s:%s@%s:%d/",
+            encoding.url_encode(convert.nonsensitive(remote.kubernetes.secret.top_level_excl_db.data["username"])),
+            encoding.url_encode(convert.nonsensitive(remote.kubernetes.secret.top_level_excl_db.data["password"])),
+            "top-level-excl-db.postgresql.svc",
+            5432,
+          )
+          exclude_current_user = false
+          explain_plans {
+            collect_interval = "1m"
+            per_collect_ratio = "1"
+          }
+          query_details {
+            collect_interval = "1m"
+          }
+          query_samples {
+            collect_interval = "15s"
+            disable_query_redaction = false
+          }
+          schema_details {
+            collect_interval = "1m"
+          }
+          enable_collectors = ["explain_plans","query_details","query_samples","schema_details"]
+
+          forward_to = [loki.relabel.database_observability_postgres_top_level_excl_db.receiver]
+        }
+
+        loki.relabel "database_observability_postgres_top_level_excl_db" {
+          forward_to = argument.logs_destinations.value
+          rule {
+            target_label = "job"
+            replacement = "integrations/db-o11y"
+          }
+          rule {
+            source_labels = ["instance"]
+            target_label = "dsn"
+          }
+          rule {
+            target_label = "instance"
+            replacement = "top-level-excl-db"
+          }
+        }
+
+        discovery.relabel "database_observability_postgres_top_level_excl_db" {
+          targets = database_observability.postgres.top_level_excl_db.targets
+          rule {
+            target_label = "job"
+            replacement = "integrations/db-o11y"
+          }
+          rule {
+            source_labels = ["instance"]
+            target_label = "dsn"
+          }
+          rule {
+            target_label = "instance"
+            replacement = "top-level-excl-db"
+          }
+        }
+        prometheus.scrape "top_level_excl_db" {
+          targets = discovery.relabel.database_observability_postgres_top_level_excl_db.output
+          clustering {
+            enabled = true
+          }
+
+          scrape_interval = "60s"
+          scrape_timeout = "10s"
+          scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
+          scrape_classic_histograms = false
+          scrape_native_histograms = false
+          forward_to = argument.metrics_destinations.value
+        }
+      }
 respects an explicit jobLabel override under db o11y:
   1: |
     |-
@@ -570,6 +660,7 @@ respects an explicit jobLabel override under db o11y:
             "my-db.postgresql.svc",
             5432,
           )
+          exclude_current_user = true
           explain_plans {
             collect_interval = "1m"
             per_collect_ratio = "1"
@@ -580,13 +671,9 @@ respects an explicit jobLabel override under db o11y:
           query_samples {
             collect_interval = "15s"
             disable_query_redaction = false
-            exclude_current_user = true
           }
           schema_details {
             collect_interval = "1m"
-            cache_enabled = true
-            cache_size = 256
-            cache_ttl = "10m"
           }
           enable_collectors = ["explain_plans","query_details","query_samples","schema_details"]
 
@@ -674,6 +761,7 @@ should create the PostgreSQL config:
             "my-db.postgresql.svc",
             5432,
           )
+          exclude_current_user = true
           explain_plans {
             collect_interval = "1m"
             per_collect_ratio = "1"
@@ -684,13 +772,9 @@ should create the PostgreSQL config:
           query_samples {
             collect_interval = "15s"
             disable_query_redaction = false
-            exclude_current_user = true
           }
           schema_details {
             collect_interval = "1m"
-            cache_enabled = true
-            cache_size = 256
-            cache_ttl = "10m"
           }
           enable_collectors = ["explain_plans","query_details","query_samples","schema_details"]
 
@@ -763,6 +847,7 @@ works with multiple PostgreSQL Instances:
         database_observability.postgres "test_db" {
           targets = prometheus.exporter.postgres.test_db.targets
           data_source_name = string.format("postgresql://%s:%d/", "database.test.svc", 5432)
+          exclude_current_user = true
           explain_plans {
             collect_interval = "1m"
             per_collect_ratio = "1"
@@ -773,13 +858,9 @@ works with multiple PostgreSQL Instances:
           query_samples {
             collect_interval = "15s"
             disable_query_redaction = false
-            exclude_current_user = true
           }
           schema_details {
             collect_interval = "1m"
-            cache_enabled = true
-            cache_size = 256
-            cache_ttl = "10m"
           }
           enable_collectors = ["explain_plans","query_details","query_samples","schema_details"]
 
@@ -841,6 +922,7 @@ works with multiple PostgreSQL Instances:
         database_observability.postgres "staging_db" {
           targets = prometheus.exporter.postgres.staging_db.targets
           data_source_name = "root:password@database.staging.svc:3306/"
+          exclude_current_user = true
           explain_plans {
             collect_interval = "1m"
             per_collect_ratio = "1"
@@ -851,13 +933,9 @@ works with multiple PostgreSQL Instances:
           query_samples {
             collect_interval = "15s"
             disable_query_redaction = false
-            exclude_current_user = true
           }
           schema_details {
             collect_interval = "1m"
-            cache_enabled = true
-            cache_size = 256
-            cache_ttl = "10m"
           }
           enable_collectors = ["explain_plans","query_details","query_samples","schema_details"]
 
@@ -934,6 +1012,7 @@ works with multiple PostgreSQL Instances:
             "database.prod.svc",
             5432,
           )
+          exclude_current_user = true
           explain_plans {
             collect_interval = "1m"
             per_collect_ratio = "1"
@@ -944,13 +1023,9 @@ works with multiple PostgreSQL Instances:
           query_samples {
             collect_interval = "15s"
             disable_query_redaction = false
-            exclude_current_user = true
           }
           schema_details {
             collect_interval = "1m"
-            cache_enabled = true
-            cache_size = 256
-            cache_ttl = "10m"
           }
           enable_collectors = ["explain_plans","query_details","query_samples","schema_details"]
 

--- a/charts/k8s-monitoring/charts/feature-integrations/tests/postgresql_db_o11y_metrics_test.yaml
+++ b/charts/k8s-monitoring/charts/feature-integrations/tests/postgresql_db_o11y_metrics_test.yaml
@@ -145,6 +145,27 @@ tests:
         matchSnapshot:
           path: data["metrics.alloy"]
 
+  - it: honors top-level exclude_current_user
+    set:
+      testing: {enabled: true}
+      postgresql:
+        instances:
+          - name: top-level-excl-db
+            exporter:
+              dataSource:
+                host: top-level-excl-db.postgresql.svc
+                auth:
+                  username: db-admin
+                  password: db-password
+            databaseObservability:
+              enabled: true
+              excludeCurrentUser: false
+            logs: {enabled: false}
+    asserts:
+      - template: test/configmap.yaml
+        matchSnapshot:
+          path: data["metrics.alloy"]
+
   - it: renders new db o11y options (statements_limit)
     set:
       testing: {enabled: true}

--- a/charts/k8s-monitoring/charts/feature-integrations/values.schema.json
+++ b/charts/k8s-monitoring/charts/feature-integrations/values.schema.json
@@ -1288,6 +1288,9 @@
                         "enabled": {
                             "type": "boolean"
                         },
+                        "excludeCurrentUser": {
+                            "type": "boolean"
+                        },
                         "excludeDatabases": {
                             "type": "array"
                         },

--- a/charts/k8s-monitoring/docs/examples/features/database-observability/mysql/alloy-singleton.alloy
+++ b/charts/k8s-monitoring/docs/examples/features/database-observability/mysql/alloy-singleton.alloy
@@ -51,9 +51,6 @@ declare "mysql_integration" {
     }
     schema_details {
       collect_interval = "1m"
-      cache_enabled = true
-      cache_size = 256
-      cache_ttl = "10m"
     }
     setup_consumers {
       collect_interval = "1h"

--- a/charts/k8s-monitoring/docs/examples/features/database-observability/mysql/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/features/database-observability/mysql/output.yaml
@@ -376,9 +376,6 @@ data:
         }
         schema_details {
           collect_interval = "1m"
-          cache_enabled = true
-          cache_size = 256
-          cache_ttl = "10m"
         }
         setup_consumers {
           collect_interval = "1h"

--- a/charts/k8s-monitoring/docs/examples/features/database-observability/postgresql/alloy-metrics.alloy
+++ b/charts/k8s-monitoring/docs/examples/features/database-observability/postgresql/alloy-metrics.alloy
@@ -34,6 +34,7 @@ declare "postgresql_integration" {
       "test-database-postgresql.postgresql.svc",
       5432,
     )
+    exclude_current_user = true
     explain_plans {
       collect_interval = "1m"
       per_collect_ratio = "1"
@@ -44,13 +45,9 @@ declare "postgresql_integration" {
     query_samples {
       collect_interval = "1m"
       disable_query_redaction = false
-      exclude_current_user = true
     }
     schema_details {
       collect_interval = "1m"
-      cache_enabled = true
-      cache_size = 256
-      cache_ttl = "10m"
     }
     enable_collectors = ["explain_plans","query_details","query_samples","schema_details"]
 

--- a/charts/k8s-monitoring/docs/examples/features/database-observability/postgresql/alloy-singleton.alloy
+++ b/charts/k8s-monitoring/docs/examples/features/database-observability/postgresql/alloy-singleton.alloy
@@ -34,6 +34,7 @@ declare "postgresql_integration" {
       "test-database-postgresql.postgresql.svc",
       5432,
     )
+    exclude_current_user = true
     explain_plans {
       collect_interval = "1m"
       per_collect_ratio = "1"
@@ -44,13 +45,9 @@ declare "postgresql_integration" {
     query_samples {
       collect_interval = "15s"
       disable_query_redaction = false
-      exclude_current_user = true
     }
     schema_details {
       collect_interval = "1m"
-      cache_enabled = true
-      cache_size = 256
-      cache_ttl = "10m"
     }
     enable_collectors = ["explain_plans","query_details","query_samples","schema_details"]
 

--- a/charts/k8s-monitoring/docs/examples/features/database-observability/postgresql/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/features/database-observability/postgresql/output.yaml
@@ -342,6 +342,7 @@ data:
           "test-database-postgresql.postgresql.svc",
           5432,
         )
+        exclude_current_user = true
         explain_plans {
           collect_interval = "1m"
           per_collect_ratio = "1"
@@ -352,13 +353,9 @@ data:
         query_samples {
           collect_interval = "15s"
           disable_query_redaction = false
-          exclude_current_user = true
         }
         schema_details {
           collect_interval = "1m"
-          cache_enabled = true
-          cache_size = 256
-          cache_ttl = "10m"
         }
         enable_collectors = ["explain_plans","query_details","query_samples","schema_details"]
     

--- a/charts/k8s-monitoring/tests/platform/grafana-cloud/database-observability/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/platform/grafana-cloud/database-observability/.rendered/output.yaml
@@ -397,9 +397,6 @@ data:
         }
         schema_details {
           collect_interval = "1m"
-          cache_enabled = true
-          cache_size = 256
-          cache_ttl = "10m"
         }
         setup_consumers {
           collect_interval = "1h"
@@ -503,6 +500,7 @@ data:
           "test-postgresql-db.postgresql.svc",
           5432,
         )
+        exclude_current_user = true
         explain_plans {
           collect_interval = "1m"
           per_collect_ratio = "1"
@@ -513,13 +511,9 @@ data:
         query_samples {
           collect_interval = "15s"
           disable_query_redaction = false
-          exclude_current_user = true
         }
         schema_details {
           collect_interval = "1m"
-          cache_enabled = true
-          cache_size = 256
-          cache_ttl = "10m"
         }
         enable_collectors = ["explain_plans","query_details","query_samples","schema_details"]
     


### PR DESCRIPTION
# Description

*   Database Observability: add top-level `databaseObservability.excludeCurrentUser` for PostgreSQL (new in Alloy 1.17.0). The per-collector `databaseObservability.collectors.querySamples.excludeCurrentUser` is now deprecated but still honored when explicitly set.
*   Database Observability: stop rendering the now-deprecated `schema_details.cache_enabled` / `cache_size` / `cache_ttl` arguments for MySQL and PostgreSQL (Alloy 1.17.0 ignores them). The `cacheEnabled` / `cacheSize` / `cacheTTL` values keys are kept for backwards compatibility but documented as no-op.

## Authorship

-  [x] I, a human, wrote this pull request description myself.
