### PR TITLE
maint: align makefiles with readme instructions

### DIFF
--- a/charts/k8s-monitoring/tests/platform/aks/Makefile
+++ b/charts/k8s-monitoring/tests/platform/aks/Makefile
@@ -1,3 +1,8 @@
+.PHONY: run-test
+run-test:
+	direnv allow .
+	direnv exec . sh -c '$(MAKE) clean all && helm-test .'
+
 .PHONY: clean
 clean:
 	rm -f grafana-cloud-credentials.yaml

--- a/charts/k8s-monitoring/tests/platform/eks-addon-with-terraform/Makefile
+++ b/charts/k8s-monitoring/tests/platform/eks-addon-with-terraform/Makefile
@@ -1,3 +1,8 @@
+.PHONY: run-test
+run-test:
+	direnv allow .
+	direnv exec . sh -c '$(MAKE) clean all && helm-test .'
+
 .PHONY: clean
 clean:
 	rm -f deployments/test-variables.yaml deployments/grafana-cloud.yaml deployments/grafana-cloud-credentials.yaml vars.tf

--- a/charts/k8s-monitoring/tests/platform/eks-addon/Makefile
+++ b/charts/k8s-monitoring/tests/platform/eks-addon/Makefile
@@ -1,3 +1,8 @@
+.PHONY: run-test
+run-test:
+	direnv allow .
+	direnv exec . sh -c '$(MAKE) clean all && helm-test .'
+
 .PHONY: clean
 clean:
 	rm -f deployments/test-variables.yaml deployments/grafana-cloud.yaml deployments/grafana-cloud-credentials.yaml

--- a/charts/k8s-monitoring/tests/platform/eks-fargate/Makefile
+++ b/charts/k8s-monitoring/tests/platform/eks-fargate/Makefile
@@ -1,3 +1,8 @@
+.PHONY: run-test
+run-test:
+	direnv allow .
+	direnv exec . sh -c '$(MAKE) clean all && helm-test .'
+
 .PHONY: clean
 clean:
 	rm -f grafana-cloud-credentials.yaml

--- a/charts/k8s-monitoring/tests/platform/eks-with-windows/Makefile
+++ b/charts/k8s-monitoring/tests/platform/eks-with-windows/Makefile
@@ -1,3 +1,8 @@
+.PHONY: run-test
+run-test:
+	direnv allow .
+	direnv exec . sh -c '$(MAKE) clean all && helm-test .'
+
 .PHONY: clean
 clean:
 	rm -f grafana-cloud-credentials.yaml

--- a/charts/k8s-monitoring/tests/platform/gke-autopilot/Makefile
+++ b/charts/k8s-monitoring/tests/platform/gke-autopilot/Makefile
@@ -1,3 +1,8 @@
+.PHONY: run-test
+run-test:
+	direnv allow .
+	direnv exec . sh -c '$(MAKE) clean all && helm-test .'
+
 .PHONY: clean
 clean:
 	rm -f grafana-cloud-credentials.yaml

--- a/charts/k8s-monitoring/tests/platform/gke/Makefile
+++ b/charts/k8s-monitoring/tests/platform/gke/Makefile
@@ -1,3 +1,8 @@
+.PHONY: run-test
+run-test:
+	direnv allow .
+	direnv exec . sh -c '$(MAKE) clean all && helm-test .'
+
 .PHONY: clean
 clean:
 	rm -f grafana-cloud-credentials.yaml

--- a/charts/k8s-monitoring/tests/platform/gpu/Makefile
+++ b/charts/k8s-monitoring/tests/platform/gpu/Makefile
@@ -1,3 +1,8 @@
+.PHONY: run-test
+run-test:
+	direnv allow .
+	direnv exec . sh -c '$(MAKE) clean all && helm-test .'
+
 .PHONY: clean
 clean:
 	rm -f grafana-cloud-credentials.yaml

--- a/charts/k8s-monitoring/tests/platform/openshift/Makefile
+++ b/charts/k8s-monitoring/tests/platform/openshift/Makefile
@@ -1,3 +1,8 @@
+.PHONY: run-test
+run-test:
+	direnv allow .
+	direnv exec . sh -c '$(MAKE) clean all && helm-test .'
+
 .PHONY: clean
 clean:
 	rm -f grafana-cloud-credentials.yaml

--- a/charts/k8s-monitoring/tests/platform/otlp-gateway/Makefile
+++ b/charts/k8s-monitoring/tests/platform/otlp-gateway/Makefile
@@ -1,3 +1,8 @@
+.PHONY: run-test
+run-test:
+	direnv allow .
+	direnv exec . sh -c '$(MAKE) clean all && helm-test .'
+
 .PHONY: clean
 clean:
 	rm -f grafana-cloud-credentials.yaml

--- a/charts/k8s-monitoring/tests/platform/remote-config/Makefile
+++ b/charts/k8s-monitoring/tests/platform/remote-config/Makefile
@@ -1,3 +1,8 @@
+.PHONY: run-test
+run-test:
+	direnv allow .
+	direnv exec . sh -c '$(MAKE) clean all && helm-test .'
+
 .PHONY: clean
 clean:
 	rm -f grafana-cloud-credentials.yaml


### PR DESCRIPTION
# Description

The README in the tests folder says to run this target, but it didnt exist. I don't love having to use `direnv exec` but I couldn't get the envrc to work properly without it.

## Authorship

-   [x] I, a human, wrote this pull request description myself.

