### PR TITLE
fix: align gke tests with new default cluster external IP rules

### DIFF
--- a/charts/k8s-monitoring/tests/platform/gke-autopilot/.envrc
+++ b/charts/k8s-monitoring/tests/platform/gke-autopilot/.envrc
@@ -3,6 +3,8 @@ op --account grafana.1password.com read --out-file sak.json "op://Kubernetes Mon
 gcloud auth activate-service-account "${GCP_SERVICE_ACCOUNT}" --key-file=sak.json
 rm sak.json
 
+export CLOUDSDK_CORE_PROJECT=grafana-k8s-monitoring
+export CLOUDSDK_CONTAINER_USE_DNS_ENDPOINT=true
 export GRAFANA_CLOUD_METRICS_USERNAME=$(op --account grafana.1password.com read "op://Kubernetes Monitoring/helmchart Prometheus/username")
 export GRAFANA_CLOUD_LOGS_USERNAME=$(op --account grafana.1password.com read "op://Kubernetes Monitoring/helmchart Loki/username")
 export GRAFANA_CLOUD_RW_POLICY_TOKEN=$(op --account grafana.1password.com read "op://Kubernetes Monitoring/helmchart Prometheus/password")

--- a/charts/k8s-monitoring/tests/platform/gke-autopilot/.gitignore
+++ b/charts/k8s-monitoring/tests/platform/gke-autopilot/.gitignore
@@ -1,3 +1,5 @@
 .random
 grafana-cloud-credentials.yaml
 kubeconfig.yaml
+sak.json
+gke_gcloud_auth_plugin_cache

--- a/charts/k8s-monitoring/tests/platform/gke-autopilot/test-plan.yaml
+++ b/charts/k8s-monitoring/tests/platform/gke-autopilot/test-plan.yaml
@@ -13,7 +13,6 @@ subject:
 
 cluster:
   type: gke-autopilot
-  # us-west1's default network has a Cloud NAT, letting private nodes pull public images.
   zone: us-west1
   args:
     - --labels source=k8s-monitoring-helm-platform-test

--- a/charts/k8s-monitoring/tests/platform/gke-autopilot/test-plan.yaml
+++ b/charts/k8s-monitoring/tests/platform/gke-autopilot/test-plan.yaml
@@ -13,9 +13,19 @@ subject:
 
 cluster:
   type: gke-autopilot
-  zone: us-central1
+  # us-west1's default network has a Cloud NAT, letting private nodes pull public images.
+  zone: us-west1
   args:
     - --labels source=k8s-monitoring-helm-platform-test
+    # Org policy (compute.vmExternalIpAccess) forbids external node IPs -> private nodes.
+    # No public control-plane IP; reached via the IAM-gated DNS endpoint
+    # (requires CLOUDSDK_CONTAINER_USE_DNS_ENDPOINT=true in .envrc / CI).
+    # Autopilot is always VPC-native (no --enable-ip-alias) and create-auto needs
+    # --enable-master-authorized-networks set explicitly with --enable-private-endpoint.
+    - --enable-private-nodes
+    - --enable-private-endpoint
+    - --enable-master-authorized-networks
+    - --enable-dns-access
   appendRandomNumber: true
 
 dependencies:

--- a/charts/k8s-monitoring/tests/platform/gke-autopilot/test-plan.yaml
+++ b/charts/k8s-monitoring/tests/platform/gke-autopilot/test-plan.yaml
@@ -1,7 +1,7 @@
 ---
 apiVersion: helm-chart-toolbox.grafana.com/v1
 kind: TestPlan
-name: gke
+name: gke-autopilot
 
 subject:
   releaseName: k8smon

--- a/charts/k8s-monitoring/tests/platform/gke/.envrc
+++ b/charts/k8s-monitoring/tests/platform/gke/.envrc
@@ -3,6 +3,8 @@ op --account grafana.1password.com read --out-file sak.json "op://Kubernetes Mon
 gcloud auth activate-service-account "${GCP_SERVICE_ACCOUNT}" --key-file=sak.json
 rm sak.json
 
+export CLOUDSDK_CORE_PROJECT=grafana-k8s-monitoring
+export CLOUDSDK_CONTAINER_USE_DNS_ENDPOINT=true
 export GRAFANA_CLOUD_METRICS_USERNAME=$(op --account grafana.1password.com read "op://Kubernetes Monitoring/helmchart Prometheus/username")
 export GRAFANA_CLOUD_LOGS_USERNAME=$(op --account grafana.1password.com read "op://Kubernetes Monitoring/helmchart Loki/username")
 export GRAFANA_CLOUD_RW_POLICY_TOKEN=$(op --account grafana.1password.com read "op://Kubernetes Monitoring/helmchart Prometheus/password")

--- a/charts/k8s-monitoring/tests/platform/gke/.gitignore
+++ b/charts/k8s-monitoring/tests/platform/gke/.gitignore
@@ -1,3 +1,5 @@
 .random
 grafana-cloud-credentials.yaml
 kubeconfig.yaml
+sak.json
+gke_gcloud_auth_plugin_cache

--- a/charts/k8s-monitoring/tests/platform/gke/test-plan.yaml
+++ b/charts/k8s-monitoring/tests/platform/gke/test-plan.yaml
@@ -15,10 +15,19 @@ subject:
 
 cluster:
   type: gke
-  zone: us-central1
+  # us-west1's default network has a Cloud NAT, letting private nodes pull public images.
+  zone: us-west1
   args:
     - --num-nodes=1
     - --labels source=k8s-monitoring-helm-platform-test
+    # Org policy (compute.vmExternalIpAccess) forbids external node IPs -> private nodes.
+    # No public control-plane IP; reached via the IAM-gated DNS endpoint
+    # (requires CLOUDSDK_CONTAINER_USE_DNS_ENDPOINT=true in .envrc / CI).
+    - --enable-ip-alias
+    - --enable-private-nodes
+    - --enable-private-endpoint
+    - --enable-master-authorized-networks
+    - --enable-dns-access
   appendRandomNumber: true
 
 dependencies:

--- a/charts/k8s-monitoring/tests/platform/gke/test-plan.yaml
+++ b/charts/k8s-monitoring/tests/platform/gke/test-plan.yaml
@@ -15,7 +15,6 @@ subject:
 
 cluster:
   type: gke
-  # us-west1's default network has a Cloud NAT, letting private nodes pull public images.
   zone: us-west1
   args:
     - --num-nodes=1


### PR DESCRIPTION
# Description

New gke cluster policies means no external IPs or public images are allowed. Adjust the chart's tests to work within these constraints. The 2 primary fixes are:

- use dns to access the cluster instead of a single public IP. 
- switch to us-west1 which allows pulling public images.

Depends on https://github.com/grafana/helm-chart-toolbox/pull/118
Fixes https://github.com/grafana/k8s-monitoring-helm/issues/2758

<!--Authorship attestation. See AGENTS.md for details. AI agents must not check this box on behalf
of the user; the human author must check it themselves before the PR is ready for review.-->
## Authorship

-   [x] I, a human, wrote this pull request description myself.

