### PR TITLE
Ensure that service.name and service.namespace are set on logging and profiling features

### DIFF
--- a/charts/k8s-monitoring/CHANGELOG.md
+++ b/charts/k8s-monitoring/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ## 4.3.0
 
+*   Align `service.name`/`service.namespace` detection on logs (new opt-in `alignServiceNameWithOTelSemConv` flag) and profiles with the [OpenTelemetry Kubernetes semantic conventions](https://opentelemetry.io/docs/specs/semconv/non-normative/k8s-attributes/) that Grafana Beyla uses, so telemetry correlates across metrics, logs, traces, and profiles for the same workload. (#2547) (@petewall)
 *   Allow a destination to be disabled by setting `disabled: true`. Disabled destinations are excluded from all destination lists, secrets, and generated Alloy instances, which makes it possible to remove a destination that was defined in a shared or parent values file. (#2800) (@petewall)
 *   Add the `nop` destination, which drops all telemetry sent to it. (#1461) (@TylerHelmuth)
 *   Add the `otel-receiver` collector preset, which opens the standard OTLP receiver ports on the collector (4317 for OTLP gRPC and 4318 for OTLP HTTP). (@petewall)

--- a/charts/k8s-monitoring/charts/feature-application-observability/README.md
+++ b/charts/k8s-monitoring/charts/feature-application-observability/README.md
@@ -20,6 +20,35 @@ applicationObservability:
     ...
 ```
 
+## Service name and namespace detection
+
+By default, this feature relies on the application's OpenTelemetry SDK to set `service.name` and `service.namespace`.
+
+Set `alignServiceNameWithOTelSemConv: true` to opt in to having this feature fill those values in (without overwriting
+anything the application already reported) following the
+[OpenTelemetry semantic conventions for Kubernetes attributes](https://opentelemetry.io/docs/specs/semconv/non-normative/k8s-attributes/).
+These are also what Grafana Beyla uses, so enabling this flag makes `service.name` consistent across metrics, logs,
+traces, and profiles from the same workload. Enabling the flag also automatically enables
+`processors.k8sattributes.otelAnnotations`, which translates `resource.opentelemetry.io/*` pod annotations into
+resource attributes.
+
+When the flag is enabled, `service.name` is set to the first value found from the following ordered list:
+
+1.  The `service.name` resource attribute reported by the application
+2.  The `resource.opentelemetry.io/service.name` pod annotation
+3.  The `app.kubernetes.io/instance` pod label
+4.  The `app.kubernetes.io/name` pod label
+5.  The name of the workload that owns the pod (Deployment, StatefulSet, DaemonSet, CronJob, Job, ...)
+6.  The pod name
+
+`service.namespace` is set to the first value found from: the `service.namespace` resource attribute reported by the
+application, then the `resource.opentelemetry.io/service.namespace` pod annotation, then the pod namespace.
+
+Note: OpenTelemetry SDKs that are not configured with a service name report `unknown_service:<language>`. Because that
+counts as a reported value, the fallback list does not apply to it.
+
+To pin a specific service name for a workload, set the `resource.opentelemetry.io/service.name` annotation on the pod.
+
 ## Testing
 
 This chart contains unit tests to verify the generated configuration. The hidden value `deployAsConfigMap` will render
@@ -49,6 +78,12 @@ Be sure perform actual integration testing in a live environment in the main [k8
 
 <!--alex disable host-hostess-->
 ## Values
+
+### General
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| alignServiceNameWithOTelSemConv | bool | `false` | Align the `service.name` and `service.namespace` resource attributes with the [OpenTelemetry semantic conventions for Kubernetes attributes](https://opentelemetry.io/docs/specs/semconv/non-normative/k8s-attributes/) (which is what Grafana Beyla uses) when the application has not reported them itself. When enabled, the detection chain becomes: pod annotation `resource.opentelemetry.io/service.name` → pod label `app.kubernetes.io/instance` → pod label `app.kubernetes.io/name` → owner workload name (Deployment, StatefulSet, etc.) → pod name. Enabling this also enables `processors.k8sattributes.otelAnnotations`. |
 
 ### Connectors: Grafana Cloud Host Info
 
@@ -149,7 +184,7 @@ Be sure perform actual integration testing in a live environment in the main [k8
 | processors.k8sattributes.filters.ownNode | bool | `false` | Only extract Kubernetes attributes for telemetry data coming from the same node as this Alloy instance. |
 | processors.k8sattributes.labels | list | `[]` | Kubernetes labels to extract and add to the attributes of the received telemetry data in the form of a list of otelcol.processor.k8sattributes extract > label blocks. See the [Alloy documentation](https://grafana.com/docs/alloy/latest/reference/components/otelcol/otelcol.processor.k8sattributes/#label-extract) for details on how to configure label blocks. |
 | processors.k8sattributes.metadata | list | `["k8s.namespace.name","k8s.pod.name","k8s.deployment.name","k8s.statefulset.name","k8s.daemonset.name","k8s.cronjob.name","k8s.job.name","k8s.node.name","k8s.pod.uid","k8s.pod.start_time"]` | Kubernetes metadata to extract and add to the attributes of the received telemetry data. |
-| processors.k8sattributes.otelAnnotations | bool | `false` | Whether to automatically set the recommended OpenTelemetry [resource attributes](https://opentelemetry.io/docs/specs/semconv/non-normative/k8s-attributes/). |
+| processors.k8sattributes.otelAnnotations | bool | `false` | Whether to automatically set the recommended OpenTelemetry [resource attributes](https://opentelemetry.io/docs/specs/semconv/non-normative/k8s-attributes/). This translates pod annotations like `resource.opentelemetry.io/service.name` into resource attributes. Automatically enabled when `alignServiceNameWithOTelSemConv` is true. |
 | processors.k8sattributes.passthrough | bool | `false` | Pass through signals as-is, only adding a `k8s.pod.ip` resource attribute. |
 | processors.k8sattributes.podAssociation | list | `[{"from":"resource_attribute","name":"k8s.pod.ip"},{"from":"resource_attribute","name":"k8s.pod.uid"},{"from":"connection"}]` | Defines the rules on how to associate logs/traces/metrics to Pods. |
 

--- a/charts/k8s-monitoring/charts/feature-application-observability/README.md.gotmpl
+++ b/charts/k8s-monitoring/charts/feature-application-observability/README.md.gotmpl
@@ -22,6 +22,35 @@ applicationObservability:
     ...
 ```
 
+## Service name and namespace detection
+
+By default, this feature relies on the application's OpenTelemetry SDK to set `service.name` and `service.namespace`.
+
+Set `alignServiceNameWithOTelSemConv: true` to opt in to having this feature fill those values in (without overwriting
+anything the application already reported) following the
+[OpenTelemetry semantic conventions for Kubernetes attributes](https://opentelemetry.io/docs/specs/semconv/non-normative/k8s-attributes/).
+These are also what Grafana Beyla uses, so enabling this flag makes `service.name` consistent across metrics, logs,
+traces, and profiles from the same workload. Enabling the flag also automatically enables
+`processors.k8sattributes.otelAnnotations`, which translates `resource.opentelemetry.io/*` pod annotations into
+resource attributes.
+
+When the flag is enabled, `service.name` is set to the first value found from the following ordered list:
+
+1.  The `service.name` resource attribute reported by the application
+2.  The `resource.opentelemetry.io/service.name` pod annotation
+3.  The `app.kubernetes.io/instance` pod label
+4.  The `app.kubernetes.io/name` pod label
+5.  The name of the workload that owns the pod (Deployment, StatefulSet, DaemonSet, CronJob, Job, ...)
+6.  The pod name
+
+`service.namespace` is set to the first value found from: the `service.namespace` resource attribute reported by the
+application, then the `resource.opentelemetry.io/service.namespace` pod annotation, then the pod namespace.
+
+Note: OpenTelemetry SDKs that are not configured with a service name report `unknown_service:<language>`. Because that
+counts as a reported value, the fallback list does not apply to it.
+
+To pin a specific service name for a workload, set the `resource.opentelemetry.io/service.name` annotation on the pod.
+
 ## Testing
 
 This chart contains unit tests to verify the generated configuration. The hidden value `deployAsConfigMap` will render

--- a/charts/k8s-monitoring/charts/feature-application-observability/templates/_processor_k8sattributes.tpl
+++ b/charts/k8s-monitoring/charts/feature-application-observability/templates/_processor_k8sattributes.tpl
@@ -49,11 +49,25 @@ otelcol.processor.k8sattributes "{{ .name | default "default" }}" {
   }
   {{- end }}
   extract {
-{{- if .Values.processors.k8sattributes.otelAnnotations }}
-    otel_annotations = {{ .Values.processors.k8sattributes.otelAnnotations }}
+{{- if or .Values.processors.k8sattributes.otelAnnotations .Values.alignServiceNameWithOTelSemConv }}
+    otel_annotations = true
 {{- end }}
 {{- if .Values.processors.k8sattributes.metadata }}
     metadata = {{ .Values.processors.k8sattributes.metadata | toJson }}
+{{- end }}
+{{- if .Values.alignServiceNameWithOTelSemConv }}
+    // Extracted into temporary attributes for service.name detection, then deleted in the transform processor.
+    // Temporary names are used so the cleanup never deletes an `app.kubernetes.io/*` attribute the user extracted.
+    label {
+      tag_name = "k8s_monitoring.tmp.instance"
+      key = "app.kubernetes.io/instance"
+      from = "pod"
+    }
+    label {
+      tag_name = "k8s_monitoring.tmp.name"
+      key = "app.kubernetes.io/name"
+      from = "pod"
+    }
 {{- end }}
 {{- range .Values.processors.k8sattributes.labels }}
     label {

--- a/charts/k8s-monitoring/charts/feature-application-observability/templates/_processor_transform.tpl
+++ b/charts/k8s-monitoring/charts/feature-application-observability/templates/_processor_transform.tpl
@@ -1,17 +1,51 @@
 {{/* Inputs: Values (values) metricsOutput, logsOutput, tracesOutput, name */}}
 {{/* https://grafana.com/docs/alloy/latest/reference/components/otelcol/otelcol.processor.transform/ */}}
 {{- define "feature.applicationObservability.processor.transform.alloy.target" }}otelcol.processor.transform.{{ .name | default "default" }}.input{{ end }}
+{{/*
+Fallback statements to detect service.name and service.namespace when not set by the application or by the
+resource.opentelemetry.io/* pod annotations (extracted by the k8sattributes processor). Follows the OpenTelemetry
+semantic conventions for Kubernetes service names: instance label, name label, workload owner name, pod name.
+*/}}
+{{- define "feature.applicationObservability.processor.transform.serviceDetectionStatements" }}
+// Set service.name by choosing the first value found from the following ordered list:
+// - service.name as reported by the application or set from the resource.opentelemetry.io/service.name annotation
+// - pod.label[app.kubernetes.io/instance]
+// - pod.label[app.kubernetes.io/name]
+// - k8s.workload.name (Deployment, StatefulSet, DaemonSet, CronJob, Job, ...)
+// - k8s.pod.name
+// The instance/name pod labels are read from temporary attributes (k8s_monitoring.tmp.*) extracted by the
+// k8sattributes processor, so the cleanup below only ever deletes attributes this feature added.
+`set(resource.attributes["service.name"], resource.attributes["k8s_monitoring.tmp.instance"]) where (resource.attributes["service.name"] == nil or resource.attributes["service.name"] == "") and resource.attributes["k8s_monitoring.tmp.instance"] != nil and resource.attributes["k8s_monitoring.tmp.instance"] != ""`,
+`set(resource.attributes["service.name"], resource.attributes["k8s_monitoring.tmp.name"]) where (resource.attributes["service.name"] == nil or resource.attributes["service.name"] == "") and resource.attributes["k8s_monitoring.tmp.name"] != nil and resource.attributes["k8s_monitoring.tmp.name"] != ""`,
+`set(resource.attributes["service.name"], resource.attributes["k8s.deployment.name"]) where (resource.attributes["service.name"] == nil or resource.attributes["service.name"] == "") and resource.attributes["k8s.deployment.name"] != nil and resource.attributes["k8s.deployment.name"] != ""`,
+`set(resource.attributes["service.name"], resource.attributes["k8s.replicaset.name"]) where (resource.attributes["service.name"] == nil or resource.attributes["service.name"] == "") and resource.attributes["k8s.replicaset.name"] != nil and resource.attributes["k8s.replicaset.name"] != ""`,
+`set(resource.attributes["service.name"], resource.attributes["k8s.statefulset.name"]) where (resource.attributes["service.name"] == nil or resource.attributes["service.name"] == "") and resource.attributes["k8s.statefulset.name"] != nil and resource.attributes["k8s.statefulset.name"] != ""`,
+`set(resource.attributes["service.name"], resource.attributes["k8s.daemonset.name"]) where (resource.attributes["service.name"] == nil or resource.attributes["service.name"] == "") and resource.attributes["k8s.daemonset.name"] != nil and resource.attributes["k8s.daemonset.name"] != ""`,
+`set(resource.attributes["service.name"], resource.attributes["k8s.cronjob.name"]) where (resource.attributes["service.name"] == nil or resource.attributes["service.name"] == "") and resource.attributes["k8s.cronjob.name"] != nil and resource.attributes["k8s.cronjob.name"] != ""`,
+`set(resource.attributes["service.name"], resource.attributes["k8s.job.name"]) where (resource.attributes["service.name"] == nil or resource.attributes["service.name"] == "") and resource.attributes["k8s.job.name"] != nil and resource.attributes["k8s.job.name"] != ""`,
+`set(resource.attributes["service.name"], resource.attributes["k8s.pod.name"]) where (resource.attributes["service.name"] == nil or resource.attributes["service.name"] == "") and resource.attributes["k8s.pod.name"] != nil and resource.attributes["k8s.pod.name"] != ""`,
+
+// Set service.namespace to the pod namespace if not already set
+`set(resource.attributes["service.namespace"], resource.attributes["k8s.namespace.name"]) where (resource.attributes["service.namespace"] == nil or resource.attributes["service.namespace"] == "") and resource.attributes["k8s.namespace.name"] != nil and resource.attributes["k8s.namespace.name"] != ""`,
+
+// Remove the temporary attributes used for service.name detection
+`delete_key(resource.attributes, "k8s_monitoring.tmp.instance")`,
+`delete_key(resource.attributes, "k8s_monitoring.tmp.name")`,
+{{- end }}
 {{- define "feature.applicationObservability.processor.transform.alloy" }}
 otelcol.processor.transform "{{ .name | default "default" }}" {
   error_mode = {{ .Values.processors.transform.errorMode | quote }}
 
 {{- if .Values.metrics.enabled }}
-{{- if .Values.metrics.transforms.resource }}
+{{- if or .Values.metrics.transforms.resource .Values.alignServiceNameWithOTelSemConv }}
   metric_statements {
     context = "resource"
     statements = [
 {{- range $transform := .Values.metrics.transforms.resource }}
 {{ $transform | quote | indent 6 }},
+{{- end }}
+{{- if .Values.alignServiceNameWithOTelSemConv }}
+{{- include "feature.applicationObservability.processor.transform.serviceDetectionStatements" . | indent 6 }}
 {{- end }}
     ]
   }
@@ -49,6 +83,9 @@ otelcol.processor.transform "{{ .name | default "default" }}" {
       "set(attributes[\"pod\"], attributes[\"k8s.pod.name\"])",
       "set(attributes[\"namespace\"], attributes[\"k8s.namespace.name\"])",
       "set(attributes[\"loki.resource.labels\"], \"{{ .Values.logs.transforms.labels | join ", " }}\")",
+{{- if .Values.alignServiceNameWithOTelSemConv }}
+{{- include "feature.applicationObservability.processor.transform.serviceDetectionStatements" . | indent 6 }}
+{{- end }}
     ]
   }
 {{- if .Values.logs.transforms.log }}
@@ -63,12 +100,15 @@ otelcol.processor.transform "{{ .name | default "default" }}" {
 {{- end }}
 {{- end }}
 {{- if .Values.traces.enabled }}
-{{- if .Values.traces.transforms.resource }}
+{{- if or .Values.traces.transforms.resource .Values.alignServiceNameWithOTelSemConv }}
   trace_statements {
     context = "resource"
     statements = [
 {{- range $transform := .Values.traces.transforms.resource }}
 {{ $transform | quote | indent 6 }},
+{{- end }}
+{{- if .Values.alignServiceNameWithOTelSemConv }}
+{{- include "feature.applicationObservability.processor.transform.serviceDetectionStatements" . | indent 6 }}
 {{- end }}
     ]
   }

--- a/charts/k8s-monitoring/charts/feature-application-observability/values.schema.json
+++ b/charts/k8s-monitoring/charts/feature-application-observability/values.schema.json
@@ -2,6 +2,9 @@
     "$schema": "http://json-schema.org/schema#",
     "type": "object",
     "properties": {
+        "alignServiceNameWithOTelSemConv": {
+            "type": "boolean"
+        },
         "connectors": {
             "type": "object",
             "properties": {

--- a/charts/k8s-monitoring/charts/feature-application-observability/values.yaml
+++ b/charts/k8s-monitoring/charts/feature-application-observability/values.yaml
@@ -4,6 +4,15 @@ global:
   # @section -- Global Settings
   namespaceOverride: ""
 
+# -- Align the `service.name` and `service.namespace` resource attributes with the
+# [OpenTelemetry semantic conventions for Kubernetes attributes](https://opentelemetry.io/docs/specs/semconv/non-normative/k8s-attributes/)
+# (which is what Grafana Beyla uses) when the application has not reported them itself. When enabled, the detection
+# chain becomes: pod annotation `resource.opentelemetry.io/service.name` → pod label `app.kubernetes.io/instance` →
+# pod label `app.kubernetes.io/name` → owner workload name (Deployment, StatefulSet, etc.) → pod name. Enabling this
+# also enables `processors.k8sattributes.otelAnnotations`.
+# @section -- General
+alignServiceNameWithOTelSemConv: false
+
 receivers:
   otlp:
     # The OTLP gRPC receiver configuration.
@@ -212,6 +221,8 @@ processors:
 
     # -- Whether to automatically set the recommended OpenTelemetry
     # [resource attributes](https://opentelemetry.io/docs/specs/semconv/non-normative/k8s-attributes/).
+    # This translates pod annotations like `resource.opentelemetry.io/service.name` into resource attributes.
+    # Automatically enabled when `alignServiceNameWithOTelSemConv` is true.
     # @section -- Processors: K8s Attributes
     otelAnnotations: false
 

--- a/charts/k8s-monitoring/charts/feature-pod-logs-via-loki/README.md
+++ b/charts/k8s-monitoring/charts/feature-pod-logs-via-loki/README.md
@@ -14,6 +14,31 @@ podLogsViaLoki:
   enabled: true
 ```
 
+## Service name and namespace detection
+
+This feature sets the `service_name` and `service_namespace` labels on collected logs. The default detection chain
+for `service_name` is, in order: the `resource.opentelemetry.io/service.name` pod annotation, the
+`app.kubernetes.io/name` pod label, and the container name.
+
+Set `alignServiceNameWithOTelSemConv: true` to opt in to the
+[OpenTelemetry semantic conventions for Kubernetes attributes](https://opentelemetry.io/docs/specs/semconv/non-normative/k8s-attributes/)
+instead. These are also what Grafana Beyla uses for application metrics, so enabling this flag makes `service_name`
+consistent across metrics, logs, traces, and profiles from the same workload. The chain becomes:
+
+1.  The `resource.opentelemetry.io/service.name` pod annotation
+2.  The `app.kubernetes.io/instance` pod label
+3.  The `app.kubernetes.io/name` pod label
+4.  The name of the workload that owns the pod (Deployment, StatefulSet, DaemonSet, CronJob, Job, ...). For pods owned
+    by a Deployment via a ReplicaSet, the Deployment name is used.
+5.  The pod name
+6.  The container name
+
+In either mode, `service_namespace` is set to the first value found from: the
+`resource.opentelemetry.io/service.namespace` pod annotation, then the pod namespace.
+
+To pin a specific service name for a workload, set the `resource.opentelemetry.io/service.name` annotation on the
+pod. It takes the highest precedence in every mode.
+
 ## Testing
 
 This chart contains unit tests to verify the generated configuration. The hidden value `deployAsConfigMap` will render
@@ -43,6 +68,18 @@ Be sure perform actual integration testing in a live environment in the main [k8
 
 ## Values
 
+### Log Processing
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| alignServiceNameWithOTelSemConv | bool | `false` | Align the `service_name` label with the [OpenTelemetry semantic conventions for Kubernetes attributes](https://opentelemetry.io/docs/specs/semconv/non-normative/k8s-attributes/) (which is what Grafana Beyla uses). When enabled, the detection chain becomes: pod annotation `resource.opentelemetry.io/service.name` → pod label `app.kubernetes.io/instance` → pod label `app.kubernetes.io/name` → owner workload name (Deployment, StatefulSet, etc.) → pod name → container name. When disabled, the previous chain is used: annotation → pod label `app.kubernetes.io/name` → container name. |
+| annotations | object | `{"job":"k8s.grafana.com/logs.job"}` | Log labels to set with values copied from the Kubernetes Pod annotations. Format: `<log_label>: <kubernetes_annotation>`. |
+| cri.maxPartialLines | int | `100` | Maximum number of partial lines to hold in memory before forcing a merge. Increase this value if logs are being lost due to partial line limits. |
+| defaultLogFormat | string | `"cri"` | Default parsing format if it cannot be determined from container UID. Options are `null`, `cri`, or `docker`. |
+| labels | object | `{"app_kubernetes_io_name":"app.kubernetes.io/name"}` | Log labels to set with values copied from the Kubernetes Pod labels. Format: `<log_label>: <kubernetes_label>`. |
+| staticLabels | object | `{}` | Log labels to set with static values. |
+| staticLabelsFrom | object | `{}` | Log labels to set with static values, not quoted so it can reference config components. |
+
 ### Discovery Settings
 
 | Key | Type | Default | Description |
@@ -55,17 +92,6 @@ Be sure perform actual integration testing in a live environment in the main [k8
 | labelSelectors | object | `{}` | Filter the list of discovered pods and services by labels. Only for the "volumes" gather method. Example: `labelSelectors: { 'app': 'myapp' }` will only discover pods with the label `app=myapp`. Example: `labelSelectors: { 'app': ['myapp', 'myotherapp'] }` will only discover pods with the label `app=myapp` or `app=myotherapp`. |
 | namespaces | list | `[]` | Only capture logs from pods in these namespaces (`[]` means all namespaces). |
 | nodeSelectors | object | `{}` | Filter the list of discovered nodes by labels. Only for the "volumes" gather method. Example: `nodeSelectors: { 'kubernetes.io/os': 'linux' }` |
-
-### Log Processing
-
-| Key | Type | Default | Description |
-|-----|------|---------|-------------|
-| annotations | object | `{"job":"k8s.grafana.com/logs.job"}` | Log labels to set with values copied from the Kubernetes Pod annotations. Format: `<log_label>: <kubernetes_annotation>`. |
-| cri.maxPartialLines | int | `100` | Maximum number of partial lines to hold in memory before forcing a merge. Increase this value if logs are being lost due to partial line limits. |
-| defaultLogFormat | string | `"cri"` | Default parsing format if it cannot be determined from container UID. Options are `null`, `cri`, or `docker`. |
-| labels | object | `{"app_kubernetes_io_name":"app.kubernetes.io/name"}` | Log labels to set with values copied from the Kubernetes Pod labels. Format: `<log_label>: <kubernetes_label>`. |
-| staticLabels | object | `{}` | Log labels to set with static values. |
-| staticLabelsFrom | object | `{}` | Log labels to set with static values, not quoted so it can reference config components. |
 
 ### Processing settings
 

--- a/charts/k8s-monitoring/charts/feature-pod-logs-via-loki/README.md.gotmpl
+++ b/charts/k8s-monitoring/charts/feature-pod-logs-via-loki/README.md.gotmpl
@@ -16,6 +16,31 @@ podLogsViaLoki:
   enabled: true
 ```
 
+## Service name and namespace detection
+
+This feature sets the `service_name` and `service_namespace` labels on collected logs. The default detection chain
+for `service_name` is, in order: the `resource.opentelemetry.io/service.name` pod annotation, the
+`app.kubernetes.io/name` pod label, and the container name.
+
+Set `alignServiceNameWithOTelSemConv: true` to opt in to the
+[OpenTelemetry semantic conventions for Kubernetes attributes](https://opentelemetry.io/docs/specs/semconv/non-normative/k8s-attributes/)
+instead. These are also what Grafana Beyla uses for application metrics, so enabling this flag makes `service_name`
+consistent across metrics, logs, traces, and profiles from the same workload. The chain becomes:
+
+1.  The `resource.opentelemetry.io/service.name` pod annotation
+2.  The `app.kubernetes.io/instance` pod label
+3.  The `app.kubernetes.io/name` pod label
+4.  The name of the workload that owns the pod (Deployment, StatefulSet, DaemonSet, CronJob, Job, ...). For pods owned
+    by a Deployment via a ReplicaSet, the Deployment name is used.
+5.  The pod name
+6.  The container name
+
+In either mode, `service_namespace` is set to the first value found from: the
+`resource.opentelemetry.io/service.namespace` pod annotation, then the pod namespace.
+
+To pin a specific service name for a workload, set the `resource.opentelemetry.io/service.name` annotation on the
+pod. It takes the highest precedence in every mode.
+
 ## Testing
 
 This chart contains unit tests to verify the generated configuration. The hidden value `deployAsConfigMap` will render

--- a/charts/k8s-monitoring/charts/feature-pod-logs-via-loki/templates/_discovery.alloy.tpl
+++ b/charts/k8s-monitoring/charts/feature-pod-logs-via-loki/templates/_discovery.alloy.tpl
@@ -108,6 +108,45 @@ discovery.relabel "filtered_pods" {
     target_label = "tmp_container_runtime"
   }
 
+{{- if .Values.alignServiceNameWithOTelSemConv }}
+  // Compute the workload (owner) name. For ReplicaSet-owned pods, strip the
+  // pod-template hash to recover the Deployment name (matches Beyla / OTel Operator).
+  rule {
+    source_labels = ["__meta_kubernetes_pod_controller_name"]
+    target_label = "__tmp_workload_name"
+  }
+  rule {
+    source_labels = ["__meta_kubernetes_pod_controller_kind", "__meta_kubernetes_pod_controller_name"]
+    regex = "ReplicaSet;(.+)-[^-]+"
+    replacement = "$1"
+    target_label = "__tmp_workload_name"
+  }
+
+  // explicitly set service_name. if not set, loki will automatically try to populate a default.
+  // see https://grafana.com/docs/loki/latest/get-started/labels/#default-labels-for-all-users
+  //
+  // choose the first value found from the following ordered list:
+  // - pod.annotation[resource.opentelemetry.io/service.name]
+  // - pod.label[app.kubernetes.io/instance]
+  // - pod.label[app.kubernetes.io/name]
+  // - k8s.workload.name (Deployment, StatefulSet, DaemonSet, CronJob, Job, ...)
+  // - k8s.pod.name
+  // - k8s.container.name
+  rule {
+    source_labels = [
+      {{ include "pod_annotation" "resource.opentelemetry.io/service.name" | quote }},
+      {{ include "pod_label" "app.kubernetes.io/instance" | quote }},
+      {{ include "pod_label" "app.kubernetes.io/name" | quote }},
+      "__tmp_workload_name",
+      "__meta_kubernetes_pod_name",
+      "__meta_kubernetes_pod_container_name",
+    ]
+    separator = ";"
+    regex = "^(?:;*)?([^;]+).*$"
+    replacement = "$1"
+    target_label = "service_name"
+  }
+{{- else }}
   // explicitly set service_name. if not set, loki will automatically try to populate a default.
   // see https://grafana.com/docs/loki/latest/get-started/labels/#default-labels-for-all-users
   //
@@ -126,6 +165,7 @@ discovery.relabel "filtered_pods" {
     replacement = "$1"
     target_label = "service_name"
   }
+{{- end }}
 
   // explicitly set service_namespace.
   //

--- a/charts/k8s-monitoring/charts/feature-pod-logs-via-loki/tests/__snapshot__/default_test.yaml.snap
+++ b/charts/k8s-monitoring/charts/feature-pod-logs-via-loki/tests/__snapshot__/default_test.yaml.snap
@@ -48,7 +48,6 @@ should allow setting static labels:
             replacement = "$1"
             target_label = "tmp_container_runtime"
           }
-
           // explicitly set service_name. if not set, loki will automatically try to populate a default.
           // see https://grafana.com/docs/loki/latest/get-started/labels/#default-labels-for-all-users
           //
@@ -252,7 +251,6 @@ should allow setting structured metadata:
             replacement = "$1"
             target_label = "tmp_container_runtime"
           }
-
           // explicitly set service_name. if not set, loki will automatically try to populate a default.
           // see https://grafana.com/docs/loki/latest/get-started/labels/#default-labels-for-all-users
           //
@@ -455,7 +453,6 @@ should allow using label selectors:
             replacement = "$1"
             target_label = "tmp_container_runtime"
           }
-
           // explicitly set service_name. if not set, loki will automatically try to populate a default.
           // see https://grafana.com/docs/loki/latest/get-started/labels/#default-labels-for-all-users
           //
@@ -656,7 +653,6 @@ should allow using label selectors with multiple values:
             replacement = "$1"
             target_label = "tmp_container_runtime"
           }
-
           // explicitly set service_name. if not set, loki will automatically try to populate a default.
           // see https://grafana.com/docs/loki/latest/get-started/labels/#default-labels-for-all-users
           //
@@ -853,7 +849,6 @@ should allow using the secret filter:
             replacement = "$1"
             target_label = "tmp_container_runtime"
           }
-
           // explicitly set service_name. if not set, loki will automatically try to populate a default.
           // see https://grafana.com/docs/loki/latest/get-started/labels/#default-labels-for-all-users
           //
@@ -1055,7 +1050,6 @@ should allow using the secret filter with a gitleaks config and other settings:
             replacement = "$1"
             target_label = "tmp_container_runtime"
           }
-
           // explicitly set service_name. if not set, loki will automatically try to populate a default.
           // see https://grafana.com/docs/loki/latest/get-started/labels/#default-labels-for-all-users
           //
@@ -1258,7 +1252,6 @@ should allow using the secret filter with an allowlist:
             replacement = "$1"
             target_label = "tmp_container_runtime"
           }
-
           // explicitly set service_name. if not set, loki will automatically try to populate a default.
           // see https://grafana.com/docs/loki/latest/get-started/labels/#default-labels-for-all-users
           //
@@ -1464,7 +1457,6 @@ should allow using the secret filter with an inclusion filter, to split which lo
             replacement = "$1"
             target_label = "tmp_container_runtime"
           }
-
           // explicitly set service_name. if not set, loki will automatically try to populate a default.
           // see https://grafana.com/docs/loki/latest/get-started/labels/#default-labels-for-all-users
           //
@@ -1704,7 +1696,6 @@ should render the default configuration:
             replacement = "$1"
             target_label = "tmp_container_runtime"
           }
-
           // explicitly set service_name. if not set, loki will automatically try to populate a default.
           // see https://grafana.com/docs/loki/latest/get-started/labels/#default-labels-for-all-users
           //

--- a/charts/k8s-monitoring/charts/feature-pod-logs-via-loki/tests/__snapshot__/node_labels_test.yaml.snap
+++ b/charts/k8s-monitoring/charts/feature-pod-logs-via-loki/tests/__snapshot__/node_labels_test.yaml.snap
@@ -51,7 +51,6 @@ should add the attach_metadata block to the discovery.kubernetes:
             replacement = "$1"
             target_label = "tmp_container_runtime"
           }
-
           // explicitly set service_name. if not set, loki will automatically try to populate a default.
           // see https://grafana.com/docs/loki/latest/get-started/labels/#default-labels-for-all-users
           //
@@ -263,7 +262,6 @@ should add the node architecture label rules to the discovery relabel:
             replacement = "$1"
             target_label = "tmp_container_runtime"
           }
-
           // explicitly set service_name. if not set, loki will automatically try to populate a default.
           // see https://grafana.com/docs/loki/latest/get-started/labels/#default-labels-for-all-users
           //
@@ -473,7 +471,6 @@ should add the node availability zone label rules to the discovery relabel:
             replacement = "$1"
             target_label = "tmp_container_runtime"
           }
-
           // explicitly set service_name. if not set, loki will automatically try to populate a default.
           // see https://grafana.com/docs/loki/latest/get-started/labels/#default-labels-for-all-users
           //
@@ -684,7 +681,6 @@ should add the node instance type label rules to the discovery relabel:
             replacement = "$1"
             target_label = "tmp_container_runtime"
           }
-
           // explicitly set service_name. if not set, loki will automatically try to populate a default.
           // see https://grafana.com/docs/loki/latest/get-started/labels/#default-labels-for-all-users
           //
@@ -894,7 +890,6 @@ should add the node os label rules to the discovery relabel:
             replacement = "$1"
             target_label = "tmp_container_runtime"
           }
-
           // explicitly set service_name. if not set, loki will automatically try to populate a default.
           // see https://grafana.com/docs/loki/latest/get-started/labels/#default-labels-for-all-users
           //
@@ -1105,7 +1100,6 @@ should add the node pool label rules to the discovery relabel:
             replacement = "$1"
             target_label = "tmp_container_runtime"
           }
-
           // explicitly set service_name. if not set, loki will automatically try to populate a default.
           // see https://grafana.com/docs/loki/latest/get-started/labels/#default-labels-for-all-users
           //
@@ -1318,7 +1312,6 @@ should add the node region label rules to the discovery relabel:
             replacement = "$1"
             target_label = "tmp_container_runtime"
           }
-
           // explicitly set service_name. if not set, loki will automatically try to populate a default.
           // see https://grafana.com/docs/loki/latest/get-started/labels/#default-labels-for-all-users
           //
@@ -1528,7 +1521,6 @@ should add the node role label rules to the discovery relabel:
             replacement = "$1"
             target_label = "tmp_container_runtime"
           }
-
           // explicitly set service_name. if not set, loki will automatically try to populate a default.
           // see https://grafana.com/docs/loki/latest/get-started/labels/#default-labels-for-all-users
           //

--- a/charts/k8s-monitoring/charts/feature-pod-logs-via-loki/values.schema.json
+++ b/charts/k8s-monitoring/charts/feature-pod-logs-via-loki/values.schema.json
@@ -2,6 +2,9 @@
     "$schema": "http://json-schema.org/schema#",
     "type": "object",
     "properties": {
+        "alignServiceNameWithOTelSemConv": {
+            "type": "boolean"
+        },
         "annotationSelector": {
             "type": "string"
         },

--- a/charts/k8s-monitoring/charts/feature-pod-logs-via-loki/values.yaml
+++ b/charts/k8s-monitoring/charts/feature-pod-logs-via-loki/values.yaml
@@ -93,6 +93,15 @@ annotations:
 # @section -- Volume Log Gathering
 onlyGatherNewLogLines: true
 
+# -- Align the `service_name` label with the
+# [OpenTelemetry semantic conventions for Kubernetes attributes](https://opentelemetry.io/docs/specs/semconv/non-normative/k8s-attributes/)
+# (which is what Grafana Beyla uses). When enabled, the detection chain becomes:
+# pod annotation `resource.opentelemetry.io/service.name` → pod label `app.kubernetes.io/instance` → pod label
+# `app.kubernetes.io/name` → owner workload name (Deployment, StatefulSet, etc.) → pod name → container name.
+# When disabled, the previous chain is used: annotation → pod label `app.kubernetes.io/name` → container name.
+# @section -- Log Processing
+alignServiceNameWithOTelSemConv: false
+
 # -- Default parsing format if it cannot be determined from container UID. Options are `null`, `cri`, or `docker`.
 # @section -- Log Processing
 defaultLogFormat: cri

--- a/charts/k8s-monitoring/charts/feature-pod-logs-via-opentelemetry/README.md
+++ b/charts/k8s-monitoring/charts/feature-pod-logs-via-opentelemetry/README.md
@@ -14,6 +14,33 @@ podLogsViaOpenTelemetry:
   enabled: true
 ```
 
+## Service name and namespace detection
+
+This feature sets the `service.name` and `service.namespace` resource attributes on collected logs. The default
+detection chain for `service.name` is, in order: the `resource.opentelemetry.io/service.name` pod annotation, the
+workload owner name (Deployment, StatefulSet, etc.), the pod name, and the container name.
+
+Set `alignServiceNameWithOTelSemConv: true` to opt in to the
+[OpenTelemetry semantic conventions for Kubernetes attributes](https://opentelemetry.io/docs/specs/semconv/non-normative/k8s-attributes/)
+instead. These are also what Grafana Beyla uses for application metrics, so enabling this flag makes `service.name`
+consistent across metrics, logs, traces, and profiles from the same workload. The chain becomes:
+
+1.  The `resource.opentelemetry.io/service.name` pod annotation
+2.  The `app.kubernetes.io/instance` pod label
+3.  The `app.kubernetes.io/name` pod label
+4.  The name of the workload that owns the pod (Deployment, StatefulSet, DaemonSet, CronJob, Job, ...)
+5.  The pod name
+6.  The container name
+
+When the flag is enabled, the `service.version` resource attribute is also populated from the
+`app.kubernetes.io/version` pod label.
+
+In either mode, `service.namespace` is set to the first value found from: the
+`resource.opentelemetry.io/service.namespace` pod annotation, then the pod namespace.
+
+To pin a specific service name for a workload, set the `resource.opentelemetry.io/service.name` annotation on the
+pod. It takes the highest precedence in every mode.
+
 ## Testing
 
 This chart contains unit tests to verify the generated configuration. The hidden value `deployAsConfigMap` will render
@@ -43,19 +70,11 @@ Be sure perform actual integration testing in a live environment in the main [k8
 
 ## Values
 
-### Pod Discovery
-
-| Key | Type | Default | Description |
-|-----|------|---------|-------------|
-| annotationSelector | string | `"logs.grafana.com/pods.enabled"` | Pod annotation to use for controlling log discovery. If a pod has this annotation, it will either enable or disable gathering of logs, depending on the value of the discoveryMethod. |
-| discoveryMethod | string | `"all"` | Controls the behavior of discovering pods for logs. Possible values: `all`, `annotation`. When set to "all", every pod (filtered by the namespace and label selectors) will have their logs gathered. When set to "annotation", only pods with the annotation selector set to something other than "false", "no" or "skip" will have their logs gathered. |
-| excludeNamespaces | list | `[]` | Do not capture logs from any pods in these namespaces. |
-| namespaces | list | `[]` | Only capture logs from pods in these namespaces (`[]` means all namespaces). |
-
 ### Log Processing
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
+| alignServiceNameWithOTelSemConv | bool | `false` | Align the `service.name` resource attribute with the [OpenTelemetry semantic conventions for Kubernetes attributes](https://opentelemetry.io/docs/specs/semconv/non-normative/k8s-attributes/) (which is what Grafana Beyla uses). When enabled, the detection chain becomes: pod annotation `resource.opentelemetry.io/service.name` → pod label `app.kubernetes.io/instance` → pod label `app.kubernetes.io/name` → owner workload name (Deployment, StatefulSet, etc.) → pod name → container name. The `service.version` resource attribute is similarly detected from the `app.kubernetes.io/version` pod label. |
 | annotations | object | `{}` | Log attributes to set with values copied from the Kubernetes Pod annotations. Format: `<log_label>: <kubernetes_annotation>`. |
 | labels | object | `{"app_kubernetes_io_name":"app.kubernetes.io/name"}` | Log attributes to set with values copied from the Kubernetes Pod labels. Format: `<log_label>: <kubernetes_label>`. |
 | namespaceAnnotations | object | `{}` | Log attributes to set with values copied from the Kubernetes Namespace annotations. Format: `<log_label>: <kubernetes_namespace_annotation>`. |
@@ -65,6 +84,15 @@ Be sure perform actual integration testing in a live environment in the main [k8
 | otelAnnotations | bool | `false` | Whether to automatically set the recommended OpenTelemetry [resource attributes](https://opentelemetry.io/docs/specs/semconv/non-normative/k8s-attributes/). |
 | staticAttributes | object | `{}` | Log attributes to set with static values. |
 | staticAttributesFrom | object | `{}` | Log attributes to set with static values, not quoted so it can reference config components. |
+
+### Pod Discovery
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| annotationSelector | string | `"logs.grafana.com/pods.enabled"` | Pod annotation to use for controlling log discovery. If a pod has this annotation, it will either enable or disable gathering of logs, depending on the value of the discoveryMethod. |
+| discoveryMethod | string | `"all"` | Controls the behavior of discovering pods for logs. Possible values: `all`, `annotation`. When set to "all", every pod (filtered by the namespace and label selectors) will have their logs gathered. When set to "annotation", only pods with the annotation selector set to something other than "false", "no" or "skip" will have their logs gathered. |
+| excludeNamespaces | list | `[]` | Do not capture logs from any pods in these namespaces. |
+| namespaces | list | `[]` | Only capture logs from pods in these namespaces (`[]` means all namespaces). |
 
 ### Global Settings
 

--- a/charts/k8s-monitoring/charts/feature-pod-logs-via-opentelemetry/README.md.gotmpl
+++ b/charts/k8s-monitoring/charts/feature-pod-logs-via-opentelemetry/README.md.gotmpl
@@ -16,6 +16,33 @@ podLogsViaOpenTelemetry:
   enabled: true
 ```
 
+## Service name and namespace detection
+
+This feature sets the `service.name` and `service.namespace` resource attributes on collected logs. The default
+detection chain for `service.name` is, in order: the `resource.opentelemetry.io/service.name` pod annotation, the
+workload owner name (Deployment, StatefulSet, etc.), the pod name, and the container name.
+
+Set `alignServiceNameWithOTelSemConv: true` to opt in to the
+[OpenTelemetry semantic conventions for Kubernetes attributes](https://opentelemetry.io/docs/specs/semconv/non-normative/k8s-attributes/)
+instead. These are also what Grafana Beyla uses for application metrics, so enabling this flag makes `service.name`
+consistent across metrics, logs, traces, and profiles from the same workload. The chain becomes:
+
+1.  The `resource.opentelemetry.io/service.name` pod annotation
+2.  The `app.kubernetes.io/instance` pod label
+3.  The `app.kubernetes.io/name` pod label
+4.  The name of the workload that owns the pod (Deployment, StatefulSet, DaemonSet, CronJob, Job, ...)
+5.  The pod name
+6.  The container name
+
+When the flag is enabled, the `service.version` resource attribute is also populated from the
+`app.kubernetes.io/version` pod label.
+
+In either mode, `service.namespace` is set to the first value found from: the
+`resource.opentelemetry.io/service.namespace` pod annotation, then the pod namespace.
+
+To pin a specific service name for a workload, set the `resource.opentelemetry.io/service.name` annotation on the
+pod. It takes the highest precedence in every mode.
+
 ## Testing
 
 This chart contains unit tests to verify the generated configuration. The hidden value `deployAsConfigMap` will render

--- a/charts/k8s-monitoring/charts/feature-pod-logs-via-opentelemetry/templates/_module.alloy.tpl
+++ b/charts/k8s-monitoring/charts/feature-pod-logs-via-opentelemetry/templates/_module.alloy.tpl
@@ -87,6 +87,26 @@ declare "pod_logs_via_opentelemetry" {
         from     = "namespace"
       }
 {{- end }}
+{{- if .Values.alignServiceNameWithOTelSemConv }}
+      // Extracted into temporary attributes for service.name / service.version detection, then deleted in the
+      // transform processor below. Temporary names are used so the cleanup never deletes an `app.kubernetes.io/*`
+      // attribute the user extracted.
+      label {
+        tag_name = "k8s_monitoring.tmp.instance"
+        key      = "app.kubernetes.io/instance"
+        from     = "pod"
+      }
+      label {
+        tag_name = "k8s_monitoring.tmp.name"
+        key      = "app.kubernetes.io/name"
+        from     = "pod"
+      }
+      label {
+        tag_name = "k8s_monitoring.tmp.version"
+        key      = "app.kubernetes.io/version"
+        from     = "pod"
+      }
+{{- end }}
 {{- range $attribute, $label := .Values.labels }}
       label {
         tag_name = {{ $attribute | quote }}
@@ -140,6 +160,19 @@ declare "pod_logs_via_opentelemetry" {
         `delete_key(attributes, "k8s.container.restart_count")`,
         `delete_key(attributes, {{ .Values.annotationSelector | quote }})`,
 
+{{- if .Values.alignServiceNameWithOTelSemConv }}
+        // Set service.name by choosing the first value found from the following ordered list:
+        // - pod.annotation[resource.opentelemetry.io/service.name] (set by the k8sattributes processor above)
+        // - pod.label[app.kubernetes.io/instance]
+        // - pod.label[app.kubernetes.io/name]
+        // - k8s.workload.name (Deployment, StatefulSet, DaemonSet, CronJob, Job, ...)
+        // - k8s.pod.name
+        // - k8s.container.name
+        // The instance/name/version pod labels are read from temporary attributes (k8s_monitoring.tmp.*) so the
+        // cleanup below only ever deletes attributes this feature added.
+        `set(resource.attributes["service.name"], resource.attributes["k8s_monitoring.tmp.instance"]) where (resource.attributes["service.name"] == nil or resource.attributes["service.name"] == "") and resource.attributes["k8s_monitoring.tmp.instance"] != nil and resource.attributes["k8s_monitoring.tmp.instance"] != ""`,
+        `set(resource.attributes["service.name"], resource.attributes["k8s_monitoring.tmp.name"]) where (resource.attributes["service.name"] == nil or resource.attributes["service.name"] == "") and resource.attributes["k8s_monitoring.tmp.name"] != nil and resource.attributes["k8s_monitoring.tmp.name"] != ""`,
+{{- end }}
         `set(attributes["service.name"], attributes["app.kubernetes.io/name"]) where (attributes["service.name"] == nil or attributes["service.name"] == "") and attributes["app.kubernetes.io/name"] != nil and attributes["app.kubernetes.io/name"] != ""`,
         `set(attributes["service.name"], attributes["k8s.deployment.name"]) where (attributes["service.name"] == nil or attributes["service.name"] == "") and attributes["k8s.deployment.name"] != nil and attributes["k8s.deployment.name"] != ""`,
         `set(attributes["service.name"], attributes["k8s.replicaset.name"]) where (attributes["service.name"] == nil or attributes["service.name"] == "") and attributes["k8s.replicaset.name"] != nil and attributes["k8s.replicaset.name"] != ""`,
@@ -151,10 +184,19 @@ declare "pod_logs_via_opentelemetry" {
         `set(attributes["service.name"], attributes["k8s.container.name"]) where (attributes["service.name"] == nil or attributes["service.name"] == "") and attributes["k8s.container.name"] != nil and attributes["k8s.container.name"] != ""`,
 
         `set(attributes["service.namespace"], attributes["k8s.namespace.name"]) where (attributes["service.namespace"] == nil or attributes["service.namespace"] == "") and attributes["k8s.namespace.name"] != nil and attributes["k8s.namespace.name"] != ""`,
-
+{{ if .Values.alignServiceNameWithOTelSemConv }}
+        `set(resource.attributes["service.version"], resource.attributes["k8s_monitoring.tmp.version"]) where resource.attributes["service.version"] == nil and resource.attributes["k8s_monitoring.tmp.version"] != nil and resource.attributes["k8s_monitoring.tmp.version"] != ""`,
+{{- end }}
         `set(attributes["service.version"], attributes["app.kubernetes.io/version"]) where attributes["service.version"] == nil`,
 
         `set(attributes["service.instance.id"], Concat([attributes["k8s.namespace.name"], attributes["k8s.pod.name"], attributes["k8s.container.name"]], ".")) where attributes["service.instance.id"] == nil`,
+{{- if .Values.alignServiceNameWithOTelSemConv }}
+
+        // Remove the temporary attributes used for service.name / service.version detection
+        `delete_key(resource.attributes, "k8s_monitoring.tmp.instance")`,
+        `delete_key(resource.attributes, "k8s_monitoring.tmp.name")`,
+        `delete_key(resource.attributes, "k8s_monitoring.tmp.version")`,
+{{- end }}
 {{- range $attribute, $value := .Values.staticAttributes }}
         `set(attributes[{{ $attribute | quote }}], {{ $value | quote }})`,
 {{- end }}

--- a/charts/k8s-monitoring/charts/feature-pod-logs-via-opentelemetry/tests/__snapshot__/default_test.yaml.snap
+++ b/charts/k8s-monitoring/charts/feature-pod-logs-via-opentelemetry/tests/__snapshot__/default_test.yaml.snap
@@ -86,7 +86,6 @@ can utilize the otel annotations flag:
             statements = [
               `delete_key(attributes, "k8s.container.restart_count")`,
               `delete_key(attributes, "logs.grafana.com/pods.enabled")`,
-
               `set(attributes["service.name"], attributes["app.kubernetes.io/name"]) where (attributes["service.name"] == nil or attributes["service.name"] == "") and attributes["app.kubernetes.io/name"] != nil and attributes["app.kubernetes.io/name"] != ""`,
               `set(attributes["service.name"], attributes["k8s.deployment.name"]) where (attributes["service.name"] == nil or attributes["service.name"] == "") and attributes["k8s.deployment.name"] != nil and attributes["k8s.deployment.name"] != ""`,
               `set(attributes["service.name"], attributes["k8s.replicaset.name"]) where (attributes["service.name"] == nil or attributes["service.name"] == "") and attributes["k8s.replicaset.name"] != nil and attributes["k8s.replicaset.name"] != ""`,
@@ -205,7 +204,6 @@ should allow setting log attributes:
             statements = [
               `delete_key(attributes, "k8s.container.restart_count")`,
               `delete_key(attributes, "logs.grafana.com/pods.enabled")`,
-
               `set(attributes["service.name"], attributes["app.kubernetes.io/name"]) where (attributes["service.name"] == nil or attributes["service.name"] == "") and attributes["app.kubernetes.io/name"] != nil and attributes["app.kubernetes.io/name"] != ""`,
               `set(attributes["service.name"], attributes["k8s.deployment.name"]) where (attributes["service.name"] == nil or attributes["service.name"] == "") and attributes["k8s.deployment.name"] != nil and attributes["k8s.deployment.name"] != ""`,
               `set(attributes["service.name"], attributes["k8s.replicaset.name"]) where (attributes["service.name"] == nil or attributes["service.name"] == "") and attributes["k8s.replicaset.name"] != nil and attributes["k8s.replicaset.name"] != ""`,
@@ -324,7 +322,6 @@ should allow setting resource attributes:
             statements = [
               `delete_key(attributes, "k8s.container.restart_count")`,
               `delete_key(attributes, "logs.grafana.com/pods.enabled")`,
-
               `set(attributes["service.name"], attributes["app.kubernetes.io/name"]) where (attributes["service.name"] == nil or attributes["service.name"] == "") and attributes["app.kubernetes.io/name"] != nil and attributes["app.kubernetes.io/name"] != ""`,
               `set(attributes["service.name"], attributes["k8s.deployment.name"]) where (attributes["service.name"] == nil or attributes["service.name"] == "") and attributes["k8s.deployment.name"] != nil and attributes["k8s.deployment.name"] != ""`,
               `set(attributes["service.name"], attributes["k8s.replicaset.name"]) where (attributes["service.name"] == nil or attributes["service.name"] == "") and attributes["k8s.replicaset.name"] != nil and attributes["k8s.replicaset.name"] != ""`,
@@ -443,7 +440,6 @@ should allow using label selectors:
             statements = [
               `delete_key(attributes, "k8s.container.restart_count")`,
               `delete_key(attributes, "logs.grafana.com/pods.enabled")`,
-
               `set(attributes["service.name"], attributes["app.kubernetes.io/name"]) where (attributes["service.name"] == nil or attributes["service.name"] == "") and attributes["app.kubernetes.io/name"] != nil and attributes["app.kubernetes.io/name"] != ""`,
               `set(attributes["service.name"], attributes["k8s.deployment.name"]) where (attributes["service.name"] == nil or attributes["service.name"] == "") and attributes["k8s.deployment.name"] != nil and attributes["k8s.deployment.name"] != ""`,
               `set(attributes["service.name"], attributes["k8s.replicaset.name"]) where (attributes["service.name"] == nil or attributes["service.name"] == "") and attributes["k8s.replicaset.name"] != nil and attributes["k8s.replicaset.name"] != ""`,
@@ -562,7 +558,6 @@ should allow using label selectors with multiple values:
             statements = [
               `delete_key(attributes, "k8s.container.restart_count")`,
               `delete_key(attributes, "logs.grafana.com/pods.enabled")`,
-
               `set(attributes["service.name"], attributes["app.kubernetes.io/name"]) where (attributes["service.name"] == nil or attributes["service.name"] == "") and attributes["app.kubernetes.io/name"] != nil and attributes["app.kubernetes.io/name"] != ""`,
               `set(attributes["service.name"], attributes["k8s.deployment.name"]) where (attributes["service.name"] == nil or attributes["service.name"] == "") and attributes["k8s.deployment.name"] != nil and attributes["k8s.deployment.name"] != ""`,
               `set(attributes["service.name"], attributes["k8s.replicaset.name"]) where (attributes["service.name"] == nil or attributes["service.name"] == "") and attributes["k8s.replicaset.name"] != nil and attributes["k8s.replicaset.name"] != ""`,
@@ -681,7 +676,6 @@ should render the default configuration:
             statements = [
               `delete_key(attributes, "k8s.container.restart_count")`,
               `delete_key(attributes, "logs.grafana.com/pods.enabled")`,
-
               `set(attributes["service.name"], attributes["app.kubernetes.io/name"]) where (attributes["service.name"] == nil or attributes["service.name"] == "") and attributes["app.kubernetes.io/name"] != nil and attributes["app.kubernetes.io/name"] != ""`,
               `set(attributes["service.name"], attributes["k8s.deployment.name"]) where (attributes["service.name"] == nil or attributes["service.name"] == "") and attributes["k8s.deployment.name"] != nil and attributes["k8s.deployment.name"] != ""`,
               `set(attributes["service.name"], attributes["k8s.replicaset.name"]) where (attributes["service.name"] == nil or attributes["service.name"] == "") and attributes["k8s.replicaset.name"] != nil and attributes["k8s.replicaset.name"] != ""`,

--- a/charts/k8s-monitoring/charts/feature-pod-logs-via-opentelemetry/tests/__snapshot__/node_labels_test.yaml.snap
+++ b/charts/k8s-monitoring/charts/feature-pod-logs-via-opentelemetry/tests/__snapshot__/node_labels_test.yaml.snap
@@ -91,7 +91,6 @@ should add the attach_metadata block to the discovery.kubernetes:
             statements = [
               `delete_key(attributes, "k8s.container.restart_count")`,
               `delete_key(attributes, "logs.grafana.com/pods.enabled")`,
-
               `set(attributes["service.name"], attributes["app.kubernetes.io/name"]) where (attributes["service.name"] == nil or attributes["service.name"] == "") and attributes["app.kubernetes.io/name"] != nil and attributes["app.kubernetes.io/name"] != ""`,
               `set(attributes["service.name"], attributes["k8s.deployment.name"]) where (attributes["service.name"] == nil or attributes["service.name"] == "") and attributes["k8s.deployment.name"] != nil and attributes["k8s.deployment.name"] != ""`,
               `set(attributes["service.name"], attributes["k8s.replicaset.name"]) where (attributes["service.name"] == nil or attributes["service.name"] == "") and attributes["k8s.replicaset.name"] != nil and attributes["k8s.replicaset.name"] != ""`,
@@ -215,7 +214,6 @@ should add the node architecture label rules to the discovery relabel:
             statements = [
               `delete_key(attributes, "k8s.container.restart_count")`,
               `delete_key(attributes, "logs.grafana.com/pods.enabled")`,
-
               `set(attributes["service.name"], attributes["app.kubernetes.io/name"]) where (attributes["service.name"] == nil or attributes["service.name"] == "") and attributes["app.kubernetes.io/name"] != nil and attributes["app.kubernetes.io/name"] != ""`,
               `set(attributes["service.name"], attributes["k8s.deployment.name"]) where (attributes["service.name"] == nil or attributes["service.name"] == "") and attributes["k8s.deployment.name"] != nil and attributes["k8s.deployment.name"] != ""`,
               `set(attributes["service.name"], attributes["k8s.replicaset.name"]) where (attributes["service.name"] == nil or attributes["service.name"] == "") and attributes["k8s.replicaset.name"] != nil and attributes["k8s.replicaset.name"] != ""`,
@@ -339,7 +337,6 @@ should add the node availability zone label rules to the discovery relabel:
             statements = [
               `delete_key(attributes, "k8s.container.restart_count")`,
               `delete_key(attributes, "logs.grafana.com/pods.enabled")`,
-
               `set(attributes["service.name"], attributes["app.kubernetes.io/name"]) where (attributes["service.name"] == nil or attributes["service.name"] == "") and attributes["app.kubernetes.io/name"] != nil and attributes["app.kubernetes.io/name"] != ""`,
               `set(attributes["service.name"], attributes["k8s.deployment.name"]) where (attributes["service.name"] == nil or attributes["service.name"] == "") and attributes["k8s.deployment.name"] != nil and attributes["k8s.deployment.name"] != ""`,
               `set(attributes["service.name"], attributes["k8s.replicaset.name"]) where (attributes["service.name"] == nil or attributes["service.name"] == "") and attributes["k8s.replicaset.name"] != nil and attributes["k8s.replicaset.name"] != ""`,
@@ -463,7 +460,6 @@ should add the node instance type label rules to the discovery relabel:
             statements = [
               `delete_key(attributes, "k8s.container.restart_count")`,
               `delete_key(attributes, "logs.grafana.com/pods.enabled")`,
-
               `set(attributes["service.name"], attributes["app.kubernetes.io/name"]) where (attributes["service.name"] == nil or attributes["service.name"] == "") and attributes["app.kubernetes.io/name"] != nil and attributes["app.kubernetes.io/name"] != ""`,
               `set(attributes["service.name"], attributes["k8s.deployment.name"]) where (attributes["service.name"] == nil or attributes["service.name"] == "") and attributes["k8s.deployment.name"] != nil and attributes["k8s.deployment.name"] != ""`,
               `set(attributes["service.name"], attributes["k8s.replicaset.name"]) where (attributes["service.name"] == nil or attributes["service.name"] == "") and attributes["k8s.replicaset.name"] != nil and attributes["k8s.replicaset.name"] != ""`,
@@ -587,7 +583,6 @@ should add the node os label rules to the discovery relabel:
             statements = [
               `delete_key(attributes, "k8s.container.restart_count")`,
               `delete_key(attributes, "logs.grafana.com/pods.enabled")`,
-
               `set(attributes["service.name"], attributes["app.kubernetes.io/name"]) where (attributes["service.name"] == nil or attributes["service.name"] == "") and attributes["app.kubernetes.io/name"] != nil and attributes["app.kubernetes.io/name"] != ""`,
               `set(attributes["service.name"], attributes["k8s.deployment.name"]) where (attributes["service.name"] == nil or attributes["service.name"] == "") and attributes["k8s.deployment.name"] != nil and attributes["k8s.deployment.name"] != ""`,
               `set(attributes["service.name"], attributes["k8s.replicaset.name"]) where (attributes["service.name"] == nil or attributes["service.name"] == "") and attributes["k8s.replicaset.name"] != nil and attributes["k8s.replicaset.name"] != ""`,
@@ -711,7 +706,6 @@ should add the node pool label rules to the discovery relabel:
             statements = [
               `delete_key(attributes, "k8s.container.restart_count")`,
               `delete_key(attributes, "logs.grafana.com/pods.enabled")`,
-
               `set(attributes["service.name"], attributes["app.kubernetes.io/name"]) where (attributes["service.name"] == nil or attributes["service.name"] == "") and attributes["app.kubernetes.io/name"] != nil and attributes["app.kubernetes.io/name"] != ""`,
               `set(attributes["service.name"], attributes["k8s.deployment.name"]) where (attributes["service.name"] == nil or attributes["service.name"] == "") and attributes["k8s.deployment.name"] != nil and attributes["k8s.deployment.name"] != ""`,
               `set(attributes["service.name"], attributes["k8s.replicaset.name"]) where (attributes["service.name"] == nil or attributes["service.name"] == "") and attributes["k8s.replicaset.name"] != nil and attributes["k8s.replicaset.name"] != ""`,
@@ -835,7 +829,6 @@ should add the node region label rules to the discovery relabel:
             statements = [
               `delete_key(attributes, "k8s.container.restart_count")`,
               `delete_key(attributes, "logs.grafana.com/pods.enabled")`,
-
               `set(attributes["service.name"], attributes["app.kubernetes.io/name"]) where (attributes["service.name"] == nil or attributes["service.name"] == "") and attributes["app.kubernetes.io/name"] != nil and attributes["app.kubernetes.io/name"] != ""`,
               `set(attributes["service.name"], attributes["k8s.deployment.name"]) where (attributes["service.name"] == nil or attributes["service.name"] == "") and attributes["k8s.deployment.name"] != nil and attributes["k8s.deployment.name"] != ""`,
               `set(attributes["service.name"], attributes["k8s.replicaset.name"]) where (attributes["service.name"] == nil or attributes["service.name"] == "") and attributes["k8s.replicaset.name"] != nil and attributes["k8s.replicaset.name"] != ""`,
@@ -959,7 +952,6 @@ should add the node role label rules to the discovery relabel:
             statements = [
               `delete_key(attributes, "k8s.container.restart_count")`,
               `delete_key(attributes, "logs.grafana.com/pods.enabled")`,
-
               `set(attributes["service.name"], attributes["app.kubernetes.io/name"]) where (attributes["service.name"] == nil or attributes["service.name"] == "") and attributes["app.kubernetes.io/name"] != nil and attributes["app.kubernetes.io/name"] != ""`,
               `set(attributes["service.name"], attributes["k8s.deployment.name"]) where (attributes["service.name"] == nil or attributes["service.name"] == "") and attributes["k8s.deployment.name"] != nil and attributes["k8s.deployment.name"] != ""`,
               `set(attributes["service.name"], attributes["k8s.replicaset.name"]) where (attributes["service.name"] == nil or attributes["service.name"] == "") and attributes["k8s.replicaset.name"] != nil and attributes["k8s.replicaset.name"] != ""`,

--- a/charts/k8s-monitoring/charts/feature-pod-logs-via-opentelemetry/values.schema.json
+++ b/charts/k8s-monitoring/charts/feature-pod-logs-via-opentelemetry/values.schema.json
@@ -2,6 +2,9 @@
     "$schema": "http://json-schema.org/schema#",
     "type": "object",
     "properties": {
+        "alignServiceNameWithOTelSemConv": {
+            "type": "boolean"
+        },
         "annotationSelector": {
             "type": "string"
         },

--- a/charts/k8s-monitoring/charts/feature-pod-logs-via-opentelemetry/values.yaml
+++ b/charts/k8s-monitoring/charts/feature-pod-logs-via-opentelemetry/values.yaml
@@ -72,3 +72,12 @@ otelAnnotations: false
 # -- Only gather new log lines since this was deployed. Do not gather historical log lines.
 # @section -- Volume Log Gathering
 onlyGatherNewLogLines: true
+
+# -- Align the `service.name` resource attribute with the
+# [OpenTelemetry semantic conventions for Kubernetes attributes](https://opentelemetry.io/docs/specs/semconv/non-normative/k8s-attributes/)
+# (which is what Grafana Beyla uses). When enabled, the detection chain becomes:
+# pod annotation `resource.opentelemetry.io/service.name` → pod label `app.kubernetes.io/instance` → pod label
+# `app.kubernetes.io/name` → owner workload name (Deployment, StatefulSet, etc.) → pod name → container name.
+# The `service.version` resource attribute is similarly detected from the `app.kubernetes.io/version` pod label.
+# @section -- Log Processing
+alignServiceNameWithOTelSemConv: false

--- a/charts/k8s-monitoring/charts/feature-profiling/README.md
+++ b/charts/k8s-monitoring/charts/feature-profiling/README.md
@@ -14,6 +14,32 @@ profiling:
   enabled: true
 ```
 
+## Service name and namespace detection
+
+This feature sets the `service_name` and `service_namespace` labels on collected profiles, following the
+[OpenTelemetry Operator service name conventions](https://opentelemetry.io/docs/specs/semconv/non-normative/k8s-attributes/).
+This matches the behavior of Grafana Beyla, so telemetry from the same workload correlates across metrics, logs,
+traces, and profiles.
+
+`service_name` is set to the first value found from the following ordered list:
+
+1.  The `resource.opentelemetry.io/service.name` pod annotation
+2.  The `app.kubernetes.io/instance` pod label
+3.  The `app.kubernetes.io/name` pod label
+4.  The name of the workload that owns the pod (Deployment, StatefulSet, DaemonSet, CronJob, Job, ...). For pods owned
+    by a Deployment via a ReplicaSet, the Deployment name is used.
+5.  The pod name
+6.  The container name
+
+`service_namespace` is set to the first value found from the following ordered list:
+
+1.  The `resource.opentelemetry.io/service.namespace` pod annotation
+2.  The pod namespace
+
+To pin a specific service name for a workload, for example, to preserve the value used by previous versions of this
+chart, set the `resource.opentelemetry.io/service.name` annotation on the pod. It takes the highest precedence in
+every telemetry path.
+
 ## Testing
 
 This chart contains unit tests to verify the generated configuration. The hidden value `deployAsConfigMap` will render

--- a/charts/k8s-monitoring/charts/feature-profiling/README.md.gotmpl
+++ b/charts/k8s-monitoring/charts/feature-profiling/README.md.gotmpl
@@ -16,6 +16,32 @@ profiling:
   enabled: true
 ```
 
+## Service name and namespace detection
+
+This feature sets the `service_name` and `service_namespace` labels on collected profiles, following the
+[OpenTelemetry Operator service name conventions](https://opentelemetry.io/docs/specs/semconv/non-normative/k8s-attributes/).
+This matches the behavior of Grafana Beyla, so telemetry from the same workload correlates across metrics, logs,
+traces, and profiles.
+
+`service_name` is set to the first value found from the following ordered list:
+
+1.  The `resource.opentelemetry.io/service.name` pod annotation
+2.  The `app.kubernetes.io/instance` pod label
+3.  The `app.kubernetes.io/name` pod label
+4.  The name of the workload that owns the pod (Deployment, StatefulSet, DaemonSet, CronJob, Job, ...). For pods owned
+    by a Deployment via a ReplicaSet, the Deployment name is used.
+5.  The pod name
+6.  The container name
+
+`service_namespace` is set to the first value found from the following ordered list:
+
+1.  The `resource.opentelemetry.io/service.namespace` pod annotation
+2.  The pod namespace
+
+To pin a specific service name for a workload, for example, to preserve the value used by previous versions of this
+chart, set the `resource.opentelemetry.io/service.name` annotation on the pod. It takes the highest precedence in
+every telemetry path.
+
 ## Testing
 
 This chart contains unit tests to verify the generated configuration. The hidden value `deployAsConfigMap` will render

--- a/charts/k8s-monitoring/charts/feature-profiling/templates/_ebpf.tpl
+++ b/charts/k8s-monitoring/charts/feature-profiling/templates/_ebpf.tpl
@@ -81,10 +81,25 @@ discovery.relabel "ebpf_pods" {
     target_label = "container"
   }
 
+  // Compute the workload (owner) name. For ReplicaSet-owned pods, strip the
+  // pod-template hash to recover the Deployment name (matches Beyla / OTel Operator).
+  rule {
+    source_labels = ["__meta_kubernetes_pod_controller_name"]
+    target_label = "__tmp_workload_name"
+  }
+  rule {
+    source_labels = ["__meta_kubernetes_pod_controller_kind", "__meta_kubernetes_pod_controller_name"]
+    regex = "ReplicaSet;(.+)-[^-]+"
+    replacement = "$1"
+    target_label = "__tmp_workload_name"
+  }
+
   // Set service_name by choosing the first value found from the following ordered list:
   // - pod.annotation[resource.opentelemetry.io/service.name]
   // - pod.label[app.kubernetes.io/instance]
   // - pod.label[app.kubernetes.io/name]
+  // - k8s.workload.name (Deployment, StatefulSet, DaemonSet, CronJob, Job, ...)
+  // - k8s.pod.name
   // - k8s.container.name
   rule {
     action = "replace"
@@ -92,6 +107,8 @@ discovery.relabel "ebpf_pods" {
       {{ include "pod_annotation" "resource.opentelemetry.io/service.name" | quote }},
       {{ include "pod_label" "app.kubernetes.io/instance" | quote }},
       {{ include "pod_label" "app.kubernetes.io/name" | quote }},
+      "__tmp_workload_name",
+      "pod",
       "container",
     ]
     separator = ";"

--- a/charts/k8s-monitoring/charts/feature-profiling/templates/_java.tpl
+++ b/charts/k8s-monitoring/charts/feature-profiling/templates/_java.tpl
@@ -107,10 +107,25 @@ discovery.relabel "java_pods" {
     target_label = "container"
   }
 
+  // Compute the workload (owner) name. For ReplicaSet-owned pods, strip the
+  // pod-template hash to recover the Deployment name (matches Beyla / OTel Operator).
+  rule {
+    source_labels = ["__meta_kubernetes_pod_controller_name"]
+    target_label = "__tmp_workload_name"
+  }
+  rule {
+    source_labels = ["__meta_kubernetes_pod_controller_kind", "__meta_kubernetes_pod_controller_name"]
+    regex = "ReplicaSet;(.+)-[^-]+"
+    replacement = "$1"
+    target_label = "__tmp_workload_name"
+  }
+
   // Set service_name by choosing the first value found from the following ordered list:
   // - pod.annotation[resource.opentelemetry.io/service.name]
   // - pod.label[app.kubernetes.io/instance]
   // - pod.label[app.kubernetes.io/name]
+  // - k8s.workload.name (Deployment, StatefulSet, DaemonSet, CronJob, Job, ...)
+  // - k8s.pod.name
   // - k8s.container.name
   rule {
     action = "replace"
@@ -118,6 +133,8 @@ discovery.relabel "java_pods" {
       {{ include "pod_annotation" "resource.opentelemetry.io/service.name" | quote }},
       {{ include "pod_label" "app.kubernetes.io/instance" | quote }},
       {{ include "pod_label" "app.kubernetes.io/name" | quote }},
+      "__tmp_workload_name",
+      "pod",
       "container",
     ]
     separator = ";"

--- a/charts/k8s-monitoring/charts/feature-profiling/templates/_pprof.tpl
+++ b/charts/k8s-monitoring/charts/feature-profiling/templates/_pprof.tpl
@@ -68,10 +68,25 @@ discovery.relabel "pprof_pods" {
     target_label  = "container"
   }
 
+  // Compute the workload (owner) name. For ReplicaSet-owned pods, strip the
+  // pod-template hash to recover the Deployment name (matches Beyla / OTel Operator).
+  rule {
+    source_labels = ["__meta_kubernetes_pod_controller_name"]
+    target_label = "__tmp_workload_name"
+  }
+  rule {
+    source_labels = ["__meta_kubernetes_pod_controller_kind", "__meta_kubernetes_pod_controller_name"]
+    regex = "ReplicaSet;(.+)-[^-]+"
+    replacement = "$1"
+    target_label = "__tmp_workload_name"
+  }
+
   // Set service_name by choosing the first value found from the following ordered list:
   // - pod.annotation[resource.opentelemetry.io/service.name]
   // - pod.label[app.kubernetes.io/instance]
   // - pod.label[app.kubernetes.io/name]
+  // - k8s.workload.name (Deployment, StatefulSet, DaemonSet, CronJob, Job, ...)
+  // - k8s.pod.name
   // - k8s.container.name
   rule {
     action = "replace"
@@ -79,6 +94,8 @@ discovery.relabel "pprof_pods" {
       {{ include "pod_annotation" "resource.opentelemetry.io/service.name" | quote }},
       {{ include "pod_label" "app.kubernetes.io/instance" | quote }},
       {{ include "pod_label" "app.kubernetes.io/name" | quote }},
+      "__tmp_workload_name",
+      "pod",
       "container",
     ]
     separator = ";"

--- a/charts/k8s-monitoring/charts/feature-profiling/tests/__snapshot__/ebpf_test.yaml.snap
+++ b/charts/k8s-monitoring/charts/feature-profiling/tests/__snapshot__/ebpf_test.yaml.snap
@@ -49,10 +49,25 @@ should be able to filter by label and annotation:
             target_label = "container"
           }
 
+          // Compute the workload (owner) name. For ReplicaSet-owned pods, strip the
+          // pod-template hash to recover the Deployment name (matches Beyla / OTel Operator).
+          rule {
+            source_labels = ["__meta_kubernetes_pod_controller_name"]
+            target_label = "__tmp_workload_name"
+          }
+          rule {
+            source_labels = ["__meta_kubernetes_pod_controller_kind", "__meta_kubernetes_pod_controller_name"]
+            regex = "ReplicaSet;(.+)-[^-]+"
+            replacement = "$1"
+            target_label = "__tmp_workload_name"
+          }
+
           // Set service_name by choosing the first value found from the following ordered list:
           // - pod.annotation[resource.opentelemetry.io/service.name]
           // - pod.label[app.kubernetes.io/instance]
           // - pod.label[app.kubernetes.io/name]
+          // - k8s.workload.name (Deployment, StatefulSet, DaemonSet, CronJob, Job, ...)
+          // - k8s.pod.name
           // - k8s.container.name
           rule {
             action = "replace"
@@ -60,6 +75,8 @@ should be able to filter by label and annotation:
               "__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_name",
               "__meta_kubernetes_pod_label_app_kubernetes_io_instance",
               "__meta_kubernetes_pod_label_app_kubernetes_io_name",
+              "__tmp_workload_name",
+              "pod",
               "container",
             ]
             separator = ";"
@@ -165,10 +182,25 @@ should be able to filter by namespace and extra discovery rules:
             target_label = "container"
           }
 
+          // Compute the workload (owner) name. For ReplicaSet-owned pods, strip the
+          // pod-template hash to recover the Deployment name (matches Beyla / OTel Operator).
+          rule {
+            source_labels = ["__meta_kubernetes_pod_controller_name"]
+            target_label = "__tmp_workload_name"
+          }
+          rule {
+            source_labels = ["__meta_kubernetes_pod_controller_kind", "__meta_kubernetes_pod_controller_name"]
+            regex = "ReplicaSet;(.+)-[^-]+"
+            replacement = "$1"
+            target_label = "__tmp_workload_name"
+          }
+
           // Set service_name by choosing the first value found from the following ordered list:
           // - pod.annotation[resource.opentelemetry.io/service.name]
           // - pod.label[app.kubernetes.io/instance]
           // - pod.label[app.kubernetes.io/name]
+          // - k8s.workload.name (Deployment, StatefulSet, DaemonSet, CronJob, Job, ...)
+          // - k8s.pod.name
           // - k8s.container.name
           rule {
             action = "replace"
@@ -176,6 +208,8 @@ should be able to filter by namespace and extra discovery rules:
               "__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_name",
               "__meta_kubernetes_pod_label_app_kubernetes_io_instance",
               "__meta_kubernetes_pod_label_app_kubernetes_io_name",
+              "__tmp_workload_name",
+              "pod",
               "container",
             ]
             separator = ";"
@@ -283,10 +317,25 @@ should be able to target all pods, without requiring the annotation:
             target_label = "container"
           }
 
+          // Compute the workload (owner) name. For ReplicaSet-owned pods, strip the
+          // pod-template hash to recover the Deployment name (matches Beyla / OTel Operator).
+          rule {
+            source_labels = ["__meta_kubernetes_pod_controller_name"]
+            target_label = "__tmp_workload_name"
+          }
+          rule {
+            source_labels = ["__meta_kubernetes_pod_controller_kind", "__meta_kubernetes_pod_controller_name"]
+            regex = "ReplicaSet;(.+)-[^-]+"
+            replacement = "$1"
+            target_label = "__tmp_workload_name"
+          }
+
           // Set service_name by choosing the first value found from the following ordered list:
           // - pod.annotation[resource.opentelemetry.io/service.name]
           // - pod.label[app.kubernetes.io/instance]
           // - pod.label[app.kubernetes.io/name]
+          // - k8s.workload.name (Deployment, StatefulSet, DaemonSet, CronJob, Job, ...)
+          // - k8s.pod.name
           // - k8s.container.name
           rule {
             action = "replace"
@@ -294,6 +343,8 @@ should be able to target all pods, without requiring the annotation:
               "__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_name",
               "__meta_kubernetes_pod_label_app_kubernetes_io_instance",
               "__meta_kubernetes_pod_label_app_kubernetes_io_name",
+              "__tmp_workload_name",
+              "pod",
               "container",
             ]
             separator = ";"
@@ -396,10 +447,25 @@ should build the eBPF profiling configuration:
             target_label = "container"
           }
 
+          // Compute the workload (owner) name. For ReplicaSet-owned pods, strip the
+          // pod-template hash to recover the Deployment name (matches Beyla / OTel Operator).
+          rule {
+            source_labels = ["__meta_kubernetes_pod_controller_name"]
+            target_label = "__tmp_workload_name"
+          }
+          rule {
+            source_labels = ["__meta_kubernetes_pod_controller_kind", "__meta_kubernetes_pod_controller_name"]
+            regex = "ReplicaSet;(.+)-[^-]+"
+            replacement = "$1"
+            target_label = "__tmp_workload_name"
+          }
+
           // Set service_name by choosing the first value found from the following ordered list:
           // - pod.annotation[resource.opentelemetry.io/service.name]
           // - pod.label[app.kubernetes.io/instance]
           // - pod.label[app.kubernetes.io/name]
+          // - k8s.workload.name (Deployment, StatefulSet, DaemonSet, CronJob, Job, ...)
+          // - k8s.pod.name
           // - k8s.container.name
           rule {
             action = "replace"
@@ -407,6 +473,8 @@ should build the eBPF profiling configuration:
               "__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_name",
               "__meta_kubernetes_pod_label_app_kubernetes_io_instance",
               "__meta_kubernetes_pod_label_app_kubernetes_io_name",
+              "__tmp_workload_name",
+              "pod",
               "container",
             ]
             separator = ";"

--- a/charts/k8s-monitoring/charts/feature-profiling/tests/__snapshot__/java_test.yaml.snap
+++ b/charts/k8s-monitoring/charts/feature-profiling/tests/__snapshot__/java_test.yaml.snap
@@ -67,10 +67,25 @@ should be able to filter by label and annotation:
             target_label = "container"
           }
 
+          // Compute the workload (owner) name. For ReplicaSet-owned pods, strip the
+          // pod-template hash to recover the Deployment name (matches Beyla / OTel Operator).
+          rule {
+            source_labels = ["__meta_kubernetes_pod_controller_name"]
+            target_label = "__tmp_workload_name"
+          }
+          rule {
+            source_labels = ["__meta_kubernetes_pod_controller_kind", "__meta_kubernetes_pod_controller_name"]
+            regex = "ReplicaSet;(.+)-[^-]+"
+            replacement = "$1"
+            target_label = "__tmp_workload_name"
+          }
+
           // Set service_name by choosing the first value found from the following ordered list:
           // - pod.annotation[resource.opentelemetry.io/service.name]
           // - pod.label[app.kubernetes.io/instance]
           // - pod.label[app.kubernetes.io/name]
+          // - k8s.workload.name (Deployment, StatefulSet, DaemonSet, CronJob, Job, ...)
+          // - k8s.pod.name
           // - k8s.container.name
           rule {
             action = "replace"
@@ -78,6 +93,8 @@ should be able to filter by label and annotation:
               "__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_name",
               "__meta_kubernetes_pod_label_app_kubernetes_io_instance",
               "__meta_kubernetes_pod_label_app_kubernetes_io_name",
+              "__tmp_workload_name",
+              "pod",
               "container",
             ]
             separator = ";"
@@ -197,10 +214,25 @@ should be able to target all pods, without requiring the annotation:
             target_label = "container"
           }
 
+          // Compute the workload (owner) name. For ReplicaSet-owned pods, strip the
+          // pod-template hash to recover the Deployment name (matches Beyla / OTel Operator).
+          rule {
+            source_labels = ["__meta_kubernetes_pod_controller_name"]
+            target_label = "__tmp_workload_name"
+          }
+          rule {
+            source_labels = ["__meta_kubernetes_pod_controller_kind", "__meta_kubernetes_pod_controller_name"]
+            regex = "ReplicaSet;(.+)-[^-]+"
+            replacement = "$1"
+            target_label = "__tmp_workload_name"
+          }
+
           // Set service_name by choosing the first value found from the following ordered list:
           // - pod.annotation[resource.opentelemetry.io/service.name]
           // - pod.label[app.kubernetes.io/instance]
           // - pod.label[app.kubernetes.io/name]
+          // - k8s.workload.name (Deployment, StatefulSet, DaemonSet, CronJob, Job, ...)
+          // - k8s.pod.name
           // - k8s.container.name
           rule {
             action = "replace"
@@ -208,6 +240,8 @@ should be able to target all pods, without requiring the annotation:
               "__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_name",
               "__meta_kubernetes_pod_label_app_kubernetes_io_instance",
               "__meta_kubernetes_pod_label_app_kubernetes_io_name",
+              "__tmp_workload_name",
+              "pod",
               "container",
             ]
             separator = ";"
@@ -327,10 +361,25 @@ should build the Java profiling configuration:
             target_label = "container"
           }
 
+          // Compute the workload (owner) name. For ReplicaSet-owned pods, strip the
+          // pod-template hash to recover the Deployment name (matches Beyla / OTel Operator).
+          rule {
+            source_labels = ["__meta_kubernetes_pod_controller_name"]
+            target_label = "__tmp_workload_name"
+          }
+          rule {
+            source_labels = ["__meta_kubernetes_pod_controller_kind", "__meta_kubernetes_pod_controller_name"]
+            regex = "ReplicaSet;(.+)-[^-]+"
+            replacement = "$1"
+            target_label = "__tmp_workload_name"
+          }
+
           // Set service_name by choosing the first value found from the following ordered list:
           // - pod.annotation[resource.opentelemetry.io/service.name]
           // - pod.label[app.kubernetes.io/instance]
           // - pod.label[app.kubernetes.io/name]
+          // - k8s.workload.name (Deployment, StatefulSet, DaemonSet, CronJob, Job, ...)
+          // - k8s.pod.name
           // - k8s.container.name
           rule {
             action = "replace"
@@ -338,6 +387,8 @@ should build the Java profiling configuration:
               "__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_name",
               "__meta_kubernetes_pod_label_app_kubernetes_io_instance",
               "__meta_kubernetes_pod_label_app_kubernetes_io_name",
+              "__tmp_workload_name",
+              "pod",
               "container",
             ]
             separator = ";"

--- a/charts/k8s-monitoring/charts/feature-profiling/tests/__snapshot__/pprof_test.yaml.snap
+++ b/charts/k8s-monitoring/charts/feature-profiling/tests/__snapshot__/pprof_test.yaml.snap
@@ -39,10 +39,25 @@ allows you to remove the bearer token:
             target_label  = "container"
           }
 
+          // Compute the workload (owner) name. For ReplicaSet-owned pods, strip the
+          // pod-template hash to recover the Deployment name (matches Beyla / OTel Operator).
+          rule {
+            source_labels = ["__meta_kubernetes_pod_controller_name"]
+            target_label = "__tmp_workload_name"
+          }
+          rule {
+            source_labels = ["__meta_kubernetes_pod_controller_kind", "__meta_kubernetes_pod_controller_name"]
+            regex = "ReplicaSet;(.+)-[^-]+"
+            replacement = "$1"
+            target_label = "__tmp_workload_name"
+          }
+
           // Set service_name by choosing the first value found from the following ordered list:
           // - pod.annotation[resource.opentelemetry.io/service.name]
           // - pod.label[app.kubernetes.io/instance]
           // - pod.label[app.kubernetes.io/name]
+          // - k8s.workload.name (Deployment, StatefulSet, DaemonSet, CronJob, Job, ...)
+          // - k8s.pod.name
           // - k8s.container.name
           rule {
             action = "replace"
@@ -50,6 +65,8 @@ allows you to remove the bearer token:
               "__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_name",
               "__meta_kubernetes_pod_label_app_kubernetes_io_instance",
               "__meta_kubernetes_pod_label_app_kubernetes_io_name",
+              "__tmp_workload_name",
+              "pod",
               "container",
             ]
             separator = ";"
@@ -843,10 +860,25 @@ should be able to filter by label and annotation:
             target_label  = "container"
           }
 
+          // Compute the workload (owner) name. For ReplicaSet-owned pods, strip the
+          // pod-template hash to recover the Deployment name (matches Beyla / OTel Operator).
+          rule {
+            source_labels = ["__meta_kubernetes_pod_controller_name"]
+            target_label = "__tmp_workload_name"
+          }
+          rule {
+            source_labels = ["__meta_kubernetes_pod_controller_kind", "__meta_kubernetes_pod_controller_name"]
+            regex = "ReplicaSet;(.+)-[^-]+"
+            replacement = "$1"
+            target_label = "__tmp_workload_name"
+          }
+
           // Set service_name by choosing the first value found from the following ordered list:
           // - pod.annotation[resource.opentelemetry.io/service.name]
           // - pod.label[app.kubernetes.io/instance]
           // - pod.label[app.kubernetes.io/name]
+          // - k8s.workload.name (Deployment, StatefulSet, DaemonSet, CronJob, Job, ...)
+          // - k8s.pod.name
           // - k8s.container.name
           rule {
             action = "replace"
@@ -854,6 +886,8 @@ should be able to filter by label and annotation:
               "__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_name",
               "__meta_kubernetes_pod_label_app_kubernetes_io_instance",
               "__meta_kubernetes_pod_label_app_kubernetes_io_name",
+              "__tmp_workload_name",
+              "pod",
               "container",
             ]
             separator = ";"
@@ -1647,10 +1681,25 @@ should build the pprof profiling configuration:
             target_label  = "container"
           }
 
+          // Compute the workload (owner) name. For ReplicaSet-owned pods, strip the
+          // pod-template hash to recover the Deployment name (matches Beyla / OTel Operator).
+          rule {
+            source_labels = ["__meta_kubernetes_pod_controller_name"]
+            target_label = "__tmp_workload_name"
+          }
+          rule {
+            source_labels = ["__meta_kubernetes_pod_controller_kind", "__meta_kubernetes_pod_controller_name"]
+            regex = "ReplicaSet;(.+)-[^-]+"
+            replacement = "$1"
+            target_label = "__tmp_workload_name"
+          }
+
           // Set service_name by choosing the first value found from the following ordered list:
           // - pod.annotation[resource.opentelemetry.io/service.name]
           // - pod.label[app.kubernetes.io/instance]
           // - pod.label[app.kubernetes.io/name]
+          // - k8s.workload.name (Deployment, StatefulSet, DaemonSet, CronJob, Job, ...)
+          // - k8s.pod.name
           // - k8s.container.name
           rule {
             action = "replace"
@@ -1658,6 +1707,8 @@ should build the pprof profiling configuration:
               "__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_name",
               "__meta_kubernetes_pod_label_app_kubernetes_io_instance",
               "__meta_kubernetes_pod_label_app_kubernetes_io_name",
+              "__tmp_workload_name",
+              "pod",
               "container",
             ]
             separator = ";"

--- a/charts/k8s-monitoring/docs/examples/auth/bearer-token/alloy-logs.alloy
+++ b/charts/k8s-monitoring/docs/examples/auth/bearer-token/alloy-logs.alloy
@@ -46,7 +46,6 @@ declare "pod_logs_via_loki" {
       replacement = "$1"
       target_label = "tmp_container_runtime"
     }
-
     // explicitly set service_name. if not set, loki will automatically try to populate a default.
     // see https://grafana.com/docs/loki/latest/get-started/labels/#default-labels-for-all-users
     //

--- a/charts/k8s-monitoring/docs/examples/auth/bearer-token/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/auth/bearer-token/output.yaml
@@ -79,7 +79,6 @@ data:
           replacement = "$1"
           target_label = "tmp_container_runtime"
         }
-    
         // explicitly set service_name. if not set, loki will automatically try to populate a default.
         // see https://grafana.com/docs/loki/latest/get-started/labels/#default-labels-for-all-users
         //

--- a/charts/k8s-monitoring/docs/examples/auth/embedded-secrets/alloy-logs.alloy
+++ b/charts/k8s-monitoring/docs/examples/auth/embedded-secrets/alloy-logs.alloy
@@ -46,7 +46,6 @@ declare "pod_logs_via_loki" {
       replacement = "$1"
       target_label = "tmp_container_runtime"
     }
-
     // explicitly set service_name. if not set, loki will automatically try to populate a default.
     // see https://grafana.com/docs/loki/latest/get-started/labels/#default-labels-for-all-users
     //

--- a/charts/k8s-monitoring/docs/examples/auth/embedded-secrets/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/auth/embedded-secrets/output.yaml
@@ -69,7 +69,6 @@ data:
           replacement = "$1"
           target_label = "tmp_container_runtime"
         }
-    
         // explicitly set service_name. if not set, loki will automatically try to populate a default.
         // see https://grafana.com/docs/loki/latest/get-started/labels/#default-labels-for-all-users
         //

--- a/charts/k8s-monitoring/docs/examples/auth/external-secrets/alloy-logs.alloy
+++ b/charts/k8s-monitoring/docs/examples/auth/external-secrets/alloy-logs.alloy
@@ -46,7 +46,6 @@ declare "pod_logs_via_loki" {
       replacement = "$1"
       target_label = "tmp_container_runtime"
     }
-
     // explicitly set service_name. if not set, loki will automatically try to populate a default.
     // see https://grafana.com/docs/loki/latest/get-started/labels/#default-labels-for-all-users
     //

--- a/charts/k8s-monitoring/docs/examples/auth/external-secrets/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/auth/external-secrets/output.yaml
@@ -69,7 +69,6 @@ data:
           replacement = "$1"
           target_label = "tmp_container_runtime"
         }
-    
         // explicitly set service_name. if not set, loki will automatically try to populate a default.
         // see https://grafana.com/docs/loki/latest/get-started/labels/#default-labels-for-all-users
         //

--- a/charts/k8s-monitoring/docs/examples/auth/oauth2/alloy-logs.alloy
+++ b/charts/k8s-monitoring/docs/examples/auth/oauth2/alloy-logs.alloy
@@ -227,7 +227,6 @@ declare "pod_logs_via_loki" {
       replacement = "$1"
       target_label = "tmp_container_runtime"
     }
-
     // explicitly set service_name. if not set, loki will automatically try to populate a default.
     // see https://grafana.com/docs/loki/latest/get-started/labels/#default-labels-for-all-users
     //

--- a/charts/k8s-monitoring/docs/examples/auth/oauth2/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/auth/oauth2/output.yaml
@@ -333,7 +333,6 @@ data:
           replacement = "$1"
           target_label = "tmp_container_runtime"
         }
-    
         // explicitly set service_name. if not set, loki will automatically try to populate a default.
         // see https://grafana.com/docs/loki/latest/get-started/labels/#default-labels-for-all-users
         //

--- a/charts/k8s-monitoring/docs/examples/collector-storage/alloy-logs.alloy
+++ b/charts/k8s-monitoring/docs/examples/collector-storage/alloy-logs.alloy
@@ -46,7 +46,6 @@ declare "pod_logs_via_loki" {
       replacement = "$1"
       target_label = "tmp_container_runtime"
     }
-
     // explicitly set service_name. if not set, loki will automatically try to populate a default.
     // see https://grafana.com/docs/loki/latest/get-started/labels/#default-labels-for-all-users
     //

--- a/charts/k8s-monitoring/docs/examples/collector-storage/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/collector-storage/output.yaml
@@ -142,7 +142,6 @@ data:
           replacement = "$1"
           target_label = "tmp_container_runtime"
         }
-    
         // explicitly set service_name. if not set, loki will automatically try to populate a default.
         // see https://grafana.com/docs/loki/latest/get-started/labels/#default-labels-for-all-users
         //

--- a/charts/k8s-monitoring/docs/examples/dataProcessors/custom/scrub-log-pii/alloy-logs.alloy
+++ b/charts/k8s-monitoring/docs/examples/dataProcessors/custom/scrub-log-pii/alloy-logs.alloy
@@ -49,7 +49,6 @@ declare "pod_logs_via_loki" {
       replacement = "$1"
       target_label = "tmp_container_runtime"
     }
-
     // explicitly set service_name. if not set, loki will automatically try to populate a default.
     // see https://grafana.com/docs/loki/latest/get-started/labels/#default-labels-for-all-users
     //
@@ -321,7 +320,6 @@ declare "pod_logs_via_opentelemetry" {
       statements = [
         `delete_key(attributes, "k8s.container.restart_count")`,
         `delete_key(attributes, "logs.grafana.com/pods.enabled")`,
-
         `set(attributes["service.name"], attributes["app.kubernetes.io/name"]) where (attributes["service.name"] == nil or attributes["service.name"] == "") and attributes["app.kubernetes.io/name"] != nil and attributes["app.kubernetes.io/name"] != ""`,
         `set(attributes["service.name"], attributes["k8s.deployment.name"]) where (attributes["service.name"] == nil or attributes["service.name"] == "") and attributes["k8s.deployment.name"] != nil and attributes["k8s.deployment.name"] != ""`,
         `set(attributes["service.name"], attributes["k8s.replicaset.name"]) where (attributes["service.name"] == nil or attributes["service.name"] == "") and attributes["k8s.replicaset.name"] != nil and attributes["k8s.replicaset.name"] != ""`,
@@ -333,7 +331,6 @@ declare "pod_logs_via_opentelemetry" {
         `set(attributes["service.name"], attributes["k8s.container.name"]) where (attributes["service.name"] == nil or attributes["service.name"] == "") and attributes["k8s.container.name"] != nil and attributes["k8s.container.name"] != ""`,
 
         `set(attributes["service.namespace"], attributes["k8s.namespace.name"]) where (attributes["service.namespace"] == nil or attributes["service.namespace"] == "") and attributes["k8s.namespace.name"] != nil and attributes["k8s.namespace.name"] != ""`,
-
         `set(attributes["service.version"], attributes["app.kubernetes.io/version"]) where attributes["service.version"] == nil`,
 
         `set(attributes["service.instance.id"], Concat([attributes["k8s.namespace.name"], attributes["k8s.pod.name"], attributes["k8s.container.name"]], ".")) where attributes["service.instance.id"] == nil`,

--- a/charts/k8s-monitoring/docs/examples/dataProcessors/custom/scrub-log-pii/alloy-logs.alloy
+++ b/charts/k8s-monitoring/docs/examples/dataProcessors/custom/scrub-log-pii/alloy-logs.alloy
@@ -331,6 +331,7 @@ declare "pod_logs_via_opentelemetry" {
         `set(attributes["service.name"], attributes["k8s.container.name"]) where (attributes["service.name"] == nil or attributes["service.name"] == "") and attributes["k8s.container.name"] != nil and attributes["k8s.container.name"] != ""`,
 
         `set(attributes["service.namespace"], attributes["k8s.namespace.name"]) where (attributes["service.namespace"] == nil or attributes["service.namespace"] == "") and attributes["k8s.namespace.name"] != nil and attributes["k8s.namespace.name"] != ""`,
+
         `set(attributes["service.version"], attributes["app.kubernetes.io/version"]) where attributes["service.version"] == nil`,
 
         `set(attributes["service.instance.id"], Concat([attributes["k8s.namespace.name"], attributes["k8s.pod.name"], attributes["k8s.container.name"]], ".")) where attributes["service.instance.id"] == nil`,

--- a/charts/k8s-monitoring/docs/examples/dataProcessors/custom/scrub-log-pii/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/dataProcessors/custom/scrub-log-pii/output.yaml
@@ -378,6 +378,7 @@ data:
             `set(attributes["service.name"], attributes["k8s.container.name"]) where (attributes["service.name"] == nil or attributes["service.name"] == "") and attributes["k8s.container.name"] != nil and attributes["k8s.container.name"] != ""`,
     
             `set(attributes["service.namespace"], attributes["k8s.namespace.name"]) where (attributes["service.namespace"] == nil or attributes["service.namespace"] == "") and attributes["k8s.namespace.name"] != nil and attributes["k8s.namespace.name"] != ""`,
+    
             `set(attributes["service.version"], attributes["app.kubernetes.io/version"]) where attributes["service.version"] == nil`,
     
             `set(attributes["service.instance.id"], Concat([attributes["k8s.namespace.name"], attributes["k8s.pod.name"], attributes["k8s.container.name"]], ".")) where attributes["service.instance.id"] == nil`,

--- a/charts/k8s-monitoring/docs/examples/dataProcessors/custom/scrub-log-pii/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/dataProcessors/custom/scrub-log-pii/output.yaml
@@ -96,7 +96,6 @@ data:
           replacement = "$1"
           target_label = "tmp_container_runtime"
         }
-    
         // explicitly set service_name. if not set, loki will automatically try to populate a default.
         // see https://grafana.com/docs/loki/latest/get-started/labels/#default-labels-for-all-users
         //
@@ -368,7 +367,6 @@ data:
           statements = [
             `delete_key(attributes, "k8s.container.restart_count")`,
             `delete_key(attributes, "logs.grafana.com/pods.enabled")`,
-    
             `set(attributes["service.name"], attributes["app.kubernetes.io/name"]) where (attributes["service.name"] == nil or attributes["service.name"] == "") and attributes["app.kubernetes.io/name"] != nil and attributes["app.kubernetes.io/name"] != ""`,
             `set(attributes["service.name"], attributes["k8s.deployment.name"]) where (attributes["service.name"] == nil or attributes["service.name"] == "") and attributes["k8s.deployment.name"] != nil and attributes["k8s.deployment.name"] != ""`,
             `set(attributes["service.name"], attributes["k8s.replicaset.name"]) where (attributes["service.name"] == nil or attributes["service.name"] == "") and attributes["k8s.replicaset.name"] != nil and attributes["k8s.replicaset.name"] != ""`,
@@ -380,7 +378,6 @@ data:
             `set(attributes["service.name"], attributes["k8s.container.name"]) where (attributes["service.name"] == nil or attributes["service.name"] == "") and attributes["k8s.container.name"] != nil and attributes["k8s.container.name"] != ""`,
     
             `set(attributes["service.namespace"], attributes["k8s.namespace.name"]) where (attributes["service.namespace"] == nil or attributes["service.namespace"] == "") and attributes["k8s.namespace.name"] != nil and attributes["k8s.namespace.name"] != ""`,
-    
             `set(attributes["service.version"], attributes["app.kubernetes.io/version"]) where attributes["service.version"] == nil`,
     
             `set(attributes["service.instance.id"], Concat([attributes["k8s.namespace.name"], attributes["k8s.pod.name"], attributes["k8s.container.name"]], ".")) where attributes["service.instance.id"] == nil`,

--- a/charts/k8s-monitoring/docs/examples/dataProcessors/custom/static-label/alloy-logs.alloy
+++ b/charts/k8s-monitoring/docs/examples/dataProcessors/custom/static-label/alloy-logs.alloy
@@ -46,7 +46,6 @@ declare "pod_logs_via_loki" {
       replacement = "$1"
       target_label = "tmp_container_runtime"
     }
-
     // explicitly set service_name. if not set, loki will automatically try to populate a default.
     // see https://grafana.com/docs/loki/latest/get-started/labels/#default-labels-for-all-users
     //

--- a/charts/k8s-monitoring/docs/examples/dataProcessors/custom/static-label/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/dataProcessors/custom/static-label/output.yaml
@@ -81,7 +81,6 @@ data:
           replacement = "$1"
           target_label = "tmp_container_runtime"
         }
-    
         // explicitly set service_name. if not set, loki will automatically try to populate a default.
         // see https://grafana.com/docs/loki/latest/get-started/labels/#default-labels-for-all-users
         //

--- a/charts/k8s-monitoring/docs/examples/dataProcessors/ec2Enrichment/alloy.alloy
+++ b/charts/k8s-monitoring/docs/examples/dataProcessors/ec2Enrichment/alloy.alloy
@@ -508,7 +508,6 @@ declare "pod_logs_via_loki" {
       replacement = "$1"
       target_label = "tmp_container_runtime"
     }
-
     // explicitly set service_name. if not set, loki will automatically try to populate a default.
     // see https://grafana.com/docs/loki/latest/get-started/labels/#default-labels-for-all-users
     //

--- a/charts/k8s-monitoring/docs/examples/dataProcessors/ec2Enrichment/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/dataProcessors/ec2Enrichment/output.yaml
@@ -610,7 +610,6 @@ data:
           replacement = "$1"
           target_label = "tmp_container_runtime"
         }
-    
         // explicitly set service_name. if not set, loki will automatically try to populate a default.
         // see https://grafana.com/docs/loki/latest/get-started/labels/#default-labels-for-all-users
         //

--- a/charts/k8s-monitoring/docs/examples/dataProcessors/kubernetesEnrichment/labels-and-annotations/alloy.alloy
+++ b/charts/k8s-monitoring/docs/examples/dataProcessors/kubernetesEnrichment/labels-and-annotations/alloy.alloy
@@ -781,7 +781,6 @@ declare "pod_logs_via_loki" {
       replacement = "$1"
       target_label = "tmp_container_runtime"
     }
-
     // explicitly set service_name. if not set, loki will automatically try to populate a default.
     // see https://grafana.com/docs/loki/latest/get-started/labels/#default-labels-for-all-users
     //

--- a/charts/k8s-monitoring/docs/examples/dataProcessors/kubernetesEnrichment/labels-and-annotations/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/dataProcessors/kubernetesEnrichment/labels-and-annotations/output.yaml
@@ -833,7 +833,6 @@ data:
           replacement = "$1"
           target_label = "tmp_container_runtime"
         }
-    
         // explicitly set service_name. if not set, loki will automatically try to populate a default.
         // see https://grafana.com/docs/loki/latest/get-started/labels/#default-labels-for-all-users
         //

--- a/charts/k8s-monitoring/docs/examples/destinations/custom/debug/alloy-logs.alloy
+++ b/charts/k8s-monitoring/docs/examples/destinations/custom/debug/alloy-logs.alloy
@@ -53,7 +53,6 @@ declare "pod_logs_via_loki" {
       replacement = "$1"
       target_label = "tmp_container_runtime"
     }
-
     // explicitly set service_name. if not set, loki will automatically try to populate a default.
     // see https://grafana.com/docs/loki/latest/get-started/labels/#default-labels-for-all-users
     //

--- a/charts/k8s-monitoring/docs/examples/destinations/custom/debug/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/destinations/custom/debug/output.yaml
@@ -88,7 +88,6 @@ data:
           replacement = "$1"
           target_label = "tmp_container_runtime"
         }
-    
         // explicitly set service_name. if not set, loki will automatically try to populate a default.
         // see https://grafana.com/docs/loki/latest/get-started/labels/#default-labels-for-all-users
         //

--- a/charts/k8s-monitoring/docs/examples/destinations/loki-stdout/README.md
+++ b/charts/k8s-monitoring/docs/examples/destinations/loki-stdout/README.md
@@ -38,6 +38,7 @@ destinations:
 # Will automatically go to both loki and lokiStdout destinations
 podLogsViaLoki:
   enabled: true
+  alignServiceNameWithOTelSemConv: true
 
 collectors:
   alloy-logs:

--- a/charts/k8s-monitoring/docs/examples/destinations/loki-stdout/alloy-logs.alloy
+++ b/charts/k8s-monitoring/docs/examples/destinations/loki-stdout/alloy-logs.alloy
@@ -46,18 +46,36 @@ declare "pod_logs_via_loki" {
       replacement = "$1"
       target_label = "tmp_container_runtime"
     }
+    // Compute the workload (owner) name. For ReplicaSet-owned pods, strip the
+    // pod-template hash to recover the Deployment name (matches Beyla / OTel Operator).
+    rule {
+      source_labels = ["__meta_kubernetes_pod_controller_name"]
+      target_label = "__tmp_workload_name"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_pod_controller_kind", "__meta_kubernetes_pod_controller_name"]
+      regex = "ReplicaSet;(.+)-[^-]+"
+      replacement = "$1"
+      target_label = "__tmp_workload_name"
+    }
 
     // explicitly set service_name. if not set, loki will automatically try to populate a default.
     // see https://grafana.com/docs/loki/latest/get-started/labels/#default-labels-for-all-users
     //
     // choose the first value found from the following ordered list:
     // - pod.annotation[resource.opentelemetry.io/service.name]
+    // - pod.label[app.kubernetes.io/instance]
     // - pod.label[app.kubernetes.io/name]
+    // - k8s.workload.name (Deployment, StatefulSet, DaemonSet, CronJob, Job, ...)
+    // - k8s.pod.name
     // - k8s.container.name
     rule {
       source_labels = [
         "__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_name",
+        "__meta_kubernetes_pod_label_app_kubernetes_io_instance",
         "__meta_kubernetes_pod_label_app_kubernetes_io_name",
+        "__tmp_workload_name",
+        "__meta_kubernetes_pod_name",
         "__meta_kubernetes_pod_container_name",
       ]
       separator = ";"

--- a/charts/k8s-monitoring/docs/examples/destinations/loki-stdout/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/destinations/loki-stdout/output.yaml
@@ -81,18 +81,36 @@ data:
           replacement = "$1"
           target_label = "tmp_container_runtime"
         }
+        // Compute the workload (owner) name. For ReplicaSet-owned pods, strip the
+        // pod-template hash to recover the Deployment name (matches Beyla / OTel Operator).
+        rule {
+          source_labels = ["__meta_kubernetes_pod_controller_name"]
+          target_label = "__tmp_workload_name"
+        }
+        rule {
+          source_labels = ["__meta_kubernetes_pod_controller_kind", "__meta_kubernetes_pod_controller_name"]
+          regex = "ReplicaSet;(.+)-[^-]+"
+          replacement = "$1"
+          target_label = "__tmp_workload_name"
+        }
     
         // explicitly set service_name. if not set, loki will automatically try to populate a default.
         // see https://grafana.com/docs/loki/latest/get-started/labels/#default-labels-for-all-users
         //
         // choose the first value found from the following ordered list:
         // - pod.annotation[resource.opentelemetry.io/service.name]
+        // - pod.label[app.kubernetes.io/instance]
         // - pod.label[app.kubernetes.io/name]
+        // - k8s.workload.name (Deployment, StatefulSet, DaemonSet, CronJob, Job, ...)
+        // - k8s.pod.name
         // - k8s.container.name
         rule {
           source_labels = [
             "__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_name",
+            "__meta_kubernetes_pod_label_app_kubernetes_io_instance",
             "__meta_kubernetes_pod_label_app_kubernetes_io_name",
+            "__tmp_workload_name",
+            "__meta_kubernetes_pod_name",
             "__meta_kubernetes_pod_container_name",
           ]
           separator = ";"

--- a/charts/k8s-monitoring/docs/examples/destinations/loki-stdout/test/test-plan.yaml
+++ b/charts/k8s-monitoring/docs/examples/destinations/loki-stdout/test/test-plan.yaml
@@ -46,10 +46,10 @@ tests:
             - query: sum(count_over_time({cluster="$CLUSTER", namespace="default", app_kubernetes_io_name="alloy-operator"}[1h]))
               type: logql
 
-            # Pod logs from production namespace come through
-            - query: sum(count_over_time({cluster="$CLUSTER", namespace="production", service_name="busybox"}[1h]))
+            # Pod logs from production namespace come through (service_name comes from the Deployment name)
+            - query: sum(count_over_time({cluster="$CLUSTER", namespace="production", service_name="prod-pods"}[1h]))
               type: logql
 
             # Pod logs from production namespace are also logged by alloy-logs
-            - query: sum(count_over_time({cluster="loki-stdout-destination-test", namespace="default", service_name="alloy-logs"}[1h] |~ "loki.echo.lokistdout" |~ "entry=\"level=ERROR Something went wrong\"" |~ "namespace=\\\\\"production\\\\\""))
+            - query: sum(count_over_time({cluster="loki-stdout-destination-test", namespace="default", service_name="k8smon-alloy-logs"}[1h] |~ "loki.echo.lokistdout" |~ "entry=\"level=ERROR Something went wrong\"" |~ "namespace=\\\\\"production\\\\\""))
               type: logql

--- a/charts/k8s-monitoring/docs/examples/destinations/loki-stdout/values.yaml
+++ b/charts/k8s-monitoring/docs/examples/destinations/loki-stdout/values.yaml
@@ -24,6 +24,7 @@ destinations:
 # Will automatically go to both loki and lokiStdout destinations
 podLogsViaLoki:
   enabled: true
+  alignServiceNameWithOTelSemConv: true
 
 collectors:
   alloy-logs:

--- a/charts/k8s-monitoring/docs/examples/destinations/nop/alloy-logs.alloy
+++ b/charts/k8s-monitoring/docs/examples/destinations/nop/alloy-logs.alloy
@@ -46,7 +46,6 @@ declare "pod_logs_via_loki" {
       replacement = "$1"
       target_label = "tmp_container_runtime"
     }
-
     // explicitly set service_name. if not set, loki will automatically try to populate a default.
     // see https://grafana.com/docs/loki/latest/get-started/labels/#default-labels-for-all-users
     //

--- a/charts/k8s-monitoring/docs/examples/destinations/nop/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/destinations/nop/output.yaml
@@ -86,7 +86,6 @@ data:
           replacement = "$1"
           target_label = "tmp_container_runtime"
         }
-    
         // explicitly set service_name. if not set, loki will automatically try to populate a default.
         // see https://grafana.com/docs/loki/latest/get-started/labels/#default-labels-for-all-users
         //

--- a/charts/k8s-monitoring/docs/examples/destinations/otlp-endpoint/alloy-logs.alloy
+++ b/charts/k8s-monitoring/docs/examples/destinations/otlp-endpoint/alloy-logs.alloy
@@ -46,7 +46,6 @@ declare "pod_logs_via_loki" {
       replacement = "$1"
       target_label = "tmp_container_runtime"
     }
-
     // explicitly set service_name. if not set, loki will automatically try to populate a default.
     // see https://grafana.com/docs/loki/latest/get-started/labels/#default-labels-for-all-users
     //

--- a/charts/k8s-monitoring/docs/examples/destinations/otlp-endpoint/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/destinations/otlp-endpoint/output.yaml
@@ -153,7 +153,6 @@ data:
           replacement = "$1"
           target_label = "tmp_container_runtime"
         }
-    
         // explicitly set service_name. if not set, loki will automatically try to populate a default.
         // see https://grafana.com/docs/loki/latest/get-started/labels/#default-labels-for-all-users
         //

--- a/charts/k8s-monitoring/docs/examples/exclude-by-namespace/alloy-daemonset.alloy
+++ b/charts/k8s-monitoring/docs/examples/exclude-by-namespace/alloy-daemonset.alloy
@@ -51,7 +51,6 @@ declare "pod_logs_via_loki" {
       replacement = "$1"
       target_label = "tmp_container_runtime"
     }
-
     // explicitly set service_name. if not set, loki will automatically try to populate a default.
     // see https://grafana.com/docs/loki/latest/get-started/labels/#default-labels-for-all-users
     //
@@ -251,10 +250,25 @@ declare "profiling" {
       target_label = "container"
     }
 
+    // Compute the workload (owner) name. For ReplicaSet-owned pods, strip the
+    // pod-template hash to recover the Deployment name (matches Beyla / OTel Operator).
+    rule {
+      source_labels = ["__meta_kubernetes_pod_controller_name"]
+      target_label = "__tmp_workload_name"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_pod_controller_kind", "__meta_kubernetes_pod_controller_name"]
+      regex = "ReplicaSet;(.+)-[^-]+"
+      replacement = "$1"
+      target_label = "__tmp_workload_name"
+    }
+
     // Set service_name by choosing the first value found from the following ordered list:
     // - pod.annotation[resource.opentelemetry.io/service.name]
     // - pod.label[app.kubernetes.io/instance]
     // - pod.label[app.kubernetes.io/name]
+    // - k8s.workload.name (Deployment, StatefulSet, DaemonSet, CronJob, Job, ...)
+    // - k8s.pod.name
     // - k8s.container.name
     rule {
       action = "replace"
@@ -262,6 +276,8 @@ declare "profiling" {
         "__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_name",
         "__meta_kubernetes_pod_label_app_kubernetes_io_instance",
         "__meta_kubernetes_pod_label_app_kubernetes_io_name",
+        "__tmp_workload_name",
+        "pod",
         "container",
       ]
       separator = ";"
@@ -379,10 +395,25 @@ declare "profiling" {
       target_label = "container"
     }
 
+    // Compute the workload (owner) name. For ReplicaSet-owned pods, strip the
+    // pod-template hash to recover the Deployment name (matches Beyla / OTel Operator).
+    rule {
+      source_labels = ["__meta_kubernetes_pod_controller_name"]
+      target_label = "__tmp_workload_name"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_pod_controller_kind", "__meta_kubernetes_pod_controller_name"]
+      regex = "ReplicaSet;(.+)-[^-]+"
+      replacement = "$1"
+      target_label = "__tmp_workload_name"
+    }
+
     // Set service_name by choosing the first value found from the following ordered list:
     // - pod.annotation[resource.opentelemetry.io/service.name]
     // - pod.label[app.kubernetes.io/instance]
     // - pod.label[app.kubernetes.io/name]
+    // - k8s.workload.name (Deployment, StatefulSet, DaemonSet, CronJob, Job, ...)
+    // - k8s.pod.name
     // - k8s.container.name
     rule {
       action = "replace"
@@ -390,6 +421,8 @@ declare "profiling" {
         "__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_name",
         "__meta_kubernetes_pod_label_app_kubernetes_io_instance",
         "__meta_kubernetes_pod_label_app_kubernetes_io_name",
+        "__tmp_workload_name",
+        "pod",
         "container",
       ]
       separator = ";"
@@ -484,10 +517,25 @@ declare "profiling" {
       target_label  = "container"
     }
 
+    // Compute the workload (owner) name. For ReplicaSet-owned pods, strip the
+    // pod-template hash to recover the Deployment name (matches Beyla / OTel Operator).
+    rule {
+      source_labels = ["__meta_kubernetes_pod_controller_name"]
+      target_label = "__tmp_workload_name"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_pod_controller_kind", "__meta_kubernetes_pod_controller_name"]
+      regex = "ReplicaSet;(.+)-[^-]+"
+      replacement = "$1"
+      target_label = "__tmp_workload_name"
+    }
+
     // Set service_name by choosing the first value found from the following ordered list:
     // - pod.annotation[resource.opentelemetry.io/service.name]
     // - pod.label[app.kubernetes.io/instance]
     // - pod.label[app.kubernetes.io/name]
+    // - k8s.workload.name (Deployment, StatefulSet, DaemonSet, CronJob, Job, ...)
+    // - k8s.pod.name
     // - k8s.container.name
     rule {
       action = "replace"
@@ -495,6 +543,8 @@ declare "profiling" {
         "__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_name",
         "__meta_kubernetes_pod_label_app_kubernetes_io_instance",
         "__meta_kubernetes_pod_label_app_kubernetes_io_name",
+        "__tmp_workload_name",
+        "pod",
         "container",
       ]
       separator = ";"

--- a/charts/k8s-monitoring/docs/examples/exclude-by-namespace/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/exclude-by-namespace/output.yaml
@@ -124,7 +124,6 @@ data:
           replacement = "$1"
           target_label = "tmp_container_runtime"
         }
-    
         // explicitly set service_name. if not set, loki will automatically try to populate a default.
         // see https://grafana.com/docs/loki/latest/get-started/labels/#default-labels-for-all-users
         //
@@ -324,10 +323,25 @@ data:
           target_label = "container"
         }
     
+        // Compute the workload (owner) name. For ReplicaSet-owned pods, strip the
+        // pod-template hash to recover the Deployment name (matches Beyla / OTel Operator).
+        rule {
+          source_labels = ["__meta_kubernetes_pod_controller_name"]
+          target_label = "__tmp_workload_name"
+        }
+        rule {
+          source_labels = ["__meta_kubernetes_pod_controller_kind", "__meta_kubernetes_pod_controller_name"]
+          regex = "ReplicaSet;(.+)-[^-]+"
+          replacement = "$1"
+          target_label = "__tmp_workload_name"
+        }
+    
         // Set service_name by choosing the first value found from the following ordered list:
         // - pod.annotation[resource.opentelemetry.io/service.name]
         // - pod.label[app.kubernetes.io/instance]
         // - pod.label[app.kubernetes.io/name]
+        // - k8s.workload.name (Deployment, StatefulSet, DaemonSet, CronJob, Job, ...)
+        // - k8s.pod.name
         // - k8s.container.name
         rule {
           action = "replace"
@@ -335,6 +349,8 @@ data:
             "__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_name",
             "__meta_kubernetes_pod_label_app_kubernetes_io_instance",
             "__meta_kubernetes_pod_label_app_kubernetes_io_name",
+            "__tmp_workload_name",
+            "pod",
             "container",
           ]
           separator = ";"
@@ -452,10 +468,25 @@ data:
           target_label = "container"
         }
     
+        // Compute the workload (owner) name. For ReplicaSet-owned pods, strip the
+        // pod-template hash to recover the Deployment name (matches Beyla / OTel Operator).
+        rule {
+          source_labels = ["__meta_kubernetes_pod_controller_name"]
+          target_label = "__tmp_workload_name"
+        }
+        rule {
+          source_labels = ["__meta_kubernetes_pod_controller_kind", "__meta_kubernetes_pod_controller_name"]
+          regex = "ReplicaSet;(.+)-[^-]+"
+          replacement = "$1"
+          target_label = "__tmp_workload_name"
+        }
+    
         // Set service_name by choosing the first value found from the following ordered list:
         // - pod.annotation[resource.opentelemetry.io/service.name]
         // - pod.label[app.kubernetes.io/instance]
         // - pod.label[app.kubernetes.io/name]
+        // - k8s.workload.name (Deployment, StatefulSet, DaemonSet, CronJob, Job, ...)
+        // - k8s.pod.name
         // - k8s.container.name
         rule {
           action = "replace"
@@ -463,6 +494,8 @@ data:
             "__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_name",
             "__meta_kubernetes_pod_label_app_kubernetes_io_instance",
             "__meta_kubernetes_pod_label_app_kubernetes_io_name",
+            "__tmp_workload_name",
+            "pod",
             "container",
           ]
           separator = ";"
@@ -557,10 +590,25 @@ data:
           target_label  = "container"
         }
     
+        // Compute the workload (owner) name. For ReplicaSet-owned pods, strip the
+        // pod-template hash to recover the Deployment name (matches Beyla / OTel Operator).
+        rule {
+          source_labels = ["__meta_kubernetes_pod_controller_name"]
+          target_label = "__tmp_workload_name"
+        }
+        rule {
+          source_labels = ["__meta_kubernetes_pod_controller_kind", "__meta_kubernetes_pod_controller_name"]
+          regex = "ReplicaSet;(.+)-[^-]+"
+          replacement = "$1"
+          target_label = "__tmp_workload_name"
+        }
+    
         // Set service_name by choosing the first value found from the following ordered list:
         // - pod.annotation[resource.opentelemetry.io/service.name]
         // - pod.label[app.kubernetes.io/instance]
         // - pod.label[app.kubernetes.io/name]
+        // - k8s.workload.name (Deployment, StatefulSet, DaemonSet, CronJob, Job, ...)
+        // - k8s.pod.name
         // - k8s.container.name
         rule {
           action = "replace"
@@ -568,6 +616,8 @@ data:
             "__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_name",
             "__meta_kubernetes_pod_label_app_kubernetes_io_instance",
             "__meta_kubernetes_pod_label_app_kubernetes_io_name",
+            "__tmp_workload_name",
+            "pod",
             "container",
           ]
           separator = ";"

--- a/charts/k8s-monitoring/docs/examples/extra-rules/alloy-logs.alloy
+++ b/charts/k8s-monitoring/docs/examples/extra-rules/alloy-logs.alloy
@@ -46,7 +46,6 @@ declare "pod_logs_via_loki" {
       replacement = "$1"
       target_label = "tmp_container_runtime"
     }
-
     // explicitly set service_name. if not set, loki will automatically try to populate a default.
     // see https://grafana.com/docs/loki/latest/get-started/labels/#default-labels-for-all-users
     //

--- a/charts/k8s-monitoring/docs/examples/extra-rules/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/extra-rules/output.yaml
@@ -142,7 +142,6 @@ data:
           replacement = "$1"
           target_label = "tmp_container_runtime"
         }
-    
         // explicitly set service_name. if not set, loki will automatically try to populate a default.
         // see https://grafana.com/docs/loki/latest/get-started/labels/#default-labels-for-all-users
         //

--- a/charts/k8s-monitoring/docs/examples/features/cluster-metrics/control-plane-monitoring/alloy-logs.alloy
+++ b/charts/k8s-monitoring/docs/examples/features/cluster-metrics/control-plane-monitoring/alloy-logs.alloy
@@ -46,7 +46,6 @@ declare "pod_logs_via_loki" {
       replacement = "$1"
       target_label = "tmp_container_runtime"
     }
-
     // explicitly set service_name. if not set, loki will automatically try to populate a default.
     // see https://grafana.com/docs/loki/latest/get-started/labels/#default-labels-for-all-users
     //

--- a/charts/k8s-monitoring/docs/examples/features/cluster-metrics/control-plane-monitoring/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/features/cluster-metrics/control-plane-monitoring/output.yaml
@@ -142,7 +142,6 @@ data:
           replacement = "$1"
           target_label = "tmp_container_runtime"
         }
-    
         // explicitly set service_name. if not set, loki will automatically try to populate a default.
         // see https://grafana.com/docs/loki/latest/get-started/labels/#default-labels-for-all-users
         //

--- a/charts/k8s-monitoring/docs/examples/features/database-observability/mysql/alloy-logs.alloy
+++ b/charts/k8s-monitoring/docs/examples/features/database-observability/mysql/alloy-logs.alloy
@@ -46,7 +46,6 @@ declare "pod_logs_via_loki" {
       replacement = "$1"
       target_label = "tmp_container_runtime"
     }
-
     // explicitly set service_name. if not set, loki will automatically try to populate a default.
     // see https://grafana.com/docs/loki/latest/get-started/labels/#default-labels-for-all-users
     //

--- a/charts/k8s-monitoring/docs/examples/features/database-observability/mysql/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/features/database-observability/mysql/output.yaml
@@ -81,7 +81,6 @@ data:
           replacement = "$1"
           target_label = "tmp_container_runtime"
         }
-    
         // explicitly set service_name. if not set, loki will automatically try to populate a default.
         // see https://grafana.com/docs/loki/latest/get-started/labels/#default-labels-for-all-users
         //

--- a/charts/k8s-monitoring/docs/examples/features/database-observability/postgresql/alloy-logs.alloy
+++ b/charts/k8s-monitoring/docs/examples/features/database-observability/postgresql/alloy-logs.alloy
@@ -46,7 +46,6 @@ declare "pod_logs_via_loki" {
       replacement = "$1"
       target_label = "tmp_container_runtime"
     }
-
     // explicitly set service_name. if not set, loki will automatically try to populate a default.
     // see https://grafana.com/docs/loki/latest/get-started/labels/#default-labels-for-all-users
     //

--- a/charts/k8s-monitoring/docs/examples/features/database-observability/postgresql/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/features/database-observability/postgresql/output.yaml
@@ -81,7 +81,6 @@ data:
           replacement = "$1"
           target_label = "tmp_container_runtime"
         }
-    
         // explicitly set service_name. if not set, loki will automatically try to populate a default.
         // see https://grafana.com/docs/loki/latest/get-started/labels/#default-labels-for-all-users
         //

--- a/charts/k8s-monitoring/docs/examples/features/integrations/grafana/alloy-logs.alloy
+++ b/charts/k8s-monitoring/docs/examples/features/integrations/grafana/alloy-logs.alloy
@@ -46,7 +46,6 @@ declare "pod_logs_via_loki" {
       replacement = "$1"
       target_label = "tmp_container_runtime"
     }
-
     // explicitly set service_name. if not set, loki will automatically try to populate a default.
     // see https://grafana.com/docs/loki/latest/get-started/labels/#default-labels-for-all-users
     //

--- a/charts/k8s-monitoring/docs/examples/features/integrations/grafana/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/features/integrations/grafana/output.yaml
@@ -69,7 +69,6 @@ data:
           replacement = "$1"
           target_label = "tmp_container_runtime"
         }
-    
         // explicitly set service_name. if not set, loki will automatically try to populate a default.
         // see https://grafana.com/docs/loki/latest/get-started/labels/#default-labels-for-all-users
         //

--- a/charts/k8s-monitoring/docs/examples/features/integrations/loki/alloy-logs.alloy
+++ b/charts/k8s-monitoring/docs/examples/features/integrations/loki/alloy-logs.alloy
@@ -46,7 +46,6 @@ declare "pod_logs_via_loki" {
       replacement = "$1"
       target_label = "tmp_container_runtime"
     }
-
     // explicitly set service_name. if not set, loki will automatically try to populate a default.
     // see https://grafana.com/docs/loki/latest/get-started/labels/#default-labels-for-all-users
     //

--- a/charts/k8s-monitoring/docs/examples/features/integrations/loki/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/features/integrations/loki/output.yaml
@@ -69,7 +69,6 @@ data:
           replacement = "$1"
           target_label = "tmp_container_runtime"
         }
-    
         // explicitly set service_name. if not set, loki will automatically try to populate a default.
         // see https://grafana.com/docs/loki/latest/get-started/labels/#default-labels-for-all-users
         //

--- a/charts/k8s-monitoring/docs/examples/features/integrations/mimir/alloy-logs.alloy
+++ b/charts/k8s-monitoring/docs/examples/features/integrations/mimir/alloy-logs.alloy
@@ -46,7 +46,6 @@ declare "pod_logs_via_loki" {
       replacement = "$1"
       target_label = "tmp_container_runtime"
     }
-
     // explicitly set service_name. if not set, loki will automatically try to populate a default.
     // see https://grafana.com/docs/loki/latest/get-started/labels/#default-labels-for-all-users
     //

--- a/charts/k8s-monitoring/docs/examples/features/integrations/mimir/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/features/integrations/mimir/output.yaml
@@ -69,7 +69,6 @@ data:
           replacement = "$1"
           target_label = "tmp_container_runtime"
         }
-    
         // explicitly set service_name. if not set, loki will automatically try to populate a default.
         // see https://grafana.com/docs/loki/latest/get-started/labels/#default-labels-for-all-users
         //

--- a/charts/k8s-monitoring/docs/examples/features/integrations/multiple/alloy-logs.alloy
+++ b/charts/k8s-monitoring/docs/examples/features/integrations/multiple/alloy-logs.alloy
@@ -46,7 +46,6 @@ declare "pod_logs_via_loki" {
       replacement = "$1"
       target_label = "tmp_container_runtime"
     }
-
     // explicitly set service_name. if not set, loki will automatically try to populate a default.
     // see https://grafana.com/docs/loki/latest/get-started/labels/#default-labels-for-all-users
     //

--- a/charts/k8s-monitoring/docs/examples/features/integrations/multiple/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/features/integrations/multiple/output.yaml
@@ -79,7 +79,6 @@ data:
           replacement = "$1"
           target_label = "tmp_container_runtime"
         }
-    
         // explicitly set service_name. if not set, loki will automatically try to populate a default.
         // see https://grafana.com/docs/loki/latest/get-started/labels/#default-labels-for-all-users
         //

--- a/charts/k8s-monitoring/docs/examples/features/integrations/mysql/alloy-logs.alloy
+++ b/charts/k8s-monitoring/docs/examples/features/integrations/mysql/alloy-logs.alloy
@@ -46,7 +46,6 @@ declare "pod_logs_via_loki" {
       replacement = "$1"
       target_label = "tmp_container_runtime"
     }
-
     // explicitly set service_name. if not set, loki will automatically try to populate a default.
     // see https://grafana.com/docs/loki/latest/get-started/labels/#default-labels-for-all-users
     //

--- a/charts/k8s-monitoring/docs/examples/features/integrations/mysql/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/features/integrations/mysql/output.yaml
@@ -79,7 +79,6 @@ data:
           replacement = "$1"
           target_label = "tmp_container_runtime"
         }
-    
         // explicitly set service_name. if not set, loki will automatically try to populate a default.
         // see https://grafana.com/docs/loki/latest/get-started/labels/#default-labels-for-all-users
         //

--- a/charts/k8s-monitoring/docs/examples/features/integrations/postgresql/alloy-logs.alloy
+++ b/charts/k8s-monitoring/docs/examples/features/integrations/postgresql/alloy-logs.alloy
@@ -46,7 +46,6 @@ declare "pod_logs_via_loki" {
       replacement = "$1"
       target_label = "tmp_container_runtime"
     }
-
     // explicitly set service_name. if not set, loki will automatically try to populate a default.
     // see https://grafana.com/docs/loki/latest/get-started/labels/#default-labels-for-all-users
     //

--- a/charts/k8s-monitoring/docs/examples/features/integrations/postgresql/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/features/integrations/postgresql/output.yaml
@@ -81,7 +81,6 @@ data:
           replacement = "$1"
           target_label = "tmp_container_runtime"
         }
-    
         // explicitly set service_name. if not set, loki will automatically try to populate a default.
         // see https://grafana.com/docs/loki/latest/get-started/labels/#default-labels-for-all-users
         //

--- a/charts/k8s-monitoring/docs/examples/features/kubernetes-manifests/default/alloy-logs.alloy
+++ b/charts/k8s-monitoring/docs/examples/features/kubernetes-manifests/default/alloy-logs.alloy
@@ -46,7 +46,6 @@ declare "pod_logs_via_loki" {
       replacement = "$1"
       target_label = "tmp_container_runtime"
     }
-
     // explicitly set service_name. if not set, loki will automatically try to populate a default.
     // see https://grafana.com/docs/loki/latest/get-started/labels/#default-labels-for-all-users
     //

--- a/charts/k8s-monitoring/docs/examples/features/kubernetes-manifests/default/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/features/kubernetes-manifests/default/output.yaml
@@ -126,7 +126,6 @@ data:
           replacement = "$1"
           target_label = "tmp_container_runtime"
         }
-    
         // explicitly set service_name. if not set, loki will automatically try to populate a default.
         // see https://grafana.com/docs/loki/latest/get-started/labels/#default-labels-for-all-users
         //

--- a/charts/k8s-monitoring/docs/examples/features/pod-logs-via-loki/default/alloy-logs.alloy
+++ b/charts/k8s-monitoring/docs/examples/features/pod-logs-via-loki/default/alloy-logs.alloy
@@ -46,7 +46,6 @@ declare "pod_logs_via_loki" {
       replacement = "$1"
       target_label = "tmp_container_runtime"
     }
-
     // explicitly set service_name. if not set, loki will automatically try to populate a default.
     // see https://grafana.com/docs/loki/latest/get-started/labels/#default-labels-for-all-users
     //

--- a/charts/k8s-monitoring/docs/examples/features/pod-logs-via-loki/default/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/features/pod-logs-via-loki/default/output.yaml
@@ -69,7 +69,6 @@ data:
           replacement = "$1"
           target_label = "tmp_container_runtime"
         }
-    
         // explicitly set service_name. if not set, loki will automatically try to populate a default.
         // see https://grafana.com/docs/loki/latest/get-started/labels/#default-labels-for-all-users
         //

--- a/charts/k8s-monitoring/docs/examples/features/pod-logs-via-loki/multiline/alloy-logs.alloy
+++ b/charts/k8s-monitoring/docs/examples/features/pod-logs-via-loki/multiline/alloy-logs.alloy
@@ -46,7 +46,6 @@ declare "pod_logs_via_loki" {
       replacement = "$1"
       target_label = "tmp_container_runtime"
     }
-
     // explicitly set service_name. if not set, loki will automatically try to populate a default.
     // see https://grafana.com/docs/loki/latest/get-started/labels/#default-labels-for-all-users
     //

--- a/charts/k8s-monitoring/docs/examples/features/pod-logs-via-loki/multiline/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/features/pod-logs-via-loki/multiline/output.yaml
@@ -81,7 +81,6 @@ data:
           replacement = "$1"
           target_label = "tmp_container_runtime"
         }
-    
         // explicitly set service_name. if not set, loki will automatically try to populate a default.
         // see https://grafana.com/docs/loki/latest/get-started/labels/#default-labels-for-all-users
         //

--- a/charts/k8s-monitoring/docs/examples/features/pod-logs-via-opentelemetry/README.md
+++ b/charts/k8s-monitoring/docs/examples/features/pod-logs-via-opentelemetry/README.md
@@ -30,6 +30,7 @@ destinations:
 
 podLogsViaOpenTelemetry:
   enabled: true
+  alignServiceNameWithOTelSemConv: true
   namespaces:
     - development
     - production

--- a/charts/k8s-monitoring/docs/examples/features/pod-logs-via-opentelemetry/alloy-logs.alloy
+++ b/charts/k8s-monitoring/docs/examples/features/pod-logs-via-opentelemetry/alloy-logs.alloy
@@ -54,6 +54,24 @@ declare "pod_logs_via_opentelemetry" {
         key      = "logs.grafana.com/pods.enabled"
         from     = "pod"
       }
+      // Extracted into temporary attributes for service.name / service.version detection, then deleted in the
+      // transform processor below. Temporary names are used so the cleanup never deletes an `app.kubernetes.io/*`
+      // attribute the user extracted.
+      label {
+        tag_name = "k8s_monitoring.tmp.instance"
+        key      = "app.kubernetes.io/instance"
+        from     = "pod"
+      }
+      label {
+        tag_name = "k8s_monitoring.tmp.name"
+        key      = "app.kubernetes.io/name"
+        from     = "pod"
+      }
+      label {
+        tag_name = "k8s_monitoring.tmp.version"
+        key      = "app.kubernetes.io/version"
+        from     = "pod"
+      }
       label {
         tag_name = "app_kubernetes_io_name"
         key      = "app.kubernetes.io/name"
@@ -92,7 +110,17 @@ declare "pod_logs_via_opentelemetry" {
       statements = [
         `delete_key(attributes, "k8s.container.restart_count")`,
         `delete_key(attributes, "logs.grafana.com/pods.enabled")`,
-
+        // Set service.name by choosing the first value found from the following ordered list:
+        // - pod.annotation[resource.opentelemetry.io/service.name] (set by the k8sattributes processor above)
+        // - pod.label[app.kubernetes.io/instance]
+        // - pod.label[app.kubernetes.io/name]
+        // - k8s.workload.name (Deployment, StatefulSet, DaemonSet, CronJob, Job, ...)
+        // - k8s.pod.name
+        // - k8s.container.name
+        // The instance/name/version pod labels are read from temporary attributes (k8s_monitoring.tmp.*) so the
+        // cleanup below only ever deletes attributes this feature added.
+        `set(resource.attributes["service.name"], resource.attributes["k8s_monitoring.tmp.instance"]) where (resource.attributes["service.name"] == nil or resource.attributes["service.name"] == "") and resource.attributes["k8s_monitoring.tmp.instance"] != nil and resource.attributes["k8s_monitoring.tmp.instance"] != ""`,
+        `set(resource.attributes["service.name"], resource.attributes["k8s_monitoring.tmp.name"]) where (resource.attributes["service.name"] == nil or resource.attributes["service.name"] == "") and resource.attributes["k8s_monitoring.tmp.name"] != nil and resource.attributes["k8s_monitoring.tmp.name"] != ""`,
         `set(attributes["service.name"], attributes["app.kubernetes.io/name"]) where (attributes["service.name"] == nil or attributes["service.name"] == "") and attributes["app.kubernetes.io/name"] != nil and attributes["app.kubernetes.io/name"] != ""`,
         `set(attributes["service.name"], attributes["k8s.deployment.name"]) where (attributes["service.name"] == nil or attributes["service.name"] == "") and attributes["k8s.deployment.name"] != nil and attributes["k8s.deployment.name"] != ""`,
         `set(attributes["service.name"], attributes["k8s.replicaset.name"]) where (attributes["service.name"] == nil or attributes["service.name"] == "") and attributes["k8s.replicaset.name"] != nil and attributes["k8s.replicaset.name"] != ""`,
@@ -105,9 +133,15 @@ declare "pod_logs_via_opentelemetry" {
 
         `set(attributes["service.namespace"], attributes["k8s.namespace.name"]) where (attributes["service.namespace"] == nil or attributes["service.namespace"] == "") and attributes["k8s.namespace.name"] != nil and attributes["k8s.namespace.name"] != ""`,
 
+        `set(resource.attributes["service.version"], resource.attributes["k8s_monitoring.tmp.version"]) where resource.attributes["service.version"] == nil and resource.attributes["k8s_monitoring.tmp.version"] != nil and resource.attributes["k8s_monitoring.tmp.version"] != ""`,
         `set(attributes["service.version"], attributes["app.kubernetes.io/version"]) where attributes["service.version"] == nil`,
 
         `set(attributes["service.instance.id"], Concat([attributes["k8s.namespace.name"], attributes["k8s.pod.name"], attributes["k8s.container.name"]], ".")) where attributes["service.instance.id"] == nil`,
+
+        // Remove the temporary attributes used for service.name / service.version detection
+        `delete_key(resource.attributes, "k8s_monitoring.tmp.instance")`,
+        `delete_key(resource.attributes, "k8s_monitoring.tmp.name")`,
+        `delete_key(resource.attributes, "k8s_monitoring.tmp.version")`,
       ]
     }
 

--- a/charts/k8s-monitoring/docs/examples/features/pod-logs-via-opentelemetry/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/features/pod-logs-via-opentelemetry/output.yaml
@@ -89,6 +89,24 @@ data:
             key      = "logs.grafana.com/pods.enabled"
             from     = "pod"
           }
+          // Extracted into temporary attributes for service.name / service.version detection, then deleted in the
+          // transform processor below. Temporary names are used so the cleanup never deletes an `app.kubernetes.io/*`
+          // attribute the user extracted.
+          label {
+            tag_name = "k8s_monitoring.tmp.instance"
+            key      = "app.kubernetes.io/instance"
+            from     = "pod"
+          }
+          label {
+            tag_name = "k8s_monitoring.tmp.name"
+            key      = "app.kubernetes.io/name"
+            from     = "pod"
+          }
+          label {
+            tag_name = "k8s_monitoring.tmp.version"
+            key      = "app.kubernetes.io/version"
+            from     = "pod"
+          }
           label {
             tag_name = "app_kubernetes_io_name"
             key      = "app.kubernetes.io/name"
@@ -127,7 +145,17 @@ data:
           statements = [
             `delete_key(attributes, "k8s.container.restart_count")`,
             `delete_key(attributes, "logs.grafana.com/pods.enabled")`,
-    
+            // Set service.name by choosing the first value found from the following ordered list:
+            // - pod.annotation[resource.opentelemetry.io/service.name] (set by the k8sattributes processor above)
+            // - pod.label[app.kubernetes.io/instance]
+            // - pod.label[app.kubernetes.io/name]
+            // - k8s.workload.name (Deployment, StatefulSet, DaemonSet, CronJob, Job, ...)
+            // - k8s.pod.name
+            // - k8s.container.name
+            // The instance/name/version pod labels are read from temporary attributes (k8s_monitoring.tmp.*) so the
+            // cleanup below only ever deletes attributes this feature added.
+            `set(resource.attributes["service.name"], resource.attributes["k8s_monitoring.tmp.instance"]) where (resource.attributes["service.name"] == nil or resource.attributes["service.name"] == "") and resource.attributes["k8s_monitoring.tmp.instance"] != nil and resource.attributes["k8s_monitoring.tmp.instance"] != ""`,
+            `set(resource.attributes["service.name"], resource.attributes["k8s_monitoring.tmp.name"]) where (resource.attributes["service.name"] == nil or resource.attributes["service.name"] == "") and resource.attributes["k8s_monitoring.tmp.name"] != nil and resource.attributes["k8s_monitoring.tmp.name"] != ""`,
             `set(attributes["service.name"], attributes["app.kubernetes.io/name"]) where (attributes["service.name"] == nil or attributes["service.name"] == "") and attributes["app.kubernetes.io/name"] != nil and attributes["app.kubernetes.io/name"] != ""`,
             `set(attributes["service.name"], attributes["k8s.deployment.name"]) where (attributes["service.name"] == nil or attributes["service.name"] == "") and attributes["k8s.deployment.name"] != nil and attributes["k8s.deployment.name"] != ""`,
             `set(attributes["service.name"], attributes["k8s.replicaset.name"]) where (attributes["service.name"] == nil or attributes["service.name"] == "") and attributes["k8s.replicaset.name"] != nil and attributes["k8s.replicaset.name"] != ""`,
@@ -140,9 +168,15 @@ data:
     
             `set(attributes["service.namespace"], attributes["k8s.namespace.name"]) where (attributes["service.namespace"] == nil or attributes["service.namespace"] == "") and attributes["k8s.namespace.name"] != nil and attributes["k8s.namespace.name"] != ""`,
     
+            `set(resource.attributes["service.version"], resource.attributes["k8s_monitoring.tmp.version"]) where resource.attributes["service.version"] == nil and resource.attributes["k8s_monitoring.tmp.version"] != nil and resource.attributes["k8s_monitoring.tmp.version"] != ""`,
             `set(attributes["service.version"], attributes["app.kubernetes.io/version"]) where attributes["service.version"] == nil`,
     
             `set(attributes["service.instance.id"], Concat([attributes["k8s.namespace.name"], attributes["k8s.pod.name"], attributes["k8s.container.name"]], ".")) where attributes["service.instance.id"] == nil`,
+    
+            // Remove the temporary attributes used for service.name / service.version detection
+            `delete_key(resource.attributes, "k8s_monitoring.tmp.instance")`,
+            `delete_key(resource.attributes, "k8s_monitoring.tmp.name")`,
+            `delete_key(resource.attributes, "k8s_monitoring.tmp.version")`,
           ]
         }
     

--- a/charts/k8s-monitoring/docs/examples/features/pod-logs-via-opentelemetry/values.yaml
+++ b/charts/k8s-monitoring/docs/examples/features/pod-logs-via-opentelemetry/values.yaml
@@ -18,6 +18,7 @@ destinations:
 
 podLogsViaOpenTelemetry:
   enabled: true
+  alignServiceNameWithOTelSemConv: true
   namespaces:
     - development
     - production

--- a/charts/k8s-monitoring/docs/examples/features/profiling/default/alloy-profiles.alloy
+++ b/charts/k8s-monitoring/docs/examples/features/profiling/default/alloy-profiles.alloy
@@ -41,10 +41,25 @@ declare "profiling" {
       target_label = "container"
     }
 
+    // Compute the workload (owner) name. For ReplicaSet-owned pods, strip the
+    // pod-template hash to recover the Deployment name (matches Beyla / OTel Operator).
+    rule {
+      source_labels = ["__meta_kubernetes_pod_controller_name"]
+      target_label = "__tmp_workload_name"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_pod_controller_kind", "__meta_kubernetes_pod_controller_name"]
+      regex = "ReplicaSet;(.+)-[^-]+"
+      replacement = "$1"
+      target_label = "__tmp_workload_name"
+    }
+
     // Set service_name by choosing the first value found from the following ordered list:
     // - pod.annotation[resource.opentelemetry.io/service.name]
     // - pod.label[app.kubernetes.io/instance]
     // - pod.label[app.kubernetes.io/name]
+    // - k8s.workload.name (Deployment, StatefulSet, DaemonSet, CronJob, Job, ...)
+    // - k8s.pod.name
     // - k8s.container.name
     rule {
       action = "replace"
@@ -52,6 +67,8 @@ declare "profiling" {
         "__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_name",
         "__meta_kubernetes_pod_label_app_kubernetes_io_instance",
         "__meta_kubernetes_pod_label_app_kubernetes_io_name",
+        "__tmp_workload_name",
+        "pod",
         "container",
       ]
       separator = ";"
@@ -164,10 +181,25 @@ declare "profiling" {
       target_label = "container"
     }
 
+    // Compute the workload (owner) name. For ReplicaSet-owned pods, strip the
+    // pod-template hash to recover the Deployment name (matches Beyla / OTel Operator).
+    rule {
+      source_labels = ["__meta_kubernetes_pod_controller_name"]
+      target_label = "__tmp_workload_name"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_pod_controller_kind", "__meta_kubernetes_pod_controller_name"]
+      regex = "ReplicaSet;(.+)-[^-]+"
+      replacement = "$1"
+      target_label = "__tmp_workload_name"
+    }
+
     // Set service_name by choosing the first value found from the following ordered list:
     // - pod.annotation[resource.opentelemetry.io/service.name]
     // - pod.label[app.kubernetes.io/instance]
     // - pod.label[app.kubernetes.io/name]
+    // - k8s.workload.name (Deployment, StatefulSet, DaemonSet, CronJob, Job, ...)
+    // - k8s.pod.name
     // - k8s.container.name
     rule {
       action = "replace"
@@ -175,6 +207,8 @@ declare "profiling" {
         "__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_name",
         "__meta_kubernetes_pod_label_app_kubernetes_io_instance",
         "__meta_kubernetes_pod_label_app_kubernetes_io_name",
+        "__tmp_workload_name",
+        "pod",
         "container",
       ]
       separator = ";"
@@ -264,10 +298,25 @@ declare "profiling" {
       target_label  = "container"
     }
 
+    // Compute the workload (owner) name. For ReplicaSet-owned pods, strip the
+    // pod-template hash to recover the Deployment name (matches Beyla / OTel Operator).
+    rule {
+      source_labels = ["__meta_kubernetes_pod_controller_name"]
+      target_label = "__tmp_workload_name"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_pod_controller_kind", "__meta_kubernetes_pod_controller_name"]
+      regex = "ReplicaSet;(.+)-[^-]+"
+      replacement = "$1"
+      target_label = "__tmp_workload_name"
+    }
+
     // Set service_name by choosing the first value found from the following ordered list:
     // - pod.annotation[resource.opentelemetry.io/service.name]
     // - pod.label[app.kubernetes.io/instance]
     // - pod.label[app.kubernetes.io/name]
+    // - k8s.workload.name (Deployment, StatefulSet, DaemonSet, CronJob, Job, ...)
+    // - k8s.pod.name
     // - k8s.container.name
     rule {
       action = "replace"
@@ -275,6 +324,8 @@ declare "profiling" {
         "__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_name",
         "__meta_kubernetes_pod_label_app_kubernetes_io_instance",
         "__meta_kubernetes_pod_label_app_kubernetes_io_name",
+        "__tmp_workload_name",
+        "pod",
         "container",
       ]
       separator = ";"

--- a/charts/k8s-monitoring/docs/examples/features/profiling/default/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/features/profiling/default/output.yaml
@@ -64,10 +64,25 @@ data:
           target_label = "container"
         }
     
+        // Compute the workload (owner) name. For ReplicaSet-owned pods, strip the
+        // pod-template hash to recover the Deployment name (matches Beyla / OTel Operator).
+        rule {
+          source_labels = ["__meta_kubernetes_pod_controller_name"]
+          target_label = "__tmp_workload_name"
+        }
+        rule {
+          source_labels = ["__meta_kubernetes_pod_controller_kind", "__meta_kubernetes_pod_controller_name"]
+          regex = "ReplicaSet;(.+)-[^-]+"
+          replacement = "$1"
+          target_label = "__tmp_workload_name"
+        }
+    
         // Set service_name by choosing the first value found from the following ordered list:
         // - pod.annotation[resource.opentelemetry.io/service.name]
         // - pod.label[app.kubernetes.io/instance]
         // - pod.label[app.kubernetes.io/name]
+        // - k8s.workload.name (Deployment, StatefulSet, DaemonSet, CronJob, Job, ...)
+        // - k8s.pod.name
         // - k8s.container.name
         rule {
           action = "replace"
@@ -75,6 +90,8 @@ data:
             "__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_name",
             "__meta_kubernetes_pod_label_app_kubernetes_io_instance",
             "__meta_kubernetes_pod_label_app_kubernetes_io_name",
+            "__tmp_workload_name",
+            "pod",
             "container",
           ]
           separator = ";"
@@ -187,10 +204,25 @@ data:
           target_label = "container"
         }
     
+        // Compute the workload (owner) name. For ReplicaSet-owned pods, strip the
+        // pod-template hash to recover the Deployment name (matches Beyla / OTel Operator).
+        rule {
+          source_labels = ["__meta_kubernetes_pod_controller_name"]
+          target_label = "__tmp_workload_name"
+        }
+        rule {
+          source_labels = ["__meta_kubernetes_pod_controller_kind", "__meta_kubernetes_pod_controller_name"]
+          regex = "ReplicaSet;(.+)-[^-]+"
+          replacement = "$1"
+          target_label = "__tmp_workload_name"
+        }
+    
         // Set service_name by choosing the first value found from the following ordered list:
         // - pod.annotation[resource.opentelemetry.io/service.name]
         // - pod.label[app.kubernetes.io/instance]
         // - pod.label[app.kubernetes.io/name]
+        // - k8s.workload.name (Deployment, StatefulSet, DaemonSet, CronJob, Job, ...)
+        // - k8s.pod.name
         // - k8s.container.name
         rule {
           action = "replace"
@@ -198,6 +230,8 @@ data:
             "__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_name",
             "__meta_kubernetes_pod_label_app_kubernetes_io_instance",
             "__meta_kubernetes_pod_label_app_kubernetes_io_name",
+            "__tmp_workload_name",
+            "pod",
             "container",
           ]
           separator = ";"
@@ -287,10 +321,25 @@ data:
           target_label  = "container"
         }
     
+        // Compute the workload (owner) name. For ReplicaSet-owned pods, strip the
+        // pod-template hash to recover the Deployment name (matches Beyla / OTel Operator).
+        rule {
+          source_labels = ["__meta_kubernetes_pod_controller_name"]
+          target_label = "__tmp_workload_name"
+        }
+        rule {
+          source_labels = ["__meta_kubernetes_pod_controller_kind", "__meta_kubernetes_pod_controller_name"]
+          regex = "ReplicaSet;(.+)-[^-]+"
+          replacement = "$1"
+          target_label = "__tmp_workload_name"
+        }
+    
         // Set service_name by choosing the first value found from the following ordered list:
         // - pod.annotation[resource.opentelemetry.io/service.name]
         // - pod.label[app.kubernetes.io/instance]
         // - pod.label[app.kubernetes.io/name]
+        // - k8s.workload.name (Deployment, StatefulSet, DaemonSet, CronJob, Job, ...)
+        // - k8s.pod.name
         // - k8s.container.name
         rule {
           action = "replace"
@@ -298,6 +347,8 @@ data:
             "__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_name",
             "__meta_kubernetes_pod_label_app_kubernetes_io_instance",
             "__meta_kubernetes_pod_label_app_kubernetes_io_name",
+            "__tmp_workload_name",
+            "pod",
             "container",
           ]
           separator = ";"

--- a/charts/k8s-monitoring/docs/examples/include-by-namespace/alloy-logs.alloy
+++ b/charts/k8s-monitoring/docs/examples/include-by-namespace/alloy-logs.alloy
@@ -49,7 +49,6 @@ declare "pod_logs_via_loki" {
       replacement = "$1"
       target_label = "tmp_container_runtime"
     }
-
     // explicitly set service_name. if not set, loki will automatically try to populate a default.
     // see https://grafana.com/docs/loki/latest/get-started/labels/#default-labels-for-all-users
     //

--- a/charts/k8s-monitoring/docs/examples/include-by-namespace/alloy-profiles.alloy
+++ b/charts/k8s-monitoring/docs/examples/include-by-namespace/alloy-profiles.alloy
@@ -44,10 +44,25 @@ declare "profiling" {
       target_label = "container"
     }
 
+    // Compute the workload (owner) name. For ReplicaSet-owned pods, strip the
+    // pod-template hash to recover the Deployment name (matches Beyla / OTel Operator).
+    rule {
+      source_labels = ["__meta_kubernetes_pod_controller_name"]
+      target_label = "__tmp_workload_name"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_pod_controller_kind", "__meta_kubernetes_pod_controller_name"]
+      regex = "ReplicaSet;(.+)-[^-]+"
+      replacement = "$1"
+      target_label = "__tmp_workload_name"
+    }
+
     // Set service_name by choosing the first value found from the following ordered list:
     // - pod.annotation[resource.opentelemetry.io/service.name]
     // - pod.label[app.kubernetes.io/instance]
     // - pod.label[app.kubernetes.io/name]
+    // - k8s.workload.name (Deployment, StatefulSet, DaemonSet, CronJob, Job, ...)
+    // - k8s.pod.name
     // - k8s.container.name
     rule {
       action = "replace"
@@ -55,6 +70,8 @@ declare "profiling" {
         "__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_name",
         "__meta_kubernetes_pod_label_app_kubernetes_io_instance",
         "__meta_kubernetes_pod_label_app_kubernetes_io_name",
+        "__tmp_workload_name",
+        "pod",
         "container",
       ]
       separator = ";"
@@ -170,10 +187,25 @@ declare "profiling" {
       target_label = "container"
     }
 
+    // Compute the workload (owner) name. For ReplicaSet-owned pods, strip the
+    // pod-template hash to recover the Deployment name (matches Beyla / OTel Operator).
+    rule {
+      source_labels = ["__meta_kubernetes_pod_controller_name"]
+      target_label = "__tmp_workload_name"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_pod_controller_kind", "__meta_kubernetes_pod_controller_name"]
+      regex = "ReplicaSet;(.+)-[^-]+"
+      replacement = "$1"
+      target_label = "__tmp_workload_name"
+    }
+
     // Set service_name by choosing the first value found from the following ordered list:
     // - pod.annotation[resource.opentelemetry.io/service.name]
     // - pod.label[app.kubernetes.io/instance]
     // - pod.label[app.kubernetes.io/name]
+    // - k8s.workload.name (Deployment, StatefulSet, DaemonSet, CronJob, Job, ...)
+    // - k8s.pod.name
     // - k8s.container.name
     rule {
       action = "replace"
@@ -181,6 +213,8 @@ declare "profiling" {
         "__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_name",
         "__meta_kubernetes_pod_label_app_kubernetes_io_instance",
         "__meta_kubernetes_pod_label_app_kubernetes_io_name",
+        "__tmp_workload_name",
+        "pod",
         "container",
       ]
       separator = ";"
@@ -273,10 +307,25 @@ declare "profiling" {
       target_label  = "container"
     }
 
+    // Compute the workload (owner) name. For ReplicaSet-owned pods, strip the
+    // pod-template hash to recover the Deployment name (matches Beyla / OTel Operator).
+    rule {
+      source_labels = ["__meta_kubernetes_pod_controller_name"]
+      target_label = "__tmp_workload_name"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_pod_controller_kind", "__meta_kubernetes_pod_controller_name"]
+      regex = "ReplicaSet;(.+)-[^-]+"
+      replacement = "$1"
+      target_label = "__tmp_workload_name"
+    }
+
     // Set service_name by choosing the first value found from the following ordered list:
     // - pod.annotation[resource.opentelemetry.io/service.name]
     // - pod.label[app.kubernetes.io/instance]
     // - pod.label[app.kubernetes.io/name]
+    // - k8s.workload.name (Deployment, StatefulSet, DaemonSet, CronJob, Job, ...)
+    // - k8s.pod.name
     // - k8s.container.name
     rule {
       action = "replace"
@@ -284,6 +333,8 @@ declare "profiling" {
         "__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_name",
         "__meta_kubernetes_pod_label_app_kubernetes_io_instance",
         "__meta_kubernetes_pod_label_app_kubernetes_io_name",
+        "__tmp_workload_name",
+        "pod",
         "container",
       ]
       separator = ";"

--- a/charts/k8s-monitoring/docs/examples/include-by-namespace/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/include-by-namespace/output.yaml
@@ -173,7 +173,6 @@ data:
           replacement = "$1"
           target_label = "tmp_container_runtime"
         }
-    
         // explicitly set service_name. if not set, loki will automatically try to populate a default.
         // see https://grafana.com/docs/loki/latest/get-started/labels/#default-labels-for-all-users
         //
@@ -1432,10 +1431,25 @@ data:
           target_label = "container"
         }
     
+        // Compute the workload (owner) name. For ReplicaSet-owned pods, strip the
+        // pod-template hash to recover the Deployment name (matches Beyla / OTel Operator).
+        rule {
+          source_labels = ["__meta_kubernetes_pod_controller_name"]
+          target_label = "__tmp_workload_name"
+        }
+        rule {
+          source_labels = ["__meta_kubernetes_pod_controller_kind", "__meta_kubernetes_pod_controller_name"]
+          regex = "ReplicaSet;(.+)-[^-]+"
+          replacement = "$1"
+          target_label = "__tmp_workload_name"
+        }
+    
         // Set service_name by choosing the first value found from the following ordered list:
         // - pod.annotation[resource.opentelemetry.io/service.name]
         // - pod.label[app.kubernetes.io/instance]
         // - pod.label[app.kubernetes.io/name]
+        // - k8s.workload.name (Deployment, StatefulSet, DaemonSet, CronJob, Job, ...)
+        // - k8s.pod.name
         // - k8s.container.name
         rule {
           action = "replace"
@@ -1443,6 +1457,8 @@ data:
             "__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_name",
             "__meta_kubernetes_pod_label_app_kubernetes_io_instance",
             "__meta_kubernetes_pod_label_app_kubernetes_io_name",
+            "__tmp_workload_name",
+            "pod",
             "container",
           ]
           separator = ";"
@@ -1558,10 +1574,25 @@ data:
           target_label = "container"
         }
     
+        // Compute the workload (owner) name. For ReplicaSet-owned pods, strip the
+        // pod-template hash to recover the Deployment name (matches Beyla / OTel Operator).
+        rule {
+          source_labels = ["__meta_kubernetes_pod_controller_name"]
+          target_label = "__tmp_workload_name"
+        }
+        rule {
+          source_labels = ["__meta_kubernetes_pod_controller_kind", "__meta_kubernetes_pod_controller_name"]
+          regex = "ReplicaSet;(.+)-[^-]+"
+          replacement = "$1"
+          target_label = "__tmp_workload_name"
+        }
+    
         // Set service_name by choosing the first value found from the following ordered list:
         // - pod.annotation[resource.opentelemetry.io/service.name]
         // - pod.label[app.kubernetes.io/instance]
         // - pod.label[app.kubernetes.io/name]
+        // - k8s.workload.name (Deployment, StatefulSet, DaemonSet, CronJob, Job, ...)
+        // - k8s.pod.name
         // - k8s.container.name
         rule {
           action = "replace"
@@ -1569,6 +1600,8 @@ data:
             "__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_name",
             "__meta_kubernetes_pod_label_app_kubernetes_io_instance",
             "__meta_kubernetes_pod_label_app_kubernetes_io_name",
+            "__tmp_workload_name",
+            "pod",
             "container",
           ]
           separator = ";"
@@ -1661,10 +1694,25 @@ data:
           target_label  = "container"
         }
     
+        // Compute the workload (owner) name. For ReplicaSet-owned pods, strip the
+        // pod-template hash to recover the Deployment name (matches Beyla / OTel Operator).
+        rule {
+          source_labels = ["__meta_kubernetes_pod_controller_name"]
+          target_label = "__tmp_workload_name"
+        }
+        rule {
+          source_labels = ["__meta_kubernetes_pod_controller_kind", "__meta_kubernetes_pod_controller_name"]
+          regex = "ReplicaSet;(.+)-[^-]+"
+          replacement = "$1"
+          target_label = "__tmp_workload_name"
+        }
+    
         // Set service_name by choosing the first value found from the following ordered list:
         // - pod.annotation[resource.opentelemetry.io/service.name]
         // - pod.label[app.kubernetes.io/instance]
         // - pod.label[app.kubernetes.io/name]
+        // - k8s.workload.name (Deployment, StatefulSet, DaemonSet, CronJob, Job, ...)
+        // - k8s.pod.name
         // - k8s.container.name
         rule {
           action = "replace"
@@ -1672,6 +1720,8 @@ data:
             "__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_name",
             "__meta_kubernetes_pod_label_app_kubernetes_io_instance",
             "__meta_kubernetes_pod_label_app_kubernetes_io_name",
+            "__tmp_workload_name",
+            "pod",
             "container",
           ]
           separator = ";"

--- a/charts/k8s-monitoring/docs/examples/istio-ambient/alloy-logs.alloy
+++ b/charts/k8s-monitoring/docs/examples/istio-ambient/alloy-logs.alloy
@@ -46,7 +46,6 @@ declare "pod_logs_via_loki" {
       replacement = "$1"
       target_label = "tmp_container_runtime"
     }
-
     // explicitly set service_name. if not set, loki will automatically try to populate a default.
     // see https://grafana.com/docs/loki/latest/get-started/labels/#default-labels-for-all-users
     //

--- a/charts/k8s-monitoring/docs/examples/istio-ambient/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/istio-ambient/output.yaml
@@ -165,7 +165,6 @@ data:
           replacement = "$1"
           target_label = "tmp_container_runtime"
         }
-    
         // explicitly set service_name. if not set, loki will automatically try to populate a default.
         // see https://grafana.com/docs/loki/latest/get-started/labels/#default-labels-for-all-users
         //

--- a/charts/k8s-monitoring/docs/examples/istio-service-mesh/alloy-logs.alloy
+++ b/charts/k8s-monitoring/docs/examples/istio-service-mesh/alloy-logs.alloy
@@ -46,7 +46,6 @@ declare "pod_logs_via_loki" {
       replacement = "$1"
       target_label = "tmp_container_runtime"
     }
-
     // explicitly set service_name. if not set, loki will automatically try to populate a default.
     // see https://grafana.com/docs/loki/latest/get-started/labels/#default-labels-for-all-users
     //

--- a/charts/k8s-monitoring/docs/examples/istio-service-mesh/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/istio-service-mesh/output.yaml
@@ -165,7 +165,6 @@ data:
           replacement = "$1"
           target_label = "tmp_container_runtime"
         }
-    
         // explicitly set service_name. if not set, loki will automatically try to populate a default.
         // see https://grafana.com/docs/loki/latest/get-started/labels/#default-labels-for-all-users
         //

--- a/charts/k8s-monitoring/docs/examples/log-metrics/alloy-logs.alloy
+++ b/charts/k8s-monitoring/docs/examples/log-metrics/alloy-logs.alloy
@@ -46,7 +46,6 @@ declare "pod_logs_via_loki" {
       replacement = "$1"
       target_label = "tmp_container_runtime"
     }
-
     // explicitly set service_name. if not set, loki will automatically try to populate a default.
     // see https://grafana.com/docs/loki/latest/get-started/labels/#default-labels-for-all-users
     //

--- a/charts/k8s-monitoring/docs/examples/log-metrics/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/log-metrics/output.yaml
@@ -69,7 +69,6 @@ data:
           replacement = "$1"
           target_label = "tmp_container_runtime"
         }
-    
         // explicitly set service_name. if not set, loki will automatically try to populate a default.
         // see https://grafana.com/docs/loki/latest/get-started/labels/#default-labels-for-all-users
         //

--- a/charts/k8s-monitoring/docs/examples/meta-monitoring/alloy.alloy
+++ b/charts/k8s-monitoring/docs/examples/meta-monitoring/alloy.alloy
@@ -1875,7 +1875,6 @@ declare "pod_logs_via_loki" {
       replacement = "$1"
       target_label = "tmp_container_runtime"
     }
-
     // explicitly set service_name. if not set, loki will automatically try to populate a default.
     // see https://grafana.com/docs/loki/latest/get-started/labels/#default-labels-for-all-users
     //

--- a/charts/k8s-monitoring/docs/examples/meta-monitoring/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/meta-monitoring/output.yaml
@@ -1932,7 +1932,6 @@ data:
           replacement = "$1"
           target_label = "tmp_container_runtime"
         }
-    
         // explicitly set service_name. if not set, loki will automatically try to populate a default.
         // see https://grafana.com/docs/loki/latest/get-started/labels/#default-labels-for-all-users
         //

--- a/charts/k8s-monitoring/docs/examples/name-overrides/namespace-override/alloy-logs.alloy
+++ b/charts/k8s-monitoring/docs/examples/name-overrides/namespace-override/alloy-logs.alloy
@@ -46,7 +46,6 @@ declare "pod_logs_via_loki" {
       replacement = "$1"
       target_label = "tmp_container_runtime"
     }
-
     // explicitly set service_name. if not set, loki will automatically try to populate a default.
     // see https://grafana.com/docs/loki/latest/get-started/labels/#default-labels-for-all-users
     //

--- a/charts/k8s-monitoring/docs/examples/name-overrides/namespace-override/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/name-overrides/namespace-override/output.yaml
@@ -69,7 +69,6 @@ data:
           replacement = "$1"
           target_label = "tmp_container_runtime"
         }
-    
         // explicitly set service_name. if not set, loki will automatically try to populate a default.
         // see https://grafana.com/docs/loki/latest/get-started/labels/#default-labels-for-all-users
         //

--- a/charts/k8s-monitoring/docs/examples/namespace-labels-and-annotations/alloy-logs.alloy
+++ b/charts/k8s-monitoring/docs/examples/namespace-labels-and-annotations/alloy-logs.alloy
@@ -46,7 +46,6 @@ declare "pod_logs_via_loki" {
       replacement = "$1"
       target_label = "tmp_container_runtime"
     }
-
     // explicitly set service_name. if not set, loki will automatically try to populate a default.
     // see https://grafana.com/docs/loki/latest/get-started/labels/#default-labels-for-all-users
     //

--- a/charts/k8s-monitoring/docs/examples/namespace-labels-and-annotations/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/namespace-labels-and-annotations/output.yaml
@@ -142,7 +142,6 @@ data:
           replacement = "$1"
           target_label = "tmp_container_runtime"
         }
-    
         // explicitly set service_name. if not set, loki will automatically try to populate a default.
         // see https://grafana.com/docs/loki/latest/get-started/labels/#default-labels-for-all-users
         //

--- a/charts/k8s-monitoring/docs/examples/platforms/azure-aks/alloy-logs.alloy
+++ b/charts/k8s-monitoring/docs/examples/platforms/azure-aks/alloy-logs.alloy
@@ -46,7 +46,6 @@ declare "pod_logs_via_loki" {
       replacement = "$1"
       target_label = "tmp_container_runtime"
     }
-
     // explicitly set service_name. if not set, loki will automatically try to populate a default.
     // see https://grafana.com/docs/loki/latest/get-started/labels/#default-labels-for-all-users
     //

--- a/charts/k8s-monitoring/docs/examples/platforms/azure-aks/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/platforms/azure-aks/output.yaml
@@ -142,7 +142,6 @@ data:
           replacement = "$1"
           target_label = "tmp_container_runtime"
         }
-    
         // explicitly set service_name. if not set, loki will automatically try to populate a default.
         // see https://grafana.com/docs/loki/latest/get-started/labels/#default-labels-for-all-users
         //

--- a/charts/k8s-monitoring/docs/examples/platforms/gke-autopilot/alloy-logs.alloy
+++ b/charts/k8s-monitoring/docs/examples/platforms/gke-autopilot/alloy-logs.alloy
@@ -46,7 +46,6 @@ declare "pod_logs_via_loki" {
       replacement = "$1"
       target_label = "tmp_container_runtime"
     }
-
     // explicitly set service_name. if not set, loki will automatically try to populate a default.
     // see https://grafana.com/docs/loki/latest/get-started/labels/#default-labels-for-all-users
     //

--- a/charts/k8s-monitoring/docs/examples/platforms/gke-autopilot/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/platforms/gke-autopilot/output.yaml
@@ -86,7 +86,6 @@ data:
           replacement = "$1"
           target_label = "tmp_container_runtime"
         }
-    
         // explicitly set service_name. if not set, loki will automatically try to populate a default.
         // see https://grafana.com/docs/loki/latest/get-started/labels/#default-labels-for-all-users
         //

--- a/charts/k8s-monitoring/docs/examples/platforms/openshift/alloy-logs.alloy
+++ b/charts/k8s-monitoring/docs/examples/platforms/openshift/alloy-logs.alloy
@@ -46,7 +46,6 @@ declare "pod_logs_via_loki" {
       replacement = "$1"
       target_label = "tmp_container_runtime"
     }
-
     // explicitly set service_name. if not set, loki will automatically try to populate a default.
     // see https://grafana.com/docs/loki/latest/get-started/labels/#default-labels-for-all-users
     //

--- a/charts/k8s-monitoring/docs/examples/platforms/openshift/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/platforms/openshift/output.yaml
@@ -82,7 +82,6 @@ data:
           replacement = "$1"
           target_label = "tmp_container_runtime"
         }
-    
         // explicitly set service_name. if not set, loki will automatically try to populate a default.
         // see https://grafana.com/docs/loki/latest/get-started/labels/#default-labels-for-all-users
         //

--- a/charts/k8s-monitoring/docs/examples/pod-labels-and-annotations/alloy-logs.alloy
+++ b/charts/k8s-monitoring/docs/examples/pod-labels-and-annotations/alloy-logs.alloy
@@ -46,7 +46,6 @@ declare "pod_logs_via_loki" {
       replacement = "$1"
       target_label = "tmp_container_runtime"
     }
-
     // explicitly set service_name. if not set, loki will automatically try to populate a default.
     // see https://grafana.com/docs/loki/latest/get-started/labels/#default-labels-for-all-users
     //

--- a/charts/k8s-monitoring/docs/examples/pod-labels-and-annotations/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/pod-labels-and-annotations/output.yaml
@@ -142,7 +142,6 @@ data:
           replacement = "$1"
           target_label = "tmp_container_runtime"
         }
-    
         // explicitly set service_name. if not set, loki will automatically try to populate a default.
         // see https://grafana.com/docs/loki/latest/get-started/labels/#default-labels-for-all-users
         //

--- a/charts/k8s-monitoring/docs/examples/private-image-registries/globally/alloy-logs.alloy
+++ b/charts/k8s-monitoring/docs/examples/private-image-registries/globally/alloy-logs.alloy
@@ -46,7 +46,6 @@ declare "pod_logs_via_loki" {
       replacement = "$1"
       target_label = "tmp_container_runtime"
     }
-
     // explicitly set service_name. if not set, loki will automatically try to populate a default.
     // see https://grafana.com/docs/loki/latest/get-started/labels/#default-labels-for-all-users
     //

--- a/charts/k8s-monitoring/docs/examples/private-image-registries/globally/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/private-image-registries/globally/output.yaml
@@ -176,7 +176,6 @@ data:
           replacement = "$1"
           target_label = "tmp_container_runtime"
         }
-    
         // explicitly set service_name. if not set, loki will automatically try to populate a default.
         // see https://grafana.com/docs/loki/latest/get-started/labels/#default-labels-for-all-users
         //

--- a/charts/k8s-monitoring/docs/examples/proxies/alloy-logs.alloy
+++ b/charts/k8s-monitoring/docs/examples/proxies/alloy-logs.alloy
@@ -46,7 +46,6 @@ declare "pod_logs_via_loki" {
       replacement = "$1"
       target_label = "tmp_container_runtime"
     }
-
     // explicitly set service_name. if not set, loki will automatically try to populate a default.
     // see https://grafana.com/docs/loki/latest/get-started/labels/#default-labels-for-all-users
     //

--- a/charts/k8s-monitoring/docs/examples/proxies/alloy-profiles.alloy
+++ b/charts/k8s-monitoring/docs/examples/proxies/alloy-profiles.alloy
@@ -41,10 +41,25 @@ declare "profiling" {
       target_label = "container"
     }
 
+    // Compute the workload (owner) name. For ReplicaSet-owned pods, strip the
+    // pod-template hash to recover the Deployment name (matches Beyla / OTel Operator).
+    rule {
+      source_labels = ["__meta_kubernetes_pod_controller_name"]
+      target_label = "__tmp_workload_name"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_pod_controller_kind", "__meta_kubernetes_pod_controller_name"]
+      regex = "ReplicaSet;(.+)-[^-]+"
+      replacement = "$1"
+      target_label = "__tmp_workload_name"
+    }
+
     // Set service_name by choosing the first value found from the following ordered list:
     // - pod.annotation[resource.opentelemetry.io/service.name]
     // - pod.label[app.kubernetes.io/instance]
     // - pod.label[app.kubernetes.io/name]
+    // - k8s.workload.name (Deployment, StatefulSet, DaemonSet, CronJob, Job, ...)
+    // - k8s.pod.name
     // - k8s.container.name
     rule {
       action = "replace"
@@ -52,6 +67,8 @@ declare "profiling" {
         "__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_name",
         "__meta_kubernetes_pod_label_app_kubernetes_io_instance",
         "__meta_kubernetes_pod_label_app_kubernetes_io_name",
+        "__tmp_workload_name",
+        "pod",
         "container",
       ]
       separator = ";"
@@ -164,10 +181,25 @@ declare "profiling" {
       target_label = "container"
     }
 
+    // Compute the workload (owner) name. For ReplicaSet-owned pods, strip the
+    // pod-template hash to recover the Deployment name (matches Beyla / OTel Operator).
+    rule {
+      source_labels = ["__meta_kubernetes_pod_controller_name"]
+      target_label = "__tmp_workload_name"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_pod_controller_kind", "__meta_kubernetes_pod_controller_name"]
+      regex = "ReplicaSet;(.+)-[^-]+"
+      replacement = "$1"
+      target_label = "__tmp_workload_name"
+    }
+
     // Set service_name by choosing the first value found from the following ordered list:
     // - pod.annotation[resource.opentelemetry.io/service.name]
     // - pod.label[app.kubernetes.io/instance]
     // - pod.label[app.kubernetes.io/name]
+    // - k8s.workload.name (Deployment, StatefulSet, DaemonSet, CronJob, Job, ...)
+    // - k8s.pod.name
     // - k8s.container.name
     rule {
       action = "replace"
@@ -175,6 +207,8 @@ declare "profiling" {
         "__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_name",
         "__meta_kubernetes_pod_label_app_kubernetes_io_instance",
         "__meta_kubernetes_pod_label_app_kubernetes_io_name",
+        "__tmp_workload_name",
+        "pod",
         "container",
       ]
       separator = ";"
@@ -264,10 +298,25 @@ declare "profiling" {
       target_label  = "container"
     }
 
+    // Compute the workload (owner) name. For ReplicaSet-owned pods, strip the
+    // pod-template hash to recover the Deployment name (matches Beyla / OTel Operator).
+    rule {
+      source_labels = ["__meta_kubernetes_pod_controller_name"]
+      target_label = "__tmp_workload_name"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_pod_controller_kind", "__meta_kubernetes_pod_controller_name"]
+      regex = "ReplicaSet;(.+)-[^-]+"
+      replacement = "$1"
+      target_label = "__tmp_workload_name"
+    }
+
     // Set service_name by choosing the first value found from the following ordered list:
     // - pod.annotation[resource.opentelemetry.io/service.name]
     // - pod.label[app.kubernetes.io/instance]
     // - pod.label[app.kubernetes.io/name]
+    // - k8s.workload.name (Deployment, StatefulSet, DaemonSet, CronJob, Job, ...)
+    // - k8s.pod.name
     // - k8s.container.name
     rule {
       action = "replace"
@@ -275,6 +324,8 @@ declare "profiling" {
         "__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_name",
         "__meta_kubernetes_pod_label_app_kubernetes_io_instance",
         "__meta_kubernetes_pod_label_app_kubernetes_io_name",
+        "__tmp_workload_name",
+        "pod",
         "container",
       ]
       separator = ";"

--- a/charts/k8s-monitoring/docs/examples/proxies/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/proxies/output.yaml
@@ -157,7 +157,6 @@ data:
           replacement = "$1"
           target_label = "tmp_container_runtime"
         }
-    
         // explicitly set service_name. if not set, loki will automatically try to populate a default.
         // see https://grafana.com/docs/loki/latest/get-started/labels/#default-labels-for-all-users
         //
@@ -999,10 +998,25 @@ data:
           target_label = "container"
         }
     
+        // Compute the workload (owner) name. For ReplicaSet-owned pods, strip the
+        // pod-template hash to recover the Deployment name (matches Beyla / OTel Operator).
+        rule {
+          source_labels = ["__meta_kubernetes_pod_controller_name"]
+          target_label = "__tmp_workload_name"
+        }
+        rule {
+          source_labels = ["__meta_kubernetes_pod_controller_kind", "__meta_kubernetes_pod_controller_name"]
+          regex = "ReplicaSet;(.+)-[^-]+"
+          replacement = "$1"
+          target_label = "__tmp_workload_name"
+        }
+    
         // Set service_name by choosing the first value found from the following ordered list:
         // - pod.annotation[resource.opentelemetry.io/service.name]
         // - pod.label[app.kubernetes.io/instance]
         // - pod.label[app.kubernetes.io/name]
+        // - k8s.workload.name (Deployment, StatefulSet, DaemonSet, CronJob, Job, ...)
+        // - k8s.pod.name
         // - k8s.container.name
         rule {
           action = "replace"
@@ -1010,6 +1024,8 @@ data:
             "__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_name",
             "__meta_kubernetes_pod_label_app_kubernetes_io_instance",
             "__meta_kubernetes_pod_label_app_kubernetes_io_name",
+            "__tmp_workload_name",
+            "pod",
             "container",
           ]
           separator = ";"
@@ -1122,10 +1138,25 @@ data:
           target_label = "container"
         }
     
+        // Compute the workload (owner) name. For ReplicaSet-owned pods, strip the
+        // pod-template hash to recover the Deployment name (matches Beyla / OTel Operator).
+        rule {
+          source_labels = ["__meta_kubernetes_pod_controller_name"]
+          target_label = "__tmp_workload_name"
+        }
+        rule {
+          source_labels = ["__meta_kubernetes_pod_controller_kind", "__meta_kubernetes_pod_controller_name"]
+          regex = "ReplicaSet;(.+)-[^-]+"
+          replacement = "$1"
+          target_label = "__tmp_workload_name"
+        }
+    
         // Set service_name by choosing the first value found from the following ordered list:
         // - pod.annotation[resource.opentelemetry.io/service.name]
         // - pod.label[app.kubernetes.io/instance]
         // - pod.label[app.kubernetes.io/name]
+        // - k8s.workload.name (Deployment, StatefulSet, DaemonSet, CronJob, Job, ...)
+        // - k8s.pod.name
         // - k8s.container.name
         rule {
           action = "replace"
@@ -1133,6 +1164,8 @@ data:
             "__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_name",
             "__meta_kubernetes_pod_label_app_kubernetes_io_instance",
             "__meta_kubernetes_pod_label_app_kubernetes_io_name",
+            "__tmp_workload_name",
+            "pod",
             "container",
           ]
           separator = ";"
@@ -1222,10 +1255,25 @@ data:
           target_label  = "container"
         }
     
+        // Compute the workload (owner) name. For ReplicaSet-owned pods, strip the
+        // pod-template hash to recover the Deployment name (matches Beyla / OTel Operator).
+        rule {
+          source_labels = ["__meta_kubernetes_pod_controller_name"]
+          target_label = "__tmp_workload_name"
+        }
+        rule {
+          source_labels = ["__meta_kubernetes_pod_controller_kind", "__meta_kubernetes_pod_controller_name"]
+          regex = "ReplicaSet;(.+)-[^-]+"
+          replacement = "$1"
+          target_label = "__tmp_workload_name"
+        }
+    
         // Set service_name by choosing the first value found from the following ordered list:
         // - pod.annotation[resource.opentelemetry.io/service.name]
         // - pod.label[app.kubernetes.io/instance]
         // - pod.label[app.kubernetes.io/name]
+        // - k8s.workload.name (Deployment, StatefulSet, DaemonSet, CronJob, Job, ...)
+        // - k8s.pod.name
         // - k8s.container.name
         rule {
           action = "replace"
@@ -1233,6 +1281,8 @@ data:
             "__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_name",
             "__meta_kubernetes_pod_label_app_kubernetes_io_instance",
             "__meta_kubernetes_pod_label_app_kubernetes_io_name",
+            "__tmp_workload_name",
+            "pod",
             "container",
           ]
           separator = ";"

--- a/charts/k8s-monitoring/docs/examples/rbac-no-cluster-roles/alloy-logs.alloy
+++ b/charts/k8s-monitoring/docs/examples/rbac-no-cluster-roles/alloy-logs.alloy
@@ -49,7 +49,6 @@ declare "pod_logs_via_loki" {
       replacement = "$1"
       target_label = "tmp_container_runtime"
     }
-
     // explicitly set service_name. if not set, loki will automatically try to populate a default.
     // see https://grafana.com/docs/loki/latest/get-started/labels/#default-labels-for-all-users
     //

--- a/charts/k8s-monitoring/docs/examples/rbac-no-cluster-roles/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/rbac-no-cluster-roles/output.yaml
@@ -157,7 +157,6 @@ data:
           replacement = "$1"
           target_label = "tmp_container_runtime"
         }
-    
         // explicitly set service_name. if not set, loki will automatically try to populate a default.
         // see https://grafana.com/docs/loki/latest/get-started/labels/#default-labels-for-all-users
         //

--- a/charts/k8s-monitoring/docs/examples/tail-sampling/alloy-logs.alloy
+++ b/charts/k8s-monitoring/docs/examples/tail-sampling/alloy-logs.alloy
@@ -46,7 +46,6 @@ declare "pod_logs_via_loki" {
       replacement = "$1"
       target_label = "tmp_container_runtime"
     }
-
     // explicitly set service_name. if not set, loki will automatically try to populate a default.
     // see https://grafana.com/docs/loki/latest/get-started/labels/#default-labels-for-all-users
     //

--- a/charts/k8s-monitoring/docs/examples/tail-sampling/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/tail-sampling/output.yaml
@@ -142,7 +142,6 @@ data:
           replacement = "$1"
           target_label = "tmp_container_runtime"
         }
-    
         // explicitly set service_name. if not set, loki will automatically try to populate a default.
         // see https://grafana.com/docs/loki/latest/get-started/labels/#default-labels-for-all-users
         //

--- a/charts/k8s-monitoring/docs/examples/tolerations/alloy-logs.alloy
+++ b/charts/k8s-monitoring/docs/examples/tolerations/alloy-logs.alloy
@@ -46,7 +46,6 @@ declare "pod_logs_via_loki" {
       replacement = "$1"
       target_label = "tmp_container_runtime"
     }
-
     // explicitly set service_name. if not set, loki will automatically try to populate a default.
     // see https://grafana.com/docs/loki/latest/get-started/labels/#default-labels-for-all-users
     //

--- a/charts/k8s-monitoring/docs/examples/tolerations/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/tolerations/output.yaml
@@ -186,7 +186,6 @@ data:
           replacement = "$1"
           target_label = "tmp_container_runtime"
         }
-    
         // explicitly set service_name. if not set, loki will automatically try to populate a default.
         // see https://grafana.com/docs/loki/latest/get-started/labels/#default-labels-for-all-users
         //

--- a/charts/k8s-monitoring/tests/__snapshot__/feature_integrations_test.yaml.snap
+++ b/charts/k8s-monitoring/tests/__snapshot__/feature_integrations_test.yaml.snap
@@ -49,7 +49,6 @@ works when a logs-only integration is enabled:
             replacement = "$1"
             target_label = "tmp_container_runtime"
           }
-
           // explicitly set service_name. if not set, loki will automatically try to populate a default.
           // see https://grafana.com/docs/loki/latest/get-started/labels/#default-labels-for-all-users
           //
@@ -773,7 +772,6 @@ works with multiple logs-only integrations:
             replacement = "$1"
             target_label = "tmp_container_runtime"
           }
-
           // explicitly set service_name. if not set, loki will automatically try to populate a default.
           // see https://grafana.com/docs/loki/latest/get-started/labels/#default-labels-for-all-users
           //

--- a/charts/k8s-monitoring/tests/__snapshot__/feature_pod_logs_test.yaml.snap
+++ b/charts/k8s-monitoring/tests/__snapshot__/feature_pod_logs_test.yaml.snap
@@ -49,7 +49,6 @@ renders the config to gather Kubernetes Pod logs:
             replacement = "$1"
             target_label = "tmp_container_runtime"
           }
-
           // explicitly set service_name. if not set, loki will automatically try to populate a default.
           // see https://grafana.com/docs/loki/latest/get-started/labels/#default-labels-for-all-users
           //

--- a/charts/k8s-monitoring/tests/__snapshot__/feature_pod_logs_via_opentelemetry_test.yaml.snap
+++ b/charts/k8s-monitoring/tests/__snapshot__/feature_pod_logs_via_opentelemetry_test.yaml.snap
@@ -87,7 +87,6 @@ renders the config to gather Kubernetes Pod logs:
             statements = [
               `delete_key(attributes, "k8s.container.restart_count")`,
               `delete_key(attributes, "logs.grafana.com/pods.enabled")`,
-
               `set(attributes["service.name"], attributes["app.kubernetes.io/name"]) where (attributes["service.name"] == nil or attributes["service.name"] == "") and attributes["app.kubernetes.io/name"] != nil and attributes["app.kubernetes.io/name"] != ""`,
               `set(attributes["service.name"], attributes["k8s.deployment.name"]) where (attributes["service.name"] == nil or attributes["service.name"] == "") and attributes["k8s.deployment.name"] != nil and attributes["k8s.deployment.name"] != ""`,
               `set(attributes["service.name"], attributes["k8s.replicaset.name"]) where (attributes["service.name"] == nil or attributes["service.name"] == "") and attributes["k8s.replicaset.name"] != nil and attributes["k8s.replicaset.name"] != ""`,

--- a/charts/k8s-monitoring/tests/integration/annotation-autodiscovery/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/integration/annotation-autodiscovery/.rendered/output.yaml
@@ -81,7 +81,6 @@ data:
           replacement = "$1"
           target_label = "tmp_container_runtime"
         }
-    
         // explicitly set service_name. if not set, loki will automatically try to populate a default.
         // see https://grafana.com/docs/loki/latest/get-started/labels/#default-labels-for-all-users
         //

--- a/charts/k8s-monitoring/tests/integration/application-observability/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/integration/application-observability/.rendered/output.yaml
@@ -86,7 +86,20 @@ data:
       otelcol.processor.k8sattributes "default" {
         passthrough = false
         extract {
+          otel_annotations = true
           metadata = ["k8s.namespace.name","k8s.pod.name","k8s.deployment.name","k8s.statefulset.name","k8s.daemonset.name","k8s.cronjob.name","k8s.job.name","k8s.node.name","k8s.pod.uid","k8s.pod.start_time"]
+          // Extracted into temporary attributes for service.name detection, then deleted in the transform processor.
+          // Temporary names are used so the cleanup never deletes an `app.kubernetes.io/*` attribute the user extracted.
+          label {
+            tag_name = "k8s_monitoring.tmp.instance"
+            key = "app.kubernetes.io/instance"
+            from = "pod"
+          }
+          label {
+            tag_name = "k8s_monitoring.tmp.name"
+            key = "app.kubernetes.io/name"
+            from = "pod"
+          }
         }
         pod_association {
           source {
@@ -124,6 +137,64 @@ data:
       // Transform Processor
       otelcol.processor.transform "default" {
         error_mode = "ignore"
+        metric_statements {
+          context = "resource"
+          statements = [
+            // Set service.name by choosing the first value found from the following ordered list:
+            // - service.name as reported by the application or set from the resource.opentelemetry.io/service.name annotation
+            // - pod.label[app.kubernetes.io/instance]
+            // - pod.label[app.kubernetes.io/name]
+            // - k8s.workload.name (Deployment, StatefulSet, DaemonSet, CronJob, Job, ...)
+            // - k8s.pod.name
+            // The instance/name pod labels are read from temporary attributes (k8s_monitoring.tmp.*) extracted by the
+            // k8sattributes processor, so the cleanup below only ever deletes attributes this feature added.
+            `set(resource.attributes["service.name"], resource.attributes["k8s_monitoring.tmp.instance"]) where (resource.attributes["service.name"] == nil or resource.attributes["service.name"] == "") and resource.attributes["k8s_monitoring.tmp.instance"] != nil and resource.attributes["k8s_monitoring.tmp.instance"] != ""`,
+            `set(resource.attributes["service.name"], resource.attributes["k8s_monitoring.tmp.name"]) where (resource.attributes["service.name"] == nil or resource.attributes["service.name"] == "") and resource.attributes["k8s_monitoring.tmp.name"] != nil and resource.attributes["k8s_monitoring.tmp.name"] != ""`,
+            `set(resource.attributes["service.name"], resource.attributes["k8s.deployment.name"]) where (resource.attributes["service.name"] == nil or resource.attributes["service.name"] == "") and resource.attributes["k8s.deployment.name"] != nil and resource.attributes["k8s.deployment.name"] != ""`,
+            `set(resource.attributes["service.name"], resource.attributes["k8s.replicaset.name"]) where (resource.attributes["service.name"] == nil or resource.attributes["service.name"] == "") and resource.attributes["k8s.replicaset.name"] != nil and resource.attributes["k8s.replicaset.name"] != ""`,
+            `set(resource.attributes["service.name"], resource.attributes["k8s.statefulset.name"]) where (resource.attributes["service.name"] == nil or resource.attributes["service.name"] == "") and resource.attributes["k8s.statefulset.name"] != nil and resource.attributes["k8s.statefulset.name"] != ""`,
+            `set(resource.attributes["service.name"], resource.attributes["k8s.daemonset.name"]) where (resource.attributes["service.name"] == nil or resource.attributes["service.name"] == "") and resource.attributes["k8s.daemonset.name"] != nil and resource.attributes["k8s.daemonset.name"] != ""`,
+            `set(resource.attributes["service.name"], resource.attributes["k8s.cronjob.name"]) where (resource.attributes["service.name"] == nil or resource.attributes["service.name"] == "") and resource.attributes["k8s.cronjob.name"] != nil and resource.attributes["k8s.cronjob.name"] != ""`,
+            `set(resource.attributes["service.name"], resource.attributes["k8s.job.name"]) where (resource.attributes["service.name"] == nil or resource.attributes["service.name"] == "") and resource.attributes["k8s.job.name"] != nil and resource.attributes["k8s.job.name"] != ""`,
+            `set(resource.attributes["service.name"], resource.attributes["k8s.pod.name"]) where (resource.attributes["service.name"] == nil or resource.attributes["service.name"] == "") and resource.attributes["k8s.pod.name"] != nil and resource.attributes["k8s.pod.name"] != ""`,
+    
+            // Set service.namespace to the pod namespace if not already set
+            `set(resource.attributes["service.namespace"], resource.attributes["k8s.namespace.name"]) where (resource.attributes["service.namespace"] == nil or resource.attributes["service.namespace"] == "") and resource.attributes["k8s.namespace.name"] != nil and resource.attributes["k8s.namespace.name"] != ""`,
+    
+            // Remove the temporary attributes used for service.name detection
+            `delete_key(resource.attributes, "k8s_monitoring.tmp.instance")`,
+            `delete_key(resource.attributes, "k8s_monitoring.tmp.name")`,
+          ]
+        }
+        trace_statements {
+          context = "resource"
+          statements = [
+            // Set service.name by choosing the first value found from the following ordered list:
+            // - service.name as reported by the application or set from the resource.opentelemetry.io/service.name annotation
+            // - pod.label[app.kubernetes.io/instance]
+            // - pod.label[app.kubernetes.io/name]
+            // - k8s.workload.name (Deployment, StatefulSet, DaemonSet, CronJob, Job, ...)
+            // - k8s.pod.name
+            // The instance/name pod labels are read from temporary attributes (k8s_monitoring.tmp.*) extracted by the
+            // k8sattributes processor, so the cleanup below only ever deletes attributes this feature added.
+            `set(resource.attributes["service.name"], resource.attributes["k8s_monitoring.tmp.instance"]) where (resource.attributes["service.name"] == nil or resource.attributes["service.name"] == "") and resource.attributes["k8s_monitoring.tmp.instance"] != nil and resource.attributes["k8s_monitoring.tmp.instance"] != ""`,
+            `set(resource.attributes["service.name"], resource.attributes["k8s_monitoring.tmp.name"]) where (resource.attributes["service.name"] == nil or resource.attributes["service.name"] == "") and resource.attributes["k8s_monitoring.tmp.name"] != nil and resource.attributes["k8s_monitoring.tmp.name"] != ""`,
+            `set(resource.attributes["service.name"], resource.attributes["k8s.deployment.name"]) where (resource.attributes["service.name"] == nil or resource.attributes["service.name"] == "") and resource.attributes["k8s.deployment.name"] != nil and resource.attributes["k8s.deployment.name"] != ""`,
+            `set(resource.attributes["service.name"], resource.attributes["k8s.replicaset.name"]) where (resource.attributes["service.name"] == nil or resource.attributes["service.name"] == "") and resource.attributes["k8s.replicaset.name"] != nil and resource.attributes["k8s.replicaset.name"] != ""`,
+            `set(resource.attributes["service.name"], resource.attributes["k8s.statefulset.name"]) where (resource.attributes["service.name"] == nil or resource.attributes["service.name"] == "") and resource.attributes["k8s.statefulset.name"] != nil and resource.attributes["k8s.statefulset.name"] != ""`,
+            `set(resource.attributes["service.name"], resource.attributes["k8s.daemonset.name"]) where (resource.attributes["service.name"] == nil or resource.attributes["service.name"] == "") and resource.attributes["k8s.daemonset.name"] != nil and resource.attributes["k8s.daemonset.name"] != ""`,
+            `set(resource.attributes["service.name"], resource.attributes["k8s.cronjob.name"]) where (resource.attributes["service.name"] == nil or resource.attributes["service.name"] == "") and resource.attributes["k8s.cronjob.name"] != nil and resource.attributes["k8s.cronjob.name"] != ""`,
+            `set(resource.attributes["service.name"], resource.attributes["k8s.job.name"]) where (resource.attributes["service.name"] == nil or resource.attributes["service.name"] == "") and resource.attributes["k8s.job.name"] != nil and resource.attributes["k8s.job.name"] != ""`,
+            `set(resource.attributes["service.name"], resource.attributes["k8s.pod.name"]) where (resource.attributes["service.name"] == nil or resource.attributes["service.name"] == "") and resource.attributes["k8s.pod.name"] != nil and resource.attributes["k8s.pod.name"] != ""`,
+    
+            // Set service.namespace to the pod namespace if not already set
+            `set(resource.attributes["service.namespace"], resource.attributes["k8s.namespace.name"]) where (resource.attributes["service.namespace"] == nil or resource.attributes["service.namespace"] == "") and resource.attributes["k8s.namespace.name"] != nil and resource.attributes["k8s.namespace.name"] != ""`,
+    
+            // Remove the temporary attributes used for service.name detection
+            `delete_key(resource.attributes, "k8s_monitoring.tmp.instance")`,
+            `delete_key(resource.attributes, "k8s_monitoring.tmp.name")`,
+          ]
+        }
         trace_statements {
           context = "span"
           statements = [

--- a/charts/k8s-monitoring/tests/integration/application-observability/values.yaml
+++ b/charts/k8s-monitoring/tests/integration/application-observability/values.yaml
@@ -18,6 +18,7 @@ destinations:
 
 applicationObservability:
   enabled: true
+  alignServiceNameWithOTelSemConv: true
   collector: alloy-receiver
   receivers:
     otlp:

--- a/charts/k8s-monitoring/tests/integration/auth/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/integration/auth/.rendered/output.yaml
@@ -147,7 +147,6 @@ data:
           replacement = "$1"
           target_label = "tmp_container_runtime"
         }
-    
         // explicitly set service_name. if not set, loki will automatically try to populate a default.
         // see https://grafana.com/docs/loki/latest/get-started/labels/#default-labels-for-all-users
         //

--- a/charts/k8s-monitoring/tests/integration/cluster-monitoring/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/integration/cluster-monitoring/.rendered/output.yaml
@@ -154,7 +154,6 @@ data:
           replacement = "$1"
           target_label = "tmp_container_runtime"
         }
-    
         // explicitly set service_name. if not set, loki will automatically try to populate a default.
         // see https://grafana.com/docs/loki/latest/get-started/labels/#default-labels-for-all-users
         //

--- a/charts/k8s-monitoring/tests/integration/control-plane-monitoring/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/integration/control-plane-monitoring/.rendered/output.yaml
@@ -115,7 +115,6 @@ data:
           replacement = "$1"
           target_label = "tmp_container_runtime"
         }
-    
         // explicitly set service_name. if not set, loki will automatically try to populate a default.
         // see https://grafana.com/docs/loki/latest/get-started/labels/#default-labels-for-all-users
         //

--- a/charts/k8s-monitoring/tests/integration/pod-logs/default/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/integration/pod-logs/default/.rendered/output.yaml
@@ -81,18 +81,36 @@ data:
           replacement = "$1"
           target_label = "tmp_container_runtime"
         }
+        // Compute the workload (owner) name. For ReplicaSet-owned pods, strip the
+        // pod-template hash to recover the Deployment name (matches Beyla / OTel Operator).
+        rule {
+          source_labels = ["__meta_kubernetes_pod_controller_name"]
+          target_label = "__tmp_workload_name"
+        }
+        rule {
+          source_labels = ["__meta_kubernetes_pod_controller_kind", "__meta_kubernetes_pod_controller_name"]
+          regex = "ReplicaSet;(.+)-[^-]+"
+          replacement = "$1"
+          target_label = "__tmp_workload_name"
+        }
     
         // explicitly set service_name. if not set, loki will automatically try to populate a default.
         // see https://grafana.com/docs/loki/latest/get-started/labels/#default-labels-for-all-users
         //
         // choose the first value found from the following ordered list:
         // - pod.annotation[resource.opentelemetry.io/service.name]
+        // - pod.label[app.kubernetes.io/instance]
         // - pod.label[app.kubernetes.io/name]
+        // - k8s.workload.name (Deployment, StatefulSet, DaemonSet, CronJob, Job, ...)
+        // - k8s.pod.name
         // - k8s.container.name
         rule {
           source_labels = [
             "__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_name",
+            "__meta_kubernetes_pod_label_app_kubernetes_io_instance",
             "__meta_kubernetes_pod_label_app_kubernetes_io_name",
+            "__tmp_workload_name",
+            "__meta_kubernetes_pod_name",
             "__meta_kubernetes_pod_container_name",
           ]
           separator = ";"

--- a/charts/k8s-monitoring/tests/integration/pod-logs/default/test-plan.yaml
+++ b/charts/k8s-monitoring/tests/integration/pod-logs/default/test-plan.yaml
@@ -51,3 +51,8 @@ tests:
             # Gets Pod logs based on annotation job label
             - query: count_over_time({cluster="$CLUSTER", job="dev-pod", namespace="development"}[1h])
               type: logql
+
+            # alignServiceNameWithOTelSemConv is enabled, so service_name is set to the Deployment name (prod-pods),
+            # not the container name (busybox).
+            - query: count_over_time({cluster="$CLUSTER", service_name="prod-pods", namespace="production"}[1h])
+              type: logql

--- a/charts/k8s-monitoring/tests/integration/pod-logs/default/values.yaml
+++ b/charts/k8s-monitoring/tests/integration/pod-logs/default/values.yaml
@@ -16,6 +16,7 @@ destinations:
 
 podLogsViaLoki:
   enabled: true
+  alignServiceNameWithOTelSemConv: true
   collector: alloy-logs
 
 collectors:

--- a/charts/k8s-monitoring/tests/integration/pod-logs/log-metrics/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/integration/pod-logs/log-metrics/.rendered/output.yaml
@@ -81,7 +81,6 @@ data:
           replacement = "$1"
           target_label = "tmp_container_runtime"
         }
-    
         // explicitly set service_name. if not set, loki will automatically try to populate a default.
         // see https://grafana.com/docs/loki/latest/get-started/labels/#default-labels-for-all-users
         //

--- a/charts/k8s-monitoring/tests/integration/pod-logs/secret-filter/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/integration/pod-logs/secret-filter/.rendered/output.yaml
@@ -81,7 +81,6 @@ data:
           replacement = "$1"
           target_label = "tmp_container_runtime"
         }
-    
         // explicitly set service_name. if not set, loki will automatically try to populate a default.
         // see https://grafana.com/docs/loki/latest/get-started/labels/#default-labels-for-all-users
         //

--- a/charts/k8s-monitoring/tests/integration/profiling/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/integration/profiling/.rendered/output.yaml
@@ -64,10 +64,25 @@ data:
           target_label = "container"
         }
     
+        // Compute the workload (owner) name. For ReplicaSet-owned pods, strip the
+        // pod-template hash to recover the Deployment name (matches Beyla / OTel Operator).
+        rule {
+          source_labels = ["__meta_kubernetes_pod_controller_name"]
+          target_label = "__tmp_workload_name"
+        }
+        rule {
+          source_labels = ["__meta_kubernetes_pod_controller_kind", "__meta_kubernetes_pod_controller_name"]
+          regex = "ReplicaSet;(.+)-[^-]+"
+          replacement = "$1"
+          target_label = "__tmp_workload_name"
+        }
+    
         // Set service_name by choosing the first value found from the following ordered list:
         // - pod.annotation[resource.opentelemetry.io/service.name]
         // - pod.label[app.kubernetes.io/instance]
         // - pod.label[app.kubernetes.io/name]
+        // - k8s.workload.name (Deployment, StatefulSet, DaemonSet, CronJob, Job, ...)
+        // - k8s.pod.name
         // - k8s.container.name
         rule {
           action = "replace"
@@ -75,6 +90,8 @@ data:
             "__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_name",
             "__meta_kubernetes_pod_label_app_kubernetes_io_instance",
             "__meta_kubernetes_pod_label_app_kubernetes_io_name",
+            "__tmp_workload_name",
+            "pod",
             "container",
           ]
           separator = ";"
@@ -187,10 +204,25 @@ data:
           target_label = "container"
         }
     
+        // Compute the workload (owner) name. For ReplicaSet-owned pods, strip the
+        // pod-template hash to recover the Deployment name (matches Beyla / OTel Operator).
+        rule {
+          source_labels = ["__meta_kubernetes_pod_controller_name"]
+          target_label = "__tmp_workload_name"
+        }
+        rule {
+          source_labels = ["__meta_kubernetes_pod_controller_kind", "__meta_kubernetes_pod_controller_name"]
+          regex = "ReplicaSet;(.+)-[^-]+"
+          replacement = "$1"
+          target_label = "__tmp_workload_name"
+        }
+    
         // Set service_name by choosing the first value found from the following ordered list:
         // - pod.annotation[resource.opentelemetry.io/service.name]
         // - pod.label[app.kubernetes.io/instance]
         // - pod.label[app.kubernetes.io/name]
+        // - k8s.workload.name (Deployment, StatefulSet, DaemonSet, CronJob, Job, ...)
+        // - k8s.pod.name
         // - k8s.container.name
         rule {
           action = "replace"
@@ -198,6 +230,8 @@ data:
             "__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_name",
             "__meta_kubernetes_pod_label_app_kubernetes_io_instance",
             "__meta_kubernetes_pod_label_app_kubernetes_io_name",
+            "__tmp_workload_name",
+            "pod",
             "container",
           ]
           separator = ";"
@@ -287,10 +321,25 @@ data:
           target_label  = "container"
         }
     
+        // Compute the workload (owner) name. For ReplicaSet-owned pods, strip the
+        // pod-template hash to recover the Deployment name (matches Beyla / OTel Operator).
+        rule {
+          source_labels = ["__meta_kubernetes_pod_controller_name"]
+          target_label = "__tmp_workload_name"
+        }
+        rule {
+          source_labels = ["__meta_kubernetes_pod_controller_kind", "__meta_kubernetes_pod_controller_name"]
+          regex = "ReplicaSet;(.+)-[^-]+"
+          replacement = "$1"
+          target_label = "__tmp_workload_name"
+        }
+    
         // Set service_name by choosing the first value found from the following ordered list:
         // - pod.annotation[resource.opentelemetry.io/service.name]
         // - pod.label[app.kubernetes.io/instance]
         // - pod.label[app.kubernetes.io/name]
+        // - k8s.workload.name (Deployment, StatefulSet, DaemonSet, CronJob, Job, ...)
+        // - k8s.pod.name
         // - k8s.container.name
         rule {
           action = "replace"
@@ -298,6 +347,8 @@ data:
             "__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_name",
             "__meta_kubernetes_pod_label_app_kubernetes_io_instance",
             "__meta_kubernetes_pod_label_app_kubernetes_io_name",
+            "__tmp_workload_name",
+            "pod",
             "container",
           ]
           separator = ";"

--- a/charts/k8s-monitoring/tests/integration/prom-and-loki-to-otlp/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/integration/prom-and-loki-to-otlp/.rendered/output.yaml
@@ -126,7 +126,6 @@ data:
           replacement = "$1"
           target_label = "tmp_container_runtime"
         }
-    
         // explicitly set service_name. if not set, loki will automatically try to populate a default.
         // see https://grafana.com/docs/loki/latest/get-started/labels/#default-labels-for-all-users
         //

--- a/charts/k8s-monitoring/tests/integration/proxies/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/integration/proxies/.rendered/output.yaml
@@ -81,7 +81,6 @@ data:
           replacement = "$1"
           target_label = "tmp_container_runtime"
         }
-    
         // explicitly set service_name. if not set, loki will automatically try to populate a default.
         // see https://grafana.com/docs/loki/latest/get-started/labels/#default-labels-for-all-users
         //

--- a/charts/k8s-monitoring/tests/integration/service-graph-metrics/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/integration/service-graph-metrics/.rendered/output.yaml
@@ -124,7 +124,6 @@ data:
           statements = [
             `delete_key(attributes, "k8s.container.restart_count")`,
             `delete_key(attributes, "logs.grafana.com/pods.enabled")`,
-    
             `set(attributes["service.name"], attributes["app.kubernetes.io/name"]) where (attributes["service.name"] == nil or attributes["service.name"] == "") and attributes["app.kubernetes.io/name"] != nil and attributes["app.kubernetes.io/name"] != ""`,
             `set(attributes["service.name"], attributes["k8s.deployment.name"]) where (attributes["service.name"] == nil or attributes["service.name"] == "") and attributes["k8s.deployment.name"] != nil and attributes["k8s.deployment.name"] != ""`,
             `set(attributes["service.name"], attributes["k8s.replicaset.name"]) where (attributes["service.name"] == nil or attributes["service.name"] == "") and attributes["k8s.replicaset.name"] != nil and attributes["k8s.replicaset.name"] != ""`,

--- a/charts/k8s-monitoring/tests/integration/service-integrations/grafana/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/integration/service-integrations/grafana/.rendered/output.yaml
@@ -126,7 +126,6 @@ data:
           replacement = "$1"
           target_label = "tmp_container_runtime"
         }
-    
         // explicitly set service_name. if not set, loki will automatically try to populate a default.
         // see https://grafana.com/docs/loki/latest/get-started/labels/#default-labels-for-all-users
         //

--- a/charts/k8s-monitoring/tests/integration/service-integrations/loki/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/integration/service-integrations/loki/.rendered/output.yaml
@@ -126,7 +126,6 @@ data:
           replacement = "$1"
           target_label = "tmp_container_runtime"
         }
-    
         // explicitly set service_name. if not set, loki will automatically try to populate a default.
         // see https://grafana.com/docs/loki/latest/get-started/labels/#default-labels-for-all-users
         //

--- a/charts/k8s-monitoring/tests/integration/service-integrations/mysql/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/integration/service-integrations/mysql/.rendered/output.yaml
@@ -81,7 +81,6 @@ data:
           replacement = "$1"
           target_label = "tmp_container_runtime"
         }
-    
         // explicitly set service_name. if not set, loki will automatically try to populate a default.
         // see https://grafana.com/docs/loki/latest/get-started/labels/#default-labels-for-all-users
         //

--- a/charts/k8s-monitoring/tests/integration/service-integrations/tempo/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/integration/service-integrations/tempo/.rendered/output.yaml
@@ -126,7 +126,6 @@ data:
           replacement = "$1"
           target_label = "tmp_container_runtime"
         }
-    
         // explicitly set service_name. if not set, loki will automatically try to populate a default.
         // see https://grafana.com/docs/loki/latest/get-started/labels/#default-labels-for-all-users
         //

--- a/charts/k8s-monitoring/tests/integration/split-destinations/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/integration/split-destinations/.rendered/output.yaml
@@ -165,7 +165,6 @@ data:
           replacement = "$1"
           target_label = "tmp_container_runtime"
         }
-    
         // explicitly set service_name. if not set, loki will automatically try to populate a default.
         // see https://grafana.com/docs/loki/latest/get-started/labels/#default-labels-for-all-users
         //

--- a/charts/k8s-monitoring/tests/integration/uninstall/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/integration/uninstall/.rendered/output.yaml
@@ -193,7 +193,6 @@ data:
           replacement = "$1"
           target_label = "tmp_container_runtime"
         }
-    
         // explicitly set service_name. if not set, loki will automatically try to populate a default.
         // see https://grafana.com/docs/loki/latest/get-started/labels/#default-labels-for-all-users
         //

--- a/charts/k8s-monitoring/tests/integration/upgrade/minor/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/integration/upgrade/minor/.rendered/output.yaml
@@ -193,7 +193,6 @@ data:
           replacement = "$1"
           target_label = "tmp_container_runtime"
         }
-    
         // explicitly set service_name. if not set, loki will automatically try to populate a default.
         // see https://grafana.com/docs/loki/latest/get-started/labels/#default-labels-for-all-users
         //

--- a/charts/k8s-monitoring/tests/integration/upgrade/patch/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/integration/upgrade/patch/.rendered/output.yaml
@@ -193,7 +193,6 @@ data:
           replacement = "$1"
           target_label = "tmp_container_runtime"
         }
-    
         // explicitly set service_name. if not set, loki will automatically try to populate a default.
         // see https://grafana.com/docs/loki/latest/get-started/labels/#default-labels-for-all-users
         //

--- a/charts/k8s-monitoring/tests/platform/aks/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/platform/aks/.rendered/output.yaml
@@ -142,7 +142,6 @@ data:
           replacement = "$1"
           target_label = "tmp_container_runtime"
         }
-    
         // explicitly set service_name. if not set, loki will automatically try to populate a default.
         // see https://grafana.com/docs/loki/latest/get-started/labels/#default-labels-for-all-users
         //

--- a/charts/k8s-monitoring/tests/platform/eks-fargate/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/platform/eks-fargate/.rendered/output.yaml
@@ -103,7 +103,6 @@ data:
           replacement = "$1"
           target_label = "tmp_container_runtime"
         }
-    
         // explicitly set service_name. if not set, loki will automatically try to populate a default.
         // see https://grafana.com/docs/loki/latest/get-started/labels/#default-labels-for-all-users
         //

--- a/charts/k8s-monitoring/tests/platform/eks-with-windows/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/platform/eks-with-windows/.rendered/output.yaml
@@ -323,7 +323,6 @@ data:
           replacement = "$1"
           target_label = "tmp_container_runtime"
         }
-    
         // explicitly set service_name. if not set, loki will automatically try to populate a default.
         // see https://grafana.com/docs/loki/latest/get-started/labels/#default-labels-for-all-users
         //

--- a/charts/k8s-monitoring/tests/platform/gke-autopilot/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/platform/gke-autopilot/.rendered/output.yaml
@@ -86,7 +86,6 @@ data:
           replacement = "$1"
           target_label = "tmp_container_runtime"
         }
-    
         // explicitly set service_name. if not set, loki will automatically try to populate a default.
         // see https://grafana.com/docs/loki/latest/get-started/labels/#default-labels-for-all-users
         //

--- a/charts/k8s-monitoring/tests/platform/gke/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/platform/gke/.rendered/output.yaml
@@ -118,7 +118,6 @@ data:
           replacement = "$1"
           target_label = "tmp_container_runtime"
         }
-    
         // explicitly set service_name. if not set, loki will automatically try to populate a default.
         // see https://grafana.com/docs/loki/latest/get-started/labels/#default-labels-for-all-users
         //

--- a/charts/k8s-monitoring/tests/platform/grafana-cloud/app-observability/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/platform/grafana-cloud/app-observability/.rendered/output.yaml
@@ -69,7 +69,6 @@ data:
           replacement = "$1"
           target_label = "tmp_container_runtime"
         }
-    
         // explicitly set service_name. if not set, loki will automatically try to populate a default.
         // see https://grafana.com/docs/loki/latest/get-started/labels/#default-labels-for-all-users
         //

--- a/charts/k8s-monitoring/tests/platform/grafana-cloud/database-observability/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/platform/grafana-cloud/database-observability/.rendered/output.yaml
@@ -69,7 +69,6 @@ data:
           replacement = "$1"
           target_label = "tmp_container_runtime"
         }
-    
         // explicitly set service_name. if not set, loki will automatically try to populate a default.
         // see https://grafana.com/docs/loki/latest/get-started/labels/#default-labels-for-all-users
         //

--- a/charts/k8s-monitoring/tests/platform/grafana-cloud/k8s-monitoring/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/platform/grafana-cloud/k8s-monitoring/.rendered/output.yaml
@@ -186,7 +186,6 @@ data:
           replacement = "$1"
           target_label = "tmp_container_runtime"
         }
-    
         // explicitly set service_name. if not set, loki will automatically try to populate a default.
         // see https://grafana.com/docs/loki/latest/get-started/labels/#default-labels-for-all-users
         //

--- a/charts/k8s-monitoring/tests/platform/openshift/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/platform/openshift/.rendered/output.yaml
@@ -85,7 +85,6 @@ data:
           replacement = "$1"
           target_label = "tmp_container_runtime"
         }
-    
         // explicitly set service_name. if not set, loki will automatically try to populate a default.
         // see https://grafana.com/docs/loki/latest/get-started/labels/#default-labels-for-all-users
         //

--- a/charts/k8s-monitoring/tests/platform/otlp-gateway/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/platform/otlp-gateway/.rendered/output.yaml
@@ -949,7 +949,6 @@ data:
           replacement = "$1"
           target_label = "tmp_container_runtime"
         }
-    
         // explicitly set service_name. if not set, loki will automatically try to populate a default.
         // see https://grafana.com/docs/loki/latest/get-started/labels/#default-labels-for-all-users
         //


### PR DESCRIPTION
# Description

Adds consistency to the way that we detect and set the `service.name` and `service.namespace` labels and attributes, which mean they should match with application traces better.

Fixes #

## Authorship

-   [X] I, a human, wrote this pull request description myself.
