### PR TITLE
Set memory request on alloy container

### DIFF
--- a/charts/k8s-monitoring/collectors/upstream/alloy-values.yaml
+++ b/charts/k8s-monitoring/collectors/upstream/alloy-values.yaml
@@ -95,7 +95,9 @@ alloy:
   # -- Security context to apply to the Grafana Alloy container.
   securityContext: {}
   # -- Resource requests and limits to apply to the Grafana Alloy container.
-  resources: {}
+  resources:
+    requests:
+      memory: "128Mi"
   # -- Set lifecycle hooks for the Grafana Alloy container.
   lifecycle: {}
   # preStop:


### PR DESCRIPTION
Without this, the pod's overall memory request is only 50 MiB, because only `config-reloader` sets a memory request value. This causes the pod to always appear to exceed its memory request.

Max memory usage of `alloy` container observed over 5 days: 116 MiB.

Verified by updating my own values.yaml:

```
      ~ values                     = [
          ~ <<-EOT
                ...
                collectors:
                  alloy-metrics:
              +     alloy:
              +       resources:
              +         requests:
              +           memory: "128Mi"
                    presets:
                      - clustered
                      - statefulset
                  alloy-singleton:
              +     alloy:
              +       resources:
              +         requests:
              +           memory: "128Mi"
                    presets:
                      - singleton
                  alloy-logs:
              +     alloy:
              +       resources:
              +         requests:
              +           memory: "128Mi"
                    presets:
                      - filesystem-log-reader
                      - daemonset
```

And observed that the pod no longer appears to exceed its memory request, because both containers set an appropriate memory request.

<img width="1240" height="614" alt="Screenshot_20260705_131044" src="https://github.com/user-attachments/assets/c0caf4a8-1ff3-4664-9757-d85f90b7c251" />


<!--Authorship attestation. See AGENTS.md for details. AI agents must not check this box on behalf
of the user; the human author must check it themselves before the PR is ready for review.-->
## Authorship

-   [x] I, a human, wrote this pull request description myself.

