### PR TITLE
fix: prefer explicit service_name label over job-derived service.name in OTLP destinations

### DIFF
--- a/charts/k8s-monitoring/CHANGELOG.md
+++ b/charts/k8s-monitoring/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 *   Change the default remote configuration `pollFrequency` from `5m` to `30s`. (@TylerHelmuth)
 *   Add `CLUSTER_NAME` environment variable to remote-config-enabled collectors alongside `NAMESPACE` and `POD_NAME`. (#2775) (@petewall)
+*   Fix OTLP destinations deriving the wrong service identity for metrics converted from a Prometheus scrape. The conversion sets `service.name` to the full `job` label (e.g. `namespace/workload` from Grafana Beyla), breaking service-to-logs correlation in Application Observability. A new normalization step after `otelcol.receiver.prometheus` prefers the explicit `service_name` label; OTLP-native telemetry is unaffected. (#2783) (@mbaykara)
 
 ## 4.2.0
 

--- a/charts/k8s-monitoring/docs/examples/auth/oauth2/alloy-logs.alloy
+++ b/charts/k8s-monitoring/docs/examples/auth/oauth2/alloy-logs.alloy
@@ -339,9 +339,38 @@ pod_logs_via_loki "feature" {
 // Destination: otel-endpoint (otlp)
 otelcol.receiver.prometheus "otel_endpoint" {
   output {
-    metrics = [otelcol.processor.attributes.otel_endpoint.input]
+    metrics = [otelcol.processor.transform.otel_endpoint_scrape_normalize.input]
   }
 } // otelcol.receiver.prometheus "otel_endpoint"
+
+// Repairs artifacts of the Prometheus-to-OTLP conversion performed by
+// otelcol.receiver.prometheus. Only metrics that came from a Prometheus scrape pass
+// through this component; OTLP-native telemetry enters the pipeline further down.
+otelcol.processor.transform "otel_endpoint_scrape_normalize" {
+  error_mode = "ignore"
+  metric_statements {
+    context = "resource"
+    statements = [
+      // The conversion sets service.name to the full Prometheus job label (e.g.
+      // "namespace/workload"). When the scrape target declares its identity explicitly
+      // with a service_name label on its own target_info metric (e.g. Grafana Beyla),
+      // prefer that value and drop the duplicate.
+      `set(attributes["service.name"], attributes["service_name"]) where attributes["service_name"] != nil and attributes["service_name"] != ""`,
+      `delete_key(attributes, "service_name") where attributes["service_name"] == attributes["service.name"]`,
+    ]
+  }
+  metric_statements {
+    context = "datapoint"
+    statements = [
+      // Same correction for scrape targets that put service_name on every series
+      // instead of exposing a target_info metric.
+      `set(resource.attributes["service.name"], attributes["service_name"]) where attributes["service_name"] != nil and attributes["service_name"] != ""`,
+    ]
+  }
+  output {
+    metrics = [otelcol.processor.attributes.otel_endpoint.input]
+  }
+} // otelcol.processor.transform "otel_endpoint_scrape_normalize"
 otelcol.receiver.loki "otel_endpoint" {
   output {
     logs = [otelcol.processor.attributes.otel_endpoint.input]

--- a/charts/k8s-monitoring/docs/examples/auth/oauth2/alloy-metrics.alloy
+++ b/charts/k8s-monitoring/docs/examples/auth/oauth2/alloy-metrics.alloy
@@ -892,9 +892,38 @@ prometheus_operator_objects "feature" {
 // Destination: otel-endpoint (otlp)
 otelcol.receiver.prometheus "otel_endpoint" {
   output {
-    metrics = [otelcol.processor.attributes.otel_endpoint.input]
+    metrics = [otelcol.processor.transform.otel_endpoint_scrape_normalize.input]
   }
 } // otelcol.receiver.prometheus "otel_endpoint"
+
+// Repairs artifacts of the Prometheus-to-OTLP conversion performed by
+// otelcol.receiver.prometheus. Only metrics that came from a Prometheus scrape pass
+// through this component; OTLP-native telemetry enters the pipeline further down.
+otelcol.processor.transform "otel_endpoint_scrape_normalize" {
+  error_mode = "ignore"
+  metric_statements {
+    context = "resource"
+    statements = [
+      // The conversion sets service.name to the full Prometheus job label (e.g.
+      // "namespace/workload"). When the scrape target declares its identity explicitly
+      // with a service_name label on its own target_info metric (e.g. Grafana Beyla),
+      // prefer that value and drop the duplicate.
+      `set(attributes["service.name"], attributes["service_name"]) where attributes["service_name"] != nil and attributes["service_name"] != ""`,
+      `delete_key(attributes, "service_name") where attributes["service_name"] == attributes["service.name"]`,
+    ]
+  }
+  metric_statements {
+    context = "datapoint"
+    statements = [
+      // Same correction for scrape targets that put service_name on every series
+      // instead of exposing a target_info metric.
+      `set(resource.attributes["service.name"], attributes["service_name"]) where attributes["service_name"] != nil and attributes["service_name"] != ""`,
+    ]
+  }
+  output {
+    metrics = [otelcol.processor.attributes.otel_endpoint.input]
+  }
+} // otelcol.processor.transform "otel_endpoint_scrape_normalize"
 otelcol.receiver.loki "otel_endpoint" {
   output {
     logs = [otelcol.processor.attributes.otel_endpoint.input]

--- a/charts/k8s-monitoring/docs/examples/auth/oauth2/alloy-singleton.alloy
+++ b/charts/k8s-monitoring/docs/examples/auth/oauth2/alloy-singleton.alloy
@@ -131,9 +131,38 @@ prometheus.relabel "kubernetes_monitoring_telemetry" {
 // Destination: otel-endpoint (otlp)
 otelcol.receiver.prometheus "otel_endpoint" {
   output {
-    metrics = [otelcol.processor.attributes.otel_endpoint.input]
+    metrics = [otelcol.processor.transform.otel_endpoint_scrape_normalize.input]
   }
 } // otelcol.receiver.prometheus "otel_endpoint"
+
+// Repairs artifacts of the Prometheus-to-OTLP conversion performed by
+// otelcol.receiver.prometheus. Only metrics that came from a Prometheus scrape pass
+// through this component; OTLP-native telemetry enters the pipeline further down.
+otelcol.processor.transform "otel_endpoint_scrape_normalize" {
+  error_mode = "ignore"
+  metric_statements {
+    context = "resource"
+    statements = [
+      // The conversion sets service.name to the full Prometheus job label (e.g.
+      // "namespace/workload"). When the scrape target declares its identity explicitly
+      // with a service_name label on its own target_info metric (e.g. Grafana Beyla),
+      // prefer that value and drop the duplicate.
+      `set(attributes["service.name"], attributes["service_name"]) where attributes["service_name"] != nil and attributes["service_name"] != ""`,
+      `delete_key(attributes, "service_name") where attributes["service_name"] == attributes["service.name"]`,
+    ]
+  }
+  metric_statements {
+    context = "datapoint"
+    statements = [
+      // Same correction for scrape targets that put service_name on every series
+      // instead of exposing a target_info metric.
+      `set(resource.attributes["service.name"], attributes["service_name"]) where attributes["service_name"] != nil and attributes["service_name"] != ""`,
+    ]
+  }
+  output {
+    metrics = [otelcol.processor.attributes.otel_endpoint.input]
+  }
+} // otelcol.processor.transform "otel_endpoint_scrape_normalize"
 otelcol.receiver.loki "otel_endpoint" {
   output {
     logs = [otelcol.processor.attributes.otel_endpoint.input]

--- a/charts/k8s-monitoring/docs/examples/auth/oauth2/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/auth/oauth2/output.yaml
@@ -445,9 +445,38 @@ data:
     // Destination: otel-endpoint (otlp)
     otelcol.receiver.prometheus "otel_endpoint" {
       output {
-        metrics = [otelcol.processor.attributes.otel_endpoint.input]
+        metrics = [otelcol.processor.transform.otel_endpoint_scrape_normalize.input]
       }
     } // otelcol.receiver.prometheus "otel_endpoint"
+    
+    // Repairs artifacts of the Prometheus-to-OTLP conversion performed by
+    // otelcol.receiver.prometheus. Only metrics that came from a Prometheus scrape pass
+    // through this component; OTLP-native telemetry enters the pipeline further down.
+    otelcol.processor.transform "otel_endpoint_scrape_normalize" {
+      error_mode = "ignore"
+      metric_statements {
+        context = "resource"
+        statements = [
+          // The conversion sets service.name to the full Prometheus job label (e.g.
+          // "namespace/workload"). When the scrape target declares its identity explicitly
+          // with a service_name label on its own target_info metric (e.g. Grafana Beyla),
+          // prefer that value and drop the duplicate.
+          `set(attributes["service.name"], attributes["service_name"]) where attributes["service_name"] != nil and attributes["service_name"] != ""`,
+          `delete_key(attributes, "service_name") where attributes["service_name"] == attributes["service.name"]`,
+        ]
+      }
+      metric_statements {
+        context = "datapoint"
+        statements = [
+          // Same correction for scrape targets that put service_name on every series
+          // instead of exposing a target_info metric.
+          `set(resource.attributes["service.name"], attributes["service_name"]) where attributes["service_name"] != nil and attributes["service_name"] != ""`,
+        ]
+      }
+      output {
+        metrics = [otelcol.processor.attributes.otel_endpoint.input]
+      }
+    } // otelcol.processor.transform "otel_endpoint_scrape_normalize"
     otelcol.receiver.loki "otel_endpoint" {
       output {
         logs = [otelcol.processor.attributes.otel_endpoint.input]
@@ -1544,9 +1573,38 @@ data:
     // Destination: otel-endpoint (otlp)
     otelcol.receiver.prometheus "otel_endpoint" {
       output {
-        metrics = [otelcol.processor.attributes.otel_endpoint.input]
+        metrics = [otelcol.processor.transform.otel_endpoint_scrape_normalize.input]
       }
     } // otelcol.receiver.prometheus "otel_endpoint"
+    
+    // Repairs artifacts of the Prometheus-to-OTLP conversion performed by
+    // otelcol.receiver.prometheus. Only metrics that came from a Prometheus scrape pass
+    // through this component; OTLP-native telemetry enters the pipeline further down.
+    otelcol.processor.transform "otel_endpoint_scrape_normalize" {
+      error_mode = "ignore"
+      metric_statements {
+        context = "resource"
+        statements = [
+          // The conversion sets service.name to the full Prometheus job label (e.g.
+          // "namespace/workload"). When the scrape target declares its identity explicitly
+          // with a service_name label on its own target_info metric (e.g. Grafana Beyla),
+          // prefer that value and drop the duplicate.
+          `set(attributes["service.name"], attributes["service_name"]) where attributes["service_name"] != nil and attributes["service_name"] != ""`,
+          `delete_key(attributes, "service_name") where attributes["service_name"] == attributes["service.name"]`,
+        ]
+      }
+      metric_statements {
+        context = "datapoint"
+        statements = [
+          // Same correction for scrape targets that put service_name on every series
+          // instead of exposing a target_info metric.
+          `set(resource.attributes["service.name"], attributes["service_name"]) where attributes["service_name"] != nil and attributes["service_name"] != ""`,
+        ]
+      }
+      output {
+        metrics = [otelcol.processor.attributes.otel_endpoint.input]
+      }
+    } // otelcol.processor.transform "otel_endpoint_scrape_normalize"
     otelcol.receiver.loki "otel_endpoint" {
       output {
         logs = [otelcol.processor.attributes.otel_endpoint.input]
@@ -1882,9 +1940,38 @@ data:
     // Destination: otel-endpoint (otlp)
     otelcol.receiver.prometheus "otel_endpoint" {
       output {
-        metrics = [otelcol.processor.attributes.otel_endpoint.input]
+        metrics = [otelcol.processor.transform.otel_endpoint_scrape_normalize.input]
       }
     } // otelcol.receiver.prometheus "otel_endpoint"
+    
+    // Repairs artifacts of the Prometheus-to-OTLP conversion performed by
+    // otelcol.receiver.prometheus. Only metrics that came from a Prometheus scrape pass
+    // through this component; OTLP-native telemetry enters the pipeline further down.
+    otelcol.processor.transform "otel_endpoint_scrape_normalize" {
+      error_mode = "ignore"
+      metric_statements {
+        context = "resource"
+        statements = [
+          // The conversion sets service.name to the full Prometheus job label (e.g.
+          // "namespace/workload"). When the scrape target declares its identity explicitly
+          // with a service_name label on its own target_info metric (e.g. Grafana Beyla),
+          // prefer that value and drop the duplicate.
+          `set(attributes["service.name"], attributes["service_name"]) where attributes["service_name"] != nil and attributes["service_name"] != ""`,
+          `delete_key(attributes, "service_name") where attributes["service_name"] == attributes["service.name"]`,
+        ]
+      }
+      metric_statements {
+        context = "datapoint"
+        statements = [
+          // Same correction for scrape targets that put service_name on every series
+          // instead of exposing a target_info metric.
+          `set(resource.attributes["service.name"], attributes["service_name"]) where attributes["service_name"] != nil and attributes["service_name"] != ""`,
+        ]
+      }
+      output {
+        metrics = [otelcol.processor.attributes.otel_endpoint.input]
+      }
+    } // otelcol.processor.transform "otel_endpoint_scrape_normalize"
     otelcol.receiver.loki "otel_endpoint" {
       output {
         logs = [otelcol.processor.attributes.otel_endpoint.input]

--- a/charts/k8s-monitoring/docs/examples/destinations/otlp-endpoint/alloy-logs.alloy
+++ b/charts/k8s-monitoring/docs/examples/destinations/otlp-endpoint/alloy-logs.alloy
@@ -209,9 +209,38 @@ otelcol.storage.file "otlp_gateway_queue_storage" {
 // Destination: otlp-gateway (otlp)
 otelcol.receiver.prometheus "otlp_gateway" {
   output {
-    metrics = [otelcol.processor.attributes.otlp_gateway.input]
+    metrics = [otelcol.processor.transform.otlp_gateway_scrape_normalize.input]
   }
 } // otelcol.receiver.prometheus "otlp_gateway"
+
+// Repairs artifacts of the Prometheus-to-OTLP conversion performed by
+// otelcol.receiver.prometheus. Only metrics that came from a Prometheus scrape pass
+// through this component; OTLP-native telemetry enters the pipeline further down.
+otelcol.processor.transform "otlp_gateway_scrape_normalize" {
+  error_mode = "ignore"
+  metric_statements {
+    context = "resource"
+    statements = [
+      // The conversion sets service.name to the full Prometheus job label (e.g.
+      // "namespace/workload"). When the scrape target declares its identity explicitly
+      // with a service_name label on its own target_info metric (e.g. Grafana Beyla),
+      // prefer that value and drop the duplicate.
+      `set(attributes["service.name"], attributes["service_name"]) where attributes["service_name"] != nil and attributes["service_name"] != ""`,
+      `delete_key(attributes, "service_name") where attributes["service_name"] == attributes["service.name"]`,
+    ]
+  }
+  metric_statements {
+    context = "datapoint"
+    statements = [
+      // Same correction for scrape targets that put service_name on every series
+      // instead of exposing a target_info metric.
+      `set(resource.attributes["service.name"], attributes["service_name"]) where attributes["service_name"] != nil and attributes["service_name"] != ""`,
+    ]
+  }
+  output {
+    metrics = [otelcol.processor.attributes.otlp_gateway.input]
+  }
+} // otelcol.processor.transform "otlp_gateway_scrape_normalize"
 otelcol.receiver.loki "otlp_gateway" {
   output {
     logs = [otelcol.processor.attributes.otlp_gateway.input]

--- a/charts/k8s-monitoring/docs/examples/destinations/otlp-endpoint/alloy-metrics.alloy
+++ b/charts/k8s-monitoring/docs/examples/destinations/otlp-endpoint/alloy-metrics.alloy
@@ -545,9 +545,38 @@ otelcol.storage.file "otlp_gateway_queue_storage" {
 // Destination: otlp-gateway (otlp)
 otelcol.receiver.prometheus "otlp_gateway" {
   output {
-    metrics = [otelcol.processor.attributes.otlp_gateway.input]
+    metrics = [otelcol.processor.transform.otlp_gateway_scrape_normalize.input]
   }
 } // otelcol.receiver.prometheus "otlp_gateway"
+
+// Repairs artifacts of the Prometheus-to-OTLP conversion performed by
+// otelcol.receiver.prometheus. Only metrics that came from a Prometheus scrape pass
+// through this component; OTLP-native telemetry enters the pipeline further down.
+otelcol.processor.transform "otlp_gateway_scrape_normalize" {
+  error_mode = "ignore"
+  metric_statements {
+    context = "resource"
+    statements = [
+      // The conversion sets service.name to the full Prometheus job label (e.g.
+      // "namespace/workload"). When the scrape target declares its identity explicitly
+      // with a service_name label on its own target_info metric (e.g. Grafana Beyla),
+      // prefer that value and drop the duplicate.
+      `set(attributes["service.name"], attributes["service_name"]) where attributes["service_name"] != nil and attributes["service_name"] != ""`,
+      `delete_key(attributes, "service_name") where attributes["service_name"] == attributes["service.name"]`,
+    ]
+  }
+  metric_statements {
+    context = "datapoint"
+    statements = [
+      // Same correction for scrape targets that put service_name on every series
+      // instead of exposing a target_info metric.
+      `set(resource.attributes["service.name"], attributes["service_name"]) where attributes["service_name"] != nil and attributes["service_name"] != ""`,
+    ]
+  }
+  output {
+    metrics = [otelcol.processor.attributes.otlp_gateway.input]
+  }
+} // otelcol.processor.transform "otlp_gateway_scrape_normalize"
 otelcol.receiver.loki "otlp_gateway" {
   output {
     logs = [otelcol.processor.attributes.otlp_gateway.input]

--- a/charts/k8s-monitoring/docs/examples/destinations/otlp-endpoint/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/destinations/otlp-endpoint/output.yaml
@@ -316,9 +316,38 @@ data:
     // Destination: otlp-gateway (otlp)
     otelcol.receiver.prometheus "otlp_gateway" {
       output {
-        metrics = [otelcol.processor.attributes.otlp_gateway.input]
+        metrics = [otelcol.processor.transform.otlp_gateway_scrape_normalize.input]
       }
     } // otelcol.receiver.prometheus "otlp_gateway"
+    
+    // Repairs artifacts of the Prometheus-to-OTLP conversion performed by
+    // otelcol.receiver.prometheus. Only metrics that came from a Prometheus scrape pass
+    // through this component; OTLP-native telemetry enters the pipeline further down.
+    otelcol.processor.transform "otlp_gateway_scrape_normalize" {
+      error_mode = "ignore"
+      metric_statements {
+        context = "resource"
+        statements = [
+          // The conversion sets service.name to the full Prometheus job label (e.g.
+          // "namespace/workload"). When the scrape target declares its identity explicitly
+          // with a service_name label on its own target_info metric (e.g. Grafana Beyla),
+          // prefer that value and drop the duplicate.
+          `set(attributes["service.name"], attributes["service_name"]) where attributes["service_name"] != nil and attributes["service_name"] != ""`,
+          `delete_key(attributes, "service_name") where attributes["service_name"] == attributes["service.name"]`,
+        ]
+      }
+      metric_statements {
+        context = "datapoint"
+        statements = [
+          // Same correction for scrape targets that put service_name on every series
+          // instead of exposing a target_info metric.
+          `set(resource.attributes["service.name"], attributes["service_name"]) where attributes["service_name"] != nil and attributes["service_name"] != ""`,
+        ]
+      }
+      output {
+        metrics = [otelcol.processor.attributes.otlp_gateway.input]
+      }
+    } // otelcol.processor.transform "otlp_gateway_scrape_normalize"
     otelcol.receiver.loki "otlp_gateway" {
       output {
         logs = [otelcol.processor.attributes.otlp_gateway.input]
@@ -1070,9 +1099,38 @@ data:
     // Destination: otlp-gateway (otlp)
     otelcol.receiver.prometheus "otlp_gateway" {
       output {
-        metrics = [otelcol.processor.attributes.otlp_gateway.input]
+        metrics = [otelcol.processor.transform.otlp_gateway_scrape_normalize.input]
       }
     } // otelcol.receiver.prometheus "otlp_gateway"
+    
+    // Repairs artifacts of the Prometheus-to-OTLP conversion performed by
+    // otelcol.receiver.prometheus. Only metrics that came from a Prometheus scrape pass
+    // through this component; OTLP-native telemetry enters the pipeline further down.
+    otelcol.processor.transform "otlp_gateway_scrape_normalize" {
+      error_mode = "ignore"
+      metric_statements {
+        context = "resource"
+        statements = [
+          // The conversion sets service.name to the full Prometheus job label (e.g.
+          // "namespace/workload"). When the scrape target declares its identity explicitly
+          // with a service_name label on its own target_info metric (e.g. Grafana Beyla),
+          // prefer that value and drop the duplicate.
+          `set(attributes["service.name"], attributes["service_name"]) where attributes["service_name"] != nil and attributes["service_name"] != ""`,
+          `delete_key(attributes, "service_name") where attributes["service_name"] == attributes["service.name"]`,
+        ]
+      }
+      metric_statements {
+        context = "datapoint"
+        statements = [
+          // Same correction for scrape targets that put service_name on every series
+          // instead of exposing a target_info metric.
+          `set(resource.attributes["service.name"], attributes["service_name"]) where attributes["service_name"] != nil and attributes["service_name"] != ""`,
+        ]
+      }
+      output {
+        metrics = [otelcol.processor.attributes.otlp_gateway.input]
+      }
+    } // otelcol.processor.transform "otlp_gateway_scrape_normalize"
     otelcol.receiver.loki "otlp_gateway" {
       output {
         logs = [otelcol.processor.attributes.otlp_gateway.input]

--- a/charts/k8s-monitoring/docs/examples/features/application-observability/default/alloy-receiver.alloy
+++ b/charts/k8s-monitoring/docs/examples/features/application-observability/default/alloy-receiver.alloy
@@ -199,9 +199,38 @@ prometheus.relabel "kubernetes_monitoring_telemetry" {
 // Destination: otlp-gateway (otlp)
 otelcol.receiver.prometheus "otlp_gateway" {
   output {
-    metrics = [otelcol.processor.attributes.otlp_gateway.input]
+    metrics = [otelcol.processor.transform.otlp_gateway_scrape_normalize.input]
   }
 } // otelcol.receiver.prometheus "otlp_gateway"
+
+// Repairs artifacts of the Prometheus-to-OTLP conversion performed by
+// otelcol.receiver.prometheus. Only metrics that came from a Prometheus scrape pass
+// through this component; OTLP-native telemetry enters the pipeline further down.
+otelcol.processor.transform "otlp_gateway_scrape_normalize" {
+  error_mode = "ignore"
+  metric_statements {
+    context = "resource"
+    statements = [
+      // The conversion sets service.name to the full Prometheus job label (e.g.
+      // "namespace/workload"). When the scrape target declares its identity explicitly
+      // with a service_name label on its own target_info metric (e.g. Grafana Beyla),
+      // prefer that value and drop the duplicate.
+      `set(attributes["service.name"], attributes["service_name"]) where attributes["service_name"] != nil and attributes["service_name"] != ""`,
+      `delete_key(attributes, "service_name") where attributes["service_name"] == attributes["service.name"]`,
+    ]
+  }
+  metric_statements {
+    context = "datapoint"
+    statements = [
+      // Same correction for scrape targets that put service_name on every series
+      // instead of exposing a target_info metric.
+      `set(resource.attributes["service.name"], attributes["service_name"]) where attributes["service_name"] != nil and attributes["service_name"] != ""`,
+    ]
+  }
+  output {
+    metrics = [otelcol.processor.attributes.otlp_gateway.input]
+  }
+} // otelcol.processor.transform "otlp_gateway_scrape_normalize"
 otelcol.receiver.loki "otlp_gateway" {
   output {
     logs = [otelcol.processor.attributes.otlp_gateway.input]

--- a/charts/k8s-monitoring/docs/examples/features/application-observability/default/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/features/application-observability/default/output.yaml
@@ -222,9 +222,38 @@ data:
     // Destination: otlp-gateway (otlp)
     otelcol.receiver.prometheus "otlp_gateway" {
       output {
-        metrics = [otelcol.processor.attributes.otlp_gateway.input]
+        metrics = [otelcol.processor.transform.otlp_gateway_scrape_normalize.input]
       }
     } // otelcol.receiver.prometheus "otlp_gateway"
+    
+    // Repairs artifacts of the Prometheus-to-OTLP conversion performed by
+    // otelcol.receiver.prometheus. Only metrics that came from a Prometheus scrape pass
+    // through this component; OTLP-native telemetry enters the pipeline further down.
+    otelcol.processor.transform "otlp_gateway_scrape_normalize" {
+      error_mode = "ignore"
+      metric_statements {
+        context = "resource"
+        statements = [
+          // The conversion sets service.name to the full Prometheus job label (e.g.
+          // "namespace/workload"). When the scrape target declares its identity explicitly
+          // with a service_name label on its own target_info metric (e.g. Grafana Beyla),
+          // prefer that value and drop the duplicate.
+          `set(attributes["service.name"], attributes["service_name"]) where attributes["service_name"] != nil and attributes["service_name"] != ""`,
+          `delete_key(attributes, "service_name") where attributes["service_name"] == attributes["service.name"]`,
+        ]
+      }
+      metric_statements {
+        context = "datapoint"
+        statements = [
+          // Same correction for scrape targets that put service_name on every series
+          // instead of exposing a target_info metric.
+          `set(resource.attributes["service.name"], attributes["service_name"]) where attributes["service_name"] != nil and attributes["service_name"] != ""`,
+        ]
+      }
+      output {
+        metrics = [otelcol.processor.attributes.otlp_gateway.input]
+      }
+    } // otelcol.processor.transform "otlp_gateway_scrape_normalize"
     otelcol.receiver.loki "otlp_gateway" {
       output {
         logs = [otelcol.processor.attributes.otlp_gateway.input]

--- a/charts/k8s-monitoring/docs/examples/features/application-observability/tail-sampling/alloy-receiver.alloy
+++ b/charts/k8s-monitoring/docs/examples/features/application-observability/tail-sampling/alloy-receiver.alloy
@@ -199,9 +199,38 @@ prometheus.relabel "kubernetes_monitoring_telemetry" {
 // Destination: otlp-gateway (otlp)
 otelcol.receiver.prometheus "otlp_gateway" {
   output {
-    metrics = [otelcol.processor.attributes.otlp_gateway.input]
+    metrics = [otelcol.processor.transform.otlp_gateway_scrape_normalize.input]
   }
 } // otelcol.receiver.prometheus "otlp_gateway"
+
+// Repairs artifacts of the Prometheus-to-OTLP conversion performed by
+// otelcol.receiver.prometheus. Only metrics that came from a Prometheus scrape pass
+// through this component; OTLP-native telemetry enters the pipeline further down.
+otelcol.processor.transform "otlp_gateway_scrape_normalize" {
+  error_mode = "ignore"
+  metric_statements {
+    context = "resource"
+    statements = [
+      // The conversion sets service.name to the full Prometheus job label (e.g.
+      // "namespace/workload"). When the scrape target declares its identity explicitly
+      // with a service_name label on its own target_info metric (e.g. Grafana Beyla),
+      // prefer that value and drop the duplicate.
+      `set(attributes["service.name"], attributes["service_name"]) where attributes["service_name"] != nil and attributes["service_name"] != ""`,
+      `delete_key(attributes, "service_name") where attributes["service_name"] == attributes["service.name"]`,
+    ]
+  }
+  metric_statements {
+    context = "datapoint"
+    statements = [
+      // Same correction for scrape targets that put service_name on every series
+      // instead of exposing a target_info metric.
+      `set(resource.attributes["service.name"], attributes["service_name"]) where attributes["service_name"] != nil and attributes["service_name"] != ""`,
+    ]
+  }
+  output {
+    metrics = [otelcol.processor.attributes.otlp_gateway.input]
+  }
+} // otelcol.processor.transform "otlp_gateway_scrape_normalize"
 otelcol.receiver.loki "otlp_gateway" {
   output {
     logs = [otelcol.processor.attributes.otlp_gateway.input]

--- a/charts/k8s-monitoring/docs/examples/features/application-observability/tail-sampling/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/features/application-observability/tail-sampling/output.yaml
@@ -222,9 +222,38 @@ data:
     // Destination: otlp-gateway (otlp)
     otelcol.receiver.prometheus "otlp_gateway" {
       output {
-        metrics = [otelcol.processor.attributes.otlp_gateway.input]
+        metrics = [otelcol.processor.transform.otlp_gateway_scrape_normalize.input]
       }
     } // otelcol.receiver.prometheus "otlp_gateway"
+    
+    // Repairs artifacts of the Prometheus-to-OTLP conversion performed by
+    // otelcol.receiver.prometheus. Only metrics that came from a Prometheus scrape pass
+    // through this component; OTLP-native telemetry enters the pipeline further down.
+    otelcol.processor.transform "otlp_gateway_scrape_normalize" {
+      error_mode = "ignore"
+      metric_statements {
+        context = "resource"
+        statements = [
+          // The conversion sets service.name to the full Prometheus job label (e.g.
+          // "namespace/workload"). When the scrape target declares its identity explicitly
+          // with a service_name label on its own target_info metric (e.g. Grafana Beyla),
+          // prefer that value and drop the duplicate.
+          `set(attributes["service.name"], attributes["service_name"]) where attributes["service_name"] != nil and attributes["service_name"] != ""`,
+          `delete_key(attributes, "service_name") where attributes["service_name"] == attributes["service.name"]`,
+        ]
+      }
+      metric_statements {
+        context = "datapoint"
+        statements = [
+          // Same correction for scrape targets that put service_name on every series
+          // instead of exposing a target_info metric.
+          `set(resource.attributes["service.name"], attributes["service_name"]) where attributes["service_name"] != nil and attributes["service_name"] != ""`,
+        ]
+      }
+      output {
+        metrics = [otelcol.processor.attributes.otlp_gateway.input]
+      }
+    } // otelcol.processor.transform "otlp_gateway_scrape_normalize"
     otelcol.receiver.loki "otlp_gateway" {
       output {
         logs = [otelcol.processor.attributes.otlp_gateway.input]

--- a/charts/k8s-monitoring/docs/examples/features/auto-instrumentation/beyla-metrics-and-traces/alloy.alloy
+++ b/charts/k8s-monitoring/docs/examples/features/auto-instrumentation/beyla-metrics-and-traces/alloy.alloy
@@ -261,9 +261,38 @@ prometheus.relabel "kubernetes_monitoring_telemetry" {
 // Destination: otlp-gateway (otlp)
 otelcol.receiver.prometheus "otlp_gateway" {
   output {
-    metrics = [otelcol.processor.attributes.otlp_gateway.input]
+    metrics = [otelcol.processor.transform.otlp_gateway_scrape_normalize.input]
   }
 } // otelcol.receiver.prometheus "otlp_gateway"
+
+// Repairs artifacts of the Prometheus-to-OTLP conversion performed by
+// otelcol.receiver.prometheus. Only metrics that came from a Prometheus scrape pass
+// through this component; OTLP-native telemetry enters the pipeline further down.
+otelcol.processor.transform "otlp_gateway_scrape_normalize" {
+  error_mode = "ignore"
+  metric_statements {
+    context = "resource"
+    statements = [
+      // The conversion sets service.name to the full Prometheus job label (e.g.
+      // "namespace/workload"). When the scrape target declares its identity explicitly
+      // with a service_name label on its own target_info metric (e.g. Grafana Beyla),
+      // prefer that value and drop the duplicate.
+      `set(attributes["service.name"], attributes["service_name"]) where attributes["service_name"] != nil and attributes["service_name"] != ""`,
+      `delete_key(attributes, "service_name") where attributes["service_name"] == attributes["service.name"]`,
+    ]
+  }
+  metric_statements {
+    context = "datapoint"
+    statements = [
+      // Same correction for scrape targets that put service_name on every series
+      // instead of exposing a target_info metric.
+      `set(resource.attributes["service.name"], attributes["service_name"]) where attributes["service_name"] != nil and attributes["service_name"] != ""`,
+    ]
+  }
+  output {
+    metrics = [otelcol.processor.attributes.otlp_gateway.input]
+  }
+} // otelcol.processor.transform "otlp_gateway_scrape_normalize"
 otelcol.receiver.loki "otlp_gateway" {
   output {
     logs = [otelcol.processor.attributes.otlp_gateway.input]

--- a/charts/k8s-monitoring/docs/examples/features/auto-instrumentation/beyla-metrics-and-traces/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/features/auto-instrumentation/beyla-metrics-and-traces/output.yaml
@@ -300,9 +300,38 @@ data:
     // Destination: otlp-gateway (otlp)
     otelcol.receiver.prometheus "otlp_gateway" {
       output {
-        metrics = [otelcol.processor.attributes.otlp_gateway.input]
+        metrics = [otelcol.processor.transform.otlp_gateway_scrape_normalize.input]
       }
     } // otelcol.receiver.prometheus "otlp_gateway"
+    
+    // Repairs artifacts of the Prometheus-to-OTLP conversion performed by
+    // otelcol.receiver.prometheus. Only metrics that came from a Prometheus scrape pass
+    // through this component; OTLP-native telemetry enters the pipeline further down.
+    otelcol.processor.transform "otlp_gateway_scrape_normalize" {
+      error_mode = "ignore"
+      metric_statements {
+        context = "resource"
+        statements = [
+          // The conversion sets service.name to the full Prometheus job label (e.g.
+          // "namespace/workload"). When the scrape target declares its identity explicitly
+          // with a service_name label on its own target_info metric (e.g. Grafana Beyla),
+          // prefer that value and drop the duplicate.
+          `set(attributes["service.name"], attributes["service_name"]) where attributes["service_name"] != nil and attributes["service_name"] != ""`,
+          `delete_key(attributes, "service_name") where attributes["service_name"] == attributes["service.name"]`,
+        ]
+      }
+      metric_statements {
+        context = "datapoint"
+        statements = [
+          // Same correction for scrape targets that put service_name on every series
+          // instead of exposing a target_info metric.
+          `set(resource.attributes["service.name"], attributes["service_name"]) where attributes["service_name"] != nil and attributes["service_name"] != ""`,
+        ]
+      }
+      output {
+        metrics = [otelcol.processor.attributes.otlp_gateway.input]
+      }
+    } // otelcol.processor.transform "otlp_gateway_scrape_normalize"
     otelcol.receiver.loki "otlp_gateway" {
       output {
         logs = [otelcol.processor.attributes.otlp_gateway.input]

--- a/charts/k8s-monitoring/docs/examples/proxies/alloy-receiver.alloy
+++ b/charts/k8s-monitoring/docs/examples/proxies/alloy-receiver.alloy
@@ -137,9 +137,38 @@ application_observability "feature" {
 // Destination: otlpgateway (otlp)
 otelcol.receiver.prometheus "otlpgateway" {
   output {
-    metrics = [otelcol.processor.attributes.otlpgateway.input]
+    metrics = [otelcol.processor.transform.otlpgateway_scrape_normalize.input]
   }
 } // otelcol.receiver.prometheus "otlpgateway"
+
+// Repairs artifacts of the Prometheus-to-OTLP conversion performed by
+// otelcol.receiver.prometheus. Only metrics that came from a Prometheus scrape pass
+// through this component; OTLP-native telemetry enters the pipeline further down.
+otelcol.processor.transform "otlpgateway_scrape_normalize" {
+  error_mode = "ignore"
+  metric_statements {
+    context = "resource"
+    statements = [
+      // The conversion sets service.name to the full Prometheus job label (e.g.
+      // "namespace/workload"). When the scrape target declares its identity explicitly
+      // with a service_name label on its own target_info metric (e.g. Grafana Beyla),
+      // prefer that value and drop the duplicate.
+      `set(attributes["service.name"], attributes["service_name"]) where attributes["service_name"] != nil and attributes["service_name"] != ""`,
+      `delete_key(attributes, "service_name") where attributes["service_name"] == attributes["service.name"]`,
+    ]
+  }
+  metric_statements {
+    context = "datapoint"
+    statements = [
+      // Same correction for scrape targets that put service_name on every series
+      // instead of exposing a target_info metric.
+      `set(resource.attributes["service.name"], attributes["service_name"]) where attributes["service_name"] != nil and attributes["service_name"] != ""`,
+    ]
+  }
+  output {
+    metrics = [otelcol.processor.attributes.otlpgateway.input]
+  }
+} // otelcol.processor.transform "otlpgateway_scrape_normalize"
 otelcol.receiver.loki "otlpgateway" {
   output {
     logs = [otelcol.processor.attributes.otlpgateway.input]

--- a/charts/k8s-monitoring/docs/examples/proxies/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/proxies/output.yaml
@@ -2163,9 +2163,38 @@ data:
     // Destination: otlpgateway (otlp)
     otelcol.receiver.prometheus "otlpgateway" {
       output {
-        metrics = [otelcol.processor.attributes.otlpgateway.input]
+        metrics = [otelcol.processor.transform.otlpgateway_scrape_normalize.input]
       }
     } // otelcol.receiver.prometheus "otlpgateway"
+    
+    // Repairs artifacts of the Prometheus-to-OTLP conversion performed by
+    // otelcol.receiver.prometheus. Only metrics that came from a Prometheus scrape pass
+    // through this component; OTLP-native telemetry enters the pipeline further down.
+    otelcol.processor.transform "otlpgateway_scrape_normalize" {
+      error_mode = "ignore"
+      metric_statements {
+        context = "resource"
+        statements = [
+          // The conversion sets service.name to the full Prometheus job label (e.g.
+          // "namespace/workload"). When the scrape target declares its identity explicitly
+          // with a service_name label on its own target_info metric (e.g. Grafana Beyla),
+          // prefer that value and drop the duplicate.
+          `set(attributes["service.name"], attributes["service_name"]) where attributes["service_name"] != nil and attributes["service_name"] != ""`,
+          `delete_key(attributes, "service_name") where attributes["service_name"] == attributes["service.name"]`,
+        ]
+      }
+      metric_statements {
+        context = "datapoint"
+        statements = [
+          // Same correction for scrape targets that put service_name on every series
+          // instead of exposing a target_info metric.
+          `set(resource.attributes["service.name"], attributes["service_name"]) where attributes["service_name"] != nil and attributes["service_name"] != ""`,
+        ]
+      }
+      output {
+        metrics = [otelcol.processor.attributes.otlpgateway.input]
+      }
+    } // otelcol.processor.transform "otlpgateway_scrape_normalize"
     otelcol.receiver.loki "otlpgateway" {
       output {
         logs = [otelcol.processor.attributes.otlpgateway.input]

--- a/charts/k8s-monitoring/templates/destinations/_destination_otlp.tpl
+++ b/charts/k8s-monitoring/templates/destinations/_destination_otlp.tpl
@@ -18,9 +18,38 @@
 {{- if eq (include "destinations.otlp.supports_metrics" .) "true" }}
 otelcol.receiver.prometheus {{ include "helper.alloy_name" $.destinationName | quote }} {
   output {
-    metrics = [{{ include "destinations.otlp.alloy.otlp.metrics.target" (dict "destination" . "destinationName" $.destinationName) | trim }}]
+    metrics = [otelcol.processor.transform.{{ include "helper.alloy_name" $.destinationName }}_scrape_normalize.input]
   }
 } // otelcol.receiver.prometheus "{{ include "helper.alloy_name" $.destinationName }}"
+
+// Repairs artifacts of the Prometheus-to-OTLP conversion performed by
+// otelcol.receiver.prometheus. Only metrics that came from a Prometheus scrape pass
+// through this component; OTLP-native telemetry enters the pipeline further down.
+otelcol.processor.transform {{ printf "%s_scrape_normalize" (include "helper.alloy_name" $.destinationName) | quote }} {
+  error_mode = {{ .processors.transform.errorMode | quote }}
+  metric_statements {
+    context = "resource"
+    statements = [
+      // The conversion sets service.name to the full Prometheus job label (e.g.
+      // "namespace/workload"). When the scrape target declares its identity explicitly
+      // with a service_name label on its own target_info metric (e.g. Grafana Beyla),
+      // prefer that value and drop the duplicate.
+      `set(attributes["service.name"], attributes["service_name"]) where attributes["service_name"] != nil and attributes["service_name"] != ""`,
+      `delete_key(attributes, "service_name") where attributes["service_name"] == attributes["service.name"]`,
+    ]
+  }
+  metric_statements {
+    context = "datapoint"
+    statements = [
+      // Same correction for scrape targets that put service_name on every series
+      // instead of exposing a target_info metric.
+      `set(resource.attributes["service.name"], attributes["service_name"]) where attributes["service_name"] != nil and attributes["service_name"] != ""`,
+    ]
+  }
+  output {
+    metrics = [{{ include "destinations.otlp.alloy.otlp.metrics.target" (dict "destination" . "destinationName" $.destinationName) | trim }}]
+  }
+} // otelcol.processor.transform "{{ include "helper.alloy_name" $.destinationName }}_scrape_normalize"
 {{- end }}
 {{- if eq (include "destinations.otlp.supports_logs" .) "true" }}
 otelcol.receiver.loki {{ include "helper.alloy_name" $.destinationName | quote }} {

--- a/charts/k8s-monitoring/tests/__snapshot__/destination_otlp_test.yaml.snap
+++ b/charts/k8s-monitoring/tests/__snapshot__/destination_otlp_test.yaml.snap
@@ -4,9 +4,38 @@ allows you to disable retry on failure:
       // Destination: test (otlp)
       otelcol.receiver.prometheus "test" {
         output {
-          metrics = [otelcol.processor.attributes.test.input]
+          metrics = [otelcol.processor.transform.test_scrape_normalize.input]
         }
       } // otelcol.receiver.prometheus "test"
+
+      // Repairs artifacts of the Prometheus-to-OTLP conversion performed by
+      // otelcol.receiver.prometheus. Only metrics that came from a Prometheus scrape pass
+      // through this component; OTLP-native telemetry enters the pipeline further down.
+      otelcol.processor.transform "test_scrape_normalize" {
+        error_mode = "ignore"
+        metric_statements {
+          context = "resource"
+          statements = [
+            // The conversion sets service.name to the full Prometheus job label (e.g.
+            // "namespace/workload"). When the scrape target declares its identity explicitly
+            // with a service_name label on its own target_info metric (e.g. Grafana Beyla),
+            // prefer that value and drop the duplicate.
+            `set(attributes["service.name"], attributes["service_name"]) where attributes["service_name"] != nil and attributes["service_name"] != ""`,
+            `delete_key(attributes, "service_name") where attributes["service_name"] == attributes["service.name"]`,
+          ]
+        }
+        metric_statements {
+          context = "datapoint"
+          statements = [
+            // Same correction for scrape targets that put service_name on every series
+            // instead of exposing a target_info metric.
+            `set(resource.attributes["service.name"], attributes["service_name"]) where attributes["service_name"] != nil and attributes["service_name"] != ""`,
+          ]
+        }
+        output {
+          metrics = [otelcol.processor.attributes.test.input]
+        }
+      } // otelcol.processor.transform "test_scrape_normalize"
       otelcol.receiver.loki "test" {
         output {
           logs = [otelcol.processor.attributes.test.input]
@@ -187,9 +216,38 @@ allows you to set a timeout:
       // Destination: test (otlp)
       otelcol.receiver.prometheus "test" {
         output {
-          metrics = [otelcol.processor.attributes.test.input]
+          metrics = [otelcol.processor.transform.test_scrape_normalize.input]
         }
       } // otelcol.receiver.prometheus "test"
+
+      // Repairs artifacts of the Prometheus-to-OTLP conversion performed by
+      // otelcol.receiver.prometheus. Only metrics that came from a Prometheus scrape pass
+      // through this component; OTLP-native telemetry enters the pipeline further down.
+      otelcol.processor.transform "test_scrape_normalize" {
+        error_mode = "ignore"
+        metric_statements {
+          context = "resource"
+          statements = [
+            // The conversion sets service.name to the full Prometheus job label (e.g.
+            // "namespace/workload"). When the scrape target declares its identity explicitly
+            // with a service_name label on its own target_info metric (e.g. Grafana Beyla),
+            // prefer that value and drop the duplicate.
+            `set(attributes["service.name"], attributes["service_name"]) where attributes["service_name"] != nil and attributes["service_name"] != ""`,
+            `delete_key(attributes, "service_name") where attributes["service_name"] == attributes["service.name"]`,
+          ]
+        }
+        metric_statements {
+          context = "datapoint"
+          statements = [
+            // Same correction for scrape targets that put service_name on every series
+            // instead of exposing a target_info metric.
+            `set(resource.attributes["service.name"], attributes["service_name"]) where attributes["service_name"] != nil and attributes["service_name"] != ""`,
+          ]
+        }
+        output {
+          metrics = [otelcol.processor.attributes.test.input]
+        }
+      } // otelcol.processor.transform "test_scrape_normalize"
       otelcol.receiver.loki "test" {
         output {
           logs = [otelcol.processor.attributes.test.input]
@@ -371,9 +429,38 @@ allows you to set a timeout when using http:
       // Destination: test (otlp)
       otelcol.receiver.prometheus "test" {
         output {
-          metrics = [otelcol.processor.attributes.test.input]
+          metrics = [otelcol.processor.transform.test_scrape_normalize.input]
         }
       } // otelcol.receiver.prometheus "test"
+
+      // Repairs artifacts of the Prometheus-to-OTLP conversion performed by
+      // otelcol.receiver.prometheus. Only metrics that came from a Prometheus scrape pass
+      // through this component; OTLP-native telemetry enters the pipeline further down.
+      otelcol.processor.transform "test_scrape_normalize" {
+        error_mode = "ignore"
+        metric_statements {
+          context = "resource"
+          statements = [
+            // The conversion sets service.name to the full Prometheus job label (e.g.
+            // "namespace/workload"). When the scrape target declares its identity explicitly
+            // with a service_name label on its own target_info metric (e.g. Grafana Beyla),
+            // prefer that value and drop the duplicate.
+            `set(attributes["service.name"], attributes["service_name"]) where attributes["service_name"] != nil and attributes["service_name"] != ""`,
+            `delete_key(attributes, "service_name") where attributes["service_name"] == attributes["service.name"]`,
+          ]
+        }
+        metric_statements {
+          context = "datapoint"
+          statements = [
+            // Same correction for scrape targets that put service_name on every series
+            // instead of exposing a target_info metric.
+            `set(resource.attributes["service.name"], attributes["service_name"]) where attributes["service_name"] != nil and attributes["service_name"] != ""`,
+          ]
+        }
+        output {
+          metrics = [otelcol.processor.attributes.test.input]
+        }
+      } // otelcol.processor.transform "test_scrape_normalize"
       otelcol.receiver.loki "test" {
         output {
           logs = [otelcol.processor.attributes.test.input]
@@ -555,9 +642,38 @@ allows you to set per-signal paths when using http:
       // Destination: test (otlp)
       otelcol.receiver.prometheus "test" {
         output {
-          metrics = [otelcol.processor.attributes.test.input]
+          metrics = [otelcol.processor.transform.test_scrape_normalize.input]
         }
       } // otelcol.receiver.prometheus "test"
+
+      // Repairs artifacts of the Prometheus-to-OTLP conversion performed by
+      // otelcol.receiver.prometheus. Only metrics that came from a Prometheus scrape pass
+      // through this component; OTLP-native telemetry enters the pipeline further down.
+      otelcol.processor.transform "test_scrape_normalize" {
+        error_mode = "ignore"
+        metric_statements {
+          context = "resource"
+          statements = [
+            // The conversion sets service.name to the full Prometheus job label (e.g.
+            // "namespace/workload"). When the scrape target declares its identity explicitly
+            // with a service_name label on its own target_info metric (e.g. Grafana Beyla),
+            // prefer that value and drop the duplicate.
+            `set(attributes["service.name"], attributes["service_name"]) where attributes["service_name"] != nil and attributes["service_name"] != ""`,
+            `delete_key(attributes, "service_name") where attributes["service_name"] == attributes["service.name"]`,
+          ]
+        }
+        metric_statements {
+          context = "datapoint"
+          statements = [
+            // Same correction for scrape targets that put service_name on every series
+            // instead of exposing a target_info metric.
+            `set(resource.attributes["service.name"], attributes["service_name"]) where attributes["service_name"] != nil and attributes["service_name"] != ""`,
+          ]
+        }
+        output {
+          metrics = [otelcol.processor.attributes.test.input]
+        }
+      } // otelcol.processor.transform "test_scrape_normalize"
       otelcol.receiver.loki "test" {
         output {
           logs = [otelcol.processor.attributes.test.input]
@@ -741,9 +857,38 @@ allows you to use basic authentication:
       // Destination: test (otlp)
       otelcol.receiver.prometheus "test" {
         output {
-          metrics = [otelcol.processor.attributes.test.input]
+          metrics = [otelcol.processor.transform.test_scrape_normalize.input]
         }
       } // otelcol.receiver.prometheus "test"
+
+      // Repairs artifacts of the Prometheus-to-OTLP conversion performed by
+      // otelcol.receiver.prometheus. Only metrics that came from a Prometheus scrape pass
+      // through this component; OTLP-native telemetry enters the pipeline further down.
+      otelcol.processor.transform "test_scrape_normalize" {
+        error_mode = "ignore"
+        metric_statements {
+          context = "resource"
+          statements = [
+            // The conversion sets service.name to the full Prometheus job label (e.g.
+            // "namespace/workload"). When the scrape target declares its identity explicitly
+            // with a service_name label on its own target_info metric (e.g. Grafana Beyla),
+            // prefer that value and drop the duplicate.
+            `set(attributes["service.name"], attributes["service_name"]) where attributes["service_name"] != nil and attributes["service_name"] != ""`,
+            `delete_key(attributes, "service_name") where attributes["service_name"] == attributes["service.name"]`,
+          ]
+        }
+        metric_statements {
+          context = "datapoint"
+          statements = [
+            // Same correction for scrape targets that put service_name on every series
+            // instead of exposing a target_info metric.
+            `set(resource.attributes["service.name"], attributes["service_name"]) where attributes["service_name"] != nil and attributes["service_name"] != ""`,
+          ]
+        }
+        output {
+          metrics = [otelcol.processor.attributes.test.input]
+        }
+      } // otelcol.processor.transform "test_scrape_normalize"
       otelcol.receiver.loki "test" {
         output {
           logs = [otelcol.processor.attributes.test.input]
@@ -935,9 +1080,38 @@ allows you to use basic authentication with a numeric username:
       // Destination: test (otlp)
       otelcol.receiver.prometheus "test" {
         output {
-          metrics = [otelcol.processor.attributes.test.input]
+          metrics = [otelcol.processor.transform.test_scrape_normalize.input]
         }
       } // otelcol.receiver.prometheus "test"
+
+      // Repairs artifacts of the Prometheus-to-OTLP conversion performed by
+      // otelcol.receiver.prometheus. Only metrics that came from a Prometheus scrape pass
+      // through this component; OTLP-native telemetry enters the pipeline further down.
+      otelcol.processor.transform "test_scrape_normalize" {
+        error_mode = "ignore"
+        metric_statements {
+          context = "resource"
+          statements = [
+            // The conversion sets service.name to the full Prometheus job label (e.g.
+            // "namespace/workload"). When the scrape target declares its identity explicitly
+            // with a service_name label on its own target_info metric (e.g. Grafana Beyla),
+            // prefer that value and drop the duplicate.
+            `set(attributes["service.name"], attributes["service_name"]) where attributes["service_name"] != nil and attributes["service_name"] != ""`,
+            `delete_key(attributes, "service_name") where attributes["service_name"] == attributes["service.name"]`,
+          ]
+        }
+        metric_statements {
+          context = "datapoint"
+          statements = [
+            // Same correction for scrape targets that put service_name on every series
+            // instead of exposing a target_info metric.
+            `set(resource.attributes["service.name"], attributes["service_name"]) where attributes["service_name"] != nil and attributes["service_name"] != ""`,
+          ]
+        }
+        output {
+          metrics = [otelcol.processor.attributes.test.input]
+        }
+      } // otelcol.processor.transform "test_scrape_normalize"
       otelcol.receiver.loki "test" {
         output {
           logs = [otelcol.processor.attributes.test.input]
@@ -1129,9 +1303,38 @@ allows you to use cluster.nameFrom:
       // Destination: test (otlp)
       otelcol.receiver.prometheus "test" {
         output {
-          metrics = [otelcol.processor.attributes.test.input]
+          metrics = [otelcol.processor.transform.test_scrape_normalize.input]
         }
       } // otelcol.receiver.prometheus "test"
+
+      // Repairs artifacts of the Prometheus-to-OTLP conversion performed by
+      // otelcol.receiver.prometheus. Only metrics that came from a Prometheus scrape pass
+      // through this component; OTLP-native telemetry enters the pipeline further down.
+      otelcol.processor.transform "test_scrape_normalize" {
+        error_mode = "ignore"
+        metric_statements {
+          context = "resource"
+          statements = [
+            // The conversion sets service.name to the full Prometheus job label (e.g.
+            // "namespace/workload"). When the scrape target declares its identity explicitly
+            // with a service_name label on its own target_info metric (e.g. Grafana Beyla),
+            // prefer that value and drop the duplicate.
+            `set(attributes["service.name"], attributes["service_name"]) where attributes["service_name"] != nil and attributes["service_name"] != ""`,
+            `delete_key(attributes, "service_name") where attributes["service_name"] == attributes["service.name"]`,
+          ]
+        }
+        metric_statements {
+          context = "datapoint"
+          statements = [
+            // Same correction for scrape targets that put service_name on every series
+            // instead of exposing a target_info metric.
+            `set(resource.attributes["service.name"], attributes["service_name"]) where attributes["service_name"] != nil and attributes["service_name"] != ""`,
+          ]
+        }
+        output {
+          metrics = [otelcol.processor.attributes.test.input]
+        }
+      } // otelcol.processor.transform "test_scrape_normalize"
       otelcol.receiver.loki "test" {
         output {
           logs = [otelcol.processor.attributes.test.input]
@@ -1312,9 +1515,38 @@ creates the Alloy components for an OTLP destination:
       // Destination: test (otlp)
       otelcol.receiver.prometheus "test" {
         output {
-          metrics = [otelcol.processor.attributes.test.input]
+          metrics = [otelcol.processor.transform.test_scrape_normalize.input]
         }
       } // otelcol.receiver.prometheus "test"
+
+      // Repairs artifacts of the Prometheus-to-OTLP conversion performed by
+      // otelcol.receiver.prometheus. Only metrics that came from a Prometheus scrape pass
+      // through this component; OTLP-native telemetry enters the pipeline further down.
+      otelcol.processor.transform "test_scrape_normalize" {
+        error_mode = "ignore"
+        metric_statements {
+          context = "resource"
+          statements = [
+            // The conversion sets service.name to the full Prometheus job label (e.g.
+            // "namespace/workload"). When the scrape target declares its identity explicitly
+            // with a service_name label on its own target_info metric (e.g. Grafana Beyla),
+            // prefer that value and drop the duplicate.
+            `set(attributes["service.name"], attributes["service_name"]) where attributes["service_name"] != nil and attributes["service_name"] != ""`,
+            `delete_key(attributes, "service_name") where attributes["service_name"] == attributes["service.name"]`,
+          ]
+        }
+        metric_statements {
+          context = "datapoint"
+          statements = [
+            // Same correction for scrape targets that put service_name on every series
+            // instead of exposing a target_info metric.
+            `set(resource.attributes["service.name"], attributes["service_name"]) where attributes["service_name"] != nil and attributes["service_name"] != ""`,
+          ]
+        }
+        output {
+          metrics = [otelcol.processor.attributes.test.input]
+        }
+      } // otelcol.processor.transform "test_scrape_normalize"
       otelcol.receiver.loki "test" {
         output {
           logs = [otelcol.processor.attributes.test.input]

--- a/charts/k8s-monitoring/tests/__snapshot__/feature_pod_logs_via_opentelemetry_test.yaml.snap
+++ b/charts/k8s-monitoring/tests/__snapshot__/feature_pod_logs_via_opentelemetry_test.yaml.snap
@@ -178,9 +178,38 @@ renders the config to gather Kubernetes Pod logs:
       // Destination: otlp (otlp)
       otelcol.receiver.prometheus "otlp" {
         output {
-          metrics = [otelcol.processor.attributes.otlp.input]
+          metrics = [otelcol.processor.transform.otlp_scrape_normalize.input]
         }
       } // otelcol.receiver.prometheus "otlp"
+
+      // Repairs artifacts of the Prometheus-to-OTLP conversion performed by
+      // otelcol.receiver.prometheus. Only metrics that came from a Prometheus scrape pass
+      // through this component; OTLP-native telemetry enters the pipeline further down.
+      otelcol.processor.transform "otlp_scrape_normalize" {
+        error_mode = "ignore"
+        metric_statements {
+          context = "resource"
+          statements = [
+            // The conversion sets service.name to the full Prometheus job label (e.g.
+            // "namespace/workload"). When the scrape target declares its identity explicitly
+            // with a service_name label on its own target_info metric (e.g. Grafana Beyla),
+            // prefer that value and drop the duplicate.
+            `set(attributes["service.name"], attributes["service_name"]) where attributes["service_name"] != nil and attributes["service_name"] != ""`,
+            `delete_key(attributes, "service_name") where attributes["service_name"] == attributes["service.name"]`,
+          ]
+        }
+        metric_statements {
+          context = "datapoint"
+          statements = [
+            // Same correction for scrape targets that put service_name on every series
+            // instead of exposing a target_info metric.
+            `set(resource.attributes["service.name"], attributes["service_name"]) where attributes["service_name"] != nil and attributes["service_name"] != ""`,
+          ]
+        }
+        output {
+          metrics = [otelcol.processor.attributes.otlp.input]
+        }
+      } // otelcol.processor.transform "otlp_scrape_normalize"
       otelcol.receiver.loki "otlp" {
         output {
           logs = [otelcol.processor.attributes.otlp.input]

--- a/charts/k8s-monitoring/tests/integration/auth/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/integration/auth/.rendered/output.yaml
@@ -835,9 +835,38 @@ data:
     // Destination: prometheus-otlp-basicauth (otlp)
     otelcol.receiver.prometheus "prometheus_otlp_basicauth" {
       output {
-        metrics = [otelcol.processor.attributes.prometheus_otlp_basicauth.input]
+        metrics = [otelcol.processor.transform.prometheus_otlp_basicauth_scrape_normalize.input]
       }
     } // otelcol.receiver.prometheus "prometheus_otlp_basicauth"
+    
+    // Repairs artifacts of the Prometheus-to-OTLP conversion performed by
+    // otelcol.receiver.prometheus. Only metrics that came from a Prometheus scrape pass
+    // through this component; OTLP-native telemetry enters the pipeline further down.
+    otelcol.processor.transform "prometheus_otlp_basicauth_scrape_normalize" {
+      error_mode = "ignore"
+      metric_statements {
+        context = "resource"
+        statements = [
+          // The conversion sets service.name to the full Prometheus job label (e.g.
+          // "namespace/workload"). When the scrape target declares its identity explicitly
+          // with a service_name label on its own target_info metric (e.g. Grafana Beyla),
+          // prefer that value and drop the duplicate.
+          `set(attributes["service.name"], attributes["service_name"]) where attributes["service_name"] != nil and attributes["service_name"] != ""`,
+          `delete_key(attributes, "service_name") where attributes["service_name"] == attributes["service.name"]`,
+        ]
+      }
+      metric_statements {
+        context = "datapoint"
+        statements = [
+          // Same correction for scrape targets that put service_name on every series
+          // instead of exposing a target_info metric.
+          `set(resource.attributes["service.name"], attributes["service_name"]) where attributes["service_name"] != nil and attributes["service_name"] != ""`,
+        ]
+      }
+      output {
+        metrics = [otelcol.processor.attributes.prometheus_otlp_basicauth.input]
+      }
+    } // otelcol.processor.transform "prometheus_otlp_basicauth_scrape_normalize"
     otelcol.processor.attributes "prometheus_otlp_basicauth" {
       action {
         key = "destination"
@@ -941,9 +970,38 @@ data:
     // Destination: prometheus-otlp-bearer-token (otlp)
     otelcol.receiver.prometheus "prometheus_otlp_bearer_token" {
       output {
-        metrics = [otelcol.processor.attributes.prometheus_otlp_bearer_token.input]
+        metrics = [otelcol.processor.transform.prometheus_otlp_bearer_token_scrape_normalize.input]
       }
     } // otelcol.receiver.prometheus "prometheus_otlp_bearer_token"
+    
+    // Repairs artifacts of the Prometheus-to-OTLP conversion performed by
+    // otelcol.receiver.prometheus. Only metrics that came from a Prometheus scrape pass
+    // through this component; OTLP-native telemetry enters the pipeline further down.
+    otelcol.processor.transform "prometheus_otlp_bearer_token_scrape_normalize" {
+      error_mode = "ignore"
+      metric_statements {
+        context = "resource"
+        statements = [
+          // The conversion sets service.name to the full Prometheus job label (e.g.
+          // "namespace/workload"). When the scrape target declares its identity explicitly
+          // with a service_name label on its own target_info metric (e.g. Grafana Beyla),
+          // prefer that value and drop the duplicate.
+          `set(attributes["service.name"], attributes["service_name"]) where attributes["service_name"] != nil and attributes["service_name"] != ""`,
+          `delete_key(attributes, "service_name") where attributes["service_name"] == attributes["service.name"]`,
+        ]
+      }
+      metric_statements {
+        context = "datapoint"
+        statements = [
+          // Same correction for scrape targets that put service_name on every series
+          // instead of exposing a target_info metric.
+          `set(resource.attributes["service.name"], attributes["service_name"]) where attributes["service_name"] != nil and attributes["service_name"] != ""`,
+        ]
+      }
+      output {
+        metrics = [otelcol.processor.attributes.prometheus_otlp_bearer_token.input]
+      }
+    } // otelcol.processor.transform "prometheus_otlp_bearer_token_scrape_normalize"
     otelcol.processor.attributes "prometheus_otlp_bearer_token" {
       action {
         key = "destination"
@@ -1046,9 +1104,38 @@ data:
     // Destination: prometheus-otlp-noauth (otlp)
     otelcol.receiver.prometheus "prometheus_otlp_noauth" {
       output {
-        metrics = [otelcol.processor.attributes.prometheus_otlp_noauth.input]
+        metrics = [otelcol.processor.transform.prometheus_otlp_noauth_scrape_normalize.input]
       }
     } // otelcol.receiver.prometheus "prometheus_otlp_noauth"
+    
+    // Repairs artifacts of the Prometheus-to-OTLP conversion performed by
+    // otelcol.receiver.prometheus. Only metrics that came from a Prometheus scrape pass
+    // through this component; OTLP-native telemetry enters the pipeline further down.
+    otelcol.processor.transform "prometheus_otlp_noauth_scrape_normalize" {
+      error_mode = "ignore"
+      metric_statements {
+        context = "resource"
+        statements = [
+          // The conversion sets service.name to the full Prometheus job label (e.g.
+          // "namespace/workload"). When the scrape target declares its identity explicitly
+          // with a service_name label on its own target_info metric (e.g. Grafana Beyla),
+          // prefer that value and drop the duplicate.
+          `set(attributes["service.name"], attributes["service_name"]) where attributes["service_name"] != nil and attributes["service_name"] != ""`,
+          `delete_key(attributes, "service_name") where attributes["service_name"] == attributes["service.name"]`,
+        ]
+      }
+      metric_statements {
+        context = "datapoint"
+        statements = [
+          // Same correction for scrape targets that put service_name on every series
+          // instead of exposing a target_info metric.
+          `set(resource.attributes["service.name"], attributes["service_name"]) where attributes["service_name"] != nil and attributes["service_name"] != ""`,
+        ]
+      }
+      output {
+        metrics = [otelcol.processor.attributes.prometheus_otlp_noauth.input]
+      }
+    } // otelcol.processor.transform "prometheus_otlp_noauth_scrape_normalize"
     otelcol.processor.attributes "prometheus_otlp_noauth" {
       action {
         key = "destination"

--- a/charts/k8s-monitoring/tests/integration/prom-and-loki-to-otlp/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/integration/prom-and-loki-to-otlp/.rendered/output.yaml
@@ -850,9 +850,38 @@ data:
     // Destination: prometheus (otlp)
     otelcol.receiver.prometheus "prometheus" {
       output {
-        metrics = [otelcol.processor.attributes.prometheus.input]
+        metrics = [otelcol.processor.transform.prometheus_scrape_normalize.input]
       }
     } // otelcol.receiver.prometheus "prometheus"
+    
+    // Repairs artifacts of the Prometheus-to-OTLP conversion performed by
+    // otelcol.receiver.prometheus. Only metrics that came from a Prometheus scrape pass
+    // through this component; OTLP-native telemetry enters the pipeline further down.
+    otelcol.processor.transform "prometheus_scrape_normalize" {
+      error_mode = "ignore"
+      metric_statements {
+        context = "resource"
+        statements = [
+          // The conversion sets service.name to the full Prometheus job label (e.g.
+          // "namespace/workload"). When the scrape target declares its identity explicitly
+          // with a service_name label on its own target_info metric (e.g. Grafana Beyla),
+          // prefer that value and drop the duplicate.
+          `set(attributes["service.name"], attributes["service_name"]) where attributes["service_name"] != nil and attributes["service_name"] != ""`,
+          `delete_key(attributes, "service_name") where attributes["service_name"] == attributes["service.name"]`,
+        ]
+      }
+      metric_statements {
+        context = "datapoint"
+        statements = [
+          // Same correction for scrape targets that put service_name on every series
+          // instead of exposing a target_info metric.
+          `set(resource.attributes["service.name"], attributes["service_name"]) where attributes["service_name"] != nil and attributes["service_name"] != ""`,
+        ]
+      }
+      output {
+        metrics = [otelcol.processor.attributes.prometheus.input]
+      }
+    } // otelcol.processor.transform "prometheus_scrape_normalize"
     otelcol.processor.attributes "prometheus" {
       output {
         metrics = [otelcol.processor.transform.prometheus.input]
@@ -1207,9 +1236,38 @@ data:
     // Destination: prometheus (otlp)
     otelcol.receiver.prometheus "prometheus" {
       output {
-        metrics = [otelcol.processor.attributes.prometheus.input]
+        metrics = [otelcol.processor.transform.prometheus_scrape_normalize.input]
       }
     } // otelcol.receiver.prometheus "prometheus"
+    
+    // Repairs artifacts of the Prometheus-to-OTLP conversion performed by
+    // otelcol.receiver.prometheus. Only metrics that came from a Prometheus scrape pass
+    // through this component; OTLP-native telemetry enters the pipeline further down.
+    otelcol.processor.transform "prometheus_scrape_normalize" {
+      error_mode = "ignore"
+      metric_statements {
+        context = "resource"
+        statements = [
+          // The conversion sets service.name to the full Prometheus job label (e.g.
+          // "namespace/workload"). When the scrape target declares its identity explicitly
+          // with a service_name label on its own target_info metric (e.g. Grafana Beyla),
+          // prefer that value and drop the duplicate.
+          `set(attributes["service.name"], attributes["service_name"]) where attributes["service_name"] != nil and attributes["service_name"] != ""`,
+          `delete_key(attributes, "service_name") where attributes["service_name"] == attributes["service.name"]`,
+        ]
+      }
+      metric_statements {
+        context = "datapoint"
+        statements = [
+          // Same correction for scrape targets that put service_name on every series
+          // instead of exposing a target_info metric.
+          `set(resource.attributes["service.name"], attributes["service_name"]) where attributes["service_name"] != nil and attributes["service_name"] != ""`,
+        ]
+      }
+      output {
+        metrics = [otelcol.processor.attributes.prometheus.input]
+      }
+    } // otelcol.processor.transform "prometheus_scrape_normalize"
     otelcol.processor.attributes "prometheus" {
       output {
         metrics = [otelcol.processor.transform.prometheus.input]

--- a/charts/k8s-monitoring/tests/platform/grafana-cloud/app-observability/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/platform/grafana-cloud/app-observability/.rendered/output.yaml
@@ -229,9 +229,38 @@ data:
     // Destination: otlp-gateway (otlp)
     otelcol.receiver.prometheus "otlp_gateway" {
       output {
-        metrics = [otelcol.processor.attributes.otlp_gateway.input]
+        metrics = [otelcol.processor.transform.otlp_gateway_scrape_normalize.input]
       }
     } // otelcol.receiver.prometheus "otlp_gateway"
+    
+    // Repairs artifacts of the Prometheus-to-OTLP conversion performed by
+    // otelcol.receiver.prometheus. Only metrics that came from a Prometheus scrape pass
+    // through this component; OTLP-native telemetry enters the pipeline further down.
+    otelcol.processor.transform "otlp_gateway_scrape_normalize" {
+      error_mode = "ignore"
+      metric_statements {
+        context = "resource"
+        statements = [
+          // The conversion sets service.name to the full Prometheus job label (e.g.
+          // "namespace/workload"). When the scrape target declares its identity explicitly
+          // with a service_name label on its own target_info metric (e.g. Grafana Beyla),
+          // prefer that value and drop the duplicate.
+          `set(attributes["service.name"], attributes["service_name"]) where attributes["service_name"] != nil and attributes["service_name"] != ""`,
+          `delete_key(attributes, "service_name") where attributes["service_name"] == attributes["service.name"]`,
+        ]
+      }
+      metric_statements {
+        context = "datapoint"
+        statements = [
+          // Same correction for scrape targets that put service_name on every series
+          // instead of exposing a target_info metric.
+          `set(resource.attributes["service.name"], attributes["service_name"]) where attributes["service_name"] != nil and attributes["service_name"] != ""`,
+        ]
+      }
+      output {
+        metrics = [otelcol.processor.attributes.otlp_gateway.input]
+      }
+    } // otelcol.processor.transform "otlp_gateway_scrape_normalize"
     otelcol.receiver.loki "otlp_gateway" {
       output {
         logs = [otelcol.processor.attributes.otlp_gateway.input]
@@ -628,9 +657,38 @@ data:
     // Destination: otlp-gateway (otlp)
     otelcol.receiver.prometheus "otlp_gateway" {
       output {
-        metrics = [otelcol.processor.attributes.otlp_gateway.input]
+        metrics = [otelcol.processor.transform.otlp_gateway_scrape_normalize.input]
       }
     } // otelcol.receiver.prometheus "otlp_gateway"
+    
+    // Repairs artifacts of the Prometheus-to-OTLP conversion performed by
+    // otelcol.receiver.prometheus. Only metrics that came from a Prometheus scrape pass
+    // through this component; OTLP-native telemetry enters the pipeline further down.
+    otelcol.processor.transform "otlp_gateway_scrape_normalize" {
+      error_mode = "ignore"
+      metric_statements {
+        context = "resource"
+        statements = [
+          // The conversion sets service.name to the full Prometheus job label (e.g.
+          // "namespace/workload"). When the scrape target declares its identity explicitly
+          // with a service_name label on its own target_info metric (e.g. Grafana Beyla),
+          // prefer that value and drop the duplicate.
+          `set(attributes["service.name"], attributes["service_name"]) where attributes["service_name"] != nil and attributes["service_name"] != ""`,
+          `delete_key(attributes, "service_name") where attributes["service_name"] == attributes["service.name"]`,
+        ]
+      }
+      metric_statements {
+        context = "datapoint"
+        statements = [
+          // Same correction for scrape targets that put service_name on every series
+          // instead of exposing a target_info metric.
+          `set(resource.attributes["service.name"], attributes["service_name"]) where attributes["service_name"] != nil and attributes["service_name"] != ""`,
+        ]
+      }
+      output {
+        metrics = [otelcol.processor.attributes.otlp_gateway.input]
+      }
+    } // otelcol.processor.transform "otlp_gateway_scrape_normalize"
     otelcol.receiver.loki "otlp_gateway" {
       output {
         logs = [otelcol.processor.attributes.otlp_gateway.input]

--- a/charts/k8s-monitoring/tests/platform/grafana-cloud/k8s-monitoring/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/platform/grafana-cloud/k8s-monitoring/.rendered/output.yaml
@@ -1590,9 +1590,38 @@ data:
     // Destination: grafana-cloud-otlp-endpoint (otlp)
     otelcol.receiver.prometheus "grafana_cloud_otlp_endpoint" {
       output {
-        metrics = [otelcol.processor.attributes.grafana_cloud_otlp_endpoint.input]
+        metrics = [otelcol.processor.transform.grafana_cloud_otlp_endpoint_scrape_normalize.input]
       }
     } // otelcol.receiver.prometheus "grafana_cloud_otlp_endpoint"
+    
+    // Repairs artifacts of the Prometheus-to-OTLP conversion performed by
+    // otelcol.receiver.prometheus. Only metrics that came from a Prometheus scrape pass
+    // through this component; OTLP-native telemetry enters the pipeline further down.
+    otelcol.processor.transform "grafana_cloud_otlp_endpoint_scrape_normalize" {
+      error_mode = "ignore"
+      metric_statements {
+        context = "resource"
+        statements = [
+          // The conversion sets service.name to the full Prometheus job label (e.g.
+          // "namespace/workload"). When the scrape target declares its identity explicitly
+          // with a service_name label on its own target_info metric (e.g. Grafana Beyla),
+          // prefer that value and drop the duplicate.
+          `set(attributes["service.name"], attributes["service_name"]) where attributes["service_name"] != nil and attributes["service_name"] != ""`,
+          `delete_key(attributes, "service_name") where attributes["service_name"] == attributes["service.name"]`,
+        ]
+      }
+      metric_statements {
+        context = "datapoint"
+        statements = [
+          // Same correction for scrape targets that put service_name on every series
+          // instead of exposing a target_info metric.
+          `set(resource.attributes["service.name"], attributes["service_name"]) where attributes["service_name"] != nil and attributes["service_name"] != ""`,
+        ]
+      }
+      output {
+        metrics = [otelcol.processor.attributes.grafana_cloud_otlp_endpoint.input]
+      }
+    } // otelcol.processor.transform "grafana_cloud_otlp_endpoint_scrape_normalize"
     otelcol.receiver.loki "grafana_cloud_otlp_endpoint" {
       output {
         logs = [otelcol.processor.attributes.grafana_cloud_otlp_endpoint.input]

--- a/charts/k8s-monitoring/tests/platform/otlp-gateway/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/platform/otlp-gateway/.rendered/output.yaml
@@ -1157,9 +1157,38 @@ data:
     // Destination: otlp-gateway (otlp)
     otelcol.receiver.prometheus "otlp_gateway" {
       output {
-        metrics = [otelcol.processor.attributes.otlp_gateway.input]
+        metrics = [otelcol.processor.transform.otlp_gateway_scrape_normalize.input]
       }
     } // otelcol.receiver.prometheus "otlp_gateway"
+    
+    // Repairs artifacts of the Prometheus-to-OTLP conversion performed by
+    // otelcol.receiver.prometheus. Only metrics that came from a Prometheus scrape pass
+    // through this component; OTLP-native telemetry enters the pipeline further down.
+    otelcol.processor.transform "otlp_gateway_scrape_normalize" {
+      error_mode = "ignore"
+      metric_statements {
+        context = "resource"
+        statements = [
+          // The conversion sets service.name to the full Prometheus job label (e.g.
+          // "namespace/workload"). When the scrape target declares its identity explicitly
+          // with a service_name label on its own target_info metric (e.g. Grafana Beyla),
+          // prefer that value and drop the duplicate.
+          `set(attributes["service.name"], attributes["service_name"]) where attributes["service_name"] != nil and attributes["service_name"] != ""`,
+          `delete_key(attributes, "service_name") where attributes["service_name"] == attributes["service.name"]`,
+        ]
+      }
+      metric_statements {
+        context = "datapoint"
+        statements = [
+          // Same correction for scrape targets that put service_name on every series
+          // instead of exposing a target_info metric.
+          `set(resource.attributes["service.name"], attributes["service_name"]) where attributes["service_name"] != nil and attributes["service_name"] != ""`,
+        ]
+      }
+      output {
+        metrics = [otelcol.processor.attributes.otlp_gateway.input]
+      }
+    } // otelcol.processor.transform "otlp_gateway_scrape_normalize"
     otelcol.receiver.loki "otlp_gateway" {
       output {
         logs = [otelcol.processor.attributes.otlp_gateway.input]


### PR DESCRIPTION
Fixes #2783

When metrics from a Prometheus scrape (e.g. Beyla's `prometheus_export`) are sent through an OTLP destination, `otelcol.receiver.prometheus` sets resource `service.name` to the full `job` label - for Beyla that is `<namespace>/<workload>`. The existing transform only promotes the explicit `service_name` datapoint attribute when the resource attribute is empty, so the wrong value survives. The OTLP gateway then reconstructs `job` as `<ns>/<ns>/<workload>`, Application Observability derives `service_name="<ns>/<workload>"`, and its Logs tab queries match nothing (pod logs carry the plain `service_name="<workload>"`). It also produces the `;`-joined conflict values in `target_info`.

This adds one transform statement: overwrite resource `service.name` with the explicit `service_name` datapoint attribute when the resource value is job-shaped (contains `/`) and differs. OTLP-native telemetry is unaffected (no `service_name` datapoint attribute); prometheus destinations are unaffected (template not involved).

Verified end-to-end on a live cluster (chart 4.2.0, Beyla, OTLP-only destination, OTel demo app): stored series become `job="otel-demo/cart"` / `service_name="cart"`, the Application Observability Logs tab populates, and the duplicate `x;y` values disappear.
