### PR TITLE
Set the CLUSTER_NAME environment variable for remote config collectors

### DIFF
--- a/charts/k8s-monitoring/CHANGELOG.md
+++ b/charts/k8s-monitoring/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+*   Add `CLUSTER_NAME` environment variable to remote-config-enabled collectors alongside `NAMESPACE` and `POD_NAME`. (#2775) (@petewall)
+
 ## 4.2.0
 
 *   Add `hostMetrics.linuxHosts.source` (`node-exporter` (default) or `alloy`). With `alloy`, Linux host metrics are collected directly by the assigned collector via `prometheus.exporter.unix`, requiring no Node Exporter deployment. This needs a privileged DaemonSet that mounts the host filesystem, configured with the new `presets: [linux-host-monitor, daemonset]`. The `nodeLabels` enrichment is not yet supported with `source: alloy`. (#2660) (@petewall)

--- a/charts/k8s-monitoring/docs/examples/auth/external-secrets/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/auth/external-secrets/output.yaml
@@ -1146,6 +1146,8 @@ spec:
       valueFrom:
         fieldRef:
           fieldPath: metadata.name
+    - name: CLUSTER_NAME
+      value: external-secrets-example-cluster
     - name: GCLOUD_RW_API_KEY
       valueFrom:
         secretKeyRef:

--- a/charts/k8s-monitoring/docs/examples/instrumentation-hub/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/instrumentation-hub/output.yaml
@@ -842,6 +842,8 @@ spec:
       valueFrom:
         fieldRef:
           fieldPath: metadata.name
+    - name: CLUSTER_NAME
+      value: instrumentation-hub-test-cluster
     - name: GCLOUD_RW_API_KEY
       valueFrom:
         secretKeyRef:

--- a/charts/k8s-monitoring/docs/examples/remote-config/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/remote-config/output.yaml
@@ -396,6 +396,8 @@ spec:
       valueFrom:
         fieldRef:
           fieldPath: metadata.name
+    - name: CLUSTER_NAME
+      value: remote-config-example-cluster
     - name: GCLOUD_RW_API_KEY
       valueFrom:
         secretKeyRef:
@@ -464,6 +466,8 @@ spec:
       valueFrom:
         fieldRef:
           fieldPath: metadata.name
+    - name: CLUSTER_NAME
+      value: remote-config-example-cluster
     - name: GCLOUD_RW_API_KEY
       valueFrom:
         secretKeyRef:

--- a/charts/k8s-monitoring/templates/collectors/_collector_remoteConfig.tpl
+++ b/charts/k8s-monitoring/templates/collectors/_collector_remoteConfig.tpl
@@ -11,6 +11,9 @@
     {{- if eq (include "collectors.hasExtraEnv" (deepCopy $ | merge (dict "collectorName" $collectorName "envVarName" "POD_NAME"))) "false" }}
       {{- $extraEnv = (include "collectors.set_extra_env" (dict "envList" $extraEnv "name" "POD_NAME" "valueFrom" (dict "fieldRef" (dict "fieldPath" "metadata.name")))) | fromYamlArray }}
     {{- end }}
+    {{- if and $.Values.cluster.name (eq (include "collectors.hasExtraEnv" (deepCopy $ | merge (dict "collectorName" $collectorName "envVarName" "CLUSTER_NAME"))) "false") }}
+      {{- $extraEnv = (include "collectors.set_extra_env" (dict "envList" $extraEnv "name" "CLUSTER_NAME" "value" $.Values.cluster.name)) | fromYamlArray }}
+    {{- end }}
     {{- if eq (include "collectors.hasExtraEnv" (deepCopy $ | merge (dict "collectorName" $collectorName "envVarName" "GCLOUD_RW_API_KEY"))) "false" }}
       {{- $remoteConfigValues := merge (dict "type" "remoteConfig") (get $collectorValues "remoteConfig") }}
       {{- if eq (include "secrets.usesKubernetesSecret" $remoteConfigValues ) "true" }}

--- a/charts/k8s-monitoring/tests/platform/grafana-cloud/instrumentation-hub/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/platform/grafana-cloud/instrumentation-hub/.rendered/output.yaml
@@ -1576,6 +1576,8 @@ spec:
       valueFrom:
         fieldRef:
           fieldPath: metadata.name
+    - name: CLUSTER_NAME
+      value: instrumentation-hub-test-cluster
     - name: GCLOUD_RW_API_KEY
       valueFrom:
         secretKeyRef:

--- a/charts/k8s-monitoring/tests/platform/remote-config/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/platform/remote-config/.rendered/output.yaml
@@ -380,6 +380,8 @@ spec:
       valueFrom:
         fieldRef:
           fieldPath: metadata.name
+    - name: CLUSTER_NAME
+      value: remote-config-test
     - name: GCLOUD_RW_API_KEY
       valueFrom:
         secretKeyRef:
@@ -448,6 +450,8 @@ spec:
       valueFrom:
         fieldRef:
           fieldPath: metadata.name
+    - name: CLUSTER_NAME
+      value: remote-config-test
     - name: GCLOUD_RW_API_KEY
       valueFrom:
         secretKeyRef:


### PR DESCRIPTION
<!--Describe what this change does and why.-->
# Description

Adds `CLUSTER_NAME` when remote config is enabled for a collector. Only adds if the user hadn't already set it.

Fixes #2775 

<!--Authorship attestation. See AGENTS.md for details. AI agents must not check this box on behalf
of the user; the human author must check it themselves before the PR is ready for review.-->
## Authorship

-   [X] I, a human, wrote this pull request description myself.

<!--Please delete paragraphs that you did not use before submitting.-->
