### PR TITLE
fix: reconcile scraped target_info resource attributes in OTLP destinations

### DIFF
--- a/charts/k8s-monitoring/CHANGELOG.md
+++ b/charts/k8s-monitoring/CHANGELOG.md
@@ -5,6 +5,7 @@
 *   Change the default remote configuration `pollFrequency` from `5m` to `30s`. (@TylerHelmuth)
 *   Add `CLUSTER_NAME` environment variable to remote-config-enabled collectors alongside `NAMESPACE` and `POD_NAME`. (#2775) (@petewall)
 *   Fix OTLP destinations deriving the wrong service identity for metrics converted from a Prometheus scrape. The conversion sets `service.name` to the full `job` label (e.g. `namespace/workload` from Grafana Beyla), breaking service-to-logs correlation in Application Observability. A new normalization step after `otelcol.receiver.prometheus` prefers the explicit `service_name` label; OTLP-native telemetry is unaffected. (#2783) (@mbaykara)
+*   Fix OTLP destinations producing `;`-joined duplicate label values on `target_info` (e.g. `k8s_cluster_name="c;c"`) when a scrape target exposes its own `target_info` metric. Flat resource attributes from the conversion (`service_namespace`, `deployment_environment`, `deployment_environment_name`, `k8s_cluster_name`) are reconciled into their dotted equivalents and dropped when the values match. (#2786) (@mbaykara)
 
 ## 4.2.0
 

--- a/charts/k8s-monitoring/CHANGELOG.md
+++ b/charts/k8s-monitoring/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 *   Change the default remote configuration `pollFrequency` from `5m` to `30s`. (@TylerHelmuth)
 *   Add `CLUSTER_NAME` environment variable to remote-config-enabled collectors alongside `NAMESPACE` and `POD_NAME`. (#2775) (@petewall)
+*   Fix OTLP destinations deriving the wrong service identity for metrics converted from a Prometheus scrape. The conversion sets `service.name` to the full `job` label (e.g. `namespace/workload` from Grafana Beyla), breaking service-to-logs correlation in Application Observability. A new normalization step after `otelcol.receiver.prometheus` prefers the explicit `service_name` label; OTLP-native telemetry is unaffected. (#2783) (@mbaykara)
 
 ## 4.2.0
 

--- a/charts/k8s-monitoring/docs/examples/auth/oauth2/alloy-logs.alloy
+++ b/charts/k8s-monitoring/docs/examples/auth/oauth2/alloy-logs.alloy
@@ -357,6 +357,15 @@ otelcol.processor.transform "otel_endpoint_scrape_normalize" {
       // prefer that value and drop the duplicate.
       `set(attributes["service.name"], attributes["service_name"]) where attributes["service_name"] != nil and attributes["service_name"] != ""`,
       `delete_key(attributes, "service_name") where attributes["service_name"] == attributes["service.name"]`,
+      // The same conversion turns other flat target_info labels into resource attributes.
+      // Promote them to their OpenTelemetry counterparts and drop the flat duplicates, so
+      // the OTLP endpoint does not receive two conflicting spellings of the same attribute.
+      `set(attributes["service.namespace"], attributes["service_namespace"]) where (attributes["service.namespace"] == nil or attributes["service.namespace"] == "") and attributes["service_namespace"] != nil and attributes["service_namespace"] != ""`,
+      `delete_key(attributes, "service_namespace") where attributes["service_namespace"] == attributes["service.namespace"]`,
+      `set(attributes["deployment.environment"], attributes["deployment_environment"]) where (attributes["deployment.environment"] == nil or attributes["deployment.environment"] == "") and attributes["deployment_environment"] != nil and attributes["deployment_environment"] != ""`,
+      `delete_key(attributes, "deployment_environment") where attributes["deployment_environment"] == attributes["deployment.environment"]`,
+      `set(attributes["deployment.environment.name"], attributes["deployment_environment_name"]) where (attributes["deployment.environment.name"] == nil or attributes["deployment.environment.name"] == "") and attributes["deployment_environment_name"] != nil and attributes["deployment_environment_name"] != ""`,
+      `delete_key(attributes, "deployment_environment_name") where attributes["deployment_environment_name"] == attributes["deployment.environment.name"]`,
     ]
   }
   metric_statements {
@@ -407,6 +416,11 @@ otelcol.processor.transform "otel_endpoint" {
       `delete_key(attributes, "container.image.repo_digests")`,
       `delete_key(attributes, "os.description")`,
       `delete_key(attributes, "os.build_id")`,
+      // Scrape targets that expose their own target_info metric (e.g. Grafana Beyla) can
+      // carry a flat k8s_cluster_name resource attribute, which conflicts with the
+      // k8s.cluster.name attribute set above and gets ";"-joined by the Prometheus OTLP
+      // endpoint. Drop the flat copy when the values match.
+      `delete_key(attributes, "k8s_cluster_name") where attributes["k8s_cluster_name"] == attributes["k8s.cluster.name"]`,
     ]
   }
 

--- a/charts/k8s-monitoring/docs/examples/auth/oauth2/alloy-logs.alloy
+++ b/charts/k8s-monitoring/docs/examples/auth/oauth2/alloy-logs.alloy
@@ -339,9 +339,38 @@ pod_logs_via_loki "feature" {
 // Destination: otel-endpoint (otlp)
 otelcol.receiver.prometheus "otel_endpoint" {
   output {
-    metrics = [otelcol.processor.attributes.otel_endpoint.input]
+    metrics = [otelcol.processor.transform.otel_endpoint_scrape_normalize.input]
   }
 } // otelcol.receiver.prometheus "otel_endpoint"
+
+// Repairs artifacts of the Prometheus-to-OTLP conversion performed by
+// otelcol.receiver.prometheus. Only metrics that came from a Prometheus scrape pass
+// through this component; OTLP-native telemetry enters the pipeline further down.
+otelcol.processor.transform "otel_endpoint_scrape_normalize" {
+  error_mode = "ignore"
+  metric_statements {
+    context = "resource"
+    statements = [
+      // The conversion sets service.name to the full Prometheus job label (e.g.
+      // "namespace/workload"). When the scrape target declares its identity explicitly
+      // with a service_name label on its own target_info metric (e.g. Grafana Beyla),
+      // prefer that value and drop the duplicate.
+      `set(attributes["service.name"], attributes["service_name"]) where attributes["service_name"] != nil and attributes["service_name"] != ""`,
+      `delete_key(attributes, "service_name") where attributes["service_name"] == attributes["service.name"]`,
+    ]
+  }
+  metric_statements {
+    context = "datapoint"
+    statements = [
+      // Same correction for scrape targets that put service_name on every series
+      // instead of exposing a target_info metric.
+      `set(resource.attributes["service.name"], attributes["service_name"]) where attributes["service_name"] != nil and attributes["service_name"] != ""`,
+    ]
+  }
+  output {
+    metrics = [otelcol.processor.attributes.otel_endpoint.input]
+  }
+} // otelcol.processor.transform "otel_endpoint_scrape_normalize"
 otelcol.receiver.loki "otel_endpoint" {
   output {
     logs = [otelcol.processor.attributes.otel_endpoint.input]

--- a/charts/k8s-monitoring/docs/examples/auth/oauth2/alloy-metrics.alloy
+++ b/charts/k8s-monitoring/docs/examples/auth/oauth2/alloy-metrics.alloy
@@ -910,6 +910,15 @@ otelcol.processor.transform "otel_endpoint_scrape_normalize" {
       // prefer that value and drop the duplicate.
       `set(attributes["service.name"], attributes["service_name"]) where attributes["service_name"] != nil and attributes["service_name"] != ""`,
       `delete_key(attributes, "service_name") where attributes["service_name"] == attributes["service.name"]`,
+      // The same conversion turns other flat target_info labels into resource attributes.
+      // Promote them to their OpenTelemetry counterparts and drop the flat duplicates, so
+      // the OTLP endpoint does not receive two conflicting spellings of the same attribute.
+      `set(attributes["service.namespace"], attributes["service_namespace"]) where (attributes["service.namespace"] == nil or attributes["service.namespace"] == "") and attributes["service_namespace"] != nil and attributes["service_namespace"] != ""`,
+      `delete_key(attributes, "service_namespace") where attributes["service_namespace"] == attributes["service.namespace"]`,
+      `set(attributes["deployment.environment"], attributes["deployment_environment"]) where (attributes["deployment.environment"] == nil or attributes["deployment.environment"] == "") and attributes["deployment_environment"] != nil and attributes["deployment_environment"] != ""`,
+      `delete_key(attributes, "deployment_environment") where attributes["deployment_environment"] == attributes["deployment.environment"]`,
+      `set(attributes["deployment.environment.name"], attributes["deployment_environment_name"]) where (attributes["deployment.environment.name"] == nil or attributes["deployment.environment.name"] == "") and attributes["deployment_environment_name"] != nil and attributes["deployment_environment_name"] != ""`,
+      `delete_key(attributes, "deployment_environment_name") where attributes["deployment_environment_name"] == attributes["deployment.environment.name"]`,
     ]
   }
   metric_statements {
@@ -960,6 +969,11 @@ otelcol.processor.transform "otel_endpoint" {
       `delete_key(attributes, "container.image.repo_digests")`,
       `delete_key(attributes, "os.description")`,
       `delete_key(attributes, "os.build_id")`,
+      // Scrape targets that expose their own target_info metric (e.g. Grafana Beyla) can
+      // carry a flat k8s_cluster_name resource attribute, which conflicts with the
+      // k8s.cluster.name attribute set above and gets ";"-joined by the Prometheus OTLP
+      // endpoint. Drop the flat copy when the values match.
+      `delete_key(attributes, "k8s_cluster_name") where attributes["k8s_cluster_name"] == attributes["k8s.cluster.name"]`,
     ]
   }
 

--- a/charts/k8s-monitoring/docs/examples/auth/oauth2/alloy-metrics.alloy
+++ b/charts/k8s-monitoring/docs/examples/auth/oauth2/alloy-metrics.alloy
@@ -892,9 +892,38 @@ prometheus_operator_objects "feature" {
 // Destination: otel-endpoint (otlp)
 otelcol.receiver.prometheus "otel_endpoint" {
   output {
-    metrics = [otelcol.processor.attributes.otel_endpoint.input]
+    metrics = [otelcol.processor.transform.otel_endpoint_scrape_normalize.input]
   }
 } // otelcol.receiver.prometheus "otel_endpoint"
+
+// Repairs artifacts of the Prometheus-to-OTLP conversion performed by
+// otelcol.receiver.prometheus. Only metrics that came from a Prometheus scrape pass
+// through this component; OTLP-native telemetry enters the pipeline further down.
+otelcol.processor.transform "otel_endpoint_scrape_normalize" {
+  error_mode = "ignore"
+  metric_statements {
+    context = "resource"
+    statements = [
+      // The conversion sets service.name to the full Prometheus job label (e.g.
+      // "namespace/workload"). When the scrape target declares its identity explicitly
+      // with a service_name label on its own target_info metric (e.g. Grafana Beyla),
+      // prefer that value and drop the duplicate.
+      `set(attributes["service.name"], attributes["service_name"]) where attributes["service_name"] != nil and attributes["service_name"] != ""`,
+      `delete_key(attributes, "service_name") where attributes["service_name"] == attributes["service.name"]`,
+    ]
+  }
+  metric_statements {
+    context = "datapoint"
+    statements = [
+      // Same correction for scrape targets that put service_name on every series
+      // instead of exposing a target_info metric.
+      `set(resource.attributes["service.name"], attributes["service_name"]) where attributes["service_name"] != nil and attributes["service_name"] != ""`,
+    ]
+  }
+  output {
+    metrics = [otelcol.processor.attributes.otel_endpoint.input]
+  }
+} // otelcol.processor.transform "otel_endpoint_scrape_normalize"
 otelcol.receiver.loki "otel_endpoint" {
   output {
     logs = [otelcol.processor.attributes.otel_endpoint.input]

--- a/charts/k8s-monitoring/docs/examples/auth/oauth2/alloy-singleton.alloy
+++ b/charts/k8s-monitoring/docs/examples/auth/oauth2/alloy-singleton.alloy
@@ -149,6 +149,15 @@ otelcol.processor.transform "otel_endpoint_scrape_normalize" {
       // prefer that value and drop the duplicate.
       `set(attributes["service.name"], attributes["service_name"]) where attributes["service_name"] != nil and attributes["service_name"] != ""`,
       `delete_key(attributes, "service_name") where attributes["service_name"] == attributes["service.name"]`,
+      // The same conversion turns other flat target_info labels into resource attributes.
+      // Promote them to their OpenTelemetry counterparts and drop the flat duplicates, so
+      // the OTLP endpoint does not receive two conflicting spellings of the same attribute.
+      `set(attributes["service.namespace"], attributes["service_namespace"]) where (attributes["service.namespace"] == nil or attributes["service.namespace"] == "") and attributes["service_namespace"] != nil and attributes["service_namespace"] != ""`,
+      `delete_key(attributes, "service_namespace") where attributes["service_namespace"] == attributes["service.namespace"]`,
+      `set(attributes["deployment.environment"], attributes["deployment_environment"]) where (attributes["deployment.environment"] == nil or attributes["deployment.environment"] == "") and attributes["deployment_environment"] != nil and attributes["deployment_environment"] != ""`,
+      `delete_key(attributes, "deployment_environment") where attributes["deployment_environment"] == attributes["deployment.environment"]`,
+      `set(attributes["deployment.environment.name"], attributes["deployment_environment_name"]) where (attributes["deployment.environment.name"] == nil or attributes["deployment.environment.name"] == "") and attributes["deployment_environment_name"] != nil and attributes["deployment_environment_name"] != ""`,
+      `delete_key(attributes, "deployment_environment_name") where attributes["deployment_environment_name"] == attributes["deployment.environment.name"]`,
     ]
   }
   metric_statements {
@@ -199,6 +208,11 @@ otelcol.processor.transform "otel_endpoint" {
       `delete_key(attributes, "container.image.repo_digests")`,
       `delete_key(attributes, "os.description")`,
       `delete_key(attributes, "os.build_id")`,
+      // Scrape targets that expose their own target_info metric (e.g. Grafana Beyla) can
+      // carry a flat k8s_cluster_name resource attribute, which conflicts with the
+      // k8s.cluster.name attribute set above and gets ";"-joined by the Prometheus OTLP
+      // endpoint. Drop the flat copy when the values match.
+      `delete_key(attributes, "k8s_cluster_name") where attributes["k8s_cluster_name"] == attributes["k8s.cluster.name"]`,
     ]
   }
 

--- a/charts/k8s-monitoring/docs/examples/auth/oauth2/alloy-singleton.alloy
+++ b/charts/k8s-monitoring/docs/examples/auth/oauth2/alloy-singleton.alloy
@@ -131,9 +131,38 @@ prometheus.relabel "kubernetes_monitoring_telemetry" {
 // Destination: otel-endpoint (otlp)
 otelcol.receiver.prometheus "otel_endpoint" {
   output {
-    metrics = [otelcol.processor.attributes.otel_endpoint.input]
+    metrics = [otelcol.processor.transform.otel_endpoint_scrape_normalize.input]
   }
 } // otelcol.receiver.prometheus "otel_endpoint"
+
+// Repairs artifacts of the Prometheus-to-OTLP conversion performed by
+// otelcol.receiver.prometheus. Only metrics that came from a Prometheus scrape pass
+// through this component; OTLP-native telemetry enters the pipeline further down.
+otelcol.processor.transform "otel_endpoint_scrape_normalize" {
+  error_mode = "ignore"
+  metric_statements {
+    context = "resource"
+    statements = [
+      // The conversion sets service.name to the full Prometheus job label (e.g.
+      // "namespace/workload"). When the scrape target declares its identity explicitly
+      // with a service_name label on its own target_info metric (e.g. Grafana Beyla),
+      // prefer that value and drop the duplicate.
+      `set(attributes["service.name"], attributes["service_name"]) where attributes["service_name"] != nil and attributes["service_name"] != ""`,
+      `delete_key(attributes, "service_name") where attributes["service_name"] == attributes["service.name"]`,
+    ]
+  }
+  metric_statements {
+    context = "datapoint"
+    statements = [
+      // Same correction for scrape targets that put service_name on every series
+      // instead of exposing a target_info metric.
+      `set(resource.attributes["service.name"], attributes["service_name"]) where attributes["service_name"] != nil and attributes["service_name"] != ""`,
+    ]
+  }
+  output {
+    metrics = [otelcol.processor.attributes.otel_endpoint.input]
+  }
+} // otelcol.processor.transform "otel_endpoint_scrape_normalize"
 otelcol.receiver.loki "otel_endpoint" {
   output {
     logs = [otelcol.processor.attributes.otel_endpoint.input]

--- a/charts/k8s-monitoring/docs/examples/auth/oauth2/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/auth/oauth2/output.yaml
@@ -463,6 +463,15 @@ data:
           // prefer that value and drop the duplicate.
           `set(attributes["service.name"], attributes["service_name"]) where attributes["service_name"] != nil and attributes["service_name"] != ""`,
           `delete_key(attributes, "service_name") where attributes["service_name"] == attributes["service.name"]`,
+          // The same conversion turns other flat target_info labels into resource attributes.
+          // Promote them to their OpenTelemetry counterparts and drop the flat duplicates, so
+          // the OTLP endpoint does not receive two conflicting spellings of the same attribute.
+          `set(attributes["service.namespace"], attributes["service_namespace"]) where (attributes["service.namespace"] == nil or attributes["service.namespace"] == "") and attributes["service_namespace"] != nil and attributes["service_namespace"] != ""`,
+          `delete_key(attributes, "service_namespace") where attributes["service_namespace"] == attributes["service.namespace"]`,
+          `set(attributes["deployment.environment"], attributes["deployment_environment"]) where (attributes["deployment.environment"] == nil or attributes["deployment.environment"] == "") and attributes["deployment_environment"] != nil and attributes["deployment_environment"] != ""`,
+          `delete_key(attributes, "deployment_environment") where attributes["deployment_environment"] == attributes["deployment.environment"]`,
+          `set(attributes["deployment.environment.name"], attributes["deployment_environment_name"]) where (attributes["deployment.environment.name"] == nil or attributes["deployment.environment.name"] == "") and attributes["deployment_environment_name"] != nil and attributes["deployment_environment_name"] != ""`,
+          `delete_key(attributes, "deployment_environment_name") where attributes["deployment_environment_name"] == attributes["deployment.environment.name"]`,
         ]
       }
       metric_statements {
@@ -513,6 +522,11 @@ data:
           `delete_key(attributes, "container.image.repo_digests")`,
           `delete_key(attributes, "os.description")`,
           `delete_key(attributes, "os.build_id")`,
+          // Scrape targets that expose their own target_info metric (e.g. Grafana Beyla) can
+          // carry a flat k8s_cluster_name resource attribute, which conflicts with the
+          // k8s.cluster.name attribute set above and gets ";"-joined by the Prometheus OTLP
+          // endpoint. Drop the flat copy when the values match.
+          `delete_key(attributes, "k8s_cluster_name") where attributes["k8s_cluster_name"] == attributes["k8s.cluster.name"]`,
         ]
       }
     
@@ -1591,6 +1605,15 @@ data:
           // prefer that value and drop the duplicate.
           `set(attributes["service.name"], attributes["service_name"]) where attributes["service_name"] != nil and attributes["service_name"] != ""`,
           `delete_key(attributes, "service_name") where attributes["service_name"] == attributes["service.name"]`,
+          // The same conversion turns other flat target_info labels into resource attributes.
+          // Promote them to their OpenTelemetry counterparts and drop the flat duplicates, so
+          // the OTLP endpoint does not receive two conflicting spellings of the same attribute.
+          `set(attributes["service.namespace"], attributes["service_namespace"]) where (attributes["service.namespace"] == nil or attributes["service.namespace"] == "") and attributes["service_namespace"] != nil and attributes["service_namespace"] != ""`,
+          `delete_key(attributes, "service_namespace") where attributes["service_namespace"] == attributes["service.namespace"]`,
+          `set(attributes["deployment.environment"], attributes["deployment_environment"]) where (attributes["deployment.environment"] == nil or attributes["deployment.environment"] == "") and attributes["deployment_environment"] != nil and attributes["deployment_environment"] != ""`,
+          `delete_key(attributes, "deployment_environment") where attributes["deployment_environment"] == attributes["deployment.environment"]`,
+          `set(attributes["deployment.environment.name"], attributes["deployment_environment_name"]) where (attributes["deployment.environment.name"] == nil or attributes["deployment.environment.name"] == "") and attributes["deployment_environment_name"] != nil and attributes["deployment_environment_name"] != ""`,
+          `delete_key(attributes, "deployment_environment_name") where attributes["deployment_environment_name"] == attributes["deployment.environment.name"]`,
         ]
       }
       metric_statements {
@@ -1641,6 +1664,11 @@ data:
           `delete_key(attributes, "container.image.repo_digests")`,
           `delete_key(attributes, "os.description")`,
           `delete_key(attributes, "os.build_id")`,
+          // Scrape targets that expose their own target_info metric (e.g. Grafana Beyla) can
+          // carry a flat k8s_cluster_name resource attribute, which conflicts with the
+          // k8s.cluster.name attribute set above and gets ";"-joined by the Prometheus OTLP
+          // endpoint. Drop the flat copy when the values match.
+          `delete_key(attributes, "k8s_cluster_name") where attributes["k8s_cluster_name"] == attributes["k8s.cluster.name"]`,
         ]
       }
     
@@ -1958,6 +1986,15 @@ data:
           // prefer that value and drop the duplicate.
           `set(attributes["service.name"], attributes["service_name"]) where attributes["service_name"] != nil and attributes["service_name"] != ""`,
           `delete_key(attributes, "service_name") where attributes["service_name"] == attributes["service.name"]`,
+          // The same conversion turns other flat target_info labels into resource attributes.
+          // Promote them to their OpenTelemetry counterparts and drop the flat duplicates, so
+          // the OTLP endpoint does not receive two conflicting spellings of the same attribute.
+          `set(attributes["service.namespace"], attributes["service_namespace"]) where (attributes["service.namespace"] == nil or attributes["service.namespace"] == "") and attributes["service_namespace"] != nil and attributes["service_namespace"] != ""`,
+          `delete_key(attributes, "service_namespace") where attributes["service_namespace"] == attributes["service.namespace"]`,
+          `set(attributes["deployment.environment"], attributes["deployment_environment"]) where (attributes["deployment.environment"] == nil or attributes["deployment.environment"] == "") and attributes["deployment_environment"] != nil and attributes["deployment_environment"] != ""`,
+          `delete_key(attributes, "deployment_environment") where attributes["deployment_environment"] == attributes["deployment.environment"]`,
+          `set(attributes["deployment.environment.name"], attributes["deployment_environment_name"]) where (attributes["deployment.environment.name"] == nil or attributes["deployment.environment.name"] == "") and attributes["deployment_environment_name"] != nil and attributes["deployment_environment_name"] != ""`,
+          `delete_key(attributes, "deployment_environment_name") where attributes["deployment_environment_name"] == attributes["deployment.environment.name"]`,
         ]
       }
       metric_statements {
@@ -2008,6 +2045,11 @@ data:
           `delete_key(attributes, "container.image.repo_digests")`,
           `delete_key(attributes, "os.description")`,
           `delete_key(attributes, "os.build_id")`,
+          // Scrape targets that expose their own target_info metric (e.g. Grafana Beyla) can
+          // carry a flat k8s_cluster_name resource attribute, which conflicts with the
+          // k8s.cluster.name attribute set above and gets ";"-joined by the Prometheus OTLP
+          // endpoint. Drop the flat copy when the values match.
+          `delete_key(attributes, "k8s_cluster_name") where attributes["k8s_cluster_name"] == attributes["k8s.cluster.name"]`,
         ]
       }
     

--- a/charts/k8s-monitoring/docs/examples/auth/oauth2/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/auth/oauth2/output.yaml
@@ -445,9 +445,38 @@ data:
     // Destination: otel-endpoint (otlp)
     otelcol.receiver.prometheus "otel_endpoint" {
       output {
-        metrics = [otelcol.processor.attributes.otel_endpoint.input]
+        metrics = [otelcol.processor.transform.otel_endpoint_scrape_normalize.input]
       }
     } // otelcol.receiver.prometheus "otel_endpoint"
+    
+    // Repairs artifacts of the Prometheus-to-OTLP conversion performed by
+    // otelcol.receiver.prometheus. Only metrics that came from a Prometheus scrape pass
+    // through this component; OTLP-native telemetry enters the pipeline further down.
+    otelcol.processor.transform "otel_endpoint_scrape_normalize" {
+      error_mode = "ignore"
+      metric_statements {
+        context = "resource"
+        statements = [
+          // The conversion sets service.name to the full Prometheus job label (e.g.
+          // "namespace/workload"). When the scrape target declares its identity explicitly
+          // with a service_name label on its own target_info metric (e.g. Grafana Beyla),
+          // prefer that value and drop the duplicate.
+          `set(attributes["service.name"], attributes["service_name"]) where attributes["service_name"] != nil and attributes["service_name"] != ""`,
+          `delete_key(attributes, "service_name") where attributes["service_name"] == attributes["service.name"]`,
+        ]
+      }
+      metric_statements {
+        context = "datapoint"
+        statements = [
+          // Same correction for scrape targets that put service_name on every series
+          // instead of exposing a target_info metric.
+          `set(resource.attributes["service.name"], attributes["service_name"]) where attributes["service_name"] != nil and attributes["service_name"] != ""`,
+        ]
+      }
+      output {
+        metrics = [otelcol.processor.attributes.otel_endpoint.input]
+      }
+    } // otelcol.processor.transform "otel_endpoint_scrape_normalize"
     otelcol.receiver.loki "otel_endpoint" {
       output {
         logs = [otelcol.processor.attributes.otel_endpoint.input]
@@ -1544,9 +1573,38 @@ data:
     // Destination: otel-endpoint (otlp)
     otelcol.receiver.prometheus "otel_endpoint" {
       output {
-        metrics = [otelcol.processor.attributes.otel_endpoint.input]
+        metrics = [otelcol.processor.transform.otel_endpoint_scrape_normalize.input]
       }
     } // otelcol.receiver.prometheus "otel_endpoint"
+    
+    // Repairs artifacts of the Prometheus-to-OTLP conversion performed by
+    // otelcol.receiver.prometheus. Only metrics that came from a Prometheus scrape pass
+    // through this component; OTLP-native telemetry enters the pipeline further down.
+    otelcol.processor.transform "otel_endpoint_scrape_normalize" {
+      error_mode = "ignore"
+      metric_statements {
+        context = "resource"
+        statements = [
+          // The conversion sets service.name to the full Prometheus job label (e.g.
+          // "namespace/workload"). When the scrape target declares its identity explicitly
+          // with a service_name label on its own target_info metric (e.g. Grafana Beyla),
+          // prefer that value and drop the duplicate.
+          `set(attributes["service.name"], attributes["service_name"]) where attributes["service_name"] != nil and attributes["service_name"] != ""`,
+          `delete_key(attributes, "service_name") where attributes["service_name"] == attributes["service.name"]`,
+        ]
+      }
+      metric_statements {
+        context = "datapoint"
+        statements = [
+          // Same correction for scrape targets that put service_name on every series
+          // instead of exposing a target_info metric.
+          `set(resource.attributes["service.name"], attributes["service_name"]) where attributes["service_name"] != nil and attributes["service_name"] != ""`,
+        ]
+      }
+      output {
+        metrics = [otelcol.processor.attributes.otel_endpoint.input]
+      }
+    } // otelcol.processor.transform "otel_endpoint_scrape_normalize"
     otelcol.receiver.loki "otel_endpoint" {
       output {
         logs = [otelcol.processor.attributes.otel_endpoint.input]
@@ -1882,9 +1940,38 @@ data:
     // Destination: otel-endpoint (otlp)
     otelcol.receiver.prometheus "otel_endpoint" {
       output {
-        metrics = [otelcol.processor.attributes.otel_endpoint.input]
+        metrics = [otelcol.processor.transform.otel_endpoint_scrape_normalize.input]
       }
     } // otelcol.receiver.prometheus "otel_endpoint"
+    
+    // Repairs artifacts of the Prometheus-to-OTLP conversion performed by
+    // otelcol.receiver.prometheus. Only metrics that came from a Prometheus scrape pass
+    // through this component; OTLP-native telemetry enters the pipeline further down.
+    otelcol.processor.transform "otel_endpoint_scrape_normalize" {
+      error_mode = "ignore"
+      metric_statements {
+        context = "resource"
+        statements = [
+          // The conversion sets service.name to the full Prometheus job label (e.g.
+          // "namespace/workload"). When the scrape target declares its identity explicitly
+          // with a service_name label on its own target_info metric (e.g. Grafana Beyla),
+          // prefer that value and drop the duplicate.
+          `set(attributes["service.name"], attributes["service_name"]) where attributes["service_name"] != nil and attributes["service_name"] != ""`,
+          `delete_key(attributes, "service_name") where attributes["service_name"] == attributes["service.name"]`,
+        ]
+      }
+      metric_statements {
+        context = "datapoint"
+        statements = [
+          // Same correction for scrape targets that put service_name on every series
+          // instead of exposing a target_info metric.
+          `set(resource.attributes["service.name"], attributes["service_name"]) where attributes["service_name"] != nil and attributes["service_name"] != ""`,
+        ]
+      }
+      output {
+        metrics = [otelcol.processor.attributes.otel_endpoint.input]
+      }
+    } // otelcol.processor.transform "otel_endpoint_scrape_normalize"
     otelcol.receiver.loki "otel_endpoint" {
       output {
         logs = [otelcol.processor.attributes.otel_endpoint.input]

--- a/charts/k8s-monitoring/docs/examples/destinations/otlp-endpoint/alloy-logs.alloy
+++ b/charts/k8s-monitoring/docs/examples/destinations/otlp-endpoint/alloy-logs.alloy
@@ -227,6 +227,15 @@ otelcol.processor.transform "otlp_gateway_scrape_normalize" {
       // prefer that value and drop the duplicate.
       `set(attributes["service.name"], attributes["service_name"]) where attributes["service_name"] != nil and attributes["service_name"] != ""`,
       `delete_key(attributes, "service_name") where attributes["service_name"] == attributes["service.name"]`,
+      // The same conversion turns other flat target_info labels into resource attributes.
+      // Promote them to their OpenTelemetry counterparts and drop the flat duplicates, so
+      // the OTLP endpoint does not receive two conflicting spellings of the same attribute.
+      `set(attributes["service.namespace"], attributes["service_namespace"]) where (attributes["service.namespace"] == nil or attributes["service.namespace"] == "") and attributes["service_namespace"] != nil and attributes["service_namespace"] != ""`,
+      `delete_key(attributes, "service_namespace") where attributes["service_namespace"] == attributes["service.namespace"]`,
+      `set(attributes["deployment.environment"], attributes["deployment_environment"]) where (attributes["deployment.environment"] == nil or attributes["deployment.environment"] == "") and attributes["deployment_environment"] != nil and attributes["deployment_environment"] != ""`,
+      `delete_key(attributes, "deployment_environment") where attributes["deployment_environment"] == attributes["deployment.environment"]`,
+      `set(attributes["deployment.environment.name"], attributes["deployment_environment_name"]) where (attributes["deployment.environment.name"] == nil or attributes["deployment.environment.name"] == "") and attributes["deployment_environment_name"] != nil and attributes["deployment_environment_name"] != ""`,
+      `delete_key(attributes, "deployment_environment_name") where attributes["deployment_environment_name"] == attributes["deployment.environment.name"]`,
     ]
   }
   metric_statements {
@@ -277,6 +286,11 @@ otelcol.processor.transform "otlp_gateway" {
       `delete_key(attributes, "container.image.repo_digests")`,
       `delete_key(attributes, "os.description")`,
       `delete_key(attributes, "os.build_id")`,
+      // Scrape targets that expose their own target_info metric (e.g. Grafana Beyla) can
+      // carry a flat k8s_cluster_name resource attribute, which conflicts with the
+      // k8s.cluster.name attribute set above and gets ";"-joined by the Prometheus OTLP
+      // endpoint. Drop the flat copy when the values match.
+      `delete_key(attributes, "k8s_cluster_name") where attributes["k8s_cluster_name"] == attributes["k8s.cluster.name"]`,
     ]
   }
 

--- a/charts/k8s-monitoring/docs/examples/destinations/otlp-endpoint/alloy-logs.alloy
+++ b/charts/k8s-monitoring/docs/examples/destinations/otlp-endpoint/alloy-logs.alloy
@@ -209,9 +209,38 @@ otelcol.storage.file "otlp_gateway_queue_storage" {
 // Destination: otlp-gateway (otlp)
 otelcol.receiver.prometheus "otlp_gateway" {
   output {
-    metrics = [otelcol.processor.attributes.otlp_gateway.input]
+    metrics = [otelcol.processor.transform.otlp_gateway_scrape_normalize.input]
   }
 } // otelcol.receiver.prometheus "otlp_gateway"
+
+// Repairs artifacts of the Prometheus-to-OTLP conversion performed by
+// otelcol.receiver.prometheus. Only metrics that came from a Prometheus scrape pass
+// through this component; OTLP-native telemetry enters the pipeline further down.
+otelcol.processor.transform "otlp_gateway_scrape_normalize" {
+  error_mode = "ignore"
+  metric_statements {
+    context = "resource"
+    statements = [
+      // The conversion sets service.name to the full Prometheus job label (e.g.
+      // "namespace/workload"). When the scrape target declares its identity explicitly
+      // with a service_name label on its own target_info metric (e.g. Grafana Beyla),
+      // prefer that value and drop the duplicate.
+      `set(attributes["service.name"], attributes["service_name"]) where attributes["service_name"] != nil and attributes["service_name"] != ""`,
+      `delete_key(attributes, "service_name") where attributes["service_name"] == attributes["service.name"]`,
+    ]
+  }
+  metric_statements {
+    context = "datapoint"
+    statements = [
+      // Same correction for scrape targets that put service_name on every series
+      // instead of exposing a target_info metric.
+      `set(resource.attributes["service.name"], attributes["service_name"]) where attributes["service_name"] != nil and attributes["service_name"] != ""`,
+    ]
+  }
+  output {
+    metrics = [otelcol.processor.attributes.otlp_gateway.input]
+  }
+} // otelcol.processor.transform "otlp_gateway_scrape_normalize"
 otelcol.receiver.loki "otlp_gateway" {
   output {
     logs = [otelcol.processor.attributes.otlp_gateway.input]

--- a/charts/k8s-monitoring/docs/examples/destinations/otlp-endpoint/alloy-metrics.alloy
+++ b/charts/k8s-monitoring/docs/examples/destinations/otlp-endpoint/alloy-metrics.alloy
@@ -545,9 +545,38 @@ otelcol.storage.file "otlp_gateway_queue_storage" {
 // Destination: otlp-gateway (otlp)
 otelcol.receiver.prometheus "otlp_gateway" {
   output {
-    metrics = [otelcol.processor.attributes.otlp_gateway.input]
+    metrics = [otelcol.processor.transform.otlp_gateway_scrape_normalize.input]
   }
 } // otelcol.receiver.prometheus "otlp_gateway"
+
+// Repairs artifacts of the Prometheus-to-OTLP conversion performed by
+// otelcol.receiver.prometheus. Only metrics that came from a Prometheus scrape pass
+// through this component; OTLP-native telemetry enters the pipeline further down.
+otelcol.processor.transform "otlp_gateway_scrape_normalize" {
+  error_mode = "ignore"
+  metric_statements {
+    context = "resource"
+    statements = [
+      // The conversion sets service.name to the full Prometheus job label (e.g.
+      // "namespace/workload"). When the scrape target declares its identity explicitly
+      // with a service_name label on its own target_info metric (e.g. Grafana Beyla),
+      // prefer that value and drop the duplicate.
+      `set(attributes["service.name"], attributes["service_name"]) where attributes["service_name"] != nil and attributes["service_name"] != ""`,
+      `delete_key(attributes, "service_name") where attributes["service_name"] == attributes["service.name"]`,
+    ]
+  }
+  metric_statements {
+    context = "datapoint"
+    statements = [
+      // Same correction for scrape targets that put service_name on every series
+      // instead of exposing a target_info metric.
+      `set(resource.attributes["service.name"], attributes["service_name"]) where attributes["service_name"] != nil and attributes["service_name"] != ""`,
+    ]
+  }
+  output {
+    metrics = [otelcol.processor.attributes.otlp_gateway.input]
+  }
+} // otelcol.processor.transform "otlp_gateway_scrape_normalize"
 otelcol.receiver.loki "otlp_gateway" {
   output {
     logs = [otelcol.processor.attributes.otlp_gateway.input]

--- a/charts/k8s-monitoring/docs/examples/destinations/otlp-endpoint/alloy-metrics.alloy
+++ b/charts/k8s-monitoring/docs/examples/destinations/otlp-endpoint/alloy-metrics.alloy
@@ -563,6 +563,15 @@ otelcol.processor.transform "otlp_gateway_scrape_normalize" {
       // prefer that value and drop the duplicate.
       `set(attributes["service.name"], attributes["service_name"]) where attributes["service_name"] != nil and attributes["service_name"] != ""`,
       `delete_key(attributes, "service_name") where attributes["service_name"] == attributes["service.name"]`,
+      // The same conversion turns other flat target_info labels into resource attributes.
+      // Promote them to their OpenTelemetry counterparts and drop the flat duplicates, so
+      // the OTLP endpoint does not receive two conflicting spellings of the same attribute.
+      `set(attributes["service.namespace"], attributes["service_namespace"]) where (attributes["service.namespace"] == nil or attributes["service.namespace"] == "") and attributes["service_namespace"] != nil and attributes["service_namespace"] != ""`,
+      `delete_key(attributes, "service_namespace") where attributes["service_namespace"] == attributes["service.namespace"]`,
+      `set(attributes["deployment.environment"], attributes["deployment_environment"]) where (attributes["deployment.environment"] == nil or attributes["deployment.environment"] == "") and attributes["deployment_environment"] != nil and attributes["deployment_environment"] != ""`,
+      `delete_key(attributes, "deployment_environment") where attributes["deployment_environment"] == attributes["deployment.environment"]`,
+      `set(attributes["deployment.environment.name"], attributes["deployment_environment_name"]) where (attributes["deployment.environment.name"] == nil or attributes["deployment.environment.name"] == "") and attributes["deployment_environment_name"] != nil and attributes["deployment_environment_name"] != ""`,
+      `delete_key(attributes, "deployment_environment_name") where attributes["deployment_environment_name"] == attributes["deployment.environment.name"]`,
     ]
   }
   metric_statements {
@@ -613,6 +622,11 @@ otelcol.processor.transform "otlp_gateway" {
       `delete_key(attributes, "container.image.repo_digests")`,
       `delete_key(attributes, "os.description")`,
       `delete_key(attributes, "os.build_id")`,
+      // Scrape targets that expose their own target_info metric (e.g. Grafana Beyla) can
+      // carry a flat k8s_cluster_name resource attribute, which conflicts with the
+      // k8s.cluster.name attribute set above and gets ";"-joined by the Prometheus OTLP
+      // endpoint. Drop the flat copy when the values match.
+      `delete_key(attributes, "k8s_cluster_name") where attributes["k8s_cluster_name"] == attributes["k8s.cluster.name"]`,
     ]
   }
 

--- a/charts/k8s-monitoring/docs/examples/destinations/otlp-endpoint/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/destinations/otlp-endpoint/output.yaml
@@ -316,9 +316,38 @@ data:
     // Destination: otlp-gateway (otlp)
     otelcol.receiver.prometheus "otlp_gateway" {
       output {
-        metrics = [otelcol.processor.attributes.otlp_gateway.input]
+        metrics = [otelcol.processor.transform.otlp_gateway_scrape_normalize.input]
       }
     } // otelcol.receiver.prometheus "otlp_gateway"
+    
+    // Repairs artifacts of the Prometheus-to-OTLP conversion performed by
+    // otelcol.receiver.prometheus. Only metrics that came from a Prometheus scrape pass
+    // through this component; OTLP-native telemetry enters the pipeline further down.
+    otelcol.processor.transform "otlp_gateway_scrape_normalize" {
+      error_mode = "ignore"
+      metric_statements {
+        context = "resource"
+        statements = [
+          // The conversion sets service.name to the full Prometheus job label (e.g.
+          // "namespace/workload"). When the scrape target declares its identity explicitly
+          // with a service_name label on its own target_info metric (e.g. Grafana Beyla),
+          // prefer that value and drop the duplicate.
+          `set(attributes["service.name"], attributes["service_name"]) where attributes["service_name"] != nil and attributes["service_name"] != ""`,
+          `delete_key(attributes, "service_name") where attributes["service_name"] == attributes["service.name"]`,
+        ]
+      }
+      metric_statements {
+        context = "datapoint"
+        statements = [
+          // Same correction for scrape targets that put service_name on every series
+          // instead of exposing a target_info metric.
+          `set(resource.attributes["service.name"], attributes["service_name"]) where attributes["service_name"] != nil and attributes["service_name"] != ""`,
+        ]
+      }
+      output {
+        metrics = [otelcol.processor.attributes.otlp_gateway.input]
+      }
+    } // otelcol.processor.transform "otlp_gateway_scrape_normalize"
     otelcol.receiver.loki "otlp_gateway" {
       output {
         logs = [otelcol.processor.attributes.otlp_gateway.input]
@@ -1070,9 +1099,38 @@ data:
     // Destination: otlp-gateway (otlp)
     otelcol.receiver.prometheus "otlp_gateway" {
       output {
-        metrics = [otelcol.processor.attributes.otlp_gateway.input]
+        metrics = [otelcol.processor.transform.otlp_gateway_scrape_normalize.input]
       }
     } // otelcol.receiver.prometheus "otlp_gateway"
+    
+    // Repairs artifacts of the Prometheus-to-OTLP conversion performed by
+    // otelcol.receiver.prometheus. Only metrics that came from a Prometheus scrape pass
+    // through this component; OTLP-native telemetry enters the pipeline further down.
+    otelcol.processor.transform "otlp_gateway_scrape_normalize" {
+      error_mode = "ignore"
+      metric_statements {
+        context = "resource"
+        statements = [
+          // The conversion sets service.name to the full Prometheus job label (e.g.
+          // "namespace/workload"). When the scrape target declares its identity explicitly
+          // with a service_name label on its own target_info metric (e.g. Grafana Beyla),
+          // prefer that value and drop the duplicate.
+          `set(attributes["service.name"], attributes["service_name"]) where attributes["service_name"] != nil and attributes["service_name"] != ""`,
+          `delete_key(attributes, "service_name") where attributes["service_name"] == attributes["service.name"]`,
+        ]
+      }
+      metric_statements {
+        context = "datapoint"
+        statements = [
+          // Same correction for scrape targets that put service_name on every series
+          // instead of exposing a target_info metric.
+          `set(resource.attributes["service.name"], attributes["service_name"]) where attributes["service_name"] != nil and attributes["service_name"] != ""`,
+        ]
+      }
+      output {
+        metrics = [otelcol.processor.attributes.otlp_gateway.input]
+      }
+    } // otelcol.processor.transform "otlp_gateway_scrape_normalize"
     otelcol.receiver.loki "otlp_gateway" {
       output {
         logs = [otelcol.processor.attributes.otlp_gateway.input]

--- a/charts/k8s-monitoring/docs/examples/destinations/otlp-endpoint/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/destinations/otlp-endpoint/output.yaml
@@ -334,6 +334,15 @@ data:
           // prefer that value and drop the duplicate.
           `set(attributes["service.name"], attributes["service_name"]) where attributes["service_name"] != nil and attributes["service_name"] != ""`,
           `delete_key(attributes, "service_name") where attributes["service_name"] == attributes["service.name"]`,
+          // The same conversion turns other flat target_info labels into resource attributes.
+          // Promote them to their OpenTelemetry counterparts and drop the flat duplicates, so
+          // the OTLP endpoint does not receive two conflicting spellings of the same attribute.
+          `set(attributes["service.namespace"], attributes["service_namespace"]) where (attributes["service.namespace"] == nil or attributes["service.namespace"] == "") and attributes["service_namespace"] != nil and attributes["service_namespace"] != ""`,
+          `delete_key(attributes, "service_namespace") where attributes["service_namespace"] == attributes["service.namespace"]`,
+          `set(attributes["deployment.environment"], attributes["deployment_environment"]) where (attributes["deployment.environment"] == nil or attributes["deployment.environment"] == "") and attributes["deployment_environment"] != nil and attributes["deployment_environment"] != ""`,
+          `delete_key(attributes, "deployment_environment") where attributes["deployment_environment"] == attributes["deployment.environment"]`,
+          `set(attributes["deployment.environment.name"], attributes["deployment_environment_name"]) where (attributes["deployment.environment.name"] == nil or attributes["deployment.environment.name"] == "") and attributes["deployment_environment_name"] != nil and attributes["deployment_environment_name"] != ""`,
+          `delete_key(attributes, "deployment_environment_name") where attributes["deployment_environment_name"] == attributes["deployment.environment.name"]`,
         ]
       }
       metric_statements {
@@ -384,6 +393,11 @@ data:
           `delete_key(attributes, "container.image.repo_digests")`,
           `delete_key(attributes, "os.description")`,
           `delete_key(attributes, "os.build_id")`,
+          // Scrape targets that expose their own target_info metric (e.g. Grafana Beyla) can
+          // carry a flat k8s_cluster_name resource attribute, which conflicts with the
+          // k8s.cluster.name attribute set above and gets ";"-joined by the Prometheus OTLP
+          // endpoint. Drop the flat copy when the values match.
+          `delete_key(attributes, "k8s_cluster_name") where attributes["k8s_cluster_name"] == attributes["k8s.cluster.name"]`,
         ]
       }
     
@@ -1117,6 +1131,15 @@ data:
           // prefer that value and drop the duplicate.
           `set(attributes["service.name"], attributes["service_name"]) where attributes["service_name"] != nil and attributes["service_name"] != ""`,
           `delete_key(attributes, "service_name") where attributes["service_name"] == attributes["service.name"]`,
+          // The same conversion turns other flat target_info labels into resource attributes.
+          // Promote them to their OpenTelemetry counterparts and drop the flat duplicates, so
+          // the OTLP endpoint does not receive two conflicting spellings of the same attribute.
+          `set(attributes["service.namespace"], attributes["service_namespace"]) where (attributes["service.namespace"] == nil or attributes["service.namespace"] == "") and attributes["service_namespace"] != nil and attributes["service_namespace"] != ""`,
+          `delete_key(attributes, "service_namespace") where attributes["service_namespace"] == attributes["service.namespace"]`,
+          `set(attributes["deployment.environment"], attributes["deployment_environment"]) where (attributes["deployment.environment"] == nil or attributes["deployment.environment"] == "") and attributes["deployment_environment"] != nil and attributes["deployment_environment"] != ""`,
+          `delete_key(attributes, "deployment_environment") where attributes["deployment_environment"] == attributes["deployment.environment"]`,
+          `set(attributes["deployment.environment.name"], attributes["deployment_environment_name"]) where (attributes["deployment.environment.name"] == nil or attributes["deployment.environment.name"] == "") and attributes["deployment_environment_name"] != nil and attributes["deployment_environment_name"] != ""`,
+          `delete_key(attributes, "deployment_environment_name") where attributes["deployment_environment_name"] == attributes["deployment.environment.name"]`,
         ]
       }
       metric_statements {
@@ -1167,6 +1190,11 @@ data:
           `delete_key(attributes, "container.image.repo_digests")`,
           `delete_key(attributes, "os.description")`,
           `delete_key(attributes, "os.build_id")`,
+          // Scrape targets that expose their own target_info metric (e.g. Grafana Beyla) can
+          // carry a flat k8s_cluster_name resource attribute, which conflicts with the
+          // k8s.cluster.name attribute set above and gets ";"-joined by the Prometheus OTLP
+          // endpoint. Drop the flat copy when the values match.
+          `delete_key(attributes, "k8s_cluster_name") where attributes["k8s_cluster_name"] == attributes["k8s.cluster.name"]`,
         ]
       }
     

--- a/charts/k8s-monitoring/docs/examples/features/application-observability/default/alloy-receiver.alloy
+++ b/charts/k8s-monitoring/docs/examples/features/application-observability/default/alloy-receiver.alloy
@@ -217,6 +217,15 @@ otelcol.processor.transform "otlp_gateway_scrape_normalize" {
       // prefer that value and drop the duplicate.
       `set(attributes["service.name"], attributes["service_name"]) where attributes["service_name"] != nil and attributes["service_name"] != ""`,
       `delete_key(attributes, "service_name") where attributes["service_name"] == attributes["service.name"]`,
+      // The same conversion turns other flat target_info labels into resource attributes.
+      // Promote them to their OpenTelemetry counterparts and drop the flat duplicates, so
+      // the OTLP endpoint does not receive two conflicting spellings of the same attribute.
+      `set(attributes["service.namespace"], attributes["service_namespace"]) where (attributes["service.namespace"] == nil or attributes["service.namespace"] == "") and attributes["service_namespace"] != nil and attributes["service_namespace"] != ""`,
+      `delete_key(attributes, "service_namespace") where attributes["service_namespace"] == attributes["service.namespace"]`,
+      `set(attributes["deployment.environment"], attributes["deployment_environment"]) where (attributes["deployment.environment"] == nil or attributes["deployment.environment"] == "") and attributes["deployment_environment"] != nil and attributes["deployment_environment"] != ""`,
+      `delete_key(attributes, "deployment_environment") where attributes["deployment_environment"] == attributes["deployment.environment"]`,
+      `set(attributes["deployment.environment.name"], attributes["deployment_environment_name"]) where (attributes["deployment.environment.name"] == nil or attributes["deployment.environment.name"] == "") and attributes["deployment_environment_name"] != nil and attributes["deployment_environment_name"] != ""`,
+      `delete_key(attributes, "deployment_environment_name") where attributes["deployment_environment_name"] == attributes["deployment.environment.name"]`,
     ]
   }
   metric_statements {
@@ -267,6 +276,11 @@ otelcol.processor.transform "otlp_gateway" {
       `delete_key(attributes, "container.image.repo_digests")`,
       `delete_key(attributes, "os.description")`,
       `delete_key(attributes, "os.build_id")`,
+      // Scrape targets that expose their own target_info metric (e.g. Grafana Beyla) can
+      // carry a flat k8s_cluster_name resource attribute, which conflicts with the
+      // k8s.cluster.name attribute set above and gets ";"-joined by the Prometheus OTLP
+      // endpoint. Drop the flat copy when the values match.
+      `delete_key(attributes, "k8s_cluster_name") where attributes["k8s_cluster_name"] == attributes["k8s.cluster.name"]`,
     ]
   }
 

--- a/charts/k8s-monitoring/docs/examples/features/application-observability/default/alloy-receiver.alloy
+++ b/charts/k8s-monitoring/docs/examples/features/application-observability/default/alloy-receiver.alloy
@@ -199,9 +199,38 @@ prometheus.relabel "kubernetes_monitoring_telemetry" {
 // Destination: otlp-gateway (otlp)
 otelcol.receiver.prometheus "otlp_gateway" {
   output {
-    metrics = [otelcol.processor.attributes.otlp_gateway.input]
+    metrics = [otelcol.processor.transform.otlp_gateway_scrape_normalize.input]
   }
 } // otelcol.receiver.prometheus "otlp_gateway"
+
+// Repairs artifacts of the Prometheus-to-OTLP conversion performed by
+// otelcol.receiver.prometheus. Only metrics that came from a Prometheus scrape pass
+// through this component; OTLP-native telemetry enters the pipeline further down.
+otelcol.processor.transform "otlp_gateway_scrape_normalize" {
+  error_mode = "ignore"
+  metric_statements {
+    context = "resource"
+    statements = [
+      // The conversion sets service.name to the full Prometheus job label (e.g.
+      // "namespace/workload"). When the scrape target declares its identity explicitly
+      // with a service_name label on its own target_info metric (e.g. Grafana Beyla),
+      // prefer that value and drop the duplicate.
+      `set(attributes["service.name"], attributes["service_name"]) where attributes["service_name"] != nil and attributes["service_name"] != ""`,
+      `delete_key(attributes, "service_name") where attributes["service_name"] == attributes["service.name"]`,
+    ]
+  }
+  metric_statements {
+    context = "datapoint"
+    statements = [
+      // Same correction for scrape targets that put service_name on every series
+      // instead of exposing a target_info metric.
+      `set(resource.attributes["service.name"], attributes["service_name"]) where attributes["service_name"] != nil and attributes["service_name"] != ""`,
+    ]
+  }
+  output {
+    metrics = [otelcol.processor.attributes.otlp_gateway.input]
+  }
+} // otelcol.processor.transform "otlp_gateway_scrape_normalize"
 otelcol.receiver.loki "otlp_gateway" {
   output {
     logs = [otelcol.processor.attributes.otlp_gateway.input]

--- a/charts/k8s-monitoring/docs/examples/features/application-observability/default/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/features/application-observability/default/output.yaml
@@ -222,9 +222,38 @@ data:
     // Destination: otlp-gateway (otlp)
     otelcol.receiver.prometheus "otlp_gateway" {
       output {
-        metrics = [otelcol.processor.attributes.otlp_gateway.input]
+        metrics = [otelcol.processor.transform.otlp_gateway_scrape_normalize.input]
       }
     } // otelcol.receiver.prometheus "otlp_gateway"
+    
+    // Repairs artifacts of the Prometheus-to-OTLP conversion performed by
+    // otelcol.receiver.prometheus. Only metrics that came from a Prometheus scrape pass
+    // through this component; OTLP-native telemetry enters the pipeline further down.
+    otelcol.processor.transform "otlp_gateway_scrape_normalize" {
+      error_mode = "ignore"
+      metric_statements {
+        context = "resource"
+        statements = [
+          // The conversion sets service.name to the full Prometheus job label (e.g.
+          // "namespace/workload"). When the scrape target declares its identity explicitly
+          // with a service_name label on its own target_info metric (e.g. Grafana Beyla),
+          // prefer that value and drop the duplicate.
+          `set(attributes["service.name"], attributes["service_name"]) where attributes["service_name"] != nil and attributes["service_name"] != ""`,
+          `delete_key(attributes, "service_name") where attributes["service_name"] == attributes["service.name"]`,
+        ]
+      }
+      metric_statements {
+        context = "datapoint"
+        statements = [
+          // Same correction for scrape targets that put service_name on every series
+          // instead of exposing a target_info metric.
+          `set(resource.attributes["service.name"], attributes["service_name"]) where attributes["service_name"] != nil and attributes["service_name"] != ""`,
+        ]
+      }
+      output {
+        metrics = [otelcol.processor.attributes.otlp_gateway.input]
+      }
+    } // otelcol.processor.transform "otlp_gateway_scrape_normalize"
     otelcol.receiver.loki "otlp_gateway" {
       output {
         logs = [otelcol.processor.attributes.otlp_gateway.input]

--- a/charts/k8s-monitoring/docs/examples/features/application-observability/default/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/features/application-observability/default/output.yaml
@@ -240,6 +240,15 @@ data:
           // prefer that value and drop the duplicate.
           `set(attributes["service.name"], attributes["service_name"]) where attributes["service_name"] != nil and attributes["service_name"] != ""`,
           `delete_key(attributes, "service_name") where attributes["service_name"] == attributes["service.name"]`,
+          // The same conversion turns other flat target_info labels into resource attributes.
+          // Promote them to their OpenTelemetry counterparts and drop the flat duplicates, so
+          // the OTLP endpoint does not receive two conflicting spellings of the same attribute.
+          `set(attributes["service.namespace"], attributes["service_namespace"]) where (attributes["service.namespace"] == nil or attributes["service.namespace"] == "") and attributes["service_namespace"] != nil and attributes["service_namespace"] != ""`,
+          `delete_key(attributes, "service_namespace") where attributes["service_namespace"] == attributes["service.namespace"]`,
+          `set(attributes["deployment.environment"], attributes["deployment_environment"]) where (attributes["deployment.environment"] == nil or attributes["deployment.environment"] == "") and attributes["deployment_environment"] != nil and attributes["deployment_environment"] != ""`,
+          `delete_key(attributes, "deployment_environment") where attributes["deployment_environment"] == attributes["deployment.environment"]`,
+          `set(attributes["deployment.environment.name"], attributes["deployment_environment_name"]) where (attributes["deployment.environment.name"] == nil or attributes["deployment.environment.name"] == "") and attributes["deployment_environment_name"] != nil and attributes["deployment_environment_name"] != ""`,
+          `delete_key(attributes, "deployment_environment_name") where attributes["deployment_environment_name"] == attributes["deployment.environment.name"]`,
         ]
       }
       metric_statements {
@@ -290,6 +299,11 @@ data:
           `delete_key(attributes, "container.image.repo_digests")`,
           `delete_key(attributes, "os.description")`,
           `delete_key(attributes, "os.build_id")`,
+          // Scrape targets that expose their own target_info metric (e.g. Grafana Beyla) can
+          // carry a flat k8s_cluster_name resource attribute, which conflicts with the
+          // k8s.cluster.name attribute set above and gets ";"-joined by the Prometheus OTLP
+          // endpoint. Drop the flat copy when the values match.
+          `delete_key(attributes, "k8s_cluster_name") where attributes["k8s_cluster_name"] == attributes["k8s.cluster.name"]`,
         ]
       }
     

--- a/charts/k8s-monitoring/docs/examples/features/application-observability/tail-sampling/alloy-receiver.alloy
+++ b/charts/k8s-monitoring/docs/examples/features/application-observability/tail-sampling/alloy-receiver.alloy
@@ -217,6 +217,15 @@ otelcol.processor.transform "otlp_gateway_scrape_normalize" {
       // prefer that value and drop the duplicate.
       `set(attributes["service.name"], attributes["service_name"]) where attributes["service_name"] != nil and attributes["service_name"] != ""`,
       `delete_key(attributes, "service_name") where attributes["service_name"] == attributes["service.name"]`,
+      // The same conversion turns other flat target_info labels into resource attributes.
+      // Promote them to their OpenTelemetry counterparts and drop the flat duplicates, so
+      // the OTLP endpoint does not receive two conflicting spellings of the same attribute.
+      `set(attributes["service.namespace"], attributes["service_namespace"]) where (attributes["service.namespace"] == nil or attributes["service.namespace"] == "") and attributes["service_namespace"] != nil and attributes["service_namespace"] != ""`,
+      `delete_key(attributes, "service_namespace") where attributes["service_namespace"] == attributes["service.namespace"]`,
+      `set(attributes["deployment.environment"], attributes["deployment_environment"]) where (attributes["deployment.environment"] == nil or attributes["deployment.environment"] == "") and attributes["deployment_environment"] != nil and attributes["deployment_environment"] != ""`,
+      `delete_key(attributes, "deployment_environment") where attributes["deployment_environment"] == attributes["deployment.environment"]`,
+      `set(attributes["deployment.environment.name"], attributes["deployment_environment_name"]) where (attributes["deployment.environment.name"] == nil or attributes["deployment.environment.name"] == "") and attributes["deployment_environment_name"] != nil and attributes["deployment_environment_name"] != ""`,
+      `delete_key(attributes, "deployment_environment_name") where attributes["deployment_environment_name"] == attributes["deployment.environment.name"]`,
     ]
   }
   metric_statements {
@@ -266,6 +275,11 @@ otelcol.processor.transform "otlp_gateway" {
       `delete_key(attributes, "container.image.repo_digests")`,
       `delete_key(attributes, "os.description")`,
       `delete_key(attributes, "os.build_id")`,
+      // Scrape targets that expose their own target_info metric (e.g. Grafana Beyla) can
+      // carry a flat k8s_cluster_name resource attribute, which conflicts with the
+      // k8s.cluster.name attribute set above and gets ";"-joined by the Prometheus OTLP
+      // endpoint. Drop the flat copy when the values match.
+      `delete_key(attributes, "k8s_cluster_name") where attributes["k8s_cluster_name"] == attributes["k8s.cluster.name"]`,
     ]
   }
 

--- a/charts/k8s-monitoring/docs/examples/features/application-observability/tail-sampling/alloy-receiver.alloy
+++ b/charts/k8s-monitoring/docs/examples/features/application-observability/tail-sampling/alloy-receiver.alloy
@@ -199,9 +199,38 @@ prometheus.relabel "kubernetes_monitoring_telemetry" {
 // Destination: otlp-gateway (otlp)
 otelcol.receiver.prometheus "otlp_gateway" {
   output {
-    metrics = [otelcol.processor.attributes.otlp_gateway.input]
+    metrics = [otelcol.processor.transform.otlp_gateway_scrape_normalize.input]
   }
 } // otelcol.receiver.prometheus "otlp_gateway"
+
+// Repairs artifacts of the Prometheus-to-OTLP conversion performed by
+// otelcol.receiver.prometheus. Only metrics that came from a Prometheus scrape pass
+// through this component; OTLP-native telemetry enters the pipeline further down.
+otelcol.processor.transform "otlp_gateway_scrape_normalize" {
+  error_mode = "ignore"
+  metric_statements {
+    context = "resource"
+    statements = [
+      // The conversion sets service.name to the full Prometheus job label (e.g.
+      // "namespace/workload"). When the scrape target declares its identity explicitly
+      // with a service_name label on its own target_info metric (e.g. Grafana Beyla),
+      // prefer that value and drop the duplicate.
+      `set(attributes["service.name"], attributes["service_name"]) where attributes["service_name"] != nil and attributes["service_name"] != ""`,
+      `delete_key(attributes, "service_name") where attributes["service_name"] == attributes["service.name"]`,
+    ]
+  }
+  metric_statements {
+    context = "datapoint"
+    statements = [
+      // Same correction for scrape targets that put service_name on every series
+      // instead of exposing a target_info metric.
+      `set(resource.attributes["service.name"], attributes["service_name"]) where attributes["service_name"] != nil and attributes["service_name"] != ""`,
+    ]
+  }
+  output {
+    metrics = [otelcol.processor.attributes.otlp_gateway.input]
+  }
+} // otelcol.processor.transform "otlp_gateway_scrape_normalize"
 otelcol.receiver.loki "otlp_gateway" {
   output {
     logs = [otelcol.processor.attributes.otlp_gateway.input]

--- a/charts/k8s-monitoring/docs/examples/features/application-observability/tail-sampling/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/features/application-observability/tail-sampling/output.yaml
@@ -240,6 +240,15 @@ data:
           // prefer that value and drop the duplicate.
           `set(attributes["service.name"], attributes["service_name"]) where attributes["service_name"] != nil and attributes["service_name"] != ""`,
           `delete_key(attributes, "service_name") where attributes["service_name"] == attributes["service.name"]`,
+          // The same conversion turns other flat target_info labels into resource attributes.
+          // Promote them to their OpenTelemetry counterparts and drop the flat duplicates, so
+          // the OTLP endpoint does not receive two conflicting spellings of the same attribute.
+          `set(attributes["service.namespace"], attributes["service_namespace"]) where (attributes["service.namespace"] == nil or attributes["service.namespace"] == "") and attributes["service_namespace"] != nil and attributes["service_namespace"] != ""`,
+          `delete_key(attributes, "service_namespace") where attributes["service_namespace"] == attributes["service.namespace"]`,
+          `set(attributes["deployment.environment"], attributes["deployment_environment"]) where (attributes["deployment.environment"] == nil or attributes["deployment.environment"] == "") and attributes["deployment_environment"] != nil and attributes["deployment_environment"] != ""`,
+          `delete_key(attributes, "deployment_environment") where attributes["deployment_environment"] == attributes["deployment.environment"]`,
+          `set(attributes["deployment.environment.name"], attributes["deployment_environment_name"]) where (attributes["deployment.environment.name"] == nil or attributes["deployment.environment.name"] == "") and attributes["deployment_environment_name"] != nil and attributes["deployment_environment_name"] != ""`,
+          `delete_key(attributes, "deployment_environment_name") where attributes["deployment_environment_name"] == attributes["deployment.environment.name"]`,
         ]
       }
       metric_statements {
@@ -289,6 +298,11 @@ data:
           `delete_key(attributes, "container.image.repo_digests")`,
           `delete_key(attributes, "os.description")`,
           `delete_key(attributes, "os.build_id")`,
+          // Scrape targets that expose their own target_info metric (e.g. Grafana Beyla) can
+          // carry a flat k8s_cluster_name resource attribute, which conflicts with the
+          // k8s.cluster.name attribute set above and gets ";"-joined by the Prometheus OTLP
+          // endpoint. Drop the flat copy when the values match.
+          `delete_key(attributes, "k8s_cluster_name") where attributes["k8s_cluster_name"] == attributes["k8s.cluster.name"]`,
         ]
       }
     

--- a/charts/k8s-monitoring/docs/examples/features/application-observability/tail-sampling/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/features/application-observability/tail-sampling/output.yaml
@@ -222,9 +222,38 @@ data:
     // Destination: otlp-gateway (otlp)
     otelcol.receiver.prometheus "otlp_gateway" {
       output {
-        metrics = [otelcol.processor.attributes.otlp_gateway.input]
+        metrics = [otelcol.processor.transform.otlp_gateway_scrape_normalize.input]
       }
     } // otelcol.receiver.prometheus "otlp_gateway"
+    
+    // Repairs artifacts of the Prometheus-to-OTLP conversion performed by
+    // otelcol.receiver.prometheus. Only metrics that came from a Prometheus scrape pass
+    // through this component; OTLP-native telemetry enters the pipeline further down.
+    otelcol.processor.transform "otlp_gateway_scrape_normalize" {
+      error_mode = "ignore"
+      metric_statements {
+        context = "resource"
+        statements = [
+          // The conversion sets service.name to the full Prometheus job label (e.g.
+          // "namespace/workload"). When the scrape target declares its identity explicitly
+          // with a service_name label on its own target_info metric (e.g. Grafana Beyla),
+          // prefer that value and drop the duplicate.
+          `set(attributes["service.name"], attributes["service_name"]) where attributes["service_name"] != nil and attributes["service_name"] != ""`,
+          `delete_key(attributes, "service_name") where attributes["service_name"] == attributes["service.name"]`,
+        ]
+      }
+      metric_statements {
+        context = "datapoint"
+        statements = [
+          // Same correction for scrape targets that put service_name on every series
+          // instead of exposing a target_info metric.
+          `set(resource.attributes["service.name"], attributes["service_name"]) where attributes["service_name"] != nil and attributes["service_name"] != ""`,
+        ]
+      }
+      output {
+        metrics = [otelcol.processor.attributes.otlp_gateway.input]
+      }
+    } // otelcol.processor.transform "otlp_gateway_scrape_normalize"
     otelcol.receiver.loki "otlp_gateway" {
       output {
         logs = [otelcol.processor.attributes.otlp_gateway.input]

--- a/charts/k8s-monitoring/docs/examples/features/auto-instrumentation/beyla-metrics-and-traces/alloy.alloy
+++ b/charts/k8s-monitoring/docs/examples/features/auto-instrumentation/beyla-metrics-and-traces/alloy.alloy
@@ -261,9 +261,38 @@ prometheus.relabel "kubernetes_monitoring_telemetry" {
 // Destination: otlp-gateway (otlp)
 otelcol.receiver.prometheus "otlp_gateway" {
   output {
-    metrics = [otelcol.processor.attributes.otlp_gateway.input]
+    metrics = [otelcol.processor.transform.otlp_gateway_scrape_normalize.input]
   }
 } // otelcol.receiver.prometheus "otlp_gateway"
+
+// Repairs artifacts of the Prometheus-to-OTLP conversion performed by
+// otelcol.receiver.prometheus. Only metrics that came from a Prometheus scrape pass
+// through this component; OTLP-native telemetry enters the pipeline further down.
+otelcol.processor.transform "otlp_gateway_scrape_normalize" {
+  error_mode = "ignore"
+  metric_statements {
+    context = "resource"
+    statements = [
+      // The conversion sets service.name to the full Prometheus job label (e.g.
+      // "namespace/workload"). When the scrape target declares its identity explicitly
+      // with a service_name label on its own target_info metric (e.g. Grafana Beyla),
+      // prefer that value and drop the duplicate.
+      `set(attributes["service.name"], attributes["service_name"]) where attributes["service_name"] != nil and attributes["service_name"] != ""`,
+      `delete_key(attributes, "service_name") where attributes["service_name"] == attributes["service.name"]`,
+    ]
+  }
+  metric_statements {
+    context = "datapoint"
+    statements = [
+      // Same correction for scrape targets that put service_name on every series
+      // instead of exposing a target_info metric.
+      `set(resource.attributes["service.name"], attributes["service_name"]) where attributes["service_name"] != nil and attributes["service_name"] != ""`,
+    ]
+  }
+  output {
+    metrics = [otelcol.processor.attributes.otlp_gateway.input]
+  }
+} // otelcol.processor.transform "otlp_gateway_scrape_normalize"
 otelcol.receiver.loki "otlp_gateway" {
   output {
     logs = [otelcol.processor.attributes.otlp_gateway.input]

--- a/charts/k8s-monitoring/docs/examples/features/auto-instrumentation/beyla-metrics-and-traces/alloy.alloy
+++ b/charts/k8s-monitoring/docs/examples/features/auto-instrumentation/beyla-metrics-and-traces/alloy.alloy
@@ -279,6 +279,15 @@ otelcol.processor.transform "otlp_gateway_scrape_normalize" {
       // prefer that value and drop the duplicate.
       `set(attributes["service.name"], attributes["service_name"]) where attributes["service_name"] != nil and attributes["service_name"] != ""`,
       `delete_key(attributes, "service_name") where attributes["service_name"] == attributes["service.name"]`,
+      // The same conversion turns other flat target_info labels into resource attributes.
+      // Promote them to their OpenTelemetry counterparts and drop the flat duplicates, so
+      // the OTLP endpoint does not receive two conflicting spellings of the same attribute.
+      `set(attributes["service.namespace"], attributes["service_namespace"]) where (attributes["service.namespace"] == nil or attributes["service.namespace"] == "") and attributes["service_namespace"] != nil and attributes["service_namespace"] != ""`,
+      `delete_key(attributes, "service_namespace") where attributes["service_namespace"] == attributes["service.namespace"]`,
+      `set(attributes["deployment.environment"], attributes["deployment_environment"]) where (attributes["deployment.environment"] == nil or attributes["deployment.environment"] == "") and attributes["deployment_environment"] != nil and attributes["deployment_environment"] != ""`,
+      `delete_key(attributes, "deployment_environment") where attributes["deployment_environment"] == attributes["deployment.environment"]`,
+      `set(attributes["deployment.environment.name"], attributes["deployment_environment_name"]) where (attributes["deployment.environment.name"] == nil or attributes["deployment.environment.name"] == "") and attributes["deployment_environment_name"] != nil and attributes["deployment_environment_name"] != ""`,
+      `delete_key(attributes, "deployment_environment_name") where attributes["deployment_environment_name"] == attributes["deployment.environment.name"]`,
     ]
   }
   metric_statements {
@@ -329,6 +338,11 @@ otelcol.processor.transform "otlp_gateway" {
       `delete_key(attributes, "container.image.repo_digests")`,
       `delete_key(attributes, "os.description")`,
       `delete_key(attributes, "os.build_id")`,
+      // Scrape targets that expose their own target_info metric (e.g. Grafana Beyla) can
+      // carry a flat k8s_cluster_name resource attribute, which conflicts with the
+      // k8s.cluster.name attribute set above and gets ";"-joined by the Prometheus OTLP
+      // endpoint. Drop the flat copy when the values match.
+      `delete_key(attributes, "k8s_cluster_name") where attributes["k8s_cluster_name"] == attributes["k8s.cluster.name"]`,
     ]
   }
 

--- a/charts/k8s-monitoring/docs/examples/features/auto-instrumentation/beyla-metrics-and-traces/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/features/auto-instrumentation/beyla-metrics-and-traces/output.yaml
@@ -300,9 +300,38 @@ data:
     // Destination: otlp-gateway (otlp)
     otelcol.receiver.prometheus "otlp_gateway" {
       output {
-        metrics = [otelcol.processor.attributes.otlp_gateway.input]
+        metrics = [otelcol.processor.transform.otlp_gateway_scrape_normalize.input]
       }
     } // otelcol.receiver.prometheus "otlp_gateway"
+    
+    // Repairs artifacts of the Prometheus-to-OTLP conversion performed by
+    // otelcol.receiver.prometheus. Only metrics that came from a Prometheus scrape pass
+    // through this component; OTLP-native telemetry enters the pipeline further down.
+    otelcol.processor.transform "otlp_gateway_scrape_normalize" {
+      error_mode = "ignore"
+      metric_statements {
+        context = "resource"
+        statements = [
+          // The conversion sets service.name to the full Prometheus job label (e.g.
+          // "namespace/workload"). When the scrape target declares its identity explicitly
+          // with a service_name label on its own target_info metric (e.g. Grafana Beyla),
+          // prefer that value and drop the duplicate.
+          `set(attributes["service.name"], attributes["service_name"]) where attributes["service_name"] != nil and attributes["service_name"] != ""`,
+          `delete_key(attributes, "service_name") where attributes["service_name"] == attributes["service.name"]`,
+        ]
+      }
+      metric_statements {
+        context = "datapoint"
+        statements = [
+          // Same correction for scrape targets that put service_name on every series
+          // instead of exposing a target_info metric.
+          `set(resource.attributes["service.name"], attributes["service_name"]) where attributes["service_name"] != nil and attributes["service_name"] != ""`,
+        ]
+      }
+      output {
+        metrics = [otelcol.processor.attributes.otlp_gateway.input]
+      }
+    } // otelcol.processor.transform "otlp_gateway_scrape_normalize"
     otelcol.receiver.loki "otlp_gateway" {
       output {
         logs = [otelcol.processor.attributes.otlp_gateway.input]

--- a/charts/k8s-monitoring/docs/examples/features/auto-instrumentation/beyla-metrics-and-traces/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/features/auto-instrumentation/beyla-metrics-and-traces/output.yaml
@@ -318,6 +318,15 @@ data:
           // prefer that value and drop the duplicate.
           `set(attributes["service.name"], attributes["service_name"]) where attributes["service_name"] != nil and attributes["service_name"] != ""`,
           `delete_key(attributes, "service_name") where attributes["service_name"] == attributes["service.name"]`,
+          // The same conversion turns other flat target_info labels into resource attributes.
+          // Promote them to their OpenTelemetry counterparts and drop the flat duplicates, so
+          // the OTLP endpoint does not receive two conflicting spellings of the same attribute.
+          `set(attributes["service.namespace"], attributes["service_namespace"]) where (attributes["service.namespace"] == nil or attributes["service.namespace"] == "") and attributes["service_namespace"] != nil and attributes["service_namespace"] != ""`,
+          `delete_key(attributes, "service_namespace") where attributes["service_namespace"] == attributes["service.namespace"]`,
+          `set(attributes["deployment.environment"], attributes["deployment_environment"]) where (attributes["deployment.environment"] == nil or attributes["deployment.environment"] == "") and attributes["deployment_environment"] != nil and attributes["deployment_environment"] != ""`,
+          `delete_key(attributes, "deployment_environment") where attributes["deployment_environment"] == attributes["deployment.environment"]`,
+          `set(attributes["deployment.environment.name"], attributes["deployment_environment_name"]) where (attributes["deployment.environment.name"] == nil or attributes["deployment.environment.name"] == "") and attributes["deployment_environment_name"] != nil and attributes["deployment_environment_name"] != ""`,
+          `delete_key(attributes, "deployment_environment_name") where attributes["deployment_environment_name"] == attributes["deployment.environment.name"]`,
         ]
       }
       metric_statements {
@@ -368,6 +377,11 @@ data:
           `delete_key(attributes, "container.image.repo_digests")`,
           `delete_key(attributes, "os.description")`,
           `delete_key(attributes, "os.build_id")`,
+          // Scrape targets that expose their own target_info metric (e.g. Grafana Beyla) can
+          // carry a flat k8s_cluster_name resource attribute, which conflicts with the
+          // k8s.cluster.name attribute set above and gets ";"-joined by the Prometheus OTLP
+          // endpoint. Drop the flat copy when the values match.
+          `delete_key(attributes, "k8s_cluster_name") where attributes["k8s_cluster_name"] == attributes["k8s.cluster.name"]`,
         ]
       }
     

--- a/charts/k8s-monitoring/docs/examples/proxies/alloy-receiver.alloy
+++ b/charts/k8s-monitoring/docs/examples/proxies/alloy-receiver.alloy
@@ -155,6 +155,15 @@ otelcol.processor.transform "otlpgateway_scrape_normalize" {
       // prefer that value and drop the duplicate.
       `set(attributes["service.name"], attributes["service_name"]) where attributes["service_name"] != nil and attributes["service_name"] != ""`,
       `delete_key(attributes, "service_name") where attributes["service_name"] == attributes["service.name"]`,
+      // The same conversion turns other flat target_info labels into resource attributes.
+      // Promote them to their OpenTelemetry counterparts and drop the flat duplicates, so
+      // the OTLP endpoint does not receive two conflicting spellings of the same attribute.
+      `set(attributes["service.namespace"], attributes["service_namespace"]) where (attributes["service.namespace"] == nil or attributes["service.namespace"] == "") and attributes["service_namespace"] != nil and attributes["service_namespace"] != ""`,
+      `delete_key(attributes, "service_namespace") where attributes["service_namespace"] == attributes["service.namespace"]`,
+      `set(attributes["deployment.environment"], attributes["deployment_environment"]) where (attributes["deployment.environment"] == nil or attributes["deployment.environment"] == "") and attributes["deployment_environment"] != nil and attributes["deployment_environment"] != ""`,
+      `delete_key(attributes, "deployment_environment") where attributes["deployment_environment"] == attributes["deployment.environment"]`,
+      `set(attributes["deployment.environment.name"], attributes["deployment_environment_name"]) where (attributes["deployment.environment.name"] == nil or attributes["deployment.environment.name"] == "") and attributes["deployment_environment_name"] != nil and attributes["deployment_environment_name"] != ""`,
+      `delete_key(attributes, "deployment_environment_name") where attributes["deployment_environment_name"] == attributes["deployment.environment.name"]`,
     ]
   }
   metric_statements {
@@ -205,6 +214,11 @@ otelcol.processor.transform "otlpgateway" {
       `delete_key(attributes, "container.image.repo_digests")`,
       `delete_key(attributes, "os.description")`,
       `delete_key(attributes, "os.build_id")`,
+      // Scrape targets that expose their own target_info metric (e.g. Grafana Beyla) can
+      // carry a flat k8s_cluster_name resource attribute, which conflicts with the
+      // k8s.cluster.name attribute set above and gets ";"-joined by the Prometheus OTLP
+      // endpoint. Drop the flat copy when the values match.
+      `delete_key(attributes, "k8s_cluster_name") where attributes["k8s_cluster_name"] == attributes["k8s.cluster.name"]`,
     ]
   }
 

--- a/charts/k8s-monitoring/docs/examples/proxies/alloy-receiver.alloy
+++ b/charts/k8s-monitoring/docs/examples/proxies/alloy-receiver.alloy
@@ -137,9 +137,38 @@ application_observability "feature" {
 // Destination: otlpgateway (otlp)
 otelcol.receiver.prometheus "otlpgateway" {
   output {
-    metrics = [otelcol.processor.attributes.otlpgateway.input]
+    metrics = [otelcol.processor.transform.otlpgateway_scrape_normalize.input]
   }
 } // otelcol.receiver.prometheus "otlpgateway"
+
+// Repairs artifacts of the Prometheus-to-OTLP conversion performed by
+// otelcol.receiver.prometheus. Only metrics that came from a Prometheus scrape pass
+// through this component; OTLP-native telemetry enters the pipeline further down.
+otelcol.processor.transform "otlpgateway_scrape_normalize" {
+  error_mode = "ignore"
+  metric_statements {
+    context = "resource"
+    statements = [
+      // The conversion sets service.name to the full Prometheus job label (e.g.
+      // "namespace/workload"). When the scrape target declares its identity explicitly
+      // with a service_name label on its own target_info metric (e.g. Grafana Beyla),
+      // prefer that value and drop the duplicate.
+      `set(attributes["service.name"], attributes["service_name"]) where attributes["service_name"] != nil and attributes["service_name"] != ""`,
+      `delete_key(attributes, "service_name") where attributes["service_name"] == attributes["service.name"]`,
+    ]
+  }
+  metric_statements {
+    context = "datapoint"
+    statements = [
+      // Same correction for scrape targets that put service_name on every series
+      // instead of exposing a target_info metric.
+      `set(resource.attributes["service.name"], attributes["service_name"]) where attributes["service_name"] != nil and attributes["service_name"] != ""`,
+    ]
+  }
+  output {
+    metrics = [otelcol.processor.attributes.otlpgateway.input]
+  }
+} // otelcol.processor.transform "otlpgateway_scrape_normalize"
 otelcol.receiver.loki "otlpgateway" {
   output {
     logs = [otelcol.processor.attributes.otlpgateway.input]

--- a/charts/k8s-monitoring/docs/examples/proxies/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/proxies/output.yaml
@@ -2163,9 +2163,38 @@ data:
     // Destination: otlpgateway (otlp)
     otelcol.receiver.prometheus "otlpgateway" {
       output {
-        metrics = [otelcol.processor.attributes.otlpgateway.input]
+        metrics = [otelcol.processor.transform.otlpgateway_scrape_normalize.input]
       }
     } // otelcol.receiver.prometheus "otlpgateway"
+    
+    // Repairs artifacts of the Prometheus-to-OTLP conversion performed by
+    // otelcol.receiver.prometheus. Only metrics that came from a Prometheus scrape pass
+    // through this component; OTLP-native telemetry enters the pipeline further down.
+    otelcol.processor.transform "otlpgateway_scrape_normalize" {
+      error_mode = "ignore"
+      metric_statements {
+        context = "resource"
+        statements = [
+          // The conversion sets service.name to the full Prometheus job label (e.g.
+          // "namespace/workload"). When the scrape target declares its identity explicitly
+          // with a service_name label on its own target_info metric (e.g. Grafana Beyla),
+          // prefer that value and drop the duplicate.
+          `set(attributes["service.name"], attributes["service_name"]) where attributes["service_name"] != nil and attributes["service_name"] != ""`,
+          `delete_key(attributes, "service_name") where attributes["service_name"] == attributes["service.name"]`,
+        ]
+      }
+      metric_statements {
+        context = "datapoint"
+        statements = [
+          // Same correction for scrape targets that put service_name on every series
+          // instead of exposing a target_info metric.
+          `set(resource.attributes["service.name"], attributes["service_name"]) where attributes["service_name"] != nil and attributes["service_name"] != ""`,
+        ]
+      }
+      output {
+        metrics = [otelcol.processor.attributes.otlpgateway.input]
+      }
+    } // otelcol.processor.transform "otlpgateway_scrape_normalize"
     otelcol.receiver.loki "otlpgateway" {
       output {
         logs = [otelcol.processor.attributes.otlpgateway.input]

--- a/charts/k8s-monitoring/docs/examples/proxies/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/proxies/output.yaml
@@ -2181,6 +2181,15 @@ data:
           // prefer that value and drop the duplicate.
           `set(attributes["service.name"], attributes["service_name"]) where attributes["service_name"] != nil and attributes["service_name"] != ""`,
           `delete_key(attributes, "service_name") where attributes["service_name"] == attributes["service.name"]`,
+          // The same conversion turns other flat target_info labels into resource attributes.
+          // Promote them to their OpenTelemetry counterparts and drop the flat duplicates, so
+          // the OTLP endpoint does not receive two conflicting spellings of the same attribute.
+          `set(attributes["service.namespace"], attributes["service_namespace"]) where (attributes["service.namespace"] == nil or attributes["service.namespace"] == "") and attributes["service_namespace"] != nil and attributes["service_namespace"] != ""`,
+          `delete_key(attributes, "service_namespace") where attributes["service_namespace"] == attributes["service.namespace"]`,
+          `set(attributes["deployment.environment"], attributes["deployment_environment"]) where (attributes["deployment.environment"] == nil or attributes["deployment.environment"] == "") and attributes["deployment_environment"] != nil and attributes["deployment_environment"] != ""`,
+          `delete_key(attributes, "deployment_environment") where attributes["deployment_environment"] == attributes["deployment.environment"]`,
+          `set(attributes["deployment.environment.name"], attributes["deployment_environment_name"]) where (attributes["deployment.environment.name"] == nil or attributes["deployment.environment.name"] == "") and attributes["deployment_environment_name"] != nil and attributes["deployment_environment_name"] != ""`,
+          `delete_key(attributes, "deployment_environment_name") where attributes["deployment_environment_name"] == attributes["deployment.environment.name"]`,
         ]
       }
       metric_statements {
@@ -2231,6 +2240,11 @@ data:
           `delete_key(attributes, "container.image.repo_digests")`,
           `delete_key(attributes, "os.description")`,
           `delete_key(attributes, "os.build_id")`,
+          // Scrape targets that expose their own target_info metric (e.g. Grafana Beyla) can
+          // carry a flat k8s_cluster_name resource attribute, which conflicts with the
+          // k8s.cluster.name attribute set above and gets ";"-joined by the Prometheus OTLP
+          // endpoint. Drop the flat copy when the values match.
+          `delete_key(attributes, "k8s_cluster_name") where attributes["k8s_cluster_name"] == attributes["k8s.cluster.name"]`,
         ]
       }
     

--- a/charts/k8s-monitoring/templates/destinations/_destination_otlp.tpl
+++ b/charts/k8s-monitoring/templates/destinations/_destination_otlp.tpl
@@ -18,9 +18,38 @@
 {{- if eq (include "destinations.otlp.supports_metrics" .) "true" }}
 otelcol.receiver.prometheus {{ include "helper.alloy_name" $.destinationName | quote }} {
   output {
-    metrics = [{{ include "destinations.otlp.alloy.otlp.metrics.target" (dict "destination" . "destinationName" $.destinationName) | trim }}]
+    metrics = [otelcol.processor.transform.{{ include "helper.alloy_name" $.destinationName }}_scrape_normalize.input]
   }
 } // otelcol.receiver.prometheus "{{ include "helper.alloy_name" $.destinationName }}"
+
+// Repairs artifacts of the Prometheus-to-OTLP conversion performed by
+// otelcol.receiver.prometheus. Only metrics that came from a Prometheus scrape pass
+// through this component; OTLP-native telemetry enters the pipeline further down.
+otelcol.processor.transform {{ printf "%s_scrape_normalize" (include "helper.alloy_name" $.destinationName) | quote }} {
+  error_mode = {{ .processors.transform.errorMode | quote }}
+  metric_statements {
+    context = "resource"
+    statements = [
+      // The conversion sets service.name to the full Prometheus job label (e.g.
+      // "namespace/workload"). When the scrape target declares its identity explicitly
+      // with a service_name label on its own target_info metric (e.g. Grafana Beyla),
+      // prefer that value and drop the duplicate.
+      `set(attributes["service.name"], attributes["service_name"]) where attributes["service_name"] != nil and attributes["service_name"] != ""`,
+      `delete_key(attributes, "service_name") where attributes["service_name"] == attributes["service.name"]`,
+    ]
+  }
+  metric_statements {
+    context = "datapoint"
+    statements = [
+      // Same correction for scrape targets that put service_name on every series
+      // instead of exposing a target_info metric.
+      `set(resource.attributes["service.name"], attributes["service_name"]) where attributes["service_name"] != nil and attributes["service_name"] != ""`,
+    ]
+  }
+  output {
+    metrics = [{{ include "destinations.otlp.alloy.otlp.metrics.target" (dict "destination" . "destinationName" $.destinationName) | trim }}]
+  }
+} // otelcol.processor.transform "{{ include "helper.alloy_name" $.destinationName }}_scrape_normalize"
 {{- end }}
 {{- if eq (include "destinations.otlp.supports_logs" .) "true" }}
 otelcol.receiver.loki {{ include "helper.alloy_name" $.destinationName | quote }} {

--- a/charts/k8s-monitoring/templates/destinations/_destination_otlp.tpl
+++ b/charts/k8s-monitoring/templates/destinations/_destination_otlp.tpl
@@ -36,6 +36,15 @@ otelcol.processor.transform {{ printf "%s_scrape_normalize" (include "helper.all
       // prefer that value and drop the duplicate.
       `set(attributes["service.name"], attributes["service_name"]) where attributes["service_name"] != nil and attributes["service_name"] != ""`,
       `delete_key(attributes, "service_name") where attributes["service_name"] == attributes["service.name"]`,
+      // The same conversion turns other flat target_info labels into resource attributes.
+      // Promote them to their OpenTelemetry counterparts and drop the flat duplicates, so
+      // the OTLP endpoint does not receive two conflicting spellings of the same attribute.
+      `set(attributes["service.namespace"], attributes["service_namespace"]) where (attributes["service.namespace"] == nil or attributes["service.namespace"] == "") and attributes["service_namespace"] != nil and attributes["service_namespace"] != ""`,
+      `delete_key(attributes, "service_namespace") where attributes["service_namespace"] == attributes["service.namespace"]`,
+      `set(attributes["deployment.environment"], attributes["deployment_environment"]) where (attributes["deployment.environment"] == nil or attributes["deployment.environment"] == "") and attributes["deployment_environment"] != nil and attributes["deployment_environment"] != ""`,
+      `delete_key(attributes, "deployment_environment") where attributes["deployment_environment"] == attributes["deployment.environment"]`,
+      `set(attributes["deployment.environment.name"], attributes["deployment_environment_name"]) where (attributes["deployment.environment.name"] == nil or attributes["deployment.environment.name"] == "") and attributes["deployment_environment_name"] != nil and attributes["deployment_environment_name"] != ""`,
+      `delete_key(attributes, "deployment_environment_name") where attributes["deployment_environment_name"] == attributes["deployment.environment.name"]`,
     ]
   }
   metric_statements {
@@ -113,6 +122,11 @@ otelcol.processor.transform {{ include "helper.alloy_name" $.destinationName | q
 {{- range $resourceAttribute := $resourceAttributesToRemove }}
       `delete_key(attributes, {{ $resourceAttribute | quote }})`,
 {{- end }}
+      // Scrape targets that expose their own target_info metric (e.g. Grafana Beyla) can
+      // carry a flat k8s_cluster_name resource attribute, which conflicts with the
+      // k8s.cluster.name attribute set above and gets ";"-joined by the Prometheus OTLP
+      // endpoint. Drop the flat copy when the values match.
+      `delete_key(attributes, "k8s_cluster_name") where attributes["k8s_cluster_name"] == attributes["k8s.cluster.name"]`,
 {{- range $transform := .processors.transform.metrics.resource }}
 {{ $transform | quote | indent 6 }},
 {{- end }}

--- a/charts/k8s-monitoring/tests/__snapshot__/destination_otlp_test.yaml.snap
+++ b/charts/k8s-monitoring/tests/__snapshot__/destination_otlp_test.yaml.snap
@@ -4,9 +4,38 @@ allows you to disable retry on failure:
       // Destination: test (otlp)
       otelcol.receiver.prometheus "test" {
         output {
-          metrics = [otelcol.processor.attributes.test.input]
+          metrics = [otelcol.processor.transform.test_scrape_normalize.input]
         }
       } // otelcol.receiver.prometheus "test"
+
+      // Repairs artifacts of the Prometheus-to-OTLP conversion performed by
+      // otelcol.receiver.prometheus. Only metrics that came from a Prometheus scrape pass
+      // through this component; OTLP-native telemetry enters the pipeline further down.
+      otelcol.processor.transform "test_scrape_normalize" {
+        error_mode = "ignore"
+        metric_statements {
+          context = "resource"
+          statements = [
+            // The conversion sets service.name to the full Prometheus job label (e.g.
+            // "namespace/workload"). When the scrape target declares its identity explicitly
+            // with a service_name label on its own target_info metric (e.g. Grafana Beyla),
+            // prefer that value and drop the duplicate.
+            `set(attributes["service.name"], attributes["service_name"]) where attributes["service_name"] != nil and attributes["service_name"] != ""`,
+            `delete_key(attributes, "service_name") where attributes["service_name"] == attributes["service.name"]`,
+          ]
+        }
+        metric_statements {
+          context = "datapoint"
+          statements = [
+            // Same correction for scrape targets that put service_name on every series
+            // instead of exposing a target_info metric.
+            `set(resource.attributes["service.name"], attributes["service_name"]) where attributes["service_name"] != nil and attributes["service_name"] != ""`,
+          ]
+        }
+        output {
+          metrics = [otelcol.processor.attributes.test.input]
+        }
+      } // otelcol.processor.transform "test_scrape_normalize"
       otelcol.receiver.loki "test" {
         output {
           logs = [otelcol.processor.attributes.test.input]
@@ -187,9 +216,38 @@ allows you to set a timeout:
       // Destination: test (otlp)
       otelcol.receiver.prometheus "test" {
         output {
-          metrics = [otelcol.processor.attributes.test.input]
+          metrics = [otelcol.processor.transform.test_scrape_normalize.input]
         }
       } // otelcol.receiver.prometheus "test"
+
+      // Repairs artifacts of the Prometheus-to-OTLP conversion performed by
+      // otelcol.receiver.prometheus. Only metrics that came from a Prometheus scrape pass
+      // through this component; OTLP-native telemetry enters the pipeline further down.
+      otelcol.processor.transform "test_scrape_normalize" {
+        error_mode = "ignore"
+        metric_statements {
+          context = "resource"
+          statements = [
+            // The conversion sets service.name to the full Prometheus job label (e.g.
+            // "namespace/workload"). When the scrape target declares its identity explicitly
+            // with a service_name label on its own target_info metric (e.g. Grafana Beyla),
+            // prefer that value and drop the duplicate.
+            `set(attributes["service.name"], attributes["service_name"]) where attributes["service_name"] != nil and attributes["service_name"] != ""`,
+            `delete_key(attributes, "service_name") where attributes["service_name"] == attributes["service.name"]`,
+          ]
+        }
+        metric_statements {
+          context = "datapoint"
+          statements = [
+            // Same correction for scrape targets that put service_name on every series
+            // instead of exposing a target_info metric.
+            `set(resource.attributes["service.name"], attributes["service_name"]) where attributes["service_name"] != nil and attributes["service_name"] != ""`,
+          ]
+        }
+        output {
+          metrics = [otelcol.processor.attributes.test.input]
+        }
+      } // otelcol.processor.transform "test_scrape_normalize"
       otelcol.receiver.loki "test" {
         output {
           logs = [otelcol.processor.attributes.test.input]
@@ -371,9 +429,38 @@ allows you to set a timeout when using http:
       // Destination: test (otlp)
       otelcol.receiver.prometheus "test" {
         output {
-          metrics = [otelcol.processor.attributes.test.input]
+          metrics = [otelcol.processor.transform.test_scrape_normalize.input]
         }
       } // otelcol.receiver.prometheus "test"
+
+      // Repairs artifacts of the Prometheus-to-OTLP conversion performed by
+      // otelcol.receiver.prometheus. Only metrics that came from a Prometheus scrape pass
+      // through this component; OTLP-native telemetry enters the pipeline further down.
+      otelcol.processor.transform "test_scrape_normalize" {
+        error_mode = "ignore"
+        metric_statements {
+          context = "resource"
+          statements = [
+            // The conversion sets service.name to the full Prometheus job label (e.g.
+            // "namespace/workload"). When the scrape target declares its identity explicitly
+            // with a service_name label on its own target_info metric (e.g. Grafana Beyla),
+            // prefer that value and drop the duplicate.
+            `set(attributes["service.name"], attributes["service_name"]) where attributes["service_name"] != nil and attributes["service_name"] != ""`,
+            `delete_key(attributes, "service_name") where attributes["service_name"] == attributes["service.name"]`,
+          ]
+        }
+        metric_statements {
+          context = "datapoint"
+          statements = [
+            // Same correction for scrape targets that put service_name on every series
+            // instead of exposing a target_info metric.
+            `set(resource.attributes["service.name"], attributes["service_name"]) where attributes["service_name"] != nil and attributes["service_name"] != ""`,
+          ]
+        }
+        output {
+          metrics = [otelcol.processor.attributes.test.input]
+        }
+      } // otelcol.processor.transform "test_scrape_normalize"
       otelcol.receiver.loki "test" {
         output {
           logs = [otelcol.processor.attributes.test.input]
@@ -555,9 +642,38 @@ allows you to set per-signal paths when using http:
       // Destination: test (otlp)
       otelcol.receiver.prometheus "test" {
         output {
-          metrics = [otelcol.processor.attributes.test.input]
+          metrics = [otelcol.processor.transform.test_scrape_normalize.input]
         }
       } // otelcol.receiver.prometheus "test"
+
+      // Repairs artifacts of the Prometheus-to-OTLP conversion performed by
+      // otelcol.receiver.prometheus. Only metrics that came from a Prometheus scrape pass
+      // through this component; OTLP-native telemetry enters the pipeline further down.
+      otelcol.processor.transform "test_scrape_normalize" {
+        error_mode = "ignore"
+        metric_statements {
+          context = "resource"
+          statements = [
+            // The conversion sets service.name to the full Prometheus job label (e.g.
+            // "namespace/workload"). When the scrape target declares its identity explicitly
+            // with a service_name label on its own target_info metric (e.g. Grafana Beyla),
+            // prefer that value and drop the duplicate.
+            `set(attributes["service.name"], attributes["service_name"]) where attributes["service_name"] != nil and attributes["service_name"] != ""`,
+            `delete_key(attributes, "service_name") where attributes["service_name"] == attributes["service.name"]`,
+          ]
+        }
+        metric_statements {
+          context = "datapoint"
+          statements = [
+            // Same correction for scrape targets that put service_name on every series
+            // instead of exposing a target_info metric.
+            `set(resource.attributes["service.name"], attributes["service_name"]) where attributes["service_name"] != nil and attributes["service_name"] != ""`,
+          ]
+        }
+        output {
+          metrics = [otelcol.processor.attributes.test.input]
+        }
+      } // otelcol.processor.transform "test_scrape_normalize"
       otelcol.receiver.loki "test" {
         output {
           logs = [otelcol.processor.attributes.test.input]
@@ -741,9 +857,38 @@ allows you to use basic authentication:
       // Destination: test (otlp)
       otelcol.receiver.prometheus "test" {
         output {
-          metrics = [otelcol.processor.attributes.test.input]
+          metrics = [otelcol.processor.transform.test_scrape_normalize.input]
         }
       } // otelcol.receiver.prometheus "test"
+
+      // Repairs artifacts of the Prometheus-to-OTLP conversion performed by
+      // otelcol.receiver.prometheus. Only metrics that came from a Prometheus scrape pass
+      // through this component; OTLP-native telemetry enters the pipeline further down.
+      otelcol.processor.transform "test_scrape_normalize" {
+        error_mode = "ignore"
+        metric_statements {
+          context = "resource"
+          statements = [
+            // The conversion sets service.name to the full Prometheus job label (e.g.
+            // "namespace/workload"). When the scrape target declares its identity explicitly
+            // with a service_name label on its own target_info metric (e.g. Grafana Beyla),
+            // prefer that value and drop the duplicate.
+            `set(attributes["service.name"], attributes["service_name"]) where attributes["service_name"] != nil and attributes["service_name"] != ""`,
+            `delete_key(attributes, "service_name") where attributes["service_name"] == attributes["service.name"]`,
+          ]
+        }
+        metric_statements {
+          context = "datapoint"
+          statements = [
+            // Same correction for scrape targets that put service_name on every series
+            // instead of exposing a target_info metric.
+            `set(resource.attributes["service.name"], attributes["service_name"]) where attributes["service_name"] != nil and attributes["service_name"] != ""`,
+          ]
+        }
+        output {
+          metrics = [otelcol.processor.attributes.test.input]
+        }
+      } // otelcol.processor.transform "test_scrape_normalize"
       otelcol.receiver.loki "test" {
         output {
           logs = [otelcol.processor.attributes.test.input]
@@ -935,9 +1080,38 @@ allows you to use basic authentication with a numeric username:
       // Destination: test (otlp)
       otelcol.receiver.prometheus "test" {
         output {
-          metrics = [otelcol.processor.attributes.test.input]
+          metrics = [otelcol.processor.transform.test_scrape_normalize.input]
         }
       } // otelcol.receiver.prometheus "test"
+
+      // Repairs artifacts of the Prometheus-to-OTLP conversion performed by
+      // otelcol.receiver.prometheus. Only metrics that came from a Prometheus scrape pass
+      // through this component; OTLP-native telemetry enters the pipeline further down.
+      otelcol.processor.transform "test_scrape_normalize" {
+        error_mode = "ignore"
+        metric_statements {
+          context = "resource"
+          statements = [
+            // The conversion sets service.name to the full Prometheus job label (e.g.
+            // "namespace/workload"). When the scrape target declares its identity explicitly
+            // with a service_name label on its own target_info metric (e.g. Grafana Beyla),
+            // prefer that value and drop the duplicate.
+            `set(attributes["service.name"], attributes["service_name"]) where attributes["service_name"] != nil and attributes["service_name"] != ""`,
+            `delete_key(attributes, "service_name") where attributes["service_name"] == attributes["service.name"]`,
+          ]
+        }
+        metric_statements {
+          context = "datapoint"
+          statements = [
+            // Same correction for scrape targets that put service_name on every series
+            // instead of exposing a target_info metric.
+            `set(resource.attributes["service.name"], attributes["service_name"]) where attributes["service_name"] != nil and attributes["service_name"] != ""`,
+          ]
+        }
+        output {
+          metrics = [otelcol.processor.attributes.test.input]
+        }
+      } // otelcol.processor.transform "test_scrape_normalize"
       otelcol.receiver.loki "test" {
         output {
           logs = [otelcol.processor.attributes.test.input]
@@ -1129,9 +1303,38 @@ allows you to use cluster.nameFrom:
       // Destination: test (otlp)
       otelcol.receiver.prometheus "test" {
         output {
-          metrics = [otelcol.processor.attributes.test.input]
+          metrics = [otelcol.processor.transform.test_scrape_normalize.input]
         }
       } // otelcol.receiver.prometheus "test"
+
+      // Repairs artifacts of the Prometheus-to-OTLP conversion performed by
+      // otelcol.receiver.prometheus. Only metrics that came from a Prometheus scrape pass
+      // through this component; OTLP-native telemetry enters the pipeline further down.
+      otelcol.processor.transform "test_scrape_normalize" {
+        error_mode = "ignore"
+        metric_statements {
+          context = "resource"
+          statements = [
+            // The conversion sets service.name to the full Prometheus job label (e.g.
+            // "namespace/workload"). When the scrape target declares its identity explicitly
+            // with a service_name label on its own target_info metric (e.g. Grafana Beyla),
+            // prefer that value and drop the duplicate.
+            `set(attributes["service.name"], attributes["service_name"]) where attributes["service_name"] != nil and attributes["service_name"] != ""`,
+            `delete_key(attributes, "service_name") where attributes["service_name"] == attributes["service.name"]`,
+          ]
+        }
+        metric_statements {
+          context = "datapoint"
+          statements = [
+            // Same correction for scrape targets that put service_name on every series
+            // instead of exposing a target_info metric.
+            `set(resource.attributes["service.name"], attributes["service_name"]) where attributes["service_name"] != nil and attributes["service_name"] != ""`,
+          ]
+        }
+        output {
+          metrics = [otelcol.processor.attributes.test.input]
+        }
+      } // otelcol.processor.transform "test_scrape_normalize"
       otelcol.receiver.loki "test" {
         output {
           logs = [otelcol.processor.attributes.test.input]
@@ -1312,9 +1515,38 @@ creates the Alloy components for an OTLP destination:
       // Destination: test (otlp)
       otelcol.receiver.prometheus "test" {
         output {
-          metrics = [otelcol.processor.attributes.test.input]
+          metrics = [otelcol.processor.transform.test_scrape_normalize.input]
         }
       } // otelcol.receiver.prometheus "test"
+
+      // Repairs artifacts of the Prometheus-to-OTLP conversion performed by
+      // otelcol.receiver.prometheus. Only metrics that came from a Prometheus scrape pass
+      // through this component; OTLP-native telemetry enters the pipeline further down.
+      otelcol.processor.transform "test_scrape_normalize" {
+        error_mode = "ignore"
+        metric_statements {
+          context = "resource"
+          statements = [
+            // The conversion sets service.name to the full Prometheus job label (e.g.
+            // "namespace/workload"). When the scrape target declares its identity explicitly
+            // with a service_name label on its own target_info metric (e.g. Grafana Beyla),
+            // prefer that value and drop the duplicate.
+            `set(attributes["service.name"], attributes["service_name"]) where attributes["service_name"] != nil and attributes["service_name"] != ""`,
+            `delete_key(attributes, "service_name") where attributes["service_name"] == attributes["service.name"]`,
+          ]
+        }
+        metric_statements {
+          context = "datapoint"
+          statements = [
+            // Same correction for scrape targets that put service_name on every series
+            // instead of exposing a target_info metric.
+            `set(resource.attributes["service.name"], attributes["service_name"]) where attributes["service_name"] != nil and attributes["service_name"] != ""`,
+          ]
+        }
+        output {
+          metrics = [otelcol.processor.attributes.test.input]
+        }
+      } // otelcol.processor.transform "test_scrape_normalize"
       otelcol.receiver.loki "test" {
         output {
           logs = [otelcol.processor.attributes.test.input]

--- a/charts/k8s-monitoring/tests/__snapshot__/destination_otlp_test.yaml.snap
+++ b/charts/k8s-monitoring/tests/__snapshot__/destination_otlp_test.yaml.snap
@@ -22,6 +22,15 @@ allows you to disable retry on failure:
             // prefer that value and drop the duplicate.
             `set(attributes["service.name"], attributes["service_name"]) where attributes["service_name"] != nil and attributes["service_name"] != ""`,
             `delete_key(attributes, "service_name") where attributes["service_name"] == attributes["service.name"]`,
+            // The same conversion turns other flat target_info labels into resource attributes.
+            // Promote them to their OpenTelemetry counterparts and drop the flat duplicates, so
+            // the OTLP endpoint does not receive two conflicting spellings of the same attribute.
+            `set(attributes["service.namespace"], attributes["service_namespace"]) where (attributes["service.namespace"] == nil or attributes["service.namespace"] == "") and attributes["service_namespace"] != nil and attributes["service_namespace"] != ""`,
+            `delete_key(attributes, "service_namespace") where attributes["service_namespace"] == attributes["service.namespace"]`,
+            `set(attributes["deployment.environment"], attributes["deployment_environment"]) where (attributes["deployment.environment"] == nil or attributes["deployment.environment"] == "") and attributes["deployment_environment"] != nil and attributes["deployment_environment"] != ""`,
+            `delete_key(attributes, "deployment_environment") where attributes["deployment_environment"] == attributes["deployment.environment"]`,
+            `set(attributes["deployment.environment.name"], attributes["deployment_environment_name"]) where (attributes["deployment.environment.name"] == nil or attributes["deployment.environment.name"] == "") and attributes["deployment_environment_name"] != nil and attributes["deployment_environment_name"] != ""`,
+            `delete_key(attributes, "deployment_environment_name") where attributes["deployment_environment_name"] == attributes["deployment.environment.name"]`,
           ]
         }
         metric_statements {
@@ -72,6 +81,11 @@ allows you to disable retry on failure:
             `delete_key(attributes, "container.image.repo_digests")`,
             `delete_key(attributes, "os.description")`,
             `delete_key(attributes, "os.build_id")`,
+            // Scrape targets that expose their own target_info metric (e.g. Grafana Beyla) can
+            // carry a flat k8s_cluster_name resource attribute, which conflicts with the
+            // k8s.cluster.name attribute set above and gets ";"-joined by the Prometheus OTLP
+            // endpoint. Drop the flat copy when the values match.
+            `delete_key(attributes, "k8s_cluster_name") where attributes["k8s_cluster_name"] == attributes["k8s.cluster.name"]`,
           ]
         }
 
@@ -234,6 +248,15 @@ allows you to set a timeout:
             // prefer that value and drop the duplicate.
             `set(attributes["service.name"], attributes["service_name"]) where attributes["service_name"] != nil and attributes["service_name"] != ""`,
             `delete_key(attributes, "service_name") where attributes["service_name"] == attributes["service.name"]`,
+            // The same conversion turns other flat target_info labels into resource attributes.
+            // Promote them to their OpenTelemetry counterparts and drop the flat duplicates, so
+            // the OTLP endpoint does not receive two conflicting spellings of the same attribute.
+            `set(attributes["service.namespace"], attributes["service_namespace"]) where (attributes["service.namespace"] == nil or attributes["service.namespace"] == "") and attributes["service_namespace"] != nil and attributes["service_namespace"] != ""`,
+            `delete_key(attributes, "service_namespace") where attributes["service_namespace"] == attributes["service.namespace"]`,
+            `set(attributes["deployment.environment"], attributes["deployment_environment"]) where (attributes["deployment.environment"] == nil or attributes["deployment.environment"] == "") and attributes["deployment_environment"] != nil and attributes["deployment_environment"] != ""`,
+            `delete_key(attributes, "deployment_environment") where attributes["deployment_environment"] == attributes["deployment.environment"]`,
+            `set(attributes["deployment.environment.name"], attributes["deployment_environment_name"]) where (attributes["deployment.environment.name"] == nil or attributes["deployment.environment.name"] == "") and attributes["deployment_environment_name"] != nil and attributes["deployment_environment_name"] != ""`,
+            `delete_key(attributes, "deployment_environment_name") where attributes["deployment_environment_name"] == attributes["deployment.environment.name"]`,
           ]
         }
         metric_statements {
@@ -284,6 +307,11 @@ allows you to set a timeout:
             `delete_key(attributes, "container.image.repo_digests")`,
             `delete_key(attributes, "os.description")`,
             `delete_key(attributes, "os.build_id")`,
+            // Scrape targets that expose their own target_info metric (e.g. Grafana Beyla) can
+            // carry a flat k8s_cluster_name resource attribute, which conflicts with the
+            // k8s.cluster.name attribute set above and gets ";"-joined by the Prometheus OTLP
+            // endpoint. Drop the flat copy when the values match.
+            `delete_key(attributes, "k8s_cluster_name") where attributes["k8s_cluster_name"] == attributes["k8s.cluster.name"]`,
           ]
         }
 
@@ -447,6 +475,15 @@ allows you to set a timeout when using http:
             // prefer that value and drop the duplicate.
             `set(attributes["service.name"], attributes["service_name"]) where attributes["service_name"] != nil and attributes["service_name"] != ""`,
             `delete_key(attributes, "service_name") where attributes["service_name"] == attributes["service.name"]`,
+            // The same conversion turns other flat target_info labels into resource attributes.
+            // Promote them to their OpenTelemetry counterparts and drop the flat duplicates, so
+            // the OTLP endpoint does not receive two conflicting spellings of the same attribute.
+            `set(attributes["service.namespace"], attributes["service_namespace"]) where (attributes["service.namespace"] == nil or attributes["service.namespace"] == "") and attributes["service_namespace"] != nil and attributes["service_namespace"] != ""`,
+            `delete_key(attributes, "service_namespace") where attributes["service_namespace"] == attributes["service.namespace"]`,
+            `set(attributes["deployment.environment"], attributes["deployment_environment"]) where (attributes["deployment.environment"] == nil or attributes["deployment.environment"] == "") and attributes["deployment_environment"] != nil and attributes["deployment_environment"] != ""`,
+            `delete_key(attributes, "deployment_environment") where attributes["deployment_environment"] == attributes["deployment.environment"]`,
+            `set(attributes["deployment.environment.name"], attributes["deployment_environment_name"]) where (attributes["deployment.environment.name"] == nil or attributes["deployment.environment.name"] == "") and attributes["deployment_environment_name"] != nil and attributes["deployment_environment_name"] != ""`,
+            `delete_key(attributes, "deployment_environment_name") where attributes["deployment_environment_name"] == attributes["deployment.environment.name"]`,
           ]
         }
         metric_statements {
@@ -497,6 +534,11 @@ allows you to set a timeout when using http:
             `delete_key(attributes, "container.image.repo_digests")`,
             `delete_key(attributes, "os.description")`,
             `delete_key(attributes, "os.build_id")`,
+            // Scrape targets that expose their own target_info metric (e.g. Grafana Beyla) can
+            // carry a flat k8s_cluster_name resource attribute, which conflicts with the
+            // k8s.cluster.name attribute set above and gets ";"-joined by the Prometheus OTLP
+            // endpoint. Drop the flat copy when the values match.
+            `delete_key(attributes, "k8s_cluster_name") where attributes["k8s_cluster_name"] == attributes["k8s.cluster.name"]`,
           ]
         }
 
@@ -660,6 +702,15 @@ allows you to set per-signal paths when using http:
             // prefer that value and drop the duplicate.
             `set(attributes["service.name"], attributes["service_name"]) where attributes["service_name"] != nil and attributes["service_name"] != ""`,
             `delete_key(attributes, "service_name") where attributes["service_name"] == attributes["service.name"]`,
+            // The same conversion turns other flat target_info labels into resource attributes.
+            // Promote them to their OpenTelemetry counterparts and drop the flat duplicates, so
+            // the OTLP endpoint does not receive two conflicting spellings of the same attribute.
+            `set(attributes["service.namespace"], attributes["service_namespace"]) where (attributes["service.namespace"] == nil or attributes["service.namespace"] == "") and attributes["service_namespace"] != nil and attributes["service_namespace"] != ""`,
+            `delete_key(attributes, "service_namespace") where attributes["service_namespace"] == attributes["service.namespace"]`,
+            `set(attributes["deployment.environment"], attributes["deployment_environment"]) where (attributes["deployment.environment"] == nil or attributes["deployment.environment"] == "") and attributes["deployment_environment"] != nil and attributes["deployment_environment"] != ""`,
+            `delete_key(attributes, "deployment_environment") where attributes["deployment_environment"] == attributes["deployment.environment"]`,
+            `set(attributes["deployment.environment.name"], attributes["deployment_environment_name"]) where (attributes["deployment.environment.name"] == nil or attributes["deployment.environment.name"] == "") and attributes["deployment_environment_name"] != nil and attributes["deployment_environment_name"] != ""`,
+            `delete_key(attributes, "deployment_environment_name") where attributes["deployment_environment_name"] == attributes["deployment.environment.name"]`,
           ]
         }
         metric_statements {
@@ -710,6 +761,11 @@ allows you to set per-signal paths when using http:
             `delete_key(attributes, "container.image.repo_digests")`,
             `delete_key(attributes, "os.description")`,
             `delete_key(attributes, "os.build_id")`,
+            // Scrape targets that expose their own target_info metric (e.g. Grafana Beyla) can
+            // carry a flat k8s_cluster_name resource attribute, which conflicts with the
+            // k8s.cluster.name attribute set above and gets ";"-joined by the Prometheus OTLP
+            // endpoint. Drop the flat copy when the values match.
+            `delete_key(attributes, "k8s_cluster_name") where attributes["k8s_cluster_name"] == attributes["k8s.cluster.name"]`,
           ]
         }
 
@@ -875,6 +931,15 @@ allows you to use basic authentication:
             // prefer that value and drop the duplicate.
             `set(attributes["service.name"], attributes["service_name"]) where attributes["service_name"] != nil and attributes["service_name"] != ""`,
             `delete_key(attributes, "service_name") where attributes["service_name"] == attributes["service.name"]`,
+            // The same conversion turns other flat target_info labels into resource attributes.
+            // Promote them to their OpenTelemetry counterparts and drop the flat duplicates, so
+            // the OTLP endpoint does not receive two conflicting spellings of the same attribute.
+            `set(attributes["service.namespace"], attributes["service_namespace"]) where (attributes["service.namespace"] == nil or attributes["service.namespace"] == "") and attributes["service_namespace"] != nil and attributes["service_namespace"] != ""`,
+            `delete_key(attributes, "service_namespace") where attributes["service_namespace"] == attributes["service.namespace"]`,
+            `set(attributes["deployment.environment"], attributes["deployment_environment"]) where (attributes["deployment.environment"] == nil or attributes["deployment.environment"] == "") and attributes["deployment_environment"] != nil and attributes["deployment_environment"] != ""`,
+            `delete_key(attributes, "deployment_environment") where attributes["deployment_environment"] == attributes["deployment.environment"]`,
+            `set(attributes["deployment.environment.name"], attributes["deployment_environment_name"]) where (attributes["deployment.environment.name"] == nil or attributes["deployment.environment.name"] == "") and attributes["deployment_environment_name"] != nil and attributes["deployment_environment_name"] != ""`,
+            `delete_key(attributes, "deployment_environment_name") where attributes["deployment_environment_name"] == attributes["deployment.environment.name"]`,
           ]
         }
         metric_statements {
@@ -925,6 +990,11 @@ allows you to use basic authentication:
             `delete_key(attributes, "container.image.repo_digests")`,
             `delete_key(attributes, "os.description")`,
             `delete_key(attributes, "os.build_id")`,
+            // Scrape targets that expose their own target_info metric (e.g. Grafana Beyla) can
+            // carry a flat k8s_cluster_name resource attribute, which conflicts with the
+            // k8s.cluster.name attribute set above and gets ";"-joined by the Prometheus OTLP
+            // endpoint. Drop the flat copy when the values match.
+            `delete_key(attributes, "k8s_cluster_name") where attributes["k8s_cluster_name"] == attributes["k8s.cluster.name"]`,
           ]
         }
 
@@ -1098,6 +1168,15 @@ allows you to use basic authentication with a numeric username:
             // prefer that value and drop the duplicate.
             `set(attributes["service.name"], attributes["service_name"]) where attributes["service_name"] != nil and attributes["service_name"] != ""`,
             `delete_key(attributes, "service_name") where attributes["service_name"] == attributes["service.name"]`,
+            // The same conversion turns other flat target_info labels into resource attributes.
+            // Promote them to their OpenTelemetry counterparts and drop the flat duplicates, so
+            // the OTLP endpoint does not receive two conflicting spellings of the same attribute.
+            `set(attributes["service.namespace"], attributes["service_namespace"]) where (attributes["service.namespace"] == nil or attributes["service.namespace"] == "") and attributes["service_namespace"] != nil and attributes["service_namespace"] != ""`,
+            `delete_key(attributes, "service_namespace") where attributes["service_namespace"] == attributes["service.namespace"]`,
+            `set(attributes["deployment.environment"], attributes["deployment_environment"]) where (attributes["deployment.environment"] == nil or attributes["deployment.environment"] == "") and attributes["deployment_environment"] != nil and attributes["deployment_environment"] != ""`,
+            `delete_key(attributes, "deployment_environment") where attributes["deployment_environment"] == attributes["deployment.environment"]`,
+            `set(attributes["deployment.environment.name"], attributes["deployment_environment_name"]) where (attributes["deployment.environment.name"] == nil or attributes["deployment.environment.name"] == "") and attributes["deployment_environment_name"] != nil and attributes["deployment_environment_name"] != ""`,
+            `delete_key(attributes, "deployment_environment_name") where attributes["deployment_environment_name"] == attributes["deployment.environment.name"]`,
           ]
         }
         metric_statements {
@@ -1148,6 +1227,11 @@ allows you to use basic authentication with a numeric username:
             `delete_key(attributes, "container.image.repo_digests")`,
             `delete_key(attributes, "os.description")`,
             `delete_key(attributes, "os.build_id")`,
+            // Scrape targets that expose their own target_info metric (e.g. Grafana Beyla) can
+            // carry a flat k8s_cluster_name resource attribute, which conflicts with the
+            // k8s.cluster.name attribute set above and gets ";"-joined by the Prometheus OTLP
+            // endpoint. Drop the flat copy when the values match.
+            `delete_key(attributes, "k8s_cluster_name") where attributes["k8s_cluster_name"] == attributes["k8s.cluster.name"]`,
           ]
         }
 
@@ -1321,6 +1405,15 @@ allows you to use cluster.nameFrom:
             // prefer that value and drop the duplicate.
             `set(attributes["service.name"], attributes["service_name"]) where attributes["service_name"] != nil and attributes["service_name"] != ""`,
             `delete_key(attributes, "service_name") where attributes["service_name"] == attributes["service.name"]`,
+            // The same conversion turns other flat target_info labels into resource attributes.
+            // Promote them to their OpenTelemetry counterparts and drop the flat duplicates, so
+            // the OTLP endpoint does not receive two conflicting spellings of the same attribute.
+            `set(attributes["service.namespace"], attributes["service_namespace"]) where (attributes["service.namespace"] == nil or attributes["service.namespace"] == "") and attributes["service_namespace"] != nil and attributes["service_namespace"] != ""`,
+            `delete_key(attributes, "service_namespace") where attributes["service_namespace"] == attributes["service.namespace"]`,
+            `set(attributes["deployment.environment"], attributes["deployment_environment"]) where (attributes["deployment.environment"] == nil or attributes["deployment.environment"] == "") and attributes["deployment_environment"] != nil and attributes["deployment_environment"] != ""`,
+            `delete_key(attributes, "deployment_environment") where attributes["deployment_environment"] == attributes["deployment.environment"]`,
+            `set(attributes["deployment.environment.name"], attributes["deployment_environment_name"]) where (attributes["deployment.environment.name"] == nil or attributes["deployment.environment.name"] == "") and attributes["deployment_environment_name"] != nil and attributes["deployment_environment_name"] != ""`,
+            `delete_key(attributes, "deployment_environment_name") where attributes["deployment_environment_name"] == attributes["deployment.environment.name"]`,
           ]
         }
         metric_statements {
@@ -1371,6 +1464,11 @@ allows you to use cluster.nameFrom:
             `delete_key(attributes, "container.image.repo_digests")`,
             `delete_key(attributes, "os.description")`,
             `delete_key(attributes, "os.build_id")`,
+            // Scrape targets that expose their own target_info metric (e.g. Grafana Beyla) can
+            // carry a flat k8s_cluster_name resource attribute, which conflicts with the
+            // k8s.cluster.name attribute set above and gets ";"-joined by the Prometheus OTLP
+            // endpoint. Drop the flat copy when the values match.
+            `delete_key(attributes, "k8s_cluster_name") where attributes["k8s_cluster_name"] == attributes["k8s.cluster.name"]`,
           ]
         }
 
@@ -1533,6 +1631,15 @@ creates the Alloy components for an OTLP destination:
             // prefer that value and drop the duplicate.
             `set(attributes["service.name"], attributes["service_name"]) where attributes["service_name"] != nil and attributes["service_name"] != ""`,
             `delete_key(attributes, "service_name") where attributes["service_name"] == attributes["service.name"]`,
+            // The same conversion turns other flat target_info labels into resource attributes.
+            // Promote them to their OpenTelemetry counterparts and drop the flat duplicates, so
+            // the OTLP endpoint does not receive two conflicting spellings of the same attribute.
+            `set(attributes["service.namespace"], attributes["service_namespace"]) where (attributes["service.namespace"] == nil or attributes["service.namespace"] == "") and attributes["service_namespace"] != nil and attributes["service_namespace"] != ""`,
+            `delete_key(attributes, "service_namespace") where attributes["service_namespace"] == attributes["service.namespace"]`,
+            `set(attributes["deployment.environment"], attributes["deployment_environment"]) where (attributes["deployment.environment"] == nil or attributes["deployment.environment"] == "") and attributes["deployment_environment"] != nil and attributes["deployment_environment"] != ""`,
+            `delete_key(attributes, "deployment_environment") where attributes["deployment_environment"] == attributes["deployment.environment"]`,
+            `set(attributes["deployment.environment.name"], attributes["deployment_environment_name"]) where (attributes["deployment.environment.name"] == nil or attributes["deployment.environment.name"] == "") and attributes["deployment_environment_name"] != nil and attributes["deployment_environment_name"] != ""`,
+            `delete_key(attributes, "deployment_environment_name") where attributes["deployment_environment_name"] == attributes["deployment.environment.name"]`,
           ]
         }
         metric_statements {
@@ -1583,6 +1690,11 @@ creates the Alloy components for an OTLP destination:
             `delete_key(attributes, "container.image.repo_digests")`,
             `delete_key(attributes, "os.description")`,
             `delete_key(attributes, "os.build_id")`,
+            // Scrape targets that expose their own target_info metric (e.g. Grafana Beyla) can
+            // carry a flat k8s_cluster_name resource attribute, which conflicts with the
+            // k8s.cluster.name attribute set above and gets ";"-joined by the Prometheus OTLP
+            // endpoint. Drop the flat copy when the values match.
+            `delete_key(attributes, "k8s_cluster_name") where attributes["k8s_cluster_name"] == attributes["k8s.cluster.name"]`,
           ]
         }
 

--- a/charts/k8s-monitoring/tests/__snapshot__/feature_pod_logs_via_opentelemetry_test.yaml.snap
+++ b/charts/k8s-monitoring/tests/__snapshot__/feature_pod_logs_via_opentelemetry_test.yaml.snap
@@ -196,6 +196,15 @@ renders the config to gather Kubernetes Pod logs:
             // prefer that value and drop the duplicate.
             `set(attributes["service.name"], attributes["service_name"]) where attributes["service_name"] != nil and attributes["service_name"] != ""`,
             `delete_key(attributes, "service_name") where attributes["service_name"] == attributes["service.name"]`,
+            // The same conversion turns other flat target_info labels into resource attributes.
+            // Promote them to their OpenTelemetry counterparts and drop the flat duplicates, so
+            // the OTLP endpoint does not receive two conflicting spellings of the same attribute.
+            `set(attributes["service.namespace"], attributes["service_namespace"]) where (attributes["service.namespace"] == nil or attributes["service.namespace"] == "") and attributes["service_namespace"] != nil and attributes["service_namespace"] != ""`,
+            `delete_key(attributes, "service_namespace") where attributes["service_namespace"] == attributes["service.namespace"]`,
+            `set(attributes["deployment.environment"], attributes["deployment_environment"]) where (attributes["deployment.environment"] == nil or attributes["deployment.environment"] == "") and attributes["deployment_environment"] != nil and attributes["deployment_environment"] != ""`,
+            `delete_key(attributes, "deployment_environment") where attributes["deployment_environment"] == attributes["deployment.environment"]`,
+            `set(attributes["deployment.environment.name"], attributes["deployment_environment_name"]) where (attributes["deployment.environment.name"] == nil or attributes["deployment.environment.name"] == "") and attributes["deployment_environment_name"] != nil and attributes["deployment_environment_name"] != ""`,
+            `delete_key(attributes, "deployment_environment_name") where attributes["deployment_environment_name"] == attributes["deployment.environment.name"]`,
           ]
         }
         metric_statements {
@@ -246,6 +255,11 @@ renders the config to gather Kubernetes Pod logs:
             `delete_key(attributes, "container.image.repo_digests")`,
             `delete_key(attributes, "os.description")`,
             `delete_key(attributes, "os.build_id")`,
+            // Scrape targets that expose their own target_info metric (e.g. Grafana Beyla) can
+            // carry a flat k8s_cluster_name resource attribute, which conflicts with the
+            // k8s.cluster.name attribute set above and gets ";"-joined by the Prometheus OTLP
+            // endpoint. Drop the flat copy when the values match.
+            `delete_key(attributes, "k8s_cluster_name") where attributes["k8s_cluster_name"] == attributes["k8s.cluster.name"]`,
           ]
         }
 

--- a/charts/k8s-monitoring/tests/__snapshot__/feature_pod_logs_via_opentelemetry_test.yaml.snap
+++ b/charts/k8s-monitoring/tests/__snapshot__/feature_pod_logs_via_opentelemetry_test.yaml.snap
@@ -178,9 +178,38 @@ renders the config to gather Kubernetes Pod logs:
       // Destination: otlp (otlp)
       otelcol.receiver.prometheus "otlp" {
         output {
-          metrics = [otelcol.processor.attributes.otlp.input]
+          metrics = [otelcol.processor.transform.otlp_scrape_normalize.input]
         }
       } // otelcol.receiver.prometheus "otlp"
+
+      // Repairs artifacts of the Prometheus-to-OTLP conversion performed by
+      // otelcol.receiver.prometheus. Only metrics that came from a Prometheus scrape pass
+      // through this component; OTLP-native telemetry enters the pipeline further down.
+      otelcol.processor.transform "otlp_scrape_normalize" {
+        error_mode = "ignore"
+        metric_statements {
+          context = "resource"
+          statements = [
+            // The conversion sets service.name to the full Prometheus job label (e.g.
+            // "namespace/workload"). When the scrape target declares its identity explicitly
+            // with a service_name label on its own target_info metric (e.g. Grafana Beyla),
+            // prefer that value and drop the duplicate.
+            `set(attributes["service.name"], attributes["service_name"]) where attributes["service_name"] != nil and attributes["service_name"] != ""`,
+            `delete_key(attributes, "service_name") where attributes["service_name"] == attributes["service.name"]`,
+          ]
+        }
+        metric_statements {
+          context = "datapoint"
+          statements = [
+            // Same correction for scrape targets that put service_name on every series
+            // instead of exposing a target_info metric.
+            `set(resource.attributes["service.name"], attributes["service_name"]) where attributes["service_name"] != nil and attributes["service_name"] != ""`,
+          ]
+        }
+        output {
+          metrics = [otelcol.processor.attributes.otlp.input]
+        }
+      } // otelcol.processor.transform "otlp_scrape_normalize"
       otelcol.receiver.loki "otlp" {
         output {
           logs = [otelcol.processor.attributes.otlp.input]

--- a/charts/k8s-monitoring/tests/integration/auth/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/integration/auth/.rendered/output.yaml
@@ -853,6 +853,15 @@ data:
           // prefer that value and drop the duplicate.
           `set(attributes["service.name"], attributes["service_name"]) where attributes["service_name"] != nil and attributes["service_name"] != ""`,
           `delete_key(attributes, "service_name") where attributes["service_name"] == attributes["service.name"]`,
+          // The same conversion turns other flat target_info labels into resource attributes.
+          // Promote them to their OpenTelemetry counterparts and drop the flat duplicates, so
+          // the OTLP endpoint does not receive two conflicting spellings of the same attribute.
+          `set(attributes["service.namespace"], attributes["service_namespace"]) where (attributes["service.namespace"] == nil or attributes["service.namespace"] == "") and attributes["service_namespace"] != nil and attributes["service_namespace"] != ""`,
+          `delete_key(attributes, "service_namespace") where attributes["service_namespace"] == attributes["service.namespace"]`,
+          `set(attributes["deployment.environment"], attributes["deployment_environment"]) where (attributes["deployment.environment"] == nil or attributes["deployment.environment"] == "") and attributes["deployment_environment"] != nil and attributes["deployment_environment"] != ""`,
+          `delete_key(attributes, "deployment_environment") where attributes["deployment_environment"] == attributes["deployment.environment"]`,
+          `set(attributes["deployment.environment.name"], attributes["deployment_environment_name"]) where (attributes["deployment.environment.name"] == nil or attributes["deployment.environment.name"] == "") and attributes["deployment_environment_name"] != nil and attributes["deployment_environment_name"] != ""`,
+          `delete_key(attributes, "deployment_environment_name") where attributes["deployment_environment_name"] == attributes["deployment.environment.name"]`,
         ]
       }
       metric_statements {
@@ -901,6 +910,11 @@ data:
           `delete_key(attributes, "container.image.repo_digests")`,
           `delete_key(attributes, "os.description")`,
           `delete_key(attributes, "os.build_id")`,
+          // Scrape targets that expose their own target_info metric (e.g. Grafana Beyla) can
+          // carry a flat k8s_cluster_name resource attribute, which conflicts with the
+          // k8s.cluster.name attribute set above and gets ";"-joined by the Prometheus OTLP
+          // endpoint. Drop the flat copy when the values match.
+          `delete_key(attributes, "k8s_cluster_name") where attributes["k8s_cluster_name"] == attributes["k8s.cluster.name"]`,
         ]
       }
     
@@ -988,6 +1002,15 @@ data:
           // prefer that value and drop the duplicate.
           `set(attributes["service.name"], attributes["service_name"]) where attributes["service_name"] != nil and attributes["service_name"] != ""`,
           `delete_key(attributes, "service_name") where attributes["service_name"] == attributes["service.name"]`,
+          // The same conversion turns other flat target_info labels into resource attributes.
+          // Promote them to their OpenTelemetry counterparts and drop the flat duplicates, so
+          // the OTLP endpoint does not receive two conflicting spellings of the same attribute.
+          `set(attributes["service.namespace"], attributes["service_namespace"]) where (attributes["service.namespace"] == nil or attributes["service.namespace"] == "") and attributes["service_namespace"] != nil and attributes["service_namespace"] != ""`,
+          `delete_key(attributes, "service_namespace") where attributes["service_namespace"] == attributes["service.namespace"]`,
+          `set(attributes["deployment.environment"], attributes["deployment_environment"]) where (attributes["deployment.environment"] == nil or attributes["deployment.environment"] == "") and attributes["deployment_environment"] != nil and attributes["deployment_environment"] != ""`,
+          `delete_key(attributes, "deployment_environment") where attributes["deployment_environment"] == attributes["deployment.environment"]`,
+          `set(attributes["deployment.environment.name"], attributes["deployment_environment_name"]) where (attributes["deployment.environment.name"] == nil or attributes["deployment.environment.name"] == "") and attributes["deployment_environment_name"] != nil and attributes["deployment_environment_name"] != ""`,
+          `delete_key(attributes, "deployment_environment_name") where attributes["deployment_environment_name"] == attributes["deployment.environment.name"]`,
         ]
       }
       metric_statements {
@@ -1036,6 +1059,11 @@ data:
           `delete_key(attributes, "container.image.repo_digests")`,
           `delete_key(attributes, "os.description")`,
           `delete_key(attributes, "os.build_id")`,
+          // Scrape targets that expose their own target_info metric (e.g. Grafana Beyla) can
+          // carry a flat k8s_cluster_name resource attribute, which conflicts with the
+          // k8s.cluster.name attribute set above and gets ";"-joined by the Prometheus OTLP
+          // endpoint. Drop the flat copy when the values match.
+          `delete_key(attributes, "k8s_cluster_name") where attributes["k8s_cluster_name"] == attributes["k8s.cluster.name"]`,
         ]
       }
     
@@ -1122,6 +1150,15 @@ data:
           // prefer that value and drop the duplicate.
           `set(attributes["service.name"], attributes["service_name"]) where attributes["service_name"] != nil and attributes["service_name"] != ""`,
           `delete_key(attributes, "service_name") where attributes["service_name"] == attributes["service.name"]`,
+          // The same conversion turns other flat target_info labels into resource attributes.
+          // Promote them to their OpenTelemetry counterparts and drop the flat duplicates, so
+          // the OTLP endpoint does not receive two conflicting spellings of the same attribute.
+          `set(attributes["service.namespace"], attributes["service_namespace"]) where (attributes["service.namespace"] == nil or attributes["service.namespace"] == "") and attributes["service_namespace"] != nil and attributes["service_namespace"] != ""`,
+          `delete_key(attributes, "service_namespace") where attributes["service_namespace"] == attributes["service.namespace"]`,
+          `set(attributes["deployment.environment"], attributes["deployment_environment"]) where (attributes["deployment.environment"] == nil or attributes["deployment.environment"] == "") and attributes["deployment_environment"] != nil and attributes["deployment_environment"] != ""`,
+          `delete_key(attributes, "deployment_environment") where attributes["deployment_environment"] == attributes["deployment.environment"]`,
+          `set(attributes["deployment.environment.name"], attributes["deployment_environment_name"]) where (attributes["deployment.environment.name"] == nil or attributes["deployment.environment.name"] == "") and attributes["deployment_environment_name"] != nil and attributes["deployment_environment_name"] != ""`,
+          `delete_key(attributes, "deployment_environment_name") where attributes["deployment_environment_name"] == attributes["deployment.environment.name"]`,
         ]
       }
       metric_statements {
@@ -1170,6 +1207,11 @@ data:
           `delete_key(attributes, "container.image.repo_digests")`,
           `delete_key(attributes, "os.description")`,
           `delete_key(attributes, "os.build_id")`,
+          // Scrape targets that expose their own target_info metric (e.g. Grafana Beyla) can
+          // carry a flat k8s_cluster_name resource attribute, which conflicts with the
+          // k8s.cluster.name attribute set above and gets ";"-joined by the Prometheus OTLP
+          // endpoint. Drop the flat copy when the values match.
+          `delete_key(attributes, "k8s_cluster_name") where attributes["k8s_cluster_name"] == attributes["k8s.cluster.name"]`,
         ]
       }
     

--- a/charts/k8s-monitoring/tests/integration/auth/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/integration/auth/.rendered/output.yaml
@@ -835,9 +835,38 @@ data:
     // Destination: prometheus-otlp-basicauth (otlp)
     otelcol.receiver.prometheus "prometheus_otlp_basicauth" {
       output {
-        metrics = [otelcol.processor.attributes.prometheus_otlp_basicauth.input]
+        metrics = [otelcol.processor.transform.prometheus_otlp_basicauth_scrape_normalize.input]
       }
     } // otelcol.receiver.prometheus "prometheus_otlp_basicauth"
+    
+    // Repairs artifacts of the Prometheus-to-OTLP conversion performed by
+    // otelcol.receiver.prometheus. Only metrics that came from a Prometheus scrape pass
+    // through this component; OTLP-native telemetry enters the pipeline further down.
+    otelcol.processor.transform "prometheus_otlp_basicauth_scrape_normalize" {
+      error_mode = "ignore"
+      metric_statements {
+        context = "resource"
+        statements = [
+          // The conversion sets service.name to the full Prometheus job label (e.g.
+          // "namespace/workload"). When the scrape target declares its identity explicitly
+          // with a service_name label on its own target_info metric (e.g. Grafana Beyla),
+          // prefer that value and drop the duplicate.
+          `set(attributes["service.name"], attributes["service_name"]) where attributes["service_name"] != nil and attributes["service_name"] != ""`,
+          `delete_key(attributes, "service_name") where attributes["service_name"] == attributes["service.name"]`,
+        ]
+      }
+      metric_statements {
+        context = "datapoint"
+        statements = [
+          // Same correction for scrape targets that put service_name on every series
+          // instead of exposing a target_info metric.
+          `set(resource.attributes["service.name"], attributes["service_name"]) where attributes["service_name"] != nil and attributes["service_name"] != ""`,
+        ]
+      }
+      output {
+        metrics = [otelcol.processor.attributes.prometheus_otlp_basicauth.input]
+      }
+    } // otelcol.processor.transform "prometheus_otlp_basicauth_scrape_normalize"
     otelcol.processor.attributes "prometheus_otlp_basicauth" {
       action {
         key = "destination"
@@ -941,9 +970,38 @@ data:
     // Destination: prometheus-otlp-bearer-token (otlp)
     otelcol.receiver.prometheus "prometheus_otlp_bearer_token" {
       output {
-        metrics = [otelcol.processor.attributes.prometheus_otlp_bearer_token.input]
+        metrics = [otelcol.processor.transform.prometheus_otlp_bearer_token_scrape_normalize.input]
       }
     } // otelcol.receiver.prometheus "prometheus_otlp_bearer_token"
+    
+    // Repairs artifacts of the Prometheus-to-OTLP conversion performed by
+    // otelcol.receiver.prometheus. Only metrics that came from a Prometheus scrape pass
+    // through this component; OTLP-native telemetry enters the pipeline further down.
+    otelcol.processor.transform "prometheus_otlp_bearer_token_scrape_normalize" {
+      error_mode = "ignore"
+      metric_statements {
+        context = "resource"
+        statements = [
+          // The conversion sets service.name to the full Prometheus job label (e.g.
+          // "namespace/workload"). When the scrape target declares its identity explicitly
+          // with a service_name label on its own target_info metric (e.g. Grafana Beyla),
+          // prefer that value and drop the duplicate.
+          `set(attributes["service.name"], attributes["service_name"]) where attributes["service_name"] != nil and attributes["service_name"] != ""`,
+          `delete_key(attributes, "service_name") where attributes["service_name"] == attributes["service.name"]`,
+        ]
+      }
+      metric_statements {
+        context = "datapoint"
+        statements = [
+          // Same correction for scrape targets that put service_name on every series
+          // instead of exposing a target_info metric.
+          `set(resource.attributes["service.name"], attributes["service_name"]) where attributes["service_name"] != nil and attributes["service_name"] != ""`,
+        ]
+      }
+      output {
+        metrics = [otelcol.processor.attributes.prometheus_otlp_bearer_token.input]
+      }
+    } // otelcol.processor.transform "prometheus_otlp_bearer_token_scrape_normalize"
     otelcol.processor.attributes "prometheus_otlp_bearer_token" {
       action {
         key = "destination"
@@ -1046,9 +1104,38 @@ data:
     // Destination: prometheus-otlp-noauth (otlp)
     otelcol.receiver.prometheus "prometheus_otlp_noauth" {
       output {
-        metrics = [otelcol.processor.attributes.prometheus_otlp_noauth.input]
+        metrics = [otelcol.processor.transform.prometheus_otlp_noauth_scrape_normalize.input]
       }
     } // otelcol.receiver.prometheus "prometheus_otlp_noauth"
+    
+    // Repairs artifacts of the Prometheus-to-OTLP conversion performed by
+    // otelcol.receiver.prometheus. Only metrics that came from a Prometheus scrape pass
+    // through this component; OTLP-native telemetry enters the pipeline further down.
+    otelcol.processor.transform "prometheus_otlp_noauth_scrape_normalize" {
+      error_mode = "ignore"
+      metric_statements {
+        context = "resource"
+        statements = [
+          // The conversion sets service.name to the full Prometheus job label (e.g.
+          // "namespace/workload"). When the scrape target declares its identity explicitly
+          // with a service_name label on its own target_info metric (e.g. Grafana Beyla),
+          // prefer that value and drop the duplicate.
+          `set(attributes["service.name"], attributes["service_name"]) where attributes["service_name"] != nil and attributes["service_name"] != ""`,
+          `delete_key(attributes, "service_name") where attributes["service_name"] == attributes["service.name"]`,
+        ]
+      }
+      metric_statements {
+        context = "datapoint"
+        statements = [
+          // Same correction for scrape targets that put service_name on every series
+          // instead of exposing a target_info metric.
+          `set(resource.attributes["service.name"], attributes["service_name"]) where attributes["service_name"] != nil and attributes["service_name"] != ""`,
+        ]
+      }
+      output {
+        metrics = [otelcol.processor.attributes.prometheus_otlp_noauth.input]
+      }
+    } // otelcol.processor.transform "prometheus_otlp_noauth_scrape_normalize"
     otelcol.processor.attributes "prometheus_otlp_noauth" {
       action {
         key = "destination"

--- a/charts/k8s-monitoring/tests/integration/prom-and-loki-to-otlp/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/integration/prom-and-loki-to-otlp/.rendered/output.yaml
@@ -850,9 +850,38 @@ data:
     // Destination: prometheus (otlp)
     otelcol.receiver.prometheus "prometheus" {
       output {
-        metrics = [otelcol.processor.attributes.prometheus.input]
+        metrics = [otelcol.processor.transform.prometheus_scrape_normalize.input]
       }
     } // otelcol.receiver.prometheus "prometheus"
+    
+    // Repairs artifacts of the Prometheus-to-OTLP conversion performed by
+    // otelcol.receiver.prometheus. Only metrics that came from a Prometheus scrape pass
+    // through this component; OTLP-native telemetry enters the pipeline further down.
+    otelcol.processor.transform "prometheus_scrape_normalize" {
+      error_mode = "ignore"
+      metric_statements {
+        context = "resource"
+        statements = [
+          // The conversion sets service.name to the full Prometheus job label (e.g.
+          // "namespace/workload"). When the scrape target declares its identity explicitly
+          // with a service_name label on its own target_info metric (e.g. Grafana Beyla),
+          // prefer that value and drop the duplicate.
+          `set(attributes["service.name"], attributes["service_name"]) where attributes["service_name"] != nil and attributes["service_name"] != ""`,
+          `delete_key(attributes, "service_name") where attributes["service_name"] == attributes["service.name"]`,
+        ]
+      }
+      metric_statements {
+        context = "datapoint"
+        statements = [
+          // Same correction for scrape targets that put service_name on every series
+          // instead of exposing a target_info metric.
+          `set(resource.attributes["service.name"], attributes["service_name"]) where attributes["service_name"] != nil and attributes["service_name"] != ""`,
+        ]
+      }
+      output {
+        metrics = [otelcol.processor.attributes.prometheus.input]
+      }
+    } // otelcol.processor.transform "prometheus_scrape_normalize"
     otelcol.processor.attributes "prometheus" {
       output {
         metrics = [otelcol.processor.transform.prometheus.input]
@@ -1207,9 +1236,38 @@ data:
     // Destination: prometheus (otlp)
     otelcol.receiver.prometheus "prometheus" {
       output {
-        metrics = [otelcol.processor.attributes.prometheus.input]
+        metrics = [otelcol.processor.transform.prometheus_scrape_normalize.input]
       }
     } // otelcol.receiver.prometheus "prometheus"
+    
+    // Repairs artifacts of the Prometheus-to-OTLP conversion performed by
+    // otelcol.receiver.prometheus. Only metrics that came from a Prometheus scrape pass
+    // through this component; OTLP-native telemetry enters the pipeline further down.
+    otelcol.processor.transform "prometheus_scrape_normalize" {
+      error_mode = "ignore"
+      metric_statements {
+        context = "resource"
+        statements = [
+          // The conversion sets service.name to the full Prometheus job label (e.g.
+          // "namespace/workload"). When the scrape target declares its identity explicitly
+          // with a service_name label on its own target_info metric (e.g. Grafana Beyla),
+          // prefer that value and drop the duplicate.
+          `set(attributes["service.name"], attributes["service_name"]) where attributes["service_name"] != nil and attributes["service_name"] != ""`,
+          `delete_key(attributes, "service_name") where attributes["service_name"] == attributes["service.name"]`,
+        ]
+      }
+      metric_statements {
+        context = "datapoint"
+        statements = [
+          // Same correction for scrape targets that put service_name on every series
+          // instead of exposing a target_info metric.
+          `set(resource.attributes["service.name"], attributes["service_name"]) where attributes["service_name"] != nil and attributes["service_name"] != ""`,
+        ]
+      }
+      output {
+        metrics = [otelcol.processor.attributes.prometheus.input]
+      }
+    } // otelcol.processor.transform "prometheus_scrape_normalize"
     otelcol.processor.attributes "prometheus" {
       output {
         metrics = [otelcol.processor.transform.prometheus.input]

--- a/charts/k8s-monitoring/tests/integration/prom-and-loki-to-otlp/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/integration/prom-and-loki-to-otlp/.rendered/output.yaml
@@ -868,6 +868,15 @@ data:
           // prefer that value and drop the duplicate.
           `set(attributes["service.name"], attributes["service_name"]) where attributes["service_name"] != nil and attributes["service_name"] != ""`,
           `delete_key(attributes, "service_name") where attributes["service_name"] == attributes["service.name"]`,
+          // The same conversion turns other flat target_info labels into resource attributes.
+          // Promote them to their OpenTelemetry counterparts and drop the flat duplicates, so
+          // the OTLP endpoint does not receive two conflicting spellings of the same attribute.
+          `set(attributes["service.namespace"], attributes["service_namespace"]) where (attributes["service.namespace"] == nil or attributes["service.namespace"] == "") and attributes["service_namespace"] != nil and attributes["service_namespace"] != ""`,
+          `delete_key(attributes, "service_namespace") where attributes["service_namespace"] == attributes["service.namespace"]`,
+          `set(attributes["deployment.environment"], attributes["deployment_environment"]) where (attributes["deployment.environment"] == nil or attributes["deployment.environment"] == "") and attributes["deployment_environment"] != nil and attributes["deployment_environment"] != ""`,
+          `delete_key(attributes, "deployment_environment") where attributes["deployment_environment"] == attributes["deployment.environment"]`,
+          `set(attributes["deployment.environment.name"], attributes["deployment_environment_name"]) where (attributes["deployment.environment.name"] == nil or attributes["deployment.environment.name"] == "") and attributes["deployment_environment_name"] != nil and attributes["deployment_environment_name"] != ""`,
+          `delete_key(attributes, "deployment_environment_name") where attributes["deployment_environment_name"] == attributes["deployment.environment.name"]`,
         ]
       }
       metric_statements {
@@ -910,6 +919,11 @@ data:
           `delete_key(attributes, "container.image.repo_digests")`,
           `delete_key(attributes, "os.description")`,
           `delete_key(attributes, "os.build_id")`,
+          // Scrape targets that expose their own target_info metric (e.g. Grafana Beyla) can
+          // carry a flat k8s_cluster_name resource attribute, which conflicts with the
+          // k8s.cluster.name attribute set above and gets ";"-joined by the Prometheus OTLP
+          // endpoint. Drop the flat copy when the values match.
+          `delete_key(attributes, "k8s_cluster_name") where attributes["k8s_cluster_name"] == attributes["k8s.cluster.name"]`,
         ]
       }
     
@@ -1254,6 +1268,15 @@ data:
           // prefer that value and drop the duplicate.
           `set(attributes["service.name"], attributes["service_name"]) where attributes["service_name"] != nil and attributes["service_name"] != ""`,
           `delete_key(attributes, "service_name") where attributes["service_name"] == attributes["service.name"]`,
+          // The same conversion turns other flat target_info labels into resource attributes.
+          // Promote them to their OpenTelemetry counterparts and drop the flat duplicates, so
+          // the OTLP endpoint does not receive two conflicting spellings of the same attribute.
+          `set(attributes["service.namespace"], attributes["service_namespace"]) where (attributes["service.namespace"] == nil or attributes["service.namespace"] == "") and attributes["service_namespace"] != nil and attributes["service_namespace"] != ""`,
+          `delete_key(attributes, "service_namespace") where attributes["service_namespace"] == attributes["service.namespace"]`,
+          `set(attributes["deployment.environment"], attributes["deployment_environment"]) where (attributes["deployment.environment"] == nil or attributes["deployment.environment"] == "") and attributes["deployment_environment"] != nil and attributes["deployment_environment"] != ""`,
+          `delete_key(attributes, "deployment_environment") where attributes["deployment_environment"] == attributes["deployment.environment"]`,
+          `set(attributes["deployment.environment.name"], attributes["deployment_environment_name"]) where (attributes["deployment.environment.name"] == nil or attributes["deployment.environment.name"] == "") and attributes["deployment_environment_name"] != nil and attributes["deployment_environment_name"] != ""`,
+          `delete_key(attributes, "deployment_environment_name") where attributes["deployment_environment_name"] == attributes["deployment.environment.name"]`,
         ]
       }
       metric_statements {
@@ -1296,6 +1319,11 @@ data:
           `delete_key(attributes, "container.image.repo_digests")`,
           `delete_key(attributes, "os.description")`,
           `delete_key(attributes, "os.build_id")`,
+          // Scrape targets that expose their own target_info metric (e.g. Grafana Beyla) can
+          // carry a flat k8s_cluster_name resource attribute, which conflicts with the
+          // k8s.cluster.name attribute set above and gets ";"-joined by the Prometheus OTLP
+          // endpoint. Drop the flat copy when the values match.
+          `delete_key(attributes, "k8s_cluster_name") where attributes["k8s_cluster_name"] == attributes["k8s.cluster.name"]`,
         ]
       }
     

--- a/charts/k8s-monitoring/tests/platform/grafana-cloud/app-observability/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/platform/grafana-cloud/app-observability/.rendered/output.yaml
@@ -229,9 +229,38 @@ data:
     // Destination: otlp-gateway (otlp)
     otelcol.receiver.prometheus "otlp_gateway" {
       output {
-        metrics = [otelcol.processor.attributes.otlp_gateway.input]
+        metrics = [otelcol.processor.transform.otlp_gateway_scrape_normalize.input]
       }
     } // otelcol.receiver.prometheus "otlp_gateway"
+    
+    // Repairs artifacts of the Prometheus-to-OTLP conversion performed by
+    // otelcol.receiver.prometheus. Only metrics that came from a Prometheus scrape pass
+    // through this component; OTLP-native telemetry enters the pipeline further down.
+    otelcol.processor.transform "otlp_gateway_scrape_normalize" {
+      error_mode = "ignore"
+      metric_statements {
+        context = "resource"
+        statements = [
+          // The conversion sets service.name to the full Prometheus job label (e.g.
+          // "namespace/workload"). When the scrape target declares its identity explicitly
+          // with a service_name label on its own target_info metric (e.g. Grafana Beyla),
+          // prefer that value and drop the duplicate.
+          `set(attributes["service.name"], attributes["service_name"]) where attributes["service_name"] != nil and attributes["service_name"] != ""`,
+          `delete_key(attributes, "service_name") where attributes["service_name"] == attributes["service.name"]`,
+        ]
+      }
+      metric_statements {
+        context = "datapoint"
+        statements = [
+          // Same correction for scrape targets that put service_name on every series
+          // instead of exposing a target_info metric.
+          `set(resource.attributes["service.name"], attributes["service_name"]) where attributes["service_name"] != nil and attributes["service_name"] != ""`,
+        ]
+      }
+      output {
+        metrics = [otelcol.processor.attributes.otlp_gateway.input]
+      }
+    } // otelcol.processor.transform "otlp_gateway_scrape_normalize"
     otelcol.receiver.loki "otlp_gateway" {
       output {
         logs = [otelcol.processor.attributes.otlp_gateway.input]
@@ -628,9 +657,38 @@ data:
     // Destination: otlp-gateway (otlp)
     otelcol.receiver.prometheus "otlp_gateway" {
       output {
-        metrics = [otelcol.processor.attributes.otlp_gateway.input]
+        metrics = [otelcol.processor.transform.otlp_gateway_scrape_normalize.input]
       }
     } // otelcol.receiver.prometheus "otlp_gateway"
+    
+    // Repairs artifacts of the Prometheus-to-OTLP conversion performed by
+    // otelcol.receiver.prometheus. Only metrics that came from a Prometheus scrape pass
+    // through this component; OTLP-native telemetry enters the pipeline further down.
+    otelcol.processor.transform "otlp_gateway_scrape_normalize" {
+      error_mode = "ignore"
+      metric_statements {
+        context = "resource"
+        statements = [
+          // The conversion sets service.name to the full Prometheus job label (e.g.
+          // "namespace/workload"). When the scrape target declares its identity explicitly
+          // with a service_name label on its own target_info metric (e.g. Grafana Beyla),
+          // prefer that value and drop the duplicate.
+          `set(attributes["service.name"], attributes["service_name"]) where attributes["service_name"] != nil and attributes["service_name"] != ""`,
+          `delete_key(attributes, "service_name") where attributes["service_name"] == attributes["service.name"]`,
+        ]
+      }
+      metric_statements {
+        context = "datapoint"
+        statements = [
+          // Same correction for scrape targets that put service_name on every series
+          // instead of exposing a target_info metric.
+          `set(resource.attributes["service.name"], attributes["service_name"]) where attributes["service_name"] != nil and attributes["service_name"] != ""`,
+        ]
+      }
+      output {
+        metrics = [otelcol.processor.attributes.otlp_gateway.input]
+      }
+    } // otelcol.processor.transform "otlp_gateway_scrape_normalize"
     otelcol.receiver.loki "otlp_gateway" {
       output {
         logs = [otelcol.processor.attributes.otlp_gateway.input]

--- a/charts/k8s-monitoring/tests/platform/grafana-cloud/app-observability/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/platform/grafana-cloud/app-observability/.rendered/output.yaml
@@ -247,6 +247,15 @@ data:
           // prefer that value and drop the duplicate.
           `set(attributes["service.name"], attributes["service_name"]) where attributes["service_name"] != nil and attributes["service_name"] != ""`,
           `delete_key(attributes, "service_name") where attributes["service_name"] == attributes["service.name"]`,
+          // The same conversion turns other flat target_info labels into resource attributes.
+          // Promote them to their OpenTelemetry counterparts and drop the flat duplicates, so
+          // the OTLP endpoint does not receive two conflicting spellings of the same attribute.
+          `set(attributes["service.namespace"], attributes["service_namespace"]) where (attributes["service.namespace"] == nil or attributes["service.namespace"] == "") and attributes["service_namespace"] != nil and attributes["service_namespace"] != ""`,
+          `delete_key(attributes, "service_namespace") where attributes["service_namespace"] == attributes["service.namespace"]`,
+          `set(attributes["deployment.environment"], attributes["deployment_environment"]) where (attributes["deployment.environment"] == nil or attributes["deployment.environment"] == "") and attributes["deployment_environment"] != nil and attributes["deployment_environment"] != ""`,
+          `delete_key(attributes, "deployment_environment") where attributes["deployment_environment"] == attributes["deployment.environment"]`,
+          `set(attributes["deployment.environment.name"], attributes["deployment_environment_name"]) where (attributes["deployment.environment.name"] == nil or attributes["deployment.environment.name"] == "") and attributes["deployment_environment_name"] != nil and attributes["deployment_environment_name"] != ""`,
+          `delete_key(attributes, "deployment_environment_name") where attributes["deployment_environment_name"] == attributes["deployment.environment.name"]`,
         ]
       }
       metric_statements {
@@ -297,6 +306,11 @@ data:
           `delete_key(attributes, "container.image.repo_digests")`,
           `delete_key(attributes, "os.description")`,
           `delete_key(attributes, "os.build_id")`,
+          // Scrape targets that expose their own target_info metric (e.g. Grafana Beyla) can
+          // carry a flat k8s_cluster_name resource attribute, which conflicts with the
+          // k8s.cluster.name attribute set above and gets ";"-joined by the Prometheus OTLP
+          // endpoint. Drop the flat copy when the values match.
+          `delete_key(attributes, "k8s_cluster_name") where attributes["k8s_cluster_name"] == attributes["k8s.cluster.name"]`,
         ]
       }
     
@@ -675,6 +689,15 @@ data:
           // prefer that value and drop the duplicate.
           `set(attributes["service.name"], attributes["service_name"]) where attributes["service_name"] != nil and attributes["service_name"] != ""`,
           `delete_key(attributes, "service_name") where attributes["service_name"] == attributes["service.name"]`,
+          // The same conversion turns other flat target_info labels into resource attributes.
+          // Promote them to their OpenTelemetry counterparts and drop the flat duplicates, so
+          // the OTLP endpoint does not receive two conflicting spellings of the same attribute.
+          `set(attributes["service.namespace"], attributes["service_namespace"]) where (attributes["service.namespace"] == nil or attributes["service.namespace"] == "") and attributes["service_namespace"] != nil and attributes["service_namespace"] != ""`,
+          `delete_key(attributes, "service_namespace") where attributes["service_namespace"] == attributes["service.namespace"]`,
+          `set(attributes["deployment.environment"], attributes["deployment_environment"]) where (attributes["deployment.environment"] == nil or attributes["deployment.environment"] == "") and attributes["deployment_environment"] != nil and attributes["deployment_environment"] != ""`,
+          `delete_key(attributes, "deployment_environment") where attributes["deployment_environment"] == attributes["deployment.environment"]`,
+          `set(attributes["deployment.environment.name"], attributes["deployment_environment_name"]) where (attributes["deployment.environment.name"] == nil or attributes["deployment.environment.name"] == "") and attributes["deployment_environment_name"] != nil and attributes["deployment_environment_name"] != ""`,
+          `delete_key(attributes, "deployment_environment_name") where attributes["deployment_environment_name"] == attributes["deployment.environment.name"]`,
         ]
       }
       metric_statements {
@@ -725,6 +748,11 @@ data:
           `delete_key(attributes, "container.image.repo_digests")`,
           `delete_key(attributes, "os.description")`,
           `delete_key(attributes, "os.build_id")`,
+          // Scrape targets that expose their own target_info metric (e.g. Grafana Beyla) can
+          // carry a flat k8s_cluster_name resource attribute, which conflicts with the
+          // k8s.cluster.name attribute set above and gets ";"-joined by the Prometheus OTLP
+          // endpoint. Drop the flat copy when the values match.
+          `delete_key(attributes, "k8s_cluster_name") where attributes["k8s_cluster_name"] == attributes["k8s.cluster.name"]`,
         ]
       }
     

--- a/charts/k8s-monitoring/tests/platform/grafana-cloud/k8s-monitoring/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/platform/grafana-cloud/k8s-monitoring/.rendered/output.yaml
@@ -1590,9 +1590,38 @@ data:
     // Destination: grafana-cloud-otlp-endpoint (otlp)
     otelcol.receiver.prometheus "grafana_cloud_otlp_endpoint" {
       output {
-        metrics = [otelcol.processor.attributes.grafana_cloud_otlp_endpoint.input]
+        metrics = [otelcol.processor.transform.grafana_cloud_otlp_endpoint_scrape_normalize.input]
       }
     } // otelcol.receiver.prometheus "grafana_cloud_otlp_endpoint"
+    
+    // Repairs artifacts of the Prometheus-to-OTLP conversion performed by
+    // otelcol.receiver.prometheus. Only metrics that came from a Prometheus scrape pass
+    // through this component; OTLP-native telemetry enters the pipeline further down.
+    otelcol.processor.transform "grafana_cloud_otlp_endpoint_scrape_normalize" {
+      error_mode = "ignore"
+      metric_statements {
+        context = "resource"
+        statements = [
+          // The conversion sets service.name to the full Prometheus job label (e.g.
+          // "namespace/workload"). When the scrape target declares its identity explicitly
+          // with a service_name label on its own target_info metric (e.g. Grafana Beyla),
+          // prefer that value and drop the duplicate.
+          `set(attributes["service.name"], attributes["service_name"]) where attributes["service_name"] != nil and attributes["service_name"] != ""`,
+          `delete_key(attributes, "service_name") where attributes["service_name"] == attributes["service.name"]`,
+        ]
+      }
+      metric_statements {
+        context = "datapoint"
+        statements = [
+          // Same correction for scrape targets that put service_name on every series
+          // instead of exposing a target_info metric.
+          `set(resource.attributes["service.name"], attributes["service_name"]) where attributes["service_name"] != nil and attributes["service_name"] != ""`,
+        ]
+      }
+      output {
+        metrics = [otelcol.processor.attributes.grafana_cloud_otlp_endpoint.input]
+      }
+    } // otelcol.processor.transform "grafana_cloud_otlp_endpoint_scrape_normalize"
     otelcol.receiver.loki "grafana_cloud_otlp_endpoint" {
       output {
         logs = [otelcol.processor.attributes.grafana_cloud_otlp_endpoint.input]

--- a/charts/k8s-monitoring/tests/platform/grafana-cloud/k8s-monitoring/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/platform/grafana-cloud/k8s-monitoring/.rendered/output.yaml
@@ -1608,6 +1608,15 @@ data:
           // prefer that value and drop the duplicate.
           `set(attributes["service.name"], attributes["service_name"]) where attributes["service_name"] != nil and attributes["service_name"] != ""`,
           `delete_key(attributes, "service_name") where attributes["service_name"] == attributes["service.name"]`,
+          // The same conversion turns other flat target_info labels into resource attributes.
+          // Promote them to their OpenTelemetry counterparts and drop the flat duplicates, so
+          // the OTLP endpoint does not receive two conflicting spellings of the same attribute.
+          `set(attributes["service.namespace"], attributes["service_namespace"]) where (attributes["service.namespace"] == nil or attributes["service.namespace"] == "") and attributes["service_namespace"] != nil and attributes["service_namespace"] != ""`,
+          `delete_key(attributes, "service_namespace") where attributes["service_namespace"] == attributes["service.namespace"]`,
+          `set(attributes["deployment.environment"], attributes["deployment_environment"]) where (attributes["deployment.environment"] == nil or attributes["deployment.environment"] == "") and attributes["deployment_environment"] != nil and attributes["deployment_environment"] != ""`,
+          `delete_key(attributes, "deployment_environment") where attributes["deployment_environment"] == attributes["deployment.environment"]`,
+          `set(attributes["deployment.environment.name"], attributes["deployment_environment_name"]) where (attributes["deployment.environment.name"] == nil or attributes["deployment.environment.name"] == "") and attributes["deployment_environment_name"] != nil and attributes["deployment_environment_name"] != ""`,
+          `delete_key(attributes, "deployment_environment_name") where attributes["deployment_environment_name"] == attributes["deployment.environment.name"]`,
         ]
       }
       metric_statements {
@@ -1658,6 +1667,11 @@ data:
           `delete_key(attributes, "container.image.repo_digests")`,
           `delete_key(attributes, "os.description")`,
           `delete_key(attributes, "os.build_id")`,
+          // Scrape targets that expose their own target_info metric (e.g. Grafana Beyla) can
+          // carry a flat k8s_cluster_name resource attribute, which conflicts with the
+          // k8s.cluster.name attribute set above and gets ";"-joined by the Prometheus OTLP
+          // endpoint. Drop the flat copy when the values match.
+          `delete_key(attributes, "k8s_cluster_name") where attributes["k8s_cluster_name"] == attributes["k8s.cluster.name"]`,
         ]
       }
     

--- a/charts/k8s-monitoring/tests/platform/otlp-gateway/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/platform/otlp-gateway/.rendered/output.yaml
@@ -1157,9 +1157,38 @@ data:
     // Destination: otlp-gateway (otlp)
     otelcol.receiver.prometheus "otlp_gateway" {
       output {
-        metrics = [otelcol.processor.attributes.otlp_gateway.input]
+        metrics = [otelcol.processor.transform.otlp_gateway_scrape_normalize.input]
       }
     } // otelcol.receiver.prometheus "otlp_gateway"
+    
+    // Repairs artifacts of the Prometheus-to-OTLP conversion performed by
+    // otelcol.receiver.prometheus. Only metrics that came from a Prometheus scrape pass
+    // through this component; OTLP-native telemetry enters the pipeline further down.
+    otelcol.processor.transform "otlp_gateway_scrape_normalize" {
+      error_mode = "ignore"
+      metric_statements {
+        context = "resource"
+        statements = [
+          // The conversion sets service.name to the full Prometheus job label (e.g.
+          // "namespace/workload"). When the scrape target declares its identity explicitly
+          // with a service_name label on its own target_info metric (e.g. Grafana Beyla),
+          // prefer that value and drop the duplicate.
+          `set(attributes["service.name"], attributes["service_name"]) where attributes["service_name"] != nil and attributes["service_name"] != ""`,
+          `delete_key(attributes, "service_name") where attributes["service_name"] == attributes["service.name"]`,
+        ]
+      }
+      metric_statements {
+        context = "datapoint"
+        statements = [
+          // Same correction for scrape targets that put service_name on every series
+          // instead of exposing a target_info metric.
+          `set(resource.attributes["service.name"], attributes["service_name"]) where attributes["service_name"] != nil and attributes["service_name"] != ""`,
+        ]
+      }
+      output {
+        metrics = [otelcol.processor.attributes.otlp_gateway.input]
+      }
+    } // otelcol.processor.transform "otlp_gateway_scrape_normalize"
     otelcol.receiver.loki "otlp_gateway" {
       output {
         logs = [otelcol.processor.attributes.otlp_gateway.input]

--- a/charts/k8s-monitoring/tests/platform/otlp-gateway/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/platform/otlp-gateway/.rendered/output.yaml
@@ -1175,6 +1175,15 @@ data:
           // prefer that value and drop the duplicate.
           `set(attributes["service.name"], attributes["service_name"]) where attributes["service_name"] != nil and attributes["service_name"] != ""`,
           `delete_key(attributes, "service_name") where attributes["service_name"] == attributes["service.name"]`,
+          // The same conversion turns other flat target_info labels into resource attributes.
+          // Promote them to their OpenTelemetry counterparts and drop the flat duplicates, so
+          // the OTLP endpoint does not receive two conflicting spellings of the same attribute.
+          `set(attributes["service.namespace"], attributes["service_namespace"]) where (attributes["service.namespace"] == nil or attributes["service.namespace"] == "") and attributes["service_namespace"] != nil and attributes["service_namespace"] != ""`,
+          `delete_key(attributes, "service_namespace") where attributes["service_namespace"] == attributes["service.namespace"]`,
+          `set(attributes["deployment.environment"], attributes["deployment_environment"]) where (attributes["deployment.environment"] == nil or attributes["deployment.environment"] == "") and attributes["deployment_environment"] != nil and attributes["deployment_environment"] != ""`,
+          `delete_key(attributes, "deployment_environment") where attributes["deployment_environment"] == attributes["deployment.environment"]`,
+          `set(attributes["deployment.environment.name"], attributes["deployment_environment_name"]) where (attributes["deployment.environment.name"] == nil or attributes["deployment.environment.name"] == "") and attributes["deployment_environment_name"] != nil and attributes["deployment_environment_name"] != ""`,
+          `delete_key(attributes, "deployment_environment_name") where attributes["deployment_environment_name"] == attributes["deployment.environment.name"]`,
         ]
       }
       metric_statements {
@@ -1225,6 +1234,11 @@ data:
           `delete_key(attributes, "container.image.repo_digests")`,
           `delete_key(attributes, "os.description")`,
           `delete_key(attributes, "os.build_id")`,
+          // Scrape targets that expose their own target_info metric (e.g. Grafana Beyla) can
+          // carry a flat k8s_cluster_name resource attribute, which conflicts with the
+          // k8s.cluster.name attribute set above and gets ";"-joined by the Prometheus OTLP
+          // endpoint. Drop the flat copy when the values match.
+          `delete_key(attributes, "k8s_cluster_name") where attributes["k8s_cluster_name"] == attributes["k8s.cluster.name"]`,
         ]
       }
     


### PR DESCRIPTION
Fixes #2786. Includes the reworked #2783 fix as its base commit (see below) - if the direction here works, #2784 will be updated to match.

## Problem

Scrape targets that expose their own `target_info` metric (e.g. Grafana Beyla) get its labels converted verbatim into flat resource attributes (`service_name`, `service_namespace`, `deployment_environment`, `k8s_cluster_name`) by `otelcol.receiver.prometheus`. The destination transform then adds the dotted equivalents, and since both variants translate to the same Prometheus label, the OTLP endpoint joins the values with `;` (`k8s_cluster_name="c;c"`, `service_name="cart;cart"`), polluting `target_info` and everything that joins on it (Asserts, Entity Graph, Application Observability enrichment).

## Approach

Following the review feedback on #2784 (a value-pattern check on `service.name` could break users who set such names on purpose), the corrections no longer guess provenance from the data. A dedicated `otelcol.processor.transform "<destination>_scrape_normalize"` now sits directly between `otelcol.receiver.prometheus` and the rest of the destination pipeline. Everything passing through it came from a Prometheus scrape, so:

- `service.name` synthesized from the `job` label is replaced with the explicit `service_name` label when the target provides one - no regex heuristics needed.
- The flat `service_namespace`, `deployment_environment`, and `deployment_environment_name` resource attributes are promoted to their dotted counterparts and the flat copies dropped when equal.
- OTLP-native telemetry never enters this component, so user-set resource attributes cannot be affected.

The only statement left in the shared transform is the `k8s_cluster_name` dedup, because `k8s.cluster.name` is set from chart values there (after the normalize step). It is an equality-guarded `delete_key`, so it only removes an exact duplicate.

The statements are grouped and commented in the rendered config.

## Verification

Verified on a live cluster (chart 4.2.0 + Beyla + OTLP-only destination, equivalent statements applied via destination `processors.transform` values): `target_info` values become single (`service_name="cart"`, no `;`), the Application Observability service identity matches the pod logs, and its Logs tab populates.
