### PR TITLE
Explicitly set `false` to Beyla's K8s Cache and SDK Injector Controller

### DIFF
--- a/charts/k8s-monitoring/CHANGELOG.md
+++ b/charts/k8s-monitoring/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+*   Surface `deploy: false` defaults for `telemetryServices.beyla` and `telemetryServices.sdkInjector` in the top-level values, matching the other telemetry services. This prevents them from deploying unintentionally on Helm versions affected by a subchart value coalescing regression (helm/helm#32132). (#2781, #2782) (@petewall)
 *   Change the default remote configuration `pollFrequency` from `5m` to `30s`. (@TylerHelmuth)
 *   Add `CLUSTER_NAME` environment variable to remote-config-enabled collectors alongside `NAMESPACE` and `POD_NAME`. (#2775) (@petewall)
 

--- a/charts/k8s-monitoring/README.md
+++ b/charts/k8s-monitoring/README.md
@@ -658,7 +658,7 @@ details:
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | telemetryServices.beyla.deploy | bool | `false` | Deploy Grafana Beyla's Kubernetes cache. |
-| telemetryServices.beyla.k8sCache.replicas | int | `0` | Number of replicas for the Beyla Kubernetes metadata cache. Set to a positive number to deploy the cache. |
+| telemetryServices.beyla.k8sCache.replicas | int | `0` | Number of replicas for the Beyla Kubernetes metadata cache. Set to a positive number and set telemetryServices.beyla.deploy=true to deploy the cache. |
 | telemetryServices.k8s-manifest-tail.deploy | bool | `false` | Deploy k8s-manifest-tail to watch and log Kubernetes manifest changes. |
 | telemetryServices.kepler.deploy | bool | `false` | Deploy [Kepler](https://sustainable-computing.io/) to gather energy usage metrics from the Kubernetes Cluster nodes. |
 | telemetryServices.kube-state-metrics.deploy | bool | `false` | Deploy kube-state-metrics to expose Kubernetes object metadata as Prometheus metrics. |

--- a/charts/k8s-monitoring/README.md
+++ b/charts/k8s-monitoring/README.md
@@ -657,11 +657,14 @@ details:
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
+| telemetryServices.beyla.deploy | bool | `false` | Deploy Grafana Beyla's Kubernetes cache. |
+| telemetryServices.beyla.k8sCache.replicas | int | `0` | Number of replicas for the Beyla Kubernetes metadata cache. Set to a positive number to deploy the cache. |
 | telemetryServices.k8s-manifest-tail.deploy | bool | `false` | Deploy k8s-manifest-tail to watch and log Kubernetes manifest changes. |
 | telemetryServices.kepler.deploy | bool | `false` | Deploy [Kepler](https://sustainable-computing.io/) to gather energy usage metrics from the Kubernetes Cluster nodes. |
 | telemetryServices.kube-state-metrics.deploy | bool | `false` | Deploy kube-state-metrics to expose Kubernetes object metadata as Prometheus metrics. |
 | telemetryServices.node-exporter.deploy | bool | `false` | Deploy Node Exporter to gather Linux node hardware and OS metrics. |
 | telemetryServices.opencost.deploy | bool | `false` | Deploy OpenCost to calculate and expose Kubernetes cost allocation metrics. |
+| telemetryServices.sdkInjector.deploy | bool | `false` | Deploy the SDK Injector. |
 | telemetryServices.windows-exporter.deploy | bool | `false` | Deploy Windows Exporter to gather Windows node hardware and OS metrics. |
 
 ### Other Values

--- a/charts/k8s-monitoring/values.schema.json
+++ b/charts/k8s-monitoring/values.schema.json
@@ -663,6 +663,22 @@
         "telemetryServices": {
             "type": "object",
             "properties": {
+                "beyla": {
+                    "type": "object",
+                    "properties": {
+                        "deploy": {
+                            "type": "boolean"
+                        },
+                        "k8sCache": {
+                            "type": "object",
+                            "properties": {
+                                "replicas": {
+                                    "type": "integer"
+                                }
+                            }
+                        }
+                    }
+                },
                 "k8s-manifest-tail": {
                     "type": "object",
                     "properties": {
@@ -696,6 +712,14 @@
                     }
                 },
                 "opencost": {
+                    "type": "object",
+                    "properties": {
+                        "deploy": {
+                            "type": "boolean"
+                        }
+                    }
+                },
+                "sdkInjector": {
                     "type": "object",
                     "properties": {
                         "deploy": {

--- a/charts/k8s-monitoring/values.yaml
+++ b/charts/k8s-monitoring/values.yaml
@@ -601,6 +601,24 @@ telemetryServices:
     # @section -- Telemetry Services
     deploy: false
 
+  # [Beyla](https://github.com/grafana/beyla) provides a Kubernetes cache that supplies metadata to Beyla instances.
+  beyla:
+    # -- Deploy Grafana Beyla's Kubernetes cache.
+    # @section -- Telemetry Services
+    deploy: false
+
+    # Options for the Grafana Beyla Kubernetes metadata cache.
+    k8sCache:
+      # -- Number of replicas for the Beyla Kubernetes metadata cache. Set to a positive number to deploy the cache.
+      # @section -- Telemetry Services
+      replicas: 0
+
+  # The [SDK Injector](https://github.com/grafana/k8s-injection-controller) auto-instruments applications with the Beyla SDK.
+  sdkInjector:
+    # -- Deploy the SDK Injector.
+    # @section -- Telemetry Services
+    deploy: false
+
 # The Alloy Operator is a Kubernetes Operator that manages Alloy instances and their lifecycle.
 # To see all valid settings, please see the [Alloy Operator documentation](https://github.com/grafana/alloy-operator/tree/main/charts/alloy-operator).
 alloy-operator:

--- a/charts/k8s-monitoring/values.yaml
+++ b/charts/k8s-monitoring/values.yaml
@@ -609,7 +609,7 @@ telemetryServices:
 
     # Options for the Grafana Beyla Kubernetes metadata cache.
     k8sCache:
-      # -- Number of replicas for the Beyla Kubernetes metadata cache. Set to a positive number to deploy the cache.
+      # -- Number of replicas for the Beyla Kubernetes metadata cache. Set to a positive number and set telemetryServices.beyla.deploy=true to deploy the cache.
       # @section -- Telemetry Services
       replicas: 0
 


### PR DESCRIPTION
<!--Describe what this change does and why.-->
# Description

Explicitly set `false` for the new deployments in 4.2: Beyla’s K8s Cache and the SDK Injector Controller
This also gives nice targets for users when they want to enable them.

Fixes #2781 (because the sdk injector shouldn't have been deployed)
Fixes #2782

<!--Authorship attestation. See AGENTS.md for details. AI agents must not check this box on behalf
of the user; the human author must check it themselves before the PR is ready for review.-->
## Authorship

-   [X] I, a human, wrote this pull request description myself.

<!--Please delete paragraphs that you did not use before submitting.-->
