### PR TITLE
Fix unrecognized block name "rule_namespace"

### DIFF
--- a/charts/k8s-monitoring/CHANGELOG.md
+++ b/charts/k8s-monitoring/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+*   Fix `unrecognized block name "rule_namespace"` error when using the `rules.namespaces` field of the `prometheus` destination to limit the PrometheusRules object discovery to specific namespaces (#2802) (@sebasnabas)
+
 ## 4.2.1
 
 *   Add the `root`, `host-network`, `host-storage`, and `host-cgroup` collector presets and deprecate the `privileged` preset. `root` sets the privileged root `securityContext`, `host-network` sets `hostPID`/`hostNetwork`/`dnsPolicy`, and `host-storage`/`host-cgroup` mount host paths. `privileged` is unchanged and still works, but cannot be combined with these new presets. (#2796) (@TylerHelmuth)

--- a/charts/k8s-monitoring/templates/destinations/_destination_prometheus.tpl
+++ b/charts/k8s-monitoring/templates/destinations/_destination_prometheus.tpl
@@ -89,10 +89,10 @@ prometheus.enrich "{{ include "helper.alloy_name" $.destinationName }}_pod" {
 
 prometheus.remote_write {{ include "helper.alloy_name" $.destinationName | quote }} {
   endpoint {
-{{- if .urlFrom }} 
+{{- if .urlFrom }}
     url = {{ .urlFrom }}
 {{- else }}
-    url = {{ .url | quote }} 
+    url = {{ .url | quote }}
 {{- end }}
 {{- if .protobufMessage }}
     protobuf_message = {{ .protobufMessage | quote }}
@@ -417,14 +417,15 @@ mimir.rules.kubernetes {{ include "helper.alloy_name" $.destinationName | quote 
   proxy_url = {{ .proxyURL | quote }}
 {{- end }}
 
-{{- range $namespace := .rules.namespaces }}
-  rule_namespace {
-    name = {{ $namespace | quote }}
-  }
-{{- end }}
-
-{{- if or .rules.namespaceLabelSelectors .rules.namespaceLabelExpressions }}
+{{- if or .rules.namespaceLabelSelectors .rules.namespaceLabelExpressions .rules.namespaces }}
   rule_namespace_selector {
+{{- if .rules.namespaces }}
+    match_expression {
+      key = "kubernetes.io/metadata.name"
+      operator = "In"
+      values = {{ .rules.namespaces | toJson }}
+    }
+{{- end }}
 {{- if .rules.namespaceLabelSelectors }}
     match_labels = {
 {{- range $key, $value := .rules.namespaceLabelSelectors }}

--- a/charts/k8s-monitoring/tests/destination_prometheus_rules_test.yaml
+++ b/charts/k8s-monitoring/tests/destination_prometheus_rules_test.yaml
@@ -24,7 +24,7 @@ tests:
           path: data["config.alloy"]
           pattern: 'mimir\.rules\.kubernetes'
 
-  - it: renders mimir.rules.kubernetes when rules.enabled is true
+  - it: renders mimir.rules.kubernetes with namespaces when rules.enabled is true
     template: alloy-config.yaml
     set:
       cluster:
@@ -48,10 +48,66 @@ tests:
           pattern: 'mimir\.rules\.kubernetes "prometheus"'
       - matchRegex:
           path: data["config.alloy"]
-          pattern: 'rule_namespace \{\s*name = "default"'
+          pattern: 'rule_namespace_selector \{\s*match_expression {\s*key = "kubernetes\.io\/metadata.name"\s*operator = "In"\s*values = \["default","monitoring"\]'
+
+  - it: renders mimir.rules.kubernetes without namespace selector and rules.namespaces is empty
+    template: alloy-config.yaml
+    set:
+      cluster:
+        name: ci-test-cluster
+      destinations:
+        prometheus:
+          type: prometheus
+          url: http://prometheus.svc:9009/api/v1/push
+          rules:
+            enabled: true
+            namespaces: []
+        loki:
+          type: loki
+          url: http://loki.svc:3100/api/push
+      clusterEvents:
+        enabled: true
+      collectors: {alloy: {}}
+    asserts:
       - matchRegex:
           path: data["config.alloy"]
-          pattern: 'rule_namespace \{\s*name = "monitoring"'
+          pattern: 'mimir\.rules\.kubernetes "prometheus"'
+      - notMatchRegex:
+          path: data["config.alloy"]
+          pattern: 'rule_namespace_selector \{\s*match_expression \{'
+
+  - it: renders mimir.rules.kubernetes with namespaceLabelSelector when rules.namespaceLabelSelector is set
+    template: alloy-config.yaml
+    set:
+      cluster:
+        name: ci-test-cluster
+      destinations:
+        prometheus:
+          type: prometheus
+          url: http://prometheus.svc:9009/api/v1/push
+          rules:
+            enabled: true
+            namespaces: [default]
+            namespaceLabelExpressions:
+              - key: "my-label"
+                operator: "In"
+                values: ["my-value"]
+        loki:
+          type: loki
+          url: http://loki.svc:3100/api/push
+      clusterEvents:
+        enabled: true
+      collectors: {alloy: {}}
+    asserts:
+      - matchRegex:
+          path: data["config.alloy"]
+          pattern: 'mimir\.rules\.kubernetes "prometheus"'
+      - matchRegex:
+          path: data["config.alloy"]
+          pattern: 'rule_namespace_selector \{\s*match_expression {\s*key = "kubernetes\.io\/metadata.name"\s*operator = "In"\s*values = \["default"\]'
+      - matchRegex:
+          path: data["config.alloy"]
+          pattern: 'rule_namespace_selector \{\s*match_expression {\s*key = "kubernetes\.io\/metadata.name"\s*operator = "In"\s*values = \["default"\]\s*\}\s*match_expression {\s*key = "my-label"\s*operator = "In"\s*values = \["my-value"\]'
 
   - it: uses rules.address as the Ruler base URL when set, instead of url
     template: alloy-config.yaml


### PR DESCRIPTION

<!--Describe what this change does and why.-->
# Description

The block "rule_namespace" doesn't exist in the Alloy configuration. But we can keep the `rules.namespaces` value and use it with the namespace selector and the well-known "kubernetes.io/metadata.name" label to filter by namespace name.

Fixes #2802 

<!--Authorship attestation. See AGENTS.md for details. AI agents must not check this box on behalf
of the user; the human author must check it themselves before the PR is ready for review.-->
## Authorship

-   [x] I, a human, wrote this pull request description myself.

<!--Please delete paragraphs that you did not use before submitting.-->
