### PR TITLE
Infer basic auth type

### DIFF
--- a/charts/k8s-monitoring/CHANGELOG.md
+++ b/charts/k8s-monitoring/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+*   Infer `auth.type: basic` for remote configuration and destinations when a username and password are set but `auth.type` is not. (#2809) (@TylerHelmuth)
+
 ## 4.2.1
 
 *   Add the `root`, `host-network`, `host-storage`, and `host-cgroup` collector presets and deprecate the `privileged` preset. `root` sets the privileged root `securityContext`, `host-network` sets `hostPID`/`hostNetwork`/`dnsPolicy`, and `host-storage`/`host-cgroup` mount host paths. `privileged` is unchanged and still works, but cannot be combined with these new presets. (#2796) (@TylerHelmuth)

--- a/charts/k8s-monitoring/charts/feature-integrations/templates/secrets/_helpers.tpl
+++ b/charts/k8s-monitoring/charts/feature-integrations/templates/secrets/_helpers.tpl
@@ -1,8 +1,17 @@
 {{/* Helper function to return the auth type, defaulting to none */}}
+{{/* When the type is unset, infers "basic" if both a username and a password are provided. */}}
 {{/* Inputs: . (user of the secret, needs name, secret, auth) */}}
-{{- define "secrets.authType" }}
-{{- if hasKey . "auth" }}{{ .auth.type | default "none" }}{{ else }}none{{ end }}
-{{- end }}
+{{- define "secrets.authType" -}}
+{{- if not (hasKey . "auth") -}}
+none
+{{- else if .auth.type -}}
+{{ .auth.type }}
+{{- else if and (or .auth.username .auth.usernameFrom) (or .auth.password .auth.passwordFrom) -}}
+basic
+{{- else -}}
+none
+{{- end -}}
+{{- end -}}
 
 {{/* Helper function to determine the secret type */}}
 {{/* Inputs: . (user of the secret, needs name, secret, auth) */}}

--- a/charts/k8s-monitoring/collectors/alloy-values.yaml
+++ b/charts/k8s-monitoring/collectors/alloy-values.yaml
@@ -57,9 +57,10 @@ remoteConfig:
   proxyConnectHeader: {}
 
   auth:
-    # -- The type of authentication to use for the remote config server.
+    # -- The type of authentication to use for the remote config server. When unset, defaults to `basic` if a username
+    # and password are provided, otherwise `none`.
     # @section -- Remote Configuration: Authentication
-    type: "none"
+    type: ""
 
     # -- The username to use for the remote config server.
     # @section -- Remote Configuration: Authentication

--- a/charts/k8s-monitoring/destinations/loki-values.yaml
+++ b/charts/k8s-monitoring/destinations/loki-values.yaml
@@ -113,9 +113,10 @@ writeAheadLog:
 
 auth:
   # -- The type of authentication to do.
-  # Options are "none" (default), "basic", "bearerToken", "oauth2".
+  # Options are "none", "basic", "bearerToken", "oauth2". When unset, defaults to "basic" if a username and
+  # password are provided, otherwise "none".
   # @section -- Authentication
-  type: none
+  type: ""
 
   # -- The username for basic authentication.
   # @section -- Authentication - Basic

--- a/charts/k8s-monitoring/destinations/otlp-values.yaml
+++ b/charts/k8s-monitoring/destinations/otlp-values.yaml
@@ -79,9 +79,10 @@ clusterLabels: [cluster, k8s.cluster.name]
 
 auth:
   # -- The type of authentication to do.
-  # Options are "none" (default), "basic", "bearerToken", "oauth2", "sigv4".
+  # Options are "none", "basic", "bearerToken", "oauth2", "sigv4". When unset, defaults to "basic" if a username and
+  # password are provided, otherwise "none".
   # @section -- Authentication
-  type: none
+  type: ""
 
   # -- The username for basic authentication.
   # @section -- Authentication - Basic

--- a/charts/k8s-monitoring/destinations/prometheus-values.yaml
+++ b/charts/k8s-monitoring/destinations/prometheus-values.yaml
@@ -88,9 +88,10 @@ metricEnrichment:
 
 auth:
   # -- The type of authentication to do.
-  # Options are "none" (default), "basic", "bearerToken", "oauth2", "sigv4".
+  # Options are "none", "basic", "bearerToken", "oauth2", "sigv4". When unset, defaults to "basic" if a username and
+  # password are provided, otherwise "none".
   # @section -- Authentication
-  type: none
+  type: ""
 
   # -- The username for basic authentication.
   # @section -- Authentication - Basic

--- a/charts/k8s-monitoring/destinations/pyroscope-values.yaml
+++ b/charts/k8s-monitoring/destinations/pyroscope-values.yaml
@@ -73,9 +73,10 @@ maxBackoffRetries: 10
 
 auth:
   # -- The type of authentication to do.
-  # Options are "none" (default), "basic", "bearerToken".
+  # Options are "none", "basic", "bearerToken". When unset, defaults to "basic" if a username and
+  # password are provided, otherwise "none".
   # @section -- Authentication
-  type: none
+  type: ""
 
   # -- The username for basic authentication.
   # @section -- Authentication - Basic

--- a/charts/k8s-monitoring/docs/collectors/alloy.md
+++ b/charts/k8s-monitoring/docs/collectors/alloy.md
@@ -61,7 +61,7 @@ Settings for each primary Alloy instance come from several potential sources, in
 | remoteConfig.auth.password | string | `""` | The password to use for the remote config server. |
 | remoteConfig.auth.passwordFrom | string | `""` | Raw config for accessing the password. |
 | remoteConfig.auth.passwordKey | string | `"password"` | The key for storing the password in the secret. |
-| remoteConfig.auth.type | string | `"none"` | The type of authentication to use for the remote config server. |
+| remoteConfig.auth.type | string | `""` | The type of authentication to use for the remote config server. When unset, defaults to `basic` if a username and password are provided, otherwise `none`. |
 | remoteConfig.auth.username | string | `""` | The username to use for the remote config server. |
 | remoteConfig.auth.usernameFrom | string | `""` | Raw config for accessing the password. |
 | remoteConfig.auth.usernameKey | string | `"username"` | The key for storing the username in the secret. |

--- a/charts/k8s-monitoring/docs/destinations/loki.md
+++ b/charts/k8s-monitoring/docs/destinations/loki.md
@@ -66,7 +66,7 @@ This defines the options for defining a destination for logs that use the Loki p
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| auth.type | string | `"none"` | The type of authentication to do. Options are "none" (default), "basic", "bearerToken", "oauth2". |
+| auth.type | string | `""` | The type of authentication to do. Options are "none", "basic", "bearerToken", "oauth2". When unset, defaults to "basic" if a username and password are provided, otherwise "none". |
 
 ### General
 

--- a/charts/k8s-monitoring/docs/destinations/otlp.md
+++ b/charts/k8s-monitoring/docs/destinations/otlp.md
@@ -66,7 +66,7 @@ This defines the options for defining a destination for OpenTelemetry data that 
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| auth.type | string | `"none"` | The type of authentication to do. Options are "none" (default), "basic", "bearerToken", "oauth2", "sigv4". |
+| auth.type | string | `""` | The type of authentication to do. Options are "none", "basic", "bearerToken", "oauth2", "sigv4". When unset, defaults to "basic" if a username and password are provided, otherwise "none". |
 
 ### General
 

--- a/charts/k8s-monitoring/docs/destinations/prometheus.md
+++ b/charts/k8s-monitoring/docs/destinations/prometheus.md
@@ -85,7 +85,7 @@ This defines the options for defining a destination for metrics that use the Pro
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| auth.type | string | `"none"` | The type of authentication to do. Options are "none" (default), "basic", "bearerToken", "oauth2", "sigv4". |
+| auth.type | string | `""` | The type of authentication to do. Options are "none", "basic", "bearerToken", "oauth2", "sigv4". When unset, defaults to "basic" if a username and password are provided, otherwise "none". |
 
 ### General
 

--- a/charts/k8s-monitoring/docs/destinations/pyroscope.md
+++ b/charts/k8s-monitoring/docs/destinations/pyroscope.md
@@ -65,7 +65,7 @@ This defines the options for defining a destination for profiles that use the Py
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| auth.type | string | `"none"` | The type of authentication to do. Options are "none" (default), "basic", "bearerToken". |
+| auth.type | string | `""` | The type of authentication to do. Options are "none", "basic", "bearerToken". When unset, defaults to "basic" if a username and password are provided, otherwise "none". |
 
 ### General
 

--- a/charts/k8s-monitoring/templates/NOTES.txt
+++ b/charts/k8s-monitoring/templates/NOTES.txt
@@ -43,3 +43,4 @@ It will:
     https://github.com/grafana/k8s-monitoring-helm/tree/main/charts/k8s-monitoring/docs/destinations#ecosystem-translation
 {{- end }}
 {{- include "collectors.notes.warnings" . }}
+{{- include "destinations.notes.inferredAuth" . }}

--- a/charts/k8s-monitoring/templates/collectors/_collector_notes.tpl
+++ b/charts/k8s-monitoring/templates/collectors/_collector_notes.tpl
@@ -14,6 +14,33 @@
 {{/* Entry point for collector-level warnings. Add new collector warning notes here. */}}
 {{- define "collectors.notes.warnings" }}
 {{- include "collectors.notes.istio" . }}
+{{- include "collectors.notes.remoteConfigInferredAuth" . }}
+{{- end }}
+
+{{/* Warns when a collector's remote configuration authentication type is being inferred as "basic". */}}
+{{- define "collectors.notes.remoteConfigInferredAuth" }}
+{{- $affected := list }}
+{{- range $collectorName := include "collectors.list.enabled" . | fromYamlArray }}
+  {{- $collectorValues := include "collector.alloy.values" (dict "Values" $.Values "Files" $.Files "collectorName" $collectorName) | fromYaml }}
+  {{- if dig "remoteConfig" "enabled" false $collectorValues }}
+    {{- $auth := dig "remoteConfig" "auth" dict $collectorValues }}
+    {{- $hasUsername := or $auth.username $auth.usernameFrom }}
+    {{- $hasPassword := or $auth.password $auth.passwordFrom }}
+    {{- if and (not $auth.type) $hasUsername $hasPassword }}
+      {{- $affected = append $affected $collectorName }}
+    {{- end }}
+  {{- end }}
+{{- end }}
+{{- if $affected }}
+
+⚠️ Inferring the remote configuration authentication type as "basic" because a username and password were provided
+without an explicit "remoteConfig.auth.type"
+
+Affected collector(s):
+{{- range $name := $affected }}
+* {{ $name }}
+{{- end }}
+{{- end }}
 {{- end }}
 
 {{/*

--- a/charts/k8s-monitoring/templates/collectors/_collector_remoteConfig.tpl
+++ b/charts/k8s-monitoring/templates/collectors/_collector_remoteConfig.tpl
@@ -64,7 +64,10 @@ remotecfg {
 {{- if .proxyFromEnvironment }}
   proxy_from_environment = {{ .proxyFromEnvironment }}
 {{- end }}
-{{- if eq (include "secrets.authType" .) "basic" }}
+{{- $hasUsername := or (.auth).username (.auth).usernameFrom }}
+{{- $hasPassword := or (.auth).password (.auth).passwordFrom }}
+{{- $authTypeUnset := not (.auth).type }}
+{{- if or (eq (.auth).type "basic") (and $authTypeUnset $hasUsername $hasPassword) }}
   basic_auth {
     username = {{ include "secrets.read" (dict "object" . "key" "auth.username" "nonsensitive" true) }}
     password = {{ include "secrets.read" (dict "object" . "key" "auth.password") }}

--- a/charts/k8s-monitoring/templates/destinations/_destination_notes.tpl
+++ b/charts/k8s-monitoring/templates/destinations/_destination_notes.tpl
@@ -1,0 +1,23 @@
+{{/*
+Warns when a destination's authentication type is being inferred as "basic" because a username and
+password were provided without an explicit "auth.type". Mirrors the inference in "secrets.authType"
+so users are aware authentication was enabled implicitly.
+*/}}
+{{- define "destinations.notes.inferredAuth" }}
+{{- $affected := list }}
+{{- range $destinationName, $destination := .Values.destinations }}
+  {{- if and (not (dig "auth" "type" "" $destination)) (eq (include "secrets.authType" $destination) "basic") }}
+    {{- $affected = append $affected $destinationName }}
+  {{- end }}
+{{- end }}
+{{- if $affected }}
+
+⚠️ Inferring the authentication type as "basic" because a username and password were provided
+without an explicit "auth.type"
+
+Affected destination(s):
+{{- range $name := $affected }}
+* {{ $name }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/charts/k8s-monitoring/templates/destinations/_destination_otlp.tpl
+++ b/charts/k8s-monitoring/templates/destinations/_destination_otlp.tpl
@@ -544,13 +544,13 @@ otelcol.exporter.otlphttp {{ include "helper.alloy_name" $.destinationName | quo
 {{- if .proxyURL }}
     proxy_url = {{ .proxyURL | quote }}
 {{- end }}
-{{- if eq .auth.type "basic" }}
+{{- if eq (include "secrets.authType" .) "basic" }}
     auth = otelcol.auth.basic.{{ include "helper.alloy_name" $.destinationName }}.handler
-{{- else if eq .auth.type "bearerToken" }}
+{{- else if eq (include "secrets.authType" .) "bearerToken" }}
     auth = otelcol.auth.bearer.{{ include "helper.alloy_name" $.destinationName }}.handler
-{{- else if eq .auth.type "oauth2" }}
+{{- else if eq (include "secrets.authType" .) "oauth2" }}
     auth = otelcol.auth.oauth2.{{ include "helper.alloy_name" $.destinationName }}.handler
-{{- else if eq .auth.type "sigv4" }}
+{{- else if eq (include "secrets.authType" .) "sigv4" }}
     auth = otelcol.auth.sigv4.{{ include "helper.alloy_name" $.destinationName }}.handler
 {{- end }}
 {{- if or (eq (include "secrets.usesSecret" (dict "object" . "name" $.destinationName "key" "tenantId")) "true") .extraHeaders .extraHeadersFrom }}

--- a/charts/k8s-monitoring/templates/secrets/_helpers.tpl
+++ b/charts/k8s-monitoring/templates/secrets/_helpers.tpl
@@ -1,8 +1,17 @@
 {{/* Helper function to return the auth type, defaulting to none */}}
+{{/* When the type is unset, infers "basic" if both a username and a password are provided. */}}
 {{/* Inputs: . (user of the secret, needs name, secret, auth) */}}
-{{- define "secrets.authType" }}
-{{- if hasKey . "auth" }}{{ .auth.type | default "none" }}{{ else }}none{{ end }}
-{{- end }}
+{{- define "secrets.authType" -}}
+{{- if not (hasKey . "auth") -}}
+none
+{{- else if .auth.type -}}
+{{ .auth.type }}
+{{- else if and (or .auth.username .auth.usernameFrom) (or .auth.password .auth.passwordFrom) -}}
+basic
+{{- else -}}
+none
+{{- end -}}
+{{- end -}}
 
 {{/* Helper function to determine the secret type */}}
 {{/* Inputs: . (user of the secret, needs name, secret, auth) */}}

--- a/charts/k8s-monitoring/templates/secrets/test/secrets.yaml
+++ b/charts/k8s-monitoring/templates/secrets/test/secrets.yaml
@@ -22,6 +22,12 @@ data:
   testEmptyAuth: {{ include "secrets.authType" (dict "auth" (dict)) | quote }}
   testEmptyType: {{ include "secrets.authType" (dict "auth" (dict "type" "")) | quote }}
   testAuthTypeBasic: {{ include "secrets.authType" (dict "auth" (dict "type" "basic")) | quote }}
+  testInferBasicFromUsernameAndPassword: {{ include "secrets.authType" $usernameAndPassword | quote }}
+  testInferBasicFromRefs: {{ include "secrets.authType" $allSecretsHaveRefs | quote }}
+  testInferBasicFromMixedValueAndRef: {{ include "secrets.authType" $oneSecretHasRef | quote }}
+  testNoInferFromUsernameOnly: {{ include "secrets.authType" (dict "auth" (dict "username" "my-username")) | quote }}
+  testNoInferFromPasswordOnly: {{ include "secrets.authType" (dict "auth" (dict "password" "my-password")) | quote }}
+  testExplicitNoneHonoredWithCredentials: {{ include "secrets.authType" (dict "auth" (dict "type" "none" "username" "my-username" "password" "my-password")) | quote }}
 
 ---
 apiVersion: v1

--- a/charts/k8s-monitoring/tests/collector_remoteconfig_auth_notes_test.yaml
+++ b/charts/k8s-monitoring/tests/collector_remoteconfig_auth_notes_test.yaml
@@ -1,0 +1,99 @@
+# yamllint disable rule:document-start rule:line-length rule:trailing-spaces
+suite: Collectors - Notes - Remote Config inferred auth warning
+templates:
+  - NOTES.txt
+tests:
+  - it: warns when the auth type is inferred as basic from a username and password
+    set:
+      cluster: {name: ci-test-cluster}
+      collectors:
+        alloy-metrics:
+          remoteConfig:
+            enabled: true
+            url: https://fleet-management-prod-001.grafana.net
+            auth:
+              username: 123456
+              password: "It's a secret to everyone"
+    asserts:
+      - matchRegexRaw:
+          pattern: 'Inferring the remote configuration authentication type as "basic"'
+      - matchRegexRaw:
+          pattern: '\* alloy-metrics'
+
+  - it: warns when the auth type is inferred from From references
+    set:
+      cluster: {name: ci-test-cluster}
+      collectors:
+        alloy-metrics:
+          remoteConfig:
+            enabled: true
+            url: https://fleet-management-prod-001.grafana.net
+            auth:
+              usernameFrom: sys.env("REMOTECFG_USERNAME")
+              passwordFrom: sys.env("REMOTECFG_PASSWORD")
+    asserts:
+      - matchRegexRaw:
+          pattern: 'Inferring the remote configuration authentication type as "basic"'
+      - matchRegexRaw:
+          pattern: '\* alloy-metrics'
+
+  - it: does not warn when the auth type is explicitly set to basic
+    set:
+      cluster: {name: ci-test-cluster}
+      collectors:
+        alloy-metrics:
+          remoteConfig:
+            enabled: true
+            url: https://fleet-management-prod-001.grafana.net
+            auth:
+              type: basic
+              username: 123456
+              password: "It's a secret to everyone"
+    asserts:
+      - notMatchRegexRaw:
+          pattern: 'Inferring the remote configuration authentication type'
+
+  - it: does not warn when the auth type is explicitly set to none
+    set:
+      cluster: {name: ci-test-cluster}
+      collectors:
+        alloy-metrics:
+          remoteConfig:
+            enabled: true
+            url: https://fleet-management-prod-001.grafana.net
+            auth:
+              type: none
+              username: 123456
+              password: "It's a secret to everyone"
+    asserts:
+      - notMatchRegexRaw:
+          pattern: 'Inferring the remote configuration authentication type'
+
+  - it: does not warn when only a username is provided
+    set:
+      cluster: {name: ci-test-cluster}
+      collectors:
+        alloy-metrics:
+          remoteConfig:
+            enabled: true
+            url: https://fleet-management-prod-001.grafana.net
+            auth:
+              username: 123456
+    asserts:
+      - notMatchRegexRaw:
+          pattern: 'Inferring the remote configuration authentication type'
+
+  - it: does not warn when remote config is disabled
+    set:
+      cluster: {name: ci-test-cluster}
+      collectors:
+        alloy-metrics:
+          remoteConfig:
+            enabled: false
+            url: https://fleet-management-prod-001.grafana.net
+            auth:
+              username: 123456
+              password: "It's a secret to everyone"
+    asserts:
+      - notMatchRegexRaw:
+          pattern: 'Inferring the remote configuration authentication type'

--- a/charts/k8s-monitoring/tests/destination_auth_inference_test.yaml
+++ b/charts/k8s-monitoring/tests/destination_auth_inference_test.yaml
@@ -1,0 +1,137 @@
+# yamllint disable rule:document-start rule:line-length rule:trailing-spaces
+suite: Destinations - Inferred basic auth
+templates:
+  - alloy-config.yaml
+tests:
+  - it: infers basic auth for a prometheus destination when username and password are set without a type
+    set:
+      cluster: {name: test-cluster}
+      collectors: {alloy-singleton: {extraConfig: " ", includeDestinations: ["test"]}}
+      selfReporting: {enabled: false}
+      destinations:
+        test:
+          type: prometheus
+          url: https://prometheus.example.com
+          auth:
+            username: my-username
+            password: my-password
+    asserts:
+      - matchRegex:
+          path: data["config.alloy"]
+          pattern: 'basic_auth \{'
+
+  - it: infers basic auth for a loki destination when username and password are set without a type
+    set:
+      cluster: {name: test-cluster}
+      collectors: {alloy-singleton: {extraConfig: " ", includeDestinations: ["test"]}}
+      selfReporting: {enabled: false}
+      destinations:
+        test:
+          type: loki
+          url: https://loki.example.com
+          auth:
+            username: my-username
+            password: my-password
+    asserts:
+      - matchRegex:
+          path: data["config.alloy"]
+          pattern: 'basic_auth \{'
+
+  - it: infers basic auth for a pyroscope destination when username and password are set without a type
+    set:
+      cluster: {name: test-cluster}
+      collectors: {alloy-singleton: {extraConfig: " ", includeDestinations: ["test"]}}
+      selfReporting: {enabled: false}
+      destinations:
+        test:
+          type: pyroscope
+          url: https://pyroscope.example.com
+          auth:
+            username: my-username
+            password: my-password
+    asserts:
+      - matchRegex:
+          path: data["config.alloy"]
+          pattern: 'basic_auth \{'
+
+  - it: infers basic auth for an otlp destination when username and password are set without a type
+    set:
+      cluster: {name: test-cluster}
+      collectors: {alloy-singleton: {extraConfig: " ", includeDestinations: ["test"]}}
+      selfReporting: {enabled: false}
+      destinations:
+        test:
+          type: otlp
+          url: https://otlp.example.com
+          auth:
+            username: my-username
+            password: my-password
+    asserts:
+      - matchRegex:
+          path: data["config.alloy"]
+          pattern: 'otelcol\.auth\.basic\.'
+
+  - it: infers basic auth from usernameFrom and passwordFrom references
+    set:
+      cluster: {name: test-cluster}
+      collectors: {alloy-singleton: {extraConfig: " ", includeDestinations: ["test"]}}
+      selfReporting: {enabled: false}
+      destinations:
+        test:
+          type: prometheus
+          url: https://prometheus.example.com
+          auth:
+            usernameFrom: sys.env("USERNAME")
+            passwordFrom: sys.env("PASSWORD")
+    asserts:
+      - matchRegex:
+          path: data["config.alloy"]
+          pattern: 'basic_auth \{'
+
+  - it: honors an explicit auth type of none even when credentials are provided
+    set:
+      cluster: {name: test-cluster}
+      collectors: {alloy-singleton: {extraConfig: " ", includeDestinations: ["test"]}}
+      selfReporting: {enabled: false}
+      destinations:
+        test:
+          type: prometheus
+          url: https://prometheus.example.com
+          auth:
+            type: none
+            username: my-username
+            password: my-password
+    asserts:
+      - notMatchRegex:
+          path: data["config.alloy"]
+          pattern: 'basic_auth \{'
+
+  - it: does not infer basic auth when only a username is provided
+    set:
+      cluster: {name: test-cluster}
+      collectors: {alloy-singleton: {extraConfig: " ", includeDestinations: ["test"]}}
+      selfReporting: {enabled: false}
+      destinations:
+        test:
+          type: prometheus
+          url: https://prometheus.example.com
+          auth:
+            username: my-username
+    asserts:
+      - notMatchRegex:
+          path: data["config.alloy"]
+          pattern: 'basic_auth \{'
+
+  - it: does not infer basic auth when no credentials are provided
+    set:
+      cluster: {name: test-cluster}
+      collectors: {alloy-singleton: {extraConfig: " ", includeDestinations: ["test"]}}
+      selfReporting: {enabled: false}
+      destinations:
+        test:
+          type: prometheus
+          url: https://prometheus.example.com
+    asserts:
+      - notMatchRegex:
+          path: data["config.alloy"]
+          pattern: 'basic_auth \{'

--- a/charts/k8s-monitoring/tests/destination_auth_notes_test.yaml
+++ b/charts/k8s-monitoring/tests/destination_auth_notes_test.yaml
@@ -1,0 +1,89 @@
+# yamllint disable rule:document-start rule:line-length rule:trailing-spaces
+suite: Destinations - Notes - Inferred auth warning
+templates:
+  - NOTES.txt
+tests:
+  - it: warns when a destination's auth type is inferred as basic
+    set:
+      cluster: {name: test-cluster}
+      collectors: {alloy-singleton: {extraConfig: " ", includeDestinations: ["test"]}}
+      selfReporting: {enabled: false}
+      destinations:
+        test:
+          type: prometheus
+          url: https://prometheus.example.com
+          auth:
+            username: my-username
+            password: my-password
+    asserts:
+      - matchRegexRaw:
+          pattern: 'Inferring the authentication type as "basic"'
+      - matchRegexRaw:
+          pattern: '\* test'
+
+  - it: warns when the auth type is inferred from From references
+    set:
+      cluster: {name: test-cluster}
+      collectors: {alloy-singleton: {extraConfig: " ", includeDestinations: ["test"]}}
+      selfReporting: {enabled: false}
+      destinations:
+        test:
+          type: prometheus
+          url: https://prometheus.example.com
+          auth:
+            usernameFrom: sys.env("USERNAME")
+            passwordFrom: sys.env("PASSWORD")
+    asserts:
+      - matchRegexRaw:
+          pattern: 'Inferring the authentication type as "basic"'
+      - matchRegexRaw:
+          pattern: '\* test'
+
+  - it: does not warn when the auth type is explicitly set to basic
+    set:
+      cluster: {name: test-cluster}
+      collectors: {alloy-singleton: {extraConfig: " ", includeDestinations: ["test"]}}
+      selfReporting: {enabled: false}
+      destinations:
+        test:
+          type: prometheus
+          url: https://prometheus.example.com
+          auth:
+            type: basic
+            username: my-username
+            password: my-password
+    asserts:
+      - notMatchRegexRaw:
+          pattern: 'Inferring the authentication type'
+
+  - it: does not warn when the auth type is explicitly set to none
+    set:
+      cluster: {name: test-cluster}
+      collectors: {alloy-singleton: {extraConfig: " ", includeDestinations: ["test"]}}
+      selfReporting: {enabled: false}
+      destinations:
+        test:
+          type: prometheus
+          url: https://prometheus.example.com
+          auth:
+            type: none
+            username: my-username
+            password: my-password
+    asserts:
+      - notMatchRegexRaw:
+          pattern: 'Inferring the authentication type'
+
+  - it: does not warn when only a username is provided
+    set:
+      cluster: {name: test-cluster}
+      collectors: {alloy-singleton: {extraConfig: " ", includeDestinations: ["test"]}}
+      selfReporting: {enabled: false}
+      destinations:
+        test:
+          type: prometheus
+          url: https://prometheus.example.com
+          auth:
+            username: my-username
+    asserts:
+      - notMatchRegexRaw:
+          pattern: 'Inferring the authentication type'

--- a/charts/k8s-monitoring/tests/feature_remoteConfig_test.yaml
+++ b/charts/k8s-monitoring/tests/feature_remoteConfig_test.yaml
@@ -69,3 +69,160 @@ tests:
           of: ConfigMap
       - matchSnapshot:
           path: data["config.alloy"]
+
+  - it: defaults auth type to basic when username and password are provided without a type
+    template: alloy-config.yaml
+    set:
+      cluster:
+        name: ci-test-cluster
+      collectors:
+        alloy-metrics:
+          remoteConfig:
+            enabled: true
+            url: https://fleet-management-prod-001.grafana.net
+            auth:
+              username: 123456
+              password: "It's a secret to everyone"
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - matchRegex:
+          path: data["config.alloy"]
+          pattern: 'basic_auth \{'
+      - matchRegex:
+          path: data["config.alloy"]
+          pattern: 'username = convert.nonsensitive\(remote.kubernetes.secret.alloy_metrics_remote_cfg.data\["username"\]\)'
+      - matchRegex:
+          path: data["config.alloy"]
+          pattern: 'password = remote.kubernetes.secret.alloy_metrics_remote_cfg.data\["password"\]'
+
+  - it: defaults auth type to basic with embedded credentials when no type is set
+    template: alloy-config.yaml
+    set:
+      cluster:
+        name: ci-test-cluster
+      collectors:
+        alloy-metrics:
+          remoteConfig:
+            enabled: true
+            url: https://fleet-management-prod-001.grafana.net
+            secret:
+              embed: true
+            auth:
+              username: 123456
+              password: "It's a secret to everyone"
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - matchRegex:
+          path: data["config.alloy"]
+          pattern: 'basic_auth \{'
+      - matchRegex:
+          path: data["config.alloy"]
+          pattern: 'username = "123456"'
+      - matchRegex:
+          path: data["config.alloy"]
+          pattern: "password = \"It's a secret to everyone\""
+
+  - it: defaults auth type to basic when username and password are provided via From references
+    template: alloy-config.yaml
+    set:
+      cluster:
+        name: ci-test-cluster
+      collectors:
+        alloy-metrics:
+          remoteConfig:
+            enabled: true
+            url: https://fleet-management-prod-001.grafana.net
+            auth:
+              usernameFrom: sys.env("REMOTECFG_USERNAME")
+              passwordFrom: sys.env("REMOTECFG_PASSWORD")
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - matchRegex:
+          path: data["config.alloy"]
+          pattern: 'basic_auth \{'
+      - matchRegex:
+          path: data["config.alloy"]
+          pattern: 'username = sys.env\("REMOTECFG_USERNAME"\)'
+      - matchRegex:
+          path: data["config.alloy"]
+          pattern: 'password = sys.env\("REMOTECFG_PASSWORD"\)'
+
+  - it: does not render basic_auth when only a username is provided without a type
+    template: alloy-config.yaml
+    set:
+      cluster:
+        name: ci-test-cluster
+      collectors:
+        alloy-metrics:
+          remoteConfig:
+            enabled: true
+            url: https://fleet-management-prod-001.grafana.net
+            auth:
+              username: 123456
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - notMatchRegex:
+          path: data["config.alloy"]
+          pattern: 'basic_auth \{'
+
+  - it: does not render basic_auth when no auth type or credentials are provided
+    template: alloy-config.yaml
+    set:
+      cluster:
+        name: ci-test-cluster
+      collectors:
+        alloy-metrics:
+          remoteConfig:
+            enabled: true
+            url: https://fleet-management-prod-001.grafana.net
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - notMatchRegex:
+          path: data["config.alloy"]
+          pattern: 'basic_auth \{'
+
+  - it: honors an explicit auth type of none even when credentials are provided
+    template: alloy-config.yaml
+    set:
+      cluster:
+        name: ci-test-cluster
+      collectors:
+        alloy-metrics:
+          remoteConfig:
+            enabled: true
+            url: https://fleet-management-prod-001.grafana.net
+            auth:
+              type: none
+              username: 123456
+              password: "It's a secret to everyone"
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - notMatchRegex:
+          path: data["config.alloy"]
+          pattern: 'basic_auth \{'
+
+  - it: does not auto-default to basic for an external secret without an explicit auth type
+    template: alloy-config.yaml
+    set:
+      cluster:
+        name: ci-test-cluster
+      collectors:
+        alloy-metrics:
+          remoteConfig:
+            enabled: true
+            url: https://fleet-management-prod-001.grafana.net
+            secret:
+              create: false
+              name: my-remote-cfg-secret
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - notMatchRegex:
+          path: data["config.alloy"]
+          pattern: 'basic_auth \{'

--- a/charts/k8s-monitoring/tests/unittest_secrets_test.yaml
+++ b/charts/k8s-monitoring/tests/unittest_secrets_test.yaml
@@ -11,6 +11,12 @@ tests:
       - {equal: {path: "data.testEmptyAuth",      value: "none"   }, documentIndex: 0 }
       - {equal: {path: "data.testEmptyType",      value: "none"   }, documentIndex: 0 }
       - {equal: {path: "data.testAuthTypeBasic",  value: "basic"  }, documentIndex: 0 }
+      - {equal: {path: "data.testInferBasicFromUsernameAndPassword",  value: "basic" }, documentIndex: 0 }
+      - {equal: {path: "data.testInferBasicFromRefs",                 value: "basic" }, documentIndex: 0 }
+      - {equal: {path: "data.testInferBasicFromMixedValueAndRef",     value: "basic" }, documentIndex: 0 }
+      - {equal: {path: "data.testNoInferFromUsernameOnly",            value: "none"  }, documentIndex: 0 }
+      - {equal: {path: "data.testNoInferFromPasswordOnly",            value: "none"  }, documentIndex: 0 }
+      - {equal: {path: "data.testExplicitNoneHonoredWithCredentials", value: "none"  }, documentIndex: 0 }
 
   - it: secrets.secretType works appropriately
     set:


### PR DESCRIPTION
<!--Describe what this change does and why.-->
# Description

Updates the chart to infer `basic` auth type if no value is provided but username/password are provided.

- Fixes https://github.com/grafana/k8s-monitoring-helm/issues/2809

Tested with 

```yaml
cluster:
  name: demo
selfReporting:
  enabled: false
collectors:
  alloy-singleton:
    extraConfig: " "
    includeDestinations: ["metrics"]
  alloy-metrics:
    remoteConfig:
      enabled: true
      url: https://fleet-management-prod-001.grafana.net
      auth:
        username: "123456"
        password: "a secret to everyone"
    alloy:
      extraEnv:
        - name: GCLOUD_RW_API_KEY
          value: fake-token
destinations:
  metrics:
    type: prometheus
    url: https://prometheus.example.com
    auth:
      username: my-username
      password: my-password
```

```
NOTES:
Grafana k8s-monitoring Helm chart deployed!

This chart will install the following components:
* Grafana Alloy Operator
* Grafana Alloy "alloy-metrics" (daemonset)
* Grafana Alloy "alloy-singleton" (daemonset)

⚠️ Inferring the remote configuration authentication type as "basic" because a username and password were provided
without an explicit "remoteConfig.auth.type"

Affected collector(s):
* alloy-metrics

⚠️ Inferring the authentication type as "basic" because a username and password were provided
without an explicit "auth.type"

Affected destination(s):
* metrics
```

<!--Authorship attestation. See AGENTS.md for details. AI agents must not check this box on behalf
of the user; the human author must check it themselves before the PR is ready for review.-->
## Authorship

-   [x] I, a human, wrote this pull request description myself.

<!--Please delete paragraphs that you did not use before submitting.-->
