### PR TITLE
fix: beyla.service.targetPort now correctly sets other ports as documented

### DIFF
--- a/charts/k8s-monitoring/charts/feature-auto-instrumentation/templates/_beyla-config.tpl
+++ b/charts/k8s-monitoring/charts/feature-auto-instrumentation/templates/_beyla-config.tpl
@@ -39,5 +39,5 @@
   {{- end }}
 {{- end }}
 
-{{- merge $config $overrides | toYaml }}
+{{- merge $overrides $config | toYaml }}
 {{- end }}

--- a/charts/k8s-monitoring/tests/feature_beyla_config_test.yaml
+++ b/charts/k8s-monitoring/tests/feature_beyla_config_test.yaml
@@ -98,6 +98,49 @@ tests:
               path: /metrics
               port: 9090
 
+  - it: sets both config ports from service.targetPort alone
+    set:
+      cluster: {name: beyla-config-cluster}
+      autoInstrumentation:
+        enabled: true
+        beyla:
+          service:
+            targetPort: 9095
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - equal:
+          path: data["beyla-config.yml"]
+          value: |-
+            attributes:
+              kubernetes:
+                cluster_name: beyla-config-cluster
+                enable: true
+            discovery:
+              exclude_instrument:
+              - exe_path: '{*alloy*,*otelcol*,*beyla*}'
+              instrument:
+              - k8s_namespace: '*'
+            filter:
+              network:
+                k8s_dst_owner_name:
+                  not_match: '{kube*,*jaeger-agent*,*prometheus*,*promtail*,*grafana-agent*}'
+                k8s_src_owner_name:
+                  not_match: '{kube*,*jaeger-agent*,*prometheus*,*promtail*,*grafana-agent*}'
+            internal_metrics:
+              prometheus:
+                path: /internal/metrics
+                port: 9095
+            prometheus_export:
+              features:
+              - application
+              - network
+              - application_service_graph
+              - application_span
+              - application_host
+              path: /metrics
+              port: 9095
+
   - it: sets otel_traces_export endpoint when deliverTracesToApplicationObservability is enabled (default)
     set:
       cluster: {name: beyla-config-cluster}


### PR DESCRIPTION
# Description

Fixes a bug where we were merging in the wrong direction resulting in unexpected behavior

- Fixes https://github.com/grafana/k8s-monitoring-helm/issues/2114

<!--Authorship attestation. See AGENTS.md for details. AI agents must not check this box on behalf
of the user; the human author must check it themselves before the PR is ready for review.-->
## Authorship

-   [x] I, a human, wrote this pull request description myself.

<!--Please delete paragraphs that you did not use before submitting.-->
