### PR TITLE
fix: argocd integration test always failed for forks

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -120,7 +120,7 @@ jobs:
           fi
           helm-chart-toolbox/tools/helm-test/helm-test "${TEST_DIRECTORY}"
         env:
-          BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
+          TARGET_REVISION: ${{ github.event_name == 'pull_request' && format('refs/pull/{0}/merge', github.event.pull_request.number) || github.ref_name }}
           KUBECONFIG: "${{ github.workspace }}/source/charts/k8s-monitoring/${{ matrix.test }}/kubeconfig.yaml"
           TEST_DIRECTORY: "source/charts/k8s-monitoring/${{ matrix.test }}"
           DELETE_CLUSTER: true

--- a/charts/k8s-monitoring/docs/examples/deployment-alternatives/argocd/test/Makefile
+++ b/charts/k8s-monitoring/docs/examples/deployment-alternatives/argocd/test/Makefile
@@ -11,13 +11,14 @@ clean: ;
 .PHONY: all
 all: ../k8s-monitoring-application.yaml
 
-BRANCH_NAME ?= $(shell git rev-parse --abbrev-ref HEAD)
+TARGET_REVISION ?= $(shell git rev-parse --abbrev-ref HEAD)
+export TARGET_REVISION
 
 # Declare the target as phony to ensure it always runs
 .PHONY: ../k8s-monitoring-application.yaml
 ../k8s-monitoring-application.yaml:
-	@echo "Setting targetRevision to $(BRANCH_NAME)"
-	@yq eval '.spec.source.targetRevision = "$(BRANCH_NAME)"' $@ > temp.yaml
+	@echo "Setting targetRevision to $${TARGET_REVISION}"
+	@yq eval '.spec.source.targetRevision = strenv(TARGET_REVISION)' $@ > temp.yaml
 	@cp temp.yaml $@
 	@rm temp.yaml
 


### PR DESCRIPTION
# Description

The way the argocd test was setup it was trying to look for the fork branch in the main repo, which doesn't work. For example, if I open a PR from a fork, `tylerhelmuth/k8s-monitoring-helm`, using a branch called `fix-flaky-test` the test would tell argo "Download the chart from github.com/grafana/k8s-monitoring-helm, branch fix-flaky-test, and deploy it.”", but `fix-flaky-test` doesn't exist on `grafana/k8s-monitoring-helm`. The fix is instead to look for the branch in `refs/pull/<number>/merge`.

Also fix an issue where the branch's name was used directly in a make command. This opened us up to some code execution (theoretically) if the branch was named as executable code.

- Fixes https://github.com/grafana/k8s-monitoring-helm/issues/2808

<!--Authorship attestation. See AGENTS.md for details. AI agents must not check this box on behalf
of the user; the human author must check it themselves before the PR is ready for review.-->
## Authorship

-   [x] I, a human, wrote this pull request description myself.

<!--Please delete paragraphs that you did not use before submitting.-->
