### PR TITLE
Remove empty image and container labels from `container_pressure_*` metrics

### DIFF
--- a/charts/k8s-monitoring/CHANGELOG.md
+++ b/charts/k8s-monitoring/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+*   Remove empty `image` and `container` labels from cAdvisor's `container_pressure_.*` metrics (#2561) (@petewall)
 *   Infer `auth.type: basic` for remote configuration and destinations when a username and password are set but `auth.type` is not. (#2809) (@TylerHelmuth)
 *   Fix `unrecognized block name "rule_namespace"` error when using the `rules.namespaces` field of the `prometheus` destination to limit the PrometheusRules object discovery to specific namespaces (#2802) (@sebasnabas)
 *   Fix `autoInstrumentation.beyla.service.targetPort` not propagating to the generated Beyla config ports, which previously required setting the port in three places. (#2811) (@TylerHelmuth)

--- a/charts/k8s-monitoring/charts/feature-cluster-metrics/templates/_cadvisor.alloy.tpl
+++ b/charts/k8s-monitoring/charts/feature-cluster-metrics/templates/_cadvisor.alloy.tpl
@@ -87,7 +87,7 @@ prometheus.relabel "cadvisor" {
   rule {
     source_labels = ["__name__","container"]
     separator = "@"
-    regex = "(container_cpu_.*|container_fs_.*|container_memory_.*)@"
+    regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_pressure_.*)@"
     action = "drop"
   }
 {{- end }}
@@ -96,7 +96,7 @@ prometheus.relabel "cadvisor" {
   rule {
     source_labels = ["__name__","image"]
     separator = "@"
-    regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_network_.*)@"
+    regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_network_.*|container_pressure_.*)@"
     action = "drop"
   }
 {{- end }}

--- a/charts/k8s-monitoring/docs/examples/auth/oauth2/alloy-metrics.alloy
+++ b/charts/k8s-monitoring/docs/examples/auth/oauth2/alloy-metrics.alloy
@@ -492,14 +492,14 @@ declare "cluster_metrics" {
     rule {
       source_labels = ["__name__","container"]
       separator = "@"
-      regex = "(container_cpu_.*|container_fs_.*|container_memory_.*)@"
+      regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_pressure_.*)@"
       action = "drop"
     }
     // Drop empty image labels, addressing https://github.com/google/cadvisor/issues/2688
     rule {
       source_labels = ["__name__","image"]
       separator = "@"
-      regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_network_.*)@"
+      regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_network_.*|container_pressure_.*)@"
       action = "drop"
     }
     // Normalizing unimportant labels (not deleting to continue satisfying <label>!="" checks)

--- a/charts/k8s-monitoring/docs/examples/auth/oauth2/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/auth/oauth2/output.yaml
@@ -1187,14 +1187,14 @@ data:
         rule {
           source_labels = ["__name__","container"]
           separator = "@"
-          regex = "(container_cpu_.*|container_fs_.*|container_memory_.*)@"
+          regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_pressure_.*)@"
           action = "drop"
         }
         // Drop empty image labels, addressing https://github.com/google/cadvisor/issues/2688
         rule {
           source_labels = ["__name__","image"]
           separator = "@"
-          regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_network_.*)@"
+          regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_network_.*|container_pressure_.*)@"
           action = "drop"
         }
         // Normalizing unimportant labels (not deleting to continue satisfying <label>!="" checks)

--- a/charts/k8s-monitoring/docs/examples/auth/sigv4/alloy-metrics.alloy
+++ b/charts/k8s-monitoring/docs/examples/auth/sigv4/alloy-metrics.alloy
@@ -151,14 +151,14 @@ declare "cluster_metrics" {
     rule {
       source_labels = ["__name__","container"]
       separator = "@"
-      regex = "(container_cpu_.*|container_fs_.*|container_memory_.*)@"
+      regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_pressure_.*)@"
       action = "drop"
     }
     // Drop empty image labels, addressing https://github.com/google/cadvisor/issues/2688
     rule {
       source_labels = ["__name__","image"]
       separator = "@"
-      regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_network_.*)@"
+      regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_network_.*|container_pressure_.*)@"
       action = "drop"
     }
     // Normalizing unimportant labels (not deleting to continue satisfying <label>!="" checks)

--- a/charts/k8s-monitoring/docs/examples/auth/sigv4/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/auth/sigv4/output.yaml
@@ -202,14 +202,14 @@ data:
         rule {
           source_labels = ["__name__","container"]
           separator = "@"
-          regex = "(container_cpu_.*|container_fs_.*|container_memory_.*)@"
+          regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_pressure_.*)@"
           action = "drop"
         }
         // Drop empty image labels, addressing https://github.com/google/cadvisor/issues/2688
         rule {
           source_labels = ["__name__","image"]
           separator = "@"
-          regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_network_.*)@"
+          regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_network_.*|container_pressure_.*)@"
           action = "drop"
         }
         // Normalizing unimportant labels (not deleting to continue satisfying <label>!="" checks)

--- a/charts/k8s-monitoring/docs/examples/collector-storage/alloy-metrics.alloy
+++ b/charts/k8s-monitoring/docs/examples/collector-storage/alloy-metrics.alloy
@@ -151,14 +151,14 @@ declare "cluster_metrics" {
     rule {
       source_labels = ["__name__","container"]
       separator = "@"
-      regex = "(container_cpu_.*|container_fs_.*|container_memory_.*)@"
+      regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_pressure_.*)@"
       action = "drop"
     }
     // Drop empty image labels, addressing https://github.com/google/cadvisor/issues/2688
     rule {
       source_labels = ["__name__","image"]
       separator = "@"
-      regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_network_.*)@"
+      regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_network_.*|container_pressure_.*)@"
       action = "drop"
     }
     // Normalizing unimportant labels (not deleting to continue satisfying <label>!="" checks)

--- a/charts/k8s-monitoring/docs/examples/collector-storage/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/collector-storage/output.yaml
@@ -482,14 +482,14 @@ data:
         rule {
           source_labels = ["__name__","container"]
           separator = "@"
-          regex = "(container_cpu_.*|container_fs_.*|container_memory_.*)@"
+          regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_pressure_.*)@"
           action = "drop"
         }
         // Drop empty image labels, addressing https://github.com/google/cadvisor/issues/2688
         rule {
           source_labels = ["__name__","image"]
           separator = "@"
-          regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_network_.*)@"
+          regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_network_.*|container_pressure_.*)@"
           action = "drop"
         }
         // Normalizing unimportant labels (not deleting to continue satisfying <label>!="" checks)

--- a/charts/k8s-monitoring/docs/examples/dataProcessors/kubernetesEnrichment/labels-and-annotations/alloy.alloy
+++ b/charts/k8s-monitoring/docs/examples/dataProcessors/kubernetesEnrichment/labels-and-annotations/alloy.alloy
@@ -551,14 +551,14 @@ declare "cluster_metrics" {
     rule {
       source_labels = ["__name__","container"]
       separator = "@"
-      regex = "(container_cpu_.*|container_fs_.*|container_memory_.*)@"
+      regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_pressure_.*)@"
       action = "drop"
     }
     // Drop empty image labels, addressing https://github.com/google/cadvisor/issues/2688
     rule {
       source_labels = ["__name__","image"]
       separator = "@"
-      regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_network_.*)@"
+      regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_network_.*|container_pressure_.*)@"
       action = "drop"
     }
     // Normalizing unimportant labels (not deleting to continue satisfying <label>!="" checks)

--- a/charts/k8s-monitoring/docs/examples/dataProcessors/kubernetesEnrichment/labels-and-annotations/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/dataProcessors/kubernetesEnrichment/labels-and-annotations/output.yaml
@@ -603,14 +603,14 @@ data:
         rule {
           source_labels = ["__name__","container"]
           separator = "@"
-          regex = "(container_cpu_.*|container_fs_.*|container_memory_.*)@"
+          regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_pressure_.*)@"
           action = "drop"
         }
         // Drop empty image labels, addressing https://github.com/google/cadvisor/issues/2688
         rule {
           source_labels = ["__name__","image"]
           separator = "@"
-          regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_network_.*)@"
+          regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_network_.*|container_pressure_.*)@"
           action = "drop"
         }
         // Normalizing unimportant labels (not deleting to continue satisfying <label>!="" checks)

--- a/charts/k8s-monitoring/docs/examples/destinations/otlp-endpoint/alloy-metrics.alloy
+++ b/charts/k8s-monitoring/docs/examples/destinations/otlp-endpoint/alloy-metrics.alloy
@@ -151,14 +151,14 @@ declare "cluster_metrics" {
     rule {
       source_labels = ["__name__","container"]
       separator = "@"
-      regex = "(container_cpu_.*|container_fs_.*|container_memory_.*)@"
+      regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_pressure_.*)@"
       action = "drop"
     }
     // Drop empty image labels, addressing https://github.com/google/cadvisor/issues/2688
     rule {
       source_labels = ["__name__","image"]
       separator = "@"
-      regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_network_.*)@"
+      regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_network_.*|container_pressure_.*)@"
       action = "drop"
     }
     // Normalizing unimportant labels (not deleting to continue satisfying <label>!="" checks)

--- a/charts/k8s-monitoring/docs/examples/destinations/otlp-endpoint/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/destinations/otlp-endpoint/output.yaml
@@ -719,14 +719,14 @@ data:
         rule {
           source_labels = ["__name__","container"]
           separator = "@"
-          regex = "(container_cpu_.*|container_fs_.*|container_memory_.*)@"
+          regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_pressure_.*)@"
           action = "drop"
         }
         // Drop empty image labels, addressing https://github.com/google/cadvisor/issues/2688
         rule {
           source_labels = ["__name__","image"]
           separator = "@"
-          regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_network_.*)@"
+          regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_network_.*|container_pressure_.*)@"
           action = "drop"
         }
         // Normalizing unimportant labels (not deleting to continue satisfying <label>!="" checks)

--- a/charts/k8s-monitoring/docs/examples/exclude-by-namespace/alloy-metrics.alloy
+++ b/charts/k8s-monitoring/docs/examples/exclude-by-namespace/alloy-metrics.alloy
@@ -563,14 +563,14 @@ declare "cluster_metrics" {
     rule {
       source_labels = ["__name__","container"]
       separator = "@"
-      regex = "(container_cpu_.*|container_fs_.*|container_memory_.*)@"
+      regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_pressure_.*)@"
       action = "drop"
     }
     // Drop empty image labels, addressing https://github.com/google/cadvisor/issues/2688
     rule {
       source_labels = ["__name__","image"]
       separator = "@"
-      regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_network_.*)@"
+      regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_network_.*|container_pressure_.*)@"
       action = "drop"
     }
     // Normalizing unimportant labels (not deleting to continue satisfying <label>!="" checks)

--- a/charts/k8s-monitoring/docs/examples/exclude-by-namespace/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/exclude-by-namespace/output.yaml
@@ -1945,14 +1945,14 @@ data:
         rule {
           source_labels = ["__name__","container"]
           separator = "@"
-          regex = "(container_cpu_.*|container_fs_.*|container_memory_.*)@"
+          regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_pressure_.*)@"
           action = "drop"
         }
         // Drop empty image labels, addressing https://github.com/google/cadvisor/issues/2688
         rule {
           source_labels = ["__name__","image"]
           separator = "@"
-          regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_network_.*)@"
+          regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_network_.*|container_pressure_.*)@"
           action = "drop"
         }
         // Normalizing unimportant labels (not deleting to continue satisfying <label>!="" checks)

--- a/charts/k8s-monitoring/docs/examples/extra-rules/alloy-metrics.alloy
+++ b/charts/k8s-monitoring/docs/examples/extra-rules/alloy-metrics.alloy
@@ -151,14 +151,14 @@ declare "cluster_metrics" {
     rule {
       source_labels = ["__name__","container"]
       separator = "@"
-      regex = "(container_cpu_.*|container_fs_.*|container_memory_.*)@"
+      regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_pressure_.*)@"
       action = "drop"
     }
     // Drop empty image labels, addressing https://github.com/google/cadvisor/issues/2688
     rule {
       source_labels = ["__name__","image"]
       separator = "@"
-      regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_network_.*)@"
+      regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_network_.*|container_pressure_.*)@"
       action = "drop"
     }
     // Normalizing unimportant labels (not deleting to continue satisfying <label>!="" checks)

--- a/charts/k8s-monitoring/docs/examples/extra-rules/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/extra-rules/output.yaml
@@ -510,14 +510,14 @@ data:
         rule {
           source_labels = ["__name__","container"]
           separator = "@"
-          regex = "(container_cpu_.*|container_fs_.*|container_memory_.*)@"
+          regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_pressure_.*)@"
           action = "drop"
         }
         // Drop empty image labels, addressing https://github.com/google/cadvisor/issues/2688
         rule {
           source_labels = ["__name__","image"]
           separator = "@"
-          regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_network_.*)@"
+          regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_network_.*|container_pressure_.*)@"
           action = "drop"
         }
         // Normalizing unimportant labels (not deleting to continue satisfying <label>!="" checks)

--- a/charts/k8s-monitoring/docs/examples/features/cluster-metrics/control-plane-monitoring/alloy-metrics.alloy
+++ b/charts/k8s-monitoring/docs/examples/features/cluster-metrics/control-plane-monitoring/alloy-metrics.alloy
@@ -151,14 +151,14 @@ declare "cluster_metrics" {
     rule {
       source_labels = ["__name__","container"]
       separator = "@"
-      regex = "(container_cpu_.*|container_fs_.*|container_memory_.*)@"
+      regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_pressure_.*)@"
       action = "drop"
     }
     // Drop empty image labels, addressing https://github.com/google/cadvisor/issues/2688
     rule {
       source_labels = ["__name__","image"]
       separator = "@"
-      regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_network_.*)@"
+      regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_network_.*|container_pressure_.*)@"
       action = "drop"
     }
     // Normalizing unimportant labels (not deleting to continue satisfying <label>!="" checks)

--- a/charts/k8s-monitoring/docs/examples/features/cluster-metrics/control-plane-monitoring/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/features/cluster-metrics/control-plane-monitoring/output.yaml
@@ -482,14 +482,14 @@ data:
         rule {
           source_labels = ["__name__","container"]
           separator = "@"
-          regex = "(container_cpu_.*|container_fs_.*|container_memory_.*)@"
+          regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_pressure_.*)@"
           action = "drop"
         }
         // Drop empty image labels, addressing https://github.com/google/cadvisor/issues/2688
         rule {
           source_labels = ["__name__","image"]
           separator = "@"
-          regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_network_.*)@"
+          regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_network_.*|container_pressure_.*)@"
           action = "drop"
         }
         // Normalizing unimportant labels (not deleting to continue satisfying <label>!="" checks)

--- a/charts/k8s-monitoring/docs/examples/features/cluster-metrics/default/alloy-metrics.alloy
+++ b/charts/k8s-monitoring/docs/examples/features/cluster-metrics/default/alloy-metrics.alloy
@@ -151,14 +151,14 @@ declare "cluster_metrics" {
     rule {
       source_labels = ["__name__","container"]
       separator = "@"
-      regex = "(container_cpu_.*|container_fs_.*|container_memory_.*)@"
+      regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_pressure_.*)@"
       action = "drop"
     }
     // Drop empty image labels, addressing https://github.com/google/cadvisor/issues/2688
     rule {
       source_labels = ["__name__","image"]
       separator = "@"
-      regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_network_.*)@"
+      regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_network_.*|container_pressure_.*)@"
       action = "drop"
     }
     // Normalizing unimportant labels (not deleting to continue satisfying <label>!="" checks)

--- a/charts/k8s-monitoring/docs/examples/features/cluster-metrics/default/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/features/cluster-metrics/default/output.yaml
@@ -191,14 +191,14 @@ data:
         rule {
           source_labels = ["__name__","container"]
           separator = "@"
-          regex = "(container_cpu_.*|container_fs_.*|container_memory_.*)@"
+          regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_pressure_.*)@"
           action = "drop"
         }
         // Drop empty image labels, addressing https://github.com/google/cadvisor/issues/2688
         rule {
           source_labels = ["__name__","image"]
           separator = "@"
-          regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_network_.*)@"
+          regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_network_.*|container_pressure_.*)@"
           action = "drop"
         }
         // Normalizing unimportant labels (not deleting to continue satisfying <label>!="" checks)

--- a/charts/k8s-monitoring/docs/examples/features/cost-metrics/default/alloy-metrics.alloy
+++ b/charts/k8s-monitoring/docs/examples/features/cost-metrics/default/alloy-metrics.alloy
@@ -151,14 +151,14 @@ declare "cluster_metrics" {
     rule {
       source_labels = ["__name__","container"]
       separator = "@"
-      regex = "(container_cpu_.*|container_fs_.*|container_memory_.*)@"
+      regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_pressure_.*)@"
       action = "drop"
     }
     // Drop empty image labels, addressing https://github.com/google/cadvisor/issues/2688
     rule {
       source_labels = ["__name__","image"]
       separator = "@"
-      regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_network_.*)@"
+      regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_network_.*|container_pressure_.*)@"
       action = "drop"
     }
     // Normalizing unimportant labels (not deleting to continue satisfying <label>!="" checks)

--- a/charts/k8s-monitoring/docs/examples/features/cost-metrics/default/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/features/cost-metrics/default/output.yaml
@@ -206,14 +206,14 @@ data:
         rule {
           source_labels = ["__name__","container"]
           separator = "@"
-          regex = "(container_cpu_.*|container_fs_.*|container_memory_.*)@"
+          regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_pressure_.*)@"
           action = "drop"
         }
         // Drop empty image labels, addressing https://github.com/google/cadvisor/issues/2688
         rule {
           source_labels = ["__name__","image"]
           separator = "@"
-          regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_network_.*)@"
+          regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_network_.*|container_pressure_.*)@"
           action = "drop"
         }
         // Normalizing unimportant labels (not deleting to continue satisfying <label>!="" checks)

--- a/charts/k8s-monitoring/docs/examples/images/images-by-digest/alloy-metrics.alloy
+++ b/charts/k8s-monitoring/docs/examples/images/images-by-digest/alloy-metrics.alloy
@@ -212,14 +212,14 @@ declare "cluster_metrics" {
     rule {
       source_labels = ["__name__","container"]
       separator = "@"
-      regex = "(container_cpu_.*|container_fs_.*|container_memory_.*)@"
+      regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_pressure_.*)@"
       action = "drop"
     }
     // Drop empty image labels, addressing https://github.com/google/cadvisor/issues/2688
     rule {
       source_labels = ["__name__","image"]
       separator = "@"
-      regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_network_.*)@"
+      regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_network_.*|container_pressure_.*)@"
       action = "drop"
     }
     // Normalizing unimportant labels (not deleting to continue satisfying <label>!="" checks)

--- a/charts/k8s-monitoring/docs/examples/images/images-by-digest/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/images/images-by-digest/output.yaml
@@ -352,14 +352,14 @@ data:
         rule {
           source_labels = ["__name__","container"]
           separator = "@"
-          regex = "(container_cpu_.*|container_fs_.*|container_memory_.*)@"
+          regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_pressure_.*)@"
           action = "drop"
         }
         // Drop empty image labels, addressing https://github.com/google/cadvisor/issues/2688
         rule {
           source_labels = ["__name__","image"]
           separator = "@"
-          regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_network_.*)@"
+          regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_network_.*|container_pressure_.*)@"
           action = "drop"
         }
         // Normalizing unimportant labels (not deleting to continue satisfying <label>!="" checks)

--- a/charts/k8s-monitoring/docs/examples/include-by-namespace/alloy-metrics.alloy
+++ b/charts/k8s-monitoring/docs/examples/include-by-namespace/alloy-metrics.alloy
@@ -559,14 +559,14 @@ declare "cluster_metrics" {
     rule {
       source_labels = ["__name__","container"]
       separator = "@"
-      regex = "(container_cpu_.*|container_fs_.*|container_memory_.*)@"
+      regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_pressure_.*)@"
       action = "drop"
     }
     // Drop empty image labels, addressing https://github.com/google/cadvisor/issues/2688
     rule {
       source_labels = ["__name__","image"]
       separator = "@"
-      regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_network_.*)@"
+      regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_network_.*|container_pressure_.*)@"
       action = "drop"
     }
     // Normalizing unimportant labels (not deleting to continue satisfying <label>!="" checks)

--- a/charts/k8s-monitoring/docs/examples/include-by-namespace/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/include-by-namespace/output.yaml
@@ -931,14 +931,14 @@ data:
         rule {
           source_labels = ["__name__","container"]
           separator = "@"
-          regex = "(container_cpu_.*|container_fs_.*|container_memory_.*)@"
+          regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_pressure_.*)@"
           action = "drop"
         }
         // Drop empty image labels, addressing https://github.com/google/cadvisor/issues/2688
         rule {
           source_labels = ["__name__","image"]
           separator = "@"
-          regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_network_.*)@"
+          regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_network_.*|container_pressure_.*)@"
           action = "drop"
         }
         // Normalizing unimportant labels (not deleting to continue satisfying <label>!="" checks)

--- a/charts/k8s-monitoring/docs/examples/istio-ambient/alloy-metrics.alloy
+++ b/charts/k8s-monitoring/docs/examples/istio-ambient/alloy-metrics.alloy
@@ -151,14 +151,14 @@ declare "cluster_metrics" {
     rule {
       source_labels = ["__name__","container"]
       separator = "@"
-      regex = "(container_cpu_.*|container_fs_.*|container_memory_.*)@"
+      regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_pressure_.*)@"
       action = "drop"
     }
     // Drop empty image labels, addressing https://github.com/google/cadvisor/issues/2688
     rule {
       source_labels = ["__name__","image"]
       separator = "@"
-      regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_network_.*)@"
+      regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_network_.*|container_pressure_.*)@"
       action = "drop"
     }
     // Normalizing unimportant labels (not deleting to continue satisfying <label>!="" checks)

--- a/charts/k8s-monitoring/docs/examples/istio-ambient/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/istio-ambient/output.yaml
@@ -515,14 +515,14 @@ data:
         rule {
           source_labels = ["__name__","container"]
           separator = "@"
-          regex = "(container_cpu_.*|container_fs_.*|container_memory_.*)@"
+          regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_pressure_.*)@"
           action = "drop"
         }
         // Drop empty image labels, addressing https://github.com/google/cadvisor/issues/2688
         rule {
           source_labels = ["__name__","image"]
           separator = "@"
-          regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_network_.*)@"
+          regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_network_.*|container_pressure_.*)@"
           action = "drop"
         }
         // Normalizing unimportant labels (not deleting to continue satisfying <label>!="" checks)

--- a/charts/k8s-monitoring/docs/examples/istio-service-mesh/alloy-metrics.alloy
+++ b/charts/k8s-monitoring/docs/examples/istio-service-mesh/alloy-metrics.alloy
@@ -151,14 +151,14 @@ declare "cluster_metrics" {
     rule {
       source_labels = ["__name__","container"]
       separator = "@"
-      regex = "(container_cpu_.*|container_fs_.*|container_memory_.*)@"
+      regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_pressure_.*)@"
       action = "drop"
     }
     // Drop empty image labels, addressing https://github.com/google/cadvisor/issues/2688
     rule {
       source_labels = ["__name__","image"]
       separator = "@"
-      regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_network_.*)@"
+      regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_network_.*|container_pressure_.*)@"
       action = "drop"
     }
     // Normalizing unimportant labels (not deleting to continue satisfying <label>!="" checks)

--- a/charts/k8s-monitoring/docs/examples/istio-service-mesh/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/istio-service-mesh/output.yaml
@@ -515,14 +515,14 @@ data:
         rule {
           source_labels = ["__name__","container"]
           separator = "@"
-          regex = "(container_cpu_.*|container_fs_.*|container_memory_.*)@"
+          regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_pressure_.*)@"
           action = "drop"
         }
         // Drop empty image labels, addressing https://github.com/google/cadvisor/issues/2688
         rule {
           source_labels = ["__name__","image"]
           separator = "@"
-          regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_network_.*)@"
+          regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_network_.*|container_pressure_.*)@"
           action = "drop"
         }
         // Normalizing unimportant labels (not deleting to continue satisfying <label>!="" checks)

--- a/charts/k8s-monitoring/docs/examples/meta-monitoring/alloy.alloy
+++ b/charts/k8s-monitoring/docs/examples/meta-monitoring/alloy.alloy
@@ -201,14 +201,14 @@ declare "cluster_metrics" {
     rule {
       source_labels = ["__name__","container"]
       separator = "@"
-      regex = "(container_cpu_.*|container_fs_.*|container_memory_.*)@"
+      regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_pressure_.*)@"
       action = "drop"
     }
     // Drop empty image labels, addressing https://github.com/google/cadvisor/issues/2688
     rule {
       source_labels = ["__name__","image"]
       separator = "@"
-      regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_network_.*)@"
+      regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_network_.*|container_pressure_.*)@"
       action = "drop"
     }
     // Normalizing unimportant labels (not deleting to continue satisfying <label>!="" checks)

--- a/charts/k8s-monitoring/docs/examples/meta-monitoring/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/meta-monitoring/output.yaml
@@ -258,14 +258,14 @@ data:
         rule {
           source_labels = ["__name__","container"]
           separator = "@"
-          regex = "(container_cpu_.*|container_fs_.*|container_memory_.*)@"
+          regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_pressure_.*)@"
           action = "drop"
         }
         // Drop empty image labels, addressing https://github.com/google/cadvisor/issues/2688
         rule {
           source_labels = ["__name__","image"]
           separator = "@"
-          regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_network_.*)@"
+          regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_network_.*|container_pressure_.*)@"
           action = "drop"
         }
         // Normalizing unimportant labels (not deleting to continue satisfying <label>!="" checks)

--- a/charts/k8s-monitoring/docs/examples/metric-enrichment/alloy-metrics.alloy
+++ b/charts/k8s-monitoring/docs/examples/metric-enrichment/alloy-metrics.alloy
@@ -151,14 +151,14 @@ declare "cluster_metrics" {
     rule {
       source_labels = ["__name__","container"]
       separator = "@"
-      regex = "(container_cpu_.*|container_fs_.*|container_memory_.*)@"
+      regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_pressure_.*)@"
       action = "drop"
     }
     // Drop empty image labels, addressing https://github.com/google/cadvisor/issues/2688
     rule {
       source_labels = ["__name__","image"]
       separator = "@"
-      regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_network_.*)@"
+      regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_network_.*|container_pressure_.*)@"
       action = "drop"
     }
     // Normalizing unimportant labels (not deleting to continue satisfying <label>!="" checks)

--- a/charts/k8s-monitoring/docs/examples/metric-enrichment/namespace-and-pod-labels/alloy-metrics.alloy
+++ b/charts/k8s-monitoring/docs/examples/metric-enrichment/namespace-and-pod-labels/alloy-metrics.alloy
@@ -151,14 +151,14 @@ declare "cluster_metrics" {
     rule {
       source_labels = ["__name__","container"]
       separator = "@"
-      regex = "(container_cpu_.*|container_fs_.*|container_memory_.*)@"
+      regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_pressure_.*)@"
       action = "drop"
     }
     // Drop empty image labels, addressing https://github.com/google/cadvisor/issues/2688
     rule {
       source_labels = ["__name__","image"]
       separator = "@"
-      regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_network_.*)@"
+      regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_network_.*|container_pressure_.*)@"
       action = "drop"
     }
     // Normalizing unimportant labels (not deleting to continue satisfying <label>!="" checks)

--- a/charts/k8s-monitoring/docs/examples/metric-enrichment/namespace-and-pod-labels/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/metric-enrichment/namespace-and-pod-labels/output.yaml
@@ -247,14 +247,14 @@ data:
         rule {
           source_labels = ["__name__","container"]
           separator = "@"
-          regex = "(container_cpu_.*|container_fs_.*|container_memory_.*)@"
+          regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_pressure_.*)@"
           action = "drop"
         }
         // Drop empty image labels, addressing https://github.com/google/cadvisor/issues/2688
         rule {
           source_labels = ["__name__","image"]
           separator = "@"
-          regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_network_.*)@"
+          regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_network_.*|container_pressure_.*)@"
           action = "drop"
         }
         // Normalizing unimportant labels (not deleting to continue satisfying <label>!="" checks)

--- a/charts/k8s-monitoring/docs/examples/metric-enrichment/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/metric-enrichment/output.yaml
@@ -247,14 +247,14 @@ data:
         rule {
           source_labels = ["__name__","container"]
           separator = "@"
-          regex = "(container_cpu_.*|container_fs_.*|container_memory_.*)@"
+          regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_pressure_.*)@"
           action = "drop"
         }
         // Drop empty image labels, addressing https://github.com/google/cadvisor/issues/2688
         rule {
           source_labels = ["__name__","image"]
           separator = "@"
-          regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_network_.*)@"
+          regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_network_.*|container_pressure_.*)@"
           action = "drop"
         }
         // Normalizing unimportant labels (not deleting to continue satisfying <label>!="" checks)

--- a/charts/k8s-monitoring/docs/examples/metrics-tuning/alloy-metrics.alloy
+++ b/charts/k8s-monitoring/docs/examples/metrics-tuning/alloy-metrics.alloy
@@ -508,14 +508,14 @@ declare "cluster_metrics" {
     rule {
       source_labels = ["__name__","container"]
       separator = "@"
-      regex = "(container_cpu_.*|container_fs_.*|container_memory_.*)@"
+      regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_pressure_.*)@"
       action = "drop"
     }
     // Drop empty image labels, addressing https://github.com/google/cadvisor/issues/2688
     rule {
       source_labels = ["__name__","image"]
       separator = "@"
-      regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_network_.*)@"
+      regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_network_.*|container_pressure_.*)@"
       action = "drop"
     }
     // Normalizing unimportant labels (not deleting to continue satisfying <label>!="" checks)

--- a/charts/k8s-monitoring/docs/examples/metrics-tuning/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/metrics-tuning/output.yaml
@@ -565,14 +565,14 @@ data:
         rule {
           source_labels = ["__name__","container"]
           separator = "@"
-          regex = "(container_cpu_.*|container_fs_.*|container_memory_.*)@"
+          regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_pressure_.*)@"
           action = "drop"
         }
         // Drop empty image labels, addressing https://github.com/google/cadvisor/issues/2688
         rule {
           source_labels = ["__name__","image"]
           separator = "@"
-          regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_network_.*)@"
+          regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_network_.*|container_pressure_.*)@"
           action = "drop"
         }
         // Normalizing unimportant labels (not deleting to continue satisfying <label>!="" checks)

--- a/charts/k8s-monitoring/docs/examples/name-overrides/fullname-overrides/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/name-overrides/fullname-overrides/output.yaml
@@ -236,14 +236,14 @@ data:
         rule {
           source_labels = ["__name__","container"]
           separator = "@"
-          regex = "(container_cpu_.*|container_fs_.*|container_memory_.*)@"
+          regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_pressure_.*)@"
           action = "drop"
         }
         // Drop empty image labels, addressing https://github.com/google/cadvisor/issues/2688
         rule {
           source_labels = ["__name__","image"]
           separator = "@"
-          regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_network_.*)@"
+          regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_network_.*|container_pressure_.*)@"
           action = "drop"
         }
         // Normalizing unimportant labels (not deleting to continue satisfying <label>!="" checks)

--- a/charts/k8s-monitoring/docs/examples/name-overrides/name-overrides/alloy-metrics.alloy
+++ b/charts/k8s-monitoring/docs/examples/name-overrides/name-overrides/alloy-metrics.alloy
@@ -151,14 +151,14 @@ declare "cluster_metrics" {
     rule {
       source_labels = ["__name__","container"]
       separator = "@"
-      regex = "(container_cpu_.*|container_fs_.*|container_memory_.*)@"
+      regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_pressure_.*)@"
       action = "drop"
     }
     // Drop empty image labels, addressing https://github.com/google/cadvisor/issues/2688
     rule {
       source_labels = ["__name__","image"]
       separator = "@"
-      regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_network_.*)@"
+      regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_network_.*|container_pressure_.*)@"
       action = "drop"
     }
     // Normalizing unimportant labels (not deleting to continue satisfying <label>!="" checks)

--- a/charts/k8s-monitoring/docs/examples/name-overrides/name-overrides/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/name-overrides/name-overrides/output.yaml
@@ -236,14 +236,14 @@ data:
         rule {
           source_labels = ["__name__","container"]
           separator = "@"
-          regex = "(container_cpu_.*|container_fs_.*|container_memory_.*)@"
+          regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_pressure_.*)@"
           action = "drop"
         }
         // Drop empty image labels, addressing https://github.com/google/cadvisor/issues/2688
         rule {
           source_labels = ["__name__","image"]
           separator = "@"
-          regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_network_.*)@"
+          regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_network_.*|container_pressure_.*)@"
           action = "drop"
         }
         // Normalizing unimportant labels (not deleting to continue satisfying <label>!="" checks)

--- a/charts/k8s-monitoring/docs/examples/namespace-labels-and-annotations/alloy-metrics.alloy
+++ b/charts/k8s-monitoring/docs/examples/namespace-labels-and-annotations/alloy-metrics.alloy
@@ -151,14 +151,14 @@ declare "cluster_metrics" {
     rule {
       source_labels = ["__name__","container"]
       separator = "@"
-      regex = "(container_cpu_.*|container_fs_.*|container_memory_.*)@"
+      regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_pressure_.*)@"
       action = "drop"
     }
     // Drop empty image labels, addressing https://github.com/google/cadvisor/issues/2688
     rule {
       source_labels = ["__name__","image"]
       separator = "@"
-      regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_network_.*)@"
+      regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_network_.*|container_pressure_.*)@"
       action = "drop"
     }
     // Normalizing unimportant labels (not deleting to continue satisfying <label>!="" checks)

--- a/charts/k8s-monitoring/docs/examples/namespace-labels-and-annotations/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/namespace-labels-and-annotations/output.yaml
@@ -482,14 +482,14 @@ data:
         rule {
           source_labels = ["__name__","container"]
           separator = "@"
-          regex = "(container_cpu_.*|container_fs_.*|container_memory_.*)@"
+          regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_pressure_.*)@"
           action = "drop"
         }
         // Drop empty image labels, addressing https://github.com/google/cadvisor/issues/2688
         rule {
           source_labels = ["__name__","image"]
           separator = "@"
-          regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_network_.*)@"
+          regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_network_.*|container_pressure_.*)@"
           action = "drop"
         }
         // Normalizing unimportant labels (not deleting to continue satisfying <label>!="" checks)

--- a/charts/k8s-monitoring/docs/examples/platforms/azure-aks/alloy-metrics.alloy
+++ b/charts/k8s-monitoring/docs/examples/platforms/azure-aks/alloy-metrics.alloy
@@ -151,14 +151,14 @@ declare "cluster_metrics" {
     rule {
       source_labels = ["__name__","container"]
       separator = "@"
-      regex = "(container_cpu_.*|container_fs_.*|container_memory_.*)@"
+      regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_pressure_.*)@"
       action = "drop"
     }
     // Drop empty image labels, addressing https://github.com/google/cadvisor/issues/2688
     rule {
       source_labels = ["__name__","image"]
       separator = "@"
-      regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_network_.*)@"
+      regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_network_.*|container_pressure_.*)@"
       action = "drop"
     }
     // Normalizing unimportant labels (not deleting to continue satisfying <label>!="" checks)

--- a/charts/k8s-monitoring/docs/examples/platforms/azure-aks/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/platforms/azure-aks/output.yaml
@@ -482,14 +482,14 @@ data:
         rule {
           source_labels = ["__name__","container"]
           separator = "@"
-          regex = "(container_cpu_.*|container_fs_.*|container_memory_.*)@"
+          regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_pressure_.*)@"
           action = "drop"
         }
         // Drop empty image labels, addressing https://github.com/google/cadvisor/issues/2688
         rule {
           source_labels = ["__name__","image"]
           separator = "@"
-          regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_network_.*)@"
+          regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_network_.*|container_pressure_.*)@"
           action = "drop"
         }
         // Normalizing unimportant labels (not deleting to continue satisfying <label>!="" checks)

--- a/charts/k8s-monitoring/docs/examples/platforms/eks-fargate/alloy-metrics.alloy
+++ b/charts/k8s-monitoring/docs/examples/platforms/eks-fargate/alloy-metrics.alloy
@@ -151,14 +151,14 @@ declare "cluster_metrics" {
     rule {
       source_labels = ["__name__","container"]
       separator = "@"
-      regex = "(container_cpu_.*|container_fs_.*|container_memory_.*)@"
+      regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_pressure_.*)@"
       action = "drop"
     }
     // Drop empty image labels, addressing https://github.com/google/cadvisor/issues/2688
     rule {
       source_labels = ["__name__","image"]
       separator = "@"
-      regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_network_.*)@"
+      regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_network_.*|container_pressure_.*)@"
       action = "drop"
     }
     // Normalizing unimportant labels (not deleting to continue satisfying <label>!="" checks)

--- a/charts/k8s-monitoring/docs/examples/platforms/eks-fargate/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/platforms/eks-fargate/output.yaml
@@ -403,14 +403,14 @@ data:
         rule {
           source_labels = ["__name__","container"]
           separator = "@"
-          regex = "(container_cpu_.*|container_fs_.*|container_memory_.*)@"
+          regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_pressure_.*)@"
           action = "drop"
         }
         // Drop empty image labels, addressing https://github.com/google/cadvisor/issues/2688
         rule {
           source_labels = ["__name__","image"]
           separator = "@"
-          regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_network_.*)@"
+          regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_network_.*|container_pressure_.*)@"
           action = "drop"
         }
         // Normalizing unimportant labels (not deleting to continue satisfying <label>!="" checks)

--- a/charts/k8s-monitoring/docs/examples/platforms/gke-autopilot/alloy-metrics.alloy
+++ b/charts/k8s-monitoring/docs/examples/platforms/gke-autopilot/alloy-metrics.alloy
@@ -151,14 +151,14 @@ declare "cluster_metrics" {
     rule {
       source_labels = ["__name__","container"]
       separator = "@"
-      regex = "(container_cpu_.*|container_fs_.*|container_memory_.*)@"
+      regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_pressure_.*)@"
       action = "drop"
     }
     // Drop empty image labels, addressing https://github.com/google/cadvisor/issues/2688
     rule {
       source_labels = ["__name__","image"]
       separator = "@"
-      regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_network_.*)@"
+      regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_network_.*|container_pressure_.*)@"
       action = "drop"
     }
     // Normalizing unimportant labels (not deleting to continue satisfying <label>!="" checks)

--- a/charts/k8s-monitoring/docs/examples/platforms/gke-autopilot/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/platforms/gke-autopilot/output.yaml
@@ -426,14 +426,14 @@ data:
         rule {
           source_labels = ["__name__","container"]
           separator = "@"
-          regex = "(container_cpu_.*|container_fs_.*|container_memory_.*)@"
+          regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_pressure_.*)@"
           action = "drop"
         }
         // Drop empty image labels, addressing https://github.com/google/cadvisor/issues/2688
         rule {
           source_labels = ["__name__","image"]
           separator = "@"
-          regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_network_.*)@"
+          regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_network_.*|container_pressure_.*)@"
           action = "drop"
         }
         // Normalizing unimportant labels (not deleting to continue satisfying <label>!="" checks)

--- a/charts/k8s-monitoring/docs/examples/platforms/openshift/alloy-metrics.alloy
+++ b/charts/k8s-monitoring/docs/examples/platforms/openshift/alloy-metrics.alloy
@@ -151,14 +151,14 @@ declare "cluster_metrics" {
     rule {
       source_labels = ["__name__","container"]
       separator = "@"
-      regex = "(container_cpu_.*|container_fs_.*|container_memory_.*)@"
+      regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_pressure_.*)@"
       action = "drop"
     }
     // Drop empty image labels, addressing https://github.com/google/cadvisor/issues/2688
     rule {
       source_labels = ["__name__","image"]
       separator = "@"
-      regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_network_.*)@"
+      regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_network_.*|container_pressure_.*)@"
       action = "drop"
     }
     // Normalizing unimportant labels (not deleting to continue satisfying <label>!="" checks)

--- a/charts/k8s-monitoring/docs/examples/platforms/openshift/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/platforms/openshift/output.yaml
@@ -422,14 +422,14 @@ data:
         rule {
           source_labels = ["__name__","container"]
           separator = "@"
-          regex = "(container_cpu_.*|container_fs_.*|container_memory_.*)@"
+          regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_pressure_.*)@"
           action = "drop"
         }
         // Drop empty image labels, addressing https://github.com/google/cadvisor/issues/2688
         rule {
           source_labels = ["__name__","image"]
           separator = "@"
-          regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_network_.*)@"
+          regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_network_.*|container_pressure_.*)@"
           action = "drop"
         }
         // Normalizing unimportant labels (not deleting to continue satisfying <label>!="" checks)

--- a/charts/k8s-monitoring/docs/examples/pod-labels-and-annotations/alloy-metrics.alloy
+++ b/charts/k8s-monitoring/docs/examples/pod-labels-and-annotations/alloy-metrics.alloy
@@ -151,14 +151,14 @@ declare "cluster_metrics" {
     rule {
       source_labels = ["__name__","container"]
       separator = "@"
-      regex = "(container_cpu_.*|container_fs_.*|container_memory_.*)@"
+      regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_pressure_.*)@"
       action = "drop"
     }
     // Drop empty image labels, addressing https://github.com/google/cadvisor/issues/2688
     rule {
       source_labels = ["__name__","image"]
       separator = "@"
-      regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_network_.*)@"
+      regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_network_.*|container_pressure_.*)@"
       action = "drop"
     }
     // Normalizing unimportant labels (not deleting to continue satisfying <label>!="" checks)

--- a/charts/k8s-monitoring/docs/examples/pod-labels-and-annotations/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/pod-labels-and-annotations/output.yaml
@@ -492,14 +492,14 @@ data:
         rule {
           source_labels = ["__name__","container"]
           separator = "@"
-          regex = "(container_cpu_.*|container_fs_.*|container_memory_.*)@"
+          regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_pressure_.*)@"
           action = "drop"
         }
         // Drop empty image labels, addressing https://github.com/google/cadvisor/issues/2688
         rule {
           source_labels = ["__name__","image"]
           separator = "@"
-          regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_network_.*)@"
+          regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_network_.*|container_pressure_.*)@"
           action = "drop"
         }
         // Normalizing unimportant labels (not deleting to continue satisfying <label>!="" checks)

--- a/charts/k8s-monitoring/docs/examples/private-image-registries/globally/alloy-metrics.alloy
+++ b/charts/k8s-monitoring/docs/examples/private-image-registries/globally/alloy-metrics.alloy
@@ -151,14 +151,14 @@ declare "cluster_metrics" {
     rule {
       source_labels = ["__name__","container"]
       separator = "@"
-      regex = "(container_cpu_.*|container_fs_.*|container_memory_.*)@"
+      regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_pressure_.*)@"
       action = "drop"
     }
     // Drop empty image labels, addressing https://github.com/google/cadvisor/issues/2688
     rule {
       source_labels = ["__name__","image"]
       separator = "@"
-      regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_network_.*)@"
+      regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_network_.*|container_pressure_.*)@"
       action = "drop"
     }
     // Normalizing unimportant labels (not deleting to continue satisfying <label>!="" checks)

--- a/charts/k8s-monitoring/docs/examples/private-image-registries/globally/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/private-image-registries/globally/output.yaml
@@ -516,14 +516,14 @@ data:
         rule {
           source_labels = ["__name__","container"]
           separator = "@"
-          regex = "(container_cpu_.*|container_fs_.*|container_memory_.*)@"
+          regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_pressure_.*)@"
           action = "drop"
         }
         // Drop empty image labels, addressing https://github.com/google/cadvisor/issues/2688
         rule {
           source_labels = ["__name__","image"]
           separator = "@"
-          regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_network_.*)@"
+          regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_network_.*|container_pressure_.*)@"
           action = "drop"
         }
         // Normalizing unimportant labels (not deleting to continue satisfying <label>!="" checks)

--- a/charts/k8s-monitoring/docs/examples/private-image-registries/individual/alloy-metrics.alloy
+++ b/charts/k8s-monitoring/docs/examples/private-image-registries/individual/alloy-metrics.alloy
@@ -212,14 +212,14 @@ declare "cluster_metrics" {
     rule {
       source_labels = ["__name__","container"]
       separator = "@"
-      regex = "(container_cpu_.*|container_fs_.*|container_memory_.*)@"
+      regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_pressure_.*)@"
       action = "drop"
     }
     // Drop empty image labels, addressing https://github.com/google/cadvisor/issues/2688
     rule {
       source_labels = ["__name__","image"]
       separator = "@"
-      regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_network_.*)@"
+      regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_network_.*|container_pressure_.*)@"
       action = "drop"
     }
     // Normalizing unimportant labels (not deleting to continue satisfying <label>!="" checks)

--- a/charts/k8s-monitoring/docs/examples/private-image-registries/individual/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/private-image-registries/individual/output.yaml
@@ -352,14 +352,14 @@ data:
         rule {
           source_labels = ["__name__","container"]
           separator = "@"
-          regex = "(container_cpu_.*|container_fs_.*|container_memory_.*)@"
+          regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_pressure_.*)@"
           action = "drop"
         }
         // Drop empty image labels, addressing https://github.com/google/cadvisor/issues/2688
         rule {
           source_labels = ["__name__","image"]
           separator = "@"
-          regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_network_.*)@"
+          regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_network_.*|container_pressure_.*)@"
           action = "drop"
         }
         // Normalizing unimportant labels (not deleting to continue satisfying <label>!="" checks)

--- a/charts/k8s-monitoring/docs/examples/proxies/alloy-metrics.alloy
+++ b/charts/k8s-monitoring/docs/examples/proxies/alloy-metrics.alloy
@@ -151,14 +151,14 @@ declare "cluster_metrics" {
     rule {
       source_labels = ["__name__","container"]
       separator = "@"
-      regex = "(container_cpu_.*|container_fs_.*|container_memory_.*)@"
+      regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_pressure_.*)@"
       action = "drop"
     }
     // Drop empty image labels, addressing https://github.com/google/cadvisor/issues/2688
     rule {
       source_labels = ["__name__","image"]
       separator = "@"
-      regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_network_.*)@"
+      regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_network_.*|container_pressure_.*)@"
       action = "drop"
     }
     // Normalizing unimportant labels (not deleting to continue satisfying <label>!="" checks)

--- a/charts/k8s-monitoring/docs/examples/proxies/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/proxies/output.yaml
@@ -498,14 +498,14 @@ data:
         rule {
           source_labels = ["__name__","container"]
           separator = "@"
-          regex = "(container_cpu_.*|container_fs_.*|container_memory_.*)@"
+          regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_pressure_.*)@"
           action = "drop"
         }
         // Drop empty image labels, addressing https://github.com/google/cadvisor/issues/2688
         rule {
           source_labels = ["__name__","image"]
           separator = "@"
-          regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_network_.*)@"
+          regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_network_.*|container_pressure_.*)@"
           action = "drop"
         }
         // Normalizing unimportant labels (not deleting to continue satisfying <label>!="" checks)

--- a/charts/k8s-monitoring/docs/examples/resource-requests-and-limits/alloy-metrics.alloy
+++ b/charts/k8s-monitoring/docs/examples/resource-requests-and-limits/alloy-metrics.alloy
@@ -212,14 +212,14 @@ declare "cluster_metrics" {
     rule {
       source_labels = ["__name__","container"]
       separator = "@"
-      regex = "(container_cpu_.*|container_fs_.*|container_memory_.*)@"
+      regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_pressure_.*)@"
       action = "drop"
     }
     // Drop empty image labels, addressing https://github.com/google/cadvisor/issues/2688
     rule {
       source_labels = ["__name__","image"]
       separator = "@"
-      regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_network_.*)@"
+      regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_network_.*|container_pressure_.*)@"
       action = "drop"
     }
     // Normalizing unimportant labels (not deleting to continue satisfying <label>!="" checks)

--- a/charts/k8s-monitoring/docs/examples/resource-requests-and-limits/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/resource-requests-and-limits/output.yaml
@@ -352,14 +352,14 @@ data:
         rule {
           source_labels = ["__name__","container"]
           separator = "@"
-          regex = "(container_cpu_.*|container_fs_.*|container_memory_.*)@"
+          regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_pressure_.*)@"
           action = "drop"
         }
         // Drop empty image labels, addressing https://github.com/google/cadvisor/issues/2688
         rule {
           source_labels = ["__name__","image"]
           separator = "@"
-          regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_network_.*)@"
+          regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_network_.*|container_pressure_.*)@"
           action = "drop"
         }
         // Normalizing unimportant labels (not deleting to continue satisfying <label>!="" checks)

--- a/charts/k8s-monitoring/docs/examples/scalability/autoscaling/alloy-metrics.alloy
+++ b/charts/k8s-monitoring/docs/examples/scalability/autoscaling/alloy-metrics.alloy
@@ -151,14 +151,14 @@ declare "cluster_metrics" {
     rule {
       source_labels = ["__name__","container"]
       separator = "@"
-      regex = "(container_cpu_.*|container_fs_.*|container_memory_.*)@"
+      regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_pressure_.*)@"
       action = "drop"
     }
     // Drop empty image labels, addressing https://github.com/google/cadvisor/issues/2688
     rule {
       source_labels = ["__name__","image"]
       separator = "@"
-      regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_network_.*)@"
+      regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_network_.*|container_pressure_.*)@"
       action = "drop"
     }
     // Normalizing unimportant labels (not deleting to continue satisfying <label>!="" checks)

--- a/charts/k8s-monitoring/docs/examples/scalability/autoscaling/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/scalability/autoscaling/output.yaml
@@ -247,14 +247,14 @@ data:
         rule {
           source_labels = ["__name__","container"]
           separator = "@"
-          regex = "(container_cpu_.*|container_fs_.*|container_memory_.*)@"
+          regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_pressure_.*)@"
           action = "drop"
         }
         // Drop empty image labels, addressing https://github.com/google/cadvisor/issues/2688
         rule {
           source_labels = ["__name__","image"]
           separator = "@"
-          regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_network_.*)@"
+          regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_network_.*|container_pressure_.*)@"
           action = "drop"
         }
         // Normalizing unimportant labels (not deleting to continue satisfying <label>!="" checks)

--- a/charts/k8s-monitoring/docs/examples/scalability/high-availability-kube-state-metrics/alloy-metrics.alloy
+++ b/charts/k8s-monitoring/docs/examples/scalability/high-availability-kube-state-metrics/alloy-metrics.alloy
@@ -151,14 +151,14 @@ declare "cluster_metrics" {
     rule {
       source_labels = ["__name__","container"]
       separator = "@"
-      regex = "(container_cpu_.*|container_fs_.*|container_memory_.*)@"
+      regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_pressure_.*)@"
       action = "drop"
     }
     // Drop empty image labels, addressing https://github.com/google/cadvisor/issues/2688
     rule {
       source_labels = ["__name__","image"]
       separator = "@"
-      regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_network_.*)@"
+      regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_network_.*|container_pressure_.*)@"
       action = "drop"
     }
     // Normalizing unimportant labels (not deleting to continue satisfying <label>!="" checks)

--- a/charts/k8s-monitoring/docs/examples/scalability/high-availability-kube-state-metrics/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/scalability/high-availability-kube-state-metrics/output.yaml
@@ -247,14 +247,14 @@ data:
         rule {
           source_labels = ["__name__","container"]
           separator = "@"
-          regex = "(container_cpu_.*|container_fs_.*|container_memory_.*)@"
+          regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_pressure_.*)@"
           action = "drop"
         }
         // Drop empty image labels, addressing https://github.com/google/cadvisor/issues/2688
         rule {
           source_labels = ["__name__","image"]
           separator = "@"
-          regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_network_.*)@"
+          regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_network_.*|container_pressure_.*)@"
           action = "drop"
         }
         // Normalizing unimportant labels (not deleting to continue satisfying <label>!="" checks)

--- a/charts/k8s-monitoring/docs/examples/scalability/keda-autoscaling/alloy-metrics.alloy
+++ b/charts/k8s-monitoring/docs/examples/scalability/keda-autoscaling/alloy-metrics.alloy
@@ -151,14 +151,14 @@ declare "cluster_metrics" {
     rule {
       source_labels = ["__name__","container"]
       separator = "@"
-      regex = "(container_cpu_.*|container_fs_.*|container_memory_.*)@"
+      regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_pressure_.*)@"
       action = "drop"
     }
     // Drop empty image labels, addressing https://github.com/google/cadvisor/issues/2688
     rule {
       source_labels = ["__name__","image"]
       separator = "@"
-      regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_network_.*)@"
+      regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_network_.*|container_pressure_.*)@"
       action = "drop"
     }
     // Normalizing unimportant labels (not deleting to continue satisfying <label>!="" checks)

--- a/charts/k8s-monitoring/docs/examples/scalability/keda-autoscaling/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/scalability/keda-autoscaling/output.yaml
@@ -208,14 +208,14 @@ data:
         rule {
           source_labels = ["__name__","container"]
           separator = "@"
-          regex = "(container_cpu_.*|container_fs_.*|container_memory_.*)@"
+          regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_pressure_.*)@"
           action = "drop"
         }
         // Drop empty image labels, addressing https://github.com/google/cadvisor/issues/2688
         rule {
           source_labels = ["__name__","image"]
           separator = "@"
-          regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_network_.*)@"
+          regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_network_.*|container_pressure_.*)@"
           action = "drop"
         }
         // Normalizing unimportant labels (not deleting to continue satisfying <label>!="" checks)

--- a/charts/k8s-monitoring/docs/examples/scalability/sharded-kube-state-metrics/alloy-metrics.alloy
+++ b/charts/k8s-monitoring/docs/examples/scalability/sharded-kube-state-metrics/alloy-metrics.alloy
@@ -151,14 +151,14 @@ declare "cluster_metrics" {
     rule {
       source_labels = ["__name__","container"]
       separator = "@"
-      regex = "(container_cpu_.*|container_fs_.*|container_memory_.*)@"
+      regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_pressure_.*)@"
       action = "drop"
     }
     // Drop empty image labels, addressing https://github.com/google/cadvisor/issues/2688
     rule {
       source_labels = ["__name__","image"]
       separator = "@"
-      regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_network_.*)@"
+      regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_network_.*|container_pressure_.*)@"
       action = "drop"
     }
     // Normalizing unimportant labels (not deleting to continue satisfying <label>!="" checks)

--- a/charts/k8s-monitoring/docs/examples/scalability/sharded-kube-state-metrics/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/scalability/sharded-kube-state-metrics/output.yaml
@@ -247,14 +247,14 @@ data:
         rule {
           source_labels = ["__name__","container"]
           separator = "@"
-          regex = "(container_cpu_.*|container_fs_.*|container_memory_.*)@"
+          regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_pressure_.*)@"
           action = "drop"
         }
         // Drop empty image labels, addressing https://github.com/google/cadvisor/issues/2688
         rule {
           source_labels = ["__name__","image"]
           separator = "@"
-          regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_network_.*)@"
+          regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_network_.*|container_pressure_.*)@"
           action = "drop"
         }
         // Normalizing unimportant labels (not deleting to continue satisfying <label>!="" checks)

--- a/charts/k8s-monitoring/docs/examples/tail-sampling/alloy-metrics.alloy
+++ b/charts/k8s-monitoring/docs/examples/tail-sampling/alloy-metrics.alloy
@@ -151,14 +151,14 @@ declare "cluster_metrics" {
     rule {
       source_labels = ["__name__","container"]
       separator = "@"
-      regex = "(container_cpu_.*|container_fs_.*|container_memory_.*)@"
+      regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_pressure_.*)@"
       action = "drop"
     }
     // Drop empty image labels, addressing https://github.com/google/cadvisor/issues/2688
     rule {
       source_labels = ["__name__","image"]
       separator = "@"
-      regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_network_.*)@"
+      regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_network_.*|container_pressure_.*)@"
       action = "drop"
     }
     // Normalizing unimportant labels (not deleting to continue satisfying <label>!="" checks)

--- a/charts/k8s-monitoring/docs/examples/tail-sampling/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/tail-sampling/output.yaml
@@ -482,14 +482,14 @@ data:
         rule {
           source_labels = ["__name__","container"]
           separator = "@"
-          regex = "(container_cpu_.*|container_fs_.*|container_memory_.*)@"
+          regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_pressure_.*)@"
           action = "drop"
         }
         // Drop empty image labels, addressing https://github.com/google/cadvisor/issues/2688
         rule {
           source_labels = ["__name__","image"]
           separator = "@"
-          regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_network_.*)@"
+          regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_network_.*|container_pressure_.*)@"
           action = "drop"
         }
         // Normalizing unimportant labels (not deleting to continue satisfying <label>!="" checks)

--- a/charts/k8s-monitoring/docs/examples/tolerations/alloy-metrics.alloy
+++ b/charts/k8s-monitoring/docs/examples/tolerations/alloy-metrics.alloy
@@ -212,14 +212,14 @@ declare "cluster_metrics" {
     rule {
       source_labels = ["__name__","container"]
       separator = "@"
-      regex = "(container_cpu_.*|container_fs_.*|container_memory_.*)@"
+      regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_pressure_.*)@"
       action = "drop"
     }
     // Drop empty image labels, addressing https://github.com/google/cadvisor/issues/2688
     rule {
       source_labels = ["__name__","image"]
       separator = "@"
-      regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_network_.*)@"
+      regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_network_.*|container_pressure_.*)@"
       action = "drop"
     }
     // Normalizing unimportant labels (not deleting to continue satisfying <label>!="" checks)

--- a/charts/k8s-monitoring/docs/examples/tolerations/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/tolerations/output.yaml
@@ -587,14 +587,14 @@ data:
         rule {
           source_labels = ["__name__","container"]
           separator = "@"
-          regex = "(container_cpu_.*|container_fs_.*|container_memory_.*)@"
+          regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_pressure_.*)@"
           action = "drop"
         }
         // Drop empty image labels, addressing https://github.com/google/cadvisor/issues/2688
         rule {
           source_labels = ["__name__","image"]
           separator = "@"
-          regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_network_.*)@"
+          regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_network_.*|container_pressure_.*)@"
           action = "drop"
         }
         // Normalizing unimportant labels (not deleting to continue satisfying <label>!="" checks)

--- a/charts/k8s-monitoring/tests/integration/cluster-monitoring/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/integration/cluster-monitoring/.rendered/output.yaml
@@ -504,14 +504,14 @@ data:
         rule {
           source_labels = ["__name__","container"]
           separator = "@"
-          regex = "(container_cpu_.*|container_fs_.*|container_memory_.*)@"
+          regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_pressure_.*)@"
           action = "drop"
         }
         // Drop empty image labels, addressing https://github.com/google/cadvisor/issues/2688
         rule {
           source_labels = ["__name__","image"]
           separator = "@"
-          regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_network_.*)@"
+          regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_network_.*|container_pressure_.*)@"
           action = "drop"
         }
         // Normalizing unimportant labels (not deleting to continue satisfying <label>!="" checks)

--- a/charts/k8s-monitoring/tests/integration/control-plane-monitoring/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/integration/control-plane-monitoring/.rendered/output.yaml
@@ -510,14 +510,14 @@ data:
         rule {
           source_labels = ["__name__","container"]
           separator = "@"
-          regex = "(container_cpu_.*|container_fs_.*|container_memory_.*)@"
+          regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_pressure_.*)@"
           action = "drop"
         }
         // Drop empty image labels, addressing https://github.com/google/cadvisor/issues/2688
         rule {
           source_labels = ["__name__","image"]
           separator = "@"
-          regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_network_.*)@"
+          regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_network_.*|container_pressure_.*)@"
           action = "drop"
         }
         // Normalizing unimportant labels (not deleting to continue satisfying <label>!="" checks)

--- a/charts/k8s-monitoring/tests/integration/prom-and-loki-to-otlp/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/integration/prom-and-loki-to-otlp/.rendered/output.yaml
@@ -562,14 +562,14 @@ data:
         rule {
           source_labels = ["__name__","container"]
           separator = "@"
-          regex = "(container_cpu_.*|container_fs_.*|container_memory_.*)@"
+          regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_pressure_.*)@"
           action = "drop"
         }
         // Drop empty image labels, addressing https://github.com/google/cadvisor/issues/2688
         rule {
           source_labels = ["__name__","image"]
           separator = "@"
-          regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_network_.*)@"
+          regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_network_.*|container_pressure_.*)@"
           action = "drop"
         }
         // Normalizing unimportant labels (not deleting to continue satisfying <label>!="" checks)

--- a/charts/k8s-monitoring/tests/integration/service-integrations/coredns/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/integration/service-integrations/coredns/.rendered/output.yaml
@@ -191,14 +191,14 @@ data:
         rule {
           source_labels = ["__name__","container"]
           separator = "@"
-          regex = "(container_cpu_.*|container_fs_.*|container_memory_.*)@"
+          regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_pressure_.*)@"
           action = "drop"
         }
         // Drop empty image labels, addressing https://github.com/google/cadvisor/issues/2688
         rule {
           source_labels = ["__name__","image"]
           separator = "@"
-          regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_network_.*)@"
+          regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_network_.*|container_pressure_.*)@"
           action = "drop"
         }
         // Normalizing unimportant labels (not deleting to continue satisfying <label>!="" checks)

--- a/charts/k8s-monitoring/tests/integration/service-integrations/grafana/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/integration/service-integrations/grafana/.rendered/output.yaml
@@ -533,14 +533,14 @@ data:
         rule {
           source_labels = ["__name__","container"]
           separator = "@"
-          regex = "(container_cpu_.*|container_fs_.*|container_memory_.*)@"
+          regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_pressure_.*)@"
           action = "drop"
         }
         // Drop empty image labels, addressing https://github.com/google/cadvisor/issues/2688
         rule {
           source_labels = ["__name__","image"]
           separator = "@"
-          regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_network_.*)@"
+          regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_network_.*|container_pressure_.*)@"
           action = "drop"
         }
         // Normalizing unimportant labels (not deleting to continue satisfying <label>!="" checks)

--- a/charts/k8s-monitoring/tests/integration/service-integrations/loki/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/integration/service-integrations/loki/.rendered/output.yaml
@@ -542,14 +542,14 @@ data:
         rule {
           source_labels = ["__name__","container"]
           separator = "@"
-          regex = "(container_cpu_.*|container_fs_.*|container_memory_.*)@"
+          regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_pressure_.*)@"
           action = "drop"
         }
         // Drop empty image labels, addressing https://github.com/google/cadvisor/issues/2688
         rule {
           source_labels = ["__name__","image"]
           separator = "@"
-          regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_network_.*)@"
+          regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_network_.*|container_pressure_.*)@"
           action = "drop"
         }
         // Normalizing unimportant labels (not deleting to continue satisfying <label>!="" checks)

--- a/charts/k8s-monitoring/tests/integration/service-integrations/tempo/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/integration/service-integrations/tempo/.rendered/output.yaml
@@ -535,14 +535,14 @@ data:
         rule {
           source_labels = ["__name__","container"]
           separator = "@"
-          regex = "(container_cpu_.*|container_fs_.*|container_memory_.*)@"
+          regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_pressure_.*)@"
           action = "drop"
         }
         // Drop empty image labels, addressing https://github.com/google/cadvisor/issues/2688
         rule {
           source_labels = ["__name__","image"]
           separator = "@"
-          regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_network_.*)@"
+          regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_network_.*|container_pressure_.*)@"
           action = "drop"
         }
         // Normalizing unimportant labels (not deleting to continue satisfying <label>!="" checks)

--- a/charts/k8s-monitoring/tests/integration/sharded-kube-state-metrics/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/integration/sharded-kube-state-metrics/.rendered/output.yaml
@@ -551,14 +551,14 @@ data:
         rule {
           source_labels = ["__name__","container"]
           separator = "@"
-          regex = "(container_cpu_.*|container_fs_.*|container_memory_.*)@"
+          regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_pressure_.*)@"
           action = "drop"
         }
         // Drop empty image labels, addressing https://github.com/google/cadvisor/issues/2688
         rule {
           source_labels = ["__name__","image"]
           separator = "@"
-          regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_network_.*)@"
+          regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_network_.*|container_pressure_.*)@"
           action = "drop"
         }
         // Normalizing unimportant labels (not deleting to continue satisfying <label>!="" checks)

--- a/charts/k8s-monitoring/tests/integration/split-destinations/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/integration/split-destinations/.rendered/output.yaml
@@ -619,14 +619,14 @@ data:
         rule {
           source_labels = ["__name__","container"]
           separator = "@"
-          regex = "(container_cpu_.*|container_fs_.*|container_memory_.*)@"
+          regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_pressure_.*)@"
           action = "drop"
         }
         // Drop empty image labels, addressing https://github.com/google/cadvisor/issues/2688
         rule {
           source_labels = ["__name__","image"]
           separator = "@"
-          regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_network_.*)@"
+          regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_network_.*|container_pressure_.*)@"
           action = "drop"
         }
         // Normalizing unimportant labels (not deleting to continue satisfying <label>!="" checks)

--- a/charts/k8s-monitoring/tests/integration/uninstall/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/integration/uninstall/.rendered/output.yaml
@@ -543,14 +543,14 @@ data:
         rule {
           source_labels = ["__name__","container"]
           separator = "@"
-          regex = "(container_cpu_.*|container_fs_.*|container_memory_.*)@"
+          regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_pressure_.*)@"
           action = "drop"
         }
         // Drop empty image labels, addressing https://github.com/google/cadvisor/issues/2688
         rule {
           source_labels = ["__name__","image"]
           separator = "@"
-          regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_network_.*)@"
+          regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_network_.*|container_pressure_.*)@"
           action = "drop"
         }
         // Normalizing unimportant labels (not deleting to continue satisfying <label>!="" checks)

--- a/charts/k8s-monitoring/tests/integration/upgrade/minor/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/integration/upgrade/minor/.rendered/output.yaml
@@ -547,14 +547,14 @@ data:
         rule {
           source_labels = ["__name__","container"]
           separator = "@"
-          regex = "(container_cpu_.*|container_fs_.*|container_memory_.*)@"
+          regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_pressure_.*)@"
           action = "drop"
         }
         // Drop empty image labels, addressing https://github.com/google/cadvisor/issues/2688
         rule {
           source_labels = ["__name__","image"]
           separator = "@"
-          regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_network_.*)@"
+          regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_network_.*|container_pressure_.*)@"
           action = "drop"
         }
         // Normalizing unimportant labels (not deleting to continue satisfying <label>!="" checks)

--- a/charts/k8s-monitoring/tests/integration/upgrade/patch/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/integration/upgrade/patch/.rendered/output.yaml
@@ -547,14 +547,14 @@ data:
         rule {
           source_labels = ["__name__","container"]
           separator = "@"
-          regex = "(container_cpu_.*|container_fs_.*|container_memory_.*)@"
+          regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_pressure_.*)@"
           action = "drop"
         }
         // Drop empty image labels, addressing https://github.com/google/cadvisor/issues/2688
         rule {
           source_labels = ["__name__","image"]
           separator = "@"
-          regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_network_.*)@"
+          regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_network_.*|container_pressure_.*)@"
           action = "drop"
         }
         // Normalizing unimportant labels (not deleting to continue satisfying <label>!="" checks)

--- a/charts/k8s-monitoring/tests/integration/upgrade/storage/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/integration/upgrade/storage/.rendered/output.yaml
@@ -202,14 +202,14 @@ data:
         rule {
           source_labels = ["__name__","container"]
           separator = "@"
-          regex = "(container_cpu_.*|container_fs_.*|container_memory_.*)@"
+          regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_pressure_.*)@"
           action = "drop"
         }
         // Drop empty image labels, addressing https://github.com/google/cadvisor/issues/2688
         rule {
           source_labels = ["__name__","image"]
           separator = "@"
-          regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_network_.*)@"
+          regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_network_.*|container_pressure_.*)@"
           action = "drop"
         }
         // Normalizing unimportant labels (not deleting to continue satisfying <label>!="" checks)

--- a/charts/k8s-monitoring/tests/platform/aks/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/platform/aks/.rendered/output.yaml
@@ -495,14 +495,14 @@ data:
         rule {
           source_labels = ["__name__","container"]
           separator = "@"
-          regex = "(container_cpu_.*|container_fs_.*|container_memory_.*)@"
+          regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_pressure_.*)@"
           action = "drop"
         }
         // Drop empty image labels, addressing https://github.com/google/cadvisor/issues/2688
         rule {
           source_labels = ["__name__","image"]
           separator = "@"
-          regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_network_.*)@"
+          regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_network_.*|container_pressure_.*)@"
           action = "drop"
         }
         // Normalizing unimportant labels (not deleting to continue satisfying <label>!="" checks)

--- a/charts/k8s-monitoring/tests/platform/eks-fargate/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/platform/eks-fargate/.rendered/output.yaml
@@ -640,14 +640,14 @@ data:
         rule {
           source_labels = ["__name__","container"]
           separator = "@"
-          regex = "(container_cpu_.*|container_fs_.*|container_memory_.*)@"
+          regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_pressure_.*)@"
           action = "drop"
         }
         // Drop empty image labels, addressing https://github.com/google/cadvisor/issues/2688
         rule {
           source_labels = ["__name__","image"]
           separator = "@"
-          regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_network_.*)@"
+          regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_network_.*|container_pressure_.*)@"
           action = "drop"
         }
         // Normalizing unimportant labels (not deleting to continue satisfying <label>!="" checks)

--- a/charts/k8s-monitoring/tests/platform/eks-with-windows/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/platform/eks-with-windows/.rendered/output.yaml
@@ -805,14 +805,14 @@ data:
         rule {
           source_labels = ["__name__","container"]
           separator = "@"
-          regex = "(container_cpu_.*|container_fs_.*|container_memory_.*)@"
+          regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_pressure_.*)@"
           action = "drop"
         }
         // Drop empty image labels, addressing https://github.com/google/cadvisor/issues/2688
         rule {
           source_labels = ["__name__","image"]
           separator = "@"
-          regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_network_.*)@"
+          regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_network_.*|container_pressure_.*)@"
           action = "drop"
         }
         // Normalizing unimportant labels (not deleting to continue satisfying <label>!="" checks)

--- a/charts/k8s-monitoring/tests/platform/gke-autopilot/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/platform/gke-autopilot/.rendered/output.yaml
@@ -439,14 +439,14 @@ data:
         rule {
           source_labels = ["__name__","container"]
           separator = "@"
-          regex = "(container_cpu_.*|container_fs_.*|container_memory_.*)@"
+          regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_pressure_.*)@"
           action = "drop"
         }
         // Drop empty image labels, addressing https://github.com/google/cadvisor/issues/2688
         rule {
           source_labels = ["__name__","image"]
           separator = "@"
-          regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_network_.*)@"
+          regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_network_.*|container_pressure_.*)@"
           action = "drop"
         }
         // Normalizing unimportant labels (not deleting to continue satisfying <label>!="" checks)

--- a/charts/k8s-monitoring/tests/platform/gke/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/platform/gke/.rendered/output.yaml
@@ -471,14 +471,14 @@ data:
         rule {
           source_labels = ["__name__","container"]
           separator = "@"
-          regex = "(container_cpu_.*|container_fs_.*|container_memory_.*)@"
+          regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_pressure_.*)@"
           action = "drop"
         }
         // Drop empty image labels, addressing https://github.com/google/cadvisor/issues/2688
         rule {
           source_labels = ["__name__","image"]
           separator = "@"
-          regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_network_.*)@"
+          regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_network_.*|container_pressure_.*)@"
           action = "drop"
         }
         // Normalizing unimportant labels (not deleting to continue satisfying <label>!="" checks)

--- a/charts/k8s-monitoring/tests/platform/gpu/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/platform/gpu/.rendered/output.yaml
@@ -208,14 +208,14 @@ data:
         rule {
           source_labels = ["__name__","container"]
           separator = "@"
-          regex = "(container_cpu_.*|container_fs_.*|container_memory_.*)@"
+          regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_pressure_.*)@"
           action = "drop"
         }
         // Drop empty image labels, addressing https://github.com/google/cadvisor/issues/2688
         rule {
           source_labels = ["__name__","image"]
           separator = "@"
-          regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_network_.*)@"
+          regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_network_.*|container_pressure_.*)@"
           action = "drop"
         }
         // Normalizing unimportant labels (not deleting to continue satisfying <label>!="" checks)

--- a/charts/k8s-monitoring/tests/platform/grafana-cloud/k8s-monitoring/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/platform/grafana-cloud/k8s-monitoring/.rendered/output.yaml
@@ -602,14 +602,14 @@ data:
         rule {
           source_labels = ["__name__","container"]
           separator = "@"
-          regex = "(container_cpu_.*|container_fs_.*|container_memory_.*)@"
+          regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_pressure_.*)@"
           action = "drop"
         }
         // Drop empty image labels, addressing https://github.com/google/cadvisor/issues/2688
         rule {
           source_labels = ["__name__","image"]
           separator = "@"
-          regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_network_.*)@"
+          regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_network_.*|container_pressure_.*)@"
           action = "drop"
         }
         // Normalizing unimportant labels (not deleting to continue satisfying <label>!="" checks)

--- a/charts/k8s-monitoring/tests/platform/openshift/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/platform/openshift/.rendered/output.yaml
@@ -499,14 +499,14 @@ data:
         rule {
           source_labels = ["__name__","container"]
           separator = "@"
-          regex = "(container_cpu_.*|container_fs_.*|container_memory_.*)@"
+          regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_pressure_.*)@"
           action = "drop"
         }
         // Drop empty image labels, addressing https://github.com/google/cadvisor/issues/2688
         rule {
           source_labels = ["__name__","image"]
           separator = "@"
-          regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_network_.*)@"
+          regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_network_.*|container_pressure_.*)@"
           action = "drop"
         }
         // Normalizing unimportant labels (not deleting to continue satisfying <label>!="" checks)

--- a/charts/k8s-monitoring/tests/platform/otlp-gateway/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/platform/otlp-gateway/.rendered/output.yaml
@@ -208,14 +208,14 @@ data:
         rule {
           source_labels = ["__name__","container"]
           separator = "@"
-          regex = "(container_cpu_.*|container_fs_.*|container_memory_.*)@"
+          regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_pressure_.*)@"
           action = "drop"
         }
         // Drop empty image labels, addressing https://github.com/google/cadvisor/issues/2688
         rule {
           source_labels = ["__name__","image"]
           separator = "@"
-          regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_network_.*)@"
+          regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_network_.*|container_pressure_.*)@"
           action = "drop"
         }
         // Normalizing unimportant labels (not deleting to continue satisfying <label>!="" checks)


### PR DESCRIPTION
<!--Describe what this change does and why.-->
# Description

Adds this metric group to the list of metrics that we sanitize for empty image and container labels.
These labels are *not* in the default allow list, but the user wanted them, in case they include them.

Fixes #2561

<!--Authorship attestation. See AGENTS.md for details. AI agents must not check this box on behalf
of the user; the human author must check it themselves before the PR is ready for review.-->
## Authorship

-   [X] I, a human, wrote this pull request description myself.

<!--Please delete paragraphs that you did not use before submitting.-->
