### PR TITLE
maint: give argocd more time to run

### DIFF
--- a/charts/k8s-monitoring/docs/examples/deployment-alternatives/argocd/test/test-plan.yaml
+++ b/charts/k8s-monitoring/docs/examples/deployment-alternatives/argocd/test/test-plan.yaml
@@ -6,6 +6,7 @@ name: argocd
 subject:
   type: manifest
   path: ../k8s-monitoring-application.yaml
+  sleepAfter: 120
 
 cluster:
   type: kind

--- a/charts/k8s-monitoring/docs/examples/features/pod-logs-objects/test/test-plan.yaml
+++ b/charts/k8s-monitoring/docs/examples/features/pod-logs-objects/test/test-plan.yaml
@@ -13,6 +13,7 @@ cluster:
 
 dependencies:
   - url: https://raw.githubusercontent.com/grafana/alloy/refs/heads/main/operations/helm/charts/alloy/charts/crds/crds/monitoring.grafana.com_podlogs.yaml
+    sleepAfter: 10
   - directory: dependencies
   - preset: loki
   - preset: grafana


### PR DESCRIPTION
<!--Describe what this change does and why.-->
# Description

[I saw a failure on main as well](https://github.com/grafana/k8s-monitoring-helm/actions/runs/29050125742/job/86228441468) that is actually flaky (unlike the fork issue). Increasing the amount of time it has to setup.

- Fixes https://github.com/grafana/k8s-monitoring-helm/issues/2808

<!--Authorship attestation. See AGENTS.md for details. AI agents must not check this box on behalf
of the user; the human author must check it themselves before the PR is ready for review.-->
## Authorship

-   [x] I, a human, wrote this pull request description myself.

<!--Please delete paragraphs that you did not use before submitting.-->
