### PR TITLE
Remove the subchart owners, which block merging

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,12 +3,3 @@
 
 # Global owners
 *                                                                 @petewall @rlankfo @TylerHelmuth
-
-# Chart owners
-charts/k8s-monitoring/charts/feature-annotation-autodiscovery     @grafana/k8s-monitoring-dev
-charts/k8s-monitoring/charts/feature-cluster-events               @grafana/k8s-monitoring-dev
-charts/k8s-monitoring/charts/feature-cluster-metrics              @grafana/k8s-monitoring-dev
-charts/k8s-monitoring/charts/feature-pod-logs                     @grafana/k8s-monitoring-dev
-charts/k8s-monitoring/charts/feature-profiling                    @simonswine
-charts/k8s-monitoring/charts/feature-prometheus-operator-objects  @grafana/k8s-monitoring-dev
-charts/k8s-monitoring-v1                                          @grafana/k8s-monitoring-dev


### PR DESCRIPTION
# Description

Removes the subchart owners from CODEOWNERS, which block merging of changes to those charts. Often the folks in those lists are not involved int he chart changes. Anytime they are required, the can be added manually to the PR reviewers list.

## Authorship

-   [X] I, a human, wrote this pull request description myself.

<!--Please delete paragraphs that you did not use before submitting.-->
