### PR TITLE
Add the option to attach namespace labels to pod logs features

### DIFF
--- a/charts/k8s-monitoring/CHANGELOG.md
+++ b/charts/k8s-monitoring/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+*   Add `attachNamespaceMetadata` option to the Pod Logs (via Loki and via Kubernetes API) features. When enabled, namespace labels are attached to pod discovery targets and made available as `__meta_kubernetes_namespace_label_*`. (@petewall, @tdudas)
 *   Remove empty `image` and `container` labels from cAdvisor's `container_pressure_.*` metrics (#2561) (@petewall)
 *   Infer `auth.type: basic` for remote configuration and destinations when a username and password are set but `auth.type` is not. (#2809) (@TylerHelmuth)
 *   Fix `unrecognized block name "rule_namespace"` error when using the `rules.namespaces` field of the `prometheus` destination to limit the PrometheusRules object discovery to specific namespaces (#2802) (@sebasnabas)

--- a/charts/k8s-monitoring/charts/feature-pod-logs-via-kubernetes-api/README.md
+++ b/charts/k8s-monitoring/charts/feature-pod-logs-via-kubernetes-api/README.md
@@ -50,6 +50,7 @@ Be sure perform actual integration testing in a live environment in the main [k8
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | annotationSelector | string | `"logs.grafana.com/pods.enabled"` | Pod annotation to use for controlling log discovery. If a pod has this annotation, it will either enable or disable gathering of logs, depending on the value of the discoveryMethod. |
+| attachNamespaceMetadata | bool | `false` | Attach namespace metadata to pod discovery targets. When enabled, all namespace labels are available as log labels via `__meta_kubernetes_namespace_label_*`. |
 | discoveryMethod | string | `"all"` | Controls the behavior of discovering pods for logs. Possible values: `all`, `annotation`. When set to "all", every pod (filtered by the namespace and label selectors) will have their logs gathered. When set to "annotation", only pods with the annotation selector set to something other than "false", "no" or "skip" will have their logs gathered. |
 | excludeNamespaces | list | `[]` | Do not capture logs from any pods in these namespaces. |
 | extraDiscoveryRules | string | `""` | Rules to filter pods for log gathering. Only used for "volumes" or "kubernetesApi" gather methods. |

--- a/charts/k8s-monitoring/charts/feature-pod-logs-via-kubernetes-api/templates/_module.alloy.tpl
+++ b/charts/k8s-monitoring/charts/feature-pod-logs-via-kubernetes-api/templates/_module.alloy.tpl
@@ -39,7 +39,25 @@ declare "pod_logs_via_kubernetes_api" {
       label = {{ $nodeSelectors | join "," | quote }}
     }
 {{- end }}
-  {{- include "feature.podLogsViaKubernetesApi.attachNodeMetadata" . | indent 4 }}
+{{- $attachNodeMetadata := false -}}
+{{- $attachNodeMetadata = or $attachNodeMetadata (not (empty .Values.nodeSelectors)) -}}
+{{- $attachNodeMetadata = or $attachNodeMetadata .Values.nodeLabels.nodePool -}}
+{{- $attachNodeMetadata = or $attachNodeMetadata .Values.nodeLabels.region -}}
+{{- $attachNodeMetadata = or $attachNodeMetadata .Values.nodeLabels.availabilityZone -}}
+{{- $attachNodeMetadata = or $attachNodeMetadata .Values.nodeLabels.nodeRole -}}
+{{- $attachNodeMetadata = or $attachNodeMetadata .Values.nodeLabels.nodeOS -}}
+{{- $attachNodeMetadata = or $attachNodeMetadata .Values.nodeLabels.nodeArchitecture -}}
+{{- $attachNodeMetadata = or $attachNodeMetadata .Values.nodeLabels.instanceType -}}
+{{- if or .Values.attachNamespaceMetadata $attachNodeMetadata }}
+    attach_metadata {
+  {{- if .Values.attachNamespaceMetadata }}
+      namespace = true
+  {{- end }}
+  {{- if $attachNodeMetadata }}
+      node = true
+  {{- end }}
+    }
+{{- end }}
   } // discovery.kubernetes "pods"
 
   {{- include "feature.podLogsViaKubernetesApi.discovery.alloy" . | nindent 2 }}

--- a/charts/k8s-monitoring/charts/feature-pod-logs-via-kubernetes-api/templates/_nodes_common.tpl
+++ b/charts/k8s-monitoring/charts/feature-pod-logs-via-kubernetes-api/templates/_nodes_common.tpl
@@ -1,20 +1,3 @@
-{{- define "feature.podLogsViaKubernetesApi.attachNodeMetadata" }}
-{{- $attachMetadata := false -}}
-{{- $attachMetadata = or $attachMetadata (not (empty .Values.nodeSelectors)) -}}
-{{- $attachMetadata = or $attachMetadata .Values.nodeLabels.nodePool -}}
-{{- $attachMetadata = or $attachMetadata .Values.nodeLabels.region -}}
-{{- $attachMetadata = or $attachMetadata .Values.nodeLabels.availabilityZone -}}
-{{- $attachMetadata = or $attachMetadata .Values.nodeLabels.nodeRole -}}
-{{- $attachMetadata = or $attachMetadata .Values.nodeLabels.nodeOS -}}
-{{- $attachMetadata = or $attachMetadata .Values.nodeLabels.nodeArchitecture -}}
-{{- $attachMetadata = or $attachMetadata .Values.nodeLabels.instanceType -}}
-{{- if eq $attachMetadata true }}
-attach_metadata {
-  node = true
-}
-{{- end }}
-{{- end }}
-
 {{- define "feature.podLogsViaKubernetesApi.nodeDiscoveryRules" }}
 {{- if eq .Values.nodeLabels.nodePool true }}
 

--- a/charts/k8s-monitoring/charts/feature-pod-logs-via-kubernetes-api/tests/__snapshot__/namespace_metadata_test.yaml.snap
+++ b/charts/k8s-monitoring/charts/feature-pod-logs-via-kubernetes-api/tests/__snapshot__/namespace_metadata_test.yaml.snap
@@ -1,0 +1,367 @@
+should attach both namespace and node metadata when both are enabled:
+  1: |
+    |-
+      declare "pod_logs_via_kubernetes_api" {
+        argument "logs_destinations" {
+          comment = "Must be a list of log destinations where collected logs should be forwarded to"
+        }
+
+        discovery.kubernetes "pods" {
+          role = "pod"
+          attach_metadata {
+            namespace = true
+            node = true
+          }
+        } // discovery.kubernetes "pods"
+
+        discovery.relabel "filtered_pods" {
+          targets = discovery.kubernetes.pods.targets
+          rule {
+            source_labels = ["__meta_kubernetes_namespace"]
+            action = "replace"
+            target_label = "namespace"
+          }
+          rule {  // Drop anything with a "falsy" annotation value
+            source_labels = ["__meta_kubernetes_pod_annotation_logs_grafana_com_pods_enabled"]
+            regex = "(false|no|skip)"
+            action = "drop"
+          }
+          rule {
+            source_labels = ["__meta_kubernetes_pod_name"]
+            target_label = "pod"
+          }
+          rule {
+            source_labels = ["__meta_kubernetes_pod_container_name"]
+            target_label = "container"
+          }
+          rule {
+            source_labels = ["__meta_kubernetes_namespace", "__meta_kubernetes_pod_container_name"]
+            separator = "/"
+            target_label = "job"
+          }
+
+          // set the container runtime as a label
+          rule {
+            source_labels = ["__meta_kubernetes_pod_container_id"]
+            regex = "^(\\S+):\\/\\/.+$"
+            target_label = "tmp_container_runtime"
+          }
+
+          // explicitly set service_name. if not set, loki will automatically try to populate a default.
+          // see https://grafana.com/docs/loki/latest/get-started/labels/#default-labels-for-all-users
+          //
+          // choose the first value found from the following ordered list:
+          // - pod.annotation[resource.opentelemetry.io/service.name]
+          // - pod.label[app.kubernetes.io/name]
+          // - k8s.pod.name
+          // - k8s.container.name
+          rule {
+            action = "replace"
+            source_labels = [
+              "__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_name",
+              "__meta_kubernetes_pod_label_app_kubernetes_io_name",
+              "container",
+            ]
+            separator = ";"
+            regex = "^(?:;*)?([^;]+).*$"
+            replacement = "$1"
+            target_label = "service_name"
+          }
+
+          // explicitly set service_namespace.
+          //
+          // choose the first value found from the following ordered list:
+          // - pod.annotation[resource.opentelemetry.io/service.namespace]
+          // - pod.namespace
+          rule {
+            action = "replace"
+            source_labels = [
+              "__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_namespace",
+              "namespace",
+            ]
+            separator = ";"
+            regex = "^(?:;*)?([^;]+).*$"
+            replacement = "$1"
+            target_label = "service_namespace"
+          }
+
+          // explicitly set service_instance_id.
+          //
+          // choose the first value found from the following ordered list:
+          // - pod.annotation[resource.opentelemetry.io/service.instance.id]
+          // - concat([k8s.namespace.name, k8s.pod.name, k8s.container.name], '.')
+          rule {
+            source_labels = ["__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_instance_id"]
+            target_label = "service_instance_id"
+          }
+          rule {
+            source_labels = ["service_instance_id", "namespace", "pod", "container"]
+            separator = "."
+            regex = "^\\.([^.]+\\.[^.]+\\.[^.]+)$"
+            target_label = "service_instance_id"
+          }
+
+          // set resource attributes
+          rule {
+            action = "labelmap"
+            regex = "__meta_kubernetes_pod_annotation_resource_opentelemetry_io_(.+)"
+          }
+          rule {
+            source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_job"]
+            regex = "(.+)"
+            target_label = "job"
+          }
+          rule {
+            source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+            regex = "(.+)"
+            target_label = "app_kubernetes_io_name"
+          }
+
+          rule {
+            source_labels = [
+              "__meta_kubernetes_node_label_karpenter_sh_nodepool",
+              "__meta_kubernetes_node_label_cloud_google_com_gke_nodepool",
+              "__meta_kubernetes_node_label_eks_amazonaws_com_nodegroup",
+              "__meta_kubernetes_node_label_kubernetes_azure_com_agentpool",
+              "__meta_kubernetes_node_label_agentpool",
+            ]
+            regex = "^(?:;*)?([^;]+).*$"
+            target_label = "nodepool"
+          }
+        } // discovery.relabel "filtered_pods"
+
+        loki.source.kubernetes "pod_logs" {
+          targets = discovery.relabel.filtered_pods.output
+          clustering {
+            enabled = true
+          }
+          forward_to = [loki.process.pod_logs.receiver]
+        } // loki.source.kubernetes "pod_logs"
+
+        loki.process "pod_logs" {
+          stage.match {
+            selector = "{tmp_container_runtime=~\"containerd|cri-o|\"}"
+            // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
+            stage.cri {
+              max_partial_lines = 100
+            }
+
+            // Set the extract flags and stream values as labels
+            stage.labels {
+              values = {
+                flags  = "",
+                stream  = "",
+              }
+            }
+          }
+
+          stage.match {
+            selector = "{tmp_container_runtime=\"docker\"}"
+            // the docker processing stage extracts the following k/v pairs: log, stream, time
+            stage.docker {}
+
+            // Set the extract stream value as a label
+            stage.labels {
+              values = {
+                stream  = "",
+              }
+            }
+          }
+
+          // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
+          // namespace, pod, and container labels. Drop any structured metadata. Also drop the temporary
+          // container runtime label as it is no longer needed.
+          stage.label_drop {
+            values = [
+              "filename",
+              "tmp_container_runtime",
+            ]
+          }
+          stage.structured_metadata {
+            values = {
+              "k8s_pod_name" = "k8s_pod_name",
+              "pod" = "pod",
+              "service_instance_id" = "service_instance_id",
+            }
+          }
+
+          forward_to = argument.logs_destinations.value
+        } // loki.secretfilter "pod_logs"
+      } // declare "pod_logs_via_kubernetes_api"
+should attach namespace metadata when attachNamespaceMetadata is enabled:
+  1: |
+    |-
+      declare "pod_logs_via_kubernetes_api" {
+        argument "logs_destinations" {
+          comment = "Must be a list of log destinations where collected logs should be forwarded to"
+        }
+
+        discovery.kubernetes "pods" {
+          role = "pod"
+          attach_metadata {
+            namespace = true
+          }
+        } // discovery.kubernetes "pods"
+
+        discovery.relabel "filtered_pods" {
+          targets = discovery.kubernetes.pods.targets
+          rule {
+            source_labels = ["__meta_kubernetes_namespace"]
+            action = "replace"
+            target_label = "namespace"
+          }
+          rule {  // Drop anything with a "falsy" annotation value
+            source_labels = ["__meta_kubernetes_pod_annotation_logs_grafana_com_pods_enabled"]
+            regex = "(false|no|skip)"
+            action = "drop"
+          }
+          rule {
+            source_labels = ["__meta_kubernetes_pod_name"]
+            target_label = "pod"
+          }
+          rule {
+            source_labels = ["__meta_kubernetes_pod_container_name"]
+            target_label = "container"
+          }
+          rule {
+            source_labels = ["__meta_kubernetes_namespace", "__meta_kubernetes_pod_container_name"]
+            separator = "/"
+            target_label = "job"
+          }
+
+          // set the container runtime as a label
+          rule {
+            source_labels = ["__meta_kubernetes_pod_container_id"]
+            regex = "^(\\S+):\\/\\/.+$"
+            target_label = "tmp_container_runtime"
+          }
+
+          // explicitly set service_name. if not set, loki will automatically try to populate a default.
+          // see https://grafana.com/docs/loki/latest/get-started/labels/#default-labels-for-all-users
+          //
+          // choose the first value found from the following ordered list:
+          // - pod.annotation[resource.opentelemetry.io/service.name]
+          // - pod.label[app.kubernetes.io/name]
+          // - k8s.pod.name
+          // - k8s.container.name
+          rule {
+            action = "replace"
+            source_labels = [
+              "__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_name",
+              "__meta_kubernetes_pod_label_app_kubernetes_io_name",
+              "container",
+            ]
+            separator = ";"
+            regex = "^(?:;*)?([^;]+).*$"
+            replacement = "$1"
+            target_label = "service_name"
+          }
+
+          // explicitly set service_namespace.
+          //
+          // choose the first value found from the following ordered list:
+          // - pod.annotation[resource.opentelemetry.io/service.namespace]
+          // - pod.namespace
+          rule {
+            action = "replace"
+            source_labels = [
+              "__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_namespace",
+              "namespace",
+            ]
+            separator = ";"
+            regex = "^(?:;*)?([^;]+).*$"
+            replacement = "$1"
+            target_label = "service_namespace"
+          }
+
+          // explicitly set service_instance_id.
+          //
+          // choose the first value found from the following ordered list:
+          // - pod.annotation[resource.opentelemetry.io/service.instance.id]
+          // - concat([k8s.namespace.name, k8s.pod.name, k8s.container.name], '.')
+          rule {
+            source_labels = ["__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_instance_id"]
+            target_label = "service_instance_id"
+          }
+          rule {
+            source_labels = ["service_instance_id", "namespace", "pod", "container"]
+            separator = "."
+            regex = "^\\.([^.]+\\.[^.]+\\.[^.]+)$"
+            target_label = "service_instance_id"
+          }
+
+          // set resource attributes
+          rule {
+            action = "labelmap"
+            regex = "__meta_kubernetes_pod_annotation_resource_opentelemetry_io_(.+)"
+          }
+          rule {
+            source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_job"]
+            regex = "(.+)"
+            target_label = "job"
+          }
+          rule {
+            source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+            regex = "(.+)"
+            target_label = "app_kubernetes_io_name"
+          }
+        } // discovery.relabel "filtered_pods"
+
+        loki.source.kubernetes "pod_logs" {
+          targets = discovery.relabel.filtered_pods.output
+          clustering {
+            enabled = true
+          }
+          forward_to = [loki.process.pod_logs.receiver]
+        } // loki.source.kubernetes "pod_logs"
+
+        loki.process "pod_logs" {
+          stage.match {
+            selector = "{tmp_container_runtime=~\"containerd|cri-o|\"}"
+            // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
+            stage.cri {
+              max_partial_lines = 100
+            }
+
+            // Set the extract flags and stream values as labels
+            stage.labels {
+              values = {
+                flags  = "",
+                stream  = "",
+              }
+            }
+          }
+
+          stage.match {
+            selector = "{tmp_container_runtime=\"docker\"}"
+            // the docker processing stage extracts the following k/v pairs: log, stream, time
+            stage.docker {}
+
+            // Set the extract stream value as a label
+            stage.labels {
+              values = {
+                stream  = "",
+              }
+            }
+          }
+
+          // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
+          // namespace, pod, and container labels. Drop any structured metadata. Also drop the temporary
+          // container runtime label as it is no longer needed.
+          stage.label_drop {
+            values = [
+              "filename",
+              "tmp_container_runtime",
+            ]
+          }
+          stage.structured_metadata {
+            values = {
+              "k8s_pod_name" = "k8s_pod_name",
+              "pod" = "pod",
+              "service_instance_id" = "service_instance_id",
+            }
+          }
+
+          forward_to = argument.logs_destinations.value
+        } // loki.secretfilter "pod_logs"
+      } // declare "pod_logs_via_kubernetes_api"

--- a/charts/k8s-monitoring/charts/feature-pod-logs-via-kubernetes-api/tests/namespace_metadata_test.yaml
+++ b/charts/k8s-monitoring/charts/feature-pod-logs-via-kubernetes-api/tests/namespace_metadata_test.yaml
@@ -1,0 +1,42 @@
+# yamllint disable rule:document-start rule:line-length rule:trailing-spaces
+suite: Feature - Pod Logs via Kubernetes API - Namespace Metadata
+templates:
+  - test/configmap.yaml
+tests:
+  - it: should not add the attach_metadata block by default
+    set:
+      testing: {enabled: true}
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - notMatchRegex:
+          path: data["module.alloy"]
+          pattern: attach_metadata
+
+  - it: should attach namespace metadata when attachNamespaceMetadata is enabled
+    set:
+      testing: {enabled: true}
+      attachNamespaceMetadata: true
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - matchRegex:
+          path: data["module.alloy"]
+          pattern: 'attach_metadata \{\s*namespace = true\s*\}'
+      - matchSnapshot:
+          path: data["module.alloy"]
+
+  - it: should attach both namespace and node metadata when both are enabled
+    set:
+      testing: {enabled: true}
+      attachNamespaceMetadata: true
+      nodeLabels:
+        nodePool: true
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - matchRegex:
+          path: data["module.alloy"]
+          pattern: 'attach_metadata \{\s*namespace = true\s*node = true\s*\}'
+      - matchSnapshot:
+          path: data["module.alloy"]

--- a/charts/k8s-monitoring/charts/feature-pod-logs-via-kubernetes-api/values.schema.json
+++ b/charts/k8s-monitoring/charts/feature-pod-logs-via-kubernetes-api/values.schema.json
@@ -13,6 +13,9 @@
                 }
             }
         },
+        "attachNamespaceMetadata": {
+            "type": "boolean"
+        },
         "cri": {
             "type": "object",
             "properties": {

--- a/charts/k8s-monitoring/charts/feature-pod-logs-via-kubernetes-api/values.yaml
+++ b/charts/k8s-monitoring/charts/feature-pod-logs-via-kubernetes-api/values.yaml
@@ -52,6 +52,11 @@ annotationSelector: "logs.grafana.com/pods.enabled"
 # @section -- Discovery Settings
 extraDiscoveryRules: ""
 
+# -- Attach namespace metadata to pod discovery targets. When enabled, all namespace labels
+# are available as log labels via `__meta_kubernetes_namespace_label_*`.
+# @section -- Discovery Settings
+attachNamespaceMetadata: false
+
 # Configures which node labels to attach to the logs
 nodeLabels:
   # -- Whether or not to attach the nodepool label

--- a/charts/k8s-monitoring/charts/feature-pod-logs-via-loki/README.md
+++ b/charts/k8s-monitoring/charts/feature-pod-logs-via-loki/README.md
@@ -48,7 +48,13 @@ Be sure perform actual integration testing in a live environment in the main [k8
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | annotationSelector | string | `"logs.grafana.com/pods.enabled"` | Pod annotation to use for controlling log discovery. If a pod has this annotation, it will either enable or disable gathering of logs, depending on the value of the discoveryMethod. |
+| attachNamespaceMetadata | bool | `false` | Attach namespace metadata to pod discovery targets. When enabled, all namespace labels are available as log labels via `__meta_kubernetes_namespace_label_*`. |
 | discoveryMethod | string | `"all"` | Controls the behavior of discovering pods for logs. Possible values: `all`, `annotation`. When set to "all", every pod (filtered by the namespace and label selectors) will have their logs gathered. When set to "annotation", only pods with the annotation selector set to something other than "false", "no" or "skip" will have their logs gathered. |
+| excludeNamespaces | list | `[]` | Do not capture logs from any pods in these namespaces. |
+| extraDiscoveryRules | string | `""` | Rules to filter pods for log gathering. Only used for "volumes" or "kubernetesApi" gather methods. |
+| labelSelectors | object | `{}` | Filter the list of discovered pods and services by labels. Only for the "volumes" gather method. Example: `labelSelectors: { 'app': 'myapp' }` will only discover pods with the label `app=myapp`. Example: `labelSelectors: { 'app': ['myapp', 'myotherapp'] }` will only discover pods with the label `app=myapp` or `app=myotherapp`. |
+| namespaces | list | `[]` | Only capture logs from pods in these namespaces (`[]` means all namespaces). |
+| nodeSelectors | object | `{}` | Filter the list of discovered nodes by labels. Only for the "volumes" gather method. Example: `nodeSelectors: { 'kubernetes.io/os': 'linux' }` |
 
 ### Log Processing
 
@@ -60,16 +66,6 @@ Be sure perform actual integration testing in a live environment in the main [k8
 | labels | object | `{"app_kubernetes_io_name":"app.kubernetes.io/name"}` | Log labels to set with values copied from the Kubernetes Pod labels. Format: `<log_label>: <kubernetes_label>`. |
 | staticLabels | object | `{}` | Log labels to set with static values. |
 | staticLabelsFrom | object | `{}` | Log labels to set with static values, not quoted so it can reference config components. |
-
-### Pod Discovery
-
-| Key | Type | Default | Description |
-|-----|------|---------|-------------|
-| excludeNamespaces | list | `[]` | Do not capture logs from any pods in these namespaces. |
-| extraDiscoveryRules | string | `""` | Rules to filter pods for log gathering. Only used for "volumes" or "kubernetesApi" gather methods. |
-| labelSelectors | object | `{}` | Filter the list of discovered pods and services by labels. Only for the "volumes" gather method. Example: `labelSelectors: { 'app': 'myapp' }` will only discover pods with the label `app=myapp`. Example: `labelSelectors: { 'app': ['myapp', 'myotherapp'] }` will only discover pods with the label `app=myapp` or `app=myotherapp`. |
-| namespaces | list | `[]` | Only capture logs from pods in these namespaces (`[]` means all namespaces). |
-| nodeSelectors | object | `{}` | Filter the list of discovered nodes by labels. Only for the "volumes" gather method. Example: `nodeSelectors: { 'kubernetes.io/os': 'linux' }` |
 
 ### Processing settings
 

--- a/charts/k8s-monitoring/charts/feature-pod-logs-via-loki/templates/_discovery.alloy.tpl
+++ b/charts/k8s-monitoring/charts/feature-pod-logs-via-loki/templates/_discovery.alloy.tpl
@@ -38,7 +38,25 @@ discovery.kubernetes "pods" {
       label = {{ $nodeSelectors | join "," | quote }}
     }
 {{- end }}
-{{- include "feature.podLogsViaLoki.attachNodeMetadata" . | indent 2 }}
+{{- $attachNodeMetadata := false -}}
+{{- $attachNodeMetadata = or $attachNodeMetadata (not (empty .Values.nodeSelectors)) -}}
+{{- $attachNodeMetadata = or $attachNodeMetadata .Values.nodeLabels.nodePool -}}
+{{- $attachNodeMetadata = or $attachNodeMetadata .Values.nodeLabels.region -}}
+{{- $attachNodeMetadata = or $attachNodeMetadata .Values.nodeLabels.availabilityZone -}}
+{{- $attachNodeMetadata = or $attachNodeMetadata .Values.nodeLabels.nodeRole -}}
+{{- $attachNodeMetadata = or $attachNodeMetadata .Values.nodeLabels.nodeOS -}}
+{{- $attachNodeMetadata = or $attachNodeMetadata .Values.nodeLabels.nodeArchitecture -}}
+{{- $attachNodeMetadata = or $attachNodeMetadata .Values.nodeLabels.instanceType -}}
+{{- if or .Values.attachNamespaceMetadata $attachNodeMetadata }}
+  attach_metadata {
+  {{- if .Values.attachNamespaceMetadata }}
+    namespace = true
+  {{- end }}
+  {{- if $attachNodeMetadata }}
+    node = true
+  {{- end }}
+  }
+{{- end }}
 } // discovery.kubernetes "pods"
 
 discovery.relabel "filtered_pods" {

--- a/charts/k8s-monitoring/charts/feature-pod-logs-via-loki/templates/_nodes_common.tpl
+++ b/charts/k8s-monitoring/charts/feature-pod-logs-via-loki/templates/_nodes_common.tpl
@@ -1,20 +1,3 @@
-{{- define "feature.podLogsViaLoki.attachNodeMetadata" }}
-{{- $attachMetadata := false -}}
-{{- $attachMetadata = or $attachMetadata (not (empty .Values.nodeSelectors)) -}}
-{{- $attachMetadata = or $attachMetadata .Values.nodeLabels.nodePool -}}
-{{- $attachMetadata = or $attachMetadata .Values.nodeLabels.region -}}
-{{- $attachMetadata = or $attachMetadata .Values.nodeLabels.availabilityZone -}}
-{{- $attachMetadata = or $attachMetadata .Values.nodeLabels.nodeRole -}}
-{{- $attachMetadata = or $attachMetadata .Values.nodeLabels.nodeOS -}}
-{{- $attachMetadata = or $attachMetadata .Values.nodeLabels.nodeArchitecture -}}
-{{- $attachMetadata = or $attachMetadata .Values.nodeLabels.instanceType -}}
-{{- if eq $attachMetadata true }}
-attach_metadata {
-  node = true
-}
-{{- end }}
-{{- end }}
-
 {{- define "feature.podLogsViaLoki.nodeDiscoveryRules" }}
 {{- if eq .Values.nodeLabels.nodePool true }}
 

--- a/charts/k8s-monitoring/charts/feature-pod-logs-via-loki/tests/__snapshot__/namespace_metadata_test.yaml.snap
+++ b/charts/k8s-monitoring/charts/feature-pod-logs-via-loki/tests/__snapshot__/namespace_metadata_test.yaml.snap
@@ -1,0 +1,413 @@
+should attach both namespace and node metadata when both are enabled:
+  1: |
+    |-
+      declare "pod_logs_via_loki" {
+        argument "logs_destinations" {
+          comment = "Must be a list of log destinations where collected logs should be forwarded to"
+        }
+
+        discovery.kubernetes "pods" {
+          role = "pod"
+          selectors {
+            role = "pod"
+            field = "spec.nodeName=" + sys.env("HOSTNAME")
+          }
+            attach_metadata {
+              namespace = true
+              node = true
+            }
+        } // discovery.kubernetes "pods"
+
+        discovery.relabel "filtered_pods" {
+          targets = discovery.kubernetes.pods.targets
+          rule {
+            source_labels = ["__meta_kubernetes_namespace"]
+            action = "replace"
+            target_label = "namespace"
+          }
+          rule {  // Drop anything with a "falsy" annotation value
+            source_labels = ["__meta_kubernetes_pod_annotation_logs_grafana_com_pods_enabled"]
+            regex = "(false|no|skip)"
+            action = "drop"
+          }
+          rule {
+            source_labels = ["__meta_kubernetes_pod_name"]
+            target_label = "pod"
+          }
+          rule {
+            source_labels = ["__meta_kubernetes_pod_container_name"]
+            target_label = "container"
+          }
+          rule {
+            source_labels = ["__meta_kubernetes_namespace", "__meta_kubernetes_pod_container_name"]
+            separator = "/"
+            replacement = "$1"
+            target_label = "job"
+          }
+
+          // set the container runtime as a label
+          rule {
+            source_labels = ["__meta_kubernetes_pod_container_id"]
+            regex = "^(\\S+):\\/\\/.+$"
+            replacement = "$1"
+            target_label = "tmp_container_runtime"
+          }
+
+          // explicitly set service_name. if not set, loki will automatically try to populate a default.
+          // see https://grafana.com/docs/loki/latest/get-started/labels/#default-labels-for-all-users
+          //
+          // choose the first value found from the following ordered list:
+          // - pod.annotation[resource.opentelemetry.io/service.name]
+          // - pod.label[app.kubernetes.io/name]
+          // - k8s.container.name
+          rule {
+            source_labels = [
+              "__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_name",
+              "__meta_kubernetes_pod_label_app_kubernetes_io_name",
+              "__meta_kubernetes_pod_container_name",
+            ]
+            separator = ";"
+            regex = "^(?:;*)?([^;]+).*$"
+            replacement = "$1"
+            target_label = "service_name"
+          }
+
+          // explicitly set service_namespace.
+          //
+          // choose the first value found from the following ordered list:
+          // - pod.annotation[resource.opentelemetry.io/service.namespace]
+          // - pod.namespace
+          rule {
+            source_labels = [
+              "__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_namespace",
+              "namespace",
+            ]
+            separator = ";"
+            regex = "^(?:;*)?([^;]+).*$"
+            replacement = "$1"
+            target_label = "service_namespace"
+          }
+
+          // explicitly set service_instance_id.
+          //
+          // choose the first value found from the following ordered list:
+          // - pod.annotation[resource.opentelemetry.io/service.instance.id]
+          // - concat([k8s.namespace.name, k8s.pod.name, k8s.container.name], '.')
+          rule {
+            source_labels = ["__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_instance_id"]
+            target_label = "service_instance_id"
+          }
+          rule {
+            source_labels = ["service_instance_id", "namespace", "pod", "container"]
+            separator = "."
+            regex = "^\\.([^.]+\\.[^.]+\\.[^.]+)$"
+            target_label = "service_instance_id"
+          }
+
+          // set resource attributes
+          rule {
+            action = "labelmap"
+            regex = "__meta_kubernetes_pod_annotation_resource_opentelemetry_io_(.+)"
+          }
+          rule {
+            source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_job"]
+            regex = "(.+)"
+            target_label = "job"
+          }
+          rule {
+            source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+            regex = "(.+)"
+            target_label = "app_kubernetes_io_name"
+          }
+
+          // Set the pod log path.
+          rule {
+            source_labels = ["__meta_kubernetes_pod_uid", "__meta_kubernetes_pod_container_name"]
+            separator = "/"
+            replacement = "/var/log/pods/*$1/*.log"
+            target_label = "__path__"
+          }
+
+          // If kubernetes.io/config.mirror is set, this is a static pod, created by the kubelet.
+          // It's logs live on a different path.
+          rule {
+            source_labels = ["__meta_kubernetes_pod_annotation_kubernetes_io_config_mirror", "__meta_kubernetes_pod_container_name"]
+            separator = "/"
+            regex = "(.+/.+)"
+            replacement = "/var/log/pods/*$1/*.log"
+            target_label = "__path__"
+          }
+
+          rule {
+            source_labels = [
+              "__meta_kubernetes_node_label_karpenter_sh_nodepool",
+              "__meta_kubernetes_node_label_cloud_google_com_gke_nodepool",
+              "__meta_kubernetes_node_label_eks_amazonaws_com_nodegroup",
+              "__meta_kubernetes_node_label_kubernetes_azure_com_agentpool",
+              "__meta_kubernetes_node_label_agentpool",
+            ]
+            regex = "^(?:;*)?([^;]+).*$"
+            target_label = "nodepool"
+          }
+        } // discovery.relabel "filtered_pods"
+
+        local.file_match "pod_logs" {
+          path_targets = discovery.relabel.filtered_pods.output
+        } // local.file_match "pod_logs"
+
+        loki.source.file "pod_logs" {
+          targets    = local.file_match.pod_logs.targets
+          tail_from_end = true
+          forward_to = [loki.process.pod_logs.receiver]
+        } // loki.source.file "pod_logs"
+
+        loki.process "pod_logs" {
+          stage.match {
+            selector = "{tmp_container_runtime=~\"containerd|cri-o|\"}"
+            // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
+            stage.cri {
+              max_partial_lines = 100
+            }
+
+            // Set the extract flags and stream values as labels
+            stage.labels {
+              values = {
+                flags  = "",
+                stream  = "",
+              }
+            }
+          }
+
+          stage.match {
+            selector = "{tmp_container_runtime=\"docker\"}"
+            // the docker processing stage extracts the following k/v pairs: log, stream, time
+            stage.docker {}
+
+            // Set the extract stream value as a label
+            stage.labels {
+              values = {
+                stream  = "",
+              }
+            }
+          }
+
+          // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
+          // namespace, pod, and container labels. Drop any structured metadata. Also drop the temporary
+          // container runtime label as it is no longer needed.
+          stage.label_drop {
+            values = [
+              "filename",
+              "tmp_container_runtime",
+            ]
+          }
+          stage.structured_metadata {
+            values = {
+              "k8s_pod_name" = "k8s_pod_name",
+              "pod" = "pod",
+              "service_instance_id" = "service_instance_id",
+            }
+          }
+
+          forward_to = argument.logs_destinations.value
+        } // loki.secretfilter "pod_logs"
+      } // declare "pod_logs_via_loki"
+should attach namespace metadata when attachNamespaceMetadata is enabled:
+  1: |
+    |-
+      declare "pod_logs_via_loki" {
+        argument "logs_destinations" {
+          comment = "Must be a list of log destinations where collected logs should be forwarded to"
+        }
+
+        discovery.kubernetes "pods" {
+          role = "pod"
+          selectors {
+            role = "pod"
+            field = "spec.nodeName=" + sys.env("HOSTNAME")
+          }
+            attach_metadata {
+              namespace = true
+            }
+        } // discovery.kubernetes "pods"
+
+        discovery.relabel "filtered_pods" {
+          targets = discovery.kubernetes.pods.targets
+          rule {
+            source_labels = ["__meta_kubernetes_namespace"]
+            action = "replace"
+            target_label = "namespace"
+          }
+          rule {  // Drop anything with a "falsy" annotation value
+            source_labels = ["__meta_kubernetes_pod_annotation_logs_grafana_com_pods_enabled"]
+            regex = "(false|no|skip)"
+            action = "drop"
+          }
+          rule {
+            source_labels = ["__meta_kubernetes_pod_name"]
+            target_label = "pod"
+          }
+          rule {
+            source_labels = ["__meta_kubernetes_pod_container_name"]
+            target_label = "container"
+          }
+          rule {
+            source_labels = ["__meta_kubernetes_namespace", "__meta_kubernetes_pod_container_name"]
+            separator = "/"
+            replacement = "$1"
+            target_label = "job"
+          }
+
+          // set the container runtime as a label
+          rule {
+            source_labels = ["__meta_kubernetes_pod_container_id"]
+            regex = "^(\\S+):\\/\\/.+$"
+            replacement = "$1"
+            target_label = "tmp_container_runtime"
+          }
+
+          // explicitly set service_name. if not set, loki will automatically try to populate a default.
+          // see https://grafana.com/docs/loki/latest/get-started/labels/#default-labels-for-all-users
+          //
+          // choose the first value found from the following ordered list:
+          // - pod.annotation[resource.opentelemetry.io/service.name]
+          // - pod.label[app.kubernetes.io/name]
+          // - k8s.container.name
+          rule {
+            source_labels = [
+              "__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_name",
+              "__meta_kubernetes_pod_label_app_kubernetes_io_name",
+              "__meta_kubernetes_pod_container_name",
+            ]
+            separator = ";"
+            regex = "^(?:;*)?([^;]+).*$"
+            replacement = "$1"
+            target_label = "service_name"
+          }
+
+          // explicitly set service_namespace.
+          //
+          // choose the first value found from the following ordered list:
+          // - pod.annotation[resource.opentelemetry.io/service.namespace]
+          // - pod.namespace
+          rule {
+            source_labels = [
+              "__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_namespace",
+              "namespace",
+            ]
+            separator = ";"
+            regex = "^(?:;*)?([^;]+).*$"
+            replacement = "$1"
+            target_label = "service_namespace"
+          }
+
+          // explicitly set service_instance_id.
+          //
+          // choose the first value found from the following ordered list:
+          // - pod.annotation[resource.opentelemetry.io/service.instance.id]
+          // - concat([k8s.namespace.name, k8s.pod.name, k8s.container.name], '.')
+          rule {
+            source_labels = ["__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_instance_id"]
+            target_label = "service_instance_id"
+          }
+          rule {
+            source_labels = ["service_instance_id", "namespace", "pod", "container"]
+            separator = "."
+            regex = "^\\.([^.]+\\.[^.]+\\.[^.]+)$"
+            target_label = "service_instance_id"
+          }
+
+          // set resource attributes
+          rule {
+            action = "labelmap"
+            regex = "__meta_kubernetes_pod_annotation_resource_opentelemetry_io_(.+)"
+          }
+          rule {
+            source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_job"]
+            regex = "(.+)"
+            target_label = "job"
+          }
+          rule {
+            source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+            regex = "(.+)"
+            target_label = "app_kubernetes_io_name"
+          }
+
+          // Set the pod log path.
+          rule {
+            source_labels = ["__meta_kubernetes_pod_uid", "__meta_kubernetes_pod_container_name"]
+            separator = "/"
+            replacement = "/var/log/pods/*$1/*.log"
+            target_label = "__path__"
+          }
+
+          // If kubernetes.io/config.mirror is set, this is a static pod, created by the kubelet.
+          // It's logs live on a different path.
+          rule {
+            source_labels = ["__meta_kubernetes_pod_annotation_kubernetes_io_config_mirror", "__meta_kubernetes_pod_container_name"]
+            separator = "/"
+            regex = "(.+/.+)"
+            replacement = "/var/log/pods/*$1/*.log"
+            target_label = "__path__"
+          }
+        } // discovery.relabel "filtered_pods"
+
+        local.file_match "pod_logs" {
+          path_targets = discovery.relabel.filtered_pods.output
+        } // local.file_match "pod_logs"
+
+        loki.source.file "pod_logs" {
+          targets    = local.file_match.pod_logs.targets
+          tail_from_end = true
+          forward_to = [loki.process.pod_logs.receiver]
+        } // loki.source.file "pod_logs"
+
+        loki.process "pod_logs" {
+          stage.match {
+            selector = "{tmp_container_runtime=~\"containerd|cri-o|\"}"
+            // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
+            stage.cri {
+              max_partial_lines = 100
+            }
+
+            // Set the extract flags and stream values as labels
+            stage.labels {
+              values = {
+                flags  = "",
+                stream  = "",
+              }
+            }
+          }
+
+          stage.match {
+            selector = "{tmp_container_runtime=\"docker\"}"
+            // the docker processing stage extracts the following k/v pairs: log, stream, time
+            stage.docker {}
+
+            // Set the extract stream value as a label
+            stage.labels {
+              values = {
+                stream  = "",
+              }
+            }
+          }
+
+          // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
+          // namespace, pod, and container labels. Drop any structured metadata. Also drop the temporary
+          // container runtime label as it is no longer needed.
+          stage.label_drop {
+            values = [
+              "filename",
+              "tmp_container_runtime",
+            ]
+          }
+          stage.structured_metadata {
+            values = {
+              "k8s_pod_name" = "k8s_pod_name",
+              "pod" = "pod",
+              "service_instance_id" = "service_instance_id",
+            }
+          }
+
+          forward_to = argument.logs_destinations.value
+        } // loki.secretfilter "pod_logs"
+      } // declare "pod_logs_via_loki"

--- a/charts/k8s-monitoring/charts/feature-pod-logs-via-loki/tests/namespace_metadata_test.yaml
+++ b/charts/k8s-monitoring/charts/feature-pod-logs-via-loki/tests/namespace_metadata_test.yaml
@@ -1,0 +1,42 @@
+# yamllint disable rule:document-start rule:line-length rule:trailing-spaces
+suite: Feature - Pod Logs via Loki - Namespace Metadata
+templates:
+  - test/configmap.yaml
+tests:
+  - it: should not add the attach_metadata block by default
+    set:
+      testing: {enabled: true}
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - notMatchRegex:
+          path: data["module.alloy"]
+          pattern: attach_metadata
+
+  - it: should attach namespace metadata when attachNamespaceMetadata is enabled
+    set:
+      testing: {enabled: true}
+      attachNamespaceMetadata: true
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - matchRegex:
+          path: data["module.alloy"]
+          pattern: 'attach_metadata \{\s*namespace = true\s*\}'
+      - matchSnapshot:
+          path: data["module.alloy"]
+
+  - it: should attach both namespace and node metadata when both are enabled
+    set:
+      testing: {enabled: true}
+      attachNamespaceMetadata: true
+      nodeLabels:
+        nodePool: true
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - matchRegex:
+          path: data["module.alloy"]
+          pattern: 'attach_metadata \{\s*namespace = true\s*node = true\s*\}'
+      - matchSnapshot:
+          path: data["module.alloy"]

--- a/charts/k8s-monitoring/charts/feature-pod-logs-via-loki/values.schema.json
+++ b/charts/k8s-monitoring/charts/feature-pod-logs-via-loki/values.schema.json
@@ -13,6 +13,9 @@
                 }
             }
         },
+        "attachNamespaceMetadata": {
+            "type": "boolean"
+        },
         "cri": {
             "type": "object",
             "properties": {

--- a/charts/k8s-monitoring/charts/feature-pod-logs-via-loki/values.yaml
+++ b/charts/k8s-monitoring/charts/feature-pod-logs-via-loki/values.yaml
@@ -5,22 +5,22 @@ global:
   namespaceOverride: ""
 
 # -- Only capture logs from pods in these namespaces (`[]` means all namespaces).
-# @section -- Pod Discovery
+# @section -- Discovery Settings
 namespaces: []
 
 # -- Do not capture logs from any pods in these namespaces.
-# @section -- Pod Discovery
+# @section -- Discovery Settings
 excludeNamespaces: []
 
 # -- Filter the list of discovered nodes by labels. Only for the "volumes" gather method.
 # Example: `nodeSelectors: { 'kubernetes.io/os': 'linux' }`
-# @section -- Pod Discovery
+# @section -- Discovery Settings
 nodeSelectors: {}
 
 # -- Filter the list of discovered pods and services by labels. Only for the "volumes" gather method.
 # Example: `labelSelectors: { 'app': 'myapp' }` will only discover pods with the label `app=myapp`.
 # Example: `labelSelectors: { 'app': ['myapp', 'myotherapp'] }` will only discover pods with the label `app=myapp` or `app=myotherapp`.
-# @section -- Pod Discovery
+# @section -- Discovery Settings
 labelSelectors: {}
 
 # -- Controls the behavior of discovering pods for logs. Possible values: `all`, `annotation`.
@@ -37,8 +37,13 @@ discoveryMethod: "all"
 annotationSelector: "logs.grafana.com/pods.enabled"
 
 # -- Rules to filter pods for log gathering. Only used for "volumes" or "kubernetesApi" gather methods.
-# @section -- Pod Discovery
+# @section -- Discovery Settings
 extraDiscoveryRules: ""
+
+# -- Attach namespace metadata to pod discovery targets. When enabled, all namespace labels
+# are available as log labels via `__meta_kubernetes_namespace_label_*`.
+# @section -- Discovery Settings
+attachNamespaceMetadata: false
 
 # Configures which node labels to attach to the logs
 nodeLabels:


### PR DESCRIPTION
<!--Describe what this change does and why.-->
# Description

This adds the option to attach namespace labels to pod logs features. This is a much lighter-weight alternative to using the k8s enrichment option, since it all happens at discovery time.

Fixes #2321

Replaces #2372

<!--Authorship attestation. See AGENTS.md for details. AI agents must not check this box on behalf
of the user; the human author must check it themselves before the PR is ready for review.-->
## Authorship

-   [X] I, a human, wrote this pull request description myself.

<!--Please delete paragraphs that you did not use before submitting.-->
