### PR TITLE
fix: standardize on upper-case in level lables

### DIFF
--- a/charts/k8s-monitoring/CHANGELOG.md
+++ b/charts/k8s-monitoring/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-*   Fix standardize on upper-case in level lables (#2844) (@saruprim)
+*   Fix standardize on upper-case in level labels (#2844) (@saruprim)
 
 ## 4.2.2
 

--- a/charts/k8s-monitoring/CHANGELOG.md
+++ b/charts/k8s-monitoring/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+*   Fix standardize on upper-case in level lables (#2844) (@saruprim)
+
 ## 4.2.2
 
 *   Add `attachNamespaceMetadata` option to the Pod Logs (via Loki and via Kubernetes API) features. When enabled, namespace labels are attached to pod discovery targets and made available as `__meta_kubernetes_namespace_label_*`. (@petewall, @tdudas)

--- a/charts/k8s-monitoring/charts/feature-node-logs/templates/_module.alloy.tpl
+++ b/charts/k8s-monitoring/charts/feature-node-logs/templates/_module.alloy.tpl
@@ -198,9 +198,20 @@ declare "node_logs" {
     }
 
     // Standardize on upper-case
-    stage.template {
-      source   = "level"
-      template = "{{ "{{ ToUpper .Value }}"}}"
+    stage.match {
+      selector = "{level!=\"UNKNOWN\"}"
+
+      stage.template {
+        source   = "level"
+        template = "{{ "{{ .Value | ToUpper }}" }}"
+      }
+
+      // Set the level after 'ToUpper' as the label
+      stage.labels {
+        values = {
+          level = "",
+        }
+      }
     }
 
     {{- /* the stage.structured_metadata block needs to be conditionalized because the support for enabling structured metadata can be disabled */ -}}

--- a/charts/k8s-monitoring/docs/examples/auth/oauth2/alloy-logs.alloy
+++ b/charts/k8s-monitoring/docs/examples/auth/oauth2/alloy-logs.alloy
@@ -166,9 +166,20 @@ declare "node_logs" {
     }
 
     // Standardize on upper-case
-    stage.template {
-      source   = "level"
-      template = "{{ ToUpper .Value }}"
+    stage.match {
+      selector = "{level!=\"UNKNOWN\"}"
+
+      stage.template {
+        source   = "level"
+        template = "{{ .Value | ToUpper }}"
+      }
+
+      // Set the level after 'ToUpper' as the label
+      stage.labels {
+        values = {
+          level = "",
+        }
+      }
     }
 
     forward_to = argument.logs_destinations.value

--- a/charts/k8s-monitoring/docs/examples/auth/oauth2/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/auth/oauth2/output.yaml
@@ -272,9 +272,20 @@ data:
         }
     
         // Standardize on upper-case
-        stage.template {
-          source   = "level"
-          template = "{{ ToUpper .Value }}"
+        stage.match {
+          selector = "{level!=\"UNKNOWN\"}"
+    
+          stage.template {
+            source   = "level"
+            template = "{{ .Value | ToUpper }}"
+          }
+    
+          // Set the level after 'ToUpper' as the label
+          stage.labels {
+            values = {
+              level = "",
+            }
+          }
         }
     
         forward_to = argument.logs_destinations.value

--- a/charts/k8s-monitoring/docs/examples/dataProcessors/ec2Enrichment/alloy.alloy
+++ b/charts/k8s-monitoring/docs/examples/dataProcessors/ec2Enrichment/alloy.alloy
@@ -415,9 +415,20 @@ declare "node_logs" {
     }
 
     // Standardize on upper-case
-    stage.template {
-      source   = "level"
-      template = "{{ ToUpper .Value }}"
+    stage.match {
+      selector = "{level!=\"UNKNOWN\"}"
+
+      stage.template {
+        source   = "level"
+        template = "{{ .Value | ToUpper }}"
+      }
+
+      // Set the level after 'ToUpper' as the label
+      stage.labels {
+        values = {
+          level = "",
+        }
+      }
     }
 
     forward_to = argument.logs_destinations.value

--- a/charts/k8s-monitoring/docs/examples/dataProcessors/ec2Enrichment/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/dataProcessors/ec2Enrichment/output.yaml
@@ -517,9 +517,20 @@ data:
         }
     
         // Standardize on upper-case
-        stage.template {
-          source   = "level"
-          template = "{{ ToUpper .Value }}"
+        stage.match {
+          selector = "{level!=\"UNKNOWN\"}"
+    
+          stage.template {
+            source   = "level"
+            template = "{{ .Value | ToUpper }}"
+          }
+    
+          // Set the level after 'ToUpper' as the label
+          stage.labels {
+            values = {
+              level = "",
+            }
+          }
         }
     
         forward_to = argument.logs_destinations.value

--- a/charts/k8s-monitoring/docs/examples/features/node-logs/default/alloy-logs.alloy
+++ b/charts/k8s-monitoring/docs/examples/features/node-logs/default/alloy-logs.alloy
@@ -171,9 +171,20 @@ declare "node_logs" {
     }
 
     // Standardize on upper-case
-    stage.template {
-      source   = "level"
-      template = "{{ ToUpper .Value }}"
+    stage.match {
+      selector = "{level!=\"UNKNOWN\"}"
+
+      stage.template {
+        source   = "level"
+        template = "{{ .Value | ToUpper }}"
+      }
+
+      // Set the level after 'ToUpper' as the label
+      stage.labels {
+        values = {
+          level = "",
+        }
+      }
     }
 
     forward_to = argument.logs_destinations.value

--- a/charts/k8s-monitoring/docs/examples/features/node-logs/default/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/features/node-logs/default/output.yaml
@@ -206,9 +206,20 @@ data:
         }
     
         // Standardize on upper-case
-        stage.template {
-          source   = "level"
-          template = "{{ ToUpper .Value }}"
+        stage.match {
+          selector = "{level!=\"UNKNOWN\"}"
+    
+          stage.template {
+            source   = "level"
+            template = "{{ .Value | ToUpper }}"
+          }
+    
+          // Set the level after 'ToUpper' as the label
+          stage.labels {
+            values = {
+              level = "",
+            }
+          }
         }
     
         forward_to = argument.logs_destinations.value

--- a/charts/k8s-monitoring/tests/platform/eks-with-windows/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/platform/eks-with-windows/.rendered/output.yaml
@@ -262,9 +262,20 @@ data:
         }
     
         // Standardize on upper-case
-        stage.template {
-          source   = "level"
-          template = "{{ ToUpper .Value }}"
+        stage.match {
+          selector = "{level!=\"UNKNOWN\"}"
+    
+          stage.template {
+            source   = "level"
+            template = "{{ .Value | ToUpper }}"
+          }
+    
+          // Set the level after 'ToUpper' as the label
+          stage.labels {
+            values = {
+              level = "",
+            }
+          }
         }
     
         forward_to = argument.logs_destinations.value


### PR DESCRIPTION
# Description

The current `stage.template` only updates the value in the extracted map. It does not update the `level` label sent to Loki because the modified value is not promoted back using `stage.labels`.

This change adds `stage.labels` after the template stage to ensure the normalized value is used as the Loki label.

This fixes cases where log levels were normalized internally but the updated value was not reflected in Loki labels.

<!--Authorship attestation. See AGENTS.md for details. AI agents must not check this box on behalf
of the user; the human author must check it themselves before the PR is ready for review.-->
## Authorship

-   [x] I, a human, wrote this pull request description myself.