### PR TITLE
feat: add destination routing

### DIFF
--- a/charts/k8s-monitoring/AGENTS.md
+++ b/charts/k8s-monitoring/AGENTS.md
@@ -156,6 +156,7 @@ podLogsViaLoki:
 -   `otlp` - Send to any OTLP endpoint (Tempo, Grafana Cloud, etc.)
 -   `prometheus` - Remote write to Prometheus-compatible endpoint
 -   `pyroscope` - Send profiles to Pyroscope
+-   `router` - Route telemetry to other destinations based on an attribute value
 <!-- END DESTINATIONS -->
 
 **Configure a destination:**

--- a/charts/k8s-monitoring/CHANGELOG.md
+++ b/charts/k8s-monitoring/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 *   Add the `windows` collector preset, which configures Alloy to run on Windows nodes as a HostProcess container. (@petewall)
+*   Add the `router` destination, which routes telemetry to different destinations based on the value of a resource attribute or label (default `k8s.namespace.name`). Routes are evaluated in order and the first match wins; unmatched data goes to the required `defaultDestinations`. (#2849) (@mbaykara)
 
 ## 4.3.1
 

--- a/charts/k8s-monitoring/Makefile
+++ b/charts/k8s-monitoring/Makefile
@@ -233,6 +233,7 @@ AGENTS.md: AGENTS.md.gotmpl $(FEATURE_CHARTS) $(DESTINATION_VALUES_FILES) $(INTE
 			nop) desc="Drop all telemetry (no storage; for measuring volume before choosing real destinations)";; \
 			otlp) desc="Send to any OTLP endpoint (Tempo, Grafana Cloud, etc.)";; \
 			pyroscope) desc="Send profiles to Pyroscope";; \
+			router) desc="Route telemetry to other destinations based on an attribute value";; \
 			custom) desc="Custom destination configuration";; \
 			*) desc="Send data to $$name";; \
 		esac; \

--- a/charts/k8s-monitoring/destinations/router-values.yaml
+++ b/charts/k8s-monitoring/destinations/router-values.yaml
@@ -1,0 +1,52 @@
+---
+# -- The name for this router destination. A router is not a real telemetry backend: it is a
+# virtual destination that a feature points at (`destinations: [myRouter]`) which then fans
+# telemetry out to real destinations based on an attribute value.
+# @section -- General
+name: ""
+
+# -- Set to `true` to disable this destination. Disabled destinations are excluded from all telemetry data flows, which
+# is useful for removing a destination that was defined in a shared or parent values file.
+# @section -- General
+disabled: false
+
+# -- The resource attribute (OTLP-ecosystem telemetry) or label (Prometheus/Loki/Pyroscope-ecosystem telemetry) whose
+# value decides which downstream destination(s) a given record is routed to. Must start with a letter or underscore
+# and contain only letters, digits, underscores, dots, slashes, and hyphens (no quotes, backticks, backslashes, or
+# whitespace). The well-known value `k8s.namespace.name` is automatically mapped to the `namespace` label for
+# label-based ecosystems. Any other attribute that is ALSO a valid Prometheus label name (letters/digits/underscore
+# only, starting with a letter or underscore -- so no dots, slashes, or hyphens) is used verbatim as the label name.
+# Attributes outside that stricter label-name grammar have no label equivalent, so label-based ecosystems fall back
+# to `defaultDestinations` only.
+# @section -- Routing
+attribute: "k8s.namespace.name"
+
+# -- Routing rules, evaluated in declaration order: the first rule whose `match` matches wins. Records that don't
+# match any rule (or whose matched rule does not list a destination for a given signal) fall back to
+# `defaultDestinations`.
+# @section -- Routing
+# @default -- []
+routes: []
+# - match:
+#     equals: "team-a"
+#   destinations:
+#     - team-a-mimir
+#   # -- Optional: restrict this route to specific signals. Defaults to all signals.
+#   signals:
+#     - metrics
+#     - logs
+# - match:
+#     in:
+#       - team-b
+#       - team-c
+#   destinations:
+#     - shared-mimir
+# - match:
+#     matches: "^team-.*-canary$"
+#   destinations:
+#     - canary-mimir
+
+# -- Destinations to fall back to when no route matches. MANDATORY: every router must define at least one default
+# destination, otherwise unmatched telemetry has nowhere to go.
+# @section -- Routing
+defaultDestinations: []

--- a/charts/k8s-monitoring/docs/DestinationRouting.md
+++ b/charts/k8s-monitoring/docs/DestinationRouting.md
@@ -1,0 +1,245 @@
+# Destination routing
+
+The `router` destination type sends telemetry to different real destinations based on the value of
+an attribute (OpenTelemetry Protocol telemetry) or a mapped label (scraped metrics, Loki logs, and
+Pyroscope profiles), all from a single release. This is useful for splitting telemetry by tenant,
+team, or environment without deploying a separate collector or release per group.
+
+## What a router is
+
+A router is not a telemetry backend. It never receives a URL, credentials, or a protocol. It is a
+virtual destination: a named entry under `destinations` with `type: router` that a feature points
+at the same way it would point at any other destination, by listing its name in that feature's
+`destinations`. When a record reaches the router, the router evaluates its route table, decides
+which real destination(s) the record should go to, and forwards it there.
+
+```yaml
+destinations:
+  platform:
+    type: otlp
+    url: http://tempo.tempo.svc:443/otlp
+  stack-a:
+    type: otlp
+    url: http://tempo-stack-a.tempo.svc:443/otlp
+  tenantRouter:
+    type: router
+    routes:
+      - match:
+          equals: tenant-a
+        destinations:
+          - stack-a
+    defaultDestinations:
+      - platform
+
+podLogsViaOpenTelemetry:
+  enabled: true
+  destinations:
+    - tenantRouter
+```
+
+## Configuration reference
+
+A router destination supports the following fields:
+
+-   `attribute` (string, defaults to `k8s.namespace.name`) - the attribute whose value decides
+    routing. It must start with a letter or underscore and contain only letters, digits,
+    underscores, dots, slashes, and hyphens.
+-   `routes` (list) - an ordered list of routing rules. Each entry has:
+    -   `match` - exactly one of `equals`, `in`, or `matches`:
+        -   `equals` (string) - the attribute value must equal this string.
+        -   `in` (list of strings) - the attribute value must equal one of these strings.
+        -   `matches` (string) - the attribute value must match this pattern (see
+            [Pattern matching](#pattern-matching), below).
+    -   `destinations` (list of strings, required, at least one entry) - the real destination(s) to
+        send a matching record to.
+    -   `signals` (list, optional) - restricts this route to a subset of `metrics`, `logs`,
+        `traces`, `profiles`. When absent, the route applies to every signal.
+-   `defaultDestinations` (list of strings, **mandatory**, at least one entry) - the destination(s)
+    for records that don't match any route.
+
+## Semantics
+
+Routes are evaluated in the order they're declared, and the first matching route wins for each
+signal. A router is a terminal destination: it never talks to a real backend itself, so it
+requires at least one entry in `defaultDestinations` for records that fall through every route (or
+that match a route whose `destinations` don't carry the signal being routed). A record is sent to
+exactly one set of destinations per signal, either the matched route's `destinations` or
+`defaultDestinations`. There's no combining a route's destinations with the default; matching is
+exclusive.
+
+## Routing happens on the collection pipeline, not the destination
+
+Where a record enters the pipeline decides whether it can route on the router's `attribute` at
+all, independent of where the record is ultimately sent. Scraped metrics, Loki pod logs, and
+Pyroscope profiles are routed on the mapped label before anything is converted to OpenTelemetry
+Protocol, even when the matched destination happens to be an OpenTelemetry Protocol destination.
+Only telemetry that's collected via OpenTelemetry Protocol from the start (for example,
+`podLogsViaOpenTelemetry`, `applicationObservability`) can route on an arbitrary attribute.
+
+The `attribute` field maps to a label as follows:
+
+-   `k8s.namespace.name` (the default) maps to the `namespace` label.
+-   Any other attribute that is itself a valid Prometheus label name (letters, digits, and
+    underscores only, starting with a letter or underscore) is used as that label name.
+-   Any other attribute has no label equivalent. On the scraped-metrics, Loki, and Pyroscope
+    collection pipelines, routing on that attribute falls through to `defaultDestinations` for
+    every record, and the chart emits a warning (`W-a`) at render time to flag this. The
+    OpenTelemetry Protocol collection pipeline is unaffected, because it routes on the attribute
+    directly.
+
+## Explicit opt-in is required
+
+Routers are excluded from a feature's implicit destination selection. If a feature has no
+`destinations` list of its own, the chart never picks a router for it automatically, even if the
+router is the only destination that would otherwise qualify. Every feature that should send
+telemetry through a router must list that router by name:
+
+```yaml
+podLogsViaOpenTelemetry:
+  enabled: true
+  destinations:
+    - tenantRouter
+```
+
+The chart emits a warning at render time when a router is configured but at least one enabled
+feature has no explicit `destinations` list, since that feature won't use the router.
+
+## Pattern matching
+
+`match.equals` and `match.in` compare against literal strings: any pattern metacharacters in the
+values are escaped before being used for comparison, so a value like `team.a` matches only the
+literal string `team.a`. `match.matches`, by contrast, is a pattern: its value is used as-is, so a
+value like `^team-.*-canary$` matches any string with that shape.
+
+The implementation differs by collection pipeline, and `match.matches` is not anchored the same
+way on every pipeline:
+
+-   On the label-based pipelines (scraped metrics, Loki, Pyroscope), the router builds an anchored
+    pattern for `equals`/`in`, and the underlying label-matching mechanism always anchors the
+    whole value (Prometheus semantics) -- including for `matches`, so the pattern must match the
+    entire label value, not part of it.
+-   On the OpenTelemetry Protocol pipeline, `equals` and `in` become exact string comparisons
+    (`in` becomes an OR-chain of comparisons, since the underlying transform language has no
+    native list-membership operator), and `matches` is passed to that language's pattern-matching
+    function, which matches anywhere within the attribute value rather than anchoring to the whole
+    string. All values are escaped for the string-literal context they're spliced into.
+
+Because of this difference, write `match.matches` patterns fully anchored (`^...$`) so they
+behave consistently across every collection pipeline.
+
+## Router-to-router isn't supported
+
+A route or `defaultDestinations` entry can't point at another router destination. Chaining routers
+would wire one router's fan-out into another router's inputs, forming a cycle in the generated
+Alloy pipeline, so the chart fails the render with a clear error message.
+
+## Scaling
+
+Each real destination a router can reach adds one Alloy component gate per downstream per signal,
+so the number of generated components grows about linearly with the number of destinations a
+router fans out to (across whichever signals actually flow through it). A router that only ever
+sees one signal, or that fans out to a small number of destinations, stays cheap; a router that
+fans out to many destinations across every signal generates proportionally more Alloy components.
+
+## Worked examples
+
+### Example 1: OpenTelemetry Protocol tenant-per-namespace
+
+Application traces and logs collected via OpenTelemetry Protocol are split by tenant namespace,
+with every other namespace landing on a shared platform destination:
+
+```yaml
+destinations:
+  platform:
+    type: otlp
+    url: http://tempo-platform.tempo.svc:443/otlp
+  stack-a:
+    type: otlp
+    url: http://tempo-stack-a.tempo.svc:443/otlp
+  stack-b:
+    type: otlp
+    url: http://tempo-stack-b.tempo.svc:443/otlp
+  tenantRouter:
+    type: router
+    routes:
+      - match:
+          equals: tenant-a
+        destinations:
+          - stack-a
+      - match:
+          in:
+            - tenant-b
+            - tenant-b-canary
+        destinations:
+          - stack-b
+    defaultDestinations:
+      - platform
+
+applicationObservability:
+  enabled: true
+  destinations:
+    - tenantRouter
+```
+
+A record whose `k8s.namespace.name` resource attribute is `tenant-a` goes to `stack-a`. A record
+from `tenant-b` or `tenant-b-canary` goes to `stack-b`. Every other record goes to `platform`.
+
+### Example 2: mixed Prometheus, Loki, and OpenTelemetry Protocol, per-signal
+
+A single router serves scraped cluster metrics, Loki pod logs, and OpenTelemetry Protocol traces
+at once, with different destinations and a per-route `signals` restriction:
+
+```yaml
+destinations:
+  mimir:
+    type: prometheus
+    url: http://prometheus.prometheus.svc:9090/api/v1/write
+  loki:
+    type: loki
+    url: http://loki.loki.svc:3100/loki/api/v1/push
+  tempo:
+    type: otlp
+    url: http://tempo.tempo.svc:443/otlp
+  team-router:
+    type: router
+    attribute: team
+    routes:
+      - match:
+          equals: checkout
+        destinations:
+          - mimir
+          - loki
+        signals:
+          - metrics
+          - logs
+      - match:
+          equals: payments
+        destinations:
+          - tempo
+        signals:
+          - traces
+    defaultDestinations:
+      - mimir
+      - loki
+
+clusterMetrics:
+  enabled: true
+  destinations:
+    - team-router
+
+podLogsViaLoki:
+  enabled: true
+  destinations:
+    - team-router
+
+applicationObservability:
+  enabled: true
+  destinations:
+    - team-router
+```
+
+Here `attribute: team` is dot-free and matches the Prometheus label-name grammar, so it's usable
+as a label on the scraped-metrics and Loki pipelines as well as an attribute on the OpenTelemetry
+Protocol pipeline. Cluster metrics and pod logs tagged `team: checkout` go to `mimir` and `loki`
+respectively; traces tagged `team: payments` go to `tempo`; everything else falls back to
+`mimir`/`loki` for the signals those destinations carry.

--- a/charts/k8s-monitoring/docs/destinations/router.md
+++ b/charts/k8s-monitoring/docs/destinations/router.md
@@ -1,0 +1,20 @@
+# router
+
+<!-- textlint-disable terminology -->
+## Values
+
+### Routing
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| attribute | string | `"k8s.namespace.name"` | The resource attribute (OTLP-ecosystem telemetry) or label (Prometheus/Loki/Pyroscope-ecosystem telemetry) whose value decides which downstream destination(s) a given record is routed to. Must start with a letter or underscore and contain only letters, digits, underscores, dots, slashes, and hyphens (no quotes, backticks, backslashes, or whitespace). The well-known value `k8s.namespace.name` is automatically mapped to the `namespace` label for label-based ecosystems. Any other attribute that is ALSO a valid Prometheus label name (letters/digits/underscore only, starting with a letter or underscore -- so no dots, slashes, or hyphens) is used verbatim as the label name. Attributes outside that stricter label-name grammar have no label equivalent, so label-based ecosystems fall back to `defaultDestinations` only. |
+| defaultDestinations | list | `[]` | Destinations to fall back to when no route matches. MANDATORY: every router must define at least one default destination, otherwise unmatched telemetry has nowhere to go. |
+| routes | list | [] | Routing rules, evaluated in declaration order: the first rule whose `match` matches wins. Records that don't match any rule (or whose matched rule does not list a destination for a given signal) fall back to `defaultDestinations`. |
+
+### General
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| disabled | bool | `false` | Set to `true` to disable this destination. Disabled destinations are excluded from all telemetry data flows, which is useful for removing a destination that was defined in a shared or parent values file. |
+| name | string | `""` | The name for this router destination. A router is not a real telemetry backend: it is a virtual destination that a feature points at (`destinations: [myRouter]`) which then fans telemetry out to real destinations based on an attribute value. |
+<!-- textlint-enable terminology -->

--- a/charts/k8s-monitoring/docs/examples/destination-router/README.md
+++ b/charts/k8s-monitoring/docs/examples/destination-router/README.md
@@ -1,0 +1,96 @@
+<!--
+(NOTE: Do not edit README.md directly. It is a generated file!)
+(      To make changes, please modify values.yaml or description.txt and run `make examples`)
+-->
+# Destination Router
+
+This example shows how to use the `router` destination to fan pod logs out to different real
+destinations based on the Kubernetes namespace they came from, without teaching the
+`podLogsViaOpenTelemetry` feature anything about tenant-specific plumbing.
+
+A router is not a real telemetry backend. It is a virtual destination that inspects an attribute
+(or the mapped label, for label-based collection pipelines) on each record and forwards it to one
+or more real downstream destinations. In this example, the router is named `tenantRouter` and
+routes on the default attribute, `k8s.namespace.name`:
+
+```yaml
+destinations:
+  tenantRouter:
+    type: router
+    routes:
+      - match:
+          equals: tenant-a
+        destinations:
+          - stack-a
+    defaultDestinations:
+      - platform
+```
+
+Pod logs collected from the `tenant-a` namespace are sent to the `stack-a` destination. Pod logs
+from every other namespace fall back to `defaultDestinations` and are sent to `platform`.
+
+Because routers are excluded from implicit destination selection, the feature that should use one
+must name it explicitly:
+
+```yaml
+podLogsViaOpenTelemetry:
+  enabled: true
+  destinations:
+    - tenantRouter
+```
+
+For a complete reference of the router configuration options, routing semantics, and how routing
+behaves across the different collection pipelines (scraped metrics, Loki logs, Pyroscope profiles,
+and OpenTelemetry Protocol), refer to [Destination routing](../../DestinationRouting.md).
+
+## Values
+
+<!-- textlint-disable terminology -->
+```yaml
+---
+cluster:
+  name: destination-router
+
+destinations:
+  stack-a:
+    type: otlp
+    protocol: http
+    url: http://tempo-stack-a.tempo.svc:443/otlp
+    metrics: {enabled: true}
+    logs: {enabled: true}
+    traces: {enabled: true}
+  platform:
+    type: otlp
+    protocol: http
+    url: http://tempo-platform.tempo.svc:443/otlp
+    metrics: {enabled: true}
+    logs: {enabled: true}
+    traces: {enabled: true}
+  tenantRouter:
+    type: router
+    # Routes on the default attribute, k8s.namespace.name, which is automatically mapped to the
+    # "namespace" label for label-based collection pipelines.
+    routes:
+      - match:
+          equals: tenant-a
+        destinations:
+          - stack-a
+    # MANDATORY: every router must define at least one fallback destination for records that
+    # don't match any route.
+    defaultDestinations:
+      - platform
+
+podLogsViaOpenTelemetry:
+  enabled: true
+  collector: alloy-logs
+  # Routers are excluded from implicit destination selection, so they must be named explicitly.
+  destinations:
+    - tenantRouter
+
+collectors:
+  alloy-logs:
+    presets: [filesystem-log-reader, daemonset]
+    alloy:
+      stabilityLevel: public-preview
+```
+<!-- textlint-enable terminology -->

--- a/charts/k8s-monitoring/docs/examples/destination-router/alloy-logs.alloy
+++ b/charts/k8s-monitoring/docs/examples/destination-router/alloy-logs.alloy
@@ -1,0 +1,870 @@
+// Feature: Pod Logs (OpenTelemetry)
+declare "pod_logs_via_opentelemetry" {
+  argument "logs_destinations" {
+    comment = "Must be a list of log destinations where collected logs should be forwarded to"
+  }
+
+  otelcol.receiver.filelog "pod_logs" {
+    include = ["/var/log/pods/*/*/*.log"]
+    start_at = "end"
+    include_file_name = false
+    include_file_path = true
+
+    operators = [
+      // Container operator will set k8s.pod.name, k8s.pod.uid, k8s.container.name, k8s.container.restart_count, and k8s.namespace.name
+      {
+        type                       = "container",
+        add_metadata_from_filepath = true,
+      },
+    ]
+
+    output {
+      logs = [otelcol.processor.k8sattributes.pod_logs.input]
+    }
+  } // otelcol.receiver.filelog "pod_logs"
+
+  otelcol.processor.k8sattributes "pod_logs" {
+    pod_association {
+      source {
+        from = "resource_attribute"
+        name = "k8s.pod.uid"
+      }
+    }
+
+    extract {
+      otel_annotations = false
+      metadata = [
+        "k8s.deployment.name",
+        "k8s.statefulset.name",
+        "k8s.daemonset.name",
+        "k8s.cronjob.name",
+        "k8s.job.name",
+        "k8s.node.name",
+      ]
+      annotation {
+        key_regex = "resource.opentelemetry.io/(.*)"
+        tag_name  = "$1"
+        from      = "pod"
+      }
+      annotation {
+        tag_name = "logs.grafana.com/pods.enabled"
+        key      = "logs.grafana.com/pods.enabled"
+        from     = "pod"
+      }
+      label {
+        tag_name = "app_kubernetes_io_name"
+        key      = "app.kubernetes.io/name"
+        from     = "pod"
+      }
+    }
+
+    output {
+      logs = [otelcol.processor.filter.pod_logs.input]
+    }
+  } // otelcol.processor.k8sattributes "pod_logs"
+
+  otelcol.processor.filter "pod_logs" {
+    error_mode = "ignore"
+    logs {
+      log_record = [
+        `resource.attributes["logs.grafana.com/pods.enabled"] == "false"`,
+        `resource.attributes["logs.grafana.com/pods.enabled"] == "no"`,
+        `resource.attributes["logs.grafana.com/pods.enabled"] == "skip"`,
+      ]
+    }
+    output {
+      logs = [otelcol.processor.transform.pod_logs.input]
+    }
+  } // otelcol.processor.filter "pod_logs"
+
+  otelcol.processor.transform "pod_logs" {
+    error_mode = "ignore"
+    log_statements {
+      context = "resource"
+      statements = [
+        `delete_key(attributes, "k8s.container.restart_count")`,
+        `delete_key(attributes, "logs.grafana.com/pods.enabled")`,
+        `set(attributes["service.name"], attributes["app.kubernetes.io/name"]) where (attributes["service.name"] == nil or attributes["service.name"] == "") and attributes["app.kubernetes.io/name"] != nil and attributes["app.kubernetes.io/name"] != ""`,
+        `set(attributes["service.name"], attributes["k8s.deployment.name"]) where (attributes["service.name"] == nil or attributes["service.name"] == "") and attributes["k8s.deployment.name"] != nil and attributes["k8s.deployment.name"] != ""`,
+        `set(attributes["service.name"], attributes["k8s.replicaset.name"]) where (attributes["service.name"] == nil or attributes["service.name"] == "") and attributes["k8s.replicaset.name"] != nil and attributes["k8s.replicaset.name"] != ""`,
+        `set(attributes["service.name"], attributes["k8s.statefulset.name"]) where (attributes["service.name"] == nil or attributes["service.name"] == "") and attributes["k8s.statefulset.name"] != nil and attributes["k8s.statefulset.name"] != ""`,
+        `set(attributes["service.name"], attributes["k8s.daemonset.name"]) where (attributes["service.name"] == nil or attributes["service.name"] == "") and attributes["k8s.daemonset.name"] != nil and attributes["k8s.daemonset.name"] != ""`,
+        `set(attributes["service.name"], attributes["k8s.cronjob.name"]) where (attributes["service.name"] == nil or attributes["service.name"] == "") and attributes["k8s.cronjob.name"] != nil and attributes["k8s.cronjob.name"] != ""`,
+        `set(attributes["service.name"], attributes["k8s.job.name"]) where (attributes["service.name"] == nil or attributes["service.name"] == "") and attributes["k8s.job.name"] != nil and attributes["k8s.job.name"] != ""`,
+        `set(attributes["service.name"], attributes["k8s.pod.name"]) where (attributes["service.name"] == nil or attributes["service.name"] == "") and attributes["k8s.pod.name"] != nil and attributes["k8s.pod.name"] != ""`,
+        `set(attributes["service.name"], attributes["k8s.container.name"]) where (attributes["service.name"] == nil or attributes["service.name"] == "") and attributes["k8s.container.name"] != nil and attributes["k8s.container.name"] != ""`,
+
+        `set(attributes["service.namespace"], attributes["k8s.namespace.name"]) where (attributes["service.namespace"] == nil or attributes["service.namespace"] == "") and attributes["k8s.namespace.name"] != nil and attributes["k8s.namespace.name"] != ""`,
+
+        `set(attributes["service.version"], attributes["app.kubernetes.io/version"]) where attributes["service.version"] == nil`,
+
+        `set(attributes["service.instance.id"], Concat([attributes["k8s.namespace.name"], attributes["k8s.pod.name"], attributes["k8s.container.name"]], ".")) where attributes["service.instance.id"] == nil`,
+      ]
+    }
+
+    log_statements {
+      context = "log"
+      statements = [
+        `delete_key(attributes, "log.file.path")`,
+      ]
+    }
+
+    output {
+      logs = argument.logs_destinations.value
+    }
+  } // otelcol.processor.transform "pod_logs"
+} // declare "pod_logs_via_opentelemetry"
+pod_logs_via_opentelemetry "feature" {
+  logs_destinations = [
+    otelcol.processor.transform.tenantrouter_logs_otlp.input,
+  ]
+}
+
+
+
+
+
+
+
+
+
+
+
+// Destination: platform (otlp)
+otelcol.receiver.prometheus "platform" {
+  output {
+    metrics = [otelcol.processor.transform.platform_scrape_normalize.input]
+  }
+} // otelcol.receiver.prometheus "platform"
+
+// Repairs artifacts of the Prometheus-to-OTLP conversion performed by
+// otelcol.receiver.prometheus. Only metrics that came from a Prometheus scrape pass
+// through this component; OTLP-native telemetry enters the pipeline further down.
+otelcol.processor.transform "platform_scrape_normalize" {
+  error_mode = "ignore"
+  metric_statements {
+    context = "resource"
+    statements = [
+      // The conversion sets service.name to the full Prometheus job label (e.g.
+      // "namespace/workload"). When the scrape target declares its identity explicitly
+      // with a service_name label on its own target_info metric (e.g. Grafana Beyla),
+      // prefer that value and drop the duplicate.
+      `set(attributes["service.name"], attributes["service_name"]) where attributes["service_name"] != nil and attributes["service_name"] != ""`,
+      `delete_key(attributes, "service_name") where attributes["service_name"] == attributes["service.name"]`,
+      // The same conversion turns other flat target_info labels into resource attributes.
+      // Promote them to their OpenTelemetry counterparts and drop the flat duplicates, so
+      // the OTLP endpoint does not receive two conflicting spellings of the same attribute.
+      `set(attributes["service.namespace"], attributes["service_namespace"]) where (attributes["service.namespace"] == nil or attributes["service.namespace"] == "") and attributes["service_namespace"] != nil and attributes["service_namespace"] != ""`,
+      `delete_key(attributes, "service_namespace") where attributes["service_namespace"] == attributes["service.namespace"]`,
+      `set(attributes["deployment.environment"], attributes["deployment_environment"]) where (attributes["deployment.environment"] == nil or attributes["deployment.environment"] == "") and attributes["deployment_environment"] != nil and attributes["deployment_environment"] != ""`,
+      `delete_key(attributes, "deployment_environment") where attributes["deployment_environment"] == attributes["deployment.environment"]`,
+      `set(attributes["deployment.environment.name"], attributes["deployment_environment_name"]) where (attributes["deployment.environment.name"] == nil or attributes["deployment.environment.name"] == "") and attributes["deployment_environment_name"] != nil and attributes["deployment_environment_name"] != ""`,
+      `delete_key(attributes, "deployment_environment_name") where attributes["deployment_environment_name"] == attributes["deployment.environment.name"]`,
+    ]
+  }
+  metric_statements {
+    context = "datapoint"
+    statements = [
+      // Same correction for scrape targets that put service_name on every series
+      // instead of exposing a target_info metric.
+      `set(resource.attributes["service.name"], attributes["service_name"]) where attributes["service_name"] != nil and attributes["service_name"] != ""`,
+    ]
+  }
+  output {
+    metrics = [otelcol.processor.attributes.platform.input]
+  }
+} // otelcol.processor.transform "platform_scrape_normalize"
+otelcol.receiver.loki "platform" {
+  output {
+    logs = [otelcol.processor.attributes.platform.input]
+  }
+} // otelcol.receiver.loki "platform"
+otelcol.processor.attributes "platform" {
+  output {
+    metrics = [otelcol.processor.transform.platform.input]
+    logs = [otelcol.processor.transform.platform.input]
+    traces = [otelcol.processor.transform.platform.input]
+  }
+} // otelcol.processor.attributes "platform"
+
+otelcol.processor.transform "platform" {
+  error_mode = "ignore"
+  metric_statements {
+    context = "resource"
+    statements = [
+      `set(attributes["cluster"], "destination-router")`,
+      `set(attributes["k8s.cluster.name"], "destination-router")`,
+      `delete_key(attributes, "process.pid")`,
+      `delete_key(attributes, "process.parent_pid")`,
+      `delete_key(attributes, "process.executable.path")`,
+      `delete_key(attributes, "process.command_line")`,
+      `delete_key(attributes, "process.command_args")`,
+      `delete_key(attributes, "process.owner")`,
+      `delete_key(attributes, "process.runtime.version")`,
+      `delete_key(attributes, "process.runtime.description")`,
+      `delete_key(attributes, "host.ip")`,
+      `delete_key(attributes, "host.mac")`,
+      `delete_key(attributes, "k8s.pod.start_time")`,
+      `delete_key(attributes, "k8s.pod.uid")`,
+      `delete_key(attributes, "container.image.id")`,
+      `delete_key(attributes, "container.image.repo_digests")`,
+      `delete_key(attributes, "os.description")`,
+      `delete_key(attributes, "os.build_id")`,
+      // Scrape targets that expose their own target_info metric (e.g. Grafana Beyla) can
+      // carry a flat k8s_cluster_name resource attribute, which conflicts with the
+      // k8s.cluster.name attribute set above and gets ";"-joined by the Prometheus OTLP
+      // endpoint. Drop the flat copy when the values match.
+      `delete_key(attributes, "k8s_cluster_name") where attributes["k8s_cluster_name"] == attributes["k8s.cluster.name"]`,
+    ]
+  }
+
+  metric_statements {
+    context = "datapoint"
+    statements = [
+      `set(attributes["cluster"], "destination-router")`,
+      `set(attributes["k8s.cluster.name"], "destination-router")`,
+      `set(resource.attributes["deployment.environment"], attributes["deployment_environment"] ) where resource.attributes["deployment.environment"] == nil and attributes["deployment_environment"] != nil`,
+      `delete_key(attributes, "deployment_environment") where attributes["deployment_environment"] == resource.attributes["deployment.environment"]`,
+      `set(resource.attributes["deployment.environment.name"], attributes["deployment_environment_name"] ) where resource.attributes["deployment.environment.name"] == nil and attributes["deployment_environment_name"] != nil`,
+      `delete_key(attributes, "deployment_environment_name") where attributes["deployment_environment_name"] == resource.attributes["deployment.environment.name"]`,
+      `set(resource.attributes["service.name"], attributes["service_name"] ) where (resource.attributes["service.name"] == nil or resource.attributes["service.name"] == "") and attributes["service_name"] != nil and attributes["service_name"] != ""`,
+      `delete_key(attributes, "service_name") where attributes["service_name"] == resource.attributes["service.name"]`,
+      `set(resource.attributes["service.namespace"], attributes["service_namespace"] ) where (resource.attributes["service.namespace"] == nil or resource.attributes["service.namespace"] == "") and attributes["service_namespace"] != nil and attributes["service_namespace"] != ""`,
+      `delete_key(attributes, "service_namespace") where attributes["service_namespace"] == resource.attributes["service.namespace"]`,
+    ]
+  }
+  log_statements {
+    context = "resource"
+    statements = [
+      `set(attributes["cluster"], "destination-router")`,
+      `set(attributes["k8s.cluster.name"], "destination-router")`,
+      `delete_key(attributes, "process.pid")`,
+      `delete_key(attributes, "process.parent_pid")`,
+      `delete_key(attributes, "process.executable.path")`,
+      `delete_key(attributes, "process.command_line")`,
+      `delete_key(attributes, "process.command_args")`,
+      `delete_key(attributes, "process.owner")`,
+      `delete_key(attributes, "process.runtime.version")`,
+      `delete_key(attributes, "process.runtime.description")`,
+      `delete_key(attributes, "host.ip")`,
+      `delete_key(attributes, "host.mac")`,
+      `delete_key(attributes, "k8s.pod.start_time")`,
+      `delete_key(attributes, "k8s.pod.uid")`,
+      `delete_key(attributes, "container.image.id")`,
+      `delete_key(attributes, "container.image.repo_digests")`,
+      `delete_key(attributes, "os.description")`,
+      `delete_key(attributes, "os.build_id")`,
+    ]
+  }
+
+  log_statements {
+    context = "log"
+    statements = [
+      `delete_key(attributes, "loki.attribute.labels")`,
+      `delete_key(attributes, "loki.resource.labels")`,
+      `set(resource.attributes["k8s.container.name"], attributes["container"] ) where resource.attributes["k8s.container.name"] == nil and attributes["container"] != nil`,
+      `delete_key(attributes, "container") where attributes["container"] == resource.attributes["k8s.container.name"]`,
+      `set(resource.attributes["k8s.cronjob.name"], attributes["cronjob"] ) where resource.attributes["k8s.cronjob.name"] == nil and attributes["cronjob"] != nil`,
+      `delete_key(attributes, "cronjob") where attributes["cronjob"] == resource.attributes["k8s.cronjob.name"]`,
+      `set(resource.attributes["k8s.daemonset.name"], attributes["daemonset"] ) where resource.attributes["k8s.daemonset.name"] == nil and attributes["daemonset"] != nil`,
+      `delete_key(attributes, "daemonset") where attributes["daemonset"] == resource.attributes["k8s.daemonset.name"]`,
+      `set(resource.attributes["k8s.deployment.name"], attributes["deployment"] ) where resource.attributes["k8s.deployment.name"] == nil and attributes["deployment"] != nil`,
+      `delete_key(attributes, "deployment") where attributes["deployment"] == resource.attributes["k8s.deployment.name"]`,
+      `set(resource.attributes["deployment.environment"], attributes["deployment_environment"] ) where resource.attributes["deployment.environment"] == nil and attributes["deployment_environment"] != nil`,
+      `delete_key(attributes, "deployment_environment") where attributes["deployment_environment"] == resource.attributes["deployment.environment"]`,
+      `set(resource.attributes["deployment.environment.name"], attributes["deployment_environment_name"] ) where resource.attributes["deployment.environment.name"] == nil and attributes["deployment_environment_name"] != nil`,
+      `delete_key(attributes, "deployment_environment_name") where attributes["deployment_environment_name"] == resource.attributes["deployment.environment.name"]`,
+      `set(resource.attributes["k8s.job.name"], attributes["job_name"] ) where resource.attributes["k8s.job.name"] == nil and attributes["job_name"] != nil`,
+      `delete_key(attributes, "job_name") where attributes["job_name"] == resource.attributes["k8s.job.name"]`,
+      `set(resource.attributes["k8s.namespace.name"], attributes["namespace"] ) where resource.attributes["k8s.namespace.name"] == nil and attributes["namespace"] != nil`,
+      `delete_key(attributes, "namespace") where attributes["namespace"] == resource.attributes["k8s.namespace.name"]`,
+      `set(resource.attributes["k8s.pod.name"], attributes["pod"] ) where resource.attributes["k8s.pod.name"] == nil and attributes["pod"] != nil`,
+      `delete_key(attributes, "pod") where attributes["pod"] == resource.attributes["k8s.pod.name"]`,
+      `set(resource.attributes["k8s.replicaset.name"], attributes["replicaset"] ) where resource.attributes["k8s.replicaset.name"] == nil and attributes["replicaset"] != nil`,
+      `delete_key(attributes, "replicaset") where attributes["replicaset"] == resource.attributes["k8s.replicaset.name"]`,
+      `set(resource.attributes["service.name"], attributes["service_name"] ) where (resource.attributes["service.name"] == nil or resource.attributes["service.name"] == "") and attributes["service_name"] != nil and attributes["service_name"] != ""`,
+      `delete_key(attributes, "service_name") where attributes["service_name"] == resource.attributes["service.name"]`,
+      `set(resource.attributes["service.namespace"], attributes["service_namespace"] ) where (resource.attributes["service.namespace"] == nil or resource.attributes["service.namespace"] == "") and attributes["service_namespace"] != nil and attributes["service_namespace"] != ""`,
+      `delete_key(attributes, "service_namespace") where attributes["service_namespace"] == resource.attributes["service.namespace"]`,
+      `set(resource.attributes["k8s.statefulset.name"], attributes["statefulset"] ) where resource.attributes["k8s.statefulset.name"] == nil and attributes["statefulset"] != nil`,
+      `delete_key(attributes, "statefulset") where attributes["statefulset"] == resource.attributes["k8s.statefulset.name"]`,
+    ]
+  }
+
+  trace_statements {
+    context = "resource"
+    statements = [
+      `set(attributes["cluster"], "destination-router")`,
+      `set(attributes["k8s.cluster.name"], "destination-router")`,
+      `delete_key(attributes, "process.pid")`,
+      `delete_key(attributes, "process.parent_pid")`,
+      `delete_key(attributes, "process.executable.path")`,
+      `delete_key(attributes, "process.command_line")`,
+      `delete_key(attributes, "process.command_args")`,
+      `delete_key(attributes, "process.owner")`,
+      `delete_key(attributes, "process.runtime.version")`,
+      `delete_key(attributes, "process.runtime.description")`,
+      `delete_key(attributes, "host.ip")`,
+      `delete_key(attributes, "host.mac")`,
+      `delete_key(attributes, "k8s.pod.start_time")`,
+      `delete_key(attributes, "k8s.pod.uid")`,
+      `delete_key(attributes, "container.image.id")`,
+      `delete_key(attributes, "container.image.repo_digests")`,
+      `delete_key(attributes, "os.description")`,
+      `delete_key(attributes, "os.build_id")`,
+    ]
+  }
+
+  output {
+    metrics = [otelcol.processor.batch.platform.input]
+    logs = [otelcol.processor.batch.platform.input]
+    traces = [otelcol.processor.batch.platform.input]
+  }
+} // otelcol.processor.transform "platform"
+
+otelcol.processor.batch "platform" {
+  timeout = "2s"
+  send_batch_size = 8192
+  send_batch_max_size = 0
+
+  output {
+    metrics = [otelcol.exporter.otlphttp.platform.input]
+    logs = [otelcol.exporter.otlphttp.platform.input]
+    traces = [otelcol.exporter.otlphttp.platform.input]
+  }
+} // otelcol.processor.batch "platform"
+otelcol.exporter.otlphttp "platform" {
+  client {
+    endpoint = "http://tempo-platform.tempo.svc:443/otlp"
+    tls {
+      insecure = false
+      insecure_skip_verify = false
+    }
+  }
+
+  retry_on_failure {
+    enabled = true
+    initial_interval = "5s"
+    max_interval = "30s"
+    max_elapsed_time = "5m"
+  }
+
+  sending_queue {
+    enabled = true
+  }
+} // otelcol.exporter.otlphttp "platform"
+
+// Destination: stack-a (otlp)
+otelcol.receiver.prometheus "stack_a" {
+  output {
+    metrics = [otelcol.processor.transform.stack_a_scrape_normalize.input]
+  }
+} // otelcol.receiver.prometheus "stack_a"
+
+// Repairs artifacts of the Prometheus-to-OTLP conversion performed by
+// otelcol.receiver.prometheus. Only metrics that came from a Prometheus scrape pass
+// through this component; OTLP-native telemetry enters the pipeline further down.
+otelcol.processor.transform "stack_a_scrape_normalize" {
+  error_mode = "ignore"
+  metric_statements {
+    context = "resource"
+    statements = [
+      // The conversion sets service.name to the full Prometheus job label (e.g.
+      // "namespace/workload"). When the scrape target declares its identity explicitly
+      // with a service_name label on its own target_info metric (e.g. Grafana Beyla),
+      // prefer that value and drop the duplicate.
+      `set(attributes["service.name"], attributes["service_name"]) where attributes["service_name"] != nil and attributes["service_name"] != ""`,
+      `delete_key(attributes, "service_name") where attributes["service_name"] == attributes["service.name"]`,
+      // The same conversion turns other flat target_info labels into resource attributes.
+      // Promote them to their OpenTelemetry counterparts and drop the flat duplicates, so
+      // the OTLP endpoint does not receive two conflicting spellings of the same attribute.
+      `set(attributes["service.namespace"], attributes["service_namespace"]) where (attributes["service.namespace"] == nil or attributes["service.namespace"] == "") and attributes["service_namespace"] != nil and attributes["service_namespace"] != ""`,
+      `delete_key(attributes, "service_namespace") where attributes["service_namespace"] == attributes["service.namespace"]`,
+      `set(attributes["deployment.environment"], attributes["deployment_environment"]) where (attributes["deployment.environment"] == nil or attributes["deployment.environment"] == "") and attributes["deployment_environment"] != nil and attributes["deployment_environment"] != ""`,
+      `delete_key(attributes, "deployment_environment") where attributes["deployment_environment"] == attributes["deployment.environment"]`,
+      `set(attributes["deployment.environment.name"], attributes["deployment_environment_name"]) where (attributes["deployment.environment.name"] == nil or attributes["deployment.environment.name"] == "") and attributes["deployment_environment_name"] != nil and attributes["deployment_environment_name"] != ""`,
+      `delete_key(attributes, "deployment_environment_name") where attributes["deployment_environment_name"] == attributes["deployment.environment.name"]`,
+    ]
+  }
+  metric_statements {
+    context = "datapoint"
+    statements = [
+      // Same correction for scrape targets that put service_name on every series
+      // instead of exposing a target_info metric.
+      `set(resource.attributes["service.name"], attributes["service_name"]) where attributes["service_name"] != nil and attributes["service_name"] != ""`,
+    ]
+  }
+  output {
+    metrics = [otelcol.processor.attributes.stack_a.input]
+  }
+} // otelcol.processor.transform "stack_a_scrape_normalize"
+otelcol.receiver.loki "stack_a" {
+  output {
+    logs = [otelcol.processor.attributes.stack_a.input]
+  }
+} // otelcol.receiver.loki "stack_a"
+otelcol.processor.attributes "stack_a" {
+  output {
+    metrics = [otelcol.processor.transform.stack_a.input]
+    logs = [otelcol.processor.transform.stack_a.input]
+    traces = [otelcol.processor.transform.stack_a.input]
+  }
+} // otelcol.processor.attributes "stack_a"
+
+otelcol.processor.transform "stack_a" {
+  error_mode = "ignore"
+  metric_statements {
+    context = "resource"
+    statements = [
+      `set(attributes["cluster"], "destination-router")`,
+      `set(attributes["k8s.cluster.name"], "destination-router")`,
+      `delete_key(attributes, "process.pid")`,
+      `delete_key(attributes, "process.parent_pid")`,
+      `delete_key(attributes, "process.executable.path")`,
+      `delete_key(attributes, "process.command_line")`,
+      `delete_key(attributes, "process.command_args")`,
+      `delete_key(attributes, "process.owner")`,
+      `delete_key(attributes, "process.runtime.version")`,
+      `delete_key(attributes, "process.runtime.description")`,
+      `delete_key(attributes, "host.ip")`,
+      `delete_key(attributes, "host.mac")`,
+      `delete_key(attributes, "k8s.pod.start_time")`,
+      `delete_key(attributes, "k8s.pod.uid")`,
+      `delete_key(attributes, "container.image.id")`,
+      `delete_key(attributes, "container.image.repo_digests")`,
+      `delete_key(attributes, "os.description")`,
+      `delete_key(attributes, "os.build_id")`,
+      // Scrape targets that expose their own target_info metric (e.g. Grafana Beyla) can
+      // carry a flat k8s_cluster_name resource attribute, which conflicts with the
+      // k8s.cluster.name attribute set above and gets ";"-joined by the Prometheus OTLP
+      // endpoint. Drop the flat copy when the values match.
+      `delete_key(attributes, "k8s_cluster_name") where attributes["k8s_cluster_name"] == attributes["k8s.cluster.name"]`,
+    ]
+  }
+
+  metric_statements {
+    context = "datapoint"
+    statements = [
+      `set(attributes["cluster"], "destination-router")`,
+      `set(attributes["k8s.cluster.name"], "destination-router")`,
+      `set(resource.attributes["deployment.environment"], attributes["deployment_environment"] ) where resource.attributes["deployment.environment"] == nil and attributes["deployment_environment"] != nil`,
+      `delete_key(attributes, "deployment_environment") where attributes["deployment_environment"] == resource.attributes["deployment.environment"]`,
+      `set(resource.attributes["deployment.environment.name"], attributes["deployment_environment_name"] ) where resource.attributes["deployment.environment.name"] == nil and attributes["deployment_environment_name"] != nil`,
+      `delete_key(attributes, "deployment_environment_name") where attributes["deployment_environment_name"] == resource.attributes["deployment.environment.name"]`,
+      `set(resource.attributes["service.name"], attributes["service_name"] ) where (resource.attributes["service.name"] == nil or resource.attributes["service.name"] == "") and attributes["service_name"] != nil and attributes["service_name"] != ""`,
+      `delete_key(attributes, "service_name") where attributes["service_name"] == resource.attributes["service.name"]`,
+      `set(resource.attributes["service.namespace"], attributes["service_namespace"] ) where (resource.attributes["service.namespace"] == nil or resource.attributes["service.namespace"] == "") and attributes["service_namespace"] != nil and attributes["service_namespace"] != ""`,
+      `delete_key(attributes, "service_namespace") where attributes["service_namespace"] == resource.attributes["service.namespace"]`,
+    ]
+  }
+  log_statements {
+    context = "resource"
+    statements = [
+      `set(attributes["cluster"], "destination-router")`,
+      `set(attributes["k8s.cluster.name"], "destination-router")`,
+      `delete_key(attributes, "process.pid")`,
+      `delete_key(attributes, "process.parent_pid")`,
+      `delete_key(attributes, "process.executable.path")`,
+      `delete_key(attributes, "process.command_line")`,
+      `delete_key(attributes, "process.command_args")`,
+      `delete_key(attributes, "process.owner")`,
+      `delete_key(attributes, "process.runtime.version")`,
+      `delete_key(attributes, "process.runtime.description")`,
+      `delete_key(attributes, "host.ip")`,
+      `delete_key(attributes, "host.mac")`,
+      `delete_key(attributes, "k8s.pod.start_time")`,
+      `delete_key(attributes, "k8s.pod.uid")`,
+      `delete_key(attributes, "container.image.id")`,
+      `delete_key(attributes, "container.image.repo_digests")`,
+      `delete_key(attributes, "os.description")`,
+      `delete_key(attributes, "os.build_id")`,
+    ]
+  }
+
+  log_statements {
+    context = "log"
+    statements = [
+      `delete_key(attributes, "loki.attribute.labels")`,
+      `delete_key(attributes, "loki.resource.labels")`,
+      `set(resource.attributes["k8s.container.name"], attributes["container"] ) where resource.attributes["k8s.container.name"] == nil and attributes["container"] != nil`,
+      `delete_key(attributes, "container") where attributes["container"] == resource.attributes["k8s.container.name"]`,
+      `set(resource.attributes["k8s.cronjob.name"], attributes["cronjob"] ) where resource.attributes["k8s.cronjob.name"] == nil and attributes["cronjob"] != nil`,
+      `delete_key(attributes, "cronjob") where attributes["cronjob"] == resource.attributes["k8s.cronjob.name"]`,
+      `set(resource.attributes["k8s.daemonset.name"], attributes["daemonset"] ) where resource.attributes["k8s.daemonset.name"] == nil and attributes["daemonset"] != nil`,
+      `delete_key(attributes, "daemonset") where attributes["daemonset"] == resource.attributes["k8s.daemonset.name"]`,
+      `set(resource.attributes["k8s.deployment.name"], attributes["deployment"] ) where resource.attributes["k8s.deployment.name"] == nil and attributes["deployment"] != nil`,
+      `delete_key(attributes, "deployment") where attributes["deployment"] == resource.attributes["k8s.deployment.name"]`,
+      `set(resource.attributes["deployment.environment"], attributes["deployment_environment"] ) where resource.attributes["deployment.environment"] == nil and attributes["deployment_environment"] != nil`,
+      `delete_key(attributes, "deployment_environment") where attributes["deployment_environment"] == resource.attributes["deployment.environment"]`,
+      `set(resource.attributes["deployment.environment.name"], attributes["deployment_environment_name"] ) where resource.attributes["deployment.environment.name"] == nil and attributes["deployment_environment_name"] != nil`,
+      `delete_key(attributes, "deployment_environment_name") where attributes["deployment_environment_name"] == resource.attributes["deployment.environment.name"]`,
+      `set(resource.attributes["k8s.job.name"], attributes["job_name"] ) where resource.attributes["k8s.job.name"] == nil and attributes["job_name"] != nil`,
+      `delete_key(attributes, "job_name") where attributes["job_name"] == resource.attributes["k8s.job.name"]`,
+      `set(resource.attributes["k8s.namespace.name"], attributes["namespace"] ) where resource.attributes["k8s.namespace.name"] == nil and attributes["namespace"] != nil`,
+      `delete_key(attributes, "namespace") where attributes["namespace"] == resource.attributes["k8s.namespace.name"]`,
+      `set(resource.attributes["k8s.pod.name"], attributes["pod"] ) where resource.attributes["k8s.pod.name"] == nil and attributes["pod"] != nil`,
+      `delete_key(attributes, "pod") where attributes["pod"] == resource.attributes["k8s.pod.name"]`,
+      `set(resource.attributes["k8s.replicaset.name"], attributes["replicaset"] ) where resource.attributes["k8s.replicaset.name"] == nil and attributes["replicaset"] != nil`,
+      `delete_key(attributes, "replicaset") where attributes["replicaset"] == resource.attributes["k8s.replicaset.name"]`,
+      `set(resource.attributes["service.name"], attributes["service_name"] ) where (resource.attributes["service.name"] == nil or resource.attributes["service.name"] == "") and attributes["service_name"] != nil and attributes["service_name"] != ""`,
+      `delete_key(attributes, "service_name") where attributes["service_name"] == resource.attributes["service.name"]`,
+      `set(resource.attributes["service.namespace"], attributes["service_namespace"] ) where (resource.attributes["service.namespace"] == nil or resource.attributes["service.namespace"] == "") and attributes["service_namespace"] != nil and attributes["service_namespace"] != ""`,
+      `delete_key(attributes, "service_namespace") where attributes["service_namespace"] == resource.attributes["service.namespace"]`,
+      `set(resource.attributes["k8s.statefulset.name"], attributes["statefulset"] ) where resource.attributes["k8s.statefulset.name"] == nil and attributes["statefulset"] != nil`,
+      `delete_key(attributes, "statefulset") where attributes["statefulset"] == resource.attributes["k8s.statefulset.name"]`,
+    ]
+  }
+
+  trace_statements {
+    context = "resource"
+    statements = [
+      `set(attributes["cluster"], "destination-router")`,
+      `set(attributes["k8s.cluster.name"], "destination-router")`,
+      `delete_key(attributes, "process.pid")`,
+      `delete_key(attributes, "process.parent_pid")`,
+      `delete_key(attributes, "process.executable.path")`,
+      `delete_key(attributes, "process.command_line")`,
+      `delete_key(attributes, "process.command_args")`,
+      `delete_key(attributes, "process.owner")`,
+      `delete_key(attributes, "process.runtime.version")`,
+      `delete_key(attributes, "process.runtime.description")`,
+      `delete_key(attributes, "host.ip")`,
+      `delete_key(attributes, "host.mac")`,
+      `delete_key(attributes, "k8s.pod.start_time")`,
+      `delete_key(attributes, "k8s.pod.uid")`,
+      `delete_key(attributes, "container.image.id")`,
+      `delete_key(attributes, "container.image.repo_digests")`,
+      `delete_key(attributes, "os.description")`,
+      `delete_key(attributes, "os.build_id")`,
+    ]
+  }
+
+  output {
+    metrics = [otelcol.processor.batch.stack_a.input]
+    logs = [otelcol.processor.batch.stack_a.input]
+    traces = [otelcol.processor.batch.stack_a.input]
+  }
+} // otelcol.processor.transform "stack_a"
+
+otelcol.processor.batch "stack_a" {
+  timeout = "2s"
+  send_batch_size = 8192
+  send_batch_max_size = 0
+
+  output {
+    metrics = [otelcol.exporter.otlphttp.stack_a.input]
+    logs = [otelcol.exporter.otlphttp.stack_a.input]
+    traces = [otelcol.exporter.otlphttp.stack_a.input]
+  }
+} // otelcol.processor.batch "stack_a"
+otelcol.exporter.otlphttp "stack_a" {
+  client {
+    endpoint = "http://tempo-stack-a.tempo.svc:443/otlp"
+    tls {
+      insecure = false
+      insecure_skip_verify = false
+    }
+  }
+
+  retry_on_failure {
+    enabled = true
+    initial_interval = "5s"
+    max_interval = "30s"
+    max_elapsed_time = "5m"
+  }
+
+  sending_queue {
+    enabled = true
+  }
+} // otelcol.exporter.otlphttp "stack_a"
+
+// Destination: tenantRouter (router)
+// ROUTER: prometheus-ecosystem metrics arrive here, get labeled with "selected_destinations"
+// based on k8s.namespace.name (label "namespace"), and fan out to one gate per downstream destination.
+prometheus.relabel "tenantrouter_metrics_prometheus" {
+
+  rule {
+    target_label = "selected_destinations"
+    replacement  = "platform"
+  }
+  rule {
+    source_labels = ["namespace"]
+    regex         = "^tenant-a$"
+    target_label  = "selected_destinations"
+    replacement   = "stack-a"
+  }
+  forward_to = [prometheus.relabel.tenantrouter_platform_gate_metrics_prometheus.receiver, prometheus.relabel.tenantrouter_stack_a_gate_metrics_prometheus.receiver, ]
+} // prometheus.relabel "tenantrouter_metrics_prometheus"
+
+prometheus.relabel "tenantrouter_platform_gate_metrics_prometheus" {
+  forward_to = [otelcol.receiver.prometheus.platform.receiver]
+  rule {
+    source_labels = ["selected_destinations"]
+    regex         = "(^|.*,)platform(,.*|$)"
+    action        = "keep"
+  }
+  rule {
+    action = "labeldrop"
+    regex  = "selected_destinations"
+  }
+}
+
+prometheus.relabel "tenantrouter_stack_a_gate_metrics_prometheus" {
+  forward_to = [otelcol.receiver.prometheus.stack_a.receiver]
+  rule {
+    source_labels = ["selected_destinations"]
+    regex         = "(^|.*,)stack-a(,.*|$)"
+    action        = "keep"
+  }
+  rule {
+    action = "labeldrop"
+    regex  = "selected_destinations"
+  }
+}
+// ROUTER: OTLP-ecosystem metrics arrive here, get an OTTL-set "selected_destinations" resource
+// attribute based on k8s.namespace.name, and fan out to one gate per downstream destination.
+otelcol.processor.transform "tenantrouter_metrics_otlp" {
+  error_mode = "ignore"
+  metric_statements {
+    context = "resource"
+    statements = [
+
+      "set(attributes[\"selected_destinations\"], \"platform\")",
+      "set(attributes[\"selected_destinations\"], \"stack-a\") where attributes[\"k8s.namespace.name\"] == \"tenant-a\"",
+    ]
+  }
+  output {
+    metrics = [otelcol.processor.filter.tenantrouter_platform_gate_metrics_otlp.input, otelcol.processor.filter.tenantrouter_stack_a_gate_metrics_otlp.input, ]
+  }
+} // otelcol.processor.transform "tenantrouter_metrics_otlp"
+
+otelcol.processor.filter "tenantrouter_platform_gate_metrics_otlp" {
+  error_mode = "ignore"
+  metrics {
+    metric = [
+      "not IsMatch(resource.attributes[\"selected_destinations\"], \"(^|.*,)platform(,.*|$)\")",
+    ]
+  }
+  output {
+    metrics = [otelcol.processor.transform.tenantrouter_platform_gate_metrics_otlp_strip.input]
+  }
+}
+otelcol.processor.transform "tenantrouter_platform_gate_metrics_otlp_strip" {
+  error_mode = "ignore"
+  metric_statements {
+    context = "resource"
+    statements = [
+      "delete_key(attributes, \"selected_destinations\")",
+    ]
+  }
+  output {
+    metrics = [otelcol.processor.attributes.platform.input]
+  }
+}
+
+otelcol.processor.filter "tenantrouter_stack_a_gate_metrics_otlp" {
+  error_mode = "ignore"
+  metrics {
+    metric = [
+      "not IsMatch(resource.attributes[\"selected_destinations\"], \"(^|.*,)stack-a(,.*|$)\")",
+    ]
+  }
+  output {
+    metrics = [otelcol.processor.transform.tenantrouter_stack_a_gate_metrics_otlp_strip.input]
+  }
+}
+otelcol.processor.transform "tenantrouter_stack_a_gate_metrics_otlp_strip" {
+  error_mode = "ignore"
+  metric_statements {
+    context = "resource"
+    statements = [
+      "delete_key(attributes, \"selected_destinations\")",
+    ]
+  }
+  output {
+    metrics = [otelcol.processor.attributes.stack_a.input]
+  }
+}
+// ROUTER: Loki-ecosystem logs arrive here, get labeled with "selected_destinations"
+// based on k8s.namespace.name (label "namespace"), and fan out to one gate per downstream destination.
+loki.relabel "tenantrouter_logs_loki" {
+
+  rule {
+    target_label = "selected_destinations"
+    replacement  = "platform"
+  }
+  rule {
+    source_labels = ["namespace"]
+    regex         = "^tenant-a$"
+    target_label  = "selected_destinations"
+    replacement   = "stack-a"
+  }
+  forward_to = [loki.relabel.tenantrouter_platform_gate_logs_loki.receiver, loki.relabel.tenantrouter_stack_a_gate_logs_loki.receiver, ]
+} // loki.relabel "tenantrouter_logs_loki"
+
+loki.relabel "tenantrouter_platform_gate_logs_loki" {
+  forward_to = [otelcol.receiver.loki.platform.receiver]
+  rule {
+    source_labels = ["selected_destinations"]
+    regex         = "(^|.*,)platform(,.*|$)"
+    action        = "keep"
+  }
+  rule {
+    action = "labeldrop"
+    regex  = "selected_destinations"
+  }
+  max_cache_size = 100
+}
+
+loki.relabel "tenantrouter_stack_a_gate_logs_loki" {
+  forward_to = [otelcol.receiver.loki.stack_a.receiver]
+  rule {
+    source_labels = ["selected_destinations"]
+    regex         = "(^|.*,)stack-a(,.*|$)"
+    action        = "keep"
+  }
+  rule {
+    action = "labeldrop"
+    regex  = "selected_destinations"
+  }
+  max_cache_size = 100
+}
+// ROUTER: OTLP-ecosystem logs arrive here, get an OTTL-set "selected_destinations" resource
+// attribute based on k8s.namespace.name, and fan out to one gate per downstream destination.
+otelcol.processor.transform "tenantrouter_logs_otlp" {
+  error_mode = "ignore"
+  log_statements {
+    context = "resource"
+    statements = [
+
+      "set(attributes[\"selected_destinations\"], \"platform\")",
+      "set(attributes[\"selected_destinations\"], \"stack-a\") where attributes[\"k8s.namespace.name\"] == \"tenant-a\"",
+    ]
+  }
+  output {
+    logs = [otelcol.processor.filter.tenantrouter_platform_gate_logs_otlp.input, otelcol.processor.filter.tenantrouter_stack_a_gate_logs_otlp.input, ]
+  }
+} // otelcol.processor.transform "tenantrouter_logs_otlp"
+
+otelcol.processor.filter "tenantrouter_platform_gate_logs_otlp" {
+  error_mode = "ignore"
+  logs {
+    log_record = [
+      "not IsMatch(resource.attributes[\"selected_destinations\"], \"(^|.*,)platform(,.*|$)\")",
+    ]
+  }
+  output {
+    logs = [otelcol.processor.transform.tenantrouter_platform_gate_logs_otlp_strip.input]
+  }
+}
+otelcol.processor.transform "tenantrouter_platform_gate_logs_otlp_strip" {
+  error_mode = "ignore"
+  log_statements {
+    context = "resource"
+    statements = [
+      "delete_key(attributes, \"selected_destinations\")",
+    ]
+  }
+  output {
+    logs = [otelcol.processor.attributes.platform.input]
+  }
+}
+
+otelcol.processor.filter "tenantrouter_stack_a_gate_logs_otlp" {
+  error_mode = "ignore"
+  logs {
+    log_record = [
+      "not IsMatch(resource.attributes[\"selected_destinations\"], \"(^|.*,)stack-a(,.*|$)\")",
+    ]
+  }
+  output {
+    logs = [otelcol.processor.transform.tenantrouter_stack_a_gate_logs_otlp_strip.input]
+  }
+}
+otelcol.processor.transform "tenantrouter_stack_a_gate_logs_otlp_strip" {
+  error_mode = "ignore"
+  log_statements {
+    context = "resource"
+    statements = [
+      "delete_key(attributes, \"selected_destinations\")",
+    ]
+  }
+  output {
+    logs = [otelcol.processor.attributes.stack_a.input]
+  }
+}
+// ROUTER: OTLP traces arrive here, get an OTTL-set "selected_destinations" resource attribute
+// based on k8s.namespace.name, and fan out to one gate per downstream destination.
+otelcol.processor.transform "tenantrouter_traces_otlp" {
+  error_mode = "ignore"
+  trace_statements {
+    context = "resource"
+    statements = [
+
+      "set(attributes[\"selected_destinations\"], \"platform\")",
+      "set(attributes[\"selected_destinations\"], \"stack-a\") where attributes[\"k8s.namespace.name\"] == \"tenant-a\"",
+    ]
+  }
+  output {
+    traces = [otelcol.processor.filter.tenantrouter_platform_gate_traces_otlp.input, otelcol.processor.filter.tenantrouter_stack_a_gate_traces_otlp.input, ]
+  }
+} // otelcol.processor.transform "tenantrouter_traces_otlp"
+
+otelcol.processor.filter "tenantrouter_platform_gate_traces_otlp" {
+  error_mode = "ignore"
+  traces {
+    span = [
+      "not IsMatch(resource.attributes[\"selected_destinations\"], \"(^|.*,)platform(,.*|$)\")",
+    ]
+  }
+  output {
+    traces = [otelcol.processor.transform.tenantrouter_platform_gate_traces_otlp_strip.input]
+  }
+}
+otelcol.processor.transform "tenantrouter_platform_gate_traces_otlp_strip" {
+  error_mode = "ignore"
+  trace_statements {
+    context = "resource"
+    statements = [
+      "delete_key(attributes, \"selected_destinations\")",
+    ]
+  }
+  output {
+    traces = [otelcol.processor.attributes.platform.input]
+  }
+}
+
+otelcol.processor.filter "tenantrouter_stack_a_gate_traces_otlp" {
+  error_mode = "ignore"
+  traces {
+    span = [
+      "not IsMatch(resource.attributes[\"selected_destinations\"], \"(^|.*,)stack-a(,.*|$)\")",
+    ]
+  }
+  output {
+    traces = [otelcol.processor.transform.tenantrouter_stack_a_gate_traces_otlp_strip.input]
+  }
+}
+otelcol.processor.transform "tenantrouter_stack_a_gate_traces_otlp_strip" {
+  error_mode = "ignore"
+  trace_statements {
+    context = "resource"
+    statements = [
+      "delete_key(attributes, \"selected_destinations\")",
+    ]
+  }
+  output {
+    traces = [otelcol.processor.attributes.stack_a.input]
+  }
+}
+// ROUTER: Pyroscope-ecosystem profiles arrive here, get labeled with "selected_destinations"
+// based on k8s.namespace.name (label "namespace"), and fan out to one gate per downstream destination.
+pyroscope.relabel "tenantrouter_profiles_pyroscope" {
+
+  rule {
+    target_label = "selected_destinations"
+    replacement  = "platform"
+  }
+  forward_to = []
+} // pyroscope.relabel "tenantrouter_profiles_pyroscope"
+

--- a/charts/k8s-monitoring/docs/examples/destination-router/description.txt
+++ b/charts/k8s-monitoring/docs/examples/destination-router/description.txt
@@ -1,0 +1,40 @@
+# Destination Router
+
+This example shows how to use the `router` destination to fan pod logs out to different real
+destinations based on the Kubernetes namespace they came from, without teaching the
+`podLogsViaOpenTelemetry` feature anything about tenant-specific plumbing.
+
+A router is not a real telemetry backend. It is a virtual destination that inspects an attribute
+(or the mapped label, for label-based collection pipelines) on each record and forwards it to one
+or more real downstream destinations. In this example, the router is named `tenantRouter` and
+routes on the default attribute, `k8s.namespace.name`:
+
+```yaml
+destinations:
+  tenantRouter:
+    type: router
+    routes:
+      - match:
+          equals: tenant-a
+        destinations:
+          - stack-a
+    defaultDestinations:
+      - platform
+```
+
+Pod logs collected from the `tenant-a` namespace are sent to the `stack-a` destination. Pod logs
+from every other namespace fall back to `defaultDestinations` and are sent to `platform`.
+
+Because routers are excluded from implicit destination selection, the feature that should use one
+must name it explicitly:
+
+```yaml
+podLogsViaOpenTelemetry:
+  enabled: true
+  destinations:
+    - tenantRouter
+```
+
+For a complete reference of the router configuration options, routing semantics, and how routing
+behaves across the different collection pipelines (scraped metrics, Loki logs, Pyroscope profiles,
+and OpenTelemetry Protocol), refer to [Destination routing](../../DestinationRouting.md).

--- a/charts/k8s-monitoring/docs/examples/destination-router/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/destination-router/output.yaml
@@ -1,0 +1,1412 @@
+---
+# Source: k8s-monitoring/charts/alloy-operator/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: k8smon-alloy-operator
+  namespace: default
+  labels:
+    helm.sh/chart: alloy-operator-0.6.2
+    app.kubernetes.io/name: alloy-operator
+    app.kubernetes.io/instance: k8smon
+    app.kubernetes.io/version: "1.11.0"
+    app.kubernetes.io/managed-by: Helm
+automountServiceAccountToken: true
+---
+# Source: k8s-monitoring/templates/alloy-config.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: k8smon-alloy-logs
+  namespace: default
+data:
+  config.alloy: |
+    // Feature: Pod Logs (OpenTelemetry)
+    declare "pod_logs_via_opentelemetry" {
+      argument "logs_destinations" {
+        comment = "Must be a list of log destinations where collected logs should be forwarded to"
+      }
+    
+      otelcol.receiver.filelog "pod_logs" {
+        include = ["/var/log/pods/*/*/*.log"]
+        start_at = "end"
+        include_file_name = false
+        include_file_path = true
+    
+        operators = [
+          // Container operator will set k8s.pod.name, k8s.pod.uid, k8s.container.name, k8s.container.restart_count, and k8s.namespace.name
+          {
+            type                       = "container",
+            add_metadata_from_filepath = true,
+          },
+        ]
+    
+        output {
+          logs = [otelcol.processor.k8sattributes.pod_logs.input]
+        }
+      } // otelcol.receiver.filelog "pod_logs"
+    
+      otelcol.processor.k8sattributes "pod_logs" {
+        pod_association {
+          source {
+            from = "resource_attribute"
+            name = "k8s.pod.uid"
+          }
+        }
+    
+        extract {
+          otel_annotations = false
+          metadata = [
+            "k8s.deployment.name",
+            "k8s.statefulset.name",
+            "k8s.daemonset.name",
+            "k8s.cronjob.name",
+            "k8s.job.name",
+            "k8s.node.name",
+          ]
+          annotation {
+            key_regex = "resource.opentelemetry.io/(.*)"
+            tag_name  = "$1"
+            from      = "pod"
+          }
+          annotation {
+            tag_name = "logs.grafana.com/pods.enabled"
+            key      = "logs.grafana.com/pods.enabled"
+            from     = "pod"
+          }
+          label {
+            tag_name = "app_kubernetes_io_name"
+            key      = "app.kubernetes.io/name"
+            from     = "pod"
+          }
+        }
+    
+        output {
+          logs = [otelcol.processor.filter.pod_logs.input]
+        }
+      } // otelcol.processor.k8sattributes "pod_logs"
+    
+      otelcol.processor.filter "pod_logs" {
+        error_mode = "ignore"
+        logs {
+          log_record = [
+            `resource.attributes["logs.grafana.com/pods.enabled"] == "false"`,
+            `resource.attributes["logs.grafana.com/pods.enabled"] == "no"`,
+            `resource.attributes["logs.grafana.com/pods.enabled"] == "skip"`,
+          ]
+        }
+        output {
+          logs = [otelcol.processor.transform.pod_logs.input]
+        }
+      } // otelcol.processor.filter "pod_logs"
+    
+      otelcol.processor.transform "pod_logs" {
+        error_mode = "ignore"
+        log_statements {
+          context = "resource"
+          statements = [
+            `delete_key(attributes, "k8s.container.restart_count")`,
+            `delete_key(attributes, "logs.grafana.com/pods.enabled")`,
+            `set(attributes["service.name"], attributes["app.kubernetes.io/name"]) where (attributes["service.name"] == nil or attributes["service.name"] == "") and attributes["app.kubernetes.io/name"] != nil and attributes["app.kubernetes.io/name"] != ""`,
+            `set(attributes["service.name"], attributes["k8s.deployment.name"]) where (attributes["service.name"] == nil or attributes["service.name"] == "") and attributes["k8s.deployment.name"] != nil and attributes["k8s.deployment.name"] != ""`,
+            `set(attributes["service.name"], attributes["k8s.replicaset.name"]) where (attributes["service.name"] == nil or attributes["service.name"] == "") and attributes["k8s.replicaset.name"] != nil and attributes["k8s.replicaset.name"] != ""`,
+            `set(attributes["service.name"], attributes["k8s.statefulset.name"]) where (attributes["service.name"] == nil or attributes["service.name"] == "") and attributes["k8s.statefulset.name"] != nil and attributes["k8s.statefulset.name"] != ""`,
+            `set(attributes["service.name"], attributes["k8s.daemonset.name"]) where (attributes["service.name"] == nil or attributes["service.name"] == "") and attributes["k8s.daemonset.name"] != nil and attributes["k8s.daemonset.name"] != ""`,
+            `set(attributes["service.name"], attributes["k8s.cronjob.name"]) where (attributes["service.name"] == nil or attributes["service.name"] == "") and attributes["k8s.cronjob.name"] != nil and attributes["k8s.cronjob.name"] != ""`,
+            `set(attributes["service.name"], attributes["k8s.job.name"]) where (attributes["service.name"] == nil or attributes["service.name"] == "") and attributes["k8s.job.name"] != nil and attributes["k8s.job.name"] != ""`,
+            `set(attributes["service.name"], attributes["k8s.pod.name"]) where (attributes["service.name"] == nil or attributes["service.name"] == "") and attributes["k8s.pod.name"] != nil and attributes["k8s.pod.name"] != ""`,
+            `set(attributes["service.name"], attributes["k8s.container.name"]) where (attributes["service.name"] == nil or attributes["service.name"] == "") and attributes["k8s.container.name"] != nil and attributes["k8s.container.name"] != ""`,
+    
+            `set(attributes["service.namespace"], attributes["k8s.namespace.name"]) where (attributes["service.namespace"] == nil or attributes["service.namespace"] == "") and attributes["k8s.namespace.name"] != nil and attributes["k8s.namespace.name"] != ""`,
+    
+            `set(attributes["service.version"], attributes["app.kubernetes.io/version"]) where attributes["service.version"] == nil`,
+    
+            `set(attributes["service.instance.id"], Concat([attributes["k8s.namespace.name"], attributes["k8s.pod.name"], attributes["k8s.container.name"]], ".")) where attributes["service.instance.id"] == nil`,
+          ]
+        }
+    
+        log_statements {
+          context = "log"
+          statements = [
+            `delete_key(attributes, "log.file.path")`,
+          ]
+        }
+    
+        output {
+          logs = argument.logs_destinations.value
+        }
+      } // otelcol.processor.transform "pod_logs"
+    } // declare "pod_logs_via_opentelemetry"
+    pod_logs_via_opentelemetry "feature" {
+      logs_destinations = [
+        otelcol.processor.transform.tenantrouter_logs_otlp.input,
+      ]
+    }
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    // Destination: platform (otlp)
+    otelcol.receiver.prometheus "platform" {
+      output {
+        metrics = [otelcol.processor.transform.platform_scrape_normalize.input]
+      }
+    } // otelcol.receiver.prometheus "platform"
+    
+    // Repairs artifacts of the Prometheus-to-OTLP conversion performed by
+    // otelcol.receiver.prometheus. Only metrics that came from a Prometheus scrape pass
+    // through this component; OTLP-native telemetry enters the pipeline further down.
+    otelcol.processor.transform "platform_scrape_normalize" {
+      error_mode = "ignore"
+      metric_statements {
+        context = "resource"
+        statements = [
+          // The conversion sets service.name to the full Prometheus job label (e.g.
+          // "namespace/workload"). When the scrape target declares its identity explicitly
+          // with a service_name label on its own target_info metric (e.g. Grafana Beyla),
+          // prefer that value and drop the duplicate.
+          `set(attributes["service.name"], attributes["service_name"]) where attributes["service_name"] != nil and attributes["service_name"] != ""`,
+          `delete_key(attributes, "service_name") where attributes["service_name"] == attributes["service.name"]`,
+          // The same conversion turns other flat target_info labels into resource attributes.
+          // Promote them to their OpenTelemetry counterparts and drop the flat duplicates, so
+          // the OTLP endpoint does not receive two conflicting spellings of the same attribute.
+          `set(attributes["service.namespace"], attributes["service_namespace"]) where (attributes["service.namespace"] == nil or attributes["service.namespace"] == "") and attributes["service_namespace"] != nil and attributes["service_namespace"] != ""`,
+          `delete_key(attributes, "service_namespace") where attributes["service_namespace"] == attributes["service.namespace"]`,
+          `set(attributes["deployment.environment"], attributes["deployment_environment"]) where (attributes["deployment.environment"] == nil or attributes["deployment.environment"] == "") and attributes["deployment_environment"] != nil and attributes["deployment_environment"] != ""`,
+          `delete_key(attributes, "deployment_environment") where attributes["deployment_environment"] == attributes["deployment.environment"]`,
+          `set(attributes["deployment.environment.name"], attributes["deployment_environment_name"]) where (attributes["deployment.environment.name"] == nil or attributes["deployment.environment.name"] == "") and attributes["deployment_environment_name"] != nil and attributes["deployment_environment_name"] != ""`,
+          `delete_key(attributes, "deployment_environment_name") where attributes["deployment_environment_name"] == attributes["deployment.environment.name"]`,
+        ]
+      }
+      metric_statements {
+        context = "datapoint"
+        statements = [
+          // Same correction for scrape targets that put service_name on every series
+          // instead of exposing a target_info metric.
+          `set(resource.attributes["service.name"], attributes["service_name"]) where attributes["service_name"] != nil and attributes["service_name"] != ""`,
+        ]
+      }
+      output {
+        metrics = [otelcol.processor.attributes.platform.input]
+      }
+    } // otelcol.processor.transform "platform_scrape_normalize"
+    otelcol.receiver.loki "platform" {
+      output {
+        logs = [otelcol.processor.attributes.platform.input]
+      }
+    } // otelcol.receiver.loki "platform"
+    otelcol.processor.attributes "platform" {
+      output {
+        metrics = [otelcol.processor.transform.platform.input]
+        logs = [otelcol.processor.transform.platform.input]
+        traces = [otelcol.processor.transform.platform.input]
+      }
+    } // otelcol.processor.attributes "platform"
+    
+    otelcol.processor.transform "platform" {
+      error_mode = "ignore"
+      metric_statements {
+        context = "resource"
+        statements = [
+          `set(attributes["cluster"], "destination-router")`,
+          `set(attributes["k8s.cluster.name"], "destination-router")`,
+          `delete_key(attributes, "process.pid")`,
+          `delete_key(attributes, "process.parent_pid")`,
+          `delete_key(attributes, "process.executable.path")`,
+          `delete_key(attributes, "process.command_line")`,
+          `delete_key(attributes, "process.command_args")`,
+          `delete_key(attributes, "process.owner")`,
+          `delete_key(attributes, "process.runtime.version")`,
+          `delete_key(attributes, "process.runtime.description")`,
+          `delete_key(attributes, "host.ip")`,
+          `delete_key(attributes, "host.mac")`,
+          `delete_key(attributes, "k8s.pod.start_time")`,
+          `delete_key(attributes, "k8s.pod.uid")`,
+          `delete_key(attributes, "container.image.id")`,
+          `delete_key(attributes, "container.image.repo_digests")`,
+          `delete_key(attributes, "os.description")`,
+          `delete_key(attributes, "os.build_id")`,
+          // Scrape targets that expose their own target_info metric (e.g. Grafana Beyla) can
+          // carry a flat k8s_cluster_name resource attribute, which conflicts with the
+          // k8s.cluster.name attribute set above and gets ";"-joined by the Prometheus OTLP
+          // endpoint. Drop the flat copy when the values match.
+          `delete_key(attributes, "k8s_cluster_name") where attributes["k8s_cluster_name"] == attributes["k8s.cluster.name"]`,
+        ]
+      }
+    
+      metric_statements {
+        context = "datapoint"
+        statements = [
+          `set(attributes["cluster"], "destination-router")`,
+          `set(attributes["k8s.cluster.name"], "destination-router")`,
+          `set(resource.attributes["deployment.environment"], attributes["deployment_environment"] ) where resource.attributes["deployment.environment"] == nil and attributes["deployment_environment"] != nil`,
+          `delete_key(attributes, "deployment_environment") where attributes["deployment_environment"] == resource.attributes["deployment.environment"]`,
+          `set(resource.attributes["deployment.environment.name"], attributes["deployment_environment_name"] ) where resource.attributes["deployment.environment.name"] == nil and attributes["deployment_environment_name"] != nil`,
+          `delete_key(attributes, "deployment_environment_name") where attributes["deployment_environment_name"] == resource.attributes["deployment.environment.name"]`,
+          `set(resource.attributes["service.name"], attributes["service_name"] ) where (resource.attributes["service.name"] == nil or resource.attributes["service.name"] == "") and attributes["service_name"] != nil and attributes["service_name"] != ""`,
+          `delete_key(attributes, "service_name") where attributes["service_name"] == resource.attributes["service.name"]`,
+          `set(resource.attributes["service.namespace"], attributes["service_namespace"] ) where (resource.attributes["service.namespace"] == nil or resource.attributes["service.namespace"] == "") and attributes["service_namespace"] != nil and attributes["service_namespace"] != ""`,
+          `delete_key(attributes, "service_namespace") where attributes["service_namespace"] == resource.attributes["service.namespace"]`,
+        ]
+      }
+      log_statements {
+        context = "resource"
+        statements = [
+          `set(attributes["cluster"], "destination-router")`,
+          `set(attributes["k8s.cluster.name"], "destination-router")`,
+          `delete_key(attributes, "process.pid")`,
+          `delete_key(attributes, "process.parent_pid")`,
+          `delete_key(attributes, "process.executable.path")`,
+          `delete_key(attributes, "process.command_line")`,
+          `delete_key(attributes, "process.command_args")`,
+          `delete_key(attributes, "process.owner")`,
+          `delete_key(attributes, "process.runtime.version")`,
+          `delete_key(attributes, "process.runtime.description")`,
+          `delete_key(attributes, "host.ip")`,
+          `delete_key(attributes, "host.mac")`,
+          `delete_key(attributes, "k8s.pod.start_time")`,
+          `delete_key(attributes, "k8s.pod.uid")`,
+          `delete_key(attributes, "container.image.id")`,
+          `delete_key(attributes, "container.image.repo_digests")`,
+          `delete_key(attributes, "os.description")`,
+          `delete_key(attributes, "os.build_id")`,
+        ]
+      }
+    
+      log_statements {
+        context = "log"
+        statements = [
+          `delete_key(attributes, "loki.attribute.labels")`,
+          `delete_key(attributes, "loki.resource.labels")`,
+          `set(resource.attributes["k8s.container.name"], attributes["container"] ) where resource.attributes["k8s.container.name"] == nil and attributes["container"] != nil`,
+          `delete_key(attributes, "container") where attributes["container"] == resource.attributes["k8s.container.name"]`,
+          `set(resource.attributes["k8s.cronjob.name"], attributes["cronjob"] ) where resource.attributes["k8s.cronjob.name"] == nil and attributes["cronjob"] != nil`,
+          `delete_key(attributes, "cronjob") where attributes["cronjob"] == resource.attributes["k8s.cronjob.name"]`,
+          `set(resource.attributes["k8s.daemonset.name"], attributes["daemonset"] ) where resource.attributes["k8s.daemonset.name"] == nil and attributes["daemonset"] != nil`,
+          `delete_key(attributes, "daemonset") where attributes["daemonset"] == resource.attributes["k8s.daemonset.name"]`,
+          `set(resource.attributes["k8s.deployment.name"], attributes["deployment"] ) where resource.attributes["k8s.deployment.name"] == nil and attributes["deployment"] != nil`,
+          `delete_key(attributes, "deployment") where attributes["deployment"] == resource.attributes["k8s.deployment.name"]`,
+          `set(resource.attributes["deployment.environment"], attributes["deployment_environment"] ) where resource.attributes["deployment.environment"] == nil and attributes["deployment_environment"] != nil`,
+          `delete_key(attributes, "deployment_environment") where attributes["deployment_environment"] == resource.attributes["deployment.environment"]`,
+          `set(resource.attributes["deployment.environment.name"], attributes["deployment_environment_name"] ) where resource.attributes["deployment.environment.name"] == nil and attributes["deployment_environment_name"] != nil`,
+          `delete_key(attributes, "deployment_environment_name") where attributes["deployment_environment_name"] == resource.attributes["deployment.environment.name"]`,
+          `set(resource.attributes["k8s.job.name"], attributes["job_name"] ) where resource.attributes["k8s.job.name"] == nil and attributes["job_name"] != nil`,
+          `delete_key(attributes, "job_name") where attributes["job_name"] == resource.attributes["k8s.job.name"]`,
+          `set(resource.attributes["k8s.namespace.name"], attributes["namespace"] ) where resource.attributes["k8s.namespace.name"] == nil and attributes["namespace"] != nil`,
+          `delete_key(attributes, "namespace") where attributes["namespace"] == resource.attributes["k8s.namespace.name"]`,
+          `set(resource.attributes["k8s.pod.name"], attributes["pod"] ) where resource.attributes["k8s.pod.name"] == nil and attributes["pod"] != nil`,
+          `delete_key(attributes, "pod") where attributes["pod"] == resource.attributes["k8s.pod.name"]`,
+          `set(resource.attributes["k8s.replicaset.name"], attributes["replicaset"] ) where resource.attributes["k8s.replicaset.name"] == nil and attributes["replicaset"] != nil`,
+          `delete_key(attributes, "replicaset") where attributes["replicaset"] == resource.attributes["k8s.replicaset.name"]`,
+          `set(resource.attributes["service.name"], attributes["service_name"] ) where (resource.attributes["service.name"] == nil or resource.attributes["service.name"] == "") and attributes["service_name"] != nil and attributes["service_name"] != ""`,
+          `delete_key(attributes, "service_name") where attributes["service_name"] == resource.attributes["service.name"]`,
+          `set(resource.attributes["service.namespace"], attributes["service_namespace"] ) where (resource.attributes["service.namespace"] == nil or resource.attributes["service.namespace"] == "") and attributes["service_namespace"] != nil and attributes["service_namespace"] != ""`,
+          `delete_key(attributes, "service_namespace") where attributes["service_namespace"] == resource.attributes["service.namespace"]`,
+          `set(resource.attributes["k8s.statefulset.name"], attributes["statefulset"] ) where resource.attributes["k8s.statefulset.name"] == nil and attributes["statefulset"] != nil`,
+          `delete_key(attributes, "statefulset") where attributes["statefulset"] == resource.attributes["k8s.statefulset.name"]`,
+        ]
+      }
+    
+      trace_statements {
+        context = "resource"
+        statements = [
+          `set(attributes["cluster"], "destination-router")`,
+          `set(attributes["k8s.cluster.name"], "destination-router")`,
+          `delete_key(attributes, "process.pid")`,
+          `delete_key(attributes, "process.parent_pid")`,
+          `delete_key(attributes, "process.executable.path")`,
+          `delete_key(attributes, "process.command_line")`,
+          `delete_key(attributes, "process.command_args")`,
+          `delete_key(attributes, "process.owner")`,
+          `delete_key(attributes, "process.runtime.version")`,
+          `delete_key(attributes, "process.runtime.description")`,
+          `delete_key(attributes, "host.ip")`,
+          `delete_key(attributes, "host.mac")`,
+          `delete_key(attributes, "k8s.pod.start_time")`,
+          `delete_key(attributes, "k8s.pod.uid")`,
+          `delete_key(attributes, "container.image.id")`,
+          `delete_key(attributes, "container.image.repo_digests")`,
+          `delete_key(attributes, "os.description")`,
+          `delete_key(attributes, "os.build_id")`,
+        ]
+      }
+    
+      output {
+        metrics = [otelcol.processor.batch.platform.input]
+        logs = [otelcol.processor.batch.platform.input]
+        traces = [otelcol.processor.batch.platform.input]
+      }
+    } // otelcol.processor.transform "platform"
+    
+    otelcol.processor.batch "platform" {
+      timeout = "2s"
+      send_batch_size = 8192
+      send_batch_max_size = 0
+    
+      output {
+        metrics = [otelcol.exporter.otlphttp.platform.input]
+        logs = [otelcol.exporter.otlphttp.platform.input]
+        traces = [otelcol.exporter.otlphttp.platform.input]
+      }
+    } // otelcol.processor.batch "platform"
+    otelcol.exporter.otlphttp "platform" {
+      client {
+        endpoint = "http://tempo-platform.tempo.svc:443/otlp"
+        tls {
+          insecure = false
+          insecure_skip_verify = false
+        }
+      }
+    
+      retry_on_failure {
+        enabled = true
+        initial_interval = "5s"
+        max_interval = "30s"
+        max_elapsed_time = "5m"
+      }
+    
+      sending_queue {
+        enabled = true
+      }
+    } // otelcol.exporter.otlphttp "platform"
+    
+    // Destination: stack-a (otlp)
+    otelcol.receiver.prometheus "stack_a" {
+      output {
+        metrics = [otelcol.processor.transform.stack_a_scrape_normalize.input]
+      }
+    } // otelcol.receiver.prometheus "stack_a"
+    
+    // Repairs artifacts of the Prometheus-to-OTLP conversion performed by
+    // otelcol.receiver.prometheus. Only metrics that came from a Prometheus scrape pass
+    // through this component; OTLP-native telemetry enters the pipeline further down.
+    otelcol.processor.transform "stack_a_scrape_normalize" {
+      error_mode = "ignore"
+      metric_statements {
+        context = "resource"
+        statements = [
+          // The conversion sets service.name to the full Prometheus job label (e.g.
+          // "namespace/workload"). When the scrape target declares its identity explicitly
+          // with a service_name label on its own target_info metric (e.g. Grafana Beyla),
+          // prefer that value and drop the duplicate.
+          `set(attributes["service.name"], attributes["service_name"]) where attributes["service_name"] != nil and attributes["service_name"] != ""`,
+          `delete_key(attributes, "service_name") where attributes["service_name"] == attributes["service.name"]`,
+          // The same conversion turns other flat target_info labels into resource attributes.
+          // Promote them to their OpenTelemetry counterparts and drop the flat duplicates, so
+          // the OTLP endpoint does not receive two conflicting spellings of the same attribute.
+          `set(attributes["service.namespace"], attributes["service_namespace"]) where (attributes["service.namespace"] == nil or attributes["service.namespace"] == "") and attributes["service_namespace"] != nil and attributes["service_namespace"] != ""`,
+          `delete_key(attributes, "service_namespace") where attributes["service_namespace"] == attributes["service.namespace"]`,
+          `set(attributes["deployment.environment"], attributes["deployment_environment"]) where (attributes["deployment.environment"] == nil or attributes["deployment.environment"] == "") and attributes["deployment_environment"] != nil and attributes["deployment_environment"] != ""`,
+          `delete_key(attributes, "deployment_environment") where attributes["deployment_environment"] == attributes["deployment.environment"]`,
+          `set(attributes["deployment.environment.name"], attributes["deployment_environment_name"]) where (attributes["deployment.environment.name"] == nil or attributes["deployment.environment.name"] == "") and attributes["deployment_environment_name"] != nil and attributes["deployment_environment_name"] != ""`,
+          `delete_key(attributes, "deployment_environment_name") where attributes["deployment_environment_name"] == attributes["deployment.environment.name"]`,
+        ]
+      }
+      metric_statements {
+        context = "datapoint"
+        statements = [
+          // Same correction for scrape targets that put service_name on every series
+          // instead of exposing a target_info metric.
+          `set(resource.attributes["service.name"], attributes["service_name"]) where attributes["service_name"] != nil and attributes["service_name"] != ""`,
+        ]
+      }
+      output {
+        metrics = [otelcol.processor.attributes.stack_a.input]
+      }
+    } // otelcol.processor.transform "stack_a_scrape_normalize"
+    otelcol.receiver.loki "stack_a" {
+      output {
+        logs = [otelcol.processor.attributes.stack_a.input]
+      }
+    } // otelcol.receiver.loki "stack_a"
+    otelcol.processor.attributes "stack_a" {
+      output {
+        metrics = [otelcol.processor.transform.stack_a.input]
+        logs = [otelcol.processor.transform.stack_a.input]
+        traces = [otelcol.processor.transform.stack_a.input]
+      }
+    } // otelcol.processor.attributes "stack_a"
+    
+    otelcol.processor.transform "stack_a" {
+      error_mode = "ignore"
+      metric_statements {
+        context = "resource"
+        statements = [
+          `set(attributes["cluster"], "destination-router")`,
+          `set(attributes["k8s.cluster.name"], "destination-router")`,
+          `delete_key(attributes, "process.pid")`,
+          `delete_key(attributes, "process.parent_pid")`,
+          `delete_key(attributes, "process.executable.path")`,
+          `delete_key(attributes, "process.command_line")`,
+          `delete_key(attributes, "process.command_args")`,
+          `delete_key(attributes, "process.owner")`,
+          `delete_key(attributes, "process.runtime.version")`,
+          `delete_key(attributes, "process.runtime.description")`,
+          `delete_key(attributes, "host.ip")`,
+          `delete_key(attributes, "host.mac")`,
+          `delete_key(attributes, "k8s.pod.start_time")`,
+          `delete_key(attributes, "k8s.pod.uid")`,
+          `delete_key(attributes, "container.image.id")`,
+          `delete_key(attributes, "container.image.repo_digests")`,
+          `delete_key(attributes, "os.description")`,
+          `delete_key(attributes, "os.build_id")`,
+          // Scrape targets that expose their own target_info metric (e.g. Grafana Beyla) can
+          // carry a flat k8s_cluster_name resource attribute, which conflicts with the
+          // k8s.cluster.name attribute set above and gets ";"-joined by the Prometheus OTLP
+          // endpoint. Drop the flat copy when the values match.
+          `delete_key(attributes, "k8s_cluster_name") where attributes["k8s_cluster_name"] == attributes["k8s.cluster.name"]`,
+        ]
+      }
+    
+      metric_statements {
+        context = "datapoint"
+        statements = [
+          `set(attributes["cluster"], "destination-router")`,
+          `set(attributes["k8s.cluster.name"], "destination-router")`,
+          `set(resource.attributes["deployment.environment"], attributes["deployment_environment"] ) where resource.attributes["deployment.environment"] == nil and attributes["deployment_environment"] != nil`,
+          `delete_key(attributes, "deployment_environment") where attributes["deployment_environment"] == resource.attributes["deployment.environment"]`,
+          `set(resource.attributes["deployment.environment.name"], attributes["deployment_environment_name"] ) where resource.attributes["deployment.environment.name"] == nil and attributes["deployment_environment_name"] != nil`,
+          `delete_key(attributes, "deployment_environment_name") where attributes["deployment_environment_name"] == resource.attributes["deployment.environment.name"]`,
+          `set(resource.attributes["service.name"], attributes["service_name"] ) where (resource.attributes["service.name"] == nil or resource.attributes["service.name"] == "") and attributes["service_name"] != nil and attributes["service_name"] != ""`,
+          `delete_key(attributes, "service_name") where attributes["service_name"] == resource.attributes["service.name"]`,
+          `set(resource.attributes["service.namespace"], attributes["service_namespace"] ) where (resource.attributes["service.namespace"] == nil or resource.attributes["service.namespace"] == "") and attributes["service_namespace"] != nil and attributes["service_namespace"] != ""`,
+          `delete_key(attributes, "service_namespace") where attributes["service_namespace"] == resource.attributes["service.namespace"]`,
+        ]
+      }
+      log_statements {
+        context = "resource"
+        statements = [
+          `set(attributes["cluster"], "destination-router")`,
+          `set(attributes["k8s.cluster.name"], "destination-router")`,
+          `delete_key(attributes, "process.pid")`,
+          `delete_key(attributes, "process.parent_pid")`,
+          `delete_key(attributes, "process.executable.path")`,
+          `delete_key(attributes, "process.command_line")`,
+          `delete_key(attributes, "process.command_args")`,
+          `delete_key(attributes, "process.owner")`,
+          `delete_key(attributes, "process.runtime.version")`,
+          `delete_key(attributes, "process.runtime.description")`,
+          `delete_key(attributes, "host.ip")`,
+          `delete_key(attributes, "host.mac")`,
+          `delete_key(attributes, "k8s.pod.start_time")`,
+          `delete_key(attributes, "k8s.pod.uid")`,
+          `delete_key(attributes, "container.image.id")`,
+          `delete_key(attributes, "container.image.repo_digests")`,
+          `delete_key(attributes, "os.description")`,
+          `delete_key(attributes, "os.build_id")`,
+        ]
+      }
+    
+      log_statements {
+        context = "log"
+        statements = [
+          `delete_key(attributes, "loki.attribute.labels")`,
+          `delete_key(attributes, "loki.resource.labels")`,
+          `set(resource.attributes["k8s.container.name"], attributes["container"] ) where resource.attributes["k8s.container.name"] == nil and attributes["container"] != nil`,
+          `delete_key(attributes, "container") where attributes["container"] == resource.attributes["k8s.container.name"]`,
+          `set(resource.attributes["k8s.cronjob.name"], attributes["cronjob"] ) where resource.attributes["k8s.cronjob.name"] == nil and attributes["cronjob"] != nil`,
+          `delete_key(attributes, "cronjob") where attributes["cronjob"] == resource.attributes["k8s.cronjob.name"]`,
+          `set(resource.attributes["k8s.daemonset.name"], attributes["daemonset"] ) where resource.attributes["k8s.daemonset.name"] == nil and attributes["daemonset"] != nil`,
+          `delete_key(attributes, "daemonset") where attributes["daemonset"] == resource.attributes["k8s.daemonset.name"]`,
+          `set(resource.attributes["k8s.deployment.name"], attributes["deployment"] ) where resource.attributes["k8s.deployment.name"] == nil and attributes["deployment"] != nil`,
+          `delete_key(attributes, "deployment") where attributes["deployment"] == resource.attributes["k8s.deployment.name"]`,
+          `set(resource.attributes["deployment.environment"], attributes["deployment_environment"] ) where resource.attributes["deployment.environment"] == nil and attributes["deployment_environment"] != nil`,
+          `delete_key(attributes, "deployment_environment") where attributes["deployment_environment"] == resource.attributes["deployment.environment"]`,
+          `set(resource.attributes["deployment.environment.name"], attributes["deployment_environment_name"] ) where resource.attributes["deployment.environment.name"] == nil and attributes["deployment_environment_name"] != nil`,
+          `delete_key(attributes, "deployment_environment_name") where attributes["deployment_environment_name"] == resource.attributes["deployment.environment.name"]`,
+          `set(resource.attributes["k8s.job.name"], attributes["job_name"] ) where resource.attributes["k8s.job.name"] == nil and attributes["job_name"] != nil`,
+          `delete_key(attributes, "job_name") where attributes["job_name"] == resource.attributes["k8s.job.name"]`,
+          `set(resource.attributes["k8s.namespace.name"], attributes["namespace"] ) where resource.attributes["k8s.namespace.name"] == nil and attributes["namespace"] != nil`,
+          `delete_key(attributes, "namespace") where attributes["namespace"] == resource.attributes["k8s.namespace.name"]`,
+          `set(resource.attributes["k8s.pod.name"], attributes["pod"] ) where resource.attributes["k8s.pod.name"] == nil and attributes["pod"] != nil`,
+          `delete_key(attributes, "pod") where attributes["pod"] == resource.attributes["k8s.pod.name"]`,
+          `set(resource.attributes["k8s.replicaset.name"], attributes["replicaset"] ) where resource.attributes["k8s.replicaset.name"] == nil and attributes["replicaset"] != nil`,
+          `delete_key(attributes, "replicaset") where attributes["replicaset"] == resource.attributes["k8s.replicaset.name"]`,
+          `set(resource.attributes["service.name"], attributes["service_name"] ) where (resource.attributes["service.name"] == nil or resource.attributes["service.name"] == "") and attributes["service_name"] != nil and attributes["service_name"] != ""`,
+          `delete_key(attributes, "service_name") where attributes["service_name"] == resource.attributes["service.name"]`,
+          `set(resource.attributes["service.namespace"], attributes["service_namespace"] ) where (resource.attributes["service.namespace"] == nil or resource.attributes["service.namespace"] == "") and attributes["service_namespace"] != nil and attributes["service_namespace"] != ""`,
+          `delete_key(attributes, "service_namespace") where attributes["service_namespace"] == resource.attributes["service.namespace"]`,
+          `set(resource.attributes["k8s.statefulset.name"], attributes["statefulset"] ) where resource.attributes["k8s.statefulset.name"] == nil and attributes["statefulset"] != nil`,
+          `delete_key(attributes, "statefulset") where attributes["statefulset"] == resource.attributes["k8s.statefulset.name"]`,
+        ]
+      }
+    
+      trace_statements {
+        context = "resource"
+        statements = [
+          `set(attributes["cluster"], "destination-router")`,
+          `set(attributes["k8s.cluster.name"], "destination-router")`,
+          `delete_key(attributes, "process.pid")`,
+          `delete_key(attributes, "process.parent_pid")`,
+          `delete_key(attributes, "process.executable.path")`,
+          `delete_key(attributes, "process.command_line")`,
+          `delete_key(attributes, "process.command_args")`,
+          `delete_key(attributes, "process.owner")`,
+          `delete_key(attributes, "process.runtime.version")`,
+          `delete_key(attributes, "process.runtime.description")`,
+          `delete_key(attributes, "host.ip")`,
+          `delete_key(attributes, "host.mac")`,
+          `delete_key(attributes, "k8s.pod.start_time")`,
+          `delete_key(attributes, "k8s.pod.uid")`,
+          `delete_key(attributes, "container.image.id")`,
+          `delete_key(attributes, "container.image.repo_digests")`,
+          `delete_key(attributes, "os.description")`,
+          `delete_key(attributes, "os.build_id")`,
+        ]
+      }
+    
+      output {
+        metrics = [otelcol.processor.batch.stack_a.input]
+        logs = [otelcol.processor.batch.stack_a.input]
+        traces = [otelcol.processor.batch.stack_a.input]
+      }
+    } // otelcol.processor.transform "stack_a"
+    
+    otelcol.processor.batch "stack_a" {
+      timeout = "2s"
+      send_batch_size = 8192
+      send_batch_max_size = 0
+    
+      output {
+        metrics = [otelcol.exporter.otlphttp.stack_a.input]
+        logs = [otelcol.exporter.otlphttp.stack_a.input]
+        traces = [otelcol.exporter.otlphttp.stack_a.input]
+      }
+    } // otelcol.processor.batch "stack_a"
+    otelcol.exporter.otlphttp "stack_a" {
+      client {
+        endpoint = "http://tempo-stack-a.tempo.svc:443/otlp"
+        tls {
+          insecure = false
+          insecure_skip_verify = false
+        }
+      }
+    
+      retry_on_failure {
+        enabled = true
+        initial_interval = "5s"
+        max_interval = "30s"
+        max_elapsed_time = "5m"
+      }
+    
+      sending_queue {
+        enabled = true
+      }
+    } // otelcol.exporter.otlphttp "stack_a"
+    
+    // Destination: tenantRouter (router)
+    // ROUTER: prometheus-ecosystem metrics arrive here, get labeled with "selected_destinations"
+    // based on k8s.namespace.name (label "namespace"), and fan out to one gate per downstream destination.
+    prometheus.relabel "tenantrouter_metrics_prometheus" {
+    
+      rule {
+        target_label = "selected_destinations"
+        replacement  = "platform"
+      }
+      rule {
+        source_labels = ["namespace"]
+        regex         = "^tenant-a$"
+        target_label  = "selected_destinations"
+        replacement   = "stack-a"
+      }
+      forward_to = [prometheus.relabel.tenantrouter_platform_gate_metrics_prometheus.receiver, prometheus.relabel.tenantrouter_stack_a_gate_metrics_prometheus.receiver, ]
+    } // prometheus.relabel "tenantrouter_metrics_prometheus"
+    
+    prometheus.relabel "tenantrouter_platform_gate_metrics_prometheus" {
+      forward_to = [otelcol.receiver.prometheus.platform.receiver]
+      rule {
+        source_labels = ["selected_destinations"]
+        regex         = "(^|.*,)platform(,.*|$)"
+        action        = "keep"
+      }
+      rule {
+        action = "labeldrop"
+        regex  = "selected_destinations"
+      }
+    }
+    
+    prometheus.relabel "tenantrouter_stack_a_gate_metrics_prometheus" {
+      forward_to = [otelcol.receiver.prometheus.stack_a.receiver]
+      rule {
+        source_labels = ["selected_destinations"]
+        regex         = "(^|.*,)stack-a(,.*|$)"
+        action        = "keep"
+      }
+      rule {
+        action = "labeldrop"
+        regex  = "selected_destinations"
+      }
+    }
+    // ROUTER: OTLP-ecosystem metrics arrive here, get an OTTL-set "selected_destinations" resource
+    // attribute based on k8s.namespace.name, and fan out to one gate per downstream destination.
+    otelcol.processor.transform "tenantrouter_metrics_otlp" {
+      error_mode = "ignore"
+      metric_statements {
+        context = "resource"
+        statements = [
+    
+          "set(attributes[\"selected_destinations\"], \"platform\")",
+          "set(attributes[\"selected_destinations\"], \"stack-a\") where attributes[\"k8s.namespace.name\"] == \"tenant-a\"",
+        ]
+      }
+      output {
+        metrics = [otelcol.processor.filter.tenantrouter_platform_gate_metrics_otlp.input, otelcol.processor.filter.tenantrouter_stack_a_gate_metrics_otlp.input, ]
+      }
+    } // otelcol.processor.transform "tenantrouter_metrics_otlp"
+    
+    otelcol.processor.filter "tenantrouter_platform_gate_metrics_otlp" {
+      error_mode = "ignore"
+      metrics {
+        metric = [
+          "not IsMatch(resource.attributes[\"selected_destinations\"], \"(^|.*,)platform(,.*|$)\")",
+        ]
+      }
+      output {
+        metrics = [otelcol.processor.transform.tenantrouter_platform_gate_metrics_otlp_strip.input]
+      }
+    }
+    otelcol.processor.transform "tenantrouter_platform_gate_metrics_otlp_strip" {
+      error_mode = "ignore"
+      metric_statements {
+        context = "resource"
+        statements = [
+          "delete_key(attributes, \"selected_destinations\")",
+        ]
+      }
+      output {
+        metrics = [otelcol.processor.attributes.platform.input]
+      }
+    }
+    
+    otelcol.processor.filter "tenantrouter_stack_a_gate_metrics_otlp" {
+      error_mode = "ignore"
+      metrics {
+        metric = [
+          "not IsMatch(resource.attributes[\"selected_destinations\"], \"(^|.*,)stack-a(,.*|$)\")",
+        ]
+      }
+      output {
+        metrics = [otelcol.processor.transform.tenantrouter_stack_a_gate_metrics_otlp_strip.input]
+      }
+    }
+    otelcol.processor.transform "tenantrouter_stack_a_gate_metrics_otlp_strip" {
+      error_mode = "ignore"
+      metric_statements {
+        context = "resource"
+        statements = [
+          "delete_key(attributes, \"selected_destinations\")",
+        ]
+      }
+      output {
+        metrics = [otelcol.processor.attributes.stack_a.input]
+      }
+    }
+    // ROUTER: Loki-ecosystem logs arrive here, get labeled with "selected_destinations"
+    // based on k8s.namespace.name (label "namespace"), and fan out to one gate per downstream destination.
+    loki.relabel "tenantrouter_logs_loki" {
+    
+      rule {
+        target_label = "selected_destinations"
+        replacement  = "platform"
+      }
+      rule {
+        source_labels = ["namespace"]
+        regex         = "^tenant-a$"
+        target_label  = "selected_destinations"
+        replacement   = "stack-a"
+      }
+      forward_to = [loki.relabel.tenantrouter_platform_gate_logs_loki.receiver, loki.relabel.tenantrouter_stack_a_gate_logs_loki.receiver, ]
+    } // loki.relabel "tenantrouter_logs_loki"
+    
+    loki.relabel "tenantrouter_platform_gate_logs_loki" {
+      forward_to = [otelcol.receiver.loki.platform.receiver]
+      rule {
+        source_labels = ["selected_destinations"]
+        regex         = "(^|.*,)platform(,.*|$)"
+        action        = "keep"
+      }
+      rule {
+        action = "labeldrop"
+        regex  = "selected_destinations"
+      }
+      max_cache_size = 100
+    }
+    
+    loki.relabel "tenantrouter_stack_a_gate_logs_loki" {
+      forward_to = [otelcol.receiver.loki.stack_a.receiver]
+      rule {
+        source_labels = ["selected_destinations"]
+        regex         = "(^|.*,)stack-a(,.*|$)"
+        action        = "keep"
+      }
+      rule {
+        action = "labeldrop"
+        regex  = "selected_destinations"
+      }
+      max_cache_size = 100
+    }
+    // ROUTER: OTLP-ecosystem logs arrive here, get an OTTL-set "selected_destinations" resource
+    // attribute based on k8s.namespace.name, and fan out to one gate per downstream destination.
+    otelcol.processor.transform "tenantrouter_logs_otlp" {
+      error_mode = "ignore"
+      log_statements {
+        context = "resource"
+        statements = [
+    
+          "set(attributes[\"selected_destinations\"], \"platform\")",
+          "set(attributes[\"selected_destinations\"], \"stack-a\") where attributes[\"k8s.namespace.name\"] == \"tenant-a\"",
+        ]
+      }
+      output {
+        logs = [otelcol.processor.filter.tenantrouter_platform_gate_logs_otlp.input, otelcol.processor.filter.tenantrouter_stack_a_gate_logs_otlp.input, ]
+      }
+    } // otelcol.processor.transform "tenantrouter_logs_otlp"
+    
+    otelcol.processor.filter "tenantrouter_platform_gate_logs_otlp" {
+      error_mode = "ignore"
+      logs {
+        log_record = [
+          "not IsMatch(resource.attributes[\"selected_destinations\"], \"(^|.*,)platform(,.*|$)\")",
+        ]
+      }
+      output {
+        logs = [otelcol.processor.transform.tenantrouter_platform_gate_logs_otlp_strip.input]
+      }
+    }
+    otelcol.processor.transform "tenantrouter_platform_gate_logs_otlp_strip" {
+      error_mode = "ignore"
+      log_statements {
+        context = "resource"
+        statements = [
+          "delete_key(attributes, \"selected_destinations\")",
+        ]
+      }
+      output {
+        logs = [otelcol.processor.attributes.platform.input]
+      }
+    }
+    
+    otelcol.processor.filter "tenantrouter_stack_a_gate_logs_otlp" {
+      error_mode = "ignore"
+      logs {
+        log_record = [
+          "not IsMatch(resource.attributes[\"selected_destinations\"], \"(^|.*,)stack-a(,.*|$)\")",
+        ]
+      }
+      output {
+        logs = [otelcol.processor.transform.tenantrouter_stack_a_gate_logs_otlp_strip.input]
+      }
+    }
+    otelcol.processor.transform "tenantrouter_stack_a_gate_logs_otlp_strip" {
+      error_mode = "ignore"
+      log_statements {
+        context = "resource"
+        statements = [
+          "delete_key(attributes, \"selected_destinations\")",
+        ]
+      }
+      output {
+        logs = [otelcol.processor.attributes.stack_a.input]
+      }
+    }
+    // ROUTER: OTLP traces arrive here, get an OTTL-set "selected_destinations" resource attribute
+    // based on k8s.namespace.name, and fan out to one gate per downstream destination.
+    otelcol.processor.transform "tenantrouter_traces_otlp" {
+      error_mode = "ignore"
+      trace_statements {
+        context = "resource"
+        statements = [
+    
+          "set(attributes[\"selected_destinations\"], \"platform\")",
+          "set(attributes[\"selected_destinations\"], \"stack-a\") where attributes[\"k8s.namespace.name\"] == \"tenant-a\"",
+        ]
+      }
+      output {
+        traces = [otelcol.processor.filter.tenantrouter_platform_gate_traces_otlp.input, otelcol.processor.filter.tenantrouter_stack_a_gate_traces_otlp.input, ]
+      }
+    } // otelcol.processor.transform "tenantrouter_traces_otlp"
+    
+    otelcol.processor.filter "tenantrouter_platform_gate_traces_otlp" {
+      error_mode = "ignore"
+      traces {
+        span = [
+          "not IsMatch(resource.attributes[\"selected_destinations\"], \"(^|.*,)platform(,.*|$)\")",
+        ]
+      }
+      output {
+        traces = [otelcol.processor.transform.tenantrouter_platform_gate_traces_otlp_strip.input]
+      }
+    }
+    otelcol.processor.transform "tenantrouter_platform_gate_traces_otlp_strip" {
+      error_mode = "ignore"
+      trace_statements {
+        context = "resource"
+        statements = [
+          "delete_key(attributes, \"selected_destinations\")",
+        ]
+      }
+      output {
+        traces = [otelcol.processor.attributes.platform.input]
+      }
+    }
+    
+    otelcol.processor.filter "tenantrouter_stack_a_gate_traces_otlp" {
+      error_mode = "ignore"
+      traces {
+        span = [
+          "not IsMatch(resource.attributes[\"selected_destinations\"], \"(^|.*,)stack-a(,.*|$)\")",
+        ]
+      }
+      output {
+        traces = [otelcol.processor.transform.tenantrouter_stack_a_gate_traces_otlp_strip.input]
+      }
+    }
+    otelcol.processor.transform "tenantrouter_stack_a_gate_traces_otlp_strip" {
+      error_mode = "ignore"
+      trace_statements {
+        context = "resource"
+        statements = [
+          "delete_key(attributes, \"selected_destinations\")",
+        ]
+      }
+      output {
+        traces = [otelcol.processor.attributes.stack_a.input]
+      }
+    }
+    // ROUTER: Pyroscope-ecosystem profiles arrive here, get labeled with "selected_destinations"
+    // based on k8s.namespace.name (label "namespace"), and fan out to one gate per downstream destination.
+    pyroscope.relabel "tenantrouter_profiles_pyroscope" {
+    
+      rule {
+        target_label = "selected_destinations"
+        replacement  = "platform"
+      }
+      forward_to = []
+    } // pyroscope.relabel "tenantrouter_profiles_pyroscope"
+---
+# Source: k8s-monitoring/charts/alloy-operator/templates/rbac/alloy-manager.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: k8smon-alloy-operator-alloy-manager
+  labels:
+    helm.sh/chart: alloy-operator-0.6.2
+    app.kubernetes.io/name: alloy-operator
+    app.kubernetes.io/instance: k8smon
+    app.kubernetes.io/version: "1.11.0"
+    app.kubernetes.io/managed-by: Helm
+rules:
+  - apiGroups:
+      - collectors.grafana.com
+    resources:
+      - alloys
+      - alloys/status
+      - alloys/finalizers
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+---
+# Source: k8s-monitoring/charts/alloy-operator/templates/rbac/alloy-objects.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: k8smon-alloy-operator
+rules:
+  # Rules which allow the management of ConfigMaps, ServiceAccounts, and Services.
+  - apiGroups: [""]
+    resources: ["configmaps", "secrets", "serviceaccounts", "services"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+  # Rules which allow the management of DaemonSets, Deployments, and StatefulSets.
+  - apiGroups: ["apps"]
+    resources: ["daemonsets", "deployments", "statefulsets"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+  # Rules which allow the management of Horizontal Pod Autoscalers.
+  - apiGroups: ["autoscaling"]
+    resources: ["horizontalpodautoscalers"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+  # Rules which allow the management of Ingresses and NetworkPolicies.
+  - apiGroups: ["networking.k8s.io"]
+    resources: ["ingresses", "networkpolicies"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+  # Rules which allow the management of PodDisruptionBudgets.
+  - apiGroups: ["policy"]
+    resources: ["poddisruptionbudgets"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+  # Rules which allow the management of ClusterRoles, ClusterRoleBindings, Roles, and RoleBindings.
+  # `bind` and `escalate` are required so the operator can create ClusterRoles/Roles for the Alloy
+  # instances it manages. Kubernetes' privilege-escalation prevention requires the creator to either
+  # already hold every permission it grants, or to have `escalate` (for roles) and `bind` (for
+  # rolebindings). The operator's role doesn't enumerate every permission Alloy ever needs, so these
+  # two verbs are required for the operator to function. `impersonate` and other dangerous verbs are
+  # intentionally omitted.
+  - apiGroups: ["rbac.authorization.k8s.io"]
+    resources: ["clusterroles", "clusterrolebindings", "roles", "rolebindings"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete", "bind", "escalate"]
+---
+# Source: k8s-monitoring/charts/alloy-operator/templates/rbac/alloy-manager.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: k8smon-alloy-operator-alloy-manager
+  labels:
+    helm.sh/chart: alloy-operator-0.6.2
+    app.kubernetes.io/name: alloy-operator
+    app.kubernetes.io/instance: k8smon
+    app.kubernetes.io/version: "1.11.0"
+    app.kubernetes.io/managed-by: Helm
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: k8smon-alloy-operator-alloy-manager
+subjects:
+  - kind: ServiceAccount
+    name: k8smon-alloy-operator
+    namespace: default
+---
+# Source: k8s-monitoring/charts/alloy-operator/templates/rbac/alloy-objects.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: k8smon-alloy-operator
+  labels:
+    helm.sh/chart: alloy-operator-0.6.2
+    app.kubernetes.io/name: alloy-operator
+    app.kubernetes.io/instance: k8smon
+    app.kubernetes.io/version: "1.11.0"
+    app.kubernetes.io/managed-by: Helm
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: k8smon-alloy-operator
+subjects:
+  - kind: ServiceAccount
+    name: k8smon-alloy-operator
+    namespace: default
+---
+# Source: k8s-monitoring/charts/alloy-operator/templates/rbac/leader-election.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: k8smon-alloy-operator-leader-election-role
+  namespace: default
+  labels:
+    helm.sh/chart: alloy-operator-0.6.2
+    app.kubernetes.io/name: alloy-operator
+    app.kubernetes.io/instance: k8smon
+    app.kubernetes.io/version: "1.11.0"
+    app.kubernetes.io/managed-by: Helm
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+  - apiGroups:
+      - coordination.k8s.io
+    resources:
+      - leases
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - create
+      - patch
+---
+# Source: k8s-monitoring/charts/alloy-operator/templates/rbac/leader-election.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: k8smon-alloy-operator-leader-election-rolebinding
+  namespace: default
+  labels:
+    helm.sh/chart: alloy-operator-0.6.2
+    app.kubernetes.io/name: alloy-operator
+    app.kubernetes.io/instance: k8smon
+    app.kubernetes.io/version: "1.11.0"
+    app.kubernetes.io/managed-by: Helm
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: k8smon-alloy-operator-leader-election-role
+subjects:
+  - kind: ServiceAccount
+    name: k8smon-alloy-operator
+    namespace: default
+---
+# Source: k8s-monitoring/charts/alloy-operator/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: k8smon-alloy-operator
+  namespace: default
+  labels:
+    helm.sh/chart: alloy-operator-0.6.2
+    app.kubernetes.io/name: alloy-operator
+    app.kubernetes.io/instance: k8smon
+    app.kubernetes.io/version: "1.11.0"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  type: ClusterIP
+  ports:
+    - name: http
+      port: 8081
+      targetPort: http
+      protocol: TCP
+    - name: metrics
+      port: 8082
+      targetPort: metrics
+      protocol: TCP
+  selector:
+    app.kubernetes.io/name: alloy-operator
+    app.kubernetes.io/instance: k8smon
+---
+# Source: k8s-monitoring/charts/alloy-operator/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: k8smon-alloy-operator
+  namespace: default
+  labels:
+    helm.sh/chart: alloy-operator-0.6.2
+    app.kubernetes.io/name: alloy-operator
+    app.kubernetes.io/instance: k8smon
+    app.kubernetes.io/version: "1.11.0"
+    app.kubernetes.io/managed-by: Helm
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: alloy-operator
+      app.kubernetes.io/instance: k8smon
+  template:
+    metadata:
+      labels:
+        helm.sh/chart: alloy-operator-0.6.2
+        app.kubernetes.io/name: alloy-operator
+        app.kubernetes.io/instance: k8smon
+        app.kubernetes.io/version: "1.11.0"
+        app.kubernetes.io/managed-by: Helm
+    spec:
+      serviceAccountName: k8smon-alloy-operator
+      securityContext:
+        runAsNonRoot: true
+      containers:
+        - name: alloy-operator
+          image: "ghcr.io/grafana/alloy-operator:1.11.0"
+          imagePullPolicy: IfNotPresent
+          args:
+            - --health-probe-bind-address=:8081
+            - --metrics-bind-address=:8082
+            - --leader-elect
+            - --leader-election-id=k8smon-alloy-operator
+
+          ports:
+            - name: http
+              containerPort: 8081
+              protocol: TCP
+            - name: metrics
+              containerPort: 8082
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 8081
+            initialDelaySeconds: 15
+            periodSeconds: 20
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: 8081
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          resources:
+            limits: {}
+            requests: {}
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
+      nodeSelector:
+        kubernetes.io/os: linux
+---
+# Source: k8s-monitoring/templates/alloy.yaml
+apiVersion: collectors.grafana.com/v1alpha1
+kind: Alloy
+metadata:
+  name: k8smon-alloy-logs
+  namespace: default
+  annotations:
+    helm.sdk.operatorframework.io/uninstall-wait: "true"
+spec:
+  alloy:
+    configMap:
+      create: false
+    mounts:
+      dockercontainers: true
+      varlog: true
+    resources: {}
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        add:
+        - CHOWN
+        - DAC_OVERRIDE
+        - FOWNER
+        - FSETID
+        - KILL
+        - SETGID
+        - SETUID
+        - SETPCAP
+        - NET_BIND_SERVICE
+        - NET_RAW
+        - SYS_CHROOT
+        - MKNOD
+        - AUDIT_WRITE
+        - SETFCAP
+        drop:
+        - ALL
+      seccompProfile:
+        type: RuntimeDefault
+    stabilityLevel: public-preview
+  controller:
+    nodeSelector:
+      kubernetes.io/os: linux
+    podAnnotations:
+      k8s.grafana.com/logs.job: integrations/alloy
+    tolerations:
+    - effect: NoSchedule
+      operator: Exists
+    type: daemonset
+  crds:
+    create: false
+  nameOverride: alloy-logs
+---
+# Source: k8s-monitoring/templates/hooks/post-install_add-finalizer.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: k8smon-k8s-monitoring-add-finalizer
+  namespace: default
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+    "helm.sh/hook-weight": "5"
+---
+# Source: k8s-monitoring/templates/hooks/pre-delete_remove-alloy-and-finalizer.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: k8smon-k8s-monitoring-remove-alloy-and-finalizer
+  namespace: default
+  annotations:
+    helm.sh/hook: pre-delete
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+---
+# Source: k8s-monitoring/templates/hooks/post-install_add-finalizer.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: k8smon-k8s-monitoring-add-finalizer
+  namespace: default
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+    "helm.sh/hook-weight": "5"
+rules:
+  - apiGroups: ["apps"]
+    resources: ["deployments"]
+    verbs: ["get", "list", "watch", "patch"]
+---
+# Source: k8s-monitoring/templates/hooks/pre-delete_remove-alloy-and-finalizer.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: k8smon-k8s-monitoring-remove-alloy-and-finalizer
+  namespace: default
+  annotations:
+    helm.sh/hook: pre-delete
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+rules:
+  - apiGroups: ["apps"]
+    resources: ["deployments"]
+    verbs: ["get", "list", "watch", "patch"]
+  - apiGroups: ["collectors.grafana.com"]
+    resources: ["alloys"]
+    verbs: ["get", "list", "watch", "delete"]
+---
+# Source: k8s-monitoring/templates/hooks/post-install_add-finalizer.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: k8smon-k8s-monitoring-add-finalizer
+  namespace: default
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+    "helm.sh/hook-weight": "5"
+subjects:
+  - kind: ServiceAccount
+    name: k8smon-k8s-monitoring-add-finalizer
+    namespace: default
+roleRef:
+  kind: Role
+  name: k8smon-k8s-monitoring-add-finalizer
+  apiGroup: rbac.authorization.k8s.io
+---
+# Source: k8s-monitoring/templates/hooks/pre-delete_remove-alloy-and-finalizer.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: k8smon-k8s-monitoring-remove-alloy-and-finalizer
+  namespace: default
+  annotations:
+    helm.sh/hook: pre-delete
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+subjects:
+  - kind: ServiceAccount
+    name: k8smon-k8s-monitoring-remove-alloy-and-finalizer
+    namespace: default
+roleRef:
+  kind: Role
+  name: k8smon-k8s-monitoring-remove-alloy-and-finalizer
+  apiGroup: rbac.authorization.k8s.io
+---
+# Source: k8s-monitoring/templates/hooks/post-install_add-finalizer.yaml
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: k8smon-k8s-monitoring-add-finalizer
+  namespace: default
+  labels:
+    app.kubernetes.io/name: k8smon-k8s-monitoring-add-finalizer
+    app.kubernetes.io/instance: k8smon
+    helm.sh/chart: k8s-monitoring-4.3.1
+  annotations:
+    helm.sh/hook: post-install,post-upgrade
+    helm.sh/hook-weight: "15"
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+spec:
+  ttlSecondsAfterFinished: 300
+  backoffLimit: 3
+  template:
+    metadata:
+      name: k8smon-k8s-monitoring-add-finalizer
+      labels:
+        app.kubernetes.io/name: k8smon-k8s-monitoring
+        app.kubernetes.io/instance: k8smon
+        linkerd.io/inject: disabled
+        sidecar.istio.io/inject: "false"
+    spec:
+      restartPolicy: Never
+      nodeSelector:
+        kubernetes.io/os: linux
+      serviceAccountName: k8smon-k8s-monitoring-add-finalizer
+      containers:
+        - name: add-finalizers
+          image: "ghcr.io/grafana/helm-chart-toolbox-kubectl:0.1.2"
+          imagePullPolicy: IfNotPresent
+          command:
+            - /bin/bash
+            - -ce
+            - |
+              kubectl patch \
+                --namespace=default \
+                --patch='{"metadata":{"finalizers":["k8s.grafana.com/finalizer"]}}' \
+                deployment/k8smon-alloy-operator
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 4242
+            seccompProfile:
+              type: RuntimeDefault
+---
+# Source: k8s-monitoring/templates/hooks/pre-delete_remove-alloy-and-finalizer.yaml
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: k8smon-k8s-monitoring-remove-alloy-and-finalizer
+  namespace: default
+  labels:
+    app.kubernetes.io/name: k8smon-k8s-monitoring-remove-alloy-and-finalizer
+    app.kubernetes.io/instance: k8smon
+    helm.sh/chart: k8s-monitoring-4.3.1
+  annotations:
+    helm.sh/hook: pre-delete
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+spec:
+  ttlSecondsAfterFinished: 300
+  backoffLimit: 3
+  template:
+    metadata:
+      name: k8smon-k8s-monitoring-remove-alloy-and-finalizer
+      labels:
+        app.kubernetes.io/name: k8smon-k8s-monitoring
+        app.kubernetes.io/instance: k8smon
+        linkerd.io/inject: disabled
+        sidecar.istio.io/inject: "false"
+    spec:
+      restartPolicy: Never
+      nodeSelector:
+        kubernetes.io/os: linux
+      serviceAccountName: k8smon-k8s-monitoring-remove-alloy-and-finalizer
+      containers:
+        - name: remove-finalizers
+          image: "ghcr.io/grafana/helm-chart-toolbox-kubectl:0.1.2"
+          imagePullPolicy: IfNotPresent
+          command:
+            - /bin/bash
+            - -ce
+            - |
+              echo "Deleting Alloy instance: alloy/k8smon-alloy-logs..."
+              kubectl delete alloy/k8smon-alloy-logs --ignore-not-found=true --wait
+              kubectl wait --for=delete alloy/k8smon-alloy-logs --timeout=60s || echo "Timed out waiting for deletion of alloy/k8smon-alloy-logs or it may not exist."
+
+              kubectl patch \
+                --namespace=default \
+                --type merge \
+                --patch='{"metadata":{"finalizers":null}}' \
+                deployment/k8smon-alloy-operator
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 4242
+            seccompProfile:
+              type: RuntimeDefault

--- a/charts/k8s-monitoring/docs/examples/destination-router/values.yaml
+++ b/charts/k8s-monitoring/docs/examples/destination-router/values.yaml
@@ -1,0 +1,45 @@
+---
+cluster:
+  name: destination-router
+
+destinations:
+  stack-a:
+    type: otlp
+    protocol: http
+    url: http://tempo-stack-a.tempo.svc:443/otlp
+    metrics: {enabled: true}
+    logs: {enabled: true}
+    traces: {enabled: true}
+  platform:
+    type: otlp
+    protocol: http
+    url: http://tempo-platform.tempo.svc:443/otlp
+    metrics: {enabled: true}
+    logs: {enabled: true}
+    traces: {enabled: true}
+  tenantRouter:
+    type: router
+    # Routes on the default attribute, k8s.namespace.name, which is automatically mapped to the
+    # "namespace" label for label-based collection pipelines.
+    routes:
+      - match:
+          equals: tenant-a
+        destinations:
+          - stack-a
+    # MANDATORY: every router must define at least one fallback destination for records that
+    # don't match any route.
+    defaultDestinations:
+      - platform
+
+podLogsViaOpenTelemetry:
+  enabled: true
+  collector: alloy-logs
+  # Routers are excluded from implicit destination selection, so they must be named explicitly.
+  destinations:
+    - tenantRouter
+
+collectors:
+  alloy-logs:
+    presets: [filesystem-log-reader, daemonset]
+    alloy:
+      stabilityLevel: public-preview

--- a/charts/k8s-monitoring/schema-mods/definitions/router-destination.schema.json
+++ b/charts/k8s-monitoring/schema-mods/definitions/router-destination.schema.json
@@ -1,0 +1,21 @@
+{
+    "$schema": "http://json-schema.org/schema#",
+    "type": "object",
+    "properties": {
+        "attribute": {
+            "type": "string"
+        },
+        "defaultDestinations": {
+            "type": "array"
+        },
+        "disabled": {
+            "type": "boolean"
+        },
+        "name": {
+            "type": "string"
+        },
+        "routes": {
+            "type": "array"
+        }
+    }
+}

--- a/charts/k8s-monitoring/schema-mods/destination-router-types-and-enums.json
+++ b/charts/k8s-monitoring/schema-mods/destination-router-types-and-enums.json
@@ -1,0 +1,43 @@
+{
+  "definitions": {
+    "router-destination": {"properties": {
+      "attribute": {
+        "type": "string",
+        "pattern": "^[a-zA-Z_][a-zA-Z0-9_./-]*$"
+      },
+      "defaultDestinations": {
+        "type": "array",
+        "minItems": 1,
+        "items": {"type": "string"}
+      },
+      "routes": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "destinations": {
+              "type": "array",
+              "minItems": 1,
+              "items": {"type": "string"}
+            },
+            "signals": {
+              "type": "array",
+              "items": {"enum": ["metrics", "logs", "traces", "profiles"]}
+            },
+            "match": {
+              "type": "object",
+              "properties": {
+                "in": {"type": "array"}
+              },
+              "oneOf": [
+                {"required": ["equals"]},
+                {"required": ["in"]},
+                {"required": ["matches"]}
+              ]
+            }
+          }
+        }
+      }
+    }}
+  }
+}

--- a/charts/k8s-monitoring/schema-mods/destination.json
+++ b/charts/k8s-monitoring/schema-mods/destination.json
@@ -10,7 +10,8 @@
         { "$ref": "#/definitions/nop-destination"},
         { "$ref": "#/definitions/otlp-destination"},
         { "$ref": "#/definitions/prometheus-destination"},
-        { "$ref": "#/definitions/pyroscope-destination"}
+        { "$ref": "#/definitions/pyroscope-destination"},
+        { "$ref": "#/definitions/router-destination"}
       ]
     },
     "destination-list": {
@@ -31,6 +32,7 @@
     "nop-destination": {"properties": {"type": {"type": "string", "const": "nop"}}},
     "otlp-destination": {"properties": {"type": {"type": "string", "const": "otlp"}}},
     "prometheus-destination": {"properties": {"type": {"type": "string", "const": "prometheus"}}},
-    "pyroscope-destination": {"properties": {"type": {"type": "string", "const": "pyroscope"}}}
+    "pyroscope-destination": {"properties": {"type": {"type": "string", "const": "pyroscope"}}},
+    "router-destination": {"properties": {"type": {"type": "string", "const": "router"}}}
   }
 }

--- a/charts/k8s-monitoring/templates/NOTES.txt
+++ b/charts/k8s-monitoring/templates/NOTES.txt
@@ -44,3 +44,4 @@ It will:
 {{- end }}
 {{- include "collectors.notes.warnings" . }}
 {{- include "destinations.notes.inferredAuth" . }}
+{{- include "destinations.notes.router" . }}

--- a/charts/k8s-monitoring/templates/alloy-config.yaml
+++ b/charts/k8s-monitoring/templates/alloy-config.yaml
@@ -7,6 +7,32 @@
   {{- end }}
 {{- end }}
 
+{{/* Router destination type. Any enabled `type: router` destination that ended up in
+     $destinationNames (because a feature pointed at it) fans out to real destinations that are
+     never referenced by a feature directly, so those downstream destinations would otherwise
+     never get a body rendered and the router's gates would dangle. Union them in here, before
+     destinations.alloy.config renders bodies below. Single-level only: a router referencing
+     another router is not resolved transitively by this pass. */}}
+{{- range $routerCandidateName := $destinationNames }}
+  {{- if hasKey $.Values.destinations $routerCandidateName }}
+    {{- $routerCandidate := get $.Values.destinations $routerCandidateName }}
+    {{- if and (eq $routerCandidate.type "router") (not $routerCandidate.disabled) }}
+      {{- range $downstreamName := ($routerCandidate.defaultDestinations | default list) }}
+        {{- if and (hasKey $.Values.destinations $downstreamName) (not (get $.Values.destinations $downstreamName).disabled) }}
+          {{- $destinationNames = append $destinationNames $downstreamName }}
+        {{- end }}
+      {{- end }}
+      {{- range $route := ($routerCandidate.routes | default list) }}
+        {{- range $downstreamName := ($route.destinations | default list) }}
+          {{- if and (hasKey $.Values.destinations $downstreamName) (not (get $.Values.destinations $downstreamName).disabled) }}
+            {{- $destinationNames = append $destinationNames $downstreamName }}
+          {{- end }}
+        {{- end }}
+      {{- end }}
+    {{- end }}
+  {{- end }}
+{{- end }}
+
 {{/* Save the top level object and add the collector name */}}
 {{- $values := dict "Values" $.Values "Chart" $.Chart "Files" $.Files "Release" $.Release "Subcharts" $.Subcharts "Template" $.Template "Capabilities" $.Capabilities "collectorName" $collectorName }}
 {{- $collectorValues := include "collector.alloy.values" $values | fromYaml }}

--- a/charts/k8s-monitoring/templates/dataProcessors/_config.alloy.tpl
+++ b/charts/k8s-monitoring/templates/dataProcessors/_config.alloy.tpl
@@ -12,17 +12,34 @@
 
      Inputs: root (.), featureKey (string), destinationNames ([]string), type, ecosystem. */}}
 {{- define "pipeline.alloy.targets.forFeature" -}}
-{{- $dp := default dict .root.Values.dataProcessors -}}
-{{- $chosenDataProcessors := dig "dataProcessors" list (default dict (get .root.Values .featureKey)) }}
+{{- $root := .root -}}
+{{- $featureKey := .featureKey -}}
+{{- $destinationNames := .destinationNames -}}
+{{- $type := .type -}}
+{{- $ecosystem := .ecosystem -}}
+{{- $dp := default dict $root.Values.dataProcessors -}}
+{{- $chosenDataProcessors := dig "dataProcessors" list (default dict (get $root.Values $featureKey)) }}
 {{- /* Resolve the chain for THIS (type, ecosystem). Only route through a stamper when at
        least one chosen processor actually supports this tuple; otherwise the stamper ref
        would be emitted here but never rendered by feature.render.forFeature (which branches
        on the same resolved chain), leaving a dangling Alloy reference. */}}
-{{- $chain := include "dataProcessors.get" (dict "dataProcessors" $dp "chosen" $chosenDataProcessors "type" .type "ecosystem" .ecosystem) | fromYamlArray -}}
+{{- $chain := include "dataProcessors.get" (dict "dataProcessors" $dp "chosen" $chosenDataProcessors "type" $type "ecosystem" $ecosystem) | fromYamlArray -}}
+{{- /* Precise router-capability check (replaces the old router-side R10 inference, see
+       destinations.router.assertCanCarry in destinations/_destination_router_validations.tpl for
+       the full rationale): this define is called once per (feature, type, ecosystem) tuple the
+       feature actually emits, with destinationNames already resolved for that tuple, so it is
+       the only seam where "the feature really sends `.type`" and "this router can carry `.type`"
+       can both be known at once. Guarded on type == router so non-router configs never even
+       enter the check -- zero-cost, zero-diff for the overwhelmingly common case. */}}
+{{- range $destName := $destinationNames }}
+  {{- if and (hasKey $root.Values.destinations $destName) (eq (get $root.Values.destinations $destName).type "router") }}
+    {{- include "destinations.router.assertCanCarry" (dict "root" $root "featureKey" $featureKey "routerName" $destName "type" $type) }}
+  {{- end }}
+{{- end -}}
 {{- if empty $chain -}}
-{{- include "destinations.alloy.targets" (dict "destinations" .root.Values.destinations "destinationNames" .destinationNames "type" .type "ecosystem" .ecosystem) -}}
+{{- include "destinations.alloy.targets" (dict "destinations" $root.Values.destinations "destinationNames" $destinationNames "type" $type "ecosystem" $ecosystem) -}}
 {{- else }}
-{{ include "pipeline.alloy.stamper.ref" (dict "feature" .featureKey "type" .type "ecosystem" .ecosystem) }},
+{{ include "pipeline.alloy.stamper.ref" (dict "feature" $featureKey "type" $type "ecosystem" $ecosystem) }},
 {{- end -}}
 {{- end }}
 

--- a/charts/k8s-monitoring/templates/destinations/_destination_helpers.tpl
+++ b/charts/k8s-monitoring/templates/destinations/_destination_helpers.tpl
@@ -15,15 +15,42 @@
 {{- define "destinations.get" }}
 {{- $destinations := list }}
 {{- $backupDestinations := list }}
-{{- range $destinationName, $destination := (include "destinations.getEnabled" .destinations | fromYaml) }}
+{{- $enabledDestinations := include "destinations.getEnabled" .destinations | fromYaml }}
+{{- /* F7: destinations that must never be picked up IMPLICITLY (i.e. when a feature sets no
+       explicit `destinations:` filter): a router itself, and every real destination named as
+       one of its routes[].destinations/defaultDestinations. A router already fans telemetry out
+       to those downstreams on its own, so implicitly also sending the same feature's data
+       straight to them (bypassing the router's routing rules entirely) would double-deliver it
+       and, for a per-tenant router, leak data to every tenant stack outside the router's rules.
+       Routers (and whatever sits behind them) must therefore be opted into explicitly with
+       `destinations: [myRouter]` -- which is the documented, intended way to use a router. This
+       only affects the empty-filter (implicit) branch below; an explicit filter naming a router
+       or one of its downstreams still works exactly as before. */}}
+{{- $routerShadowed := dict }}
+{{- range $destinationName, $destination := $enabledDestinations }}
+  {{- if eq $destination.type "router" }}
+    {{- $_ := set $routerShadowed $destinationName true }}
+    {{- range $d := ($destination.defaultDestinations | default list) }}
+      {{- $_ := set $routerShadowed $d true }}
+    {{- end }}
+    {{- range $route := ($destination.routes | default list) }}
+      {{- range $d := ($route.destinations | default list) }}
+        {{- $_ := set $routerShadowed $d true }}
+      {{- end }}
+    {{- end }}
+  {{- end }}
+{{- end }}
+{{- range $destinationName, $destination := $enabledDestinations }}
   {{- /* Does this destination support the telemetry data type? */}}
   {{- if eq (include (printf "destinations.%s.supports_%s" $destination.type $.type) $destination) "true" }}
     {{- if empty $.filter }}
+      {{- if not (hasKey $routerShadowed $destinationName) }}
       {{- /* Is this destination in the ecosystem? */}}
-      {{- if eq $.ecosystem (include (printf "destinations.%s.ecosystem" $destination.type) .) }}
+      {{- if eq $.ecosystem (include (printf "destinations.%s.ecosystem" $destination.type) $destination) }}
         {{- $destinations = append $destinations $destinationName }}
       {{- else }}
         {{- $backupDestinations = append $backupDestinations $destinationName }}
+      {{- end }}
       {{- end }}
 
     {{- /* Did the data source choose this destination? */}}

--- a/charts/k8s-monitoring/templates/destinations/_destination_notes.tpl
+++ b/charts/k8s-monitoring/templates/destinations/_destination_notes.tpl
@@ -21,3 +21,43 @@ Affected destination(s):
 {{- end }}
 {{- end }}
 {{- end }}
+
+{{/* Entry point for router destination-type warnings. Runs destinations.router.notes (see
+     _destination_router_validations.tpl) once per enabled router destination, then the
+     implicit-selection reminder below once for the whole release. */}}
+{{- define "destinations.notes.router" }}
+{{- range $destinationName, $destination := (include "destinations.getEnabled" .Values.destinations | fromYaml) }}
+  {{- if eq $destination.type "router" }}
+    {{- include "destinations.router.notes" (dict "Values" $ "Destination" $destination "DestinationName" $destinationName) }}
+  {{- end }}
+{{- end }}
+{{- include "destinations.notes.routerImplicitSelection" . }}
+{{- end }}
+
+{{/*
+W-c: routers require explicit "destinations: [<router-name>]" opt-in per feature -- a router is
+deliberately excluded from implicit destination selection (see the F7 comment on
+destinations.get), so a feature left with no explicit destinations list will never pick one up on
+its own, even when the router would otherwise be the only viable destination. Fires at most once,
+whenever at least one enabled router exists and at least one enabled feature has no explicit
+destinations list.
+*/}}
+{{- define "destinations.notes.routerImplicitSelection" }}
+{{- $hasRouter := false }}
+{{- range $destinationName, $destination := (include "destinations.getEnabled" .Values.destinations | fromYaml) }}
+  {{- if eq $destination.type "router" }}{{- $hasRouter = true }}{{- end }}
+{{- end }}
+{{- if $hasRouter }}
+  {{- $implicitFeatures := list }}
+  {{- range $feature := (include "features.list.enabled" .) | fromYamlArray }}
+    {{- $featureValues := index $.Values $feature }}
+    {{- if empty ($featureValues.destinations | default list) }}
+      {{- $implicitFeatures = append $implicitFeatures $feature }}
+    {{- end }}
+  {{- end }}
+  {{- if $implicitFeatures }}
+
+WARNING: Router destination(s) are configured, but a router requires an explicit "destinations: [<router-name>]" entry on each feature that should use it -- routers are excluded from implicit destination selection. The following enabled feature(s) have no explicit destinations list and will therefore not use a router: {{ join ", " $implicitFeatures }}.
+  {{- end }}
+{{- end }}
+{{- end }}

--- a/charts/k8s-monitoring/templates/destinations/_destination_router.tpl
+++ b/charts/k8s-monitoring/templates/destinations/_destination_router.tpl
@@ -1,0 +1,319 @@
+{{/* The `router` destination type. A router is a virtual destination: it never talks to a real
+     backend. It inspects an attribute (OTLP resource attribute) or the mapped label
+     (Prometheus/Loki/Pyroscope) on each record, stamps a `selected_destinations` marker via a
+     first-match-wins route table, and fans the record out to one or more real downstream
+     destinations. Fan-out reuses the chart's existing per-destination gate helpers
+     (pipeline.alloy.gate.ref / pipeline.alloy.gate.render, see
+     templates/dataProcessors/_config.alloy.tpl), so a router composes with the normal
+     destination machinery rather than duplicating it.
+
+     A router renders in the caller's pipeline ecosystem automatically: the per-tuple
+     `.target` helpers below are invoked by destinations.alloy.targets with the feature's
+     (ecosystem, signal), so scraped metrics route on the label path and OTLP-collected data
+     routes on the OTTL path, independent of where the data is ultimately sent.
+
+     Input is validated by destinations.router.validate (see _destination_validations.tpl)
+     before this body renders: defaultDestinations is present and non-empty, every referenced
+     downstream exists and is not itself a router, match blocks are well-formed. This body
+     therefore assumes valid input. */}}
+
+{{/* Filters an "allDownstream" list down to the destinations that actually support a given signal. */}}
+{{/* Inputs: allDownstream ([]string), downstreamInfo (map of name -> {type, values}), signal (string) */}}
+{{- define "destinations.router.downstreamForSignal" }}
+{{- $result := list }}
+{{- $signal := .signal }}
+{{- $downstreamInfo := .downstreamInfo }}
+{{- range $d := .allDownstream }}
+  {{- $info := get $downstreamInfo $d }}
+  {{- if eq (include (printf "destinations.%s.supports_%s" $info.type $signal) $info.values) "true" }}
+    {{- $result = append $result $d }}
+  {{- end }}
+{{- end }}
+{{- $result | toYaml }}
+{{- end }}
+
+{{/* Inputs: . (root object), destination (map), destinationName (name of this destination) */}}
+{{- define "destinations.router.alloy" }}
+{{- with .destination }}
+{{- $routerName := $.destinationName }}
+{{- $alloyName := include "helper.alloy_name" $routerName }}
+{{- $attribute := .attribute }}
+{{- $routes := .routes | default list }}
+{{- $defaultDestinations := .defaultDestinations | default list }}
+
+{{- /* Label name used for label-based ecosystems (prometheus/loki/pyroscope). Empty means "no
+       label equivalent for this attribute" -> those ecosystems fall back to defaults only.
+       Only promoted when the attribute is also a syntactically valid Prometheus label name
+       (destinations.router.validate already rejects anything that isn't a valid OTTL attribute
+       name, but that's a looser grammar than label names allow -- e.g. `foo-bar` or `foo/bar`
+       are valid attribute names but not valid `source_labels` entries). */}}
+{{- $labelName := "" }}
+{{- if eq $attribute "k8s.namespace.name" }}
+  {{- $labelName = "namespace" }}
+{{- else if regexMatch "^[a-zA-Z_][a-zA-Z0-9_]*$" $attribute }}
+  {{- $labelName = $attribute }}
+{{- end }}
+
+{{- /* Union of every destination this router can ever send to: routes[].destinations + defaultDestinations. */}}
+{{- $allDownstream := list }}
+{{- range $d := $defaultDestinations }}
+  {{- if not (has $d $allDownstream) }}{{- $allDownstream = append $allDownstream $d }}{{- end }}
+{{- end }}
+{{- range $route := $routes }}
+  {{- range $d := ($route.destinations | default list) }}
+    {{- if not (has $d $allDownstream) }}{{- $allDownstream = append $allDownstream $d }}{{- end }}
+  {{- end }}
+{{- end }}
+
+{{- /* Resolve each downstream's type + fully-merged-with-defaults values once.
+       destinations.router.validate has already asserted every downstream exists. */}}
+{{- $downstreamInfo := dict }}
+{{- range $d := $allDownstream }}
+  {{- $dest := get $.Values.destinations $d }}
+  {{- $defaults := (printf "destinations/%s-values.yaml" $dest.type) | $.Files.Get | fromYaml }}
+  {{- $merged := mergeOverwrite $defaults $dest }}
+  {{- $_ := set $downstreamInfo $d (dict "type" $dest.type "values" $merged) }}
+{{- end }}
+
+{{- /* ---------------- metrics/prometheus ---------------- */}}
+{{- $metricsDownstream := include "destinations.router.downstreamForSignal" (dict "allDownstream" $allDownstream "downstreamInfo" $downstreamInfo "signal" "metrics") | fromYamlArray }}
+// ROUTER: prometheus-ecosystem metrics arrive here, get labeled with "selected_destinations"
+// based on {{ $attribute }}{{ if $labelName }} (label "{{ $labelName }}"){{ else }} (no label equivalent - defaults only){{ end }}, and fan out to one gate per downstream destination.
+prometheus.relabel {{ printf "%s_metrics_prometheus" $alloyName | quote }} {
+{{ include "destinations.router.labelRules" (dict "routes" $routes "defaultDestinations" $defaultDestinations "signal" "metrics" "labelName" $labelName "downstreamInfo" $downstreamInfo) | indent 2 }}
+  forward_to = [{{ range $d := $metricsDownstream }}{{ include "pipeline.alloy.gate.ref" (dict "processor" $routerName "destination" $d "type" "metrics" "ecosystem" "prometheus") }}, {{ end }}]
+} // prometheus.relabel "{{ $alloyName }}_metrics_prometheus"
+{{- range $d := $metricsDownstream }}
+{{- $info := get $downstreamInfo $d }}
+{{ include "pipeline.alloy.gate.render" (dict "processor" $routerName "destination" $d "type" "metrics" "ecosystem" "prometheus" "destinationTarget" (include (printf "destinations.%s.alloy.prometheus.metrics.target" $info.type) (dict "destination" $info.values "destinationName" $d) | trim)) }}
+{{- end }}
+
+{{- /* ---------------- metrics/otlp ---------------- */}}
+// ROUTER: OTLP-ecosystem metrics arrive here, get an OTTL-set "selected_destinations" resource
+// attribute based on {{ $attribute }}, and fan out to one gate per downstream destination.
+otelcol.processor.transform {{ printf "%s_metrics_otlp" $alloyName | quote }} {
+  error_mode = "ignore"
+  metric_statements {
+    context = "resource"
+    statements = [
+{{ include "destinations.router.ottlStatements" (dict "routes" $routes "defaultDestinations" $defaultDestinations "signal" "metrics" "attribute" $attribute "downstreamInfo" $downstreamInfo) | indent 6 }}
+    ]
+  }
+  output {
+    metrics = [{{ range $d := $metricsDownstream }}{{ include "pipeline.alloy.gate.ref" (dict "processor" $routerName "destination" $d "type" "metrics" "ecosystem" "otlp") }}, {{ end }}]
+  }
+} // otelcol.processor.transform "{{ $alloyName }}_metrics_otlp"
+{{- range $d := $metricsDownstream }}
+{{- $info := get $downstreamInfo $d }}
+{{ include "pipeline.alloy.gate.render" (dict "processor" $routerName "destination" $d "type" "metrics" "ecosystem" "otlp" "destinationTarget" (include (printf "destinations.%s.alloy.otlp.metrics.target" $info.type) (dict "destination" $info.values "destinationName" $d) | trim)) }}
+{{- end }}
+
+{{- /* ---------------- logs/loki ---------------- */}}
+{{- $logsDownstream := include "destinations.router.downstreamForSignal" (dict "allDownstream" $allDownstream "downstreamInfo" $downstreamInfo "signal" "logs") | fromYamlArray }}
+// ROUTER: Loki-ecosystem logs arrive here, get labeled with "selected_destinations"
+// based on {{ $attribute }}{{ if $labelName }} (label "{{ $labelName }}"){{ else }} (no label equivalent - defaults only){{ end }}, and fan out to one gate per downstream destination.
+loki.relabel {{ printf "%s_logs_loki" $alloyName | quote }} {
+{{ include "destinations.router.labelRules" (dict "routes" $routes "defaultDestinations" $defaultDestinations "signal" "logs" "labelName" $labelName "downstreamInfo" $downstreamInfo) | indent 2 }}
+  forward_to = [{{ range $d := $logsDownstream }}{{ include "pipeline.alloy.gate.ref" (dict "processor" $routerName "destination" $d "type" "logs" "ecosystem" "loki") }}, {{ end }}]
+} // loki.relabel "{{ $alloyName }}_logs_loki"
+{{- range $d := $logsDownstream }}
+{{- $info := get $downstreamInfo $d }}
+{{ include "pipeline.alloy.gate.render" (dict "processor" $routerName "destination" $d "type" "logs" "ecosystem" "loki" "destinationTarget" (include (printf "destinations.%s.alloy.loki.logs.target" $info.type) (dict "destination" $info.values "destinationName" $d) | trim)) }}
+{{- end }}
+
+{{- /* ---------------- logs/otlp ---------------- */}}
+// ROUTER: OTLP-ecosystem logs arrive here, get an OTTL-set "selected_destinations" resource
+// attribute based on {{ $attribute }}, and fan out to one gate per downstream destination.
+otelcol.processor.transform {{ printf "%s_logs_otlp" $alloyName | quote }} {
+  error_mode = "ignore"
+  log_statements {
+    context = "resource"
+    statements = [
+{{ include "destinations.router.ottlStatements" (dict "routes" $routes "defaultDestinations" $defaultDestinations "signal" "logs" "attribute" $attribute "downstreamInfo" $downstreamInfo) | indent 6 }}
+    ]
+  }
+  output {
+    logs = [{{ range $d := $logsDownstream }}{{ include "pipeline.alloy.gate.ref" (dict "processor" $routerName "destination" $d "type" "logs" "ecosystem" "otlp") }}, {{ end }}]
+  }
+} // otelcol.processor.transform "{{ $alloyName }}_logs_otlp"
+{{- range $d := $logsDownstream }}
+{{- $info := get $downstreamInfo $d }}
+{{ include "pipeline.alloy.gate.render" (dict "processor" $routerName "destination" $d "type" "logs" "ecosystem" "otlp" "destinationTarget" (include (printf "destinations.%s.alloy.otlp.logs.target" $info.type) (dict "destination" $info.values "destinationName" $d) | trim)) }}
+{{- end }}
+
+{{- /* ---------------- traces/otlp ---------------- */}}
+{{- $tracesDownstream := include "destinations.router.downstreamForSignal" (dict "allDownstream" $allDownstream "downstreamInfo" $downstreamInfo "signal" "traces") | fromYamlArray }}
+// ROUTER: OTLP traces arrive here, get an OTTL-set "selected_destinations" resource attribute
+// based on {{ $attribute }}, and fan out to one gate per downstream destination.
+otelcol.processor.transform {{ printf "%s_traces_otlp" $alloyName | quote }} {
+  error_mode = "ignore"
+  trace_statements {
+    context = "resource"
+    statements = [
+{{ include "destinations.router.ottlStatements" (dict "routes" $routes "defaultDestinations" $defaultDestinations "signal" "traces" "attribute" $attribute "downstreamInfo" $downstreamInfo) | indent 6 }}
+    ]
+  }
+  output {
+    traces = [{{ range $d := $tracesDownstream }}{{ include "pipeline.alloy.gate.ref" (dict "processor" $routerName "destination" $d "type" "traces" "ecosystem" "otlp") }}, {{ end }}]
+  }
+} // otelcol.processor.transform "{{ $alloyName }}_traces_otlp"
+{{- range $d := $tracesDownstream }}
+{{- $info := get $downstreamInfo $d }}
+{{ include "pipeline.alloy.gate.render" (dict "processor" $routerName "destination" $d "type" "traces" "ecosystem" "otlp" "destinationTarget" (include (printf "destinations.%s.alloy.otlp.traces.target" $info.type) (dict "destination" $info.values "destinationName" $d) | trim)) }}
+{{- end }}
+
+{{- /* ---------------- profiles/pyroscope ---------------- */}}
+{{- $profilesDownstream := include "destinations.router.downstreamForSignal" (dict "allDownstream" $allDownstream "downstreamInfo" $downstreamInfo "signal" "profiles") | fromYamlArray }}
+// ROUTER: Pyroscope-ecosystem profiles arrive here, get labeled with "selected_destinations"
+// based on {{ $attribute }}{{ if $labelName }} (label "{{ $labelName }}"){{ else }} (no label equivalent - defaults only){{ end }}, and fan out to one gate per downstream destination.
+pyroscope.relabel {{ printf "%s_profiles_pyroscope" $alloyName | quote }} {
+{{ include "destinations.router.labelRules" (dict "routes" $routes "defaultDestinations" $defaultDestinations "signal" "profiles" "labelName" $labelName "downstreamInfo" $downstreamInfo) | indent 2 }}
+  forward_to = [{{ range $d := $profilesDownstream }}{{ include "pipeline.alloy.gate.ref" (dict "processor" $routerName "destination" $d "type" "profiles" "ecosystem" "pyroscope") }}, {{ end }}]
+} // pyroscope.relabel "{{ $alloyName }}_profiles_pyroscope"
+{{- range $d := $profilesDownstream }}
+{{- $info := get $downstreamInfo $d }}
+{{ include "pipeline.alloy.gate.render" (dict "processor" $routerName "destination" $d "type" "profiles" "ecosystem" "pyroscope" "destinationTarget" (include (printf "destinations.%s.alloy.pyroscope.profiles.target" $info.type) (dict "destination" $info.values "destinationName" $d) | trim)) }}
+{{- end }}
+
+{{- end }}
+{{- end }}
+
+{{/* Inputs: routes ([]route), defaultDestinations ([]string), signal (string), labelName (string, may be empty) */}}
+{{/* Output: `rule { ... }` blocks for a prometheus.relabel/loki.relabel/pyroscope.relabel component:
+     the default is written unconditionally first, then each route whose signals list (if any)
+     includes this signal is written in REVERSE declaration order, so relabel's sequential
+     rule evaluation makes the FIRST-declared matching route win (later rules overwrite earlier
+     ones, and we emit the first route last). */}}
+{{- define "destinations.router.labelRules" }}
+rule {
+  target_label = "selected_destinations"
+  replacement  = {{ join "," .defaultDestinations | quote }}
+}
+{{- if .labelName }}
+{{- $signal := .signal }}
+{{- $downstreamInfo := .downstreamInfo }}
+{{- $routes := .routes }}
+{{- $n := len $routes }}
+{{- range $i := until $n }}
+  {{- $route := index $routes (sub (sub $n 1) $i) }}
+  {{- if or (not $route.signals) (has $signal $route.signals) }}
+    {{- /* F5: a route's destinations are the RAW list from values (may include destinations
+           that don't carry this signal at all). Filter to the ones that actually support this
+           signal before stamping -- an unfiltered stamp would name a destination that has no
+           gate rendered for this signal (destinations.router.alloy only renders gates for
+           downstreamForSignal-filtered lists), so a matching record's marker would match no
+           gate's `keep` filter and vanish instead of falling back to defaultDestinations. If
+           NOTHING in the route survives the filter for this signal, skip the rule entirely so
+           the unconditional default rule above is left standing for matching records. */}}
+    {{- $routeDestinations := $route.destinations | default list }}
+    {{- $filteredDestinations := include "destinations.router.downstreamForSignal" (dict "allDownstream" $routeDestinations "downstreamInfo" $downstreamInfo "signal" $signal) | fromYamlArray }}
+    {{- if not (empty $filteredDestinations) }}
+rule {
+  source_labels = ["{{ $.labelName }}"]
+  regex         = {{ include "destinations.router.matchRegex" $route.match | quote }}
+  target_label  = "selected_destinations"
+  replacement   = {{ join "," $filteredDestinations | quote }}
+}
+    {{- end }}
+  {{- end }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/* Inputs: a `match` block ({equals|in|matches}) */}}
+{{/* Output: a fully-anchored regex matching the label VALUE. String values are escaped via
+     regexQuoteMeta since they arrive as free-form user input, not regex syntax (except `matches`,
+     which is documented as a raw regex). */}}
+{{- define "destinations.router.matchRegex" }}
+{{- if hasKey . "equals" }}{{ printf "^%s$" (regexQuoteMeta (toString .equals)) }}
+{{- else if hasKey . "in" }}
+  {{- $parts := list }}
+  {{- range $v := .in }}{{ $parts = append $parts (regexQuoteMeta (toString $v)) }}{{ end }}
+  {{- printf "^(%s)$" (join "|" $parts) }}
+{{- else if hasKey . "matches" }}{{ .matches }}
+{{- end }}
+{{- end }}
+
+{{/* Inputs: routes ([]route), defaultDestinations ([]string), signal (string), attribute (string) */}}
+{{/* Output: comma-separated `set(attributes[...], ...) where ...` OTTL statement lines for an
+     otelcol.processor.transform statements list: default unconditional first, then each matching
+     route in REVERSE order (same first-route-wins trick as labelRules, since OTTL statements
+     execute sequentially and each `set` overwrites the previous value). */}}
+{{- define "destinations.router.ottlStatements" }}
+{{- /* F4: rendered with Helm `quote` (Go %q), not a backtick raw string, so the OUTER Alloy
+       string literal correctly escapes double-quotes, backslashes, and newlines that may appear
+       in destination/attribute values (a raw backtick string breaks the moment a value contains
+       a literal backtick, and can't be used at all for a value containing a newline). ottlEscape
+       still does the INNER OTTL-string-literal escaping; quote handles the outer Alloy layer,
+       mirroring the stamper idiom in templates/dataProcessors/_config.alloy.tpl. */}}
+{{ printf `set(attributes["selected_destinations"], "%s")` (include "destinations.router.ottlEscape" (join "," .defaultDestinations)) | quote }},
+{{- $signal := .signal }}
+{{- $attribute := .attribute }}
+{{- $downstreamInfo := .downstreamInfo }}
+{{- $routes := .routes }}
+{{- $n := len $routes }}
+{{- range $i := until $n }}
+  {{- $route := index $routes (sub (sub $n 1) $i) }}
+  {{- if or (not $route.signals) (has $signal $route.signals) }}
+    {{- /* F5: see the identical filter in destinations.router.labelRules above. */}}
+    {{- $routeDestinations := $route.destinations | default list }}
+    {{- $filteredDestinations := include "destinations.router.downstreamForSignal" (dict "allDownstream" $routeDestinations "downstreamInfo" $downstreamInfo "signal" $signal) | fromYamlArray }}
+    {{- if not (empty $filteredDestinations) }}
+{{ printf `set(attributes["selected_destinations"], "%s") where %s` (include "destinations.router.ottlEscape" (join "," $filteredDestinations)) (include "destinations.router.ottlCondition" (dict "attribute" $attribute "match" $route.match)) | quote }},
+    {{- end }}
+  {{- end }}
+{{- end }}
+{{- end }}
+
+{{/* Inputs: a string. Output: the string with backslashes then double-quotes escaped, so it is
+     safe to splice into a double-quoted OTTL string literal. Order matters: escaping quotes
+     before backslashes would double-escape the backslashes just introduced. */}}
+{{- define "destinations.router.ottlEscape" }}
+{{- . | replace "\\" "\\\\" | replace "\"" "\\\"" }}
+{{- end }}
+
+{{/* Inputs: attribute (string), match ({equals|in|matches}) */}}
+{{/* Output: an OTTL boolean condition testing the resource attribute against the match. */}}
+{{- define "destinations.router.ottlCondition" }}
+{{- if hasKey .match "equals" }}attributes["{{ .attribute }}"] == "{{ include "destinations.router.ottlEscape" (toString .match.equals) }}"
+{{- else if hasKey .match "in" }}{{/* F1: OTTL has no `in` operator -- render an OR-chain of `==`
+        comparisons instead. Each value goes through ottlEscape exactly like the `equals` branch,
+        and the whole chain is parenthesized so it composes safely with the `where` clause it's
+        spliced into (and with any surrounding boolean logic). */}}({{ range $i, $v := .match.in }}{{ if $i }} or {{ end }}attributes["{{ $.attribute }}"] == "{{ include "destinations.router.ottlEscape" (toString $v) }}"{{ end }})
+{{- else if hasKey .match "matches" }}{{/* F2: `matches` is documented as a raw regex, but it is
+        still spliced into a double-quoted OTTL string literal, so backslashes and quotes inside
+        it must go through the same INNER-layer escaping as equals/in (e.g. `^team-\d+$` must
+        render as `^team-\\d+$` so OTTL's own string-literal parser un-escapes it back to the
+        intended `\d`). This is regex-content-preserving: ottlEscape never touches regex
+        metacharacters, only the two characters that are unsafe inside a double-quoted OTTL
+        string. */}}IsMatch(attributes["{{ .attribute }}"], "{{ include "destinations.router.ottlEscape" .match.matches }}") == true
+{{- end }}
+{{- end }}
+
+{{- define "secrets.list.router" }}{{ end -}}
+
+{{- define "destinations.router.alloy.prometheus.metrics.target" }}prometheus.relabel.{{ include "helper.alloy_name" .destinationName }}_metrics_prometheus.receiver{{ end -}}
+{{- define "destinations.router.alloy.otlp.metrics.target" }}otelcol.processor.transform.{{ include "helper.alloy_name" .destinationName }}_metrics_otlp.input{{ end -}}
+{{- define "destinations.router.alloy.loki.logs.target" }}loki.relabel.{{ include "helper.alloy_name" .destinationName }}_logs_loki.receiver{{ end -}}
+{{- define "destinations.router.alloy.otlp.logs.target" }}otelcol.processor.transform.{{ include "helper.alloy_name" .destinationName }}_logs_otlp.input{{ end -}}
+{{- define "destinations.router.alloy.otlp.traces.target" }}otelcol.processor.transform.{{ include "helper.alloy_name" .destinationName }}_traces_otlp.input{{ end -}}
+{{- define "destinations.router.alloy.pyroscope.profiles.target" }}pyroscope.relabel.{{ include "helper.alloy_name" .destinationName }}_profiles_pyroscope.receiver{{ end -}}
+
+{{/* A router accepts every signal. supports_<signal> is called with only the router's own
+     values (destinations.get / destinations.alloy.targets pass `$destination`, never the root),
+     so it cannot inspect downstream capability here. Per-downstream capability is resolved in the
+     body (destinations.router.downstreamForSignal excludes a downstream from a signal it does not
+     support), and destinations.router.validate warns when a route ends up with no downstream for
+     a signal it covers. */}}
+{{- define "destinations.router.supports_metrics" }}true{{ end -}}
+{{- define "destinations.router.supports_logs" }}true{{ end -}}
+{{- define "destinations.router.supports_traces" }}true{{ end -}}
+{{- define "destinations.router.supports_profiles" }}true{{ end -}}
+
+{{/* ecosystem is a single value, but a router is multi-ecosystem. We return "otlp". A
+     destination's ecosystem only affects implicit destination selection (destinations.get when a
+     feature has no explicit `destinations:` list): a router is a primary candidate only for otlp
+     lookups, and a backup elsewhere. In practice this means routers must be opted into
+     explicitly with `destinations: [myRouter]` on each feature — which is the intended, explicit
+     way to use a router. Documented in the destination routing guide. */}}
+{{- define "destinations.router.ecosystem" }}otlp{{ end -}}

--- a/charts/k8s-monitoring/templates/destinations/_destination_router_validations.tpl
+++ b/charts/k8s-monitoring/templates/destinations/_destination_router_validations.tpl
@@ -1,0 +1,441 @@
+{{- /* Validates a `router` destination (see destinations/router-values.yaml and
+       _destination_router.tpl for what this feeds). A router is a virtual destination: it never
+       talks to a backend itself, it only fans telemetry out to real downstream destinations. That
+       means its validation has to reach outside its own destination block into the full
+       destinations map, to confirm every reference it makes (routes[].destinations,
+       defaultDestinations) actually exists, is enabled, and isn't itself another router. */}}
+{{- /* Inputs: Values (root context -- the object destinations.validate itself was called with,
+       i.e. `$` from inside its enclosing range over destinations, NOT the chart's `.Values` map.
+       So `.Values.Values` here is the chart's actual `.Values`, and `.Values.Values.destinations`
+       is the full destinations map. This is required because, unlike otlp validation, router
+       validation needs to look up destinations besides its own.), Destination (a router
+       Destination), DestinationName (the destination's name) */}}
+{{- define "destinations.router.validate" }}
+  {{- $name := .DestinationName }}
+  {{- $router := .Destination }}
+  {{- $root := .Values }}
+  {{- $allDestinations := .Values.Values.destinations | default dict }}
+  {{- $enabledDestinations := include "destinations.getEnabled" $allDestinations | fromYaml }}
+  {{- /* Minor (a): routers aren't valid route/defaultDestinations targets (R8 below already
+         forbids referencing one), so don't suggest them in R6's "known destinations" list. */}}
+  {{- $knownDestinationNames := list }}
+  {{- range $k, $v := $enabledDestinations }}
+    {{- if ne $v.type "router" }}{{- $knownDestinationNames = append $knownDestinationNames $k }}{{- end }}
+  {{- end }}
+  {{- $knownDestinationNames = $knownDestinationNames | sortAlpha }}
+  {{- $routes := $router.routes | default list }}
+  {{- $defaultDestinations := $router.defaultDestinations | default list }}
+
+  {{- /* R0: `attribute` (defaults to k8s.namespace.name when unset) must be a syntactically
+         valid attribute name: non-empty, starting with a letter/underscore, containing only
+         letters/digits/underscore/dot/slash/hyphen, and critically no quotes, backticks,
+         backslashes, or whitespace. destinations.router.ottlCondition splices this value
+         unquoted into `attributes["<attribute>"]`, so anything outside this grammar (e.g.
+         `foo"] == "x`) would let user input break out of the OTTL string literal and inject
+         arbitrary OTTL/Alloy syntax. */}}
+  {{- $attribute := $router.attribute | default "k8s.namespace.name" }}
+  {{- if not (regexMatch "^[a-zA-Z_][a-zA-Z0-9_./-]*$" $attribute) }}
+    {{- $msg := list "" (printf "Destination \"%s\" (type: router) has an invalid attribute: %q." $name $attribute) }}
+    {{- $msg = append $msg "Please use a valid attribute name." }}
+    {{- $msg = append $msg "It must start with a letter or underscore and contain only letters, digits, underscores, dots, slashes, and hyphens -- no quotes, backticks, backslashes, or whitespace." }}
+    {{- $msg = append $msg "Please set:" }}
+    {{- $msg = append $msg "destinations:" }}
+    {{- $msg = append $msg (printf "  %s:" $name) }}
+    {{- $msg = append $msg "    type: router" }}
+    {{- $msg = append $msg "    attribute: k8s.namespace.name" }}
+    {{- fail (join "\n" $msg) }}
+  {{- end }}
+
+  {{- /* R1: defaultDestinations is mandatory. A router is a terminal destination: records that
+         don't match any route (or match a route that doesn't cover their signal) fall back to
+         defaultDestinations, so unmatched telemetry always needs somewhere to land. */}}
+  {{- if empty $defaultDestinations }}
+    {{- $msg := list "" (printf "Destination \"%s\" (type: router) does not have any defaultDestinations." $name) }}
+    {{- $msg = append $msg "A router is a terminal destination, so it must name at least one fallback destination for records that don't match any route." }}
+    {{- $msg = append $msg "Please set:" }}
+    {{- $msg = append $msg "destinations:" }}
+    {{- $msg = append $msg (printf "  %s:" $name) }}
+    {{- $msg = append $msg "    type: router" }}
+    {{- $msg = append $msg "    defaultDestinations:" }}
+    {{- $msg = append $msg "      - my-destination" }}
+    {{- fail (join "\n" $msg) }}
+  {{- end }}
+
+  {{- range $i, $route := $routes }}
+    {{- $routeNum := add1 $i }}
+    {{- $match := $route.match | default dict }}
+    {{- $matchKeys := list }}
+    {{- range $k := list "equals" "in" "matches" }}
+      {{- if hasKey $match $k }}{{- $matchKeys = append $matchKeys $k }}{{- end }}
+    {{- end }}
+
+    {{- /* R2: exactly one of equals/in/matches. */}}
+    {{- if eq (len $matchKeys) 0 }}
+      {{- $msg := list "" (printf "Destination \"%s\" (type: router) has a route (#%d) with no match condition." $name $routeNum) }}
+      {{- $msg = append $msg "Every route must set exactly one of match.equals, match.in, or match.matches." }}
+      {{- $msg = append $msg "Please set:" }}
+      {{- $msg = append $msg "destinations:" }}
+      {{- $msg = append $msg (printf "  %s:" $name) }}
+      {{- $msg = append $msg "    type: router" }}
+      {{- $msg = append $msg "    routes:" }}
+      {{- $msg = append $msg "      - match:" }}
+      {{- $msg = append $msg "          equals: my-value" }}
+      {{- $msg = append $msg "        destinations:" }}
+      {{- $msg = append $msg "          - my-destination" }}
+      {{- fail (join "\n" $msg) }}
+    {{- else if gt (len $matchKeys) 1 }}
+      {{- $msg := list "" (printf "Destination \"%s\" (type: router) has a route (#%d) with multiple match conditions set: %s." $name $routeNum (join ", " $matchKeys)) }}
+      {{- $msg = append $msg "Exactly one of match.equals, match.in, or match.matches is required per route." }}
+      {{- $msg = append $msg "Please remove all but one of these fields." }}
+      {{- fail (join "\n" $msg) }}
+    {{- end }}
+
+    {{- /* R2b: `in` must be a list. A scalar value here (e.g. `in: foo` parsed as a YAML string)
+           passes the schema's `oneOf` required-key check and R3's `empty` check below (a
+           non-empty string is not "empty"), but R4's and the body's `range $v := $match.in` over
+           a plain string is not supported by Go's text/template range action, so it fails render
+           with a raw, confusing "range can't iterate over ..." error. Catch it here, before any
+           range over match.in, with a clear message instead. */}}
+    {{- if and (hasKey $match "in") (not (kindIs "slice" $match.in)) }}
+      {{- $msg := list "" (printf "Destination \"%s\" (type: router) has a route (#%d) whose match.in value is not a list: %v." $name $routeNum $match.in) }}
+      {{- $msg = append $msg "The `in` match must be a list, e.g. `in: [value1, value2]`." }}
+      {{- $msg = append $msg "Please set:" }}
+      {{- $msg = append $msg "destinations:" }}
+      {{- $msg = append $msg (printf "  %s:" $name) }}
+      {{- $msg = append $msg "    type: router" }}
+      {{- $msg = append $msg "    routes:" }}
+      {{- $msg = append $msg "      - match:" }}
+      {{- $msg = append $msg "          in: [my-value-a, my-value-b]" }}
+      {{- fail (join "\n" $msg) }}
+    {{- end }}
+
+    {{- /* R3: `in` must be non-empty. Only reachable when it's the sole match key (R2 already
+           failed on zero or multiple match keys). */}}
+    {{- if and (hasKey $match "in") (empty $match.in) }}
+      {{- $msg := list "" (printf "Destination \"%s\" (type: router) has a route (#%d) with an empty match.in list." $name $routeNum) }}
+      {{- $msg = append $msg "match.in needs at least one value to match against." }}
+      {{- $msg = append $msg "Please set:" }}
+      {{- $msg = append $msg "destinations:" }}
+      {{- $msg = append $msg (printf "  %s:" $name) }}
+      {{- $msg = append $msg "    type: router" }}
+      {{- $msg = append $msg "    routes:" }}
+      {{- $msg = append $msg "      - match:" }}
+      {{- $msg = append $msg "          in: [my-value-a, my-value-b]" }}
+      {{- fail (join "\n" $msg) }}
+    {{- end }}
+
+    {{- /* R4: match values must be strings. They get spliced into a regex (equals/in, via
+           regexQuoteMeta) or used verbatim as a regex (matches), so a YAML value parsed as a
+           bool/number/null (e.g. an unquoted `true` or `123`) is very likely not what the user
+           meant to match against. */}}
+    {{- if hasKey $match "equals" }}
+      {{- if not (kindIs "string" $match.equals) }}
+        {{- $msg := list "" (printf "Destination \"%s\" (type: router) has a route (#%d) whose match.equals value is not a string: %v." $name $routeNum $match.equals) }}
+        {{- $msg = append $msg "Please quote it so it isn't parsed as a YAML number, boolean, or null:" }}
+        {{- $msg = append $msg "destinations:" }}
+        {{- $msg = append $msg (printf "  %s:" $name) }}
+        {{- $msg = append $msg "    type: router" }}
+        {{- $msg = append $msg "    routes:" }}
+        {{- $msg = append $msg "      - match:" }}
+        {{- $msg = append $msg (printf "          equals: \"%v\"" $match.equals) }}
+        {{- fail (join "\n" $msg) }}
+      {{- end }}
+    {{- end }}
+    {{- if hasKey $match "in" }}
+      {{- range $v := $match.in }}
+        {{- if not (kindIs "string" $v) }}
+          {{- $msg := list "" (printf "Destination \"%s\" (type: router) has a route (#%d) whose match.in list contains a non-string value: %v." $name $routeNum $v) }}
+          {{- $msg = append $msg "Please quote it so it isn't parsed as a YAML number, boolean, or null:" }}
+          {{- $msg = append $msg "destinations:" }}
+          {{- $msg = append $msg (printf "  %s:" $name) }}
+          {{- $msg = append $msg "    type: router" }}
+          {{- $msg = append $msg "    routes:" }}
+          {{- $msg = append $msg "      - match:" }}
+          {{- $msg = append $msg (printf "          in: [\"%v\"]" $v) }}
+          {{- fail (join "\n" $msg) }}
+        {{- end }}
+      {{- end }}
+    {{- end }}
+    {{- if hasKey $match "matches" }}
+      {{- if not (kindIs "string" $match.matches) }}
+        {{- $msg := list "" (printf "Destination \"%s\" (type: router) has a route (#%d) whose match.matches value is not a string: %v." $name $routeNum $match.matches) }}
+        {{- $msg = append $msg "Please quote it so it isn't parsed as a YAML number, boolean, or null:" }}
+        {{- $msg = append $msg "destinations:" }}
+        {{- $msg = append $msg (printf "  %s:" $name) }}
+        {{- $msg = append $msg "    type: router" }}
+        {{- $msg = append $msg "    routes:" }}
+        {{- $msg = append $msg "      - match:" }}
+        {{- $msg = append $msg (printf "          matches: \"%v\"" $match.matches) }}
+        {{- fail (join "\n" $msg) }}
+      {{- end }}
+
+      {{- /* R5: matches must compile as a regex. mustRegexMatch fails the template with Go's
+             regexp compile error if it doesn't, which is acceptable here: the body
+             (destinations.router.ottlCondition / matchRegex) uses this same string as a regex, so
+             a compile error here is exactly the error the user needs to see. */}}
+      {{- $_ := mustRegexMatch $match.matches "" }}
+    {{- end }}
+
+    {{- /* R5b: every route must have at least one destination. An empty or missing destinations
+           list would pass every other check yet silently blackhole every record that matches
+           this route (the router body would stamp/select an empty destination list for it, so
+           the record matches no downstream gate for any signal and simply vanishes instead of
+           falling back to defaultDestinations). */}}
+    {{- if empty ($route.destinations | default list) }}
+      {{- $msg := list "" (printf "Destination \"%s\" (type: router) has a route (#%d) with an empty or missing destinations list." $name $routeNum) }}
+      {{- $msg = append $msg "A route with no destinations would silently drop every record that matches it." }}
+      {{- $msg = append $msg "Please set at least one destination:" }}
+      {{- $msg = append $msg "destinations:" }}
+      {{- $msg = append $msg (printf "  %s:" $name) }}
+      {{- $msg = append $msg "    type: router" }}
+      {{- $msg = append $msg "    routes:" }}
+      {{- $msg = append $msg "      - match:" }}
+      {{- $msg = append $msg "          equals: my-value" }}
+      {{- $msg = append $msg "        destinations:" }}
+      {{- $msg = append $msg "          - my-destination" }}
+      {{- fail (join "\n" $msg) }}
+    {{- end }}
+
+    {{- /* R6 (route destinations): every referenced destination must exist and be enabled. */}}
+    {{- $routeDestinations := $route.destinations | default list }}
+    {{- range $d := $routeDestinations }}
+      {{- if not (hasKey $enabledDestinations $d) }}
+        {{- $msg := list "" (printf "Destination \"%s\" (type: router) has a route (#%d) referencing unknown destination \"%s\"." $name $routeNum $d) }}
+        {{- $msg = append $msg "The destination must exist and be enabled." }}
+        {{- $msg = append $msg "Please reference one of the known destinations:" }}
+        {{- range $k := $knownDestinationNames }}{{- $msg = append $msg (printf "  %s" $k) }}{{- end }}
+        {{- fail (join "\n" $msg) }}
+      {{- end }}
+    {{- end }}
+
+    {{- /* R7: signals (when present) must be non-empty and only contain known signal names. */}}
+    {{- if hasKey $route "signals" }}
+      {{- if empty $route.signals }}
+        {{- $msg := list "" (printf "Destination \"%s\" (type: router) has a route (#%d) with an empty signals list." $name $routeNum) }}
+        {{- $msg = append $msg "Either remove the signals field to match all signals, or list at least one of: metrics, logs, traces, profiles." }}
+        {{- fail (join "\n" $msg) }}
+      {{- end }}
+      {{- range $s := $route.signals }}
+        {{- if not (has $s (list "metrics" "logs" "traces" "profiles")) }}
+          {{- $msg := list "" (printf "Destination \"%s\" (type: router) has a route (#%d) with an unknown signal \"%s\"." $name $routeNum $s) }}
+          {{- $msg = append $msg "Please use one of: metrics, logs, traces, profiles." }}
+          {{- fail (join "\n" $msg) }}
+        {{- end }}
+      {{- end }}
+    {{- end }}
+
+    {{- /* R8 (cycle, route destinations): a route must not point at another router. Chaining
+           routers would try to wire one router's fan-out gates into another router's OTTL/label
+           inputs, which _destination_router.tpl does not support and would form a cycle in the
+           generated Alloy pipeline. */}}
+    {{- range $d := $routeDestinations }}
+      {{- if hasKey $enabledDestinations $d }}
+        {{- if eq (get $enabledDestinations $d).type "router" }}
+          {{- $msg := list "" (printf "Destination \"%s\" (type: router) has a route (#%d) referencing another router destination \"%s\"." $name $routeNum $d) }}
+          {{- $msg = append $msg "Routing telemetry from one router into another router would create a cycle in the generated Alloy pipeline, so it is not supported." }}
+          {{- $msg = append $msg "Please point routes and defaultDestinations at real (non-router) destinations." }}
+          {{- fail (join "\n" $msg) }}
+        {{- end }}
+      {{- end }}
+    {{- end }}
+  {{- end }}
+
+  {{- /* R6 (defaultDestinations): every default destination must exist and be enabled. */}}
+  {{- range $d := $defaultDestinations }}
+    {{- if not (hasKey $enabledDestinations $d) }}
+      {{- $msg := list "" (printf "Destination \"%s\" (type: router) has a defaultDestinations entry referencing unknown destination \"%s\"." $name $d) }}
+      {{- $msg = append $msg "The destination must exist and be enabled." }}
+      {{- $msg = append $msg "Please reference one of the known destinations:" }}
+      {{- range $k := $knownDestinationNames }}{{- $msg = append $msg (printf "  %s" $k) }}{{- end }}
+      {{- fail (join "\n" $msg) }}
+    {{- end }}
+  {{- end }}
+
+  {{- /* R8 (cycle, defaultDestinations): same cycle guard as routes, above. */}}
+  {{- range $d := $defaultDestinations }}
+    {{- if hasKey $enabledDestinations $d }}
+      {{- if eq (get $enabledDestinations $d).type "router" }}
+        {{- $msg := list "" (printf "Destination \"%s\" (type: router) has a defaultDestinations entry referencing another router destination \"%s\"." $name $d) }}
+        {{- $msg = append $msg "Routing telemetry from one router into another router would create a cycle in the generated Alloy pipeline, so it is not supported." }}
+        {{- $msg = append $msg "Please point routes and defaultDestinations at real (non-router) destinations." }}
+        {{- fail (join "\n" $msg) }}
+      {{- end }}
+    {{- end }}
+  {{- end }}
+
+  {{- /* R10 (defaultDestinations signal coverage) used to hard-fail here by INFERRING which
+         signals were "in play" on the router (all four when it had no routes). That inference
+         was a false positive generator: a no-routes fan-out router with e.g. otlp
+         defaultDestinations would fail on "profiles" (otlp can't carry profiles) even when the
+         only feature actually using the router sends logs. The router itself has no way to know
+         which signals a feature will actually forward through it -- only the forwarding seam
+         does. See destinations.router.assertCanCarry below, invoked from
+         pipeline.alloy.targets.forFeature (templates/dataProcessors/_config.alloy.tpl) once per
+         (feature, type, ecosystem) a feature actually emits, which is where "signal actually
+         sent" and "router capability" can be checked together without guessing. */}}
+
+  {{- /* R9 (unsupported-signal warning, deliberately not a hard failure here): a route can
+         legitimately mix downstreams that don't all support the same signals -- e.g. a route with
+         no `signals` filter pointing at both a metrics+logs destination and a traces-only
+         destination is a normal way to fan out mixed telemetry. destinations.router.alloy already
+         handles this per-signal (destinations.router.downstreamForSignal drops a downstream from a
+         signal's forward_to/output list when it doesn't support that signal), so silently dropping
+         is correct behavior, not a bug -- but it's a rendering step the user should still be
+         warned about. That warning belongs in the destinations.notes mechanism (Phase 4), not
+         here: hard-failing would make legitimate mixed-signal routing impossible. See
+         destinations.router.notes below, wired into NOTES.txt via destinations.notes.router. */}}
+{{- end }}
+
+{{/* Precise, false-positive-free replacement for the old R10 inference: asserts that a router
+     destination can actually deliver ONE signal a feature is ACTUALLY forwarding to it. Invoked
+     from pipeline.alloy.targets.forFeature (templates/dataProcessors/_config.alloy.tpl) once per
+     (feature, type, ecosystem) tuple the feature emits, and only when a router destination is
+     among that tuple's resolved destinationNames -- this is the only place in the chart where a
+     feature's real per-destination signal is known, so it is the only place this check can be
+     both correct (never fires for a signal the feature doesn't send) and complete (always fires
+     for a signal the feature does send that would be dropped).
+
+     Capability mirrors destinations.router.downstreamForSignal / the router body exactly: the
+     router can carry `.type` if defaultDestinations has an entry that supports `.type`, OR any
+     route that covers `.type` (no `signals` filter, or `signals` includes `.type`) has a
+     destination that supports `.type`. A route that does NOT cover `.type` is irrelevant --
+     records of this signal never match it in the body (destinations.router.alloy's per-signal
+     labelRules/ottlStatements only emit a rule for a route when the route covers that signal),
+     so its destinations' capability for `.type` is not this check's concern.
+
+     Inputs: root (full Values, i.e. `.root` from pipeline.alloy.targets.forFeature),
+     featureKey (string), routerName (string, a destinations key already confirmed to be
+     type: router by the caller), type (metrics|logs|traces|profiles). */}}
+{{- define "destinations.router.assertCanCarry" }}
+  {{- $root := .root }}
+  {{- $featureKey := .featureKey }}
+  {{- $routerName := .routerName }}
+  {{- $type := .type }}
+  {{- $allDestinations := $root.Values.destinations | default dict }}
+  {{- $enabledDestinations := include "destinations.getEnabled" $allDestinations | fromYaml }}
+  {{- $router := get $enabledDestinations $routerName }}
+  {{- $routes := $router.routes | default list }}
+  {{- $defaultDestinations := $router.defaultDestinations | default list }}
+
+  {{- /* Union of every destination this router can ever send to (routes[].destinations +
+         defaultDestinations), same as destinations.router.alloy's $allDownstream. */}}
+  {{- $allDownstream := list }}
+  {{- range $d := $defaultDestinations }}
+    {{- if not (has $d $allDownstream) }}{{- $allDownstream = append $allDownstream $d }}{{- end }}
+  {{- end }}
+  {{- range $route := $routes }}
+    {{- range $d := ($route.destinations | default list) }}
+      {{- if not (has $d $allDownstream) }}{{- $allDownstream = append $allDownstream $d }}{{- end }}
+    {{- end }}
+  {{- end }}
+
+  {{- /* Resolve each downstream's type + fully-merged-with-defaults values once, same as
+         destinations.router.alloy's $downstreamInfo. Every name here has already been confirmed
+         (by destinations.router.validate's R6/R8 checks) to exist, be enabled, and not be a
+         router. */}}
+  {{- $downstreamInfo := dict }}
+  {{- range $d := $allDownstream }}
+    {{- if hasKey $enabledDestinations $d }}
+      {{- $dest := get $enabledDestinations $d }}
+      {{- $defaults := (printf "destinations/%s-values.yaml" $dest.type) | $root.Files.Get | fromYaml }}
+      {{- $merged := mergeOverwrite $defaults $dest }}
+      {{- $_ := set $downstreamInfo $d (dict "type" $dest.type "values" $merged) }}
+    {{- end }}
+  {{- end }}
+
+  {{- $capable := false }}
+  {{- $defaultCovered := include "destinations.router.downstreamForSignal" (dict "allDownstream" $defaultDestinations "downstreamInfo" $downstreamInfo "signal" $type) | fromYamlArray }}
+  {{- if not (empty $defaultCovered) }}
+    {{- $capable = true }}
+  {{- end }}
+  {{- if not $capable }}
+    {{- range $route := $routes }}
+      {{- if or (not (hasKey $route "signals")) (has $type $route.signals) }}
+        {{- $routeDestinations := $route.destinations | default list }}
+        {{- $routeCovered := include "destinations.router.downstreamForSignal" (dict "allDownstream" $routeDestinations "downstreamInfo" $downstreamInfo "signal" $type) | fromYamlArray }}
+        {{- if not (empty $routeCovered) }}
+          {{- $capable = true }}
+        {{- end }}
+      {{- end }}
+    {{- end }}
+  {{- end }}
+
+  {{- if not $capable }}
+    {{- $msg := list "" (printf "Feature \"%s\" sends %s to router destination \"%s\", but that router has no route or defaultDestinations entry that can accept %s." $featureKey $type $routerName $type) }}
+    {{- $msg = append $msg (printf "%s reaching this router would be dropped." $type) }}
+    {{- $msg = append $msg (printf "Please add a destination that supports %s to the router's routes or defaultDestinations." $type) }}
+    {{- fail (join "\n" $msg) }}
+  {{- end }}
+{{- end }}
+
+{{/* Phase 4: soft, render-time warnings for a single enabled router destination. Telemetry still
+     flows in every case this covers (it falls back to defaultDestinations), so these are notes,
+     not validation failures -- see R9 above for why. Invoked once per enabled router destination
+     from destinations.notes.router (_destination_notes.tpl). This define assumes valid input:
+     destinations.router.validate has already run and rejected malformed attributes/routes. */}}
+{{- /* Inputs: Values (root context, same convention as destinations.router.validate above),
+       Destination (a router Destination), DestinationName (the destination's name) */}}
+{{- define "destinations.router.notes" }}
+  {{- $root := .Values }}
+  {{- $name := .DestinationName }}
+  {{- $router := .Destination }}
+  {{- $allDestinations := $root.Values.destinations | default dict }}
+  {{- $enabledDestinations := include "destinations.getEnabled" $allDestinations | fromYaml }}
+  {{- $attribute := $router.attribute | default "k8s.namespace.name" }}
+  {{- $routes := $router.routes | default list }}
+  {{- $defaultDestinations := $router.defaultDestinations | default list }}
+
+  {{- /* W-a: the attribute has no valid Prometheus/Loki/Pyroscope label equivalent (same
+         promotion rule as the body's $labelName in destinations.router.alloy). On those
+         label-based collection pipelines, routing is applied before any OTLP conversion could
+         happen, so an attribute that can't become a label falls through to defaultDestinations
+         on those ecosystems even if the matched downstream is itself an OTLP destination -- only
+         telemetry that is actually collected via OTLP can route on an arbitrary attribute. */}}
+  {{- if and (ne $attribute "k8s.namespace.name") (not (regexMatch "^[a-zA-Z_][a-zA-Z0-9_]*$" $attribute)) }}
+
+WARNING: Router "{{ $name }}" routes on attribute "{{ $attribute }}", which is not "k8s.namespace.name" and does not match the Prometheus/Loki/Pyroscope label-name grammar (^[a-zA-Z_][a-zA-Z0-9_]*$), so it has no valid label equivalent. On the Prometheus, Loki, and Pyroscope collection pipelines (scraped metrics, Loki pod logs, Pyroscope profiles), routing on "{{ $attribute }}" falls through to defaultDestinations -- even when the matched destination is OTLP -- because routing is applied on the collection pipeline before any OTLP conversion; only OTLP-collected telemetry can route on an arbitrary attribute.
+  {{- end }}
+
+  {{- /* W-b: for each route, for each signal it covers, warn if NONE of its destinations support
+         that signal. Computed the same way destinations.router.alloy computes it
+         (downstreamForSignal / supports_<signal>), so this fires exactly when the F5 fallback
+         kicks in for that route/signal. */}}
+  {{- $allDownstream := list }}
+  {{- range $d := $defaultDestinations }}
+    {{- if not (has $d $allDownstream) }}{{- $allDownstream = append $allDownstream $d }}{{- end }}
+  {{- end }}
+  {{- range $route := $routes }}
+    {{- range $d := ($route.destinations | default list) }}
+      {{- if not (has $d $allDownstream) }}{{- $allDownstream = append $allDownstream $d }}{{- end }}
+    {{- end }}
+  {{- end }}
+  {{- $downstreamInfo := dict }}
+  {{- range $d := $allDownstream }}
+    {{- if hasKey $enabledDestinations $d }}
+      {{- $dest := get $enabledDestinations $d }}
+      {{- $defaults := (printf "destinations/%s-values.yaml" $dest.type) | $root.Files.Get | fromYaml }}
+      {{- $merged := mergeOverwrite $defaults $dest }}
+      {{- $_ := set $downstreamInfo $d (dict "type" $dest.type "values" $merged) }}
+    {{- end }}
+  {{- end }}
+  {{- range $i, $route := $routes }}
+    {{- $routeNum := add1 $i }}
+    {{- $routeDestinations := $route.destinations | default list }}
+    {{- $signals := $route.signals | default (list "metrics" "logs" "traces" "profiles") }}
+    {{- range $signal := $signals }}
+      {{- $covered := include "destinations.router.downstreamForSignal" (dict "allDownstream" $routeDestinations "downstreamInfo" $downstreamInfo "signal" $signal) | fromYamlArray }}
+      {{- if empty $covered }}
+
+WARNING: Router "{{ $name }}" route #{{ $routeNum }} covers the "{{ $signal }}" signal, but none of its destinations support {{ $signal }}. Matched {{ $signal }} for this route falls back to defaultDestinations.
+      {{- end }}
+    {{- end }}
+  {{- end }}
+
+  {{- /* W-b2 (defaultDestinations signal coverage) used to be warned about here, but is now a
+         hard install-time failure enforced in destinations.router.validate (R10, above) -- a
+         router is terminal, so a signal in play here with no capable defaultDestinations is a
+         genuine silent drop, not something that should only be surfaced as a NOTES.txt warning.
+         Install fails before notes render, so this note would be dead code; see R10's comment for
+         the full rationale (in-play-signal inference, why supports_<signal> is unconditionally
+         true for a router, etc.). */}}
+{{- end }}

--- a/charts/k8s-monitoring/templates/destinations/_destination_types.tpl
+++ b/charts/k8s-monitoring/templates/destinations/_destination_types.tpl
@@ -7,4 +7,5 @@
 - otlp
 - prometheus
 - pyroscope
+- router
 {{- end -}}

--- a/charts/k8s-monitoring/templates/destinations/_destination_validations.tpl
+++ b/charts/k8s-monitoring/templates/destinations/_destination_validations.tpl
@@ -89,6 +89,15 @@
       {{- include "destinations.otlp.validate" (dict "Values" . "Destination" $destination "DestinationName" $destinationName) -}}
     {{- end }}
 
+    {{/* Router destination validations. Note: $ (not .) is used here to reach the root context --
+         "." has been rebound by the enclosing range to the current $destination, so only $ still
+         points at what destinations.validate itself was called with. Router validation needs the
+         full destinations map (unlike otlp validation, which only looks at its own Destination),
+         so this distinction matters here. */}}
+    {{- if (eq $destination.type "router") }}
+      {{- include "destinations.router.validate" (dict "Values" $ "Destination" $destination "DestinationName" $destinationName) -}}
+    {{- end }}
+
     {{/* Validate the rules.collector reference for destinations that opt into rule sync. */}}
     {{- if and (dig "rules" "enabled" false $destination) (dig "rules" "collector" "" $destination) }}
       {{- $rulesCollector := $destination.rules.collector }}

--- a/charts/k8s-monitoring/tests/destination_router_notes_test.yaml
+++ b/charts/k8s-monitoring/tests/destination_router_notes_test.yaml
@@ -1,0 +1,163 @@
+# yamllint disable rule:document-start rule:line-length rule:trailing-spaces
+suite: Destinations - Notes - Router warnings
+templates:
+  - NOTES.txt
+tests:
+  - it: warns when the attribute has no valid Prometheus/Loki/Pyroscope label equivalent (W-a)
+    set:
+      cluster: {name: test-cluster}
+      collectors: {alloy-singleton: {extraConfig: " ", includeDestinations: ["my-router"]}}
+      selfReporting: {enabled: false}
+      destinations:
+        platform:
+          type: otlp
+          url: https://otlp.example.com
+        my-router:
+          type: router
+          attribute: "some.weird-attr"
+          routes:
+            - match: {equals: tenant-a}
+              destinations: [platform]
+          defaultDestinations: [platform]
+    asserts:
+      - matchRegexRaw:
+          pattern: 'Router "my-router" routes on attribute "some\.weird-attr"'
+      - matchRegexRaw:
+          pattern: 'only OTLP-collected telemetry can route on an arbitrary attribute'
+
+  - it: does not warn W-a for the well-known k8s.namespace.name attribute
+    set:
+      cluster: {name: test-cluster}
+      collectors: {alloy-singleton: {extraConfig: " ", includeDestinations: ["my-router"]}}
+      selfReporting: {enabled: false}
+      destinations:
+        platform:
+          type: otlp
+          url: https://otlp.example.com
+        my-router:
+          type: router
+          attribute: "k8s.namespace.name"
+          routes:
+            - match: {equals: tenant-a}
+              destinations: [platform]
+          defaultDestinations: [platform]
+    asserts:
+      - notMatchRegexRaw:
+          pattern: 'has no valid label equivalent'
+
+  - it: warns when a route covers a signal none of its destinations support (W-b)
+    set:
+      cluster: {name: test-cluster}
+      collectors: {alloy-singleton: {extraConfig: " ", includeDestinations: ["my-router"]}}
+      selfReporting: {enabled: false}
+      destinations:
+        platform:
+          type: otlp
+          url: https://otlp.example.com
+        logs-only:
+          type: loki
+          url: https://loki.example.com
+        my-router:
+          type: router
+          attribute: "k8s.namespace.name"
+          routes:
+            - match: {equals: tenant-a}
+              destinations: [logs-only]
+              signals: [metrics, logs]
+          defaultDestinations: [platform]
+    asserts:
+      - matchRegexRaw:
+          pattern: 'Router "my-router" route #1 covers the "metrics" signal, but none of its destinations support metrics\. Matched metrics for this route falls back to defaultDestinations\.'
+      - notMatchRegexRaw:
+          pattern: 'covers the "logs" signal'
+
+  - it: warns per matching signal across multiple routes (W-b, route index is 1-based)
+    set:
+      cluster: {name: test-cluster}
+      collectors: {alloy-singleton: {extraConfig: " ", includeDestinations: ["my-router"]}}
+      selfReporting: {enabled: false}
+      destinations:
+        platform:
+          type: otlp
+          url: https://otlp.example.com
+        logs-only:
+          type: loki
+          url: https://loki.example.com
+        my-router:
+          type: router
+          attribute: "k8s.namespace.name"
+          routes:
+            - match: {equals: tenant-a}
+              destinations: [platform]
+              signals: [metrics]
+            - match: {equals: tenant-b}
+              destinations: [logs-only]
+              signals: [traces]
+          defaultDestinations: [platform]
+    asserts:
+      - matchRegexRaw:
+          pattern: 'Router "my-router" route #2 covers the "traces" signal, but none of its destinations support traces\.'
+      - notMatchRegexRaw:
+          pattern: 'route #1 covers'
+
+  - it: warns that an enabled router requires explicit feature opt-in (W-c)
+    set:
+      cluster: {name: test-cluster}
+      selfReporting: {enabled: false}
+      clusterMetrics:
+        enabled: true
+      telemetryServices:
+        kube-state-metrics:
+          deploy: true
+      collectors:
+        alloy-metrics:
+          presets: [clustered]
+      destinations:
+        platform:
+          type: otlp
+          url: https://otlp.example.com
+        other:
+          type: otlp
+          url: https://otlp2.example.com
+        my-router:
+          type: router
+          attribute: "k8s.namespace.name"
+          routes:
+            - match: {equals: tenant-a}
+              destinations: [platform]
+              signals: [metrics]
+          defaultDestinations: [platform]
+    asserts:
+      - matchRegexRaw:
+          pattern: 'routers are excluded from implicit destination selection'
+      - matchRegexRaw:
+          pattern: 'will therefore not use a router: clusterMetrics'
+
+  - it: does not warn about anything for a clean, explicit router configuration (negative)
+    set:
+      cluster: {name: test-cluster}
+      selfReporting: {enabled: false}
+      clusterMetrics:
+        enabled: true
+        destinations: [my-router]
+      telemetryServices:
+        kube-state-metrics:
+          deploy: true
+      collectors:
+        alloy-metrics:
+          presets: [clustered]
+      destinations:
+        platform:
+          type: otlp
+          url: https://otlp.example.com
+        my-router:
+          type: router
+          attribute: "k8s.namespace.name"
+          routes:
+            - match: {equals: tenant-a}
+              destinations: [platform]
+              signals: [metrics]
+          defaultDestinations: [platform]
+    asserts:
+      - notMatchRegexRaw:
+          pattern: 'WARNING'

--- a/charts/k8s-monitoring/tests/destination_router_test.yaml
+++ b/charts/k8s-monitoring/tests/destination_router_test.yaml
@@ -1,0 +1,330 @@
+# yamllint disable rule:document-start rule:line-length rule:trailing-spaces
+suite: Destinations - Router render
+templates:
+  - alloy-config.yaml
+tests:
+  - it: OTLP fan-out - default-first ordering, per-downstream gates, both bodies render (F1-F7 baseline)
+    set:
+      cluster: {name: test-cluster}
+      selfReporting: {enabled: false}
+      destinations:
+        stack-a:
+          type: otlp
+          url: https://otlp-stack-a.example.com
+        platform:
+          type: otlp
+          url: https://otlp-platform.example.com
+        my-router:
+          type: router
+          attribute: k8s.namespace.name
+          routes:
+            - match: {equals: tenant-a}
+              destinations: [stack-a]
+          defaultDestinations: [platform]
+      podLogsViaOpenTelemetry:
+        enabled: true
+        destinations: [my-router]
+      collectors:
+        alloy-logs:
+          presets: [filesystem-log-reader, daemonset]
+          alloy:
+            stabilityLevel: public-preview
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - matchRegex:
+          path: data["config.alloy"]
+          pattern: '"set\(attributes\[\\"selected_destinations\\"\], \\"platform\\"\)"[\s\S]*"set\(attributes\[\\"selected_destinations\\"\], \\"stack-a\\"\) where attributes\[\\"k8s\.namespace\.name\\"\] == \\"tenant-a\\""'
+      - matchRegex:
+          path: data["config.alloy"]
+          pattern: 'otelcol\.processor\.filter "my_router_platform_gate_logs_otlp"'
+      - matchRegex:
+          path: data["config.alloy"]
+          pattern: 'otelcol\.processor\.filter "my_router_stack_a_gate_logs_otlp"'
+      - matchRegex:
+          path: data["config.alloy"]
+          pattern: 'otelcol\.exporter\.otlp "platform"'
+      - matchRegex:
+          path: data["config.alloy"]
+          pattern: 'otelcol\.exporter\.otlp "stack_a"'
+
+  - it: first-match-wins - an earlier-declared route beats a later-declared route that also matches (F-order)
+    set:
+      cluster: {name: test-cluster}
+      selfReporting: {enabled: false}
+      destinations:
+        stack-a:
+          type: otlp
+          url: https://otlp-stack-a.example.com
+        platform:
+          type: otlp
+          url: https://otlp-platform.example.com
+        my-router:
+          type: router
+          attribute: k8s.namespace.name
+          routes:
+            - match: {equals: tenant-a}
+              destinations: [stack-a]
+            - match: {matches: "^tenant-.*$"}
+              destinations: [platform]
+          defaultDestinations: [platform]
+      podLogsViaOpenTelemetry:
+        enabled: true
+        destinations: [my-router]
+      collectors:
+        alloy-logs:
+          presets: [filesystem-log-reader, daemonset]
+          alloy:
+            stabilityLevel: public-preview
+    asserts:
+      - isKind:
+          of: ConfigMap
+      # The second-declared route (matches) is rendered FIRST, and the first-declared route
+      # (equals) is rendered LAST, so OTTL's sequential set()-overwrite semantics make the
+      # first-DECLARED route win for a record that matches both.
+      - matchRegex:
+          path: data["config.alloy"]
+          pattern: '"set\(attributes\[\\"selected_destinations\\"\], \\"platform\\"\) where IsMatch\(attributes\[\\"k8s\.namespace\.name\\"\], \\"\^tenant-\.\*\$\\"\) == true"[\s\S]*"set\(attributes\[\\"selected_destinations\\"\], \\"stack-a\\"\) where attributes\[\\"k8s\.namespace\.name\\"\] == \\"tenant-a\\""'
+
+  - it: match.in renders as a parenthesized OR-chain, not the invalid OTTL "in" operator (F1)
+    set:
+      cluster: {name: test-cluster}
+      selfReporting: {enabled: false}
+      destinations:
+        stack-a:
+          type: otlp
+          url: https://otlp-stack-a.example.com
+        platform:
+          type: otlp
+          url: https://otlp-platform.example.com
+        my-router:
+          type: router
+          attribute: k8s.namespace.name
+          routes:
+            - match: {in: [tenant-a, tenant-b]}
+              destinations: [stack-a]
+          defaultDestinations: [platform]
+      podLogsViaOpenTelemetry:
+        enabled: true
+        destinations: [my-router]
+      collectors:
+        alloy-logs:
+          presets: [filesystem-log-reader, daemonset]
+          alloy:
+            stabilityLevel: public-preview
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - matchRegex:
+          path: data["config.alloy"]
+          pattern: '"set\(attributes\[\\"selected_destinations\\"\], \\"stack-a\\"\) where \(attributes\[\\"k8s\.namespace\.name\\"\] == \\"tenant-a\\" or attributes\[\\"k8s\.namespace\.name\\"\] == \\"tenant-b\\"\)"'
+      - notMatchRegex:
+          path: data["config.alloy"]
+          pattern: ' in \['
+
+  - it: match.matches double-escapes backslashes so OTTL's own string parser un-escapes them back to a real regex (F2)
+    set:
+      cluster: {name: test-cluster}
+      selfReporting: {enabled: false}
+      destinations:
+        stack-a:
+          type: otlp
+          url: https://otlp-stack-a.example.com
+        platform:
+          type: otlp
+          url: https://otlp-platform.example.com
+        my-router:
+          type: router
+          attribute: k8s.namespace.name
+          routes:
+            - match: {matches: "^team-\\d+$"}
+              destinations: [stack-a]
+          defaultDestinations: [platform]
+      podLogsViaOpenTelemetry:
+        enabled: true
+        destinations: [my-router]
+      collectors:
+        alloy-logs:
+          presets: [filesystem-log-reader, daemonset]
+          alloy:
+            stabilityLevel: public-preview
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - matchRegex:
+          path: data["config.alloy"]
+          pattern: '"set\(attributes\[\\"selected_destinations\\"\], \\"stack-a\\"\) where IsMatch\(attributes\[\\"k8s\.namespace\.name\\"\], \\"\^team-\\\\\\\\d\+\$\\"\) == true"'
+      - notMatchRegex:
+          path: data["config.alloy"]
+          pattern: 'team-\\d\+\$'
+
+  - it: a double-quote in an equals value cannot break out of the OTTL string literal (F3/F4)
+    set:
+      cluster: {name: test-cluster}
+      selfReporting: {enabled: false}
+      destinations:
+        stack-a:
+          type: otlp
+          url: https://otlp-stack-a.example.com
+        platform:
+          type: otlp
+          url: https://otlp-platform.example.com
+        my-router:
+          type: router
+          attribute: k8s.namespace.name
+          routes:
+            - match: {equals: 'a" or true or "b'}
+              destinations: [stack-a]
+          defaultDestinations: [platform]
+      podLogsViaOpenTelemetry:
+        enabled: true
+        destinations: [my-router]
+      collectors:
+        alloy-logs:
+          presets: [filesystem-log-reader, daemonset]
+          alloy:
+            stabilityLevel: public-preview
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - matchRegex:
+          path: data["config.alloy"]
+          pattern: '"set\(attributes\[\\"selected_destinations\\"\], \\"stack-a\\"\) where attributes\[\\"k8s\.namespace\.name\\"\] == \\"a\\\\\\" or true or \\\\\\"b\\""'
+      - notMatchRegex:
+          path: data["config.alloy"]
+          pattern: '== "a" or true or "b"'
+
+  - it: label path - prometheus.relabel routes on the namespace label with default-first ordering, per-downstream gates
+    set:
+      cluster: {name: test-cluster}
+      selfReporting: {enabled: false}
+      destinations:
+        mimir:
+          type: prometheus
+          url: https://prometheus-mimir.example.com
+        platform-prom:
+          type: prometheus
+          url: https://prometheus-platform.example.com
+        my-router:
+          type: router
+          attribute: k8s.namespace.name
+          routes:
+            - match: {equals: tenant-a}
+              destinations: [mimir]
+          defaultDestinations: [platform-prom]
+      clusterMetrics:
+        enabled: true
+        destinations: [my-router]
+      telemetryServices:
+        kube-state-metrics:
+          deploy: true
+      collectors:
+        alloy-metrics:
+          presets: [clustered]
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - matchRegex:
+          path: data["config.alloy"]
+          pattern: 'replacement  = "platform-prom"[\s\S]*regex         = "\^tenant-a\$"[\s\S]*replacement   = "mimir"'
+      - matchRegex:
+          path: data["config.alloy"]
+          pattern: 'prometheus\.relabel "my_router_mimir_gate_metrics_prometheus"'
+      - matchRegex:
+          path: data["config.alloy"]
+          pattern: 'prometheus\.relabel "my_router_platform_prom_gate_metrics_prometheus"'
+      - matchRegex:
+          path: data["config.alloy"]
+          pattern: 'prometheus\.remote_write "mimir"'
+      - matchRegex:
+          path: data["config.alloy"]
+          pattern: 'prometheus\.remote_write "platform_prom"'
+
+  - it: per-signal fallback - a route pointing only at a destination that cannot carry the signal is skipped for that signal (F5)
+    set:
+      cluster: {name: test-cluster}
+      selfReporting: {enabled: false}
+      destinations:
+        loki-only-dest:
+          type: loki
+          url: https://loki.example.com
+        platform:
+          type: otlp
+          url: https://otlp-platform.example.com
+        my-router:
+          type: router
+          attribute: k8s.namespace.name
+          routes:
+            - match: {equals: plain}
+              destinations: [loki-only-dest]
+          defaultDestinations: [platform]
+      clusterMetrics:
+        enabled: true
+        destinations: [my-router]
+      telemetryServices:
+        kube-state-metrics:
+          deploy: true
+      collectors:
+        alloy-metrics:
+          presets: [clustered]
+    asserts:
+      - isKind:
+          of: ConfigMap
+      # The metrics-ecosystem components only ever stamp/gate the default ("platform"); a loki-only
+      # destination never gets a metrics gate, so matched records for "plain" keep the default marker.
+      - matchRegex:
+          path: data["config.alloy"]
+          pattern: '"set\(attributes\[\\"selected_destinations\\"\], \\"platform\\"\)"'
+      - notMatchRegex:
+          path: data["config.alloy"]
+          pattern: 'my_router_loki_only_dest_gate_metrics'
+      # Sanity: loki-only-dest DOES get a logs gate, proving the signal filter -- not a rendering
+      # bug -- is why it's absent from the metrics gates above.
+      - matchRegex:
+          path: data["config.alloy"]
+          pattern: 'my_router_loki_only_dest_gate_logs'
+
+  - it: a route's signals filter only applies its rule to the matching signal's router component (F6/route.signals)
+    set:
+      cluster: {name: test-cluster}
+      selfReporting: {enabled: false}
+      destinations:
+        mimir:
+          type: prometheus
+          url: https://prometheus-mimir.example.com
+        loki-dest:
+          type: loki
+          url: https://loki.example.com
+        my-router:
+          type: router
+          attribute: k8s.namespace.name
+          routes:
+            - match: {equals: tenant-a}
+              destinations: [loki-dest]
+              signals: [logs]
+          defaultDestinations: [mimir, loki-dest]
+      clusterMetrics:
+        enabled: true
+        destinations: [my-router]
+        collector: alloy-metrics
+      podLogsViaLoki:
+        enabled: true
+        destinations: [my-router]
+        collector: alloy-logs
+      telemetryServices:
+        kube-state-metrics:
+          deploy: true
+      collectors:
+        alloy-metrics:
+          presets: [clustered]
+        alloy-logs:
+          presets: [filesystem-log-reader, daemonset]
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - matchRegex:
+          path: data["config.alloy"]
+          pattern: 'loki\.relabel "my_router_logs_loki" \{[\s\S]*?rule \{\s*source_labels = \["namespace"\]\s*regex\s*= "\^tenant-a\$"\s*target_label\s*= "selected_destinations"\s*replacement\s*= "loki-dest"\s*\}[\s\S]*?\} // loki\.relabel "my_router_logs_loki"'
+      - notMatchRegex:
+          path: data["config.alloy"]
+          pattern: 'prometheus\.relabel "my_router_metrics_prometheus" \{[\s\S]*?rule \{\s*source_labels = \["namespace"\]\s*regex\s*= "\^tenant-a\$"\s*target_label\s*= "selected_destinations"\s*replacement\s*= "loki-dest"\s*\}[\s\S]*?\} // prometheus\.relabel "my_router_metrics_prometheus"'

--- a/charts/k8s-monitoring/tests/destination_router_validations_test.yaml
+++ b/charts/k8s-monitoring/tests/destination_router_validations_test.yaml
@@ -1,0 +1,519 @@
+# yamllint disable rule:document-start rule:line-length rule:trailing-spaces
+suite: Validations - Router Destination
+templates:
+  - validations.yaml
+tests:
+  - it: requires at least one defaultDestinations entry (R1)
+    set:
+      cluster: {name: test-cluster}
+      destinations:
+        platform:
+          type: otlp
+          url: https://otlp.example.com
+        my-router:
+          type: router
+          routes:
+            - match: {equals: tenant-a}
+              destinations: [platform]
+    asserts:
+      - failedTemplate:
+          errorMessage: |-
+            Destination "my-router" (type: router) does not have any defaultDestinations.
+            A router is a terminal destination, so it must name at least one fallback destination for records that don't match any route.
+            Please set:
+            destinations:
+              my-router:
+                type: router
+                defaultDestinations:
+                  - my-destination
+
+  - it: rejects a route with no match condition (R2)
+    set:
+      cluster: {name: test-cluster}
+      destinations:
+        platform:
+          type: otlp
+          url: https://otlp.example.com
+        my-router:
+          type: router
+          routes:
+            - destinations: [platform]
+          defaultDestinations: [platform]
+    asserts:
+      - failedTemplate:
+          errorMessage: |-
+            Destination "my-router" (type: router) has a route (#1) with no match condition.
+            Every route must set exactly one of match.equals, match.in, or match.matches.
+            Please set:
+            destinations:
+              my-router:
+                type: router
+                routes:
+                  - match:
+                      equals: my-value
+                    destinations:
+                      - my-destination
+
+  - it: rejects a route with multiple match conditions (R2)
+    set:
+      cluster: {name: test-cluster}
+      destinations:
+        platform:
+          type: otlp
+          url: https://otlp.example.com
+        my-router:
+          type: router
+          routes:
+            - match: {equals: tenant-a, in: [tenant-b]}
+              destinations: [platform]
+          defaultDestinations: [platform]
+    asserts:
+      - failedTemplate:
+          errorMessage: |-
+            Destination "my-router" (type: router) has a route (#1) with multiple match conditions set: equals, in.
+            Exactly one of match.equals, match.in, or match.matches is required per route.
+            Please remove all but one of these fields.
+
+  - it: rejects match.in given as a string instead of a list (R2b)
+    set:
+      cluster: {name: test-cluster}
+      destinations:
+        platform:
+          type: otlp
+          url: https://otlp.example.com
+        my-router:
+          type: router
+          routes:
+            - match: {in: "foo"}
+              destinations: [platform]
+          defaultDestinations: [platform]
+    asserts:
+      - failedTemplate:
+          errorMessage: |-
+            Destination "my-router" (type: router) has a route (#1) whose match.in value is not a list: foo.
+            The `in` match must be a list, e.g. `in: [value1, value2]`.
+            Please set:
+            destinations:
+              my-router:
+                type: router
+                routes:
+                  - match:
+                      in: [my-value-a, my-value-b]
+
+  - it: rejects an empty match.in list (R3)
+    set:
+      cluster: {name: test-cluster}
+      destinations:
+        platform:
+          type: otlp
+          url: https://otlp.example.com
+        my-router:
+          type: router
+          routes:
+            - match: {in: []}
+              destinations: [platform]
+          defaultDestinations: [platform]
+    asserts:
+      - failedTemplate:
+          errorMessage: |-
+            Destination "my-router" (type: router) has a route (#1) with an empty match.in list.
+            match.in needs at least one value to match against.
+            Please set:
+            destinations:
+              my-router:
+                type: router
+                routes:
+                  - match:
+                      in: [my-value-a, my-value-b]
+
+  - it: rejects a non-string match.equals value (R4)
+    set:
+      cluster: {name: test-cluster}
+      destinations:
+        platform:
+          type: otlp
+          url: https://otlp.example.com
+        my-router:
+          type: router
+          routes:
+            - match: {equals: true}
+              destinations: [platform]
+          defaultDestinations: [platform]
+    asserts:
+      - failedTemplate:
+          errorMessage: |-
+            Destination "my-router" (type: router) has a route (#1) whose match.equals value is not a string: true.
+            Please quote it so it isn't parsed as a YAML number, boolean, or null:
+            destinations:
+              my-router:
+                type: router
+                routes:
+                  - match:
+                      equals: "true"
+
+  - it: rejects a non-string entry in match.in (R4)
+    set:
+      cluster: {name: test-cluster}
+      destinations:
+        platform:
+          type: otlp
+          url: https://otlp.example.com
+        my-router:
+          type: router
+          routes:
+            - match: {in: [123]}
+              destinations: [platform]
+          defaultDestinations: [platform]
+    asserts:
+      - failedTemplate:
+          errorMessage: |-
+            Destination "my-router" (type: router) has a route (#1) whose match.in list contains a non-string value: 123.
+            Please quote it so it isn't parsed as a YAML number, boolean, or null:
+            destinations:
+              my-router:
+                type: router
+                routes:
+                  - match:
+                      in: ["123"]
+
+  - it: rejects a non-string match.matches value (R4)
+    set:
+      cluster: {name: test-cluster}
+      destinations:
+        platform:
+          type: otlp
+          url: https://otlp.example.com
+        my-router:
+          type: router
+          routes:
+            - match: {matches: false}
+              destinations: [platform]
+          defaultDestinations: [platform]
+    asserts:
+      - failedTemplate:
+          errorMessage: |-
+            Destination "my-router" (type: router) has a route (#1) whose match.matches value is not a string: false.
+            Please quote it so it isn't parsed as a YAML number, boolean, or null:
+            destinations:
+              my-router:
+                type: router
+                routes:
+                  - match:
+                      matches: "false"
+
+  - it: rejects a match.matches value that does not compile as a regex (R5)
+    set:
+      cluster: {name: test-cluster}
+      destinations:
+        platform:
+          type: otlp
+          url: https://otlp.example.com
+        my-router:
+          type: router
+          routes:
+            - match: {matches: "["}
+              destinations: [platform]
+          defaultDestinations: [platform]
+    asserts:
+      - failedTemplate:
+          errorPattern: error parsing regexp
+
+  - it: rejects a route destination that does not exist (R6)
+    set:
+      cluster: {name: test-cluster}
+      destinations:
+        platform:
+          type: otlp
+          url: https://otlp.example.com
+        my-router:
+          type: router
+          routes:
+            - match: {equals: tenant-a}
+              destinations: [doesnotexist]
+          defaultDestinations: [platform]
+    asserts:
+      - failedTemplate:
+          errorMessage: |-
+            Destination "my-router" (type: router) has a route (#1) referencing unknown destination "doesnotexist".
+            The destination must exist and be enabled.
+            Please reference one of the known destinations:
+              platform
+
+  - it: rejects a defaultDestinations entry that is disabled (R6)
+    set:
+      cluster: {name: test-cluster}
+      destinations:
+        platform:
+          type: otlp
+          url: https://otlp.example.com
+          disabled: true
+        my-router:
+          type: router
+          routes: []
+          defaultDestinations: [platform]
+    asserts:
+      - failedTemplate:
+          errorMessage: |-
+            Destination "my-router" (type: router) has a defaultDestinations entry referencing unknown destination "platform".
+            The destination must exist and be enabled.
+            Please reference one of the known destinations:
+
+  - it: rejects an empty signals list on a route (R7)
+    set:
+      cluster: {name: test-cluster}
+      destinations:
+        platform:
+          type: otlp
+          url: https://otlp.example.com
+        my-router:
+          type: router
+          routes:
+            - match: {equals: tenant-a}
+              destinations: [platform]
+              signals: []
+          defaultDestinations: [platform]
+    asserts:
+      - failedTemplate:
+          errorMessage: |-
+            Destination "my-router" (type: router) has a route (#1) with an empty signals list.
+            Either remove the signals field to match all signals, or list at least one of: metrics, logs, traces, profiles.
+
+  - it: rejects an unknown signal name on a route (R7)
+    set:
+      cluster: {name: test-cluster}
+      destinations:
+        platform:
+          type: otlp
+          url: https://otlp.example.com
+        my-router:
+          type: router
+          routes:
+            - match: {equals: tenant-a}
+              destinations: [platform]
+              signals: [bogus]
+          defaultDestinations: [platform]
+    asserts:
+      - failedTemplate:
+          errorMessage: |-
+            Destination "my-router" (type: router) has a route (#1) with an unknown signal "bogus".
+            Please use one of: metrics, logs, traces, profiles.
+
+  - it: rejects a route destination that is itself a router (R8)
+    set:
+      cluster: {name: test-cluster}
+      destinations:
+        platform:
+          type: otlp
+          url: https://otlp.example.com
+        other-router:
+          type: router
+          routes: []
+          defaultDestinations: [platform]
+        my-router:
+          type: router
+          routes:
+            - match: {equals: tenant-a}
+              destinations: [other-router]
+          defaultDestinations: [platform]
+    asserts:
+      - failedTemplate:
+          errorMessage: |-
+            Destination "my-router" (type: router) has a route (#1) referencing another router destination "other-router".
+            Routing telemetry from one router into another router would create a cycle in the generated Alloy pipeline, so it is not supported.
+            Please point routes and defaultDestinations at real (non-router) destinations.
+
+  - it: rejects a defaultDestinations entry that is itself a router (R8)
+    set:
+      cluster: {name: test-cluster}
+      destinations:
+        platform:
+          type: otlp
+          url: https://otlp.example.com
+        other-router:
+          type: router
+          routes: []
+          defaultDestinations: [platform]
+        my-router:
+          type: router
+          routes: []
+          defaultDestinations: [other-router]
+    asserts:
+      - failedTemplate:
+          errorMessage: |-
+            Destination "my-router" (type: router) has a defaultDestinations entry referencing another router destination "other-router".
+            Routing telemetry from one router into another router would create a cycle in the generated Alloy pipeline, so it is not supported.
+            Please point routes and defaultDestinations at real (non-router) destinations.
+
+  - it: allows a valid router configuration with routes and defaults
+    set:
+      cluster: {name: test-cluster}
+      destinations:
+        platform:
+          type: otlp
+          url: https://otlp.example.com
+        my-router:
+          type: router
+          attribute: k8s.namespace.name
+          routes:
+            - match: {equals: tenant-a}
+              destinations: [platform]
+          defaultDestinations: [platform]
+      collectors: {alloy-receiver: {extraConfig: "// simulated feature"}}
+    asserts:
+      - notFailedTemplate: {}
+
+---
+# yamllint disable rule:document-start rule:line-length rule:trailing-spaces
+# This suite covers destinations.router.assertCanCarry, the seam check that replaced the old,
+# false-positive-prone R10 (see destinations/_destination_router_validations.tpl). Unlike the
+# suite above, these cases need a real, enabled feature forwarding real telemetry through the
+# router -- that is the whole point of the seam (only pipeline.alloy.targets.forFeature knows
+# which signal a feature is actually sending) -- so they render alloy-config.yaml, not
+# validations.yaml.
+suite: Validations - Router Destination Seam Check (destinations.router.assertCanCarry)
+templates:
+  - alloy-config.yaml
+tests:
+  - it: fails when a feature actually sends a signal to a router whose no-routes defaultDestinations cannot carry it
+    set:
+      cluster: {name: test-cluster}
+      selfReporting: {enabled: false}
+      podLogsViaOpenTelemetry:
+        enabled: true
+        destinations: [my-router]
+      collectors:
+        alloy-logs:
+          presets: [filesystem-log-reader, daemonset]
+          alloy:
+            stabilityLevel: public-preview
+      destinations:
+        mimir:
+          type: prometheus
+          url: https://prometheus.example.com/api/v1/write
+        my-router:
+          type: router
+          attribute: "k8s.namespace.name"
+          routes: []
+          defaultDestinations: [mimir]
+    asserts:
+      - failedTemplate:
+          errorMessage: |-
+            Feature "podLogsViaOpenTelemetry" sends logs to router destination "my-router", but that router has no route or defaultDestinations entry that can accept logs.
+            logs reaching this router would be dropped.
+            Please add a destination that supports logs to the router's routes or defaultDestinations.
+
+  - it: fails when a feature's signal only matches a route pointing at a destination that cannot carry it, and defaults can't either
+    set:
+      cluster: {name: test-cluster}
+      selfReporting: {enabled: false}
+      podLogsViaOpenTelemetry:
+        enabled: true
+        destinations: [my-router]
+      collectors:
+        alloy-logs:
+          presets: [filesystem-log-reader, daemonset]
+          alloy:
+            stabilityLevel: public-preview
+      destinations:
+        mimir:
+          type: prometheus
+          url: https://prometheus.example.com/api/v1/write
+        my-router:
+          type: router
+          attribute: "k8s.namespace.name"
+          routes:
+            - match: {equals: tenant-a}
+              destinations: [mimir]
+              signals: [logs]
+          defaultDestinations: [mimir]
+    asserts:
+      - failedTemplate:
+          errorMessage: |-
+            Feature "podLogsViaOpenTelemetry" sends logs to router destination "my-router", but that router has no route or defaultDestinations entry that can accept logs.
+            logs reaching this router would be dropped.
+            Please add a destination that supports logs to the router's routes or defaultDestinations.
+
+  - it: allows a no-routes fan-out router with otlp defaultDestinations when the only feature routed through it sends logs (false-positive fix)
+    set:
+      cluster: {name: test-cluster}
+      selfReporting: {enabled: false}
+      podLogsViaOpenTelemetry:
+        enabled: true
+        destinations: [fanout]
+      collectors:
+        alloy-logs:
+          presets: [filesystem-log-reader, daemonset]
+          alloy:
+            stabilityLevel: public-preview
+      destinations:
+        a:
+          type: otlp
+          url: https://otlp-a.example.com
+        b:
+          type: otlp
+          url: https://otlp-b.example.com
+        fanout:
+          type: router
+          defaultDestinations: [a, b]
+    asserts:
+      - notFailedTemplate: {}
+
+  - it: allows a metrics-only feature through a router whose defaultDestinations is otlp-only
+    set:
+      cluster: {name: test-cluster}
+      selfReporting: {enabled: false}
+      clusterMetrics:
+        enabled: true
+        destinations: [my-router]
+      telemetryServices:
+        kube-state-metrics:
+          deploy: true
+      collectors:
+        alloy-metrics:
+          presets: [clustered]
+      destinations:
+        platform:
+          type: otlp
+          url: https://otlp.example.com
+        my-router:
+          type: router
+          defaultDestinations: [platform]
+    asserts:
+      - notFailedTemplate: {}
+
+  - it: allows a per-signal split - a route covers logs, defaults cover metrics
+    set:
+      cluster: {name: test-cluster}
+      selfReporting: {enabled: false}
+      clusterMetrics:
+        enabled: true
+        destinations: [my-router]
+        collector: alloy-metrics
+      podLogsViaLoki:
+        enabled: true
+        destinations: [my-router]
+        collector: alloy-logs
+      telemetryServices:
+        kube-state-metrics:
+          deploy: true
+      collectors:
+        alloy-metrics:
+          presets: [clustered]
+        alloy-logs:
+          presets: [filesystem-log-reader, daemonset]
+      destinations:
+        platform:
+          type: otlp
+          url: https://otlp.example.com
+        loki-dest:
+          type: loki
+          url: https://loki.example.com
+        my-router:
+          type: router
+          routes:
+            - match: {equals: tenant-a}
+              destinations: [loki-dest]
+              signals: [logs]
+          defaultDestinations: [platform]
+    asserts:
+      - notFailedTemplate: {}

--- a/charts/k8s-monitoring/tests/destination_validations_test.yaml
+++ b/charts/k8s-monitoring/tests/destination_validations_test.yaml
@@ -31,7 +31,7 @@ tests:
             Please set:
             destinations:
               a-destination-with-no-type:
-                type: custom, loki-stdout, loki, nop, otlp, prometheus, or pyroscope
+                type: custom, loki-stdout, loki, nop, otlp, prometheus, pyroscope, or router
 
   - it: validates the destination type
     set:
@@ -48,7 +48,7 @@ tests:
             Please set:
             destinations:
               a-destination-with-an-invalid-type:
-                type: custom, loki-stdout, loki, nop, otlp, prometheus, or pyroscope
+                type: custom, loki-stdout, loki, nop, otlp, prometheus, pyroscope, or router
 
   - it: skips validation for disabled destinations
     set:

--- a/charts/k8s-monitoring/values.schema.json
+++ b/charts/k8s-monitoring/values.schema.json
@@ -3147,6 +3147,83 @@
                 }
             }
         },
+        "router-destination": {
+            "type": "object",
+            "properties": {
+                "attribute": {
+                    "type": "string",
+                    "pattern": "^[a-zA-Z_][a-zA-Z0-9_./-]*$"
+                },
+                "defaultDestinations": {
+                    "type": "array",
+                    "minItems": 1,
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "disabled": {
+                    "type": "boolean"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "routes": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "destinations": {
+                                "type": "array",
+                                "minItems": 1,
+                                "items": {
+                                    "type": "string"
+                                }
+                            },
+                            "signals": {
+                                "type": "array",
+                                "items": {
+                                    "enum": [
+                                        "metrics",
+                                        "logs",
+                                        "traces",
+                                        "profiles"
+                                    ]
+                                }
+                            },
+                            "match": {
+                                "type": "object",
+                                "properties": {
+                                    "in": {
+                                        "type": "array"
+                                    }
+                                },
+                                "oneOf": [
+                                    {
+                                        "required": [
+                                            "equals"
+                                        ]
+                                    },
+                                    {
+                                        "required": [
+                                            "in"
+                                        ]
+                                    },
+                                    {
+                                        "required": [
+                                            "matches"
+                                        ]
+                                    }
+                                ]
+                            }
+                        }
+                    }
+                },
+                "type": {
+                    "type": "string",
+                    "const": "router"
+                }
+            }
+        },
         "dataProcessor": {
             "type": "object",
             "anyOf": [
@@ -3193,6 +3270,9 @@
                 },
                 {
                     "$ref": "#/definitions/pyroscope-destination"
+                },
+                {
+                    "$ref": "#/definitions/router-destination"
                 }
             ]
         },


### PR DESCRIPTION

Fixes #2849

Adds attribute-based destination routing to the k8s-monitoring chart. A new top-level destinationRouting block routes telemetry to different destinations based on a resource attribute (default k8s.namespace.name) from a single Helm release, instead of fanning every feature's data out to all of its destinations.

* Ordered, first-match-wins routes (equals/in/matches), evaluated per signal with an optional per-route signals list
* unmatched data falls through to default.destinations or each feature's own destinations. 
* OTLP destinations route on any resource attribute; Prometheus, Loki, and Pyroscope route on the mapped label. 
* Includes validation, deployment-notes warnings, a docs page, and an example.

outdated, removed this version
> example
> 
> ```yaml
> destinations:
>   stack-a:
>     type: otlp
>     protocol: http
>     url: http://tenant-a.example.com/otlp
>   platform:
>     type: otlp
>     protocol: http
>     url: http://platform.example.com/otlp
> 
> destinationRouting:
>   enabled: true
>   attribute: k8s.namespace.name
>   routes:
>     - match: {equals: tenant-a}
>       destinations: [stack-a]
>   default:
>     destinations: [platform]
> ```
> * Unmatched data goes to default.destinations; when default is omitted it falls through to each feature's own destinations: (current behavior).
> 