### PR TITLE
fix: remove unused field spanMetricsOnly from docs

### DIFF
--- a/charts/k8s-monitoring/docs/examples/features/auto-instrumentation/beyla-metrics/README.md
+++ b/charts/k8s-monitoring/docs/examples/features/auto-instrumentation/beyla-metrics/README.md
@@ -23,7 +23,8 @@ destinations:
 autoInstrumentation:
   enabled: true
   collector: alloy-metrics
-  spanMetricsOnly: true
+  beyla:
+    deliverTracesToApplicationObservability: false
 
 collectors:
   alloy-metrics:

--- a/charts/k8s-monitoring/docs/examples/features/auto-instrumentation/beyla-metrics/values.yaml
+++ b/charts/k8s-monitoring/docs/examples/features/auto-instrumentation/beyla-metrics/values.yaml
@@ -10,7 +10,8 @@ destinations:
 autoInstrumentation:
   enabled: true
   collector: alloy-metrics
-  spanMetricsOnly: true
+  beyla:
+    deliverTracesToApplicationObservability: false
 
 collectors:
   alloy-metrics:

--- a/charts/k8s-monitoring/docs/examples/features/auto-instrumentation/discovery-rules/README.md
+++ b/charts/k8s-monitoring/docs/examples/features/auto-instrumentation/discovery-rules/README.md
@@ -29,8 +29,8 @@ destinations:
 
 autoInstrumentation:
   enabled: true
-  spanMetricsOnly: true
   beyla:
+    deliverTracesToApplicationObservability: false
     config:
       data:
         discovery:

--- a/charts/k8s-monitoring/docs/examples/features/auto-instrumentation/discovery-rules/values.yaml
+++ b/charts/k8s-monitoring/docs/examples/features/auto-instrumentation/discovery-rules/values.yaml
@@ -9,8 +9,8 @@ destinations:
 
 autoInstrumentation:
   enabled: true
-  spanMetricsOnly: true
   beyla:
+    deliverTracesToApplicationObservability: false
     config:
       data:
         discovery:

--- a/charts/k8s-monitoring/docs/examples/features/auto-instrumentation/span-metrics-only/README.md
+++ b/charts/k8s-monitoring/docs/examples/features/auto-instrumentation/span-metrics-only/README.md
@@ -17,7 +17,7 @@ This configuration is useful when you want:
 
 ## How It Works
 
-When `spanMetricsOnly: true` is set:
+When `beyla.deliverTracesToApplicationObservability: false` is set:
 
 1.  Beyla automatically instruments applications using eBPF
 2.  Beyla generates span metrics (RED metrics) from HTTP/gRPC calls
@@ -26,7 +26,7 @@ When `spanMetricsOnly: true` is set:
 
 ## When to Use This
 
-Choose `spanMetricsOnly: true` when:
+Choose `beyla.deliverTracesToApplicationObservability: false` when:
 
 *   You want observability without trace storage costs
 *   You need RED metrics but not detailed trace analysis
@@ -35,7 +35,7 @@ Choose `spanMetricsOnly: true` when:
 
 ## Alternative
 
-If you need full traces from Beyla, set `spanMetricsOnly: false` (the default) or omit the field entirely. See the [beyla-metrics-and-traces example](../beyla-metrics-and-traces/) for that configuration.
+If you need full traces from Beyla, set `beyla.deliverTracesToApplicationObservability: true` (the default) or omit the field entirely. See the [beyla-metrics-and-traces example](../beyla-metrics-and-traces/) for that configuration.
 
 ## Values
 

--- a/charts/k8s-monitoring/docs/examples/features/auto-instrumentation/span-metrics-only/description.txt
+++ b/charts/k8s-monitoring/docs/examples/features/auto-instrumentation/span-metrics-only/description.txt
@@ -13,7 +13,7 @@ This configuration is useful when you want:
 
 ## How It Works
 
-When `spanMetricsOnly: true` is set:
+When `beyla.deliverTracesToApplicationObservability: false` is set:
 
 1.  Beyla automatically instruments applications using eBPF
 2.  Beyla generates span metrics (RED metrics) from HTTP/gRPC calls
@@ -22,7 +22,7 @@ When `spanMetricsOnly: true` is set:
 
 ## When to Use This
 
-Choose `spanMetricsOnly: true` when:
+Choose `beyla.deliverTracesToApplicationObservability: false` when:
 
 *   You want observability without trace storage costs
 *   You need RED metrics but not detailed trace analysis
@@ -31,4 +31,4 @@ Choose `spanMetricsOnly: true` when:
 
 ## Alternative
 
-If you need full traces from Beyla, set `spanMetricsOnly: false` (the default) or omit the field entirely. See the [beyla-metrics-and-traces example](../beyla-metrics-and-traces/) for that configuration.
+If you need full traces from Beyla, set `beyla.deliverTracesToApplicationObservability: true` (the default) or omit the field entirely. See the [beyla-metrics-and-traces example](../beyla-metrics-and-traces/) for that configuration.

--- a/charts/k8s-monitoring/docs/examples/resource-requests-and-limits/README.md
+++ b/charts/k8s-monitoring/docs/examples/resource-requests-and-limits/README.md
@@ -50,8 +50,8 @@ hostMetrics:
 autoInstrumentation:
   enabled: true
   collector: alloy-metrics
-  spanMetricsOnly: true
   beyla:
+    deliverTracesToApplicationObservability: false
     resources:
       limits:
         cpu: 100m

--- a/charts/k8s-monitoring/docs/examples/resource-requests-and-limits/values.yaml
+++ b/charts/k8s-monitoring/docs/examples/resource-requests-and-limits/values.yaml
@@ -28,8 +28,8 @@ hostMetrics:
 autoInstrumentation:
   enabled: true
   collector: alloy-metrics
-  spanMetricsOnly: true
   beyla:
+    deliverTracesToApplicationObservability: false
     resources:
       limits:
         cpu: 100m

--- a/charts/k8s-monitoring/docs/examples/tolerations/README.md
+++ b/charts/k8s-monitoring/docs/examples/tolerations/README.md
@@ -45,8 +45,8 @@ hostMetrics:
 autoInstrumentation:
   enabled: true
   collector: alloy-metrics
-  spanMetricsOnly: true
   beyla:
+    deliverTracesToApplicationObservability: false
     tolerations:
       - key: protected-node
         effect: NoSchedule

--- a/charts/k8s-monitoring/docs/examples/tolerations/values.yaml
+++ b/charts/k8s-monitoring/docs/examples/tolerations/values.yaml
@@ -31,8 +31,8 @@ hostMetrics:
 autoInstrumentation:
   enabled: true
   collector: alloy-metrics
-  spanMetricsOnly: true
   beyla:
+    deliverTracesToApplicationObservability: false
     tolerations:
       - key: protected-node
         effect: NoSchedule


### PR DESCRIPTION
# Description

`beyla.deliverTracesToApplicationObservability` is the actual control, `spanMetricsOnly: true` is not used. 

- Fixes https://github.com/grafana/k8s-monitoring-helm/issues/2861

<!--Authorship attestation. See AGENTS.md for details. AI agents must not check this box on behalf
of the user; the human author must check it themselves before the PR is ready for review.-->
## Authorship

-   [x] I, a human, wrote this pull request description myself.

<!--Please delete paragraphs that you did not use before submitting.-->
