### PR TITLE
Makefile improvements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,12 +25,12 @@ check-helm-version:
 ##@ Build
 .PHONY: clean
 clean: ## Clean all charts
-	make -C charts/k8s-monitoring $@;
+	$(MAKE) -C charts/k8s-monitoring $@;
 
 ##@ Build
 .PHONY: build
 build: check-helm-version ## Build all charts
-	make -C charts/k8s-monitoring $@;
+	$(MAKE) -C charts/k8s-monitoring $@;
 
 ##@ Keys
 .PHONY: update-signing-keys
@@ -45,7 +45,7 @@ keys/prometheus-community-pubkey.gpg:
 ##@ Tests
 .PHONY: test
 test: build lint ## Run tests for all charts
-	make -C charts/k8s-monitoring $@;
+	$(MAKE) -C charts/k8s-monitoring $@;
 
 .PHONY: lint
 lint: lint-alloy lint-shell lint-markdown lint-terraform lint-text lint-yaml lint-alex lint-misspell lint-actionlint lint-zizmor ## Run all linters
@@ -122,7 +122,7 @@ lint-check-dead-links: ## Lint text files and check for dead links
 
 .PHONY: lint-yaml
 # renovate: datasource=docker depName=cytopia/yamllint
-YAMLLINT_VERSION = 1
+YAMLLINT_VERSION = 1-0.10
 lint-yaml: ## Lint yaml files
 	@if command -v yamllint &> /dev/null; then \
 		yamllint --strict --config-file .yamllint.yml .; \

--- a/Makefile
+++ b/Makefile
@@ -57,12 +57,14 @@ lint-alloy: ## Lint Alloy files
 	rm -rf data-alloy  # Clean up temporary Alloy data directory
 
 .PHONY: lint-shell
+# renovate: datasource=docker depName=koalaman/shellcheck
+SHELLCHECK_VERSION = v0.11.0
 SHELL_SCRIPTS = $(shell find . -type f -name "*.sh" -not \( -path "./node_modules/*" -o -path "./data-alloy/*" -o -path "./.git/*" -o -path "./charts/k8s-monitoring-v1/test/spec/*" -o -path "./charts/k8s-monitoring/tests/example-checks/spec/*" -o -path "./charts/k8s-monitoring/tests/misc-checks/spec/*" \))
 lint-shell: ## Lint shell scripts
 	@if command -v shellcheck &> /dev/null; then \
 		shellcheck $(SHELL_SCRIPTS); \
 	else \
-		docker run --rm -v $(shell pwd):/src --workdir /src koalaman/shellcheck:stable --rcfile .shellcheckrc $(SHELL_SCRIPTS); \
+		docker run --rm -v $(shell pwd):/src --workdir /src koalaman/shellcheck:$(SHELLCHECK_VERSION) --rcfile .shellcheckrc $(SHELL_SCRIPTS); \
 	fi
 
 .PHONY: lint-markdown
@@ -78,12 +80,14 @@ lint-markdown: ## Lint markdown files
 
 TERRAFORM_DIRS = $(shell find . -name 'vars.tf' -exec dirname {} \;)
 .PHONY: lint-terraform
+# renovate: datasource=docker depName=ghcr.io/terraform-linters/tflint
+TFLINT_VERSION = v0.64.0
 lint-terraform: ## Lint terraform files
 	@for dir in $(TERRAFORM_DIRS); do \
 		if command -v tflint &> /dev/null; then \
 			tflint --chdir "$${dir}"; \
 		else \
-			docker run --rm -v $(shell pwd)/$${dir}:/data ghcr.io/terraform-linters/tflint; \
+			docker run --rm -v $(shell pwd)/$${dir}:/data ghcr.io/terraform-linters/tflint:$(TFLINT_VERSION); \
 		fi; \
 	done
 
@@ -117,11 +121,13 @@ lint-check-dead-links: ## Lint text files and check for dead links
 	fi
 
 .PHONY: lint-yaml
+# renovate: datasource=docker depName=cytopia/yamllint
+YAMLLINT_VERSION = 1
 lint-yaml: ## Lint yaml files
 	@if command -v yamllint &> /dev/null; then \
 		yamllint --strict --config-file .yamllint.yml .; \
 	else \
-		docker run --rm -v $(shell pwd):/data cytopia/yamllint:latest --config-file .yamllint.yml .; \
+		docker run --rm -v $(shell pwd):/data cytopia/yamllint:$(YAMLLINT_VERSION) --config-file .yamllint.yml .; \
 	fi
 
 .PHONY: lint-alex
@@ -146,19 +152,23 @@ lint-misspell: ## Check for common misspellings
 	fi
 
 .PHONY: lint-actionlint
+# renovate: datasource=docker depName=rhysd/actionlint
+ACTIONLINT_VERSION = 1.7.12
 lint-actionlint: ## Lint GitHub Action workflows
 	@if command -v actionlint &> /dev/null; then \
 		actionlint .github/workflows/*.yml .github/workflows/*.yaml; \
 	else \
-		docker run --rm -v $(shell pwd):/src --workdir /src rhysd/actionlint:latest .github/workflows/*.yml .github/workflows/*.yaml; \
+		docker run --rm -v $(shell pwd):/src --workdir /src rhysd/actionlint:$(ACTIONLINT_VERSION) .github/workflows/*.yml .github/workflows/*.yaml; \
 	fi
 
 .PHONY: lint-zizmor
+# renovate: datasource=docker depName=ghcr.io/zizmorcore/zizmor
+ZIZMOR_VERSION = 1.27.0
 lint-zizmor: ## Statically analyze GitHub Action workflows
 	@if command -v zizmor&> /dev/null; then \
 		zizmor .; \
 	else \
-		docker run --rm -v $(shell pwd):/src --workdir /src ghcr.io/zizmorcore/zizmor:latest .; \
+		docker run --rm -v $(shell pwd):/src --workdir /src ghcr.io/zizmorcore/zizmor:$(ZIZMOR_VERSION) .; \
 	fi
 
 

--- a/charts/k8s-monitoring/Makefile
+++ b/charts/k8s-monitoring/Makefile
@@ -10,6 +10,9 @@ DOC_GENERATOR_IMAGE_VERSION = 0.2.4
 # renovate: datasource=docker depName=ghcr.io/grafana/helm-chart-toolbox-schema-generator
 SCHEMA_GENERATOR_IMAGE_VERSION = 0.2.4
 
+# Pinned manually and intentionally NOT tracked by Renovate: the tag is
+# <helm-version>-<helm-unittest-version>, so an automated bump would also change
+# the bundled Helm version. Update it deliberately.
 HELM_UNITTEST_IMAGE_VERSION = 3.18.4-1.0.0
 
 HAS_HELM_UNITTEST := $(shell $(HELM) plugin list | grep unittest 2> /dev/null)
@@ -268,20 +271,25 @@ EXAMPLE_README_FILES := $(EXAMPLE_VALUES_FILES:values.yaml=README.md)
 NON_RENDERED_INTEGRATION_TEST_VALUES_FILES = $(shell find tests/integration -name .no-render | sed 's/.no-render/values.yaml/')
 INTEGRATION_TEST_VALUES_FILES = $(filter-out $(NON_RENDERED_INTEGRATION_TEST_VALUES_FILES),$(shell find tests/integration -name values.yaml))
 INTEGRATION_TEST_OUTPUT_FILES = $(INTEGRATION_TEST_VALUES_FILES:values.yaml=.rendered/output.yaml)
-INTEGRATION_TEST_ALLOY_FILES = $(call alloy_rendered_files,$(INTEGRATION_TEST_VALUES_FILES),.alloy)
+INTEGRATION_TEST_ALLOY_FILES := $(call alloy_rendered_files,$(INTEGRATION_TEST_VALUES_FILES),.alloy)
 
 NON_RENDERED_PLATFORM_TEST_VALUES_FILES := $(shell find tests/platform -name .no-render | sed 's/.no-render/values.yaml/')
 PLATFORM_TEST_VALUES_FILES := $(filter-out $(NON_RENDERED_PLATFORM_TEST_VALUES_FILES),$(shell find tests/platform -name values.yaml))
 PLATFORM_TEST_OUTPUT_FILES := $(PLATFORM_TEST_VALUES_FILES:values.yaml=.rendered/output.yaml)
-PLATFORM_TEST_ALLOY_FILES = $(call alloy_rendered_files,$(PLATFORM_TEST_VALUES_FILES),.alloy)
+PLATFORM_TEST_ALLOY_FILES := $(call alloy_rendered_files,$(PLATFORM_TEST_VALUES_FILES),.alloy)
 
-# Everything `helm template` reads while rendering the parent chart. Any template files that are generated MUST be
-# listed explicitly because they wont be found by the $(CHART_TEMPLATE_FILES) wildcard
+# Everything `helm template` reads while rendering the parent chart, so editing any of these re-renders the outputs.
+# Files pulled in with .Files.Get (the collector values, the extracted upstream alloy values, the collector presets, and
+# the OTLP resource-attributes remove-list) and the generated *.tpl files must be listed explicitly: the
+# $(CHART_TEMPLATE_FILES)/$(CHART_YAML_FILES) wildcards only cover templates/ and are evaluated (by find, at parse time)
+# before generated files exist.
 HELM_TEMPLATE_DEPS := Chart.yaml Chart.lock values.yaml values.schema.json \
 	templates/destinations/_destination_types.tpl \
 	templates/dataProcessors/_dataProcessor_types.tpl \
 	$(COLLECTOR_PRESET_FILES) \
+	$(COLLECTOR_VALUES_FILES) \
 	collectors/upstream/alloy-values.yaml \
+	default-remove-lists/resource-attributes.yaml \
 	$(DESTINATION_VALUES_FILES) $(CHART_TEMPLATE_FILES) $(CHART_YAML_FILES)
 
 %/output.yaml: %/values.yaml $(HELM_TEMPLATE_DEPS) | build-features
@@ -347,7 +355,7 @@ clean: clean-examples
 	rm -f $(DATA_PROCESSOR_SCHEMA_FILES) $(DATA_PROCESSOR_DOCS_FILES)
 	set -e && \
 	for chart in $(FEATURE_CHARTS); do \
-		make -C $$chart clean; \
+		$(MAKE) -C $$chart clean; \
 	done
 
 .PHONY: clean-examples
@@ -358,7 +366,7 @@ clean-examples:
 build-features:
 	set -e && \
 	for chart in $(FEATURE_CHARTS); do \
-		make -C $$chart build; \
+		$(MAKE) -C $$chart build; \
 	done
 
 # Verify the signatures of signed Grafana chart dependencies.
@@ -369,7 +377,7 @@ verify-signatures:
 		--version $(ALLOY_OPERATOR_VERSION) \
 		--verify --keyring $(GRAFANA_HELM_CHARTS_KEYRING) \
 		--destination "$$(mktemp -d)"
-	make -C charts/telemetry-services verify-signatures
+	$(MAKE) -C charts/telemetry-services verify-signatures
 
 # Build targets
 .PHONY: build
@@ -391,7 +399,7 @@ test: unittest lint-helm lint-configs example-checks misc-checks test-features
 test-features:
 	set -e && \
 	for chart in $(FEATURE_CHARTS); do \
-		make -C $$chart test; \
+		$(MAKE) -C $$chart test; \
 	done
 
 lint-configs: $(EXAMPLE_ALLOY_FILES)
@@ -419,5 +427,5 @@ else
 endif
 	set -e && \
 	for chart in $(FEATURE_CHARTS); do \
-		make -C $$chart update-test-snapshots; \
+		$(MAKE) -C $$chart update-test-snapshots; \
 	done

--- a/charts/k8s-monitoring/Makefile
+++ b/charts/k8s-monitoring/Makefile
@@ -256,7 +256,8 @@ AGENTS.md: AGENTS.md.gotmpl $(FEATURE_CHARTS) $(DESTINATION_VALUES_FILES) $(INTE
 # Example targets
 EXAMPLE_RELEASE_NAME=k8smon
 
-alloy_files = $(if $(1),$(shell yq e '(filename | sub("[^/]*$$"; "")) as $$dir | .collectors | keys | .[] | $$dir + . + "$(2)"' $(1)))
+alloy_files = $(if $(1),$(shell yq e '(filename | sub("[^/]*$$"; "")) as $$dir | .collectors // {} | keys | .[] | $$dir + . + "$(2)"' $(1)))
+alloy_rendered_files = $(if $(1),$(shell yq e '(filename | sub("[^/]*$$"; ".rendered/")) as $$dir | .collectors // {} | keys | .[] | $$dir + . + "$(2)"' $(1)))
 
 NON_RENDERED_EXAMPLE_VALUES_FILES = $(shell find docs/examples -name .no-render | sed 's/.no-render/values.yaml/')
 EXAMPLE_VALUES_FILES := $(filter-out $(NON_RENDERED_EXAMPLE_VALUES_FILES),$(shell find docs/examples -name values.yaml))
@@ -267,12 +268,12 @@ EXAMPLE_README_FILES := $(EXAMPLE_VALUES_FILES:values.yaml=README.md)
 NON_RENDERED_INTEGRATION_TEST_VALUES_FILES = $(shell find tests/integration -name .no-render | sed 's/.no-render/values.yaml/')
 INTEGRATION_TEST_VALUES_FILES = $(filter-out $(NON_RENDERED_INTEGRATION_TEST_VALUES_FILES),$(shell find tests/integration -name values.yaml))
 INTEGRATION_TEST_OUTPUT_FILES = $(INTEGRATION_TEST_VALUES_FILES:values.yaml=.rendered/output.yaml)
-INTEGRATION_TEST_ALLOY_FILES = $(call alloy_files,$(INTEGRATION_TEST_OUTPUT_FILES),.yaml)
+INTEGRATION_TEST_ALLOY_FILES = $(call alloy_rendered_files,$(INTEGRATION_TEST_VALUES_FILES),.alloy)
 
 NON_RENDERED_PLATFORM_TEST_VALUES_FILES := $(shell find tests/platform -name .no-render | sed 's/.no-render/values.yaml/')
 PLATFORM_TEST_VALUES_FILES := $(filter-out $(NON_RENDERED_PLATFORM_TEST_VALUES_FILES),$(shell find tests/platform -name values.yaml))
 PLATFORM_TEST_OUTPUT_FILES := $(PLATFORM_TEST_VALUES_FILES:values.yaml=.rendered/output.yaml)
-PLATFORM_TEST_ALLOY_FILES = $(call alloy_files,$(PLATFORM_TEST_OUTPUT_FILES),.yaml)
+PLATFORM_TEST_ALLOY_FILES = $(call alloy_rendered_files,$(PLATFORM_TEST_VALUES_FILES),.alloy)
 
 # Everything `helm template` reads while rendering the parent chart. Any template files that are generated MUST be
 # listed explicitly because they wont be found by the $(CHART_TEMPLATE_FILES) wildcard
@@ -351,7 +352,7 @@ clean: clean-examples
 
 .PHONY: clean-examples
 clean-examples:
-	rm -f $(EXAMPLE_OUTPUT_FILES) $(EXAMPLE_ALLOY_FILES) $(EXAMPLE_README_FILES) $(INTEGRATION_TEST_OUTPUT_FILES) $(PLATFORM_TEST_OUTPUT_FILES)
+	rm -f $(EXAMPLE_OUTPUT_FILES) $(EXAMPLE_ALLOY_FILES) $(EXAMPLE_README_FILES) $(INTEGRATION_TEST_OUTPUT_FILES) $(INTEGRATION_TEST_ALLOY_FILES) $(PLATFORM_TEST_OUTPUT_FILES) $(PLATFORM_TEST_ALLOY_FILES)
 
 .PHONY: build-features
 build-features:

--- a/charts/k8s-monitoring/Makefile
+++ b/charts/k8s-monitoring/Makefile
@@ -5,8 +5,17 @@ else
 HELM = ../../scripts/helm-with-version $(HELM_VERSION)
 endif
 
+# renovate: datasource=docker depName=ghcr.io/grafana/helm-chart-toolbox-doc-generator
+DOC_GENERATOR_IMAGE_VERSION = 0.2.4
+# renovate: datasource=docker depName=ghcr.io/grafana/helm-chart-toolbox-schema-generator
+SCHEMA_GENERATOR_IMAGE_VERSION = 0.2.4
+
+HELM_UNITTEST_IMAGE_VERSION = 3.18.4-1.0.0
+
 HAS_HELM_UNITTEST := $(shell $(HELM) plugin list | grep unittest 2> /dev/null)
 HAS_SHELLSPEC := $(shell command -v shellspec;)
+# renovate: datasource=docker depName=shellspec/shellspec
+SHELLSPEC_IMAGE_VERSION = 0.28.1
 
 CHART_TEMPLATE_FILES = $(shell find templates -name "*.tpl")
 CHART_YAML_FILES = $(shell find templates -name "*.yaml")
@@ -49,14 +58,16 @@ INTEGRATION_VALUES_FILES = $(shell find charts/feature-integrations/integrations
 
 .SECONDEXPANSION:
 docs/collectors/%.md: collectors/%-values.yaml $$(wildcard docs/collectors/.doc_templates/%.gotmpl)
-	docker run --platform linux/amd64 --rm --volume $(shell pwd):/chart ghcr.io/grafana/helm-chart-toolbox-doc-generator --file /chart/$< --template /chart/docs/collectors/.doc_templates/$(shell basename -s -values.yaml $<).gotmpl > $@
+	docker run --platform linux/amd64 --rm --volume $(CURDIR):/chart ghcr.io/grafana/helm-chart-toolbox-doc-generator:$(DOC_GENERATOR_IMAGE_VERSION) \
+		--file /chart/$< --template /chart/docs/collectors/.doc_templates/$(shell basename -s -values.yaml $<).gotmpl > $@
 
 docs/collectors/presets/%.md: collectors/presets/%.yaml
 	@echo '<!--' > $@
 	@echo '(NOTE: Do not edit README.md directly. It is a generated file!)' >> $@
 	@echo '(      To make changes, please modify values.yaml or description.txt and run `make examples`)' >> $@
 	@echo '-->' >> $@
-	docker run --platform linux/amd64 --rm --volume $(shell pwd):/chart ghcr.io/grafana/helm-chart-toolbox-doc-generator --file /chart/$< --template /chart/docs/collectors/presets/.doc_templates/$(shell basename -s .yaml $<).gotmpl >> $@
+	docker run --platform linux/amd64 --rm --volume $(CURDIR):/chart ghcr.io/grafana/helm-chart-toolbox-doc-generator:$(DOC_GENERATOR_IMAGE_VERSION) \
+		--file /chart/$< --template /chart/docs/collectors/presets/.doc_templates/$(shell basename -s .yaml $<).gotmpl >> $@
 
 	@echo '' >> $@
 	@echo '<!-- textlint-disable terminology -->' >> $@
@@ -67,19 +78,24 @@ docs/collectors/presets/%.md: collectors/presets/%.yaml
 
 
 docs/destinations/%.md: destinations/%-values.yaml $$(wildcard docs/destinations/.doc_templates/%.gotmpl)
-	docker run --platform linux/amd64 --rm --volume $(shell pwd):/chart ghcr.io/grafana/helm-chart-toolbox-doc-generator --file /chart/$< --template /chart/docs/destinations/.doc_templates/$(shell basename -s -values.yaml $<).gotmpl > $@
+	docker run --platform linux/amd64 --rm --volume $(CURDIR):/chart ghcr.io/grafana/helm-chart-toolbox-doc-generator:$(DOC_GENERATOR_IMAGE_VERSION) \
+		--file /chart/$< --template /chart/docs/destinations/.doc_templates/$(shell basename -s -values.yaml $<).gotmpl > $@
 
 docs/dataProcessors/%.md: dataProcessors/%-values.yaml $$(wildcard docs/dataProcessors/.doc_templates/%.gotmpl)
-	docker run --platform linux/amd64 --rm --volume $(shell pwd):/chart ghcr.io/grafana/helm-chart-toolbox-doc-generator --file /chart/$< --template /chart/docs/dataProcessors/.doc_templates/$(shell basename -s -values.yaml $<).gotmpl > $@
+	docker run --platform linux/amd64 --rm --volume $(CURDIR):/chart ghcr.io/grafana/helm-chart-toolbox-doc-generator:$(DOC_GENERATOR_IMAGE_VERSION) \
+		--file /chart/$< --template /chart/docs/dataProcessors/.doc_templates/$(shell basename -s -values.yaml $<).gotmpl > $@
 
 schema-mods/definitions/%-collector.schema.json: collectors/%-values.yaml
-	docker run --platform linux/amd64 --rm --volume $(shell pwd):/chart ghcr.io/grafana/helm-chart-toolbox-schema-generator --file /chart/$< > $@
+	docker run --rm --platform linux/amd64 --volume $(CURDIR):/chart ghcr.io/grafana/helm-chart-toolbox-schema-generator:$(SCHEMA_GENERATOR_IMAGE_VERSION) \
+		--file /chart/$< > $@
 
 schema-mods/definitions/%-destination.schema.json: destinations/%-values.yaml
-	docker run --platform linux/amd64 --rm --volume $(shell pwd):/chart ghcr.io/grafana/helm-chart-toolbox-schema-generator --file /chart/$< > $@
+	docker run --rm --platform linux/amd64 --volume $(CURDIR):/chart ghcr.io/grafana/helm-chart-toolbox-schema-generator:$(SCHEMA_GENERATOR_IMAGE_VERSION) \
+		--file /chart/$< > $@
 
 schema-mods/definitions/%-dataProcessor.schema.json: dataProcessors/%-values.yaml
-	docker run --platform linux/amd64 --rm --volume $(shell pwd):/chart ghcr.io/grafana/helm-chart-toolbox-schema-generator --file /chart/$< > $@
+	docker run --rm --platform linux/amd64 --volume $(CURDIR):/chart ghcr.io/grafana/helm-chart-toolbox-schema-generator:$(SCHEMA_GENERATOR_IMAGE_VERSION) \
+		--file /chart/$< > $@
 
 NUMBER_OF_DESTINATION_VALUES_FILES := $(words $(DESTINATION_VALUES_FILES))
 schema-mods/destination.json: $(DESTINATION_SCHEMA_FILES)
@@ -183,10 +199,10 @@ Chart.lock: Chart.yaml
 	@touch Chart.lock # Ensure the timestamp is updated
 
 values.schema.json: values.yaml $(COLLECTOR_SCHEMA_FILES) $(DESTINATION_SCHEMA_FILES) $(DATA_PROCESSOR_SCHEMA_FILES) $(SCHEMA_MODS_JSON_FILES) $(SCHEMA_MODS_JQ_FILES) schema-mods/destination.json schema-mods/dataProcessor.json
-	docker run --rm --platform linux/amd64 --volume $(shell pwd):/chart ghcr.io/grafana/helm-chart-toolbox-schema-generator --chart /chart > $@
+	docker run --rm --platform linux/amd64 --volume $(CURDIR):/chart ghcr.io/grafana/helm-chart-toolbox-schema-generator:$(SCHEMA_GENERATOR_IMAGE_VERSION) --chart /chart > $@
 
 README.md: README.md.gotmpl values.yaml Chart.yaml
-	docker run --rm --platform linux/amd64 --volume $(shell pwd):/chart ghcr.io/grafana/helm-chart-toolbox-doc-generator --chart /chart > $@
+	docker run --platform linux/amd64 --rm --volume $(CURDIR):/chart ghcr.io/grafana/helm-chart-toolbox-doc-generator:$(DOC_GENERATOR_IMAGE_VERSION) --chart /chart > $@
 
 # AGENTS.md generation - auto-discovers features, destinations, and integrations
 AGENTS.md: AGENTS.md.gotmpl $(FEATURE_CHARTS) $(DESTINATION_VALUES_FILES) $(INTEGRATION_VALUES_FILES)
@@ -239,32 +255,38 @@ AGENTS.md: AGENTS.md.gotmpl $(FEATURE_CHARTS) $(DESTINATION_VALUES_FILES) $(INTE
 
 # Example targets
 EXAMPLE_RELEASE_NAME=k8smon
+
+alloy_files = $(if $(1),$(shell yq e '(filename | sub("[^/]*$$"; "")) as $$dir | .collectors | keys | .[] | $$dir + . + "$(2)"' $(1)))
+
 NON_RENDERED_EXAMPLE_VALUES_FILES = $(shell find docs/examples -name .no-render | sed 's/.no-render/values.yaml/')
 EXAMPLE_VALUES_FILES := $(filter-out $(NON_RENDERED_EXAMPLE_VALUES_FILES),$(shell find docs/examples -name values.yaml))
 EXAMPLE_OUTPUT_FILES := $(EXAMPLE_VALUES_FILES:values.yaml=output.yaml)
-EXAMPLE_ALLOY_FILES = $(foreach file,$(EXAMPLE_VALUES_FILES),$(call alloy_configs, $(file)))
+EXAMPLE_ALLOY_FILES := $(call alloy_files,$(EXAMPLE_VALUES_FILES),.alloy)
 EXAMPLE_README_FILES := $(EXAMPLE_VALUES_FILES:values.yaml=README.md)
 
 NON_RENDERED_INTEGRATION_TEST_VALUES_FILES = $(shell find tests/integration -name .no-render | sed 's/.no-render/values.yaml/')
 INTEGRATION_TEST_VALUES_FILES = $(filter-out $(NON_RENDERED_INTEGRATION_TEST_VALUES_FILES),$(shell find tests/integration -name values.yaml))
 INTEGRATION_TEST_OUTPUT_FILES = $(INTEGRATION_TEST_VALUES_FILES:values.yaml=.rendered/output.yaml)
-INTEGRATION_TEST_ALLOY_INSTANCE_FILES = $(foreach file,$(INTEGRATION_TEST_OUTPUT_FILES),$(call alloy_instances, $(file)))
+INTEGRATION_TEST_ALLOY_FILES = $(call alloy_files,$(INTEGRATION_TEST_OUTPUT_FILES),.yaml)
 
 NON_RENDERED_PLATFORM_TEST_VALUES_FILES := $(shell find tests/platform -name .no-render | sed 's/.no-render/values.yaml/')
 PLATFORM_TEST_VALUES_FILES := $(filter-out $(NON_RENDERED_PLATFORM_TEST_VALUES_FILES),$(shell find tests/platform -name values.yaml))
 PLATFORM_TEST_OUTPUT_FILES := $(PLATFORM_TEST_VALUES_FILES:values.yaml=.rendered/output.yaml)
+PLATFORM_TEST_ALLOY_FILES = $(call alloy_files,$(PLATFORM_TEST_OUTPUT_FILES),.yaml)
 
-alloy_configs = $(shell \
-	DIR="$(shell dirname $(1))/" yq e '.collectors | keys | .[] | env(DIR) + . + ".alloy"' $(1) \
-)
-alloy_instances = $(shell \
-	DIR="$(shell dirname $(1))/" yq e '.collectors | keys | .[] | env(DIR) + . + ".yaml"' $(1) \
-)
+# Everything `helm template` reads while rendering the parent chart. Any template files that are generated MUST be
+# listed explicitly because they wont be found by the $(CHART_TEMPLATE_FILES) wildcard
+HELM_TEMPLATE_DEPS := Chart.yaml Chart.lock values.yaml values.schema.json \
+	templates/destinations/_destination_types.tpl \
+	templates/dataProcessors/_dataProcessor_types.tpl \
+	$(COLLECTOR_PRESET_FILES) \
+	collectors/upstream/alloy-values.yaml \
+	$(DESTINATION_VALUES_FILES) $(CHART_TEMPLATE_FILES) $(CHART_YAML_FILES)
 
-%/output.yaml: %/values.yaml Chart.yaml Chart.lock values.yaml values.schema.json templates/destinations/_destination_types.tpl $(DESTINATION_VALUES_FILES) $(CHART_TEMPLATE_FILES) $(CHART_YAML_FILES)
+%/output.yaml: %/values.yaml $(HELM_TEMPLATE_DEPS) | build-features
 	$(HELM) template $(EXAMPLE_RELEASE_NAME) . -f $< > $@
 
-%/.rendered/output.yaml: %/values.yaml Chart.yaml Chart.lock values.yaml values.schema.json templates/destinations/_destination_types.tpl $(DESTINATION_VALUES_FILES) $(CHART_TEMPLATE_FILES) $(CHART_YAML_FILES)
+%/.rendered/output.yaml: %/values.yaml $(HELM_TEMPLATE_DEPS) | build-features
 	mkdir -p $(dir $@)
 	$(HELM) template $(EXAMPLE_RELEASE_NAME) . -f $< > $@
 
@@ -292,14 +314,14 @@ alloy_instances = $(shell \
 	@echo '<!-- textlint-enable terminology -->' >> $@
 
 .PHONY: examples
-examples: $(EXAMPLE_OUTPUT_FILES) $(EXAMPLE_ALLOY_FILES) $(EXAMPLE_README_FILES) $(INTEGRATION_TEST_OUTPUT_FILES) $(PLATFORM_TEST_OUTPUT_FILES)
+examples: $(EXAMPLE_OUTPUT_FILES) $(EXAMPLE_ALLOY_FILES) $(EXAMPLE_README_FILES) $(INTEGRATION_TEST_OUTPUT_FILES) $(INTEGRATION_TEST_ALLOY_FILES) $(PLATFORM_TEST_OUTPUT_FILES) $(PLATFORM_TEST_ALLOY_FILES)
 
 .PHONY: example-checks
 example-checks: $(EXAMPLE_OUTPUT_FILES)
 ifdef HAS_SHELLSPEC
 	shellspec -c tests/example-checks
 else
-	docker run --platform linux/amd64 --rm --volume $(shell pwd):/src shellspec/shellspec -c /src/tests/example-checks -s /bin/sh
+	docker run --platform linux/amd64 --rm --volume $(CURDIR):/src shellspec/shellspec:$(SHELLSPEC_IMAGE_VERSION) -c /src/tests/example-checks -s /bin/sh
 endif
 
 
@@ -308,7 +330,7 @@ misc-checks: Chart.yaml
 ifdef HAS_SHELLSPEC
 	ALLOY_OPERATOR_VERSION=$(ALLOY_OPERATOR_VERSION) shellspec -c tests/misc-checks
 else
-	docker run --platform linux/amd64 --rm --env ALLOY_OPERATOR_VERSION=$(ALLOY_OPERATOR_VERSION) --volume $(shell pwd):/src shellspec/shellspec -c /src/tests/misc-checks -s /bin/sh
+	docker run --platform linux/amd64 --rm --env ALLOY_OPERATOR_VERSION=$(ALLOY_OPERATOR_VERSION) --volume $(CURDIR):/src shellspec/shellspec:$(SHELLSPEC_IMAGE_VERSION) -c /src/tests/misc-checks -s /bin/sh
 endif
 
 .PHONY: integration-test-checks
@@ -331,6 +353,7 @@ clean: clean-examples
 clean-examples:
 	rm -f $(EXAMPLE_OUTPUT_FILES) $(EXAMPLE_ALLOY_FILES) $(EXAMPLE_README_FILES) $(INTEGRATION_TEST_OUTPUT_FILES) $(PLATFORM_TEST_OUTPUT_FILES)
 
+.PHONY: build-features
 build-features:
 	set -e && \
 	for chart in $(FEATURE_CHARTS); do \
@@ -383,7 +406,7 @@ unittest: values.schema.json templates/destinations/_destination_types.tpl templ
 ifdef HAS_HELM_UNITTEST
 	$(HELM) unittest --failfast --with-subchart=false .
 else
-	docker run --rm --volume $(shell pwd):/apps helmunittest/helm-unittest:3.18.4-1.0.0 --failfast --with-subchart=false .
+	docker run --rm --volume $(CURDIR):/apps helmunittest/helm-unittest:$(HELM_UNITTEST_IMAGE_VERSION) --failfast --with-subchart=false .
 endif
 
 .PHONY: update-test-snapshots
@@ -391,7 +414,7 @@ update-test-snapshots:
 ifdef HAS_HELM_UNITTEST
 	$(HELM) unittest --with-subchart=false . --update-snapshot
 else
-	docker run --rm --volume $(shell pwd):/apps helmunittest/helm-unittest:3.18.4-1.0.0 --with-subchart=false . --update-snapshot
+	docker run --rm --volume $(CURDIR):/apps helmunittest/helm-unittest:$(HELM_UNITTEST_IMAGE_VERSION) --with-subchart=false . --update-snapshot
 endif
 	set -e && \
 	for chart in $(FEATURE_CHARTS); do \

--- a/charts/k8s-monitoring/charts/feature-annotation-autodiscovery/Makefile
+++ b/charts/k8s-monitoring/charts/feature-annotation-autodiscovery/Makefile
@@ -10,6 +10,9 @@ DOC_GENERATOR_IMAGE_VERSION = 0.2.4
 # renovate: datasource=docker depName=ghcr.io/grafana/helm-chart-toolbox-schema-generator
 SCHEMA_GENERATOR_IMAGE_VERSION = 0.2.4
 
+# Pinned manually and intentionally NOT tracked by Renovate: the tag is
+# <helm-version>-<helm-unittest-version>, so an automated bump would also change
+# the bundled Helm version. Update it deliberately.
 HELM_UNITTEST_IMAGE_VERSION = 3.18.4-1.0.0
 
 HAS_HELM_UNITTEST := $(shell $(HELM) plugin list | grep unittest 2> /dev/null)

--- a/charts/k8s-monitoring/charts/feature-annotation-autodiscovery/Makefile
+++ b/charts/k8s-monitoring/charts/feature-annotation-autodiscovery/Makefile
@@ -5,18 +5,25 @@ else
 HELM = ../../../../scripts/helm-with-version $(HELM_VERSION)
 endif
 
+# renovate: datasource=docker depName=ghcr.io/grafana/helm-chart-toolbox-doc-generator
+DOC_GENERATOR_IMAGE_VERSION = 0.2.4
+# renovate: datasource=docker depName=ghcr.io/grafana/helm-chart-toolbox-schema-generator
+SCHEMA_GENERATOR_IMAGE_VERSION = 0.2.4
+
+HELM_UNITTEST_IMAGE_VERSION = 3.18.4-1.0.0
+
 HAS_HELM_UNITTEST := $(shell $(HELM) plugin list | grep unittest 2> /dev/null)
 
 .SECONDEXPANSION:
 README.md: values.yaml Chart.yaml $$(wildcard README.md.gotmpl)
-	docker run --rm --platform linux/amd64 --volume $(shell pwd):/chart ghcr.io/grafana/helm-chart-toolbox-doc-generator --chart /chart > $@
+	docker run --rm --platform linux/amd64 --volume $(shell pwd):/chart ghcr.io/grafana/helm-chart-toolbox-doc-generator:$(DOC_GENERATOR_IMAGE_VERSION) --chart /chart > $@
 
 Chart.lock: Chart.yaml
 	$(HELM) dependency update .
 	@touch Chart.lock # Ensure the timestamp is updated
 
 values.schema.json: values.yaml $$(wildcard schema-mods/*)
-	docker run --rm --platform linux/amd64 --volume $(shell pwd):/chart ghcr.io/grafana/helm-chart-toolbox-schema-generator --chart /chart > $@
+	docker run --rm --platform linux/amd64 --volume $(shell pwd):/chart ghcr.io/grafana/helm-chart-toolbox-schema-generator:$(SCHEMA_GENERATOR_IMAGE_VERSION) --chart /chart > $@
 
 .PHONY: clean
 clean:
@@ -32,7 +39,7 @@ test: build
 ifdef HAS_HELM_UNITTEST
 	$(HELM) unittest .
 else
-	docker run --rm --volume $(shell pwd):/apps helmunittest/helm-unittest:3.18.4-1.0.0 .
+	docker run --rm --volume $(shell pwd):/apps helmunittest/helm-unittest:$(HELM_UNITTEST_IMAGE_VERSION) .
 endif
 
 .PHONY: update-test-snapshots
@@ -40,5 +47,5 @@ update-test-snapshots:
 ifdef HAS_HELM_UNITTEST
 	$(HELM) unittest . --update-snapshot
 else
-	docker run --rm --volume $(shell pwd):/apps helmunittest/helm-unittest:3.18.4-1.0.0 . --update-snapshot
+	docker run --rm --volume $(shell pwd):/apps helmunittest/helm-unittest:$(HELM_UNITTEST_IMAGE_VERSION) . --update-snapshot
 endif

--- a/charts/k8s-monitoring/charts/feature-application-observability/Makefile
+++ b/charts/k8s-monitoring/charts/feature-application-observability/Makefile
@@ -10,6 +10,9 @@ DOC_GENERATOR_IMAGE_VERSION = 0.2.4
 # renovate: datasource=docker depName=ghcr.io/grafana/helm-chart-toolbox-schema-generator
 SCHEMA_GENERATOR_IMAGE_VERSION = 0.2.4
 
+# Pinned manually and intentionally NOT tracked by Renovate: the tag is
+# <helm-version>-<helm-unittest-version>, so an automated bump would also change
+# the bundled Helm version. Update it deliberately.
 HELM_UNITTEST_IMAGE_VERSION = 3.18.4-1.0.0
 
 HAS_HELM_UNITTEST := $(shell $(HELM) plugin list | grep unittest 2> /dev/null)

--- a/charts/k8s-monitoring/charts/feature-application-observability/Makefile
+++ b/charts/k8s-monitoring/charts/feature-application-observability/Makefile
@@ -5,18 +5,25 @@ else
 HELM = ../../../../scripts/helm-with-version $(HELM_VERSION)
 endif
 
+# renovate: datasource=docker depName=ghcr.io/grafana/helm-chart-toolbox-doc-generator
+DOC_GENERATOR_IMAGE_VERSION = 0.2.4
+# renovate: datasource=docker depName=ghcr.io/grafana/helm-chart-toolbox-schema-generator
+SCHEMA_GENERATOR_IMAGE_VERSION = 0.2.4
+
+HELM_UNITTEST_IMAGE_VERSION = 3.18.4-1.0.0
+
 HAS_HELM_UNITTEST := $(shell $(HELM) plugin list | grep unittest 2> /dev/null)
 
 .SECONDEXPANSION:
 README.md: values.yaml Chart.yaml $$(wildcard README.md.gotmpl)
-	docker run --rm --platform linux/amd64 --volume $(shell pwd):/chart ghcr.io/grafana/helm-chart-toolbox-doc-generator --chart /chart > $@
+	docker run --rm --platform linux/amd64 --volume $(shell pwd):/chart ghcr.io/grafana/helm-chart-toolbox-doc-generator:$(DOC_GENERATOR_IMAGE_VERSION) --chart /chart > $@
 
 Chart.lock: Chart.yaml
 	$(HELM) dependency update .
 	@touch Chart.lock # Ensure the timestamp is updated
 
 values.schema.json: values.yaml $$(wildcard schema-mods/*)
-	docker run --rm --platform linux/amd64 --volume $(shell pwd):/chart ghcr.io/grafana/helm-chart-toolbox-schema-generator --chart /chart > $@
+	docker run --rm --platform linux/amd64 --volume $(shell pwd):/chart ghcr.io/grafana/helm-chart-toolbox-schema-generator:$(SCHEMA_GENERATOR_IMAGE_VERSION) --chart /chart > $@
 
 .PHONY: clean
 clean:
@@ -32,7 +39,7 @@ test: build
 ifdef HAS_HELM_UNITTEST
 	$(HELM) unittest .
 else
-	docker run --rm --volume $(shell pwd):/apps helmunittest/helm-unittest:3.18.4-1.0.0 .
+	docker run --rm --volume $(shell pwd):/apps helmunittest/helm-unittest:$(HELM_UNITTEST_IMAGE_VERSION) .
 endif
 
 .PHONY: update-test-snapshots
@@ -40,5 +47,5 @@ update-test-snapshots:
 ifdef HAS_HELM_UNITTEST
 	$(HELM) unittest . --update-snapshot
 else
-	docker run --rm --volume $(shell pwd):/apps helmunittest/helm-unittest:3.18.4-1.0.0 . --update-snapshot
+	docker run --rm --volume $(shell pwd):/apps helmunittest/helm-unittest:$(HELM_UNITTEST_IMAGE_VERSION) . --update-snapshot
 endif

--- a/charts/k8s-monitoring/charts/feature-auto-instrumentation/Makefile
+++ b/charts/k8s-monitoring/charts/feature-auto-instrumentation/Makefile
@@ -10,6 +10,9 @@ DOC_GENERATOR_IMAGE_VERSION = 0.2.4
 # renovate: datasource=docker depName=ghcr.io/grafana/helm-chart-toolbox-schema-generator
 SCHEMA_GENERATOR_IMAGE_VERSION = 0.2.4
 
+# Pinned manually and intentionally NOT tracked by Renovate: the tag is
+# <helm-version>-<helm-unittest-version>, so an automated bump would also change
+# the bundled Helm version. Update it deliberately.
 HELM_UNITTEST_IMAGE_VERSION = 3.18.4-1.0.0
 
 HAS_HELM_UNITTEST := $(shell $(HELM) plugin list | grep unittest 2> /dev/null)

--- a/charts/k8s-monitoring/charts/feature-auto-instrumentation/Makefile
+++ b/charts/k8s-monitoring/charts/feature-auto-instrumentation/Makefile
@@ -5,18 +5,25 @@ else
 HELM = ../../../../scripts/helm-with-version $(HELM_VERSION)
 endif
 
+# renovate: datasource=docker depName=ghcr.io/grafana/helm-chart-toolbox-doc-generator
+DOC_GENERATOR_IMAGE_VERSION = 0.2.4
+# renovate: datasource=docker depName=ghcr.io/grafana/helm-chart-toolbox-schema-generator
+SCHEMA_GENERATOR_IMAGE_VERSION = 0.2.4
+
+HELM_UNITTEST_IMAGE_VERSION = 3.18.4-1.0.0
+
 HAS_HELM_UNITTEST := $(shell $(HELM) plugin list | grep unittest 2> /dev/null)
 
 .SECONDEXPANSION:
 README.md: values.yaml Chart.yaml $$(wildcard README.md.gotmpl)
-	docker run --rm --platform linux/amd64 --volume $(shell pwd):/chart ghcr.io/grafana/helm-chart-toolbox-doc-generator --chart /chart > $@
+	docker run --rm --platform linux/amd64 --volume $(shell pwd):/chart ghcr.io/grafana/helm-chart-toolbox-doc-generator:$(DOC_GENERATOR_IMAGE_VERSION) --chart /chart > $@
 
 Chart.lock: Chart.yaml
 	$(HELM) dependency update .
 	@touch Chart.lock # Ensure the timestamp is updated
 
 values.schema.json: values.yaml $$(wildcard schema-mods/*)
-	docker run --rm --platform linux/amd64 --volume $(shell pwd):/chart ghcr.io/grafana/helm-chart-toolbox-schema-generator --chart /chart > $@
+	docker run --rm --platform linux/amd64 --volume $(shell pwd):/chart ghcr.io/grafana/helm-chart-toolbox-schema-generator:$(SCHEMA_GENERATOR_IMAGE_VERSION) --chart /chart > $@
 
 .PHONY: clean
 clean:
@@ -34,7 +41,7 @@ test: build
 ifdef HAS_HELM_UNITTEST
 	$(HELM) unittest .
 else
-	docker run --rm --volume $(shell pwd):/apps helmunittest/helm-unittest:3.18.4-1.0.0 .
+	docker run --rm --volume $(shell pwd):/apps helmunittest/helm-unittest:$(HELM_UNITTEST_IMAGE_VERSION) .
 endif
 
 .PHONY: update-test-snapshots
@@ -42,5 +49,5 @@ update-test-snapshots:
 ifdef HAS_HELM_UNITTEST
 	$(HELM) unittest . --update-snapshot
 else
-	docker run --rm --volume $(shell pwd):/apps helmunittest/helm-unittest:3.18.4-1.0.0 . --update-snapshot
+	docker run --rm --volume $(shell pwd):/apps helmunittest/helm-unittest:$(HELM_UNITTEST_IMAGE_VERSION) . --update-snapshot
 endif

--- a/charts/k8s-monitoring/charts/feature-cluster-events/Makefile
+++ b/charts/k8s-monitoring/charts/feature-cluster-events/Makefile
@@ -10,6 +10,9 @@ DOC_GENERATOR_IMAGE_VERSION = 0.2.4
 # renovate: datasource=docker depName=ghcr.io/grafana/helm-chart-toolbox-schema-generator
 SCHEMA_GENERATOR_IMAGE_VERSION = 0.2.4
 
+# Pinned manually and intentionally NOT tracked by Renovate: the tag is
+# <helm-version>-<helm-unittest-version>, so an automated bump would also change
+# the bundled Helm version. Update it deliberately.
 HELM_UNITTEST_IMAGE_VERSION = 3.18.4-1.0.0
 
 HAS_HELM_UNITTEST := $(shell $(HELM) plugin list | grep unittest 2> /dev/null)

--- a/charts/k8s-monitoring/charts/feature-cluster-events/Makefile
+++ b/charts/k8s-monitoring/charts/feature-cluster-events/Makefile
@@ -5,18 +5,25 @@ else
 HELM = ../../../../scripts/helm-with-version $(HELM_VERSION)
 endif
 
+# renovate: datasource=docker depName=ghcr.io/grafana/helm-chart-toolbox-doc-generator
+DOC_GENERATOR_IMAGE_VERSION = 0.2.4
+# renovate: datasource=docker depName=ghcr.io/grafana/helm-chart-toolbox-schema-generator
+SCHEMA_GENERATOR_IMAGE_VERSION = 0.2.4
+
+HELM_UNITTEST_IMAGE_VERSION = 3.18.4-1.0.0
+
 HAS_HELM_UNITTEST := $(shell $(HELM) plugin list | grep unittest 2> /dev/null)
 
 .SECONDEXPANSION:
 README.md: values.yaml Chart.yaml $$(wildcard README.md.gotmpl)
-	docker run --rm --platform linux/amd64 --volume $(shell pwd):/chart ghcr.io/grafana/helm-chart-toolbox-doc-generator --chart /chart > $@
+	docker run --rm --platform linux/amd64 --volume $(shell pwd):/chart ghcr.io/grafana/helm-chart-toolbox-doc-generator:$(DOC_GENERATOR_IMAGE_VERSION) --chart /chart > $@
 
 Chart.lock: Chart.yaml
 	$(HELM) dependency update .
 	@touch Chart.lock # Ensure the timestamp is updated
 
 values.schema.json: values.yaml $$(wildcard schema-mods/*)
-	docker run --rm --platform linux/amd64 --volume $(shell pwd):/chart ghcr.io/grafana/helm-chart-toolbox-schema-generator --chart /chart > $@
+	docker run --rm --platform linux/amd64 --volume $(shell pwd):/chart ghcr.io/grafana/helm-chart-toolbox-schema-generator:$(SCHEMA_GENERATOR_IMAGE_VERSION) --chart /chart > $@
 
 .PHONY: clean
 clean:
@@ -32,7 +39,7 @@ test: build
 ifdef HAS_HELM_UNITTEST
 	$(HELM) unittest .
 else
-	docker run --rm --volume $(shell pwd):/apps helmunittest/helm-unittest:3.18.4-1.0.0 .
+	docker run --rm --volume $(shell pwd):/apps helmunittest/helm-unittest:$(HELM_UNITTEST_IMAGE_VERSION) .
 endif
 
 .PHONY: update-test-snapshots
@@ -40,5 +47,5 @@ update-test-snapshots:
 ifdef HAS_HELM_UNITTEST
 	$(HELM) unittest . --update-snapshot
 else
-	docker run --rm --volume $(shell pwd):/apps helmunittest/helm-unittest:3.18.4-1.0.0 . --update-snapshot
+	docker run --rm --volume $(shell pwd):/apps helmunittest/helm-unittest:$(HELM_UNITTEST_IMAGE_VERSION) . --update-snapshot
 endif

--- a/charts/k8s-monitoring/charts/feature-cluster-metrics/Makefile
+++ b/charts/k8s-monitoring/charts/feature-cluster-metrics/Makefile
@@ -10,6 +10,9 @@ DOC_GENERATOR_IMAGE_VERSION = 0.2.4
 # renovate: datasource=docker depName=ghcr.io/grafana/helm-chart-toolbox-schema-generator
 SCHEMA_GENERATOR_IMAGE_VERSION = 0.2.4
 
+# Pinned manually and intentionally NOT tracked by Renovate: the tag is
+# <helm-version>-<helm-unittest-version>, so an automated bump would also change
+# the bundled Helm version. Update it deliberately.
 HELM_UNITTEST_IMAGE_VERSION = 3.18.4-1.0.0
 
 HAS_HELM_UNITTEST := $(shell $(HELM) plugin list | grep unittest 2> /dev/null)

--- a/charts/k8s-monitoring/charts/feature-cluster-metrics/Makefile
+++ b/charts/k8s-monitoring/charts/feature-cluster-metrics/Makefile
@@ -5,6 +5,13 @@ else
 HELM = ../../../../scripts/helm-with-version $(HELM_VERSION)
 endif
 
+# renovate: datasource=docker depName=ghcr.io/grafana/helm-chart-toolbox-doc-generator
+DOC_GENERATOR_IMAGE_VERSION = 0.2.4
+# renovate: datasource=docker depName=ghcr.io/grafana/helm-chart-toolbox-schema-generator
+SCHEMA_GENERATOR_IMAGE_VERSION = 0.2.4
+
+HELM_UNITTEST_IMAGE_VERSION = 3.18.4-1.0.0
+
 HAS_HELM_UNITTEST := $(shell $(HELM) plugin list | grep unittest 2> /dev/null)
 ALLOW_LISTS := default-allow-lists/cadvisor.yaml \
 	default-allow-lists/kube-state-metrics.yaml \
@@ -14,14 +21,14 @@ ALLOW_LISTS := default-allow-lists/cadvisor.yaml \
 
 .SECONDEXPANSION:
 README.md: values.yaml Chart.yaml $$(wildcard README.md.gotmpl)
-	docker run --rm --platform linux/amd64 --volume $(shell pwd):/chart ghcr.io/grafana/helm-chart-toolbox-doc-generator --chart /chart > $@
+	docker run --rm --platform linux/amd64 --volume $(shell pwd):/chart ghcr.io/grafana/helm-chart-toolbox-doc-generator:$(DOC_GENERATOR_IMAGE_VERSION) --chart /chart > $@
 
 Chart.lock: Chart.yaml
 	$(HELM) dependency update .
 	@touch Chart.lock # Ensure the timestamp is updated
 
 values.schema.json: values.yaml $$(wildcard schema-mods/*)
-	docker run --rm --platform linux/amd64 --volume $(shell pwd):/chart ghcr.io/grafana/helm-chart-toolbox-schema-generator --chart /chart > $@
+	docker run --rm --platform linux/amd64 --volume $(shell pwd):/chart ghcr.io/grafana/helm-chart-toolbox-schema-generator:$(SCHEMA_GENERATOR_IMAGE_VERSION) --chart /chart > $@
 
 default-allow-lists/%.yaml: ../../../../allowLists/%.yaml
 	mkdir -p $(shell dirname $@)
@@ -41,7 +48,7 @@ test: build
 ifdef HAS_HELM_UNITTEST
 	$(HELM) unittest .
 else
-	docker run --rm --volume $(shell pwd):/apps helmunittest/helm-unittest:3.18.4-1.0.0 .
+	docker run --rm --volume $(shell pwd):/apps helmunittest/helm-unittest:$(HELM_UNITTEST_IMAGE_VERSION) .
 endif
 
 .PHONY: update-test-snapshots
@@ -49,5 +56,5 @@ update-test-snapshots:
 ifdef HAS_HELM_UNITTEST
 	$(HELM) unittest . --update-snapshot
 else
-	docker run --rm --volume $(shell pwd):/apps helmunittest/helm-unittest:3.18.4-1.0.0 . --update-snapshot
+	docker run --rm --volume $(shell pwd):/apps helmunittest/helm-unittest:$(HELM_UNITTEST_IMAGE_VERSION) . --update-snapshot
 endif

--- a/charts/k8s-monitoring/charts/feature-cost-metrics/Makefile
+++ b/charts/k8s-monitoring/charts/feature-cost-metrics/Makefile
@@ -5,19 +5,26 @@ else
 HELM = ../../../../scripts/helm-with-version $(HELM_VERSION)
 endif
 
+# renovate: datasource=docker depName=ghcr.io/grafana/helm-chart-toolbox-doc-generator
+DOC_GENERATOR_IMAGE_VERSION = 0.2.4
+# renovate: datasource=docker depName=ghcr.io/grafana/helm-chart-toolbox-schema-generator
+SCHEMA_GENERATOR_IMAGE_VERSION = 0.2.4
+
+HELM_UNITTEST_IMAGE_VERSION = 3.18.4-1.0.0
+
 HAS_HELM_UNITTEST := $(shell $(HELM) plugin list | grep unittest 2> /dev/null)
 ALLOW_LISTS := default-allow-lists/opencost.yaml
 
 .SECONDEXPANSION:
 README.md: values.yaml Chart.yaml $$(wildcard README.md.gotmpl)
-	docker run --rm --platform linux/amd64 --volume $(shell pwd):/chart ghcr.io/grafana/helm-chart-toolbox-doc-generator --chart /chart > $@
+	docker run --rm --platform linux/amd64 --volume $(shell pwd):/chart ghcr.io/grafana/helm-chart-toolbox-doc-generator:$(DOC_GENERATOR_IMAGE_VERSION) --chart /chart > $@
 
 Chart.lock: Chart.yaml
 	$(HELM) dependency update .
 	@touch Chart.lock # Ensure the timestamp is updated
 
 values.schema.json: values.yaml $$(wildcard schema-mods/*)
-	docker run --rm --platform linux/amd64 --volume $(shell pwd):/chart ghcr.io/grafana/helm-chart-toolbox-schema-generator --chart /chart > $@
+	docker run --rm --platform linux/amd64 --volume $(shell pwd):/chart ghcr.io/grafana/helm-chart-toolbox-schema-generator:$(SCHEMA_GENERATOR_IMAGE_VERSION) --chart /chart > $@
 
 default-allow-lists/%.yaml: ../../../../allowLists/%.yaml
 	mkdir -p $(shell dirname $@)
@@ -37,7 +44,7 @@ test: build
 ifdef HAS_HELM_UNITTEST
 	$(HELM) unittest .
 else
-	docker run --rm --volume $(shell pwd):/apps helmunittest/helm-unittest:3.18.4-1.0.0 .
+	docker run --rm --volume $(shell pwd):/apps helmunittest/helm-unittest:$(HELM_UNITTEST_IMAGE_VERSION) .
 endif
 
 .PHONY: update-test-snapshots
@@ -45,5 +52,5 @@ update-test-snapshots:
 ifdef HAS_HELM_UNITTEST
 	$(HELM) unittest . --update-snapshot
 else
-	docker run --rm --volume $(shell pwd):/apps helmunittest/helm-unittest:3.18.4-1.0.0 . --update-snapshot
+	docker run --rm --volume $(shell pwd):/apps helmunittest/helm-unittest:$(HELM_UNITTEST_IMAGE_VERSION) . --update-snapshot
 endif

--- a/charts/k8s-monitoring/charts/feature-cost-metrics/Makefile
+++ b/charts/k8s-monitoring/charts/feature-cost-metrics/Makefile
@@ -10,6 +10,9 @@ DOC_GENERATOR_IMAGE_VERSION = 0.2.4
 # renovate: datasource=docker depName=ghcr.io/grafana/helm-chart-toolbox-schema-generator
 SCHEMA_GENERATOR_IMAGE_VERSION = 0.2.4
 
+# Pinned manually and intentionally NOT tracked by Renovate: the tag is
+# <helm-version>-<helm-unittest-version>, so an automated bump would also change
+# the bundled Helm version. Update it deliberately.
 HELM_UNITTEST_IMAGE_VERSION = 3.18.4-1.0.0
 
 HAS_HELM_UNITTEST := $(shell $(HELM) plugin list | grep unittest 2> /dev/null)

--- a/charts/k8s-monitoring/charts/feature-host-metrics/Makefile
+++ b/charts/k8s-monitoring/charts/feature-host-metrics/Makefile
@@ -10,6 +10,9 @@ DOC_GENERATOR_IMAGE_VERSION = 0.2.4
 # renovate: datasource=docker depName=ghcr.io/grafana/helm-chart-toolbox-schema-generator
 SCHEMA_GENERATOR_IMAGE_VERSION = 0.2.4
 
+# Pinned manually and intentionally NOT tracked by Renovate: the tag is
+# <helm-version>-<helm-unittest-version>, so an automated bump would also change
+# the bundled Helm version. Update it deliberately.
 HELM_UNITTEST_IMAGE_VERSION = 3.18.4-1.0.0
 
 HAS_HELM_UNITTEST := $(shell $(HELM) plugin list | grep unittest 2> /dev/null)

--- a/charts/k8s-monitoring/charts/feature-host-metrics/Makefile
+++ b/charts/k8s-monitoring/charts/feature-host-metrics/Makefile
@@ -5,6 +5,13 @@ else
 HELM = ../../../../scripts/helm-with-version $(HELM_VERSION)
 endif
 
+# renovate: datasource=docker depName=ghcr.io/grafana/helm-chart-toolbox-doc-generator
+DOC_GENERATOR_IMAGE_VERSION = 0.2.4
+# renovate: datasource=docker depName=ghcr.io/grafana/helm-chart-toolbox-schema-generator
+SCHEMA_GENERATOR_IMAGE_VERSION = 0.2.4
+
+HELM_UNITTEST_IMAGE_VERSION = 3.18.4-1.0.0
+
 HAS_HELM_UNITTEST := $(shell $(HELM) plugin list | grep unittest 2> /dev/null)
 ALLOW_LISTS := default-allow-lists/kepler.yaml \
 	default-allow-lists/node-exporter.yaml \
@@ -13,14 +20,14 @@ ALLOW_LISTS := default-allow-lists/kepler.yaml \
 
 .SECONDEXPANSION:
 README.md: values.yaml Chart.yaml $$(wildcard README.md.gotmpl)
-	docker run --rm --platform linux/amd64 --volume $(shell pwd):/chart ghcr.io/grafana/helm-chart-toolbox-doc-generator --chart /chart > $@
+	docker run --rm --platform linux/amd64 --volume $(shell pwd):/chart ghcr.io/grafana/helm-chart-toolbox-doc-generator:$(DOC_GENERATOR_IMAGE_VERSION) --chart /chart > $@
 
 Chart.lock: Chart.yaml
 	$(HELM) dependency update .
 	@touch Chart.lock # Ensure the timestamp is updated
 
 values.schema.json: values.yaml $$(wildcard schema-mods/*)
-	docker run --rm --platform linux/amd64 --volume $(shell pwd):/chart ghcr.io/grafana/helm-chart-toolbox-schema-generator --chart /chart > $@
+	docker run --rm --platform linux/amd64 --volume $(shell pwd):/chart ghcr.io/grafana/helm-chart-toolbox-schema-generator:$(SCHEMA_GENERATOR_IMAGE_VERSION) --chart /chart > $@
 
 default-allow-lists/%.yaml: ../../../../allowLists/%.yaml
 	mkdir -p $(shell dirname $@)
@@ -40,7 +47,7 @@ test: build
 ifdef HAS_HELM_UNITTEST
 	$(HELM) unittest .
 else
-	docker run --rm --volume $(shell pwd):/apps helmunittest/helm-unittest:3.18.4-1.0.0 .
+	docker run --rm --volume $(shell pwd):/apps helmunittest/helm-unittest:$(HELM_UNITTEST_IMAGE_VERSION) .
 endif
 
 .PHONY: update-test-snapshots
@@ -48,5 +55,5 @@ update-test-snapshots:
 ifdef HAS_HELM_UNITTEST
 	$(HELM) unittest . --update-snapshot
 else
-	docker run --rm --volume $(shell pwd):/apps helmunittest/helm-unittest:3.18.4-1.0.0 . --update-snapshot
+	docker run --rm --volume $(shell pwd):/apps helmunittest/helm-unittest:$(HELM_UNITTEST_IMAGE_VERSION) . --update-snapshot
 endif

--- a/charts/k8s-monitoring/charts/feature-integrations/Makefile
+++ b/charts/k8s-monitoring/charts/feature-integrations/Makefile
@@ -10,6 +10,9 @@ DOC_GENERATOR_IMAGE_VERSION = 0.2.4
 # renovate: datasource=docker depName=ghcr.io/grafana/helm-chart-toolbox-schema-generator
 SCHEMA_GENERATOR_IMAGE_VERSION = 0.2.4
 
+# Pinned manually and intentionally NOT tracked by Renovate: the tag is
+# <helm-version>-<helm-unittest-version>, so an automated bump would also change
+# the bundled Helm version. Update it deliberately.
 HELM_UNITTEST_IMAGE_VERSION = 3.18.4-1.0.0
 
 HAS_HELM_UNITTEST := $(shell $(HELM) plugin list | grep unittest 2> /dev/null)

--- a/charts/k8s-monitoring/charts/feature-integrations/Makefile
+++ b/charts/k8s-monitoring/charts/feature-integrations/Makefile
@@ -5,6 +5,13 @@ else
 HELM = ../../../../scripts/helm-with-version $(HELM_VERSION)
 endif
 
+# renovate: datasource=docker depName=ghcr.io/grafana/helm-chart-toolbox-doc-generator
+DOC_GENERATOR_IMAGE_VERSION = 0.2.4
+# renovate: datasource=docker depName=ghcr.io/grafana/helm-chart-toolbox-schema-generator
+SCHEMA_GENERATOR_IMAGE_VERSION = 0.2.4
+
+HELM_UNITTEST_IMAGE_VERSION = 3.18.4-1.0.0
+
 HAS_HELM_UNITTEST := $(shell $(HELM) plugin list | grep unittest 2> /dev/null)
 
 SCHEMA_MODS_JSON_FILES = $(shell find schema-mods -name "*.json")
@@ -28,11 +35,11 @@ Chart.lock: Chart.yaml
 
 .SECONDEXPANSION:
 docs/integrations/%.md: integrations/%-values.yaml $$(wildcard docs/integrations/.doc_templates/%.gotmpl)
-	docker run --platform linux/amd64 --rm --volume $(shell pwd):/chart ghcr.io/grafana/helm-chart-toolbox-doc-generator --file /chart/$< --template /chart/docs/integrations/.doc_templates/$(shell basename -s -values.yaml $<).gotmpl > $@
+	docker run --platform linux/amd64 --rm --volume $(shell pwd):/chart ghcr.io/grafana/helm-chart-toolbox-doc-generator:$(DOC_GENERATOR_IMAGE_VERSION) --file /chart/$< --template /chart/docs/integrations/.doc_templates/$(shell basename -s -values.yaml $<).gotmpl > $@
 
 schema-mods/definitions/%-integration.schema.json: integrations/%-values.yaml
 	@mkdir -p $(shell dirname $@)
-	@docker run --platform linux/amd64 --rm --volume $(shell pwd):/chart ghcr.io/grafana/helm-chart-toolbox-schema-generator --file /chart/$< > $@
+	@docker run --platform linux/amd64 --rm --volume $(shell pwd):/chart ghcr.io/grafana/helm-chart-toolbox-schema-generator:$(SCHEMA_GENERATOR_IMAGE_VERSION) --file /chart/$< > $@
 
 NUMBER_OF_INTEGRATION_VALUES_FILES := $(words $(INTEGRATION_VALUES_FILES))
 schema-mods/integration-list.json: $(INTEGRATION_VALUES_FILES)
@@ -72,10 +79,10 @@ templates/_integration_types.tpl: $(INTEGRATION_VALUES_FILES)
 	echo '{{- end -}}' >> $@
 
 values.schema.json: values.yaml $(INTEGRATION_SCHEMA_FILES) $(SCHEMA_MODS_JSON_FILES) $(SCHEMA_MODS_JQ_FILES) schema-mods/integration-list.json
-	docker run --rm --platform linux/amd64 --volume $(shell pwd):/chart ghcr.io/grafana/helm-chart-toolbox-schema-generator --chart /chart > $@
+	docker run --rm --platform linux/amd64 --volume $(shell pwd):/chart ghcr.io/grafana/helm-chart-toolbox-schema-generator:$(SCHEMA_GENERATOR_IMAGE_VERSION) --chart /chart > $@
 
 README.md: values.yaml Chart.yaml $$(wildcard README.md.gotmpl)
-	docker run --rm --platform linux/amd64 --volume $(shell pwd):/chart ghcr.io/grafana/helm-chart-toolbox-doc-generator --chart /chart > $@
+	docker run --rm --platform linux/amd64 --volume $(shell pwd):/chart ghcr.io/grafana/helm-chart-toolbox-doc-generator:$(DOC_GENERATOR_IMAGE_VERSION) --chart /chart > $@
 
 .PHONY: clean
 clean:
@@ -93,7 +100,7 @@ test: build
 ifdef HAS_HELM_UNITTEST
 	$(HELM) unittest .
 else
-	docker run --rm --volume $(shell pwd):/apps helmunittest/helm-unittest:3.18.4-1.0.0 .
+	docker run --rm --volume $(shell pwd):/apps helmunittest/helm-unittest:$(HELM_UNITTEST_IMAGE_VERSION) .
 endif
 
 .PHONY: update-test-snapshots
@@ -101,5 +108,5 @@ update-test-snapshots:
 ifdef HAS_HELM_UNITTEST
 	$(HELM) unittest . --update-snapshot
 else
-	docker run --rm --volume $(shell pwd):/apps helmunittest/helm-unittest:3.18.4-1.0.0 . --update-snapshot
+	docker run --rm --volume $(shell pwd):/apps helmunittest/helm-unittest:$(HELM_UNITTEST_IMAGE_VERSION) . --update-snapshot
 endif

--- a/charts/k8s-monitoring/charts/feature-kubernetes-manifests/Makefile
+++ b/charts/k8s-monitoring/charts/feature-kubernetes-manifests/Makefile
@@ -10,6 +10,9 @@ DOC_GENERATOR_IMAGE_VERSION = 0.2.4
 # renovate: datasource=docker depName=ghcr.io/grafana/helm-chart-toolbox-schema-generator
 SCHEMA_GENERATOR_IMAGE_VERSION = 0.2.4
 
+# Pinned manually and intentionally NOT tracked by Renovate: the tag is
+# <helm-version>-<helm-unittest-version>, so an automated bump would also change
+# the bundled Helm version. Update it deliberately.
 HELM_UNITTEST_IMAGE_VERSION = 3.18.4-1.0.0
 
 HAS_HELM_UNITTEST := $(shell $(HELM) plugin list | grep unittest 2> /dev/null)

--- a/charts/k8s-monitoring/charts/feature-kubernetes-manifests/Makefile
+++ b/charts/k8s-monitoring/charts/feature-kubernetes-manifests/Makefile
@@ -5,18 +5,25 @@ else
 HELM = ../../../../scripts/helm-with-version $(HELM_VERSION)
 endif
 
+# renovate: datasource=docker depName=ghcr.io/grafana/helm-chart-toolbox-doc-generator
+DOC_GENERATOR_IMAGE_VERSION = 0.2.4
+# renovate: datasource=docker depName=ghcr.io/grafana/helm-chart-toolbox-schema-generator
+SCHEMA_GENERATOR_IMAGE_VERSION = 0.2.4
+
+HELM_UNITTEST_IMAGE_VERSION = 3.18.4-1.0.0
+
 HAS_HELM_UNITTEST := $(shell $(HELM) plugin list | grep unittest 2> /dev/null)
 
 .SECONDEXPANSION:
 README.md: values.yaml Chart.yaml $$(wildcard README.md.gotmpl)
-	docker run --rm --platform linux/amd64 --volume $(shell pwd):/chart ghcr.io/grafana/helm-chart-toolbox-doc-generator --chart /chart > $@
+	docker run --rm --platform linux/amd64 --volume $(shell pwd):/chart ghcr.io/grafana/helm-chart-toolbox-doc-generator:$(DOC_GENERATOR_IMAGE_VERSION) --chart /chart > $@
 
 Chart.lock: Chart.yaml
 	$(HELM) dependency update .
 	@touch Chart.lock # Ensure the timestamp is updated
 
 values.schema.json: values.yaml $$(wildcard schema-mods/*)
-	docker run --rm --platform linux/amd64 --volume $(shell pwd):/chart ghcr.io/grafana/helm-chart-toolbox-schema-generator --chart /chart > $@
+	docker run --rm --platform linux/amd64 --volume $(shell pwd):/chart ghcr.io/grafana/helm-chart-toolbox-schema-generator:$(SCHEMA_GENERATOR_IMAGE_VERSION) --chart /chart > $@
 
 .PHONY: clean
 clean:
@@ -32,7 +39,7 @@ test: build
 ifdef HAS_HELM_UNITTEST
 	$(HELM) unittest .
 else
-	docker run --rm --volume $(shell pwd):/apps helmunittest/helm-unittest:3.18.4-1.0.0 .
+	docker run --rm --volume $(shell pwd):/apps helmunittest/helm-unittest:$(HELM_UNITTEST_IMAGE_VERSION) .
 endif
 
 .PHONY: update-test-snapshots
@@ -40,5 +47,5 @@ update-test-snapshots:
 ifdef HAS_HELM_UNITTEST
 	$(HELM) unittest . --update-snapshot
 else
-	docker run --rm --volume $(shell pwd):/apps helmunittest/helm-unittest:3.18.4-1.0.0 . --update-snapshot
+	docker run --rm --volume $(shell pwd):/apps helmunittest/helm-unittest:$(HELM_UNITTEST_IMAGE_VERSION) . --update-snapshot
 endif

--- a/charts/k8s-monitoring/charts/feature-node-logs/Makefile
+++ b/charts/k8s-monitoring/charts/feature-node-logs/Makefile
@@ -10,6 +10,9 @@ DOC_GENERATOR_IMAGE_VERSION = 0.2.4
 # renovate: datasource=docker depName=ghcr.io/grafana/helm-chart-toolbox-schema-generator
 SCHEMA_GENERATOR_IMAGE_VERSION = 0.2.4
 
+# Pinned manually and intentionally NOT tracked by Renovate: the tag is
+# <helm-version>-<helm-unittest-version>, so an automated bump would also change
+# the bundled Helm version. Update it deliberately.
 HELM_UNITTEST_IMAGE_VERSION = 3.18.4-1.0.0
 
 HAS_HELM_UNITTEST := $(shell $(HELM) plugin list | grep unittest 2> /dev/null)

--- a/charts/k8s-monitoring/charts/feature-node-logs/Makefile
+++ b/charts/k8s-monitoring/charts/feature-node-logs/Makefile
@@ -5,18 +5,25 @@ else
 HELM = ../../../../scripts/helm-with-version $(HELM_VERSION)
 endif
 
+# renovate: datasource=docker depName=ghcr.io/grafana/helm-chart-toolbox-doc-generator
+DOC_GENERATOR_IMAGE_VERSION = 0.2.4
+# renovate: datasource=docker depName=ghcr.io/grafana/helm-chart-toolbox-schema-generator
+SCHEMA_GENERATOR_IMAGE_VERSION = 0.2.4
+
+HELM_UNITTEST_IMAGE_VERSION = 3.18.4-1.0.0
+
 HAS_HELM_UNITTEST := $(shell $(HELM) plugin list | grep unittest 2> /dev/null)
 
 .SECONDEXPANSION:
 README.md: values.yaml Chart.yaml $$(wildcard README.md.gotmpl)
-	docker run --rm --platform linux/amd64 --volume $(shell pwd):/chart ghcr.io/grafana/helm-chart-toolbox-doc-generator --chart /chart > $@
+	docker run --rm --platform linux/amd64 --volume $(shell pwd):/chart ghcr.io/grafana/helm-chart-toolbox-doc-generator:$(DOC_GENERATOR_IMAGE_VERSION) --chart /chart > $@
 
 Chart.lock: Chart.yaml
 	$(HELM) dependency update .
 	@touch Chart.lock # Ensure the timestamp is updated
 
 values.schema.json: values.yaml $$(wildcard schema-mods/*)
-	docker run --rm --platform linux/amd64 --volume $(shell pwd):/chart ghcr.io/grafana/helm-chart-toolbox-schema-generator --chart /chart > $@
+	docker run --rm --platform linux/amd64 --volume $(shell pwd):/chart ghcr.io/grafana/helm-chart-toolbox-schema-generator:$(SCHEMA_GENERATOR_IMAGE_VERSION) --chart /chart > $@
 
 .PHONY: clean
 clean:
@@ -32,7 +39,7 @@ test: build
 ifdef HAS_HELM_UNITTEST
 	$(HELM) unittest .
 else
-	docker run --rm --volume $(shell pwd):/apps helmunittest/helm-unittest:3.18.4-1.0.0 .
+	docker run --rm --volume $(shell pwd):/apps helmunittest/helm-unittest:$(HELM_UNITTEST_IMAGE_VERSION) .
 endif
 
 .PHONY: update-test-snapshots
@@ -40,5 +47,5 @@ update-test-snapshots:
 ifdef HAS_HELM_UNITTEST
 	$(HELM) unittest . --update-snapshot
 else
-	docker run --rm --volume $(shell pwd):/apps helmunittest/helm-unittest:3.18.4-1.0.0 . --update-snapshot
+	docker run --rm --volume $(shell pwd):/apps helmunittest/helm-unittest:$(HELM_UNITTEST_IMAGE_VERSION) . --update-snapshot
 endif

--- a/charts/k8s-monitoring/charts/feature-pod-logs-objects/Makefile
+++ b/charts/k8s-monitoring/charts/feature-pod-logs-objects/Makefile
@@ -10,6 +10,9 @@ DOC_GENERATOR_IMAGE_VERSION = 0.2.4
 # renovate: datasource=docker depName=ghcr.io/grafana/helm-chart-toolbox-schema-generator
 SCHEMA_GENERATOR_IMAGE_VERSION = 0.2.4
 
+# Pinned manually and intentionally NOT tracked by Renovate: the tag is
+# <helm-version>-<helm-unittest-version>, so an automated bump would also change
+# the bundled Helm version. Update it deliberately.
 HELM_UNITTEST_IMAGE_VERSION = 3.18.4-1.0.0
 
 HAS_HELM_UNITTEST := $(shell $(HELM) plugin list | grep unittest 2> /dev/null)

--- a/charts/k8s-monitoring/charts/feature-pod-logs-objects/Makefile
+++ b/charts/k8s-monitoring/charts/feature-pod-logs-objects/Makefile
@@ -5,18 +5,25 @@ else
 HELM = ../../../../scripts/helm-with-version $(HELM_VERSION)
 endif
 
+# renovate: datasource=docker depName=ghcr.io/grafana/helm-chart-toolbox-doc-generator
+DOC_GENERATOR_IMAGE_VERSION = 0.2.4
+# renovate: datasource=docker depName=ghcr.io/grafana/helm-chart-toolbox-schema-generator
+SCHEMA_GENERATOR_IMAGE_VERSION = 0.2.4
+
+HELM_UNITTEST_IMAGE_VERSION = 3.18.4-1.0.0
+
 HAS_HELM_UNITTEST := $(shell $(HELM) plugin list | grep unittest 2> /dev/null)
 
 .SECONDEXPANSION:
 README.md: values.yaml Chart.yaml $$(wildcard README.md.gotmpl)
-	docker run --rm --platform linux/amd64 --volume $(shell pwd):/chart ghcr.io/grafana/helm-chart-toolbox-doc-generator --chart /chart > $@
+	docker run --rm --platform linux/amd64 --volume $(shell pwd):/chart ghcr.io/grafana/helm-chart-toolbox-doc-generator:$(DOC_GENERATOR_IMAGE_VERSION) --chart /chart > $@
 
 Chart.lock: Chart.yaml
 	$(HELM) dependency update .
 	@touch Chart.lock # Ensure the timestamp is updated
 
 values.schema.json: values.yaml $$(wildcard schema-mods/*)
-	docker run --rm --platform linux/amd64 --volume $(shell pwd):/chart ghcr.io/grafana/helm-chart-toolbox-schema-generator --chart /chart > $@
+	docker run --rm --platform linux/amd64 --volume $(shell pwd):/chart ghcr.io/grafana/helm-chart-toolbox-schema-generator:$(SCHEMA_GENERATOR_IMAGE_VERSION) --chart /chart > $@
 
 .PHONY: clean
 clean:
@@ -32,7 +39,7 @@ test: build
 ifdef HAS_HELM_UNITTEST
 	$(HELM) unittest .
 else
-	docker run --rm --volume $(shell pwd):/apps helmunittest/helm-unittest:3.18.4-1.0.0 .
+	docker run --rm --volume $(shell pwd):/apps helmunittest/helm-unittest:$(HELM_UNITTEST_IMAGE_VERSION) .
 endif
 
 .PHONY: update-test-snapshots
@@ -40,5 +47,5 @@ update-test-snapshots:
 ifdef HAS_HELM_UNITTEST
 	$(HELM) unittest . --update-snapshot
 else
-	docker run --rm --volume $(shell pwd):/apps helmunittest/helm-unittest:3.18.4-1.0.0 . --update-snapshot
+	docker run --rm --volume $(shell pwd):/apps helmunittest/helm-unittest:$(HELM_UNITTEST_IMAGE_VERSION) . --update-snapshot
 endif

--- a/charts/k8s-monitoring/charts/feature-pod-logs-via-kubernetes-api/Makefile
+++ b/charts/k8s-monitoring/charts/feature-pod-logs-via-kubernetes-api/Makefile
@@ -10,6 +10,9 @@ DOC_GENERATOR_IMAGE_VERSION = 0.2.4
 # renovate: datasource=docker depName=ghcr.io/grafana/helm-chart-toolbox-schema-generator
 SCHEMA_GENERATOR_IMAGE_VERSION = 0.2.4
 
+# Pinned manually and intentionally NOT tracked by Renovate: the tag is
+# <helm-version>-<helm-unittest-version>, so an automated bump would also change
+# the bundled Helm version. Update it deliberately.
 HELM_UNITTEST_IMAGE_VERSION = 3.18.4-1.0.0
 
 HAS_HELM_UNITTEST := $(shell $(HELM) plugin list | grep unittest 2> /dev/null)

--- a/charts/k8s-monitoring/charts/feature-pod-logs-via-kubernetes-api/Makefile
+++ b/charts/k8s-monitoring/charts/feature-pod-logs-via-kubernetes-api/Makefile
@@ -5,18 +5,25 @@ else
 HELM = ../../../../scripts/helm-with-version $(HELM_VERSION)
 endif
 
+# renovate: datasource=docker depName=ghcr.io/grafana/helm-chart-toolbox-doc-generator
+DOC_GENERATOR_IMAGE_VERSION = 0.2.4
+# renovate: datasource=docker depName=ghcr.io/grafana/helm-chart-toolbox-schema-generator
+SCHEMA_GENERATOR_IMAGE_VERSION = 0.2.4
+
+HELM_UNITTEST_IMAGE_VERSION = 3.18.4-1.0.0
+
 HAS_HELM_UNITTEST := $(shell $(HELM) plugin list | grep unittest 2> /dev/null)
 
 .SECONDEXPANSION:
 README.md: values.yaml Chart.yaml $$(wildcard README.md.gotmpl)
-	docker run --rm --platform linux/amd64 --volume $(shell pwd):/chart ghcr.io/grafana/helm-chart-toolbox-doc-generator --chart /chart > $@
+	docker run --rm --platform linux/amd64 --volume $(shell pwd):/chart ghcr.io/grafana/helm-chart-toolbox-doc-generator:$(DOC_GENERATOR_IMAGE_VERSION) --chart /chart > $@
 
 Chart.lock: Chart.yaml
 	$(HELM) dependency update .
 	@touch Chart.lock # Ensure the timestamp is updated
 
 values.schema.json: values.yaml $$(wildcard schema-mods/*)
-	docker run --rm --platform linux/amd64 --volume $(shell pwd):/chart ghcr.io/grafana/helm-chart-toolbox-schema-generator --chart /chart > $@
+	docker run --rm --platform linux/amd64 --volume $(shell pwd):/chart ghcr.io/grafana/helm-chart-toolbox-schema-generator:$(SCHEMA_GENERATOR_IMAGE_VERSION) --chart /chart > $@
 
 .PHONY: clean
 clean:
@@ -32,7 +39,7 @@ test: build
 ifdef HAS_HELM_UNITTEST
 	$(HELM) unittest .
 else
-	docker run --rm --volume $(shell pwd):/apps helmunittest/helm-unittest:3.18.4-1.0.0 .
+	docker run --rm --volume $(shell pwd):/apps helmunittest/helm-unittest:$(HELM_UNITTEST_IMAGE_VERSION) .
 endif
 
 .PHONY: update-test-snapshots
@@ -40,5 +47,5 @@ update-test-snapshots:
 ifdef HAS_HELM_UNITTEST
 	$(HELM) unittest . --update-snapshot
 else
-	docker run --rm --volume $(shell pwd):/apps helmunittest/helm-unittest:3.18.4-1.0.0 . --update-snapshot
+	docker run --rm --volume $(shell pwd):/apps helmunittest/helm-unittest:$(HELM_UNITTEST_IMAGE_VERSION) . --update-snapshot
 endif

--- a/charts/k8s-monitoring/charts/feature-pod-logs-via-loki/Makefile
+++ b/charts/k8s-monitoring/charts/feature-pod-logs-via-loki/Makefile
@@ -10,6 +10,9 @@ DOC_GENERATOR_IMAGE_VERSION = 0.2.4
 # renovate: datasource=docker depName=ghcr.io/grafana/helm-chart-toolbox-schema-generator
 SCHEMA_GENERATOR_IMAGE_VERSION = 0.2.4
 
+# Pinned manually and intentionally NOT tracked by Renovate: the tag is
+# <helm-version>-<helm-unittest-version>, so an automated bump would also change
+# the bundled Helm version. Update it deliberately.
 HELM_UNITTEST_IMAGE_VERSION = 3.18.4-1.0.0
 
 HAS_HELM_UNITTEST := $(shell $(HELM) plugin list | grep unittest 2> /dev/null)

--- a/charts/k8s-monitoring/charts/feature-pod-logs-via-loki/Makefile
+++ b/charts/k8s-monitoring/charts/feature-pod-logs-via-loki/Makefile
@@ -5,18 +5,25 @@ else
 HELM = ../../../../scripts/helm-with-version $(HELM_VERSION)
 endif
 
+# renovate: datasource=docker depName=ghcr.io/grafana/helm-chart-toolbox-doc-generator
+DOC_GENERATOR_IMAGE_VERSION = 0.2.4
+# renovate: datasource=docker depName=ghcr.io/grafana/helm-chart-toolbox-schema-generator
+SCHEMA_GENERATOR_IMAGE_VERSION = 0.2.4
+
+HELM_UNITTEST_IMAGE_VERSION = 3.18.4-1.0.0
+
 HAS_HELM_UNITTEST := $(shell $(HELM) plugin list | grep unittest 2> /dev/null)
 
 .SECONDEXPANSION:
 README.md: values.yaml Chart.yaml $$(wildcard README.md.gotmpl)
-	docker run --rm --platform linux/amd64 --volume $(shell pwd):/chart ghcr.io/grafana/helm-chart-toolbox-doc-generator --chart /chart > $@
+	docker run --rm --platform linux/amd64 --volume $(shell pwd):/chart ghcr.io/grafana/helm-chart-toolbox-doc-generator:$(DOC_GENERATOR_IMAGE_VERSION) --chart /chart > $@
 
 Chart.lock: Chart.yaml
 	$(HELM) dependency update .
 	@touch Chart.lock # Ensure the timestamp is updated
 
 values.schema.json: values.yaml $$(wildcard schema-mods/*)
-	docker run --rm --platform linux/amd64 --volume $(shell pwd):/chart ghcr.io/grafana/helm-chart-toolbox-schema-generator --chart /chart > $@
+	docker run --rm --platform linux/amd64 --volume $(shell pwd):/chart ghcr.io/grafana/helm-chart-toolbox-schema-generator:$(SCHEMA_GENERATOR_IMAGE_VERSION) --chart /chart > $@
 
 .PHONY: clean
 clean:
@@ -32,7 +39,7 @@ test: build
 ifdef HAS_HELM_UNITTEST
 	$(HELM) unittest .
 else
-	docker run --rm --volume $(shell pwd):/apps helmunittest/helm-unittest:3.18.4-1.0.0 .
+	docker run --rm --volume $(shell pwd):/apps helmunittest/helm-unittest:$(HELM_UNITTEST_IMAGE_VERSION) .
 endif
 
 .PHONY: update-test-snapshots
@@ -40,5 +47,5 @@ update-test-snapshots:
 ifdef HAS_HELM_UNITTEST
 	$(HELM) unittest . --update-snapshot
 else
-	docker run --rm --volume $(shell pwd):/apps helmunittest/helm-unittest:3.18.4-1.0.0 . --update-snapshot
+	docker run --rm --volume $(shell pwd):/apps helmunittest/helm-unittest:$(HELM_UNITTEST_IMAGE_VERSION) . --update-snapshot
 endif

--- a/charts/k8s-monitoring/charts/feature-pod-logs-via-opentelemetry/Makefile
+++ b/charts/k8s-monitoring/charts/feature-pod-logs-via-opentelemetry/Makefile
@@ -10,6 +10,9 @@ DOC_GENERATOR_IMAGE_VERSION = 0.2.4
 # renovate: datasource=docker depName=ghcr.io/grafana/helm-chart-toolbox-schema-generator
 SCHEMA_GENERATOR_IMAGE_VERSION = 0.2.4
 
+# Pinned manually and intentionally NOT tracked by Renovate: the tag is
+# <helm-version>-<helm-unittest-version>, so an automated bump would also change
+# the bundled Helm version. Update it deliberately.
 HELM_UNITTEST_IMAGE_VERSION = 3.18.4-1.0.0
 
 HAS_HELM_UNITTEST := $(shell $(HELM) plugin list | grep unittest 2> /dev/null)

--- a/charts/k8s-monitoring/charts/feature-pod-logs-via-opentelemetry/Makefile
+++ b/charts/k8s-monitoring/charts/feature-pod-logs-via-opentelemetry/Makefile
@@ -5,18 +5,25 @@ else
 HELM = ../../../../scripts/helm-with-version $(HELM_VERSION)
 endif
 
+# renovate: datasource=docker depName=ghcr.io/grafana/helm-chart-toolbox-doc-generator
+DOC_GENERATOR_IMAGE_VERSION = 0.2.4
+# renovate: datasource=docker depName=ghcr.io/grafana/helm-chart-toolbox-schema-generator
+SCHEMA_GENERATOR_IMAGE_VERSION = 0.2.4
+
+HELM_UNITTEST_IMAGE_VERSION = 3.18.4-1.0.0
+
 HAS_HELM_UNITTEST := $(shell $(HELM) plugin list | grep unittest 2> /dev/null)
 
 .SECONDEXPANSION:
 README.md: values.yaml Chart.yaml $$(wildcard README.md.gotmpl)
-	docker run --rm --platform linux/amd64 --volume $(shell pwd):/chart ghcr.io/grafana/helm-chart-toolbox-doc-generator --chart /chart > $@
+	docker run --rm --platform linux/amd64 --volume $(shell pwd):/chart ghcr.io/grafana/helm-chart-toolbox-doc-generator:$(DOC_GENERATOR_IMAGE_VERSION) --chart /chart > $@
 
 Chart.lock: Chart.yaml
 	$(HELM) dependency update .
 	@touch Chart.lock # Ensure the timestamp is updated
 
 values.schema.json: values.yaml $$(wildcard schema-mods/*)
-	docker run --rm --platform linux/amd64 --volume $(shell pwd):/chart ghcr.io/grafana/helm-chart-toolbox-schema-generator --chart /chart > $@
+	docker run --rm --platform linux/amd64 --volume $(shell pwd):/chart ghcr.io/grafana/helm-chart-toolbox-schema-generator:$(SCHEMA_GENERATOR_IMAGE_VERSION) --chart /chart > $@
 
 .PHONY: clean
 clean:
@@ -32,7 +39,7 @@ test: build
 ifdef HAS_HELM_UNITTEST
 	$(HELM) unittest .
 else
-	docker run --rm --volume $(shell pwd):/apps helmunittest/helm-unittest:3.18.4-1.0.0 .
+	docker run --rm --volume $(shell pwd):/apps helmunittest/helm-unittest:$(HELM_UNITTEST_IMAGE_VERSION) .
 endif
 
 .PHONY: update-test-snapshots
@@ -40,5 +47,5 @@ update-test-snapshots:
 ifdef HAS_HELM_UNITTEST
 	$(HELM) unittest . --update-snapshot
 else
-	docker run --rm --volume $(shell pwd):/apps helmunittest/helm-unittest:3.18.4-1.0.0 . --update-snapshot
+	docker run --rm --volume $(shell pwd):/apps helmunittest/helm-unittest:$(HELM_UNITTEST_IMAGE_VERSION) . --update-snapshot
 endif

--- a/charts/k8s-monitoring/charts/feature-profiles-receiver/Makefile
+++ b/charts/k8s-monitoring/charts/feature-profiles-receiver/Makefile
@@ -10,6 +10,9 @@ DOC_GENERATOR_IMAGE_VERSION = 0.2.4
 # renovate: datasource=docker depName=ghcr.io/grafana/helm-chart-toolbox-schema-generator
 SCHEMA_GENERATOR_IMAGE_VERSION = 0.2.4
 
+# Pinned manually and intentionally NOT tracked by Renovate: the tag is
+# <helm-version>-<helm-unittest-version>, so an automated bump would also change
+# the bundled Helm version. Update it deliberately.
 HELM_UNITTEST_IMAGE_VERSION = 3.18.4-1.0.0
 
 HAS_HELM_UNITTEST := $(shell $(HELM) plugin list | grep unittest 2> /dev/null)

--- a/charts/k8s-monitoring/charts/feature-profiles-receiver/Makefile
+++ b/charts/k8s-monitoring/charts/feature-profiles-receiver/Makefile
@@ -5,18 +5,25 @@ else
 HELM = ../../../../scripts/helm-with-version $(HELM_VERSION)
 endif
 
+# renovate: datasource=docker depName=ghcr.io/grafana/helm-chart-toolbox-doc-generator
+DOC_GENERATOR_IMAGE_VERSION = 0.2.4
+# renovate: datasource=docker depName=ghcr.io/grafana/helm-chart-toolbox-schema-generator
+SCHEMA_GENERATOR_IMAGE_VERSION = 0.2.4
+
+HELM_UNITTEST_IMAGE_VERSION = 3.18.4-1.0.0
+
 HAS_HELM_UNITTEST := $(shell $(HELM) plugin list | grep unittest 2> /dev/null)
 
 .SECONDEXPANSION:
 README.md: values.yaml Chart.yaml $$(wildcard README.md.gotmpl)
-	docker run --rm --platform linux/amd64 --volume $(shell pwd):/chart ghcr.io/grafana/helm-chart-toolbox-doc-generator --chart /chart > $@
+	docker run --rm --platform linux/amd64 --volume $(shell pwd):/chart ghcr.io/grafana/helm-chart-toolbox-doc-generator:$(DOC_GENERATOR_IMAGE_VERSION) --chart /chart > $@
 
 Chart.lock: Chart.yaml
 	$(HELM) dependency update .
 	@touch Chart.lock # Ensure the timestamp is updated
 
 values.schema.json: values.yaml $$(wildcard schema-mods/*)
-	docker run --rm --platform linux/amd64 --volume $(shell pwd):/chart ghcr.io/grafana/helm-chart-toolbox-schema-generator --chart /chart > $@
+	docker run --rm --platform linux/amd64 --volume $(shell pwd):/chart ghcr.io/grafana/helm-chart-toolbox-schema-generator:$(SCHEMA_GENERATOR_IMAGE_VERSION) --chart /chart > $@
 
 .PHONY: clean
 clean:
@@ -32,7 +39,7 @@ test: build
 ifdef HAS_HELM_UNITTEST
 	$(HELM) unittest .
 else
-	docker run --rm --volume $(shell pwd):/apps helmunittest/helm-unittest:3.18.4-1.0.0 .
+	docker run --rm --volume $(shell pwd):/apps helmunittest/helm-unittest:$(HELM_UNITTEST_IMAGE_VERSION) .
 endif
 
 .PHONY: update-test-snapshots
@@ -40,5 +47,5 @@ update-test-snapshots:
 ifdef HAS_HELM_UNITTEST
 	$(HELM) unittest . --update-snapshot
 else
-	docker run --rm --volume $(shell pwd):/apps helmunittest/helm-unittest:3.18.4-1.0.0 . --update-snapshot
+	docker run --rm --volume $(shell pwd):/apps helmunittest/helm-unittest:$(HELM_UNITTEST_IMAGE_VERSION) . --update-snapshot
 endif

--- a/charts/k8s-monitoring/charts/feature-profiling/Makefile
+++ b/charts/k8s-monitoring/charts/feature-profiling/Makefile
@@ -10,6 +10,9 @@ DOC_GENERATOR_IMAGE_VERSION = 0.2.4
 # renovate: datasource=docker depName=ghcr.io/grafana/helm-chart-toolbox-schema-generator
 SCHEMA_GENERATOR_IMAGE_VERSION = 0.2.4
 
+# Pinned manually and intentionally NOT tracked by Renovate: the tag is
+# <helm-version>-<helm-unittest-version>, so an automated bump would also change
+# the bundled Helm version. Update it deliberately.
 HELM_UNITTEST_IMAGE_VERSION = 3.18.4-1.0.0
 
 HAS_HELM_UNITTEST := $(shell $(HELM) plugin list | grep unittest 2> /dev/null)

--- a/charts/k8s-monitoring/charts/feature-profiling/Makefile
+++ b/charts/k8s-monitoring/charts/feature-profiling/Makefile
@@ -5,18 +5,25 @@ else
 HELM = ../../../../scripts/helm-with-version $(HELM_VERSION)
 endif
 
+# renovate: datasource=docker depName=ghcr.io/grafana/helm-chart-toolbox-doc-generator
+DOC_GENERATOR_IMAGE_VERSION = 0.2.4
+# renovate: datasource=docker depName=ghcr.io/grafana/helm-chart-toolbox-schema-generator
+SCHEMA_GENERATOR_IMAGE_VERSION = 0.2.4
+
+HELM_UNITTEST_IMAGE_VERSION = 3.18.4-1.0.0
+
 HAS_HELM_UNITTEST := $(shell $(HELM) plugin list | grep unittest 2> /dev/null)
 
 .SECONDEXPANSION:
 README.md: values.yaml Chart.yaml $$(wildcard README.md.gotmpl)
-	docker run --rm --platform linux/amd64 --volume $(shell pwd):/chart ghcr.io/grafana/helm-chart-toolbox-doc-generator --chart /chart > $@
+	docker run --rm --platform linux/amd64 --volume $(shell pwd):/chart ghcr.io/grafana/helm-chart-toolbox-doc-generator:$(DOC_GENERATOR_IMAGE_VERSION) --chart /chart > $@
 
 Chart.lock: Chart.yaml
 	$(HELM) dependency update .
 	@touch Chart.lock # Ensure the timestamp is updated
 
 values.schema.json: values.yaml $$(wildcard schema-mods/*)
-	docker run --rm --platform linux/amd64 --volume $(shell pwd):/chart ghcr.io/grafana/helm-chart-toolbox-schema-generator --chart /chart > $@
+	docker run --rm --platform linux/amd64 --volume $(shell pwd):/chart ghcr.io/grafana/helm-chart-toolbox-schema-generator:$(SCHEMA_GENERATOR_IMAGE_VERSION) --chart /chart > $@
 
 .PHONY: clean
 clean:
@@ -32,7 +39,7 @@ test: build
 ifdef HAS_HELM_UNITTEST
 	$(HELM) unittest .
 else
-	docker run --rm --volume $(shell pwd):/apps helmunittest/helm-unittest:3.18.4-1.0.0 .
+	docker run --rm --volume $(shell pwd):/apps helmunittest/helm-unittest:$(HELM_UNITTEST_IMAGE_VERSION) .
 endif
 
 .PHONY: update-test-snapshots
@@ -40,5 +47,5 @@ update-test-snapshots:
 ifdef HAS_HELM_UNITTEST
 	$(HELM) unittest . --update-snapshot
 else
-	docker run --rm --volume $(shell pwd):/apps helmunittest/helm-unittest:3.18.4-1.0.0 . --update-snapshot
+	docker run --rm --volume $(shell pwd):/apps helmunittest/helm-unittest:$(HELM_UNITTEST_IMAGE_VERSION) . --update-snapshot
 endif

--- a/charts/k8s-monitoring/charts/feature-prometheus-operator-objects/Makefile
+++ b/charts/k8s-monitoring/charts/feature-prometheus-operator-objects/Makefile
@@ -10,6 +10,9 @@ DOC_GENERATOR_IMAGE_VERSION = 0.2.4
 # renovate: datasource=docker depName=ghcr.io/grafana/helm-chart-toolbox-schema-generator
 SCHEMA_GENERATOR_IMAGE_VERSION = 0.2.4
 
+# Pinned manually and intentionally NOT tracked by Renovate: the tag is
+# <helm-version>-<helm-unittest-version>, so an automated bump would also change
+# the bundled Helm version. Update it deliberately.
 HELM_UNITTEST_IMAGE_VERSION = 3.18.4-1.0.0
 
 HAS_HELM_UNITTEST := $(shell $(HELM) plugin list | grep unittest 2> /dev/null)

--- a/charts/k8s-monitoring/charts/feature-prometheus-operator-objects/Makefile
+++ b/charts/k8s-monitoring/charts/feature-prometheus-operator-objects/Makefile
@@ -5,18 +5,25 @@ else
 HELM = ../../../../scripts/helm-with-version $(HELM_VERSION)
 endif
 
+# renovate: datasource=docker depName=ghcr.io/grafana/helm-chart-toolbox-doc-generator
+DOC_GENERATOR_IMAGE_VERSION = 0.2.4
+# renovate: datasource=docker depName=ghcr.io/grafana/helm-chart-toolbox-schema-generator
+SCHEMA_GENERATOR_IMAGE_VERSION = 0.2.4
+
+HELM_UNITTEST_IMAGE_VERSION = 3.18.4-1.0.0
+
 HAS_HELM_UNITTEST := $(shell $(HELM) plugin list | grep unittest 2> /dev/null)
 
 .SECONDEXPANSION:
 README.md: values.yaml Chart.yaml $$(wildcard README.md.gotmpl)
-	docker run --rm --platform linux/amd64 --volume $(shell pwd):/chart ghcr.io/grafana/helm-chart-toolbox-doc-generator --chart /chart > $@
+	docker run --rm --platform linux/amd64 --volume $(shell pwd):/chart ghcr.io/grafana/helm-chart-toolbox-doc-generator:$(DOC_GENERATOR_IMAGE_VERSION) --chart /chart > $@
 
 Chart.lock: Chart.yaml
 	$(HELM) dependency update .
 	@touch Chart.lock # Ensure the timestamp is updated
 
 values.schema.json: values.yaml $$(wildcard schema-mods/*)
-	docker run --rm --platform linux/amd64 --volume $(shell pwd):/chart ghcr.io/grafana/helm-chart-toolbox-schema-generator --chart /chart > $@
+	docker run --rm --platform linux/amd64 --volume $(shell pwd):/chart ghcr.io/grafana/helm-chart-toolbox-schema-generator:$(SCHEMA_GENERATOR_IMAGE_VERSION) --chart /chart > $@
 
 .PHONY: clean
 clean:
@@ -33,7 +40,7 @@ test: build
 ifdef HAS_HELM_UNITTEST
 	$(HELM) unittest .
 else
-	docker run --rm --volume $(shell pwd):/apps helmunittest/helm-unittest:3.18.4-1.0.0 .
+	docker run --rm --volume $(shell pwd):/apps helmunittest/helm-unittest:$(HELM_UNITTEST_IMAGE_VERSION) .
 endif
 
 .PHONY: update-test-snapshots
@@ -41,5 +48,5 @@ update-test-snapshots:
 ifdef HAS_HELM_UNITTEST
 	$(HELM) unittest . --update-snapshot
 else
-	docker run --rm --volume $(shell pwd):/apps helmunittest/helm-unittest:3.18.4-1.0.0 . --update-snapshot
+	docker run --rm --volume $(shell pwd):/apps helmunittest/helm-unittest:$(HELM_UNITTEST_IMAGE_VERSION) . --update-snapshot
 endif

--- a/charts/k8s-monitoring/charts/telemetry-services/.gitignore
+++ b/charts/k8s-monitoring/charts/telemetry-services/.gitignore
@@ -1,0 +1,2 @@
+# Signature-verification stamp cache (charts/*/Makefile verify-signatures)
+.verified/

--- a/charts/k8s-monitoring/charts/telemetry-services/Makefile
+++ b/charts/k8s-monitoring/charts/telemetry-services/Makefile
@@ -5,6 +5,9 @@ else
 HELM = ../../../../scripts/helm-with-version $(HELM_VERSION)
 endif
 
+# Pinned manually and intentionally NOT tracked by Renovate: the tag is
+# <helm-version>-<helm-unittest-version>, so an automated bump would also change
+# the bundled Helm version. Update it deliberately.
 HELM_UNITTEST_IMAGE_VERSION = 3.18.4-1.0.0
 
 HAS_HELM_UNITTEST := $(shell $(HELM) plugin list | grep unittest 2> /dev/null)

--- a/charts/k8s-monitoring/charts/telemetry-services/Makefile
+++ b/charts/k8s-monitoring/charts/telemetry-services/Makefile
@@ -20,6 +20,9 @@ PROMETHEUS_COMMUNITY_KEYRING := ../../../../keys/prometheus-community-pubkey.gpg
 # so it is verified against the signing workflow's certificate identity instead of
 # a keyring. This chart depends on the signed OCI artifact directly (see Chart.yaml).
 COSIGN ?= cosign
+HAS_COSIGN := $(shell command -v $(COSIGN) 2> /dev/null)
+# renovate: datasource=docker depName=ghcr.io/sigstore/cosign/cosign
+COSIGN_IMAGE_VERSION = v3.1.2
 OPENCOST_VERSION := $(shell yq '.dependencies[] | select(.name == "opencost") | .version' Chart.yaml)
 OPENCOST_OCI_CHART := ghcr.io/opencost/charts/opencost
 OPENCOST_COSIGN_IDENTITY := https://github.com/opencost/opencost-helm-chart/.github/workflows/publish.yml@refs/heads/main
@@ -97,11 +100,23 @@ $(VERIFY_CACHE)/prometheus-windows-exporter-$(WINDOWS_EXPORTER_VERSION): $(PROME
 		--destination "$$tmp"
 	@touch $@
 
+# Use a locally installed cosign when present, otherwise fall back to the cosign
+# image (same pattern as helm-unittest/shellspec) so verification is always
+# enforced - including in jobs that reach this via build-features but don't
+# install cosign. The stamp is touched only after a successful verify.
 $(VERIFY_CACHE)/opencost-$(OPENCOST_VERSION): | $(VERIFY_CACHE)
+ifdef HAS_COSIGN
 	$(COSIGN) verify $(OPENCOST_OCI_CHART):$(OPENCOST_VERSION) \
 		--certificate-identity $(OPENCOST_COSIGN_IDENTITY) \
 		--certificate-oidc-issuer $(OPENCOST_COSIGN_ISSUER) \
 		> /dev/null
+else
+	docker run --rm ghcr.io/sigstore/cosign/cosign:$(COSIGN_IMAGE_VERSION) \
+		verify $(OPENCOST_OCI_CHART):$(OPENCOST_VERSION) \
+		--certificate-identity $(OPENCOST_COSIGN_IDENTITY) \
+		--certificate-oidc-issuer $(OPENCOST_COSIGN_ISSUER) \
+		> /dev/null
+endif
 	@touch $@
 
 VERIFY_SIGNATURE_STAMPS := \

--- a/charts/k8s-monitoring/charts/telemetry-services/Makefile
+++ b/charts/k8s-monitoring/charts/telemetry-services/Makefile
@@ -37,36 +37,80 @@ values.schema.json: values.yaml $$(wildcard schema-mods/*)
 .PHONY: clean
 clean:
 	rm -f README.md values.schema.json $(ALLOW_LISTS)
+	rm -rf $(VERIFY_CACHE)
 
 .PHONY: build
 build: README.md Chart.lock values.schema.json $(ALLOW_LISTS)
 
-.PHONY: verify-signatures
-verify-signatures: ## Verify the signatures of the signed chart dependencies
+# Verifying a signed dependency is network-heavy (a helm pull + GPG check, or a cosign + Rekor lookup) but only
+# meaningful when the pinned version or the trusted key changes. Each check records success in a stamp file under
+# $(VERIFY_CACHE), so unchanged builds skip the network entirely.
+#
+# Stamps also expire: any older than VERIFY_TTL_MINUTES (24h) are pruned when this Makefile is parsed, so a long-lived
+# working copy re-verifies at least daily. That bounds how long a cached success can outlive an upstream revocation - a
+# distrusted cosign/Sigstore root, or a keyring update - before a local build re-checks it.
+VERIFY_CACHE := .verified
+VERIFY_TTL_MINUTES := 1440
+
+# Drop expired stamps.
+_prune := $(shell find $(VERIFY_CACHE) -type f ! -name .gitignore -mmin +$(VERIFY_TTL_MINUTES) -delete 2>/dev/null)
+
+$(VERIFY_CACHE):
+	@mkdir -p $@
+	@printf '*\n' > $@/.gitignore   # self-ignore the cache for all clones/CI
+
+$(VERIFY_CACHE)/k8s-manifest-tail-$(K8S_MANIFEST_TAIL_VERSION): $(GRAFANA_HELM_CHARTS_KEYRING) | $(VERIFY_CACHE)
+	tmp="$$(mktemp -d)"; trap 'rm -rf "$$tmp"' EXIT; \
 	$(HELM) pull k8s-manifest-tail \
 		--repo https://grafana.github.io/helm-charts \
 		--version $(K8S_MANIFEST_TAIL_VERSION) \
 		--verify --keyring $(GRAFANA_HELM_CHARTS_KEYRING) \
-		--destination "$$(mktemp -d)"
+		--destination "$$tmp"
+	@touch $@
+
+$(VERIFY_CACHE)/kube-state-metrics-$(KUBE_STATE_METRICS_VERSION): $(PROMETHEUS_COMMUNITY_KEYRING) | $(VERIFY_CACHE)
+	tmp="$$(mktemp -d)"; trap 'rm -rf "$$tmp"' EXIT; \
 	$(HELM) pull kube-state-metrics \
 		--repo https://prometheus-community.github.io/helm-charts \
 		--version $(KUBE_STATE_METRICS_VERSION) \
 		--verify --keyring $(PROMETHEUS_COMMUNITY_KEYRING) \
-		--destination "$$(mktemp -d)"
+		--destination "$$tmp"
+	@touch $@
+
+$(VERIFY_CACHE)/prometheus-node-exporter-$(NODE_EXPORTER_VERSION): $(PROMETHEUS_COMMUNITY_KEYRING) | $(VERIFY_CACHE)
+	tmp="$$(mktemp -d)"; trap 'rm -rf "$$tmp"' EXIT; \
 	$(HELM) pull prometheus-node-exporter \
 		--repo https://prometheus-community.github.io/helm-charts \
 		--version $(NODE_EXPORTER_VERSION) \
 		--verify --keyring $(PROMETHEUS_COMMUNITY_KEYRING) \
-		--destination "$$(mktemp -d)"
+		--destination "$$tmp"
+	@touch $@
+
+$(VERIFY_CACHE)/prometheus-windows-exporter-$(WINDOWS_EXPORTER_VERSION): $(PROMETHEUS_COMMUNITY_KEYRING) | $(VERIFY_CACHE)
+	tmp="$$(mktemp -d)"; trap 'rm -rf "$$tmp"' EXIT; \
 	$(HELM) pull prometheus-windows-exporter \
 		--repo https://prometheus-community.github.io/helm-charts \
 		--version $(WINDOWS_EXPORTER_VERSION) \
 		--verify --keyring $(PROMETHEUS_COMMUNITY_KEYRING) \
-		--destination "$$(mktemp -d)"
+		--destination "$$tmp"
+	@touch $@
+
+$(VERIFY_CACHE)/opencost-$(OPENCOST_VERSION): | $(VERIFY_CACHE)
 	$(COSIGN) verify $(OPENCOST_OCI_CHART):$(OPENCOST_VERSION) \
 		--certificate-identity $(OPENCOST_COSIGN_IDENTITY) \
 		--certificate-oidc-issuer $(OPENCOST_COSIGN_ISSUER) \
 		> /dev/null
+	@touch $@
+
+VERIFY_SIGNATURE_STAMPS := \
+	$(VERIFY_CACHE)/k8s-manifest-tail-$(K8S_MANIFEST_TAIL_VERSION) \
+	$(VERIFY_CACHE)/kube-state-metrics-$(KUBE_STATE_METRICS_VERSION) \
+	$(VERIFY_CACHE)/prometheus-node-exporter-$(NODE_EXPORTER_VERSION) \
+	$(VERIFY_CACHE)/prometheus-windows-exporter-$(WINDOWS_EXPORTER_VERSION) \
+	$(VERIFY_CACHE)/opencost-$(OPENCOST_VERSION)
+
+.PHONY: verify-signatures
+verify-signatures: $(VERIFY_SIGNATURE_STAMPS) ## Verify the signatures of the signed chart dependencies
 
 .PHONY: test
 test: build

--- a/charts/k8s-monitoring/charts/telemetry-services/Makefile
+++ b/charts/k8s-monitoring/charts/telemetry-services/Makefile
@@ -5,6 +5,8 @@ else
 HELM = ../../../../scripts/helm-with-version $(HELM_VERSION)
 endif
 
+HELM_UNITTEST_IMAGE_VERSION = 3.18.4-1.0.0
+
 HAS_HELM_UNITTEST := $(shell $(HELM) plugin list | grep unittest 2> /dev/null)
 
 K8S_MANIFEST_TAIL_VERSION := $(shell yq '.dependencies[] | select(.name == "k8s-manifest-tail") | .version' Chart.yaml)
@@ -123,7 +125,7 @@ test: build
 ifdef HAS_HELM_UNITTEST
 	$(HELM) unittest .
 else
-	docker run --rm --volume $(shell pwd):/apps helmunittest/helm-unittest:3.18.4-1.0.0 .
+	docker run --rm --volume $(shell pwd):/apps helmunittest/helm-unittest:$(HELM_UNITTEST_IMAGE_VERSION) .
 endif
 
 .PHONY: update-test-snapshots
@@ -131,5 +133,5 @@ update-test-snapshots:
 ifdef HAS_HELM_UNITTEST
 	$(HELM) unittest . --update-snapshot
 else
-	docker run --rm --volume $(shell pwd):/apps helmunittest/helm-unittest:3.18.4-1.0.0 . --update-snapshot
+	docker run --rm --volume $(shell pwd):/apps helmunittest/helm-unittest:$(HELM_UNITTEST_IMAGE_VERSION) . --update-snapshot
 endif

--- a/charts/k8s-monitoring/tests/integration/annotation-autodiscovery/.rendered/alloy-logs.alloy
+++ b/charts/k8s-monitoring/tests/integration/annotation-autodiscovery/.rendered/alloy-logs.alloy
@@ -1,0 +1,236 @@
+// Feature: Pod Logs (Loki)
+declare "pod_logs_via_loki" {
+  argument "logs_destinations" {
+    comment = "Must be a list of log destinations where collected logs should be forwarded to"
+  }
+
+  discovery.kubernetes "pods" {
+    role = "pod"
+    selectors {
+      role = "pod"
+      field = "spec.nodeName=" + sys.env("HOSTNAME")
+    }
+  } // discovery.kubernetes "pods"
+
+  discovery.relabel "filtered_pods" {
+    targets = discovery.kubernetes.pods.targets
+    rule {
+      source_labels = ["__meta_kubernetes_namespace"]
+      action = "replace"
+      target_label = "namespace"
+    }
+    rule {  // Drop anything with a "falsy" annotation value
+      source_labels = ["__meta_kubernetes_pod_annotation_logs_grafana_com_pods_enabled"]
+      regex = "(false|no|skip)"
+      action = "drop"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_pod_name"]
+      target_label = "pod"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_pod_container_name"]
+      target_label = "container"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_namespace", "__meta_kubernetes_pod_container_name"]
+      separator = "/"
+      replacement = "$1"
+      target_label = "job"
+    }
+
+    // set the container runtime as a label
+    rule {
+      source_labels = ["__meta_kubernetes_pod_container_id"]
+      regex = "^(\\S+):\\/\\/.+$"
+      replacement = "$1"
+      target_label = "tmp_container_runtime"
+    }
+    // explicitly set service_name. if not set, loki will automatically try to populate a default.
+    // see https://grafana.com/docs/loki/latest/get-started/labels/#default-labels-for-all-users
+    //
+    // choose the first value found from the following ordered list:
+    // - pod.annotation[resource.opentelemetry.io/service.name]
+    // - pod.label[app.kubernetes.io/name]
+    // - k8s.container.name
+    rule {
+      source_labels = [
+        "__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_name",
+        "__meta_kubernetes_pod_label_app_kubernetes_io_name",
+        "__meta_kubernetes_pod_container_name",
+      ]
+      separator = ";"
+      regex = "^(?:;*)?([^;]+).*$"
+      replacement = "$1"
+      target_label = "service_name"
+    }
+
+    // explicitly set service_namespace.
+    //
+    // choose the first value found from the following ordered list:
+    // - pod.annotation[resource.opentelemetry.io/service.namespace]
+    // - pod.namespace
+    rule {
+      source_labels = [
+        "__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_namespace",
+        "namespace",
+      ]
+      separator = ";"
+      regex = "^(?:;*)?([^;]+).*$"
+      replacement = "$1"
+      target_label = "service_namespace"
+    }
+
+    // explicitly set service_instance_id.
+    //
+    // choose the first value found from the following ordered list:
+    // - pod.annotation[resource.opentelemetry.io/service.instance.id]
+    // - concat([k8s.namespace.name, k8s.pod.name, k8s.container.name], '.')
+    rule {
+      source_labels = ["__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_instance_id"]
+      target_label = "service_instance_id"
+    }
+    rule {
+      source_labels = ["service_instance_id", "namespace", "pod", "container"]
+      separator = "."
+      regex = "^\\.([^.]+\\.[^.]+\\.[^.]+)$"
+      target_label = "service_instance_id"
+    }
+
+    // set resource attributes
+    rule {
+      action = "labelmap"
+      regex = "__meta_kubernetes_pod_annotation_resource_opentelemetry_io_(.+)"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_job"]
+      regex = "(.+)"
+      target_label = "job"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+      regex = "(.+)"
+      target_label = "app_kubernetes_io_name"
+    }
+
+    // Set the pod log path.
+    rule {
+      source_labels = ["__meta_kubernetes_pod_uid", "__meta_kubernetes_pod_container_name"]
+      separator = "/"
+      replacement = "/var/log/pods/*$1/*.log"
+      target_label = "__path__"
+    }
+
+    // If kubernetes.io/config.mirror is set, this is a static pod, created by the kubelet.
+    // It's logs live on a different path.
+    rule {
+      source_labels = ["__meta_kubernetes_pod_annotation_kubernetes_io_config_mirror", "__meta_kubernetes_pod_container_name"]
+      separator = "/"
+      regex = "(.+/.+)"
+      replacement = "/var/log/pods/*$1/*.log"
+      target_label = "__path__"
+    }
+  } // discovery.relabel "filtered_pods"
+
+  local.file_match "pod_logs" {
+    path_targets = discovery.relabel.filtered_pods.output
+  } // local.file_match "pod_logs"
+
+  loki.source.file "pod_logs" {
+    targets    = local.file_match.pod_logs.targets
+    tail_from_end = true
+    forward_to = [loki.process.pod_logs.receiver]
+  } // loki.source.file "pod_logs"
+
+  loki.process "pod_logs" {
+    stage.match {
+      selector = "{tmp_container_runtime=~\"containerd|cri-o|\"}"
+      // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
+      stage.cri {
+        max_partial_lines = 100
+      }
+
+      // Set the extract flags and stream values as labels
+      stage.labels {
+        values = {
+          flags  = "",
+          stream  = "",
+        }
+      }
+    }
+
+    stage.match {
+      selector = "{tmp_container_runtime=\"docker\"}"
+      // the docker processing stage extracts the following k/v pairs: log, stream, time
+      stage.docker {}
+
+      // Set the extract stream value as a label
+      stage.labels {
+        values = {
+          stream  = "",
+        }
+      }
+    }
+
+    // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
+    // namespace, pod, and container labels. Drop any structured metadata. Also drop the temporary
+    // container runtime label as it is no longer needed.
+    stage.label_drop {
+      values = [
+        "filename",
+        "tmp_container_runtime",
+      ]
+    }
+    stage.structured_metadata {
+      values = {
+        "k8s_pod_name" = "k8s_pod_name",
+        "pod" = "pod",
+        "service_instance_id" = "service_instance_id",
+      }
+    }
+
+    forward_to = argument.logs_destinations.value
+  } // loki.secretfilter "pod_logs"
+} // declare "pod_logs_via_loki"
+pod_logs_via_loki "feature" {
+  logs_destinations = [
+    loki.write.localloki.receiver,
+  ]
+}
+
+
+
+
+
+// Destination: localLoki (loki)
+otelcol.exporter.loki "localloki" {
+  forward_to = [loki.write.localloki.receiver]
+} // otelcol.exporter.loki "localloki"
+
+loki.write "localloki" {
+  endpoint {
+    url = "http://loki.loki.svc:3100/loki/api/v1/push"
+    retry_on_http_429 = true
+    tenant_id = convert.nonsensitive(remote.kubernetes.secret.localloki.data["tenantId"])
+    basic_auth {
+      username = convert.nonsensitive(remote.kubernetes.secret.localloki.data["username"])
+      password = remote.kubernetes.secret.localloki.data["password"]
+    }
+    tls_config {
+      insecure_skip_verify = false
+    }
+    min_backoff_period = "500ms"
+    max_backoff_period = "5m"
+    max_backoff_retries = "10"
+  }
+  external_labels = {
+    "cluster" = "annotation-autodiscovery-test",
+    "k8s_cluster_name" = "annotation-autodiscovery-test",
+  }
+} // loki.write "localloki"
+
+remote.kubernetes.secret "localloki" {
+  name      = "localloki-k8smon-k8s-monitoring"
+  namespace = "default"
+} // remote.kubernetes.secret "localloki"
+

--- a/charts/k8s-monitoring/tests/integration/annotation-autodiscovery/.rendered/alloy-metrics.alloy
+++ b/charts/k8s-monitoring/tests/integration/annotation-autodiscovery/.rendered/alloy-metrics.alloy
@@ -1,0 +1,454 @@
+// Feature: Annotation Autodiscovery
+declare "annotation_autodiscovery" {
+  argument "metrics_destinations" {
+    comment = "Must be a list of metric destinations where collected metrics should be forwarded to"
+  }
+
+  discovery.kubernetes "pods" {
+    role = "pod"
+    selectors {
+      role = "pod"
+      label = "color=blue"
+    }
+  } // discovery.kubernetes "pods"
+
+  discovery.relabel "annotation_autodiscovery_pods" {
+    targets = discovery.kubernetes.pods.targets
+    rule {
+      source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_scrape"]
+      regex = "true"
+      action = "keep"
+    }
+    // Only keep pods that are running, ready, and not init containers.
+    rule {
+      source_labels = [
+        "__meta_kubernetes_pod_phase",
+        "__meta_kubernetes_pod_ready",
+        "__meta_kubernetes_pod_container_init",
+      ]
+      regex = "Running;true;false"
+      action = "keep"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_pod_name"]
+      target_label = "pod"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_pod_container_name"]
+      target_label = "container"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_namespace"]
+      target_label = "namespace"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_job"]
+      target_label = "job"
+    }
+    rule {
+      source_labels = ["job", "__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+      regex = ";(.+)"
+      target_label = "job"
+    }
+    rule {
+      source_labels = ["job", "__meta_kubernetes_pod_label_app"]
+      regex = ";(.+)"
+      target_label = "job"
+    }
+    rule {
+      source_labels = ["job", "container"]
+      regex = ";(.+)"
+      target_label = "job"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_instance"]
+      target_label = "instance"
+    }
+
+    // Rules to choose the right container
+    rule {
+      source_labels = ["container"]
+      target_label = "__tmp_container"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_container"]
+      regex = "(.+)"
+      target_label = "__tmp_container"
+    }
+    rule {
+      source_labels = ["container"]
+      action = "keepequal"
+      target_label = "__tmp_container"
+    }
+    rule {
+      action = "labeldrop"
+      regex = "__tmp_container"
+    }
+
+    // Set metrics path
+    rule {
+      source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_path"]
+      regex = "(.+)"
+      target_label = "__metrics_path__"
+    }
+
+    // Set metrics scraping URL parameters
+    rule {
+      action = "labelmap"
+      regex = "__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_param_(.+)"
+      replacement = "__param_$1"
+    }
+
+    // Choose the pod port
+    // The discovery generates a target for each declared container port of the pod.
+    // If the metricsPortName annotation has value, keep only the target where the port name matches the one of the annotation.
+    rule {
+      source_labels = ["__meta_kubernetes_pod_container_port_name"]
+      target_label = "__tmp_port"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_portName"]
+      regex = "(.+)"
+      target_label = "__tmp_port"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_pod_container_port_name"]
+      action = "keepequal"
+      target_label = "__tmp_port"
+    }
+    rule {
+      action = "labeldrop"
+      regex = "__tmp_port"
+    }
+
+    // If the metrics port number annotation has a value, override the target address to use it, regardless whether it is
+    // one of the declared ports on that Pod.
+    rule {
+      source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_portNumber", "__meta_kubernetes_pod_ip"]
+      regex = "(\\d+);(([A-Fa-f0-9]{1,4}::?){1,7}[A-Fa-f0-9]{1,4})"
+      replacement = "[$2]:$1" // IPv6
+      target_label = "__address__"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_portNumber", "__meta_kubernetes_pod_ip"]
+      regex = "(\\d+);((([0-9]+?)(\\.|$)){4})" // IPv4, takes priority over IPv6 when both exists
+      replacement = "$2:$1"
+      target_label = "__address__"
+    }
+
+    rule {
+      source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_scheme"]
+      regex = "(.+)"
+      target_label = "__scheme__"
+    }
+
+    rule {
+      source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_scrapeInterval"]
+      regex = "(.+)"
+      target_label = "__scrape_interval__"
+    }
+    rule {
+      source_labels = ["__scrape_interval__"]
+      regex = ""
+      replacement = "60s"
+      target_label = "__scrape_interval__"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_scrapeTimeout"]
+      regex = "(.+)"
+      target_label = "__scrape_timeout__"
+    }
+    rule {
+      source_labels = ["__scrape_timeout__"]
+      regex = ""
+      replacement = "10s"
+      target_label = "__scrape_timeout__"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_pod_label_color"]
+      target_label = "color"
+    }
+    rule {
+      source_labels = ["__scrape_interval__"]
+      target_label = "scrape_interval"
+    }
+    rule {
+      source_labels = ["__scrape_timeout__"]
+      target_label = "scrape_timeout"
+    }
+  } // discovery.relabel "annotation_autodiscovery_pods"
+
+  discovery.kubernetes "services" {
+    role = "service"
+  } // discovery.kubernetes "services"
+
+  discovery.relabel "annotation_autodiscovery_services" {
+    targets = discovery.kubernetes.services.targets
+    rule {
+      source_labels = ["__meta_kubernetes_service_annotation_k8s_grafana_com_scrape"]
+      regex = "true"
+      action = "keep"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_service_name"]
+      target_label = "service"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_namespace"]
+      target_label = "namespace"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_service_annotation_k8s_grafana_com_job"]
+      target_label = "job"
+    }
+    rule {
+      source_labels = ["job", "__meta_kubernetes_service_label_app_kubernetes_io_name"]
+      regex = ";(.+)"
+      target_label = "job"
+    }
+    rule {
+      source_labels = ["job", "__meta_kubernetes_service_label_app"]
+      regex = ";(.+)"
+      target_label = "job"
+    }
+    rule {
+      source_labels = ["job", "service"]
+      regex = ";(.+)"
+      target_label = "job"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_service_annotation_k8s_grafana_com_instance"]
+      target_label = "instance"
+    }
+
+    // Set metrics path
+    rule {
+      source_labels = ["__meta_kubernetes_service_annotation_k8s_grafana_com_metrics_path"]
+      target_label = "__metrics_path__"
+    }
+
+    // Set metrics scraping URL parameters
+    rule {
+      action = "labelmap"
+      regex = "__meta_kubernetes_service_annotation_k8s_grafana_com_metrics_param_(.+)"
+      replacement = "__param_$1"
+    }
+
+    // Choose the service port
+    rule {
+      source_labels = ["__meta_kubernetes_service_port_name"]
+      target_label = "__tmp_port"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_service_annotation_k8s_grafana_com_metrics_portName"]
+      regex = "(.+)"
+      target_label = "__tmp_port"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_service_port_name"]
+      action = "keepequal"
+      target_label = "__tmp_port"
+    }
+
+    rule {
+      source_labels = ["__meta_kubernetes_service_port_number"]
+      target_label = "__tmp_port"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_service_annotation_k8s_grafana_com_metrics_portNumber"]
+      regex = "(.+)"
+      target_label = "__tmp_port"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_service_port_number"]
+      action = "keepequal"
+      target_label = "__tmp_port"
+    }
+    rule {
+      action = "labeldrop"
+      regex = "__tmp_port"
+    }
+
+    rule {
+      source_labels = ["__meta_kubernetes_service_annotation_k8s_grafana_com_metrics_scheme"]
+      regex = "(.+)"
+      target_label = "__scheme__"
+    }
+
+    rule {
+      source_labels = ["__meta_kubernetes_service_annotation_k8s_grafana_com_metrics_scrapeInterval"]
+      regex = "(.+)"
+      target_label = "__scrape_interval__"
+    }
+    rule {
+      source_labels = ["__scrape_interval__"]
+      regex = ""
+      replacement = "60s"
+      target_label = "__scrape_interval__"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_service_annotation_k8s_grafana_com_metrics_scrapeTimeout"]
+      regex = "(.+)"
+      target_label = "__scrape_timeout__"
+    }
+    rule {
+      source_labels = ["__scrape_timeout__"]
+      regex = ""
+      replacement = "10s"
+      target_label = "__scrape_timeout__"
+    }
+    rule {
+      source_labels = ["__scrape_interval__"]
+      target_label = "scrape_interval"
+    }
+    rule {
+      source_labels = ["__scrape_timeout__"]
+      target_label = "scrape_timeout"
+    }
+  } // discovery.relabel "annotation_autodiscovery_services"
+
+  discovery.relabel "annotation_autodiscovery_http" {
+    targets = array.concat(discovery.relabel.annotation_autodiscovery_pods.output, discovery.relabel.annotation_autodiscovery_services.output)
+    rule {
+      source_labels = ["__scheme__"]
+      regex = "https"
+      action = "drop"
+    }
+  } // discovery.relabel "annotation_autodiscovery_http"
+
+  discovery.relabel "annotation_autodiscovery_https" {
+    targets = array.concat(discovery.relabel.annotation_autodiscovery_pods.output, discovery.relabel.annotation_autodiscovery_services.output)
+    rule {
+      source_labels = ["__scheme__"]
+      regex = "https"
+      action = "keep"
+    }
+  } // discovery.relabel "annotation_autodiscovery_https"
+
+  prometheus.scrape "annotation_autodiscovery_http" {
+    targets = discovery.relabel.annotation_autodiscovery_http.output
+    honor_labels = true
+    bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+    scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
+    scrape_classic_histograms = false
+    scrape_native_histograms = false
+    convert_classic_histograms_to_nhcb = false
+    clustering {
+      enabled = true
+    }
+
+    forward_to = argument.metrics_destinations.value
+  } // prometheus.scrape "annotation_autodiscovery_http"
+
+  prometheus.scrape "annotation_autodiscovery_https" {
+    targets = discovery.relabel.annotation_autodiscovery_https.output
+    honor_labels = true
+    bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+    tls_config {
+      insecure_skip_verify = true
+    }
+    scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
+    scrape_classic_histograms = false
+    scrape_native_histograms = false
+    convert_classic_histograms_to_nhcb = false
+    clustering {
+      enabled = true
+    }
+
+    forward_to = argument.metrics_destinations.value
+  } // prometheus.relabel "annotation_autodiscovery"
+} // declare "annotation_autodiscovery"
+annotation_autodiscovery "feature" {
+  metrics_destinations = [
+    prometheus.remote_write.prometheus.receiver,
+  ]
+}
+// Self Reporting
+prometheus.exporter.unix "kubernetes_monitoring_telemetry" {
+  set_collectors = ["textfile"]
+  textfile {
+    directory = "/etc/release-info"
+  }
+} // prometheus.exporter.unix "kubernetes_monitoring_telemetry"
+
+discovery.relabel "kubernetes_monitoring_telemetry" {
+  targets = prometheus.exporter.unix.kubernetes_monitoring_telemetry.targets
+  rule {
+    target_label = "instance"
+    action = "replace"
+    replacement = "k8smon"
+  }
+  rule {
+    target_label = "job"
+    action = "replace"
+    replacement = "integrations/kubernetes/kubernetes_monitoring_telemetry"
+  }
+} // discovery.relabel "kubernetes_monitoring_telemetry"
+
+prometheus.scrape "kubernetes_monitoring_telemetry" {
+  job_name   = "integrations/kubernetes/kubernetes_monitoring_telemetry"
+  targets    = discovery.relabel.kubernetes_monitoring_telemetry.output
+  scrape_interval = "60s"
+  clustering {
+    enabled = true
+  }
+  forward_to = [prometheus.relabel.kubernetes_monitoring_telemetry.receiver]
+} // prometheus.scrape "kubernetes_monitoring_telemetry"
+
+prometheus.relabel "kubernetes_monitoring_telemetry" {
+  rule {
+    source_labels = ["__name__"]
+    regex = "grafana_kubernetes_monitoring_.*"
+    action = "keep"
+  }
+  forward_to = [
+    prometheus.remote_write.prometheus.receiver,
+  ]
+} // prometheus.relabel "kubernetes_monitoring_telemetry"
+
+
+
+
+
+// Destination: prometheus (prometheus)
+otelcol.exporter.prometheus "prometheus" {
+  add_metric_suffixes = true
+  resource_to_telemetry_conversion = false
+  keep_identifying_resource_attributes = true
+  forward_to = [prometheus.remote_write.prometheus.receiver]
+} // otelcol.exporter.prometheus "prometheus"
+
+prometheus.remote_write "prometheus" {
+  endpoint {
+    url = "http://prometheus-server.prometheus.svc:9090/api/v1/write"
+    headers = {
+    }
+    tls_config {
+      insecure_skip_verify = false
+    }
+    send_native_histograms = false
+
+    queue_config {
+      capacity = 10000
+      min_shards = 1
+      max_shards = 50
+      max_samples_per_send = 2000
+      batch_send_deadline = "5s"
+      min_backoff = "30ms"
+      max_backoff = "5s"
+      retry_on_http_429 = true
+      sample_age_limit = "0s"
+    }
+  }
+
+  wal {
+    truncate_frequency = "2h"
+    min_keepalive_time = "5m"
+    max_keepalive_time = "8h"
+  }
+  external_labels = {
+    "cluster" = "annotation-autodiscovery-test",
+    "k8s_cluster_name" = "annotation-autodiscovery-test",
+  }
+} // prometheus.remote_write "prometheus"
+

--- a/charts/k8s-monitoring/tests/integration/application-observability/.rendered/alloy-receiver.alloy
+++ b/charts/k8s-monitoring/tests/integration/application-observability/.rendered/alloy-receiver.alloy
@@ -1,0 +1,759 @@
+// Feature: Application Observability
+declare "application_observability" {
+  argument "metrics_destinations" {
+    comment = "Must be a list of metrics destinations where collected metrics should be forwarded to"
+  }
+
+  argument "logs_destinations" {
+    comment = "Must be a list of log destinations where collected logs should be forwarded to"
+  }
+
+  argument "traces_destinations" {
+    comment = "Must be a list of trace destinations where collected trace should be forwarded to"
+  }
+
+  // OTLP Receiver
+  otelcol.receiver.otlp "receiver" {
+    grpc {
+      endpoint = "0.0.0.0:4317"
+      include_metadata = false
+      max_recv_msg_size = "4MiB"
+      read_buffer_size = "512KiB"
+      write_buffer_size = "32KiB"
+      keepalive {
+        server_parameters {
+          max_connection_age = "30s"
+          max_connection_age_grace = "10s"
+        }
+        enforcement_policy {
+          permit_without_stream = true
+        }
+      }
+    }
+    http {
+      endpoint = "0.0.0.0:4318"
+      include_metadata = false
+      max_request_body_size = "20MiB"
+    }
+    debug_metrics {
+      disable_high_cardinality_metrics = true
+    }
+    output {
+      metrics = [otelcol.processor.resourcedetection.default.input]
+      traces = [otelcol.processor.resourcedetection.default.input]
+    }
+  } // otelcol.receiver.otlp "receiver"
+
+  // Resource Detection Processor
+  otelcol.processor.resourcedetection "default" {
+    detectors = ["env","system"]
+    override = true
+
+    system {
+      hostname_sources = ["os"]
+    }
+
+    output {
+      metrics = [otelcol.processor.k8sattributes.default.input]
+      traces = [otelcol.processor.k8sattributes.default.input]
+    }
+  }
+
+  // K8s Attributes Processor
+  otelcol.processor.k8sattributes "default" {
+    passthrough = false
+    extract {
+      otel_annotations = true
+      metadata = ["k8s.namespace.name","k8s.pod.name","k8s.deployment.name","k8s.statefulset.name","k8s.daemonset.name","k8s.cronjob.name","k8s.job.name","k8s.node.name","k8s.pod.uid","k8s.pod.start_time"]
+      // Extracted into temporary attributes for service.name detection, then deleted in the transform processor.
+      // Temporary names are used so the cleanup never deletes an `app.kubernetes.io/*` attribute the user extracted.
+      label {
+        tag_name = "k8s_monitoring.tmp.instance"
+        key = "app.kubernetes.io/instance"
+        from = "pod"
+      }
+      label {
+        tag_name = "k8s_monitoring.tmp.name"
+        key = "app.kubernetes.io/name"
+        from = "pod"
+      }
+    }
+    pod_association {
+      source {
+        from = "resource_attribute"
+        name = "k8s.pod.ip"
+      }
+    }
+    pod_association {
+      source {
+        from = "resource_attribute"
+        name = "k8s.pod.uid"
+      }
+    }
+    pod_association {
+      source {
+        from = "connection"
+      }
+    }
+
+    output {
+      metrics = [otelcol.processor.transform.default.input]
+      traces = [otelcol.processor.transform.default.input, otelcol.connector.host_info.default.input]
+    }
+  }
+
+  // Host Info Connector
+  otelcol.connector.host_info "default" {
+    host_identifiers = [ "k8s.node.name" ]
+
+    output {
+      metrics = [otelcol.processor.batch.default.input]
+    }
+  }
+
+  // Transform Processor
+  otelcol.processor.transform "default" {
+    error_mode = "ignore"
+    metric_statements {
+      context = "resource"
+      statements = [
+        // Set service.name by choosing the first value found from the following ordered list:
+        // - service.name as reported by the application or set from the resource.opentelemetry.io/service.name annotation
+        // - pod.label[app.kubernetes.io/instance]
+        // - pod.label[app.kubernetes.io/name]
+        // - k8s.workload.name (Deployment, StatefulSet, DaemonSet, CronJob, Job, ...)
+        // - k8s.pod.name
+        // The instance/name pod labels are read from temporary attributes (k8s_monitoring.tmp.*) extracted by the
+        // k8sattributes processor, so the cleanup below only ever deletes attributes this feature added.
+        `set(resource.attributes["service.name"], resource.attributes["k8s_monitoring.tmp.instance"]) where (resource.attributes["service.name"] == nil or resource.attributes["service.name"] == "") and resource.attributes["k8s_monitoring.tmp.instance"] != nil and resource.attributes["k8s_monitoring.tmp.instance"] != ""`,
+        `set(resource.attributes["service.name"], resource.attributes["k8s_monitoring.tmp.name"]) where (resource.attributes["service.name"] == nil or resource.attributes["service.name"] == "") and resource.attributes["k8s_monitoring.tmp.name"] != nil and resource.attributes["k8s_monitoring.tmp.name"] != ""`,
+        `set(resource.attributes["service.name"], resource.attributes["k8s.deployment.name"]) where (resource.attributes["service.name"] == nil or resource.attributes["service.name"] == "") and resource.attributes["k8s.deployment.name"] != nil and resource.attributes["k8s.deployment.name"] != ""`,
+        `set(resource.attributes["service.name"], resource.attributes["k8s.replicaset.name"]) where (resource.attributes["service.name"] == nil or resource.attributes["service.name"] == "") and resource.attributes["k8s.replicaset.name"] != nil and resource.attributes["k8s.replicaset.name"] != ""`,
+        `set(resource.attributes["service.name"], resource.attributes["k8s.statefulset.name"]) where (resource.attributes["service.name"] == nil or resource.attributes["service.name"] == "") and resource.attributes["k8s.statefulset.name"] != nil and resource.attributes["k8s.statefulset.name"] != ""`,
+        `set(resource.attributes["service.name"], resource.attributes["k8s.daemonset.name"]) where (resource.attributes["service.name"] == nil or resource.attributes["service.name"] == "") and resource.attributes["k8s.daemonset.name"] != nil and resource.attributes["k8s.daemonset.name"] != ""`,
+        `set(resource.attributes["service.name"], resource.attributes["k8s.cronjob.name"]) where (resource.attributes["service.name"] == nil or resource.attributes["service.name"] == "") and resource.attributes["k8s.cronjob.name"] != nil and resource.attributes["k8s.cronjob.name"] != ""`,
+        `set(resource.attributes["service.name"], resource.attributes["k8s.job.name"]) where (resource.attributes["service.name"] == nil or resource.attributes["service.name"] == "") and resource.attributes["k8s.job.name"] != nil and resource.attributes["k8s.job.name"] != ""`,
+        `set(resource.attributes["service.name"], resource.attributes["k8s.pod.name"]) where (resource.attributes["service.name"] == nil or resource.attributes["service.name"] == "") and resource.attributes["k8s.pod.name"] != nil and resource.attributes["k8s.pod.name"] != ""`,
+
+        // Set service.namespace to the pod namespace if not already set
+        `set(resource.attributes["service.namespace"], resource.attributes["k8s.namespace.name"]) where (resource.attributes["service.namespace"] == nil or resource.attributes["service.namespace"] == "") and resource.attributes["k8s.namespace.name"] != nil and resource.attributes["k8s.namespace.name"] != ""`,
+
+        // Remove the temporary attributes used for service.name detection
+        `delete_key(resource.attributes, "k8s_monitoring.tmp.instance")`,
+        `delete_key(resource.attributes, "k8s_monitoring.tmp.name")`,
+      ]
+    }
+    trace_statements {
+      context = "resource"
+      statements = [
+        // Set service.name by choosing the first value found from the following ordered list:
+        // - service.name as reported by the application or set from the resource.opentelemetry.io/service.name annotation
+        // - pod.label[app.kubernetes.io/instance]
+        // - pod.label[app.kubernetes.io/name]
+        // - k8s.workload.name (Deployment, StatefulSet, DaemonSet, CronJob, Job, ...)
+        // - k8s.pod.name
+        // The instance/name pod labels are read from temporary attributes (k8s_monitoring.tmp.*) extracted by the
+        // k8sattributes processor, so the cleanup below only ever deletes attributes this feature added.
+        `set(resource.attributes["service.name"], resource.attributes["k8s_monitoring.tmp.instance"]) where (resource.attributes["service.name"] == nil or resource.attributes["service.name"] == "") and resource.attributes["k8s_monitoring.tmp.instance"] != nil and resource.attributes["k8s_monitoring.tmp.instance"] != ""`,
+        `set(resource.attributes["service.name"], resource.attributes["k8s_monitoring.tmp.name"]) where (resource.attributes["service.name"] == nil or resource.attributes["service.name"] == "") and resource.attributes["k8s_monitoring.tmp.name"] != nil and resource.attributes["k8s_monitoring.tmp.name"] != ""`,
+        `set(resource.attributes["service.name"], resource.attributes["k8s.deployment.name"]) where (resource.attributes["service.name"] == nil or resource.attributes["service.name"] == "") and resource.attributes["k8s.deployment.name"] != nil and resource.attributes["k8s.deployment.name"] != ""`,
+        `set(resource.attributes["service.name"], resource.attributes["k8s.replicaset.name"]) where (resource.attributes["service.name"] == nil or resource.attributes["service.name"] == "") and resource.attributes["k8s.replicaset.name"] != nil and resource.attributes["k8s.replicaset.name"] != ""`,
+        `set(resource.attributes["service.name"], resource.attributes["k8s.statefulset.name"]) where (resource.attributes["service.name"] == nil or resource.attributes["service.name"] == "") and resource.attributes["k8s.statefulset.name"] != nil and resource.attributes["k8s.statefulset.name"] != ""`,
+        `set(resource.attributes["service.name"], resource.attributes["k8s.daemonset.name"]) where (resource.attributes["service.name"] == nil or resource.attributes["service.name"] == "") and resource.attributes["k8s.daemonset.name"] != nil and resource.attributes["k8s.daemonset.name"] != ""`,
+        `set(resource.attributes["service.name"], resource.attributes["k8s.cronjob.name"]) where (resource.attributes["service.name"] == nil or resource.attributes["service.name"] == "") and resource.attributes["k8s.cronjob.name"] != nil and resource.attributes["k8s.cronjob.name"] != ""`,
+        `set(resource.attributes["service.name"], resource.attributes["k8s.job.name"]) where (resource.attributes["service.name"] == nil or resource.attributes["service.name"] == "") and resource.attributes["k8s.job.name"] != nil and resource.attributes["k8s.job.name"] != ""`,
+        `set(resource.attributes["service.name"], resource.attributes["k8s.pod.name"]) where (resource.attributes["service.name"] == nil or resource.attributes["service.name"] == "") and resource.attributes["k8s.pod.name"] != nil and resource.attributes["k8s.pod.name"] != ""`,
+
+        // Set service.namespace to the pod namespace if not already set
+        `set(resource.attributes["service.namespace"], resource.attributes["k8s.namespace.name"]) where (resource.attributes["service.namespace"] == nil or resource.attributes["service.namespace"] == "") and resource.attributes["k8s.namespace.name"] != nil and resource.attributes["k8s.namespace.name"] != ""`,
+
+        // Remove the temporary attributes used for service.name detection
+        `delete_key(resource.attributes, "k8s_monitoring.tmp.instance")`,
+        `delete_key(resource.attributes, "k8s_monitoring.tmp.name")`,
+      ]
+    }
+    trace_statements {
+      context = "span"
+      statements = [
+       "set_semconv_span_name(\"1.37.0\", \"original_span_name\")",
+      ]
+    }
+
+    output {
+      metrics = [otelcol.processor.batch.default.input]
+      traces = [otelcol.processor.filter.span_metrics_prefilter.input, otelcol.processor.batch.default.input]
+    }
+  }
+
+  // Span Metrics Connector
+  otelcol.processor.filter "span_metrics_prefilter" {
+    error_mode = "silent"
+    traces {
+      span = [
+        `resource.attributes["span.metrics.skip"] != nil or attributes["span.metrics.skip"] != nil`,
+        `kind == 1`,
+      ]
+    }
+    output {
+      traces = [otelcol.connector.spanmetrics.default.input]
+    }
+  } // otelcol.processor.filter "span_metrics_prefilter"
+
+  otelcol.connector.spanmetrics "default" {
+    exclude_dimensions = []
+    dimensions_cache_size = 1000
+    aggregation_cardinality_limit = 1000
+    namespace = "traces.span.metrics"
+
+    histogram {
+      disable = false
+      unit = "s"
+      explicit {
+        buckets = ["2ms","4ms","6ms","8ms","10ms","50ms","100ms","200ms","400ms","800ms","1s","1400ms","2s","5s","10s","15s"]
+      }
+    }
+
+    output {
+      metrics = [otelcol.processor.transform.span_metrics_transform.input]
+    }
+  }
+
+  otelcol.processor.transform "span_metrics_transform" {
+     metric_statements {
+      context = "datapoint"
+      statements = [
+        `set(attributes["collector.id"], "` + constants.hostname + `")`,
+        `set(resource.attributes["service.instance.id"], resource.attributes["k8s.pod.name"]) where resource.attributes["service.instance.id"] == nil and resource.attributes["k8s.pod.name"] != nil`,
+        `set(resource.attributes["service.instance.id"], resource.attributes["k8s.pod.uid"]) where resource.attributes["service.instance.id"] == nil and resource.attributes["k8s.pod.uid"] != nil`,
+      ]
+    }
+
+    metric_statements {
+      context = "scope"
+      statements = [
+        `set(resource.attributes["source"], "spanmetrics") where name == "spanmetricsconnector"`,
+      ]
+    }
+
+    output {
+      metrics = [otelcol.processor.batch.default.input]
+    }
+  } // otelcol.processor.transform "span_metrics_transform"
+
+  // Batch Processor
+  otelcol.processor.batch "default" {
+    send_batch_size = 8192
+    send_batch_max_size = 0
+    timeout = "2s"
+
+    output {
+      metrics = argument.metrics_destinations.value
+      traces = argument.traces_destinations.value
+    }
+  }
+} // declare "application_observability"
+application_observability "feature" {
+  metrics_destinations = [
+    otelcol.exporter.prometheus.localprometheus.input,
+  ]
+  logs_destinations = [
+
+  ]
+  traces_destinations = [
+    otelcol.processor.attributes.localtempo.input,
+  ]
+}
+
+
+
+
+
+declare "alloy_integration" {
+  argument "metrics_destinations" {
+    comment = "Must be a list of metric destinations where collected metrics should be forwarded to"
+  }
+
+  declare "alloy_integration_discovery" {
+    argument "namespaces" {
+      comment = "The namespaces to look for targets in (default: [] is all namespaces)"
+      optional = true
+    }
+
+    argument "field_selectors" {
+      comment = "The field selectors to use to find matching targets (default: [])"
+      optional = true
+    }
+
+    argument "label_selectors" {
+      comment = "The label selectors to use to find matching targets (default: [\"app.kubernetes.io/name=alloy\"])"
+      optional = true
+    }
+
+    argument "port_name" {
+      comment = "The of the port to scrape metrics from (default: http-metrics)"
+      optional = true
+    }
+
+    // Alloy service discovery for all of the pods
+    discovery.kubernetes "alloy_pods" {
+      role = "pod"
+
+      selectors {
+        role = "pod"
+        field = string.join(coalesce(argument.field_selectors.value, []), ",")
+        label = string.join(coalesce(argument.label_selectors.value, ["app.kubernetes.io/name=alloy"]), ",")
+      }
+
+      namespaces {
+        names = coalesce(argument.namespaces.value, [])
+      }
+
+    } // discovery.kubernetes "alloy_pods"
+
+    // alloy relabelings (pre-scrape)
+    discovery.relabel "alloy_pods" {
+      targets = discovery.kubernetes.alloy_pods.targets
+
+      // keep only the specified metrics port name, and pods that are Running and ready
+      rule {
+        source_labels = [
+          "__meta_kubernetes_pod_container_port_name",
+          "__meta_kubernetes_pod_phase",
+          "__meta_kubernetes_pod_ready",
+          "__meta_kubernetes_pod_container_init",
+        ]
+        separator = "@"
+        regex = coalesce(argument.port_name.value, "metrics") + "@Running@true@false"
+        action = "keep"
+      }
+
+      rule {
+        source_labels = ["__meta_kubernetes_namespace"]
+        target_label  = "namespace"
+      }
+
+      rule {
+        source_labels = ["__meta_kubernetes_pod_name"]
+        target_label  = "pod"
+      }
+
+      rule {
+        source_labels = ["__meta_kubernetes_pod_container_name"]
+        target_label  = "container"
+      }
+
+      // set the workload to the controller kind and name
+      rule {
+        action = "lowercase"
+        source_labels = ["__meta_kubernetes_pod_controller_kind"]
+        target_label  = "workload_type"
+      }
+
+      rule {
+        source_labels = ["__meta_kubernetes_pod_controller_name"]
+        target_label  = "workload"
+      }
+
+      // remove the hash from the ReplicaSet
+      rule {
+        source_labels = [
+          "workload_type",
+          "workload",
+        ]
+        separator = "/"
+        regex = "replicaset/(.+)-.+$"
+        target_label  = "workload"
+      }
+
+      // set the app name if specified as metadata labels "app:" or "app.kubernetes.io/name:" or "k8s-app:"
+      rule {
+        action = "replace"
+        source_labels = [
+          "__meta_kubernetes_pod_label_app_kubernetes_io_name",
+          "__meta_kubernetes_pod_label_k8s_app",
+          "__meta_kubernetes_pod_label_app",
+        ]
+        separator = ";"
+        regex = "^(?:;*)?([^;]+).*$"
+        replacement = "$1"
+        target_label = "app"
+      }
+
+      // set the component if specified as metadata labels "component:" or "app.kubernetes.io/component:" or "k8s-component:"
+      rule {
+        action = "replace"
+        source_labels = [
+          "__meta_kubernetes_pod_label_app_kubernetes_io_component",
+          "__meta_kubernetes_pod_label_k8s_component",
+          "__meta_kubernetes_pod_label_component",
+        ]
+        regex = "^(?:;*)?([^;]+).*$"
+        replacement = "$1"
+        target_label = "component"
+      }
+
+      // set a source label
+      rule {
+        action = "replace"
+        replacement = "kubernetes"
+        target_label = "source"
+      }
+
+    } // discovery.relabel "alloy_pods"
+
+    export "output" {
+      value = discovery.relabel.alloy_pods.output
+    }
+  }
+
+  declare "alloy_integration_scrape" {
+    argument "targets" {
+      comment = "Must be a list() of targets"
+    }
+
+    argument "forward_to" {
+      comment = "Must be a list(MetricsReceiver) where collected metrics should be forwarded to"
+    }
+
+    argument "job_label" {
+      comment = "The job label to add for all Alloy metrics (default: integrations/alloy)"
+      optional = true
+    }
+
+    argument "keep_metrics" {
+      comment = "A regular expression of metrics to keep (default: see below)"
+      optional = true
+    }
+
+    argument "drop_metrics" {
+      comment = "A regular expression of metrics to drop (default: see below)"
+      optional = true
+    }
+
+    argument "scrape_interval" {
+      comment = "How often to scrape metrics from the targets (default: 60s)"
+      optional = true
+    }
+
+    argument "scrape_timeout" {
+      comment = "The timeout for scraping metrics from the targets (default: 10s)"
+      optional = true
+    }
+
+    argument "scrape_protocols" {
+      comment = "The scrape protocols to use for scraping metrics"
+      optional = true
+    }
+
+    argument "scrape_classic_histograms" {
+      comment = "Whether to scrape classic histograms (default: false)."
+      optional = true
+    }
+
+    argument "scrape_native_histograms" {
+      comment = "Whether to scrape native histograms (default: false)."
+      optional = true
+    }
+
+    argument "max_cache_size" {
+      comment = "The maximum number of elements to hold in the relabeling cache (default: 100000).  This should be at least 2x-5x your largest scrape target or samples appended rate."
+      optional = true
+    }
+
+    argument "clustering" {
+      comment = "Whether or not clustering should be enabled (default: false)"
+      optional = true
+    }
+
+    prometheus.scrape "alloy" {
+      job_name = coalesce(argument.job_label.value, "integrations/alloy")
+      forward_to = [prometheus.relabel.alloy.receiver]
+      targets = argument.targets.value
+      scrape_interval = coalesce(argument.scrape_interval.value, "60s")
+      scrape_timeout = coalesce(argument.scrape_timeout.value, "10s")
+      scrape_protocols = argument.scrape_protocols.value
+      scrape_classic_histograms = argument.scrape_classic_histograms.value
+      scrape_native_histograms = argument.scrape_native_histograms.value
+
+      clustering {
+        enabled = coalesce(argument.clustering.value, false)
+      }
+    } // prometheus.scrape "alloy"
+
+    // alloy metric relabelings (post-scrape)
+    prometheus.relabel "alloy" {
+      forward_to = argument.forward_to.value
+      max_cache_size = coalesce(argument.max_cache_size.value, 100000)
+
+      // drop metrics that match the drop_metrics regex
+      rule {
+        source_labels = ["__name__"]
+        regex = coalesce(argument.drop_metrics.value, "")
+        action = "drop"
+      }
+
+      // keep only metrics that match the keep_metrics regex
+      rule {
+        source_labels = ["__name__"]
+        regex = coalesce(argument.keep_metrics.value, ".*")
+        action = "keep"
+      }
+
+      // remove the component_id label from any metric that starts with log_bytes or log_lines, these are custom metrics that are generated
+      // as part of the log annotation modules in this repo
+      rule {
+        action = "replace"
+        source_labels = ["__name__"]
+        regex = "^log_(bytes|lines).+"
+        replacement = ""
+        target_label = "component_id"
+      }
+
+      // set the namespace label to that of the exported_namespace
+      rule {
+        action = "replace"
+        source_labels = ["__name__", "exported_namespace"]
+        separator = "@"
+        regex = "^log_(bytes|lines).+@(.+)"
+        replacement = "$2"
+        target_label = "namespace"
+      }
+
+      // set the pod label to that of the exported_pod
+      rule {
+        action = "replace"
+        source_labels = ["__name__", "exported_pod"]
+        separator = "@"
+        regex = "^log_(bytes|lines).+@(.+)"
+        replacement = "$2"
+        target_label = "pod"
+      }
+
+      // set the container label to that of the exported_container
+      rule {
+        action = "replace"
+        source_labels = ["__name__", "exported_container"]
+        separator = "@"
+        regex = "^log_(bytes|lines).+@(.+)"
+        replacement = "$2"
+        target_label = "container"
+      }
+
+      // set the job label to that of the exported_job
+      rule {
+        action = "replace"
+        source_labels = ["__name__", "exported_job"]
+        separator = "@"
+        regex = "^log_(bytes|lines).+@(.+)"
+        replacement = "$2"
+        target_label = "job"
+      }
+
+      // set the instance label to that of the exported_instance
+      rule {
+        action = "replace"
+        source_labels = ["__name__", "exported_instance"]
+        separator = "@"
+        regex = "^log_(bytes|lines).+@(.+)"
+        replacement = "$2"
+        target_label = "instance"
+      }
+
+      rule {
+        action = "labeldrop"
+        regex = "exported_(namespace|pod|container|job|instance)"
+      }
+    } // prometheus.relabel "alloy"
+  }
+
+  alloy_integration_discovery "alloy_app" {
+    port_name = "http-metrics"
+    label_selectors = ["app.kubernetes.io/name=alloy-app"]
+  }
+
+  alloy_integration_scrape "alloy_app" {
+    targets = alloy_integration_discovery.alloy_app.output
+    job_label = "integrations/alloy"
+    clustering = true
+    keep_metrics = "up|scrape_samples_scraped|alloy_build_info"
+    scrape_interval = "60s"
+    scrape_timeout = "10s"
+    scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
+    scrape_classic_histograms = false
+    scrape_native_histograms = false
+    max_cache_size = 100000
+    forward_to = argument.metrics_destinations.value
+  }
+}
+alloy_integration "integration" {
+  metrics_destinations = [
+    prometheus.remote_write.localprometheus.receiver,
+  ]
+}
+
+
+
+
+
+
+
+
+
+// Self Reporting
+prometheus.exporter.unix "kubernetes_monitoring_telemetry" {
+  set_collectors = ["textfile"]
+  textfile {
+    directory = "/etc/release-info"
+  }
+} // prometheus.exporter.unix "kubernetes_monitoring_telemetry"
+
+discovery.relabel "kubernetes_monitoring_telemetry" {
+  targets = prometheus.exporter.unix.kubernetes_monitoring_telemetry.targets
+  rule {
+    target_label = "instance"
+    action = "replace"
+    replacement = "k8smon"
+  }
+  rule {
+    target_label = "job"
+    action = "replace"
+    replacement = "integrations/kubernetes/kubernetes_monitoring_telemetry"
+  }
+} // discovery.relabel "kubernetes_monitoring_telemetry"
+
+prometheus.scrape "kubernetes_monitoring_telemetry" {
+  job_name   = "integrations/kubernetes/kubernetes_monitoring_telemetry"
+  targets    = discovery.relabel.kubernetes_monitoring_telemetry.output
+  scrape_interval = "60s"
+  clustering {
+    enabled = true
+  }
+  forward_to = [prometheus.relabel.kubernetes_monitoring_telemetry.receiver]
+} // prometheus.scrape "kubernetes_monitoring_telemetry"
+
+prometheus.relabel "kubernetes_monitoring_telemetry" {
+  rule {
+    source_labels = ["__name__"]
+    regex = "grafana_kubernetes_monitoring_.*"
+    action = "keep"
+  }
+  forward_to = [
+    prometheus.remote_write.localprometheus.receiver,
+  ]
+} // prometheus.relabel "kubernetes_monitoring_telemetry"
+
+
+
+
+
+// Destination: localPrometheus (prometheus)
+otelcol.exporter.prometheus "localprometheus" {
+  add_metric_suffixes = true
+  resource_to_telemetry_conversion = false
+  keep_identifying_resource_attributes = true
+  forward_to = [prometheus.remote_write.localprometheus.receiver]
+} // otelcol.exporter.prometheus "localprometheus"
+
+prometheus.remote_write "localprometheus" {
+  endpoint {
+    url = "http://prometheus-server.prometheus.svc:9090/api/v1/write"
+    headers = {
+    }
+    tls_config {
+      insecure_skip_verify = false
+    }
+    send_native_histograms = false
+
+    queue_config {
+      capacity = 10000
+      min_shards = 1
+      max_shards = 50
+      max_samples_per_send = 2000
+      batch_send_deadline = "5s"
+      min_backoff = "30ms"
+      max_backoff = "5s"
+      retry_on_http_429 = true
+      sample_age_limit = "0s"
+    }
+  }
+
+  wal {
+    truncate_frequency = "2h"
+    min_keepalive_time = "5m"
+    max_keepalive_time = "8h"
+  }
+  external_labels = {
+    "cluster" = "application-observability-test",
+    "k8s_cluster_name" = "application-observability-test",
+  }
+} // prometheus.remote_write "localprometheus"
+
+// Destination: localTempo (otlp)
+otelcol.processor.attributes "localtempo" {
+  output {
+    traces = [otelcol.processor.transform.localtempo.input]
+  }
+} // otelcol.processor.attributes "localtempo"
+
+otelcol.processor.transform "localtempo" {
+  error_mode = "ignore"
+
+  trace_statements {
+    context = "resource"
+    statements = [
+      `set(attributes["cluster"], "application-observability-test")`,
+      `set(attributes["k8s.cluster.name"], "application-observability-test")`,
+      `delete_key(attributes, "process.pid")`,
+      `delete_key(attributes, "process.parent_pid")`,
+      `delete_key(attributes, "process.executable.path")`,
+      `delete_key(attributes, "process.command_line")`,
+      `delete_key(attributes, "process.command_args")`,
+      `delete_key(attributes, "process.owner")`,
+      `delete_key(attributes, "process.runtime.version")`,
+      `delete_key(attributes, "process.runtime.description")`,
+      `delete_key(attributes, "host.ip")`,
+      `delete_key(attributes, "host.mac")`,
+      `delete_key(attributes, "k8s.pod.start_time")`,
+      `delete_key(attributes, "k8s.pod.uid")`,
+      `delete_key(attributes, "container.image.id")`,
+      `delete_key(attributes, "container.image.repo_digests")`,
+      `delete_key(attributes, "os.description")`,
+      `delete_key(attributes, "os.build_id")`,
+    ]
+  }
+
+  output {
+    traces = [otelcol.processor.batch.localtempo.input]
+  }
+} // otelcol.processor.transform "localtempo"
+
+otelcol.processor.batch "localtempo" {
+  timeout = "2s"
+  send_batch_size = 8192
+  send_batch_max_size = 0
+
+  output {
+    traces = [otelcol.exporter.otlp.localtempo.input]
+  }
+} // otelcol.processor.batch "localtempo"
+otelcol.exporter.otlp "localtempo" {
+  client {
+    endpoint = "tempo.tempo.svc:4317"
+    tls {
+      insecure = true
+      insecure_skip_verify = true
+    }
+  }
+
+  retry_on_failure {
+    enabled = true
+    initial_interval = "5s"
+    max_interval = "30s"
+    max_elapsed_time = "5m"
+  }
+
+  sending_queue {
+    enabled = true
+  }
+} // otelcol.exporter.otlp "localtempo"
+

--- a/charts/k8s-monitoring/tests/integration/auth/.rendered/alloy-logs.alloy
+++ b/charts/k8s-monitoring/tests/integration/auth/.rendered/alloy-logs.alloy
@@ -1,0 +1,341 @@
+// Feature: Pod Logs (Loki)
+declare "pod_logs_via_loki" {
+  argument "logs_destinations" {
+    comment = "Must be a list of log destinations where collected logs should be forwarded to"
+  }
+
+  discovery.kubernetes "pods" {
+    role = "pod"
+    selectors {
+      role = "pod"
+      field = "spec.nodeName=" + sys.env("HOSTNAME")
+    }
+    namespaces {
+      names = ["default"]
+    }
+  } // discovery.kubernetes "pods"
+
+  discovery.relabel "filtered_pods" {
+    targets = discovery.kubernetes.pods.targets
+    rule {
+      source_labels = ["__meta_kubernetes_namespace"]
+      action = "replace"
+      target_label = "namespace"
+    }
+    rule {  // Drop anything with a "falsy" annotation value
+      source_labels = ["__meta_kubernetes_pod_annotation_logs_grafana_com_pods_enabled"]
+      regex = "(false|no|skip)"
+      action = "drop"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_pod_name"]
+      target_label = "pod"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_pod_container_name"]
+      target_label = "container"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_namespace", "__meta_kubernetes_pod_container_name"]
+      separator = "/"
+      replacement = "$1"
+      target_label = "job"
+    }
+
+    // set the container runtime as a label
+    rule {
+      source_labels = ["__meta_kubernetes_pod_container_id"]
+      regex = "^(\\S+):\\/\\/.+$"
+      replacement = "$1"
+      target_label = "tmp_container_runtime"
+    }
+    // explicitly set service_name. if not set, loki will automatically try to populate a default.
+    // see https://grafana.com/docs/loki/latest/get-started/labels/#default-labels-for-all-users
+    //
+    // choose the first value found from the following ordered list:
+    // - pod.annotation[resource.opentelemetry.io/service.name]
+    // - pod.label[app.kubernetes.io/name]
+    // - k8s.container.name
+    rule {
+      source_labels = [
+        "__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_name",
+        "__meta_kubernetes_pod_label_app_kubernetes_io_name",
+        "__meta_kubernetes_pod_container_name",
+      ]
+      separator = ";"
+      regex = "^(?:;*)?([^;]+).*$"
+      replacement = "$1"
+      target_label = "service_name"
+    }
+
+    // explicitly set service_namespace.
+    //
+    // choose the first value found from the following ordered list:
+    // - pod.annotation[resource.opentelemetry.io/service.namespace]
+    // - pod.namespace
+    rule {
+      source_labels = [
+        "__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_namespace",
+        "namespace",
+      ]
+      separator = ";"
+      regex = "^(?:;*)?([^;]+).*$"
+      replacement = "$1"
+      target_label = "service_namespace"
+    }
+
+    // explicitly set service_instance_id.
+    //
+    // choose the first value found from the following ordered list:
+    // - pod.annotation[resource.opentelemetry.io/service.instance.id]
+    // - concat([k8s.namespace.name, k8s.pod.name, k8s.container.name], '.')
+    rule {
+      source_labels = ["__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_instance_id"]
+      target_label = "service_instance_id"
+    }
+    rule {
+      source_labels = ["service_instance_id", "namespace", "pod", "container"]
+      separator = "."
+      regex = "^\\.([^.]+\\.[^.]+\\.[^.]+)$"
+      target_label = "service_instance_id"
+    }
+
+    // set resource attributes
+    rule {
+      action = "labelmap"
+      regex = "__meta_kubernetes_pod_annotation_resource_opentelemetry_io_(.+)"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_job"]
+      regex = "(.+)"
+      target_label = "job"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+      regex = "(.+)"
+      target_label = "app_kubernetes_io_name"
+    }
+
+    // Set the pod log path.
+    rule {
+      source_labels = ["__meta_kubernetes_pod_uid", "__meta_kubernetes_pod_container_name"]
+      separator = "/"
+      replacement = "/var/log/pods/*$1/*.log"
+      target_label = "__path__"
+    }
+
+    // If kubernetes.io/config.mirror is set, this is a static pod, created by the kubelet.
+    // It's logs live on a different path.
+    rule {
+      source_labels = ["__meta_kubernetes_pod_annotation_kubernetes_io_config_mirror", "__meta_kubernetes_pod_container_name"]
+      separator = "/"
+      regex = "(.+/.+)"
+      replacement = "/var/log/pods/*$1/*.log"
+      target_label = "__path__"
+    }
+  } // discovery.relabel "filtered_pods"
+
+  local.file_match "pod_logs" {
+    path_targets = discovery.relabel.filtered_pods.output
+  } // local.file_match "pod_logs"
+
+  loki.source.file "pod_logs" {
+    targets    = local.file_match.pod_logs.targets
+    tail_from_end = true
+    forward_to = [loki.process.pod_logs.receiver]
+  } // loki.source.file "pod_logs"
+
+  loki.process "pod_logs" {
+    stage.match {
+      selector = "{tmp_container_runtime=~\"containerd|cri-o|\"}"
+      // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
+      stage.cri {
+        max_partial_lines = 100
+      }
+
+      // Set the extract flags and stream values as labels
+      stage.labels {
+        values = {
+          flags  = "",
+          stream  = "",
+        }
+      }
+    }
+
+    stage.match {
+      selector = "{tmp_container_runtime=\"docker\"}"
+      // the docker processing stage extracts the following k/v pairs: log, stream, time
+      stage.docker {}
+
+      // Set the extract stream value as a label
+      stage.labels {
+        values = {
+          stream  = "",
+        }
+      }
+    }
+
+    // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
+    // namespace, pod, and container labels. Drop any structured metadata. Also drop the temporary
+    // container runtime label as it is no longer needed.
+    stage.label_drop {
+      values = [
+        "filename",
+        "tmp_container_runtime",
+      ]
+    }
+    stage.structured_metadata {
+      values = {
+        "k8s_pod_name" = "k8s_pod_name",
+        "pod" = "pod",
+        "service_instance_id" = "service_instance_id",
+      }
+    }
+
+    forward_to = argument.logs_destinations.value
+  } // loki.secretfilter "pod_logs"
+} // declare "pod_logs_via_loki"
+pod_logs_via_loki "feature" {
+  logs_destinations = [
+    loki.write.loki_basicauth.receiver,
+    loki.write.loki_basicauth_external_secret.receiver,
+    loki.write.loki_bearer_token.receiver,
+    loki.write.loki_noauth.receiver,
+  ]
+}
+
+
+
+
+
+// Destination: loki-basicauth (loki)
+otelcol.exporter.loki "loki_basicauth" {
+  forward_to = [loki.write.loki_basicauth.receiver]
+} // otelcol.exporter.loki "loki_basicauth"
+
+loki.write "loki_basicauth" {
+  endpoint {
+    url = "http://nginx-auth-gateway.default.svc/logs/basic/loki/api/v1/push"
+    retry_on_http_429 = true
+    tenant_id = convert.nonsensitive(remote.kubernetes.secret.loki_basicauth.data["tenantId"])
+    basic_auth {
+      username = convert.nonsensitive(remote.kubernetes.secret.loki_basicauth.data["username"])
+      password = remote.kubernetes.secret.loki_basicauth.data["password"]
+    }
+    tls_config {
+      insecure_skip_verify = false
+    }
+    min_backoff_period = "500ms"
+    max_backoff_period = "5m"
+    max_backoff_retries = "10"
+  }
+  external_labels = {
+    "cluster" = "auth-integration-test",
+    "k8s_cluster_name" = "auth-integration-test",
+    destination = "loki-basicauth",
+  }
+} // loki.write "loki_basicauth"
+
+remote.kubernetes.secret "loki_basicauth" {
+  name      = "loki-basicauth-k8smon-k8s-monitoring"
+  namespace = "default"
+} // remote.kubernetes.secret "loki_basicauth"
+
+
+// Destination: loki-basicauth-external-secret (loki)
+otelcol.exporter.loki "loki_basicauth_external_secret" {
+  forward_to = [loki.write.loki_basicauth_external_secret.receiver]
+} // otelcol.exporter.loki "loki_basicauth_external_secret"
+
+loki.write "loki_basicauth_external_secret" {
+  endpoint {
+    url = "http://nginx-auth-gateway.default.svc/logs/basic/loki/api/v1/push"
+    retry_on_http_429 = true
+    tenant_id = convert.nonsensitive(remote.kubernetes.secret.loki_basicauth_external_secret.data["lokiTenantId"])
+    basic_auth {
+      username = convert.nonsensitive(remote.kubernetes.secret.loki_basicauth_external_secret.data["lokiUsername"])
+      password = remote.kubernetes.secret.loki_basicauth_external_secret.data["lokiPassword"]
+    }
+    tls_config {
+      insecure_skip_verify = false
+      ca_pem = convert.nonsensitive(remote.kubernetes.secret.loki_basicauth_external_secret.data["ca"])
+      cert_pem = convert.nonsensitive(remote.kubernetes.secret.loki_basicauth_external_secret.data["cert"])
+      key_pem = remote.kubernetes.secret.loki_basicauth_external_secret.data["key"]
+    }
+    min_backoff_period = "500ms"
+    max_backoff_period = "5m"
+    max_backoff_retries = "10"
+  }
+  external_labels = {
+    "cluster" = "auth-integration-test",
+    "k8s_cluster_name" = "auth-integration-test",
+    destination = "loki-basicauth-external-secret",
+  }
+} // loki.write "loki_basicauth_external_secret"
+
+remote.kubernetes.secret "loki_basicauth_external_secret" {
+  name      = "credentials"
+  namespace = "default"
+} // remote.kubernetes.secret "loki_basicauth_external_secret"
+
+
+// Destination: loki-bearer-token (loki)
+otelcol.exporter.loki "loki_bearer_token" {
+  forward_to = [loki.write.loki_bearer_token.receiver]
+} // otelcol.exporter.loki "loki_bearer_token"
+
+loki.write "loki_bearer_token" {
+  endpoint {
+    url = "http://nginx-auth-gateway.default.svc/logs/bearer/loki/api/v1/push"
+    retry_on_http_429 = true
+    tenant_id = convert.nonsensitive(remote.kubernetes.secret.loki_bearer_token.data["tenantId"])
+    bearer_token = remote.kubernetes.secret.loki_bearer_token.data["bearerToken"]
+    tls_config {
+      insecure_skip_verify = false
+    }
+    min_backoff_period = "500ms"
+    max_backoff_period = "5m"
+    max_backoff_retries = "10"
+  }
+  external_labels = {
+    "cluster" = "auth-integration-test",
+    "k8s_cluster_name" = "auth-integration-test",
+    destination = "loki-bearer-token",
+  }
+} // loki.write "loki_bearer_token"
+
+remote.kubernetes.secret "loki_bearer_token" {
+  name      = "loki-bearer-token-k8smon-k8s-monitoring"
+  namespace = "default"
+} // remote.kubernetes.secret "loki_bearer_token"
+
+
+// Destination: loki-noauth (loki)
+otelcol.exporter.loki "loki_noauth" {
+  forward_to = [loki.write.loki_noauth.receiver]
+} // otelcol.exporter.loki "loki_noauth"
+
+loki.write "loki_noauth" {
+  endpoint {
+    url = "http://loki.loki.svc:3100/loki/api/v1/push"
+    retry_on_http_429 = true
+    tenant_id = convert.nonsensitive(remote.kubernetes.secret.loki_noauth.data["tenantId"])
+    tls_config {
+      insecure_skip_verify = false
+    }
+    min_backoff_period = "500ms"
+    max_backoff_period = "5m"
+    max_backoff_retries = "10"
+  }
+  external_labels = {
+    "cluster" = "auth-integration-test",
+    "k8s_cluster_name" = "auth-integration-test",
+    destination = "loki-noauth",
+  }
+} // loki.write "loki_noauth"
+
+remote.kubernetes.secret "loki_noauth" {
+  name      = "loki-noauth-k8smon-k8s-monitoring"
+  namespace = "default"
+} // remote.kubernetes.secret "loki_noauth"
+

--- a/charts/k8s-monitoring/tests/integration/auth/.rendered/alloy-metrics.alloy
+++ b/charts/k8s-monitoring/tests/integration/auth/.rendered/alloy-metrics.alloy
@@ -1,0 +1,820 @@
+// Feature: Cluster Metrics
+declare "cluster_metrics" {
+  argument "metrics_destinations" {
+    comment = "Must be a list of metric destinations where collected metrics should be forwarded to"
+  }
+  discovery.kubernetes "nodes" {
+    role = "node"
+  } // discovery.kubernetes "nodes"
+
+  discovery.relabel "nodes" {
+    targets = discovery.kubernetes.nodes.targets
+    rule {
+      source_labels = ["__meta_kubernetes_node_name"]
+      target_label  = "node"
+    }
+
+    rule {
+      replacement = "kubernetes"
+      target_label = "source"
+    }
+  } // discovery.relabel "nodes"
+
+  // Kubelet
+  discovery.relabel "kubelet" {
+    targets = discovery.relabel.nodes.output
+  } // discovery.relabel "kubelet"
+
+  prometheus.scrape "kubelet" {
+    targets  = discovery.relabel.kubelet.output
+    job_name = "integrations/kubernetes/kubelet"
+    scheme   = "https"
+    scrape_interval = "60s"
+    scrape_timeout = "10s"
+    scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
+    scrape_classic_histograms = false
+    scrape_native_histograms = false
+    convert_classic_histograms_to_nhcb = false
+    bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+
+    tls_config {
+      ca_file = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+      insecure_skip_verify = true
+      server_name = "kubernetes"
+    }
+
+    clustering {
+      enabled = true
+    }
+
+    forward_to = [prometheus.relabel.kubelet.receiver]
+  } // prometheus.scrape "kubelet"
+
+  prometheus.relabel "kubelet" {
+    max_cache_size = 100000
+    rule {
+      source_labels = ["__name__"]
+      regex = "up|scrape_samples_scraped|go_goroutines|kubelet_certificate_manager_client_expiration_renew_errors|kubelet_certificate_manager_client_ttl_seconds|kubelet_certificate_manager_server_ttl_seconds|kubelet_cgroup_manager_duration_seconds_bucket|kubelet_cgroup_manager_duration_seconds_count|kubelet_node_config_error|kubelet_node_name|kubelet_pleg_relist_duration_seconds_bucket|kubelet_pleg_relist_duration_seconds_count|kubelet_pleg_relist_interval_seconds_bucket|kubelet_pod_start_duration_seconds_bucket|kubelet_pod_start_duration_seconds_count|kubelet_pod_worker_duration_seconds_bucket|kubelet_pod_worker_duration_seconds_count|kubelet_running_container_count|kubelet_running_containers|kubelet_running_pod_count|kubelet_running_pods|kubelet_runtime_operations_errors_total|kubelet_runtime_operations_total|kubelet_server_expiration_renew_errors|kubelet_volume_stats_available_bytes|kubelet_volume_stats_capacity_bytes|kubelet_volume_stats_inodes|kubelet_volume_stats_inodes_free|kubelet_volume_stats_inodes_used|kubelet_volume_stats_used_bytes|kubernetes_build_info|namespace_workload_pod|process_cpu_seconds_total|process_resident_memory_bytes|rest_client_requests_total|storage_operation_duration_seconds_count|storage_operation_errors_total|volume_manager_total_volumes"
+      action = "keep"
+    }
+
+    forward_to = argument.metrics_destinations.value
+  } // prometheus.relabel "kubelet"
+} // declare "cluster_metrics"
+cluster_metrics "feature" {
+  metrics_destinations = [
+    prometheus.remote_write.prometheus_basicauth.receiver,
+    prometheus.remote_write.prometheus_basicauth_external_secret_1.receiver,
+    prometheus.remote_write.prometheus_basicauth_external_secret_2.receiver,
+    prometheus.remote_write.prometheus_bearer_token.receiver,
+    prometheus.remote_write.prometheus_noauth.receiver,
+    otelcol.receiver.prometheus.prometheus_otlp_basicauth.receiver,
+    otelcol.receiver.prometheus.prometheus_otlp_bearer_token.receiver,
+    otelcol.receiver.prometheus.prometheus_otlp_noauth.receiver,
+  ]
+}
+// Self Reporting
+prometheus.exporter.unix "kubernetes_monitoring_telemetry" {
+  set_collectors = ["textfile"]
+  textfile {
+    directory = "/etc/release-info"
+  }
+} // prometheus.exporter.unix "kubernetes_monitoring_telemetry"
+
+discovery.relabel "kubernetes_monitoring_telemetry" {
+  targets = prometheus.exporter.unix.kubernetes_monitoring_telemetry.targets
+  rule {
+    target_label = "instance"
+    action = "replace"
+    replacement = "k8smon"
+  }
+  rule {
+    target_label = "job"
+    action = "replace"
+    replacement = "integrations/kubernetes/kubernetes_monitoring_telemetry"
+  }
+} // discovery.relabel "kubernetes_monitoring_telemetry"
+
+prometheus.scrape "kubernetes_monitoring_telemetry" {
+  job_name   = "integrations/kubernetes/kubernetes_monitoring_telemetry"
+  targets    = discovery.relabel.kubernetes_monitoring_telemetry.output
+  scrape_interval = "60s"
+  clustering {
+    enabled = true
+  }
+  forward_to = [prometheus.relabel.kubernetes_monitoring_telemetry.receiver]
+} // prometheus.scrape "kubernetes_monitoring_telemetry"
+
+prometheus.relabel "kubernetes_monitoring_telemetry" {
+  rule {
+    source_labels = ["__name__"]
+    regex = "grafana_kubernetes_monitoring_.*"
+    action = "keep"
+  }
+  forward_to = [
+    prometheus.remote_write.prometheus_basicauth.receiver,
+    prometheus.remote_write.prometheus_basicauth_external_secret_1.receiver,
+    prometheus.remote_write.prometheus_basicauth_external_secret_2.receiver,
+    prometheus.remote_write.prometheus_bearer_token.receiver,
+    prometheus.remote_write.prometheus_noauth.receiver,
+  ]
+} // prometheus.relabel "kubernetes_monitoring_telemetry"
+
+
+
+
+
+// Destination: prometheus-basicauth (prometheus)
+otelcol.exporter.prometheus "prometheus_basicauth" {
+  add_metric_suffixes = true
+  resource_to_telemetry_conversion = false
+  keep_identifying_resource_attributes = true
+  forward_to = [prometheus.remote_write.prometheus_basicauth.receiver]
+} // otelcol.exporter.prometheus "prometheus_basicauth"
+
+prometheus.remote_write "prometheus_basicauth" {
+  endpoint {
+    url = "http://nginx-auth-gateway.default.svc/metrics/basic/api/v1/write"
+    headers = {
+    }
+    basic_auth {
+      username = convert.nonsensitive(remote.kubernetes.secret.prometheus_basicauth.data["username"])
+      password = remote.kubernetes.secret.prometheus_basicauth.data["password"]
+    }
+    tls_config {
+      insecure_skip_verify = false
+    }
+    send_native_histograms = false
+
+    queue_config {
+      capacity = 10000
+      min_shards = 1
+      max_shards = 50
+      max_samples_per_send = 2000
+      batch_send_deadline = "5s"
+      min_backoff = "30ms"
+      max_backoff = "5s"
+      retry_on_http_429 = true
+      sample_age_limit = "0s"
+    }
+  }
+
+  wal {
+    truncate_frequency = "2h"
+    min_keepalive_time = "5m"
+    max_keepalive_time = "8h"
+  }
+  external_labels = {
+    "cluster" = "auth-integration-test",
+    "k8s_cluster_name" = "auth-integration-test",
+    destination = "prometheus-basicauth",
+  }
+} // prometheus.remote_write "prometheus_basicauth"
+
+remote.kubernetes.secret "prometheus_basicauth" {
+  name      = "prometheus-basicauth-k8smon-k8s-monitoring"
+  namespace = "default"
+} // remote.kubernetes.secret "prometheus_basicauth"
+
+
+// Destination: prometheus-basicauth-external-secret-1 (prometheus)
+otelcol.exporter.prometheus "prometheus_basicauth_external_secret_1" {
+  add_metric_suffixes = true
+  resource_to_telemetry_conversion = false
+  keep_identifying_resource_attributes = true
+  forward_to = [prometheus.remote_write.prometheus_basicauth_external_secret_1.receiver]
+} // otelcol.exporter.prometheus "prometheus_basicauth_external_secret_1"
+
+prometheus.remote_write "prometheus_basicauth_external_secret_1" {
+  endpoint {
+    url = "http://nginx-auth-gateway.default.svc/metrics/basic/api/v1/write"
+    headers = {
+      "X-Scope-OrgID" = convert.nonsensitive(remote.kubernetes.secret.prometheus_basicauth_external_secret_1.data["tenantId"]),
+    }
+    basic_auth {
+      username = convert.nonsensitive(remote.kubernetes.secret.prometheus_basicauth_external_secret_1.data["username"])
+      password = remote.kubernetes.secret.prometheus_basicauth_external_secret_1.data["password"]
+    }
+    tls_config {
+      insecure_skip_verify = false
+      ca_pem = convert.nonsensitive(remote.kubernetes.secret.prometheus_basicauth_external_secret_1.data["ca"])
+      cert_pem = convert.nonsensitive(remote.kubernetes.secret.prometheus_basicauth_external_secret_1.data["cert"])
+      key_pem = remote.kubernetes.secret.prometheus_basicauth_external_secret_1.data["key"]
+    }
+    send_native_histograms = false
+
+    queue_config {
+      capacity = 10000
+      min_shards = 1
+      max_shards = 50
+      max_samples_per_send = 2000
+      batch_send_deadline = "5s"
+      min_backoff = "30ms"
+      max_backoff = "5s"
+      retry_on_http_429 = true
+      sample_age_limit = "0s"
+    }
+  }
+
+  wal {
+    truncate_frequency = "2h"
+    min_keepalive_time = "5m"
+    max_keepalive_time = "8h"
+  }
+  external_labels = {
+    "cluster" = "auth-integration-test",
+    "k8s_cluster_name" = "auth-integration-test",
+    destination = "prometheus-basicauth-external-secret-1",
+  }
+} // prometheus.remote_write "prometheus_basicauth_external_secret_1"
+
+remote.kubernetes.secret "prometheus_basicauth_external_secret_1" {
+  name      = "credentials"
+  namespace = "default"
+} // remote.kubernetes.secret "prometheus_basicauth_external_secret_1"
+
+
+// Destination: prometheus-basicauth-external-secret-2 (prometheus)
+otelcol.exporter.prometheus "prometheus_basicauth_external_secret_2" {
+  add_metric_suffixes = true
+  resource_to_telemetry_conversion = false
+  keep_identifying_resource_attributes = true
+  forward_to = [prometheus.remote_write.prometheus_basicauth_external_secret_2.receiver]
+} // otelcol.exporter.prometheus "prometheus_basicauth_external_secret_2"
+
+prometheus.remote_write "prometheus_basicauth_external_secret_2" {
+  endpoint {
+    url = "http://nginx-auth-gateway.default.svc/metrics/basic/api/v1/write"
+    headers = {
+      "X-Scope-OrgID" = convert.nonsensitive(remote.kubernetes.secret.prometheus_basicauth_external_secret_2.data["tenantId"]),
+    }
+    basic_auth {
+      username = convert.nonsensitive(remote.kubernetes.secret.prometheus_basicauth_external_secret_2.data["prometheusUsername"])
+      password = remote.kubernetes.secret.prometheus_basicauth_external_secret_2.data["prometheusPassword"]
+    }
+    tls_config {
+      insecure_skip_verify = false
+      ca_pem = convert.nonsensitive(remote.kubernetes.secret.prometheus_basicauth_external_secret_2.data["ca"])
+      cert_pem = convert.nonsensitive(remote.kubernetes.secret.prometheus_basicauth_external_secret_2.data["cert"])
+      key_pem = remote.kubernetes.secret.prometheus_basicauth_external_secret_2.data["key"]
+    }
+    send_native_histograms = false
+
+    queue_config {
+      capacity = 10000
+      min_shards = 1
+      max_shards = 50
+      max_samples_per_send = 2000
+      batch_send_deadline = "5s"
+      min_backoff = "30ms"
+      max_backoff = "5s"
+      retry_on_http_429 = true
+      sample_age_limit = "0s"
+    }
+  }
+
+  wal {
+    truncate_frequency = "2h"
+    min_keepalive_time = "5m"
+    max_keepalive_time = "8h"
+  }
+  external_labels = {
+    "cluster" = "auth-integration-test",
+    "k8s_cluster_name" = "auth-integration-test",
+    destination = "prometheus-basicauth-external-secret-2",
+  }
+} // prometheus.remote_write "prometheus_basicauth_external_secret_2"
+
+remote.kubernetes.secret "prometheus_basicauth_external_secret_2" {
+  name      = "credentials"
+  namespace = "default"
+} // remote.kubernetes.secret "prometheus_basicauth_external_secret_2"
+
+
+// Destination: prometheus-bearer-token (prometheus)
+otelcol.exporter.prometheus "prometheus_bearer_token" {
+  add_metric_suffixes = true
+  resource_to_telemetry_conversion = false
+  keep_identifying_resource_attributes = true
+  forward_to = [prometheus.remote_write.prometheus_bearer_token.receiver]
+} // otelcol.exporter.prometheus "prometheus_bearer_token"
+
+prometheus.remote_write "prometheus_bearer_token" {
+  endpoint {
+    url = "http://nginx-auth-gateway.default.svc/metrics/bearer/api/v1/write"
+    headers = {
+    }
+    bearer_token = remote.kubernetes.secret.prometheus_bearer_token.data["bearerToken"]
+    tls_config {
+      insecure_skip_verify = false
+    }
+    send_native_histograms = false
+
+    queue_config {
+      capacity = 10000
+      min_shards = 1
+      max_shards = 50
+      max_samples_per_send = 2000
+      batch_send_deadline = "5s"
+      min_backoff = "30ms"
+      max_backoff = "5s"
+      retry_on_http_429 = true
+      sample_age_limit = "0s"
+    }
+  }
+
+  wal {
+    truncate_frequency = "2h"
+    min_keepalive_time = "5m"
+    max_keepalive_time = "8h"
+  }
+  external_labels = {
+    "cluster" = "auth-integration-test",
+    "k8s_cluster_name" = "auth-integration-test",
+    destination = "prometheus-bearer-token",
+  }
+} // prometheus.remote_write "prometheus_bearer_token"
+
+remote.kubernetes.secret "prometheus_bearer_token" {
+  name      = "prometheus-bearer-token-k8smon-k8s-monitoring"
+  namespace = "default"
+} // remote.kubernetes.secret "prometheus_bearer_token"
+
+
+// Destination: prometheus-noauth (prometheus)
+otelcol.exporter.prometheus "prometheus_noauth" {
+  add_metric_suffixes = true
+  resource_to_telemetry_conversion = false
+  keep_identifying_resource_attributes = true
+  forward_to = [prometheus.remote_write.prometheus_noauth.receiver]
+} // otelcol.exporter.prometheus "prometheus_noauth"
+
+prometheus.remote_write "prometheus_noauth" {
+  endpoint {
+    url = "http://prometheus-server.prometheus.svc:9090/api/v1/write"
+    headers = {
+    }
+    tls_config {
+      insecure_skip_verify = false
+    }
+    send_native_histograms = false
+
+    queue_config {
+      capacity = 10000
+      min_shards = 1
+      max_shards = 50
+      max_samples_per_send = 2000
+      batch_send_deadline = "5s"
+      min_backoff = "30ms"
+      max_backoff = "5s"
+      retry_on_http_429 = true
+      sample_age_limit = "0s"
+    }
+  }
+
+  wal {
+    truncate_frequency = "2h"
+    min_keepalive_time = "5m"
+    max_keepalive_time = "8h"
+  }
+  external_labels = {
+    "cluster" = "auth-integration-test",
+    "k8s_cluster_name" = "auth-integration-test",
+    destination = "prometheus-noauth",
+  }
+} // prometheus.remote_write "prometheus_noauth"
+
+// Destination: prometheus-otlp-basicauth (otlp)
+otelcol.receiver.prometheus "prometheus_otlp_basicauth" {
+  output {
+    metrics = [otelcol.processor.transform.prometheus_otlp_basicauth_scrape_normalize.input]
+  }
+} // otelcol.receiver.prometheus "prometheus_otlp_basicauth"
+
+// Repairs artifacts of the Prometheus-to-OTLP conversion performed by
+// otelcol.receiver.prometheus. Only metrics that came from a Prometheus scrape pass
+// through this component; OTLP-native telemetry enters the pipeline further down.
+otelcol.processor.transform "prometheus_otlp_basicauth_scrape_normalize" {
+  error_mode = "ignore"
+  metric_statements {
+    context = "resource"
+    statements = [
+      // The conversion sets service.name to the full Prometheus job label (e.g.
+      // "namespace/workload"). When the scrape target declares its identity explicitly
+      // with a service_name label on its own target_info metric (e.g. Grafana Beyla),
+      // prefer that value and drop the duplicate.
+      `set(attributes["service.name"], attributes["service_name"]) where attributes["service_name"] != nil and attributes["service_name"] != ""`,
+      `delete_key(attributes, "service_name") where attributes["service_name"] == attributes["service.name"]`,
+      // The same conversion turns other flat target_info labels into resource attributes.
+      // Promote them to their OpenTelemetry counterparts and drop the flat duplicates, so
+      // the OTLP endpoint does not receive two conflicting spellings of the same attribute.
+      `set(attributes["service.namespace"], attributes["service_namespace"]) where (attributes["service.namespace"] == nil or attributes["service.namespace"] == "") and attributes["service_namespace"] != nil and attributes["service_namespace"] != ""`,
+      `delete_key(attributes, "service_namespace") where attributes["service_namespace"] == attributes["service.namespace"]`,
+      `set(attributes["deployment.environment"], attributes["deployment_environment"]) where (attributes["deployment.environment"] == nil or attributes["deployment.environment"] == "") and attributes["deployment_environment"] != nil and attributes["deployment_environment"] != ""`,
+      `delete_key(attributes, "deployment_environment") where attributes["deployment_environment"] == attributes["deployment.environment"]`,
+      `set(attributes["deployment.environment.name"], attributes["deployment_environment_name"]) where (attributes["deployment.environment.name"] == nil or attributes["deployment.environment.name"] == "") and attributes["deployment_environment_name"] != nil and attributes["deployment_environment_name"] != ""`,
+      `delete_key(attributes, "deployment_environment_name") where attributes["deployment_environment_name"] == attributes["deployment.environment.name"]`,
+    ]
+  }
+  metric_statements {
+    context = "datapoint"
+    statements = [
+      // Same correction for scrape targets that put service_name on every series
+      // instead of exposing a target_info metric.
+      `set(resource.attributes["service.name"], attributes["service_name"]) where attributes["service_name"] != nil and attributes["service_name"] != ""`,
+    ]
+  }
+  output {
+    metrics = [otelcol.processor.attributes.prometheus_otlp_basicauth.input]
+  }
+} // otelcol.processor.transform "prometheus_otlp_basicauth_scrape_normalize"
+otelcol.processor.attributes "prometheus_otlp_basicauth" {
+  action {
+    key = "destination"
+    action = "upsert"
+    value = "prometheus-otlp-basicauth"
+  }
+  output {
+    metrics = [otelcol.processor.transform.prometheus_otlp_basicauth.input]
+  }
+} // otelcol.processor.attributes "prometheus_otlp_basicauth"
+
+otelcol.processor.transform "prometheus_otlp_basicauth" {
+  error_mode = "ignore"
+  metric_statements {
+    context = "resource"
+    statements = [
+      `set(attributes["cluster"], "auth-integration-test")`,
+      `set(attributes["k8s.cluster.name"], "auth-integration-test")`,
+      `delete_key(attributes, "process.pid")`,
+      `delete_key(attributes, "process.parent_pid")`,
+      `delete_key(attributes, "process.executable.path")`,
+      `delete_key(attributes, "process.command_line")`,
+      `delete_key(attributes, "process.command_args")`,
+      `delete_key(attributes, "process.owner")`,
+      `delete_key(attributes, "process.runtime.version")`,
+      `delete_key(attributes, "process.runtime.description")`,
+      `delete_key(attributes, "host.ip")`,
+      `delete_key(attributes, "host.mac")`,
+      `delete_key(attributes, "k8s.pod.start_time")`,
+      `delete_key(attributes, "k8s.pod.uid")`,
+      `delete_key(attributes, "container.image.id")`,
+      `delete_key(attributes, "container.image.repo_digests")`,
+      `delete_key(attributes, "os.description")`,
+      `delete_key(attributes, "os.build_id")`,
+      // Scrape targets that expose their own target_info metric (e.g. Grafana Beyla) can
+      // carry a flat k8s_cluster_name resource attribute, which conflicts with the
+      // k8s.cluster.name attribute set above and gets ";"-joined by the Prometheus OTLP
+      // endpoint. Drop the flat copy when the values match.
+      `delete_key(attributes, "k8s_cluster_name") where attributes["k8s_cluster_name"] == attributes["k8s.cluster.name"]`,
+    ]
+  }
+
+  metric_statements {
+    context = "datapoint"
+    statements = [
+      `set(attributes["cluster"], "auth-integration-test")`,
+      `set(attributes["k8s.cluster.name"], "auth-integration-test")`,
+      `set(resource.attributes["deployment.environment"], attributes["deployment_environment"] ) where resource.attributes["deployment.environment"] == nil and attributes["deployment_environment"] != nil`,
+      `delete_key(attributes, "deployment_environment") where attributes["deployment_environment"] == resource.attributes["deployment.environment"]`,
+      `set(resource.attributes["deployment.environment.name"], attributes["deployment_environment_name"] ) where resource.attributes["deployment.environment.name"] == nil and attributes["deployment_environment_name"] != nil`,
+      `delete_key(attributes, "deployment_environment_name") where attributes["deployment_environment_name"] == resource.attributes["deployment.environment.name"]`,
+      `set(resource.attributes["service.name"], attributes["service_name"] ) where (resource.attributes["service.name"] == nil or resource.attributes["service.name"] == "") and attributes["service_name"] != nil and attributes["service_name"] != ""`,
+      `delete_key(attributes, "service_name") where attributes["service_name"] == resource.attributes["service.name"]`,
+      `set(resource.attributes["service.namespace"], attributes["service_namespace"] ) where (resource.attributes["service.namespace"] == nil or resource.attributes["service.namespace"] == "") and attributes["service_namespace"] != nil and attributes["service_namespace"] != ""`,
+      `delete_key(attributes, "service_namespace") where attributes["service_namespace"] == resource.attributes["service.namespace"]`,
+    ]
+  }
+
+  output {
+    metrics = [otelcol.processor.batch.prometheus_otlp_basicauth.input]
+  }
+} // otelcol.processor.transform "prometheus_otlp_basicauth"
+
+otelcol.processor.batch "prometheus_otlp_basicauth" {
+  timeout = "2s"
+  send_batch_size = 8192
+  send_batch_max_size = 0
+
+  output {
+    metrics = [otelcol.exporter.otlphttp.prometheus_otlp_basicauth.input]
+  }
+} // otelcol.processor.batch "prometheus_otlp_basicauth"
+otelcol.exporter.otlphttp "prometheus_otlp_basicauth" {
+  client {
+    endpoint = "http://nginx-auth-gateway.default.svc/metrics/basic/api/v1/otlp"
+    auth = otelcol.auth.basic.prometheus_otlp_basicauth.handler
+    tls {
+      insecure = false
+      insecure_skip_verify = false
+    }
+  }
+
+  retry_on_failure {
+    enabled = true
+    initial_interval = "5s"
+    max_interval = "30s"
+    max_elapsed_time = "5m"
+  }
+
+  sending_queue {
+    enabled = true
+  }
+} // otelcol.exporter.otlphttp "prometheus_otlp_basicauth"
+
+otelcol.auth.basic "prometheus_otlp_basicauth" {
+  username = convert.nonsensitive(remote.kubernetes.secret.prometheus_otlp_basicauth.data["username"])
+  password = remote.kubernetes.secret.prometheus_otlp_basicauth.data["password"]
+} // otelcol.auth.basic "prometheus_otlp_basicauth"
+
+remote.kubernetes.secret "prometheus_otlp_basicauth" {
+  name      = "prometheus-otlp-basicauth-k8smon-k8s-monitoring"
+  namespace = "default"
+} // remote.kubernetes.secret "prometheus_otlp_basicauth"
+
+
+// Destination: prometheus-otlp-bearer-token (otlp)
+otelcol.receiver.prometheus "prometheus_otlp_bearer_token" {
+  output {
+    metrics = [otelcol.processor.transform.prometheus_otlp_bearer_token_scrape_normalize.input]
+  }
+} // otelcol.receiver.prometheus "prometheus_otlp_bearer_token"
+
+// Repairs artifacts of the Prometheus-to-OTLP conversion performed by
+// otelcol.receiver.prometheus. Only metrics that came from a Prometheus scrape pass
+// through this component; OTLP-native telemetry enters the pipeline further down.
+otelcol.processor.transform "prometheus_otlp_bearer_token_scrape_normalize" {
+  error_mode = "ignore"
+  metric_statements {
+    context = "resource"
+    statements = [
+      // The conversion sets service.name to the full Prometheus job label (e.g.
+      // "namespace/workload"). When the scrape target declares its identity explicitly
+      // with a service_name label on its own target_info metric (e.g. Grafana Beyla),
+      // prefer that value and drop the duplicate.
+      `set(attributes["service.name"], attributes["service_name"]) where attributes["service_name"] != nil and attributes["service_name"] != ""`,
+      `delete_key(attributes, "service_name") where attributes["service_name"] == attributes["service.name"]`,
+      // The same conversion turns other flat target_info labels into resource attributes.
+      // Promote them to their OpenTelemetry counterparts and drop the flat duplicates, so
+      // the OTLP endpoint does not receive two conflicting spellings of the same attribute.
+      `set(attributes["service.namespace"], attributes["service_namespace"]) where (attributes["service.namespace"] == nil or attributes["service.namespace"] == "") and attributes["service_namespace"] != nil and attributes["service_namespace"] != ""`,
+      `delete_key(attributes, "service_namespace") where attributes["service_namespace"] == attributes["service.namespace"]`,
+      `set(attributes["deployment.environment"], attributes["deployment_environment"]) where (attributes["deployment.environment"] == nil or attributes["deployment.environment"] == "") and attributes["deployment_environment"] != nil and attributes["deployment_environment"] != ""`,
+      `delete_key(attributes, "deployment_environment") where attributes["deployment_environment"] == attributes["deployment.environment"]`,
+      `set(attributes["deployment.environment.name"], attributes["deployment_environment_name"]) where (attributes["deployment.environment.name"] == nil or attributes["deployment.environment.name"] == "") and attributes["deployment_environment_name"] != nil and attributes["deployment_environment_name"] != ""`,
+      `delete_key(attributes, "deployment_environment_name") where attributes["deployment_environment_name"] == attributes["deployment.environment.name"]`,
+    ]
+  }
+  metric_statements {
+    context = "datapoint"
+    statements = [
+      // Same correction for scrape targets that put service_name on every series
+      // instead of exposing a target_info metric.
+      `set(resource.attributes["service.name"], attributes["service_name"]) where attributes["service_name"] != nil and attributes["service_name"] != ""`,
+    ]
+  }
+  output {
+    metrics = [otelcol.processor.attributes.prometheus_otlp_bearer_token.input]
+  }
+} // otelcol.processor.transform "prometheus_otlp_bearer_token_scrape_normalize"
+otelcol.processor.attributes "prometheus_otlp_bearer_token" {
+  action {
+    key = "destination"
+    action = "upsert"
+    value = "prometheus-otlp-bearer-token"
+  }
+  output {
+    metrics = [otelcol.processor.transform.prometheus_otlp_bearer_token.input]
+  }
+} // otelcol.processor.attributes "prometheus_otlp_bearer_token"
+
+otelcol.processor.transform "prometheus_otlp_bearer_token" {
+  error_mode = "ignore"
+  metric_statements {
+    context = "resource"
+    statements = [
+      `set(attributes["cluster"], "auth-integration-test")`,
+      `set(attributes["k8s.cluster.name"], "auth-integration-test")`,
+      `delete_key(attributes, "process.pid")`,
+      `delete_key(attributes, "process.parent_pid")`,
+      `delete_key(attributes, "process.executable.path")`,
+      `delete_key(attributes, "process.command_line")`,
+      `delete_key(attributes, "process.command_args")`,
+      `delete_key(attributes, "process.owner")`,
+      `delete_key(attributes, "process.runtime.version")`,
+      `delete_key(attributes, "process.runtime.description")`,
+      `delete_key(attributes, "host.ip")`,
+      `delete_key(attributes, "host.mac")`,
+      `delete_key(attributes, "k8s.pod.start_time")`,
+      `delete_key(attributes, "k8s.pod.uid")`,
+      `delete_key(attributes, "container.image.id")`,
+      `delete_key(attributes, "container.image.repo_digests")`,
+      `delete_key(attributes, "os.description")`,
+      `delete_key(attributes, "os.build_id")`,
+      // Scrape targets that expose their own target_info metric (e.g. Grafana Beyla) can
+      // carry a flat k8s_cluster_name resource attribute, which conflicts with the
+      // k8s.cluster.name attribute set above and gets ";"-joined by the Prometheus OTLP
+      // endpoint. Drop the flat copy when the values match.
+      `delete_key(attributes, "k8s_cluster_name") where attributes["k8s_cluster_name"] == attributes["k8s.cluster.name"]`,
+    ]
+  }
+
+  metric_statements {
+    context = "datapoint"
+    statements = [
+      `set(attributes["cluster"], "auth-integration-test")`,
+      `set(attributes["k8s.cluster.name"], "auth-integration-test")`,
+      `set(resource.attributes["deployment.environment"], attributes["deployment_environment"] ) where resource.attributes["deployment.environment"] == nil and attributes["deployment_environment"] != nil`,
+      `delete_key(attributes, "deployment_environment") where attributes["deployment_environment"] == resource.attributes["deployment.environment"]`,
+      `set(resource.attributes["deployment.environment.name"], attributes["deployment_environment_name"] ) where resource.attributes["deployment.environment.name"] == nil and attributes["deployment_environment_name"] != nil`,
+      `delete_key(attributes, "deployment_environment_name") where attributes["deployment_environment_name"] == resource.attributes["deployment.environment.name"]`,
+      `set(resource.attributes["service.name"], attributes["service_name"] ) where (resource.attributes["service.name"] == nil or resource.attributes["service.name"] == "") and attributes["service_name"] != nil and attributes["service_name"] != ""`,
+      `delete_key(attributes, "service_name") where attributes["service_name"] == resource.attributes["service.name"]`,
+      `set(resource.attributes["service.namespace"], attributes["service_namespace"] ) where (resource.attributes["service.namespace"] == nil or resource.attributes["service.namespace"] == "") and attributes["service_namespace"] != nil and attributes["service_namespace"] != ""`,
+      `delete_key(attributes, "service_namespace") where attributes["service_namespace"] == resource.attributes["service.namespace"]`,
+    ]
+  }
+
+  output {
+    metrics = [otelcol.processor.batch.prometheus_otlp_bearer_token.input]
+  }
+} // otelcol.processor.transform "prometheus_otlp_bearer_token"
+
+otelcol.processor.batch "prometheus_otlp_bearer_token" {
+  timeout = "2s"
+  send_batch_size = 8192
+  send_batch_max_size = 0
+
+  output {
+    metrics = [otelcol.exporter.otlphttp.prometheus_otlp_bearer_token.input]
+  }
+} // otelcol.processor.batch "prometheus_otlp_bearer_token"
+otelcol.exporter.otlphttp "prometheus_otlp_bearer_token" {
+  client {
+    endpoint = "http://nginx-auth-gateway.default.svc/metrics/bearer/api/v1/otlp"
+    auth = otelcol.auth.bearer.prometheus_otlp_bearer_token.handler
+    tls {
+      insecure = false
+      insecure_skip_verify = false
+    }
+  }
+
+  retry_on_failure {
+    enabled = true
+    initial_interval = "5s"
+    max_interval = "30s"
+    max_elapsed_time = "5m"
+  }
+
+  sending_queue {
+    enabled = true
+  }
+} // otelcol.exporter.otlphttp "prometheus_otlp_bearer_token"
+
+otelcol.auth.bearer "prometheus_otlp_bearer_token" {
+  token = remote.kubernetes.secret.prometheus_otlp_bearer_token.data["bearerToken"]
+} // otelcol.auth.bearer "prometheus_otlp_bearer_token"
+
+remote.kubernetes.secret "prometheus_otlp_bearer_token" {
+  name      = "prometheus-otlp-bearer-token-k8smon-k8s-monitoring"
+  namespace = "default"
+} // remote.kubernetes.secret "prometheus_otlp_bearer_token"
+
+
+// Destination: prometheus-otlp-noauth (otlp)
+otelcol.receiver.prometheus "prometheus_otlp_noauth" {
+  output {
+    metrics = [otelcol.processor.transform.prometheus_otlp_noauth_scrape_normalize.input]
+  }
+} // otelcol.receiver.prometheus "prometheus_otlp_noauth"
+
+// Repairs artifacts of the Prometheus-to-OTLP conversion performed by
+// otelcol.receiver.prometheus. Only metrics that came from a Prometheus scrape pass
+// through this component; OTLP-native telemetry enters the pipeline further down.
+otelcol.processor.transform "prometheus_otlp_noauth_scrape_normalize" {
+  error_mode = "ignore"
+  metric_statements {
+    context = "resource"
+    statements = [
+      // The conversion sets service.name to the full Prometheus job label (e.g.
+      // "namespace/workload"). When the scrape target declares its identity explicitly
+      // with a service_name label on its own target_info metric (e.g. Grafana Beyla),
+      // prefer that value and drop the duplicate.
+      `set(attributes["service.name"], attributes["service_name"]) where attributes["service_name"] != nil and attributes["service_name"] != ""`,
+      `delete_key(attributes, "service_name") where attributes["service_name"] == attributes["service.name"]`,
+      // The same conversion turns other flat target_info labels into resource attributes.
+      // Promote them to their OpenTelemetry counterparts and drop the flat duplicates, so
+      // the OTLP endpoint does not receive two conflicting spellings of the same attribute.
+      `set(attributes["service.namespace"], attributes["service_namespace"]) where (attributes["service.namespace"] == nil or attributes["service.namespace"] == "") and attributes["service_namespace"] != nil and attributes["service_namespace"] != ""`,
+      `delete_key(attributes, "service_namespace") where attributes["service_namespace"] == attributes["service.namespace"]`,
+      `set(attributes["deployment.environment"], attributes["deployment_environment"]) where (attributes["deployment.environment"] == nil or attributes["deployment.environment"] == "") and attributes["deployment_environment"] != nil and attributes["deployment_environment"] != ""`,
+      `delete_key(attributes, "deployment_environment") where attributes["deployment_environment"] == attributes["deployment.environment"]`,
+      `set(attributes["deployment.environment.name"], attributes["deployment_environment_name"]) where (attributes["deployment.environment.name"] == nil or attributes["deployment.environment.name"] == "") and attributes["deployment_environment_name"] != nil and attributes["deployment_environment_name"] != ""`,
+      `delete_key(attributes, "deployment_environment_name") where attributes["deployment_environment_name"] == attributes["deployment.environment.name"]`,
+    ]
+  }
+  metric_statements {
+    context = "datapoint"
+    statements = [
+      // Same correction for scrape targets that put service_name on every series
+      // instead of exposing a target_info metric.
+      `set(resource.attributes["service.name"], attributes["service_name"]) where attributes["service_name"] != nil and attributes["service_name"] != ""`,
+    ]
+  }
+  output {
+    metrics = [otelcol.processor.attributes.prometheus_otlp_noauth.input]
+  }
+} // otelcol.processor.transform "prometheus_otlp_noauth_scrape_normalize"
+otelcol.processor.attributes "prometheus_otlp_noauth" {
+  action {
+    key = "destination"
+    action = "upsert"
+    value = "prometheus-otlp-noauth"
+  }
+  output {
+    metrics = [otelcol.processor.transform.prometheus_otlp_noauth.input]
+  }
+} // otelcol.processor.attributes "prometheus_otlp_noauth"
+
+otelcol.processor.transform "prometheus_otlp_noauth" {
+  error_mode = "ignore"
+  metric_statements {
+    context = "resource"
+    statements = [
+      `set(attributes["cluster"], "auth-integration-test")`,
+      `set(attributes["k8s.cluster.name"], "auth-integration-test")`,
+      `delete_key(attributes, "process.pid")`,
+      `delete_key(attributes, "process.parent_pid")`,
+      `delete_key(attributes, "process.executable.path")`,
+      `delete_key(attributes, "process.command_line")`,
+      `delete_key(attributes, "process.command_args")`,
+      `delete_key(attributes, "process.owner")`,
+      `delete_key(attributes, "process.runtime.version")`,
+      `delete_key(attributes, "process.runtime.description")`,
+      `delete_key(attributes, "host.ip")`,
+      `delete_key(attributes, "host.mac")`,
+      `delete_key(attributes, "k8s.pod.start_time")`,
+      `delete_key(attributes, "k8s.pod.uid")`,
+      `delete_key(attributes, "container.image.id")`,
+      `delete_key(attributes, "container.image.repo_digests")`,
+      `delete_key(attributes, "os.description")`,
+      `delete_key(attributes, "os.build_id")`,
+      // Scrape targets that expose their own target_info metric (e.g. Grafana Beyla) can
+      // carry a flat k8s_cluster_name resource attribute, which conflicts with the
+      // k8s.cluster.name attribute set above and gets ";"-joined by the Prometheus OTLP
+      // endpoint. Drop the flat copy when the values match.
+      `delete_key(attributes, "k8s_cluster_name") where attributes["k8s_cluster_name"] == attributes["k8s.cluster.name"]`,
+    ]
+  }
+
+  metric_statements {
+    context = "datapoint"
+    statements = [
+      `set(attributes["cluster"], "auth-integration-test")`,
+      `set(attributes["k8s.cluster.name"], "auth-integration-test")`,
+      `set(resource.attributes["deployment.environment"], attributes["deployment_environment"] ) where resource.attributes["deployment.environment"] == nil and attributes["deployment_environment"] != nil`,
+      `delete_key(attributes, "deployment_environment") where attributes["deployment_environment"] == resource.attributes["deployment.environment"]`,
+      `set(resource.attributes["deployment.environment.name"], attributes["deployment_environment_name"] ) where resource.attributes["deployment.environment.name"] == nil and attributes["deployment_environment_name"] != nil`,
+      `delete_key(attributes, "deployment_environment_name") where attributes["deployment_environment_name"] == resource.attributes["deployment.environment.name"]`,
+      `set(resource.attributes["service.name"], attributes["service_name"] ) where (resource.attributes["service.name"] == nil or resource.attributes["service.name"] == "") and attributes["service_name"] != nil and attributes["service_name"] != ""`,
+      `delete_key(attributes, "service_name") where attributes["service_name"] == resource.attributes["service.name"]`,
+      `set(resource.attributes["service.namespace"], attributes["service_namespace"] ) where (resource.attributes["service.namespace"] == nil or resource.attributes["service.namespace"] == "") and attributes["service_namespace"] != nil and attributes["service_namespace"] != ""`,
+      `delete_key(attributes, "service_namespace") where attributes["service_namespace"] == resource.attributes["service.namespace"]`,
+    ]
+  }
+
+  output {
+    metrics = [otelcol.processor.batch.prometheus_otlp_noauth.input]
+  }
+} // otelcol.processor.transform "prometheus_otlp_noauth"
+
+otelcol.processor.batch "prometheus_otlp_noauth" {
+  timeout = "2s"
+  send_batch_size = 8192
+  send_batch_max_size = 0
+
+  output {
+    metrics = [otelcol.exporter.otlphttp.prometheus_otlp_noauth.input]
+  }
+} // otelcol.processor.batch "prometheus_otlp_noauth"
+otelcol.exporter.otlphttp "prometheus_otlp_noauth" {
+  client {
+    endpoint = "http://prometheus-server.prometheus.svc:9090/api/v1/otlp"
+    tls {
+      insecure = false
+      insecure_skip_verify = false
+    }
+  }
+
+  retry_on_failure {
+    enabled = true
+    initial_interval = "5s"
+    max_interval = "30s"
+    max_elapsed_time = "5m"
+  }
+
+  sending_queue {
+    enabled = true
+  }
+} // otelcol.exporter.otlphttp "prometheus_otlp_noauth"
+

--- a/charts/k8s-monitoring/tests/integration/auto-instrumentation/.rendered/alloy-metrics.alloy
+++ b/charts/k8s-monitoring/tests/integration/auto-instrumentation/.rendered/alloy-metrics.alloy
@@ -1,0 +1,108 @@
+// Feature: Auto-Instrumentation
+declare "auto_instrumentation" {
+  argument "metrics_destinations" {
+    comment = "Must be a list of metric destinations where collected metrics should be forwarded to"
+  }
+
+  discovery.kubernetes "beyla_pods" {
+    role = "pod"
+    namespaces {
+      own_namespace = true
+    }
+    selectors {
+      role = "pod"
+      label = "app.kubernetes.io/name=beyla"
+    }
+  } // discovery.kubernetes "beyla_pods"
+
+  discovery.relabel "beyla_pods" {
+    targets = discovery.kubernetes.beyla_pods.targets
+    rule {
+      source_labels = ["__meta_kubernetes_pod_node_name"]
+      action = "replace"
+      target_label = "instance"
+    }
+  } // discovery.relabel "beyla_pods"
+
+  prometheus.scrape "beyla_applications" {
+    targets         = discovery.relabel.beyla_pods.output
+    honor_labels    = true
+    scrape_interval = "60s"
+    scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
+    scrape_classic_histograms = false
+    scrape_native_histograms = false
+    convert_classic_histograms_to_nhcb = false
+    clustering {
+      enabled = true
+    }
+    forward_to = argument.metrics_destinations.value
+  } // prometheus.scrape "beyla_applications"
+
+  prometheus.scrape "beyla_internal" {
+    targets         = discovery.relabel.beyla_pods.output
+    metrics_path    = "/internal/metrics"
+    job_name        = "integrations/beyla"
+    honor_labels    = true
+    scrape_interval = "60s"
+    scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
+    scrape_classic_histograms = false
+    scrape_native_histograms = false
+    convert_classic_histograms_to_nhcb = false
+    clustering {
+      enabled = true
+    }
+    forward_to = argument.metrics_destinations.value
+  } // prometheus.relabel "beyla"
+} // declare "auto_instrumentation"
+auto_instrumentation "feature" {
+  metrics_destinations = [
+    prometheus.remote_write.localprometheus.receiver,
+  ]
+}
+
+
+
+
+
+// Destination: localPrometheus (prometheus)
+otelcol.exporter.prometheus "localprometheus" {
+  add_metric_suffixes = true
+  resource_to_telemetry_conversion = false
+  keep_identifying_resource_attributes = true
+  forward_to = [prometheus.remote_write.localprometheus.receiver]
+} // otelcol.exporter.prometheus "localprometheus"
+
+prometheus.remote_write "localprometheus" {
+  endpoint {
+    url = "http://prometheus-server.prometheus.svc:9090/api/v1/write"
+    headers = {
+    }
+    tls_config {
+      insecure_skip_verify = false
+    }
+    send_native_histograms = false
+
+    queue_config {
+      capacity = 10000
+      min_shards = 1
+      max_shards = 50
+      max_samples_per_send = 2000
+      batch_send_deadline = "5s"
+      min_backoff = "30ms"
+      max_backoff = "5s"
+      retry_on_http_429 = true
+      sample_age_limit = "0s"
+    }
+  }
+
+  wal {
+    truncate_frequency = "2h"
+    min_keepalive_time = "5m"
+    max_keepalive_time = "8h"
+  }
+  external_labels = {
+    "cluster" = "auto-instrumentation-test",
+    "k8s_cluster_name" = "auto-instrumentation-test",
+  }
+} // prometheus.remote_write "localprometheus"
+

--- a/charts/k8s-monitoring/tests/integration/auto-instrumentation/.rendered/alloy-receiver.alloy
+++ b/charts/k8s-monitoring/tests/integration/auto-instrumentation/.rendered/alloy-receiver.alloy
@@ -1,0 +1,329 @@
+// Feature: Application Observability
+declare "application_observability" {
+  argument "metrics_destinations" {
+    comment = "Must be a list of metrics destinations where collected metrics should be forwarded to"
+  }
+
+  argument "logs_destinations" {
+    comment = "Must be a list of log destinations where collected logs should be forwarded to"
+  }
+
+  argument "traces_destinations" {
+    comment = "Must be a list of trace destinations where collected trace should be forwarded to"
+  }
+
+  // OTLP Receiver
+  otelcol.receiver.otlp "receiver" {
+    grpc {
+      endpoint = "0.0.0.0:4317"
+      include_metadata = false
+      max_recv_msg_size = "4MiB"
+      read_buffer_size = "512KiB"
+      write_buffer_size = "32KiB"
+    }
+    debug_metrics {
+      disable_high_cardinality_metrics = true
+    }
+    output {
+      metrics = [otelcol.processor.resourcedetection.default.input]
+      logs = [otelcol.processor.resourcedetection.default.input]
+      traces = [otelcol.processor.resourcedetection.default.input]
+    }
+  } // otelcol.receiver.otlp "receiver"
+
+  // Resource Detection Processor
+  otelcol.processor.resourcedetection "default" {
+    detectors = ["env","system"]
+    override = true
+
+    system {
+      hostname_sources = ["os"]
+    }
+
+    output {
+      metrics = [otelcol.processor.k8sattributes.default.input]
+      logs = [otelcol.processor.k8sattributes.default.input]
+      traces = [otelcol.processor.k8sattributes.default.input]
+    }
+  }
+
+  // K8s Attributes Processor
+  otelcol.processor.k8sattributes "default" {
+    passthrough = false
+    extract {
+      metadata = ["k8s.namespace.name","k8s.pod.name","k8s.deployment.name","k8s.statefulset.name","k8s.daemonset.name","k8s.cronjob.name","k8s.job.name","k8s.node.name","k8s.pod.uid","k8s.pod.start_time"]
+    }
+    pod_association {
+      source {
+        from = "resource_attribute"
+        name = "k8s.pod.ip"
+      }
+    }
+    pod_association {
+      source {
+        from = "resource_attribute"
+        name = "k8s.pod.uid"
+      }
+    }
+    pod_association {
+      source {
+        from = "connection"
+      }
+    }
+
+    output {
+      metrics = [otelcol.processor.transform.default.input]
+      logs = [otelcol.processor.transform.default.input]
+      traces = [otelcol.processor.transform.default.input, otelcol.connector.host_info.default.input]
+    }
+  }
+
+  // Host Info Connector
+  otelcol.connector.host_info "default" {
+    host_identifiers = [ "k8s.node.name" ]
+
+    output {
+      metrics = [otelcol.processor.batch.default.input]
+    }
+  }
+
+  // Transform Processor
+  otelcol.processor.transform "default" {
+    error_mode = "ignore"
+    log_statements {
+      context = "resource"
+      statements = [
+        "set(attributes[\"pod\"], attributes[\"k8s.pod.name\"])",
+        "set(attributes[\"namespace\"], attributes[\"k8s.namespace.name\"])",
+        "set(attributes[\"loki.resource.labels\"], \"cluster, namespace, job, pod\")",
+      ]
+    }
+    trace_statements {
+      context = "span"
+      statements = [
+       "set_semconv_span_name(\"1.37.0\", \"original_span_name\")",
+      ]
+    }
+
+    output {
+      metrics = [otelcol.processor.batch.default.input]
+      logs = [otelcol.processor.batch.default.input]
+      traces = [otelcol.processor.batch.default.input]
+    }
+  }
+
+  // Batch Processor
+  otelcol.processor.batch "default" {
+    send_batch_size = 8192
+    send_batch_max_size = 0
+    timeout = "2s"
+
+    output {
+      metrics = argument.metrics_destinations.value
+      logs = argument.logs_destinations.value
+      traces = argument.traces_destinations.value
+    }
+  }
+} // declare "application_observability"
+application_observability "feature" {
+  metrics_destinations = [
+    otelcol.exporter.prometheus.localprometheus.input,
+  ]
+  logs_destinations = [
+    otelcol.exporter.loki.localloki.input,
+  ]
+  traces_destinations = [
+    otelcol.processor.attributes.localtempo.input,
+  ]
+}
+// Self Reporting
+prometheus.exporter.unix "kubernetes_monitoring_telemetry" {
+  set_collectors = ["textfile"]
+  textfile {
+    directory = "/etc/release-info"
+  }
+} // prometheus.exporter.unix "kubernetes_monitoring_telemetry"
+
+discovery.relabel "kubernetes_monitoring_telemetry" {
+  targets = prometheus.exporter.unix.kubernetes_monitoring_telemetry.targets
+  rule {
+    target_label = "instance"
+    action = "replace"
+    replacement = "k8smon"
+  }
+  rule {
+    target_label = "job"
+    action = "replace"
+    replacement = "integrations/kubernetes/kubernetes_monitoring_telemetry"
+  }
+} // discovery.relabel "kubernetes_monitoring_telemetry"
+
+prometheus.scrape "kubernetes_monitoring_telemetry" {
+  job_name   = "integrations/kubernetes/kubernetes_monitoring_telemetry"
+  targets    = discovery.relabel.kubernetes_monitoring_telemetry.output
+  scrape_interval = "60s"
+  clustering {
+    enabled = true
+  }
+  forward_to = [prometheus.relabel.kubernetes_monitoring_telemetry.receiver]
+} // prometheus.scrape "kubernetes_monitoring_telemetry"
+
+prometheus.relabel "kubernetes_monitoring_telemetry" {
+  rule {
+    source_labels = ["__name__"]
+    regex = "grafana_kubernetes_monitoring_.*"
+    action = "keep"
+  }
+  forward_to = [
+    prometheus.remote_write.localprometheus.receiver,
+  ]
+} // prometheus.relabel "kubernetes_monitoring_telemetry"
+
+
+
+
+
+// Destination: localLoki (loki)
+otelcol.exporter.loki "localloki" {
+  forward_to = [loki.write.localloki.receiver]
+} // otelcol.exporter.loki "localloki"
+
+loki.write "localloki" {
+  endpoint {
+    url = "http://loki.loki.svc:3100/loki/api/v1/push"
+    retry_on_http_429 = true
+    tenant_id = convert.nonsensitive(remote.kubernetes.secret.localloki.data["tenantId"])
+    basic_auth {
+      username = convert.nonsensitive(remote.kubernetes.secret.localloki.data["username"])
+      password = remote.kubernetes.secret.localloki.data["password"]
+    }
+    tls_config {
+      insecure_skip_verify = false
+    }
+    min_backoff_period = "500ms"
+    max_backoff_period = "5m"
+    max_backoff_retries = "10"
+  }
+  external_labels = {
+    "cluster" = "auto-instrumentation-test",
+    "k8s_cluster_name" = "auto-instrumentation-test",
+  }
+} // loki.write "localloki"
+
+remote.kubernetes.secret "localloki" {
+  name      = "localloki-k8smon-k8s-monitoring"
+  namespace = "default"
+} // remote.kubernetes.secret "localloki"
+
+
+// Destination: localPrometheus (prometheus)
+otelcol.exporter.prometheus "localprometheus" {
+  add_metric_suffixes = true
+  resource_to_telemetry_conversion = false
+  keep_identifying_resource_attributes = true
+  forward_to = [prometheus.remote_write.localprometheus.receiver]
+} // otelcol.exporter.prometheus "localprometheus"
+
+prometheus.remote_write "localprometheus" {
+  endpoint {
+    url = "http://prometheus-server.prometheus.svc:9090/api/v1/write"
+    headers = {
+    }
+    tls_config {
+      insecure_skip_verify = false
+    }
+    send_native_histograms = false
+
+    queue_config {
+      capacity = 10000
+      min_shards = 1
+      max_shards = 50
+      max_samples_per_send = 2000
+      batch_send_deadline = "5s"
+      min_backoff = "30ms"
+      max_backoff = "5s"
+      retry_on_http_429 = true
+      sample_age_limit = "0s"
+    }
+  }
+
+  wal {
+    truncate_frequency = "2h"
+    min_keepalive_time = "5m"
+    max_keepalive_time = "8h"
+  }
+  external_labels = {
+    "cluster" = "auto-instrumentation-test",
+    "k8s_cluster_name" = "auto-instrumentation-test",
+  }
+} // prometheus.remote_write "localprometheus"
+
+// Destination: localTempo (otlp)
+otelcol.processor.attributes "localtempo" {
+  output {
+    traces = [otelcol.processor.transform.localtempo.input]
+  }
+} // otelcol.processor.attributes "localtempo"
+
+otelcol.processor.transform "localtempo" {
+  error_mode = "ignore"
+
+  trace_statements {
+    context = "resource"
+    statements = [
+      `set(attributes["cluster"], "auto-instrumentation-test")`,
+      `set(attributes["k8s.cluster.name"], "auto-instrumentation-test")`,
+      `delete_key(attributes, "process.pid")`,
+      `delete_key(attributes, "process.parent_pid")`,
+      `delete_key(attributes, "process.executable.path")`,
+      `delete_key(attributes, "process.command_line")`,
+      `delete_key(attributes, "process.command_args")`,
+      `delete_key(attributes, "process.owner")`,
+      `delete_key(attributes, "process.runtime.version")`,
+      `delete_key(attributes, "process.runtime.description")`,
+      `delete_key(attributes, "host.ip")`,
+      `delete_key(attributes, "host.mac")`,
+      `delete_key(attributes, "k8s.pod.start_time")`,
+      `delete_key(attributes, "k8s.pod.uid")`,
+      `delete_key(attributes, "container.image.id")`,
+      `delete_key(attributes, "container.image.repo_digests")`,
+      `delete_key(attributes, "os.description")`,
+      `delete_key(attributes, "os.build_id")`,
+    ]
+  }
+
+  output {
+    traces = [otelcol.processor.batch.localtempo.input]
+  }
+} // otelcol.processor.transform "localtempo"
+
+otelcol.processor.batch "localtempo" {
+  timeout = "2s"
+  send_batch_size = 8192
+  send_batch_max_size = 0
+
+  output {
+    traces = [otelcol.exporter.otlp.localtempo.input]
+  }
+} // otelcol.processor.batch "localtempo"
+otelcol.exporter.otlp "localtempo" {
+  client {
+    endpoint = "tempo.tempo.svc:4317"
+    tls {
+      insecure = true
+      insecure_skip_verify = true
+    }
+  }
+
+  retry_on_failure {
+    enabled = true
+    initial_interval = "5s"
+    max_interval = "30s"
+    max_elapsed_time = "5m"
+  }
+
+  sending_queue {
+    enabled = true
+  }
+} // otelcol.exporter.otlp "localtempo"
+

--- a/charts/k8s-monitoring/tests/integration/cluster-monitoring/.rendered/alloy-logs.alloy
+++ b/charts/k8s-monitoring/tests/integration/cluster-monitoring/.rendered/alloy-logs.alloy
@@ -1,0 +1,236 @@
+// Feature: Pod Logs (Loki)
+declare "pod_logs_via_loki" {
+  argument "logs_destinations" {
+    comment = "Must be a list of log destinations where collected logs should be forwarded to"
+  }
+
+  discovery.kubernetes "pods" {
+    role = "pod"
+    selectors {
+      role = "pod"
+      field = "spec.nodeName=" + sys.env("HOSTNAME")
+    }
+  } // discovery.kubernetes "pods"
+
+  discovery.relabel "filtered_pods" {
+    targets = discovery.kubernetes.pods.targets
+    rule {
+      source_labels = ["__meta_kubernetes_namespace"]
+      action = "replace"
+      target_label = "namespace"
+    }
+    rule {  // Drop anything with a "falsy" annotation value
+      source_labels = ["__meta_kubernetes_pod_annotation_logs_grafana_com_pods_enabled"]
+      regex = "(false|no|skip)"
+      action = "drop"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_pod_name"]
+      target_label = "pod"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_pod_container_name"]
+      target_label = "container"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_namespace", "__meta_kubernetes_pod_container_name"]
+      separator = "/"
+      replacement = "$1"
+      target_label = "job"
+    }
+
+    // set the container runtime as a label
+    rule {
+      source_labels = ["__meta_kubernetes_pod_container_id"]
+      regex = "^(\\S+):\\/\\/.+$"
+      replacement = "$1"
+      target_label = "tmp_container_runtime"
+    }
+    // explicitly set service_name. if not set, loki will automatically try to populate a default.
+    // see https://grafana.com/docs/loki/latest/get-started/labels/#default-labels-for-all-users
+    //
+    // choose the first value found from the following ordered list:
+    // - pod.annotation[resource.opentelemetry.io/service.name]
+    // - pod.label[app.kubernetes.io/name]
+    // - k8s.container.name
+    rule {
+      source_labels = [
+        "__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_name",
+        "__meta_kubernetes_pod_label_app_kubernetes_io_name",
+        "__meta_kubernetes_pod_container_name",
+      ]
+      separator = ";"
+      regex = "^(?:;*)?([^;]+).*$"
+      replacement = "$1"
+      target_label = "service_name"
+    }
+
+    // explicitly set service_namespace.
+    //
+    // choose the first value found from the following ordered list:
+    // - pod.annotation[resource.opentelemetry.io/service.namespace]
+    // - pod.namespace
+    rule {
+      source_labels = [
+        "__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_namespace",
+        "namespace",
+      ]
+      separator = ";"
+      regex = "^(?:;*)?([^;]+).*$"
+      replacement = "$1"
+      target_label = "service_namespace"
+    }
+
+    // explicitly set service_instance_id.
+    //
+    // choose the first value found from the following ordered list:
+    // - pod.annotation[resource.opentelemetry.io/service.instance.id]
+    // - concat([k8s.namespace.name, k8s.pod.name, k8s.container.name], '.')
+    rule {
+      source_labels = ["__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_instance_id"]
+      target_label = "service_instance_id"
+    }
+    rule {
+      source_labels = ["service_instance_id", "namespace", "pod", "container"]
+      separator = "."
+      regex = "^\\.([^.]+\\.[^.]+\\.[^.]+)$"
+      target_label = "service_instance_id"
+    }
+
+    // set resource attributes
+    rule {
+      action = "labelmap"
+      regex = "__meta_kubernetes_pod_annotation_resource_opentelemetry_io_(.+)"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_job"]
+      regex = "(.+)"
+      target_label = "job"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+      regex = "(.+)"
+      target_label = "app_kubernetes_io_name"
+    }
+
+    // Set the pod log path.
+    rule {
+      source_labels = ["__meta_kubernetes_pod_uid", "__meta_kubernetes_pod_container_name"]
+      separator = "/"
+      replacement = "/var/log/pods/*$1/*.log"
+      target_label = "__path__"
+    }
+
+    // If kubernetes.io/config.mirror is set, this is a static pod, created by the kubelet.
+    // It's logs live on a different path.
+    rule {
+      source_labels = ["__meta_kubernetes_pod_annotation_kubernetes_io_config_mirror", "__meta_kubernetes_pod_container_name"]
+      separator = "/"
+      regex = "(.+/.+)"
+      replacement = "/var/log/pods/*$1/*.log"
+      target_label = "__path__"
+    }
+  } // discovery.relabel "filtered_pods"
+
+  local.file_match "pod_logs" {
+    path_targets = discovery.relabel.filtered_pods.output
+  } // local.file_match "pod_logs"
+
+  loki.source.file "pod_logs" {
+    targets    = local.file_match.pod_logs.targets
+    tail_from_end = true
+    forward_to = [loki.process.pod_logs.receiver]
+  } // loki.source.file "pod_logs"
+
+  loki.process "pod_logs" {
+    stage.match {
+      selector = "{tmp_container_runtime=~\"containerd|cri-o|\"}"
+      // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
+      stage.cri {
+        max_partial_lines = 100
+      }
+
+      // Set the extract flags and stream values as labels
+      stage.labels {
+        values = {
+          flags  = "",
+          stream  = "",
+        }
+      }
+    }
+
+    stage.match {
+      selector = "{tmp_container_runtime=\"docker\"}"
+      // the docker processing stage extracts the following k/v pairs: log, stream, time
+      stage.docker {}
+
+      // Set the extract stream value as a label
+      stage.labels {
+        values = {
+          stream  = "",
+        }
+      }
+    }
+
+    // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
+    // namespace, pod, and container labels. Drop any structured metadata. Also drop the temporary
+    // container runtime label as it is no longer needed.
+    stage.label_drop {
+      values = [
+        "filename",
+        "tmp_container_runtime",
+      ]
+    }
+    stage.structured_metadata {
+      values = {
+        "k8s_pod_name" = "k8s_pod_name",
+        "pod" = "pod",
+        "service_instance_id" = "service_instance_id",
+      }
+    }
+
+    forward_to = argument.logs_destinations.value
+  } // loki.secretfilter "pod_logs"
+} // declare "pod_logs_via_loki"
+pod_logs_via_loki "feature" {
+  logs_destinations = [
+    loki.write.localloki.receiver,
+  ]
+}
+
+
+
+
+
+// Destination: localLoki (loki)
+otelcol.exporter.loki "localloki" {
+  forward_to = [loki.write.localloki.receiver]
+} // otelcol.exporter.loki "localloki"
+
+loki.write "localloki" {
+  endpoint {
+    url = "http://loki.loki.svc:3100/loki/api/v1/push"
+    retry_on_http_429 = true
+    tenant_id = convert.nonsensitive(remote.kubernetes.secret.localloki.data["tenantId"])
+    basic_auth {
+      username = convert.nonsensitive(remote.kubernetes.secret.localloki.data["username"])
+      password = remote.kubernetes.secret.localloki.data["password"]
+    }
+    tls_config {
+      insecure_skip_verify = false
+    }
+    min_backoff_period = "500ms"
+    max_backoff_period = "5m"
+    max_backoff_retries = "10"
+  }
+  external_labels = {
+    "cluster" = "cluster-monitoring-feature-test",
+    "k8s_cluster_name" = "cluster-monitoring-feature-test",
+  }
+} // loki.write "localloki"
+
+remote.kubernetes.secret "localloki" {
+  name      = "localloki-k8smon-k8s-monitoring"
+  namespace = "default"
+} // remote.kubernetes.secret "localloki"
+

--- a/charts/k8s-monitoring/tests/integration/cluster-monitoring/.rendered/alloy-metrics.alloy
+++ b/charts/k8s-monitoring/tests/integration/cluster-monitoring/.rendered/alloy-metrics.alloy
@@ -1,0 +1,615 @@
+// Feature: Cluster Metrics
+declare "cluster_metrics" {
+  argument "metrics_destinations" {
+    comment = "Must be a list of metric destinations where collected metrics should be forwarded to"
+  }
+  discovery.kubernetes "nodes" {
+    role = "node"
+  } // discovery.kubernetes "nodes"
+
+  discovery.relabel "nodes" {
+    targets = discovery.kubernetes.nodes.targets
+    rule {
+      source_labels = ["__meta_kubernetes_node_name"]
+      target_label  = "node"
+    }
+
+    rule {
+      replacement = "kubernetes"
+      target_label = "source"
+    }
+  } // discovery.relabel "nodes"
+
+  // Kubelet
+  discovery.relabel "kubelet" {
+    targets = discovery.relabel.nodes.output
+  } // discovery.relabel "kubelet"
+
+  prometheus.scrape "kubelet" {
+    targets  = discovery.relabel.kubelet.output
+    job_name = "integrations/kubernetes/kubelet"
+    scheme   = "https"
+    scrape_interval = "60s"
+    scrape_timeout = "10s"
+    scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
+    scrape_classic_histograms = false
+    scrape_native_histograms = false
+    convert_classic_histograms_to_nhcb = false
+    bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+
+    tls_config {
+      ca_file = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+      insecure_skip_verify = true
+      server_name = "kubernetes"
+    }
+
+    clustering {
+      enabled = true
+    }
+
+    forward_to = [prometheus.relabel.kubelet.receiver]
+  } // prometheus.scrape "kubelet"
+
+  prometheus.relabel "kubelet" {
+    max_cache_size = 100000
+    rule {
+      source_labels = ["__name__"]
+      regex = "up|scrape_samples_scraped|go_goroutines|kubelet_certificate_manager_client_expiration_renew_errors|kubelet_certificate_manager_client_ttl_seconds|kubelet_certificate_manager_server_ttl_seconds|kubelet_cgroup_manager_duration_seconds_bucket|kubelet_cgroup_manager_duration_seconds_count|kubelet_node_config_error|kubelet_node_name|kubelet_pleg_relist_duration_seconds_bucket|kubelet_pleg_relist_duration_seconds_count|kubelet_pleg_relist_interval_seconds_bucket|kubelet_pod_start_duration_seconds_bucket|kubelet_pod_start_duration_seconds_count|kubelet_pod_worker_duration_seconds_bucket|kubelet_pod_worker_duration_seconds_count|kubelet_running_container_count|kubelet_running_containers|kubelet_running_pod_count|kubelet_running_pods|kubelet_runtime_operations_errors_total|kubelet_runtime_operations_total|kubelet_server_expiration_renew_errors|kubelet_volume_stats_available_bytes|kubelet_volume_stats_capacity_bytes|kubelet_volume_stats_inodes|kubelet_volume_stats_inodes_free|kubelet_volume_stats_inodes_used|kubelet_volume_stats_used_bytes|kubernetes_build_info|namespace_workload_pod|process_cpu_seconds_total|process_resident_memory_bytes|rest_client_requests_total|storage_operation_duration_seconds_count|storage_operation_errors_total|volume_manager_total_volumes"
+      action = "keep"
+    }
+
+    forward_to = argument.metrics_destinations.value
+  } // prometheus.relabel "kubelet"
+
+  // Kubelet Resources
+  discovery.relabel "kubelet_resources" {
+    targets = discovery.relabel.nodes.output
+    rule {
+      replacement   = "/metrics/resource"
+      target_label  = "__metrics_path__"
+    }
+  } // discovery.relabel "kubelet_resources"
+
+  prometheus.scrape "kubelet_resources" {
+    targets = discovery.relabel.kubelet_resources.output
+    job_name = "integrations/kubernetes/resources"
+    scheme   = "https"
+    scrape_interval = "60s"
+    scrape_timeout = "10s"
+    scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
+    scrape_classic_histograms = false
+    scrape_native_histograms = false
+    convert_classic_histograms_to_nhcb = false
+    bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+
+    tls_config {
+      ca_file = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+      insecure_skip_verify = true
+      server_name = "kubernetes"
+    }
+
+    clustering {
+      enabled = true
+    }
+
+    forward_to = [prometheus.relabel.kubelet_resources.receiver]
+  } // prometheus.scrape "kubelet_resources"
+
+  prometheus.relabel "kubelet_resources" {
+    max_cache_size = 100000
+    rule {
+      source_labels = ["__name__"]
+      regex = "up|scrape_samples_scraped|node_cpu_usage_seconds_total|node_memory_working_set_bytes"
+      action = "keep"
+    }
+
+    forward_to = argument.metrics_destinations.value
+  } // prometheus.relabel "kubelet_resources"
+
+  // cAdvisor
+  discovery.relabel "cadvisor" {
+    targets = discovery.relabel.nodes.output
+    rule {
+      replacement   = "/metrics/cadvisor"
+      target_label  = "__metrics_path__"
+    }
+  } // discovery.relabel "cadvisor"
+
+  prometheus.scrape "cadvisor" {
+    targets = discovery.relabel.cadvisor.output
+    job_name = "integrations/kubernetes/cadvisor"
+    scheme = "https"
+    scrape_interval = "60s"
+    scrape_timeout = "10s"
+    scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
+    scrape_classic_histograms = false
+    scrape_native_histograms = false
+    convert_classic_histograms_to_nhcb = false
+    bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+
+    tls_config {
+      ca_file = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+      insecure_skip_verify = true
+      server_name = "kubernetes"
+    }
+
+    clustering {
+      enabled = true
+    }
+
+    forward_to = [prometheus.relabel.cadvisor.receiver]
+  } // prometheus.scrape "cadvisor"
+
+  prometheus.relabel "cadvisor" {
+    max_cache_size = 100000
+    rule {
+      source_labels = ["__name__"]
+      regex = "up|scrape_samples_scraped|container_cpu_cfs_periods_total|container_cpu_cfs_throttled_periods_total|container_cpu_usage_seconds_total|container_fs_reads_bytes_total|container_fs_reads_total|container_fs_writes_bytes_total|container_fs_writes_total|container_memory_cache|container_memory_rss|container_memory_swap|container_memory_usage_bytes|container_memory_working_set_bytes|container_network_receive_bytes_total|container_network_receive_packets_dropped_total|container_network_receive_packets_total|container_network_transmit_bytes_total|container_network_transmit_packets_dropped_total|container_network_transmit_packets_total|machine_memory_bytes"
+      action = "keep"
+    }
+    // Drop empty container labels, addressing https://github.com/google/cadvisor/issues/2688
+    rule {
+      source_labels = ["__name__","container"]
+      separator = "@"
+      regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_pressure_.*)@"
+      action = "drop"
+    }
+    // Drop empty image labels, addressing https://github.com/google/cadvisor/issues/2688
+    rule {
+      source_labels = ["__name__","image"]
+      separator = "@"
+      regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_network_.*|container_pressure_.*)@"
+      action = "drop"
+    }
+    // Normalizing unimportant labels (not deleting to continue satisfying <label>!="" checks)
+    rule {
+      source_labels = ["__name__", "boot_id"]
+      separator = "@"
+      regex = "machine_memory_bytes@.*"
+      target_label = "boot_id"
+      replacement = "NA"
+    }
+    rule {
+      source_labels = ["__name__", "system_uuid"]
+      separator = "@"
+      regex = "machine_memory_bytes@.*"
+      target_label = "system_uuid"
+      replacement = "NA"
+    }
+    // Filter out non-physical devices/interfaces
+    rule {
+      source_labels = ["__name__", "device"]
+      separator = "@"
+      regex = "container_fs_.*@(/dev/)?(mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dasd.+)"
+      target_label = "__keepme"
+      replacement = "1"
+    }
+    rule {
+      source_labels = ["__name__", "__keepme"]
+      separator = "@"
+      regex = "container_fs_.*@"
+      action = "drop"
+    }
+    rule {
+      source_labels = ["__name__"]
+      regex = "container_fs_.*"
+      target_label = "__keepme"
+      replacement = ""
+    }
+    rule {
+      source_labels = ["__name__", "interface"]
+      separator = "@"
+      regex = "container_network_.*@(en[ospx][0-9].*|wlan[0-9].*|eth[0-9].*)"
+      target_label = "__keepme"
+      replacement = "1"
+    }
+    rule {
+      source_labels = ["__name__", "__keepme"]
+      separator = "@"
+      regex = "container_network_.*@"
+      action = "drop"
+    }
+    rule {
+      source_labels = ["__name__"]
+      regex = "container_network_.*"
+      target_label = "__keepme"
+      replacement = ""
+    }
+    forward_to = argument.metrics_destinations.value
+  } // prometheus.relabel "cadvisor"
+  discovery.kubernetes "kube_state_metrics" {
+    role = "endpoints"
+
+    selectors {
+      role = "endpoints"
+      label = "release=k8smon,app.kubernetes.io/name=kube-state-metrics"
+    }
+    namespaces {
+      names = ["default"]
+    }
+  } // discovery.kubernetes "kube_state_metrics"
+
+  discovery.relabel "kube_state_metrics" {
+    targets = discovery.kubernetes.kube_state_metrics.targets
+
+    rule {
+      action = "replace"
+      replacement = "kubernetes"
+      target_label = "source"
+    }
+
+  } // discovery.relabel "kube_state_metrics"
+
+  prometheus.scrape "kube_state_metrics" {
+    targets = discovery.relabel.kube_state_metrics.output
+    job_name = "integrations/kubernetes/kube-state-metrics"
+    scrape_interval = "60s"
+    scrape_timeout = "10s"
+    scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
+    scrape_classic_histograms = false
+    scrape_native_histograms = false
+    convert_classic_histograms_to_nhcb = false
+    scheme = "http"
+    bearer_token_file = ""
+    tls_config {
+      insecure_skip_verify = true
+    }
+
+    clustering {
+      enabled = true
+    }
+    forward_to = [prometheus.relabel.kube_state_metrics.receiver]
+  } // prometheus.scrape "kube_state_metrics"
+
+  prometheus.relabel "kube_state_metrics" {
+    max_cache_size = 100000
+    rule {
+      source_labels = ["__name__"]
+      regex = "up|scrape_samples_scraped|kube_configmap_info|kube_configmap_metadata_resource_version|kube_cronjob.*|kube_daemonset.*|kube_deployment_metadata_generation|kube_deployment_spec_replicas|kube_deployment_status_condition|kube_deployment_status_observed_generation|kube_deployment_status_replicas_available|kube_deployment_status_replicas_updated|kube_horizontalpodautoscaler_spec_max_replicas|kube_horizontalpodautoscaler_spec_min_replicas|kube_horizontalpodautoscaler_status_current_replicas|kube_horizontalpodautoscaler_status_desired_replicas|kube_job.*|kube_namespace_status_phase|kube_node.*|kube_persistentvolume_status_phase|kube_persistentvolumeclaim_access_mode|kube_persistentvolumeclaim_info|kube_persistentvolumeclaim_labels|kube_persistentvolumeclaim_resource_requests_storage_bytes|kube_persistentvolumeclaim_status_phase|kube_pod_completion_time|kube_pod_container_info|kube_pod_container_resource_limits|kube_pod_container_resource_requests|kube_pod_container_status_last_terminated_reason|kube_pod_container_status_last_terminated_timestamp|kube_pod_container_status_restarts_total|kube_pod_container_status_waiting_reason|kube_pod_info|kube_pod_owner|kube_pod_restart_policy|kube_pod_spec_volumes_persistentvolumeclaims_info|kube_pod_start_time|kube_pod_status_phase|kube_pod_status_reason|kube_pod_init_.*|kube_replicaset.*|kube_resourcequota|kube_secret_metadata_resource_version|kube_statefulset.*"
+      action = "keep"
+    }
+    forward_to = argument.metrics_destinations.value
+  } // prometheus.relabel "kube_state_metrics"
+} // declare "cluster_metrics"
+cluster_metrics "feature" {
+  metrics_destinations = [
+    prometheus.remote_write.localprometheus.receiver,
+  ]
+}
+// Feature: Cost Metrics
+declare "cost_metrics" {
+  argument "metrics_destinations" {
+    comment = "Must be a list of metric destinations where collected metrics should be forwarded to"
+  }
+
+  discovery.kubernetes "opencost" {
+    role = "pod"
+    selectors {
+      role = "pod"
+      label = "app.kubernetes.io/instance=k8smon,app.kubernetes.io/name=opencost"
+    }
+    namespaces {
+      names = ["default"]
+    }
+  } // discovery.kubernetes "opencost"
+
+  discovery.relabel "opencost" {
+    targets = discovery.kubernetes.opencost.targets
+    rule {
+      source_labels = ["__meta_kubernetes_pod_node_name"]
+      action = "replace"
+      target_label = "instance"
+    }
+  } // discovery.relabel "opencost"
+
+  prometheus.scrape "opencost" {
+    targets      = discovery.relabel.opencost.output
+    job_name     = "integrations/opencost"
+    honor_labels = true
+    scrape_interval = "60s"
+    scrape_timeout = "10s"
+    scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
+    scrape_classic_histograms = false
+    scrape_native_histograms = false
+    convert_classic_histograms_to_nhcb = false
+    clustering {
+      enabled = true
+    }
+    forward_to = [prometheus.relabel.opencost.receiver]
+  } // prometheus.scrape "opencost"
+
+  prometheus.relabel "opencost" {
+    max_cache_size = 100000
+    rule {
+      source_labels = ["__name__"]
+      regex = "up|scrape_samples_scraped|container_cpu_allocation|container_gpu_allocation|container_memory_allocation_bytes|deployment_match_labels|kubecost_cluster_info|kubecost_cluster_management_cost|kubecost_cluster_memory_working_set_bytes|kubecost_http_requests_total|kubecost_http_response_size_bytes|kubecost_http_response_time_seconds|kubecost_load_balancer_cost|kubecost_network_internet_egress_cost|kubecost_network_region_egress_cost|kubecost_network_zone_egress_cost|kubecost_node_is_spot|node_cpu_hourly_cost|node_gpu_count|node_gpu_hourly_cost|node_ram_hourly_cost|node_total_hourly_cost|opencost_build_info|pod_pvc_allocation|pv_hourly_cost|service_selector_labels|statefulSet_match_labels"
+      action = "keep"
+    }
+    forward_to = argument.metrics_destinations.value
+  } // prometheus.relabel "opencost"
+} // declare "cost_metrics"
+cost_metrics "feature" {
+  metrics_destinations = [
+    prometheus.remote_write.localprometheus.receiver,
+  ]
+}
+// Feature: Host Metrics
+declare "host_metrics" {
+  argument "metrics_destinations" {
+    comment = "Must be a list of metric destinations where collected metrics should be forwarded to"
+  }
+
+  // Linux hosts via Node Exporter
+  discovery.kubernetes "node_exporter" {
+    role = "pod"
+    selectors {
+      role = "pod"
+      label = "release=k8smon,app.kubernetes.io/name=node-exporter"
+    }
+    namespaces {
+      names = ["default"]
+    }
+    attach_metadata {
+      node = true
+    }
+  } // discovery.kubernetes "node_exporter"
+
+  discovery.relabel "node_exporter" {
+    targets = discovery.kubernetes.node_exporter.targets
+
+    // keep only the specified metrics port name, and pods that are Running and ready
+    rule {
+      source_labels = [
+        "__meta_kubernetes_pod_container_init",
+        "__meta_kubernetes_pod_phase",
+        "__meta_kubernetes_pod_ready",
+      ]
+      separator = "@"
+      regex = "false@Running@true"
+      action = "keep"
+    }
+
+    // Set the instance label to the node name
+    rule {
+      source_labels = ["__meta_kubernetes_pod_node_name"]
+      target_label = "instance"
+    }
+
+    rule {
+      source_labels = ["__meta_kubernetes_namespace"]
+      target_label  = "namespace"
+    }
+
+    rule {
+      source_labels = ["__meta_kubernetes_pod_name"]
+      target_label  = "pod"
+    }
+
+    rule {
+      source_labels = ["__meta_kubernetes_pod_container_name"]
+      target_label  = "container"
+    }
+
+    // set a workload label
+    rule {
+      source_labels = [
+        "__meta_kubernetes_pod_controller_kind",
+        "__meta_kubernetes_pod_controller_name",
+      ]
+      separator = "/"
+      target_label  = "workload"
+    }
+    // remove the hash from the ReplicaSet
+    rule {
+      source_labels = ["workload"]
+      regex = "(ReplicaSet/.+)-.+"
+      target_label  = "workload"
+    }
+
+    // Set the app label.
+    //
+    // Choose the first value found from the following ordered list:
+    // - pod.label[app.kubernetes.io/name]
+    // - pod.label[k8s-app]
+    // - pod.label[app]
+    rule {
+      source_labels = [
+        "__meta_kubernetes_pod_label_app_kubernetes_io_name",
+        "__meta_kubernetes_pod_label_k8s_app",
+        "__meta_kubernetes_pod_label_app",
+      ]
+      separator = ";"
+      regex = "^(?:;*)?([^;]+).*$"
+      replacement = "$1"
+      target_label = "app"
+    }
+
+    // Set the component label.
+    //
+    // Choose the first value found from the following ordered list:
+    // - pod.label[app.kubernetes.io/component]
+    // - pod.label[k8s-component]
+    // - pod.label[component]
+    rule {
+      source_labels = [
+        "__meta_kubernetes_pod_label_app_kubernetes_io_component",
+        "__meta_kubernetes_pod_label_k8s_component",
+        "__meta_kubernetes_pod_label_component",
+      ]
+      regex = "^(?:;*)?([^;]+).*$"
+      replacement = "$1"
+      target_label = "component"
+    }
+
+    rule {
+      target_label = "source"
+      replacement = "kubernetes"
+    }
+    rule {
+      source_labels = [
+        "__meta_kubernetes_node_label_kubernetes_io_os",
+        "__meta_kubernetes_node_label_os_kubernetes_io",
+        "__meta_kubernetes_node_label_os",
+      ]
+      regex = "^(?:;*)?([^;]+).*$"
+      target_label = "os"
+    }
+  } // discovery.relabel "node_exporter"
+
+  prometheus.scrape "node_exporter" {
+    targets = discovery.relabel.node_exporter.output
+    job_name = "integrations/node_exporter"
+    scrape_interval = "60s"
+    scrape_timeout = "10s"
+    scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
+    scrape_classic_histograms = false
+    scrape_native_histograms = false
+    convert_classic_histograms_to_nhcb = false
+    scheme = "http"
+    tls_config {
+      insecure_skip_verify = true
+    }
+
+    clustering {
+      enabled = true
+    }
+    forward_to = [prometheus.relabel.node_exporter.receiver]
+  } // prometheus.scrape "node_exporter"
+
+  prometheus.relabel "node_exporter" {
+    max_cache_size = 100000
+    rule {
+      source_labels = ["__name__"]
+      regex = "up|scrape_samples_scraped|node_cpu.*|node_exporter_build_info|node_filesystem.*|node_memory.*|node_network_receive_bytes_total|node_network_receive_drop_total|node_network_transmit_bytes_total|node_network_transmit_drop_total|process_cpu_seconds_total|process_resident_memory_bytes"
+      action = "keep"
+    }
+    // Drop metrics for certain file systems
+    rule {
+      source_labels = ["__name__", "fstype"]
+      separator = "@"
+      regex = "node_filesystem.*@(ramfs|tmpfs)"
+      action = "drop"
+    }
+    forward_to = argument.metrics_destinations.value
+  } // prometheus.relabel "node_exporter"
+
+  // Energy metrics via Kepler
+  discovery.kubernetes "kepler" {
+    role = "pod"
+    selectors {
+      role = "pod"
+      label = "app.kubernetes.io/name=kepler"
+    }
+    namespaces {
+      names = ["default"]
+    }
+    attach_metadata {
+      node = true
+    }
+  } // discovery.kubernetes "kepler"
+
+  discovery.relabel "kepler" {
+    targets = discovery.kubernetes.kepler.targets
+    rule {
+      source_labels = ["__meta_kubernetes_pod_node_name"]
+      action = "replace"
+      target_label = "instance"
+    }
+    rule {
+      source_labels = [
+        "__meta_kubernetes_node_label_kubernetes_io_os",
+        "__meta_kubernetes_node_label_os_kubernetes_io",
+        "__meta_kubernetes_node_label_os",
+      ]
+      regex = "^(?:;*)?([^;]+).*$"
+      target_label = "os"
+    }
+  } // discovery.relabel "kepler"
+
+  prometheus.scrape "kepler" {
+    targets      = discovery.relabel.kepler.output
+    job_name     = "integrations/kepler"
+    honor_labels = true
+    scrape_interval = "60s"
+    scrape_timeout = "10s"
+    scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
+    scrape_classic_histograms = false
+    scrape_native_histograms = false
+    convert_classic_histograms_to_nhcb = false
+    clustering {
+      enabled = true
+    }
+    forward_to = [prometheus.relabel.kepler.receiver]
+  } // prometheus.scrape "kepler"
+
+  prometheus.relabel "kepler" {
+    max_cache_size = 100000
+    rule {
+      source_labels = ["__name__"]
+      regex = "up|scrape_samples_scraped|kepler_.*"
+      action = "keep"
+    }
+    forward_to = argument.metrics_destinations.value
+  } // prometheus.relabel "kepler"
+} // declare "host_metrics"
+host_metrics "feature" {
+  metrics_destinations = [
+    prometheus.remote_write.localprometheus.receiver,
+  ]
+}
+
+
+
+
+
+// Destination: localPrometheus (prometheus)
+otelcol.exporter.prometheus "localprometheus" {
+  add_metric_suffixes = true
+  resource_to_telemetry_conversion = false
+  keep_identifying_resource_attributes = true
+  forward_to = [prometheus.remote_write.localprometheus.receiver]
+} // otelcol.exporter.prometheus "localprometheus"
+
+prometheus.remote_write "localprometheus" {
+  endpoint {
+    url = "http://prometheus-server.prometheus.svc:9090/api/v1/write"
+    headers = {
+    }
+    basic_auth {
+      username = convert.nonsensitive(remote.kubernetes.secret.localprometheus.data["username"])
+      password = remote.kubernetes.secret.localprometheus.data["password"]
+    }
+    tls_config {
+      insecure_skip_verify = false
+    }
+    send_native_histograms = false
+
+    queue_config {
+      capacity = 10000
+      min_shards = 1
+      max_shards = 50
+      max_samples_per_send = 2000
+      batch_send_deadline = "5s"
+      min_backoff = "30ms"
+      max_backoff = "5s"
+      retry_on_http_429 = true
+      sample_age_limit = "0s"
+    }
+  }
+
+  wal {
+    truncate_frequency = "2h"
+    min_keepalive_time = "5m"
+    max_keepalive_time = "8h"
+  }
+  external_labels = {
+    "cluster" = "cluster-monitoring-feature-test",
+    "k8s_cluster_name" = "cluster-monitoring-feature-test",
+  }
+} // prometheus.remote_write "localprometheus"
+
+remote.kubernetes.secret "localprometheus" {
+  name      = "localprometheus-k8smon-k8s-monitoring"
+  namespace = "default"
+} // remote.kubernetes.secret "localprometheus"
+

--- a/charts/k8s-monitoring/tests/integration/cluster-monitoring/.rendered/alloy-singleton.alloy
+++ b/charts/k8s-monitoring/tests/integration/cluster-monitoring/.rendered/alloy-singleton.alloy
@@ -1,0 +1,214 @@
+// Feature: Cluster Events
+declare "cluster_events" {
+  argument "logs_destinations" {
+    comment = "Must be a list of log destinations where collected logs should be forwarded to"
+  }
+
+  loki.source.kubernetes_events "cluster_events" {
+    job_name   = "integrations/kubernetes/eventhandler"
+    log_format = "logfmt"
+    forward_to = [loki.process.cluster_events.receiver]
+  } // loki.source.kubernetes_events "cluster_events"
+
+  loki.process "cluster_events" {
+
+    // add a static source label to the logs so they can be differentiated / restricted if necessary
+    stage.static_labels {
+      values = {
+        "source" = "kubernetes-events",
+      }
+    }
+
+    // extract some of the fields from the log line, these could be used as labels, structured metadata, etc.
+    stage.logfmt {
+      mapping = {
+        "component" = "sourcecomponent", // map the sourcecomponent field to component
+        "kind" = "",
+        "level" = "type", // most events don't have a level but they do have a "type" i.e. Normal, Warning, Error, etc.
+        "name" = "",
+        "node" = "sourcehost", // map the sourcehost field to node
+        "reason" = "",
+      }
+    }
+    // set the extracted values as labels
+    stage.labels {
+      values = {
+        "kind" = "",
+        "level" = "",
+        "service_name" = "job",
+        "reason" = "reason",
+      }
+    }
+
+    // if kind=Node, set the node label by copying the name field
+    stage.match {
+      selector = "{kind=\"Node\"}"
+
+      stage.labels {
+        values = {
+          "node" = "name",
+        }
+      }
+    }
+
+    // set the level extracted key value as a normalized log level
+    stage.match {
+      selector = "{level=\"Normal\"}"
+
+      stage.static_labels {
+        values = {
+          level = "Info",
+        }
+      }
+    }
+    stage.structured_metadata {
+      values = {
+        "name" = "name",
+        "node" = "node",
+      }
+    }
+
+    // Drop pipeline-only labels that are not needed in the final output.
+    stage.label_drop {
+      values = ["kind"]
+    }
+
+    forward_to = argument.logs_destinations.value
+  } // loki.process "cluster_events"
+} // declare "cluster_events"
+cluster_events "feature" {
+  logs_destinations = [
+    loki.write.localloki.receiver,
+  ]
+}
+// Self Reporting
+prometheus.exporter.unix "kubernetes_monitoring_telemetry" {
+  set_collectors = ["textfile"]
+  textfile {
+    directory = "/etc/release-info"
+  }
+} // prometheus.exporter.unix "kubernetes_monitoring_telemetry"
+
+discovery.relabel "kubernetes_monitoring_telemetry" {
+  targets = prometheus.exporter.unix.kubernetes_monitoring_telemetry.targets
+  rule {
+    target_label = "instance"
+    action = "replace"
+    replacement = "k8smon"
+  }
+  rule {
+    target_label = "job"
+    action = "replace"
+    replacement = "integrations/kubernetes/kubernetes_monitoring_telemetry"
+  }
+} // discovery.relabel "kubernetes_monitoring_telemetry"
+
+prometheus.scrape "kubernetes_monitoring_telemetry" {
+  job_name   = "integrations/kubernetes/kubernetes_monitoring_telemetry"
+  targets    = discovery.relabel.kubernetes_monitoring_telemetry.output
+  scrape_interval = "60s"
+  clustering {
+    enabled = true
+  }
+  forward_to = [prometheus.relabel.kubernetes_monitoring_telemetry.receiver]
+} // prometheus.scrape "kubernetes_monitoring_telemetry"
+
+prometheus.relabel "kubernetes_monitoring_telemetry" {
+  rule {
+    source_labels = ["__name__"]
+    regex = "grafana_kubernetes_monitoring_.*"
+    action = "keep"
+  }
+  forward_to = [
+    prometheus.remote_write.localprometheus.receiver,
+  ]
+} // prometheus.relabel "kubernetes_monitoring_telemetry"
+
+
+
+
+
+// Destination: localLoki (loki)
+otelcol.exporter.loki "localloki" {
+  forward_to = [loki.write.localloki.receiver]
+} // otelcol.exporter.loki "localloki"
+
+loki.write "localloki" {
+  endpoint {
+    url = "http://loki.loki.svc:3100/loki/api/v1/push"
+    retry_on_http_429 = true
+    tenant_id = convert.nonsensitive(remote.kubernetes.secret.localloki.data["tenantId"])
+    basic_auth {
+      username = convert.nonsensitive(remote.kubernetes.secret.localloki.data["username"])
+      password = remote.kubernetes.secret.localloki.data["password"]
+    }
+    tls_config {
+      insecure_skip_verify = false
+    }
+    min_backoff_period = "500ms"
+    max_backoff_period = "5m"
+    max_backoff_retries = "10"
+  }
+  external_labels = {
+    "cluster" = "cluster-monitoring-feature-test",
+    "k8s_cluster_name" = "cluster-monitoring-feature-test",
+  }
+} // loki.write "localloki"
+
+remote.kubernetes.secret "localloki" {
+  name      = "localloki-k8smon-k8s-monitoring"
+  namespace = "default"
+} // remote.kubernetes.secret "localloki"
+
+
+// Destination: localPrometheus (prometheus)
+otelcol.exporter.prometheus "localprometheus" {
+  add_metric_suffixes = true
+  resource_to_telemetry_conversion = false
+  keep_identifying_resource_attributes = true
+  forward_to = [prometheus.remote_write.localprometheus.receiver]
+} // otelcol.exporter.prometheus "localprometheus"
+
+prometheus.remote_write "localprometheus" {
+  endpoint {
+    url = "http://prometheus-server.prometheus.svc:9090/api/v1/write"
+    headers = {
+    }
+    basic_auth {
+      username = convert.nonsensitive(remote.kubernetes.secret.localprometheus.data["username"])
+      password = remote.kubernetes.secret.localprometheus.data["password"]
+    }
+    tls_config {
+      insecure_skip_verify = false
+    }
+    send_native_histograms = false
+
+    queue_config {
+      capacity = 10000
+      min_shards = 1
+      max_shards = 50
+      max_samples_per_send = 2000
+      batch_send_deadline = "5s"
+      min_backoff = "30ms"
+      max_backoff = "5s"
+      retry_on_http_429 = true
+      sample_age_limit = "0s"
+    }
+  }
+
+  wal {
+    truncate_frequency = "2h"
+    min_keepalive_time = "5m"
+    max_keepalive_time = "8h"
+  }
+  external_labels = {
+    "cluster" = "cluster-monitoring-feature-test",
+    "k8s_cluster_name" = "cluster-monitoring-feature-test",
+  }
+} // prometheus.remote_write "localprometheus"
+
+remote.kubernetes.secret "localprometheus" {
+  name      = "localprometheus-k8smon-k8s-monitoring"
+  namespace = "default"
+} // remote.kubernetes.secret "localprometheus"
+

--- a/charts/k8s-monitoring/tests/integration/control-plane-monitoring/.rendered/alloy-logs.alloy
+++ b/charts/k8s-monitoring/tests/integration/control-plane-monitoring/.rendered/alloy-logs.alloy
@@ -1,0 +1,236 @@
+// Feature: Pod Logs (Loki)
+declare "pod_logs_via_loki" {
+  argument "logs_destinations" {
+    comment = "Must be a list of log destinations where collected logs should be forwarded to"
+  }
+
+  discovery.kubernetes "pods" {
+    role = "pod"
+    selectors {
+      role = "pod"
+      field = "spec.nodeName=" + sys.env("HOSTNAME")
+    }
+  } // discovery.kubernetes "pods"
+
+  discovery.relabel "filtered_pods" {
+    targets = discovery.kubernetes.pods.targets
+    rule {
+      source_labels = ["__meta_kubernetes_namespace"]
+      action = "replace"
+      target_label = "namespace"
+    }
+    rule {  // Drop anything with a "falsy" annotation value
+      source_labels = ["__meta_kubernetes_pod_annotation_logs_grafana_com_pods_enabled"]
+      regex = "(false|no|skip)"
+      action = "drop"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_pod_name"]
+      target_label = "pod"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_pod_container_name"]
+      target_label = "container"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_namespace", "__meta_kubernetes_pod_container_name"]
+      separator = "/"
+      replacement = "$1"
+      target_label = "job"
+    }
+
+    // set the container runtime as a label
+    rule {
+      source_labels = ["__meta_kubernetes_pod_container_id"]
+      regex = "^(\\S+):\\/\\/.+$"
+      replacement = "$1"
+      target_label = "tmp_container_runtime"
+    }
+    // explicitly set service_name. if not set, loki will automatically try to populate a default.
+    // see https://grafana.com/docs/loki/latest/get-started/labels/#default-labels-for-all-users
+    //
+    // choose the first value found from the following ordered list:
+    // - pod.annotation[resource.opentelemetry.io/service.name]
+    // - pod.label[app.kubernetes.io/name]
+    // - k8s.container.name
+    rule {
+      source_labels = [
+        "__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_name",
+        "__meta_kubernetes_pod_label_app_kubernetes_io_name",
+        "__meta_kubernetes_pod_container_name",
+      ]
+      separator = ";"
+      regex = "^(?:;*)?([^;]+).*$"
+      replacement = "$1"
+      target_label = "service_name"
+    }
+
+    // explicitly set service_namespace.
+    //
+    // choose the first value found from the following ordered list:
+    // - pod.annotation[resource.opentelemetry.io/service.namespace]
+    // - pod.namespace
+    rule {
+      source_labels = [
+        "__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_namespace",
+        "namespace",
+      ]
+      separator = ";"
+      regex = "^(?:;*)?([^;]+).*$"
+      replacement = "$1"
+      target_label = "service_namespace"
+    }
+
+    // explicitly set service_instance_id.
+    //
+    // choose the first value found from the following ordered list:
+    // - pod.annotation[resource.opentelemetry.io/service.instance.id]
+    // - concat([k8s.namespace.name, k8s.pod.name, k8s.container.name], '.')
+    rule {
+      source_labels = ["__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_instance_id"]
+      target_label = "service_instance_id"
+    }
+    rule {
+      source_labels = ["service_instance_id", "namespace", "pod", "container"]
+      separator = "."
+      regex = "^\\.([^.]+\\.[^.]+\\.[^.]+)$"
+      target_label = "service_instance_id"
+    }
+
+    // set resource attributes
+    rule {
+      action = "labelmap"
+      regex = "__meta_kubernetes_pod_annotation_resource_opentelemetry_io_(.+)"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_job"]
+      regex = "(.+)"
+      target_label = "job"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+      regex = "(.+)"
+      target_label = "app_kubernetes_io_name"
+    }
+
+    // Set the pod log path.
+    rule {
+      source_labels = ["__meta_kubernetes_pod_uid", "__meta_kubernetes_pod_container_name"]
+      separator = "/"
+      replacement = "/var/log/pods/*$1/*.log"
+      target_label = "__path__"
+    }
+
+    // If kubernetes.io/config.mirror is set, this is a static pod, created by the kubelet.
+    // It's logs live on a different path.
+    rule {
+      source_labels = ["__meta_kubernetes_pod_annotation_kubernetes_io_config_mirror", "__meta_kubernetes_pod_container_name"]
+      separator = "/"
+      regex = "(.+/.+)"
+      replacement = "/var/log/pods/*$1/*.log"
+      target_label = "__path__"
+    }
+  } // discovery.relabel "filtered_pods"
+
+  local.file_match "pod_logs" {
+    path_targets = discovery.relabel.filtered_pods.output
+  } // local.file_match "pod_logs"
+
+  loki.source.file "pod_logs" {
+    targets    = local.file_match.pod_logs.targets
+    tail_from_end = true
+    forward_to = [loki.process.pod_logs.receiver]
+  } // loki.source.file "pod_logs"
+
+  loki.process "pod_logs" {
+    stage.match {
+      selector = "{tmp_container_runtime=~\"containerd|cri-o|\"}"
+      // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
+      stage.cri {
+        max_partial_lines = 100
+      }
+
+      // Set the extract flags and stream values as labels
+      stage.labels {
+        values = {
+          flags  = "",
+          stream  = "",
+        }
+      }
+    }
+
+    stage.match {
+      selector = "{tmp_container_runtime=\"docker\"}"
+      // the docker processing stage extracts the following k/v pairs: log, stream, time
+      stage.docker {}
+
+      // Set the extract stream value as a label
+      stage.labels {
+        values = {
+          stream  = "",
+        }
+      }
+    }
+
+    // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
+    // namespace, pod, and container labels. Drop any structured metadata. Also drop the temporary
+    // container runtime label as it is no longer needed.
+    stage.label_drop {
+      values = [
+        "filename",
+        "tmp_container_runtime",
+      ]
+    }
+    stage.structured_metadata {
+      values = {
+        "k8s_pod_name" = "k8s_pod_name",
+        "pod" = "pod",
+        "service_instance_id" = "service_instance_id",
+      }
+    }
+
+    forward_to = argument.logs_destinations.value
+  } // loki.secretfilter "pod_logs"
+} // declare "pod_logs_via_loki"
+pod_logs_via_loki "feature" {
+  logs_destinations = [
+    loki.write.loki.receiver,
+  ]
+}
+
+
+
+
+
+// Destination: loki (loki)
+otelcol.exporter.loki "loki" {
+  forward_to = [loki.write.loki.receiver]
+} // otelcol.exporter.loki "loki"
+
+loki.write "loki" {
+  endpoint {
+    url = "http://loki.loki.svc:3100/loki/api/v1/push"
+    retry_on_http_429 = true
+    tenant_id = convert.nonsensitive(remote.kubernetes.secret.loki.data["tenantId"])
+    basic_auth {
+      username = convert.nonsensitive(remote.kubernetes.secret.loki.data["username"])
+      password = remote.kubernetes.secret.loki.data["password"]
+    }
+    tls_config {
+      insecure_skip_verify = false
+    }
+    min_backoff_period = "500ms"
+    max_backoff_period = "5m"
+    max_backoff_retries = "10"
+  }
+  external_labels = {
+    "cluster" = "control-plane-monitoring-test",
+    "k8s_cluster_name" = "control-plane-monitoring-test",
+  }
+} // loki.write "loki"
+
+remote.kubernetes.secret "loki" {
+  name      = "loki-k8smon-k8s-monitoring"
+  namespace = "default"
+} // remote.kubernetes.secret "loki"
+

--- a/charts/k8s-monitoring/tests/integration/control-plane-monitoring/.rendered/alloy-metrics.alloy
+++ b/charts/k8s-monitoring/tests/integration/control-plane-monitoring/.rendered/alloy-metrics.alloy
@@ -1,0 +1,815 @@
+// Feature: Cluster Metrics
+declare "cluster_metrics" {
+  argument "metrics_destinations" {
+    comment = "Must be a list of metric destinations where collected metrics should be forwarded to"
+  }
+  discovery.kubernetes "nodes" {
+    role = "node"
+  } // discovery.kubernetes "nodes"
+
+  discovery.relabel "nodes" {
+    targets = discovery.kubernetes.nodes.targets
+    rule {
+      source_labels = ["__meta_kubernetes_node_name"]
+      target_label  = "node"
+    }
+
+    rule {
+      replacement = "kubernetes"
+      target_label = "source"
+    }
+  } // discovery.relabel "nodes"
+
+  // Kubelet
+  discovery.relabel "kubelet" {
+    targets = discovery.relabel.nodes.output
+  } // discovery.relabel "kubelet"
+
+  prometheus.scrape "kubelet" {
+    targets  = discovery.relabel.kubelet.output
+    job_name = "integrations/kubernetes/kubelet"
+    scheme   = "https"
+    scrape_interval = "60s"
+    scrape_timeout = "10s"
+    scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
+    scrape_classic_histograms = false
+    scrape_native_histograms = false
+    convert_classic_histograms_to_nhcb = false
+    bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+
+    tls_config {
+      ca_file = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+      insecure_skip_verify = true
+      server_name = "kubernetes"
+    }
+
+    clustering {
+      enabled = true
+    }
+
+    forward_to = [prometheus.relabel.kubelet.receiver]
+  } // prometheus.scrape "kubelet"
+
+  prometheus.relabel "kubelet" {
+    max_cache_size = 100000
+    rule {
+      source_labels = ["__name__"]
+      regex = "up|scrape_samples_scraped|go_goroutines|kubelet_certificate_manager_client_expiration_renew_errors|kubelet_certificate_manager_client_ttl_seconds|kubelet_certificate_manager_server_ttl_seconds|kubelet_cgroup_manager_duration_seconds_bucket|kubelet_cgroup_manager_duration_seconds_count|kubelet_node_config_error|kubelet_node_name|kubelet_pleg_relist_duration_seconds_bucket|kubelet_pleg_relist_duration_seconds_count|kubelet_pleg_relist_interval_seconds_bucket|kubelet_pod_start_duration_seconds_bucket|kubelet_pod_start_duration_seconds_count|kubelet_pod_worker_duration_seconds_bucket|kubelet_pod_worker_duration_seconds_count|kubelet_running_container_count|kubelet_running_containers|kubelet_running_pod_count|kubelet_running_pods|kubelet_runtime_operations_errors_total|kubelet_runtime_operations_total|kubelet_server_expiration_renew_errors|kubelet_volume_stats_available_bytes|kubelet_volume_stats_capacity_bytes|kubelet_volume_stats_inodes|kubelet_volume_stats_inodes_free|kubelet_volume_stats_inodes_used|kubelet_volume_stats_used_bytes|kubernetes_build_info|namespace_workload_pod|process_cpu_seconds_total|process_resident_memory_bytes|rest_client_requests_total|storage_operation_duration_seconds_count|storage_operation_errors_total|volume_manager_total_volumes"
+      action = "keep"
+    }
+
+    forward_to = argument.metrics_destinations.value
+  } // prometheus.relabel "kubelet"
+
+  // Kubelet Resources
+  discovery.relabel "kubelet_resources" {
+    targets = discovery.relabel.nodes.output
+    rule {
+      replacement   = "/metrics/resource"
+      target_label  = "__metrics_path__"
+    }
+  } // discovery.relabel "kubelet_resources"
+
+  prometheus.scrape "kubelet_resources" {
+    targets = discovery.relabel.kubelet_resources.output
+    job_name = "integrations/kubernetes/resources"
+    scheme   = "https"
+    scrape_interval = "60s"
+    scrape_timeout = "10s"
+    scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
+    scrape_classic_histograms = false
+    scrape_native_histograms = false
+    convert_classic_histograms_to_nhcb = false
+    bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+
+    tls_config {
+      ca_file = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+      insecure_skip_verify = true
+      server_name = "kubernetes"
+    }
+
+    clustering {
+      enabled = true
+    }
+
+    forward_to = [prometheus.relabel.kubelet_resources.receiver]
+  } // prometheus.scrape "kubelet_resources"
+
+  prometheus.relabel "kubelet_resources" {
+    max_cache_size = 100000
+    rule {
+      source_labels = ["__name__"]
+      regex = "up|scrape_samples_scraped|node_cpu_usage_seconds_total|node_memory_working_set_bytes"
+      action = "keep"
+    }
+
+    forward_to = argument.metrics_destinations.value
+  } // prometheus.relabel "kubelet_resources"
+
+  // Kubelet Probes
+  discovery.relabel "kubelet_probes" {
+    targets = discovery.relabel.nodes.output
+    rule {
+      replacement   = "/metrics/probes"
+      target_label  = "__metrics_path__"
+    }
+  } // discovery.relabel "kubelet_probes"
+
+  prometheus.scrape "kubelet_probes" {
+    targets  = discovery.relabel.kubelet_probes.output
+    job_name = "integrations/kubernetes/probes"
+    scheme   = "https"
+    scrape_interval = "60s"
+    scrape_timeout = "10s"
+    scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
+    scrape_classic_histograms = false
+    scrape_native_histograms = false
+    convert_classic_histograms_to_nhcb = false
+    bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+
+    tls_config {
+      ca_file = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+      insecure_skip_verify = true
+      server_name = "kubernetes"
+    }
+
+    clustering {
+      enabled = true
+    }
+
+    forward_to = [prometheus.relabel.kubelet_probes.receiver]
+  } // prometheus.scrape "kubelet_probes"
+
+  prometheus.relabel "kubelet_probes" {
+    max_cache_size = 100000
+    rule {
+      source_labels = ["__name__"]
+      regex = "up|scrape_samples_scraped|prober_.*|.*"
+      action = "keep"
+    }
+
+    forward_to = argument.metrics_destinations.value
+  } // prometheus.relabel "kubelet_probes"
+
+  // cAdvisor
+  discovery.relabel "cadvisor" {
+    targets = discovery.relabel.nodes.output
+    rule {
+      replacement   = "/metrics/cadvisor"
+      target_label  = "__metrics_path__"
+    }
+  } // discovery.relabel "cadvisor"
+
+  prometheus.scrape "cadvisor" {
+    targets = discovery.relabel.cadvisor.output
+    job_name = "integrations/kubernetes/cadvisor"
+    scheme = "https"
+    scrape_interval = "60s"
+    scrape_timeout = "10s"
+    scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
+    scrape_classic_histograms = false
+    scrape_native_histograms = false
+    convert_classic_histograms_to_nhcb = false
+    bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+
+    tls_config {
+      ca_file = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+      insecure_skip_verify = true
+      server_name = "kubernetes"
+    }
+
+    clustering {
+      enabled = true
+    }
+
+    forward_to = [prometheus.relabel.cadvisor.receiver]
+  } // prometheus.scrape "cadvisor"
+
+  prometheus.relabel "cadvisor" {
+    max_cache_size = 100000
+    rule {
+      source_labels = ["__name__"]
+      regex = "up|scrape_samples_scraped|container_cpu_cfs_periods_total|container_cpu_cfs_throttled_periods_total|container_cpu_usage_seconds_total|container_fs_reads_bytes_total|container_fs_reads_total|container_fs_writes_bytes_total|container_fs_writes_total|container_memory_cache|container_memory_rss|container_memory_swap|container_memory_usage_bytes|container_memory_working_set_bytes|container_network_receive_bytes_total|container_network_receive_packets_dropped_total|container_network_receive_packets_total|container_network_transmit_bytes_total|container_network_transmit_packets_dropped_total|container_network_transmit_packets_total|machine_memory_bytes"
+      action = "keep"
+    }
+    // Drop empty container labels, addressing https://github.com/google/cadvisor/issues/2688
+    rule {
+      source_labels = ["__name__","container"]
+      separator = "@"
+      regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_pressure_.*)@"
+      action = "drop"
+    }
+    // Drop empty image labels, addressing https://github.com/google/cadvisor/issues/2688
+    rule {
+      source_labels = ["__name__","image"]
+      separator = "@"
+      regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_network_.*|container_pressure_.*)@"
+      action = "drop"
+    }
+    // Normalizing unimportant labels (not deleting to continue satisfying <label>!="" checks)
+    rule {
+      source_labels = ["__name__", "boot_id"]
+      separator = "@"
+      regex = "machine_memory_bytes@.*"
+      target_label = "boot_id"
+      replacement = "NA"
+    }
+    rule {
+      source_labels = ["__name__", "system_uuid"]
+      separator = "@"
+      regex = "machine_memory_bytes@.*"
+      target_label = "system_uuid"
+      replacement = "NA"
+    }
+    // Filter out non-physical devices/interfaces
+    rule {
+      source_labels = ["__name__", "device"]
+      separator = "@"
+      regex = "container_fs_.*@(/dev/)?(mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dasd.+)"
+      target_label = "__keepme"
+      replacement = "1"
+    }
+    rule {
+      source_labels = ["__name__", "__keepme"]
+      separator = "@"
+      regex = "container_fs_.*@"
+      action = "drop"
+    }
+    rule {
+      source_labels = ["__name__"]
+      regex = "container_fs_.*"
+      target_label = "__keepme"
+      replacement = ""
+    }
+    rule {
+      source_labels = ["__name__", "interface"]
+      separator = "@"
+      regex = "container_network_.*@(en[ospx][0-9].*|wlan[0-9].*|eth[0-9].*)"
+      target_label = "__keepme"
+      replacement = "1"
+    }
+    rule {
+      source_labels = ["__name__", "__keepme"]
+      separator = "@"
+      regex = "container_network_.*@"
+      action = "drop"
+    }
+    rule {
+      source_labels = ["__name__"]
+      regex = "container_network_.*"
+      target_label = "__keepme"
+      replacement = ""
+    }
+    forward_to = argument.metrics_destinations.value
+  } // prometheus.relabel "cadvisor"
+
+  discovery.kubernetes "apiserver" {
+    role = "endpointslice"
+
+    selectors {
+      role = "endpointslice"
+      label = "kubernetes.io/service-name=kubernetes"
+    }
+
+    namespaces {
+      names = ["default"]
+    }
+  } // discovery.kubernetes "apiserver"
+
+  discovery.relabel "apiserver" {
+    targets = discovery.kubernetes.apiserver.targets
+
+    rule {
+      source_labels = ["__meta_kubernetes_endpointslice_port_name"]
+      regex = "https"
+      action = "keep"
+    }
+
+    rule {
+      source_labels = ["__meta_kubernetes_namespace"]
+      target_label = "namespace"
+    }
+
+    rule {
+      source_labels = ["__meta_kubernetes_service_name"]
+      target_label = "service"
+    }
+
+    rule {
+      replacement = "kubernetes"
+      target_label = "source"
+    }
+  } // discovery.relabel "apiserver"
+
+  prometheus.scrape "apiserver" {
+    targets = discovery.relabel.apiserver.output
+    job_name = "integrations/kubernetes/kube-apiserver"
+    scheme = "https"
+    scrape_interval = "60s"
+    scrape_timeout = "10s"
+    scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
+    scrape_classic_histograms = false
+    scrape_native_histograms = false
+    convert_classic_histograms_to_nhcb = false
+    bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+
+    tls_config {
+      ca_file = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+      insecure_skip_verify = false
+      server_name = "kubernetes"
+    }
+
+    clustering {
+      enabled = true
+    }
+    forward_to = argument.metrics_destinations.value
+  } // prometheus.relabel "apiserver"
+
+  discovery.kubernetes "kube_controller_manager" {
+    role = "pod"
+    namespaces {
+      names = ["kube-system"]
+    }
+    selectors {
+      role = "pod"
+      label = "component=kube-controller-manager"
+    }
+  } // discovery.kubernetes "kube_controller_manager"
+
+  discovery.relabel "kube_controller_manager" {
+    targets = discovery.kubernetes.kube_controller_manager.targets
+    rule {
+      source_labels = ["__meta_kubernetes_pod_ip"]
+      replacement = "$1:10257"
+      target_label = "__address__"
+    }
+  } // discovery.relabel "kube_controller_manager"
+
+  prometheus.scrape "kube_controller_manager" {
+    targets           = discovery.relabel.kube_controller_manager.output
+    job_name          = "kube-controller-manager"
+    scheme            = "https"
+    scrape_interval   = "60s"
+    scrape_timeout = "10s"
+    scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
+    scrape_classic_histograms = false
+    scrape_native_histograms = false
+    convert_classic_histograms_to_nhcb = false
+    bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+    tls_config {
+      insecure_skip_verify = true
+    }
+    clustering {
+      enabled = true
+    }
+    forward_to = argument.metrics_destinations.value
+  } // prometheus.relabel "kube_controller_manager"
+
+  // KubeDNS
+  discovery.kubernetes "kube_dns" {
+    role = "endpointslice"
+    namespaces {
+      names = ["kube-system"]
+    }
+    selectors {
+      role = "endpointslice"
+      label = "kubernetes.io/service-name=kube-dns"
+    }
+  } // discovery.kubernetes "kube_dns"
+
+  discovery.relabel "kube_dns" {
+    targets = discovery.kubernetes.kube_dns.targets
+
+    // keep only the specified metrics port name, and pods that are Running and ready
+    rule {
+      source_labels = [
+        "__meta_kubernetes_pod_container_port_name",
+        "__meta_kubernetes_pod_phase",
+        "__meta_kubernetes_pod_ready",
+      ]
+      separator = "@"
+      regex = "metrics@Running@true"
+      action = "keep"
+    }
+
+    // drop any init containers
+    rule {
+      source_labels = ["__meta_kubernetes_pod_container_init"]
+      regex = "true"
+      action = "drop"
+    }
+
+    // set the namespace label
+    rule {
+      source_labels = ["__meta_kubernetes_namespace"]
+      target_label  = "namespace"
+    }
+
+    // set the pod label
+    rule {
+      source_labels = ["__meta_kubernetes_pod_name"]
+      target_label  = "pod"
+    }
+
+    // set the container label
+    rule {
+      source_labels = ["__meta_kubernetes_pod_container_name"]
+      target_label  = "container"
+    }
+
+    // set a workload label
+    rule {
+      source_labels = [
+        "__meta_kubernetes_pod_controller_kind",
+        "__meta_kubernetes_pod_controller_name",
+      ]
+      separator = "/"
+      target_label  = "workload"
+    }
+    // remove the hash from the ReplicaSet
+    rule {
+      source_labels = ["workload"]
+      regex = "(ReplicaSet/.+)-.+"
+      target_label  = "workload"
+    }
+
+    // set the app name if specified as metadata labels "app:" or "app.kubernetes.io/name:" or "k8s-app:"
+    rule {
+      action = "replace"
+      source_labels = [
+        "__meta_kubernetes_pod_label_app_kubernetes_io_name",
+        "__meta_kubernetes_pod_label_k8s_app",
+        "__meta_kubernetes_pod_label_app",
+      ]
+      separator = ";"
+      regex = "^(?:;*)?([^;]+).*$"
+      replacement = "$1"
+      target_label = "app"
+    }
+
+    // set the service label
+    rule {
+      source_labels = ["__meta_kubernetes_service_name"]
+      target_label  = "service"
+    }
+
+    // set a source label
+    rule {
+      action = "replace"
+      replacement = "kubernetes"
+      target_label = "source"
+    }
+  } // discovery.relabel "kube_dns"
+
+  prometheus.scrape "kube_dns" {
+    targets = discovery.relabel.kube_dns.output
+    job_name = "integrations/kubernetes/kube-dns"
+    scheme = "http"
+    scrape_interval = "60s"
+    scrape_timeout = "10s"
+    scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
+    scrape_classic_histograms = false
+    scrape_native_histograms = false
+    convert_classic_histograms_to_nhcb = false
+    clustering {
+      enabled = true
+    }
+    forward_to = argument.metrics_destinations.value
+  } // prometheus.relabel "kube_dns"
+
+  discovery.kubernetes "kube_proxy" {
+    role = "pod"
+    namespaces {
+      names = ["kube-system"]
+    }
+    selectors {
+      role = "pod"
+      label = "k8s-app=kube-proxy"
+    }
+  } // discovery.kubernetes "kube_proxy"
+
+  discovery.relabel "kube_proxy" {
+    targets = discovery.kubernetes.kube_proxy.targets
+    rule {
+      source_labels = ["__meta_kubernetes_pod_ip"]
+      replacement = "$1:10249"
+      target_label = "__address__"
+    }
+  } // discovery.relabel "kube_proxy"
+
+  prometheus.scrape "kube_proxy" {
+    targets           = discovery.relabel.kube_proxy.output
+    job_name          = "integrations/kubernetes/kube-proxy"
+    scheme            = "http"
+    scrape_interval   = "60s"
+    scrape_timeout = "10s"
+    scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
+    scrape_classic_histograms = false
+    scrape_native_histograms = false
+    convert_classic_histograms_to_nhcb = false
+    clustering {
+      enabled = true
+    }
+    forward_to = argument.metrics_destinations.value
+  } // prometheus.relabel "kube_proxy"
+
+  discovery.kubernetes "kube_scheduler" {
+    role = "pod"
+    namespaces {
+      names = ["kube-system"]
+    }
+    selectors {
+      role = "pod"
+      label = "component=kube-scheduler"
+    }
+  } // discovery.kubernetes "kube_scheduler"
+
+  discovery.relabel "kube_scheduler" {
+    targets = discovery.kubernetes.kube_scheduler.targets
+    rule {
+      source_labels = ["__meta_kubernetes_pod_ip"]
+      replacement = "$1:10259"
+      target_label = "__address__"
+    }
+  } // discovery.relabel "kube_scheduler"
+
+  prometheus.scrape "kube_scheduler" {
+    targets           = discovery.relabel.kube_scheduler.output
+    job_name          = "kube-scheduler"
+    scheme            = "https"
+    scrape_interval   = "60s"
+    scrape_timeout = "10s"
+    scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
+    scrape_classic_histograms = false
+    scrape_native_histograms = false
+    convert_classic_histograms_to_nhcb = false
+    bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+    tls_config {
+      insecure_skip_verify = true
+    }
+    clustering {
+      enabled = true
+    }
+    forward_to = argument.metrics_destinations.value
+  } // prometheus.relabel "kube_scheduler"
+  discovery.kubernetes "kube_state_metrics" {
+    role = "endpoints"
+
+    selectors {
+      role = "endpoints"
+      label = "release=k8smon,app.kubernetes.io/name=kube-state-metrics"
+    }
+    namespaces {
+      names = ["default"]
+    }
+  } // discovery.kubernetes "kube_state_metrics"
+
+  discovery.relabel "kube_state_metrics" {
+    targets = discovery.kubernetes.kube_state_metrics.targets
+
+    rule {
+      action = "replace"
+      replacement = "kubernetes"
+      target_label = "source"
+    }
+
+  } // discovery.relabel "kube_state_metrics"
+
+  prometheus.scrape "kube_state_metrics" {
+    targets = discovery.relabel.kube_state_metrics.output
+    job_name = "integrations/kubernetes/kube-state-metrics"
+    scrape_interval = "60s"
+    scrape_timeout = "10s"
+    scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
+    scrape_classic_histograms = false
+    scrape_native_histograms = false
+    convert_classic_histograms_to_nhcb = false
+    scheme = "http"
+    bearer_token_file = ""
+    tls_config {
+      insecure_skip_verify = true
+    }
+
+    clustering {
+      enabled = true
+    }
+    forward_to = [prometheus.relabel.kube_state_metrics.receiver]
+  } // prometheus.scrape "kube_state_metrics"
+
+  prometheus.relabel "kube_state_metrics" {
+    max_cache_size = 100000
+    rule {
+      source_labels = ["__name__"]
+      regex = "up|scrape_samples_scraped|kube_configmap_info|kube_configmap_metadata_resource_version|kube_cronjob.*|kube_daemonset.*|kube_deployment_metadata_generation|kube_deployment_spec_replicas|kube_deployment_status_condition|kube_deployment_status_observed_generation|kube_deployment_status_replicas_available|kube_deployment_status_replicas_updated|kube_horizontalpodautoscaler_spec_max_replicas|kube_horizontalpodautoscaler_spec_min_replicas|kube_horizontalpodautoscaler_status_current_replicas|kube_horizontalpodautoscaler_status_desired_replicas|kube_job.*|kube_namespace_status_phase|kube_node.*|kube_persistentvolume_status_phase|kube_persistentvolumeclaim_access_mode|kube_persistentvolumeclaim_info|kube_persistentvolumeclaim_labels|kube_persistentvolumeclaim_resource_requests_storage_bytes|kube_persistentvolumeclaim_status_phase|kube_pod_completion_time|kube_pod_container_info|kube_pod_container_resource_limits|kube_pod_container_resource_requests|kube_pod_container_status_last_terminated_reason|kube_pod_container_status_last_terminated_timestamp|kube_pod_container_status_restarts_total|kube_pod_container_status_waiting_reason|kube_pod_info|kube_pod_owner|kube_pod_restart_policy|kube_pod_spec_volumes_persistentvolumeclaims_info|kube_pod_start_time|kube_pod_status_phase|kube_pod_status_reason|kube_pod_init_.*|kube_replicaset.*|kube_resourcequota|kube_secret_metadata_resource_version|kube_statefulset.*"
+      action = "keep"
+    }
+    forward_to = argument.metrics_destinations.value
+  } // prometheus.relabel "kube_state_metrics"
+} // declare "cluster_metrics"
+cluster_metrics "feature" {
+  metrics_destinations = [
+    prometheus.remote_write.prometheus.receiver,
+  ]
+}
+// Feature: Host Metrics
+declare "host_metrics" {
+  argument "metrics_destinations" {
+    comment = "Must be a list of metric destinations where collected metrics should be forwarded to"
+  }
+
+  // Linux hosts via Node Exporter
+  discovery.kubernetes "node_exporter" {
+    role = "pod"
+    selectors {
+      role = "pod"
+      label = "release=k8smon,app.kubernetes.io/name=node-exporter"
+    }
+    namespaces {
+      names = ["default"]
+    }
+
+  } // discovery.kubernetes "node_exporter"
+
+  discovery.relabel "node_exporter" {
+    targets = discovery.kubernetes.node_exporter.targets
+
+    // keep only the specified metrics port name, and pods that are Running and ready
+    rule {
+      source_labels = [
+        "__meta_kubernetes_pod_container_init",
+        "__meta_kubernetes_pod_phase",
+        "__meta_kubernetes_pod_ready",
+      ]
+      separator = "@"
+      regex = "false@Running@true"
+      action = "keep"
+    }
+
+    // Set the instance label to the node name
+    rule {
+      source_labels = ["__meta_kubernetes_pod_node_name"]
+      target_label = "instance"
+    }
+
+    rule {
+      source_labels = ["__meta_kubernetes_namespace"]
+      target_label  = "namespace"
+    }
+
+    rule {
+      source_labels = ["__meta_kubernetes_pod_name"]
+      target_label  = "pod"
+    }
+
+    rule {
+      source_labels = ["__meta_kubernetes_pod_container_name"]
+      target_label  = "container"
+    }
+
+    // set a workload label
+    rule {
+      source_labels = [
+        "__meta_kubernetes_pod_controller_kind",
+        "__meta_kubernetes_pod_controller_name",
+      ]
+      separator = "/"
+      target_label  = "workload"
+    }
+    // remove the hash from the ReplicaSet
+    rule {
+      source_labels = ["workload"]
+      regex = "(ReplicaSet/.+)-.+"
+      target_label  = "workload"
+    }
+
+    // Set the app label.
+    //
+    // Choose the first value found from the following ordered list:
+    // - pod.label[app.kubernetes.io/name]
+    // - pod.label[k8s-app]
+    // - pod.label[app]
+    rule {
+      source_labels = [
+        "__meta_kubernetes_pod_label_app_kubernetes_io_name",
+        "__meta_kubernetes_pod_label_k8s_app",
+        "__meta_kubernetes_pod_label_app",
+      ]
+      separator = ";"
+      regex = "^(?:;*)?([^;]+).*$"
+      replacement = "$1"
+      target_label = "app"
+    }
+
+    // Set the component label.
+    //
+    // Choose the first value found from the following ordered list:
+    // - pod.label[app.kubernetes.io/component]
+    // - pod.label[k8s-component]
+    // - pod.label[component]
+    rule {
+      source_labels = [
+        "__meta_kubernetes_pod_label_app_kubernetes_io_component",
+        "__meta_kubernetes_pod_label_k8s_component",
+        "__meta_kubernetes_pod_label_component",
+      ]
+      regex = "^(?:;*)?([^;]+).*$"
+      replacement = "$1"
+      target_label = "component"
+    }
+
+    rule {
+      target_label = "source"
+      replacement = "kubernetes"
+    }
+
+  } // discovery.relabel "node_exporter"
+
+  prometheus.scrape "node_exporter" {
+    targets = discovery.relabel.node_exporter.output
+    job_name = "integrations/node_exporter"
+    scrape_interval = "60s"
+    scrape_timeout = "10s"
+    scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
+    scrape_classic_histograms = false
+    scrape_native_histograms = false
+    convert_classic_histograms_to_nhcb = false
+    scheme = "http"
+    tls_config {
+      insecure_skip_verify = true
+    }
+
+    clustering {
+      enabled = true
+    }
+    forward_to = [prometheus.relabel.node_exporter.receiver]
+  } // prometheus.scrape "node_exporter"
+
+  prometheus.relabel "node_exporter" {
+    max_cache_size = 100000
+    rule {
+      source_labels = ["__name__"]
+      regex = "up|scrape_samples_scraped|node_cpu.*|node_exporter_build_info|node_filesystem.*|node_memory.*|node_network_receive_bytes_total|node_network_receive_drop_total|node_network_transmit_bytes_total|node_network_transmit_drop_total|process_cpu_seconds_total|process_resident_memory_bytes"
+      action = "keep"
+    }
+    // Drop metrics for certain file systems
+    rule {
+      source_labels = ["__name__", "fstype"]
+      separator = "@"
+      regex = "node_filesystem.*@(ramfs|tmpfs)"
+      action = "drop"
+    }
+    forward_to = argument.metrics_destinations.value
+  } // prometheus.relabel "node_exporter"
+} // declare "host_metrics"
+host_metrics "feature" {
+  metrics_destinations = [
+    prometheus.remote_write.prometheus.receiver,
+  ]
+}
+
+
+
+
+
+// Destination: prometheus (prometheus)
+otelcol.exporter.prometheus "prometheus" {
+  add_metric_suffixes = true
+  resource_to_telemetry_conversion = false
+  keep_identifying_resource_attributes = true
+  forward_to = [prometheus.remote_write.prometheus.receiver]
+} // otelcol.exporter.prometheus "prometheus"
+
+prometheus.remote_write "prometheus" {
+  endpoint {
+    url = "http://prometheus-server.prometheus.svc:9090/api/v1/write"
+    headers = {
+    }
+    tls_config {
+      insecure_skip_verify = false
+    }
+    send_native_histograms = false
+
+    queue_config {
+      capacity = 10000
+      min_shards = 1
+      max_shards = 50
+      max_samples_per_send = 2000
+      batch_send_deadline = "5s"
+      min_backoff = "30ms"
+      max_backoff = "5s"
+      retry_on_http_429 = true
+      sample_age_limit = "0s"
+    }
+  }
+
+  wal {
+    truncate_frequency = "2h"
+    min_keepalive_time = "5m"
+    max_keepalive_time = "8h"
+  }
+  external_labels = {
+    "cluster" = "control-plane-monitoring-test",
+    "k8s_cluster_name" = "control-plane-monitoring-test",
+  }
+} // prometheus.remote_write "prometheus"
+

--- a/charts/k8s-monitoring/tests/integration/control-plane-monitoring/.rendered/alloy-singleton.alloy
+++ b/charts/k8s-monitoring/tests/integration/control-plane-monitoring/.rendered/alloy-singleton.alloy
@@ -1,0 +1,205 @@
+// Feature: Cluster Events
+declare "cluster_events" {
+  argument "logs_destinations" {
+    comment = "Must be a list of log destinations where collected logs should be forwarded to"
+  }
+
+  loki.source.kubernetes_events "cluster_events" {
+    job_name   = "integrations/kubernetes/eventhandler"
+    log_format = "logfmt"
+    forward_to = [loki.process.cluster_events.receiver]
+  } // loki.source.kubernetes_events "cluster_events"
+
+  loki.process "cluster_events" {
+
+    // add a static source label to the logs so they can be differentiated / restricted if necessary
+    stage.static_labels {
+      values = {
+        "source" = "kubernetes-events",
+      }
+    }
+
+    // extract some of the fields from the log line, these could be used as labels, structured metadata, etc.
+    stage.logfmt {
+      mapping = {
+        "component" = "sourcecomponent", // map the sourcecomponent field to component
+        "kind" = "",
+        "level" = "type", // most events don't have a level but they do have a "type" i.e. Normal, Warning, Error, etc.
+        "name" = "",
+        "node" = "sourcehost", // map the sourcehost field to node
+        "reason" = "",
+      }
+    }
+    // set the extracted values as labels
+    stage.labels {
+      values = {
+        "kind" = "",
+        "level" = "",
+        "service_name" = "job",
+        "reason" = "reason",
+      }
+    }
+
+    // if kind=Node, set the node label by copying the name field
+    stage.match {
+      selector = "{kind=\"Node\"}"
+
+      stage.labels {
+        values = {
+          "node" = "name",
+        }
+      }
+    }
+
+    // set the level extracted key value as a normalized log level
+    stage.match {
+      selector = "{level=\"Normal\"}"
+
+      stage.static_labels {
+        values = {
+          level = "Info",
+        }
+      }
+    }
+    stage.structured_metadata {
+      values = {
+        "name" = "name",
+        "node" = "node",
+      }
+    }
+
+    // Drop pipeline-only labels that are not needed in the final output.
+    stage.label_drop {
+      values = ["kind"]
+    }
+
+    forward_to = argument.logs_destinations.value
+  } // loki.process "cluster_events"
+} // declare "cluster_events"
+cluster_events "feature" {
+  logs_destinations = [
+    loki.write.loki.receiver,
+  ]
+}
+// Self Reporting
+prometheus.exporter.unix "kubernetes_monitoring_telemetry" {
+  set_collectors = ["textfile"]
+  textfile {
+    directory = "/etc/release-info"
+  }
+} // prometheus.exporter.unix "kubernetes_monitoring_telemetry"
+
+discovery.relabel "kubernetes_monitoring_telemetry" {
+  targets = prometheus.exporter.unix.kubernetes_monitoring_telemetry.targets
+  rule {
+    target_label = "instance"
+    action = "replace"
+    replacement = "k8smon"
+  }
+  rule {
+    target_label = "job"
+    action = "replace"
+    replacement = "integrations/kubernetes/kubernetes_monitoring_telemetry"
+  }
+} // discovery.relabel "kubernetes_monitoring_telemetry"
+
+prometheus.scrape "kubernetes_monitoring_telemetry" {
+  job_name   = "integrations/kubernetes/kubernetes_monitoring_telemetry"
+  targets    = discovery.relabel.kubernetes_monitoring_telemetry.output
+  scrape_interval = "60s"
+  clustering {
+    enabled = true
+  }
+  forward_to = [prometheus.relabel.kubernetes_monitoring_telemetry.receiver]
+} // prometheus.scrape "kubernetes_monitoring_telemetry"
+
+prometheus.relabel "kubernetes_monitoring_telemetry" {
+  rule {
+    source_labels = ["__name__"]
+    regex = "grafana_kubernetes_monitoring_.*"
+    action = "keep"
+  }
+  forward_to = [
+    prometheus.remote_write.prometheus.receiver,
+  ]
+} // prometheus.relabel "kubernetes_monitoring_telemetry"
+
+
+
+
+
+// Destination: loki (loki)
+otelcol.exporter.loki "loki" {
+  forward_to = [loki.write.loki.receiver]
+} // otelcol.exporter.loki "loki"
+
+loki.write "loki" {
+  endpoint {
+    url = "http://loki.loki.svc:3100/loki/api/v1/push"
+    retry_on_http_429 = true
+    tenant_id = convert.nonsensitive(remote.kubernetes.secret.loki.data["tenantId"])
+    basic_auth {
+      username = convert.nonsensitive(remote.kubernetes.secret.loki.data["username"])
+      password = remote.kubernetes.secret.loki.data["password"]
+    }
+    tls_config {
+      insecure_skip_verify = false
+    }
+    min_backoff_period = "500ms"
+    max_backoff_period = "5m"
+    max_backoff_retries = "10"
+  }
+  external_labels = {
+    "cluster" = "control-plane-monitoring-test",
+    "k8s_cluster_name" = "control-plane-monitoring-test",
+  }
+} // loki.write "loki"
+
+remote.kubernetes.secret "loki" {
+  name      = "loki-k8smon-k8s-monitoring"
+  namespace = "default"
+} // remote.kubernetes.secret "loki"
+
+
+// Destination: prometheus (prometheus)
+otelcol.exporter.prometheus "prometheus" {
+  add_metric_suffixes = true
+  resource_to_telemetry_conversion = false
+  keep_identifying_resource_attributes = true
+  forward_to = [prometheus.remote_write.prometheus.receiver]
+} // otelcol.exporter.prometheus "prometheus"
+
+prometheus.remote_write "prometheus" {
+  endpoint {
+    url = "http://prometheus-server.prometheus.svc:9090/api/v1/write"
+    headers = {
+    }
+    tls_config {
+      insecure_skip_verify = false
+    }
+    send_native_histograms = false
+
+    queue_config {
+      capacity = 10000
+      min_shards = 1
+      max_shards = 50
+      max_samples_per_send = 2000
+      batch_send_deadline = "5s"
+      min_backoff = "30ms"
+      max_backoff = "5s"
+      retry_on_http_429 = true
+      sample_age_limit = "0s"
+    }
+  }
+
+  wal {
+    truncate_frequency = "2h"
+    min_keepalive_time = "5m"
+    max_keepalive_time = "8h"
+  }
+  external_labels = {
+    "cluster" = "control-plane-monitoring-test",
+    "k8s_cluster_name" = "control-plane-monitoring-test",
+  }
+} // prometheus.remote_write "prometheus"
+

--- a/charts/k8s-monitoring/tests/integration/pod-logs/default/.rendered/alloy-logs.alloy
+++ b/charts/k8s-monitoring/tests/integration/pod-logs/default/.rendered/alloy-logs.alloy
@@ -1,0 +1,264 @@
+// Feature: Pod Logs (Loki)
+declare "pod_logs_via_loki" {
+  argument "logs_destinations" {
+    comment = "Must be a list of log destinations where collected logs should be forwarded to"
+  }
+
+  discovery.kubernetes "pods" {
+    role = "pod"
+    selectors {
+      role = "pod"
+      field = "spec.nodeName=" + sys.env("HOSTNAME")
+    }
+  } // discovery.kubernetes "pods"
+
+  discovery.relabel "filtered_pods" {
+    targets = discovery.kubernetes.pods.targets
+    rule {
+      source_labels = ["__meta_kubernetes_namespace"]
+      action = "replace"
+      target_label = "namespace"
+    }
+    rule {  // Drop anything with a "falsy" annotation value
+      source_labels = ["__meta_kubernetes_pod_annotation_logs_grafana_com_pods_enabled"]
+      regex = "(false|no|skip)"
+      action = "drop"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_pod_name"]
+      target_label = "pod"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_pod_container_name"]
+      target_label = "container"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_namespace", "__meta_kubernetes_pod_container_name"]
+      separator = "/"
+      replacement = "$1"
+      target_label = "job"
+    }
+
+    // set the container runtime as a label
+    rule {
+      source_labels = ["__meta_kubernetes_pod_container_id"]
+      regex = "^(\\S+):\\/\\/.+$"
+      replacement = "$1"
+      target_label = "tmp_container_runtime"
+    }
+    // Compute the workload (owner) name. For ReplicaSet-owned pods, strip the
+    // pod-template hash to recover the Deployment name (matches Beyla / OTel Operator).
+    rule {
+      source_labels = ["__meta_kubernetes_pod_controller_name"]
+      target_label = "__tmp_workload_name"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_pod_controller_kind", "__meta_kubernetes_pod_controller_name"]
+      regex = "ReplicaSet;(.+)-[^-]+"
+      replacement = "$1"
+      target_label = "__tmp_workload_name"
+    }
+
+    // explicitly set service_name. if not set, loki will automatically try to populate a default.
+    // see https://grafana.com/docs/loki/latest/get-started/labels/#default-labels-for-all-users
+    //
+    // choose the first value found from the following ordered list:
+    // - pod.annotation[resource.opentelemetry.io/service.name]
+    // - pod.label[app.kubernetes.io/instance]
+    // - pod.label[app.kubernetes.io/name]
+    // - k8s.workload.name (Deployment, StatefulSet, DaemonSet, CronJob, Job, ...)
+    // - k8s.pod.name
+    // - k8s.container.name
+    rule {
+      source_labels = [
+        "__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_name",
+        "__meta_kubernetes_pod_label_app_kubernetes_io_instance",
+        "__meta_kubernetes_pod_label_app_kubernetes_io_name",
+        "__tmp_workload_name",
+        "__meta_kubernetes_pod_name",
+        "__meta_kubernetes_pod_container_name",
+      ]
+      separator = ";"
+      regex = "^(?:;*)?([^;]+).*$"
+      replacement = "$1"
+      target_label = "service_name"
+    }
+
+    // explicitly set service_namespace.
+    //
+    // choose the first value found from the following ordered list:
+    // - pod.annotation[resource.opentelemetry.io/service.namespace]
+    // - pod.namespace
+    rule {
+      source_labels = [
+        "__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_namespace",
+        "namespace",
+      ]
+      separator = ";"
+      regex = "^(?:;*)?([^;]+).*$"
+      replacement = "$1"
+      target_label = "service_namespace"
+    }
+
+    // explicitly set service_instance_id.
+    //
+    // choose the first value found from the following ordered list:
+    // - pod.annotation[resource.opentelemetry.io/service.instance.id]
+    // - concat([k8s.namespace.name, k8s.pod.name, k8s.container.name], '.')
+    rule {
+      source_labels = ["__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_instance_id"]
+      target_label = "service_instance_id"
+    }
+    rule {
+      source_labels = ["service_instance_id", "namespace", "pod", "container"]
+      separator = "."
+      regex = "^\\.([^.]+\\.[^.]+\\.[^.]+)$"
+      target_label = "service_instance_id"
+    }
+
+    // set resource attributes
+    rule {
+      action = "labelmap"
+      regex = "__meta_kubernetes_pod_annotation_resource_opentelemetry_io_(.+)"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_job"]
+      regex = "(.+)"
+      target_label = "job"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+      regex = "(.+)"
+      target_label = "app_kubernetes_io_name"
+    }
+
+    // Set the pod log path.
+    rule {
+      source_labels = ["__meta_kubernetes_pod_uid", "__meta_kubernetes_pod_container_name"]
+      separator = "/"
+      replacement = "/var/log/pods/*$1/*.log"
+      target_label = "__path__"
+    }
+
+    // If kubernetes.io/config.mirror is set, this is a static pod, created by the kubelet.
+    // It's logs live on a different path.
+    rule {
+      source_labels = ["__meta_kubernetes_pod_annotation_kubernetes_io_config_mirror", "__meta_kubernetes_pod_container_name"]
+      separator = "/"
+      regex = "(.+/.+)"
+      replacement = "/var/log/pods/*$1/*.log"
+      target_label = "__path__"
+    }
+  } // discovery.relabel "filtered_pods"
+
+  local.file_match "pod_logs" {
+    path_targets = discovery.relabel.filtered_pods.output
+  } // local.file_match "pod_logs"
+
+  loki.source.file "pod_logs" {
+    targets    = local.file_match.pod_logs.targets
+    tail_from_end = true
+    forward_to = [loki.process.pod_logs.receiver]
+  } // loki.source.file "pod_logs"
+
+  loki.process "pod_logs" {
+    stage.match {
+      selector = "{tmp_container_runtime=~\"containerd|cri-o|\"}"
+      // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
+      stage.cri {
+        max_partial_lines = 100
+      }
+
+      // Set the extract flags and stream values as labels
+      stage.labels {
+        values = {
+          flags  = "",
+          stream  = "",
+        }
+      }
+    }
+
+    stage.match {
+      selector = "{tmp_container_runtime=\"docker\"}"
+      // the docker processing stage extracts the following k/v pairs: log, stream, time
+      stage.docker {}
+
+      // Set the extract stream value as a label
+      stage.labels {
+        values = {
+          stream  = "",
+        }
+      }
+    }
+
+    // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
+    // namespace, pod, and container labels. Drop any structured metadata. Also drop the temporary
+    // container runtime label as it is no longer needed.
+    stage.label_drop {
+      values = [
+        "filename",
+        "tmp_container_runtime",
+      ]
+    }
+    stage.structured_metadata {
+      values = {
+        "k8s_pod_name" = "k8s_pod_name",
+        "pod" = "pod",
+        "service_instance_id" = "service_instance_id",
+      }
+    }
+
+    forward_to = argument.logs_destinations.value
+  } // loki.secretfilter "pod_logs"
+} // declare "pod_logs_via_loki"
+pod_logs_via_loki "feature" {
+  logs_destinations = [
+    loki.write.localloki.receiver,
+  ]
+}
+
+
+
+
+
+
+
+
+
+
+
+
+// Destination: localLoki (loki)
+otelcol.exporter.loki "localloki" {
+  forward_to = [loki.write.localloki.receiver]
+} // otelcol.exporter.loki "localloki"
+
+loki.write "localloki" {
+  endpoint {
+    url = "http://loki.loki.svc:3100/loki/api/v1/push"
+    retry_on_http_429 = true
+    batch_size = "1MiB"
+    batch_wait = "1s"
+    tenant_id = convert.nonsensitive(remote.kubernetes.secret.localloki.data["tenantId"])
+    basic_auth {
+      username = convert.nonsensitive(remote.kubernetes.secret.localloki.data["username"])
+      password = remote.kubernetes.secret.localloki.data["password"]
+    }
+    tls_config {
+      insecure_skip_verify = false
+    }
+    min_backoff_period = "500ms"
+    max_backoff_period = "5m"
+    max_backoff_retries = "10"
+  }
+  external_labels = {
+    "cluster" = "pod-logs-feature-test",
+    "k8s_cluster_name" = "pod-logs-feature-test",
+  }
+} // loki.write "localloki"
+
+remote.kubernetes.secret "localloki" {
+  name      = "localloki-k8smon-k8s-monitoring"
+  namespace = "default"
+} // remote.kubernetes.secret "localloki"
+

--- a/charts/k8s-monitoring/tests/integration/pod-logs/log-metrics/.rendered/alloy-logs.alloy
+++ b/charts/k8s-monitoring/tests/integration/pod-logs/log-metrics/.rendered/alloy-logs.alloy
@@ -1,0 +1,247 @@
+// Feature: Pod Logs (Loki)
+declare "pod_logs_via_loki" {
+  argument "logs_destinations" {
+    comment = "Must be a list of log destinations where collected logs should be forwarded to"
+  }
+
+  discovery.kubernetes "pods" {
+    role = "pod"
+    selectors {
+      role = "pod"
+      field = "spec.nodeName=" + sys.env("HOSTNAME")
+    }
+  } // discovery.kubernetes "pods"
+
+  discovery.relabel "filtered_pods" {
+    targets = discovery.kubernetes.pods.targets
+    rule {
+      source_labels = ["__meta_kubernetes_namespace"]
+      action = "replace"
+      target_label = "namespace"
+    }
+    rule {  // Drop anything with a "falsy" annotation value
+      source_labels = ["__meta_kubernetes_pod_annotation_logs_grafana_com_pods_enabled"]
+      regex = "(false|no|skip)"
+      action = "drop"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_pod_name"]
+      target_label = "pod"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_pod_container_name"]
+      target_label = "container"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_namespace", "__meta_kubernetes_pod_container_name"]
+      separator = "/"
+      replacement = "$1"
+      target_label = "job"
+    }
+
+    // set the container runtime as a label
+    rule {
+      source_labels = ["__meta_kubernetes_pod_container_id"]
+      regex = "^(\\S+):\\/\\/.+$"
+      replacement = "$1"
+      target_label = "tmp_container_runtime"
+    }
+    // explicitly set service_name. if not set, loki will automatically try to populate a default.
+    // see https://grafana.com/docs/loki/latest/get-started/labels/#default-labels-for-all-users
+    //
+    // choose the first value found from the following ordered list:
+    // - pod.annotation[resource.opentelemetry.io/service.name]
+    // - pod.label[app.kubernetes.io/name]
+    // - k8s.container.name
+    rule {
+      source_labels = [
+        "__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_name",
+        "__meta_kubernetes_pod_label_app_kubernetes_io_name",
+        "__meta_kubernetes_pod_container_name",
+      ]
+      separator = ";"
+      regex = "^(?:;*)?([^;]+).*$"
+      replacement = "$1"
+      target_label = "service_name"
+    }
+
+    // explicitly set service_namespace.
+    //
+    // choose the first value found from the following ordered list:
+    // - pod.annotation[resource.opentelemetry.io/service.namespace]
+    // - pod.namespace
+    rule {
+      source_labels = [
+        "__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_namespace",
+        "namespace",
+      ]
+      separator = ";"
+      regex = "^(?:;*)?([^;]+).*$"
+      replacement = "$1"
+      target_label = "service_namespace"
+    }
+
+    // explicitly set service_instance_id.
+    //
+    // choose the first value found from the following ordered list:
+    // - pod.annotation[resource.opentelemetry.io/service.instance.id]
+    // - concat([k8s.namespace.name, k8s.pod.name, k8s.container.name], '.')
+    rule {
+      source_labels = ["__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_instance_id"]
+      target_label = "service_instance_id"
+    }
+    rule {
+      source_labels = ["service_instance_id", "namespace", "pod", "container"]
+      separator = "."
+      regex = "^\\.([^.]+\\.[^.]+\\.[^.]+)$"
+      target_label = "service_instance_id"
+    }
+
+    // set resource attributes
+    rule {
+      action = "labelmap"
+      regex = "__meta_kubernetes_pod_annotation_resource_opentelemetry_io_(.+)"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_job"]
+      regex = "(.+)"
+      target_label = "job"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+      regex = "(.+)"
+      target_label = "app_kubernetes_io_name"
+    }
+
+    // Set the pod log path.
+    rule {
+      source_labels = ["__meta_kubernetes_pod_uid", "__meta_kubernetes_pod_container_name"]
+      separator = "/"
+      replacement = "/var/log/pods/*$1/*.log"
+      target_label = "__path__"
+    }
+
+    // If kubernetes.io/config.mirror is set, this is a static pod, created by the kubelet.
+    // It's logs live on a different path.
+    rule {
+      source_labels = ["__meta_kubernetes_pod_annotation_kubernetes_io_config_mirror", "__meta_kubernetes_pod_container_name"]
+      separator = "/"
+      regex = "(.+/.+)"
+      replacement = "/var/log/pods/*$1/*.log"
+      target_label = "__path__"
+    }
+  } // discovery.relabel "filtered_pods"
+
+  local.file_match "pod_logs" {
+    path_targets = discovery.relabel.filtered_pods.output
+  } // local.file_match "pod_logs"
+
+  loki.source.file "pod_logs" {
+    targets    = local.file_match.pod_logs.targets
+    tail_from_end = true
+    forward_to = [loki.process.pod_logs.receiver]
+  } // loki.source.file "pod_logs"
+
+  loki.process "pod_logs" {
+    stage.match {
+      selector = "{tmp_container_runtime=~\"containerd|cri-o|\"}"
+      // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
+      stage.cri {
+        max_partial_lines = 100
+      }
+
+      // Set the extract flags and stream values as labels
+      stage.labels {
+        values = {
+          flags  = "",
+          stream  = "",
+        }
+      }
+    }
+
+    stage.match {
+      selector = "{tmp_container_runtime=\"docker\"}"
+      // the docker processing stage extracts the following k/v pairs: log, stream, time
+      stage.docker {}
+
+      // Set the extract stream value as a label
+      stage.labels {
+        values = {
+          stream  = "",
+        }
+      }
+    }
+
+    // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
+    // namespace, pod, and container labels. Drop any structured metadata. Also drop the temporary
+    // container runtime label as it is no longer needed.
+    stage.label_drop {
+      values = [
+        "filename",
+        "tmp_container_runtime",
+      ]
+    }
+    stage.structured_metadata {
+      values = {
+        "k8s_pod_name" = "k8s_pod_name",
+        "pod" = "pod",
+        "service_instance_id" = "service_instance_id",
+      }
+    }
+    stage.metrics {
+      metric.counter {
+        name        = "log_lines_total"
+        description = "total number of log lines"
+        prefix      = "my_custom_tracking_"
+
+        match_all         = true
+        action            = "inc"
+        max_idle_duration = "24h"
+      }
+    }
+
+    forward_to = argument.logs_destinations.value
+  } // loki.secretfilter "pod_logs"
+} // declare "pod_logs_via_loki"
+pod_logs_via_loki "feature" {
+  logs_destinations = [
+    loki.write.localloki.receiver,
+  ]
+}
+
+
+
+
+
+// Destination: localLoki (loki)
+otelcol.exporter.loki "localloki" {
+  forward_to = [loki.write.localloki.receiver]
+} // otelcol.exporter.loki "localloki"
+
+loki.write "localloki" {
+  endpoint {
+    url = "http://loki.loki.svc:3100/loki/api/v1/push"
+    retry_on_http_429 = true
+    tenant_id = convert.nonsensitive(remote.kubernetes.secret.localloki.data["tenantId"])
+    basic_auth {
+      username = convert.nonsensitive(remote.kubernetes.secret.localloki.data["username"])
+      password = remote.kubernetes.secret.localloki.data["password"]
+    }
+    tls_config {
+      insecure_skip_verify = false
+    }
+    min_backoff_period = "500ms"
+    max_backoff_period = "5m"
+    max_backoff_retries = "10"
+  }
+  external_labels = {
+    "cluster" = "log-metrics-test",
+    "k8s_cluster_name" = "log-metrics-test",
+  }
+} // loki.write "localloki"
+
+remote.kubernetes.secret "localloki" {
+  name      = "localloki-k8smon-k8s-monitoring"
+  namespace = "default"
+} // remote.kubernetes.secret "localloki"
+

--- a/charts/k8s-monitoring/tests/integration/pod-logs/log-metrics/.rendered/alloy-metrics.alloy
+++ b/charts/k8s-monitoring/tests/integration/pod-logs/log-metrics/.rendered/alloy-metrics.alloy
@@ -1,0 +1,411 @@
+declare "alloy_integration" {
+  argument "metrics_destinations" {
+    comment = "Must be a list of metric destinations where collected metrics should be forwarded to"
+  }
+
+  declare "alloy_integration_discovery" {
+    argument "namespaces" {
+      comment = "The namespaces to look for targets in (default: [] is all namespaces)"
+      optional = true
+    }
+
+    argument "field_selectors" {
+      comment = "The field selectors to use to find matching targets (default: [])"
+      optional = true
+    }
+
+    argument "label_selectors" {
+      comment = "The label selectors to use to find matching targets (default: [\"app.kubernetes.io/name=alloy\"])"
+      optional = true
+    }
+
+    argument "port_name" {
+      comment = "The of the port to scrape metrics from (default: http-metrics)"
+      optional = true
+    }
+
+    // Alloy service discovery for all of the pods
+    discovery.kubernetes "alloy_pods" {
+      role = "pod"
+
+      selectors {
+        role = "pod"
+        field = string.join(coalesce(argument.field_selectors.value, []), ",")
+        label = string.join(coalesce(argument.label_selectors.value, ["app.kubernetes.io/name=alloy"]), ",")
+      }
+
+      namespaces {
+        names = coalesce(argument.namespaces.value, [])
+      }
+
+    } // discovery.kubernetes "alloy_pods"
+
+    // alloy relabelings (pre-scrape)
+    discovery.relabel "alloy_pods" {
+      targets = discovery.kubernetes.alloy_pods.targets
+
+      // keep only the specified metrics port name, and pods that are Running and ready
+      rule {
+        source_labels = [
+          "__meta_kubernetes_pod_container_port_name",
+          "__meta_kubernetes_pod_phase",
+          "__meta_kubernetes_pod_ready",
+          "__meta_kubernetes_pod_container_init",
+        ]
+        separator = "@"
+        regex = coalesce(argument.port_name.value, "metrics") + "@Running@true@false"
+        action = "keep"
+      }
+
+      rule {
+        source_labels = ["__meta_kubernetes_namespace"]
+        target_label  = "namespace"
+      }
+
+      rule {
+        source_labels = ["__meta_kubernetes_pod_name"]
+        target_label  = "pod"
+      }
+
+      rule {
+        source_labels = ["__meta_kubernetes_pod_container_name"]
+        target_label  = "container"
+      }
+
+      // set the workload to the controller kind and name
+      rule {
+        action = "lowercase"
+        source_labels = ["__meta_kubernetes_pod_controller_kind"]
+        target_label  = "workload_type"
+      }
+
+      rule {
+        source_labels = ["__meta_kubernetes_pod_controller_name"]
+        target_label  = "workload"
+      }
+
+      // remove the hash from the ReplicaSet
+      rule {
+        source_labels = [
+          "workload_type",
+          "workload",
+        ]
+        separator = "/"
+        regex = "replicaset/(.+)-.+$"
+        target_label  = "workload"
+      }
+
+      // set the app name if specified as metadata labels "app:" or "app.kubernetes.io/name:" or "k8s-app:"
+      rule {
+        action = "replace"
+        source_labels = [
+          "__meta_kubernetes_pod_label_app_kubernetes_io_name",
+          "__meta_kubernetes_pod_label_k8s_app",
+          "__meta_kubernetes_pod_label_app",
+        ]
+        separator = ";"
+        regex = "^(?:;*)?([^;]+).*$"
+        replacement = "$1"
+        target_label = "app"
+      }
+
+      // set the component if specified as metadata labels "component:" or "app.kubernetes.io/component:" or "k8s-component:"
+      rule {
+        action = "replace"
+        source_labels = [
+          "__meta_kubernetes_pod_label_app_kubernetes_io_component",
+          "__meta_kubernetes_pod_label_k8s_component",
+          "__meta_kubernetes_pod_label_component",
+        ]
+        regex = "^(?:;*)?([^;]+).*$"
+        replacement = "$1"
+        target_label = "component"
+      }
+
+      // set a source label
+      rule {
+        action = "replace"
+        replacement = "kubernetes"
+        target_label = "source"
+      }
+
+    } // discovery.relabel "alloy_pods"
+
+    export "output" {
+      value = discovery.relabel.alloy_pods.output
+    }
+  }
+
+  declare "alloy_integration_scrape" {
+    argument "targets" {
+      comment = "Must be a list() of targets"
+    }
+
+    argument "forward_to" {
+      comment = "Must be a list(MetricsReceiver) where collected metrics should be forwarded to"
+    }
+
+    argument "job_label" {
+      comment = "The job label to add for all Alloy metrics (default: integrations/alloy)"
+      optional = true
+    }
+
+    argument "keep_metrics" {
+      comment = "A regular expression of metrics to keep (default: see below)"
+      optional = true
+    }
+
+    argument "drop_metrics" {
+      comment = "A regular expression of metrics to drop (default: see below)"
+      optional = true
+    }
+
+    argument "scrape_interval" {
+      comment = "How often to scrape metrics from the targets (default: 60s)"
+      optional = true
+    }
+
+    argument "scrape_timeout" {
+      comment = "The timeout for scraping metrics from the targets (default: 10s)"
+      optional = true
+    }
+
+    argument "scrape_protocols" {
+      comment = "The scrape protocols to use for scraping metrics"
+      optional = true
+    }
+
+    argument "scrape_classic_histograms" {
+      comment = "Whether to scrape classic histograms (default: false)."
+      optional = true
+    }
+
+    argument "scrape_native_histograms" {
+      comment = "Whether to scrape native histograms (default: false)."
+      optional = true
+    }
+
+    argument "max_cache_size" {
+      comment = "The maximum number of elements to hold in the relabeling cache (default: 100000).  This should be at least 2x-5x your largest scrape target or samples appended rate."
+      optional = true
+    }
+
+    argument "clustering" {
+      comment = "Whether or not clustering should be enabled (default: false)"
+      optional = true
+    }
+
+    prometheus.scrape "alloy" {
+      job_name = coalesce(argument.job_label.value, "integrations/alloy")
+      forward_to = [prometheus.relabel.alloy.receiver]
+      targets = argument.targets.value
+      scrape_interval = coalesce(argument.scrape_interval.value, "60s")
+      scrape_timeout = coalesce(argument.scrape_timeout.value, "10s")
+      scrape_protocols = argument.scrape_protocols.value
+      scrape_classic_histograms = argument.scrape_classic_histograms.value
+      scrape_native_histograms = argument.scrape_native_histograms.value
+
+      clustering {
+        enabled = coalesce(argument.clustering.value, false)
+      }
+    } // prometheus.scrape "alloy"
+
+    // alloy metric relabelings (post-scrape)
+    prometheus.relabel "alloy" {
+      forward_to = argument.forward_to.value
+      max_cache_size = coalesce(argument.max_cache_size.value, 100000)
+
+      // drop metrics that match the drop_metrics regex
+      rule {
+        source_labels = ["__name__"]
+        regex = coalesce(argument.drop_metrics.value, "")
+        action = "drop"
+      }
+
+      // keep only metrics that match the keep_metrics regex
+      rule {
+        source_labels = ["__name__"]
+        regex = coalesce(argument.keep_metrics.value, ".*")
+        action = "keep"
+      }
+
+      // remove the component_id label from any metric that starts with log_bytes or log_lines, these are custom metrics that are generated
+      // as part of the log annotation modules in this repo
+      rule {
+        action = "replace"
+        source_labels = ["__name__"]
+        regex = "^log_(bytes|lines).+"
+        replacement = ""
+        target_label = "component_id"
+      }
+
+      // set the namespace label to that of the exported_namespace
+      rule {
+        action = "replace"
+        source_labels = ["__name__", "exported_namespace"]
+        separator = "@"
+        regex = "^log_(bytes|lines).+@(.+)"
+        replacement = "$2"
+        target_label = "namespace"
+      }
+
+      // set the pod label to that of the exported_pod
+      rule {
+        action = "replace"
+        source_labels = ["__name__", "exported_pod"]
+        separator = "@"
+        regex = "^log_(bytes|lines).+@(.+)"
+        replacement = "$2"
+        target_label = "pod"
+      }
+
+      // set the container label to that of the exported_container
+      rule {
+        action = "replace"
+        source_labels = ["__name__", "exported_container"]
+        separator = "@"
+        regex = "^log_(bytes|lines).+@(.+)"
+        replacement = "$2"
+        target_label = "container"
+      }
+
+      // set the job label to that of the exported_job
+      rule {
+        action = "replace"
+        source_labels = ["__name__", "exported_job"]
+        separator = "@"
+        regex = "^log_(bytes|lines).+@(.+)"
+        replacement = "$2"
+        target_label = "job"
+      }
+
+      // set the instance label to that of the exported_instance
+      rule {
+        action = "replace"
+        source_labels = ["__name__", "exported_instance"]
+        separator = "@"
+        regex = "^log_(bytes|lines).+@(.+)"
+        replacement = "$2"
+        target_label = "instance"
+      }
+
+      rule {
+        action = "labeldrop"
+        regex = "exported_(namespace|pod|container|job|instance)"
+      }
+    } // prometheus.relabel "alloy"
+  }
+
+  alloy_integration_discovery "alloy" {
+    port_name = "http-metrics"
+    label_selectors = ["app.kubernetes.io/name in (alloy-metrics,alloy-logs)"]
+  }
+
+  alloy_integration_scrape "alloy" {
+    targets = alloy_integration_discovery.alloy.output
+    job_label = "integrations/alloy"
+    clustering = true
+    keep_metrics = "up|scrape_samples_scraped|alloy_build_info|alloy_component_controller_running_components|alloy_component_dependencies_wait_seconds|alloy_component_dependencies_wait_seconds_bucket|alloy_component_evaluation_seconds|alloy_component_evaluation_seconds_bucket|alloy_component_evaluation_seconds_count|alloy_component_evaluation_seconds_sum|alloy_component_evaluation_slow_seconds|alloy_config_hash|alloy_resources_machine_rx_bytes_total|alloy_resources_machine_tx_bytes_total|alloy_resources_process_cpu_seconds_total|alloy_resources_process_resident_memory_bytes|alloy_tcp_connections|alloy_wal_samples_appended_total|alloy_wal_storage_active_series|cluster_node_gossip_health_score|cluster_node_gossip_proto_version|cluster_node_gossip_received_events_total|cluster_node_info|cluster_node_lamport_time|cluster_node_peers|cluster_node_update_observers|cluster_transport_rx_bytes_total|cluster_transport_rx_packet_queue_length|cluster_transport_rx_packets_failed_total|cluster_transport_rx_packets_total|cluster_transport_stream_rx_bytes_total|cluster_transport_stream_rx_packets_failed_total|cluster_transport_stream_rx_packets_total|cluster_transport_stream_tx_bytes_total|cluster_transport_stream_tx_packets_failed_total|cluster_transport_stream_tx_packets_total|cluster_transport_streams|cluster_transport_tx_bytes_total|cluster_transport_tx_packet_queue_length|cluster_transport_tx_packets_failed_total|cluster_transport_tx_packets_total|otelcol_exporter_send_failed_spans_total|otelcol_exporter_sent_spans_total|go_gc_duration_seconds_count|go_goroutines|go_memstats_heap_inuse_bytes|loki_process_dropped_lines_total|loki_write_batch_retries_total|loki_write_dropped_bytes_total|loki_write_dropped_entries_total|loki_write_encoded_bytes_total|loki_write_mutated_bytes_total|loki_write_mutated_entries_total|loki_write_request_duration_seconds_bucket|loki_write_sent_bytes_total|loki_write_sent_entries_total|process_cpu_seconds_total|process_start_time_seconds|otelcol_processor_batch_batch_send_size_bucket|otelcol_processor_batch_metadata_cardinality|otelcol_processor_batch_timeout_trigger_send_total|prometheus_remote_storage_bytes_total|prometheus_remote_storage_enqueue_retries_total|prometheus_remote_storage_highest_timestamp_in_seconds|prometheus_remote_storage_metadata_bytes_total|prometheus_remote_storage_queue_highest_sent_timestamp_seconds|prometheus_remote_storage_samples_dropped_total|prometheus_remote_storage_samples_failed_total|prometheus_remote_storage_samples_pending|prometheus_remote_storage_samples_retried_total|prometheus_remote_storage_samples_total|prometheus_remote_storage_sent_batch_duration_seconds_bucket|prometheus_remote_storage_sent_batch_duration_seconds_count|prometheus_remote_storage_sent_batch_duration_seconds_sum|prometheus_remote_storage_shard_capacity|prometheus_remote_storage_shards|prometheus_remote_storage_shards_desired|prometheus_remote_storage_shards_max|prometheus_remote_storage_shards_min|prometheus_remote_storage_succeeded_samples_total|prometheus_remote_write_wal_samples_appended_total|prometheus_remote_write_wal_storage_active_series|prometheus_sd_discovered_targets|prometheus_target_interval_length_seconds_count|prometheus_target_interval_length_seconds_sum|prometheus_target_scrapes_exceeded_sample_limit_total|prometheus_target_scrapes_sample_duplicate_timestamp_total|prometheus_target_scrapes_sample_out_of_bounds_total|prometheus_target_scrapes_sample_out_of_order_total|prometheus_target_sync_length_seconds_sum|prometheus_wal_watcher_current_segment|otelcol_receiver_accepted_spans_total|otelcol_receiver_refused_spans_total|rpc_server_duration_milliseconds_bucket|scrape_duration_seconds|traces_exporter_send_failed_spans|traces_exporter_send_failed_spans_total|traces_exporter_sent_spans|traces_exporter_sent_spans_total|traces_loadbalancer_backend_outcome|traces_loadbalancer_num_backends|traces_receiver_accepted_spans|traces_receiver_accepted_spans_total|traces_receiver_refused_spans|traces_receiver_refused_spans_total|my_custom_tracking_.*"
+    scrape_interval = "60s"
+    scrape_timeout = "10s"
+    scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
+    scrape_classic_histograms = false
+    scrape_native_histograms = false
+    max_cache_size = 100000
+    forward_to = argument.metrics_destinations.value
+  }
+}
+alloy_integration "integration" {
+  metrics_destinations = [
+    prometheus.remote_write.localprometheus.receiver,
+  ]
+}
+// Self Reporting
+prometheus.exporter.unix "kubernetes_monitoring_telemetry" {
+  set_collectors = ["textfile"]
+  textfile {
+    directory = "/etc/release-info"
+  }
+} // prometheus.exporter.unix "kubernetes_monitoring_telemetry"
+
+discovery.relabel "kubernetes_monitoring_telemetry" {
+  targets = prometheus.exporter.unix.kubernetes_monitoring_telemetry.targets
+  rule {
+    target_label = "instance"
+    action = "replace"
+    replacement = "k8smon"
+  }
+  rule {
+    target_label = "job"
+    action = "replace"
+    replacement = "integrations/kubernetes/kubernetes_monitoring_telemetry"
+  }
+} // discovery.relabel "kubernetes_monitoring_telemetry"
+
+prometheus.scrape "kubernetes_monitoring_telemetry" {
+  job_name   = "integrations/kubernetes/kubernetes_monitoring_telemetry"
+  targets    = discovery.relabel.kubernetes_monitoring_telemetry.output
+  scrape_interval = "60s"
+  clustering {
+    enabled = true
+  }
+  forward_to = [prometheus.relabel.kubernetes_monitoring_telemetry.receiver]
+} // prometheus.scrape "kubernetes_monitoring_telemetry"
+
+prometheus.relabel "kubernetes_monitoring_telemetry" {
+  rule {
+    source_labels = ["__name__"]
+    regex = "grafana_kubernetes_monitoring_.*"
+    action = "keep"
+  }
+  forward_to = [
+    prometheus.remote_write.localprometheus.receiver,
+  ]
+} // prometheus.relabel "kubernetes_monitoring_telemetry"
+
+
+
+
+
+// Destination: localPrometheus (prometheus)
+otelcol.exporter.prometheus "localprometheus" {
+  add_metric_suffixes = true
+  resource_to_telemetry_conversion = false
+  keep_identifying_resource_attributes = true
+  forward_to = [prometheus.remote_write.localprometheus.receiver]
+} // otelcol.exporter.prometheus "localprometheus"
+
+prometheus.remote_write "localprometheus" {
+  endpoint {
+    url = "http://prometheus-server.prometheus.svc:9090/api/v1/write"
+    headers = {
+    }
+    tls_config {
+      insecure_skip_verify = false
+    }
+    send_native_histograms = false
+
+    queue_config {
+      capacity = 10000
+      min_shards = 1
+      max_shards = 50
+      max_samples_per_send = 2000
+      batch_send_deadline = "5s"
+      min_backoff = "30ms"
+      max_backoff = "5s"
+      retry_on_http_429 = true
+      sample_age_limit = "0s"
+    }
+  }
+
+  wal {
+    truncate_frequency = "2h"
+    min_keepalive_time = "5m"
+    max_keepalive_time = "8h"
+  }
+  external_labels = {
+    "cluster" = "log-metrics-test",
+    "k8s_cluster_name" = "log-metrics-test",
+  }
+} // prometheus.remote_write "localprometheus"
+

--- a/charts/k8s-monitoring/tests/integration/pod-logs/secret-filter/.rendered/alloy-logs.alloy
+++ b/charts/k8s-monitoring/tests/integration/pod-logs/secret-filter/.rendered/alloy-logs.alloy
@@ -1,0 +1,286 @@
+// Feature: Pod Logs (Loki)
+declare "pod_logs_via_loki" {
+  argument "logs_destinations" {
+    comment = "Must be a list of log destinations where collected logs should be forwarded to"
+  }
+
+  discovery.kubernetes "pods" {
+    role = "pod"
+    selectors {
+      role = "pod"
+      field = "spec.nodeName=" + sys.env("HOSTNAME")
+    }
+  } // discovery.kubernetes "pods"
+
+  discovery.relabel "filtered_pods" {
+    targets = discovery.kubernetes.pods.targets
+    rule {
+      source_labels = ["__meta_kubernetes_namespace"]
+      action = "replace"
+      target_label = "namespace"
+    }
+    rule {  // Drop anything with a "falsy" annotation value
+      source_labels = ["__meta_kubernetes_pod_annotation_logs_grafana_com_pods_enabled"]
+      regex = "(false|no|skip)"
+      action = "drop"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_pod_name"]
+      target_label = "pod"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_pod_container_name"]
+      target_label = "container"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_namespace", "__meta_kubernetes_pod_container_name"]
+      separator = "/"
+      replacement = "$1"
+      target_label = "job"
+    }
+
+    // set the container runtime as a label
+    rule {
+      source_labels = ["__meta_kubernetes_pod_container_id"]
+      regex = "^(\\S+):\\/\\/.+$"
+      replacement = "$1"
+      target_label = "tmp_container_runtime"
+    }
+    // explicitly set service_name. if not set, loki will automatically try to populate a default.
+    // see https://grafana.com/docs/loki/latest/get-started/labels/#default-labels-for-all-users
+    //
+    // choose the first value found from the following ordered list:
+    // - pod.annotation[resource.opentelemetry.io/service.name]
+    // - pod.label[app.kubernetes.io/name]
+    // - k8s.container.name
+    rule {
+      source_labels = [
+        "__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_name",
+        "__meta_kubernetes_pod_label_app_kubernetes_io_name",
+        "__meta_kubernetes_pod_container_name",
+      ]
+      separator = ";"
+      regex = "^(?:;*)?([^;]+).*$"
+      replacement = "$1"
+      target_label = "service_name"
+    }
+
+    // explicitly set service_namespace.
+    //
+    // choose the first value found from the following ordered list:
+    // - pod.annotation[resource.opentelemetry.io/service.namespace]
+    // - pod.namespace
+    rule {
+      source_labels = [
+        "__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_namespace",
+        "namespace",
+      ]
+      separator = ";"
+      regex = "^(?:;*)?([^;]+).*$"
+      replacement = "$1"
+      target_label = "service_namespace"
+    }
+
+    // explicitly set service_instance_id.
+    //
+    // choose the first value found from the following ordered list:
+    // - pod.annotation[resource.opentelemetry.io/service.instance.id]
+    // - concat([k8s.namespace.name, k8s.pod.name, k8s.container.name], '.')
+    rule {
+      source_labels = ["__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_instance_id"]
+      target_label = "service_instance_id"
+    }
+    rule {
+      source_labels = ["service_instance_id", "namespace", "pod", "container"]
+      separator = "."
+      regex = "^\\.([^.]+\\.[^.]+\\.[^.]+)$"
+      target_label = "service_instance_id"
+    }
+
+    // set resource attributes
+    rule {
+      action = "labelmap"
+      regex = "__meta_kubernetes_pod_annotation_resource_opentelemetry_io_(.+)"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_job"]
+      regex = "(.+)"
+      target_label = "job"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+      regex = "(.+)"
+      target_label = "app_kubernetes_io_name"
+    }
+
+    // Set the pod log path.
+    rule {
+      source_labels = ["__meta_kubernetes_pod_uid", "__meta_kubernetes_pod_container_name"]
+      separator = "/"
+      replacement = "/var/log/pods/*$1/*.log"
+      target_label = "__path__"
+    }
+
+    // If kubernetes.io/config.mirror is set, this is a static pod, created by the kubelet.
+    // It's logs live on a different path.
+    rule {
+      source_labels = ["__meta_kubernetes_pod_annotation_kubernetes_io_config_mirror", "__meta_kubernetes_pod_container_name"]
+      separator = "/"
+      regex = "(.+/.+)"
+      replacement = "/var/log/pods/*$1/*.log"
+      target_label = "__path__"
+    }
+  } // discovery.relabel "filtered_pods"
+
+  local.file_match "pod_logs" {
+    path_targets = discovery.relabel.filtered_pods.output
+  } // local.file_match "pod_logs"
+
+  loki.source.file "pod_logs" {
+    targets    = local.file_match.pod_logs.targets
+    tail_from_end = true
+    forward_to = [loki.process.pod_logs.receiver]
+  } // loki.source.file "pod_logs"
+
+  loki.process "pod_logs" {
+    stage.match {
+      selector = "{tmp_container_runtime=~\"containerd|cri-o|\"}"
+      // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
+      stage.cri {
+        max_partial_lines = 100
+      }
+
+      // Set the extract flags and stream values as labels
+      stage.labels {
+        values = {
+          flags  = "",
+          stream  = "",
+        }
+      }
+    }
+
+    stage.match {
+      selector = "{tmp_container_runtime=\"docker\"}"
+      // the docker processing stage extracts the following k/v pairs: log, stream, time
+      stage.docker {}
+
+      // Set the extract stream value as a label
+      stage.labels {
+        values = {
+          stream  = "",
+        }
+      }
+    }
+
+    // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
+    // namespace, pod, and container labels. Drop any structured metadata. Also drop the temporary
+    // container runtime label as it is no longer needed.
+    stage.label_drop {
+      values = [
+        "filename",
+        "tmp_container_runtime",
+      ]
+    }
+    stage.structured_metadata {
+      values = {
+        "k8s_pod_name" = "k8s_pod_name",
+        "pod" = "pod",
+        "service_instance_id" = "service_instance_id",
+      }
+    }
+
+    forward_to = [loki.process.secret_filter_prefilter.receiver]
+  } // loki.process "pod_logs"
+
+  loki.process "secret_filter_prefilter" {
+    stage.static_labels {
+      values = {
+        k8s_monitoring_secret_filter_inclusion = "false",
+      }
+    }
+    stage.match {
+      selector = "{namespace=\"development\"}"
+
+      stage.static_labels {
+        values = {
+          k8s_monitoring_secret_filter_inclusion = "true",
+        }
+      }
+    }
+    forward_to = [
+      loki.process.secret_filter_inclusion.receiver,
+      loki.process.secret_filter_exclusion.receiver,
+    ]
+  } // loki.process "secret_filter_prefilter"
+
+  loki.process "secret_filter_exclusion" {
+    stage.match {
+      selector = "{k8s_monitoring_secret_filter_inclusion=\"true\"}"
+      action = "drop"
+    }
+
+    forward_to = argument.logs_destinations.value
+  } // loki.process "secret_filter_exclusion"
+
+  loki.process "secret_filter_inclusion" {
+    stage.match {
+      selector = "{k8s_monitoring_secret_filter_inclusion=\"false\"}"
+      action = "drop"
+    }
+    forward_to = [loki.secretfilter.pod_logs.receiver]
+  } // loki.process "secret_filter_inclusion"
+
+  loki.secretfilter "pod_logs" {
+    redact_with = "<REDACTED:$SECRET_NAME>"
+    forward_to = argument.logs_destinations.value
+  } // loki.secretfilter "pod_logs"
+} // declare "pod_logs_via_loki"
+pod_logs_via_loki "feature" {
+  logs_destinations = [
+    loki.write.localloki.receiver,
+  ]
+}
+
+
+
+
+
+
+
+
+
+
+
+
+// Destination: localLoki (loki)
+otelcol.exporter.loki "localloki" {
+  forward_to = [loki.write.localloki.receiver]
+} // otelcol.exporter.loki "localloki"
+
+loki.write "localloki" {
+  endpoint {
+    url = "http://loki.loki.svc:3100/loki/api/v1/push"
+    retry_on_http_429 = true
+    tenant_id = convert.nonsensitive(remote.kubernetes.secret.localloki.data["tenantId"])
+    basic_auth {
+      username = convert.nonsensitive(remote.kubernetes.secret.localloki.data["username"])
+      password = remote.kubernetes.secret.localloki.data["password"]
+    }
+    tls_config {
+      insecure_skip_verify = false
+    }
+    min_backoff_period = "500ms"
+    max_backoff_period = "5m"
+    max_backoff_retries = "10"
+  }
+  external_labels = {
+    "cluster" = "pod-logs-feature-test",
+    "k8s_cluster_name" = "pod-logs-feature-test",
+  }
+} // loki.write "localloki"
+
+remote.kubernetes.secret "localloki" {
+  name      = "localloki-k8smon-k8s-monitoring"
+  namespace = "default"
+} // remote.kubernetes.secret "localloki"
+

--- a/charts/k8s-monitoring/tests/integration/profiles-receiver/.rendered/alloy-receiver.alloy
+++ b/charts/k8s-monitoring/tests/integration/profiles-receiver/.rendered/alloy-receiver.alloy
@@ -1,0 +1,57 @@
+// Feature: Profiles Receiver
+declare "profiles_receiver" {
+  argument "profiles_destinations" {
+    comment = "Must be a list of profile destinations where collected profiles should be forwarded to"
+  }
+
+  pyroscope.receive_http "default" {
+    http {
+      listen_address = "0.0.0.0"
+      listen_port = "4040"
+    }
+
+    forward_to = [pyroscope.relabel.default.receiver]
+  } // pyroscope.receive_http "default"
+
+  pyroscope.relabel "default" {
+    rule {
+      target_label = "color"
+      replacement = "blue"
+    }
+
+    forward_to = argument.profiles_destinations.value
+  } // pyroscope.relabel "default"
+} // declare "profiles_receiver"
+profiles_receiver "feature" {
+  profiles_destinations = [
+    pyroscope.write.pyro.receiver,
+  ]
+}
+
+
+
+
+
+
+
+
+// Destination: pyro (pyroscope)
+pyroscope.write "pyro" {
+  endpoint {
+    url = "http://pyroscope.pyroscope.svc:4040"
+    headers = {
+    }
+    tls_config {
+      insecure_skip_verify = false
+    }
+    min_backoff_period = "500ms"
+    max_backoff_period = "5m"
+    max_backoff_retries = "10"
+  }
+
+  external_labels = {
+    "cluster" = "profiles-receiver-feature-test",
+    "k8s_cluster_name" = "profiles-receiver-feature-test",
+  }
+} // pyroscope.write "pyro"
+

--- a/charts/k8s-monitoring/tests/integration/profiling/.rendered/alloy-profiles.alloy
+++ b/charts/k8s-monitoring/tests/integration/profiling/.rendered/alloy-profiles.alloy
@@ -1,0 +1,1112 @@
+// Feature: Profiling
+declare "profiling" {
+  argument "profiles_destinations" {
+    comment = "Must be a list of profile destinations where collected profiles should be forwarded to"
+  }
+  // Profiles: eBPF
+  discovery.kubernetes "ebpf_pods" {
+    role = "pod"
+    selectors {
+      role = "pod"
+      field = "spec.nodeName=" + sys.env("HOSTNAME")
+    }
+  } // discovery.kubernetes "ebpf_pods"
+
+  discovery.relabel "ebpf_pods" {
+    targets = discovery.kubernetes.ebpf_pods.targets
+    rule {
+      source_labels = ["__meta_kubernetes_pod_phase"]
+      regex = "Succeeded|Failed|Completed"
+      action = "drop"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_pod_annotation_profiles_grafana_com_cpu_ebpf_enabled"]
+      regex         = "true"
+      action        = "keep"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_namespace"]
+      target_label = "namespace"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_pod_name"]
+      target_label = "pod"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_pod_node_name"]
+      target_label = "node"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_pod_container_name"]
+      target_label = "container"
+    }
+
+    // Compute the workload (owner) name. For ReplicaSet-owned pods, strip the
+    // pod-template hash to recover the Deployment name (matches Beyla / OTel Operator).
+    rule {
+      source_labels = ["__meta_kubernetes_pod_controller_name"]
+      target_label = "__tmp_workload_name"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_pod_controller_kind", "__meta_kubernetes_pod_controller_name"]
+      regex = "ReplicaSet;(.+)-[^-]+"
+      replacement = "$1"
+      target_label = "__tmp_workload_name"
+    }
+
+    // Set service_name by choosing the first value found from the following ordered list:
+    // - pod.annotation[resource.opentelemetry.io/service.name]
+    // - pod.label[app.kubernetes.io/instance]
+    // - pod.label[app.kubernetes.io/name]
+    // - k8s.workload.name (Deployment, StatefulSet, DaemonSet, CronJob, Job, ...)
+    // - k8s.pod.name
+    // - k8s.container.name
+    rule {
+      action = "replace"
+      source_labels = [
+        "__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_name",
+        "__meta_kubernetes_pod_label_app_kubernetes_io_instance",
+        "__meta_kubernetes_pod_label_app_kubernetes_io_name",
+        "__tmp_workload_name",
+        "pod",
+        "container",
+      ]
+      separator = ";"
+      regex = "^(?:;*)?([^;]+).*$"
+      replacement = "$1"
+      target_label = "service_name"
+    }
+
+    // Set service_namespace by choosing the first value found from the following ordered list:
+    // - pod.annotation[resource.opentelemetry.io/service.namespace]
+    // - pod.namespace
+    rule {
+      action = "replace"
+      source_labels = [
+        "__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_namespace",
+        "namespace",
+      ]
+      separator = ";"
+      regex = "^(?:;*)?([^;]+).*$"
+      replacement = "$1"
+      target_label = "service_namespace"
+    }
+
+    // Set service_instance_id by choosing the first value found from the following ordered list:
+    // - pod.annotation[resource.opentelemetry.io/service.instance.id]
+    // - concat([k8s.namespace.name, k8s.pod.name, k8s.container.name], '.')
+    rule {
+      source_labels = ["__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_instance_id"]
+      target_label = "service_instance_id"
+    }
+    rule {
+      source_labels = ["service_instance_id", "namespace", "pod", "container"]
+      separator = "."
+      regex = "^\\.([^.]+\\.[^.]+\\.[^.]+)$"
+      target_label = "service_instance_id"
+    }
+
+    rule {
+      replacement = "alloy/pyroscope.ebpf"
+      target_label = "source"
+    }
+  } // discovery.relabel "ebpf_pods"
+
+  pyroscope.ebpf "ebpf_pods" {
+    targets = discovery.relabel.ebpf_pods.output
+    demangle = "none"
+    sample_rate = 19
+    dotnet_enabled = true
+    hotspot_enabled = true
+    perl_enabled = true
+    php_enabled = true
+    python_enabled = true
+    ruby_enabled = true
+    v8_enabled = true
+    forward_to = argument.profiles_destinations.value
+  } // pyroscope.ebpf "ebpf_pods"
+  // Profiles: Java
+  discovery.kubernetes "java_pods" {
+    role = "pod"
+    selectors {
+      role = "pod"
+      field = "spec.nodeName=" + sys.env("HOSTNAME")
+    }
+  } // discovery.kubernetes "java_pods"
+
+  discovery.relabel "potential_java_pods" {
+    targets = discovery.kubernetes.java_pods.targets
+    rule {
+      source_labels = ["__meta_kubernetes_pod_phase"]
+      regex         = "Succeeded|Failed|Completed"
+      action        = "drop"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_pod_annotation_profiles_grafana_com_java_enabled"]
+      regex         = "true"
+      action        = "keep"
+    }
+  } // discovery.relabel "potential_java_pods"
+
+  discovery.process "java_pods" {
+    join = discovery.relabel.potential_java_pods.output
+  } // discovery.process "java_pods"
+
+  discovery.relabel "java_pods" {
+    targets = discovery.process.java_pods.targets
+    rule {
+      source_labels = ["__meta_process_exe"]
+      action = "keep"
+      regex = ".*/java$"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_pod_annotation_profiles_grafana_com_java_enabled"]
+      regex         = "true"
+      action        = "keep"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_namespace"]
+      target_label = "namespace"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_pod_name"]
+      target_label = "pod"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_pod_node_name"]
+      target_label = "node"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_pod_container_name"]
+      target_label = "container"
+    }
+
+    // Compute the workload (owner) name. For ReplicaSet-owned pods, strip the
+    // pod-template hash to recover the Deployment name (matches Beyla / OTel Operator).
+    rule {
+      source_labels = ["__meta_kubernetes_pod_controller_name"]
+      target_label = "__tmp_workload_name"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_pod_controller_kind", "__meta_kubernetes_pod_controller_name"]
+      regex = "ReplicaSet;(.+)-[^-]+"
+      replacement = "$1"
+      target_label = "__tmp_workload_name"
+    }
+
+    // Set service_name by choosing the first value found from the following ordered list:
+    // - pod.annotation[resource.opentelemetry.io/service.name]
+    // - pod.label[app.kubernetes.io/instance]
+    // - pod.label[app.kubernetes.io/name]
+    // - k8s.workload.name (Deployment, StatefulSet, DaemonSet, CronJob, Job, ...)
+    // - k8s.pod.name
+    // - k8s.container.name
+    rule {
+      action = "replace"
+      source_labels = [
+        "__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_name",
+        "__meta_kubernetes_pod_label_app_kubernetes_io_instance",
+        "__meta_kubernetes_pod_label_app_kubernetes_io_name",
+        "__tmp_workload_name",
+        "pod",
+        "container",
+      ]
+      separator = ";"
+      regex = "^(?:;*)?([^;]+).*$"
+      replacement = "$1"
+      target_label = "service_name"
+    }
+
+    // Set service_namespace by choosing the first value found from the following ordered list:
+    // - pod.annotation[resource.opentelemetry.io/service.namespace]
+    // - pod.namespace
+    rule {
+      action = "replace"
+      source_labels = [
+        "__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_namespace",
+        "namespace",
+      ]
+      separator = ";"
+      regex = "^(?:;*)?([^;]+).*$"
+      replacement = "$1"
+      target_label = "service_namespace"
+    }
+
+    // Set service_instance_id by choosing the first value found from the following ordered list:
+    // - pod.annotation[resource.opentelemetry.io/service.instance.id]
+    // - concat([k8s.namespace.name, k8s.pod.name, k8s.container.name], '.')
+    rule {
+      source_labels = ["__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_instance_id"]
+      target_label = "service_instance_id"
+    }
+    rule {
+      source_labels = ["service_instance_id", "namespace", "pod", "container"]
+      separator = "."
+      regex = "^\\.([^.]+\\.[^.]+\\.[^.]+)$"
+      target_label = "service_instance_id"
+    }
+
+    rule {
+      replacement = "alloy/pyroscope.java"
+      target_label = "source"
+    }
+  } // discovery.relabel "java_pods"
+
+  pyroscope.java "java_pods" {
+    targets = discovery.relabel.java_pods.output
+    profiling_config {
+      interval = "60s"
+      alloc = "512k"
+      cpu = true
+      sample_rate = 100
+      lock = "10ms"
+      event = "itimer"
+    }
+    forward_to = argument.profiles_destinations.value
+  } // pyroscope.java "java_pods"
+  // Profiles: pprof
+  discovery.kubernetes "pprof_pods" {
+    role = "pod"
+    selectors {
+      role = "pod"
+      field = "spec.nodeName=" + sys.env("HOSTNAME")
+    }
+  } // discovery.kubernetes "pprof_pods"
+
+  discovery.relabel "pprof_pods" {
+    targets = discovery.kubernetes.pprof_pods.targets
+    rule {
+      action        = "drop"
+      source_labels = ["__meta_kubernetes_pod_phase"]
+      regex         = "Pending|Succeeded|Failed|Completed"
+    }
+
+    rule {
+      regex  = "__meta_kubernetes_pod_label_(.+)"
+      action = "labelmap"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_namespace"]
+      target_label  = "namespace"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_pod_name"]
+      target_label  = "pod"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_pod_container_name"]
+      target_label  = "container"
+    }
+
+    // Compute the workload (owner) name. For ReplicaSet-owned pods, strip the
+    // pod-template hash to recover the Deployment name (matches Beyla / OTel Operator).
+    rule {
+      source_labels = ["__meta_kubernetes_pod_controller_name"]
+      target_label = "__tmp_workload_name"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_pod_controller_kind", "__meta_kubernetes_pod_controller_name"]
+      regex = "ReplicaSet;(.+)-[^-]+"
+      replacement = "$1"
+      target_label = "__tmp_workload_name"
+    }
+
+    // Set service_name by choosing the first value found from the following ordered list:
+    // - pod.annotation[resource.opentelemetry.io/service.name]
+    // - pod.label[app.kubernetes.io/instance]
+    // - pod.label[app.kubernetes.io/name]
+    // - k8s.workload.name (Deployment, StatefulSet, DaemonSet, CronJob, Job, ...)
+    // - k8s.pod.name
+    // - k8s.container.name
+    rule {
+      action = "replace"
+      source_labels = [
+        "__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_name",
+        "__meta_kubernetes_pod_label_app_kubernetes_io_instance",
+        "__meta_kubernetes_pod_label_app_kubernetes_io_name",
+        "__tmp_workload_name",
+        "pod",
+        "container",
+      ]
+      separator = ";"
+      regex = "^(?:;*)?([^;]+).*$"
+      replacement = "$1"
+      target_label = "service_name"
+    }
+
+    // Set service_namespace by choosing the first value found from the following ordered list:
+    // - pod.annotation[resource.opentelemetry.io/service.namespace]
+    // - pod.namespace
+    rule {
+      action = "replace"
+      source_labels = [
+        "__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_namespace",
+        "namespace",
+      ]
+      separator = ";"
+      regex = "^(?:;*)?([^;]+).*$"
+      replacement = "$1"
+      target_label = "service_namespace"
+    }
+
+    // Set service_instance_id by choosing the first value found from the following ordered list:
+    // - pod.annotation[resource.opentelemetry.io/service.instance.id]
+    // - concat([k8s.namespace.name, k8s.pod.name, k8s.container.name], '.')
+    rule {
+      source_labels = ["__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_instance_id"]
+      target_label = "service_instance_id"
+    }
+    rule {
+      source_labels = ["service_instance_id", "namespace", "pod", "container"]
+      separator = "."
+      regex = "^\\.([^.]+\\.[^.]+\\.[^.]+)$"
+      target_label = "service_instance_id"
+    }
+
+    rule {
+      replacement = "alloy/pyroscope.pprof"
+      target_label = "source"
+    }
+  } // discovery.relabel "pprof_pods"
+
+  discovery.relabel "pprof_pods_block" {
+    targets = discovery.relabel.pprof_pods.output
+
+    // Keep only pods with the scrape annotation set
+    rule {
+      source_labels = ["__meta_kubernetes_pod_annotation_profiles_grafana_com_block_scrape"]
+      regex         = "true"
+      action        = "keep"
+    }
+
+    // Rules to choose the right container
+    rule {
+      source_labels = ["container"]
+      target_label = "__tmp_container"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_pod_annotation_profiles_grafana_com_block_container"]
+      regex = "(.+)"
+      target_label = "__tmp_container"
+    }
+    rule {
+      source_labels = ["container"]
+      action = "keepequal"
+      target_label = "__tmp_container"
+    }
+    rule {
+      action = "labeldrop"
+      regex = "__tmp_container"
+    }
+
+    // Rules to choose the right port by name
+    // The discovery generates a target for each declared container port of the pod.
+    // If the portName annotation has value, keep only the target where the port name matches the one of the annotation.
+    rule {
+      source_labels = ["__meta_kubernetes_pod_container_port_name"]
+      target_label = "__tmp_port"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_pod_annotation_profiles_grafana_com_block_port_name"]
+      regex = "(.+)"
+      target_label = "__tmp_port"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_pod_container_port_name"]
+      action = "keepequal"
+      target_label = "__tmp_port"
+    }
+    rule {
+      action = "labeldrop"
+      regex = "__tmp_port"
+    }
+
+    // If the portNumber annotation has a value, override the target address to use it, regardless whether it is
+    // one of the declared ports on that Pod.
+    rule {
+      source_labels = ["__meta_kubernetes_pod_annotation_profiles_grafana_com_block_port", "__meta_kubernetes_pod_ip"]
+      regex = "(\\d+);(([A-Fa-f0-9]{1,4}::?){1,7}[A-Fa-f0-9]{1,4})"
+      replacement = "[$2]:$1" // IPv6
+      target_label = "__address__"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_pod_annotation_profiles_grafana_com_block_port", "__meta_kubernetes_pod_ip"]
+      regex = "(\\d+);((([0-9]+?)(\\.|$)){4})" // IPv4, takes priority over IPv6 when both exists
+      replacement = "$2:$1"
+      target_label = "__address__"
+    }
+
+    rule {
+      source_labels = ["__meta_kubernetes_pod_annotation_profiles_grafana_com_block_scheme"]
+      regex         = "(https?)"
+      target_label  = "__scheme__"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_pod_annotation_profiles_grafana_com_block_path"]
+      regex         = "(.+)"
+      target_label  = "__profile_path__"
+    }
+  } // discovery.relabel "pprof_pods_block"
+
+  pyroscope.scrape "pyroscope_scrape_block" {
+    targets = discovery.relabel.pprof_pods_block.output
+
+    bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+    profiling_config {
+      profile.block {
+        enabled = true
+      }
+      profile.process_cpu {
+        enabled = false
+      }
+      profile.fgprof {
+        enabled = false
+      }
+      profile.godeltaprof_block {
+        enabled = false
+      }
+      profile.godeltaprof_memory {
+        enabled = false
+      }
+      profile.godeltaprof_mutex {
+        enabled = false
+      }
+      profile.goroutine {
+        enabled = false
+      }
+      profile.memory {
+        enabled = false
+      }
+      profile.mutex {
+        enabled = false
+      }
+    }
+
+    scrape_interval = "15s"
+    scrape_timeout = "18s"
+
+    forward_to = argument.profiles_destinations.value
+  } // pyroscope.scrape "pyroscope_scrape_block"
+  discovery.relabel "pprof_pods_cpu" {
+    targets = discovery.relabel.pprof_pods.output
+
+    // Keep only pods with the scrape annotation set
+    rule {
+      source_labels = ["__meta_kubernetes_pod_annotation_profiles_grafana_com_cpu_scrape"]
+      regex         = "true"
+      action        = "keep"
+    }
+
+    // Rules to choose the right container
+    rule {
+      source_labels = ["container"]
+      target_label = "__tmp_container"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_pod_annotation_profiles_grafana_com_cpu_container"]
+      regex = "(.+)"
+      target_label = "__tmp_container"
+    }
+    rule {
+      source_labels = ["container"]
+      action = "keepequal"
+      target_label = "__tmp_container"
+    }
+    rule {
+      action = "labeldrop"
+      regex = "__tmp_container"
+    }
+
+    // Rules to choose the right port by name
+    // The discovery generates a target for each declared container port of the pod.
+    // If the portName annotation has value, keep only the target where the port name matches the one of the annotation.
+    rule {
+      source_labels = ["__meta_kubernetes_pod_container_port_name"]
+      target_label = "__tmp_port"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_pod_annotation_profiles_grafana_com_cpu_port_name"]
+      regex = "(.+)"
+      target_label = "__tmp_port"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_pod_container_port_name"]
+      action = "keepequal"
+      target_label = "__tmp_port"
+    }
+    rule {
+      action = "labeldrop"
+      regex = "__tmp_port"
+    }
+
+    // If the portNumber annotation has a value, override the target address to use it, regardless whether it is
+    // one of the declared ports on that Pod.
+    rule {
+      source_labels = ["__meta_kubernetes_pod_annotation_profiles_grafana_com_cpu_port", "__meta_kubernetes_pod_ip"]
+      regex = "(\\d+);(([A-Fa-f0-9]{1,4}::?){1,7}[A-Fa-f0-9]{1,4})"
+      replacement = "[$2]:$1" // IPv6
+      target_label = "__address__"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_pod_annotation_profiles_grafana_com_cpu_port", "__meta_kubernetes_pod_ip"]
+      regex = "(\\d+);((([0-9]+?)(\\.|$)){4})" // IPv4, takes priority over IPv6 when both exists
+      replacement = "$2:$1"
+      target_label = "__address__"
+    }
+
+    rule {
+      source_labels = ["__meta_kubernetes_pod_annotation_profiles_grafana_com_cpu_scheme"]
+      regex         = "(https?)"
+      target_label  = "__scheme__"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_pod_annotation_profiles_grafana_com_cpu_path"]
+      regex         = "(.+)"
+      target_label  = "__profile_path__"
+    }
+  } // discovery.relabel "pprof_pods_cpu"
+
+  pyroscope.scrape "pyroscope_scrape_cpu" {
+    targets = discovery.relabel.pprof_pods_cpu.output
+
+    bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+    profiling_config {
+      profile.block {
+        enabled = false
+      }
+      profile.process_cpu {
+        enabled = true
+      }
+      profile.fgprof {
+        enabled = false
+      }
+      profile.godeltaprof_block {
+        enabled = false
+      }
+      profile.godeltaprof_memory {
+        enabled = false
+      }
+      profile.godeltaprof_mutex {
+        enabled = false
+      }
+      profile.goroutine {
+        enabled = false
+      }
+      profile.memory {
+        enabled = false
+      }
+      profile.mutex {
+        enabled = false
+      }
+    }
+
+    scrape_interval = "15s"
+    scrape_timeout = "18s"
+
+    forward_to = argument.profiles_destinations.value
+  } // pyroscope.scrape "pyroscope_scrape_cpu"
+  discovery.relabel "pprof_pods_fgprof" {
+    targets = discovery.relabel.pprof_pods.output
+
+    // Keep only pods with the scrape annotation set
+    rule {
+      source_labels = ["__meta_kubernetes_pod_annotation_profiles_grafana_com_fgprof_scrape"]
+      regex         = "true"
+      action        = "keep"
+    }
+
+    // Rules to choose the right container
+    rule {
+      source_labels = ["container"]
+      target_label = "__tmp_container"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_pod_annotation_profiles_grafana_com_fgprof_container"]
+      regex = "(.+)"
+      target_label = "__tmp_container"
+    }
+    rule {
+      source_labels = ["container"]
+      action = "keepequal"
+      target_label = "__tmp_container"
+    }
+    rule {
+      action = "labeldrop"
+      regex = "__tmp_container"
+    }
+
+    // Rules to choose the right port by name
+    // The discovery generates a target for each declared container port of the pod.
+    // If the portName annotation has value, keep only the target where the port name matches the one of the annotation.
+    rule {
+      source_labels = ["__meta_kubernetes_pod_container_port_name"]
+      target_label = "__tmp_port"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_pod_annotation_profiles_grafana_com_fgprof_port_name"]
+      regex = "(.+)"
+      target_label = "__tmp_port"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_pod_container_port_name"]
+      action = "keepequal"
+      target_label = "__tmp_port"
+    }
+    rule {
+      action = "labeldrop"
+      regex = "__tmp_port"
+    }
+
+    // If the portNumber annotation has a value, override the target address to use it, regardless whether it is
+    // one of the declared ports on that Pod.
+    rule {
+      source_labels = ["__meta_kubernetes_pod_annotation_profiles_grafana_com_fgprof_port", "__meta_kubernetes_pod_ip"]
+      regex = "(\\d+);(([A-Fa-f0-9]{1,4}::?){1,7}[A-Fa-f0-9]{1,4})"
+      replacement = "[$2]:$1" // IPv6
+      target_label = "__address__"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_pod_annotation_profiles_grafana_com_fgprof_port", "__meta_kubernetes_pod_ip"]
+      regex = "(\\d+);((([0-9]+?)(\\.|$)){4})" // IPv4, takes priority over IPv6 when both exists
+      replacement = "$2:$1"
+      target_label = "__address__"
+    }
+
+    rule {
+      source_labels = ["__meta_kubernetes_pod_annotation_profiles_grafana_com_fgprof_scheme"]
+      regex         = "(https?)"
+      target_label  = "__scheme__"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_pod_annotation_profiles_grafana_com_fgprof_path"]
+      regex         = "(.+)"
+      target_label  = "__profile_path__"
+    }
+  } // discovery.relabel "pprof_pods_fgprof"
+
+  pyroscope.scrape "pyroscope_scrape_fgprof" {
+    targets = discovery.relabel.pprof_pods_fgprof.output
+
+    bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+    profiling_config {
+      profile.block {
+        enabled = false
+      }
+      profile.process_cpu {
+        enabled = false
+      }
+      profile.fgprof {
+        enabled = true
+      }
+      profile.godeltaprof_block {
+        enabled = false
+      }
+      profile.godeltaprof_memory {
+        enabled = false
+      }
+      profile.godeltaprof_mutex {
+        enabled = false
+      }
+      profile.goroutine {
+        enabled = false
+      }
+      profile.memory {
+        enabled = false
+      }
+      profile.mutex {
+        enabled = false
+      }
+    }
+
+    scrape_interval = "15s"
+    scrape_timeout = "18s"
+
+    forward_to = argument.profiles_destinations.value
+  } // pyroscope.scrape "pyroscope_scrape_fgprof"
+  discovery.relabel "pprof_pods_goroutine" {
+    targets = discovery.relabel.pprof_pods.output
+
+    // Keep only pods with the scrape annotation set
+    rule {
+      source_labels = ["__meta_kubernetes_pod_annotation_profiles_grafana_com_goroutine_scrape"]
+      regex         = "true"
+      action        = "keep"
+    }
+
+    // Rules to choose the right container
+    rule {
+      source_labels = ["container"]
+      target_label = "__tmp_container"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_pod_annotation_profiles_grafana_com_goroutine_container"]
+      regex = "(.+)"
+      target_label = "__tmp_container"
+    }
+    rule {
+      source_labels = ["container"]
+      action = "keepequal"
+      target_label = "__tmp_container"
+    }
+    rule {
+      action = "labeldrop"
+      regex = "__tmp_container"
+    }
+
+    // Rules to choose the right port by name
+    // The discovery generates a target for each declared container port of the pod.
+    // If the portName annotation has value, keep only the target where the port name matches the one of the annotation.
+    rule {
+      source_labels = ["__meta_kubernetes_pod_container_port_name"]
+      target_label = "__tmp_port"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_pod_annotation_profiles_grafana_com_goroutine_port_name"]
+      regex = "(.+)"
+      target_label = "__tmp_port"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_pod_container_port_name"]
+      action = "keepequal"
+      target_label = "__tmp_port"
+    }
+    rule {
+      action = "labeldrop"
+      regex = "__tmp_port"
+    }
+
+    // If the portNumber annotation has a value, override the target address to use it, regardless whether it is
+    // one of the declared ports on that Pod.
+    rule {
+      source_labels = ["__meta_kubernetes_pod_annotation_profiles_grafana_com_goroutine_port", "__meta_kubernetes_pod_ip"]
+      regex = "(\\d+);(([A-Fa-f0-9]{1,4}::?){1,7}[A-Fa-f0-9]{1,4})"
+      replacement = "[$2]:$1" // IPv6
+      target_label = "__address__"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_pod_annotation_profiles_grafana_com_goroutine_port", "__meta_kubernetes_pod_ip"]
+      regex = "(\\d+);((([0-9]+?)(\\.|$)){4})" // IPv4, takes priority over IPv6 when both exists
+      replacement = "$2:$1"
+      target_label = "__address__"
+    }
+
+    rule {
+      source_labels = ["__meta_kubernetes_pod_annotation_profiles_grafana_com_goroutine_scheme"]
+      regex         = "(https?)"
+      target_label  = "__scheme__"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_pod_annotation_profiles_grafana_com_goroutine_path"]
+      regex         = "(.+)"
+      target_label  = "__profile_path__"
+    }
+  } // discovery.relabel "pprof_pods_goroutine"
+
+  pyroscope.scrape "pyroscope_scrape_goroutine" {
+    targets = discovery.relabel.pprof_pods_goroutine.output
+
+    bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+    profiling_config {
+      profile.block {
+        enabled = false
+      }
+      profile.process_cpu {
+        enabled = false
+      }
+      profile.fgprof {
+        enabled = false
+      }
+      profile.godeltaprof_block {
+        enabled = false
+      }
+      profile.godeltaprof_memory {
+        enabled = false
+      }
+      profile.godeltaprof_mutex {
+        enabled = false
+      }
+      profile.goroutine {
+        enabled = true
+      }
+      profile.memory {
+        enabled = false
+      }
+      profile.mutex {
+        enabled = false
+      }
+    }
+
+    scrape_interval = "15s"
+    scrape_timeout = "18s"
+
+    forward_to = argument.profiles_destinations.value
+  } // pyroscope.scrape "pyroscope_scrape_goroutine"
+  discovery.relabel "pprof_pods_memory" {
+    targets = discovery.relabel.pprof_pods.output
+
+    // Keep only pods with the scrape annotation set
+    rule {
+      source_labels = ["__meta_kubernetes_pod_annotation_profiles_grafana_com_memory_scrape"]
+      regex         = "true"
+      action        = "keep"
+    }
+
+    // Rules to choose the right container
+    rule {
+      source_labels = ["container"]
+      target_label = "__tmp_container"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_pod_annotation_profiles_grafana_com_memory_container"]
+      regex = "(.+)"
+      target_label = "__tmp_container"
+    }
+    rule {
+      source_labels = ["container"]
+      action = "keepequal"
+      target_label = "__tmp_container"
+    }
+    rule {
+      action = "labeldrop"
+      regex = "__tmp_container"
+    }
+
+    // Rules to choose the right port by name
+    // The discovery generates a target for each declared container port of the pod.
+    // If the portName annotation has value, keep only the target where the port name matches the one of the annotation.
+    rule {
+      source_labels = ["__meta_kubernetes_pod_container_port_name"]
+      target_label = "__tmp_port"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_pod_annotation_profiles_grafana_com_memory_port_name"]
+      regex = "(.+)"
+      target_label = "__tmp_port"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_pod_container_port_name"]
+      action = "keepequal"
+      target_label = "__tmp_port"
+    }
+    rule {
+      action = "labeldrop"
+      regex = "__tmp_port"
+    }
+
+    // If the portNumber annotation has a value, override the target address to use it, regardless whether it is
+    // one of the declared ports on that Pod.
+    rule {
+      source_labels = ["__meta_kubernetes_pod_annotation_profiles_grafana_com_memory_port", "__meta_kubernetes_pod_ip"]
+      regex = "(\\d+);(([A-Fa-f0-9]{1,4}::?){1,7}[A-Fa-f0-9]{1,4})"
+      replacement = "[$2]:$1" // IPv6
+      target_label = "__address__"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_pod_annotation_profiles_grafana_com_memory_port", "__meta_kubernetes_pod_ip"]
+      regex = "(\\d+);((([0-9]+?)(\\.|$)){4})" // IPv4, takes priority over IPv6 when both exists
+      replacement = "$2:$1"
+      target_label = "__address__"
+    }
+
+    rule {
+      source_labels = ["__meta_kubernetes_pod_annotation_profiles_grafana_com_memory_scheme"]
+      regex         = "(https?)"
+      target_label  = "__scheme__"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_pod_annotation_profiles_grafana_com_memory_path"]
+      regex         = "(.+)"
+      target_label  = "__profile_path__"
+    }
+  } // discovery.relabel "pprof_pods_memory"
+
+  pyroscope.scrape "pyroscope_scrape_memory" {
+    targets = discovery.relabel.pprof_pods_memory.output
+
+    bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+    profiling_config {
+      profile.block {
+        enabled = false
+      }
+      profile.process_cpu {
+        enabled = false
+      }
+      profile.fgprof {
+        enabled = false
+      }
+      profile.godeltaprof_block {
+        enabled = false
+      }
+      profile.godeltaprof_memory {
+        enabled = false
+      }
+      profile.godeltaprof_mutex {
+        enabled = false
+      }
+      profile.goroutine {
+        enabled = false
+      }
+      profile.memory {
+        enabled = true
+      }
+      profile.mutex {
+        enabled = false
+      }
+    }
+
+    scrape_interval = "15s"
+    scrape_timeout = "18s"
+
+    forward_to = argument.profiles_destinations.value
+  } // pyroscope.scrape "pyroscope_scrape_memory"
+  discovery.relabel "pprof_pods_mutex" {
+    targets = discovery.relabel.pprof_pods.output
+
+    // Keep only pods with the scrape annotation set
+    rule {
+      source_labels = ["__meta_kubernetes_pod_annotation_profiles_grafana_com_mutex_scrape"]
+      regex         = "true"
+      action        = "keep"
+    }
+
+    // Rules to choose the right container
+    rule {
+      source_labels = ["container"]
+      target_label = "__tmp_container"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_pod_annotation_profiles_grafana_com_mutex_container"]
+      regex = "(.+)"
+      target_label = "__tmp_container"
+    }
+    rule {
+      source_labels = ["container"]
+      action = "keepequal"
+      target_label = "__tmp_container"
+    }
+    rule {
+      action = "labeldrop"
+      regex = "__tmp_container"
+    }
+
+    // Rules to choose the right port by name
+    // The discovery generates a target for each declared container port of the pod.
+    // If the portName annotation has value, keep only the target where the port name matches the one of the annotation.
+    rule {
+      source_labels = ["__meta_kubernetes_pod_container_port_name"]
+      target_label = "__tmp_port"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_pod_annotation_profiles_grafana_com_mutex_port_name"]
+      regex = "(.+)"
+      target_label = "__tmp_port"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_pod_container_port_name"]
+      action = "keepequal"
+      target_label = "__tmp_port"
+    }
+    rule {
+      action = "labeldrop"
+      regex = "__tmp_port"
+    }
+
+    // If the portNumber annotation has a value, override the target address to use it, regardless whether it is
+    // one of the declared ports on that Pod.
+    rule {
+      source_labels = ["__meta_kubernetes_pod_annotation_profiles_grafana_com_mutex_port", "__meta_kubernetes_pod_ip"]
+      regex = "(\\d+);(([A-Fa-f0-9]{1,4}::?){1,7}[A-Fa-f0-9]{1,4})"
+      replacement = "[$2]:$1" // IPv6
+      target_label = "__address__"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_pod_annotation_profiles_grafana_com_mutex_port", "__meta_kubernetes_pod_ip"]
+      regex = "(\\d+);((([0-9]+?)(\\.|$)){4})" // IPv4, takes priority over IPv6 when both exists
+      replacement = "$2:$1"
+      target_label = "__address__"
+    }
+
+    rule {
+      source_labels = ["__meta_kubernetes_pod_annotation_profiles_grafana_com_mutex_scheme"]
+      regex         = "(https?)"
+      target_label  = "__scheme__"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_pod_annotation_profiles_grafana_com_mutex_path"]
+      regex         = "(.+)"
+      target_label  = "__profile_path__"
+    }
+  } // discovery.relabel "pprof_pods_mutex"
+
+  pyroscope.scrape "pyroscope_scrape_mutex" {
+    targets = discovery.relabel.pprof_pods_mutex.output
+
+    bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+    profiling_config {
+      profile.block {
+        enabled = false
+      }
+      profile.process_cpu {
+        enabled = false
+      }
+      profile.fgprof {
+        enabled = false
+      }
+      profile.godeltaprof_block {
+        enabled = false
+      }
+      profile.godeltaprof_memory {
+        enabled = false
+      }
+      profile.godeltaprof_mutex {
+        enabled = false
+      }
+      profile.goroutine {
+        enabled = false
+      }
+      profile.memory {
+        enabled = false
+      }
+      profile.mutex {
+        enabled = true
+      }
+    }
+
+    scrape_interval = "15s"
+    scrape_timeout = "18s"
+
+    forward_to = argument.profiles_destinations.value
+  } // pyroscope.scrape "pyroscope_scrape_mutex"
+} // declare "profiling"
+profiling "feature" {
+  profiles_destinations = [
+    pyroscope.write.pyro.receiver,
+  ]
+}
+
+
+
+
+
+
+
+// Destination: pyro (pyroscope)
+pyroscope.write "pyro" {
+  endpoint {
+    url = "http://pyroscope.pyroscope.svc:4040"
+    headers = {
+    }
+    tls_config {
+      insecure_skip_verify = false
+    }
+    min_backoff_period = "500ms"
+    max_backoff_period = "5m"
+    max_backoff_retries = "10"
+  }
+
+  external_labels = {
+    "cluster" = "profiling-feature-test",
+    "k8s_cluster_name" = "profiling-feature-test",
+  }
+} // pyroscope.write "pyro"
+

--- a/charts/k8s-monitoring/tests/integration/prom-and-loki-to-otlp/.rendered/alloy-logs.alloy
+++ b/charts/k8s-monitoring/tests/integration/prom-and-loki-to-otlp/.rendered/alloy-logs.alloy
@@ -1,0 +1,322 @@
+// Feature: Pod Logs (Loki)
+declare "pod_logs_via_loki" {
+  argument "logs_destinations" {
+    comment = "Must be a list of log destinations where collected logs should be forwarded to"
+  }
+
+  discovery.kubernetes "pods" {
+    role = "pod"
+    selectors {
+      role = "pod"
+      field = "spec.nodeName=" + sys.env("HOSTNAME")
+    }
+  } // discovery.kubernetes "pods"
+
+  discovery.relabel "filtered_pods" {
+    targets = discovery.kubernetes.pods.targets
+    rule {
+      source_labels = ["__meta_kubernetes_namespace"]
+      action = "replace"
+      target_label = "namespace"
+    }
+    rule {  // Drop anything with a "falsy" annotation value
+      source_labels = ["__meta_kubernetes_pod_annotation_logs_grafana_com_pods_enabled"]
+      regex = "(false|no|skip)"
+      action = "drop"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_pod_name"]
+      target_label = "pod"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_pod_container_name"]
+      target_label = "container"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_namespace", "__meta_kubernetes_pod_container_name"]
+      separator = "/"
+      replacement = "$1"
+      target_label = "job"
+    }
+
+    // set the container runtime as a label
+    rule {
+      source_labels = ["__meta_kubernetes_pod_container_id"]
+      regex = "^(\\S+):\\/\\/.+$"
+      replacement = "$1"
+      target_label = "tmp_container_runtime"
+    }
+    // explicitly set service_name. if not set, loki will automatically try to populate a default.
+    // see https://grafana.com/docs/loki/latest/get-started/labels/#default-labels-for-all-users
+    //
+    // choose the first value found from the following ordered list:
+    // - pod.annotation[resource.opentelemetry.io/service.name]
+    // - pod.label[app.kubernetes.io/name]
+    // - k8s.container.name
+    rule {
+      source_labels = [
+        "__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_name",
+        "__meta_kubernetes_pod_label_app_kubernetes_io_name",
+        "__meta_kubernetes_pod_container_name",
+      ]
+      separator = ";"
+      regex = "^(?:;*)?([^;]+).*$"
+      replacement = "$1"
+      target_label = "service_name"
+    }
+
+    // explicitly set service_namespace.
+    //
+    // choose the first value found from the following ordered list:
+    // - pod.annotation[resource.opentelemetry.io/service.namespace]
+    // - pod.namespace
+    rule {
+      source_labels = [
+        "__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_namespace",
+        "namespace",
+      ]
+      separator = ";"
+      regex = "^(?:;*)?([^;]+).*$"
+      replacement = "$1"
+      target_label = "service_namespace"
+    }
+
+    // explicitly set service_instance_id.
+    //
+    // choose the first value found from the following ordered list:
+    // - pod.annotation[resource.opentelemetry.io/service.instance.id]
+    // - concat([k8s.namespace.name, k8s.pod.name, k8s.container.name], '.')
+    rule {
+      source_labels = ["__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_instance_id"]
+      target_label = "service_instance_id"
+    }
+    rule {
+      source_labels = ["service_instance_id", "namespace", "pod", "container"]
+      separator = "."
+      regex = "^\\.([^.]+\\.[^.]+\\.[^.]+)$"
+      target_label = "service_instance_id"
+    }
+
+    // set resource attributes
+    rule {
+      action = "labelmap"
+      regex = "__meta_kubernetes_pod_annotation_resource_opentelemetry_io_(.+)"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_job"]
+      regex = "(.+)"
+      target_label = "job"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+      regex = "(.+)"
+      target_label = "app_kubernetes_io_name"
+    }
+
+    // Set the pod log path.
+    rule {
+      source_labels = ["__meta_kubernetes_pod_uid", "__meta_kubernetes_pod_container_name"]
+      separator = "/"
+      replacement = "/var/log/pods/*$1/*.log"
+      target_label = "__path__"
+    }
+
+    // If kubernetes.io/config.mirror is set, this is a static pod, created by the kubelet.
+    // It's logs live on a different path.
+    rule {
+      source_labels = ["__meta_kubernetes_pod_annotation_kubernetes_io_config_mirror", "__meta_kubernetes_pod_container_name"]
+      separator = "/"
+      regex = "(.+/.+)"
+      replacement = "/var/log/pods/*$1/*.log"
+      target_label = "__path__"
+    }
+  } // discovery.relabel "filtered_pods"
+
+  local.file_match "pod_logs" {
+    path_targets = discovery.relabel.filtered_pods.output
+  } // local.file_match "pod_logs"
+
+  loki.source.file "pod_logs" {
+    targets    = local.file_match.pod_logs.targets
+    tail_from_end = true
+    forward_to = [loki.process.pod_logs.receiver]
+  } // loki.source.file "pod_logs"
+
+  loki.process "pod_logs" {
+    stage.match {
+      selector = "{tmp_container_runtime=~\"containerd|cri-o|\"}"
+      // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
+      stage.cri {
+        max_partial_lines = 100
+      }
+
+      // Set the extract flags and stream values as labels
+      stage.labels {
+        values = {
+          flags  = "",
+          stream  = "",
+        }
+      }
+    }
+
+    stage.match {
+      selector = "{tmp_container_runtime=\"docker\"}"
+      // the docker processing stage extracts the following k/v pairs: log, stream, time
+      stage.docker {}
+
+      // Set the extract stream value as a label
+      stage.labels {
+        values = {
+          stream  = "",
+        }
+      }
+    }
+
+    // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
+    // namespace, pod, and container labels. Drop any structured metadata. Also drop the temporary
+    // container runtime label as it is no longer needed.
+    stage.label_drop {
+      values = [
+        "filename",
+        "tmp_container_runtime",
+      ]
+    }
+    stage.structured_metadata {
+      values = {
+        "service_instance_id" = "service_instance_id",
+      }
+    }
+
+    forward_to = argument.logs_destinations.value
+  } // loki.secretfilter "pod_logs"
+} // declare "pod_logs_via_loki"
+pod_logs_via_loki "feature" {
+  logs_destinations = [
+    otelcol.receiver.loki.loki.receiver,
+  ]
+}
+
+
+
+
+
+// Destination: loki (otlp)
+otelcol.receiver.loki "loki" {
+  output {
+    logs = [otelcol.processor.attributes.loki.input]
+  }
+} // otelcol.receiver.loki "loki"
+otelcol.processor.attributes "loki" {
+  output {
+    logs = [otelcol.processor.transform.loki.input]
+  }
+} // otelcol.processor.attributes "loki"
+
+otelcol.processor.transform "loki" {
+  error_mode = "ignore"
+  log_statements {
+    context = "resource"
+    statements = [
+      `set(attributes["k8s.cluster.name"], "prom-and-loki-to-otlp-test")`,
+      `delete_key(attributes, "process.pid")`,
+      `delete_key(attributes, "process.parent_pid")`,
+      `delete_key(attributes, "process.executable.path")`,
+      `delete_key(attributes, "process.command_line")`,
+      `delete_key(attributes, "process.command_args")`,
+      `delete_key(attributes, "process.owner")`,
+      `delete_key(attributes, "process.runtime.version")`,
+      `delete_key(attributes, "process.runtime.description")`,
+      `delete_key(attributes, "host.ip")`,
+      `delete_key(attributes, "host.mac")`,
+      `delete_key(attributes, "k8s.pod.start_time")`,
+      `delete_key(attributes, "k8s.pod.uid")`,
+      `delete_key(attributes, "container.image.id")`,
+      `delete_key(attributes, "container.image.repo_digests")`,
+      `delete_key(attributes, "os.description")`,
+      `delete_key(attributes, "os.build_id")`,
+    ]
+  }
+
+  log_statements {
+    context = "log"
+    statements = [
+      `delete_key(attributes, "loki.attribute.labels")`,
+      `delete_key(attributes, "loki.resource.labels")`,
+      `set(resource.attributes["k8s.container.name"], attributes["container"] ) where resource.attributes["k8s.container.name"] == nil and attributes["container"] != nil`,
+      `delete_key(attributes, "container") where attributes["container"] == resource.attributes["k8s.container.name"]`,
+      `set(resource.attributes["k8s.cronjob.name"], attributes["cronjob"] ) where resource.attributes["k8s.cronjob.name"] == nil and attributes["cronjob"] != nil`,
+      `delete_key(attributes, "cronjob") where attributes["cronjob"] == resource.attributes["k8s.cronjob.name"]`,
+      `set(resource.attributes["k8s.daemonset.name"], attributes["daemonset"] ) where resource.attributes["k8s.daemonset.name"] == nil and attributes["daemonset"] != nil`,
+      `delete_key(attributes, "daemonset") where attributes["daemonset"] == resource.attributes["k8s.daemonset.name"]`,
+      `set(resource.attributes["k8s.deployment.name"], attributes["deployment"] ) where resource.attributes["k8s.deployment.name"] == nil and attributes["deployment"] != nil`,
+      `delete_key(attributes, "deployment") where attributes["deployment"] == resource.attributes["k8s.deployment.name"]`,
+      `set(resource.attributes["deployment.environment"], attributes["deployment_environment"] ) where resource.attributes["deployment.environment"] == nil and attributes["deployment_environment"] != nil`,
+      `delete_key(attributes, "deployment_environment") where attributes["deployment_environment"] == resource.attributes["deployment.environment"]`,
+      `set(resource.attributes["deployment.environment.name"], attributes["deployment_environment_name"] ) where resource.attributes["deployment.environment.name"] == nil and attributes["deployment_environment_name"] != nil`,
+      `delete_key(attributes, "deployment_environment_name") where attributes["deployment_environment_name"] == resource.attributes["deployment.environment.name"]`,
+      `set(resource.attributes["k8s.job.name"], attributes["job_name"] ) where resource.attributes["k8s.job.name"] == nil and attributes["job_name"] != nil`,
+      `delete_key(attributes, "job_name") where attributes["job_name"] == resource.attributes["k8s.job.name"]`,
+      `set(resource.attributes["k8s.namespace.name"], attributes["namespace"] ) where resource.attributes["k8s.namespace.name"] == nil and attributes["namespace"] != nil`,
+      `delete_key(attributes, "namespace") where attributes["namespace"] == resource.attributes["k8s.namespace.name"]`,
+      `set(resource.attributes["k8s.pod.name"], attributes["pod"] ) where resource.attributes["k8s.pod.name"] == nil and attributes["pod"] != nil`,
+      `delete_key(attributes, "pod") where attributes["pod"] == resource.attributes["k8s.pod.name"]`,
+      `set(resource.attributes["k8s.replicaset.name"], attributes["replicaset"] ) where resource.attributes["k8s.replicaset.name"] == nil and attributes["replicaset"] != nil`,
+      `delete_key(attributes, "replicaset") where attributes["replicaset"] == resource.attributes["k8s.replicaset.name"]`,
+      `set(resource.attributes["service.name"], attributes["service_name"] ) where (resource.attributes["service.name"] == nil or resource.attributes["service.name"] == "") and attributes["service_name"] != nil and attributes["service_name"] != ""`,
+      `delete_key(attributes, "service_name") where attributes["service_name"] == resource.attributes["service.name"]`,
+      `set(resource.attributes["service.namespace"], attributes["service_namespace"] ) where (resource.attributes["service.namespace"] == nil or resource.attributes["service.namespace"] == "") and attributes["service_namespace"] != nil and attributes["service_namespace"] != ""`,
+      `delete_key(attributes, "service_namespace") where attributes["service_namespace"] == resource.attributes["service.namespace"]`,
+      `set(resource.attributes["k8s.statefulset.name"], attributes["statefulset"] ) where resource.attributes["k8s.statefulset.name"] == nil and attributes["statefulset"] != nil`,
+      `delete_key(attributes, "statefulset") where attributes["statefulset"] == resource.attributes["k8s.statefulset.name"]`,
+    ]
+  }
+
+  output {
+    logs = [otelcol.processor.batch.loki.input]
+  }
+} // otelcol.processor.transform "loki"
+
+otelcol.processor.batch "loki" {
+  timeout = "2s"
+  send_batch_size = 8192
+  send_batch_max_size = 0
+
+  output {
+    logs = [otelcol.exporter.otlphttp.loki.input]
+  }
+} // otelcol.processor.batch "loki"
+otelcol.exporter.otlphttp "loki" {
+  client {
+    endpoint = "http://loki.loki.svc:3100/otlp"
+    auth = otelcol.auth.basic.loki.handler
+    headers = {
+      "X-Scope-OrgID" = convert.nonsensitive(remote.kubernetes.secret.loki.data["tenantId"]),
+    }
+    tls {
+      insecure = false
+      insecure_skip_verify = false
+    }
+  }
+
+  retry_on_failure {
+    enabled = true
+    initial_interval = "5s"
+    max_interval = "30s"
+    max_elapsed_time = "5m"
+  }
+
+  sending_queue {
+    enabled = true
+  }
+} // otelcol.exporter.otlphttp "loki"
+
+otelcol.auth.basic "loki" {
+  username = convert.nonsensitive(remote.kubernetes.secret.loki.data["username"])
+  password = remote.kubernetes.secret.loki.data["password"]
+} // otelcol.auth.basic "loki"
+
+remote.kubernetes.secret "loki" {
+  name      = "loki-k8smon-k8s-monitoring"
+  namespace = "default"
+} // remote.kubernetes.secret "loki"
+

--- a/charts/k8s-monitoring/tests/integration/prom-and-loki-to-otlp/.rendered/alloy-metrics.alloy
+++ b/charts/k8s-monitoring/tests/integration/prom-and-loki-to-otlp/.rendered/alloy-metrics.alloy
@@ -1,0 +1,579 @@
+// Feature: Cluster Metrics
+declare "cluster_metrics" {
+  argument "metrics_destinations" {
+    comment = "Must be a list of metric destinations where collected metrics should be forwarded to"
+  }
+  discovery.kubernetes "nodes" {
+    role = "node"
+  } // discovery.kubernetes "nodes"
+
+  discovery.relabel "nodes" {
+    targets = discovery.kubernetes.nodes.targets
+    rule {
+      source_labels = ["__meta_kubernetes_node_name"]
+      target_label  = "node"
+    }
+
+    rule {
+      replacement = "kubernetes"
+      target_label = "source"
+    }
+  } // discovery.relabel "nodes"
+
+  // Kubelet
+  discovery.relabel "kubelet" {
+    targets = discovery.relabel.nodes.output
+  } // discovery.relabel "kubelet"
+
+  prometheus.scrape "kubelet" {
+    targets  = discovery.relabel.kubelet.output
+    job_name = "integrations/kubernetes/kubelet"
+    scheme   = "https"
+    scrape_interval = "60s"
+    scrape_timeout = "10s"
+    scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
+    scrape_classic_histograms = false
+    scrape_native_histograms = false
+    convert_classic_histograms_to_nhcb = false
+    bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+
+    tls_config {
+      ca_file = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+      insecure_skip_verify = true
+      server_name = "kubernetes"
+    }
+
+    clustering {
+      enabled = true
+    }
+
+    forward_to = [prometheus.relabel.kubelet.receiver]
+  } // prometheus.scrape "kubelet"
+
+  prometheus.relabel "kubelet" {
+    max_cache_size = 100000
+    rule {
+      source_labels = ["__name__"]
+      regex = "up|scrape_samples_scraped|go_goroutines|kubelet_certificate_manager_client_expiration_renew_errors|kubelet_certificate_manager_client_ttl_seconds|kubelet_certificate_manager_server_ttl_seconds|kubelet_cgroup_manager_duration_seconds_bucket|kubelet_cgroup_manager_duration_seconds_count|kubelet_node_config_error|kubelet_node_name|kubelet_pleg_relist_duration_seconds_bucket|kubelet_pleg_relist_duration_seconds_count|kubelet_pleg_relist_interval_seconds_bucket|kubelet_pod_start_duration_seconds_bucket|kubelet_pod_start_duration_seconds_count|kubelet_pod_worker_duration_seconds_bucket|kubelet_pod_worker_duration_seconds_count|kubelet_running_container_count|kubelet_running_containers|kubelet_running_pod_count|kubelet_running_pods|kubelet_runtime_operations_errors_total|kubelet_runtime_operations_total|kubelet_server_expiration_renew_errors|kubelet_volume_stats_available_bytes|kubelet_volume_stats_capacity_bytes|kubelet_volume_stats_inodes|kubelet_volume_stats_inodes_free|kubelet_volume_stats_inodes_used|kubelet_volume_stats_used_bytes|kubernetes_build_info|namespace_workload_pod|process_cpu_seconds_total|process_resident_memory_bytes|rest_client_requests_total|storage_operation_duration_seconds_count|storage_operation_errors_total|volume_manager_total_volumes"
+      action = "keep"
+    }
+
+    forward_to = argument.metrics_destinations.value
+  } // prometheus.relabel "kubelet"
+
+  // Kubelet Resources
+  discovery.relabel "kubelet_resources" {
+    targets = discovery.relabel.nodes.output
+    rule {
+      replacement   = "/metrics/resource"
+      target_label  = "__metrics_path__"
+    }
+  } // discovery.relabel "kubelet_resources"
+
+  prometheus.scrape "kubelet_resources" {
+    targets = discovery.relabel.kubelet_resources.output
+    job_name = "integrations/kubernetes/resources"
+    scheme   = "https"
+    scrape_interval = "60s"
+    scrape_timeout = "10s"
+    scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
+    scrape_classic_histograms = false
+    scrape_native_histograms = false
+    convert_classic_histograms_to_nhcb = false
+    bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+
+    tls_config {
+      ca_file = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+      insecure_skip_verify = true
+      server_name = "kubernetes"
+    }
+
+    clustering {
+      enabled = true
+    }
+
+    forward_to = [prometheus.relabel.kubelet_resources.receiver]
+  } // prometheus.scrape "kubelet_resources"
+
+  prometheus.relabel "kubelet_resources" {
+    max_cache_size = 100000
+    rule {
+      source_labels = ["__name__"]
+      regex = "up|scrape_samples_scraped|node_cpu_usage_seconds_total|node_memory_working_set_bytes"
+      action = "keep"
+    }
+
+    forward_to = argument.metrics_destinations.value
+  } // prometheus.relabel "kubelet_resources"
+
+  // cAdvisor
+  discovery.relabel "cadvisor" {
+    targets = discovery.relabel.nodes.output
+    rule {
+      replacement   = "/metrics/cadvisor"
+      target_label  = "__metrics_path__"
+    }
+  } // discovery.relabel "cadvisor"
+
+  prometheus.scrape "cadvisor" {
+    targets = discovery.relabel.cadvisor.output
+    job_name = "integrations/kubernetes/cadvisor"
+    scheme = "https"
+    scrape_interval = "60s"
+    scrape_timeout = "10s"
+    scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
+    scrape_classic_histograms = false
+    scrape_native_histograms = false
+    convert_classic_histograms_to_nhcb = false
+    bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+
+    tls_config {
+      ca_file = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+      insecure_skip_verify = true
+      server_name = "kubernetes"
+    }
+
+    clustering {
+      enabled = true
+    }
+
+    forward_to = [prometheus.relabel.cadvisor.receiver]
+  } // prometheus.scrape "cadvisor"
+
+  prometheus.relabel "cadvisor" {
+    max_cache_size = 100000
+    rule {
+      source_labels = ["__name__"]
+      regex = "up|scrape_samples_scraped|container_cpu_cfs_periods_total|container_cpu_cfs_throttled_periods_total|container_cpu_usage_seconds_total|container_fs_reads_bytes_total|container_fs_reads_total|container_fs_writes_bytes_total|container_fs_writes_total|container_memory_cache|container_memory_rss|container_memory_swap|container_memory_usage_bytes|container_memory_working_set_bytes|container_network_receive_bytes_total|container_network_receive_packets_dropped_total|container_network_receive_packets_total|container_network_transmit_bytes_total|container_network_transmit_packets_dropped_total|container_network_transmit_packets_total|machine_memory_bytes"
+      action = "keep"
+    }
+    // Drop empty container labels, addressing https://github.com/google/cadvisor/issues/2688
+    rule {
+      source_labels = ["__name__","container"]
+      separator = "@"
+      regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_pressure_.*)@"
+      action = "drop"
+    }
+    // Drop empty image labels, addressing https://github.com/google/cadvisor/issues/2688
+    rule {
+      source_labels = ["__name__","image"]
+      separator = "@"
+      regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_network_.*|container_pressure_.*)@"
+      action = "drop"
+    }
+    // Normalizing unimportant labels (not deleting to continue satisfying <label>!="" checks)
+    rule {
+      source_labels = ["__name__", "boot_id"]
+      separator = "@"
+      regex = "machine_memory_bytes@.*"
+      target_label = "boot_id"
+      replacement = "NA"
+    }
+    rule {
+      source_labels = ["__name__", "system_uuid"]
+      separator = "@"
+      regex = "machine_memory_bytes@.*"
+      target_label = "system_uuid"
+      replacement = "NA"
+    }
+    // Filter out non-physical devices/interfaces
+    rule {
+      source_labels = ["__name__", "device"]
+      separator = "@"
+      regex = "container_fs_.*@(/dev/)?(mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dasd.+)"
+      target_label = "__keepme"
+      replacement = "1"
+    }
+    rule {
+      source_labels = ["__name__", "__keepme"]
+      separator = "@"
+      regex = "container_fs_.*@"
+      action = "drop"
+    }
+    rule {
+      source_labels = ["__name__"]
+      regex = "container_fs_.*"
+      target_label = "__keepme"
+      replacement = ""
+    }
+    rule {
+      source_labels = ["__name__", "interface"]
+      separator = "@"
+      regex = "container_network_.*@(en[ospx][0-9].*|wlan[0-9].*|eth[0-9].*)"
+      target_label = "__keepme"
+      replacement = "1"
+    }
+    rule {
+      source_labels = ["__name__", "__keepme"]
+      separator = "@"
+      regex = "container_network_.*@"
+      action = "drop"
+    }
+    rule {
+      source_labels = ["__name__"]
+      regex = "container_network_.*"
+      target_label = "__keepme"
+      replacement = ""
+    }
+    forward_to = argument.metrics_destinations.value
+  } // prometheus.relabel "cadvisor"
+  discovery.kubernetes "kube_state_metrics" {
+    role = "endpoints"
+
+    selectors {
+      role = "endpoints"
+      label = "release=k8smon,app.kubernetes.io/name=kube-state-metrics"
+    }
+    namespaces {
+      names = ["default"]
+    }
+  } // discovery.kubernetes "kube_state_metrics"
+
+  discovery.relabel "kube_state_metrics" {
+    targets = discovery.kubernetes.kube_state_metrics.targets
+
+    rule {
+      action = "replace"
+      replacement = "kubernetes"
+      target_label = "source"
+    }
+
+  } // discovery.relabel "kube_state_metrics"
+
+  prometheus.scrape "kube_state_metrics" {
+    targets = discovery.relabel.kube_state_metrics.output
+    job_name = "integrations/kubernetes/kube-state-metrics"
+    scrape_interval = "60s"
+    scrape_timeout = "10s"
+    scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
+    scrape_classic_histograms = false
+    scrape_native_histograms = false
+    convert_classic_histograms_to_nhcb = false
+    scheme = "http"
+    bearer_token_file = ""
+    tls_config {
+      insecure_skip_verify = true
+    }
+
+    clustering {
+      enabled = true
+    }
+    forward_to = [prometheus.relabel.kube_state_metrics.receiver]
+  } // prometheus.scrape "kube_state_metrics"
+
+  prometheus.relabel "kube_state_metrics" {
+    max_cache_size = 100000
+    rule {
+      source_labels = ["__name__"]
+      regex = "up|scrape_samples_scraped|kube_configmap_info|kube_configmap_metadata_resource_version|kube_cronjob.*|kube_daemonset.*|kube_deployment_metadata_generation|kube_deployment_spec_replicas|kube_deployment_status_condition|kube_deployment_status_observed_generation|kube_deployment_status_replicas_available|kube_deployment_status_replicas_updated|kube_horizontalpodautoscaler_spec_max_replicas|kube_horizontalpodautoscaler_spec_min_replicas|kube_horizontalpodautoscaler_status_current_replicas|kube_horizontalpodautoscaler_status_desired_replicas|kube_job.*|kube_namespace_status_phase|kube_node.*|kube_persistentvolume_status_phase|kube_persistentvolumeclaim_access_mode|kube_persistentvolumeclaim_info|kube_persistentvolumeclaim_labels|kube_persistentvolumeclaim_resource_requests_storage_bytes|kube_persistentvolumeclaim_status_phase|kube_pod_completion_time|kube_pod_container_info|kube_pod_container_resource_limits|kube_pod_container_resource_requests|kube_pod_container_status_last_terminated_reason|kube_pod_container_status_last_terminated_timestamp|kube_pod_container_status_restarts_total|kube_pod_container_status_waiting_reason|kube_pod_info|kube_pod_owner|kube_pod_restart_policy|kube_pod_spec_volumes_persistentvolumeclaims_info|kube_pod_start_time|kube_pod_status_phase|kube_pod_status_reason|kube_pod_init_.*|kube_replicaset.*|kube_resourcequota|kube_secret_metadata_resource_version|kube_statefulset.*"
+      action = "keep"
+    }
+    forward_to = argument.metrics_destinations.value
+  } // prometheus.relabel "kube_state_metrics"
+} // declare "cluster_metrics"
+cluster_metrics "feature" {
+  metrics_destinations = [
+    otelcol.receiver.prometheus.prometheus.receiver,
+  ]
+}
+// Feature: Host Metrics
+declare "host_metrics" {
+  argument "metrics_destinations" {
+    comment = "Must be a list of metric destinations where collected metrics should be forwarded to"
+  }
+
+  // Linux hosts via Node Exporter
+  discovery.kubernetes "node_exporter" {
+    role = "pod"
+    selectors {
+      role = "pod"
+      label = "release=k8smon,app.kubernetes.io/name=node-exporter"
+    }
+    namespaces {
+      names = ["default"]
+    }
+
+  } // discovery.kubernetes "node_exporter"
+
+  discovery.relabel "node_exporter" {
+    targets = discovery.kubernetes.node_exporter.targets
+
+    // keep only the specified metrics port name, and pods that are Running and ready
+    rule {
+      source_labels = [
+        "__meta_kubernetes_pod_container_init",
+        "__meta_kubernetes_pod_phase",
+        "__meta_kubernetes_pod_ready",
+      ]
+      separator = "@"
+      regex = "false@Running@true"
+      action = "keep"
+    }
+
+    // Set the instance label to the node name
+    rule {
+      source_labels = ["__meta_kubernetes_pod_node_name"]
+      target_label = "instance"
+    }
+
+    rule {
+      source_labels = ["__meta_kubernetes_namespace"]
+      target_label  = "namespace"
+    }
+
+    rule {
+      source_labels = ["__meta_kubernetes_pod_name"]
+      target_label  = "pod"
+    }
+
+    rule {
+      source_labels = ["__meta_kubernetes_pod_container_name"]
+      target_label  = "container"
+    }
+
+    // set a workload label
+    rule {
+      source_labels = [
+        "__meta_kubernetes_pod_controller_kind",
+        "__meta_kubernetes_pod_controller_name",
+      ]
+      separator = "/"
+      target_label  = "workload"
+    }
+    // remove the hash from the ReplicaSet
+    rule {
+      source_labels = ["workload"]
+      regex = "(ReplicaSet/.+)-.+"
+      target_label  = "workload"
+    }
+
+    // Set the app label.
+    //
+    // Choose the first value found from the following ordered list:
+    // - pod.label[app.kubernetes.io/name]
+    // - pod.label[k8s-app]
+    // - pod.label[app]
+    rule {
+      source_labels = [
+        "__meta_kubernetes_pod_label_app_kubernetes_io_name",
+        "__meta_kubernetes_pod_label_k8s_app",
+        "__meta_kubernetes_pod_label_app",
+      ]
+      separator = ";"
+      regex = "^(?:;*)?([^;]+).*$"
+      replacement = "$1"
+      target_label = "app"
+    }
+
+    // Set the component label.
+    //
+    // Choose the first value found from the following ordered list:
+    // - pod.label[app.kubernetes.io/component]
+    // - pod.label[k8s-component]
+    // - pod.label[component]
+    rule {
+      source_labels = [
+        "__meta_kubernetes_pod_label_app_kubernetes_io_component",
+        "__meta_kubernetes_pod_label_k8s_component",
+        "__meta_kubernetes_pod_label_component",
+      ]
+      regex = "^(?:;*)?([^;]+).*$"
+      replacement = "$1"
+      target_label = "component"
+    }
+
+    rule {
+      target_label = "source"
+      replacement = "kubernetes"
+    }
+
+  } // discovery.relabel "node_exporter"
+
+  prometheus.scrape "node_exporter" {
+    targets = discovery.relabel.node_exporter.output
+    job_name = "integrations/node_exporter"
+    scrape_interval = "60s"
+    scrape_timeout = "10s"
+    scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
+    scrape_classic_histograms = false
+    scrape_native_histograms = false
+    convert_classic_histograms_to_nhcb = false
+    scheme = "http"
+    tls_config {
+      insecure_skip_verify = true
+    }
+
+    clustering {
+      enabled = true
+    }
+    forward_to = [prometheus.relabel.node_exporter.receiver]
+  } // prometheus.scrape "node_exporter"
+
+  prometheus.relabel "node_exporter" {
+    max_cache_size = 100000
+    rule {
+      source_labels = ["__name__"]
+      regex = "up|scrape_samples_scraped|node_cpu.*|node_exporter_build_info|node_filesystem.*|node_memory.*|node_network_receive_bytes_total|node_network_receive_drop_total|node_network_transmit_bytes_total|node_network_transmit_drop_total|process_cpu_seconds_total|process_resident_memory_bytes"
+      action = "keep"
+    }
+    // Drop metrics for certain file systems
+    rule {
+      source_labels = ["__name__", "fstype"]
+      separator = "@"
+      regex = "node_filesystem.*@(ramfs|tmpfs)"
+      action = "drop"
+    }
+    forward_to = argument.metrics_destinations.value
+  } // prometheus.relabel "node_exporter"
+} // declare "host_metrics"
+host_metrics "feature" {
+  metrics_destinations = [
+    otelcol.receiver.prometheus.prometheus.receiver,
+  ]
+}
+
+
+
+
+
+// Destination: prometheus (otlp)
+otelcol.receiver.prometheus "prometheus" {
+  output {
+    metrics = [otelcol.processor.transform.prometheus_scrape_normalize.input]
+  }
+} // otelcol.receiver.prometheus "prometheus"
+
+// Repairs artifacts of the Prometheus-to-OTLP conversion performed by
+// otelcol.receiver.prometheus. Only metrics that came from a Prometheus scrape pass
+// through this component; OTLP-native telemetry enters the pipeline further down.
+otelcol.processor.transform "prometheus_scrape_normalize" {
+  error_mode = "ignore"
+  metric_statements {
+    context = "resource"
+    statements = [
+      // The conversion sets service.name to the full Prometheus job label (e.g.
+      // "namespace/workload"). When the scrape target declares its identity explicitly
+      // with a service_name label on its own target_info metric (e.g. Grafana Beyla),
+      // prefer that value and drop the duplicate.
+      `set(attributes["service.name"], attributes["service_name"]) where attributes["service_name"] != nil and attributes["service_name"] != ""`,
+      `delete_key(attributes, "service_name") where attributes["service_name"] == attributes["service.name"]`,
+      // The same conversion turns other flat target_info labels into resource attributes.
+      // Promote them to their OpenTelemetry counterparts and drop the flat duplicates, so
+      // the OTLP endpoint does not receive two conflicting spellings of the same attribute.
+      `set(attributes["service.namespace"], attributes["service_namespace"]) where (attributes["service.namespace"] == nil or attributes["service.namespace"] == "") and attributes["service_namespace"] != nil and attributes["service_namespace"] != ""`,
+      `delete_key(attributes, "service_namespace") where attributes["service_namespace"] == attributes["service.namespace"]`,
+      `set(attributes["deployment.environment"], attributes["deployment_environment"]) where (attributes["deployment.environment"] == nil or attributes["deployment.environment"] == "") and attributes["deployment_environment"] != nil and attributes["deployment_environment"] != ""`,
+      `delete_key(attributes, "deployment_environment") where attributes["deployment_environment"] == attributes["deployment.environment"]`,
+      `set(attributes["deployment.environment.name"], attributes["deployment_environment_name"]) where (attributes["deployment.environment.name"] == nil or attributes["deployment.environment.name"] == "") and attributes["deployment_environment_name"] != nil and attributes["deployment_environment_name"] != ""`,
+      `delete_key(attributes, "deployment_environment_name") where attributes["deployment_environment_name"] == attributes["deployment.environment.name"]`,
+    ]
+  }
+  metric_statements {
+    context = "datapoint"
+    statements = [
+      // Same correction for scrape targets that put service_name on every series
+      // instead of exposing a target_info metric.
+      `set(resource.attributes["service.name"], attributes["service_name"]) where attributes["service_name"] != nil and attributes["service_name"] != ""`,
+    ]
+  }
+  output {
+    metrics = [otelcol.processor.attributes.prometheus.input]
+  }
+} // otelcol.processor.transform "prometheus_scrape_normalize"
+otelcol.processor.attributes "prometheus" {
+  output {
+    metrics = [otelcol.processor.transform.prometheus.input]
+  }
+} // otelcol.processor.attributes "prometheus"
+
+otelcol.processor.transform "prometheus" {
+  error_mode = "ignore"
+  metric_statements {
+    context = "resource"
+    statements = [
+      `set(attributes["k8s.cluster.name"], "prom-and-loki-to-otlp-test")`,
+      `delete_key(attributes, "process.pid")`,
+      `delete_key(attributes, "process.parent_pid")`,
+      `delete_key(attributes, "process.executable.path")`,
+      `delete_key(attributes, "process.command_line")`,
+      `delete_key(attributes, "process.command_args")`,
+      `delete_key(attributes, "process.owner")`,
+      `delete_key(attributes, "process.runtime.version")`,
+      `delete_key(attributes, "process.runtime.description")`,
+      `delete_key(attributes, "host.ip")`,
+      `delete_key(attributes, "host.mac")`,
+      `delete_key(attributes, "k8s.pod.start_time")`,
+      `delete_key(attributes, "k8s.pod.uid")`,
+      `delete_key(attributes, "container.image.id")`,
+      `delete_key(attributes, "container.image.repo_digests")`,
+      `delete_key(attributes, "os.description")`,
+      `delete_key(attributes, "os.build_id")`,
+      // Scrape targets that expose their own target_info metric (e.g. Grafana Beyla) can
+      // carry a flat k8s_cluster_name resource attribute, which conflicts with the
+      // k8s.cluster.name attribute set above and gets ";"-joined by the Prometheus OTLP
+      // endpoint. Drop the flat copy when the values match.
+      `delete_key(attributes, "k8s_cluster_name") where attributes["k8s_cluster_name"] == attributes["k8s.cluster.name"]`,
+    ]
+  }
+
+  metric_statements {
+    context = "datapoint"
+    statements = [
+      `set(attributes["k8s.cluster.name"], "prom-and-loki-to-otlp-test")`,
+      `set(resource.attributes["deployment.environment"], attributes["deployment_environment"] ) where resource.attributes["deployment.environment"] == nil and attributes["deployment_environment"] != nil`,
+      `delete_key(attributes, "deployment_environment") where attributes["deployment_environment"] == resource.attributes["deployment.environment"]`,
+      `set(resource.attributes["deployment.environment.name"], attributes["deployment_environment_name"] ) where resource.attributes["deployment.environment.name"] == nil and attributes["deployment_environment_name"] != nil`,
+      `delete_key(attributes, "deployment_environment_name") where attributes["deployment_environment_name"] == resource.attributes["deployment.environment.name"]`,
+      `set(resource.attributes["service.name"], attributes["service_name"] ) where (resource.attributes["service.name"] == nil or resource.attributes["service.name"] == "") and attributes["service_name"] != nil and attributes["service_name"] != ""`,
+      `delete_key(attributes, "service_name") where attributes["service_name"] == resource.attributes["service.name"]`,
+      `set(resource.attributes["service.namespace"], attributes["service_namespace"] ) where (resource.attributes["service.namespace"] == nil or resource.attributes["service.namespace"] == "") and attributes["service_namespace"] != nil and attributes["service_namespace"] != ""`,
+      `delete_key(attributes, "service_namespace") where attributes["service_namespace"] == resource.attributes["service.namespace"]`,
+    ]
+  }
+
+  output {
+    metrics = [otelcol.processor.batch.prometheus.input]
+  }
+} // otelcol.processor.transform "prometheus"
+
+otelcol.processor.batch "prometheus" {
+  timeout = "2s"
+  send_batch_size = 8192
+  send_batch_max_size = 0
+
+  output {
+    metrics = [otelcol.exporter.otlphttp.prometheus.input]
+  }
+} // otelcol.processor.batch "prometheus"
+otelcol.exporter.otlphttp "prometheus" {
+  client {
+    endpoint = "http://prometheus-server.prometheus.svc:9090/api/v1/otlp"
+    auth = otelcol.auth.basic.prometheus.handler
+    tls {
+      insecure = false
+      insecure_skip_verify = true
+    }
+  }
+
+  retry_on_failure {
+    enabled = true
+    initial_interval = "5s"
+    max_interval = "30s"
+    max_elapsed_time = "5m"
+  }
+
+  sending_queue {
+    enabled = true
+  }
+} // otelcol.exporter.otlphttp "prometheus"
+
+otelcol.auth.basic "prometheus" {
+  username = convert.nonsensitive(remote.kubernetes.secret.prometheus.data["username"])
+  password = remote.kubernetes.secret.prometheus.data["password"]
+} // otelcol.auth.basic "prometheus"
+
+remote.kubernetes.secret "prometheus" {
+  name      = "prometheus-k8smon-k8s-monitoring"
+  namespace = "default"
+} // remote.kubernetes.secret "prometheus"
+

--- a/charts/k8s-monitoring/tests/integration/prom-and-loki-to-otlp/.rendered/alloy-singleton.alloy
+++ b/charts/k8s-monitoring/tests/integration/prom-and-loki-to-otlp/.rendered/alloy-singleton.alloy
@@ -1,0 +1,392 @@
+// Feature: Cluster Events
+declare "cluster_events" {
+  argument "logs_destinations" {
+    comment = "Must be a list of log destinations where collected logs should be forwarded to"
+  }
+
+  loki.source.kubernetes_events "cluster_events" {
+    job_name   = "integrations/kubernetes/eventhandler"
+    log_format = "logfmt"
+    forward_to = [loki.process.cluster_events.receiver]
+  } // loki.source.kubernetes_events "cluster_events"
+
+  loki.process "cluster_events" {
+
+    // add a static source label to the logs so they can be differentiated / restricted if necessary
+    stage.static_labels {
+      values = {
+        "source" = "kubernetes-events",
+      }
+    }
+
+    // extract some of the fields from the log line, these could be used as labels, structured metadata, etc.
+    stage.logfmt {
+      mapping = {
+        "component" = "sourcecomponent", // map the sourcecomponent field to component
+        "kind" = "",
+        "level" = "type", // most events don't have a level but they do have a "type" i.e. Normal, Warning, Error, etc.
+        "name" = "",
+        "node" = "sourcehost", // map the sourcehost field to node
+        "reason" = "",
+      }
+    }
+    // set the extracted values as labels
+    stage.labels {
+      values = {
+        "kind" = "",
+        "level" = "",
+        "service_name" = "job",
+        "reason" = "reason",
+      }
+    }
+
+    // if kind=Node, set the node label by copying the name field
+    stage.match {
+      selector = "{kind=\"Node\"}"
+
+      stage.labels {
+        values = {
+          "node" = "name",
+        }
+      }
+    }
+
+    // set the level extracted key value as a normalized log level
+    stage.match {
+      selector = "{level=\"Normal\"}"
+
+      stage.static_labels {
+        values = {
+          level = "Info",
+        }
+      }
+    }
+    stage.structured_metadata {
+      values = {
+        "name" = "name",
+        "node" = "node",
+      }
+    }
+
+    // Drop pipeline-only labels that are not needed in the final output.
+    stage.label_drop {
+      values = ["kind"]
+    }
+
+    forward_to = argument.logs_destinations.value
+  } // loki.process "cluster_events"
+} // declare "cluster_events"
+cluster_events "feature" {
+  logs_destinations = [
+    otelcol.receiver.loki.loki.receiver,
+  ]
+}
+// Self Reporting
+prometheus.exporter.unix "kubernetes_monitoring_telemetry" {
+  set_collectors = ["textfile"]
+  textfile {
+    directory = "/etc/release-info"
+  }
+} // prometheus.exporter.unix "kubernetes_monitoring_telemetry"
+
+discovery.relabel "kubernetes_monitoring_telemetry" {
+  targets = prometheus.exporter.unix.kubernetes_monitoring_telemetry.targets
+  rule {
+    target_label = "instance"
+    action = "replace"
+    replacement = "k8smon"
+  }
+  rule {
+    target_label = "job"
+    action = "replace"
+    replacement = "integrations/kubernetes/kubernetes_monitoring_telemetry"
+  }
+} // discovery.relabel "kubernetes_monitoring_telemetry"
+
+prometheus.scrape "kubernetes_monitoring_telemetry" {
+  job_name   = "integrations/kubernetes/kubernetes_monitoring_telemetry"
+  targets    = discovery.relabel.kubernetes_monitoring_telemetry.output
+  scrape_interval = "60s"
+  clustering {
+    enabled = true
+  }
+  forward_to = [prometheus.relabel.kubernetes_monitoring_telemetry.receiver]
+} // prometheus.scrape "kubernetes_monitoring_telemetry"
+
+prometheus.relabel "kubernetes_monitoring_telemetry" {
+  rule {
+    source_labels = ["__name__"]
+    regex = "grafana_kubernetes_monitoring_.*"
+    action = "keep"
+  }
+  forward_to = [
+    otelcol.receiver.prometheus.prometheus.receiver,
+  ]
+} // prometheus.relabel "kubernetes_monitoring_telemetry"
+
+
+
+
+
+// Destination: loki (otlp)
+otelcol.receiver.loki "loki" {
+  output {
+    logs = [otelcol.processor.attributes.loki.input]
+  }
+} // otelcol.receiver.loki "loki"
+otelcol.processor.attributes "loki" {
+  output {
+    logs = [otelcol.processor.transform.loki.input]
+  }
+} // otelcol.processor.attributes "loki"
+
+otelcol.processor.transform "loki" {
+  error_mode = "ignore"
+  log_statements {
+    context = "resource"
+    statements = [
+      `set(attributes["k8s.cluster.name"], "prom-and-loki-to-otlp-test")`,
+      `delete_key(attributes, "process.pid")`,
+      `delete_key(attributes, "process.parent_pid")`,
+      `delete_key(attributes, "process.executable.path")`,
+      `delete_key(attributes, "process.command_line")`,
+      `delete_key(attributes, "process.command_args")`,
+      `delete_key(attributes, "process.owner")`,
+      `delete_key(attributes, "process.runtime.version")`,
+      `delete_key(attributes, "process.runtime.description")`,
+      `delete_key(attributes, "host.ip")`,
+      `delete_key(attributes, "host.mac")`,
+      `delete_key(attributes, "k8s.pod.start_time")`,
+      `delete_key(attributes, "k8s.pod.uid")`,
+      `delete_key(attributes, "container.image.id")`,
+      `delete_key(attributes, "container.image.repo_digests")`,
+      `delete_key(attributes, "os.description")`,
+      `delete_key(attributes, "os.build_id")`,
+    ]
+  }
+
+  log_statements {
+    context = "log"
+    statements = [
+      `delete_key(attributes, "loki.attribute.labels")`,
+      `delete_key(attributes, "loki.resource.labels")`,
+      `set(resource.attributes["k8s.container.name"], attributes["container"] ) where resource.attributes["k8s.container.name"] == nil and attributes["container"] != nil`,
+      `delete_key(attributes, "container") where attributes["container"] == resource.attributes["k8s.container.name"]`,
+      `set(resource.attributes["k8s.cronjob.name"], attributes["cronjob"] ) where resource.attributes["k8s.cronjob.name"] == nil and attributes["cronjob"] != nil`,
+      `delete_key(attributes, "cronjob") where attributes["cronjob"] == resource.attributes["k8s.cronjob.name"]`,
+      `set(resource.attributes["k8s.daemonset.name"], attributes["daemonset"] ) where resource.attributes["k8s.daemonset.name"] == nil and attributes["daemonset"] != nil`,
+      `delete_key(attributes, "daemonset") where attributes["daemonset"] == resource.attributes["k8s.daemonset.name"]`,
+      `set(resource.attributes["k8s.deployment.name"], attributes["deployment"] ) where resource.attributes["k8s.deployment.name"] == nil and attributes["deployment"] != nil`,
+      `delete_key(attributes, "deployment") where attributes["deployment"] == resource.attributes["k8s.deployment.name"]`,
+      `set(resource.attributes["deployment.environment"], attributes["deployment_environment"] ) where resource.attributes["deployment.environment"] == nil and attributes["deployment_environment"] != nil`,
+      `delete_key(attributes, "deployment_environment") where attributes["deployment_environment"] == resource.attributes["deployment.environment"]`,
+      `set(resource.attributes["deployment.environment.name"], attributes["deployment_environment_name"] ) where resource.attributes["deployment.environment.name"] == nil and attributes["deployment_environment_name"] != nil`,
+      `delete_key(attributes, "deployment_environment_name") where attributes["deployment_environment_name"] == resource.attributes["deployment.environment.name"]`,
+      `set(resource.attributes["k8s.job.name"], attributes["job_name"] ) where resource.attributes["k8s.job.name"] == nil and attributes["job_name"] != nil`,
+      `delete_key(attributes, "job_name") where attributes["job_name"] == resource.attributes["k8s.job.name"]`,
+      `set(resource.attributes["k8s.namespace.name"], attributes["namespace"] ) where resource.attributes["k8s.namespace.name"] == nil and attributes["namespace"] != nil`,
+      `delete_key(attributes, "namespace") where attributes["namespace"] == resource.attributes["k8s.namespace.name"]`,
+      `set(resource.attributes["k8s.pod.name"], attributes["pod"] ) where resource.attributes["k8s.pod.name"] == nil and attributes["pod"] != nil`,
+      `delete_key(attributes, "pod") where attributes["pod"] == resource.attributes["k8s.pod.name"]`,
+      `set(resource.attributes["k8s.replicaset.name"], attributes["replicaset"] ) where resource.attributes["k8s.replicaset.name"] == nil and attributes["replicaset"] != nil`,
+      `delete_key(attributes, "replicaset") where attributes["replicaset"] == resource.attributes["k8s.replicaset.name"]`,
+      `set(resource.attributes["service.name"], attributes["service_name"] ) where (resource.attributes["service.name"] == nil or resource.attributes["service.name"] == "") and attributes["service_name"] != nil and attributes["service_name"] != ""`,
+      `delete_key(attributes, "service_name") where attributes["service_name"] == resource.attributes["service.name"]`,
+      `set(resource.attributes["service.namespace"], attributes["service_namespace"] ) where (resource.attributes["service.namespace"] == nil or resource.attributes["service.namespace"] == "") and attributes["service_namespace"] != nil and attributes["service_namespace"] != ""`,
+      `delete_key(attributes, "service_namespace") where attributes["service_namespace"] == resource.attributes["service.namespace"]`,
+      `set(resource.attributes["k8s.statefulset.name"], attributes["statefulset"] ) where resource.attributes["k8s.statefulset.name"] == nil and attributes["statefulset"] != nil`,
+      `delete_key(attributes, "statefulset") where attributes["statefulset"] == resource.attributes["k8s.statefulset.name"]`,
+    ]
+  }
+
+  output {
+    logs = [otelcol.processor.batch.loki.input]
+  }
+} // otelcol.processor.transform "loki"
+
+otelcol.processor.batch "loki" {
+  timeout = "2s"
+  send_batch_size = 8192
+  send_batch_max_size = 0
+
+  output {
+    logs = [otelcol.exporter.otlphttp.loki.input]
+  }
+} // otelcol.processor.batch "loki"
+otelcol.exporter.otlphttp "loki" {
+  client {
+    endpoint = "http://loki.loki.svc:3100/otlp"
+    auth = otelcol.auth.basic.loki.handler
+    headers = {
+      "X-Scope-OrgID" = convert.nonsensitive(remote.kubernetes.secret.loki.data["tenantId"]),
+    }
+    tls {
+      insecure = false
+      insecure_skip_verify = false
+    }
+  }
+
+  retry_on_failure {
+    enabled = true
+    initial_interval = "5s"
+    max_interval = "30s"
+    max_elapsed_time = "5m"
+  }
+
+  sending_queue {
+    enabled = true
+  }
+} // otelcol.exporter.otlphttp "loki"
+
+otelcol.auth.basic "loki" {
+  username = convert.nonsensitive(remote.kubernetes.secret.loki.data["username"])
+  password = remote.kubernetes.secret.loki.data["password"]
+} // otelcol.auth.basic "loki"
+
+remote.kubernetes.secret "loki" {
+  name      = "loki-k8smon-k8s-monitoring"
+  namespace = "default"
+} // remote.kubernetes.secret "loki"
+
+
+// Destination: prometheus (otlp)
+otelcol.receiver.prometheus "prometheus" {
+  output {
+    metrics = [otelcol.processor.transform.prometheus_scrape_normalize.input]
+  }
+} // otelcol.receiver.prometheus "prometheus"
+
+// Repairs artifacts of the Prometheus-to-OTLP conversion performed by
+// otelcol.receiver.prometheus. Only metrics that came from a Prometheus scrape pass
+// through this component; OTLP-native telemetry enters the pipeline further down.
+otelcol.processor.transform "prometheus_scrape_normalize" {
+  error_mode = "ignore"
+  metric_statements {
+    context = "resource"
+    statements = [
+      // The conversion sets service.name to the full Prometheus job label (e.g.
+      // "namespace/workload"). When the scrape target declares its identity explicitly
+      // with a service_name label on its own target_info metric (e.g. Grafana Beyla),
+      // prefer that value and drop the duplicate.
+      `set(attributes["service.name"], attributes["service_name"]) where attributes["service_name"] != nil and attributes["service_name"] != ""`,
+      `delete_key(attributes, "service_name") where attributes["service_name"] == attributes["service.name"]`,
+      // The same conversion turns other flat target_info labels into resource attributes.
+      // Promote them to their OpenTelemetry counterparts and drop the flat duplicates, so
+      // the OTLP endpoint does not receive two conflicting spellings of the same attribute.
+      `set(attributes["service.namespace"], attributes["service_namespace"]) where (attributes["service.namespace"] == nil or attributes["service.namespace"] == "") and attributes["service_namespace"] != nil and attributes["service_namespace"] != ""`,
+      `delete_key(attributes, "service_namespace") where attributes["service_namespace"] == attributes["service.namespace"]`,
+      `set(attributes["deployment.environment"], attributes["deployment_environment"]) where (attributes["deployment.environment"] == nil or attributes["deployment.environment"] == "") and attributes["deployment_environment"] != nil and attributes["deployment_environment"] != ""`,
+      `delete_key(attributes, "deployment_environment") where attributes["deployment_environment"] == attributes["deployment.environment"]`,
+      `set(attributes["deployment.environment.name"], attributes["deployment_environment_name"]) where (attributes["deployment.environment.name"] == nil or attributes["deployment.environment.name"] == "") and attributes["deployment_environment_name"] != nil and attributes["deployment_environment_name"] != ""`,
+      `delete_key(attributes, "deployment_environment_name") where attributes["deployment_environment_name"] == attributes["deployment.environment.name"]`,
+    ]
+  }
+  metric_statements {
+    context = "datapoint"
+    statements = [
+      // Same correction for scrape targets that put service_name on every series
+      // instead of exposing a target_info metric.
+      `set(resource.attributes["service.name"], attributes["service_name"]) where attributes["service_name"] != nil and attributes["service_name"] != ""`,
+    ]
+  }
+  output {
+    metrics = [otelcol.processor.attributes.prometheus.input]
+  }
+} // otelcol.processor.transform "prometheus_scrape_normalize"
+otelcol.processor.attributes "prometheus" {
+  output {
+    metrics = [otelcol.processor.transform.prometheus.input]
+  }
+} // otelcol.processor.attributes "prometheus"
+
+otelcol.processor.transform "prometheus" {
+  error_mode = "ignore"
+  metric_statements {
+    context = "resource"
+    statements = [
+      `set(attributes["k8s.cluster.name"], "prom-and-loki-to-otlp-test")`,
+      `delete_key(attributes, "process.pid")`,
+      `delete_key(attributes, "process.parent_pid")`,
+      `delete_key(attributes, "process.executable.path")`,
+      `delete_key(attributes, "process.command_line")`,
+      `delete_key(attributes, "process.command_args")`,
+      `delete_key(attributes, "process.owner")`,
+      `delete_key(attributes, "process.runtime.version")`,
+      `delete_key(attributes, "process.runtime.description")`,
+      `delete_key(attributes, "host.ip")`,
+      `delete_key(attributes, "host.mac")`,
+      `delete_key(attributes, "k8s.pod.start_time")`,
+      `delete_key(attributes, "k8s.pod.uid")`,
+      `delete_key(attributes, "container.image.id")`,
+      `delete_key(attributes, "container.image.repo_digests")`,
+      `delete_key(attributes, "os.description")`,
+      `delete_key(attributes, "os.build_id")`,
+      // Scrape targets that expose their own target_info metric (e.g. Grafana Beyla) can
+      // carry a flat k8s_cluster_name resource attribute, which conflicts with the
+      // k8s.cluster.name attribute set above and gets ";"-joined by the Prometheus OTLP
+      // endpoint. Drop the flat copy when the values match.
+      `delete_key(attributes, "k8s_cluster_name") where attributes["k8s_cluster_name"] == attributes["k8s.cluster.name"]`,
+    ]
+  }
+
+  metric_statements {
+    context = "datapoint"
+    statements = [
+      `set(attributes["k8s.cluster.name"], "prom-and-loki-to-otlp-test")`,
+      `set(resource.attributes["deployment.environment"], attributes["deployment_environment"] ) where resource.attributes["deployment.environment"] == nil and attributes["deployment_environment"] != nil`,
+      `delete_key(attributes, "deployment_environment") where attributes["deployment_environment"] == resource.attributes["deployment.environment"]`,
+      `set(resource.attributes["deployment.environment.name"], attributes["deployment_environment_name"] ) where resource.attributes["deployment.environment.name"] == nil and attributes["deployment_environment_name"] != nil`,
+      `delete_key(attributes, "deployment_environment_name") where attributes["deployment_environment_name"] == resource.attributes["deployment.environment.name"]`,
+      `set(resource.attributes["service.name"], attributes["service_name"] ) where (resource.attributes["service.name"] == nil or resource.attributes["service.name"] == "") and attributes["service_name"] != nil and attributes["service_name"] != ""`,
+      `delete_key(attributes, "service_name") where attributes["service_name"] == resource.attributes["service.name"]`,
+      `set(resource.attributes["service.namespace"], attributes["service_namespace"] ) where (resource.attributes["service.namespace"] == nil or resource.attributes["service.namespace"] == "") and attributes["service_namespace"] != nil and attributes["service_namespace"] != ""`,
+      `delete_key(attributes, "service_namespace") where attributes["service_namespace"] == resource.attributes["service.namespace"]`,
+    ]
+  }
+
+  output {
+    metrics = [otelcol.processor.batch.prometheus.input]
+  }
+} // otelcol.processor.transform "prometheus"
+
+otelcol.processor.batch "prometheus" {
+  timeout = "2s"
+  send_batch_size = 8192
+  send_batch_max_size = 0
+
+  output {
+    metrics = [otelcol.exporter.otlphttp.prometheus.input]
+  }
+} // otelcol.processor.batch "prometheus"
+otelcol.exporter.otlphttp "prometheus" {
+  client {
+    endpoint = "http://prometheus-server.prometheus.svc:9090/api/v1/otlp"
+    auth = otelcol.auth.basic.prometheus.handler
+    tls {
+      insecure = false
+      insecure_skip_verify = true
+    }
+  }
+
+  retry_on_failure {
+    enabled = true
+    initial_interval = "5s"
+    max_interval = "30s"
+    max_elapsed_time = "5m"
+  }
+
+  sending_queue {
+    enabled = true
+  }
+} // otelcol.exporter.otlphttp "prometheus"
+
+otelcol.auth.basic "prometheus" {
+  username = convert.nonsensitive(remote.kubernetes.secret.prometheus.data["username"])
+  password = remote.kubernetes.secret.prometheus.data["password"]
+} // otelcol.auth.basic "prometheus"
+
+remote.kubernetes.secret "prometheus" {
+  name      = "prometheus-k8smon-k8s-monitoring"
+  namespace = "default"
+} // remote.kubernetes.secret "prometheus"
+

--- a/charts/k8s-monitoring/tests/integration/prometheus-io-annotations/.rendered/alloy-metrics.alloy
+++ b/charts/k8s-monitoring/tests/integration/prometheus-io-annotations/.rendered/alloy-metrics.alloy
@@ -1,0 +1,600 @@
+// Feature: Annotation Autodiscovery
+declare "annotation_autodiscovery" {
+  argument "metrics_destinations" {
+    comment = "Must be a list of metric destinations where collected metrics should be forwarded to"
+  }
+
+  discovery.kubernetes "pods" {
+    role = "pod"
+  } // discovery.kubernetes "pods"
+
+  discovery.relabel "annotation_autodiscovery_pods" {
+    targets = discovery.kubernetes.pods.targets
+    rule {
+      source_labels = ["__meta_kubernetes_pod_annotation_prometheus_io_scrape"]
+      regex = "true"
+      action = "keep"
+    }
+    // Only keep pods that are running, ready, and not init containers.
+    rule {
+      source_labels = [
+        "__meta_kubernetes_pod_phase",
+        "__meta_kubernetes_pod_ready",
+        "__meta_kubernetes_pod_container_init",
+      ]
+      regex = "Running;true;false"
+      action = "keep"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_pod_name"]
+      target_label = "pod"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_pod_container_name"]
+      target_label = "container"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_namespace"]
+      target_label = "namespace"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_job"]
+      target_label = "job"
+    }
+    rule {
+      source_labels = ["job", "__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+      regex = ";(.+)"
+      target_label = "job"
+    }
+    rule {
+      source_labels = ["job", "__meta_kubernetes_pod_label_app"]
+      regex = ";(.+)"
+      target_label = "job"
+    }
+    rule {
+      source_labels = ["job", "container"]
+      regex = ";(.+)"
+      target_label = "job"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_instance"]
+      target_label = "instance"
+    }
+
+    // Rules to choose the right container
+    rule {
+      source_labels = ["container"]
+      target_label = "__tmp_container"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_container"]
+      regex = "(.+)"
+      target_label = "__tmp_container"
+    }
+    rule {
+      source_labels = ["container"]
+      action = "keepequal"
+      target_label = "__tmp_container"
+    }
+    rule {
+      action = "labeldrop"
+      regex = "__tmp_container"
+    }
+
+    // Set metrics path
+    rule {
+      source_labels = ["__meta_kubernetes_pod_annotation_prometheus_io_path"]
+      regex = "(.+)"
+      target_label = "__metrics_path__"
+    }
+
+    // Set metrics scraping URL parameters
+    rule {
+      action = "labelmap"
+      regex = "__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_param_(.+)"
+      replacement = "__param_$1"
+    }
+
+    // Choose the pod port
+    // The discovery generates a target for each declared container port of the pod.
+    // If the metricsPortName annotation has value, keep only the target where the port name matches the one of the annotation.
+    rule {
+      source_labels = ["__meta_kubernetes_pod_container_port_name"]
+      target_label = "__tmp_port"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_portName"]
+      regex = "(.+)"
+      target_label = "__tmp_port"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_pod_container_port_name"]
+      action = "keepequal"
+      target_label = "__tmp_port"
+    }
+    rule {
+      action = "labeldrop"
+      regex = "__tmp_port"
+    }
+
+    // If the metrics port number annotation has a value, override the target address to use it, regardless whether it is
+    // one of the declared ports on that Pod.
+    rule {
+      source_labels = ["__meta_kubernetes_pod_annotation_prometheus_io_port", "__meta_kubernetes_pod_ip"]
+      regex = "(\\d+);(([A-Fa-f0-9]{1,4}::?){1,7}[A-Fa-f0-9]{1,4})"
+      replacement = "[$2]:$1" // IPv6
+      target_label = "__address__"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_pod_annotation_prometheus_io_port", "__meta_kubernetes_pod_ip"]
+      regex = "(\\d+);((([0-9]+?)(\\.|$)){4})" // IPv4, takes priority over IPv6 when both exists
+      replacement = "$2:$1"
+      target_label = "__address__"
+    }
+
+    rule {
+      source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_scheme"]
+      regex = "(.+)"
+      target_label = "__scheme__"
+    }
+
+    rule {
+      source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_scrapeInterval"]
+      regex = "(.+)"
+      target_label = "__scrape_interval__"
+    }
+    rule {
+      source_labels = ["__scrape_interval__"]
+      regex = ""
+      replacement = "60s"
+      target_label = "__scrape_interval__"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_scrapeTimeout"]
+      regex = "(.+)"
+      target_label = "__scrape_timeout__"
+    }
+    rule {
+      source_labels = ["__scrape_timeout__"]
+      regex = ""
+      replacement = "10s"
+      target_label = "__scrape_timeout__"
+    }
+  } // discovery.relabel "annotation_autodiscovery_pods"
+
+  discovery.kubernetes "services" {
+    role = "service"
+  } // discovery.kubernetes "services"
+
+  discovery.relabel "annotation_autodiscovery_services" {
+    targets = discovery.kubernetes.services.targets
+    rule {
+      source_labels = ["__meta_kubernetes_service_annotation_prometheus_io_scrape"]
+      regex = "true"
+      action = "keep"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_service_name"]
+      target_label = "service"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_namespace"]
+      target_label = "namespace"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_service_annotation_k8s_grafana_com_job"]
+      target_label = "job"
+    }
+    rule {
+      source_labels = ["job", "__meta_kubernetes_service_label_app_kubernetes_io_name"]
+      regex = ";(.+)"
+      target_label = "job"
+    }
+    rule {
+      source_labels = ["job", "__meta_kubernetes_service_label_app"]
+      regex = ";(.+)"
+      target_label = "job"
+    }
+    rule {
+      source_labels = ["job", "service"]
+      regex = ";(.+)"
+      target_label = "job"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_service_annotation_k8s_grafana_com_instance"]
+      target_label = "instance"
+    }
+
+    // Set metrics path
+    rule {
+      source_labels = ["__meta_kubernetes_service_annotation_prometheus_io_path"]
+      target_label = "__metrics_path__"
+    }
+
+    // Set metrics scraping URL parameters
+    rule {
+      action = "labelmap"
+      regex = "__meta_kubernetes_service_annotation_k8s_grafana_com_metrics_param_(.+)"
+      replacement = "__param_$1"
+    }
+
+    // Choose the service port
+    rule {
+      source_labels = ["__meta_kubernetes_service_port_name"]
+      target_label = "__tmp_port"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_service_annotation_k8s_grafana_com_metrics_portName"]
+      regex = "(.+)"
+      target_label = "__tmp_port"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_service_port_name"]
+      action = "keepequal"
+      target_label = "__tmp_port"
+    }
+
+    rule {
+      source_labels = ["__meta_kubernetes_service_port_number"]
+      target_label = "__tmp_port"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_service_annotation_prometheus_io_port"]
+      regex = "(.+)"
+      target_label = "__tmp_port"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_service_port_number"]
+      action = "keepequal"
+      target_label = "__tmp_port"
+    }
+    rule {
+      action = "labeldrop"
+      regex = "__tmp_port"
+    }
+
+    rule {
+      source_labels = ["__meta_kubernetes_service_annotation_k8s_grafana_com_metrics_scheme"]
+      regex = "(.+)"
+      target_label = "__scheme__"
+    }
+
+    rule {
+      source_labels = ["__meta_kubernetes_service_annotation_k8s_grafana_com_metrics_scrapeInterval"]
+      regex = "(.+)"
+      target_label = "__scrape_interval__"
+    }
+    rule {
+      source_labels = ["__scrape_interval__"]
+      regex = ""
+      replacement = "60s"
+      target_label = "__scrape_interval__"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_service_annotation_k8s_grafana_com_metrics_scrapeTimeout"]
+      regex = "(.+)"
+      target_label = "__scrape_timeout__"
+    }
+    rule {
+      source_labels = ["__scrape_timeout__"]
+      regex = ""
+      replacement = "10s"
+      target_label = "__scrape_timeout__"
+    }
+  } // discovery.relabel "annotation_autodiscovery_services"
+
+  discovery.relabel "annotation_autodiscovery_http" {
+    targets = array.concat(discovery.relabel.annotation_autodiscovery_pods.output, discovery.relabel.annotation_autodiscovery_services.output)
+    rule {
+      source_labels = ["__scheme__"]
+      regex = "https"
+      action = "drop"
+    }
+  } // discovery.relabel "annotation_autodiscovery_http"
+
+  discovery.relabel "annotation_autodiscovery_https" {
+    targets = array.concat(discovery.relabel.annotation_autodiscovery_pods.output, discovery.relabel.annotation_autodiscovery_services.output)
+    rule {
+      source_labels = ["__scheme__"]
+      regex = "https"
+      action = "keep"
+    }
+  } // discovery.relabel "annotation_autodiscovery_https"
+
+  prometheus.scrape "annotation_autodiscovery_http" {
+    targets = discovery.relabel.annotation_autodiscovery_http.output
+    honor_labels = true
+    bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+    scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
+    scrape_classic_histograms = false
+    scrape_native_histograms = false
+    convert_classic_histograms_to_nhcb = false
+    clustering {
+      enabled = true
+    }
+
+    forward_to = argument.metrics_destinations.value
+  } // prometheus.scrape "annotation_autodiscovery_http"
+
+  prometheus.scrape "annotation_autodiscovery_https" {
+    targets = discovery.relabel.annotation_autodiscovery_https.output
+    honor_labels = true
+    bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+    tls_config {
+      insecure_skip_verify = true
+    }
+    scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
+    scrape_classic_histograms = false
+    scrape_native_histograms = false
+    convert_classic_histograms_to_nhcb = false
+    clustering {
+      enabled = true
+    }
+
+    forward_to = argument.metrics_destinations.value
+  } // prometheus.relabel "annotation_autodiscovery"
+} // declare "annotation_autodiscovery"
+annotation_autodiscovery "feature" {
+  metrics_destinations = [
+    prometheus.remote_write.prometheus.receiver,
+  ]
+}
+
+
+
+
+
+// Feature: Host Metrics
+declare "host_metrics" {
+  argument "metrics_destinations" {
+    comment = "Must be a list of metric destinations where collected metrics should be forwarded to"
+  }
+
+  // Linux hosts via Node Exporter
+  discovery.kubernetes "node_exporter" {
+    role = "pod"
+    selectors {
+      role = "pod"
+      label = "release=k8smon,app.kubernetes.io/name=node-exporter"
+    }
+    namespaces {
+      names = ["default"]
+    }
+
+  } // discovery.kubernetes "node_exporter"
+
+  discovery.relabel "node_exporter" {
+    targets = discovery.kubernetes.node_exporter.targets
+
+    // keep only the specified metrics port name, and pods that are Running and ready
+    rule {
+      source_labels = [
+        "__meta_kubernetes_pod_container_init",
+        "__meta_kubernetes_pod_phase",
+        "__meta_kubernetes_pod_ready",
+      ]
+      separator = "@"
+      regex = "false@Running@true"
+      action = "keep"
+    }
+
+    // Set the instance label to the node name
+    rule {
+      source_labels = ["__meta_kubernetes_pod_node_name"]
+      target_label = "instance"
+    }
+
+    rule {
+      source_labels = ["__meta_kubernetes_namespace"]
+      target_label  = "namespace"
+    }
+
+    rule {
+      source_labels = ["__meta_kubernetes_pod_name"]
+      target_label  = "pod"
+    }
+
+    rule {
+      source_labels = ["__meta_kubernetes_pod_container_name"]
+      target_label  = "container"
+    }
+
+    // set a workload label
+    rule {
+      source_labels = [
+        "__meta_kubernetes_pod_controller_kind",
+        "__meta_kubernetes_pod_controller_name",
+      ]
+      separator = "/"
+      target_label  = "workload"
+    }
+    // remove the hash from the ReplicaSet
+    rule {
+      source_labels = ["workload"]
+      regex = "(ReplicaSet/.+)-.+"
+      target_label  = "workload"
+    }
+
+    // Set the app label.
+    //
+    // Choose the first value found from the following ordered list:
+    // - pod.label[app.kubernetes.io/name]
+    // - pod.label[k8s-app]
+    // - pod.label[app]
+    rule {
+      source_labels = [
+        "__meta_kubernetes_pod_label_app_kubernetes_io_name",
+        "__meta_kubernetes_pod_label_k8s_app",
+        "__meta_kubernetes_pod_label_app",
+      ]
+      separator = ";"
+      regex = "^(?:;*)?([^;]+).*$"
+      replacement = "$1"
+      target_label = "app"
+    }
+
+    // Set the component label.
+    //
+    // Choose the first value found from the following ordered list:
+    // - pod.label[app.kubernetes.io/component]
+    // - pod.label[k8s-component]
+    // - pod.label[component]
+    rule {
+      source_labels = [
+        "__meta_kubernetes_pod_label_app_kubernetes_io_component",
+        "__meta_kubernetes_pod_label_k8s_component",
+        "__meta_kubernetes_pod_label_component",
+      ]
+      regex = "^(?:;*)?([^;]+).*$"
+      replacement = "$1"
+      target_label = "component"
+    }
+
+    rule {
+      target_label = "source"
+      replacement = "kubernetes"
+    }
+
+  } // discovery.relabel "node_exporter"
+
+  prometheus.scrape "node_exporter" {
+    targets = discovery.relabel.node_exporter.output
+    job_name = "integrations/node_exporter"
+    scrape_interval = "60s"
+    scrape_timeout = "10s"
+    scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
+    scrape_classic_histograms = false
+    scrape_native_histograms = false
+    convert_classic_histograms_to_nhcb = false
+    scheme = "http"
+    tls_config {
+      insecure_skip_verify = true
+    }
+
+    clustering {
+      enabled = true
+    }
+    forward_to = [prometheus.relabel.node_exporter.receiver]
+  } // prometheus.scrape "node_exporter"
+
+  prometheus.relabel "node_exporter" {
+    max_cache_size = 100000
+    rule {
+      source_labels = ["__name__"]
+      regex = "up|scrape_samples_scraped|node_cpu.*|node_exporter_build_info|node_filesystem.*|node_memory.*|node_network_receive_bytes_total|node_network_receive_drop_total|node_network_transmit_bytes_total|node_network_transmit_drop_total|process_cpu_seconds_total|process_resident_memory_bytes"
+      action = "keep"
+    }
+    // Drop metrics for certain file systems
+    rule {
+      source_labels = ["__name__", "fstype"]
+      separator = "@"
+      regex = "node_filesystem.*@(ramfs|tmpfs)"
+      action = "drop"
+    }
+    forward_to = argument.metrics_destinations.value
+  } // prometheus.relabel "node_exporter"
+} // declare "host_metrics"
+host_metrics "feature" {
+  metrics_destinations = [
+    prometheus.remote_write.prometheus.receiver,
+  ]
+}
+
+
+
+
+
+
+
+
+
+
+// Self Reporting
+prometheus.exporter.unix "kubernetes_monitoring_telemetry" {
+  set_collectors = ["textfile"]
+  textfile {
+    directory = "/etc/release-info"
+  }
+} // prometheus.exporter.unix "kubernetes_monitoring_telemetry"
+
+discovery.relabel "kubernetes_monitoring_telemetry" {
+  targets = prometheus.exporter.unix.kubernetes_monitoring_telemetry.targets
+  rule {
+    target_label = "instance"
+    action = "replace"
+    replacement = "k8smon"
+  }
+  rule {
+    target_label = "job"
+    action = "replace"
+    replacement = "integrations/kubernetes/kubernetes_monitoring_telemetry"
+  }
+} // discovery.relabel "kubernetes_monitoring_telemetry"
+
+prometheus.scrape "kubernetes_monitoring_telemetry" {
+  job_name   = "integrations/kubernetes/kubernetes_monitoring_telemetry"
+  targets    = discovery.relabel.kubernetes_monitoring_telemetry.output
+  scrape_interval = "60s"
+  clustering {
+    enabled = true
+  }
+  forward_to = [prometheus.relabel.kubernetes_monitoring_telemetry.receiver]
+} // prometheus.scrape "kubernetes_monitoring_telemetry"
+
+prometheus.relabel "kubernetes_monitoring_telemetry" {
+  rule {
+    source_labels = ["__name__"]
+    regex = "grafana_kubernetes_monitoring_.*"
+    action = "keep"
+  }
+  forward_to = [
+    prometheus.remote_write.prometheus.receiver,
+  ]
+} // prometheus.relabel "kubernetes_monitoring_telemetry"
+
+
+
+
+
+// Destination: prometheus (prometheus)
+otelcol.exporter.prometheus "prometheus" {
+  add_metric_suffixes = true
+  resource_to_telemetry_conversion = false
+  keep_identifying_resource_attributes = true
+  forward_to = [prometheus.remote_write.prometheus.receiver]
+} // otelcol.exporter.prometheus "prometheus"
+
+prometheus.remote_write "prometheus" {
+  endpoint {
+    url = "http://prometheus-server.prometheus.svc:9090/api/v1/write"
+    headers = {
+    }
+    tls_config {
+      insecure_skip_verify = false
+    }
+    send_native_histograms = false
+
+    queue_config {
+      capacity = 10000
+      min_shards = 1
+      max_shards = 50
+      max_samples_per_send = 2000
+      batch_send_deadline = "5s"
+      min_backoff = "30ms"
+      max_backoff = "5s"
+      retry_on_http_429 = true
+      sample_age_limit = "0s"
+    }
+  }
+
+  wal {
+    truncate_frequency = "2h"
+    min_keepalive_time = "5m"
+    max_keepalive_time = "8h"
+  }
+  external_labels = {
+    "cluster" = "prometheus-io-annotations-test",
+    "k8s_cluster_name" = "prometheus-io-annotations-test",
+  }
+} // prometheus.remote_write "prometheus"
+

--- a/charts/k8s-monitoring/tests/integration/prometheus-operator-objects/.rendered/alloy-metrics.alloy
+++ b/charts/k8s-monitoring/tests/integration/prometheus-operator-objects/.rendered/alloy-metrics.alloy
@@ -1,0 +1,168 @@
+// Feature: Prometheus Operator Objects
+declare "prometheus_operator_objects" {
+  argument "metrics_destinations" {
+    comment = "Must be a list of metric destinations where collected metrics should be forwarded to"
+  }
+
+  // Prometheus Operator PodMonitor objects
+  prometheus.operator.podmonitors "pod_monitors" {
+    clustering {
+      enabled = true
+    }
+    scrape {
+      default_scrape_interval = "60s"
+      default_scrape_timeout = "10s"
+      scrape_native_histograms = false
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+      target_label = "service_name"
+    }
+
+    forward_to = argument.metrics_destinations.value
+  } // prometheus.relabel "podmonitors"
+
+  // Prometheus Operator Probe objects
+  prometheus.operator.probes "probes" {
+    clustering {
+      enabled = true
+    }
+    scrape {
+      default_scrape_interval = "60s"
+      default_scrape_timeout = "10s"
+      scrape_native_histograms = false
+    }
+    forward_to = argument.metrics_destinations.value
+  } // prometheus.relabel "probes"
+
+  // Prometheus Operator Probe objects
+  prometheus.operator.scrapeconfigs "scrapeConfigs" {
+    clustering {
+      enabled = true
+    }
+    scrape {
+      default_scrape_interval = "60s"
+      default_scrape_timeout = "10s"
+      scrape_native_histograms = false
+    }
+    forward_to = argument.metrics_destinations.value
+  } // prometheus.relabel "scrapeConfigs"
+
+  // Prometheus Operator ServiceMonitor objects
+  prometheus.operator.servicemonitors "service_monitors" {
+    kubernetes_role = "endpointslice"
+    selector {
+      match_labels = {
+        "app.kubernetes.io/name" = "grafana",
+      }
+    }
+    clustering {
+      enabled = true
+    }
+    scrape {
+      default_scrape_interval = "60s"
+      default_scrape_timeout = "10s"
+      scrape_native_histograms = false
+    }
+    rule {
+      source_labels = ["job"]
+      regex = "serviceMonitor/(default)/.*"
+      action = "drop"
+    }
+    forward_to = argument.metrics_destinations.value
+  } // prometheus.relabel "servicemonitors"
+} // declare "prometheus_operator_objects"
+prometheus_operator_objects "feature" {
+  metrics_destinations = [
+    prometheus.remote_write.localprometheus.receiver,
+  ]
+}
+// Self Reporting
+prometheus.exporter.unix "kubernetes_monitoring_telemetry" {
+  set_collectors = ["textfile"]
+  textfile {
+    directory = "/etc/release-info"
+  }
+} // prometheus.exporter.unix "kubernetes_monitoring_telemetry"
+
+discovery.relabel "kubernetes_monitoring_telemetry" {
+  targets = prometheus.exporter.unix.kubernetes_monitoring_telemetry.targets
+  rule {
+    target_label = "instance"
+    action = "replace"
+    replacement = "k8smon"
+  }
+  rule {
+    target_label = "job"
+    action = "replace"
+    replacement = "integrations/kubernetes/kubernetes_monitoring_telemetry"
+  }
+} // discovery.relabel "kubernetes_monitoring_telemetry"
+
+prometheus.scrape "kubernetes_monitoring_telemetry" {
+  job_name   = "integrations/kubernetes/kubernetes_monitoring_telemetry"
+  targets    = discovery.relabel.kubernetes_monitoring_telemetry.output
+  scrape_interval = "60s"
+  clustering {
+    enabled = true
+  }
+  forward_to = [prometheus.relabel.kubernetes_monitoring_telemetry.receiver]
+} // prometheus.scrape "kubernetes_monitoring_telemetry"
+
+prometheus.relabel "kubernetes_monitoring_telemetry" {
+  rule {
+    source_labels = ["__name__"]
+    regex = "grafana_kubernetes_monitoring_.*"
+    action = "keep"
+  }
+  forward_to = [
+    prometheus.remote_write.localprometheus.receiver,
+  ]
+} // prometheus.relabel "kubernetes_monitoring_telemetry"
+
+
+
+
+
+// Destination: localPrometheus (prometheus)
+otelcol.exporter.prometheus "localprometheus" {
+  add_metric_suffixes = true
+  resource_to_telemetry_conversion = false
+  keep_identifying_resource_attributes = true
+  forward_to = [prometheus.remote_write.localprometheus.receiver]
+} // otelcol.exporter.prometheus "localprometheus"
+
+prometheus.remote_write "localprometheus" {
+  endpoint {
+    url = "http://prometheus-server.prometheus.svc:9090/api/v1/write"
+    headers = {
+    }
+    tls_config {
+      insecure_skip_verify = false
+    }
+    send_native_histograms = false
+
+    queue_config {
+      capacity = 10000
+      min_shards = 1
+      max_shards = 50
+      max_samples_per_send = 2000
+      batch_send_deadline = "5s"
+      min_backoff = "30ms"
+      max_backoff = "5s"
+      retry_on_http_429 = true
+      sample_age_limit = "0s"
+    }
+  }
+
+  wal {
+    truncate_frequency = "2h"
+    min_keepalive_time = "5m"
+    max_keepalive_time = "8h"
+  }
+  external_labels = {
+    "cluster" = "prom-operator-objects-cluster",
+    "k8s_cluster_name" = "prom-operator-objects-cluster",
+  }
+} // prometheus.remote_write "localprometheus"
+

--- a/charts/k8s-monitoring/tests/integration/proxies/.rendered/alloy-logs.alloy
+++ b/charts/k8s-monitoring/tests/integration/proxies/.rendered/alloy-logs.alloy
@@ -1,0 +1,237 @@
+// Feature: Pod Logs (Loki)
+declare "pod_logs_via_loki" {
+  argument "logs_destinations" {
+    comment = "Must be a list of log destinations where collected logs should be forwarded to"
+  }
+
+  discovery.kubernetes "pods" {
+    role = "pod"
+    selectors {
+      role = "pod"
+      field = "spec.nodeName=" + sys.env("HOSTNAME")
+    }
+  } // discovery.kubernetes "pods"
+
+  discovery.relabel "filtered_pods" {
+    targets = discovery.kubernetes.pods.targets
+    rule {
+      source_labels = ["__meta_kubernetes_namespace"]
+      action = "replace"
+      target_label = "namespace"
+    }
+    rule {  // Drop anything with a "falsy" annotation value
+      source_labels = ["__meta_kubernetes_pod_annotation_logs_grafana_com_pods_enabled"]
+      regex = "(false|no|skip)"
+      action = "drop"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_pod_name"]
+      target_label = "pod"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_pod_container_name"]
+      target_label = "container"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_namespace", "__meta_kubernetes_pod_container_name"]
+      separator = "/"
+      replacement = "$1"
+      target_label = "job"
+    }
+
+    // set the container runtime as a label
+    rule {
+      source_labels = ["__meta_kubernetes_pod_container_id"]
+      regex = "^(\\S+):\\/\\/.+$"
+      replacement = "$1"
+      target_label = "tmp_container_runtime"
+    }
+    // explicitly set service_name. if not set, loki will automatically try to populate a default.
+    // see https://grafana.com/docs/loki/latest/get-started/labels/#default-labels-for-all-users
+    //
+    // choose the first value found from the following ordered list:
+    // - pod.annotation[resource.opentelemetry.io/service.name]
+    // - pod.label[app.kubernetes.io/name]
+    // - k8s.container.name
+    rule {
+      source_labels = [
+        "__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_name",
+        "__meta_kubernetes_pod_label_app_kubernetes_io_name",
+        "__meta_kubernetes_pod_container_name",
+      ]
+      separator = ";"
+      regex = "^(?:;*)?([^;]+).*$"
+      replacement = "$1"
+      target_label = "service_name"
+    }
+
+    // explicitly set service_namespace.
+    //
+    // choose the first value found from the following ordered list:
+    // - pod.annotation[resource.opentelemetry.io/service.namespace]
+    // - pod.namespace
+    rule {
+      source_labels = [
+        "__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_namespace",
+        "namespace",
+      ]
+      separator = ";"
+      regex = "^(?:;*)?([^;]+).*$"
+      replacement = "$1"
+      target_label = "service_namespace"
+    }
+
+    // explicitly set service_instance_id.
+    //
+    // choose the first value found from the following ordered list:
+    // - pod.annotation[resource.opentelemetry.io/service.instance.id]
+    // - concat([k8s.namespace.name, k8s.pod.name, k8s.container.name], '.')
+    rule {
+      source_labels = ["__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_instance_id"]
+      target_label = "service_instance_id"
+    }
+    rule {
+      source_labels = ["service_instance_id", "namespace", "pod", "container"]
+      separator = "."
+      regex = "^\\.([^.]+\\.[^.]+\\.[^.]+)$"
+      target_label = "service_instance_id"
+    }
+
+    // set resource attributes
+    rule {
+      action = "labelmap"
+      regex = "__meta_kubernetes_pod_annotation_resource_opentelemetry_io_(.+)"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_job"]
+      regex = "(.+)"
+      target_label = "job"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+      regex = "(.+)"
+      target_label = "app_kubernetes_io_name"
+    }
+
+    // Set the pod log path.
+    rule {
+      source_labels = ["__meta_kubernetes_pod_uid", "__meta_kubernetes_pod_container_name"]
+      separator = "/"
+      replacement = "/var/log/pods/*$1/*.log"
+      target_label = "__path__"
+    }
+
+    // If kubernetes.io/config.mirror is set, this is a static pod, created by the kubelet.
+    // It's logs live on a different path.
+    rule {
+      source_labels = ["__meta_kubernetes_pod_annotation_kubernetes_io_config_mirror", "__meta_kubernetes_pod_container_name"]
+      separator = "/"
+      regex = "(.+/.+)"
+      replacement = "/var/log/pods/*$1/*.log"
+      target_label = "__path__"
+    }
+  } // discovery.relabel "filtered_pods"
+
+  local.file_match "pod_logs" {
+    path_targets = discovery.relabel.filtered_pods.output
+  } // local.file_match "pod_logs"
+
+  loki.source.file "pod_logs" {
+    targets    = local.file_match.pod_logs.targets
+    tail_from_end = true
+    forward_to = [loki.process.pod_logs.receiver]
+  } // loki.source.file "pod_logs"
+
+  loki.process "pod_logs" {
+    stage.match {
+      selector = "{tmp_container_runtime=~\"containerd|cri-o|\"}"
+      // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
+      stage.cri {
+        max_partial_lines = 100
+      }
+
+      // Set the extract flags and stream values as labels
+      stage.labels {
+        values = {
+          flags  = "",
+          stream  = "",
+        }
+      }
+    }
+
+    stage.match {
+      selector = "{tmp_container_runtime=\"docker\"}"
+      // the docker processing stage extracts the following k/v pairs: log, stream, time
+      stage.docker {}
+
+      // Set the extract stream value as a label
+      stage.labels {
+        values = {
+          stream  = "",
+        }
+      }
+    }
+
+    // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
+    // namespace, pod, and container labels. Drop any structured metadata. Also drop the temporary
+    // container runtime label as it is no longer needed.
+    stage.label_drop {
+      values = [
+        "filename",
+        "tmp_container_runtime",
+      ]
+    }
+    stage.structured_metadata {
+      values = {
+        "k8s_pod_name" = "k8s_pod_name",
+        "pod" = "pod",
+        "service_instance_id" = "service_instance_id",
+      }
+    }
+
+    forward_to = argument.logs_destinations.value
+  } // loki.secretfilter "pod_logs"
+} // declare "pod_logs_via_loki"
+pod_logs_via_loki "feature" {
+  logs_destinations = [
+    loki.write.localloki.receiver,
+  ]
+}
+
+
+
+
+
+// Destination: localLoki (loki)
+otelcol.exporter.loki "localloki" {
+  forward_to = [loki.write.localloki.receiver]
+} // otelcol.exporter.loki "localloki"
+
+loki.write "localloki" {
+  endpoint {
+    url = "http://loki.loki.svc:3100/loki/api/v1/push"
+    retry_on_http_429 = true
+    tenant_id = convert.nonsensitive(remote.kubernetes.secret.localloki.data["tenantId"])
+    proxy_url = "http://proxy-server.proxy.svc:8888"
+    basic_auth {
+      username = convert.nonsensitive(remote.kubernetes.secret.localloki.data["username"])
+      password = remote.kubernetes.secret.localloki.data["password"]
+    }
+    tls_config {
+      insecure_skip_verify = true
+    }
+    min_backoff_period = "500ms"
+    max_backoff_period = "5m"
+    max_backoff_retries = "10"
+  }
+  external_labels = {
+    "cluster" = "proxies-test",
+    "k8s_cluster_name" = "proxies-test",
+  }
+} // loki.write "localloki"
+
+remote.kubernetes.secret "localloki" {
+  name      = "localloki-k8smon-k8s-monitoring"
+  namespace = "default"
+} // remote.kubernetes.secret "localloki"
+

--- a/charts/k8s-monitoring/tests/integration/proxies/.rendered/alloy-metrics.alloy
+++ b/charts/k8s-monitoring/tests/integration/proxies/.rendered/alloy-metrics.alloy
@@ -1,0 +1,370 @@
+declare "alloy_integration" {
+  argument "metrics_destinations" {
+    comment = "Must be a list of metric destinations where collected metrics should be forwarded to"
+  }
+
+  declare "alloy_integration_discovery" {
+    argument "namespaces" {
+      comment = "The namespaces to look for targets in (default: [] is all namespaces)"
+      optional = true
+    }
+
+    argument "field_selectors" {
+      comment = "The field selectors to use to find matching targets (default: [])"
+      optional = true
+    }
+
+    argument "label_selectors" {
+      comment = "The label selectors to use to find matching targets (default: [\"app.kubernetes.io/name=alloy\"])"
+      optional = true
+    }
+
+    argument "port_name" {
+      comment = "The of the port to scrape metrics from (default: http-metrics)"
+      optional = true
+    }
+
+    // Alloy service discovery for all of the pods
+    discovery.kubernetes "alloy_pods" {
+      role = "pod"
+
+      selectors {
+        role = "pod"
+        field = string.join(coalesce(argument.field_selectors.value, []), ",")
+        label = string.join(coalesce(argument.label_selectors.value, ["app.kubernetes.io/name=alloy"]), ",")
+      }
+
+      namespaces {
+        names = coalesce(argument.namespaces.value, [])
+      }
+
+    } // discovery.kubernetes "alloy_pods"
+
+    // alloy relabelings (pre-scrape)
+    discovery.relabel "alloy_pods" {
+      targets = discovery.kubernetes.alloy_pods.targets
+
+      // keep only the specified metrics port name, and pods that are Running and ready
+      rule {
+        source_labels = [
+          "__meta_kubernetes_pod_container_port_name",
+          "__meta_kubernetes_pod_phase",
+          "__meta_kubernetes_pod_ready",
+          "__meta_kubernetes_pod_container_init",
+        ]
+        separator = "@"
+        regex = coalesce(argument.port_name.value, "metrics") + "@Running@true@false"
+        action = "keep"
+      }
+
+      rule {
+        source_labels = ["__meta_kubernetes_namespace"]
+        target_label  = "namespace"
+      }
+
+      rule {
+        source_labels = ["__meta_kubernetes_pod_name"]
+        target_label  = "pod"
+      }
+
+      rule {
+        source_labels = ["__meta_kubernetes_pod_container_name"]
+        target_label  = "container"
+      }
+
+      // set the workload to the controller kind and name
+      rule {
+        action = "lowercase"
+        source_labels = ["__meta_kubernetes_pod_controller_kind"]
+        target_label  = "workload_type"
+      }
+
+      rule {
+        source_labels = ["__meta_kubernetes_pod_controller_name"]
+        target_label  = "workload"
+      }
+
+      // remove the hash from the ReplicaSet
+      rule {
+        source_labels = [
+          "workload_type",
+          "workload",
+        ]
+        separator = "/"
+        regex = "replicaset/(.+)-.+$"
+        target_label  = "workload"
+      }
+
+      // set the app name if specified as metadata labels "app:" or "app.kubernetes.io/name:" or "k8s-app:"
+      rule {
+        action = "replace"
+        source_labels = [
+          "__meta_kubernetes_pod_label_app_kubernetes_io_name",
+          "__meta_kubernetes_pod_label_k8s_app",
+          "__meta_kubernetes_pod_label_app",
+        ]
+        separator = ";"
+        regex = "^(?:;*)?([^;]+).*$"
+        replacement = "$1"
+        target_label = "app"
+      }
+
+      // set the component if specified as metadata labels "component:" or "app.kubernetes.io/component:" or "k8s-component:"
+      rule {
+        action = "replace"
+        source_labels = [
+          "__meta_kubernetes_pod_label_app_kubernetes_io_component",
+          "__meta_kubernetes_pod_label_k8s_component",
+          "__meta_kubernetes_pod_label_component",
+        ]
+        regex = "^(?:;*)?([^;]+).*$"
+        replacement = "$1"
+        target_label = "component"
+      }
+
+      // set a source label
+      rule {
+        action = "replace"
+        replacement = "kubernetes"
+        target_label = "source"
+      }
+
+    } // discovery.relabel "alloy_pods"
+
+    export "output" {
+      value = discovery.relabel.alloy_pods.output
+    }
+  }
+
+  declare "alloy_integration_scrape" {
+    argument "targets" {
+      comment = "Must be a list() of targets"
+    }
+
+    argument "forward_to" {
+      comment = "Must be a list(MetricsReceiver) where collected metrics should be forwarded to"
+    }
+
+    argument "job_label" {
+      comment = "The job label to add for all Alloy metrics (default: integrations/alloy)"
+      optional = true
+    }
+
+    argument "keep_metrics" {
+      comment = "A regular expression of metrics to keep (default: see below)"
+      optional = true
+    }
+
+    argument "drop_metrics" {
+      comment = "A regular expression of metrics to drop (default: see below)"
+      optional = true
+    }
+
+    argument "scrape_interval" {
+      comment = "How often to scrape metrics from the targets (default: 60s)"
+      optional = true
+    }
+
+    argument "scrape_timeout" {
+      comment = "The timeout for scraping metrics from the targets (default: 10s)"
+      optional = true
+    }
+
+    argument "scrape_protocols" {
+      comment = "The scrape protocols to use for scraping metrics"
+      optional = true
+    }
+
+    argument "scrape_classic_histograms" {
+      comment = "Whether to scrape classic histograms (default: false)."
+      optional = true
+    }
+
+    argument "scrape_native_histograms" {
+      comment = "Whether to scrape native histograms (default: false)."
+      optional = true
+    }
+
+    argument "max_cache_size" {
+      comment = "The maximum number of elements to hold in the relabeling cache (default: 100000).  This should be at least 2x-5x your largest scrape target or samples appended rate."
+      optional = true
+    }
+
+    argument "clustering" {
+      comment = "Whether or not clustering should be enabled (default: false)"
+      optional = true
+    }
+
+    prometheus.scrape "alloy" {
+      job_name = coalesce(argument.job_label.value, "integrations/alloy")
+      forward_to = [prometheus.relabel.alloy.receiver]
+      targets = argument.targets.value
+      scrape_interval = coalesce(argument.scrape_interval.value, "60s")
+      scrape_timeout = coalesce(argument.scrape_timeout.value, "10s")
+      scrape_protocols = argument.scrape_protocols.value
+      scrape_classic_histograms = argument.scrape_classic_histograms.value
+      scrape_native_histograms = argument.scrape_native_histograms.value
+
+      clustering {
+        enabled = coalesce(argument.clustering.value, false)
+      }
+    } // prometheus.scrape "alloy"
+
+    // alloy metric relabelings (post-scrape)
+    prometheus.relabel "alloy" {
+      forward_to = argument.forward_to.value
+      max_cache_size = coalesce(argument.max_cache_size.value, 100000)
+
+      // drop metrics that match the drop_metrics regex
+      rule {
+        source_labels = ["__name__"]
+        regex = coalesce(argument.drop_metrics.value, "")
+        action = "drop"
+      }
+
+      // keep only metrics that match the keep_metrics regex
+      rule {
+        source_labels = ["__name__"]
+        regex = coalesce(argument.keep_metrics.value, ".*")
+        action = "keep"
+      }
+
+      // remove the component_id label from any metric that starts with log_bytes or log_lines, these are custom metrics that are generated
+      // as part of the log annotation modules in this repo
+      rule {
+        action = "replace"
+        source_labels = ["__name__"]
+        regex = "^log_(bytes|lines).+"
+        replacement = ""
+        target_label = "component_id"
+      }
+
+      // set the namespace label to that of the exported_namespace
+      rule {
+        action = "replace"
+        source_labels = ["__name__", "exported_namespace"]
+        separator = "@"
+        regex = "^log_(bytes|lines).+@(.+)"
+        replacement = "$2"
+        target_label = "namespace"
+      }
+
+      // set the pod label to that of the exported_pod
+      rule {
+        action = "replace"
+        source_labels = ["__name__", "exported_pod"]
+        separator = "@"
+        regex = "^log_(bytes|lines).+@(.+)"
+        replacement = "$2"
+        target_label = "pod"
+      }
+
+      // set the container label to that of the exported_container
+      rule {
+        action = "replace"
+        source_labels = ["__name__", "exported_container"]
+        separator = "@"
+        regex = "^log_(bytes|lines).+@(.+)"
+        replacement = "$2"
+        target_label = "container"
+      }
+
+      // set the job label to that of the exported_job
+      rule {
+        action = "replace"
+        source_labels = ["__name__", "exported_job"]
+        separator = "@"
+        regex = "^log_(bytes|lines).+@(.+)"
+        replacement = "$2"
+        target_label = "job"
+      }
+
+      // set the instance label to that of the exported_instance
+      rule {
+        action = "replace"
+        source_labels = ["__name__", "exported_instance"]
+        separator = "@"
+        regex = "^log_(bytes|lines).+@(.+)"
+        replacement = "$2"
+        target_label = "instance"
+      }
+
+      rule {
+        action = "labeldrop"
+        regex = "exported_(namespace|pod|container|job|instance)"
+      }
+    } // prometheus.relabel "alloy"
+  }
+
+  alloy_integration_discovery "alloy" {
+    port_name = "http-metrics"
+    label_selectors = ["app.kubernetes.io/name in (alloy-metrics,alloy-singleton,alloy-logs,alloy-receiver)"]
+  }
+
+  alloy_integration_scrape "alloy" {
+    targets = alloy_integration_discovery.alloy.output
+    job_label = "integrations/alloy"
+    clustering = true
+    keep_metrics = "up|scrape_samples_scraped|alloy_build_info|alloy_component_controller_running_components|alloy_component_dependencies_wait_seconds|alloy_component_dependencies_wait_seconds_bucket|alloy_component_evaluation_seconds|alloy_component_evaluation_seconds_bucket|alloy_component_evaluation_seconds_count|alloy_component_evaluation_seconds_sum|alloy_component_evaluation_slow_seconds|alloy_config_hash|alloy_resources_machine_rx_bytes_total|alloy_resources_machine_tx_bytes_total|alloy_resources_process_cpu_seconds_total|alloy_resources_process_resident_memory_bytes|alloy_tcp_connections|alloy_wal_samples_appended_total|alloy_wal_storage_active_series|cluster_node_gossip_health_score|cluster_node_gossip_proto_version|cluster_node_gossip_received_events_total|cluster_node_info|cluster_node_lamport_time|cluster_node_peers|cluster_node_update_observers|cluster_transport_rx_bytes_total|cluster_transport_rx_packet_queue_length|cluster_transport_rx_packets_failed_total|cluster_transport_rx_packets_total|cluster_transport_stream_rx_bytes_total|cluster_transport_stream_rx_packets_failed_total|cluster_transport_stream_rx_packets_total|cluster_transport_stream_tx_bytes_total|cluster_transport_stream_tx_packets_failed_total|cluster_transport_stream_tx_packets_total|cluster_transport_streams|cluster_transport_tx_bytes_total|cluster_transport_tx_packet_queue_length|cluster_transport_tx_packets_failed_total|cluster_transport_tx_packets_total|otelcol_exporter_send_failed_spans_total|otelcol_exporter_sent_spans_total|go_gc_duration_seconds_count|go_goroutines|go_memstats_heap_inuse_bytes|loki_process_dropped_lines_total|loki_write_batch_retries_total|loki_write_dropped_bytes_total|loki_write_dropped_entries_total|loki_write_encoded_bytes_total|loki_write_mutated_bytes_total|loki_write_mutated_entries_total|loki_write_request_duration_seconds_bucket|loki_write_sent_bytes_total|loki_write_sent_entries_total|process_cpu_seconds_total|process_start_time_seconds|otelcol_processor_batch_batch_send_size_bucket|otelcol_processor_batch_metadata_cardinality|otelcol_processor_batch_timeout_trigger_send_total|prometheus_remote_storage_bytes_total|prometheus_remote_storage_enqueue_retries_total|prometheus_remote_storage_highest_timestamp_in_seconds|prometheus_remote_storage_metadata_bytes_total|prometheus_remote_storage_queue_highest_sent_timestamp_seconds|prometheus_remote_storage_samples_dropped_total|prometheus_remote_storage_samples_failed_total|prometheus_remote_storage_samples_pending|prometheus_remote_storage_samples_retried_total|prometheus_remote_storage_samples_total|prometheus_remote_storage_sent_batch_duration_seconds_bucket|prometheus_remote_storage_sent_batch_duration_seconds_count|prometheus_remote_storage_sent_batch_duration_seconds_sum|prometheus_remote_storage_shard_capacity|prometheus_remote_storage_shards|prometheus_remote_storage_shards_desired|prometheus_remote_storage_shards_max|prometheus_remote_storage_shards_min|prometheus_remote_storage_succeeded_samples_total|prometheus_remote_write_wal_samples_appended_total|prometheus_remote_write_wal_storage_active_series|prometheus_sd_discovered_targets|prometheus_target_interval_length_seconds_count|prometheus_target_interval_length_seconds_sum|prometheus_target_scrapes_exceeded_sample_limit_total|prometheus_target_scrapes_sample_duplicate_timestamp_total|prometheus_target_scrapes_sample_out_of_bounds_total|prometheus_target_scrapes_sample_out_of_order_total|prometheus_target_sync_length_seconds_sum|prometheus_wal_watcher_current_segment|otelcol_receiver_accepted_spans_total|otelcol_receiver_refused_spans_total|rpc_server_duration_milliseconds_bucket|scrape_duration_seconds|traces_exporter_send_failed_spans|traces_exporter_send_failed_spans_total|traces_exporter_sent_spans|traces_exporter_sent_spans_total|traces_loadbalancer_backend_outcome|traces_loadbalancer_num_backends|traces_receiver_accepted_spans|traces_receiver_accepted_spans_total|traces_receiver_refused_spans|traces_receiver_refused_spans_total"
+    scrape_interval = "60s"
+    scrape_timeout = "10s"
+    scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
+    scrape_classic_histograms = false
+    scrape_native_histograms = false
+    max_cache_size = 100000
+    forward_to = argument.metrics_destinations.value
+  }
+}
+alloy_integration "integration" {
+  metrics_destinations = [
+    prometheus.remote_write.localprometheus.receiver,
+  ]
+}
+
+
+
+
+
+// Destination: localPrometheus (prometheus)
+otelcol.exporter.prometheus "localprometheus" {
+  add_metric_suffixes = true
+  resource_to_telemetry_conversion = false
+  keep_identifying_resource_attributes = true
+  forward_to = [prometheus.remote_write.localprometheus.receiver]
+} // otelcol.exporter.prometheus "localprometheus"
+
+prometheus.remote_write "localprometheus" {
+  endpoint {
+    url = "http://prometheus-server.prometheus.svc:9090/api/v1/write"
+    headers = {
+    }
+    proxy_url = "http://proxy-server.proxy.svc:8888"
+    tls_config {
+      insecure_skip_verify = true
+    }
+    send_native_histograms = false
+
+    queue_config {
+      capacity = 10000
+      min_shards = 1
+      max_shards = 50
+      max_samples_per_send = 2000
+      batch_send_deadline = "5s"
+      min_backoff = "30ms"
+      max_backoff = "5s"
+      retry_on_http_429 = true
+      sample_age_limit = "0s"
+    }
+  }
+
+  wal {
+    truncate_frequency = "2h"
+    min_keepalive_time = "5m"
+    max_keepalive_time = "8h"
+  }
+  external_labels = {
+    "cluster" = "proxies-test",
+    "k8s_cluster_name" = "proxies-test",
+  }
+} // prometheus.remote_write "localprometheus"
+

--- a/charts/k8s-monitoring/tests/integration/proxies/.rendered/alloy-receiver.alloy
+++ b/charts/k8s-monitoring/tests/integration/proxies/.rendered/alloy-receiver.alloy
@@ -1,0 +1,292 @@
+// Feature: Application Observability
+declare "application_observability" {
+  argument "metrics_destinations" {
+    comment = "Must be a list of metrics destinations where collected metrics should be forwarded to"
+  }
+
+  argument "logs_destinations" {
+    comment = "Must be a list of log destinations where collected logs should be forwarded to"
+  }
+
+  argument "traces_destinations" {
+    comment = "Must be a list of trace destinations where collected trace should be forwarded to"
+  }
+
+  // OTLP Receiver
+  otelcol.receiver.otlp "receiver" {
+    grpc {
+      endpoint = "0.0.0.0:4317"
+      include_metadata = false
+      max_recv_msg_size = "4MiB"
+      read_buffer_size = "512KiB"
+      write_buffer_size = "32KiB"
+    }
+    debug_metrics {
+      disable_high_cardinality_metrics = true
+    }
+    output {
+      metrics = [otelcol.processor.resourcedetection.default.input]
+      logs = [otelcol.processor.resourcedetection.default.input]
+      traces = [otelcol.processor.resourcedetection.default.input]
+    }
+  } // otelcol.receiver.otlp "receiver"
+
+  // Resource Detection Processor
+  otelcol.processor.resourcedetection "default" {
+    detectors = ["env","system"]
+    override = true
+
+    system {
+      hostname_sources = ["os"]
+    }
+
+    output {
+      metrics = [otelcol.processor.k8sattributes.default.input]
+      logs = [otelcol.processor.k8sattributes.default.input]
+      traces = [otelcol.processor.k8sattributes.default.input]
+    }
+  }
+
+  // K8s Attributes Processor
+  otelcol.processor.k8sattributes "default" {
+    passthrough = false
+    extract {
+      metadata = ["k8s.namespace.name","k8s.pod.name","k8s.deployment.name","k8s.statefulset.name","k8s.daemonset.name","k8s.cronjob.name","k8s.job.name","k8s.node.name","k8s.pod.uid","k8s.pod.start_time"]
+    }
+    pod_association {
+      source {
+        from = "resource_attribute"
+        name = "k8s.pod.ip"
+      }
+    }
+    pod_association {
+      source {
+        from = "resource_attribute"
+        name = "k8s.pod.uid"
+      }
+    }
+    pod_association {
+      source {
+        from = "connection"
+      }
+    }
+
+    output {
+      metrics = [otelcol.processor.transform.default.input]
+      logs = [otelcol.processor.transform.default.input]
+      traces = [otelcol.processor.transform.default.input, otelcol.connector.host_info.default.input]
+    }
+  }
+
+  // Host Info Connector
+  otelcol.connector.host_info "default" {
+    host_identifiers = [ "k8s.node.name" ]
+
+    output {
+      metrics = [otelcol.processor.batch.default.input]
+    }
+  }
+
+  // Transform Processor
+  otelcol.processor.transform "default" {
+    error_mode = "ignore"
+    log_statements {
+      context = "resource"
+      statements = [
+        "set(attributes[\"pod\"], attributes[\"k8s.pod.name\"])",
+        "set(attributes[\"namespace\"], attributes[\"k8s.namespace.name\"])",
+        "set(attributes[\"loki.resource.labels\"], \"cluster, namespace, job, pod\")",
+      ]
+    }
+    trace_statements {
+      context = "span"
+      statements = [
+       "set_semconv_span_name(\"1.37.0\", \"original_span_name\")",
+      ]
+    }
+
+    output {
+      metrics = [otelcol.processor.batch.default.input]
+      logs = [otelcol.processor.batch.default.input]
+      traces = [otelcol.processor.batch.default.input]
+    }
+  }
+
+  // Batch Processor
+  otelcol.processor.batch "default" {
+    send_batch_size = 8192
+    send_batch_max_size = 0
+    timeout = "2s"
+
+    output {
+      metrics = argument.metrics_destinations.value
+      logs = argument.logs_destinations.value
+      traces = argument.traces_destinations.value
+    }
+  }
+} // declare "application_observability"
+application_observability "feature" {
+  metrics_destinations = [
+    otelcol.exporter.prometheus.localprometheus.input,
+  ]
+  logs_destinations = [
+    otelcol.exporter.loki.localloki.input,
+  ]
+  traces_destinations = [
+    otelcol.processor.attributes.localtempo.input,
+  ]
+}
+
+
+
+remote.http "url_test" {
+  url = "https://api.github.com/users/grafana/repos"
+}
+
+// Destination: localLoki (loki)
+otelcol.exporter.loki "localloki" {
+  forward_to = [loki.write.localloki.receiver]
+} // otelcol.exporter.loki "localloki"
+
+loki.write "localloki" {
+  endpoint {
+    url = "http://loki.loki.svc:3100/loki/api/v1/push"
+    retry_on_http_429 = true
+    tenant_id = convert.nonsensitive(remote.kubernetes.secret.localloki.data["tenantId"])
+    proxy_url = "http://proxy-server.proxy.svc:8888"
+    basic_auth {
+      username = convert.nonsensitive(remote.kubernetes.secret.localloki.data["username"])
+      password = remote.kubernetes.secret.localloki.data["password"]
+    }
+    tls_config {
+      insecure_skip_verify = true
+    }
+    min_backoff_period = "500ms"
+    max_backoff_period = "5m"
+    max_backoff_retries = "10"
+  }
+  external_labels = {
+    "cluster" = "proxies-test",
+    "k8s_cluster_name" = "proxies-test",
+  }
+} // loki.write "localloki"
+
+remote.kubernetes.secret "localloki" {
+  name      = "localloki-k8smon-k8s-monitoring"
+  namespace = "default"
+} // remote.kubernetes.secret "localloki"
+
+
+// Destination: localPrometheus (prometheus)
+otelcol.exporter.prometheus "localprometheus" {
+  add_metric_suffixes = true
+  resource_to_telemetry_conversion = false
+  keep_identifying_resource_attributes = true
+  forward_to = [prometheus.remote_write.localprometheus.receiver]
+} // otelcol.exporter.prometheus "localprometheus"
+
+prometheus.remote_write "localprometheus" {
+  endpoint {
+    url = "http://prometheus-server.prometheus.svc:9090/api/v1/write"
+    headers = {
+    }
+    proxy_url = "http://proxy-server.proxy.svc:8888"
+    tls_config {
+      insecure_skip_verify = true
+    }
+    send_native_histograms = false
+
+    queue_config {
+      capacity = 10000
+      min_shards = 1
+      max_shards = 50
+      max_samples_per_send = 2000
+      batch_send_deadline = "5s"
+      min_backoff = "30ms"
+      max_backoff = "5s"
+      retry_on_http_429 = true
+      sample_age_limit = "0s"
+    }
+  }
+
+  wal {
+    truncate_frequency = "2h"
+    min_keepalive_time = "5m"
+    max_keepalive_time = "8h"
+  }
+  external_labels = {
+    "cluster" = "proxies-test",
+    "k8s_cluster_name" = "proxies-test",
+  }
+} // prometheus.remote_write "localprometheus"
+
+// Destination: localTempo (otlp)
+otelcol.processor.attributes "localtempo" {
+  output {
+    traces = [otelcol.processor.transform.localtempo.input]
+  }
+} // otelcol.processor.attributes "localtempo"
+
+otelcol.processor.transform "localtempo" {
+  error_mode = "ignore"
+
+  trace_statements {
+    context = "resource"
+    statements = [
+      `set(attributes["cluster"], "proxies-test")`,
+      `set(attributes["k8s.cluster.name"], "proxies-test")`,
+      `delete_key(attributes, "process.pid")`,
+      `delete_key(attributes, "process.parent_pid")`,
+      `delete_key(attributes, "process.executable.path")`,
+      `delete_key(attributes, "process.command_line")`,
+      `delete_key(attributes, "process.command_args")`,
+      `delete_key(attributes, "process.owner")`,
+      `delete_key(attributes, "process.runtime.version")`,
+      `delete_key(attributes, "process.runtime.description")`,
+      `delete_key(attributes, "host.ip")`,
+      `delete_key(attributes, "host.mac")`,
+      `delete_key(attributes, "k8s.pod.start_time")`,
+      `delete_key(attributes, "k8s.pod.uid")`,
+      `delete_key(attributes, "container.image.id")`,
+      `delete_key(attributes, "container.image.repo_digests")`,
+      `delete_key(attributes, "os.description")`,
+      `delete_key(attributes, "os.build_id")`,
+    ]
+  }
+
+  output {
+    traces = [otelcol.processor.batch.localtempo.input]
+  }
+} // otelcol.processor.transform "localtempo"
+
+otelcol.processor.batch "localtempo" {
+  timeout = "2s"
+  send_batch_size = 8192
+  send_batch_max_size = 0
+
+  output {
+    traces = [otelcol.exporter.otlphttp.localtempo.input]
+  }
+} // otelcol.processor.batch "localtempo"
+otelcol.exporter.otlphttp "localtempo" {
+  client {
+    endpoint = "http://tempo.tempo.svc:4318"
+    proxy_url = "http://proxy-server.proxy.svc:8888"
+    tls {
+      insecure = true
+      insecure_skip_verify = true
+    }
+  }
+
+  retry_on_failure {
+    enabled = true
+    initial_interval = "5s"
+    max_interval = "30s"
+    max_elapsed_time = "5m"
+  }
+
+  sending_queue {
+    enabled = true
+  }
+} // otelcol.exporter.otlphttp "localtempo"
+

--- a/charts/k8s-monitoring/tests/integration/proxies/.rendered/alloy-singleton.alloy
+++ b/charts/k8s-monitoring/tests/integration/proxies/.rendered/alloy-singleton.alloy
@@ -1,0 +1,207 @@
+// Feature: Cluster Events
+declare "cluster_events" {
+  argument "logs_destinations" {
+    comment = "Must be a list of log destinations where collected logs should be forwarded to"
+  }
+
+  loki.source.kubernetes_events "cluster_events" {
+    job_name   = "integrations/kubernetes/eventhandler"
+    log_format = "logfmt"
+    forward_to = [loki.process.cluster_events.receiver]
+  } // loki.source.kubernetes_events "cluster_events"
+
+  loki.process "cluster_events" {
+
+    // add a static source label to the logs so they can be differentiated / restricted if necessary
+    stage.static_labels {
+      values = {
+        "source" = "kubernetes-events",
+      }
+    }
+
+    // extract some of the fields from the log line, these could be used as labels, structured metadata, etc.
+    stage.logfmt {
+      mapping = {
+        "component" = "sourcecomponent", // map the sourcecomponent field to component
+        "kind" = "",
+        "level" = "type", // most events don't have a level but they do have a "type" i.e. Normal, Warning, Error, etc.
+        "name" = "",
+        "node" = "sourcehost", // map the sourcehost field to node
+        "reason" = "",
+      }
+    }
+    // set the extracted values as labels
+    stage.labels {
+      values = {
+        "kind" = "",
+        "level" = "",
+        "service_name" = "job",
+        "reason" = "reason",
+      }
+    }
+
+    // if kind=Node, set the node label by copying the name field
+    stage.match {
+      selector = "{kind=\"Node\"}"
+
+      stage.labels {
+        values = {
+          "node" = "name",
+        }
+      }
+    }
+
+    // set the level extracted key value as a normalized log level
+    stage.match {
+      selector = "{level=\"Normal\"}"
+
+      stage.static_labels {
+        values = {
+          level = "Info",
+        }
+      }
+    }
+    stage.structured_metadata {
+      values = {
+        "name" = "name",
+        "node" = "node",
+      }
+    }
+
+    // Drop pipeline-only labels that are not needed in the final output.
+    stage.label_drop {
+      values = ["kind"]
+    }
+
+    forward_to = argument.logs_destinations.value
+  } // loki.process "cluster_events"
+} // declare "cluster_events"
+cluster_events "feature" {
+  logs_destinations = [
+    loki.write.localloki.receiver,
+  ]
+}
+// Self Reporting
+prometheus.exporter.unix "kubernetes_monitoring_telemetry" {
+  set_collectors = ["textfile"]
+  textfile {
+    directory = "/etc/release-info"
+  }
+} // prometheus.exporter.unix "kubernetes_monitoring_telemetry"
+
+discovery.relabel "kubernetes_monitoring_telemetry" {
+  targets = prometheus.exporter.unix.kubernetes_monitoring_telemetry.targets
+  rule {
+    target_label = "instance"
+    action = "replace"
+    replacement = "k8smon"
+  }
+  rule {
+    target_label = "job"
+    action = "replace"
+    replacement = "integrations/kubernetes/kubernetes_monitoring_telemetry"
+  }
+} // discovery.relabel "kubernetes_monitoring_telemetry"
+
+prometheus.scrape "kubernetes_monitoring_telemetry" {
+  job_name   = "integrations/kubernetes/kubernetes_monitoring_telemetry"
+  targets    = discovery.relabel.kubernetes_monitoring_telemetry.output
+  scrape_interval = "60s"
+  clustering {
+    enabled = true
+  }
+  forward_to = [prometheus.relabel.kubernetes_monitoring_telemetry.receiver]
+} // prometheus.scrape "kubernetes_monitoring_telemetry"
+
+prometheus.relabel "kubernetes_monitoring_telemetry" {
+  rule {
+    source_labels = ["__name__"]
+    regex = "grafana_kubernetes_monitoring_.*"
+    action = "keep"
+  }
+  forward_to = [
+    prometheus.remote_write.localprometheus.receiver,
+  ]
+} // prometheus.relabel "kubernetes_monitoring_telemetry"
+
+
+
+
+
+// Destination: localLoki (loki)
+otelcol.exporter.loki "localloki" {
+  forward_to = [loki.write.localloki.receiver]
+} // otelcol.exporter.loki "localloki"
+
+loki.write "localloki" {
+  endpoint {
+    url = "http://loki.loki.svc:3100/loki/api/v1/push"
+    retry_on_http_429 = true
+    tenant_id = convert.nonsensitive(remote.kubernetes.secret.localloki.data["tenantId"])
+    proxy_url = "http://proxy-server.proxy.svc:8888"
+    basic_auth {
+      username = convert.nonsensitive(remote.kubernetes.secret.localloki.data["username"])
+      password = remote.kubernetes.secret.localloki.data["password"]
+    }
+    tls_config {
+      insecure_skip_verify = true
+    }
+    min_backoff_period = "500ms"
+    max_backoff_period = "5m"
+    max_backoff_retries = "10"
+  }
+  external_labels = {
+    "cluster" = "proxies-test",
+    "k8s_cluster_name" = "proxies-test",
+  }
+} // loki.write "localloki"
+
+remote.kubernetes.secret "localloki" {
+  name      = "localloki-k8smon-k8s-monitoring"
+  namespace = "default"
+} // remote.kubernetes.secret "localloki"
+
+
+// Destination: localPrometheus (prometheus)
+otelcol.exporter.prometheus "localprometheus" {
+  add_metric_suffixes = true
+  resource_to_telemetry_conversion = false
+  keep_identifying_resource_attributes = true
+  forward_to = [prometheus.remote_write.localprometheus.receiver]
+} // otelcol.exporter.prometheus "localprometheus"
+
+prometheus.remote_write "localprometheus" {
+  endpoint {
+    url = "http://prometheus-server.prometheus.svc:9090/api/v1/write"
+    headers = {
+    }
+    proxy_url = "http://proxy-server.proxy.svc:8888"
+    tls_config {
+      insecure_skip_verify = true
+    }
+    send_native_histograms = false
+
+    queue_config {
+      capacity = 10000
+      min_shards = 1
+      max_shards = 50
+      max_samples_per_send = 2000
+      batch_send_deadline = "5s"
+      min_backoff = "30ms"
+      max_backoff = "5s"
+      retry_on_http_429 = true
+      sample_age_limit = "0s"
+    }
+  }
+
+  wal {
+    truncate_frequency = "2h"
+    min_keepalive_time = "5m"
+    max_keepalive_time = "8h"
+  }
+  external_labels = {
+    "cluster" = "proxies-test",
+    "k8s_cluster_name" = "proxies-test",
+  }
+} // prometheus.remote_write "localprometheus"
+

--- a/charts/k8s-monitoring/tests/integration/service-graph-metrics/.rendered/alloy-logs.alloy
+++ b/charts/k8s-monitoring/tests/integration/service-graph-metrics/.rendered/alloy-logs.alloy
@@ -1,0 +1,163 @@
+// Feature: Pod Logs (OpenTelemetry)
+declare "pod_logs_via_opentelemetry" {
+  argument "logs_destinations" {
+    comment = "Must be a list of log destinations where collected logs should be forwarded to"
+  }
+
+  otelcol.receiver.filelog "pod_logs" {
+    include = ["/var/log/pods/*/*/*.log"]
+    start_at = "end"
+    include_file_name = false
+    include_file_path = true
+
+    operators = [
+      // Container operator will set k8s.pod.name, k8s.pod.uid, k8s.container.name, k8s.container.restart_count, and k8s.namespace.name
+      {
+        type                       = "container",
+        add_metadata_from_filepath = true,
+      },
+    ]
+
+    output {
+      logs = [otelcol.processor.k8sattributes.pod_logs.input]
+    }
+  } // otelcol.receiver.filelog "pod_logs"
+
+  otelcol.processor.k8sattributes "pod_logs" {
+    pod_association {
+      source {
+        from = "resource_attribute"
+        name = "k8s.pod.uid"
+      }
+    }
+
+    extract {
+      otel_annotations = false
+      metadata = [
+        "k8s.deployment.name",
+        "k8s.statefulset.name",
+        "k8s.daemonset.name",
+        "k8s.cronjob.name",
+        "k8s.job.name",
+        "k8s.node.name",
+      ]
+      annotation {
+        key_regex = "resource.opentelemetry.io/(.*)"
+        tag_name  = "$1"
+        from      = "pod"
+      }
+      annotation {
+        tag_name = "logs.grafana.com/pods.enabled"
+        key      = "logs.grafana.com/pods.enabled"
+        from     = "pod"
+      }
+      label {
+        tag_name = "app_kubernetes_io_name"
+        key      = "app.kubernetes.io/name"
+        from     = "pod"
+      }
+      label {
+        tag_name = "color"
+        key      = "color"
+        from     = "namespace"
+      }
+    }
+
+    output {
+      logs = [otelcol.processor.filter.pod_logs.input]
+    }
+  } // otelcol.processor.k8sattributes "pod_logs"
+
+  otelcol.processor.filter "pod_logs" {
+    error_mode = "ignore"
+    logs {
+      log_record = [
+        `resource.attributes["logs.grafana.com/pods.enabled"] == "false"`,
+        `resource.attributes["logs.grafana.com/pods.enabled"] == "no"`,
+        `resource.attributes["logs.grafana.com/pods.enabled"] == "skip"`,
+      ]
+    }
+    output {
+      logs = [otelcol.processor.transform.pod_logs.input]
+    }
+  } // otelcol.processor.filter "pod_logs"
+
+  otelcol.processor.transform "pod_logs" {
+    error_mode = "ignore"
+    log_statements {
+      context = "resource"
+      statements = [
+        `delete_key(attributes, "k8s.container.restart_count")`,
+        `delete_key(attributes, "logs.grafana.com/pods.enabled")`,
+        `set(attributes["service.name"], attributes["app.kubernetes.io/name"]) where (attributes["service.name"] == nil or attributes["service.name"] == "") and attributes["app.kubernetes.io/name"] != nil and attributes["app.kubernetes.io/name"] != ""`,
+        `set(attributes["service.name"], attributes["k8s.deployment.name"]) where (attributes["service.name"] == nil or attributes["service.name"] == "") and attributes["k8s.deployment.name"] != nil and attributes["k8s.deployment.name"] != ""`,
+        `set(attributes["service.name"], attributes["k8s.replicaset.name"]) where (attributes["service.name"] == nil or attributes["service.name"] == "") and attributes["k8s.replicaset.name"] != nil and attributes["k8s.replicaset.name"] != ""`,
+        `set(attributes["service.name"], attributes["k8s.statefulset.name"]) where (attributes["service.name"] == nil or attributes["service.name"] == "") and attributes["k8s.statefulset.name"] != nil and attributes["k8s.statefulset.name"] != ""`,
+        `set(attributes["service.name"], attributes["k8s.daemonset.name"]) where (attributes["service.name"] == nil or attributes["service.name"] == "") and attributes["k8s.daemonset.name"] != nil and attributes["k8s.daemonset.name"] != ""`,
+        `set(attributes["service.name"], attributes["k8s.cronjob.name"]) where (attributes["service.name"] == nil or attributes["service.name"] == "") and attributes["k8s.cronjob.name"] != nil and attributes["k8s.cronjob.name"] != ""`,
+        `set(attributes["service.name"], attributes["k8s.job.name"]) where (attributes["service.name"] == nil or attributes["service.name"] == "") and attributes["k8s.job.name"] != nil and attributes["k8s.job.name"] != ""`,
+        `set(attributes["service.name"], attributes["k8s.pod.name"]) where (attributes["service.name"] == nil or attributes["service.name"] == "") and attributes["k8s.pod.name"] != nil and attributes["k8s.pod.name"] != ""`,
+        `set(attributes["service.name"], attributes["k8s.container.name"]) where (attributes["service.name"] == nil or attributes["service.name"] == "") and attributes["k8s.container.name"] != nil and attributes["k8s.container.name"] != ""`,
+
+        `set(attributes["service.namespace"], attributes["k8s.namespace.name"]) where (attributes["service.namespace"] == nil or attributes["service.namespace"] == "") and attributes["k8s.namespace.name"] != nil and attributes["k8s.namespace.name"] != ""`,
+
+        `set(attributes["service.version"], attributes["app.kubernetes.io/version"]) where attributes["service.version"] == nil`,
+
+        `set(attributes["service.instance.id"], Concat([attributes["k8s.namespace.name"], attributes["k8s.pod.name"], attributes["k8s.container.name"]], ".")) where attributes["service.instance.id"] == nil`,
+      ]
+    }
+
+    log_statements {
+      context = "log"
+      statements = [
+        `delete_key(attributes, "log.file.path")`,
+      ]
+    }
+
+    output {
+      logs = argument.logs_destinations.value
+    }
+  } // otelcol.processor.transform "pod_logs"
+} // declare "pod_logs_via_opentelemetry"
+pod_logs_via_opentelemetry "feature" {
+  logs_destinations = [
+    otelcol.exporter.loki.localloki.input,
+  ]
+}
+
+
+
+
+
+// Destination: localLoki (loki)
+otelcol.exporter.loki "localloki" {
+  forward_to = [loki.write.localloki.receiver]
+} // otelcol.exporter.loki "localloki"
+
+loki.write "localloki" {
+  endpoint {
+    url = "http://loki.loki.svc:3100/loki/api/v1/push"
+    retry_on_http_429 = true
+    tenant_id = convert.nonsensitive(remote.kubernetes.secret.localloki.data["tenantId"])
+    basic_auth {
+      username = convert.nonsensitive(remote.kubernetes.secret.localloki.data["username"])
+      password = remote.kubernetes.secret.localloki.data["password"]
+    }
+    tls_config {
+      insecure_skip_verify = false
+    }
+    min_backoff_period = "500ms"
+    max_backoff_period = "5m"
+    max_backoff_retries = "10"
+  }
+  external_labels = {
+    "cluster" = "service-graph-metrics-test",
+    "k8s_cluster_name" = "service-graph-metrics-test",
+  }
+} // loki.write "localloki"
+
+remote.kubernetes.secret "localloki" {
+  name      = "localloki-k8smon-k8s-monitoring"
+  namespace = "default"
+} // remote.kubernetes.secret "localloki"
+

--- a/charts/k8s-monitoring/tests/integration/service-graph-metrics/.rendered/alloy-metrics.alloy
+++ b/charts/k8s-monitoring/tests/integration/service-graph-metrics/.rendered/alloy-metrics.alloy
@@ -1,0 +1,388 @@
+declare "alloy_integration" {
+  argument "metrics_destinations" {
+    comment = "Must be a list of metric destinations where collected metrics should be forwarded to"
+  }
+
+  declare "alloy_integration_discovery" {
+    argument "namespaces" {
+      comment = "The namespaces to look for targets in (default: [] is all namespaces)"
+      optional = true
+    }
+
+    argument "field_selectors" {
+      comment = "The field selectors to use to find matching targets (default: [])"
+      optional = true
+    }
+
+    argument "label_selectors" {
+      comment = "The label selectors to use to find matching targets (default: [\"app.kubernetes.io/name=alloy\"])"
+      optional = true
+    }
+
+    argument "port_name" {
+      comment = "The of the port to scrape metrics from (default: http-metrics)"
+      optional = true
+    }
+
+    // Alloy service discovery for all of the pods
+    discovery.kubernetes "alloy_pods" {
+      role = "pod"
+
+      selectors {
+        role = "pod"
+        field = string.join(coalesce(argument.field_selectors.value, []), ",")
+        label = string.join(coalesce(argument.label_selectors.value, ["app.kubernetes.io/name=alloy"]), ",")
+      }
+
+      namespaces {
+        names = coalesce(argument.namespaces.value, [])
+      }
+
+    } // discovery.kubernetes "alloy_pods"
+
+    // alloy relabelings (pre-scrape)
+    discovery.relabel "alloy_pods" {
+      targets = discovery.kubernetes.alloy_pods.targets
+
+      // keep only the specified metrics port name, and pods that are Running and ready
+      rule {
+        source_labels = [
+          "__meta_kubernetes_pod_container_port_name",
+          "__meta_kubernetes_pod_phase",
+          "__meta_kubernetes_pod_ready",
+          "__meta_kubernetes_pod_container_init",
+        ]
+        separator = "@"
+        regex = coalesce(argument.port_name.value, "metrics") + "@Running@true@false"
+        action = "keep"
+      }
+
+      rule {
+        source_labels = ["__meta_kubernetes_namespace"]
+        target_label  = "namespace"
+      }
+
+      rule {
+        source_labels = ["__meta_kubernetes_pod_name"]
+        target_label  = "pod"
+      }
+
+      rule {
+        source_labels = ["__meta_kubernetes_pod_container_name"]
+        target_label  = "container"
+      }
+
+      // set the workload to the controller kind and name
+      rule {
+        action = "lowercase"
+        source_labels = ["__meta_kubernetes_pod_controller_kind"]
+        target_label  = "workload_type"
+      }
+
+      rule {
+        source_labels = ["__meta_kubernetes_pod_controller_name"]
+        target_label  = "workload"
+      }
+
+      // remove the hash from the ReplicaSet
+      rule {
+        source_labels = [
+          "workload_type",
+          "workload",
+        ]
+        separator = "/"
+        regex = "replicaset/(.+)-.+$"
+        target_label  = "workload"
+      }
+
+      // set the app name if specified as metadata labels "app:" or "app.kubernetes.io/name:" or "k8s-app:"
+      rule {
+        action = "replace"
+        source_labels = [
+          "__meta_kubernetes_pod_label_app_kubernetes_io_name",
+          "__meta_kubernetes_pod_label_k8s_app",
+          "__meta_kubernetes_pod_label_app",
+        ]
+        separator = ";"
+        regex = "^(?:;*)?([^;]+).*$"
+        replacement = "$1"
+        target_label = "app"
+      }
+
+      // set the component if specified as metadata labels "component:" or "app.kubernetes.io/component:" or "k8s-component:"
+      rule {
+        action = "replace"
+        source_labels = [
+          "__meta_kubernetes_pod_label_app_kubernetes_io_component",
+          "__meta_kubernetes_pod_label_k8s_component",
+          "__meta_kubernetes_pod_label_component",
+        ]
+        regex = "^(?:;*)?([^;]+).*$"
+        replacement = "$1"
+        target_label = "component"
+      }
+
+      // set a source label
+      rule {
+        action = "replace"
+        replacement = "kubernetes"
+        target_label = "source"
+      }
+
+    } // discovery.relabel "alloy_pods"
+
+    export "output" {
+      value = discovery.relabel.alloy_pods.output
+    }
+  }
+
+  declare "alloy_integration_scrape" {
+    argument "targets" {
+      comment = "Must be a list() of targets"
+    }
+
+    argument "forward_to" {
+      comment = "Must be a list(MetricsReceiver) where collected metrics should be forwarded to"
+    }
+
+    argument "job_label" {
+      comment = "The job label to add for all Alloy metrics (default: integrations/alloy)"
+      optional = true
+    }
+
+    argument "keep_metrics" {
+      comment = "A regular expression of metrics to keep (default: see below)"
+      optional = true
+    }
+
+    argument "drop_metrics" {
+      comment = "A regular expression of metrics to drop (default: see below)"
+      optional = true
+    }
+
+    argument "scrape_interval" {
+      comment = "How often to scrape metrics from the targets (default: 60s)"
+      optional = true
+    }
+
+    argument "scrape_timeout" {
+      comment = "The timeout for scraping metrics from the targets (default: 10s)"
+      optional = true
+    }
+
+    argument "scrape_protocols" {
+      comment = "The scrape protocols to use for scraping metrics"
+      optional = true
+    }
+
+    argument "scrape_classic_histograms" {
+      comment = "Whether to scrape classic histograms (default: false)."
+      optional = true
+    }
+
+    argument "scrape_native_histograms" {
+      comment = "Whether to scrape native histograms (default: false)."
+      optional = true
+    }
+
+    argument "max_cache_size" {
+      comment = "The maximum number of elements to hold in the relabeling cache (default: 100000).  This should be at least 2x-5x your largest scrape target or samples appended rate."
+      optional = true
+    }
+
+    argument "clustering" {
+      comment = "Whether or not clustering should be enabled (default: false)"
+      optional = true
+    }
+
+    prometheus.scrape "alloy" {
+      job_name = coalesce(argument.job_label.value, "integrations/alloy")
+      forward_to = [prometheus.relabel.alloy.receiver]
+      targets = argument.targets.value
+      scrape_interval = coalesce(argument.scrape_interval.value, "60s")
+      scrape_timeout = coalesce(argument.scrape_timeout.value, "10s")
+      scrape_protocols = argument.scrape_protocols.value
+      scrape_classic_histograms = argument.scrape_classic_histograms.value
+      scrape_native_histograms = argument.scrape_native_histograms.value
+
+      clustering {
+        enabled = coalesce(argument.clustering.value, false)
+      }
+    } // prometheus.scrape "alloy"
+
+    // alloy metric relabelings (post-scrape)
+    prometheus.relabel "alloy" {
+      forward_to = argument.forward_to.value
+      max_cache_size = coalesce(argument.max_cache_size.value, 100000)
+
+      // drop metrics that match the drop_metrics regex
+      rule {
+        source_labels = ["__name__"]
+        regex = coalesce(argument.drop_metrics.value, "")
+        action = "drop"
+      }
+
+      // keep only metrics that match the keep_metrics regex
+      rule {
+        source_labels = ["__name__"]
+        regex = coalesce(argument.keep_metrics.value, ".*")
+        action = "keep"
+      }
+
+      // remove the component_id label from any metric that starts with log_bytes or log_lines, these are custom metrics that are generated
+      // as part of the log annotation modules in this repo
+      rule {
+        action = "replace"
+        source_labels = ["__name__"]
+        regex = "^log_(bytes|lines).+"
+        replacement = ""
+        target_label = "component_id"
+      }
+
+      // set the namespace label to that of the exported_namespace
+      rule {
+        action = "replace"
+        source_labels = ["__name__", "exported_namespace"]
+        separator = "@"
+        regex = "^log_(bytes|lines).+@(.+)"
+        replacement = "$2"
+        target_label = "namespace"
+      }
+
+      // set the pod label to that of the exported_pod
+      rule {
+        action = "replace"
+        source_labels = ["__name__", "exported_pod"]
+        separator = "@"
+        regex = "^log_(bytes|lines).+@(.+)"
+        replacement = "$2"
+        target_label = "pod"
+      }
+
+      // set the container label to that of the exported_container
+      rule {
+        action = "replace"
+        source_labels = ["__name__", "exported_container"]
+        separator = "@"
+        regex = "^log_(bytes|lines).+@(.+)"
+        replacement = "$2"
+        target_label = "container"
+      }
+
+      // set the job label to that of the exported_job
+      rule {
+        action = "replace"
+        source_labels = ["__name__", "exported_job"]
+        separator = "@"
+        regex = "^log_(bytes|lines).+@(.+)"
+        replacement = "$2"
+        target_label = "job"
+      }
+
+      // set the instance label to that of the exported_instance
+      rule {
+        action = "replace"
+        source_labels = ["__name__", "exported_instance"]
+        separator = "@"
+        regex = "^log_(bytes|lines).+@(.+)"
+        replacement = "$2"
+        target_label = "instance"
+      }
+
+      rule {
+        action = "labeldrop"
+        regex = "exported_(namespace|pod|container|job|instance)"
+      }
+    } // prometheus.relabel "alloy"
+  }
+
+  alloy_integration_discovery "alloy_receiver" {
+    port_name = "http-metrics"
+    label_selectors = ["app.kubernetes.io/instance=k8smon-alloy-receiver"]
+  }
+
+  alloy_integration_scrape "alloy_receiver" {
+    targets = alloy_integration_discovery.alloy_receiver.output
+    job_label = "integrations/alloy"
+    clustering = true
+    keep_metrics = "up|scrape_samples_scraped|alloy_build_info|alloy_component_controller_running_components|alloy_component_dependencies_wait_seconds|alloy_component_dependencies_wait_seconds_bucket|alloy_component_evaluation_seconds|alloy_component_evaluation_seconds_bucket|alloy_component_evaluation_seconds_count|alloy_component_evaluation_seconds_sum|alloy_component_evaluation_slow_seconds|alloy_config_hash|alloy_resources_machine_rx_bytes_total|alloy_resources_machine_tx_bytes_total|alloy_resources_process_cpu_seconds_total|alloy_resources_process_resident_memory_bytes|alloy_tcp_connections|alloy_wal_samples_appended_total|alloy_wal_storage_active_series|cluster_node_gossip_health_score|cluster_node_gossip_proto_version|cluster_node_gossip_received_events_total|cluster_node_info|cluster_node_lamport_time|cluster_node_peers|cluster_node_update_observers|cluster_transport_rx_bytes_total|cluster_transport_rx_packet_queue_length|cluster_transport_rx_packets_failed_total|cluster_transport_rx_packets_total|cluster_transport_stream_rx_bytes_total|cluster_transport_stream_rx_packets_failed_total|cluster_transport_stream_rx_packets_total|cluster_transport_stream_tx_bytes_total|cluster_transport_stream_tx_packets_failed_total|cluster_transport_stream_tx_packets_total|cluster_transport_streams|cluster_transport_tx_bytes_total|cluster_transport_tx_packet_queue_length|cluster_transport_tx_packets_failed_total|cluster_transport_tx_packets_total|otelcol_exporter_send_failed_spans_total|otelcol_exporter_sent_spans_total|go_gc_duration_seconds_count|go_goroutines|go_memstats_heap_inuse_bytes|loki_process_dropped_lines_total|loki_write_batch_retries_total|loki_write_dropped_bytes_total|loki_write_dropped_entries_total|loki_write_encoded_bytes_total|loki_write_mutated_bytes_total|loki_write_mutated_entries_total|loki_write_request_duration_seconds_bucket|loki_write_sent_bytes_total|loki_write_sent_entries_total|process_cpu_seconds_total|process_start_time_seconds|otelcol_processor_batch_batch_send_size_bucket|otelcol_processor_batch_metadata_cardinality|otelcol_processor_batch_timeout_trigger_send_total|prometheus_remote_storage_bytes_total|prometheus_remote_storage_enqueue_retries_total|prometheus_remote_storage_highest_timestamp_in_seconds|prometheus_remote_storage_metadata_bytes_total|prometheus_remote_storage_queue_highest_sent_timestamp_seconds|prometheus_remote_storage_samples_dropped_total|prometheus_remote_storage_samples_failed_total|prometheus_remote_storage_samples_pending|prometheus_remote_storage_samples_retried_total|prometheus_remote_storage_samples_total|prometheus_remote_storage_sent_batch_duration_seconds_bucket|prometheus_remote_storage_sent_batch_duration_seconds_count|prometheus_remote_storage_sent_batch_duration_seconds_sum|prometheus_remote_storage_shard_capacity|prometheus_remote_storage_shards|prometheus_remote_storage_shards_desired|prometheus_remote_storage_shards_max|prometheus_remote_storage_shards_min|prometheus_remote_storage_succeeded_samples_total|prometheus_remote_write_wal_samples_appended_total|prometheus_remote_write_wal_storage_active_series|prometheus_sd_discovered_targets|prometheus_target_interval_length_seconds_count|prometheus_target_interval_length_seconds_sum|prometheus_target_scrapes_exceeded_sample_limit_total|prometheus_target_scrapes_sample_duplicate_timestamp_total|prometheus_target_scrapes_sample_out_of_bounds_total|prometheus_target_scrapes_sample_out_of_order_total|prometheus_target_sync_length_seconds_sum|prometheus_wal_watcher_current_segment|otelcol_receiver_accepted_spans_total|otelcol_receiver_refused_spans_total|rpc_server_duration_milliseconds_bucket|scrape_duration_seconds|traces_exporter_send_failed_spans|traces_exporter_send_failed_spans_total|traces_exporter_sent_spans|traces_exporter_sent_spans_total|traces_loadbalancer_backend_outcome|traces_loadbalancer_num_backends|traces_receiver_accepted_spans|traces_receiver_accepted_spans_total|traces_receiver_refused_spans|traces_receiver_refused_spans_total|otelcol_loadbalancer_.*"
+    scrape_interval = "60s"
+    scrape_timeout = "10s"
+    scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
+    scrape_classic_histograms = false
+    scrape_native_histograms = false
+    max_cache_size = 100000
+    forward_to = argument.metrics_destinations.value
+  }
+
+  alloy_integration_discovery "alloy_servicegraph" {
+    port_name = "http-metrics"
+    label_selectors = ["app.kubernetes.io/instance=k8smon-localtempo-servicegraph"]
+  }
+
+  alloy_integration_scrape "alloy_servicegraph" {
+    targets = alloy_integration_discovery.alloy_servicegraph.output
+    job_label = "integrations/alloy"
+    clustering = true
+    keep_metrics = "up|scrape_samples_scraped|alloy_build_info|alloy_component_controller_running_components|alloy_component_dependencies_wait_seconds|alloy_component_dependencies_wait_seconds_bucket|alloy_component_evaluation_seconds|alloy_component_evaluation_seconds_bucket|alloy_component_evaluation_seconds_count|alloy_component_evaluation_seconds_sum|alloy_component_evaluation_slow_seconds|alloy_config_hash|alloy_resources_machine_rx_bytes_total|alloy_resources_machine_tx_bytes_total|alloy_resources_process_cpu_seconds_total|alloy_resources_process_resident_memory_bytes|alloy_tcp_connections|alloy_wal_samples_appended_total|alloy_wal_storage_active_series|cluster_node_gossip_health_score|cluster_node_gossip_proto_version|cluster_node_gossip_received_events_total|cluster_node_info|cluster_node_lamport_time|cluster_node_peers|cluster_node_update_observers|cluster_transport_rx_bytes_total|cluster_transport_rx_packet_queue_length|cluster_transport_rx_packets_failed_total|cluster_transport_rx_packets_total|cluster_transport_stream_rx_bytes_total|cluster_transport_stream_rx_packets_failed_total|cluster_transport_stream_rx_packets_total|cluster_transport_stream_tx_bytes_total|cluster_transport_stream_tx_packets_failed_total|cluster_transport_stream_tx_packets_total|cluster_transport_streams|cluster_transport_tx_bytes_total|cluster_transport_tx_packet_queue_length|cluster_transport_tx_packets_failed_total|cluster_transport_tx_packets_total|otelcol_exporter_send_failed_spans_total|otelcol_exporter_sent_spans_total|go_gc_duration_seconds_count|go_goroutines|go_memstats_heap_inuse_bytes|loki_process_dropped_lines_total|loki_write_batch_retries_total|loki_write_dropped_bytes_total|loki_write_dropped_entries_total|loki_write_encoded_bytes_total|loki_write_mutated_bytes_total|loki_write_mutated_entries_total|loki_write_request_duration_seconds_bucket|loki_write_sent_bytes_total|loki_write_sent_entries_total|process_cpu_seconds_total|process_start_time_seconds|otelcol_processor_batch_batch_send_size_bucket|otelcol_processor_batch_metadata_cardinality|otelcol_processor_batch_timeout_trigger_send_total|prometheus_remote_storage_bytes_total|prometheus_remote_storage_enqueue_retries_total|prometheus_remote_storage_highest_timestamp_in_seconds|prometheus_remote_storage_metadata_bytes_total|prometheus_remote_storage_queue_highest_sent_timestamp_seconds|prometheus_remote_storage_samples_dropped_total|prometheus_remote_storage_samples_failed_total|prometheus_remote_storage_samples_pending|prometheus_remote_storage_samples_retried_total|prometheus_remote_storage_samples_total|prometheus_remote_storage_sent_batch_duration_seconds_bucket|prometheus_remote_storage_sent_batch_duration_seconds_count|prometheus_remote_storage_sent_batch_duration_seconds_sum|prometheus_remote_storage_shard_capacity|prometheus_remote_storage_shards|prometheus_remote_storage_shards_desired|prometheus_remote_storage_shards_max|prometheus_remote_storage_shards_min|prometheus_remote_storage_succeeded_samples_total|prometheus_remote_write_wal_samples_appended_total|prometheus_remote_write_wal_storage_active_series|prometheus_sd_discovered_targets|prometheus_target_interval_length_seconds_count|prometheus_target_interval_length_seconds_sum|prometheus_target_scrapes_exceeded_sample_limit_total|prometheus_target_scrapes_sample_duplicate_timestamp_total|prometheus_target_scrapes_sample_out_of_bounds_total|prometheus_target_scrapes_sample_out_of_order_total|prometheus_target_sync_length_seconds_sum|prometheus_wal_watcher_current_segment|otelcol_receiver_accepted_spans_total|otelcol_receiver_refused_spans_total|rpc_server_duration_milliseconds_bucket|scrape_duration_seconds|traces_exporter_send_failed_spans|traces_exporter_send_failed_spans_total|traces_exporter_sent_spans|traces_exporter_sent_spans_total|traces_loadbalancer_backend_outcome|traces_loadbalancer_num_backends|traces_receiver_accepted_spans|traces_receiver_accepted_spans_total|traces_receiver_refused_spans|traces_receiver_refused_spans_total|traces_service_graph_request_.*"
+    scrape_interval = "60s"
+    scrape_timeout = "10s"
+    scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
+    scrape_classic_histograms = false
+    scrape_native_histograms = false
+    max_cache_size = 100000
+    forward_to = argument.metrics_destinations.value
+  }
+}
+alloy_integration "integration" {
+  metrics_destinations = [
+    prometheus.remote_write.localprometheus.receiver,
+  ]
+}
+
+
+
+
+
+// Destination: localPrometheus (prometheus)
+otelcol.exporter.prometheus "localprometheus" {
+  add_metric_suffixes = true
+  resource_to_telemetry_conversion = false
+  keep_identifying_resource_attributes = true
+  forward_to = [prometheus.remote_write.localprometheus.receiver]
+} // otelcol.exporter.prometheus "localprometheus"
+
+prometheus.remote_write "localprometheus" {
+  endpoint {
+    url = "http://prometheus-server.prometheus.svc:9090/api/v1/write"
+    headers = {
+    }
+    tls_config {
+      insecure_skip_verify = false
+    }
+    send_native_histograms = false
+
+    queue_config {
+      capacity = 10000
+      min_shards = 1
+      max_shards = 50
+      max_samples_per_send = 2000
+      batch_send_deadline = "5s"
+      min_backoff = "30ms"
+      max_backoff = "5s"
+      retry_on_http_429 = true
+      sample_age_limit = "0s"
+    }
+  }
+
+  wal {
+    truncate_frequency = "2h"
+    min_keepalive_time = "5m"
+    max_keepalive_time = "8h"
+  }
+  external_labels = {
+    "cluster" = "service-graph-metrics-test",
+    "k8s_cluster_name" = "service-graph-metrics-test",
+  }
+} // prometheus.remote_write "localprometheus"
+

--- a/charts/k8s-monitoring/tests/integration/service-graph-metrics/.rendered/alloy-receiver.alloy
+++ b/charts/k8s-monitoring/tests/integration/service-graph-metrics/.rendered/alloy-receiver.alloy
@@ -1,0 +1,358 @@
+// Feature: Application Observability
+declare "application_observability" {
+  argument "metrics_destinations" {
+    comment = "Must be a list of metrics destinations where collected metrics should be forwarded to"
+  }
+
+  argument "logs_destinations" {
+    comment = "Must be a list of log destinations where collected logs should be forwarded to"
+  }
+
+  argument "traces_destinations" {
+    comment = "Must be a list of trace destinations where collected trace should be forwarded to"
+  }
+
+  // OTLP Receiver
+  otelcol.receiver.otlp "receiver" {
+    grpc {
+      endpoint = "0.0.0.0:4317"
+      include_metadata = false
+      max_recv_msg_size = "4MiB"
+      read_buffer_size = "512KiB"
+      write_buffer_size = "32KiB"
+    }
+    http {
+      endpoint = "0.0.0.0:4318"
+      include_metadata = false
+      max_request_body_size = "20MiB"
+    }
+    debug_metrics {
+      disable_high_cardinality_metrics = true
+    }
+    output {
+      metrics = [otelcol.processor.resourcedetection.default.input]
+      logs = [otelcol.processor.resourcedetection.default.input]
+      traces = [otelcol.processor.resourcedetection.default.input]
+    }
+  } // otelcol.receiver.otlp "receiver"
+
+  // Resource Detection Processor
+  otelcol.processor.resourcedetection "default" {
+    detectors = ["env","system"]
+    override = true
+
+    system {
+      hostname_sources = ["os"]
+    }
+
+    output {
+      metrics = [otelcol.processor.k8sattributes.default.input]
+      logs = [otelcol.processor.k8sattributes.default.input]
+      traces = [otelcol.processor.k8sattributes.default.input]
+    }
+  }
+
+  // K8s Attributes Processor
+  otelcol.processor.k8sattributes "default" {
+    passthrough = false
+    extract {
+      metadata = ["k8s.namespace.name","k8s.pod.name","k8s.deployment.name","k8s.statefulset.name","k8s.daemonset.name","k8s.cronjob.name","k8s.job.name","k8s.node.name","k8s.pod.uid","k8s.pod.start_time"]
+    }
+    pod_association {
+      source {
+        from = "resource_attribute"
+        name = "k8s.pod.ip"
+      }
+    }
+    pod_association {
+      source {
+        from = "resource_attribute"
+        name = "k8s.pod.uid"
+      }
+    }
+    pod_association {
+      source {
+        from = "connection"
+      }
+    }
+
+    output {
+      metrics = [otelcol.processor.transform.default.input]
+      logs = [otelcol.processor.transform.default.input]
+      traces = [otelcol.processor.transform.default.input, otelcol.connector.host_info.default.input]
+    }
+  }
+
+  // Host Info Connector
+  otelcol.connector.host_info "default" {
+    host_identifiers = [ "k8s.node.name" ]
+
+    output {
+      metrics = [otelcol.processor.batch.default.input]
+    }
+  }
+
+  // Transform Processor
+  otelcol.processor.transform "default" {
+    error_mode = "ignore"
+    log_statements {
+      context = "resource"
+      statements = [
+        "set(attributes[\"pod\"], attributes[\"k8s.pod.name\"])",
+        "set(attributes[\"namespace\"], attributes[\"k8s.namespace.name\"])",
+        "set(attributes[\"loki.resource.labels\"], \"cluster, namespace, job, pod\")",
+      ]
+    }
+    trace_statements {
+      context = "span"
+      statements = [
+        "replace_pattern(name, \"\\\\?.*\", \"\")",
+        "replace_match(name, \"GET /api/products/*\", \"GET /api/products/{productId}\")",
+       "set_semconv_span_name(\"1.37.0\", \"original_span_name\")",
+      ]
+    }
+
+    output {
+      metrics = [otelcol.processor.batch.default.input]
+      logs = [otelcol.processor.batch.default.input]
+      traces = [otelcol.processor.batch.default.input]
+    }
+  }
+
+  // Batch Processor
+  otelcol.processor.batch "default" {
+    send_batch_size = 8192
+    send_batch_max_size = 0
+    timeout = "2s"
+
+    output {
+      metrics = argument.metrics_destinations.value
+      logs = argument.logs_destinations.value
+      traces = argument.traces_destinations.value
+    }
+  }
+} // declare "application_observability"
+application_observability "feature" {
+  metrics_destinations = [
+    otelcol.exporter.prometheus.localprometheus.input,
+  ]
+  logs_destinations = [
+    otelcol.exporter.loki.localloki.input,
+  ]
+  traces_destinations = [
+    otelcol.processor.attributes.localtempo.input,
+  ]
+}
+// Self Reporting
+prometheus.exporter.unix "kubernetes_monitoring_telemetry" {
+  set_collectors = ["textfile"]
+  textfile {
+    directory = "/etc/release-info"
+  }
+} // prometheus.exporter.unix "kubernetes_monitoring_telemetry"
+
+discovery.relabel "kubernetes_monitoring_telemetry" {
+  targets = prometheus.exporter.unix.kubernetes_monitoring_telemetry.targets
+  rule {
+    target_label = "instance"
+    action = "replace"
+    replacement = "k8smon"
+  }
+  rule {
+    target_label = "job"
+    action = "replace"
+    replacement = "integrations/kubernetes/kubernetes_monitoring_telemetry"
+  }
+} // discovery.relabel "kubernetes_monitoring_telemetry"
+
+prometheus.scrape "kubernetes_monitoring_telemetry" {
+  job_name   = "integrations/kubernetes/kubernetes_monitoring_telemetry"
+  targets    = discovery.relabel.kubernetes_monitoring_telemetry.output
+  scrape_interval = "60s"
+  clustering {
+    enabled = true
+  }
+  forward_to = [prometheus.relabel.kubernetes_monitoring_telemetry.receiver]
+} // prometheus.scrape "kubernetes_monitoring_telemetry"
+
+prometheus.relabel "kubernetes_monitoring_telemetry" {
+  rule {
+    source_labels = ["__name__"]
+    regex = "grafana_kubernetes_monitoring_.*"
+    action = "keep"
+  }
+  forward_to = [
+    prometheus.remote_write.localprometheus.receiver,
+  ]
+} // prometheus.relabel "kubernetes_monitoring_telemetry"
+
+
+
+
+
+// Destination: localLoki (loki)
+otelcol.exporter.loki "localloki" {
+  forward_to = [loki.write.localloki.receiver]
+} // otelcol.exporter.loki "localloki"
+
+loki.write "localloki" {
+  endpoint {
+    url = "http://loki.loki.svc:3100/loki/api/v1/push"
+    retry_on_http_429 = true
+    tenant_id = convert.nonsensitive(remote.kubernetes.secret.localloki.data["tenantId"])
+    basic_auth {
+      username = convert.nonsensitive(remote.kubernetes.secret.localloki.data["username"])
+      password = remote.kubernetes.secret.localloki.data["password"]
+    }
+    tls_config {
+      insecure_skip_verify = false
+    }
+    min_backoff_period = "500ms"
+    max_backoff_period = "5m"
+    max_backoff_retries = "10"
+  }
+  external_labels = {
+    "cluster" = "service-graph-metrics-test",
+    "k8s_cluster_name" = "service-graph-metrics-test",
+  }
+} // loki.write "localloki"
+
+remote.kubernetes.secret "localloki" {
+  name      = "localloki-k8smon-k8s-monitoring"
+  namespace = "default"
+} // remote.kubernetes.secret "localloki"
+
+
+// Destination: localPrometheus (prometheus)
+otelcol.exporter.prometheus "localprometheus" {
+  add_metric_suffixes = true
+  resource_to_telemetry_conversion = false
+  keep_identifying_resource_attributes = true
+  forward_to = [prometheus.remote_write.localprometheus.receiver]
+} // otelcol.exporter.prometheus "localprometheus"
+
+prometheus.remote_write "localprometheus" {
+  endpoint {
+    url = "http://prometheus-server.prometheus.svc:9090/api/v1/write"
+    headers = {
+    }
+    tls_config {
+      insecure_skip_verify = false
+    }
+    send_native_histograms = false
+
+    queue_config {
+      capacity = 10000
+      min_shards = 1
+      max_shards = 50
+      max_samples_per_send = 2000
+      batch_send_deadline = "5s"
+      min_backoff = "30ms"
+      max_backoff = "5s"
+      retry_on_http_429 = true
+      sample_age_limit = "0s"
+    }
+  }
+
+  wal {
+    truncate_frequency = "2h"
+    min_keepalive_time = "5m"
+    max_keepalive_time = "8h"
+  }
+  external_labels = {
+    "cluster" = "service-graph-metrics-test",
+    "k8s_cluster_name" = "service-graph-metrics-test",
+  }
+} // prometheus.remote_write "localprometheus"
+
+// Destination: localTempo (otlp)
+otelcol.processor.attributes "localtempo" {
+  output {
+    traces = [otelcol.processor.transform.localtempo.input]
+  }
+} // otelcol.processor.attributes "localtempo"
+
+otelcol.processor.transform "localtempo" {
+  error_mode = "ignore"
+
+  trace_statements {
+    context = "resource"
+    statements = [
+      `set(attributes["cluster"], "service-graph-metrics-test")`,
+      `set(attributes["k8s.cluster.name"], "service-graph-metrics-test")`,
+      `delete_key(attributes, "process.pid")`,
+      `delete_key(attributes, "process.parent_pid")`,
+      `delete_key(attributes, "process.executable.path")`,
+      `delete_key(attributes, "process.command_line")`,
+      `delete_key(attributes, "process.command_args")`,
+      `delete_key(attributes, "process.owner")`,
+      `delete_key(attributes, "process.runtime.version")`,
+      `delete_key(attributes, "process.runtime.description")`,
+      `delete_key(attributes, "host.ip")`,
+      `delete_key(attributes, "host.mac")`,
+      `delete_key(attributes, "k8s.pod.start_time")`,
+      `delete_key(attributes, "k8s.pod.uid")`,
+      `delete_key(attributes, "container.image.id")`,
+      `delete_key(attributes, "container.image.repo_digests")`,
+      `delete_key(attributes, "os.description")`,
+      `delete_key(attributes, "os.build_id")`,
+    ]
+  }
+
+  output {
+    traces = [
+      otelcol.exporter.loadbalancing.localtempo_servicegraph.input,
+      otelcol.processor.batch.localtempo.input,
+    ]
+  }
+} // otelcol.processor.transform "localtempo"
+
+otelcol.exporter.loadbalancing "localtempo_servicegraph" {
+  resolver {
+    kubernetes {
+      service = "k8smon-localtempo-servicegraph"
+      ports   = [4317]
+      timeout = "60s"
+    }
+  }
+  protocol {
+    otlp {
+      client {
+        tls {
+          insecure = true
+        }
+      }
+    }
+  }
+} // otelcol.exporter.loadbalancing "localtempo_servicegraph"
+
+otelcol.processor.batch "localtempo" {
+  timeout = "2s"
+  send_batch_size = 8192
+  send_batch_max_size = 0
+
+  output {
+    traces = [otelcol.exporter.otlp.localtempo.input]
+  }
+} // otelcol.processor.batch "localtempo"
+otelcol.exporter.otlp "localtempo" {
+  client {
+    endpoint = "tempo.tempo.svc:4317"
+    tls {
+      insecure = true
+      insecure_skip_verify = true
+    }
+  }
+
+  retry_on_failure {
+    enabled = true
+    initial_interval = "5s"
+    max_interval = "30s"
+    max_elapsed_time = "5m"
+  }
+
+  sending_queue {
+    enabled = true
+  }
+} // otelcol.exporter.otlp "localtempo"
+

--- a/charts/k8s-monitoring/tests/integration/service-integrations/alloy/.rendered/alloy-metrics.alloy
+++ b/charts/k8s-monitoring/tests/integration/service-integrations/alloy/.rendered/alloy-metrics.alloy
@@ -1,0 +1,420 @@
+declare "alloy_integration" {
+  argument "metrics_destinations" {
+    comment = "Must be a list of metric destinations where collected metrics should be forwarded to"
+  }
+
+  declare "alloy_integration_discovery" {
+    argument "namespaces" {
+      comment = "The namespaces to look for targets in (default: [] is all namespaces)"
+      optional = true
+    }
+
+    argument "field_selectors" {
+      comment = "The field selectors to use to find matching targets (default: [])"
+      optional = true
+    }
+
+    argument "label_selectors" {
+      comment = "The label selectors to use to find matching targets (default: [\"app.kubernetes.io/name=alloy\"])"
+      optional = true
+    }
+
+    argument "port_name" {
+      comment = "The of the port to scrape metrics from (default: http-metrics)"
+      optional = true
+    }
+
+    // Alloy service discovery for all of the pods
+    discovery.kubernetes "alloy_pods" {
+      role = "pod"
+
+      selectors {
+        role = "pod"
+        field = string.join(coalesce(argument.field_selectors.value, []), ",")
+        label = string.join(coalesce(argument.label_selectors.value, ["app.kubernetes.io/name=alloy"]), ",")
+      }
+
+      namespaces {
+        names = coalesce(argument.namespaces.value, [])
+      }
+
+    } // discovery.kubernetes "alloy_pods"
+
+    // alloy relabelings (pre-scrape)
+    discovery.relabel "alloy_pods" {
+      targets = discovery.kubernetes.alloy_pods.targets
+
+      // keep only the specified metrics port name, and pods that are Running and ready
+      rule {
+        source_labels = [
+          "__meta_kubernetes_pod_container_port_name",
+          "__meta_kubernetes_pod_phase",
+          "__meta_kubernetes_pod_ready",
+          "__meta_kubernetes_pod_container_init",
+        ]
+        separator = "@"
+        regex = coalesce(argument.port_name.value, "metrics") + "@Running@true@false"
+        action = "keep"
+      }
+
+      rule {
+        source_labels = ["__meta_kubernetes_namespace"]
+        target_label  = "namespace"
+      }
+
+      rule {
+        source_labels = ["__meta_kubernetes_pod_name"]
+        target_label  = "pod"
+      }
+
+      rule {
+        source_labels = ["__meta_kubernetes_pod_container_name"]
+        target_label  = "container"
+      }
+
+      // set the workload to the controller kind and name
+      rule {
+        action = "lowercase"
+        source_labels = ["__meta_kubernetes_pod_controller_kind"]
+        target_label  = "workload_type"
+      }
+
+      rule {
+        source_labels = ["__meta_kubernetes_pod_controller_name"]
+        target_label  = "workload"
+      }
+
+      // remove the hash from the ReplicaSet
+      rule {
+        source_labels = [
+          "workload_type",
+          "workload",
+        ]
+        separator = "/"
+        regex = "replicaset/(.+)-.+$"
+        target_label  = "workload"
+      }
+
+      // set the app name if specified as metadata labels "app:" or "app.kubernetes.io/name:" or "k8s-app:"
+      rule {
+        action = "replace"
+        source_labels = [
+          "__meta_kubernetes_pod_label_app_kubernetes_io_name",
+          "__meta_kubernetes_pod_label_k8s_app",
+          "__meta_kubernetes_pod_label_app",
+        ]
+        separator = ";"
+        regex = "^(?:;*)?([^;]+).*$"
+        replacement = "$1"
+        target_label = "app"
+      }
+
+      // set the component if specified as metadata labels "component:" or "app.kubernetes.io/component:" or "k8s-component:"
+      rule {
+        action = "replace"
+        source_labels = [
+          "__meta_kubernetes_pod_label_app_kubernetes_io_component",
+          "__meta_kubernetes_pod_label_k8s_component",
+          "__meta_kubernetes_pod_label_component",
+        ]
+        regex = "^(?:;*)?([^;]+).*$"
+        replacement = "$1"
+        target_label = "component"
+      }
+
+      // set a source label
+      rule {
+        action = "replace"
+        replacement = "kubernetes"
+        target_label = "source"
+      }
+
+    } // discovery.relabel "alloy_pods"
+
+    export "output" {
+      value = discovery.relabel.alloy_pods.output
+    }
+  }
+
+  declare "alloy_integration_scrape" {
+    argument "targets" {
+      comment = "Must be a list() of targets"
+    }
+
+    argument "forward_to" {
+      comment = "Must be a list(MetricsReceiver) where collected metrics should be forwarded to"
+    }
+
+    argument "job_label" {
+      comment = "The job label to add for all Alloy metrics (default: integrations/alloy)"
+      optional = true
+    }
+
+    argument "keep_metrics" {
+      comment = "A regular expression of metrics to keep (default: see below)"
+      optional = true
+    }
+
+    argument "drop_metrics" {
+      comment = "A regular expression of metrics to drop (default: see below)"
+      optional = true
+    }
+
+    argument "scrape_interval" {
+      comment = "How often to scrape metrics from the targets (default: 60s)"
+      optional = true
+    }
+
+    argument "scrape_timeout" {
+      comment = "The timeout for scraping metrics from the targets (default: 10s)"
+      optional = true
+    }
+
+    argument "scrape_protocols" {
+      comment = "The scrape protocols to use for scraping metrics"
+      optional = true
+    }
+
+    argument "scrape_classic_histograms" {
+      comment = "Whether to scrape classic histograms (default: false)."
+      optional = true
+    }
+
+    argument "scrape_native_histograms" {
+      comment = "Whether to scrape native histograms (default: false)."
+      optional = true
+    }
+
+    argument "max_cache_size" {
+      comment = "The maximum number of elements to hold in the relabeling cache (default: 100000).  This should be at least 2x-5x your largest scrape target or samples appended rate."
+      optional = true
+    }
+
+    argument "clustering" {
+      comment = "Whether or not clustering should be enabled (default: false)"
+      optional = true
+    }
+
+    prometheus.scrape "alloy" {
+      job_name = coalesce(argument.job_label.value, "integrations/alloy")
+      forward_to = [prometheus.relabel.alloy.receiver]
+      targets = argument.targets.value
+      scrape_interval = coalesce(argument.scrape_interval.value, "60s")
+      scrape_timeout = coalesce(argument.scrape_timeout.value, "10s")
+      scrape_protocols = argument.scrape_protocols.value
+      scrape_classic_histograms = argument.scrape_classic_histograms.value
+      scrape_native_histograms = argument.scrape_native_histograms.value
+
+      clustering {
+        enabled = coalesce(argument.clustering.value, false)
+      }
+    } // prometheus.scrape "alloy"
+
+    // alloy metric relabelings (post-scrape)
+    prometheus.relabel "alloy" {
+      forward_to = argument.forward_to.value
+      max_cache_size = coalesce(argument.max_cache_size.value, 100000)
+
+      // drop metrics that match the drop_metrics regex
+      rule {
+        source_labels = ["__name__"]
+        regex = coalesce(argument.drop_metrics.value, "")
+        action = "drop"
+      }
+
+      // keep only metrics that match the keep_metrics regex
+      rule {
+        source_labels = ["__name__"]
+        regex = coalesce(argument.keep_metrics.value, ".*")
+        action = "keep"
+      }
+
+      // remove the component_id label from any metric that starts with log_bytes or log_lines, these are custom metrics that are generated
+      // as part of the log annotation modules in this repo
+      rule {
+        action = "replace"
+        source_labels = ["__name__"]
+        regex = "^log_(bytes|lines).+"
+        replacement = ""
+        target_label = "component_id"
+      }
+
+      // set the namespace label to that of the exported_namespace
+      rule {
+        action = "replace"
+        source_labels = ["__name__", "exported_namespace"]
+        separator = "@"
+        regex = "^log_(bytes|lines).+@(.+)"
+        replacement = "$2"
+        target_label = "namespace"
+      }
+
+      // set the pod label to that of the exported_pod
+      rule {
+        action = "replace"
+        source_labels = ["__name__", "exported_pod"]
+        separator = "@"
+        regex = "^log_(bytes|lines).+@(.+)"
+        replacement = "$2"
+        target_label = "pod"
+      }
+
+      // set the container label to that of the exported_container
+      rule {
+        action = "replace"
+        source_labels = ["__name__", "exported_container"]
+        separator = "@"
+        regex = "^log_(bytes|lines).+@(.+)"
+        replacement = "$2"
+        target_label = "container"
+      }
+
+      // set the job label to that of the exported_job
+      rule {
+        action = "replace"
+        source_labels = ["__name__", "exported_job"]
+        separator = "@"
+        regex = "^log_(bytes|lines).+@(.+)"
+        replacement = "$2"
+        target_label = "job"
+      }
+
+      // set the instance label to that of the exported_instance
+      rule {
+        action = "replace"
+        source_labels = ["__name__", "exported_instance"]
+        separator = "@"
+        regex = "^log_(bytes|lines).+@(.+)"
+        replacement = "$2"
+        target_label = "instance"
+      }
+
+      rule {
+        action = "labeldrop"
+        regex = "exported_(namespace|pod|container|job|instance)"
+      }
+    } // prometheus.relabel "alloy"
+  }
+
+  alloy_integration_discovery "alloy_metrics" {
+    port_name = "http-metrics"
+    label_selectors = ["app.kubernetes.io/name=alloy-metrics"]
+  }
+
+  alloy_integration_scrape "alloy_metrics" {
+    targets = alloy_integration_discovery.alloy_metrics.output
+    job_label = "integrations/alloy"
+    clustering = true
+    keep_metrics = "up|scrape_samples_scraped|alloy_build_info|alloy_component_controller_running_components|alloy_component_dependencies_wait_seconds|alloy_component_dependencies_wait_seconds_bucket|alloy_component_evaluation_seconds|alloy_component_evaluation_seconds_bucket|alloy_component_evaluation_seconds_count|alloy_component_evaluation_seconds_sum|alloy_component_evaluation_slow_seconds|alloy_config_hash|alloy_resources_machine_rx_bytes_total|alloy_resources_machine_tx_bytes_total|alloy_resources_process_cpu_seconds_total|alloy_resources_process_resident_memory_bytes|alloy_tcp_connections|alloy_wal_samples_appended_total|alloy_wal_storage_active_series|cluster_node_gossip_health_score|cluster_node_gossip_proto_version|cluster_node_gossip_received_events_total|cluster_node_info|cluster_node_lamport_time|cluster_node_peers|cluster_node_update_observers|cluster_transport_rx_bytes_total|cluster_transport_rx_packet_queue_length|cluster_transport_rx_packets_failed_total|cluster_transport_rx_packets_total|cluster_transport_stream_rx_bytes_total|cluster_transport_stream_rx_packets_failed_total|cluster_transport_stream_rx_packets_total|cluster_transport_stream_tx_bytes_total|cluster_transport_stream_tx_packets_failed_total|cluster_transport_stream_tx_packets_total|cluster_transport_streams|cluster_transport_tx_bytes_total|cluster_transport_tx_packet_queue_length|cluster_transport_tx_packets_failed_total|cluster_transport_tx_packets_total|otelcol_exporter_send_failed_spans_total|otelcol_exporter_sent_spans_total|go_gc_duration_seconds_count|go_goroutines|go_memstats_heap_inuse_bytes|loki_process_dropped_lines_total|loki_write_batch_retries_total|loki_write_dropped_bytes_total|loki_write_dropped_entries_total|loki_write_encoded_bytes_total|loki_write_mutated_bytes_total|loki_write_mutated_entries_total|loki_write_request_duration_seconds_bucket|loki_write_sent_bytes_total|loki_write_sent_entries_total|process_cpu_seconds_total|process_start_time_seconds|otelcol_processor_batch_batch_send_size_bucket|otelcol_processor_batch_metadata_cardinality|otelcol_processor_batch_timeout_trigger_send_total|prometheus_remote_storage_bytes_total|prometheus_remote_storage_enqueue_retries_total|prometheus_remote_storage_highest_timestamp_in_seconds|prometheus_remote_storage_metadata_bytes_total|prometheus_remote_storage_queue_highest_sent_timestamp_seconds|prometheus_remote_storage_samples_dropped_total|prometheus_remote_storage_samples_failed_total|prometheus_remote_storage_samples_pending|prometheus_remote_storage_samples_retried_total|prometheus_remote_storage_samples_total|prometheus_remote_storage_sent_batch_duration_seconds_bucket|prometheus_remote_storage_sent_batch_duration_seconds_count|prometheus_remote_storage_sent_batch_duration_seconds_sum|prometheus_remote_storage_shard_capacity|prometheus_remote_storage_shards|prometheus_remote_storage_shards_desired|prometheus_remote_storage_shards_max|prometheus_remote_storage_shards_min|prometheus_remote_storage_succeeded_samples_total|prometheus_remote_write_wal_samples_appended_total|prometheus_remote_write_wal_storage_active_series|prometheus_sd_discovered_targets|prometheus_target_interval_length_seconds_count|prometheus_target_interval_length_seconds_sum|prometheus_target_scrapes_exceeded_sample_limit_total|prometheus_target_scrapes_sample_duplicate_timestamp_total|prometheus_target_scrapes_sample_out_of_bounds_total|prometheus_target_scrapes_sample_out_of_order_total|prometheus_target_sync_length_seconds_sum|prometheus_wal_watcher_current_segment|otelcol_receiver_accepted_spans_total|otelcol_receiver_refused_spans_total|rpc_server_duration_milliseconds_bucket|scrape_duration_seconds|traces_exporter_send_failed_spans|traces_exporter_send_failed_spans_total|traces_exporter_sent_spans|traces_exporter_sent_spans_total|traces_loadbalancer_backend_outcome|traces_loadbalancer_num_backends|traces_receiver_accepted_spans|traces_receiver_accepted_spans_total|traces_receiver_refused_spans|traces_receiver_refused_spans_total"
+    scrape_interval = "60s"
+    scrape_timeout = "10s"
+    scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
+    scrape_classic_histograms = false
+    scrape_native_histograms = false
+    max_cache_size = 100000
+    forward_to = argument.metrics_destinations.value
+  }
+}
+alloy_integration "integration" {
+  metrics_destinations = [
+    prometheus.remote_write.localprometheus.receiver,
+  ]
+}
+
+
+
+
+
+
+
+
+
+// Self Reporting
+prometheus.exporter.unix "kubernetes_monitoring_telemetry" {
+  set_collectors = ["textfile"]
+  textfile {
+    directory = "/etc/release-info"
+  }
+} // prometheus.exporter.unix "kubernetes_monitoring_telemetry"
+
+discovery.relabel "kubernetes_monitoring_telemetry" {
+  targets = prometheus.exporter.unix.kubernetes_monitoring_telemetry.targets
+  rule {
+    target_label = "instance"
+    action = "replace"
+    replacement = "k8smon"
+  }
+  rule {
+    target_label = "job"
+    action = "replace"
+    replacement = "integrations/kubernetes/kubernetes_monitoring_telemetry"
+  }
+} // discovery.relabel "kubernetes_monitoring_telemetry"
+
+prometheus.scrape "kubernetes_monitoring_telemetry" {
+  job_name   = "integrations/kubernetes/kubernetes_monitoring_telemetry"
+  targets    = discovery.relabel.kubernetes_monitoring_telemetry.output
+  scrape_interval = "60s"
+  clustering {
+    enabled = true
+  }
+  forward_to = [prometheus.relabel.kubernetes_monitoring_telemetry.receiver]
+} // prometheus.scrape "kubernetes_monitoring_telemetry"
+
+prometheus.relabel "kubernetes_monitoring_telemetry" {
+  rule {
+    source_labels = ["__name__"]
+    regex = "grafana_kubernetes_monitoring_.*"
+    action = "keep"
+  }
+  forward_to = [
+    prometheus.remote_write.localprometheus.receiver,
+  ]
+} // prometheus.relabel "kubernetes_monitoring_telemetry"
+
+
+
+
+
+// Destination: localPrometheus (prometheus)
+otelcol.exporter.prometheus "localprometheus" {
+  add_metric_suffixes = true
+  resource_to_telemetry_conversion = false
+  keep_identifying_resource_attributes = true
+  forward_to = [prometheus.remote_write.localprometheus.receiver]
+} // otelcol.exporter.prometheus "localprometheus"
+
+prometheus.remote_write "localprometheus" {
+  endpoint {
+    url = "http://prometheus-server.prometheus.svc:9090/api/v1/write"
+    headers = {
+    }
+    tls_config {
+      insecure_skip_verify = false
+    }
+    send_native_histograms = false
+
+    queue_config {
+      capacity = 10000
+      min_shards = 1
+      max_shards = 50
+      max_samples_per_send = 2000
+      batch_send_deadline = "5s"
+      min_backoff = "30ms"
+      max_backoff = "5s"
+      retry_on_http_429 = true
+      sample_age_limit = "0s"
+    }
+  }
+
+  wal {
+    truncate_frequency = "2h"
+    min_keepalive_time = "5m"
+    max_keepalive_time = "8h"
+  }
+  external_labels = {
+    "cluster" = "alloy-integration-test",
+    "k8s_cluster_name" = "alloy-integration-test",
+  }
+} // prometheus.remote_write "localprometheus"
+

--- a/charts/k8s-monitoring/tests/integration/service-integrations/cert-manager/.rendered/alloy-metrics.alloy
+++ b/charts/k8s-monitoring/tests/integration/service-integrations/cert-manager/.rendered/alloy-metrics.alloy
@@ -1,0 +1,232 @@
+declare "cert_manager_integration" {
+  argument "metrics_destinations" {
+    comment = "Must be a list of metric destinations where collected metrics should be forwarded to"
+  }
+
+  discovery.kubernetes "cert_manager" {
+    role = "pod"
+
+    selectors {
+      role = "pod"
+      label = "app.kubernetes.io/name=cert-manager"
+    }
+  }
+
+  discovery.relabel "cert_manager" {
+    targets = discovery.kubernetes.cert_manager.targets
+
+    // keep only the specified metrics port name, and pods that are Running and ready
+    rule {
+      source_labels = [
+        "__meta_kubernetes_pod_container_port_name",
+        "__meta_kubernetes_pod_phase",
+        "__meta_kubernetes_pod_ready",
+      ]
+      separator = "@"
+      regex = "http-metrics@Running@true"
+      action = "keep"
+    }
+
+    // drop any init containers
+    rule {
+      source_labels = ["__meta_kubernetes_pod_container_init"]
+      regex = "true"
+      action = "drop"
+    }
+
+    // set the namespace label
+    rule {
+      source_labels = ["__meta_kubernetes_namespace"]
+      target_label  = "namespace"
+    }
+
+    // set the pod label
+    rule {
+      source_labels = ["__meta_kubernetes_pod_name"]
+      target_label  = "pod"
+    }
+
+    // set the container label
+    rule {
+      source_labels = ["__meta_kubernetes_pod_container_name"]
+      target_label  = "container"
+    }
+
+    // set a workload label
+    rule {
+      source_labels = [
+        "__meta_kubernetes_pod_controller_kind",
+        "__meta_kubernetes_pod_controller_name",
+      ]
+      separator = "/"
+      target_label  = "workload"
+    }
+    // remove the hash from the ReplicaSet
+    rule {
+      source_labels = ["workload"]
+      regex = "(ReplicaSet/.+)-.+"
+      target_label  = "workload"
+    }
+
+    // set the app name if specified as metadata labels "app:" or "app.kubernetes.io/name:" or "k8s-app:"
+    rule {
+      action = "replace"
+      source_labels = [
+        "__meta_kubernetes_pod_label_app_kubernetes_io_name",
+        "__meta_kubernetes_pod_label_k8s_app",
+        "__meta_kubernetes_pod_label_app",
+      ]
+      separator = ";"
+      regex = "^(?:;*)?([^;]+).*$"
+      replacement = "$1"
+      target_label = "app"
+    }
+
+    // set the component if specified as metadata labels "component:" or "app.kubernetes.io/component:" or "k8s-component:"
+    rule {
+      action = "replace"
+      source_labels = [
+        "__meta_kubernetes_pod_label_app_kubernetes_io_component",
+        "__meta_kubernetes_pod_label_k8s_component",
+        "__meta_kubernetes_pod_label_component",
+      ]
+      regex = "^(?:;*)?([^;]+).*$"
+      replacement = "$1"
+      target_label = "component"
+    }
+
+    // set a source label
+    rule {
+      action = "replace"
+      replacement = "kubernetes"
+      target_label = "source"
+    }
+  }
+
+  prometheus.scrape "cert_manager" {
+    targets = discovery.relabel.cert_manager.output
+    job_name = "integrations/cert-manager"
+    scrape_interval = "60s"
+    scrape_timeout = "10s"
+    scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
+    scrape_classic_histograms = false
+    scrape_native_histograms = false
+    clustering {
+      enabled = true
+    }
+    forward_to = [prometheus.relabel.cert_manager.receiver]
+  }
+
+  prometheus.relabel "cert_manager" {
+    max_cache_size = 100000
+    rule {
+      source_labels = ["__name__"]
+      regex = "scrape_samples_scraped|certmanager_.*"
+      action = "keep"
+    }
+    forward_to = argument.metrics_destinations.value
+  }
+}
+cert_manager_integration "integration" {
+  metrics_destinations = [
+    prometheus.remote_write.localprometheus.receiver,
+  ]
+}
+
+
+
+
+
+
+
+
+
+// Self Reporting
+prometheus.exporter.unix "kubernetes_monitoring_telemetry" {
+  set_collectors = ["textfile"]
+  textfile {
+    directory = "/etc/release-info"
+  }
+} // prometheus.exporter.unix "kubernetes_monitoring_telemetry"
+
+discovery.relabel "kubernetes_monitoring_telemetry" {
+  targets = prometheus.exporter.unix.kubernetes_monitoring_telemetry.targets
+  rule {
+    target_label = "instance"
+    action = "replace"
+    replacement = "k8smon"
+  }
+  rule {
+    target_label = "job"
+    action = "replace"
+    replacement = "integrations/kubernetes/kubernetes_monitoring_telemetry"
+  }
+} // discovery.relabel "kubernetes_monitoring_telemetry"
+
+prometheus.scrape "kubernetes_monitoring_telemetry" {
+  job_name   = "integrations/kubernetes/kubernetes_monitoring_telemetry"
+  targets    = discovery.relabel.kubernetes_monitoring_telemetry.output
+  scrape_interval = "60s"
+  clustering {
+    enabled = true
+  }
+  forward_to = [prometheus.relabel.kubernetes_monitoring_telemetry.receiver]
+} // prometheus.scrape "kubernetes_monitoring_telemetry"
+
+prometheus.relabel "kubernetes_monitoring_telemetry" {
+  rule {
+    source_labels = ["__name__"]
+    regex = "grafana_kubernetes_monitoring_.*"
+    action = "keep"
+  }
+  forward_to = [
+    prometheus.remote_write.localprometheus.receiver,
+  ]
+} // prometheus.relabel "kubernetes_monitoring_telemetry"
+
+
+
+
+
+// Destination: localPrometheus (prometheus)
+otelcol.exporter.prometheus "localprometheus" {
+  add_metric_suffixes = true
+  resource_to_telemetry_conversion = false
+  keep_identifying_resource_attributes = true
+  forward_to = [prometheus.remote_write.localprometheus.receiver]
+} // otelcol.exporter.prometheus "localprometheus"
+
+prometheus.remote_write "localprometheus" {
+  endpoint {
+    url = "http://prometheus-server.prometheus.svc:9090/api/v1/write"
+    headers = {
+    }
+    tls_config {
+      insecure_skip_verify = false
+    }
+    send_native_histograms = false
+
+    queue_config {
+      capacity = 10000
+      min_shards = 1
+      max_shards = 50
+      max_samples_per_send = 2000
+      batch_send_deadline = "5s"
+      min_backoff = "30ms"
+      max_backoff = "5s"
+      retry_on_http_429 = true
+      sample_age_limit = "0s"
+    }
+  }
+
+  wal {
+    truncate_frequency = "2h"
+    min_keepalive_time = "5m"
+    max_keepalive_time = "8h"
+  }
+  external_labels = {
+    "cluster" = "cert-manager-integration-test",
+    "k8s_cluster_name" = "cert-manager-integration-test",
+  }
+} // prometheus.remote_write "localprometheus"
+

--- a/charts/k8s-monitoring/tests/integration/service-integrations/coredns/.rendered/alloy-metrics.alloy
+++ b/charts/k8s-monitoring/tests/integration/service-integrations/coredns/.rendered/alloy-metrics.alloy
@@ -1,0 +1,492 @@
+// Feature: Cluster Metrics
+declare "cluster_metrics" {
+  argument "metrics_destinations" {
+    comment = "Must be a list of metric destinations where collected metrics should be forwarded to"
+  }
+  discovery.kubernetes "nodes" {
+    role = "node"
+  } // discovery.kubernetes "nodes"
+
+  discovery.relabel "nodes" {
+    targets = discovery.kubernetes.nodes.targets
+    rule {
+      source_labels = ["__meta_kubernetes_node_name"]
+      target_label  = "node"
+    }
+
+    rule {
+      replacement = "kubernetes"
+      target_label = "source"
+    }
+  } // discovery.relabel "nodes"
+
+  // Kubelet
+  discovery.relabel "kubelet" {
+    targets = discovery.relabel.nodes.output
+  } // discovery.relabel "kubelet"
+
+  prometheus.scrape "kubelet" {
+    targets  = discovery.relabel.kubelet.output
+    job_name = "integrations/kubernetes/kubelet"
+    scheme   = "https"
+    scrape_interval = "60s"
+    scrape_timeout = "10s"
+    scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
+    scrape_classic_histograms = false
+    scrape_native_histograms = false
+    convert_classic_histograms_to_nhcb = false
+    bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+
+    tls_config {
+      ca_file = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+      insecure_skip_verify = true
+      server_name = "kubernetes"
+    }
+
+    clustering {
+      enabled = true
+    }
+
+    forward_to = [prometheus.relabel.kubelet.receiver]
+  } // prometheus.scrape "kubelet"
+
+  prometheus.relabel "kubelet" {
+    max_cache_size = 100000
+    rule {
+      source_labels = ["__name__"]
+      regex = "up|scrape_samples_scraped|go_goroutines|kubelet_certificate_manager_client_expiration_renew_errors|kubelet_certificate_manager_client_ttl_seconds|kubelet_certificate_manager_server_ttl_seconds|kubelet_cgroup_manager_duration_seconds_bucket|kubelet_cgroup_manager_duration_seconds_count|kubelet_node_config_error|kubelet_node_name|kubelet_pleg_relist_duration_seconds_bucket|kubelet_pleg_relist_duration_seconds_count|kubelet_pleg_relist_interval_seconds_bucket|kubelet_pod_start_duration_seconds_bucket|kubelet_pod_start_duration_seconds_count|kubelet_pod_worker_duration_seconds_bucket|kubelet_pod_worker_duration_seconds_count|kubelet_running_container_count|kubelet_running_containers|kubelet_running_pod_count|kubelet_running_pods|kubelet_runtime_operations_errors_total|kubelet_runtime_operations_total|kubelet_server_expiration_renew_errors|kubelet_volume_stats_available_bytes|kubelet_volume_stats_capacity_bytes|kubelet_volume_stats_inodes|kubelet_volume_stats_inodes_free|kubelet_volume_stats_inodes_used|kubelet_volume_stats_used_bytes|kubernetes_build_info|namespace_workload_pod|process_cpu_seconds_total|process_resident_memory_bytes|rest_client_requests_total|storage_operation_duration_seconds_count|storage_operation_errors_total|volume_manager_total_volumes"
+      action = "keep"
+    }
+
+    forward_to = argument.metrics_destinations.value
+  } // prometheus.relabel "kubelet"
+
+  // Kubelet Resources
+  discovery.relabel "kubelet_resources" {
+    targets = discovery.relabel.nodes.output
+    rule {
+      replacement   = "/metrics/resource"
+      target_label  = "__metrics_path__"
+    }
+  } // discovery.relabel "kubelet_resources"
+
+  prometheus.scrape "kubelet_resources" {
+    targets = discovery.relabel.kubelet_resources.output
+    job_name = "integrations/kubernetes/resources"
+    scheme   = "https"
+    scrape_interval = "60s"
+    scrape_timeout = "10s"
+    scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
+    scrape_classic_histograms = false
+    scrape_native_histograms = false
+    convert_classic_histograms_to_nhcb = false
+    bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+
+    tls_config {
+      ca_file = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+      insecure_skip_verify = true
+      server_name = "kubernetes"
+    }
+
+    clustering {
+      enabled = true
+    }
+
+    forward_to = [prometheus.relabel.kubelet_resources.receiver]
+  } // prometheus.scrape "kubelet_resources"
+
+  prometheus.relabel "kubelet_resources" {
+    max_cache_size = 100000
+    rule {
+      source_labels = ["__name__"]
+      regex = "up|scrape_samples_scraped|node_cpu_usage_seconds_total|node_memory_working_set_bytes"
+      action = "keep"
+    }
+
+    forward_to = argument.metrics_destinations.value
+  } // prometheus.relabel "kubelet_resources"
+
+  // cAdvisor
+  discovery.relabel "cadvisor" {
+    targets = discovery.relabel.nodes.output
+    rule {
+      replacement   = "/metrics/cadvisor"
+      target_label  = "__metrics_path__"
+    }
+  } // discovery.relabel "cadvisor"
+
+  prometheus.scrape "cadvisor" {
+    targets = discovery.relabel.cadvisor.output
+    job_name = "integrations/kubernetes/cadvisor"
+    scheme = "https"
+    scrape_interval = "60s"
+    scrape_timeout = "10s"
+    scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
+    scrape_classic_histograms = false
+    scrape_native_histograms = false
+    convert_classic_histograms_to_nhcb = false
+    bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+
+    tls_config {
+      ca_file = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+      insecure_skip_verify = true
+      server_name = "kubernetes"
+    }
+
+    clustering {
+      enabled = true
+    }
+
+    forward_to = [prometheus.relabel.cadvisor.receiver]
+  } // prometheus.scrape "cadvisor"
+
+  prometheus.relabel "cadvisor" {
+    max_cache_size = 100000
+    rule {
+      source_labels = ["__name__"]
+      regex = "up|scrape_samples_scraped|container_cpu_cfs_periods_total|container_cpu_cfs_throttled_periods_total|container_cpu_usage_seconds_total|container_fs_reads_bytes_total|container_fs_reads_total|container_fs_writes_bytes_total|container_fs_writes_total|container_memory_cache|container_memory_rss|container_memory_swap|container_memory_usage_bytes|container_memory_working_set_bytes|container_network_receive_bytes_total|container_network_receive_packets_dropped_total|container_network_receive_packets_total|container_network_transmit_bytes_total|container_network_transmit_packets_dropped_total|container_network_transmit_packets_total|machine_memory_bytes"
+      action = "keep"
+    }
+    // Drop empty container labels, addressing https://github.com/google/cadvisor/issues/2688
+    rule {
+      source_labels = ["__name__","container"]
+      separator = "@"
+      regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_pressure_.*)@"
+      action = "drop"
+    }
+    // Drop empty image labels, addressing https://github.com/google/cadvisor/issues/2688
+    rule {
+      source_labels = ["__name__","image"]
+      separator = "@"
+      regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_network_.*|container_pressure_.*)@"
+      action = "drop"
+    }
+    // Normalizing unimportant labels (not deleting to continue satisfying <label>!="" checks)
+    rule {
+      source_labels = ["__name__", "boot_id"]
+      separator = "@"
+      regex = "machine_memory_bytes@.*"
+      target_label = "boot_id"
+      replacement = "NA"
+    }
+    rule {
+      source_labels = ["__name__", "system_uuid"]
+      separator = "@"
+      regex = "machine_memory_bytes@.*"
+      target_label = "system_uuid"
+      replacement = "NA"
+    }
+    // Filter out non-physical devices/interfaces
+    rule {
+      source_labels = ["__name__", "device"]
+      separator = "@"
+      regex = "container_fs_.*@(/dev/)?(mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dasd.+)"
+      target_label = "__keepme"
+      replacement = "1"
+    }
+    rule {
+      source_labels = ["__name__", "__keepme"]
+      separator = "@"
+      regex = "container_fs_.*@"
+      action = "drop"
+    }
+    rule {
+      source_labels = ["__name__"]
+      regex = "container_fs_.*"
+      target_label = "__keepme"
+      replacement = ""
+    }
+    rule {
+      source_labels = ["__name__", "interface"]
+      separator = "@"
+      regex = "container_network_.*@(en[ospx][0-9].*|wlan[0-9].*|eth[0-9].*)"
+      target_label = "__keepme"
+      replacement = "1"
+    }
+    rule {
+      source_labels = ["__name__", "__keepme"]
+      separator = "@"
+      regex = "container_network_.*@"
+      action = "drop"
+    }
+    rule {
+      source_labels = ["__name__"]
+      regex = "container_network_.*"
+      target_label = "__keepme"
+      replacement = ""
+    }
+    forward_to = argument.metrics_destinations.value
+  } // prometheus.relabel "cadvisor"
+
+  // KubeDNS
+  discovery.kubernetes "kube_dns" {
+    role = "endpointslice"
+    namespaces {
+      names = ["kube-system"]
+    }
+    selectors {
+      role = "endpointslice"
+      label = "kubernetes.io/service-name=kube-dns"
+    }
+  } // discovery.kubernetes "kube_dns"
+
+  discovery.relabel "kube_dns" {
+    targets = discovery.kubernetes.kube_dns.targets
+
+    // keep only the specified metrics port name, and pods that are Running and ready
+    rule {
+      source_labels = [
+        "__meta_kubernetes_pod_container_port_name",
+        "__meta_kubernetes_pod_phase",
+        "__meta_kubernetes_pod_ready",
+      ]
+      separator = "@"
+      regex = "metrics@Running@true"
+      action = "keep"
+    }
+
+    // drop any init containers
+    rule {
+      source_labels = ["__meta_kubernetes_pod_container_init"]
+      regex = "true"
+      action = "drop"
+    }
+
+    // set the namespace label
+    rule {
+      source_labels = ["__meta_kubernetes_namespace"]
+      target_label  = "namespace"
+    }
+
+    // set the pod label
+    rule {
+      source_labels = ["__meta_kubernetes_pod_name"]
+      target_label  = "pod"
+    }
+
+    // set the container label
+    rule {
+      source_labels = ["__meta_kubernetes_pod_container_name"]
+      target_label  = "container"
+    }
+
+    // set a workload label
+    rule {
+      source_labels = [
+        "__meta_kubernetes_pod_controller_kind",
+        "__meta_kubernetes_pod_controller_name",
+      ]
+      separator = "/"
+      target_label  = "workload"
+    }
+    // remove the hash from the ReplicaSet
+    rule {
+      source_labels = ["workload"]
+      regex = "(ReplicaSet/.+)-.+"
+      target_label  = "workload"
+    }
+
+    // set the app name if specified as metadata labels "app:" or "app.kubernetes.io/name:" or "k8s-app:"
+    rule {
+      action = "replace"
+      source_labels = [
+        "__meta_kubernetes_pod_label_app_kubernetes_io_name",
+        "__meta_kubernetes_pod_label_k8s_app",
+        "__meta_kubernetes_pod_label_app",
+      ]
+      separator = ";"
+      regex = "^(?:;*)?([^;]+).*$"
+      replacement = "$1"
+      target_label = "app"
+    }
+
+    // set the service label
+    rule {
+      source_labels = ["__meta_kubernetes_service_name"]
+      target_label  = "service"
+    }
+
+    // set a source label
+    rule {
+      action = "replace"
+      replacement = "kubernetes"
+      target_label = "source"
+    }
+  } // discovery.relabel "kube_dns"
+
+  prometheus.scrape "kube_dns" {
+    targets = discovery.relabel.kube_dns.output
+    job_name = "integrations/coredns"
+    scheme = "http"
+    scrape_interval = "60s"
+    scrape_timeout = "10s"
+    scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
+    scrape_classic_histograms = false
+    scrape_native_histograms = false
+    convert_classic_histograms_to_nhcb = false
+    clustering {
+      enabled = true
+    }
+    forward_to = argument.metrics_destinations.value
+  } // prometheus.relabel "kube_dns"
+  discovery.kubernetes "kube_state_metrics" {
+    role = "endpoints"
+
+    selectors {
+      role = "endpoints"
+      label = "release=k8smon,app.kubernetes.io/name=kube-state-metrics"
+    }
+    namespaces {
+      names = ["default"]
+    }
+  } // discovery.kubernetes "kube_state_metrics"
+
+  discovery.relabel "kube_state_metrics" {
+    targets = discovery.kubernetes.kube_state_metrics.targets
+
+    rule {
+      action = "replace"
+      replacement = "kubernetes"
+      target_label = "source"
+    }
+
+  } // discovery.relabel "kube_state_metrics"
+
+  prometheus.scrape "kube_state_metrics" {
+    targets = discovery.relabel.kube_state_metrics.output
+    job_name = "integrations/kubernetes/kube-state-metrics"
+    scrape_interval = "60s"
+    scrape_timeout = "10s"
+    scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
+    scrape_classic_histograms = false
+    scrape_native_histograms = false
+    convert_classic_histograms_to_nhcb = false
+    scheme = "http"
+    bearer_token_file = ""
+    tls_config {
+      insecure_skip_verify = true
+    }
+
+    clustering {
+      enabled = true
+    }
+    forward_to = [prometheus.relabel.kube_state_metrics.receiver]
+  } // prometheus.scrape "kube_state_metrics"
+
+  prometheus.relabel "kube_state_metrics" {
+    max_cache_size = 100000
+    rule {
+      source_labels = ["__name__"]
+      regex = "up|scrape_samples_scraped|kube_configmap_info|kube_configmap_metadata_resource_version|kube_cronjob.*|kube_daemonset.*|kube_deployment_metadata_generation|kube_deployment_spec_replicas|kube_deployment_status_condition|kube_deployment_status_observed_generation|kube_deployment_status_replicas_available|kube_deployment_status_replicas_updated|kube_horizontalpodautoscaler_spec_max_replicas|kube_horizontalpodautoscaler_spec_min_replicas|kube_horizontalpodautoscaler_status_current_replicas|kube_horizontalpodautoscaler_status_desired_replicas|kube_job.*|kube_namespace_status_phase|kube_node.*|kube_persistentvolume_status_phase|kube_persistentvolumeclaim_access_mode|kube_persistentvolumeclaim_info|kube_persistentvolumeclaim_labels|kube_persistentvolumeclaim_resource_requests_storage_bytes|kube_persistentvolumeclaim_status_phase|kube_pod_completion_time|kube_pod_container_info|kube_pod_container_resource_limits|kube_pod_container_resource_requests|kube_pod_container_status_last_terminated_reason|kube_pod_container_status_last_terminated_timestamp|kube_pod_container_status_restarts_total|kube_pod_container_status_waiting_reason|kube_pod_info|kube_pod_owner|kube_pod_restart_policy|kube_pod_spec_volumes_persistentvolumeclaims_info|kube_pod_start_time|kube_pod_status_phase|kube_pod_status_reason|kube_pod_init_.*|kube_replicaset.*|kube_resourcequota|kube_secret_metadata_resource_version|kube_statefulset.*"
+      action = "keep"
+    }
+    forward_to = argument.metrics_destinations.value
+  } // prometheus.relabel "kube_state_metrics"
+} // declare "cluster_metrics"
+cluster_metrics "feature" {
+  metrics_destinations = [
+    prometheus.remote_write.localprometheus.receiver,
+  ]
+}
+
+
+
+
+
+
+
+
+
+
+
+
+
+// Self Reporting
+prometheus.exporter.unix "kubernetes_monitoring_telemetry" {
+  set_collectors = ["textfile"]
+  textfile {
+    directory = "/etc/release-info"
+  }
+} // prometheus.exporter.unix "kubernetes_monitoring_telemetry"
+
+discovery.relabel "kubernetes_monitoring_telemetry" {
+  targets = prometheus.exporter.unix.kubernetes_monitoring_telemetry.targets
+  rule {
+    target_label = "instance"
+    action = "replace"
+    replacement = "k8smon"
+  }
+  rule {
+    target_label = "job"
+    action = "replace"
+    replacement = "integrations/kubernetes/kubernetes_monitoring_telemetry"
+  }
+} // discovery.relabel "kubernetes_monitoring_telemetry"
+
+prometheus.scrape "kubernetes_monitoring_telemetry" {
+  job_name   = "integrations/kubernetes/kubernetes_monitoring_telemetry"
+  targets    = discovery.relabel.kubernetes_monitoring_telemetry.output
+  scrape_interval = "60s"
+  clustering {
+    enabled = true
+  }
+  forward_to = [prometheus.relabel.kubernetes_monitoring_telemetry.receiver]
+} // prometheus.scrape "kubernetes_monitoring_telemetry"
+
+prometheus.relabel "kubernetes_monitoring_telemetry" {
+  rule {
+    source_labels = ["__name__"]
+    regex = "grafana_kubernetes_monitoring_.*"
+    action = "keep"
+  }
+  forward_to = [
+    prometheus.remote_write.localprometheus.receiver,
+  ]
+} // prometheus.relabel "kubernetes_monitoring_telemetry"
+
+
+
+
+
+// Destination: localPrometheus (prometheus)
+otelcol.exporter.prometheus "localprometheus" {
+  add_metric_suffixes = true
+  resource_to_telemetry_conversion = false
+  keep_identifying_resource_attributes = true
+  forward_to = [prometheus.remote_write.localprometheus.receiver]
+} // otelcol.exporter.prometheus "localprometheus"
+
+prometheus.remote_write "localprometheus" {
+  endpoint {
+    url = "http://prometheus-server.prometheus.svc:9090/api/v1/write"
+    headers = {
+    }
+    tls_config {
+      insecure_skip_verify = false
+    }
+    send_native_histograms = false
+
+    queue_config {
+      capacity = 10000
+      min_shards = 1
+      max_shards = 50
+      max_samples_per_send = 2000
+      batch_send_deadline = "5s"
+      min_backoff = "30ms"
+      max_backoff = "5s"
+      retry_on_http_429 = true
+      sample_age_limit = "0s"
+    }
+  }
+
+  wal {
+    truncate_frequency = "2h"
+    min_keepalive_time = "5m"
+    max_keepalive_time = "8h"
+  }
+  external_labels = {
+    "cluster" = "coredns-integration-test",
+    "k8s_cluster_name" = "coredns-integration-test",
+  }
+} // prometheus.remote_write "localprometheus"
+

--- a/charts/k8s-monitoring/tests/integration/service-integrations/etcd/.rendered/alloy-metrics.alloy
+++ b/charts/k8s-monitoring/tests/integration/service-integrations/etcd/.rendered/alloy-metrics.alloy
@@ -1,0 +1,225 @@
+declare "etcd_integration" {
+  argument "metrics_destinations" {
+    comment = "Must be a list of metric destinations where collected metrics should be forwarded to"
+  }
+
+  discovery.kubernetes "etcd" {
+    role = "pod"
+
+    selectors {
+      role = "pod"
+      label = "component=etcd"
+    }
+    namespaces {
+      names = ["kube-system"]
+    }
+  }
+
+  discovery.relabel "etcd" {
+    targets = discovery.kubernetes.etcd.targets
+
+    // keep only the specified metrics port name, and pods that are Running and ready
+    rule {
+      source_labels = [
+        "__meta_kubernetes_pod_phase",
+        "__meta_kubernetes_pod_ready",
+      ]
+      separator = "@"
+      regex = "Running@true"
+      action = "keep"
+    }
+
+    // drop any init containers
+    rule {
+      source_labels = ["__meta_kubernetes_pod_container_init"]
+      regex = "true"
+      action = "drop"
+    }
+
+    // set the metrics port
+    rule {
+      source_labels = ["__meta_kubernetes_pod_ip"]
+      replacement = "$1:2381"
+      target_label = "__address__"
+    }
+
+    rule {
+      source_labels = ["__meta_kubernetes_namespace"]
+      target_label  = "namespace"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_pod_name"]
+      target_label  = "pod"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_pod_container_name"]
+      target_label  = "container"
+    }
+    rule {
+      source_labels = [
+        "__meta_kubernetes_pod_controller_kind",
+        "__meta_kubernetes_pod_controller_name",
+      ]
+      separator = "/"
+      target_label  = "workload"
+    }
+    rule {
+      source_labels = ["workload"]
+      regex = "(ReplicaSet/.+)-.+"
+      target_label  = "workload"
+    }
+
+    rule {
+      action = "replace"
+      source_labels = [
+        "__meta_kubernetes_pod_label_app_kubernetes_io_name",
+        "__meta_kubernetes_pod_label_k8s_app",
+        "__meta_kubernetes_pod_label_app",
+      ]
+      separator = ";"
+      regex = "^(?:;*)?([^;]+).*$"
+      replacement = "$1"
+      target_label = "app"
+    }
+
+    rule {
+      action = "replace"
+      source_labels = [
+        "__meta_kubernetes_pod_label_app_kubernetes_io_component",
+        "__meta_kubernetes_pod_label_k8s_component",
+        "__meta_kubernetes_pod_label_component",
+      ]
+      regex = "^(?:;*)?([^;]+).*$"
+      replacement = "$1"
+      target_label = "component"
+    }
+
+    rule {
+      action = "replace"
+      replacement = "kubernetes"
+      target_label = "source"
+    }
+  }
+
+  prometheus.scrape "etcd" {
+    targets = discovery.relabel.etcd.output
+    job_name = "integrations/etcd"
+    scrape_interval = "60s"
+    scrape_timeout = "10s"
+    scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
+    scrape_classic_histograms = false
+    scrape_native_histograms = false
+    clustering {
+      enabled = true
+    }
+    forward_to = [prometheus.relabel.etcd.receiver]
+  }
+
+  prometheus.relabel "etcd" {
+    max_cache_size = 100000
+    forward_to = argument.metrics_destinations.value
+  }
+}
+etcd_integration "integration" {
+  metrics_destinations = [
+    prometheus.remote_write.localprometheus.receiver,
+  ]
+}
+
+
+
+
+
+
+
+
+
+// Self Reporting
+prometheus.exporter.unix "kubernetes_monitoring_telemetry" {
+  set_collectors = ["textfile"]
+  textfile {
+    directory = "/etc/release-info"
+  }
+} // prometheus.exporter.unix "kubernetes_monitoring_telemetry"
+
+discovery.relabel "kubernetes_monitoring_telemetry" {
+  targets = prometheus.exporter.unix.kubernetes_monitoring_telemetry.targets
+  rule {
+    target_label = "instance"
+    action = "replace"
+    replacement = "k8smon"
+  }
+  rule {
+    target_label = "job"
+    action = "replace"
+    replacement = "integrations/kubernetes/kubernetes_monitoring_telemetry"
+  }
+} // discovery.relabel "kubernetes_monitoring_telemetry"
+
+prometheus.scrape "kubernetes_monitoring_telemetry" {
+  job_name   = "integrations/kubernetes/kubernetes_monitoring_telemetry"
+  targets    = discovery.relabel.kubernetes_monitoring_telemetry.output
+  scrape_interval = "60s"
+  clustering {
+    enabled = true
+  }
+  forward_to = [prometheus.relabel.kubernetes_monitoring_telemetry.receiver]
+} // prometheus.scrape "kubernetes_monitoring_telemetry"
+
+prometheus.relabel "kubernetes_monitoring_telemetry" {
+  rule {
+    source_labels = ["__name__"]
+    regex = "grafana_kubernetes_monitoring_.*"
+    action = "keep"
+  }
+  forward_to = [
+    prometheus.remote_write.localprometheus.receiver,
+  ]
+} // prometheus.relabel "kubernetes_monitoring_telemetry"
+
+
+
+
+
+// Destination: localPrometheus (prometheus)
+otelcol.exporter.prometheus "localprometheus" {
+  add_metric_suffixes = true
+  resource_to_telemetry_conversion = false
+  keep_identifying_resource_attributes = true
+  forward_to = [prometheus.remote_write.localprometheus.receiver]
+} // otelcol.exporter.prometheus "localprometheus"
+
+prometheus.remote_write "localprometheus" {
+  endpoint {
+    url = "http://prometheus-server.prometheus.svc:9090/api/v1/write"
+    headers = {
+    }
+    tls_config {
+      insecure_skip_verify = false
+    }
+    send_native_histograms = false
+
+    queue_config {
+      capacity = 10000
+      min_shards = 1
+      max_shards = 50
+      max_samples_per_send = 2000
+      batch_send_deadline = "5s"
+      min_backoff = "30ms"
+      max_backoff = "5s"
+      retry_on_http_429 = true
+      sample_age_limit = "0s"
+    }
+  }
+
+  wal {
+    truncate_frequency = "2h"
+    min_keepalive_time = "5m"
+    max_keepalive_time = "8h"
+  }
+  external_labels = {
+    "cluster" = "etcd-integration-test",
+    "k8s_cluster_name" = "etcd-integration-test",
+  }
+} // prometheus.remote_write "localprometheus"
+

--- a/charts/k8s-monitoring/tests/integration/service-integrations/grafana/.rendered/alloy-logs.alloy
+++ b/charts/k8s-monitoring/tests/integration/service-integrations/grafana/.rendered/alloy-logs.alloy
@@ -1,0 +1,293 @@
+// Feature: Pod Logs (Loki)
+declare "pod_logs_via_loki" {
+  argument "logs_destinations" {
+    comment = "Must be a list of log destinations where collected logs should be forwarded to"
+  }
+
+  discovery.kubernetes "pods" {
+    role = "pod"
+    selectors {
+      role = "pod"
+      field = "spec.nodeName=" + sys.env("HOSTNAME")
+    }
+  } // discovery.kubernetes "pods"
+
+  discovery.relabel "filtered_pods" {
+    targets = discovery.kubernetes.pods.targets
+    rule {
+      source_labels = ["__meta_kubernetes_namespace"]
+      action = "replace"
+      target_label = "namespace"
+    }
+    rule {  // Drop anything with a "falsy" annotation value
+      source_labels = ["__meta_kubernetes_pod_annotation_logs_grafana_com_pods_enabled"]
+      regex = "(false|no|skip)"
+      action = "drop"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_pod_name"]
+      target_label = "pod"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_pod_container_name"]
+      target_label = "container"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_namespace", "__meta_kubernetes_pod_container_name"]
+      separator = "/"
+      replacement = "$1"
+      target_label = "job"
+    }
+
+    // set the container runtime as a label
+    rule {
+      source_labels = ["__meta_kubernetes_pod_container_id"]
+      regex = "^(\\S+):\\/\\/.+$"
+      replacement = "$1"
+      target_label = "tmp_container_runtime"
+    }
+    // explicitly set service_name. if not set, loki will automatically try to populate a default.
+    // see https://grafana.com/docs/loki/latest/get-started/labels/#default-labels-for-all-users
+    //
+    // choose the first value found from the following ordered list:
+    // - pod.annotation[resource.opentelemetry.io/service.name]
+    // - pod.label[app.kubernetes.io/name]
+    // - k8s.container.name
+    rule {
+      source_labels = [
+        "__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_name",
+        "__meta_kubernetes_pod_label_app_kubernetes_io_name",
+        "__meta_kubernetes_pod_container_name",
+      ]
+      separator = ";"
+      regex = "^(?:;*)?([^;]+).*$"
+      replacement = "$1"
+      target_label = "service_name"
+    }
+
+    // explicitly set service_namespace.
+    //
+    // choose the first value found from the following ordered list:
+    // - pod.annotation[resource.opentelemetry.io/service.namespace]
+    // - pod.namespace
+    rule {
+      source_labels = [
+        "__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_namespace",
+        "namespace",
+      ]
+      separator = ";"
+      regex = "^(?:;*)?([^;]+).*$"
+      replacement = "$1"
+      target_label = "service_namespace"
+    }
+
+    // explicitly set service_instance_id.
+    //
+    // choose the first value found from the following ordered list:
+    // - pod.annotation[resource.opentelemetry.io/service.instance.id]
+    // - concat([k8s.namespace.name, k8s.pod.name, k8s.container.name], '.')
+    rule {
+      source_labels = ["__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_instance_id"]
+      target_label = "service_instance_id"
+    }
+    rule {
+      source_labels = ["service_instance_id", "namespace", "pod", "container"]
+      separator = "."
+      regex = "^\\.([^.]+\\.[^.]+\\.[^.]+)$"
+      target_label = "service_instance_id"
+    }
+
+    // set resource attributes
+    rule {
+      action = "labelmap"
+      regex = "__meta_kubernetes_pod_annotation_resource_opentelemetry_io_(.+)"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_job"]
+      regex = "(.+)"
+      target_label = "job"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+      regex = "(.+)"
+      target_label = "app_kubernetes_io_name"
+    }
+
+    // Set the pod log path.
+    rule {
+      source_labels = ["__meta_kubernetes_pod_uid", "__meta_kubernetes_pod_container_name"]
+      separator = "/"
+      replacement = "/var/log/pods/*$1/*.log"
+      target_label = "__path__"
+    }
+
+    // If kubernetes.io/config.mirror is set, this is a static pod, created by the kubelet.
+    // It's logs live on a different path.
+    rule {
+      source_labels = ["__meta_kubernetes_pod_annotation_kubernetes_io_config_mirror", "__meta_kubernetes_pod_container_name"]
+      separator = "/"
+      regex = "(.+/.+)"
+      replacement = "/var/log/pods/*$1/*.log"
+      target_label = "__path__"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+      separator = ";"
+      regex = "(?:grafana)"
+      target_label = "job"
+      replacement = "integrations/grafana"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+      separator = ";"
+      regex = "(?:grafana)"
+      target_label = "instance"
+      replacement = "grafana"
+    }
+  } // discovery.relabel "filtered_pods"
+
+  local.file_match "pod_logs" {
+    path_targets = discovery.relabel.filtered_pods.output
+  } // local.file_match "pod_logs"
+
+  loki.source.file "pod_logs" {
+    targets    = local.file_match.pod_logs.targets
+    tail_from_end = false
+    forward_to = [loki.process.pod_logs.receiver]
+  } // loki.source.file "pod_logs"
+
+  loki.process "pod_logs" {
+    stage.match {
+      selector = "{tmp_container_runtime=~\"containerd|cri-o|\"}"
+      // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
+      stage.cri {
+        max_partial_lines = 100
+      }
+
+      // Set the extract flags and stream values as labels
+      stage.labels {
+        values = {
+          flags  = "",
+          stream  = "",
+        }
+      }
+    }
+
+    stage.match {
+      selector = "{tmp_container_runtime=\"docker\"}"
+      // the docker processing stage extracts the following k/v pairs: log, stream, time
+      stage.docker {}
+
+      // Set the extract stream value as a label
+      stage.labels {
+        values = {
+          stream  = "",
+        }
+      }
+    }
+
+    // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
+    // namespace, pod, and container labels. Drop any structured metadata. Also drop the temporary
+    // container runtime label as it is no longer needed.
+    stage.label_drop {
+      values = [
+        "filename",
+        "tmp_container_runtime",
+      ]
+    }
+    stage.structured_metadata {
+      values = {
+        "k8s_pod_name" = "k8s_pod_name",
+        "pod" = "pod",
+        "service_instance_id" = "service_instance_id",
+      }
+    }
+    // Integration: Grafana
+    stage.match {
+      selector = "{job=\"integrations/grafana\",instance=\"grafana\"}"
+
+      // Only run the logfmt parser on lines that look like Grafana's logfmt format (start with "t=").
+      // Non-logfmt lines (e.g. crash reports, init container output) would otherwise produce
+      // a flood of "failed to decode logfmt" errors. See https://github.com/grafana/k8s-monitoring-helm/issues/1726
+      stage.match {
+        selector = `{job="integrations/grafana",instance="grafana"} |~ "^t="`
+
+        // extract some of the fields from the log line
+        stage.logfmt {
+          mapping = {
+            "ts" = "t",
+            "level" = "",
+          }
+        }
+
+        // set the level as a label
+        stage.labels {
+          values = {
+            level = "level",
+          }
+        }
+        // reset the timestamp to the extracted value
+        stage.timestamp {
+          source = "ts"
+          format = "RFC3339Nano"
+        }
+        // remove the timestamp from the log line
+        stage.replace {
+          expression = `(?:^|\s+)(t=\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d+[^ ]*\s+)`
+          replace = ""
+        }
+        // drop certain log levels
+        stage.drop {
+          source = "level"
+          expression = "(?i)(debug)"
+          drop_counter_reason = "grafana-drop-log-level"
+        }
+      }
+
+    }
+
+    forward_to = argument.logs_destinations.value
+  } // loki.secretfilter "pod_logs"
+} // declare "pod_logs_via_loki"
+pod_logs_via_loki "feature" {
+  logs_destinations = [
+    loki.write.localloki.receiver,
+  ]
+}
+
+
+
+
+
+// Destination: localLoki (loki)
+otelcol.exporter.loki "localloki" {
+  forward_to = [loki.write.localloki.receiver]
+} // otelcol.exporter.loki "localloki"
+
+loki.write "localloki" {
+  endpoint {
+    url = "http://loki.loki.svc:3100/loki/api/v1/push"
+    retry_on_http_429 = true
+    tenant_id = convert.nonsensitive(remote.kubernetes.secret.localloki.data["tenantId"])
+    basic_auth {
+      username = convert.nonsensitive(remote.kubernetes.secret.localloki.data["username"])
+      password = remote.kubernetes.secret.localloki.data["password"]
+    }
+    tls_config {
+      insecure_skip_verify = false
+    }
+    min_backoff_period = "500ms"
+    max_backoff_period = "5m"
+    max_backoff_retries = "10"
+  }
+  external_labels = {
+    "cluster" = "grafana-integration-test",
+    "k8s_cluster_name" = "grafana-integration-test",
+  }
+} // loki.write "localloki"
+
+remote.kubernetes.secret "localloki" {
+  name      = "localloki-k8smon-k8s-monitoring"
+  namespace = "default"
+} // remote.kubernetes.secret "localloki"
+

--- a/charts/k8s-monitoring/tests/integration/service-integrations/grafana/.rendered/alloy-metrics.alloy
+++ b/charts/k8s-monitoring/tests/integration/service-integrations/grafana/.rendered/alloy-metrics.alloy
@@ -1,0 +1,610 @@
+// Feature: Cluster Metrics
+declare "cluster_metrics" {
+  argument "metrics_destinations" {
+    comment = "Must be a list of metric destinations where collected metrics should be forwarded to"
+  }
+  discovery.kubernetes "nodes" {
+    role = "node"
+  } // discovery.kubernetes "nodes"
+
+  discovery.relabel "nodes" {
+    targets = discovery.kubernetes.nodes.targets
+    rule {
+      source_labels = ["__meta_kubernetes_node_name"]
+      target_label  = "node"
+    }
+
+    rule {
+      replacement = "kubernetes"
+      target_label = "source"
+    }
+  } // discovery.relabel "nodes"
+
+  // Kubelet
+  discovery.relabel "kubelet" {
+    targets = discovery.relabel.nodes.output
+  } // discovery.relabel "kubelet"
+
+  prometheus.scrape "kubelet" {
+    targets  = discovery.relabel.kubelet.output
+    job_name = "integrations/kubernetes/kubelet"
+    scheme   = "https"
+    scrape_interval = "60s"
+    scrape_timeout = "10s"
+    scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
+    scrape_classic_histograms = false
+    scrape_native_histograms = false
+    convert_classic_histograms_to_nhcb = false
+    bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+
+    tls_config {
+      ca_file = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+      insecure_skip_verify = true
+      server_name = "kubernetes"
+    }
+
+    clustering {
+      enabled = true
+    }
+
+    forward_to = [prometheus.relabel.kubelet.receiver]
+  } // prometheus.scrape "kubelet"
+
+  prometheus.relabel "kubelet" {
+    max_cache_size = 100000
+    rule {
+      source_labels = ["__name__"]
+      regex = "up|scrape_samples_scraped|go_goroutines|kubelet_certificate_manager_client_expiration_renew_errors|kubelet_certificate_manager_client_ttl_seconds|kubelet_certificate_manager_server_ttl_seconds|kubelet_cgroup_manager_duration_seconds_bucket|kubelet_cgroup_manager_duration_seconds_count|kubelet_node_config_error|kubelet_node_name|kubelet_pleg_relist_duration_seconds_bucket|kubelet_pleg_relist_duration_seconds_count|kubelet_pleg_relist_interval_seconds_bucket|kubelet_pod_start_duration_seconds_bucket|kubelet_pod_start_duration_seconds_count|kubelet_pod_worker_duration_seconds_bucket|kubelet_pod_worker_duration_seconds_count|kubelet_running_container_count|kubelet_running_containers|kubelet_running_pod_count|kubelet_running_pods|kubelet_runtime_operations_errors_total|kubelet_runtime_operations_total|kubelet_server_expiration_renew_errors|kubelet_volume_stats_available_bytes|kubelet_volume_stats_capacity_bytes|kubelet_volume_stats_inodes|kubelet_volume_stats_inodes_free|kubelet_volume_stats_inodes_used|kubelet_volume_stats_used_bytes|kubernetes_build_info|namespace_workload_pod|process_cpu_seconds_total|process_resident_memory_bytes|rest_client_requests_total|storage_operation_duration_seconds_count|storage_operation_errors_total|volume_manager_total_volumes"
+      action = "keep"
+    }
+
+    forward_to = argument.metrics_destinations.value
+  } // prometheus.relabel "kubelet"
+
+  // Kubelet Resources
+  discovery.relabel "kubelet_resources" {
+    targets = discovery.relabel.nodes.output
+    rule {
+      replacement   = "/metrics/resource"
+      target_label  = "__metrics_path__"
+    }
+  } // discovery.relabel "kubelet_resources"
+
+  prometheus.scrape "kubelet_resources" {
+    targets = discovery.relabel.kubelet_resources.output
+    job_name = "integrations/kubernetes/resources"
+    scheme   = "https"
+    scrape_interval = "60s"
+    scrape_timeout = "10s"
+    scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
+    scrape_classic_histograms = false
+    scrape_native_histograms = false
+    convert_classic_histograms_to_nhcb = false
+    bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+
+    tls_config {
+      ca_file = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+      insecure_skip_verify = true
+      server_name = "kubernetes"
+    }
+
+    clustering {
+      enabled = true
+    }
+
+    forward_to = [prometheus.relabel.kubelet_resources.receiver]
+  } // prometheus.scrape "kubelet_resources"
+
+  prometheus.relabel "kubelet_resources" {
+    max_cache_size = 100000
+    rule {
+      source_labels = ["__name__"]
+      regex = "up|scrape_samples_scraped|node_cpu_usage_seconds_total|node_memory_working_set_bytes"
+      action = "keep"
+    }
+
+    forward_to = argument.metrics_destinations.value
+  } // prometheus.relabel "kubelet_resources"
+
+  // cAdvisor
+  discovery.relabel "cadvisor" {
+    targets = discovery.relabel.nodes.output
+    rule {
+      replacement   = "/metrics/cadvisor"
+      target_label  = "__metrics_path__"
+    }
+  } // discovery.relabel "cadvisor"
+
+  prometheus.scrape "cadvisor" {
+    targets = discovery.relabel.cadvisor.output
+    job_name = "integrations/kubernetes/cadvisor"
+    scheme = "https"
+    scrape_interval = "60s"
+    scrape_timeout = "10s"
+    scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
+    scrape_classic_histograms = false
+    scrape_native_histograms = false
+    convert_classic_histograms_to_nhcb = false
+    bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+
+    tls_config {
+      ca_file = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+      insecure_skip_verify = true
+      server_name = "kubernetes"
+    }
+
+    clustering {
+      enabled = true
+    }
+
+    forward_to = [prometheus.relabel.cadvisor.receiver]
+  } // prometheus.scrape "cadvisor"
+
+  prometheus.relabel "cadvisor" {
+    max_cache_size = 100000
+    rule {
+      source_labels = ["__name__"]
+      regex = "up|scrape_samples_scraped|container_cpu_cfs_periods_total|container_cpu_cfs_throttled_periods_total|container_cpu_usage_seconds_total|container_fs_reads_bytes_total|container_fs_reads_total|container_fs_writes_bytes_total|container_fs_writes_total|container_memory_cache|container_memory_rss|container_memory_swap|container_memory_usage_bytes|container_memory_working_set_bytes|container_network_receive_bytes_total|container_network_receive_packets_dropped_total|container_network_receive_packets_total|container_network_transmit_bytes_total|container_network_transmit_packets_dropped_total|container_network_transmit_packets_total|machine_memory_bytes"
+      action = "keep"
+    }
+    // Drop empty container labels, addressing https://github.com/google/cadvisor/issues/2688
+    rule {
+      source_labels = ["__name__","container"]
+      separator = "@"
+      regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_pressure_.*)@"
+      action = "drop"
+    }
+    // Drop empty image labels, addressing https://github.com/google/cadvisor/issues/2688
+    rule {
+      source_labels = ["__name__","image"]
+      separator = "@"
+      regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_network_.*|container_pressure_.*)@"
+      action = "drop"
+    }
+    // Normalizing unimportant labels (not deleting to continue satisfying <label>!="" checks)
+    rule {
+      source_labels = ["__name__", "boot_id"]
+      separator = "@"
+      regex = "machine_memory_bytes@.*"
+      target_label = "boot_id"
+      replacement = "NA"
+    }
+    rule {
+      source_labels = ["__name__", "system_uuid"]
+      separator = "@"
+      regex = "machine_memory_bytes@.*"
+      target_label = "system_uuid"
+      replacement = "NA"
+    }
+    // Filter out non-physical devices/interfaces
+    rule {
+      source_labels = ["__name__", "device"]
+      separator = "@"
+      regex = "container_fs_.*@(/dev/)?(mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dasd.+)"
+      target_label = "__keepme"
+      replacement = "1"
+    }
+    rule {
+      source_labels = ["__name__", "__keepme"]
+      separator = "@"
+      regex = "container_fs_.*@"
+      action = "drop"
+    }
+    rule {
+      source_labels = ["__name__"]
+      regex = "container_fs_.*"
+      target_label = "__keepme"
+      replacement = ""
+    }
+    rule {
+      source_labels = ["__name__", "interface"]
+      separator = "@"
+      regex = "container_network_.*@(en[ospx][0-9].*|wlan[0-9].*|eth[0-9].*)"
+      target_label = "__keepme"
+      replacement = "1"
+    }
+    rule {
+      source_labels = ["__name__", "__keepme"]
+      separator = "@"
+      regex = "container_network_.*@"
+      action = "drop"
+    }
+    rule {
+      source_labels = ["__name__"]
+      regex = "container_network_.*"
+      target_label = "__keepme"
+      replacement = ""
+    }
+    forward_to = argument.metrics_destinations.value
+  } // prometheus.relabel "cadvisor"
+  discovery.kubernetes "kube_state_metrics" {
+    role = "endpoints"
+
+    selectors {
+      role = "endpoints"
+      label = "release=k8smon,app.kubernetes.io/name=kube-state-metrics"
+    }
+    namespaces {
+      names = ["default"]
+    }
+  } // discovery.kubernetes "kube_state_metrics"
+
+  discovery.relabel "kube_state_metrics" {
+    targets = discovery.kubernetes.kube_state_metrics.targets
+
+    rule {
+      action = "replace"
+      replacement = "kubernetes"
+      target_label = "source"
+    }
+
+  } // discovery.relabel "kube_state_metrics"
+
+  prometheus.scrape "kube_state_metrics" {
+    targets = discovery.relabel.kube_state_metrics.output
+    job_name = "integrations/kubernetes/kube-state-metrics"
+    scrape_interval = "60s"
+    scrape_timeout = "10s"
+    scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
+    scrape_classic_histograms = false
+    scrape_native_histograms = false
+    convert_classic_histograms_to_nhcb = false
+    scheme = "http"
+    bearer_token_file = ""
+    tls_config {
+      insecure_skip_verify = true
+    }
+
+    clustering {
+      enabled = true
+    }
+    forward_to = [prometheus.relabel.kube_state_metrics.receiver]
+  } // prometheus.scrape "kube_state_metrics"
+
+  prometheus.relabel "kube_state_metrics" {
+    max_cache_size = 100000
+    rule {
+      source_labels = ["__name__"]
+      regex = "up|scrape_samples_scraped|kube_configmap_info|kube_configmap_metadata_resource_version|kube_cronjob.*|kube_daemonset.*|kube_deployment_metadata_generation|kube_deployment_spec_replicas|kube_deployment_status_condition|kube_deployment_status_observed_generation|kube_deployment_status_replicas_available|kube_deployment_status_replicas_updated|kube_horizontalpodautoscaler_spec_max_replicas|kube_horizontalpodautoscaler_spec_min_replicas|kube_horizontalpodautoscaler_status_current_replicas|kube_horizontalpodautoscaler_status_desired_replicas|kube_job.*|kube_namespace_status_phase|kube_node.*|kube_persistentvolume_status_phase|kube_persistentvolumeclaim_access_mode|kube_persistentvolumeclaim_info|kube_persistentvolumeclaim_labels|kube_persistentvolumeclaim_resource_requests_storage_bytes|kube_persistentvolumeclaim_status_phase|kube_pod_completion_time|kube_pod_container_info|kube_pod_container_resource_limits|kube_pod_container_resource_requests|kube_pod_container_status_last_terminated_reason|kube_pod_container_status_last_terminated_timestamp|kube_pod_container_status_restarts_total|kube_pod_container_status_waiting_reason|kube_pod_info|kube_pod_owner|kube_pod_restart_policy|kube_pod_spec_volumes_persistentvolumeclaims_info|kube_pod_start_time|kube_pod_status_phase|kube_pod_status_reason|kube_pod_init_.*|kube_replicaset.*|kube_resourcequota|kube_secret_metadata_resource_version|kube_statefulset.*"
+      action = "keep"
+    }
+    forward_to = argument.metrics_destinations.value
+  } // prometheus.relabel "kube_state_metrics"
+} // declare "cluster_metrics"
+cluster_metrics "feature" {
+  metrics_destinations = [
+    prometheus.remote_write.localprometheus.receiver,
+  ]
+}
+
+declare "grafana_integration" {
+  argument "metrics_destinations" {
+    comment = "Must be a list of metric destinations where collected metrics should be forwarded to"
+  }
+
+  declare "grafana_integration_discovery" {
+    argument "namespaces" {
+      comment = "The namespaces to look for targets in (default: [] is all namespaces)"
+      optional = true
+    }
+
+    argument "field_selectors" {
+      comment = "The field selectors to use to find matching targets (default: [])"
+      optional = true
+    }
+
+    argument "label_selectors" {
+      comment = "The label selectors to use to find matching targets (default: [\"app.kubernetes.io/name=grafana\"])"
+      optional = true
+    }
+
+    argument "port_name" {
+      comment = "The of the port to scrape metrics from (default: grafana)"
+      optional = true
+    }
+
+    // grafana service discovery for all of the pods
+    discovery.kubernetes "grafana_pods" {
+      role = "pod"
+
+      selectors {
+        role = "pod"
+        field = string.join(coalesce(argument.field_selectors.value, []), ",")
+        label = string.join(coalesce(argument.label_selectors.value, ["app.kubernetes.io/name=grafana"]), ",")
+      }
+
+      namespaces {
+        names = coalesce(argument.namespaces.value, [])
+      }
+
+    } // discovery.kubernetes "grafana_pods"
+
+    // grafana relabelings (pre-scrape)
+    discovery.relabel "grafana_pods" {
+      targets = discovery.kubernetes.grafana_pods.targets
+
+      // keep only the specified metrics port name, and pods that are Running and ready
+      rule {
+        source_labels = [
+          "__meta_kubernetes_pod_container_port_name",
+          "__meta_kubernetes_pod_phase",
+          "__meta_kubernetes_pod_ready",
+          "__meta_kubernetes_pod_container_init",
+        ]
+        separator = "@"
+        regex = coalesce(argument.port_name.value, "grafana") + "@Running@true@false"
+        action = "keep"
+      }
+
+      rule {
+        source_labels = ["__meta_kubernetes_pod_node_name"]
+        target_label = "node"
+      }
+
+
+
+      rule {
+        source_labels = ["__meta_kubernetes_namespace"]
+        target_label  = "namespace"
+      }
+
+      rule {
+        source_labels = ["__meta_kubernetes_pod_name"]
+        target_label  = "pod"
+      }
+
+      rule {
+        source_labels = ["__meta_kubernetes_pod_container_name"]
+        target_label  = "container"
+      }
+
+      // set the workload to the controller kind and name
+      rule {
+        action = "lowercase"
+        source_labels = ["__meta_kubernetes_pod_controller_kind"]
+        target_label  = "workload_type"
+      }
+
+      rule {
+        source_labels = ["__meta_kubernetes_pod_controller_name"]
+        target_label  = "workload"
+      }
+
+      // remove the hash from the ReplicaSet
+      rule {
+        source_labels = [
+          "workload_type",
+          "workload",
+        ]
+        separator = "/"
+        regex = "replicaset/(.+)-.+$"
+        target_label  = "workload"
+      }
+
+      // set the app name if specified as metadata labels "app:" or "app.kubernetes.io/name:" or "k8s-app:"
+      rule {
+        action = "replace"
+        source_labels = [
+          "__meta_kubernetes_pod_label_app_kubernetes_io_name",
+          "__meta_kubernetes_pod_label_k8s_app",
+          "__meta_kubernetes_pod_label_app",
+        ]
+        separator = ";"
+        regex = "^(?:;*)?([^;]+).*$"
+        replacement = "$1"
+        target_label = "app"
+      }
+
+      // set the component if specified as metadata labels "component:" or "app.kubernetes.io/component:" or "k8s-component:"
+      rule {
+        action = "replace"
+        source_labels = [
+          "__meta_kubernetes_pod_label_app_kubernetes_io_component",
+          "__meta_kubernetes_pod_label_k8s_component",
+          "__meta_kubernetes_pod_label_component",
+        ]
+        regex = "^(?:;*)?([^;]+).*$"
+        replacement = "$1"
+        target_label = "component"
+      }
+
+      // set a source label
+      rule {
+        action = "replace"
+        replacement = "kubernetes"
+        target_label = "source"
+      }
+
+    } // discovery.relabel "grafana_pods"
+
+    export "output" {
+      value = discovery.relabel.grafana_pods.output
+    }
+  }
+
+  declare "grafana_integration_scrape" {
+    argument "targets" {
+      comment = "Must be a list() of targets"
+    }
+
+    argument "forward_to" {
+      comment = "Must be a list(MetricsReceiver) where collected metrics should be forwarded to"
+    }
+
+    argument "job_label" {
+      comment = "The job label to add for all Grafana metrics (default: integrations/grafana)"
+      optional = true
+    }
+
+    argument "keep_metrics" {
+      comment = "A regular expression of metrics to keep (default: see below)"
+      optional = true
+    }
+
+    argument "drop_metrics" {
+      comment = "A regular expression of metrics to drop (default: see below)"
+      optional = true
+    }
+
+    argument "scrape_interval" {
+      comment = "How often to scrape metrics from the targets (default: 60s)"
+      optional = true
+    }
+
+    argument "scrape_timeout" {
+      comment = "The timeout for scraping metrics from the targets (default: 10s)"
+      optional = true
+    }
+
+    argument "scrape_protocols" {
+      comment = "The scrape protocols to use for scraping metrics"
+      optional = true
+    }
+
+    argument "scrape_classic_histograms" {
+      comment = "Whether to scrape classic histograms (default: false)."
+      optional = true
+    }
+
+    argument "scrape_native_histograms" {
+      comment = "Whether to scrape native histograms (default: false)."
+      optional = true
+    }
+
+    argument "max_cache_size" {
+      comment = "The maximum number of elements to hold in the relabeling cache (default: 100000).  This should be at least 2x-5x your largest scrape target or samples appended rate."
+      optional = true
+    }
+
+    argument "clustering" {
+      comment = "Whether or not clustering should be enabled (default: false)"
+      optional = true
+    }
+
+    prometheus.scrape "grafana" {
+      job_name = coalesce(argument.job_label.value, "integrations/grafana")
+      forward_to = [prometheus.relabel.grafana.receiver]
+      targets = argument.targets.value
+      scrape_interval = coalesce(argument.scrape_interval.value, "60s")
+      scrape_timeout = coalesce(argument.scrape_timeout.value, "10s")
+      scrape_protocols = argument.scrape_protocols.value
+      scrape_classic_histograms = argument.scrape_classic_histograms.value
+      scrape_native_histograms = argument.scrape_native_histograms.value
+
+      clustering {
+        enabled = coalesce(argument.clustering.value, false)
+      }
+    } // prometheus.scrape "grafana"
+
+    // grafana metric relabelings (post-scrape)
+    prometheus.relabel "grafana" {
+      forward_to = argument.forward_to.value
+      max_cache_size = coalesce(argument.max_cache_size.value, 100000)
+
+      // drop metrics that match the drop_metrics regex
+      rule {
+        source_labels = ["__name__"]
+        regex = coalesce(argument.drop_metrics.value, "")
+        action = "drop"
+      }
+
+      // keep only metrics that match the keep_metrics regex
+      rule {
+        source_labels = ["__name__"]
+        regex = coalesce(argument.keep_metrics.value, "(.+)")
+        action = "keep"
+      }
+
+      // the grafana-mixin expects the instance label to be the node name
+      rule {
+        source_labels = ["node"]
+        target_label = "instance"
+        replacement = "$1"
+      }
+      rule {
+        action = "labeldrop"
+        regex = "node"
+      }
+    } // prometheus.relabel "grafana"
+  }
+
+  grafana_integration_discovery "grafana" {
+    namespaces = []
+    label_selectors = ["app.kubernetes.io/name=grafana"]
+    port_name = "grafana"
+  }
+
+  grafana_integration_scrape  "grafana" {
+    targets = grafana_integration_discovery.grafana.output
+    job_label = "integrations/grafana"
+    clustering = true
+    scrape_interval = "60s"
+    scrape_timeout = "10s"
+    scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
+    scrape_classic_histograms = false
+    scrape_native_histograms = false
+    max_cache_size = 100000
+    forward_to = argument.metrics_destinations.value
+  }
+}
+grafana_integration "integration" {
+  metrics_destinations = [
+    prometheus.remote_write.localprometheus.receiver,
+  ]
+}
+
+
+
+
+
+// Destination: localPrometheus (prometheus)
+otelcol.exporter.prometheus "localprometheus" {
+  add_metric_suffixes = true
+  resource_to_telemetry_conversion = false
+  keep_identifying_resource_attributes = true
+  forward_to = [prometheus.remote_write.localprometheus.receiver]
+} // otelcol.exporter.prometheus "localprometheus"
+
+prometheus.remote_write "localprometheus" {
+  endpoint {
+    url = "http://prometheus-server.prometheus.svc:9090/api/v1/write"
+    headers = {
+    }
+    basic_auth {
+      username = convert.nonsensitive(remote.kubernetes.secret.localprometheus.data["username"])
+      password = remote.kubernetes.secret.localprometheus.data["password"]
+    }
+    tls_config {
+      insecure_skip_verify = false
+    }
+    send_native_histograms = false
+
+    queue_config {
+      capacity = 10000
+      min_shards = 1
+      max_shards = 50
+      max_samples_per_send = 2000
+      batch_send_deadline = "5s"
+      min_backoff = "30ms"
+      max_backoff = "5s"
+      retry_on_http_429 = true
+      sample_age_limit = "0s"
+    }
+  }
+
+  wal {
+    truncate_frequency = "2h"
+    min_keepalive_time = "5m"
+    max_keepalive_time = "8h"
+  }
+  external_labels = {
+    "cluster" = "grafana-integration-test",
+    "k8s_cluster_name" = "grafana-integration-test",
+  }
+} // prometheus.remote_write "localprometheus"
+
+remote.kubernetes.secret "localprometheus" {
+  name      = "localprometheus-k8smon-k8s-monitoring"
+  namespace = "default"
+} // remote.kubernetes.secret "localprometheus"
+

--- a/charts/k8s-monitoring/tests/integration/service-integrations/grafana/.rendered/alloy-singleton.alloy
+++ b/charts/k8s-monitoring/tests/integration/service-integrations/grafana/.rendered/alloy-singleton.alloy
@@ -1,0 +1,214 @@
+// Feature: Cluster Events
+declare "cluster_events" {
+  argument "logs_destinations" {
+    comment = "Must be a list of log destinations where collected logs should be forwarded to"
+  }
+
+  loki.source.kubernetes_events "cluster_events" {
+    job_name   = "integrations/kubernetes/eventhandler"
+    log_format = "logfmt"
+    forward_to = [loki.process.cluster_events.receiver]
+  } // loki.source.kubernetes_events "cluster_events"
+
+  loki.process "cluster_events" {
+
+    // add a static source label to the logs so they can be differentiated / restricted if necessary
+    stage.static_labels {
+      values = {
+        "source" = "kubernetes-events",
+      }
+    }
+
+    // extract some of the fields from the log line, these could be used as labels, structured metadata, etc.
+    stage.logfmt {
+      mapping = {
+        "component" = "sourcecomponent", // map the sourcecomponent field to component
+        "kind" = "",
+        "level" = "type", // most events don't have a level but they do have a "type" i.e. Normal, Warning, Error, etc.
+        "name" = "",
+        "node" = "sourcehost", // map the sourcehost field to node
+        "reason" = "",
+      }
+    }
+    // set the extracted values as labels
+    stage.labels {
+      values = {
+        "kind" = "",
+        "level" = "",
+        "service_name" = "job",
+        "reason" = "reason",
+      }
+    }
+
+    // if kind=Node, set the node label by copying the name field
+    stage.match {
+      selector = "{kind=\"Node\"}"
+
+      stage.labels {
+        values = {
+          "node" = "name",
+        }
+      }
+    }
+
+    // set the level extracted key value as a normalized log level
+    stage.match {
+      selector = "{level=\"Normal\"}"
+
+      stage.static_labels {
+        values = {
+          level = "Info",
+        }
+      }
+    }
+    stage.structured_metadata {
+      values = {
+        "name" = "name",
+        "node" = "node",
+      }
+    }
+
+    // Drop pipeline-only labels that are not needed in the final output.
+    stage.label_drop {
+      values = ["kind"]
+    }
+
+    forward_to = argument.logs_destinations.value
+  } // loki.process "cluster_events"
+} // declare "cluster_events"
+cluster_events "feature" {
+  logs_destinations = [
+    loki.write.localloki.receiver,
+  ]
+}
+// Self Reporting
+prometheus.exporter.unix "kubernetes_monitoring_telemetry" {
+  set_collectors = ["textfile"]
+  textfile {
+    directory = "/etc/release-info"
+  }
+} // prometheus.exporter.unix "kubernetes_monitoring_telemetry"
+
+discovery.relabel "kubernetes_monitoring_telemetry" {
+  targets = prometheus.exporter.unix.kubernetes_monitoring_telemetry.targets
+  rule {
+    target_label = "instance"
+    action = "replace"
+    replacement = "k8smon"
+  }
+  rule {
+    target_label = "job"
+    action = "replace"
+    replacement = "integrations/kubernetes/kubernetes_monitoring_telemetry"
+  }
+} // discovery.relabel "kubernetes_monitoring_telemetry"
+
+prometheus.scrape "kubernetes_monitoring_telemetry" {
+  job_name   = "integrations/kubernetes/kubernetes_monitoring_telemetry"
+  targets    = discovery.relabel.kubernetes_monitoring_telemetry.output
+  scrape_interval = "60s"
+  clustering {
+    enabled = true
+  }
+  forward_to = [prometheus.relabel.kubernetes_monitoring_telemetry.receiver]
+} // prometheus.scrape "kubernetes_monitoring_telemetry"
+
+prometheus.relabel "kubernetes_monitoring_telemetry" {
+  rule {
+    source_labels = ["__name__"]
+    regex = "grafana_kubernetes_monitoring_.*"
+    action = "keep"
+  }
+  forward_to = [
+    prometheus.remote_write.localprometheus.receiver,
+  ]
+} // prometheus.relabel "kubernetes_monitoring_telemetry"
+
+
+
+
+
+// Destination: localLoki (loki)
+otelcol.exporter.loki "localloki" {
+  forward_to = [loki.write.localloki.receiver]
+} // otelcol.exporter.loki "localloki"
+
+loki.write "localloki" {
+  endpoint {
+    url = "http://loki.loki.svc:3100/loki/api/v1/push"
+    retry_on_http_429 = true
+    tenant_id = convert.nonsensitive(remote.kubernetes.secret.localloki.data["tenantId"])
+    basic_auth {
+      username = convert.nonsensitive(remote.kubernetes.secret.localloki.data["username"])
+      password = remote.kubernetes.secret.localloki.data["password"]
+    }
+    tls_config {
+      insecure_skip_verify = false
+    }
+    min_backoff_period = "500ms"
+    max_backoff_period = "5m"
+    max_backoff_retries = "10"
+  }
+  external_labels = {
+    "cluster" = "grafana-integration-test",
+    "k8s_cluster_name" = "grafana-integration-test",
+  }
+} // loki.write "localloki"
+
+remote.kubernetes.secret "localloki" {
+  name      = "localloki-k8smon-k8s-monitoring"
+  namespace = "default"
+} // remote.kubernetes.secret "localloki"
+
+
+// Destination: localPrometheus (prometheus)
+otelcol.exporter.prometheus "localprometheus" {
+  add_metric_suffixes = true
+  resource_to_telemetry_conversion = false
+  keep_identifying_resource_attributes = true
+  forward_to = [prometheus.remote_write.localprometheus.receiver]
+} // otelcol.exporter.prometheus "localprometheus"
+
+prometheus.remote_write "localprometheus" {
+  endpoint {
+    url = "http://prometheus-server.prometheus.svc:9090/api/v1/write"
+    headers = {
+    }
+    basic_auth {
+      username = convert.nonsensitive(remote.kubernetes.secret.localprometheus.data["username"])
+      password = remote.kubernetes.secret.localprometheus.data["password"]
+    }
+    tls_config {
+      insecure_skip_verify = false
+    }
+    send_native_histograms = false
+
+    queue_config {
+      capacity = 10000
+      min_shards = 1
+      max_shards = 50
+      max_samples_per_send = 2000
+      batch_send_deadline = "5s"
+      min_backoff = "30ms"
+      max_backoff = "5s"
+      retry_on_http_429 = true
+      sample_age_limit = "0s"
+    }
+  }
+
+  wal {
+    truncate_frequency = "2h"
+    min_keepalive_time = "5m"
+    max_keepalive_time = "8h"
+  }
+  external_labels = {
+    "cluster" = "grafana-integration-test",
+    "k8s_cluster_name" = "grafana-integration-test",
+  }
+} // prometheus.remote_write "localprometheus"
+
+remote.kubernetes.secret "localprometheus" {
+  name      = "localprometheus-k8smon-k8s-monitoring"
+  namespace = "default"
+} // remote.kubernetes.secret "localprometheus"
+

--- a/charts/k8s-monitoring/tests/integration/service-integrations/loki/.rendered/alloy-logs.alloy
+++ b/charts/k8s-monitoring/tests/integration/service-integrations/loki/.rendered/alloy-logs.alloy
@@ -1,0 +1,302 @@
+// Feature: Pod Logs (Loki)
+declare "pod_logs_via_loki" {
+  argument "logs_destinations" {
+    comment = "Must be a list of log destinations where collected logs should be forwarded to"
+  }
+
+  discovery.kubernetes "pods" {
+    role = "pod"
+    selectors {
+      role = "pod"
+      field = "spec.nodeName=" + sys.env("HOSTNAME")
+    }
+  } // discovery.kubernetes "pods"
+
+  discovery.relabel "filtered_pods" {
+    targets = discovery.kubernetes.pods.targets
+    rule {
+      source_labels = ["__meta_kubernetes_namespace"]
+      action = "replace"
+      target_label = "namespace"
+    }
+    rule {  // Drop anything with a "falsy" annotation value
+      source_labels = ["__meta_kubernetes_pod_annotation_logs_grafana_com_pods_enabled"]
+      regex = "(false|no|skip)"
+      action = "drop"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_pod_name"]
+      target_label = "pod"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_pod_container_name"]
+      target_label = "container"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_namespace", "__meta_kubernetes_pod_container_name"]
+      separator = "/"
+      replacement = "$1"
+      target_label = "job"
+    }
+
+    // set the container runtime as a label
+    rule {
+      source_labels = ["__meta_kubernetes_pod_container_id"]
+      regex = "^(\\S+):\\/\\/.+$"
+      replacement = "$1"
+      target_label = "tmp_container_runtime"
+    }
+    // explicitly set service_name. if not set, loki will automatically try to populate a default.
+    // see https://grafana.com/docs/loki/latest/get-started/labels/#default-labels-for-all-users
+    //
+    // choose the first value found from the following ordered list:
+    // - pod.annotation[resource.opentelemetry.io/service.name]
+    // - pod.label[app.kubernetes.io/name]
+    // - k8s.container.name
+    rule {
+      source_labels = [
+        "__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_name",
+        "__meta_kubernetes_pod_label_app_kubernetes_io_name",
+        "__meta_kubernetes_pod_container_name",
+      ]
+      separator = ";"
+      regex = "^(?:;*)?([^;]+).*$"
+      replacement = "$1"
+      target_label = "service_name"
+    }
+
+    // explicitly set service_namespace.
+    //
+    // choose the first value found from the following ordered list:
+    // - pod.annotation[resource.opentelemetry.io/service.namespace]
+    // - pod.namespace
+    rule {
+      source_labels = [
+        "__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_namespace",
+        "namespace",
+      ]
+      separator = ";"
+      regex = "^(?:;*)?([^;]+).*$"
+      replacement = "$1"
+      target_label = "service_namespace"
+    }
+
+    // explicitly set service_instance_id.
+    //
+    // choose the first value found from the following ordered list:
+    // - pod.annotation[resource.opentelemetry.io/service.instance.id]
+    // - concat([k8s.namespace.name, k8s.pod.name, k8s.container.name], '.')
+    rule {
+      source_labels = ["__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_instance_id"]
+      target_label = "service_instance_id"
+    }
+    rule {
+      source_labels = ["service_instance_id", "namespace", "pod", "container"]
+      separator = "."
+      regex = "^\\.([^.]+\\.[^.]+\\.[^.]+)$"
+      target_label = "service_instance_id"
+    }
+
+    // set resource attributes
+    rule {
+      action = "labelmap"
+      regex = "__meta_kubernetes_pod_annotation_resource_opentelemetry_io_(.+)"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_job"]
+      regex = "(.+)"
+      target_label = "job"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+      regex = "(.+)"
+      target_label = "app_kubernetes_io_name"
+    }
+
+    // Set the pod log path.
+    rule {
+      source_labels = ["__meta_kubernetes_pod_uid", "__meta_kubernetes_pod_container_name"]
+      separator = "/"
+      replacement = "/var/log/pods/*$1/*.log"
+      target_label = "__path__"
+    }
+
+    // If kubernetes.io/config.mirror is set, this is a static pod, created by the kubelet.
+    // It's logs live on a different path.
+    rule {
+      source_labels = ["__meta_kubernetes_pod_annotation_kubernetes_io_config_mirror", "__meta_kubernetes_pod_container_name"]
+      separator = "/"
+      regex = "(.+/.+)"
+      replacement = "/var/log/pods/*$1/*.log"
+      target_label = "__path__"
+    }
+    // add static label of integration="loki" and instance="name" to pods that match the selector so they can be identified in the loki.process stages
+    rule {
+      source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+      separator = ";"
+      regex = "(?:loki)"
+      target_label = "integration"
+      replacement = "loki"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+      separator = ";"
+      regex = "(?:loki)"
+      target_label = "instance"
+      replacement = "loki"
+    }
+    // override the job label to be namespace/component so it aligns to the loki-mixin
+    rule {
+      source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name","__meta_kubernetes_namespace","__meta_kubernetes_pod_label_component"]
+      separator = ";"
+      regex = "(?:loki);([^;]+);([^;]+)"
+      target_label = "job"
+      replacement = "$1/$2"
+    }
+  } // discovery.relabel "filtered_pods"
+
+  local.file_match "pod_logs" {
+    path_targets = discovery.relabel.filtered_pods.output
+  } // local.file_match "pod_logs"
+
+  loki.source.file "pod_logs" {
+    targets    = local.file_match.pod_logs.targets
+    tail_from_end = false
+    forward_to = [loki.process.pod_logs.receiver]
+  } // loki.source.file "pod_logs"
+
+  loki.process "pod_logs" {
+    stage.match {
+      selector = "{tmp_container_runtime=~\"containerd|cri-o|\"}"
+      // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
+      stage.cri {
+        max_partial_lines = 100
+      }
+
+      // Set the extract flags and stream values as labels
+      stage.labels {
+        values = {
+          flags  = "",
+          stream  = "",
+        }
+      }
+    }
+
+    stage.match {
+      selector = "{tmp_container_runtime=\"docker\"}"
+      // the docker processing stage extracts the following k/v pairs: log, stream, time
+      stage.docker {}
+
+      // Set the extract stream value as a label
+      stage.labels {
+        values = {
+          stream  = "",
+        }
+      }
+    }
+
+    // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
+    // namespace, pod, and container labels. Drop any structured metadata. Also drop the temporary
+    // container runtime label as it is no longer needed.
+    stage.label_drop {
+      values = [
+        "filename",
+        "tmp_container_runtime",
+      ]
+    }
+    stage.structured_metadata {
+      values = {
+        "k8s_pod_name" = "k8s_pod_name",
+        "pod" = "pod",
+        "service_instance_id" = "service_instance_id",
+      }
+    }
+    // Integration: Loki
+    stage.match {
+      selector = "{integration=\"loki\",instance=\"loki\"}"
+
+      // Only run the logfmt parser on lines that look like Loki's logfmt format (start with "ts=").
+      // Components like the gateway (nginx) or canary emit non-logfmt lines and would otherwise produce
+      // a flood of "failed to decode logfmt" errors. See https://github.com/grafana/k8s-monitoring-helm/issues/1726
+      stage.match {
+        selector = `{integration="loki",instance="loki"} |~ "^ts="`
+
+        // extract some of the fields from the log line
+        stage.logfmt {
+          mapping = {
+            "ts" = "",
+            "level" = "",
+          }
+        }
+
+        // set the level as a label
+        stage.labels {
+          values = {
+            level = "level",
+          }
+        }
+        // reset the timestamp to the extracted value
+        stage.timestamp {
+          source = "ts"
+          format = "RFC3339Nano"
+        }
+        // remove the timestamp from the log line
+        stage.replace {
+          expression = `(?:^|\s+)(ts=\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d+[^ ]*\s+)`
+          replace = ""
+        }
+        // drop certain log levels
+        stage.drop {
+          source = "level"
+          expression = "(?i)(debug)"
+          drop_counter_reason = "loki-drop-log-level"
+        }
+      }
+
+    }
+
+    forward_to = argument.logs_destinations.value
+  } // loki.secretfilter "pod_logs"
+} // declare "pod_logs_via_loki"
+pod_logs_via_loki "feature" {
+  logs_destinations = [
+    loki.write.localloki.receiver,
+  ]
+}
+
+
+
+
+
+// Destination: localLoki (loki)
+otelcol.exporter.loki "localloki" {
+  forward_to = [loki.write.localloki.receiver]
+} // otelcol.exporter.loki "localloki"
+
+loki.write "localloki" {
+  endpoint {
+    url = "http://loki.loki.svc:3100/loki/api/v1/push"
+    retry_on_http_429 = true
+    tenant_id = convert.nonsensitive(remote.kubernetes.secret.localloki.data["tenantId"])
+    basic_auth {
+      username = convert.nonsensitive(remote.kubernetes.secret.localloki.data["username"])
+      password = remote.kubernetes.secret.localloki.data["password"]
+    }
+    tls_config {
+      insecure_skip_verify = false
+    }
+    min_backoff_period = "500ms"
+    max_backoff_period = "5m"
+    max_backoff_retries = "10"
+  }
+  external_labels = {
+    "cluster" = "loki-integration-test",
+    "k8s_cluster_name" = "loki-integration-test",
+  }
+} // loki.write "localloki"
+
+remote.kubernetes.secret "localloki" {
+  name      = "localloki-k8smon-k8s-monitoring"
+  namespace = "default"
+} // remote.kubernetes.secret "localloki"
+

--- a/charts/k8s-monitoring/tests/integration/service-integrations/loki/.rendered/alloy-metrics.alloy
+++ b/charts/k8s-monitoring/tests/integration/service-integrations/loki/.rendered/alloy-metrics.alloy
@@ -1,0 +1,781 @@
+// Feature: Cluster Metrics
+declare "cluster_metrics" {
+  argument "metrics_destinations" {
+    comment = "Must be a list of metric destinations where collected metrics should be forwarded to"
+  }
+  discovery.kubernetes "nodes" {
+    role = "node"
+  } // discovery.kubernetes "nodes"
+
+  discovery.relabel "nodes" {
+    targets = discovery.kubernetes.nodes.targets
+    rule {
+      source_labels = ["__meta_kubernetes_node_name"]
+      target_label  = "node"
+    }
+
+    rule {
+      replacement = "kubernetes"
+      target_label = "source"
+    }
+  } // discovery.relabel "nodes"
+
+  // Kubelet
+  discovery.relabel "kubelet" {
+    targets = discovery.relabel.nodes.output
+  } // discovery.relabel "kubelet"
+
+  prometheus.scrape "kubelet" {
+    targets  = discovery.relabel.kubelet.output
+    job_name = "integrations/kubernetes/kubelet"
+    scheme   = "https"
+    scrape_interval = "60s"
+    scrape_timeout = "10s"
+    scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
+    scrape_classic_histograms = false
+    scrape_native_histograms = false
+    convert_classic_histograms_to_nhcb = false
+    bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+
+    tls_config {
+      ca_file = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+      insecure_skip_verify = true
+      server_name = "kubernetes"
+    }
+
+    clustering {
+      enabled = true
+    }
+
+    forward_to = [prometheus.relabel.kubelet.receiver]
+  } // prometheus.scrape "kubelet"
+
+  prometheus.relabel "kubelet" {
+    max_cache_size = 100000
+    rule {
+      source_labels = ["__name__"]
+      regex = "up|scrape_samples_scraped|go_goroutines|kubelet_certificate_manager_client_expiration_renew_errors|kubelet_certificate_manager_client_ttl_seconds|kubelet_certificate_manager_server_ttl_seconds|kubelet_cgroup_manager_duration_seconds_bucket|kubelet_cgroup_manager_duration_seconds_count|kubelet_node_config_error|kubelet_node_name|kubelet_pleg_relist_duration_seconds_bucket|kubelet_pleg_relist_duration_seconds_count|kubelet_pleg_relist_interval_seconds_bucket|kubelet_pod_start_duration_seconds_bucket|kubelet_pod_start_duration_seconds_count|kubelet_pod_worker_duration_seconds_bucket|kubelet_pod_worker_duration_seconds_count|kubelet_running_container_count|kubelet_running_containers|kubelet_running_pod_count|kubelet_running_pods|kubelet_runtime_operations_errors_total|kubelet_runtime_operations_total|kubelet_server_expiration_renew_errors|kubelet_volume_stats_available_bytes|kubelet_volume_stats_capacity_bytes|kubelet_volume_stats_inodes|kubelet_volume_stats_inodes_free|kubelet_volume_stats_inodes_used|kubelet_volume_stats_used_bytes|kubernetes_build_info|namespace_workload_pod|process_cpu_seconds_total|process_resident_memory_bytes|rest_client_requests_total|storage_operation_duration_seconds_count|storage_operation_errors_total|volume_manager_total_volumes"
+      action = "keep"
+    }
+
+    forward_to = argument.metrics_destinations.value
+  } // prometheus.relabel "kubelet"
+
+  // Kubelet Resources
+  discovery.relabel "kubelet_resources" {
+    targets = discovery.relabel.nodes.output
+    rule {
+      replacement   = "/metrics/resource"
+      target_label  = "__metrics_path__"
+    }
+  } // discovery.relabel "kubelet_resources"
+
+  prometheus.scrape "kubelet_resources" {
+    targets = discovery.relabel.kubelet_resources.output
+    job_name = "integrations/kubernetes/resources"
+    scheme   = "https"
+    scrape_interval = "60s"
+    scrape_timeout = "10s"
+    scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
+    scrape_classic_histograms = false
+    scrape_native_histograms = false
+    convert_classic_histograms_to_nhcb = false
+    bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+
+    tls_config {
+      ca_file = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+      insecure_skip_verify = true
+      server_name = "kubernetes"
+    }
+
+    clustering {
+      enabled = true
+    }
+
+    forward_to = [prometheus.relabel.kubelet_resources.receiver]
+  } // prometheus.scrape "kubelet_resources"
+
+  prometheus.relabel "kubelet_resources" {
+    max_cache_size = 100000
+    rule {
+      source_labels = ["__name__"]
+      regex = "up|scrape_samples_scraped|node_cpu_usage_seconds_total|node_memory_working_set_bytes"
+      action = "keep"
+    }
+
+    forward_to = argument.metrics_destinations.value
+  } // prometheus.relabel "kubelet_resources"
+
+  // cAdvisor
+  discovery.relabel "cadvisor" {
+    targets = discovery.relabel.nodes.output
+    rule {
+      replacement   = "/metrics/cadvisor"
+      target_label  = "__metrics_path__"
+    }
+  } // discovery.relabel "cadvisor"
+
+  prometheus.scrape "cadvisor" {
+    targets = discovery.relabel.cadvisor.output
+    job_name = "integrations/kubernetes/cadvisor"
+    scheme = "https"
+    scrape_interval = "60s"
+    scrape_timeout = "10s"
+    scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
+    scrape_classic_histograms = false
+    scrape_native_histograms = false
+    convert_classic_histograms_to_nhcb = false
+    bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+
+    tls_config {
+      ca_file = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+      insecure_skip_verify = true
+      server_name = "kubernetes"
+    }
+
+    clustering {
+      enabled = true
+    }
+
+    forward_to = [prometheus.relabel.cadvisor.receiver]
+  } // prometheus.scrape "cadvisor"
+
+  prometheus.relabel "cadvisor" {
+    max_cache_size = 100000
+    rule {
+      source_labels = ["__name__"]
+      regex = "up|scrape_samples_scraped|container_cpu_cfs_periods_total|container_cpu_cfs_throttled_periods_total|container_cpu_usage_seconds_total|container_fs_reads_bytes_total|container_fs_reads_total|container_fs_writes_bytes_total|container_fs_writes_total|container_memory_cache|container_memory_rss|container_memory_swap|container_memory_usage_bytes|container_memory_working_set_bytes|container_network_receive_bytes_total|container_network_receive_packets_dropped_total|container_network_receive_packets_total|container_network_transmit_bytes_total|container_network_transmit_packets_dropped_total|container_network_transmit_packets_total|machine_memory_bytes"
+      action = "keep"
+    }
+    // Drop empty container labels, addressing https://github.com/google/cadvisor/issues/2688
+    rule {
+      source_labels = ["__name__","container"]
+      separator = "@"
+      regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_pressure_.*)@"
+      action = "drop"
+    }
+    // Drop empty image labels, addressing https://github.com/google/cadvisor/issues/2688
+    rule {
+      source_labels = ["__name__","image"]
+      separator = "@"
+      regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_network_.*|container_pressure_.*)@"
+      action = "drop"
+    }
+    // Normalizing unimportant labels (not deleting to continue satisfying <label>!="" checks)
+    rule {
+      source_labels = ["__name__", "boot_id"]
+      separator = "@"
+      regex = "machine_memory_bytes@.*"
+      target_label = "boot_id"
+      replacement = "NA"
+    }
+    rule {
+      source_labels = ["__name__", "system_uuid"]
+      separator = "@"
+      regex = "machine_memory_bytes@.*"
+      target_label = "system_uuid"
+      replacement = "NA"
+    }
+    // Filter out non-physical devices/interfaces
+    rule {
+      source_labels = ["__name__", "device"]
+      separator = "@"
+      regex = "container_fs_.*@(/dev/)?(mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dasd.+)"
+      target_label = "__keepme"
+      replacement = "1"
+    }
+    rule {
+      source_labels = ["__name__", "__keepme"]
+      separator = "@"
+      regex = "container_fs_.*@"
+      action = "drop"
+    }
+    rule {
+      source_labels = ["__name__"]
+      regex = "container_fs_.*"
+      target_label = "__keepme"
+      replacement = ""
+    }
+    rule {
+      source_labels = ["__name__", "interface"]
+      separator = "@"
+      regex = "container_network_.*@(en[ospx][0-9].*|wlan[0-9].*|eth[0-9].*)"
+      target_label = "__keepme"
+      replacement = "1"
+    }
+    rule {
+      source_labels = ["__name__", "__keepme"]
+      separator = "@"
+      regex = "container_network_.*@"
+      action = "drop"
+    }
+    rule {
+      source_labels = ["__name__"]
+      regex = "container_network_.*"
+      target_label = "__keepme"
+      replacement = ""
+    }
+    forward_to = argument.metrics_destinations.value
+  } // prometheus.relabel "cadvisor"
+  discovery.kubernetes "kube_state_metrics" {
+    role = "endpoints"
+
+    selectors {
+      role = "endpoints"
+      label = "release=k8smon,app.kubernetes.io/name=kube-state-metrics"
+    }
+    namespaces {
+      names = ["default"]
+    }
+  } // discovery.kubernetes "kube_state_metrics"
+
+  discovery.relabel "kube_state_metrics" {
+    targets = discovery.kubernetes.kube_state_metrics.targets
+
+    rule {
+      action = "replace"
+      replacement = "kubernetes"
+      target_label = "source"
+    }
+
+  } // discovery.relabel "kube_state_metrics"
+
+  prometheus.scrape "kube_state_metrics" {
+    targets = discovery.relabel.kube_state_metrics.output
+    job_name = "integrations/kubernetes/kube-state-metrics"
+    scrape_interval = "60s"
+    scrape_timeout = "10s"
+    scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
+    scrape_classic_histograms = false
+    scrape_native_histograms = false
+    convert_classic_histograms_to_nhcb = false
+    scheme = "http"
+    bearer_token_file = ""
+    tls_config {
+      insecure_skip_verify = true
+    }
+
+    clustering {
+      enabled = true
+    }
+    forward_to = [prometheus.relabel.kube_state_metrics.receiver]
+  } // prometheus.scrape "kube_state_metrics"
+
+  prometheus.relabel "kube_state_metrics" {
+    max_cache_size = 100000
+    rule {
+      source_labels = ["__name__"]
+      regex = "up|scrape_samples_scraped|kube_configmap_info|kube_configmap_metadata_resource_version|kube_cronjob.*|kube_daemonset.*|kube_deployment_metadata_generation|kube_deployment_spec_replicas|kube_deployment_status_condition|kube_deployment_status_observed_generation|kube_deployment_status_replicas_available|kube_deployment_status_replicas_updated|kube_horizontalpodautoscaler_spec_max_replicas|kube_horizontalpodautoscaler_spec_min_replicas|kube_horizontalpodautoscaler_status_current_replicas|kube_horizontalpodautoscaler_status_desired_replicas|kube_job.*|kube_namespace_status_phase|kube_node.*|kube_persistentvolume_status_phase|kube_persistentvolumeclaim_access_mode|kube_persistentvolumeclaim_info|kube_persistentvolumeclaim_labels|kube_persistentvolumeclaim_resource_requests_storage_bytes|kube_persistentvolumeclaim_status_phase|kube_pod_completion_time|kube_pod_container_info|kube_pod_container_resource_limits|kube_pod_container_resource_requests|kube_pod_container_status_last_terminated_reason|kube_pod_container_status_last_terminated_timestamp|kube_pod_container_status_restarts_total|kube_pod_container_status_waiting_reason|kube_pod_info|kube_pod_owner|kube_pod_restart_policy|kube_pod_spec_volumes_persistentvolumeclaims_info|kube_pod_start_time|kube_pod_status_phase|kube_pod_status_reason|kube_pod_init_.*|kube_replicaset.*|kube_resourcequota|kube_secret_metadata_resource_version|kube_statefulset.*"
+      action = "keep"
+    }
+    forward_to = argument.metrics_destinations.value
+  } // prometheus.relabel "kube_state_metrics"
+} // declare "cluster_metrics"
+cluster_metrics "feature" {
+  metrics_destinations = [
+    prometheus.remote_write.localprometheus.receiver,
+  ]
+}
+// Feature: Host Metrics
+declare "host_metrics" {
+  argument "metrics_destinations" {
+    comment = "Must be a list of metric destinations where collected metrics should be forwarded to"
+  }
+
+  // Linux hosts via Node Exporter
+  discovery.kubernetes "node_exporter" {
+    role = "pod"
+    selectors {
+      role = "pod"
+      label = "release=k8smon,app.kubernetes.io/name=node-exporter"
+    }
+    namespaces {
+      names = ["default"]
+    }
+
+  } // discovery.kubernetes "node_exporter"
+
+  discovery.relabel "node_exporter" {
+    targets = discovery.kubernetes.node_exporter.targets
+
+    // keep only the specified metrics port name, and pods that are Running and ready
+    rule {
+      source_labels = [
+        "__meta_kubernetes_pod_container_init",
+        "__meta_kubernetes_pod_phase",
+        "__meta_kubernetes_pod_ready",
+      ]
+      separator = "@"
+      regex = "false@Running@true"
+      action = "keep"
+    }
+
+    // Set the instance label to the node name
+    rule {
+      source_labels = ["__meta_kubernetes_pod_node_name"]
+      target_label = "instance"
+    }
+
+    rule {
+      source_labels = ["__meta_kubernetes_namespace"]
+      target_label  = "namespace"
+    }
+
+    rule {
+      source_labels = ["__meta_kubernetes_pod_name"]
+      target_label  = "pod"
+    }
+
+    rule {
+      source_labels = ["__meta_kubernetes_pod_container_name"]
+      target_label  = "container"
+    }
+
+    // set a workload label
+    rule {
+      source_labels = [
+        "__meta_kubernetes_pod_controller_kind",
+        "__meta_kubernetes_pod_controller_name",
+      ]
+      separator = "/"
+      target_label  = "workload"
+    }
+    // remove the hash from the ReplicaSet
+    rule {
+      source_labels = ["workload"]
+      regex = "(ReplicaSet/.+)-.+"
+      target_label  = "workload"
+    }
+
+    // Set the app label.
+    //
+    // Choose the first value found from the following ordered list:
+    // - pod.label[app.kubernetes.io/name]
+    // - pod.label[k8s-app]
+    // - pod.label[app]
+    rule {
+      source_labels = [
+        "__meta_kubernetes_pod_label_app_kubernetes_io_name",
+        "__meta_kubernetes_pod_label_k8s_app",
+        "__meta_kubernetes_pod_label_app",
+      ]
+      separator = ";"
+      regex = "^(?:;*)?([^;]+).*$"
+      replacement = "$1"
+      target_label = "app"
+    }
+
+    // Set the component label.
+    //
+    // Choose the first value found from the following ordered list:
+    // - pod.label[app.kubernetes.io/component]
+    // - pod.label[k8s-component]
+    // - pod.label[component]
+    rule {
+      source_labels = [
+        "__meta_kubernetes_pod_label_app_kubernetes_io_component",
+        "__meta_kubernetes_pod_label_k8s_component",
+        "__meta_kubernetes_pod_label_component",
+      ]
+      regex = "^(?:;*)?([^;]+).*$"
+      replacement = "$1"
+      target_label = "component"
+    }
+
+    rule {
+      target_label = "source"
+      replacement = "kubernetes"
+    }
+
+  } // discovery.relabel "node_exporter"
+
+  prometheus.scrape "node_exporter" {
+    targets = discovery.relabel.node_exporter.output
+    job_name = "integrations/node_exporter"
+    scrape_interval = "60s"
+    scrape_timeout = "10s"
+    scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
+    scrape_classic_histograms = false
+    scrape_native_histograms = false
+    convert_classic_histograms_to_nhcb = false
+    scheme = "http"
+    tls_config {
+      insecure_skip_verify = true
+    }
+
+    clustering {
+      enabled = true
+    }
+    forward_to = [prometheus.relabel.node_exporter.receiver]
+  } // prometheus.scrape "node_exporter"
+
+  prometheus.relabel "node_exporter" {
+    max_cache_size = 100000
+    rule {
+      source_labels = ["__name__"]
+      regex = "up|scrape_samples_scraped|node_cpu.*|node_exporter_build_info|node_filesystem.*|node_memory.*|node_network_receive_bytes_total|node_network_receive_drop_total|node_network_transmit_bytes_total|node_network_transmit_drop_total|process_cpu_seconds_total|process_resident_memory_bytes"
+      action = "keep"
+    }
+    // Drop metrics for certain file systems
+    rule {
+      source_labels = ["__name__", "fstype"]
+      separator = "@"
+      regex = "node_filesystem.*@(ramfs|tmpfs)"
+      action = "drop"
+    }
+    forward_to = argument.metrics_destinations.value
+  } // prometheus.relabel "node_exporter"
+} // declare "host_metrics"
+host_metrics "feature" {
+  metrics_destinations = [
+    prometheus.remote_write.localprometheus.receiver,
+  ]
+}
+declare "loki_integration" {
+  argument "metrics_destinations" {
+    comment = "Must be a list of metric destinations where collected metrics should be forwarded to"
+  }
+
+  declare "loki_integration_discovery" {
+    argument "namespaces" {
+      comment = "The namespaces to look for targets in (default: [] is all namespaces)"
+      optional = true
+    }
+
+    argument "field_selectors" {
+      comment = "The field selectors to use to find matching targets (default: [])"
+      optional = true
+    }
+
+    argument "label_selectors" {
+      comment = "The label selectors to use to find matching targets (default: [\"app.kubernetes.io/name=loki\"])"
+      optional = true
+    }
+
+    argument "port_name" {
+      comment = "The of the port to scrape metrics from (default: http-metrics)"
+      optional = true
+    }
+
+    // loki service discovery for all of the pods
+    discovery.kubernetes "loki_pods" {
+      role = "pod"
+
+      selectors {
+        role = "pod"
+        field = string.join(coalesce(argument.field_selectors.value, []), ",")
+        label = string.join(coalesce(argument.label_selectors.value, ["app.kubernetes.io/name=loki"]), ",")
+      }
+
+      namespaces {
+        names = coalesce(argument.namespaces.value, [])
+      }
+
+    } // discovery.kubernetes "loki_pods"
+
+    // loki relabelings (pre-scrape)
+    discovery.relabel "loki_pods" {
+      targets = discovery.kubernetes.loki_pods.targets
+
+      // keep only the specified metrics port name, and pods that are Running and ready
+      rule {
+        source_labels = [
+          "__meta_kubernetes_pod_container_port_name",
+          "__meta_kubernetes_pod_phase",
+          "__meta_kubernetes_pod_ready",
+          "__meta_kubernetes_pod_container_init",
+        ]
+        separator = "@"
+        regex = coalesce(argument.port_name.value, "http-metrics") + "@Running@true@false"
+        action = "keep"
+      }
+
+      rule {
+        source_labels = ["__meta_kubernetes_pod_node_name"]
+        target_label = "node"
+      }
+
+      // the loki-mixin expects the job label to be namespace/component
+      rule {
+        source_labels = ["__meta_kubernetes_namespace","__meta_kubernetes_pod_label_app_kubernetes_io_component"]
+        separator = "/"
+        target_label = "job"
+      }
+
+
+
+      rule {
+        source_labels = ["__meta_kubernetes_namespace"]
+        target_label  = "namespace"
+      }
+
+      rule {
+        source_labels = ["__meta_kubernetes_pod_name"]
+        target_label  = "pod"
+      }
+
+      rule {
+        source_labels = ["__meta_kubernetes_pod_container_name"]
+        target_label  = "container"
+      }
+
+      // set the workload to the controller kind and name
+      rule {
+        action = "lowercase"
+        source_labels = ["__meta_kubernetes_pod_controller_kind"]
+        target_label  = "workload_type"
+      }
+
+      rule {
+        source_labels = ["__meta_kubernetes_pod_controller_name"]
+        target_label  = "workload"
+      }
+
+      // remove the hash from the ReplicaSet
+      rule {
+        source_labels = [
+          "workload_type",
+          "workload",
+        ]
+        separator = "/"
+        regex = "replicaset/(.+)-.+$"
+        target_label  = "workload"
+      }
+
+      // set the app name if specified as metadata labels "app:" or "app.kubernetes.io/name:" or "k8s-app:"
+      rule {
+        action = "replace"
+        source_labels = [
+          "__meta_kubernetes_pod_label_app_kubernetes_io_name",
+          "__meta_kubernetes_pod_label_k8s_app",
+          "__meta_kubernetes_pod_label_app",
+        ]
+        separator = ";"
+        regex = "^(?:;*)?([^;]+).*$"
+        replacement = "$1"
+        target_label = "app"
+      }
+
+      // set the component if specified as metadata labels "component:" or "app.kubernetes.io/component:" or "k8s-component:"
+      rule {
+        action = "replace"
+        source_labels = [
+          "__meta_kubernetes_pod_label_app_kubernetes_io_component",
+          "__meta_kubernetes_pod_label_k8s_component",
+          "__meta_kubernetes_pod_label_component",
+        ]
+        regex = "^(?:;*)?([^;]+).*$"
+        replacement = "$1"
+        target_label = "component"
+      }
+
+      // set a source label
+      rule {
+        action = "replace"
+        replacement = "kubernetes"
+        target_label = "source"
+      }
+
+    } // discovery.relabel "loki_pods"
+
+    export "output" {
+      value = discovery.relabel.loki_pods.output
+    }
+  }
+
+  declare "loki_integration_scrape" {
+    argument "targets" {
+      comment = "Must be a list() of targets"
+    }
+
+    argument "forward_to" {
+      comment = "Must be a list(MetricsReceiver) where collected metrics should be forwarded to"
+    }
+
+    argument "job_label" {
+      comment = "The job label to add for all Loki metrics (default: integrations/loki)"
+      optional = true
+    }
+
+    argument "keep_metrics" {
+      comment = "A regular expression of metrics to keep (default: see below)"
+      optional = true
+    }
+
+    argument "drop_metrics" {
+      comment = "A regular expression of metrics to drop (default: see below)"
+      optional = true
+    }
+
+    argument "scrape_interval" {
+      comment = "How often to scrape metrics from the targets (default: 60s)"
+      optional = true
+    }
+
+    argument "scrape_timeout" {
+      comment = "The timeout for scraping metrics from the targets (default: 10s)"
+      optional = true
+    }
+
+    argument "scrape_protocols" {
+      comment = "The scrape protocols to use for scraping metrics"
+      optional = true
+    }
+
+    argument "scrape_classic_histograms" {
+      comment = "Whether to scrape classic histograms (default: false)."
+      optional = true
+    }
+
+    argument "scrape_native_histograms" {
+      comment = "Whether to scrape native histograms (default: false)."
+      optional = true
+    }
+
+    argument "max_cache_size" {
+      comment = "The maximum number of elements to hold in the relabeling cache (default: 100000).  This should be at least 2x-5x your largest scrape target or samples appended rate."
+      optional = true
+    }
+
+    argument "clustering" {
+      comment = "Whether or not clustering should be enabled (default: false)"
+      optional = true
+    }
+
+    prometheus.scrape "loki" {
+      job_name = coalesce(argument.job_label.value, "integrations/loki")
+      forward_to = [prometheus.relabel.loki.receiver]
+      targets = argument.targets.value
+      scrape_interval = coalesce(argument.scrape_interval.value, "60s")
+      scrape_timeout = coalesce(argument.scrape_timeout.value, "10s")
+      scrape_protocols = argument.scrape_protocols.value
+      scrape_classic_histograms = argument.scrape_classic_histograms.value
+      scrape_native_histograms = argument.scrape_native_histograms.value
+
+      clustering {
+        enabled = coalesce(argument.clustering.value, false)
+      }
+    } // prometheus.scrape "loki"
+
+    // loki metric relabelings (post-scrape)
+    prometheus.relabel "loki" {
+      forward_to = argument.forward_to.value
+      max_cache_size = coalesce(argument.max_cache_size.value, 100000)
+
+      // drop metrics that match the drop_metrics regex
+      rule {
+        source_labels = ["__name__"]
+        regex = coalesce(argument.drop_metrics.value, "")
+        action = "drop"
+      }
+
+      // keep only metrics that match the keep_metrics regex
+      rule {
+        source_labels = ["__name__"]
+        regex = coalesce(argument.keep_metrics.value, "(.+)")
+        action = "keep"
+      }
+
+      // the loki-mixin expects the instance label to be the node name
+      rule {
+        source_labels = ["node"]
+        target_label = "instance"
+        replacement = "$1"
+      }
+      rule {
+        action = "labeldrop"
+        regex = "node"
+      }
+
+      // set the memcached exporter container name from container="exporter" to container="memcached"
+      rule {
+        source_labels = ["component", "container"]
+        separator = ";"
+        regex = "memcached-[^;]+;exporter"
+        target_label = "container"
+        replacement = "memcached"
+      }
+    } // prometheus.relabel "loki"
+  }
+
+  loki_integration_discovery "loki" {
+    namespaces = []
+    label_selectors = ["app.kubernetes.io/name=loki"]
+    port_name = "http-metrics"
+  }
+
+  loki_integration_scrape  "loki" {
+    targets = loki_integration_discovery.loki.output
+    job_label = "integrations/loki"
+    clustering = true
+    keep_metrics = "up|scrape_samples_scraped|go_gc_cycles_total_gc_cycles_total|go_gc_duration_seconds|go_gc_duration_seconds_count|go_gc_duration_seconds_sum|go_gc_pauses_seconds_bucket|go_goroutines|go_memstats_heap_inuse_bytes|loki_azure_blob_request_duration_seconds_bucket|loki_azure_blob_request_duration_seconds_count|loki_bigtable_request_duration_seconds_bucket|loki_bigtable_request_duration_seconds_count|loki_bloom_blocks_cache_added_total|loki_bloom_blocks_cache_entries|loki_bloom_blocks_cache_evicted_total|loki_bloom_blocks_cache_fetched_total|loki_bloom_blocks_cache_usage_bytes|loki_bloom_chunks_indexed_total|loki_bloom_gateway_block_query_latency_seconds_bucket|loki_bloom_gateway_dequeue_duration_seconds_bucket|loki_bloom_gateway_filtered_chunks_sum|loki_bloom_gateway_filtered_series_sum|loki_bloom_gateway_inflight_tasks|loki_bloom_gateway_process_duration_seconds_bucket|loki_bloom_gateway_process_duration_seconds_count|loki_bloom_gateway_querier_chunks_filtered_total|loki_bloom_gateway_querier_chunks_skipped_total|loki_bloom_gateway_querier_chunks_total|loki_bloom_gateway_querier_series_filtered_total|loki_bloom_gateway_querier_series_skipped_total|loki_bloom_gateway_querier_series_total|loki_bloom_gateway_queue_duration_seconds_bucket|loki_bloom_gateway_queue_duration_seconds_count|loki_bloom_gateway_queue_duration_seconds_sum|loki_bloom_gateway_queue_length|loki_bloom_gateway_requested_chunks_sum|loki_bloom_gateway_requested_series_sum|loki_bloom_gateway_tasks_dequeued_bucket|loki_bloom_gateway_tasks_dequeued_total|loki_bloom_gateway_tasks_processed_total|loki_bloom_inserts_total|loki_bloom_recorder_chunks_total|loki_bloom_recorder_series_total|loki_bloom_size_bucket|loki_bloom_store_blocks_fetched_size_bytes_bucket|loki_bloom_store_blocks_fetched_sum|loki_bloom_store_download_queue_size_sum|loki_bloom_store_metas_fetched_bucket|loki_bloom_store_metas_fetched_size_bytes_bucket|loki_bloom_store_metas_fetched_sum|loki_bloom_tokens_total|loki_bloombuilder_blocks_created_total|loki_bloombuilder_blocks_reused_total|loki_bloombuilder_bytes_per_task_bucket|loki_bloombuilder_chunk_series_size_sum|loki_bloombuilder_metas_created_total|loki_bloombuilder_processing_task|loki_bloombuilder_series_per_task_bucket|loki_bloomplanner_blocks_deleted_total|loki_bloomplanner_connected_builders|loki_bloomplanner_inflight_tasks|loki_bloomplanner_metas_deleted_total|loki_bloomplanner_queue_length|loki_bloomplanner_retention_running|loki_bloomplanner_retention_time_seconds_bucket|loki_bloomplanner_tenant_tasks_completed|loki_bloomplanner_tenant_tasks_planned|loki_boltdb_shipper_compact_tables_operation_duration_seconds|loki_boltdb_shipper_compact_tables_operation_last_successful_run_timestamp_seconds|loki_boltdb_shipper_compact_tables_operation_total|loki_boltdb_shipper_request_duration_seconds_bucket|loki_boltdb_shipper_request_duration_seconds_count|loki_boltdb_shipper_request_duration_seconds_sum|loki_boltdb_shipper_retention_marker_count_total|loki_boltdb_shipper_retention_marker_table_processed_duration_seconds_bucket|loki_boltdb_shipper_retention_marker_table_processed_duration_seconds_count|loki_boltdb_shipper_retention_marker_table_processed_duration_seconds_sum|loki_boltdb_shipper_retention_marker_table_processed_total|loki_boltdb_shipper_retention_sweeper_chunk_deleted_duration_seconds_bucket|loki_boltdb_shipper_retention_sweeper_chunk_deleted_duration_seconds_count|loki_boltdb_shipper_retention_sweeper_chunk_deleted_duration_seconds_sum|loki_boltdb_shipper_retention_sweeper_marker_file_processing_current_time|loki_boltdb_shipper_retention_sweeper_marker_files_current|loki_build_info|loki_chunk_store_deduped_chunks_total|loki_chunk_store_index_entries_per_chunk_count|loki_chunk_store_index_entries_per_chunk_sum|loki_compactor_apply_retention_last_successful_run_timestamp_seconds|loki_compactor_apply_retention_operation_duration_seconds|loki_compactor_apply_retention_operation_total|loki_compactor_delete_requests_processed_total|loki_compactor_delete_requests_received_total|loki_compactor_deleted_lines|loki_compactor_load_pending_requests_attempts_total|loki_compactor_locked_table_successive_compaction_skips|loki_compactor_oldest_pending_delete_request_age_seconds|loki_compactor_pending_delete_requests_count|loki_consul_request_duration_seconds_bucket|loki_discarded_samples_total|loki_distributor_bytes_received_total|loki_distributor_ingester_append_failures_total|loki_distributor_lines_received_total|loki_distributor_structured_metadata_bytes_received_total|loki_dynamo_consumed_capacity_total|loki_dynamo_dropped_requests_total|loki_dynamo_failures_total|loki_dynamo_query_pages_count|loki_dynamo_request_duration_seconds_bucket|loki_dynamo_request_duration_seconds_count|loki_dynamo_throttled_total|loki_embeddedcache_entries|loki_embeddedcache_memory_bytes|loki_gcs_request_duration_seconds_bucket|loki_gcs_request_duration_seconds_count|loki_index_gateway_postfilter_chunks_sum|loki_index_gateway_prefilter_chunks_sum|loki_index_request_duration_seconds_bucket|loki_index_request_duration_seconds_count|loki_index_request_duration_seconds_sum|loki_ingester_chunk_age_seconds_bucket|loki_ingester_chunk_age_seconds_count|loki_ingester_chunk_age_seconds_sum|loki_ingester_chunk_bounds_hours_bucket|loki_ingester_chunk_bounds_hours_count|loki_ingester_chunk_bounds_hours_sum|loki_ingester_chunk_entries_bucket|loki_ingester_chunk_entries_count|loki_ingester_chunk_entries_sum|loki_ingester_chunk_size_bytes_bucket|loki_ingester_chunk_utilization_bucket|loki_ingester_chunk_utilization_count|loki_ingester_chunk_utilization_sum|loki_ingester_chunks_flushed_total|loki_ingester_flush_queue_length|loki_ingester_memory_chunks|loki_ingester_memory_streams|loki_ingester_streams_created_total|loki_memcache_request_duration_seconds_bucket|loki_memcache_request_duration_seconds_count|loki_panic_total|loki_prometheus_rule_group_rules|loki_request_duration_seconds_bucket|loki_request_duration_seconds_count|loki_request_duration_seconds_sum|loki_ruler_wal_appender_ready|loki_ruler_wal_disk_size|loki_ruler_wal_prometheus_remote_storage_highest_timestamp_in_seconds|loki_ruler_wal_prometheus_remote_storage_queue_highest_sent_timestamp_seconds|loki_ruler_wal_prometheus_remote_storage_samples_pending|loki_ruler_wal_prometheus_remote_storage_samples_total|loki_ruler_wal_samples_appended_total|loki_ruler_wal_storage_created_series_total|loki_s3_request_duration_seconds_bucket|loki_s3_request_duration_seconds_count|loki_objstore_bucket_operation_duration_seconds_bucket|loki_objstore_bucket_operation_duration_seconds_count|loki_objstore_bucket_operation_duration_seconds_sum|loki_objstore_bucket_operation_failures_total|loki_objstore_bucket_operations_total|loki_objstore_bucket_transport_requests_total"
+    scrape_interval = "60s"
+    scrape_timeout = "10s"
+    scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
+    scrape_classic_histograms = false
+    scrape_native_histograms = false
+    max_cache_size = 100000
+    forward_to = argument.metrics_destinations.value
+  }
+}
+loki_integration "integration" {
+  metrics_destinations = [
+    prometheus.remote_write.localprometheus.receiver,
+  ]
+}
+
+
+
+
+
+// Destination: localPrometheus (prometheus)
+otelcol.exporter.prometheus "localprometheus" {
+  add_metric_suffixes = true
+  resource_to_telemetry_conversion = false
+  keep_identifying_resource_attributes = true
+  forward_to = [prometheus.remote_write.localprometheus.receiver]
+} // otelcol.exporter.prometheus "localprometheus"
+
+prometheus.remote_write "localprometheus" {
+  endpoint {
+    url = "http://prometheus-server.prometheus.svc:9090/api/v1/write"
+    headers = {
+    }
+    basic_auth {
+      username = convert.nonsensitive(remote.kubernetes.secret.localprometheus.data["username"])
+      password = remote.kubernetes.secret.localprometheus.data["password"]
+    }
+    tls_config {
+      insecure_skip_verify = false
+    }
+    send_native_histograms = false
+
+    queue_config {
+      capacity = 10000
+      min_shards = 1
+      max_shards = 50
+      max_samples_per_send = 2000
+      batch_send_deadline = "5s"
+      min_backoff = "30ms"
+      max_backoff = "5s"
+      retry_on_http_429 = true
+      sample_age_limit = "0s"
+    }
+  }
+
+  wal {
+    truncate_frequency = "2h"
+    min_keepalive_time = "5m"
+    max_keepalive_time = "8h"
+  }
+  external_labels = {
+    "cluster" = "loki-integration-test",
+    "k8s_cluster_name" = "loki-integration-test",
+  }
+} // prometheus.remote_write "localprometheus"
+
+remote.kubernetes.secret "localprometheus" {
+  name      = "localprometheus-k8smon-k8s-monitoring"
+  namespace = "default"
+} // remote.kubernetes.secret "localprometheus"
+

--- a/charts/k8s-monitoring/tests/integration/service-integrations/loki/.rendered/alloy-singleton.alloy
+++ b/charts/k8s-monitoring/tests/integration/service-integrations/loki/.rendered/alloy-singleton.alloy
@@ -1,0 +1,214 @@
+// Feature: Cluster Events
+declare "cluster_events" {
+  argument "logs_destinations" {
+    comment = "Must be a list of log destinations where collected logs should be forwarded to"
+  }
+
+  loki.source.kubernetes_events "cluster_events" {
+    job_name   = "integrations/kubernetes/eventhandler"
+    log_format = "logfmt"
+    forward_to = [loki.process.cluster_events.receiver]
+  } // loki.source.kubernetes_events "cluster_events"
+
+  loki.process "cluster_events" {
+
+    // add a static source label to the logs so they can be differentiated / restricted if necessary
+    stage.static_labels {
+      values = {
+        "source" = "kubernetes-events",
+      }
+    }
+
+    // extract some of the fields from the log line, these could be used as labels, structured metadata, etc.
+    stage.logfmt {
+      mapping = {
+        "component" = "sourcecomponent", // map the sourcecomponent field to component
+        "kind" = "",
+        "level" = "type", // most events don't have a level but they do have a "type" i.e. Normal, Warning, Error, etc.
+        "name" = "",
+        "node" = "sourcehost", // map the sourcehost field to node
+        "reason" = "",
+      }
+    }
+    // set the extracted values as labels
+    stage.labels {
+      values = {
+        "kind" = "",
+        "level" = "",
+        "service_name" = "job",
+        "reason" = "reason",
+      }
+    }
+
+    // if kind=Node, set the node label by copying the name field
+    stage.match {
+      selector = "{kind=\"Node\"}"
+
+      stage.labels {
+        values = {
+          "node" = "name",
+        }
+      }
+    }
+
+    // set the level extracted key value as a normalized log level
+    stage.match {
+      selector = "{level=\"Normal\"}"
+
+      stage.static_labels {
+        values = {
+          level = "Info",
+        }
+      }
+    }
+    stage.structured_metadata {
+      values = {
+        "name" = "name",
+        "node" = "node",
+      }
+    }
+
+    // Drop pipeline-only labels that are not needed in the final output.
+    stage.label_drop {
+      values = ["kind"]
+    }
+
+    forward_to = argument.logs_destinations.value
+  } // loki.process "cluster_events"
+} // declare "cluster_events"
+cluster_events "feature" {
+  logs_destinations = [
+    loki.write.localloki.receiver,
+  ]
+}
+// Self Reporting
+prometheus.exporter.unix "kubernetes_monitoring_telemetry" {
+  set_collectors = ["textfile"]
+  textfile {
+    directory = "/etc/release-info"
+  }
+} // prometheus.exporter.unix "kubernetes_monitoring_telemetry"
+
+discovery.relabel "kubernetes_monitoring_telemetry" {
+  targets = prometheus.exporter.unix.kubernetes_monitoring_telemetry.targets
+  rule {
+    target_label = "instance"
+    action = "replace"
+    replacement = "k8smon"
+  }
+  rule {
+    target_label = "job"
+    action = "replace"
+    replacement = "integrations/kubernetes/kubernetes_monitoring_telemetry"
+  }
+} // discovery.relabel "kubernetes_monitoring_telemetry"
+
+prometheus.scrape "kubernetes_monitoring_telemetry" {
+  job_name   = "integrations/kubernetes/kubernetes_monitoring_telemetry"
+  targets    = discovery.relabel.kubernetes_monitoring_telemetry.output
+  scrape_interval = "60s"
+  clustering {
+    enabled = true
+  }
+  forward_to = [prometheus.relabel.kubernetes_monitoring_telemetry.receiver]
+} // prometheus.scrape "kubernetes_monitoring_telemetry"
+
+prometheus.relabel "kubernetes_monitoring_telemetry" {
+  rule {
+    source_labels = ["__name__"]
+    regex = "grafana_kubernetes_monitoring_.*"
+    action = "keep"
+  }
+  forward_to = [
+    prometheus.remote_write.localprometheus.receiver,
+  ]
+} // prometheus.relabel "kubernetes_monitoring_telemetry"
+
+
+
+
+
+// Destination: localLoki (loki)
+otelcol.exporter.loki "localloki" {
+  forward_to = [loki.write.localloki.receiver]
+} // otelcol.exporter.loki "localloki"
+
+loki.write "localloki" {
+  endpoint {
+    url = "http://loki.loki.svc:3100/loki/api/v1/push"
+    retry_on_http_429 = true
+    tenant_id = convert.nonsensitive(remote.kubernetes.secret.localloki.data["tenantId"])
+    basic_auth {
+      username = convert.nonsensitive(remote.kubernetes.secret.localloki.data["username"])
+      password = remote.kubernetes.secret.localloki.data["password"]
+    }
+    tls_config {
+      insecure_skip_verify = false
+    }
+    min_backoff_period = "500ms"
+    max_backoff_period = "5m"
+    max_backoff_retries = "10"
+  }
+  external_labels = {
+    "cluster" = "loki-integration-test",
+    "k8s_cluster_name" = "loki-integration-test",
+  }
+} // loki.write "localloki"
+
+remote.kubernetes.secret "localloki" {
+  name      = "localloki-k8smon-k8s-monitoring"
+  namespace = "default"
+} // remote.kubernetes.secret "localloki"
+
+
+// Destination: localPrometheus (prometheus)
+otelcol.exporter.prometheus "localprometheus" {
+  add_metric_suffixes = true
+  resource_to_telemetry_conversion = false
+  keep_identifying_resource_attributes = true
+  forward_to = [prometheus.remote_write.localprometheus.receiver]
+} // otelcol.exporter.prometheus "localprometheus"
+
+prometheus.remote_write "localprometheus" {
+  endpoint {
+    url = "http://prometheus-server.prometheus.svc:9090/api/v1/write"
+    headers = {
+    }
+    basic_auth {
+      username = convert.nonsensitive(remote.kubernetes.secret.localprometheus.data["username"])
+      password = remote.kubernetes.secret.localprometheus.data["password"]
+    }
+    tls_config {
+      insecure_skip_verify = false
+    }
+    send_native_histograms = false
+
+    queue_config {
+      capacity = 10000
+      min_shards = 1
+      max_shards = 50
+      max_samples_per_send = 2000
+      batch_send_deadline = "5s"
+      min_backoff = "30ms"
+      max_backoff = "5s"
+      retry_on_http_429 = true
+      sample_age_limit = "0s"
+    }
+  }
+
+  wal {
+    truncate_frequency = "2h"
+    min_keepalive_time = "5m"
+    max_keepalive_time = "8h"
+  }
+  external_labels = {
+    "cluster" = "loki-integration-test",
+    "k8s_cluster_name" = "loki-integration-test",
+  }
+} // prometheus.remote_write "localprometheus"
+
+remote.kubernetes.secret "localprometheus" {
+  name      = "localprometheus-k8smon-k8s-monitoring"
+  namespace = "default"
+} // remote.kubernetes.secret "localprometheus"
+

--- a/charts/k8s-monitoring/tests/integration/service-integrations/mysql/.rendered/alloy-logs.alloy
+++ b/charts/k8s-monitoring/tests/integration/service-integrations/mysql/.rendered/alloy-logs.alloy
@@ -1,0 +1,281 @@
+// Feature: Pod Logs (Loki)
+declare "pod_logs_via_loki" {
+  argument "logs_destinations" {
+    comment = "Must be a list of log destinations where collected logs should be forwarded to"
+  }
+
+  discovery.kubernetes "pods" {
+    role = "pod"
+    selectors {
+      role = "pod"
+      field = "spec.nodeName=" + sys.env("HOSTNAME")
+    }
+  } // discovery.kubernetes "pods"
+
+  discovery.relabel "filtered_pods" {
+    targets = discovery.kubernetes.pods.targets
+    rule {
+      source_labels = ["__meta_kubernetes_namespace"]
+      action = "replace"
+      target_label = "namespace"
+    }
+    rule {  // Drop anything with a "falsy" annotation value
+      source_labels = ["__meta_kubernetes_pod_annotation_logs_grafana_com_pods_enabled"]
+      regex = "(false|no|skip)"
+      action = "drop"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_pod_name"]
+      target_label = "pod"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_pod_container_name"]
+      target_label = "container"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_namespace", "__meta_kubernetes_pod_container_name"]
+      separator = "/"
+      replacement = "$1"
+      target_label = "job"
+    }
+
+    // set the container runtime as a label
+    rule {
+      source_labels = ["__meta_kubernetes_pod_container_id"]
+      regex = "^(\\S+):\\/\\/.+$"
+      replacement = "$1"
+      target_label = "tmp_container_runtime"
+    }
+    // explicitly set service_name. if not set, loki will automatically try to populate a default.
+    // see https://grafana.com/docs/loki/latest/get-started/labels/#default-labels-for-all-users
+    //
+    // choose the first value found from the following ordered list:
+    // - pod.annotation[resource.opentelemetry.io/service.name]
+    // - pod.label[app.kubernetes.io/name]
+    // - k8s.container.name
+    rule {
+      source_labels = [
+        "__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_name",
+        "__meta_kubernetes_pod_label_app_kubernetes_io_name",
+        "__meta_kubernetes_pod_container_name",
+      ]
+      separator = ";"
+      regex = "^(?:;*)?([^;]+).*$"
+      replacement = "$1"
+      target_label = "service_name"
+    }
+
+    // explicitly set service_namespace.
+    //
+    // choose the first value found from the following ordered list:
+    // - pod.annotation[resource.opentelemetry.io/service.namespace]
+    // - pod.namespace
+    rule {
+      source_labels = [
+        "__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_namespace",
+        "namespace",
+      ]
+      separator = ";"
+      regex = "^(?:;*)?([^;]+).*$"
+      replacement = "$1"
+      target_label = "service_namespace"
+    }
+
+    // explicitly set service_instance_id.
+    //
+    // choose the first value found from the following ordered list:
+    // - pod.annotation[resource.opentelemetry.io/service.instance.id]
+    // - concat([k8s.namespace.name, k8s.pod.name, k8s.container.name], '.')
+    rule {
+      source_labels = ["__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_instance_id"]
+      target_label = "service_instance_id"
+    }
+    rule {
+      source_labels = ["service_instance_id", "namespace", "pod", "container"]
+      separator = "."
+      regex = "^\\.([^.]+\\.[^.]+\\.[^.]+)$"
+      target_label = "service_instance_id"
+    }
+
+    // set resource attributes
+    rule {
+      action = "labelmap"
+      regex = "__meta_kubernetes_pod_annotation_resource_opentelemetry_io_(.+)"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_job"]
+      regex = "(.+)"
+      target_label = "job"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+      regex = "(.+)"
+      target_label = "app_kubernetes_io_name"
+    }
+
+    // Set the pod log path.
+    rule {
+      source_labels = ["__meta_kubernetes_pod_uid", "__meta_kubernetes_pod_container_name"]
+      separator = "/"
+      replacement = "/var/log/pods/*$1/*.log"
+      target_label = "__path__"
+    }
+
+    // If kubernetes.io/config.mirror is set, this is a static pod, created by the kubelet.
+    // It's logs live on a different path.
+    rule {
+      source_labels = ["__meta_kubernetes_pod_annotation_kubernetes_io_config_mirror", "__meta_kubernetes_pod_container_name"]
+      separator = "/"
+      regex = "(.+/.+)"
+      replacement = "/var/log/pods/*$1/*.log"
+      target_label = "__path__"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_instance"]
+      separator = ";"
+      regex = "(?:test-database)"
+      target_label = "integration"
+      replacement = "mysql"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_instance"]
+      separator = ";"
+      regex = "(?:test-database)"
+      target_label = "instance"
+      replacement = "test-database"
+    }
+  } // discovery.relabel "filtered_pods"
+
+  local.file_match "pod_logs" {
+    path_targets = discovery.relabel.filtered_pods.output
+  } // local.file_match "pod_logs"
+
+  loki.source.file "pod_logs" {
+    targets    = local.file_match.pod_logs.targets
+    tail_from_end = false
+    forward_to = [loki.process.pod_logs.receiver]
+  } // loki.source.file "pod_logs"
+
+  loki.process "pod_logs" {
+    stage.match {
+      selector = "{tmp_container_runtime=~\"containerd|cri-o|\"}"
+      // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
+      stage.cri {
+        max_partial_lines = 100
+      }
+
+      // Set the extract flags and stream values as labels
+      stage.labels {
+        values = {
+          flags  = "",
+          stream  = "",
+        }
+      }
+    }
+
+    stage.match {
+      selector = "{tmp_container_runtime=\"docker\"}"
+      // the docker processing stage extracts the following k/v pairs: log, stream, time
+      stage.docker {}
+
+      // Set the extract stream value as a label
+      stage.labels {
+        values = {
+          stream  = "",
+        }
+      }
+    }
+
+    // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
+    // namespace, pod, and container labels. Drop any structured metadata. Also drop the temporary
+    // container runtime label as it is no longer needed.
+    stage.label_drop {
+      values = [
+        "filename",
+        "tmp_container_runtime",
+      ]
+    }
+    stage.structured_metadata {
+      values = {
+        "k8s_pod_name" = "k8s_pod_name",
+        "pod" = "pod",
+        "service_instance_id" = "service_instance_id",
+      }
+    }
+    // Integration: MySQL
+    stage.match {
+      selector = "{integration=\"mysql\"}"
+
+      stage.regex {
+        expression = `(?P<timestamp>.+) (?P<thread>[\d]+) \[(?P<label>.+?)\]( \[(?P<err_code>.+?)\] \[(?P<subsystem>.+?)\])? (?P<msg>.+)`
+      }
+
+      stage.labels {
+        values = {
+          level = "label",
+          err_code = "err_code",
+          subsystem = "subsystem",
+        }
+      }
+
+      stage.drop {
+        expression = "^ *$"
+        drop_counter_reason = "drop empty lines"
+      }
+
+      stage.static_labels {
+        values = {
+          job = "integrations/mysql",
+        }
+      }
+
+      stage.label_drop {
+        values = ["integration"]
+      }
+    }
+
+    forward_to = argument.logs_destinations.value
+  } // loki.secretfilter "pod_logs"
+} // declare "pod_logs_via_loki"
+pod_logs_via_loki "feature" {
+  logs_destinations = [
+    loki.write.localloki.receiver,
+  ]
+}
+
+
+
+
+
+// Destination: localLoki (loki)
+otelcol.exporter.loki "localloki" {
+  forward_to = [loki.write.localloki.receiver]
+} // otelcol.exporter.loki "localloki"
+
+loki.write "localloki" {
+  endpoint {
+    url = "http://loki.loki.svc:3100/loki/api/v1/push"
+    retry_on_http_429 = true
+    tenant_id = convert.nonsensitive(remote.kubernetes.secret.localloki.data["tenantId"])
+    basic_auth {
+      username = convert.nonsensitive(remote.kubernetes.secret.localloki.data["username"])
+      password = remote.kubernetes.secret.localloki.data["password"]
+    }
+    tls_config {
+      insecure_skip_verify = false
+    }
+    min_backoff_period = "500ms"
+    max_backoff_period = "5m"
+    max_backoff_retries = "10"
+  }
+  external_labels = {
+    "cluster" = "mysql-integration-test-cluster",
+    "k8s_cluster_name" = "mysql-integration-test-cluster",
+  }
+} // loki.write "localloki"
+
+remote.kubernetes.secret "localloki" {
+  name      = "localloki-k8smon-k8s-monitoring"
+  namespace = "default"
+} // remote.kubernetes.secret "localloki"
+

--- a/charts/k8s-monitoring/tests/integration/service-integrations/mysql/.rendered/alloy-metrics.alloy
+++ b/charts/k8s-monitoring/tests/integration/service-integrations/mysql/.rendered/alloy-metrics.alloy
@@ -1,0 +1,143 @@
+declare "mysql_integration" {
+  argument "metrics_destinations" {
+    comment = "Must be a list of metric destinations where collected metrics should be forwarded to"
+  }
+
+  remote.kubernetes.secret "test_database" {
+    name      = "test-database-mysql"
+    namespace = "mysql"
+  } // remote.kubernetes.secret "test_database"
+
+  prometheus.exporter.mysql "test_database" {
+    data_source_name = string.format("%s:%s@(%s:%d)/",
+      convert.nonsensitive(remote.kubernetes.secret.test_database.data["mysql-username"]),
+      convert.nonsensitive(remote.kubernetes.secret.test_database.data["mysql-root-password"]),
+      "test-database-mysql.mysql.svc",
+      3306,
+    )
+    mysql.user {
+      privileges = true
+    }
+    enable_collectors = ["heartbeat","mysql.user"]
+  }
+  prometheus.scrape "test_database" {
+    targets = prometheus.exporter.mysql.test_database.targets
+    clustering {
+      enabled = true
+    }
+
+    scrape_interval = "60s"
+    scrape_timeout = "10s"
+    scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
+    scrape_classic_histograms = false
+    scrape_native_histograms = false
+    forward_to = [prometheus.relabel.test_database.receiver]
+  }
+
+  prometheus.relabel "test_database" {
+    max_cache_size = 100000
+    rule {
+      target_label = "instance"
+      replacement = "test-database"
+    }
+    rule {
+      target_label = "job"
+      replacement = "integration/mysql"
+    }
+    forward_to = argument.metrics_destinations.value
+  }
+}
+mysql_integration "integration" {
+  metrics_destinations = [
+    prometheus.remote_write.localprometheus.receiver,
+  ]
+}
+// Self Reporting
+prometheus.exporter.unix "kubernetes_monitoring_telemetry" {
+  set_collectors = ["textfile"]
+  textfile {
+    directory = "/etc/release-info"
+  }
+} // prometheus.exporter.unix "kubernetes_monitoring_telemetry"
+
+discovery.relabel "kubernetes_monitoring_telemetry" {
+  targets = prometheus.exporter.unix.kubernetes_monitoring_telemetry.targets
+  rule {
+    target_label = "instance"
+    action = "replace"
+    replacement = "k8smon"
+  }
+  rule {
+    target_label = "job"
+    action = "replace"
+    replacement = "integrations/kubernetes/kubernetes_monitoring_telemetry"
+  }
+} // discovery.relabel "kubernetes_monitoring_telemetry"
+
+prometheus.scrape "kubernetes_monitoring_telemetry" {
+  job_name   = "integrations/kubernetes/kubernetes_monitoring_telemetry"
+  targets    = discovery.relabel.kubernetes_monitoring_telemetry.output
+  scrape_interval = "60s"
+  clustering {
+    enabled = true
+  }
+  forward_to = [prometheus.relabel.kubernetes_monitoring_telemetry.receiver]
+} // prometheus.scrape "kubernetes_monitoring_telemetry"
+
+prometheus.relabel "kubernetes_monitoring_telemetry" {
+  rule {
+    source_labels = ["__name__"]
+    regex = "grafana_kubernetes_monitoring_.*"
+    action = "keep"
+  }
+  forward_to = [
+    prometheus.remote_write.localprometheus.receiver,
+  ]
+} // prometheus.relabel "kubernetes_monitoring_telemetry"
+
+
+
+
+
+// Destination: localPrometheus (prometheus)
+otelcol.exporter.prometheus "localprometheus" {
+  add_metric_suffixes = true
+  resource_to_telemetry_conversion = false
+  keep_identifying_resource_attributes = true
+  forward_to = [prometheus.remote_write.localprometheus.receiver]
+} // otelcol.exporter.prometheus "localprometheus"
+
+prometheus.remote_write "localprometheus" {
+  endpoint {
+    url = "http://prometheus-server.prometheus.svc:9090/api/v1/write"
+    headers = {
+    }
+    tls_config {
+      insecure_skip_verify = false
+    }
+    send_native_histograms = false
+
+    queue_config {
+      capacity = 10000
+      min_shards = 1
+      max_shards = 50
+      max_samples_per_send = 2000
+      batch_send_deadline = "5s"
+      min_backoff = "30ms"
+      max_backoff = "5s"
+      retry_on_http_429 = true
+      sample_age_limit = "0s"
+    }
+  }
+
+  wal {
+    truncate_frequency = "2h"
+    min_keepalive_time = "5m"
+    max_keepalive_time = "8h"
+  }
+  external_labels = {
+    "cluster" = "mysql-integration-test-cluster",
+    "k8s_cluster_name" = "mysql-integration-test-cluster",
+  }
+} // prometheus.remote_write "localprometheus"
+

--- a/charts/k8s-monitoring/tests/integration/service-integrations/tempo/.rendered/alloy-logs.alloy
+++ b/charts/k8s-monitoring/tests/integration/service-integrations/tempo/.rendered/alloy-logs.alloy
@@ -1,0 +1,295 @@
+// Feature: Pod Logs (Loki)
+declare "pod_logs_via_loki" {
+  argument "logs_destinations" {
+    comment = "Must be a list of log destinations where collected logs should be forwarded to"
+  }
+
+  discovery.kubernetes "pods" {
+    role = "pod"
+    selectors {
+      role = "pod"
+      field = "spec.nodeName=" + sys.env("HOSTNAME")
+    }
+  } // discovery.kubernetes "pods"
+
+  discovery.relabel "filtered_pods" {
+    targets = discovery.kubernetes.pods.targets
+    rule {
+      source_labels = ["__meta_kubernetes_namespace"]
+      action = "replace"
+      target_label = "namespace"
+    }
+    rule {  // Drop anything with a "falsy" annotation value
+      source_labels = ["__meta_kubernetes_pod_annotation_logs_grafana_com_pods_enabled"]
+      regex = "(false|no|skip)"
+      action = "drop"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_pod_name"]
+      target_label = "pod"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_pod_container_name"]
+      target_label = "container"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_namespace", "__meta_kubernetes_pod_container_name"]
+      separator = "/"
+      replacement = "$1"
+      target_label = "job"
+    }
+
+    // set the container runtime as a label
+    rule {
+      source_labels = ["__meta_kubernetes_pod_container_id"]
+      regex = "^(\\S+):\\/\\/.+$"
+      replacement = "$1"
+      target_label = "tmp_container_runtime"
+    }
+    // explicitly set service_name. if not set, loki will automatically try to populate a default.
+    // see https://grafana.com/docs/loki/latest/get-started/labels/#default-labels-for-all-users
+    //
+    // choose the first value found from the following ordered list:
+    // - pod.annotation[resource.opentelemetry.io/service.name]
+    // - pod.label[app.kubernetes.io/name]
+    // - k8s.container.name
+    rule {
+      source_labels = [
+        "__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_name",
+        "__meta_kubernetes_pod_label_app_kubernetes_io_name",
+        "__meta_kubernetes_pod_container_name",
+      ]
+      separator = ";"
+      regex = "^(?:;*)?([^;]+).*$"
+      replacement = "$1"
+      target_label = "service_name"
+    }
+
+    // explicitly set service_namespace.
+    //
+    // choose the first value found from the following ordered list:
+    // - pod.annotation[resource.opentelemetry.io/service.namespace]
+    // - pod.namespace
+    rule {
+      source_labels = [
+        "__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_namespace",
+        "namespace",
+      ]
+      separator = ";"
+      regex = "^(?:;*)?([^;]+).*$"
+      replacement = "$1"
+      target_label = "service_namespace"
+    }
+
+    // explicitly set service_instance_id.
+    //
+    // choose the first value found from the following ordered list:
+    // - pod.annotation[resource.opentelemetry.io/service.instance.id]
+    // - concat([k8s.namespace.name, k8s.pod.name, k8s.container.name], '.')
+    rule {
+      source_labels = ["__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_instance_id"]
+      target_label = "service_instance_id"
+    }
+    rule {
+      source_labels = ["service_instance_id", "namespace", "pod", "container"]
+      separator = "."
+      regex = "^\\.([^.]+\\.[^.]+\\.[^.]+)$"
+      target_label = "service_instance_id"
+    }
+
+    // set resource attributes
+    rule {
+      action = "labelmap"
+      regex = "__meta_kubernetes_pod_annotation_resource_opentelemetry_io_(.+)"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_job"]
+      regex = "(.+)"
+      target_label = "job"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+      regex = "(.+)"
+      target_label = "app_kubernetes_io_name"
+    }
+
+    // Set the pod log path.
+    rule {
+      source_labels = ["__meta_kubernetes_pod_uid", "__meta_kubernetes_pod_container_name"]
+      separator = "/"
+      replacement = "/var/log/pods/*$1/*.log"
+      target_label = "__path__"
+    }
+
+    // If kubernetes.io/config.mirror is set, this is a static pod, created by the kubelet.
+    // It's logs live on a different path.
+    rule {
+      source_labels = ["__meta_kubernetes_pod_annotation_kubernetes_io_config_mirror", "__meta_kubernetes_pod_container_name"]
+      separator = "/"
+      regex = "(.+/.+)"
+      replacement = "/var/log/pods/*$1/*.log"
+      target_label = "__path__"
+    }
+    // add static label of integration="tempo" and instance="name" to pods that match the selector so they can be identified in the tempo.process stages
+    rule {
+      source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+      separator = ";"
+      regex = "(?:tempo)"
+      target_label = "integration"
+      replacement = "tempo"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+      separator = ";"
+      regex = "(?:tempo)"
+      target_label = "instance"
+      replacement = "tempo"
+    }
+    // override the job label to be namespace/component so it aligns to the tempo-mixin
+    rule {
+      source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name","__meta_kubernetes_namespace","__meta_kubernetes_pod_label_component"]
+      separator = ";"
+      regex = "(?:tempo);([^;]+);([^;]+)"
+      target_label = "job"
+      replacement = "$1/$2"
+    }
+  } // discovery.relabel "filtered_pods"
+
+  local.file_match "pod_logs" {
+    path_targets = discovery.relabel.filtered_pods.output
+  } // local.file_match "pod_logs"
+
+  loki.source.file "pod_logs" {
+    targets    = local.file_match.pod_logs.targets
+    tail_from_end = false
+    forward_to = [loki.process.pod_logs.receiver]
+  } // loki.source.file "pod_logs"
+
+  loki.process "pod_logs" {
+    stage.match {
+      selector = "{tmp_container_runtime=~\"containerd|cri-o|\"}"
+      // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
+      stage.cri {
+        max_partial_lines = 100
+      }
+
+      // Set the extract flags and stream values as labels
+      stage.labels {
+        values = {
+          flags  = "",
+          stream  = "",
+        }
+      }
+    }
+
+    stage.match {
+      selector = "{tmp_container_runtime=\"docker\"}"
+      // the docker processing stage extracts the following k/v pairs: log, stream, time
+      stage.docker {}
+
+      // Set the extract stream value as a label
+      stage.labels {
+        values = {
+          stream  = "",
+        }
+      }
+    }
+
+    // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
+    // namespace, pod, and container labels. Drop any structured metadata. Also drop the temporary
+    // container runtime label as it is no longer needed.
+    stage.label_drop {
+      values = [
+        "filename",
+        "tmp_container_runtime",
+      ]
+    }
+    stage.structured_metadata {
+      values = {
+        "k8s_pod_name" = "k8s_pod_name",
+        "pod" = "pod",
+        "service_instance_id" = "service_instance_id",
+      }
+    }
+    // Integration: Tempo
+    stage.match {
+      selector = "{integration=\"tempo\",instance=\"tempo\"}"
+
+      // extract some of the fields from the log line
+      stage.logfmt {
+        mapping = {
+          "ts" = "",
+          "level" = "",
+        }
+      }
+
+      // set the level as a label
+      stage.labels {
+        values = {
+          level = "level",
+        }
+      }
+      // reset the timestamp to the extracted value
+      stage.timestamp {
+        source = "ts"
+        format = "RFC3339Nano"
+      }
+      // remove the timestamp from the log line
+      stage.replace {
+        expression = "(ts=[^ ]+\\s+)"
+        replace = ""
+      }
+      // drop certain log levels
+      stage.drop {
+        source = "level"
+        expression = "(?i)(debug)"
+        drop_counter_reason = "tempo-drop-log-level"
+      }
+
+    }
+
+    forward_to = argument.logs_destinations.value
+  } // loki.secretfilter "pod_logs"
+} // declare "pod_logs_via_loki"
+pod_logs_via_loki "feature" {
+  logs_destinations = [
+    loki.write.localloki.receiver,
+  ]
+}
+
+
+
+
+
+// Destination: localLoki (loki)
+otelcol.exporter.loki "localloki" {
+  forward_to = [loki.write.localloki.receiver]
+} // otelcol.exporter.loki "localloki"
+
+loki.write "localloki" {
+  endpoint {
+    url = "http://loki.loki.svc:3100/loki/api/v1/push"
+    retry_on_http_429 = true
+    tenant_id = convert.nonsensitive(remote.kubernetes.secret.localloki.data["tenantId"])
+    basic_auth {
+      username = convert.nonsensitive(remote.kubernetes.secret.localloki.data["username"])
+      password = remote.kubernetes.secret.localloki.data["password"]
+    }
+    tls_config {
+      insecure_skip_verify = false
+    }
+    min_backoff_period = "500ms"
+    max_backoff_period = "5m"
+    max_backoff_retries = "10"
+  }
+  external_labels = {
+    "cluster" = "tempo-integration-test",
+    "k8s_cluster_name" = "tempo-integration-test",
+  }
+} // loki.write "localloki"
+
+remote.kubernetes.secret "localloki" {
+  name      = "localloki-k8smon-k8s-monitoring"
+  namespace = "default"
+} // remote.kubernetes.secret "localloki"
+

--- a/charts/k8s-monitoring/tests/integration/service-integrations/tempo/.rendered/alloy-metrics.alloy
+++ b/charts/k8s-monitoring/tests/integration/service-integrations/tempo/.rendered/alloy-metrics.alloy
@@ -1,0 +1,489 @@
+// Feature: Cluster Metrics
+declare "cluster_metrics" {
+  argument "metrics_destinations" {
+    comment = "Must be a list of metric destinations where collected metrics should be forwarded to"
+  }
+  discovery.kubernetes "nodes" {
+    role = "node"
+  } // discovery.kubernetes "nodes"
+
+  discovery.relabel "nodes" {
+    targets = discovery.kubernetes.nodes.targets
+    rule {
+      source_labels = ["__meta_kubernetes_node_name"]
+      target_label  = "node"
+    }
+
+    rule {
+      replacement = "kubernetes"
+      target_label = "source"
+    }
+  } // discovery.relabel "nodes"
+
+  // Kubelet
+  discovery.relabel "kubelet" {
+    targets = discovery.relabel.nodes.output
+  } // discovery.relabel "kubelet"
+
+  prometheus.scrape "kubelet" {
+    targets  = discovery.relabel.kubelet.output
+    job_name = "integrations/kubernetes/kubelet"
+    scheme   = "https"
+    scrape_interval = "60s"
+    scrape_timeout = "10s"
+    scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
+    scrape_classic_histograms = false
+    scrape_native_histograms = false
+    convert_classic_histograms_to_nhcb = false
+    bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+
+    tls_config {
+      ca_file = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+      insecure_skip_verify = true
+      server_name = "kubernetes"
+    }
+
+    clustering {
+      enabled = true
+    }
+
+    forward_to = [prometheus.relabel.kubelet.receiver]
+  } // prometheus.scrape "kubelet"
+
+  prometheus.relabel "kubelet" {
+    max_cache_size = 100000
+    rule {
+      source_labels = ["__name__"]
+      regex = "up|scrape_samples_scraped|go_goroutines|kubelet_certificate_manager_client_expiration_renew_errors|kubelet_certificate_manager_client_ttl_seconds|kubelet_certificate_manager_server_ttl_seconds|kubelet_cgroup_manager_duration_seconds_bucket|kubelet_cgroup_manager_duration_seconds_count|kubelet_node_config_error|kubelet_node_name|kubelet_pleg_relist_duration_seconds_bucket|kubelet_pleg_relist_duration_seconds_count|kubelet_pleg_relist_interval_seconds_bucket|kubelet_pod_start_duration_seconds_bucket|kubelet_pod_start_duration_seconds_count|kubelet_pod_worker_duration_seconds_bucket|kubelet_pod_worker_duration_seconds_count|kubelet_running_container_count|kubelet_running_containers|kubelet_running_pod_count|kubelet_running_pods|kubelet_runtime_operations_errors_total|kubelet_runtime_operations_total|kubelet_server_expiration_renew_errors|kubelet_volume_stats_available_bytes|kubelet_volume_stats_capacity_bytes|kubelet_volume_stats_inodes|kubelet_volume_stats_inodes_free|kubelet_volume_stats_inodes_used|kubelet_volume_stats_used_bytes|kubernetes_build_info|namespace_workload_pod|process_cpu_seconds_total|process_resident_memory_bytes|rest_client_requests_total|storage_operation_duration_seconds_count|storage_operation_errors_total|volume_manager_total_volumes"
+      action = "keep"
+    }
+
+    forward_to = argument.metrics_destinations.value
+  } // prometheus.relabel "kubelet"
+
+  // Kubelet Resources
+  discovery.relabel "kubelet_resources" {
+    targets = discovery.relabel.nodes.output
+    rule {
+      replacement   = "/metrics/resource"
+      target_label  = "__metrics_path__"
+    }
+  } // discovery.relabel "kubelet_resources"
+
+  prometheus.scrape "kubelet_resources" {
+    targets = discovery.relabel.kubelet_resources.output
+    job_name = "integrations/kubernetes/resources"
+    scheme   = "https"
+    scrape_interval = "60s"
+    scrape_timeout = "10s"
+    scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
+    scrape_classic_histograms = false
+    scrape_native_histograms = false
+    convert_classic_histograms_to_nhcb = false
+    bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+
+    tls_config {
+      ca_file = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+      insecure_skip_verify = true
+      server_name = "kubernetes"
+    }
+
+    clustering {
+      enabled = true
+    }
+
+    forward_to = [prometheus.relabel.kubelet_resources.receiver]
+  } // prometheus.scrape "kubelet_resources"
+
+  prometheus.relabel "kubelet_resources" {
+    max_cache_size = 100000
+    rule {
+      source_labels = ["__name__"]
+      regex = "up|scrape_samples_scraped|node_cpu_usage_seconds_total|node_memory_working_set_bytes"
+      action = "keep"
+    }
+
+    forward_to = argument.metrics_destinations.value
+  } // prometheus.relabel "kubelet_resources"
+
+  // cAdvisor
+  discovery.relabel "cadvisor" {
+    targets = discovery.relabel.nodes.output
+    rule {
+      replacement   = "/metrics/cadvisor"
+      target_label  = "__metrics_path__"
+    }
+  } // discovery.relabel "cadvisor"
+
+  prometheus.scrape "cadvisor" {
+    targets = discovery.relabel.cadvisor.output
+    job_name = "integrations/kubernetes/cadvisor"
+    scheme = "https"
+    scrape_interval = "60s"
+    scrape_timeout = "10s"
+    scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
+    scrape_classic_histograms = false
+    scrape_native_histograms = false
+    convert_classic_histograms_to_nhcb = false
+    bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+
+    tls_config {
+      ca_file = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+      insecure_skip_verify = true
+      server_name = "kubernetes"
+    }
+
+    clustering {
+      enabled = true
+    }
+
+    forward_to = [prometheus.relabel.cadvisor.receiver]
+  } // prometheus.scrape "cadvisor"
+
+  prometheus.relabel "cadvisor" {
+    max_cache_size = 100000
+    rule {
+      source_labels = ["__name__"]
+      regex = "up|scrape_samples_scraped|container_cpu_cfs_periods_total|container_cpu_cfs_throttled_periods_total|container_cpu_usage_seconds_total|container_fs_reads_bytes_total|container_fs_reads_total|container_fs_writes_bytes_total|container_fs_writes_total|container_memory_cache|container_memory_rss|container_memory_swap|container_memory_usage_bytes|container_memory_working_set_bytes|container_network_receive_bytes_total|container_network_receive_packets_dropped_total|container_network_receive_packets_total|container_network_transmit_bytes_total|container_network_transmit_packets_dropped_total|container_network_transmit_packets_total|machine_memory_bytes"
+      action = "keep"
+    }
+    // Drop empty container labels, addressing https://github.com/google/cadvisor/issues/2688
+    rule {
+      source_labels = ["__name__","container"]
+      separator = "@"
+      regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_pressure_.*)@"
+      action = "drop"
+    }
+    // Drop empty image labels, addressing https://github.com/google/cadvisor/issues/2688
+    rule {
+      source_labels = ["__name__","image"]
+      separator = "@"
+      regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_network_.*|container_pressure_.*)@"
+      action = "drop"
+    }
+    // Normalizing unimportant labels (not deleting to continue satisfying <label>!="" checks)
+    rule {
+      source_labels = ["__name__", "boot_id"]
+      separator = "@"
+      regex = "machine_memory_bytes@.*"
+      target_label = "boot_id"
+      replacement = "NA"
+    }
+    rule {
+      source_labels = ["__name__", "system_uuid"]
+      separator = "@"
+      regex = "machine_memory_bytes@.*"
+      target_label = "system_uuid"
+      replacement = "NA"
+    }
+    // Filter out non-physical devices/interfaces
+    rule {
+      source_labels = ["__name__", "device"]
+      separator = "@"
+      regex = "container_fs_.*@(/dev/)?(mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dasd.+)"
+      target_label = "__keepme"
+      replacement = "1"
+    }
+    rule {
+      source_labels = ["__name__", "__keepme"]
+      separator = "@"
+      regex = "container_fs_.*@"
+      action = "drop"
+    }
+    rule {
+      source_labels = ["__name__"]
+      regex = "container_fs_.*"
+      target_label = "__keepme"
+      replacement = ""
+    }
+    rule {
+      source_labels = ["__name__", "interface"]
+      separator = "@"
+      regex = "container_network_.*@(en[ospx][0-9].*|wlan[0-9].*|eth[0-9].*)"
+      target_label = "__keepme"
+      replacement = "1"
+    }
+    rule {
+      source_labels = ["__name__", "__keepme"]
+      separator = "@"
+      regex = "container_network_.*@"
+      action = "drop"
+    }
+    rule {
+      source_labels = ["__name__"]
+      regex = "container_network_.*"
+      target_label = "__keepme"
+      replacement = ""
+    }
+    forward_to = argument.metrics_destinations.value
+  } // prometheus.relabel "cadvisor"
+  discovery.kubernetes "kube_state_metrics" {
+    role = "endpoints"
+
+    selectors {
+      role = "endpoints"
+      label = "release=k8smon,app.kubernetes.io/name=kube-state-metrics"
+    }
+    namespaces {
+      names = ["default"]
+    }
+  } // discovery.kubernetes "kube_state_metrics"
+
+  discovery.relabel "kube_state_metrics" {
+    targets = discovery.kubernetes.kube_state_metrics.targets
+
+    rule {
+      action = "replace"
+      replacement = "kubernetes"
+      target_label = "source"
+    }
+
+  } // discovery.relabel "kube_state_metrics"
+
+  prometheus.scrape "kube_state_metrics" {
+    targets = discovery.relabel.kube_state_metrics.output
+    job_name = "integrations/kubernetes/kube-state-metrics"
+    scrape_interval = "60s"
+    scrape_timeout = "10s"
+    scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
+    scrape_classic_histograms = false
+    scrape_native_histograms = false
+    convert_classic_histograms_to_nhcb = false
+    scheme = "http"
+    bearer_token_file = ""
+    tls_config {
+      insecure_skip_verify = true
+    }
+
+    clustering {
+      enabled = true
+    }
+    forward_to = [prometheus.relabel.kube_state_metrics.receiver]
+  } // prometheus.scrape "kube_state_metrics"
+
+  prometheus.relabel "kube_state_metrics" {
+    max_cache_size = 100000
+    rule {
+      source_labels = ["__name__"]
+      regex = "up|scrape_samples_scraped|kube_configmap_info|kube_configmap_metadata_resource_version|kube_cronjob.*|kube_daemonset.*|kube_deployment_metadata_generation|kube_deployment_spec_replicas|kube_deployment_status_condition|kube_deployment_status_observed_generation|kube_deployment_status_replicas_available|kube_deployment_status_replicas_updated|kube_horizontalpodautoscaler_spec_max_replicas|kube_horizontalpodautoscaler_spec_min_replicas|kube_horizontalpodautoscaler_status_current_replicas|kube_horizontalpodautoscaler_status_desired_replicas|kube_job.*|kube_namespace_status_phase|kube_node.*|kube_persistentvolume_status_phase|kube_persistentvolumeclaim_access_mode|kube_persistentvolumeclaim_info|kube_persistentvolumeclaim_labels|kube_persistentvolumeclaim_resource_requests_storage_bytes|kube_persistentvolumeclaim_status_phase|kube_pod_completion_time|kube_pod_container_info|kube_pod_container_resource_limits|kube_pod_container_resource_requests|kube_pod_container_status_last_terminated_reason|kube_pod_container_status_last_terminated_timestamp|kube_pod_container_status_restarts_total|kube_pod_container_status_waiting_reason|kube_pod_info|kube_pod_owner|kube_pod_restart_policy|kube_pod_spec_volumes_persistentvolumeclaims_info|kube_pod_start_time|kube_pod_status_phase|kube_pod_status_reason|kube_pod_init_.*|kube_replicaset.*|kube_resourcequota|kube_secret_metadata_resource_version|kube_statefulset.*"
+      action = "keep"
+    }
+    forward_to = argument.metrics_destinations.value
+  } // prometheus.relabel "kube_state_metrics"
+} // declare "cluster_metrics"
+cluster_metrics "feature" {
+  metrics_destinations = [
+    prometheus.remote_write.localprometheus.receiver,
+  ]
+}
+// Feature: Host Metrics
+declare "host_metrics" {
+  argument "metrics_destinations" {
+    comment = "Must be a list of metric destinations where collected metrics should be forwarded to"
+  }
+
+  // Linux hosts via Node Exporter
+  discovery.kubernetes "node_exporter" {
+    role = "pod"
+    selectors {
+      role = "pod"
+      label = "release=k8smon,app.kubernetes.io/name=node-exporter"
+    }
+    namespaces {
+      names = ["default"]
+    }
+
+  } // discovery.kubernetes "node_exporter"
+
+  discovery.relabel "node_exporter" {
+    targets = discovery.kubernetes.node_exporter.targets
+
+    // keep only the specified metrics port name, and pods that are Running and ready
+    rule {
+      source_labels = [
+        "__meta_kubernetes_pod_container_init",
+        "__meta_kubernetes_pod_phase",
+        "__meta_kubernetes_pod_ready",
+      ]
+      separator = "@"
+      regex = "false@Running@true"
+      action = "keep"
+    }
+
+    // Set the instance label to the node name
+    rule {
+      source_labels = ["__meta_kubernetes_pod_node_name"]
+      target_label = "instance"
+    }
+
+    rule {
+      source_labels = ["__meta_kubernetes_namespace"]
+      target_label  = "namespace"
+    }
+
+    rule {
+      source_labels = ["__meta_kubernetes_pod_name"]
+      target_label  = "pod"
+    }
+
+    rule {
+      source_labels = ["__meta_kubernetes_pod_container_name"]
+      target_label  = "container"
+    }
+
+    // set a workload label
+    rule {
+      source_labels = [
+        "__meta_kubernetes_pod_controller_kind",
+        "__meta_kubernetes_pod_controller_name",
+      ]
+      separator = "/"
+      target_label  = "workload"
+    }
+    // remove the hash from the ReplicaSet
+    rule {
+      source_labels = ["workload"]
+      regex = "(ReplicaSet/.+)-.+"
+      target_label  = "workload"
+    }
+
+    // Set the app label.
+    //
+    // Choose the first value found from the following ordered list:
+    // - pod.label[app.kubernetes.io/name]
+    // - pod.label[k8s-app]
+    // - pod.label[app]
+    rule {
+      source_labels = [
+        "__meta_kubernetes_pod_label_app_kubernetes_io_name",
+        "__meta_kubernetes_pod_label_k8s_app",
+        "__meta_kubernetes_pod_label_app",
+      ]
+      separator = ";"
+      regex = "^(?:;*)?([^;]+).*$"
+      replacement = "$1"
+      target_label = "app"
+    }
+
+    // Set the component label.
+    //
+    // Choose the first value found from the following ordered list:
+    // - pod.label[app.kubernetes.io/component]
+    // - pod.label[k8s-component]
+    // - pod.label[component]
+    rule {
+      source_labels = [
+        "__meta_kubernetes_pod_label_app_kubernetes_io_component",
+        "__meta_kubernetes_pod_label_k8s_component",
+        "__meta_kubernetes_pod_label_component",
+      ]
+      regex = "^(?:;*)?([^;]+).*$"
+      replacement = "$1"
+      target_label = "component"
+    }
+
+    rule {
+      target_label = "source"
+      replacement = "kubernetes"
+    }
+
+  } // discovery.relabel "node_exporter"
+
+  prometheus.scrape "node_exporter" {
+    targets = discovery.relabel.node_exporter.output
+    job_name = "integrations/node_exporter"
+    scrape_interval = "60s"
+    scrape_timeout = "10s"
+    scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
+    scrape_classic_histograms = false
+    scrape_native_histograms = false
+    convert_classic_histograms_to_nhcb = false
+    scheme = "http"
+    tls_config {
+      insecure_skip_verify = true
+    }
+
+    clustering {
+      enabled = true
+    }
+    forward_to = [prometheus.relabel.node_exporter.receiver]
+  } // prometheus.scrape "node_exporter"
+
+  prometheus.relabel "node_exporter" {
+    max_cache_size = 100000
+    rule {
+      source_labels = ["__name__"]
+      regex = "up|scrape_samples_scraped|node_cpu.*|node_exporter_build_info|node_filesystem.*|node_memory.*|node_network_receive_bytes_total|node_network_receive_drop_total|node_network_transmit_bytes_total|node_network_transmit_drop_total|process_cpu_seconds_total|process_resident_memory_bytes"
+      action = "keep"
+    }
+    // Drop metrics for certain file systems
+    rule {
+      source_labels = ["__name__", "fstype"]
+      separator = "@"
+      regex = "node_filesystem.*@(ramfs|tmpfs)"
+      action = "drop"
+    }
+    forward_to = argument.metrics_destinations.value
+  } // prometheus.relabel "node_exporter"
+} // declare "host_metrics"
+host_metrics "feature" {
+  metrics_destinations = [
+    prometheus.remote_write.localprometheus.receiver,
+  ]
+}
+
+
+
+
+
+// Destination: localPrometheus (prometheus)
+otelcol.exporter.prometheus "localprometheus" {
+  add_metric_suffixes = true
+  resource_to_telemetry_conversion = false
+  keep_identifying_resource_attributes = true
+  forward_to = [prometheus.remote_write.localprometheus.receiver]
+} // otelcol.exporter.prometheus "localprometheus"
+
+prometheus.remote_write "localprometheus" {
+  endpoint {
+    url = "http://prometheus-server.prometheus.svc:9090/api/v1/write"
+    headers = {
+    }
+    basic_auth {
+      username = convert.nonsensitive(remote.kubernetes.secret.localprometheus.data["username"])
+      password = remote.kubernetes.secret.localprometheus.data["password"]
+    }
+    tls_config {
+      insecure_skip_verify = false
+    }
+    send_native_histograms = false
+
+    queue_config {
+      capacity = 10000
+      min_shards = 1
+      max_shards = 50
+      max_samples_per_send = 2000
+      batch_send_deadline = "5s"
+      min_backoff = "30ms"
+      max_backoff = "5s"
+      retry_on_http_429 = true
+      sample_age_limit = "0s"
+    }
+  }
+
+  wal {
+    truncate_frequency = "2h"
+    min_keepalive_time = "5m"
+    max_keepalive_time = "8h"
+  }
+  external_labels = {
+    "cluster" = "tempo-integration-test",
+    "k8s_cluster_name" = "tempo-integration-test",
+  }
+} // prometheus.remote_write "localprometheus"
+
+remote.kubernetes.secret "localprometheus" {
+  name      = "localprometheus-k8smon-k8s-monitoring"
+  namespace = "default"
+} // remote.kubernetes.secret "localprometheus"
+

--- a/charts/k8s-monitoring/tests/integration/service-integrations/tempo/.rendered/alloy-singleton.alloy
+++ b/charts/k8s-monitoring/tests/integration/service-integrations/tempo/.rendered/alloy-singleton.alloy
@@ -1,0 +1,506 @@
+// Feature: Cluster Events
+declare "cluster_events" {
+  argument "logs_destinations" {
+    comment = "Must be a list of log destinations where collected logs should be forwarded to"
+  }
+
+  loki.source.kubernetes_events "cluster_events" {
+    job_name   = "integrations/kubernetes/eventhandler"
+    log_format = "logfmt"
+    forward_to = [loki.process.cluster_events.receiver]
+  } // loki.source.kubernetes_events "cluster_events"
+
+  loki.process "cluster_events" {
+
+    // add a static source label to the logs so they can be differentiated / restricted if necessary
+    stage.static_labels {
+      values = {
+        "source" = "kubernetes-events",
+      }
+    }
+
+    // extract some of the fields from the log line, these could be used as labels, structured metadata, etc.
+    stage.logfmt {
+      mapping = {
+        "component" = "sourcecomponent", // map the sourcecomponent field to component
+        "kind" = "",
+        "level" = "type", // most events don't have a level but they do have a "type" i.e. Normal, Warning, Error, etc.
+        "name" = "",
+        "node" = "sourcehost", // map the sourcehost field to node
+        "reason" = "",
+      }
+    }
+    // set the extracted values as labels
+    stage.labels {
+      values = {
+        "kind" = "",
+        "level" = "",
+        "service_name" = "job",
+        "reason" = "reason",
+      }
+    }
+
+    // if kind=Node, set the node label by copying the name field
+    stage.match {
+      selector = "{kind=\"Node\"}"
+
+      stage.labels {
+        values = {
+          "node" = "name",
+        }
+      }
+    }
+
+    // set the level extracted key value as a normalized log level
+    stage.match {
+      selector = "{level=\"Normal\"}"
+
+      stage.static_labels {
+        values = {
+          level = "Info",
+        }
+      }
+    }
+    stage.structured_metadata {
+      values = {
+        "name" = "name",
+        "node" = "node",
+      }
+    }
+
+    // Drop pipeline-only labels that are not needed in the final output.
+    stage.label_drop {
+      values = ["kind"]
+    }
+
+    forward_to = argument.logs_destinations.value
+  } // loki.process "cluster_events"
+} // declare "cluster_events"
+cluster_events "feature" {
+  logs_destinations = [
+    loki.write.localloki.receiver,
+  ]
+}
+declare "tempo_integration" {
+  argument "metrics_destinations" {
+    comment = "Must be a list of metric destinations where collected metrics should be forwarded to"
+  }
+
+  declare "tempo_integration_discovery" {
+    argument "namespaces" {
+      comment = "The namespaces to look for targets in (default: [] is all namespaces)"
+      optional = true
+    }
+
+    argument "field_selectors" {
+      comment = "The field selectors to use to find matching targets (default: [])"
+      optional = true
+    }
+
+    argument "label_selectors" {
+      comment = "The label selectors to use to find matching targets (default: [\"app.kubernetes.io/name=tempo\"])"
+      optional = true
+    }
+
+    argument "port_name" {
+      comment = "The of the port to scrape metrics from (default: http-metrics)"
+      optional = true
+    }
+
+    // tempo service discovery for all of the pods
+    discovery.kubernetes "tempo_pods" {
+      role = "pod"
+
+      selectors {
+        role = "pod"
+        field = string.join(coalesce(argument.field_selectors.value, []), ",")
+        label = string.join(coalesce(argument.label_selectors.value, ["app.kubernetes.io/name=tempo"]), ",")
+      }
+
+      namespaces {
+        names = coalesce(argument.namespaces.value, [])
+      }
+
+    } // discovery.kubernetes "tempo_pods"
+
+    // tempo relabelings (pre-scrape)
+    discovery.relabel "tempo_pods" {
+      targets = discovery.kubernetes.tempo_pods.targets
+
+      // keep only the specified metrics port name, and pods that are Running and ready
+      rule {
+        source_labels = [
+          "__meta_kubernetes_pod_container_port_name",
+          "__meta_kubernetes_pod_phase",
+          "__meta_kubernetes_pod_ready",
+          "__meta_kubernetes_pod_container_init",
+        ]
+        separator = "@"
+        regex = coalesce(argument.port_name.value, "http-metrics") + "@Running@true@false"
+        action = "keep"
+      }
+
+      rule {
+        source_labels = ["__meta_kubernetes_pod_node_name"]
+        target_label = "node"
+      }
+
+      // the tempo-mixin expects the job label to be namespace/component
+      rule {
+        source_labels = ["__meta_kubernetes_namespace","__meta_kubernetes_pod_label_app_kubernetes_io_component"]
+        separator = "/"
+        target_label = "job"
+      }
+
+
+
+      rule {
+        source_labels = ["__meta_kubernetes_namespace"]
+        target_label  = "namespace"
+      }
+
+      rule {
+        source_labels = ["__meta_kubernetes_pod_name"]
+        target_label  = "pod"
+      }
+
+      rule {
+        source_labels = ["__meta_kubernetes_pod_container_name"]
+        target_label  = "container"
+      }
+
+      // set the workload to the controller kind and name
+      rule {
+        action = "lowercase"
+        source_labels = ["__meta_kubernetes_pod_controller_kind"]
+        target_label  = "workload_type"
+      }
+
+      rule {
+        source_labels = ["__meta_kubernetes_pod_controller_name"]
+        target_label  = "workload"
+      }
+
+      // remove the hash from the ReplicaSet
+      rule {
+        source_labels = [
+          "workload_type",
+          "workload",
+        ]
+        separator = "/"
+        regex = "replicaset/(.+)-.+$"
+        target_label  = "workload"
+      }
+
+      // set the app name if specified as metadata labels "app:" or "app.kubernetes.io/name:" or "k8s-app:"
+      rule {
+        action = "replace"
+        source_labels = [
+          "__meta_kubernetes_pod_label_app_kubernetes_io_name",
+          "__meta_kubernetes_pod_label_k8s_app",
+          "__meta_kubernetes_pod_label_app",
+        ]
+        separator = ";"
+        regex = "^(?:;*)?([^;]+).*$"
+        replacement = "$1"
+        target_label = "app"
+      }
+
+      // set the component if specified as metadata labels "component:" or "app.kubernetes.io/component:" or "k8s-component:"
+      rule {
+        action = "replace"
+        source_labels = [
+          "__meta_kubernetes_pod_label_app_kubernetes_io_component",
+          "__meta_kubernetes_pod_label_k8s_component",
+          "__meta_kubernetes_pod_label_component",
+        ]
+        regex = "^(?:;*)?([^;]+).*$"
+        replacement = "$1"
+        target_label = "component"
+      }
+
+      // set a source label
+      rule {
+        action = "replace"
+        replacement = "kubernetes"
+        target_label = "source"
+      }
+
+    } // discovery.relabel "tempo_pods"
+
+    export "output" {
+      value = discovery.relabel.tempo_pods.output
+    }
+  }
+
+  declare "tempo_integration_scrape" {
+    argument "targets" {
+      comment = "Must be a list() of targets"
+    }
+
+    argument "forward_to" {
+      comment = "Must be a list(MetricsReceiver) where collected metrics should be forwarded to"
+    }
+
+    argument "job_label" {
+      comment = "The job label to add for all Tempo metrics (default: integrations/tempo)"
+      optional = true
+    }
+
+    argument "keep_metrics" {
+      comment = "A regular expression of metrics to keep (default: see below)"
+      optional = true
+    }
+
+    argument "drop_metrics" {
+      comment = "A regular expression of metrics to drop (default: see below)"
+      optional = true
+    }
+
+    argument "scrape_interval" {
+      comment = "How often to scrape metrics from the targets (default: 60s)"
+      optional = true
+    }
+
+    argument "scrape_timeout" {
+      comment = "The timeout for scraping metrics from the targets (default: 10s)"
+      optional = true
+    }
+
+    argument "scrape_protocols" {
+      comment = "The scrape protocols to use for scraping metrics"
+      optional = true
+    }
+
+    argument "scrape_classic_histograms" {
+      comment = "Whether to scrape classic histograms (default: false)."
+      optional = true
+    }
+
+    argument "scrape_native_histograms" {
+      comment = "Whether to scrape native histograms (default: false)."
+      optional = true
+    }
+
+    argument "max_cache_size" {
+      comment = "The maximum number of elements to hold in the relabeling cache (default: 100000).  This should be at least 2x-5x your largest scrape target or samples appended rate."
+      optional = true
+    }
+
+    argument "clustering" {
+      comment = "Whether or not clustering should be enabled (default: false)"
+      optional = true
+    }
+
+    prometheus.scrape "tempo" {
+      job_name = coalesce(argument.job_label.value, "integrations/tempo")
+      forward_to = [prometheus.relabel.tempo.receiver]
+      targets = argument.targets.value
+      scrape_interval = coalesce(argument.scrape_interval.value, "60s")
+      scrape_timeout = coalesce(argument.scrape_timeout.value, "10s")
+      scrape_protocols = argument.scrape_protocols.value
+      scrape_classic_histograms = argument.scrape_classic_histograms.value
+      scrape_native_histograms = argument.scrape_native_histograms.value
+
+      clustering {
+        enabled = coalesce(argument.clustering.value, false)
+      }
+    } // prometheus.scrape "tempo"
+
+    // tempo metric relabelings (post-scrape)
+    prometheus.relabel "tempo" {
+      forward_to = argument.forward_to.value
+      max_cache_size = coalesce(argument.max_cache_size.value, 100000)
+
+      // drop metrics that match the drop_metrics regex
+      rule {
+        source_labels = ["__name__"]
+        regex = coalesce(argument.drop_metrics.value, "")
+        action = "drop"
+      }
+
+      // keep only metrics that match the keep_metrics regex
+      rule {
+        source_labels = ["__name__"]
+        regex = coalesce(argument.keep_metrics.value, "(.+)")
+        action = "keep"
+      }
+
+      // the tempo-mixin expects the instance label to be the node name
+      rule {
+        source_labels = ["node"]
+        target_label = "instance"
+        replacement = "$1"
+      }
+      rule {
+        action = "labeldrop"
+        regex = "node"
+      }
+
+      // set the memcached exporter container name from container="exporter" to container="memcached"
+      rule {
+        source_labels = ["component", "container"]
+        separator = ";"
+        regex = "memcached-[^;]+;exporter"
+        target_label = "container"
+        replacement = "memcached"
+      }
+    } // prometheus.relabel "tempo"
+  }
+
+  tempo_integration_discovery "tempo" {
+    namespaces = []
+    label_selectors = ["app.kubernetes.io/name=tempo"]
+    port_name = "prom-metrics"
+  }
+
+  tempo_integration_scrape  "tempo" {
+    targets = tempo_integration_discovery.tempo.output
+    job_label = "integrations/tempo"
+    clustering = true
+    keep_metrics = "up|scrape_samples_scraped|container_cpu_usage_seconds_total|container_memory_working_set_bytes|container_network_receive_bytes_total|container_network_transmit_bytes_total|container_spec_cpu_period|container_spec_cpu_quota|container_spec_memory_limit_bytes|gauge_memberlist_health_score|go_gc_duration_seconds_count|go_goroutines|go_memstats_heap_inuse_bytes|kube_deployment_spec_replicas|kube_deployment_status_replicas_unavailable|kube_deployment_status_replicas_updated|kube_pod_container_info|kube_pod_container_resource_requests|kube_pod_container_status_restarts_total|kube_statefulset_replicas|kube_statefulset_status_replicas_current|kube_statefulset_status_replicas_ready|kube_statefulset_status_replicas_updated|kubelet_volume_stats_available_bytes|promtail_custom_bad_words_total|tempo_build_info|tempo_discarded_spans_total|tempo_distributor_bytes_received_total|tempo_distributor_metrics_generator_pushes_failures_total|tempo_distributor_push_duration_seconds_bucket|tempo_distributor_push_duration_seconds_count|tempo_distributor_push_duration_seconds_sum|tempo_distributor_queue_length|tempo_distributor_spans_received_total|tempo_ingester_blocks_cleared_total|tempo_ingester_blocks_flushed_total|tempo_ingester_failed_flushes_total|tempo_ingester_flush_duration_seconds_bucket|tempo_ingester_live_traces|tempo_ingester_traces_created_total|tempo_limits_defaults|tempo_limits_overrides|tempo_memberlist_client_cluster_members_count|tempo_memberlist_client_cluster_node_health_score|tempo_memberlist_client_kv_store_count|tempo_memcache_request_duration_seconds_bucket|tempo_memcache_request_duration_seconds_count|tempo_memcache_request_duration_seconds_sum|tempo_metrics_generator_bytes_received_total|tempo_metrics_generator_registry_active_series|tempo_metrics_generator_spans_discarded_total|tempo_metrics_generator_spans_received_total|tempo_query_frontend_queries_total|tempo_receiver_accepted_spans|tempo_receiver_refused_spans|tempo_request_duration_seconds_bucket|tempo_request_duration_seconds_count|tempo_request_duration_seconds_sum|tempo_vulture_trace_error_total|tempo_vulture_trace_total|tempodb_backend_request_duration_seconds_bucket|tempodb_backend_request_duration_seconds_count|tempodb_backend_request_duration_seconds_sum|tempodb_blocklist_length|tempodb_blocklist_poll_errors_total|tempodb_compaction_blocks_total|tempodb_compaction_bytes_written_total|tempodb_compaction_errors_total|tempodb_compaction_objects_combined_total|tempodb_compaction_objects_written_total|tempodb_compaction_outstanding_blocks|tempodb_retention_deleted_total|tempodb_retention_errors_total|tempodb_retention_marked_for_deletion_total|tempodb_work_queue_length|tempodb_work_queue_max"
+    scrape_interval = "60s"
+    scrape_timeout = "10s"
+    scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
+    scrape_classic_histograms = false
+    scrape_native_histograms = false
+    max_cache_size = 100000
+    forward_to = argument.metrics_destinations.value
+  }
+}
+tempo_integration "integration" {
+  metrics_destinations = [
+    prometheus.remote_write.localprometheus.receiver,
+  ]
+}
+// Self Reporting
+prometheus.exporter.unix "kubernetes_monitoring_telemetry" {
+  set_collectors = ["textfile"]
+  textfile {
+    directory = "/etc/release-info"
+  }
+} // prometheus.exporter.unix "kubernetes_monitoring_telemetry"
+
+discovery.relabel "kubernetes_monitoring_telemetry" {
+  targets = prometheus.exporter.unix.kubernetes_monitoring_telemetry.targets
+  rule {
+    target_label = "instance"
+    action = "replace"
+    replacement = "k8smon"
+  }
+  rule {
+    target_label = "job"
+    action = "replace"
+    replacement = "integrations/kubernetes/kubernetes_monitoring_telemetry"
+  }
+} // discovery.relabel "kubernetes_monitoring_telemetry"
+
+prometheus.scrape "kubernetes_monitoring_telemetry" {
+  job_name   = "integrations/kubernetes/kubernetes_monitoring_telemetry"
+  targets    = discovery.relabel.kubernetes_monitoring_telemetry.output
+  scrape_interval = "60s"
+  clustering {
+    enabled = true
+  }
+  forward_to = [prometheus.relabel.kubernetes_monitoring_telemetry.receiver]
+} // prometheus.scrape "kubernetes_monitoring_telemetry"
+
+prometheus.relabel "kubernetes_monitoring_telemetry" {
+  rule {
+    source_labels = ["__name__"]
+    regex = "grafana_kubernetes_monitoring_.*"
+    action = "keep"
+  }
+  forward_to = [
+    prometheus.remote_write.localprometheus.receiver,
+  ]
+} // prometheus.relabel "kubernetes_monitoring_telemetry"
+
+
+
+
+
+// Destination: localLoki (loki)
+otelcol.exporter.loki "localloki" {
+  forward_to = [loki.write.localloki.receiver]
+} // otelcol.exporter.loki "localloki"
+
+loki.write "localloki" {
+  endpoint {
+    url = "http://loki.loki.svc:3100/loki/api/v1/push"
+    retry_on_http_429 = true
+    tenant_id = convert.nonsensitive(remote.kubernetes.secret.localloki.data["tenantId"])
+    basic_auth {
+      username = convert.nonsensitive(remote.kubernetes.secret.localloki.data["username"])
+      password = remote.kubernetes.secret.localloki.data["password"]
+    }
+    tls_config {
+      insecure_skip_verify = false
+    }
+    min_backoff_period = "500ms"
+    max_backoff_period = "5m"
+    max_backoff_retries = "10"
+  }
+  external_labels = {
+    "cluster" = "tempo-integration-test",
+    "k8s_cluster_name" = "tempo-integration-test",
+  }
+} // loki.write "localloki"
+
+remote.kubernetes.secret "localloki" {
+  name      = "localloki-k8smon-k8s-monitoring"
+  namespace = "default"
+} // remote.kubernetes.secret "localloki"
+
+
+// Destination: localPrometheus (prometheus)
+otelcol.exporter.prometheus "localprometheus" {
+  add_metric_suffixes = true
+  resource_to_telemetry_conversion = false
+  keep_identifying_resource_attributes = true
+  forward_to = [prometheus.remote_write.localprometheus.receiver]
+} // otelcol.exporter.prometheus "localprometheus"
+
+prometheus.remote_write "localprometheus" {
+  endpoint {
+    url = "http://prometheus-server.prometheus.svc:9090/api/v1/write"
+    headers = {
+    }
+    basic_auth {
+      username = convert.nonsensitive(remote.kubernetes.secret.localprometheus.data["username"])
+      password = remote.kubernetes.secret.localprometheus.data["password"]
+    }
+    tls_config {
+      insecure_skip_verify = false
+    }
+    send_native_histograms = false
+
+    queue_config {
+      capacity = 10000
+      min_shards = 1
+      max_shards = 50
+      max_samples_per_send = 2000
+      batch_send_deadline = "5s"
+      min_backoff = "30ms"
+      max_backoff = "5s"
+      retry_on_http_429 = true
+      sample_age_limit = "0s"
+    }
+  }
+
+  wal {
+    truncate_frequency = "2h"
+    min_keepalive_time = "5m"
+    max_keepalive_time = "8h"
+  }
+  external_labels = {
+    "cluster" = "tempo-integration-test",
+    "k8s_cluster_name" = "tempo-integration-test",
+  }
+} // prometheus.remote_write "localprometheus"
+
+remote.kubernetes.secret "localprometheus" {
+  name      = "localprometheus-k8smon-k8s-monitoring"
+  namespace = "default"
+} // remote.kubernetes.secret "localprometheus"
+

--- a/charts/k8s-monitoring/tests/integration/sharded-kube-state-metrics/.rendered/alloy-metrics.alloy
+++ b/charts/k8s-monitoring/tests/integration/sharded-kube-state-metrics/.rendered/alloy-metrics.alloy
@@ -1,0 +1,877 @@
+// Feature: Annotation Autodiscovery
+declare "annotation_autodiscovery" {
+  argument "metrics_destinations" {
+    comment = "Must be a list of metric destinations where collected metrics should be forwarded to"
+  }
+
+  discovery.kubernetes "pods" {
+    role = "pod"
+  } // discovery.kubernetes "pods"
+
+  discovery.relabel "annotation_autodiscovery_pods" {
+    targets = discovery.kubernetes.pods.targets
+    rule {
+      source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_scrape"]
+      regex = "true"
+      action = "keep"
+    }
+    // Only keep pods that are running, ready, and not init containers.
+    rule {
+      source_labels = [
+        "__meta_kubernetes_pod_phase",
+        "__meta_kubernetes_pod_ready",
+        "__meta_kubernetes_pod_container_init",
+      ]
+      regex = "Running;true;false"
+      action = "keep"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_pod_name"]
+      target_label = "pod"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_pod_container_name"]
+      target_label = "container"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_namespace"]
+      target_label = "namespace"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_job"]
+      target_label = "job"
+    }
+    rule {
+      source_labels = ["job", "__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+      regex = ";(.+)"
+      target_label = "job"
+    }
+    rule {
+      source_labels = ["job", "__meta_kubernetes_pod_label_app"]
+      regex = ";(.+)"
+      target_label = "job"
+    }
+    rule {
+      source_labels = ["job", "container"]
+      regex = ";(.+)"
+      target_label = "job"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_instance"]
+      target_label = "instance"
+    }
+
+    // Rules to choose the right container
+    rule {
+      source_labels = ["container"]
+      target_label = "__tmp_container"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_container"]
+      regex = "(.+)"
+      target_label = "__tmp_container"
+    }
+    rule {
+      source_labels = ["container"]
+      action = "keepequal"
+      target_label = "__tmp_container"
+    }
+    rule {
+      action = "labeldrop"
+      regex = "__tmp_container"
+    }
+
+    // Set metrics path
+    rule {
+      source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_path"]
+      regex = "(.+)"
+      target_label = "__metrics_path__"
+    }
+
+    // Set metrics scraping URL parameters
+    rule {
+      action = "labelmap"
+      regex = "__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_param_(.+)"
+      replacement = "__param_$1"
+    }
+
+    // Choose the pod port
+    // The discovery generates a target for each declared container port of the pod.
+    // If the metricsPortName annotation has value, keep only the target where the port name matches the one of the annotation.
+    rule {
+      source_labels = ["__meta_kubernetes_pod_container_port_name"]
+      target_label = "__tmp_port"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_portName"]
+      regex = "(.+)"
+      target_label = "__tmp_port"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_pod_container_port_name"]
+      action = "keepequal"
+      target_label = "__tmp_port"
+    }
+    rule {
+      action = "labeldrop"
+      regex = "__tmp_port"
+    }
+
+    // If the metrics port number annotation has a value, override the target address to use it, regardless whether it is
+    // one of the declared ports on that Pod.
+    rule {
+      source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_portNumber", "__meta_kubernetes_pod_ip"]
+      regex = "(\\d+);(([A-Fa-f0-9]{1,4}::?){1,7}[A-Fa-f0-9]{1,4})"
+      replacement = "[$2]:$1" // IPv6
+      target_label = "__address__"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_portNumber", "__meta_kubernetes_pod_ip"]
+      regex = "(\\d+);((([0-9]+?)(\\.|$)){4})" // IPv4, takes priority over IPv6 when both exists
+      replacement = "$2:$1"
+      target_label = "__address__"
+    }
+
+    rule {
+      source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_scheme"]
+      regex = "(.+)"
+      target_label = "__scheme__"
+    }
+
+    rule {
+      source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_scrapeInterval"]
+      regex = "(.+)"
+      target_label = "__scrape_interval__"
+    }
+    rule {
+      source_labels = ["__scrape_interval__"]
+      regex = ""
+      replacement = "60s"
+      target_label = "__scrape_interval__"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_scrapeTimeout"]
+      regex = "(.+)"
+      target_label = "__scrape_timeout__"
+    }
+    rule {
+      source_labels = ["__scrape_timeout__"]
+      regex = ""
+      replacement = "10s"
+      target_label = "__scrape_timeout__"
+    }
+  } // discovery.relabel "annotation_autodiscovery_pods"
+
+  discovery.kubernetes "services" {
+    role = "service"
+  } // discovery.kubernetes "services"
+
+  discovery.relabel "annotation_autodiscovery_services" {
+    targets = discovery.kubernetes.services.targets
+    rule {
+      source_labels = ["__meta_kubernetes_service_annotation_k8s_grafana_com_scrape"]
+      regex = "true"
+      action = "keep"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_service_name"]
+      target_label = "service"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_namespace"]
+      target_label = "namespace"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_service_annotation_k8s_grafana_com_job"]
+      target_label = "job"
+    }
+    rule {
+      source_labels = ["job", "__meta_kubernetes_service_label_app_kubernetes_io_name"]
+      regex = ";(.+)"
+      target_label = "job"
+    }
+    rule {
+      source_labels = ["job", "__meta_kubernetes_service_label_app"]
+      regex = ";(.+)"
+      target_label = "job"
+    }
+    rule {
+      source_labels = ["job", "service"]
+      regex = ";(.+)"
+      target_label = "job"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_service_annotation_k8s_grafana_com_instance"]
+      target_label = "instance"
+    }
+
+    // Set metrics path
+    rule {
+      source_labels = ["__meta_kubernetes_service_annotation_k8s_grafana_com_metrics_path"]
+      target_label = "__metrics_path__"
+    }
+
+    // Set metrics scraping URL parameters
+    rule {
+      action = "labelmap"
+      regex = "__meta_kubernetes_service_annotation_k8s_grafana_com_metrics_param_(.+)"
+      replacement = "__param_$1"
+    }
+
+    // Choose the service port
+    rule {
+      source_labels = ["__meta_kubernetes_service_port_name"]
+      target_label = "__tmp_port"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_service_annotation_k8s_grafana_com_metrics_portName"]
+      regex = "(.+)"
+      target_label = "__tmp_port"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_service_port_name"]
+      action = "keepequal"
+      target_label = "__tmp_port"
+    }
+
+    rule {
+      source_labels = ["__meta_kubernetes_service_port_number"]
+      target_label = "__tmp_port"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_service_annotation_k8s_grafana_com_metrics_portNumber"]
+      regex = "(.+)"
+      target_label = "__tmp_port"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_service_port_number"]
+      action = "keepequal"
+      target_label = "__tmp_port"
+    }
+    rule {
+      action = "labeldrop"
+      regex = "__tmp_port"
+    }
+
+    rule {
+      source_labels = ["__meta_kubernetes_service_annotation_k8s_grafana_com_metrics_scheme"]
+      regex = "(.+)"
+      target_label = "__scheme__"
+    }
+
+    rule {
+      source_labels = ["__meta_kubernetes_service_annotation_k8s_grafana_com_metrics_scrapeInterval"]
+      regex = "(.+)"
+      target_label = "__scrape_interval__"
+    }
+    rule {
+      source_labels = ["__scrape_interval__"]
+      regex = ""
+      replacement = "60s"
+      target_label = "__scrape_interval__"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_service_annotation_k8s_grafana_com_metrics_scrapeTimeout"]
+      regex = "(.+)"
+      target_label = "__scrape_timeout__"
+    }
+    rule {
+      source_labels = ["__scrape_timeout__"]
+      regex = ""
+      replacement = "10s"
+      target_label = "__scrape_timeout__"
+    }
+  } // discovery.relabel "annotation_autodiscovery_services"
+
+  discovery.relabel "annotation_autodiscovery_http" {
+    targets = array.concat(discovery.relabel.annotation_autodiscovery_pods.output, discovery.relabel.annotation_autodiscovery_services.output)
+    rule {
+      source_labels = ["__scheme__"]
+      regex = "https"
+      action = "drop"
+    }
+  } // discovery.relabel "annotation_autodiscovery_http"
+
+  discovery.relabel "annotation_autodiscovery_https" {
+    targets = array.concat(discovery.relabel.annotation_autodiscovery_pods.output, discovery.relabel.annotation_autodiscovery_services.output)
+    rule {
+      source_labels = ["__scheme__"]
+      regex = "https"
+      action = "keep"
+    }
+  } // discovery.relabel "annotation_autodiscovery_https"
+
+  prometheus.scrape "annotation_autodiscovery_http" {
+    targets = discovery.relabel.annotation_autodiscovery_http.output
+    honor_labels = true
+    bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+    scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
+    scrape_classic_histograms = false
+    scrape_native_histograms = false
+    convert_classic_histograms_to_nhcb = false
+    clustering {
+      enabled = true
+    }
+
+    forward_to = argument.metrics_destinations.value
+  } // prometheus.scrape "annotation_autodiscovery_http"
+
+  prometheus.scrape "annotation_autodiscovery_https" {
+    targets = discovery.relabel.annotation_autodiscovery_https.output
+    honor_labels = true
+    bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+    tls_config {
+      insecure_skip_verify = true
+    }
+    scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
+    scrape_classic_histograms = false
+    scrape_native_histograms = false
+    convert_classic_histograms_to_nhcb = false
+    clustering {
+      enabled = true
+    }
+
+    forward_to = argument.metrics_destinations.value
+  } // prometheus.relabel "annotation_autodiscovery"
+} // declare "annotation_autodiscovery"
+annotation_autodiscovery "feature" {
+  metrics_destinations = [
+    prometheus.remote_write.prometheus.receiver,
+  ]
+}
+
+
+// Feature: Cluster Metrics
+declare "cluster_metrics" {
+  argument "metrics_destinations" {
+    comment = "Must be a list of metric destinations where collected metrics should be forwarded to"
+  }
+  discovery.kubernetes "nodes" {
+    role = "node"
+  } // discovery.kubernetes "nodes"
+
+  discovery.relabel "nodes" {
+    targets = discovery.kubernetes.nodes.targets
+    rule {
+      source_labels = ["__meta_kubernetes_node_name"]
+      target_label  = "node"
+    }
+
+    rule {
+      replacement = "kubernetes"
+      target_label = "source"
+    }
+  } // discovery.relabel "nodes"
+
+  // Kubelet
+  discovery.relabel "kubelet" {
+    targets = discovery.relabel.nodes.output
+  } // discovery.relabel "kubelet"
+
+  prometheus.scrape "kubelet" {
+    targets  = discovery.relabel.kubelet.output
+    job_name = "integrations/kubernetes/kubelet"
+    scheme   = "https"
+    scrape_interval = "60s"
+    scrape_timeout = "10s"
+    scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
+    scrape_classic_histograms = false
+    scrape_native_histograms = false
+    convert_classic_histograms_to_nhcb = false
+    bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+
+    tls_config {
+      ca_file = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+      insecure_skip_verify = true
+      server_name = "kubernetes"
+    }
+
+    clustering {
+      enabled = true
+    }
+
+    forward_to = [prometheus.relabel.kubelet.receiver]
+  } // prometheus.scrape "kubelet"
+
+  prometheus.relabel "kubelet" {
+    max_cache_size = 100000
+    rule {
+      source_labels = ["__name__"]
+      regex = "up|scrape_samples_scraped|go_goroutines|kubelet_certificate_manager_client_expiration_renew_errors|kubelet_certificate_manager_client_ttl_seconds|kubelet_certificate_manager_server_ttl_seconds|kubelet_cgroup_manager_duration_seconds_bucket|kubelet_cgroup_manager_duration_seconds_count|kubelet_node_config_error|kubelet_node_name|kubelet_pleg_relist_duration_seconds_bucket|kubelet_pleg_relist_duration_seconds_count|kubelet_pleg_relist_interval_seconds_bucket|kubelet_pod_start_duration_seconds_bucket|kubelet_pod_start_duration_seconds_count|kubelet_pod_worker_duration_seconds_bucket|kubelet_pod_worker_duration_seconds_count|kubelet_running_container_count|kubelet_running_containers|kubelet_running_pod_count|kubelet_running_pods|kubelet_runtime_operations_errors_total|kubelet_runtime_operations_total|kubelet_server_expiration_renew_errors|kubelet_volume_stats_available_bytes|kubelet_volume_stats_capacity_bytes|kubelet_volume_stats_inodes|kubelet_volume_stats_inodes_free|kubelet_volume_stats_inodes_used|kubelet_volume_stats_used_bytes|kubernetes_build_info|namespace_workload_pod|process_cpu_seconds_total|process_resident_memory_bytes|rest_client_requests_total|storage_operation_duration_seconds_count|storage_operation_errors_total|volume_manager_total_volumes"
+      action = "keep"
+    }
+
+    forward_to = argument.metrics_destinations.value
+  } // prometheus.relabel "kubelet"
+
+  // Kubelet Resources
+  discovery.relabel "kubelet_resources" {
+    targets = discovery.relabel.nodes.output
+    rule {
+      replacement   = "/metrics/resource"
+      target_label  = "__metrics_path__"
+    }
+  } // discovery.relabel "kubelet_resources"
+
+  prometheus.scrape "kubelet_resources" {
+    targets = discovery.relabel.kubelet_resources.output
+    job_name = "integrations/kubernetes/resources"
+    scheme   = "https"
+    scrape_interval = "60s"
+    scrape_timeout = "10s"
+    scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
+    scrape_classic_histograms = false
+    scrape_native_histograms = false
+    convert_classic_histograms_to_nhcb = false
+    bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+
+    tls_config {
+      ca_file = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+      insecure_skip_verify = true
+      server_name = "kubernetes"
+    }
+
+    clustering {
+      enabled = true
+    }
+
+    forward_to = [prometheus.relabel.kubelet_resources.receiver]
+  } // prometheus.scrape "kubelet_resources"
+
+  prometheus.relabel "kubelet_resources" {
+    max_cache_size = 100000
+    rule {
+      source_labels = ["__name__"]
+      regex = "up|scrape_samples_scraped|node_cpu_usage_seconds_total|node_memory_working_set_bytes"
+      action = "keep"
+    }
+
+    forward_to = argument.metrics_destinations.value
+  } // prometheus.relabel "kubelet_resources"
+
+  // cAdvisor
+  discovery.relabel "cadvisor" {
+    targets = discovery.relabel.nodes.output
+    rule {
+      replacement   = "/metrics/cadvisor"
+      target_label  = "__metrics_path__"
+    }
+  } // discovery.relabel "cadvisor"
+
+  prometheus.scrape "cadvisor" {
+    targets = discovery.relabel.cadvisor.output
+    job_name = "integrations/kubernetes/cadvisor"
+    scheme = "https"
+    scrape_interval = "60s"
+    scrape_timeout = "10s"
+    scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
+    scrape_classic_histograms = false
+    scrape_native_histograms = false
+    convert_classic_histograms_to_nhcb = false
+    bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+
+    tls_config {
+      ca_file = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+      insecure_skip_verify = true
+      server_name = "kubernetes"
+    }
+
+    clustering {
+      enabled = true
+    }
+
+    forward_to = [prometheus.relabel.cadvisor.receiver]
+  } // prometheus.scrape "cadvisor"
+
+  prometheus.relabel "cadvisor" {
+    max_cache_size = 100000
+    rule {
+      source_labels = ["__name__"]
+      regex = "up|scrape_samples_scraped|container_cpu_cfs_periods_total|container_cpu_cfs_throttled_periods_total|container_cpu_usage_seconds_total|container_fs_reads_bytes_total|container_fs_reads_total|container_fs_writes_bytes_total|container_fs_writes_total|container_memory_cache|container_memory_rss|container_memory_swap|container_memory_usage_bytes|container_memory_working_set_bytes|container_network_receive_bytes_total|container_network_receive_packets_dropped_total|container_network_receive_packets_total|container_network_transmit_bytes_total|container_network_transmit_packets_dropped_total|container_network_transmit_packets_total|machine_memory_bytes"
+      action = "keep"
+    }
+    // Drop empty container labels, addressing https://github.com/google/cadvisor/issues/2688
+    rule {
+      source_labels = ["__name__","container"]
+      separator = "@"
+      regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_pressure_.*)@"
+      action = "drop"
+    }
+    // Drop empty image labels, addressing https://github.com/google/cadvisor/issues/2688
+    rule {
+      source_labels = ["__name__","image"]
+      separator = "@"
+      regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_network_.*|container_pressure_.*)@"
+      action = "drop"
+    }
+    // Normalizing unimportant labels (not deleting to continue satisfying <label>!="" checks)
+    rule {
+      source_labels = ["__name__", "boot_id"]
+      separator = "@"
+      regex = "machine_memory_bytes@.*"
+      target_label = "boot_id"
+      replacement = "NA"
+    }
+    rule {
+      source_labels = ["__name__", "system_uuid"]
+      separator = "@"
+      regex = "machine_memory_bytes@.*"
+      target_label = "system_uuid"
+      replacement = "NA"
+    }
+    // Filter out non-physical devices/interfaces
+    rule {
+      source_labels = ["__name__", "device"]
+      separator = "@"
+      regex = "container_fs_.*@(/dev/)?(mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dasd.+)"
+      target_label = "__keepme"
+      replacement = "1"
+    }
+    rule {
+      source_labels = ["__name__", "__keepme"]
+      separator = "@"
+      regex = "container_fs_.*@"
+      action = "drop"
+    }
+    rule {
+      source_labels = ["__name__"]
+      regex = "container_fs_.*"
+      target_label = "__keepme"
+      replacement = ""
+    }
+    rule {
+      source_labels = ["__name__", "interface"]
+      separator = "@"
+      regex = "container_network_.*@(en[ospx][0-9].*|wlan[0-9].*|eth[0-9].*)"
+      target_label = "__keepme"
+      replacement = "1"
+    }
+    rule {
+      source_labels = ["__name__", "__keepme"]
+      separator = "@"
+      regex = "container_network_.*@"
+      action = "drop"
+    }
+    rule {
+      source_labels = ["__name__"]
+      regex = "container_network_.*"
+      target_label = "__keepme"
+      replacement = ""
+    }
+    forward_to = argument.metrics_destinations.value
+  } // prometheus.relabel "cadvisor"
+  discovery.kubernetes "kube_state_metrics" {
+    role = "endpoints"
+
+    selectors {
+      role = "endpoints"
+      label = "release=k8smon,app.kubernetes.io/name=kube-state-metrics"
+    }
+    namespaces {
+      names = ["default"]
+    }
+  } // discovery.kubernetes "kube_state_metrics"
+
+  discovery.relabel "kube_state_metrics" {
+    targets = discovery.kubernetes.kube_state_metrics.targets
+
+    rule {
+      action = "replace"
+      replacement = "kubernetes"
+      target_label = "source"
+    }
+
+  } // discovery.relabel "kube_state_metrics"
+
+  prometheus.scrape "kube_state_metrics" {
+    targets = discovery.relabel.kube_state_metrics.output
+    job_name = "integrations/kubernetes/kube-state-metrics"
+    scrape_interval = "60s"
+    scrape_timeout = "10s"
+    scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
+    scrape_classic_histograms = false
+    scrape_native_histograms = false
+    convert_classic_histograms_to_nhcb = false
+    scheme = "http"
+    bearer_token_file = ""
+    tls_config {
+      insecure_skip_verify = true
+    }
+
+    clustering {
+      enabled = true
+    }
+    forward_to = [prometheus.relabel.kube_state_metrics.receiver]
+  } // prometheus.scrape "kube_state_metrics"
+
+  prometheus.relabel "kube_state_metrics" {
+    max_cache_size = 100000
+    rule {
+      source_labels = ["__name__"]
+      regex = "up|scrape_samples_scraped|kube_configmap_info|kube_configmap_metadata_resource_version|kube_cronjob.*|kube_daemonset.*|kube_deployment_metadata_generation|kube_deployment_spec_replicas|kube_deployment_status_condition|kube_deployment_status_observed_generation|kube_deployment_status_replicas_available|kube_deployment_status_replicas_updated|kube_horizontalpodautoscaler_spec_max_replicas|kube_horizontalpodautoscaler_spec_min_replicas|kube_horizontalpodautoscaler_status_current_replicas|kube_horizontalpodautoscaler_status_desired_replicas|kube_job.*|kube_namespace_status_phase|kube_node.*|kube_persistentvolume_status_phase|kube_persistentvolumeclaim_access_mode|kube_persistentvolumeclaim_info|kube_persistentvolumeclaim_labels|kube_persistentvolumeclaim_resource_requests_storage_bytes|kube_persistentvolumeclaim_status_phase|kube_pod_completion_time|kube_pod_container_info|kube_pod_container_resource_limits|kube_pod_container_resource_requests|kube_pod_container_status_last_terminated_reason|kube_pod_container_status_last_terminated_timestamp|kube_pod_container_status_restarts_total|kube_pod_container_status_waiting_reason|kube_pod_info|kube_pod_owner|kube_pod_restart_policy|kube_pod_spec_volumes_persistentvolumeclaims_info|kube_pod_start_time|kube_pod_status_phase|kube_pod_status_reason|kube_pod_init_.*|kube_replicaset.*|kube_resourcequota|kube_secret_metadata_resource_version|kube_statefulset.*"
+      action = "keep"
+    }
+    forward_to = argument.metrics_destinations.value
+  } // prometheus.relabel "kube_state_metrics"
+} // declare "cluster_metrics"
+cluster_metrics "feature" {
+  metrics_destinations = [
+    prometheus.remote_write.prometheus.receiver,
+  ]
+}
+
+
+// Feature: Host Metrics
+declare "host_metrics" {
+  argument "metrics_destinations" {
+    comment = "Must be a list of metric destinations where collected metrics should be forwarded to"
+  }
+
+  // Linux hosts via Node Exporter
+  discovery.kubernetes "node_exporter" {
+    role = "pod"
+    selectors {
+      role = "pod"
+      label = "release=k8smon,app.kubernetes.io/name=node-exporter"
+    }
+    namespaces {
+      names = ["default"]
+    }
+
+  } // discovery.kubernetes "node_exporter"
+
+  discovery.relabel "node_exporter" {
+    targets = discovery.kubernetes.node_exporter.targets
+
+    // keep only the specified metrics port name, and pods that are Running and ready
+    rule {
+      source_labels = [
+        "__meta_kubernetes_pod_container_init",
+        "__meta_kubernetes_pod_phase",
+        "__meta_kubernetes_pod_ready",
+      ]
+      separator = "@"
+      regex = "false@Running@true"
+      action = "keep"
+    }
+
+    // Set the instance label to the node name
+    rule {
+      source_labels = ["__meta_kubernetes_pod_node_name"]
+      target_label = "instance"
+    }
+
+    rule {
+      source_labels = ["__meta_kubernetes_namespace"]
+      target_label  = "namespace"
+    }
+
+    rule {
+      source_labels = ["__meta_kubernetes_pod_name"]
+      target_label  = "pod"
+    }
+
+    rule {
+      source_labels = ["__meta_kubernetes_pod_container_name"]
+      target_label  = "container"
+    }
+
+    // set a workload label
+    rule {
+      source_labels = [
+        "__meta_kubernetes_pod_controller_kind",
+        "__meta_kubernetes_pod_controller_name",
+      ]
+      separator = "/"
+      target_label  = "workload"
+    }
+    // remove the hash from the ReplicaSet
+    rule {
+      source_labels = ["workload"]
+      regex = "(ReplicaSet/.+)-.+"
+      target_label  = "workload"
+    }
+
+    // Set the app label.
+    //
+    // Choose the first value found from the following ordered list:
+    // - pod.label[app.kubernetes.io/name]
+    // - pod.label[k8s-app]
+    // - pod.label[app]
+    rule {
+      source_labels = [
+        "__meta_kubernetes_pod_label_app_kubernetes_io_name",
+        "__meta_kubernetes_pod_label_k8s_app",
+        "__meta_kubernetes_pod_label_app",
+      ]
+      separator = ";"
+      regex = "^(?:;*)?([^;]+).*$"
+      replacement = "$1"
+      target_label = "app"
+    }
+
+    // Set the component label.
+    //
+    // Choose the first value found from the following ordered list:
+    // - pod.label[app.kubernetes.io/component]
+    // - pod.label[k8s-component]
+    // - pod.label[component]
+    rule {
+      source_labels = [
+        "__meta_kubernetes_pod_label_app_kubernetes_io_component",
+        "__meta_kubernetes_pod_label_k8s_component",
+        "__meta_kubernetes_pod_label_component",
+      ]
+      regex = "^(?:;*)?([^;]+).*$"
+      replacement = "$1"
+      target_label = "component"
+    }
+
+    rule {
+      target_label = "source"
+      replacement = "kubernetes"
+    }
+
+  } // discovery.relabel "node_exporter"
+
+  prometheus.scrape "node_exporter" {
+    targets = discovery.relabel.node_exporter.output
+    job_name = "integrations/node_exporter"
+    scrape_interval = "60s"
+    scrape_timeout = "10s"
+    scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
+    scrape_classic_histograms = false
+    scrape_native_histograms = false
+    convert_classic_histograms_to_nhcb = false
+    scheme = "http"
+    tls_config {
+      insecure_skip_verify = true
+    }
+
+    clustering {
+      enabled = true
+    }
+    forward_to = [prometheus.relabel.node_exporter.receiver]
+  } // prometheus.scrape "node_exporter"
+
+  prometheus.relabel "node_exporter" {
+    max_cache_size = 100000
+    rule {
+      source_labels = ["__name__"]
+      regex = "up|scrape_samples_scraped|node_cpu.*|node_exporter_build_info|node_filesystem.*|node_memory.*|node_network_receive_bytes_total|node_network_receive_drop_total|node_network_transmit_bytes_total|node_network_transmit_drop_total|process_cpu_seconds_total|process_resident_memory_bytes"
+      action = "keep"
+    }
+    // Drop metrics for certain file systems
+    rule {
+      source_labels = ["__name__", "fstype"]
+      separator = "@"
+      regex = "node_filesystem.*@(ramfs|tmpfs)"
+      action = "drop"
+    }
+    forward_to = argument.metrics_destinations.value
+  } // prometheus.relabel "node_exporter"
+} // declare "host_metrics"
+host_metrics "feature" {
+  metrics_destinations = [
+    prometheus.remote_write.prometheus.receiver,
+  ]
+}
+
+
+
+
+
+
+
+
+
+
+// Self Reporting
+prometheus.exporter.unix "kubernetes_monitoring_telemetry" {
+  set_collectors = ["textfile"]
+  textfile {
+    directory = "/etc/release-info"
+  }
+} // prometheus.exporter.unix "kubernetes_monitoring_telemetry"
+
+discovery.relabel "kubernetes_monitoring_telemetry" {
+  targets = prometheus.exporter.unix.kubernetes_monitoring_telemetry.targets
+  rule {
+    target_label = "instance"
+    action = "replace"
+    replacement = "k8smon"
+  }
+  rule {
+    target_label = "job"
+    action = "replace"
+    replacement = "integrations/kubernetes/kubernetes_monitoring_telemetry"
+  }
+} // discovery.relabel "kubernetes_monitoring_telemetry"
+
+prometheus.scrape "kubernetes_monitoring_telemetry" {
+  job_name   = "integrations/kubernetes/kubernetes_monitoring_telemetry"
+  targets    = discovery.relabel.kubernetes_monitoring_telemetry.output
+  scrape_interval = "60s"
+  clustering {
+    enabled = true
+  }
+  forward_to = [prometheus.relabel.kubernetes_monitoring_telemetry.receiver]
+} // prometheus.scrape "kubernetes_monitoring_telemetry"
+
+prometheus.relabel "kubernetes_monitoring_telemetry" {
+  rule {
+    source_labels = ["__name__"]
+    regex = "grafana_kubernetes_monitoring_.*"
+    action = "keep"
+  }
+  forward_to = [
+    prometheus.remote_write.prometheus.receiver,
+  ]
+} // prometheus.relabel "kubernetes_monitoring_telemetry"
+
+
+
+
+
+// Destination: prometheus (prometheus)
+otelcol.exporter.prometheus "prometheus" {
+  add_metric_suffixes = true
+  resource_to_telemetry_conversion = false
+  keep_identifying_resource_attributes = true
+  forward_to = [prometheus.remote_write.prometheus.receiver]
+} // otelcol.exporter.prometheus "prometheus"
+
+prometheus.remote_write "prometheus" {
+  endpoint {
+    url = "http://prometheus-server.prometheus.svc:9090/api/v1/write"
+    headers = {
+    }
+    tls_config {
+      insecure_skip_verify = false
+    }
+    send_native_histograms = false
+
+    queue_config {
+      capacity = 10000
+      min_shards = 1
+      max_shards = 50
+      max_samples_per_send = 2000
+      batch_send_deadline = "5s"
+      min_backoff = "30ms"
+      max_backoff = "5s"
+      retry_on_http_429 = true
+      sample_age_limit = "0s"
+    }
+  }
+
+  wal {
+    truncate_frequency = "2h"
+    min_keepalive_time = "5m"
+    max_keepalive_time = "8h"
+  }
+  external_labels = {
+    "cluster" = "sharded-kube-state-metrics-test",
+    "k8s_cluster_name" = "sharded-kube-state-metrics-test",
+  }
+} // prometheus.remote_write "prometheus"
+

--- a/charts/k8s-monitoring/tests/integration/split-destinations/.rendered/alloy-logs.alloy
+++ b/charts/k8s-monitoring/tests/integration/split-destinations/.rendered/alloy-logs.alloy
@@ -1,0 +1,278 @@
+// Feature: Pod Logs (Loki)
+declare "pod_logs_via_loki" {
+  argument "logs_destinations" {
+    comment = "Must be a list of log destinations where collected logs should be forwarded to"
+  }
+
+  discovery.kubernetes "pods" {
+    role = "pod"
+    selectors {
+      role = "pod"
+      field = "spec.nodeName=" + sys.env("HOSTNAME")
+    }
+  } // discovery.kubernetes "pods"
+
+  discovery.relabel "filtered_pods" {
+    targets = discovery.kubernetes.pods.targets
+    rule {
+      source_labels = ["__meta_kubernetes_namespace"]
+      action = "replace"
+      target_label = "namespace"
+    }
+    rule {  // Drop anything with a "falsy" annotation value
+      source_labels = ["__meta_kubernetes_pod_annotation_logs_grafana_com_pods_enabled"]
+      regex = "(false|no|skip)"
+      action = "drop"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_pod_name"]
+      target_label = "pod"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_pod_container_name"]
+      target_label = "container"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_namespace", "__meta_kubernetes_pod_container_name"]
+      separator = "/"
+      replacement = "$1"
+      target_label = "job"
+    }
+
+    // set the container runtime as a label
+    rule {
+      source_labels = ["__meta_kubernetes_pod_container_id"]
+      regex = "^(\\S+):\\/\\/.+$"
+      replacement = "$1"
+      target_label = "tmp_container_runtime"
+    }
+    // explicitly set service_name. if not set, loki will automatically try to populate a default.
+    // see https://grafana.com/docs/loki/latest/get-started/labels/#default-labels-for-all-users
+    //
+    // choose the first value found from the following ordered list:
+    // - pod.annotation[resource.opentelemetry.io/service.name]
+    // - pod.label[app.kubernetes.io/name]
+    // - k8s.container.name
+    rule {
+      source_labels = [
+        "__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_name",
+        "__meta_kubernetes_pod_label_app_kubernetes_io_name",
+        "__meta_kubernetes_pod_container_name",
+      ]
+      separator = ";"
+      regex = "^(?:;*)?([^;]+).*$"
+      replacement = "$1"
+      target_label = "service_name"
+    }
+
+    // explicitly set service_namespace.
+    //
+    // choose the first value found from the following ordered list:
+    // - pod.annotation[resource.opentelemetry.io/service.namespace]
+    // - pod.namespace
+    rule {
+      source_labels = [
+        "__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_namespace",
+        "namespace",
+      ]
+      separator = ";"
+      regex = "^(?:;*)?([^;]+).*$"
+      replacement = "$1"
+      target_label = "service_namespace"
+    }
+
+    // explicitly set service_instance_id.
+    //
+    // choose the first value found from the following ordered list:
+    // - pod.annotation[resource.opentelemetry.io/service.instance.id]
+    // - concat([k8s.namespace.name, k8s.pod.name, k8s.container.name], '.')
+    rule {
+      source_labels = ["__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_instance_id"]
+      target_label = "service_instance_id"
+    }
+    rule {
+      source_labels = ["service_instance_id", "namespace", "pod", "container"]
+      separator = "."
+      regex = "^\\.([^.]+\\.[^.]+\\.[^.]+)$"
+      target_label = "service_instance_id"
+    }
+
+    // set resource attributes
+    rule {
+      action = "labelmap"
+      regex = "__meta_kubernetes_pod_annotation_resource_opentelemetry_io_(.+)"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_job"]
+      regex = "(.+)"
+      target_label = "job"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+      regex = "(.+)"
+      target_label = "app_kubernetes_io_name"
+    }
+
+    // Set the pod log path.
+    rule {
+      source_labels = ["__meta_kubernetes_pod_uid", "__meta_kubernetes_pod_container_name"]
+      separator = "/"
+      replacement = "/var/log/pods/*$1/*.log"
+      target_label = "__path__"
+    }
+
+    // If kubernetes.io/config.mirror is set, this is a static pod, created by the kubelet.
+    // It's logs live on a different path.
+    rule {
+      source_labels = ["__meta_kubernetes_pod_annotation_kubernetes_io_config_mirror", "__meta_kubernetes_pod_container_name"]
+      separator = "/"
+      regex = "(.+/.+)"
+      replacement = "/var/log/pods/*$1/*.log"
+      target_label = "__path__"
+    }
+  } // discovery.relabel "filtered_pods"
+
+  local.file_match "pod_logs" {
+    path_targets = discovery.relabel.filtered_pods.output
+  } // local.file_match "pod_logs"
+
+  loki.source.file "pod_logs" {
+    targets    = local.file_match.pod_logs.targets
+    tail_from_end = true
+    forward_to = [loki.process.pod_logs.receiver]
+  } // loki.source.file "pod_logs"
+
+  loki.process "pod_logs" {
+    stage.match {
+      selector = "{tmp_container_runtime=~\"containerd|cri-o|\"}"
+      // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
+      stage.cri {
+        max_partial_lines = 100
+      }
+
+      // Set the extract flags and stream values as labels
+      stage.labels {
+        values = {
+          flags  = "",
+          stream  = "",
+        }
+      }
+    }
+
+    stage.match {
+      selector = "{tmp_container_runtime=\"docker\"}"
+      // the docker processing stage extracts the following k/v pairs: log, stream, time
+      stage.docker {}
+
+      // Set the extract stream value as a label
+      stage.labels {
+        values = {
+          stream  = "",
+        }
+      }
+    }
+
+    // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
+    // namespace, pod, and container labels. Drop any structured metadata. Also drop the temporary
+    // container runtime label as it is no longer needed.
+    stage.label_drop {
+      values = [
+        "filename",
+        "tmp_container_runtime",
+      ]
+    }
+    stage.structured_metadata {
+      values = {
+        "k8s_pod_name" = "k8s_pod_name",
+        "pod" = "pod",
+        "service_instance_id" = "service_instance_id",
+      }
+    }
+
+    forward_to = argument.logs_destinations.value
+  } // loki.secretfilter "pod_logs"
+} // declare "pod_logs_via_loki"
+pod_logs_via_loki "feature" {
+  logs_destinations = [
+    loki.write.alllogs.receiver,
+    loki.process.productionlogs.receiver,
+  ]
+}
+
+
+
+
+
+// Destination: allLogs (loki)
+otelcol.exporter.loki "alllogs" {
+  forward_to = [loki.write.alllogs.receiver]
+} // otelcol.exporter.loki "alllogs"
+
+loki.write "alllogs" {
+  endpoint {
+    url = "http://all-logs-loki.all-dbs.svc:3100/loki/api/v1/push"
+    retry_on_http_429 = true
+    tenant_id = convert.nonsensitive(remote.kubernetes.secret.alllogs.data["tenantId"])
+    basic_auth {
+      username = convert.nonsensitive(remote.kubernetes.secret.alllogs.data["username"])
+      password = remote.kubernetes.secret.alllogs.data["password"]
+    }
+    tls_config {
+      insecure_skip_verify = false
+    }
+    min_backoff_period = "500ms"
+    max_backoff_period = "5m"
+    max_backoff_retries = "10"
+  }
+  external_labels = {
+    "cluster" = "split-destinations-cluster",
+    "k8s_cluster_name" = "split-destinations-cluster",
+  }
+} // loki.write "alllogs"
+
+remote.kubernetes.secret "alllogs" {
+  name      = "alllogs-k8smon-k8s-monitoring"
+  namespace = "default"
+} // remote.kubernetes.secret "alllogs"
+
+
+// Destination: productionLogs (loki)
+otelcol.exporter.loki "productionlogs" {
+  forward_to = [loki.process.productionlogs.receiver]
+} // otelcol.exporter.loki "productionlogs"
+
+loki.process "productionlogs" {
+  stage.match {
+    selector = "{namespace!=\"production\"}"
+    action   = "drop"
+  }
+  forward_to = [loki.write.productionlogs.receiver]
+} // loki.process "productionlogs"
+
+loki.write "productionlogs" {
+  endpoint {
+    url = "http://prod-logs-loki.prod-dbs.svc:3100/loki/api/v1/push"
+    retry_on_http_429 = true
+    tenant_id = convert.nonsensitive(remote.kubernetes.secret.productionlogs.data["tenantId"])
+    basic_auth {
+      username = convert.nonsensitive(remote.kubernetes.secret.productionlogs.data["username"])
+      password = remote.kubernetes.secret.productionlogs.data["password"]
+    }
+    tls_config {
+      insecure_skip_verify = false
+    }
+    min_backoff_period = "500ms"
+    max_backoff_period = "5m"
+    max_backoff_retries = "10"
+  }
+  external_labels = {
+    "cluster" = "split-destinations-cluster",
+    "k8s_cluster_name" = "split-destinations-cluster",
+  }
+} // loki.write "productionlogs"
+
+remote.kubernetes.secret "productionlogs" {
+  name      = "productionlogs-k8smon-k8s-monitoring"
+  namespace = "default"
+} // remote.kubernetes.secret "productionlogs"
+

--- a/charts/k8s-monitoring/tests/integration/split-destinations/.rendered/alloy-metrics.alloy
+++ b/charts/k8s-monitoring/tests/integration/split-destinations/.rendered/alloy-metrics.alloy
@@ -1,0 +1,610 @@
+// Feature: Auto-Instrumentation
+declare "auto_instrumentation" {
+  argument "metrics_destinations" {
+    comment = "Must be a list of metric destinations where collected metrics should be forwarded to"
+  }
+
+  discovery.kubernetes "beyla_pods" {
+    role = "pod"
+    namespaces {
+      own_namespace = true
+    }
+    selectors {
+      role = "pod"
+      label = "app.kubernetes.io/name=beyla"
+    }
+  } // discovery.kubernetes "beyla_pods"
+
+  discovery.relabel "beyla_pods" {
+    targets = discovery.kubernetes.beyla_pods.targets
+    rule {
+      source_labels = ["__meta_kubernetes_pod_node_name"]
+      action = "replace"
+      target_label = "instance"
+    }
+  } // discovery.relabel "beyla_pods"
+
+  prometheus.scrape "beyla_applications" {
+    targets         = discovery.relabel.beyla_pods.output
+    honor_labels    = true
+    scrape_interval = "60s"
+    scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
+    scrape_classic_histograms = false
+    scrape_native_histograms = false
+    convert_classic_histograms_to_nhcb = false
+    clustering {
+      enabled = true
+    }
+    forward_to = argument.metrics_destinations.value
+  } // prometheus.scrape "beyla_applications"
+
+  prometheus.scrape "beyla_internal" {
+    targets         = discovery.relabel.beyla_pods.output
+    metrics_path    = "/internal/metrics"
+    job_name        = "integrations/beyla"
+    honor_labels    = true
+    scrape_interval = "60s"
+    scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
+    scrape_classic_histograms = false
+    scrape_native_histograms = false
+    convert_classic_histograms_to_nhcb = false
+    clustering {
+      enabled = true
+    }
+    forward_to = argument.metrics_destinations.value
+  } // prometheus.relabel "beyla"
+} // declare "auto_instrumentation"
+auto_instrumentation "feature" {
+  metrics_destinations = [
+    prometheus.remote_write.allmetrics.receiver,
+    prometheus.remote_write.productionmetrics.receiver,
+  ]
+}
+// Feature: Cluster Metrics
+declare "cluster_metrics" {
+  argument "metrics_destinations" {
+    comment = "Must be a list of metric destinations where collected metrics should be forwarded to"
+  }
+  discovery.kubernetes "nodes" {
+    role = "node"
+  } // discovery.kubernetes "nodes"
+
+  discovery.relabel "nodes" {
+    targets = discovery.kubernetes.nodes.targets
+    rule {
+      source_labels = ["__meta_kubernetes_node_name"]
+      target_label  = "node"
+    }
+
+    rule {
+      replacement = "kubernetes"
+      target_label = "source"
+    }
+  } // discovery.relabel "nodes"
+
+  // Kubelet
+  discovery.relabel "kubelet" {
+    targets = discovery.relabel.nodes.output
+  } // discovery.relabel "kubelet"
+
+  prometheus.scrape "kubelet" {
+    targets  = discovery.relabel.kubelet.output
+    job_name = "integrations/kubernetes/kubelet"
+    scheme   = "https"
+    scrape_interval = "60s"
+    scrape_timeout = "10s"
+    scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
+    scrape_classic_histograms = false
+    scrape_native_histograms = false
+    convert_classic_histograms_to_nhcb = false
+    bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+
+    tls_config {
+      ca_file = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+      insecure_skip_verify = true
+      server_name = "kubernetes"
+    }
+
+    clustering {
+      enabled = true
+    }
+
+    forward_to = [prometheus.relabel.kubelet.receiver]
+  } // prometheus.scrape "kubelet"
+
+  prometheus.relabel "kubelet" {
+    max_cache_size = 100000
+    rule {
+      source_labels = ["__name__"]
+      regex = "up|scrape_samples_scraped|go_goroutines|kubelet_certificate_manager_client_expiration_renew_errors|kubelet_certificate_manager_client_ttl_seconds|kubelet_certificate_manager_server_ttl_seconds|kubelet_cgroup_manager_duration_seconds_bucket|kubelet_cgroup_manager_duration_seconds_count|kubelet_node_config_error|kubelet_node_name|kubelet_pleg_relist_duration_seconds_bucket|kubelet_pleg_relist_duration_seconds_count|kubelet_pleg_relist_interval_seconds_bucket|kubelet_pod_start_duration_seconds_bucket|kubelet_pod_start_duration_seconds_count|kubelet_pod_worker_duration_seconds_bucket|kubelet_pod_worker_duration_seconds_count|kubelet_running_container_count|kubelet_running_containers|kubelet_running_pod_count|kubelet_running_pods|kubelet_runtime_operations_errors_total|kubelet_runtime_operations_total|kubelet_server_expiration_renew_errors|kubelet_volume_stats_available_bytes|kubelet_volume_stats_capacity_bytes|kubelet_volume_stats_inodes|kubelet_volume_stats_inodes_free|kubelet_volume_stats_inodes_used|kubelet_volume_stats_used_bytes|kubernetes_build_info|namespace_workload_pod|process_cpu_seconds_total|process_resident_memory_bytes|rest_client_requests_total|storage_operation_duration_seconds_count|storage_operation_errors_total|volume_manager_total_volumes"
+      action = "keep"
+    }
+
+    forward_to = argument.metrics_destinations.value
+  } // prometheus.relabel "kubelet"
+
+  // Kubelet Resources
+  discovery.relabel "kubelet_resources" {
+    targets = discovery.relabel.nodes.output
+    rule {
+      replacement   = "/metrics/resource"
+      target_label  = "__metrics_path__"
+    }
+  } // discovery.relabel "kubelet_resources"
+
+  prometheus.scrape "kubelet_resources" {
+    targets = discovery.relabel.kubelet_resources.output
+    job_name = "integrations/kubernetes/resources"
+    scheme   = "https"
+    scrape_interval = "60s"
+    scrape_timeout = "10s"
+    scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
+    scrape_classic_histograms = false
+    scrape_native_histograms = false
+    convert_classic_histograms_to_nhcb = false
+    bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+
+    tls_config {
+      ca_file = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+      insecure_skip_verify = true
+      server_name = "kubernetes"
+    }
+
+    clustering {
+      enabled = true
+    }
+
+    forward_to = [prometheus.relabel.kubelet_resources.receiver]
+  } // prometheus.scrape "kubelet_resources"
+
+  prometheus.relabel "kubelet_resources" {
+    max_cache_size = 100000
+    rule {
+      source_labels = ["__name__"]
+      regex = "up|scrape_samples_scraped|node_cpu_usage_seconds_total|node_memory_working_set_bytes"
+      action = "keep"
+    }
+
+    forward_to = argument.metrics_destinations.value
+  } // prometheus.relabel "kubelet_resources"
+
+  // cAdvisor
+  discovery.relabel "cadvisor" {
+    targets = discovery.relabel.nodes.output
+    rule {
+      replacement   = "/metrics/cadvisor"
+      target_label  = "__metrics_path__"
+    }
+  } // discovery.relabel "cadvisor"
+
+  prometheus.scrape "cadvisor" {
+    targets = discovery.relabel.cadvisor.output
+    job_name = "integrations/kubernetes/cadvisor"
+    scheme = "https"
+    scrape_interval = "60s"
+    scrape_timeout = "10s"
+    scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
+    scrape_classic_histograms = false
+    scrape_native_histograms = false
+    convert_classic_histograms_to_nhcb = false
+    bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+
+    tls_config {
+      ca_file = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+      insecure_skip_verify = true
+      server_name = "kubernetes"
+    }
+
+    clustering {
+      enabled = true
+    }
+
+    forward_to = [prometheus.relabel.cadvisor.receiver]
+  } // prometheus.scrape "cadvisor"
+
+  prometheus.relabel "cadvisor" {
+    max_cache_size = 100000
+    rule {
+      source_labels = ["__name__"]
+      regex = "up|scrape_samples_scraped|container_cpu_cfs_periods_total|container_cpu_cfs_throttled_periods_total|container_cpu_usage_seconds_total|container_fs_reads_bytes_total|container_fs_reads_total|container_fs_writes_bytes_total|container_fs_writes_total|container_memory_cache|container_memory_rss|container_memory_swap|container_memory_usage_bytes|container_memory_working_set_bytes|container_network_receive_bytes_total|container_network_receive_packets_dropped_total|container_network_receive_packets_total|container_network_transmit_bytes_total|container_network_transmit_packets_dropped_total|container_network_transmit_packets_total|machine_memory_bytes"
+      action = "keep"
+    }
+    // Drop empty container labels, addressing https://github.com/google/cadvisor/issues/2688
+    rule {
+      source_labels = ["__name__","container"]
+      separator = "@"
+      regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_pressure_.*)@"
+      action = "drop"
+    }
+    // Drop empty image labels, addressing https://github.com/google/cadvisor/issues/2688
+    rule {
+      source_labels = ["__name__","image"]
+      separator = "@"
+      regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_network_.*|container_pressure_.*)@"
+      action = "drop"
+    }
+    // Normalizing unimportant labels (not deleting to continue satisfying <label>!="" checks)
+    rule {
+      source_labels = ["__name__", "boot_id"]
+      separator = "@"
+      regex = "machine_memory_bytes@.*"
+      target_label = "boot_id"
+      replacement = "NA"
+    }
+    rule {
+      source_labels = ["__name__", "system_uuid"]
+      separator = "@"
+      regex = "machine_memory_bytes@.*"
+      target_label = "system_uuid"
+      replacement = "NA"
+    }
+    // Filter out non-physical devices/interfaces
+    rule {
+      source_labels = ["__name__", "device"]
+      separator = "@"
+      regex = "container_fs_.*@(/dev/)?(mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dasd.+)"
+      target_label = "__keepme"
+      replacement = "1"
+    }
+    rule {
+      source_labels = ["__name__", "__keepme"]
+      separator = "@"
+      regex = "container_fs_.*@"
+      action = "drop"
+    }
+    rule {
+      source_labels = ["__name__"]
+      regex = "container_fs_.*"
+      target_label = "__keepme"
+      replacement = ""
+    }
+    rule {
+      source_labels = ["__name__", "interface"]
+      separator = "@"
+      regex = "container_network_.*@(en[ospx][0-9].*|wlan[0-9].*|eth[0-9].*)"
+      target_label = "__keepme"
+      replacement = "1"
+    }
+    rule {
+      source_labels = ["__name__", "__keepme"]
+      separator = "@"
+      regex = "container_network_.*@"
+      action = "drop"
+    }
+    rule {
+      source_labels = ["__name__"]
+      regex = "container_network_.*"
+      target_label = "__keepme"
+      replacement = ""
+    }
+    forward_to = argument.metrics_destinations.value
+  } // prometheus.relabel "cadvisor"
+  discovery.kubernetes "kube_state_metrics" {
+    role = "endpoints"
+
+    selectors {
+      role = "endpoints"
+      label = "release=k8smon,app.kubernetes.io/name=kube-state-metrics"
+    }
+    namespaces {
+      names = ["default"]
+    }
+  } // discovery.kubernetes "kube_state_metrics"
+
+  discovery.relabel "kube_state_metrics" {
+    targets = discovery.kubernetes.kube_state_metrics.targets
+
+    rule {
+      action = "replace"
+      replacement = "kubernetes"
+      target_label = "source"
+    }
+
+  } // discovery.relabel "kube_state_metrics"
+
+  prometheus.scrape "kube_state_metrics" {
+    targets = discovery.relabel.kube_state_metrics.output
+    job_name = "integrations/kubernetes/kube-state-metrics"
+    scrape_interval = "60s"
+    scrape_timeout = "10s"
+    scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
+    scrape_classic_histograms = false
+    scrape_native_histograms = false
+    convert_classic_histograms_to_nhcb = false
+    scheme = "http"
+    bearer_token_file = ""
+    tls_config {
+      insecure_skip_verify = true
+    }
+
+    clustering {
+      enabled = true
+    }
+    forward_to = [prometheus.relabel.kube_state_metrics.receiver]
+  } // prometheus.scrape "kube_state_metrics"
+
+  prometheus.relabel "kube_state_metrics" {
+    max_cache_size = 100000
+    rule {
+      source_labels = ["__name__"]
+      regex = "up|scrape_samples_scraped|kube_configmap_info|kube_configmap_metadata_resource_version|kube_cronjob.*|kube_daemonset.*|kube_deployment_metadata_generation|kube_deployment_spec_replicas|kube_deployment_status_condition|kube_deployment_status_observed_generation|kube_deployment_status_replicas_available|kube_deployment_status_replicas_updated|kube_horizontalpodautoscaler_spec_max_replicas|kube_horizontalpodautoscaler_spec_min_replicas|kube_horizontalpodautoscaler_status_current_replicas|kube_horizontalpodautoscaler_status_desired_replicas|kube_job.*|kube_namespace_status_phase|kube_node.*|kube_persistentvolume_status_phase|kube_persistentvolumeclaim_access_mode|kube_persistentvolumeclaim_info|kube_persistentvolumeclaim_labels|kube_persistentvolumeclaim_resource_requests_storage_bytes|kube_persistentvolumeclaim_status_phase|kube_pod_completion_time|kube_pod_container_info|kube_pod_container_resource_limits|kube_pod_container_resource_requests|kube_pod_container_status_last_terminated_reason|kube_pod_container_status_last_terminated_timestamp|kube_pod_container_status_restarts_total|kube_pod_container_status_waiting_reason|kube_pod_info|kube_pod_owner|kube_pod_restart_policy|kube_pod_spec_volumes_persistentvolumeclaims_info|kube_pod_start_time|kube_pod_status_phase|kube_pod_status_reason|kube_pod_init_.*|kube_replicaset.*|kube_resourcequota|kube_secret_metadata_resource_version|kube_statefulset.*"
+      action = "keep"
+    }
+    forward_to = argument.metrics_destinations.value
+  } // prometheus.relabel "kube_state_metrics"
+} // declare "cluster_metrics"
+cluster_metrics "feature" {
+  metrics_destinations = [
+    prometheus.remote_write.allmetrics.receiver,
+    prometheus.remote_write.productionmetrics.receiver,
+  ]
+}
+// Feature: Host Metrics
+declare "host_metrics" {
+  argument "metrics_destinations" {
+    comment = "Must be a list of metric destinations where collected metrics should be forwarded to"
+  }
+
+  // Linux hosts via Node Exporter
+  discovery.kubernetes "node_exporter" {
+    role = "pod"
+    selectors {
+      role = "pod"
+      label = "release=k8smon,app.kubernetes.io/name=node-exporter"
+    }
+    namespaces {
+      names = ["default"]
+    }
+
+  } // discovery.kubernetes "node_exporter"
+
+  discovery.relabel "node_exporter" {
+    targets = discovery.kubernetes.node_exporter.targets
+
+    // keep only the specified metrics port name, and pods that are Running and ready
+    rule {
+      source_labels = [
+        "__meta_kubernetes_pod_container_init",
+        "__meta_kubernetes_pod_phase",
+        "__meta_kubernetes_pod_ready",
+      ]
+      separator = "@"
+      regex = "false@Running@true"
+      action = "keep"
+    }
+
+    // Set the instance label to the node name
+    rule {
+      source_labels = ["__meta_kubernetes_pod_node_name"]
+      target_label = "instance"
+    }
+
+    rule {
+      source_labels = ["__meta_kubernetes_namespace"]
+      target_label  = "namespace"
+    }
+
+    rule {
+      source_labels = ["__meta_kubernetes_pod_name"]
+      target_label  = "pod"
+    }
+
+    rule {
+      source_labels = ["__meta_kubernetes_pod_container_name"]
+      target_label  = "container"
+    }
+
+    // set a workload label
+    rule {
+      source_labels = [
+        "__meta_kubernetes_pod_controller_kind",
+        "__meta_kubernetes_pod_controller_name",
+      ]
+      separator = "/"
+      target_label  = "workload"
+    }
+    // remove the hash from the ReplicaSet
+    rule {
+      source_labels = ["workload"]
+      regex = "(ReplicaSet/.+)-.+"
+      target_label  = "workload"
+    }
+
+    // Set the app label.
+    //
+    // Choose the first value found from the following ordered list:
+    // - pod.label[app.kubernetes.io/name]
+    // - pod.label[k8s-app]
+    // - pod.label[app]
+    rule {
+      source_labels = [
+        "__meta_kubernetes_pod_label_app_kubernetes_io_name",
+        "__meta_kubernetes_pod_label_k8s_app",
+        "__meta_kubernetes_pod_label_app",
+      ]
+      separator = ";"
+      regex = "^(?:;*)?([^;]+).*$"
+      replacement = "$1"
+      target_label = "app"
+    }
+
+    // Set the component label.
+    //
+    // Choose the first value found from the following ordered list:
+    // - pod.label[app.kubernetes.io/component]
+    // - pod.label[k8s-component]
+    // - pod.label[component]
+    rule {
+      source_labels = [
+        "__meta_kubernetes_pod_label_app_kubernetes_io_component",
+        "__meta_kubernetes_pod_label_k8s_component",
+        "__meta_kubernetes_pod_label_component",
+      ]
+      regex = "^(?:;*)?([^;]+).*$"
+      replacement = "$1"
+      target_label = "component"
+    }
+
+    rule {
+      target_label = "source"
+      replacement = "kubernetes"
+    }
+
+  } // discovery.relabel "node_exporter"
+
+  prometheus.scrape "node_exporter" {
+    targets = discovery.relabel.node_exporter.output
+    job_name = "integrations/node_exporter"
+    scrape_interval = "60s"
+    scrape_timeout = "10s"
+    scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
+    scrape_classic_histograms = false
+    scrape_native_histograms = false
+    convert_classic_histograms_to_nhcb = false
+    scheme = "http"
+    tls_config {
+      insecure_skip_verify = true
+    }
+
+    clustering {
+      enabled = true
+    }
+    forward_to = [prometheus.relabel.node_exporter.receiver]
+  } // prometheus.scrape "node_exporter"
+
+  prometheus.relabel "node_exporter" {
+    max_cache_size = 100000
+    rule {
+      source_labels = ["__name__"]
+      regex = "up|scrape_samples_scraped|node_cpu.*|node_exporter_build_info|node_filesystem.*|node_memory.*|node_network_receive_bytes_total|node_network_receive_drop_total|node_network_transmit_bytes_total|node_network_transmit_drop_total|process_cpu_seconds_total|process_resident_memory_bytes"
+      action = "keep"
+    }
+    // Drop metrics for certain file systems
+    rule {
+      source_labels = ["__name__", "fstype"]
+      separator = "@"
+      regex = "node_filesystem.*@(ramfs|tmpfs)"
+      action = "drop"
+    }
+    forward_to = argument.metrics_destinations.value
+  } // prometheus.relabel "node_exporter"
+} // declare "host_metrics"
+host_metrics "feature" {
+  metrics_destinations = [
+    prometheus.remote_write.allmetrics.receiver,
+    prometheus.remote_write.productionmetrics.receiver,
+  ]
+}
+
+
+
+
+
+// Destination: allMetrics (prometheus)
+otelcol.exporter.prometheus "allmetrics" {
+  add_metric_suffixes = true
+  resource_to_telemetry_conversion = false
+  keep_identifying_resource_attributes = true
+  forward_to = [prometheus.remote_write.allmetrics.receiver]
+} // otelcol.exporter.prometheus "allmetrics"
+
+prometheus.remote_write "allmetrics" {
+  endpoint {
+    url = "http://all-metrics-prometheus-server.all-dbs.svc:9090/api/v1/write"
+    headers = {
+    }
+    basic_auth {
+      username = convert.nonsensitive(remote.kubernetes.secret.allmetrics.data["username"])
+      password = remote.kubernetes.secret.allmetrics.data["password"]
+    }
+    tls_config {
+      insecure_skip_verify = false
+    }
+    send_native_histograms = false
+
+    queue_config {
+      capacity = 10000
+      min_shards = 1
+      max_shards = 50
+      max_samples_per_send = 2000
+      batch_send_deadline = "5s"
+      min_backoff = "30ms"
+      max_backoff = "5s"
+      retry_on_http_429 = true
+      sample_age_limit = "0s"
+    }
+  }
+
+  wal {
+    truncate_frequency = "2h"
+    min_keepalive_time = "5m"
+    max_keepalive_time = "8h"
+  }
+  external_labels = {
+    "cluster" = "split-destinations-cluster",
+    "k8s_cluster_name" = "split-destinations-cluster",
+  }
+} // prometheus.remote_write "allmetrics"
+
+remote.kubernetes.secret "allmetrics" {
+  name      = "allmetrics-k8smon-k8s-monitoring"
+  namespace = "default"
+} // remote.kubernetes.secret "allmetrics"
+
+
+// Destination: productionMetrics (prometheus)
+otelcol.exporter.prometheus "productionmetrics" {
+  add_metric_suffixes = true
+  resource_to_telemetry_conversion = false
+  keep_identifying_resource_attributes = true
+  forward_to = [prometheus.remote_write.productionmetrics.receiver]
+} // otelcol.exporter.prometheus "productionmetrics"
+
+prometheus.remote_write "productionmetrics" {
+  endpoint {
+    url = "http://prod-metrics-prometheus-server.prod-dbs.svc:9090/api/v1/write"
+    headers = {
+    }
+    basic_auth {
+      username = convert.nonsensitive(remote.kubernetes.secret.productionmetrics.data["username"])
+      password = remote.kubernetes.secret.productionmetrics.data["password"]
+    }
+    tls_config {
+      insecure_skip_verify = false
+    }
+    send_native_histograms = false
+
+    queue_config {
+      capacity = 10000
+      min_shards = 1
+      max_shards = 50
+      max_samples_per_send = 2000
+      batch_send_deadline = "5s"
+      min_backoff = "30ms"
+      max_backoff = "5s"
+      retry_on_http_429 = true
+      sample_age_limit = "0s"
+    }
+    write_relabel_config {
+      source_labels = ["namespace"]
+      regex = "production"
+      action = "keep"
+    }
+  }
+
+  wal {
+    truncate_frequency = "2h"
+    min_keepalive_time = "5m"
+    max_keepalive_time = "8h"
+  }
+  external_labels = {
+    "cluster" = "split-destinations-cluster",
+    "k8s_cluster_name" = "split-destinations-cluster",
+  }
+} // prometheus.remote_write "productionmetrics"
+
+remote.kubernetes.secret "productionmetrics" {
+  name      = "productionmetrics-k8smon-k8s-monitoring"
+  namespace = "default"
+} // remote.kubernetes.secret "productionmetrics"
+

--- a/charts/k8s-monitoring/tests/integration/split-destinations/.rendered/alloy-receiver.alloy
+++ b/charts/k8s-monitoring/tests/integration/split-destinations/.rendered/alloy-receiver.alloy
@@ -1,0 +1,523 @@
+// Feature: Application Observability
+declare "application_observability" {
+  argument "metrics_destinations" {
+    comment = "Must be a list of metrics destinations where collected metrics should be forwarded to"
+  }
+
+  argument "logs_destinations" {
+    comment = "Must be a list of log destinations where collected logs should be forwarded to"
+  }
+
+  argument "traces_destinations" {
+    comment = "Must be a list of trace destinations where collected trace should be forwarded to"
+  }
+
+  // OTLP Receiver
+  otelcol.receiver.otlp "receiver" {
+    grpc {
+      endpoint = "0.0.0.0:4317"
+      include_metadata = false
+      max_recv_msg_size = "4MiB"
+      read_buffer_size = "512KiB"
+      write_buffer_size = "32KiB"
+    }
+    debug_metrics {
+      disable_high_cardinality_metrics = true
+    }
+    output {
+      metrics = [otelcol.processor.resourcedetection.default.input]
+      logs = [otelcol.processor.resourcedetection.default.input]
+      traces = [otelcol.processor.resourcedetection.default.input]
+    }
+  } // otelcol.receiver.otlp "receiver"
+
+  // Resource Detection Processor
+  otelcol.processor.resourcedetection "default" {
+    detectors = ["env","system"]
+    override = true
+
+    system {
+      hostname_sources = ["os"]
+    }
+
+    output {
+      metrics = [otelcol.processor.k8sattributes.default.input]
+      logs = [otelcol.processor.k8sattributes.default.input]
+      traces = [otelcol.processor.k8sattributes.default.input]
+    }
+  }
+
+  // K8s Attributes Processor
+  otelcol.processor.k8sattributes "default" {
+    passthrough = false
+    extract {
+      metadata = ["k8s.namespace.name","k8s.pod.name","k8s.deployment.name","k8s.statefulset.name","k8s.daemonset.name","k8s.cronjob.name","k8s.job.name","k8s.node.name","k8s.pod.uid","k8s.pod.start_time"]
+    }
+    pod_association {
+      source {
+        from = "resource_attribute"
+        name = "k8s.pod.ip"
+      }
+    }
+    pod_association {
+      source {
+        from = "resource_attribute"
+        name = "k8s.pod.uid"
+      }
+    }
+    pod_association {
+      source {
+        from = "connection"
+      }
+    }
+
+    output {
+      metrics = [otelcol.processor.transform.default.input]
+      logs = [otelcol.processor.transform.default.input]
+      traces = [otelcol.processor.transform.default.input, otelcol.connector.host_info.default.input]
+    }
+  }
+
+  // Host Info Connector
+  otelcol.connector.host_info "default" {
+    host_identifiers = [ "k8s.node.name" ]
+
+    output {
+      metrics = [otelcol.processor.batch.default.input]
+    }
+  }
+
+  // Transform Processor
+  otelcol.processor.transform "default" {
+    error_mode = "ignore"
+    log_statements {
+      context = "resource"
+      statements = [
+        "set(attributes[\"pod\"], attributes[\"k8s.pod.name\"])",
+        "set(attributes[\"namespace\"], attributes[\"k8s.namespace.name\"])",
+        "set(attributes[\"loki.resource.labels\"], \"cluster, namespace, job, pod\")",
+      ]
+    }
+    trace_statements {
+      context = "span"
+      statements = [
+       "set_semconv_span_name(\"1.37.0\", \"original_span_name\")",
+      ]
+    }
+
+    output {
+      metrics = [otelcol.processor.batch.default.input]
+      logs = [otelcol.processor.batch.default.input]
+      traces = [otelcol.processor.batch.default.input]
+    }
+  }
+
+  // Batch Processor
+  otelcol.processor.batch "default" {
+    send_batch_size = 8192
+    send_batch_max_size = 0
+    timeout = "2s"
+
+    output {
+      metrics = argument.metrics_destinations.value
+      logs = argument.logs_destinations.value
+      traces = argument.traces_destinations.value
+    }
+  }
+} // declare "application_observability"
+application_observability "feature" {
+  metrics_destinations = [
+    otelcol.exporter.prometheus.allmetrics.input,
+    otelcol.exporter.prometheus.productionmetrics.input,
+  ]
+  logs_destinations = [
+    otelcol.exporter.loki.alllogs.input,
+    otelcol.exporter.loki.productionlogs.input,
+  ]
+  traces_destinations = [
+    otelcol.processor.attributes.alltraces.input,
+    otelcol.processor.attributes.productiontraces.input,
+  ]
+}
+// Self Reporting
+prometheus.exporter.unix "kubernetes_monitoring_telemetry" {
+  set_collectors = ["textfile"]
+  textfile {
+    directory = "/etc/release-info"
+  }
+} // prometheus.exporter.unix "kubernetes_monitoring_telemetry"
+
+discovery.relabel "kubernetes_monitoring_telemetry" {
+  targets = prometheus.exporter.unix.kubernetes_monitoring_telemetry.targets
+  rule {
+    target_label = "instance"
+    action = "replace"
+    replacement = "k8smon"
+  }
+  rule {
+    target_label = "job"
+    action = "replace"
+    replacement = "integrations/kubernetes/kubernetes_monitoring_telemetry"
+  }
+} // discovery.relabel "kubernetes_monitoring_telemetry"
+
+prometheus.scrape "kubernetes_monitoring_telemetry" {
+  job_name   = "integrations/kubernetes/kubernetes_monitoring_telemetry"
+  targets    = discovery.relabel.kubernetes_monitoring_telemetry.output
+  scrape_interval = "60s"
+  clustering {
+    enabled = true
+  }
+  forward_to = [prometheus.relabel.kubernetes_monitoring_telemetry.receiver]
+} // prometheus.scrape "kubernetes_monitoring_telemetry"
+
+prometheus.relabel "kubernetes_monitoring_telemetry" {
+  rule {
+    source_labels = ["__name__"]
+    regex = "grafana_kubernetes_monitoring_.*"
+    action = "keep"
+  }
+  forward_to = [
+    prometheus.remote_write.allmetrics.receiver,
+    prometheus.remote_write.productionmetrics.receiver,
+  ]
+} // prometheus.relabel "kubernetes_monitoring_telemetry"
+
+
+
+
+
+// Destination: allLogs (loki)
+otelcol.exporter.loki "alllogs" {
+  forward_to = [loki.write.alllogs.receiver]
+} // otelcol.exporter.loki "alllogs"
+
+loki.write "alllogs" {
+  endpoint {
+    url = "http://all-logs-loki.all-dbs.svc:3100/loki/api/v1/push"
+    retry_on_http_429 = true
+    tenant_id = convert.nonsensitive(remote.kubernetes.secret.alllogs.data["tenantId"])
+    basic_auth {
+      username = convert.nonsensitive(remote.kubernetes.secret.alllogs.data["username"])
+      password = remote.kubernetes.secret.alllogs.data["password"]
+    }
+    tls_config {
+      insecure_skip_verify = false
+    }
+    min_backoff_period = "500ms"
+    max_backoff_period = "5m"
+    max_backoff_retries = "10"
+  }
+  external_labels = {
+    "cluster" = "split-destinations-cluster",
+    "k8s_cluster_name" = "split-destinations-cluster",
+  }
+} // loki.write "alllogs"
+
+remote.kubernetes.secret "alllogs" {
+  name      = "alllogs-k8smon-k8s-monitoring"
+  namespace = "default"
+} // remote.kubernetes.secret "alllogs"
+
+
+// Destination: allMetrics (prometheus)
+otelcol.exporter.prometheus "allmetrics" {
+  add_metric_suffixes = true
+  resource_to_telemetry_conversion = false
+  keep_identifying_resource_attributes = true
+  forward_to = [prometheus.remote_write.allmetrics.receiver]
+} // otelcol.exporter.prometheus "allmetrics"
+
+prometheus.remote_write "allmetrics" {
+  endpoint {
+    url = "http://all-metrics-prometheus-server.all-dbs.svc:9090/api/v1/write"
+    headers = {
+    }
+    basic_auth {
+      username = convert.nonsensitive(remote.kubernetes.secret.allmetrics.data["username"])
+      password = remote.kubernetes.secret.allmetrics.data["password"]
+    }
+    tls_config {
+      insecure_skip_verify = false
+    }
+    send_native_histograms = false
+
+    queue_config {
+      capacity = 10000
+      min_shards = 1
+      max_shards = 50
+      max_samples_per_send = 2000
+      batch_send_deadline = "5s"
+      min_backoff = "30ms"
+      max_backoff = "5s"
+      retry_on_http_429 = true
+      sample_age_limit = "0s"
+    }
+  }
+
+  wal {
+    truncate_frequency = "2h"
+    min_keepalive_time = "5m"
+    max_keepalive_time = "8h"
+  }
+  external_labels = {
+    "cluster" = "split-destinations-cluster",
+    "k8s_cluster_name" = "split-destinations-cluster",
+  }
+} // prometheus.remote_write "allmetrics"
+
+remote.kubernetes.secret "allmetrics" {
+  name      = "allmetrics-k8smon-k8s-monitoring"
+  namespace = "default"
+} // remote.kubernetes.secret "allmetrics"
+
+
+// Destination: allTraces (otlp)
+otelcol.processor.attributes "alltraces" {
+  output {
+    traces = [otelcol.processor.transform.alltraces.input]
+  }
+} // otelcol.processor.attributes "alltraces"
+
+otelcol.processor.transform "alltraces" {
+  error_mode = "ignore"
+
+  trace_statements {
+    context = "resource"
+    statements = [
+      `set(attributes["cluster"], "split-destinations-cluster")`,
+      `set(attributes["k8s.cluster.name"], "split-destinations-cluster")`,
+      `delete_key(attributes, "process.pid")`,
+      `delete_key(attributes, "process.parent_pid")`,
+      `delete_key(attributes, "process.executable.path")`,
+      `delete_key(attributes, "process.command_line")`,
+      `delete_key(attributes, "process.command_args")`,
+      `delete_key(attributes, "process.owner")`,
+      `delete_key(attributes, "process.runtime.version")`,
+      `delete_key(attributes, "process.runtime.description")`,
+      `delete_key(attributes, "host.ip")`,
+      `delete_key(attributes, "host.mac")`,
+      `delete_key(attributes, "k8s.pod.start_time")`,
+      `delete_key(attributes, "k8s.pod.uid")`,
+      `delete_key(attributes, "container.image.id")`,
+      `delete_key(attributes, "container.image.repo_digests")`,
+      `delete_key(attributes, "os.description")`,
+      `delete_key(attributes, "os.build_id")`,
+    ]
+  }
+
+  output {
+    traces = [otelcol.processor.batch.alltraces.input]
+  }
+} // otelcol.processor.transform "alltraces"
+
+otelcol.processor.batch "alltraces" {
+  timeout = "2s"
+  send_batch_size = 8192
+  send_batch_max_size = 0
+
+  output {
+    traces = [otelcol.exporter.otlp.alltraces.input]
+  }
+} // otelcol.processor.batch "alltraces"
+otelcol.exporter.otlp "alltraces" {
+  client {
+    endpoint = "all-traces-tempo.all-dbs.svc:4317"
+    tls {
+      insecure = true
+      insecure_skip_verify = true
+    }
+  }
+
+  retry_on_failure {
+    enabled = true
+    initial_interval = "5s"
+    max_interval = "30s"
+    max_elapsed_time = "5m"
+  }
+
+  sending_queue {
+    enabled = true
+  }
+} // otelcol.exporter.otlp "alltraces"
+
+// Destination: productionLogs (loki)
+otelcol.exporter.loki "productionlogs" {
+  forward_to = [loki.process.productionlogs.receiver]
+} // otelcol.exporter.loki "productionlogs"
+
+loki.process "productionlogs" {
+  stage.match {
+    selector = "{namespace!=\"production\"}"
+    action   = "drop"
+  }
+  forward_to = [loki.write.productionlogs.receiver]
+} // loki.process "productionlogs"
+
+loki.write "productionlogs" {
+  endpoint {
+    url = "http://prod-logs-loki.prod-dbs.svc:3100/loki/api/v1/push"
+    retry_on_http_429 = true
+    tenant_id = convert.nonsensitive(remote.kubernetes.secret.productionlogs.data["tenantId"])
+    basic_auth {
+      username = convert.nonsensitive(remote.kubernetes.secret.productionlogs.data["username"])
+      password = remote.kubernetes.secret.productionlogs.data["password"]
+    }
+    tls_config {
+      insecure_skip_verify = false
+    }
+    min_backoff_period = "500ms"
+    max_backoff_period = "5m"
+    max_backoff_retries = "10"
+  }
+  external_labels = {
+    "cluster" = "split-destinations-cluster",
+    "k8s_cluster_name" = "split-destinations-cluster",
+  }
+} // loki.write "productionlogs"
+
+remote.kubernetes.secret "productionlogs" {
+  name      = "productionlogs-k8smon-k8s-monitoring"
+  namespace = "default"
+} // remote.kubernetes.secret "productionlogs"
+
+
+// Destination: productionMetrics (prometheus)
+otelcol.exporter.prometheus "productionmetrics" {
+  add_metric_suffixes = true
+  resource_to_telemetry_conversion = false
+  keep_identifying_resource_attributes = true
+  forward_to = [prometheus.remote_write.productionmetrics.receiver]
+} // otelcol.exporter.prometheus "productionmetrics"
+
+prometheus.remote_write "productionmetrics" {
+  endpoint {
+    url = "http://prod-metrics-prometheus-server.prod-dbs.svc:9090/api/v1/write"
+    headers = {
+    }
+    basic_auth {
+      username = convert.nonsensitive(remote.kubernetes.secret.productionmetrics.data["username"])
+      password = remote.kubernetes.secret.productionmetrics.data["password"]
+    }
+    tls_config {
+      insecure_skip_verify = false
+    }
+    send_native_histograms = false
+
+    queue_config {
+      capacity = 10000
+      min_shards = 1
+      max_shards = 50
+      max_samples_per_send = 2000
+      batch_send_deadline = "5s"
+      min_backoff = "30ms"
+      max_backoff = "5s"
+      retry_on_http_429 = true
+      sample_age_limit = "0s"
+    }
+    write_relabel_config {
+      source_labels = ["namespace"]
+      regex = "production"
+      action = "keep"
+    }
+  }
+
+  wal {
+    truncate_frequency = "2h"
+    min_keepalive_time = "5m"
+    max_keepalive_time = "8h"
+  }
+  external_labels = {
+    "cluster" = "split-destinations-cluster",
+    "k8s_cluster_name" = "split-destinations-cluster",
+  }
+} // prometheus.remote_write "productionmetrics"
+
+remote.kubernetes.secret "productionmetrics" {
+  name      = "productionmetrics-k8smon-k8s-monitoring"
+  namespace = "default"
+} // remote.kubernetes.secret "productionmetrics"
+
+
+// Destination: productionTraces (otlp)
+otelcol.processor.attributes "productiontraces" {
+  output {
+    traces = [otelcol.processor.transform.productiontraces.input]
+  }
+} // otelcol.processor.attributes "productiontraces"
+
+otelcol.processor.transform "productiontraces" {
+  error_mode = "ignore"
+
+  trace_statements {
+    context = "resource"
+    statements = [
+      `set(attributes["cluster"], "split-destinations-cluster")`,
+      `set(attributes["k8s.cluster.name"], "split-destinations-cluster")`,
+      `delete_key(attributes, "process.pid")`,
+      `delete_key(attributes, "process.parent_pid")`,
+      `delete_key(attributes, "process.executable.path")`,
+      `delete_key(attributes, "process.command_line")`,
+      `delete_key(attributes, "process.command_args")`,
+      `delete_key(attributes, "process.owner")`,
+      `delete_key(attributes, "process.runtime.version")`,
+      `delete_key(attributes, "process.runtime.description")`,
+      `delete_key(attributes, "host.ip")`,
+      `delete_key(attributes, "host.mac")`,
+      `delete_key(attributes, "k8s.pod.start_time")`,
+      `delete_key(attributes, "k8s.pod.uid")`,
+      `delete_key(attributes, "container.image.id")`,
+      `delete_key(attributes, "container.image.repo_digests")`,
+      `delete_key(attributes, "os.description")`,
+      `delete_key(attributes, "os.build_id")`,
+    ]
+  }
+
+  output {
+    traces = [otelcol.processor.filter.productiontraces.input]
+  }
+} // otelcol.processor.transform "productiontraces"
+
+otelcol.processor.filter "productiontraces" {
+  error_mode = "ignore"
+  traces {
+    span = [
+      "resource.attributes[\"k8s.namespace.name\"] != \"prod-dbs\"",
+    ]
+  }
+
+  output {
+    traces = [otelcol.processor.batch.productiontraces.input]
+  }
+} // otelcol.processor.filter "productiontraces"
+
+otelcol.processor.batch "productiontraces" {
+  timeout = "2s"
+  send_batch_size = 8192
+  send_batch_max_size = 0
+
+  output {
+    traces = [otelcol.exporter.otlp.productiontraces.input]
+  }
+} // otelcol.processor.batch "productiontraces"
+otelcol.exporter.otlp "productiontraces" {
+  client {
+    endpoint = "prod-traces-tempo.prod-dbs.svc:4317"
+    tls {
+      insecure = true
+      insecure_skip_verify = true
+    }
+  }
+
+  retry_on_failure {
+    enabled = true
+    initial_interval = "5s"
+    max_interval = "30s"
+    max_elapsed_time = "5m"
+  }
+
+  sending_queue {
+    enabled = true
+  }
+} // otelcol.exporter.otlp "productiontraces"
+

--- a/charts/k8s-monitoring/tests/integration/statsd/.rendered/alloy-receiver.alloy
+++ b/charts/k8s-monitoring/tests/integration/statsd/.rendered/alloy-receiver.alloy
@@ -1,0 +1,107 @@
+// Self Reporting
+prometheus.exporter.unix "kubernetes_monitoring_telemetry" {
+  set_collectors = ["textfile"]
+  textfile {
+    directory = "/etc/release-info"
+  }
+} // prometheus.exporter.unix "kubernetes_monitoring_telemetry"
+
+discovery.relabel "kubernetes_monitoring_telemetry" {
+  targets = prometheus.exporter.unix.kubernetes_monitoring_telemetry.targets
+  rule {
+    target_label = "instance"
+    action = "replace"
+    replacement = "k8smon"
+  }
+  rule {
+    target_label = "job"
+    action = "replace"
+    replacement = "integrations/kubernetes/kubernetes_monitoring_telemetry"
+  }
+} // discovery.relabel "kubernetes_monitoring_telemetry"
+
+prometheus.scrape "kubernetes_monitoring_telemetry" {
+  job_name   = "integrations/kubernetes/kubernetes_monitoring_telemetry"
+  targets    = discovery.relabel.kubernetes_monitoring_telemetry.output
+  scrape_interval = "60s"
+  clustering {
+    enabled = true
+  }
+  forward_to = [prometheus.relabel.kubernetes_monitoring_telemetry.receiver]
+} // prometheus.scrape "kubernetes_monitoring_telemetry"
+
+prometheus.relabel "kubernetes_monitoring_telemetry" {
+  rule {
+    source_labels = ["__name__"]
+    regex = "grafana_kubernetes_monitoring_.*"
+    action = "keep"
+  }
+  forward_to = [
+    prometheus.remote_write.localprometheus.receiver,
+  ]
+} // prometheus.relabel "kubernetes_monitoring_telemetry"
+
+
+
+prometheus.exporter.statsd "default" {
+  listen_udp           = ":8125"
+  listen_tcp           = ":8125"
+  parse_dogstatsd_tags = true
+}
+prometheus.scrape "statsd" {
+  targets    = prometheus.exporter.statsd.default.targets
+  job_name   = "integrations/statsd"
+  forward_to = [prometheus.remote_write.localprometheus.receiver]
+}
+
+// Destination: localPrometheus (prometheus)
+otelcol.exporter.prometheus "localprometheus" {
+  add_metric_suffixes = true
+  resource_to_telemetry_conversion = false
+  keep_identifying_resource_attributes = true
+  forward_to = [prometheus.remote_write.localprometheus.receiver]
+} // otelcol.exporter.prometheus "localprometheus"
+
+prometheus.remote_write "localprometheus" {
+  endpoint {
+    url = "http://prometheus-server.prometheus.svc:9090/api/v1/write"
+    headers = {
+    }
+    basic_auth {
+      username = convert.nonsensitive(remote.kubernetes.secret.localprometheus.data["username"])
+      password = remote.kubernetes.secret.localprometheus.data["password"]
+    }
+    tls_config {
+      insecure_skip_verify = false
+    }
+    send_native_histograms = false
+
+    queue_config {
+      capacity = 10000
+      min_shards = 1
+      max_shards = 50
+      max_samples_per_send = 2000
+      batch_send_deadline = "5s"
+      min_backoff = "30ms"
+      max_backoff = "5s"
+      retry_on_http_429 = true
+      sample_age_limit = "0s"
+    }
+  }
+
+  wal {
+    truncate_frequency = "2h"
+    min_keepalive_time = "5m"
+    max_keepalive_time = "8h"
+  }
+  external_labels = {
+    "cluster" = "statsd-test",
+    "k8s_cluster_name" = "statsd-test",
+  }
+} // prometheus.remote_write "localprometheus"
+
+remote.kubernetes.secret "localprometheus" {
+  name      = "localprometheus-k8smon-k8s-monitoring"
+  namespace = "default"
+} // remote.kubernetes.secret "localprometheus"
+

--- a/charts/k8s-monitoring/tests/integration/tail-sampling/.rendered/alloy-metrics.alloy
+++ b/charts/k8s-monitoring/tests/integration/tail-sampling/.rendered/alloy-metrics.alloy
@@ -1,0 +1,388 @@
+declare "alloy_integration" {
+  argument "metrics_destinations" {
+    comment = "Must be a list of metric destinations where collected metrics should be forwarded to"
+  }
+
+  declare "alloy_integration_discovery" {
+    argument "namespaces" {
+      comment = "The namespaces to look for targets in (default: [] is all namespaces)"
+      optional = true
+    }
+
+    argument "field_selectors" {
+      comment = "The field selectors to use to find matching targets (default: [])"
+      optional = true
+    }
+
+    argument "label_selectors" {
+      comment = "The label selectors to use to find matching targets (default: [\"app.kubernetes.io/name=alloy\"])"
+      optional = true
+    }
+
+    argument "port_name" {
+      comment = "The of the port to scrape metrics from (default: http-metrics)"
+      optional = true
+    }
+
+    // Alloy service discovery for all of the pods
+    discovery.kubernetes "alloy_pods" {
+      role = "pod"
+
+      selectors {
+        role = "pod"
+        field = string.join(coalesce(argument.field_selectors.value, []), ",")
+        label = string.join(coalesce(argument.label_selectors.value, ["app.kubernetes.io/name=alloy"]), ",")
+      }
+
+      namespaces {
+        names = coalesce(argument.namespaces.value, [])
+      }
+
+    } // discovery.kubernetes "alloy_pods"
+
+    // alloy relabelings (pre-scrape)
+    discovery.relabel "alloy_pods" {
+      targets = discovery.kubernetes.alloy_pods.targets
+
+      // keep only the specified metrics port name, and pods that are Running and ready
+      rule {
+        source_labels = [
+          "__meta_kubernetes_pod_container_port_name",
+          "__meta_kubernetes_pod_phase",
+          "__meta_kubernetes_pod_ready",
+          "__meta_kubernetes_pod_container_init",
+        ]
+        separator = "@"
+        regex = coalesce(argument.port_name.value, "metrics") + "@Running@true@false"
+        action = "keep"
+      }
+
+      rule {
+        source_labels = ["__meta_kubernetes_namespace"]
+        target_label  = "namespace"
+      }
+
+      rule {
+        source_labels = ["__meta_kubernetes_pod_name"]
+        target_label  = "pod"
+      }
+
+      rule {
+        source_labels = ["__meta_kubernetes_pod_container_name"]
+        target_label  = "container"
+      }
+
+      // set the workload to the controller kind and name
+      rule {
+        action = "lowercase"
+        source_labels = ["__meta_kubernetes_pod_controller_kind"]
+        target_label  = "workload_type"
+      }
+
+      rule {
+        source_labels = ["__meta_kubernetes_pod_controller_name"]
+        target_label  = "workload"
+      }
+
+      // remove the hash from the ReplicaSet
+      rule {
+        source_labels = [
+          "workload_type",
+          "workload",
+        ]
+        separator = "/"
+        regex = "replicaset/(.+)-.+$"
+        target_label  = "workload"
+      }
+
+      // set the app name if specified as metadata labels "app:" or "app.kubernetes.io/name:" or "k8s-app:"
+      rule {
+        action = "replace"
+        source_labels = [
+          "__meta_kubernetes_pod_label_app_kubernetes_io_name",
+          "__meta_kubernetes_pod_label_k8s_app",
+          "__meta_kubernetes_pod_label_app",
+        ]
+        separator = ";"
+        regex = "^(?:;*)?([^;]+).*$"
+        replacement = "$1"
+        target_label = "app"
+      }
+
+      // set the component if specified as metadata labels "component:" or "app.kubernetes.io/component:" or "k8s-component:"
+      rule {
+        action = "replace"
+        source_labels = [
+          "__meta_kubernetes_pod_label_app_kubernetes_io_component",
+          "__meta_kubernetes_pod_label_k8s_component",
+          "__meta_kubernetes_pod_label_component",
+        ]
+        regex = "^(?:;*)?([^;]+).*$"
+        replacement = "$1"
+        target_label = "component"
+      }
+
+      // set a source label
+      rule {
+        action = "replace"
+        replacement = "kubernetes"
+        target_label = "source"
+      }
+
+    } // discovery.relabel "alloy_pods"
+
+    export "output" {
+      value = discovery.relabel.alloy_pods.output
+    }
+  }
+
+  declare "alloy_integration_scrape" {
+    argument "targets" {
+      comment = "Must be a list() of targets"
+    }
+
+    argument "forward_to" {
+      comment = "Must be a list(MetricsReceiver) where collected metrics should be forwarded to"
+    }
+
+    argument "job_label" {
+      comment = "The job label to add for all Alloy metrics (default: integrations/alloy)"
+      optional = true
+    }
+
+    argument "keep_metrics" {
+      comment = "A regular expression of metrics to keep (default: see below)"
+      optional = true
+    }
+
+    argument "drop_metrics" {
+      comment = "A regular expression of metrics to drop (default: see below)"
+      optional = true
+    }
+
+    argument "scrape_interval" {
+      comment = "How often to scrape metrics from the targets (default: 60s)"
+      optional = true
+    }
+
+    argument "scrape_timeout" {
+      comment = "The timeout for scraping metrics from the targets (default: 10s)"
+      optional = true
+    }
+
+    argument "scrape_protocols" {
+      comment = "The scrape protocols to use for scraping metrics"
+      optional = true
+    }
+
+    argument "scrape_classic_histograms" {
+      comment = "Whether to scrape classic histograms (default: false)."
+      optional = true
+    }
+
+    argument "scrape_native_histograms" {
+      comment = "Whether to scrape native histograms (default: false)."
+      optional = true
+    }
+
+    argument "max_cache_size" {
+      comment = "The maximum number of elements to hold in the relabeling cache (default: 100000).  This should be at least 2x-5x your largest scrape target or samples appended rate."
+      optional = true
+    }
+
+    argument "clustering" {
+      comment = "Whether or not clustering should be enabled (default: false)"
+      optional = true
+    }
+
+    prometheus.scrape "alloy" {
+      job_name = coalesce(argument.job_label.value, "integrations/alloy")
+      forward_to = [prometheus.relabel.alloy.receiver]
+      targets = argument.targets.value
+      scrape_interval = coalesce(argument.scrape_interval.value, "60s")
+      scrape_timeout = coalesce(argument.scrape_timeout.value, "10s")
+      scrape_protocols = argument.scrape_protocols.value
+      scrape_classic_histograms = argument.scrape_classic_histograms.value
+      scrape_native_histograms = argument.scrape_native_histograms.value
+
+      clustering {
+        enabled = coalesce(argument.clustering.value, false)
+      }
+    } // prometheus.scrape "alloy"
+
+    // alloy metric relabelings (post-scrape)
+    prometheus.relabel "alloy" {
+      forward_to = argument.forward_to.value
+      max_cache_size = coalesce(argument.max_cache_size.value, 100000)
+
+      // drop metrics that match the drop_metrics regex
+      rule {
+        source_labels = ["__name__"]
+        regex = coalesce(argument.drop_metrics.value, "")
+        action = "drop"
+      }
+
+      // keep only metrics that match the keep_metrics regex
+      rule {
+        source_labels = ["__name__"]
+        regex = coalesce(argument.keep_metrics.value, ".*")
+        action = "keep"
+      }
+
+      // remove the component_id label from any metric that starts with log_bytes or log_lines, these are custom metrics that are generated
+      // as part of the log annotation modules in this repo
+      rule {
+        action = "replace"
+        source_labels = ["__name__"]
+        regex = "^log_(bytes|lines).+"
+        replacement = ""
+        target_label = "component_id"
+      }
+
+      // set the namespace label to that of the exported_namespace
+      rule {
+        action = "replace"
+        source_labels = ["__name__", "exported_namespace"]
+        separator = "@"
+        regex = "^log_(bytes|lines).+@(.+)"
+        replacement = "$2"
+        target_label = "namespace"
+      }
+
+      // set the pod label to that of the exported_pod
+      rule {
+        action = "replace"
+        source_labels = ["__name__", "exported_pod"]
+        separator = "@"
+        regex = "^log_(bytes|lines).+@(.+)"
+        replacement = "$2"
+        target_label = "pod"
+      }
+
+      // set the container label to that of the exported_container
+      rule {
+        action = "replace"
+        source_labels = ["__name__", "exported_container"]
+        separator = "@"
+        regex = "^log_(bytes|lines).+@(.+)"
+        replacement = "$2"
+        target_label = "container"
+      }
+
+      // set the job label to that of the exported_job
+      rule {
+        action = "replace"
+        source_labels = ["__name__", "exported_job"]
+        separator = "@"
+        regex = "^log_(bytes|lines).+@(.+)"
+        replacement = "$2"
+        target_label = "job"
+      }
+
+      // set the instance label to that of the exported_instance
+      rule {
+        action = "replace"
+        source_labels = ["__name__", "exported_instance"]
+        separator = "@"
+        regex = "^log_(bytes|lines).+@(.+)"
+        replacement = "$2"
+        target_label = "instance"
+      }
+
+      rule {
+        action = "labeldrop"
+        regex = "exported_(namespace|pod|container|job|instance)"
+      }
+    } // prometheus.relabel "alloy"
+  }
+
+  alloy_integration_discovery "alloy_receiver" {
+    port_name = "http-metrics"
+    label_selectors = ["app.kubernetes.io/instance=k8smon-alloy-receiver"]
+  }
+
+  alloy_integration_scrape "alloy_receiver" {
+    targets = alloy_integration_discovery.alloy_receiver.output
+    job_label = "integrations/alloy"
+    clustering = true
+    keep_metrics = "up|scrape_samples_scraped|alloy_build_info|alloy_component_controller_running_components|alloy_component_dependencies_wait_seconds|alloy_component_dependencies_wait_seconds_bucket|alloy_component_evaluation_seconds|alloy_component_evaluation_seconds_bucket|alloy_component_evaluation_seconds_count|alloy_component_evaluation_seconds_sum|alloy_component_evaluation_slow_seconds|alloy_config_hash|alloy_resources_machine_rx_bytes_total|alloy_resources_machine_tx_bytes_total|alloy_resources_process_cpu_seconds_total|alloy_resources_process_resident_memory_bytes|alloy_tcp_connections|alloy_wal_samples_appended_total|alloy_wal_storage_active_series|cluster_node_gossip_health_score|cluster_node_gossip_proto_version|cluster_node_gossip_received_events_total|cluster_node_info|cluster_node_lamport_time|cluster_node_peers|cluster_node_update_observers|cluster_transport_rx_bytes_total|cluster_transport_rx_packet_queue_length|cluster_transport_rx_packets_failed_total|cluster_transport_rx_packets_total|cluster_transport_stream_rx_bytes_total|cluster_transport_stream_rx_packets_failed_total|cluster_transport_stream_rx_packets_total|cluster_transport_stream_tx_bytes_total|cluster_transport_stream_tx_packets_failed_total|cluster_transport_stream_tx_packets_total|cluster_transport_streams|cluster_transport_tx_bytes_total|cluster_transport_tx_packet_queue_length|cluster_transport_tx_packets_failed_total|cluster_transport_tx_packets_total|otelcol_exporter_send_failed_spans_total|otelcol_exporter_sent_spans_total|go_gc_duration_seconds_count|go_goroutines|go_memstats_heap_inuse_bytes|loki_process_dropped_lines_total|loki_write_batch_retries_total|loki_write_dropped_bytes_total|loki_write_dropped_entries_total|loki_write_encoded_bytes_total|loki_write_mutated_bytes_total|loki_write_mutated_entries_total|loki_write_request_duration_seconds_bucket|loki_write_sent_bytes_total|loki_write_sent_entries_total|process_cpu_seconds_total|process_start_time_seconds|otelcol_processor_batch_batch_send_size_bucket|otelcol_processor_batch_metadata_cardinality|otelcol_processor_batch_timeout_trigger_send_total|prometheus_remote_storage_bytes_total|prometheus_remote_storage_enqueue_retries_total|prometheus_remote_storage_highest_timestamp_in_seconds|prometheus_remote_storage_metadata_bytes_total|prometheus_remote_storage_queue_highest_sent_timestamp_seconds|prometheus_remote_storage_samples_dropped_total|prometheus_remote_storage_samples_failed_total|prometheus_remote_storage_samples_pending|prometheus_remote_storage_samples_retried_total|prometheus_remote_storage_samples_total|prometheus_remote_storage_sent_batch_duration_seconds_bucket|prometheus_remote_storage_sent_batch_duration_seconds_count|prometheus_remote_storage_sent_batch_duration_seconds_sum|prometheus_remote_storage_shard_capacity|prometheus_remote_storage_shards|prometheus_remote_storage_shards_desired|prometheus_remote_storage_shards_max|prometheus_remote_storage_shards_min|prometheus_remote_storage_succeeded_samples_total|prometheus_remote_write_wal_samples_appended_total|prometheus_remote_write_wal_storage_active_series|prometheus_sd_discovered_targets|prometheus_target_interval_length_seconds_count|prometheus_target_interval_length_seconds_sum|prometheus_target_scrapes_exceeded_sample_limit_total|prometheus_target_scrapes_sample_duplicate_timestamp_total|prometheus_target_scrapes_sample_out_of_bounds_total|prometheus_target_scrapes_sample_out_of_order_total|prometheus_target_sync_length_seconds_sum|prometheus_wal_watcher_current_segment|otelcol_receiver_accepted_spans_total|otelcol_receiver_refused_spans_total|rpc_server_duration_milliseconds_bucket|scrape_duration_seconds|traces_exporter_send_failed_spans|traces_exporter_send_failed_spans_total|traces_exporter_sent_spans|traces_exporter_sent_spans_total|traces_loadbalancer_backend_outcome|traces_loadbalancer_num_backends|traces_receiver_accepted_spans|traces_receiver_accepted_spans_total|traces_receiver_refused_spans|traces_receiver_refused_spans_total|otelcol_loadbalancer_.*"
+    scrape_interval = "60s"
+    scrape_timeout = "10s"
+    scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
+    scrape_classic_histograms = false
+    scrape_native_histograms = false
+    max_cache_size = 100000
+    forward_to = argument.metrics_destinations.value
+  }
+
+  alloy_integration_discovery "alloy_sampler" {
+    port_name = "http-metrics"
+    label_selectors = ["app.kubernetes.io/instance=k8smon-localtempo-sampler"]
+  }
+
+  alloy_integration_scrape "alloy_sampler" {
+    targets = alloy_integration_discovery.alloy_sampler.output
+    job_label = "integrations/alloy"
+    clustering = true
+    keep_metrics = "up|scrape_samples_scraped|alloy_build_info|alloy_component_controller_running_components|alloy_component_dependencies_wait_seconds|alloy_component_dependencies_wait_seconds_bucket|alloy_component_evaluation_seconds|alloy_component_evaluation_seconds_bucket|alloy_component_evaluation_seconds_count|alloy_component_evaluation_seconds_sum|alloy_component_evaluation_slow_seconds|alloy_config_hash|alloy_resources_machine_rx_bytes_total|alloy_resources_machine_tx_bytes_total|alloy_resources_process_cpu_seconds_total|alloy_resources_process_resident_memory_bytes|alloy_tcp_connections|alloy_wal_samples_appended_total|alloy_wal_storage_active_series|cluster_node_gossip_health_score|cluster_node_gossip_proto_version|cluster_node_gossip_received_events_total|cluster_node_info|cluster_node_lamport_time|cluster_node_peers|cluster_node_update_observers|cluster_transport_rx_bytes_total|cluster_transport_rx_packet_queue_length|cluster_transport_rx_packets_failed_total|cluster_transport_rx_packets_total|cluster_transport_stream_rx_bytes_total|cluster_transport_stream_rx_packets_failed_total|cluster_transport_stream_rx_packets_total|cluster_transport_stream_tx_bytes_total|cluster_transport_stream_tx_packets_failed_total|cluster_transport_stream_tx_packets_total|cluster_transport_streams|cluster_transport_tx_bytes_total|cluster_transport_tx_packet_queue_length|cluster_transport_tx_packets_failed_total|cluster_transport_tx_packets_total|otelcol_exporter_send_failed_spans_total|otelcol_exporter_sent_spans_total|go_gc_duration_seconds_count|go_goroutines|go_memstats_heap_inuse_bytes|loki_process_dropped_lines_total|loki_write_batch_retries_total|loki_write_dropped_bytes_total|loki_write_dropped_entries_total|loki_write_encoded_bytes_total|loki_write_mutated_bytes_total|loki_write_mutated_entries_total|loki_write_request_duration_seconds_bucket|loki_write_sent_bytes_total|loki_write_sent_entries_total|process_cpu_seconds_total|process_start_time_seconds|otelcol_processor_batch_batch_send_size_bucket|otelcol_processor_batch_metadata_cardinality|otelcol_processor_batch_timeout_trigger_send_total|prometheus_remote_storage_bytes_total|prometheus_remote_storage_enqueue_retries_total|prometheus_remote_storage_highest_timestamp_in_seconds|prometheus_remote_storage_metadata_bytes_total|prometheus_remote_storage_queue_highest_sent_timestamp_seconds|prometheus_remote_storage_samples_dropped_total|prometheus_remote_storage_samples_failed_total|prometheus_remote_storage_samples_pending|prometheus_remote_storage_samples_retried_total|prometheus_remote_storage_samples_total|prometheus_remote_storage_sent_batch_duration_seconds_bucket|prometheus_remote_storage_sent_batch_duration_seconds_count|prometheus_remote_storage_sent_batch_duration_seconds_sum|prometheus_remote_storage_shard_capacity|prometheus_remote_storage_shards|prometheus_remote_storage_shards_desired|prometheus_remote_storage_shards_max|prometheus_remote_storage_shards_min|prometheus_remote_storage_succeeded_samples_total|prometheus_remote_write_wal_samples_appended_total|prometheus_remote_write_wal_storage_active_series|prometheus_sd_discovered_targets|prometheus_target_interval_length_seconds_count|prometheus_target_interval_length_seconds_sum|prometheus_target_scrapes_exceeded_sample_limit_total|prometheus_target_scrapes_sample_duplicate_timestamp_total|prometheus_target_scrapes_sample_out_of_bounds_total|prometheus_target_scrapes_sample_out_of_order_total|prometheus_target_sync_length_seconds_sum|prometheus_wal_watcher_current_segment|otelcol_receiver_accepted_spans_total|otelcol_receiver_refused_spans_total|rpc_server_duration_milliseconds_bucket|scrape_duration_seconds|traces_exporter_send_failed_spans|traces_exporter_send_failed_spans_total|traces_exporter_sent_spans|traces_exporter_sent_spans_total|traces_loadbalancer_backend_outcome|traces_loadbalancer_num_backends|traces_receiver_accepted_spans|traces_receiver_accepted_spans_total|traces_receiver_refused_spans|traces_receiver_refused_spans_total|otelcol_processor_tail_sampling_.*"
+    scrape_interval = "60s"
+    scrape_timeout = "10s"
+    scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
+    scrape_classic_histograms = false
+    scrape_native_histograms = false
+    max_cache_size = 100000
+    forward_to = argument.metrics_destinations.value
+  }
+}
+alloy_integration "integration" {
+  metrics_destinations = [
+    prometheus.remote_write.localprometheus.receiver,
+  ]
+}
+
+
+
+
+
+// Destination: localPrometheus (prometheus)
+otelcol.exporter.prometheus "localprometheus" {
+  add_metric_suffixes = true
+  resource_to_telemetry_conversion = false
+  keep_identifying_resource_attributes = true
+  forward_to = [prometheus.remote_write.localprometheus.receiver]
+} // otelcol.exporter.prometheus "localprometheus"
+
+prometheus.remote_write "localprometheus" {
+  endpoint {
+    url = "http://prometheus-server.prometheus.svc:9090/api/v1/write"
+    headers = {
+    }
+    tls_config {
+      insecure_skip_verify = false
+    }
+    send_native_histograms = false
+
+    queue_config {
+      capacity = 10000
+      min_shards = 1
+      max_shards = 50
+      max_samples_per_send = 2000
+      batch_send_deadline = "5s"
+      min_backoff = "30ms"
+      max_backoff = "5s"
+      retry_on_http_429 = true
+      sample_age_limit = "0s"
+    }
+  }
+
+  wal {
+    truncate_frequency = "2h"
+    min_keepalive_time = "5m"
+    max_keepalive_time = "8h"
+  }
+  external_labels = {
+    "cluster" = "tail-sampling-test",
+    "k8s_cluster_name" = "tail-sampling-test",
+  }
+} // prometheus.remote_write "localprometheus"
+

--- a/charts/k8s-monitoring/tests/integration/tail-sampling/.rendered/alloy-receiver.alloy
+++ b/charts/k8s-monitoring/tests/integration/tail-sampling/.rendered/alloy-receiver.alloy
@@ -1,0 +1,346 @@
+// Feature: Application Observability
+declare "application_observability" {
+  argument "metrics_destinations" {
+    comment = "Must be a list of metrics destinations where collected metrics should be forwarded to"
+  }
+
+  argument "logs_destinations" {
+    comment = "Must be a list of log destinations where collected logs should be forwarded to"
+  }
+
+  argument "traces_destinations" {
+    comment = "Must be a list of trace destinations where collected trace should be forwarded to"
+  }
+
+  // OTLP Receiver
+  otelcol.receiver.otlp "receiver" {
+    grpc {
+      endpoint = "0.0.0.0:4317"
+      include_metadata = false
+      max_recv_msg_size = "4MiB"
+      read_buffer_size = "512KiB"
+      write_buffer_size = "32KiB"
+    }
+    debug_metrics {
+      disable_high_cardinality_metrics = true
+    }
+    output {
+      metrics = [otelcol.processor.resourcedetection.default.input]
+      logs = [otelcol.processor.resourcedetection.default.input]
+      traces = [otelcol.processor.resourcedetection.default.input]
+    }
+  } // otelcol.receiver.otlp "receiver"
+
+  // Resource Detection Processor
+  otelcol.processor.resourcedetection "default" {
+    detectors = ["env","system"]
+    override = true
+
+    system {
+      hostname_sources = ["os"]
+    }
+
+    output {
+      metrics = [otelcol.processor.k8sattributes.default.input]
+      logs = [otelcol.processor.k8sattributes.default.input]
+      traces = [otelcol.processor.k8sattributes.default.input]
+    }
+  }
+
+  // K8s Attributes Processor
+  otelcol.processor.k8sattributes "default" {
+    passthrough = false
+    extract {
+      metadata = ["k8s.namespace.name","k8s.pod.name","k8s.deployment.name","k8s.statefulset.name","k8s.daemonset.name","k8s.cronjob.name","k8s.job.name","k8s.node.name","k8s.pod.uid","k8s.pod.start_time"]
+    }
+    pod_association {
+      source {
+        from = "resource_attribute"
+        name = "k8s.pod.ip"
+      }
+    }
+    pod_association {
+      source {
+        from = "resource_attribute"
+        name = "k8s.pod.uid"
+      }
+    }
+    pod_association {
+      source {
+        from = "connection"
+      }
+    }
+
+    output {
+      metrics = [otelcol.processor.transform.default.input]
+      logs = [otelcol.processor.transform.default.input]
+      traces = [otelcol.processor.transform.default.input, otelcol.connector.host_info.default.input]
+    }
+  }
+
+  // Host Info Connector
+  otelcol.connector.host_info "default" {
+    host_identifiers = [ "k8s.node.name" ]
+
+    output {
+      metrics = [otelcol.processor.batch.default.input]
+    }
+  }
+
+  // Transform Processor
+  otelcol.processor.transform "default" {
+    error_mode = "ignore"
+    log_statements {
+      context = "resource"
+      statements = [
+        "set(attributes[\"pod\"], attributes[\"k8s.pod.name\"])",
+        "set(attributes[\"namespace\"], attributes[\"k8s.namespace.name\"])",
+        "set(attributes[\"loki.resource.labels\"], \"cluster, namespace, job, pod\")",
+      ]
+    }
+    trace_statements {
+      context = "span"
+      statements = [
+       "set_semconv_span_name(\"1.37.0\", \"original_span_name\")",
+      ]
+    }
+
+    output {
+      metrics = [otelcol.processor.batch.default.input]
+      logs = [otelcol.processor.batch.default.input]
+      traces = [otelcol.processor.batch.default.input]
+    }
+  }
+
+  // Batch Processor
+  otelcol.processor.batch "default" {
+    send_batch_size = 8192
+    send_batch_max_size = 0
+    timeout = "2s"
+
+    output {
+      metrics = argument.metrics_destinations.value
+      logs = argument.logs_destinations.value
+      traces = argument.traces_destinations.value
+    }
+  }
+} // declare "application_observability"
+application_observability "feature" {
+  metrics_destinations = [
+    otelcol.exporter.prometheus.localprometheus.input,
+  ]
+  logs_destinations = [
+    otelcol.exporter.loki.localloki.input,
+  ]
+  traces_destinations = [
+    otelcol.processor.attributes.localtempo.input,
+  ]
+}
+// Self Reporting
+prometheus.exporter.unix "kubernetes_monitoring_telemetry" {
+  set_collectors = ["textfile"]
+  textfile {
+    directory = "/etc/release-info"
+  }
+} // prometheus.exporter.unix "kubernetes_monitoring_telemetry"
+
+discovery.relabel "kubernetes_monitoring_telemetry" {
+  targets = prometheus.exporter.unix.kubernetes_monitoring_telemetry.targets
+  rule {
+    target_label = "instance"
+    action = "replace"
+    replacement = "k8smon"
+  }
+  rule {
+    target_label = "job"
+    action = "replace"
+    replacement = "integrations/kubernetes/kubernetes_monitoring_telemetry"
+  }
+} // discovery.relabel "kubernetes_monitoring_telemetry"
+
+prometheus.scrape "kubernetes_monitoring_telemetry" {
+  job_name   = "integrations/kubernetes/kubernetes_monitoring_telemetry"
+  targets    = discovery.relabel.kubernetes_monitoring_telemetry.output
+  scrape_interval = "60s"
+  clustering {
+    enabled = true
+  }
+  forward_to = [prometheus.relabel.kubernetes_monitoring_telemetry.receiver]
+} // prometheus.scrape "kubernetes_monitoring_telemetry"
+
+prometheus.relabel "kubernetes_monitoring_telemetry" {
+  rule {
+    source_labels = ["__name__"]
+    regex = "grafana_kubernetes_monitoring_.*"
+    action = "keep"
+  }
+  forward_to = [
+    prometheus.remote_write.localprometheus.receiver,
+  ]
+} // prometheus.relabel "kubernetes_monitoring_telemetry"
+
+
+
+
+
+// Destination: localLoki (loki)
+otelcol.exporter.loki "localloki" {
+  forward_to = [loki.write.localloki.receiver]
+} // otelcol.exporter.loki "localloki"
+
+loki.write "localloki" {
+  endpoint {
+    url = "http://loki.loki.svc:3100/loki/api/v1/push"
+    retry_on_http_429 = true
+    tenant_id = convert.nonsensitive(remote.kubernetes.secret.localloki.data["tenantId"])
+    basic_auth {
+      username = convert.nonsensitive(remote.kubernetes.secret.localloki.data["username"])
+      password = remote.kubernetes.secret.localloki.data["password"]
+    }
+    tls_config {
+      insecure_skip_verify = false
+    }
+    min_backoff_period = "500ms"
+    max_backoff_period = "5m"
+    max_backoff_retries = "10"
+  }
+  external_labels = {
+    "cluster" = "tail-sampling-test",
+    "k8s_cluster_name" = "tail-sampling-test",
+  }
+} // loki.write "localloki"
+
+remote.kubernetes.secret "localloki" {
+  name      = "localloki-k8smon-k8s-monitoring"
+  namespace = "default"
+} // remote.kubernetes.secret "localloki"
+
+
+// Destination: localPrometheus (prometheus)
+otelcol.exporter.prometheus "localprometheus" {
+  add_metric_suffixes = true
+  resource_to_telemetry_conversion = false
+  keep_identifying_resource_attributes = true
+  forward_to = [prometheus.remote_write.localprometheus.receiver]
+} // otelcol.exporter.prometheus "localprometheus"
+
+prometheus.remote_write "localprometheus" {
+  endpoint {
+    url = "http://prometheus-server.prometheus.svc:9090/api/v1/write"
+    headers = {
+    }
+    tls_config {
+      insecure_skip_verify = false
+    }
+    send_native_histograms = false
+
+    queue_config {
+      capacity = 10000
+      min_shards = 1
+      max_shards = 50
+      max_samples_per_send = 2000
+      batch_send_deadline = "5s"
+      min_backoff = "30ms"
+      max_backoff = "5s"
+      retry_on_http_429 = true
+      sample_age_limit = "0s"
+    }
+  }
+
+  wal {
+    truncate_frequency = "2h"
+    min_keepalive_time = "5m"
+    max_keepalive_time = "8h"
+  }
+  external_labels = {
+    "cluster" = "tail-sampling-test",
+    "k8s_cluster_name" = "tail-sampling-test",
+  }
+} // prometheus.remote_write "localprometheus"
+
+// Destination: localTempo (otlp)
+otelcol.processor.attributes "localtempo" {
+  output {
+    traces = [otelcol.processor.transform.localtempo.input]
+  }
+} // otelcol.processor.attributes "localtempo"
+
+otelcol.processor.transform "localtempo" {
+  error_mode = "ignore"
+
+  trace_statements {
+    context = "resource"
+    statements = [
+      `set(attributes["cluster"], "tail-sampling-test")`,
+      `set(attributes["k8s.cluster.name"], "tail-sampling-test")`,
+      `delete_key(attributes, "process.pid")`,
+      `delete_key(attributes, "process.parent_pid")`,
+      `delete_key(attributes, "process.executable.path")`,
+      `delete_key(attributes, "process.command_line")`,
+      `delete_key(attributes, "process.command_args")`,
+      `delete_key(attributes, "process.owner")`,
+      `delete_key(attributes, "process.runtime.version")`,
+      `delete_key(attributes, "process.runtime.description")`,
+      `delete_key(attributes, "host.ip")`,
+      `delete_key(attributes, "host.mac")`,
+      `delete_key(attributes, "k8s.pod.start_time")`,
+      `delete_key(attributes, "k8s.pod.uid")`,
+      `delete_key(attributes, "container.image.id")`,
+      `delete_key(attributes, "container.image.repo_digests")`,
+      `delete_key(attributes, "os.description")`,
+      `delete_key(attributes, "os.build_id")`,
+    ]
+  }
+
+  output {
+    traces = [otelcol.exporter.loadbalancing.localtempo_sampler.input]
+  }
+} // otelcol.processor.transform "localtempo"
+
+otelcol.exporter.loadbalancing "localtempo_sampler" {
+  resolver {
+    kubernetes {
+      service = "k8smon-localtempo-sampler"
+    }
+  }
+  protocol {
+    otlp {
+      client {
+        tls {
+          insecure = true
+        }
+      }
+    }
+  }
+} // otelcol.exporter.loadbalancing "localtempo_sampler"
+
+otelcol.processor.batch "localtempo" {
+  timeout = "2s"
+  send_batch_size = 8192
+  send_batch_max_size = 0
+
+  output {
+    traces = [otelcol.exporter.otlp.localtempo.input]
+  }
+} // otelcol.processor.batch "localtempo"
+otelcol.exporter.otlp "localtempo" {
+  client {
+    endpoint = "tempo.tempo.svc:4317"
+    tls {
+      insecure = true
+      insecure_skip_verify = true
+    }
+  }
+
+  retry_on_failure {
+    enabled = true
+    initial_interval = "5s"
+    max_interval = "30s"
+    max_elapsed_time = "5m"
+  }
+
+  sending_queue {
+    enabled = true
+  }
+} // otelcol.exporter.otlp "localtempo"
+

--- a/charts/k8s-monitoring/tests/integration/uninstall/.rendered/alloy-logs.alloy
+++ b/charts/k8s-monitoring/tests/integration/uninstall/.rendered/alloy-logs.alloy
@@ -1,0 +1,236 @@
+// Feature: Pod Logs (Loki)
+declare "pod_logs_via_loki" {
+  argument "logs_destinations" {
+    comment = "Must be a list of log destinations where collected logs should be forwarded to"
+  }
+
+  discovery.kubernetes "pods" {
+    role = "pod"
+    selectors {
+      role = "pod"
+      field = "spec.nodeName=" + sys.env("HOSTNAME")
+    }
+  } // discovery.kubernetes "pods"
+
+  discovery.relabel "filtered_pods" {
+    targets = discovery.kubernetes.pods.targets
+    rule {
+      source_labels = ["__meta_kubernetes_namespace"]
+      action = "replace"
+      target_label = "namespace"
+    }
+    rule {  // Drop anything with a "falsy" annotation value
+      source_labels = ["__meta_kubernetes_pod_annotation_logs_grafana_com_pods_enabled"]
+      regex = "(false|no|skip)"
+      action = "drop"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_pod_name"]
+      target_label = "pod"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_pod_container_name"]
+      target_label = "container"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_namespace", "__meta_kubernetes_pod_container_name"]
+      separator = "/"
+      replacement = "$1"
+      target_label = "job"
+    }
+
+    // set the container runtime as a label
+    rule {
+      source_labels = ["__meta_kubernetes_pod_container_id"]
+      regex = "^(\\S+):\\/\\/.+$"
+      replacement = "$1"
+      target_label = "tmp_container_runtime"
+    }
+    // explicitly set service_name. if not set, loki will automatically try to populate a default.
+    // see https://grafana.com/docs/loki/latest/get-started/labels/#default-labels-for-all-users
+    //
+    // choose the first value found from the following ordered list:
+    // - pod.annotation[resource.opentelemetry.io/service.name]
+    // - pod.label[app.kubernetes.io/name]
+    // - k8s.container.name
+    rule {
+      source_labels = [
+        "__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_name",
+        "__meta_kubernetes_pod_label_app_kubernetes_io_name",
+        "__meta_kubernetes_pod_container_name",
+      ]
+      separator = ";"
+      regex = "^(?:;*)?([^;]+).*$"
+      replacement = "$1"
+      target_label = "service_name"
+    }
+
+    // explicitly set service_namespace.
+    //
+    // choose the first value found from the following ordered list:
+    // - pod.annotation[resource.opentelemetry.io/service.namespace]
+    // - pod.namespace
+    rule {
+      source_labels = [
+        "__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_namespace",
+        "namespace",
+      ]
+      separator = ";"
+      regex = "^(?:;*)?([^;]+).*$"
+      replacement = "$1"
+      target_label = "service_namespace"
+    }
+
+    // explicitly set service_instance_id.
+    //
+    // choose the first value found from the following ordered list:
+    // - pod.annotation[resource.opentelemetry.io/service.instance.id]
+    // - concat([k8s.namespace.name, k8s.pod.name, k8s.container.name], '.')
+    rule {
+      source_labels = ["__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_instance_id"]
+      target_label = "service_instance_id"
+    }
+    rule {
+      source_labels = ["service_instance_id", "namespace", "pod", "container"]
+      separator = "."
+      regex = "^\\.([^.]+\\.[^.]+\\.[^.]+)$"
+      target_label = "service_instance_id"
+    }
+
+    // set resource attributes
+    rule {
+      action = "labelmap"
+      regex = "__meta_kubernetes_pod_annotation_resource_opentelemetry_io_(.+)"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_job"]
+      regex = "(.+)"
+      target_label = "job"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+      regex = "(.+)"
+      target_label = "app_kubernetes_io_name"
+    }
+
+    // Set the pod log path.
+    rule {
+      source_labels = ["__meta_kubernetes_pod_uid", "__meta_kubernetes_pod_container_name"]
+      separator = "/"
+      replacement = "/var/log/pods/*$1/*.log"
+      target_label = "__path__"
+    }
+
+    // If kubernetes.io/config.mirror is set, this is a static pod, created by the kubelet.
+    // It's logs live on a different path.
+    rule {
+      source_labels = ["__meta_kubernetes_pod_annotation_kubernetes_io_config_mirror", "__meta_kubernetes_pod_container_name"]
+      separator = "/"
+      regex = "(.+/.+)"
+      replacement = "/var/log/pods/*$1/*.log"
+      target_label = "__path__"
+    }
+  } // discovery.relabel "filtered_pods"
+
+  local.file_match "pod_logs" {
+    path_targets = discovery.relabel.filtered_pods.output
+  } // local.file_match "pod_logs"
+
+  loki.source.file "pod_logs" {
+    targets    = local.file_match.pod_logs.targets
+    tail_from_end = true
+    forward_to = [loki.process.pod_logs.receiver]
+  } // loki.source.file "pod_logs"
+
+  loki.process "pod_logs" {
+    stage.match {
+      selector = "{tmp_container_runtime=~\"containerd|cri-o|\"}"
+      // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
+      stage.cri {
+        max_partial_lines = 100
+      }
+
+      // Set the extract flags and stream values as labels
+      stage.labels {
+        values = {
+          flags  = "",
+          stream  = "",
+        }
+      }
+    }
+
+    stage.match {
+      selector = "{tmp_container_runtime=\"docker\"}"
+      // the docker processing stage extracts the following k/v pairs: log, stream, time
+      stage.docker {}
+
+      // Set the extract stream value as a label
+      stage.labels {
+        values = {
+          stream  = "",
+        }
+      }
+    }
+
+    // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
+    // namespace, pod, and container labels. Drop any structured metadata. Also drop the temporary
+    // container runtime label as it is no longer needed.
+    stage.label_drop {
+      values = [
+        "filename",
+        "tmp_container_runtime",
+      ]
+    }
+    stage.structured_metadata {
+      values = {
+        "k8s_pod_name" = "k8s_pod_name",
+        "pod" = "pod",
+        "service_instance_id" = "service_instance_id",
+      }
+    }
+
+    forward_to = argument.logs_destinations.value
+  } // loki.secretfilter "pod_logs"
+} // declare "pod_logs_via_loki"
+pod_logs_via_loki "feature" {
+  logs_destinations = [
+    loki.write.localloki.receiver,
+  ]
+}
+
+
+
+
+
+// Destination: localLoki (loki)
+otelcol.exporter.loki "localloki" {
+  forward_to = [loki.write.localloki.receiver]
+} // otelcol.exporter.loki "localloki"
+
+loki.write "localloki" {
+  endpoint {
+    url = "http://loki.loki.svc:3100/loki/api/v1/push"
+    retry_on_http_429 = true
+    tenant_id = convert.nonsensitive(remote.kubernetes.secret.localloki.data["tenantId"])
+    basic_auth {
+      username = convert.nonsensitive(remote.kubernetes.secret.localloki.data["username"])
+      password = remote.kubernetes.secret.localloki.data["password"]
+    }
+    tls_config {
+      insecure_skip_verify = false
+    }
+    min_backoff_period = "500ms"
+    max_backoff_period = "5m"
+    max_backoff_retries = "10"
+  }
+  external_labels = {
+    "cluster" = "uninstall-test",
+    "k8s_cluster_name" = "uninstall-test",
+  }
+} // loki.write "localloki"
+
+remote.kubernetes.secret "localloki" {
+  name      = "localloki-k8smon-k8s-monitoring"
+  namespace = "default"
+} // remote.kubernetes.secret "localloki"
+

--- a/charts/k8s-monitoring/tests/integration/uninstall/.rendered/alloy-metrics.alloy
+++ b/charts/k8s-monitoring/tests/integration/uninstall/.rendered/alloy-metrics.alloy
@@ -1,0 +1,656 @@
+// Feature: Cluster Metrics
+declare "cluster_metrics" {
+  argument "metrics_destinations" {
+    comment = "Must be a list of metric destinations where collected metrics should be forwarded to"
+  }
+  discovery.kubernetes "nodes" {
+    role = "node"
+  } // discovery.kubernetes "nodes"
+
+  discovery.relabel "nodes" {
+    targets = discovery.kubernetes.nodes.targets
+    rule {
+      source_labels = ["__meta_kubernetes_node_name"]
+      target_label  = "node"
+    }
+
+    rule {
+      replacement = "kubernetes"
+      target_label = "source"
+    }
+  } // discovery.relabel "nodes"
+
+  // Kubelet
+  discovery.relabel "kubelet" {
+    targets = discovery.relabel.nodes.output
+  } // discovery.relabel "kubelet"
+
+  prometheus.scrape "kubelet" {
+    targets  = discovery.relabel.kubelet.output
+    job_name = "integrations/kubernetes/kubelet"
+    scheme   = "https"
+    scrape_interval = "60s"
+    scrape_timeout = "10s"
+    scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
+    scrape_classic_histograms = false
+    scrape_native_histograms = false
+    convert_classic_histograms_to_nhcb = false
+    bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+
+    tls_config {
+      ca_file = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+      insecure_skip_verify = true
+      server_name = "kubernetes"
+    }
+
+    clustering {
+      enabled = true
+    }
+
+    forward_to = [prometheus.relabel.kubelet.receiver]
+  } // prometheus.scrape "kubelet"
+
+  prometheus.relabel "kubelet" {
+    max_cache_size = 100000
+    rule {
+      source_labels = ["__name__"]
+      regex = "up|scrape_samples_scraped|go_goroutines|kubelet_certificate_manager_client_expiration_renew_errors|kubelet_certificate_manager_client_ttl_seconds|kubelet_certificate_manager_server_ttl_seconds|kubelet_cgroup_manager_duration_seconds_bucket|kubelet_cgroup_manager_duration_seconds_count|kubelet_node_config_error|kubelet_node_name|kubelet_pleg_relist_duration_seconds_bucket|kubelet_pleg_relist_duration_seconds_count|kubelet_pleg_relist_interval_seconds_bucket|kubelet_pod_start_duration_seconds_bucket|kubelet_pod_start_duration_seconds_count|kubelet_pod_worker_duration_seconds_bucket|kubelet_pod_worker_duration_seconds_count|kubelet_running_container_count|kubelet_running_containers|kubelet_running_pod_count|kubelet_running_pods|kubelet_runtime_operations_errors_total|kubelet_runtime_operations_total|kubelet_server_expiration_renew_errors|kubelet_volume_stats_available_bytes|kubelet_volume_stats_capacity_bytes|kubelet_volume_stats_inodes|kubelet_volume_stats_inodes_free|kubelet_volume_stats_inodes_used|kubelet_volume_stats_used_bytes|kubernetes_build_info|namespace_workload_pod|process_cpu_seconds_total|process_resident_memory_bytes|rest_client_requests_total|storage_operation_duration_seconds_count|storage_operation_errors_total|volume_manager_total_volumes"
+      action = "keep"
+    }
+
+    forward_to = argument.metrics_destinations.value
+  } // prometheus.relabel "kubelet"
+
+  // Kubelet Resources
+  discovery.relabel "kubelet_resources" {
+    targets = discovery.relabel.nodes.output
+    rule {
+      replacement   = "/metrics/resource"
+      target_label  = "__metrics_path__"
+    }
+  } // discovery.relabel "kubelet_resources"
+
+  prometheus.scrape "kubelet_resources" {
+    targets = discovery.relabel.kubelet_resources.output
+    job_name = "integrations/kubernetes/resources"
+    scheme   = "https"
+    scrape_interval = "60s"
+    scrape_timeout = "10s"
+    scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
+    scrape_classic_histograms = false
+    scrape_native_histograms = false
+    convert_classic_histograms_to_nhcb = false
+    bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+
+    tls_config {
+      ca_file = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+      insecure_skip_verify = true
+      server_name = "kubernetes"
+    }
+
+    clustering {
+      enabled = true
+    }
+
+    forward_to = [prometheus.relabel.kubelet_resources.receiver]
+  } // prometheus.scrape "kubelet_resources"
+
+  prometheus.relabel "kubelet_resources" {
+    max_cache_size = 100000
+    rule {
+      source_labels = ["__name__"]
+      regex = "up|scrape_samples_scraped|node_cpu_usage_seconds_total|node_memory_working_set_bytes"
+      action = "keep"
+    }
+
+    forward_to = argument.metrics_destinations.value
+  } // prometheus.relabel "kubelet_resources"
+
+  // cAdvisor
+  discovery.relabel "cadvisor" {
+    targets = discovery.relabel.nodes.output
+    rule {
+      replacement   = "/metrics/cadvisor"
+      target_label  = "__metrics_path__"
+    }
+  } // discovery.relabel "cadvisor"
+
+  prometheus.scrape "cadvisor" {
+    targets = discovery.relabel.cadvisor.output
+    job_name = "integrations/kubernetes/cadvisor"
+    scheme = "https"
+    scrape_interval = "60s"
+    scrape_timeout = "10s"
+    scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
+    scrape_classic_histograms = false
+    scrape_native_histograms = false
+    convert_classic_histograms_to_nhcb = false
+    bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+
+    tls_config {
+      ca_file = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+      insecure_skip_verify = true
+      server_name = "kubernetes"
+    }
+
+    clustering {
+      enabled = true
+    }
+
+    forward_to = [prometheus.relabel.cadvisor.receiver]
+  } // prometheus.scrape "cadvisor"
+
+  prometheus.relabel "cadvisor" {
+    max_cache_size = 100000
+    rule {
+      source_labels = ["__name__"]
+      regex = "up|scrape_samples_scraped|container_cpu_cfs_periods_total|container_cpu_cfs_throttled_periods_total|container_cpu_usage_seconds_total|container_fs_reads_bytes_total|container_fs_reads_total|container_fs_writes_bytes_total|container_fs_writes_total|container_memory_cache|container_memory_rss|container_memory_swap|container_memory_usage_bytes|container_memory_working_set_bytes|container_network_receive_bytes_total|container_network_receive_packets_dropped_total|container_network_receive_packets_total|container_network_transmit_bytes_total|container_network_transmit_packets_dropped_total|container_network_transmit_packets_total|machine_memory_bytes"
+      action = "keep"
+    }
+    // Drop empty container labels, addressing https://github.com/google/cadvisor/issues/2688
+    rule {
+      source_labels = ["__name__","container"]
+      separator = "@"
+      regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_pressure_.*)@"
+      action = "drop"
+    }
+    // Drop empty image labels, addressing https://github.com/google/cadvisor/issues/2688
+    rule {
+      source_labels = ["__name__","image"]
+      separator = "@"
+      regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_network_.*|container_pressure_.*)@"
+      action = "drop"
+    }
+    // Normalizing unimportant labels (not deleting to continue satisfying <label>!="" checks)
+    rule {
+      source_labels = ["__name__", "boot_id"]
+      separator = "@"
+      regex = "machine_memory_bytes@.*"
+      target_label = "boot_id"
+      replacement = "NA"
+    }
+    rule {
+      source_labels = ["__name__", "system_uuid"]
+      separator = "@"
+      regex = "machine_memory_bytes@.*"
+      target_label = "system_uuid"
+      replacement = "NA"
+    }
+    // Filter out non-physical devices/interfaces
+    rule {
+      source_labels = ["__name__", "device"]
+      separator = "@"
+      regex = "container_fs_.*@(/dev/)?(mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dasd.+)"
+      target_label = "__keepme"
+      replacement = "1"
+    }
+    rule {
+      source_labels = ["__name__", "__keepme"]
+      separator = "@"
+      regex = "container_fs_.*@"
+      action = "drop"
+    }
+    rule {
+      source_labels = ["__name__"]
+      regex = "container_fs_.*"
+      target_label = "__keepme"
+      replacement = ""
+    }
+    rule {
+      source_labels = ["__name__", "interface"]
+      separator = "@"
+      regex = "container_network_.*@(en[ospx][0-9].*|wlan[0-9].*|eth[0-9].*)"
+      target_label = "__keepme"
+      replacement = "1"
+    }
+    rule {
+      source_labels = ["__name__", "__keepme"]
+      separator = "@"
+      regex = "container_network_.*@"
+      action = "drop"
+    }
+    rule {
+      source_labels = ["__name__"]
+      regex = "container_network_.*"
+      target_label = "__keepme"
+      replacement = ""
+    }
+    forward_to = argument.metrics_destinations.value
+  } // prometheus.relabel "cadvisor"
+  discovery.kubernetes "kube_state_metrics" {
+    role = "endpoints"
+
+    selectors {
+      role = "endpoints"
+      label = "release=k8smon,app.kubernetes.io/name=kube-state-metrics"
+    }
+    namespaces {
+      names = ["default"]
+    }
+  } // discovery.kubernetes "kube_state_metrics"
+
+  discovery.relabel "kube_state_metrics" {
+    targets = discovery.kubernetes.kube_state_metrics.targets
+
+    rule {
+      action = "replace"
+      replacement = "kubernetes"
+      target_label = "source"
+    }
+
+  } // discovery.relabel "kube_state_metrics"
+
+  prometheus.scrape "kube_state_metrics" {
+    targets = discovery.relabel.kube_state_metrics.output
+    job_name = "integrations/kubernetes/kube-state-metrics"
+    scrape_interval = "60s"
+    scrape_timeout = "10s"
+    scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
+    scrape_classic_histograms = false
+    scrape_native_histograms = false
+    convert_classic_histograms_to_nhcb = false
+    scheme = "http"
+    bearer_token_file = ""
+    tls_config {
+      insecure_skip_verify = true
+    }
+
+    clustering {
+      enabled = true
+    }
+    forward_to = [prometheus.relabel.kube_state_metrics.receiver]
+  } // prometheus.scrape "kube_state_metrics"
+
+  prometheus.relabel "kube_state_metrics" {
+    max_cache_size = 100000
+    rule {
+      source_labels = ["__name__"]
+      regex = "up|scrape_samples_scraped|kube_configmap_info|kube_configmap_metadata_resource_version|kube_cronjob.*|kube_daemonset.*|kube_deployment_metadata_generation|kube_deployment_spec_replicas|kube_deployment_status_condition|kube_deployment_status_observed_generation|kube_deployment_status_replicas_available|kube_deployment_status_replicas_updated|kube_horizontalpodautoscaler_spec_max_replicas|kube_horizontalpodautoscaler_spec_min_replicas|kube_horizontalpodautoscaler_status_current_replicas|kube_horizontalpodautoscaler_status_desired_replicas|kube_job.*|kube_namespace_status_phase|kube_node.*|kube_persistentvolume_status_phase|kube_persistentvolumeclaim_access_mode|kube_persistentvolumeclaim_info|kube_persistentvolumeclaim_labels|kube_persistentvolumeclaim_resource_requests_storage_bytes|kube_persistentvolumeclaim_status_phase|kube_pod_completion_time|kube_pod_container_info|kube_pod_container_resource_limits|kube_pod_container_resource_requests|kube_pod_container_status_last_terminated_reason|kube_pod_container_status_last_terminated_timestamp|kube_pod_container_status_restarts_total|kube_pod_container_status_waiting_reason|kube_pod_info|kube_pod_owner|kube_pod_restart_policy|kube_pod_spec_volumes_persistentvolumeclaims_info|kube_pod_start_time|kube_pod_status_phase|kube_pod_status_reason|kube_pod_init_.*|kube_replicaset.*|kube_resourcequota|kube_secret_metadata_resource_version|kube_statefulset.*"
+      action = "keep"
+    }
+    forward_to = argument.metrics_destinations.value
+  } // prometheus.relabel "kube_state_metrics"
+} // declare "cluster_metrics"
+cluster_metrics "feature" {
+  metrics_destinations = [
+    prometheus.remote_write.localprometheus.receiver,
+  ]
+}
+// Feature: Cost Metrics
+declare "cost_metrics" {
+  argument "metrics_destinations" {
+    comment = "Must be a list of metric destinations where collected metrics should be forwarded to"
+  }
+
+  discovery.kubernetes "opencost" {
+    role = "pod"
+    selectors {
+      role = "pod"
+      label = "app.kubernetes.io/instance=k8smon,app.kubernetes.io/name=opencost"
+    }
+    namespaces {
+      names = ["default"]
+    }
+  } // discovery.kubernetes "opencost"
+
+  discovery.relabel "opencost" {
+    targets = discovery.kubernetes.opencost.targets
+    rule {
+      source_labels = ["__meta_kubernetes_pod_node_name"]
+      action = "replace"
+      target_label = "instance"
+    }
+  } // discovery.relabel "opencost"
+
+  prometheus.scrape "opencost" {
+    targets      = discovery.relabel.opencost.output
+    job_name     = "integrations/opencost"
+    honor_labels = true
+    scrape_interval = "60s"
+    scrape_timeout = "10s"
+    scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
+    scrape_classic_histograms = false
+    scrape_native_histograms = false
+    convert_classic_histograms_to_nhcb = false
+    clustering {
+      enabled = true
+    }
+    forward_to = [prometheus.relabel.opencost.receiver]
+  } // prometheus.scrape "opencost"
+
+  prometheus.relabel "opencost" {
+    max_cache_size = 100000
+    rule {
+      source_labels = ["__name__"]
+      regex = "up|scrape_samples_scraped|container_cpu_allocation|container_gpu_allocation|container_memory_allocation_bytes|deployment_match_labels|kubecost_cluster_info|kubecost_cluster_management_cost|kubecost_cluster_memory_working_set_bytes|kubecost_http_requests_total|kubecost_http_response_size_bytes|kubecost_http_response_time_seconds|kubecost_load_balancer_cost|kubecost_network_internet_egress_cost|kubecost_network_region_egress_cost|kubecost_network_zone_egress_cost|kubecost_node_is_spot|node_cpu_hourly_cost|node_gpu_count|node_gpu_hourly_cost|node_ram_hourly_cost|node_total_hourly_cost|opencost_build_info|pod_pvc_allocation|pv_hourly_cost|service_selector_labels|statefulSet_match_labels"
+      action = "keep"
+    }
+    forward_to = argument.metrics_destinations.value
+  } // prometheus.relabel "opencost"
+} // declare "cost_metrics"
+cost_metrics "feature" {
+  metrics_destinations = [
+    prometheus.remote_write.localprometheus.receiver,
+  ]
+}
+// Feature: Host Metrics
+declare "host_metrics" {
+  argument "metrics_destinations" {
+    comment = "Must be a list of metric destinations where collected metrics should be forwarded to"
+  }
+
+  // Linux hosts via Node Exporter
+  discovery.kubernetes "node_exporter" {
+    role = "pod"
+    selectors {
+      role = "pod"
+      label = "release=k8smon,app.kubernetes.io/name=node-exporter"
+    }
+    namespaces {
+      names = ["default"]
+    }
+
+  } // discovery.kubernetes "node_exporter"
+
+  discovery.relabel "node_exporter" {
+    targets = discovery.kubernetes.node_exporter.targets
+
+    // keep only the specified metrics port name, and pods that are Running and ready
+    rule {
+      source_labels = [
+        "__meta_kubernetes_pod_container_init",
+        "__meta_kubernetes_pod_phase",
+        "__meta_kubernetes_pod_ready",
+      ]
+      separator = "@"
+      regex = "false@Running@true"
+      action = "keep"
+    }
+
+    // Set the instance label to the node name
+    rule {
+      source_labels = ["__meta_kubernetes_pod_node_name"]
+      target_label = "instance"
+    }
+
+    rule {
+      source_labels = ["__meta_kubernetes_namespace"]
+      target_label  = "namespace"
+    }
+
+    rule {
+      source_labels = ["__meta_kubernetes_pod_name"]
+      target_label  = "pod"
+    }
+
+    rule {
+      source_labels = ["__meta_kubernetes_pod_container_name"]
+      target_label  = "container"
+    }
+
+    // set a workload label
+    rule {
+      source_labels = [
+        "__meta_kubernetes_pod_controller_kind",
+        "__meta_kubernetes_pod_controller_name",
+      ]
+      separator = "/"
+      target_label  = "workload"
+    }
+    // remove the hash from the ReplicaSet
+    rule {
+      source_labels = ["workload"]
+      regex = "(ReplicaSet/.+)-.+"
+      target_label  = "workload"
+    }
+
+    // Set the app label.
+    //
+    // Choose the first value found from the following ordered list:
+    // - pod.label[app.kubernetes.io/name]
+    // - pod.label[k8s-app]
+    // - pod.label[app]
+    rule {
+      source_labels = [
+        "__meta_kubernetes_pod_label_app_kubernetes_io_name",
+        "__meta_kubernetes_pod_label_k8s_app",
+        "__meta_kubernetes_pod_label_app",
+      ]
+      separator = ";"
+      regex = "^(?:;*)?([^;]+).*$"
+      replacement = "$1"
+      target_label = "app"
+    }
+
+    // Set the component label.
+    //
+    // Choose the first value found from the following ordered list:
+    // - pod.label[app.kubernetes.io/component]
+    // - pod.label[k8s-component]
+    // - pod.label[component]
+    rule {
+      source_labels = [
+        "__meta_kubernetes_pod_label_app_kubernetes_io_component",
+        "__meta_kubernetes_pod_label_k8s_component",
+        "__meta_kubernetes_pod_label_component",
+      ]
+      regex = "^(?:;*)?([^;]+).*$"
+      replacement = "$1"
+      target_label = "component"
+    }
+
+    rule {
+      target_label = "source"
+      replacement = "kubernetes"
+    }
+
+  } // discovery.relabel "node_exporter"
+
+  prometheus.scrape "node_exporter" {
+    targets = discovery.relabel.node_exporter.output
+    job_name = "integrations/node_exporter"
+    scrape_interval = "60s"
+    scrape_timeout = "10s"
+    scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
+    scrape_classic_histograms = false
+    scrape_native_histograms = false
+    convert_classic_histograms_to_nhcb = false
+    scheme = "http"
+    tls_config {
+      insecure_skip_verify = true
+    }
+
+    clustering {
+      enabled = true
+    }
+    forward_to = [prometheus.relabel.node_exporter.receiver]
+  } // prometheus.scrape "node_exporter"
+
+  prometheus.relabel "node_exporter" {
+    max_cache_size = 100000
+    rule {
+      source_labels = ["__name__"]
+      regex = "up|scrape_samples_scraped|node_cpu.*|node_exporter_build_info|node_filesystem.*|node_memory.*|node_network_receive_bytes_total|node_network_receive_drop_total|node_network_transmit_bytes_total|node_network_transmit_drop_total|process_cpu_seconds_total|process_resident_memory_bytes"
+      action = "keep"
+    }
+    // Drop metrics for certain file systems
+    rule {
+      source_labels = ["__name__", "fstype"]
+      separator = "@"
+      regex = "node_filesystem.*@(ramfs|tmpfs)"
+      action = "drop"
+    }
+    forward_to = argument.metrics_destinations.value
+  } // prometheus.relabel "node_exporter"
+
+  // Windows hosts via Windows Exporter
+  discovery.kubernetes "windows_exporter_pods" {
+    role = "pod"
+    selectors {
+      role = "pod"
+      label = "release=k8smon,app.kubernetes.io/name=windows-exporter"
+    }
+    namespaces {
+      names = ["default"]
+    }
+
+  } // discovery.kubernetes "windows_exporter_pods"
+
+  discovery.relabel "windows_exporter" {
+    targets = discovery.kubernetes.windows_exporter_pods.targets
+
+    // keep only the specified metrics port name, and pods that are Running and ready
+    rule {
+      source_labels = [
+        "__meta_kubernetes_pod_container_init",
+        "__meta_kubernetes_pod_phase",
+        "__meta_kubernetes_pod_ready",
+      ]
+      separator = "@"
+      regex = "false@Running@true"
+      action = "keep"
+    }
+
+    // Set the instance label to the node name
+    rule {
+      source_labels = ["__meta_kubernetes_pod_node_name"]
+      target_label = "instance"
+    }
+
+  } // discovery.relabel "windows_exporter"
+
+  prometheus.scrape "windows_exporter" {
+    targets  = discovery.relabel.windows_exporter.output
+    job_name   = "integrations/windows-exporter"
+    scrape_interval = "60s"
+    scrape_timeout = "10s"
+    scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
+    scrape_classic_histograms = false
+    scrape_native_histograms = false
+    convert_classic_histograms_to_nhcb = false
+    clustering {
+      enabled = true
+    }
+    forward_to = [prometheus.relabel.windows_exporter.receiver]
+  } // prometheus.scrape "windows_exporter"
+
+  prometheus.relabel "windows_exporter" {
+    max_cache_size = 100000
+    rule {
+      source_labels = ["__name__"]
+      regex = "up|scrape_samples_scraped|windows_.*|node_cpu_seconds_total|node_filesystem_size_bytes|node_filesystem_avail_bytes|container_cpu_usage_seconds_total"
+      action = "keep"
+    }
+    forward_to = argument.metrics_destinations.value
+  } // prometheus.relabel "windows_exporter"
+
+  // Energy metrics via Kepler
+  discovery.kubernetes "kepler" {
+    role = "pod"
+    selectors {
+      role = "pod"
+      label = "app.kubernetes.io/name=kepler"
+    }
+    namespaces {
+      names = ["default"]
+    }
+
+  } // discovery.kubernetes "kepler"
+
+  discovery.relabel "kepler" {
+    targets = discovery.kubernetes.kepler.targets
+    rule {
+      source_labels = ["__meta_kubernetes_pod_node_name"]
+      action = "replace"
+      target_label = "instance"
+    }
+
+  } // discovery.relabel "kepler"
+
+  prometheus.scrape "kepler" {
+    targets      = discovery.relabel.kepler.output
+    job_name     = "integrations/kepler"
+    honor_labels = true
+    scrape_interval = "60s"
+    scrape_timeout = "10s"
+    scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
+    scrape_classic_histograms = false
+    scrape_native_histograms = false
+    convert_classic_histograms_to_nhcb = false
+    clustering {
+      enabled = true
+    }
+    forward_to = [prometheus.relabel.kepler.receiver]
+  } // prometheus.scrape "kepler"
+
+  prometheus.relabel "kepler" {
+    max_cache_size = 100000
+    rule {
+      source_labels = ["__name__"]
+      regex = "up|scrape_samples_scraped|kepler_.*"
+      action = "keep"
+    }
+    forward_to = argument.metrics_destinations.value
+  } // prometheus.relabel "kepler"
+} // declare "host_metrics"
+host_metrics "feature" {
+  metrics_destinations = [
+    prometheus.remote_write.localprometheus.receiver,
+  ]
+}
+
+
+
+
+
+// Destination: localPrometheus (prometheus)
+otelcol.exporter.prometheus "localprometheus" {
+  add_metric_suffixes = true
+  resource_to_telemetry_conversion = false
+  keep_identifying_resource_attributes = true
+  forward_to = [prometheus.remote_write.localprometheus.receiver]
+} // otelcol.exporter.prometheus "localprometheus"
+
+prometheus.remote_write "localprometheus" {
+  endpoint {
+    url = "http://prometheus-server.prometheus.svc:9090/api/v1/write"
+    headers = {
+    }
+    basic_auth {
+      username = convert.nonsensitive(remote.kubernetes.secret.localprometheus.data["username"])
+      password = remote.kubernetes.secret.localprometheus.data["password"]
+    }
+    tls_config {
+      insecure_skip_verify = false
+    }
+    send_native_histograms = false
+
+    queue_config {
+      capacity = 10000
+      min_shards = 1
+      max_shards = 50
+      max_samples_per_send = 2000
+      batch_send_deadline = "5s"
+      min_backoff = "30ms"
+      max_backoff = "5s"
+      retry_on_http_429 = true
+      sample_age_limit = "0s"
+    }
+  }
+
+  wal {
+    truncate_frequency = "2h"
+    min_keepalive_time = "5m"
+    max_keepalive_time = "8h"
+  }
+  external_labels = {
+    "cluster" = "uninstall-test",
+    "k8s_cluster_name" = "uninstall-test",
+  }
+} // prometheus.remote_write "localprometheus"
+
+remote.kubernetes.secret "localprometheus" {
+  name      = "localprometheus-k8smon-k8s-monitoring"
+  namespace = "default"
+} // remote.kubernetes.secret "localprometheus"
+

--- a/charts/k8s-monitoring/tests/integration/uninstall/.rendered/alloy-singleton.alloy
+++ b/charts/k8s-monitoring/tests/integration/uninstall/.rendered/alloy-singleton.alloy
@@ -1,0 +1,214 @@
+// Feature: Cluster Events
+declare "cluster_events" {
+  argument "logs_destinations" {
+    comment = "Must be a list of log destinations where collected logs should be forwarded to"
+  }
+
+  loki.source.kubernetes_events "cluster_events" {
+    job_name   = "integrations/kubernetes/eventhandler"
+    log_format = "logfmt"
+    forward_to = [loki.process.cluster_events.receiver]
+  } // loki.source.kubernetes_events "cluster_events"
+
+  loki.process "cluster_events" {
+
+    // add a static source label to the logs so they can be differentiated / restricted if necessary
+    stage.static_labels {
+      values = {
+        "source" = "kubernetes-events",
+      }
+    }
+
+    // extract some of the fields from the log line, these could be used as labels, structured metadata, etc.
+    stage.logfmt {
+      mapping = {
+        "component" = "sourcecomponent", // map the sourcecomponent field to component
+        "kind" = "",
+        "level" = "type", // most events don't have a level but they do have a "type" i.e. Normal, Warning, Error, etc.
+        "name" = "",
+        "node" = "sourcehost", // map the sourcehost field to node
+        "reason" = "",
+      }
+    }
+    // set the extracted values as labels
+    stage.labels {
+      values = {
+        "kind" = "",
+        "level" = "",
+        "service_name" = "job",
+        "reason" = "reason",
+      }
+    }
+
+    // if kind=Node, set the node label by copying the name field
+    stage.match {
+      selector = "{kind=\"Node\"}"
+
+      stage.labels {
+        values = {
+          "node" = "name",
+        }
+      }
+    }
+
+    // set the level extracted key value as a normalized log level
+    stage.match {
+      selector = "{level=\"Normal\"}"
+
+      stage.static_labels {
+        values = {
+          level = "Info",
+        }
+      }
+    }
+    stage.structured_metadata {
+      values = {
+        "name" = "name",
+        "node" = "node",
+      }
+    }
+
+    // Drop pipeline-only labels that are not needed in the final output.
+    stage.label_drop {
+      values = ["kind"]
+    }
+
+    forward_to = argument.logs_destinations.value
+  } // loki.process "cluster_events"
+} // declare "cluster_events"
+cluster_events "feature" {
+  logs_destinations = [
+    loki.write.localloki.receiver,
+  ]
+}
+// Self Reporting
+prometheus.exporter.unix "kubernetes_monitoring_telemetry" {
+  set_collectors = ["textfile"]
+  textfile {
+    directory = "/etc/release-info"
+  }
+} // prometheus.exporter.unix "kubernetes_monitoring_telemetry"
+
+discovery.relabel "kubernetes_monitoring_telemetry" {
+  targets = prometheus.exporter.unix.kubernetes_monitoring_telemetry.targets
+  rule {
+    target_label = "instance"
+    action = "replace"
+    replacement = "k8smon"
+  }
+  rule {
+    target_label = "job"
+    action = "replace"
+    replacement = "integrations/kubernetes/kubernetes_monitoring_telemetry"
+  }
+} // discovery.relabel "kubernetes_monitoring_telemetry"
+
+prometheus.scrape "kubernetes_monitoring_telemetry" {
+  job_name   = "integrations/kubernetes/kubernetes_monitoring_telemetry"
+  targets    = discovery.relabel.kubernetes_monitoring_telemetry.output
+  scrape_interval = "60s"
+  clustering {
+    enabled = true
+  }
+  forward_to = [prometheus.relabel.kubernetes_monitoring_telemetry.receiver]
+} // prometheus.scrape "kubernetes_monitoring_telemetry"
+
+prometheus.relabel "kubernetes_monitoring_telemetry" {
+  rule {
+    source_labels = ["__name__"]
+    regex = "grafana_kubernetes_monitoring_.*"
+    action = "keep"
+  }
+  forward_to = [
+    prometheus.remote_write.localprometheus.receiver,
+  ]
+} // prometheus.relabel "kubernetes_monitoring_telemetry"
+
+
+
+
+
+// Destination: localLoki (loki)
+otelcol.exporter.loki "localloki" {
+  forward_to = [loki.write.localloki.receiver]
+} // otelcol.exporter.loki "localloki"
+
+loki.write "localloki" {
+  endpoint {
+    url = "http://loki.loki.svc:3100/loki/api/v1/push"
+    retry_on_http_429 = true
+    tenant_id = convert.nonsensitive(remote.kubernetes.secret.localloki.data["tenantId"])
+    basic_auth {
+      username = convert.nonsensitive(remote.kubernetes.secret.localloki.data["username"])
+      password = remote.kubernetes.secret.localloki.data["password"]
+    }
+    tls_config {
+      insecure_skip_verify = false
+    }
+    min_backoff_period = "500ms"
+    max_backoff_period = "5m"
+    max_backoff_retries = "10"
+  }
+  external_labels = {
+    "cluster" = "uninstall-test",
+    "k8s_cluster_name" = "uninstall-test",
+  }
+} // loki.write "localloki"
+
+remote.kubernetes.secret "localloki" {
+  name      = "localloki-k8smon-k8s-monitoring"
+  namespace = "default"
+} // remote.kubernetes.secret "localloki"
+
+
+// Destination: localPrometheus (prometheus)
+otelcol.exporter.prometheus "localprometheus" {
+  add_metric_suffixes = true
+  resource_to_telemetry_conversion = false
+  keep_identifying_resource_attributes = true
+  forward_to = [prometheus.remote_write.localprometheus.receiver]
+} // otelcol.exporter.prometheus "localprometheus"
+
+prometheus.remote_write "localprometheus" {
+  endpoint {
+    url = "http://prometheus-server.prometheus.svc:9090/api/v1/write"
+    headers = {
+    }
+    basic_auth {
+      username = convert.nonsensitive(remote.kubernetes.secret.localprometheus.data["username"])
+      password = remote.kubernetes.secret.localprometheus.data["password"]
+    }
+    tls_config {
+      insecure_skip_verify = false
+    }
+    send_native_histograms = false
+
+    queue_config {
+      capacity = 10000
+      min_shards = 1
+      max_shards = 50
+      max_samples_per_send = 2000
+      batch_send_deadline = "5s"
+      min_backoff = "30ms"
+      max_backoff = "5s"
+      retry_on_http_429 = true
+      sample_age_limit = "0s"
+    }
+  }
+
+  wal {
+    truncate_frequency = "2h"
+    min_keepalive_time = "5m"
+    max_keepalive_time = "8h"
+  }
+  external_labels = {
+    "cluster" = "uninstall-test",
+    "k8s_cluster_name" = "uninstall-test",
+  }
+} // prometheus.remote_write "localprometheus"
+
+remote.kubernetes.secret "localprometheus" {
+  name      = "localprometheus-k8smon-k8s-monitoring"
+  namespace = "default"
+} // remote.kubernetes.secret "localprometheus"
+

--- a/charts/k8s-monitoring/tests/integration/upgrade/minor/.rendered/alloy-logs.alloy
+++ b/charts/k8s-monitoring/tests/integration/upgrade/minor/.rendered/alloy-logs.alloy
@@ -1,0 +1,240 @@
+// Feature: Pod Logs (Loki)
+declare "pod_logs_via_loki" {
+  argument "logs_destinations" {
+    comment = "Must be a list of log destinations where collected logs should be forwarded to"
+  }
+
+  discovery.kubernetes "pods" {
+    role = "pod"
+    selectors {
+      role = "pod"
+      field = "spec.nodeName=" + sys.env("HOSTNAME")
+    }
+  } // discovery.kubernetes "pods"
+
+  discovery.relabel "filtered_pods" {
+    targets = discovery.kubernetes.pods.targets
+    rule {
+      source_labels = ["__meta_kubernetes_namespace"]
+      action = "replace"
+      target_label = "namespace"
+    }
+    rule {  // Drop anything with a "falsy" annotation value
+      source_labels = ["__meta_kubernetes_pod_annotation_logs_grafana_com_pods_enabled"]
+      regex = "(false|no|skip)"
+      action = "drop"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_pod_name"]
+      target_label = "pod"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_pod_container_name"]
+      target_label = "container"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_namespace", "__meta_kubernetes_pod_container_name"]
+      separator = "/"
+      replacement = "$1"
+      target_label = "job"
+    }
+
+    // set the container runtime as a label
+    rule {
+      source_labels = ["__meta_kubernetes_pod_container_id"]
+      regex = "^(\\S+):\\/\\/.+$"
+      replacement = "$1"
+      target_label = "tmp_container_runtime"
+    }
+    // explicitly set service_name. if not set, loki will automatically try to populate a default.
+    // see https://grafana.com/docs/loki/latest/get-started/labels/#default-labels-for-all-users
+    //
+    // choose the first value found from the following ordered list:
+    // - pod.annotation[resource.opentelemetry.io/service.name]
+    // - pod.label[app.kubernetes.io/name]
+    // - k8s.container.name
+    rule {
+      source_labels = [
+        "__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_name",
+        "__meta_kubernetes_pod_label_app_kubernetes_io_name",
+        "__meta_kubernetes_pod_container_name",
+      ]
+      separator = ";"
+      regex = "^(?:;*)?([^;]+).*$"
+      replacement = "$1"
+      target_label = "service_name"
+    }
+
+    // explicitly set service_namespace.
+    //
+    // choose the first value found from the following ordered list:
+    // - pod.annotation[resource.opentelemetry.io/service.namespace]
+    // - pod.namespace
+    rule {
+      source_labels = [
+        "__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_namespace",
+        "namespace",
+      ]
+      separator = ";"
+      regex = "^(?:;*)?([^;]+).*$"
+      replacement = "$1"
+      target_label = "service_namespace"
+    }
+
+    // explicitly set service_instance_id.
+    //
+    // choose the first value found from the following ordered list:
+    // - pod.annotation[resource.opentelemetry.io/service.instance.id]
+    // - concat([k8s.namespace.name, k8s.pod.name, k8s.container.name], '.')
+    rule {
+      source_labels = ["__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_instance_id"]
+      target_label = "service_instance_id"
+    }
+    rule {
+      source_labels = ["service_instance_id", "namespace", "pod", "container"]
+      separator = "."
+      regex = "^\\.([^.]+\\.[^.]+\\.[^.]+)$"
+      target_label = "service_instance_id"
+    }
+
+    // set resource attributes
+    rule {
+      action = "labelmap"
+      regex = "__meta_kubernetes_pod_annotation_resource_opentelemetry_io_(.+)"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_job"]
+      regex = "(.+)"
+      target_label = "job"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+      regex = "(.+)"
+      target_label = "app_kubernetes_io_name"
+    }
+
+    // Set the pod log path.
+    rule {
+      source_labels = ["__meta_kubernetes_pod_uid", "__meta_kubernetes_pod_container_name"]
+      separator = "/"
+      replacement = "/var/log/pods/*$1/*.log"
+      target_label = "__path__"
+    }
+
+    // If kubernetes.io/config.mirror is set, this is a static pod, created by the kubelet.
+    // It's logs live on a different path.
+    rule {
+      source_labels = ["__meta_kubernetes_pod_annotation_kubernetes_io_config_mirror", "__meta_kubernetes_pod_container_name"]
+      separator = "/"
+      regex = "(.+/.+)"
+      replacement = "/var/log/pods/*$1/*.log"
+      target_label = "__path__"
+    }
+  } // discovery.relabel "filtered_pods"
+
+  local.file_match "pod_logs" {
+    path_targets = discovery.relabel.filtered_pods.output
+  } // local.file_match "pod_logs"
+
+  loki.source.file "pod_logs" {
+    targets    = local.file_match.pod_logs.targets
+    tail_from_end = true
+    forward_to = [loki.process.pod_logs.receiver]
+  } // loki.source.file "pod_logs"
+
+  loki.process "pod_logs" {
+    stage.match {
+      selector = "{tmp_container_runtime=~\"containerd|cri-o|\"}"
+      // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
+      stage.cri {
+        max_partial_lines = 100
+      }
+
+      // Set the extract flags and stream values as labels
+      stage.labels {
+        values = {
+          flags  = "",
+          stream  = "",
+        }
+      }
+    }
+
+    stage.match {
+      selector = "{tmp_container_runtime=\"docker\"}"
+      // the docker processing stage extracts the following k/v pairs: log, stream, time
+      stage.docker {}
+
+      // Set the extract stream value as a label
+      stage.labels {
+        values = {
+          stream  = "",
+        }
+      }
+    }
+
+    // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
+    // namespace, pod, and container labels. Drop any structured metadata. Also drop the temporary
+    // container runtime label as it is no longer needed.
+    stage.label_drop {
+      values = [
+        "filename",
+        "tmp_container_runtime",
+      ]
+    }
+    stage.structured_metadata {
+      values = {
+        "k8s_pod_name" = "k8s_pod_name",
+        "pod" = "pod",
+        "service_instance_id" = "service_instance_id",
+      }
+    }
+
+    forward_to = argument.logs_destinations.value
+  } // loki.secretfilter "pod_logs"
+} // declare "pod_logs_via_loki"
+pod_logs_via_loki "feature" {
+  logs_destinations = [
+    loki.write.localloki.receiver,
+  ]
+}
+
+
+
+remote.kubernetes.configmap "version" {
+  name = "k8smon-version"
+  namespace = "toolbox"
+}
+
+// Destination: localLoki (loki)
+otelcol.exporter.loki "localloki" {
+  forward_to = [loki.write.localloki.receiver]
+} // otelcol.exporter.loki "localloki"
+
+loki.write "localloki" {
+  endpoint {
+    url = "http://loki.loki.svc:3100/loki/api/v1/push"
+    retry_on_http_429 = true
+    tenant_id = convert.nonsensitive(remote.kubernetes.secret.localloki.data["tenantId"])
+    basic_auth {
+      username = convert.nonsensitive(remote.kubernetes.secret.localloki.data["username"])
+      password = remote.kubernetes.secret.localloki.data["password"]
+    }
+    tls_config {
+      insecure_skip_verify = false
+    }
+    min_backoff_period = "500ms"
+    max_backoff_period = "5m"
+    max_backoff_retries = "10"
+  }
+  external_labels = {
+    "cluster" = "minor-upgrade-test",
+    "k8s_cluster_name" = "minor-upgrade-test",
+    chart_version = remote.kubernetes.configmap.version.data["version"],
+  }
+} // loki.write "localloki"
+
+remote.kubernetes.secret "localloki" {
+  name      = "localloki-k8smon-k8s-monitoring"
+  namespace = "default"
+} // remote.kubernetes.secret "localloki"
+

--- a/charts/k8s-monitoring/tests/integration/upgrade/minor/.rendered/alloy-metrics.alloy
+++ b/charts/k8s-monitoring/tests/integration/upgrade/minor/.rendered/alloy-metrics.alloy
@@ -1,0 +1,660 @@
+// Feature: Cluster Metrics
+declare "cluster_metrics" {
+  argument "metrics_destinations" {
+    comment = "Must be a list of metric destinations where collected metrics should be forwarded to"
+  }
+  discovery.kubernetes "nodes" {
+    role = "node"
+  } // discovery.kubernetes "nodes"
+
+  discovery.relabel "nodes" {
+    targets = discovery.kubernetes.nodes.targets
+    rule {
+      source_labels = ["__meta_kubernetes_node_name"]
+      target_label  = "node"
+    }
+
+    rule {
+      replacement = "kubernetes"
+      target_label = "source"
+    }
+  } // discovery.relabel "nodes"
+
+  // Kubelet
+  discovery.relabel "kubelet" {
+    targets = discovery.relabel.nodes.output
+  } // discovery.relabel "kubelet"
+
+  prometheus.scrape "kubelet" {
+    targets  = discovery.relabel.kubelet.output
+    job_name = "integrations/kubernetes/kubelet"
+    scheme   = "https"
+    scrape_interval = "60s"
+    scrape_timeout = "10s"
+    scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
+    scrape_classic_histograms = false
+    scrape_native_histograms = false
+    convert_classic_histograms_to_nhcb = false
+    bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+
+    tls_config {
+      ca_file = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+      insecure_skip_verify = true
+      server_name = "kubernetes"
+    }
+
+    clustering {
+      enabled = true
+    }
+
+    forward_to = [prometheus.relabel.kubelet.receiver]
+  } // prometheus.scrape "kubelet"
+
+  prometheus.relabel "kubelet" {
+    max_cache_size = 100000
+    rule {
+      source_labels = ["__name__"]
+      regex = "up|scrape_samples_scraped|go_goroutines|kubelet_certificate_manager_client_expiration_renew_errors|kubelet_certificate_manager_client_ttl_seconds|kubelet_certificate_manager_server_ttl_seconds|kubelet_cgroup_manager_duration_seconds_bucket|kubelet_cgroup_manager_duration_seconds_count|kubelet_node_config_error|kubelet_node_name|kubelet_pleg_relist_duration_seconds_bucket|kubelet_pleg_relist_duration_seconds_count|kubelet_pleg_relist_interval_seconds_bucket|kubelet_pod_start_duration_seconds_bucket|kubelet_pod_start_duration_seconds_count|kubelet_pod_worker_duration_seconds_bucket|kubelet_pod_worker_duration_seconds_count|kubelet_running_container_count|kubelet_running_containers|kubelet_running_pod_count|kubelet_running_pods|kubelet_runtime_operations_errors_total|kubelet_runtime_operations_total|kubelet_server_expiration_renew_errors|kubelet_volume_stats_available_bytes|kubelet_volume_stats_capacity_bytes|kubelet_volume_stats_inodes|kubelet_volume_stats_inodes_free|kubelet_volume_stats_inodes_used|kubelet_volume_stats_used_bytes|kubernetes_build_info|namespace_workload_pod|process_cpu_seconds_total|process_resident_memory_bytes|rest_client_requests_total|storage_operation_duration_seconds_count|storage_operation_errors_total|volume_manager_total_volumes"
+      action = "keep"
+    }
+
+    forward_to = argument.metrics_destinations.value
+  } // prometheus.relabel "kubelet"
+
+  // Kubelet Resources
+  discovery.relabel "kubelet_resources" {
+    targets = discovery.relabel.nodes.output
+    rule {
+      replacement   = "/metrics/resource"
+      target_label  = "__metrics_path__"
+    }
+  } // discovery.relabel "kubelet_resources"
+
+  prometheus.scrape "kubelet_resources" {
+    targets = discovery.relabel.kubelet_resources.output
+    job_name = "integrations/kubernetes/resources"
+    scheme   = "https"
+    scrape_interval = "60s"
+    scrape_timeout = "10s"
+    scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
+    scrape_classic_histograms = false
+    scrape_native_histograms = false
+    convert_classic_histograms_to_nhcb = false
+    bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+
+    tls_config {
+      ca_file = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+      insecure_skip_verify = true
+      server_name = "kubernetes"
+    }
+
+    clustering {
+      enabled = true
+    }
+
+    forward_to = [prometheus.relabel.kubelet_resources.receiver]
+  } // prometheus.scrape "kubelet_resources"
+
+  prometheus.relabel "kubelet_resources" {
+    max_cache_size = 100000
+    rule {
+      source_labels = ["__name__"]
+      regex = "up|scrape_samples_scraped|node_cpu_usage_seconds_total|node_memory_working_set_bytes"
+      action = "keep"
+    }
+
+    forward_to = argument.metrics_destinations.value
+  } // prometheus.relabel "kubelet_resources"
+
+  // cAdvisor
+  discovery.relabel "cadvisor" {
+    targets = discovery.relabel.nodes.output
+    rule {
+      replacement   = "/metrics/cadvisor"
+      target_label  = "__metrics_path__"
+    }
+  } // discovery.relabel "cadvisor"
+
+  prometheus.scrape "cadvisor" {
+    targets = discovery.relabel.cadvisor.output
+    job_name = "integrations/kubernetes/cadvisor"
+    scheme = "https"
+    scrape_interval = "60s"
+    scrape_timeout = "10s"
+    scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
+    scrape_classic_histograms = false
+    scrape_native_histograms = false
+    convert_classic_histograms_to_nhcb = false
+    bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+
+    tls_config {
+      ca_file = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+      insecure_skip_verify = true
+      server_name = "kubernetes"
+    }
+
+    clustering {
+      enabled = true
+    }
+
+    forward_to = [prometheus.relabel.cadvisor.receiver]
+  } // prometheus.scrape "cadvisor"
+
+  prometheus.relabel "cadvisor" {
+    max_cache_size = 100000
+    rule {
+      source_labels = ["__name__"]
+      regex = "up|scrape_samples_scraped|container_cpu_cfs_periods_total|container_cpu_cfs_throttled_periods_total|container_cpu_usage_seconds_total|container_fs_reads_bytes_total|container_fs_reads_total|container_fs_writes_bytes_total|container_fs_writes_total|container_memory_cache|container_memory_rss|container_memory_swap|container_memory_usage_bytes|container_memory_working_set_bytes|container_network_receive_bytes_total|container_network_receive_packets_dropped_total|container_network_receive_packets_total|container_network_transmit_bytes_total|container_network_transmit_packets_dropped_total|container_network_transmit_packets_total|machine_memory_bytes"
+      action = "keep"
+    }
+    // Drop empty container labels, addressing https://github.com/google/cadvisor/issues/2688
+    rule {
+      source_labels = ["__name__","container"]
+      separator = "@"
+      regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_pressure_.*)@"
+      action = "drop"
+    }
+    // Drop empty image labels, addressing https://github.com/google/cadvisor/issues/2688
+    rule {
+      source_labels = ["__name__","image"]
+      separator = "@"
+      regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_network_.*|container_pressure_.*)@"
+      action = "drop"
+    }
+    // Normalizing unimportant labels (not deleting to continue satisfying <label>!="" checks)
+    rule {
+      source_labels = ["__name__", "boot_id"]
+      separator = "@"
+      regex = "machine_memory_bytes@.*"
+      target_label = "boot_id"
+      replacement = "NA"
+    }
+    rule {
+      source_labels = ["__name__", "system_uuid"]
+      separator = "@"
+      regex = "machine_memory_bytes@.*"
+      target_label = "system_uuid"
+      replacement = "NA"
+    }
+    // Filter out non-physical devices/interfaces
+    rule {
+      source_labels = ["__name__", "device"]
+      separator = "@"
+      regex = "container_fs_.*@(/dev/)?(mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dasd.+)"
+      target_label = "__keepme"
+      replacement = "1"
+    }
+    rule {
+      source_labels = ["__name__", "__keepme"]
+      separator = "@"
+      regex = "container_fs_.*@"
+      action = "drop"
+    }
+    rule {
+      source_labels = ["__name__"]
+      regex = "container_fs_.*"
+      target_label = "__keepme"
+      replacement = ""
+    }
+    rule {
+      source_labels = ["__name__", "interface"]
+      separator = "@"
+      regex = "container_network_.*@(en[ospx][0-9].*|wlan[0-9].*|eth[0-9].*)"
+      target_label = "__keepme"
+      replacement = "1"
+    }
+    rule {
+      source_labels = ["__name__", "__keepme"]
+      separator = "@"
+      regex = "container_network_.*@"
+      action = "drop"
+    }
+    rule {
+      source_labels = ["__name__"]
+      regex = "container_network_.*"
+      target_label = "__keepme"
+      replacement = ""
+    }
+    forward_to = argument.metrics_destinations.value
+  } // prometheus.relabel "cadvisor"
+  discovery.kubernetes "kube_state_metrics" {
+    role = "endpoints"
+
+    selectors {
+      role = "endpoints"
+      label = "release=k8smon,app.kubernetes.io/name=kube-state-metrics"
+    }
+    namespaces {
+      names = ["default"]
+    }
+  } // discovery.kubernetes "kube_state_metrics"
+
+  discovery.relabel "kube_state_metrics" {
+    targets = discovery.kubernetes.kube_state_metrics.targets
+
+    rule {
+      action = "replace"
+      replacement = "kubernetes"
+      target_label = "source"
+    }
+
+  } // discovery.relabel "kube_state_metrics"
+
+  prometheus.scrape "kube_state_metrics" {
+    targets = discovery.relabel.kube_state_metrics.output
+    job_name = "integrations/kubernetes/kube-state-metrics"
+    scrape_interval = "60s"
+    scrape_timeout = "10s"
+    scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
+    scrape_classic_histograms = false
+    scrape_native_histograms = false
+    convert_classic_histograms_to_nhcb = false
+    scheme = "http"
+    bearer_token_file = ""
+    tls_config {
+      insecure_skip_verify = true
+    }
+
+    clustering {
+      enabled = true
+    }
+    forward_to = [prometheus.relabel.kube_state_metrics.receiver]
+  } // prometheus.scrape "kube_state_metrics"
+
+  prometheus.relabel "kube_state_metrics" {
+    max_cache_size = 100000
+    rule {
+      source_labels = ["__name__"]
+      regex = "up|scrape_samples_scraped|kube_configmap_info|kube_configmap_metadata_resource_version|kube_cronjob.*|kube_daemonset.*|kube_deployment_metadata_generation|kube_deployment_spec_replicas|kube_deployment_status_condition|kube_deployment_status_observed_generation|kube_deployment_status_replicas_available|kube_deployment_status_replicas_updated|kube_horizontalpodautoscaler_spec_max_replicas|kube_horizontalpodautoscaler_spec_min_replicas|kube_horizontalpodautoscaler_status_current_replicas|kube_horizontalpodautoscaler_status_desired_replicas|kube_job.*|kube_namespace_status_phase|kube_node.*|kube_persistentvolume_status_phase|kube_persistentvolumeclaim_access_mode|kube_persistentvolumeclaim_info|kube_persistentvolumeclaim_labels|kube_persistentvolumeclaim_resource_requests_storage_bytes|kube_persistentvolumeclaim_status_phase|kube_pod_completion_time|kube_pod_container_info|kube_pod_container_resource_limits|kube_pod_container_resource_requests|kube_pod_container_status_last_terminated_reason|kube_pod_container_status_last_terminated_timestamp|kube_pod_container_status_restarts_total|kube_pod_container_status_waiting_reason|kube_pod_info|kube_pod_owner|kube_pod_restart_policy|kube_pod_spec_volumes_persistentvolumeclaims_info|kube_pod_start_time|kube_pod_status_phase|kube_pod_status_reason|kube_pod_init_.*|kube_replicaset.*|kube_resourcequota|kube_secret_metadata_resource_version|kube_statefulset.*"
+      action = "keep"
+    }
+    forward_to = argument.metrics_destinations.value
+  } // prometheus.relabel "kube_state_metrics"
+} // declare "cluster_metrics"
+cluster_metrics "feature" {
+  metrics_destinations = [
+    prometheus.remote_write.localprometheus.receiver,
+  ]
+}
+// Feature: Cost Metrics
+declare "cost_metrics" {
+  argument "metrics_destinations" {
+    comment = "Must be a list of metric destinations where collected metrics should be forwarded to"
+  }
+
+  discovery.kubernetes "opencost" {
+    role = "pod"
+    selectors {
+      role = "pod"
+      label = "app.kubernetes.io/instance=k8smon,app.kubernetes.io/name=opencost"
+    }
+    namespaces {
+      names = ["default"]
+    }
+  } // discovery.kubernetes "opencost"
+
+  discovery.relabel "opencost" {
+    targets = discovery.kubernetes.opencost.targets
+    rule {
+      source_labels = ["__meta_kubernetes_pod_node_name"]
+      action = "replace"
+      target_label = "instance"
+    }
+  } // discovery.relabel "opencost"
+
+  prometheus.scrape "opencost" {
+    targets      = discovery.relabel.opencost.output
+    job_name     = "integrations/opencost"
+    honor_labels = true
+    scrape_interval = "60s"
+    scrape_timeout = "10s"
+    scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
+    scrape_classic_histograms = false
+    scrape_native_histograms = false
+    convert_classic_histograms_to_nhcb = false
+    clustering {
+      enabled = true
+    }
+    forward_to = [prometheus.relabel.opencost.receiver]
+  } // prometheus.scrape "opencost"
+
+  prometheus.relabel "opencost" {
+    max_cache_size = 100000
+    rule {
+      source_labels = ["__name__"]
+      regex = "up|scrape_samples_scraped|container_cpu_allocation|container_gpu_allocation|container_memory_allocation_bytes|deployment_match_labels|kubecost_cluster_info|kubecost_cluster_management_cost|kubecost_cluster_memory_working_set_bytes|kubecost_http_requests_total|kubecost_http_response_size_bytes|kubecost_http_response_time_seconds|kubecost_load_balancer_cost|kubecost_network_internet_egress_cost|kubecost_network_region_egress_cost|kubecost_network_zone_egress_cost|kubecost_node_is_spot|node_cpu_hourly_cost|node_gpu_count|node_gpu_hourly_cost|node_ram_hourly_cost|node_total_hourly_cost|opencost_build_info|pod_pvc_allocation|pv_hourly_cost|service_selector_labels|statefulSet_match_labels"
+      action = "keep"
+    }
+    forward_to = argument.metrics_destinations.value
+  } // prometheus.relabel "opencost"
+} // declare "cost_metrics"
+cost_metrics "feature" {
+  metrics_destinations = [
+    prometheus.remote_write.localprometheus.receiver,
+  ]
+}
+// Feature: Host Metrics
+declare "host_metrics" {
+  argument "metrics_destinations" {
+    comment = "Must be a list of metric destinations where collected metrics should be forwarded to"
+  }
+
+  // Linux hosts via Node Exporter
+  discovery.kubernetes "node_exporter" {
+    role = "pod"
+    selectors {
+      role = "pod"
+      label = "release=k8smon,app.kubernetes.io/name=node-exporter"
+    }
+    namespaces {
+      names = ["default"]
+    }
+
+  } // discovery.kubernetes "node_exporter"
+
+  discovery.relabel "node_exporter" {
+    targets = discovery.kubernetes.node_exporter.targets
+
+    // keep only the specified metrics port name, and pods that are Running and ready
+    rule {
+      source_labels = [
+        "__meta_kubernetes_pod_container_init",
+        "__meta_kubernetes_pod_phase",
+        "__meta_kubernetes_pod_ready",
+      ]
+      separator = "@"
+      regex = "false@Running@true"
+      action = "keep"
+    }
+
+    // Set the instance label to the node name
+    rule {
+      source_labels = ["__meta_kubernetes_pod_node_name"]
+      target_label = "instance"
+    }
+
+    rule {
+      source_labels = ["__meta_kubernetes_namespace"]
+      target_label  = "namespace"
+    }
+
+    rule {
+      source_labels = ["__meta_kubernetes_pod_name"]
+      target_label  = "pod"
+    }
+
+    rule {
+      source_labels = ["__meta_kubernetes_pod_container_name"]
+      target_label  = "container"
+    }
+
+    // set a workload label
+    rule {
+      source_labels = [
+        "__meta_kubernetes_pod_controller_kind",
+        "__meta_kubernetes_pod_controller_name",
+      ]
+      separator = "/"
+      target_label  = "workload"
+    }
+    // remove the hash from the ReplicaSet
+    rule {
+      source_labels = ["workload"]
+      regex = "(ReplicaSet/.+)-.+"
+      target_label  = "workload"
+    }
+
+    // Set the app label.
+    //
+    // Choose the first value found from the following ordered list:
+    // - pod.label[app.kubernetes.io/name]
+    // - pod.label[k8s-app]
+    // - pod.label[app]
+    rule {
+      source_labels = [
+        "__meta_kubernetes_pod_label_app_kubernetes_io_name",
+        "__meta_kubernetes_pod_label_k8s_app",
+        "__meta_kubernetes_pod_label_app",
+      ]
+      separator = ";"
+      regex = "^(?:;*)?([^;]+).*$"
+      replacement = "$1"
+      target_label = "app"
+    }
+
+    // Set the component label.
+    //
+    // Choose the first value found from the following ordered list:
+    // - pod.label[app.kubernetes.io/component]
+    // - pod.label[k8s-component]
+    // - pod.label[component]
+    rule {
+      source_labels = [
+        "__meta_kubernetes_pod_label_app_kubernetes_io_component",
+        "__meta_kubernetes_pod_label_k8s_component",
+        "__meta_kubernetes_pod_label_component",
+      ]
+      regex = "^(?:;*)?([^;]+).*$"
+      replacement = "$1"
+      target_label = "component"
+    }
+
+    rule {
+      target_label = "source"
+      replacement = "kubernetes"
+    }
+
+  } // discovery.relabel "node_exporter"
+
+  prometheus.scrape "node_exporter" {
+    targets = discovery.relabel.node_exporter.output
+    job_name = "integrations/node_exporter"
+    scrape_interval = "60s"
+    scrape_timeout = "10s"
+    scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
+    scrape_classic_histograms = false
+    scrape_native_histograms = false
+    convert_classic_histograms_to_nhcb = false
+    scheme = "http"
+    tls_config {
+      insecure_skip_verify = true
+    }
+
+    clustering {
+      enabled = true
+    }
+    forward_to = [prometheus.relabel.node_exporter.receiver]
+  } // prometheus.scrape "node_exporter"
+
+  prometheus.relabel "node_exporter" {
+    max_cache_size = 100000
+    rule {
+      source_labels = ["__name__"]
+      regex = "up|scrape_samples_scraped|node_cpu.*|node_exporter_build_info|node_filesystem.*|node_memory.*|node_network_receive_bytes_total|node_network_receive_drop_total|node_network_transmit_bytes_total|node_network_transmit_drop_total|process_cpu_seconds_total|process_resident_memory_bytes"
+      action = "keep"
+    }
+    // Drop metrics for certain file systems
+    rule {
+      source_labels = ["__name__", "fstype"]
+      separator = "@"
+      regex = "node_filesystem.*@(ramfs|tmpfs)"
+      action = "drop"
+    }
+    forward_to = argument.metrics_destinations.value
+  } // prometheus.relabel "node_exporter"
+
+  // Windows hosts via Windows Exporter
+  discovery.kubernetes "windows_exporter_pods" {
+    role = "pod"
+    selectors {
+      role = "pod"
+      label = "release=k8smon,app.kubernetes.io/name=windows-exporter"
+    }
+    namespaces {
+      names = ["default"]
+    }
+
+  } // discovery.kubernetes "windows_exporter_pods"
+
+  discovery.relabel "windows_exporter" {
+    targets = discovery.kubernetes.windows_exporter_pods.targets
+
+    // keep only the specified metrics port name, and pods that are Running and ready
+    rule {
+      source_labels = [
+        "__meta_kubernetes_pod_container_init",
+        "__meta_kubernetes_pod_phase",
+        "__meta_kubernetes_pod_ready",
+      ]
+      separator = "@"
+      regex = "false@Running@true"
+      action = "keep"
+    }
+
+    // Set the instance label to the node name
+    rule {
+      source_labels = ["__meta_kubernetes_pod_node_name"]
+      target_label = "instance"
+    }
+
+  } // discovery.relabel "windows_exporter"
+
+  prometheus.scrape "windows_exporter" {
+    targets  = discovery.relabel.windows_exporter.output
+    job_name   = "integrations/windows-exporter"
+    scrape_interval = "60s"
+    scrape_timeout = "10s"
+    scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
+    scrape_classic_histograms = false
+    scrape_native_histograms = false
+    convert_classic_histograms_to_nhcb = false
+    clustering {
+      enabled = true
+    }
+    forward_to = [prometheus.relabel.windows_exporter.receiver]
+  } // prometheus.scrape "windows_exporter"
+
+  prometheus.relabel "windows_exporter" {
+    max_cache_size = 100000
+    rule {
+      source_labels = ["__name__"]
+      regex = "up|scrape_samples_scraped|windows_.*|node_cpu_seconds_total|node_filesystem_size_bytes|node_filesystem_avail_bytes|container_cpu_usage_seconds_total"
+      action = "keep"
+    }
+    forward_to = argument.metrics_destinations.value
+  } // prometheus.relabel "windows_exporter"
+
+  // Energy metrics via Kepler
+  discovery.kubernetes "kepler" {
+    role = "pod"
+    selectors {
+      role = "pod"
+      label = "app.kubernetes.io/name=kepler"
+    }
+    namespaces {
+      names = ["default"]
+    }
+
+  } // discovery.kubernetes "kepler"
+
+  discovery.relabel "kepler" {
+    targets = discovery.kubernetes.kepler.targets
+    rule {
+      source_labels = ["__meta_kubernetes_pod_node_name"]
+      action = "replace"
+      target_label = "instance"
+    }
+
+  } // discovery.relabel "kepler"
+
+  prometheus.scrape "kepler" {
+    targets      = discovery.relabel.kepler.output
+    job_name     = "integrations/kepler"
+    honor_labels = true
+    scrape_interval = "60s"
+    scrape_timeout = "10s"
+    scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
+    scrape_classic_histograms = false
+    scrape_native_histograms = false
+    convert_classic_histograms_to_nhcb = false
+    clustering {
+      enabled = true
+    }
+    forward_to = [prometheus.relabel.kepler.receiver]
+  } // prometheus.scrape "kepler"
+
+  prometheus.relabel "kepler" {
+    max_cache_size = 100000
+    rule {
+      source_labels = ["__name__"]
+      regex = "up|scrape_samples_scraped|kepler_.*"
+      action = "keep"
+    }
+    forward_to = argument.metrics_destinations.value
+  } // prometheus.relabel "kepler"
+} // declare "host_metrics"
+host_metrics "feature" {
+  metrics_destinations = [
+    prometheus.remote_write.localprometheus.receiver,
+  ]
+}
+
+
+
+remote.kubernetes.configmap "version" {
+  name = "k8smon-version"
+  namespace = "toolbox"
+}
+
+// Destination: localPrometheus (prometheus)
+otelcol.exporter.prometheus "localprometheus" {
+  add_metric_suffixes = true
+  resource_to_telemetry_conversion = false
+  keep_identifying_resource_attributes = true
+  forward_to = [prometheus.remote_write.localprometheus.receiver]
+} // otelcol.exporter.prometheus "localprometheus"
+
+prometheus.remote_write "localprometheus" {
+  endpoint {
+    url = "http://prometheus-server.prometheus.svc:9090/api/v1/write"
+    headers = {
+    }
+    basic_auth {
+      username = convert.nonsensitive(remote.kubernetes.secret.localprometheus.data["username"])
+      password = remote.kubernetes.secret.localprometheus.data["password"]
+    }
+    tls_config {
+      insecure_skip_verify = false
+    }
+    send_native_histograms = false
+
+    queue_config {
+      capacity = 10000
+      min_shards = 1
+      max_shards = 50
+      max_samples_per_send = 2000
+      batch_send_deadline = "5s"
+      min_backoff = "30ms"
+      max_backoff = "5s"
+      retry_on_http_429 = true
+      sample_age_limit = "0s"
+    }
+  }
+
+  wal {
+    truncate_frequency = "2h"
+    min_keepalive_time = "5m"
+    max_keepalive_time = "8h"
+  }
+  external_labels = {
+    "cluster" = "minor-upgrade-test",
+    "k8s_cluster_name" = "minor-upgrade-test",
+    chart_version = remote.kubernetes.configmap.version.data["version"],
+  }
+} // prometheus.remote_write "localprometheus"
+
+remote.kubernetes.secret "localprometheus" {
+  name      = "localprometheus-k8smon-k8s-monitoring"
+  namespace = "default"
+} // remote.kubernetes.secret "localprometheus"
+

--- a/charts/k8s-monitoring/tests/integration/upgrade/minor/.rendered/alloy-singleton.alloy
+++ b/charts/k8s-monitoring/tests/integration/upgrade/minor/.rendered/alloy-singleton.alloy
@@ -1,0 +1,219 @@
+// Feature: Cluster Events
+declare "cluster_events" {
+  argument "logs_destinations" {
+    comment = "Must be a list of log destinations where collected logs should be forwarded to"
+  }
+
+  loki.source.kubernetes_events "cluster_events" {
+    job_name   = "integrations/kubernetes/eventhandler"
+    log_format = "logfmt"
+    forward_to = [loki.process.cluster_events.receiver]
+  } // loki.source.kubernetes_events "cluster_events"
+
+  loki.process "cluster_events" {
+
+    // add a static source label to the logs so they can be differentiated / restricted if necessary
+    stage.static_labels {
+      values = {
+        "source" = "kubernetes-events",
+      }
+    }
+
+    // extract some of the fields from the log line, these could be used as labels, structured metadata, etc.
+    stage.logfmt {
+      mapping = {
+        "component" = "sourcecomponent", // map the sourcecomponent field to component
+        "kind" = "",
+        "level" = "type", // most events don't have a level but they do have a "type" i.e. Normal, Warning, Error, etc.
+        "name" = "",
+        "node" = "sourcehost", // map the sourcehost field to node
+        "reason" = "",
+      }
+    }
+    // set the extracted values as labels
+    stage.labels {
+      values = {
+        "kind" = "",
+        "level" = "",
+        "service_name" = "job",
+        "reason" = "reason",
+      }
+    }
+
+    // if kind=Node, set the node label by copying the name field
+    stage.match {
+      selector = "{kind=\"Node\"}"
+
+      stage.labels {
+        values = {
+          "node" = "name",
+        }
+      }
+    }
+
+    // set the level extracted key value as a normalized log level
+    stage.match {
+      selector = "{level=\"Normal\"}"
+
+      stage.static_labels {
+        values = {
+          level = "Info",
+        }
+      }
+    }
+    stage.structured_metadata {
+      values = {
+        "name" = "name",
+        "node" = "node",
+      }
+    }
+
+    // Drop pipeline-only labels that are not needed in the final output.
+    stage.label_drop {
+      values = ["kind"]
+    }
+
+    forward_to = argument.logs_destinations.value
+  } // loki.process "cluster_events"
+} // declare "cluster_events"
+cluster_events "feature" {
+  logs_destinations = [
+    loki.write.localloki.receiver,
+  ]
+}
+// Self Reporting
+prometheus.exporter.unix "kubernetes_monitoring_telemetry" {
+  set_collectors = ["textfile"]
+  textfile {
+    directory = "/etc/release-info"
+  }
+} // prometheus.exporter.unix "kubernetes_monitoring_telemetry"
+
+discovery.relabel "kubernetes_monitoring_telemetry" {
+  targets = prometheus.exporter.unix.kubernetes_monitoring_telemetry.targets
+  rule {
+    target_label = "instance"
+    action = "replace"
+    replacement = "k8smon"
+  }
+  rule {
+    target_label = "job"
+    action = "replace"
+    replacement = "integrations/kubernetes/kubernetes_monitoring_telemetry"
+  }
+} // discovery.relabel "kubernetes_monitoring_telemetry"
+
+prometheus.scrape "kubernetes_monitoring_telemetry" {
+  job_name   = "integrations/kubernetes/kubernetes_monitoring_telemetry"
+  targets    = discovery.relabel.kubernetes_monitoring_telemetry.output
+  scrape_interval = "60s"
+  clustering {
+    enabled = true
+  }
+  forward_to = [prometheus.relabel.kubernetes_monitoring_telemetry.receiver]
+} // prometheus.scrape "kubernetes_monitoring_telemetry"
+
+prometheus.relabel "kubernetes_monitoring_telemetry" {
+  rule {
+    source_labels = ["__name__"]
+    regex = "grafana_kubernetes_monitoring_.*"
+    action = "keep"
+  }
+  forward_to = [
+    prometheus.remote_write.localprometheus.receiver,
+  ]
+} // prometheus.relabel "kubernetes_monitoring_telemetry"
+
+
+
+remote.kubernetes.configmap "version" {
+  name = "k8smon-version"
+  namespace = "toolbox"
+}
+
+// Destination: localLoki (loki)
+otelcol.exporter.loki "localloki" {
+  forward_to = [loki.write.localloki.receiver]
+} // otelcol.exporter.loki "localloki"
+
+loki.write "localloki" {
+  endpoint {
+    url = "http://loki.loki.svc:3100/loki/api/v1/push"
+    retry_on_http_429 = true
+    tenant_id = convert.nonsensitive(remote.kubernetes.secret.localloki.data["tenantId"])
+    basic_auth {
+      username = convert.nonsensitive(remote.kubernetes.secret.localloki.data["username"])
+      password = remote.kubernetes.secret.localloki.data["password"]
+    }
+    tls_config {
+      insecure_skip_verify = false
+    }
+    min_backoff_period = "500ms"
+    max_backoff_period = "5m"
+    max_backoff_retries = "10"
+  }
+  external_labels = {
+    "cluster" = "minor-upgrade-test",
+    "k8s_cluster_name" = "minor-upgrade-test",
+    chart_version = remote.kubernetes.configmap.version.data["version"],
+  }
+} // loki.write "localloki"
+
+remote.kubernetes.secret "localloki" {
+  name      = "localloki-k8smon-k8s-monitoring"
+  namespace = "default"
+} // remote.kubernetes.secret "localloki"
+
+
+// Destination: localPrometheus (prometheus)
+otelcol.exporter.prometheus "localprometheus" {
+  add_metric_suffixes = true
+  resource_to_telemetry_conversion = false
+  keep_identifying_resource_attributes = true
+  forward_to = [prometheus.remote_write.localprometheus.receiver]
+} // otelcol.exporter.prometheus "localprometheus"
+
+prometheus.remote_write "localprometheus" {
+  endpoint {
+    url = "http://prometheus-server.prometheus.svc:9090/api/v1/write"
+    headers = {
+    }
+    basic_auth {
+      username = convert.nonsensitive(remote.kubernetes.secret.localprometheus.data["username"])
+      password = remote.kubernetes.secret.localprometheus.data["password"]
+    }
+    tls_config {
+      insecure_skip_verify = false
+    }
+    send_native_histograms = false
+
+    queue_config {
+      capacity = 10000
+      min_shards = 1
+      max_shards = 50
+      max_samples_per_send = 2000
+      batch_send_deadline = "5s"
+      min_backoff = "30ms"
+      max_backoff = "5s"
+      retry_on_http_429 = true
+      sample_age_limit = "0s"
+    }
+  }
+
+  wal {
+    truncate_frequency = "2h"
+    min_keepalive_time = "5m"
+    max_keepalive_time = "8h"
+  }
+  external_labels = {
+    "cluster" = "minor-upgrade-test",
+    "k8s_cluster_name" = "minor-upgrade-test",
+    chart_version = remote.kubernetes.configmap.version.data["version"],
+  }
+} // prometheus.remote_write "localprometheus"
+
+remote.kubernetes.secret "localprometheus" {
+  name      = "localprometheus-k8smon-k8s-monitoring"
+  namespace = "default"
+} // remote.kubernetes.secret "localprometheus"
+

--- a/charts/k8s-monitoring/tests/integration/upgrade/patch/.rendered/alloy-logs.alloy
+++ b/charts/k8s-monitoring/tests/integration/upgrade/patch/.rendered/alloy-logs.alloy
@@ -1,0 +1,240 @@
+// Feature: Pod Logs (Loki)
+declare "pod_logs_via_loki" {
+  argument "logs_destinations" {
+    comment = "Must be a list of log destinations where collected logs should be forwarded to"
+  }
+
+  discovery.kubernetes "pods" {
+    role = "pod"
+    selectors {
+      role = "pod"
+      field = "spec.nodeName=" + sys.env("HOSTNAME")
+    }
+  } // discovery.kubernetes "pods"
+
+  discovery.relabel "filtered_pods" {
+    targets = discovery.kubernetes.pods.targets
+    rule {
+      source_labels = ["__meta_kubernetes_namespace"]
+      action = "replace"
+      target_label = "namespace"
+    }
+    rule {  // Drop anything with a "falsy" annotation value
+      source_labels = ["__meta_kubernetes_pod_annotation_logs_grafana_com_pods_enabled"]
+      regex = "(false|no|skip)"
+      action = "drop"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_pod_name"]
+      target_label = "pod"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_pod_container_name"]
+      target_label = "container"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_namespace", "__meta_kubernetes_pod_container_name"]
+      separator = "/"
+      replacement = "$1"
+      target_label = "job"
+    }
+
+    // set the container runtime as a label
+    rule {
+      source_labels = ["__meta_kubernetes_pod_container_id"]
+      regex = "^(\\S+):\\/\\/.+$"
+      replacement = "$1"
+      target_label = "tmp_container_runtime"
+    }
+    // explicitly set service_name. if not set, loki will automatically try to populate a default.
+    // see https://grafana.com/docs/loki/latest/get-started/labels/#default-labels-for-all-users
+    //
+    // choose the first value found from the following ordered list:
+    // - pod.annotation[resource.opentelemetry.io/service.name]
+    // - pod.label[app.kubernetes.io/name]
+    // - k8s.container.name
+    rule {
+      source_labels = [
+        "__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_name",
+        "__meta_kubernetes_pod_label_app_kubernetes_io_name",
+        "__meta_kubernetes_pod_container_name",
+      ]
+      separator = ";"
+      regex = "^(?:;*)?([^;]+).*$"
+      replacement = "$1"
+      target_label = "service_name"
+    }
+
+    // explicitly set service_namespace.
+    //
+    // choose the first value found from the following ordered list:
+    // - pod.annotation[resource.opentelemetry.io/service.namespace]
+    // - pod.namespace
+    rule {
+      source_labels = [
+        "__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_namespace",
+        "namespace",
+      ]
+      separator = ";"
+      regex = "^(?:;*)?([^;]+).*$"
+      replacement = "$1"
+      target_label = "service_namespace"
+    }
+
+    // explicitly set service_instance_id.
+    //
+    // choose the first value found from the following ordered list:
+    // - pod.annotation[resource.opentelemetry.io/service.instance.id]
+    // - concat([k8s.namespace.name, k8s.pod.name, k8s.container.name], '.')
+    rule {
+      source_labels = ["__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_instance_id"]
+      target_label = "service_instance_id"
+    }
+    rule {
+      source_labels = ["service_instance_id", "namespace", "pod", "container"]
+      separator = "."
+      regex = "^\\.([^.]+\\.[^.]+\\.[^.]+)$"
+      target_label = "service_instance_id"
+    }
+
+    // set resource attributes
+    rule {
+      action = "labelmap"
+      regex = "__meta_kubernetes_pod_annotation_resource_opentelemetry_io_(.+)"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_job"]
+      regex = "(.+)"
+      target_label = "job"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+      regex = "(.+)"
+      target_label = "app_kubernetes_io_name"
+    }
+
+    // Set the pod log path.
+    rule {
+      source_labels = ["__meta_kubernetes_pod_uid", "__meta_kubernetes_pod_container_name"]
+      separator = "/"
+      replacement = "/var/log/pods/*$1/*.log"
+      target_label = "__path__"
+    }
+
+    // If kubernetes.io/config.mirror is set, this is a static pod, created by the kubelet.
+    // It's logs live on a different path.
+    rule {
+      source_labels = ["__meta_kubernetes_pod_annotation_kubernetes_io_config_mirror", "__meta_kubernetes_pod_container_name"]
+      separator = "/"
+      regex = "(.+/.+)"
+      replacement = "/var/log/pods/*$1/*.log"
+      target_label = "__path__"
+    }
+  } // discovery.relabel "filtered_pods"
+
+  local.file_match "pod_logs" {
+    path_targets = discovery.relabel.filtered_pods.output
+  } // local.file_match "pod_logs"
+
+  loki.source.file "pod_logs" {
+    targets    = local.file_match.pod_logs.targets
+    tail_from_end = true
+    forward_to = [loki.process.pod_logs.receiver]
+  } // loki.source.file "pod_logs"
+
+  loki.process "pod_logs" {
+    stage.match {
+      selector = "{tmp_container_runtime=~\"containerd|cri-o|\"}"
+      // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
+      stage.cri {
+        max_partial_lines = 100
+      }
+
+      // Set the extract flags and stream values as labels
+      stage.labels {
+        values = {
+          flags  = "",
+          stream  = "",
+        }
+      }
+    }
+
+    stage.match {
+      selector = "{tmp_container_runtime=\"docker\"}"
+      // the docker processing stage extracts the following k/v pairs: log, stream, time
+      stage.docker {}
+
+      // Set the extract stream value as a label
+      stage.labels {
+        values = {
+          stream  = "",
+        }
+      }
+    }
+
+    // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
+    // namespace, pod, and container labels. Drop any structured metadata. Also drop the temporary
+    // container runtime label as it is no longer needed.
+    stage.label_drop {
+      values = [
+        "filename",
+        "tmp_container_runtime",
+      ]
+    }
+    stage.structured_metadata {
+      values = {
+        "k8s_pod_name" = "k8s_pod_name",
+        "pod" = "pod",
+        "service_instance_id" = "service_instance_id",
+      }
+    }
+
+    forward_to = argument.logs_destinations.value
+  } // loki.secretfilter "pod_logs"
+} // declare "pod_logs_via_loki"
+pod_logs_via_loki "feature" {
+  logs_destinations = [
+    loki.write.localloki.receiver,
+  ]
+}
+
+
+
+remote.kubernetes.configmap "version" {
+  name = "k8smon-version"
+  namespace = "toolbox"
+}
+
+// Destination: localLoki (loki)
+otelcol.exporter.loki "localloki" {
+  forward_to = [loki.write.localloki.receiver]
+} // otelcol.exporter.loki "localloki"
+
+loki.write "localloki" {
+  endpoint {
+    url = "http://loki.loki.svc:3100/loki/api/v1/push"
+    retry_on_http_429 = true
+    tenant_id = convert.nonsensitive(remote.kubernetes.secret.localloki.data["tenantId"])
+    basic_auth {
+      username = convert.nonsensitive(remote.kubernetes.secret.localloki.data["username"])
+      password = remote.kubernetes.secret.localloki.data["password"]
+    }
+    tls_config {
+      insecure_skip_verify = false
+    }
+    min_backoff_period = "500ms"
+    max_backoff_period = "5m"
+    max_backoff_retries = "10"
+  }
+  external_labels = {
+    "cluster" = "patch-upgrade-test",
+    "k8s_cluster_name" = "patch-upgrade-test",
+    chart_version = remote.kubernetes.configmap.version.data["version"],
+  }
+} // loki.write "localloki"
+
+remote.kubernetes.secret "localloki" {
+  name      = "localloki-k8smon-k8s-monitoring"
+  namespace = "default"
+} // remote.kubernetes.secret "localloki"
+

--- a/charts/k8s-monitoring/tests/integration/upgrade/patch/.rendered/alloy-metrics.alloy
+++ b/charts/k8s-monitoring/tests/integration/upgrade/patch/.rendered/alloy-metrics.alloy
@@ -1,0 +1,660 @@
+// Feature: Cluster Metrics
+declare "cluster_metrics" {
+  argument "metrics_destinations" {
+    comment = "Must be a list of metric destinations where collected metrics should be forwarded to"
+  }
+  discovery.kubernetes "nodes" {
+    role = "node"
+  } // discovery.kubernetes "nodes"
+
+  discovery.relabel "nodes" {
+    targets = discovery.kubernetes.nodes.targets
+    rule {
+      source_labels = ["__meta_kubernetes_node_name"]
+      target_label  = "node"
+    }
+
+    rule {
+      replacement = "kubernetes"
+      target_label = "source"
+    }
+  } // discovery.relabel "nodes"
+
+  // Kubelet
+  discovery.relabel "kubelet" {
+    targets = discovery.relabel.nodes.output
+  } // discovery.relabel "kubelet"
+
+  prometheus.scrape "kubelet" {
+    targets  = discovery.relabel.kubelet.output
+    job_name = "integrations/kubernetes/kubelet"
+    scheme   = "https"
+    scrape_interval = "60s"
+    scrape_timeout = "10s"
+    scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
+    scrape_classic_histograms = false
+    scrape_native_histograms = false
+    convert_classic_histograms_to_nhcb = false
+    bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+
+    tls_config {
+      ca_file = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+      insecure_skip_verify = true
+      server_name = "kubernetes"
+    }
+
+    clustering {
+      enabled = true
+    }
+
+    forward_to = [prometheus.relabel.kubelet.receiver]
+  } // prometheus.scrape "kubelet"
+
+  prometheus.relabel "kubelet" {
+    max_cache_size = 100000
+    rule {
+      source_labels = ["__name__"]
+      regex = "up|scrape_samples_scraped|go_goroutines|kubelet_certificate_manager_client_expiration_renew_errors|kubelet_certificate_manager_client_ttl_seconds|kubelet_certificate_manager_server_ttl_seconds|kubelet_cgroup_manager_duration_seconds_bucket|kubelet_cgroup_manager_duration_seconds_count|kubelet_node_config_error|kubelet_node_name|kubelet_pleg_relist_duration_seconds_bucket|kubelet_pleg_relist_duration_seconds_count|kubelet_pleg_relist_interval_seconds_bucket|kubelet_pod_start_duration_seconds_bucket|kubelet_pod_start_duration_seconds_count|kubelet_pod_worker_duration_seconds_bucket|kubelet_pod_worker_duration_seconds_count|kubelet_running_container_count|kubelet_running_containers|kubelet_running_pod_count|kubelet_running_pods|kubelet_runtime_operations_errors_total|kubelet_runtime_operations_total|kubelet_server_expiration_renew_errors|kubelet_volume_stats_available_bytes|kubelet_volume_stats_capacity_bytes|kubelet_volume_stats_inodes|kubelet_volume_stats_inodes_free|kubelet_volume_stats_inodes_used|kubelet_volume_stats_used_bytes|kubernetes_build_info|namespace_workload_pod|process_cpu_seconds_total|process_resident_memory_bytes|rest_client_requests_total|storage_operation_duration_seconds_count|storage_operation_errors_total|volume_manager_total_volumes"
+      action = "keep"
+    }
+
+    forward_to = argument.metrics_destinations.value
+  } // prometheus.relabel "kubelet"
+
+  // Kubelet Resources
+  discovery.relabel "kubelet_resources" {
+    targets = discovery.relabel.nodes.output
+    rule {
+      replacement   = "/metrics/resource"
+      target_label  = "__metrics_path__"
+    }
+  } // discovery.relabel "kubelet_resources"
+
+  prometheus.scrape "kubelet_resources" {
+    targets = discovery.relabel.kubelet_resources.output
+    job_name = "integrations/kubernetes/resources"
+    scheme   = "https"
+    scrape_interval = "60s"
+    scrape_timeout = "10s"
+    scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
+    scrape_classic_histograms = false
+    scrape_native_histograms = false
+    convert_classic_histograms_to_nhcb = false
+    bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+
+    tls_config {
+      ca_file = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+      insecure_skip_verify = true
+      server_name = "kubernetes"
+    }
+
+    clustering {
+      enabled = true
+    }
+
+    forward_to = [prometheus.relabel.kubelet_resources.receiver]
+  } // prometheus.scrape "kubelet_resources"
+
+  prometheus.relabel "kubelet_resources" {
+    max_cache_size = 100000
+    rule {
+      source_labels = ["__name__"]
+      regex = "up|scrape_samples_scraped|node_cpu_usage_seconds_total|node_memory_working_set_bytes"
+      action = "keep"
+    }
+
+    forward_to = argument.metrics_destinations.value
+  } // prometheus.relabel "kubelet_resources"
+
+  // cAdvisor
+  discovery.relabel "cadvisor" {
+    targets = discovery.relabel.nodes.output
+    rule {
+      replacement   = "/metrics/cadvisor"
+      target_label  = "__metrics_path__"
+    }
+  } // discovery.relabel "cadvisor"
+
+  prometheus.scrape "cadvisor" {
+    targets = discovery.relabel.cadvisor.output
+    job_name = "integrations/kubernetes/cadvisor"
+    scheme = "https"
+    scrape_interval = "60s"
+    scrape_timeout = "10s"
+    scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
+    scrape_classic_histograms = false
+    scrape_native_histograms = false
+    convert_classic_histograms_to_nhcb = false
+    bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+
+    tls_config {
+      ca_file = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+      insecure_skip_verify = true
+      server_name = "kubernetes"
+    }
+
+    clustering {
+      enabled = true
+    }
+
+    forward_to = [prometheus.relabel.cadvisor.receiver]
+  } // prometheus.scrape "cadvisor"
+
+  prometheus.relabel "cadvisor" {
+    max_cache_size = 100000
+    rule {
+      source_labels = ["__name__"]
+      regex = "up|scrape_samples_scraped|container_cpu_cfs_periods_total|container_cpu_cfs_throttled_periods_total|container_cpu_usage_seconds_total|container_fs_reads_bytes_total|container_fs_reads_total|container_fs_writes_bytes_total|container_fs_writes_total|container_memory_cache|container_memory_rss|container_memory_swap|container_memory_usage_bytes|container_memory_working_set_bytes|container_network_receive_bytes_total|container_network_receive_packets_dropped_total|container_network_receive_packets_total|container_network_transmit_bytes_total|container_network_transmit_packets_dropped_total|container_network_transmit_packets_total|machine_memory_bytes"
+      action = "keep"
+    }
+    // Drop empty container labels, addressing https://github.com/google/cadvisor/issues/2688
+    rule {
+      source_labels = ["__name__","container"]
+      separator = "@"
+      regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_pressure_.*)@"
+      action = "drop"
+    }
+    // Drop empty image labels, addressing https://github.com/google/cadvisor/issues/2688
+    rule {
+      source_labels = ["__name__","image"]
+      separator = "@"
+      regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_network_.*|container_pressure_.*)@"
+      action = "drop"
+    }
+    // Normalizing unimportant labels (not deleting to continue satisfying <label>!="" checks)
+    rule {
+      source_labels = ["__name__", "boot_id"]
+      separator = "@"
+      regex = "machine_memory_bytes@.*"
+      target_label = "boot_id"
+      replacement = "NA"
+    }
+    rule {
+      source_labels = ["__name__", "system_uuid"]
+      separator = "@"
+      regex = "machine_memory_bytes@.*"
+      target_label = "system_uuid"
+      replacement = "NA"
+    }
+    // Filter out non-physical devices/interfaces
+    rule {
+      source_labels = ["__name__", "device"]
+      separator = "@"
+      regex = "container_fs_.*@(/dev/)?(mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dasd.+)"
+      target_label = "__keepme"
+      replacement = "1"
+    }
+    rule {
+      source_labels = ["__name__", "__keepme"]
+      separator = "@"
+      regex = "container_fs_.*@"
+      action = "drop"
+    }
+    rule {
+      source_labels = ["__name__"]
+      regex = "container_fs_.*"
+      target_label = "__keepme"
+      replacement = ""
+    }
+    rule {
+      source_labels = ["__name__", "interface"]
+      separator = "@"
+      regex = "container_network_.*@(en[ospx][0-9].*|wlan[0-9].*|eth[0-9].*)"
+      target_label = "__keepme"
+      replacement = "1"
+    }
+    rule {
+      source_labels = ["__name__", "__keepme"]
+      separator = "@"
+      regex = "container_network_.*@"
+      action = "drop"
+    }
+    rule {
+      source_labels = ["__name__"]
+      regex = "container_network_.*"
+      target_label = "__keepme"
+      replacement = ""
+    }
+    forward_to = argument.metrics_destinations.value
+  } // prometheus.relabel "cadvisor"
+  discovery.kubernetes "kube_state_metrics" {
+    role = "endpoints"
+
+    selectors {
+      role = "endpoints"
+      label = "release=k8smon,app.kubernetes.io/name=kube-state-metrics"
+    }
+    namespaces {
+      names = ["default"]
+    }
+  } // discovery.kubernetes "kube_state_metrics"
+
+  discovery.relabel "kube_state_metrics" {
+    targets = discovery.kubernetes.kube_state_metrics.targets
+
+    rule {
+      action = "replace"
+      replacement = "kubernetes"
+      target_label = "source"
+    }
+
+  } // discovery.relabel "kube_state_metrics"
+
+  prometheus.scrape "kube_state_metrics" {
+    targets = discovery.relabel.kube_state_metrics.output
+    job_name = "integrations/kubernetes/kube-state-metrics"
+    scrape_interval = "60s"
+    scrape_timeout = "10s"
+    scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
+    scrape_classic_histograms = false
+    scrape_native_histograms = false
+    convert_classic_histograms_to_nhcb = false
+    scheme = "http"
+    bearer_token_file = ""
+    tls_config {
+      insecure_skip_verify = true
+    }
+
+    clustering {
+      enabled = true
+    }
+    forward_to = [prometheus.relabel.kube_state_metrics.receiver]
+  } // prometheus.scrape "kube_state_metrics"
+
+  prometheus.relabel "kube_state_metrics" {
+    max_cache_size = 100000
+    rule {
+      source_labels = ["__name__"]
+      regex = "up|scrape_samples_scraped|kube_configmap_info|kube_configmap_metadata_resource_version|kube_cronjob.*|kube_daemonset.*|kube_deployment_metadata_generation|kube_deployment_spec_replicas|kube_deployment_status_condition|kube_deployment_status_observed_generation|kube_deployment_status_replicas_available|kube_deployment_status_replicas_updated|kube_horizontalpodautoscaler_spec_max_replicas|kube_horizontalpodautoscaler_spec_min_replicas|kube_horizontalpodautoscaler_status_current_replicas|kube_horizontalpodautoscaler_status_desired_replicas|kube_job.*|kube_namespace_status_phase|kube_node.*|kube_persistentvolume_status_phase|kube_persistentvolumeclaim_access_mode|kube_persistentvolumeclaim_info|kube_persistentvolumeclaim_labels|kube_persistentvolumeclaim_resource_requests_storage_bytes|kube_persistentvolumeclaim_status_phase|kube_pod_completion_time|kube_pod_container_info|kube_pod_container_resource_limits|kube_pod_container_resource_requests|kube_pod_container_status_last_terminated_reason|kube_pod_container_status_last_terminated_timestamp|kube_pod_container_status_restarts_total|kube_pod_container_status_waiting_reason|kube_pod_info|kube_pod_owner|kube_pod_restart_policy|kube_pod_spec_volumes_persistentvolumeclaims_info|kube_pod_start_time|kube_pod_status_phase|kube_pod_status_reason|kube_pod_init_.*|kube_replicaset.*|kube_resourcequota|kube_secret_metadata_resource_version|kube_statefulset.*"
+      action = "keep"
+    }
+    forward_to = argument.metrics_destinations.value
+  } // prometheus.relabel "kube_state_metrics"
+} // declare "cluster_metrics"
+cluster_metrics "feature" {
+  metrics_destinations = [
+    prometheus.remote_write.localprometheus.receiver,
+  ]
+}
+// Feature: Cost Metrics
+declare "cost_metrics" {
+  argument "metrics_destinations" {
+    comment = "Must be a list of metric destinations where collected metrics should be forwarded to"
+  }
+
+  discovery.kubernetes "opencost" {
+    role = "pod"
+    selectors {
+      role = "pod"
+      label = "app.kubernetes.io/instance=k8smon,app.kubernetes.io/name=opencost"
+    }
+    namespaces {
+      names = ["default"]
+    }
+  } // discovery.kubernetes "opencost"
+
+  discovery.relabel "opencost" {
+    targets = discovery.kubernetes.opencost.targets
+    rule {
+      source_labels = ["__meta_kubernetes_pod_node_name"]
+      action = "replace"
+      target_label = "instance"
+    }
+  } // discovery.relabel "opencost"
+
+  prometheus.scrape "opencost" {
+    targets      = discovery.relabel.opencost.output
+    job_name     = "integrations/opencost"
+    honor_labels = true
+    scrape_interval = "60s"
+    scrape_timeout = "10s"
+    scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
+    scrape_classic_histograms = false
+    scrape_native_histograms = false
+    convert_classic_histograms_to_nhcb = false
+    clustering {
+      enabled = true
+    }
+    forward_to = [prometheus.relabel.opencost.receiver]
+  } // prometheus.scrape "opencost"
+
+  prometheus.relabel "opencost" {
+    max_cache_size = 100000
+    rule {
+      source_labels = ["__name__"]
+      regex = "up|scrape_samples_scraped|container_cpu_allocation|container_gpu_allocation|container_memory_allocation_bytes|deployment_match_labels|kubecost_cluster_info|kubecost_cluster_management_cost|kubecost_cluster_memory_working_set_bytes|kubecost_http_requests_total|kubecost_http_response_size_bytes|kubecost_http_response_time_seconds|kubecost_load_balancer_cost|kubecost_network_internet_egress_cost|kubecost_network_region_egress_cost|kubecost_network_zone_egress_cost|kubecost_node_is_spot|node_cpu_hourly_cost|node_gpu_count|node_gpu_hourly_cost|node_ram_hourly_cost|node_total_hourly_cost|opencost_build_info|pod_pvc_allocation|pv_hourly_cost|service_selector_labels|statefulSet_match_labels"
+      action = "keep"
+    }
+    forward_to = argument.metrics_destinations.value
+  } // prometheus.relabel "opencost"
+} // declare "cost_metrics"
+cost_metrics "feature" {
+  metrics_destinations = [
+    prometheus.remote_write.localprometheus.receiver,
+  ]
+}
+// Feature: Host Metrics
+declare "host_metrics" {
+  argument "metrics_destinations" {
+    comment = "Must be a list of metric destinations where collected metrics should be forwarded to"
+  }
+
+  // Linux hosts via Node Exporter
+  discovery.kubernetes "node_exporter" {
+    role = "pod"
+    selectors {
+      role = "pod"
+      label = "release=k8smon,app.kubernetes.io/name=node-exporter"
+    }
+    namespaces {
+      names = ["default"]
+    }
+
+  } // discovery.kubernetes "node_exporter"
+
+  discovery.relabel "node_exporter" {
+    targets = discovery.kubernetes.node_exporter.targets
+
+    // keep only the specified metrics port name, and pods that are Running and ready
+    rule {
+      source_labels = [
+        "__meta_kubernetes_pod_container_init",
+        "__meta_kubernetes_pod_phase",
+        "__meta_kubernetes_pod_ready",
+      ]
+      separator = "@"
+      regex = "false@Running@true"
+      action = "keep"
+    }
+
+    // Set the instance label to the node name
+    rule {
+      source_labels = ["__meta_kubernetes_pod_node_name"]
+      target_label = "instance"
+    }
+
+    rule {
+      source_labels = ["__meta_kubernetes_namespace"]
+      target_label  = "namespace"
+    }
+
+    rule {
+      source_labels = ["__meta_kubernetes_pod_name"]
+      target_label  = "pod"
+    }
+
+    rule {
+      source_labels = ["__meta_kubernetes_pod_container_name"]
+      target_label  = "container"
+    }
+
+    // set a workload label
+    rule {
+      source_labels = [
+        "__meta_kubernetes_pod_controller_kind",
+        "__meta_kubernetes_pod_controller_name",
+      ]
+      separator = "/"
+      target_label  = "workload"
+    }
+    // remove the hash from the ReplicaSet
+    rule {
+      source_labels = ["workload"]
+      regex = "(ReplicaSet/.+)-.+"
+      target_label  = "workload"
+    }
+
+    // Set the app label.
+    //
+    // Choose the first value found from the following ordered list:
+    // - pod.label[app.kubernetes.io/name]
+    // - pod.label[k8s-app]
+    // - pod.label[app]
+    rule {
+      source_labels = [
+        "__meta_kubernetes_pod_label_app_kubernetes_io_name",
+        "__meta_kubernetes_pod_label_k8s_app",
+        "__meta_kubernetes_pod_label_app",
+      ]
+      separator = ";"
+      regex = "^(?:;*)?([^;]+).*$"
+      replacement = "$1"
+      target_label = "app"
+    }
+
+    // Set the component label.
+    //
+    // Choose the first value found from the following ordered list:
+    // - pod.label[app.kubernetes.io/component]
+    // - pod.label[k8s-component]
+    // - pod.label[component]
+    rule {
+      source_labels = [
+        "__meta_kubernetes_pod_label_app_kubernetes_io_component",
+        "__meta_kubernetes_pod_label_k8s_component",
+        "__meta_kubernetes_pod_label_component",
+      ]
+      regex = "^(?:;*)?([^;]+).*$"
+      replacement = "$1"
+      target_label = "component"
+    }
+
+    rule {
+      target_label = "source"
+      replacement = "kubernetes"
+    }
+
+  } // discovery.relabel "node_exporter"
+
+  prometheus.scrape "node_exporter" {
+    targets = discovery.relabel.node_exporter.output
+    job_name = "integrations/node_exporter"
+    scrape_interval = "60s"
+    scrape_timeout = "10s"
+    scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
+    scrape_classic_histograms = false
+    scrape_native_histograms = false
+    convert_classic_histograms_to_nhcb = false
+    scheme = "http"
+    tls_config {
+      insecure_skip_verify = true
+    }
+
+    clustering {
+      enabled = true
+    }
+    forward_to = [prometheus.relabel.node_exporter.receiver]
+  } // prometheus.scrape "node_exporter"
+
+  prometheus.relabel "node_exporter" {
+    max_cache_size = 100000
+    rule {
+      source_labels = ["__name__"]
+      regex = "up|scrape_samples_scraped|node_cpu.*|node_exporter_build_info|node_filesystem.*|node_memory.*|node_network_receive_bytes_total|node_network_receive_drop_total|node_network_transmit_bytes_total|node_network_transmit_drop_total|process_cpu_seconds_total|process_resident_memory_bytes"
+      action = "keep"
+    }
+    // Drop metrics for certain file systems
+    rule {
+      source_labels = ["__name__", "fstype"]
+      separator = "@"
+      regex = "node_filesystem.*@(ramfs|tmpfs)"
+      action = "drop"
+    }
+    forward_to = argument.metrics_destinations.value
+  } // prometheus.relabel "node_exporter"
+
+  // Windows hosts via Windows Exporter
+  discovery.kubernetes "windows_exporter_pods" {
+    role = "pod"
+    selectors {
+      role = "pod"
+      label = "release=k8smon,app.kubernetes.io/name=windows-exporter"
+    }
+    namespaces {
+      names = ["default"]
+    }
+
+  } // discovery.kubernetes "windows_exporter_pods"
+
+  discovery.relabel "windows_exporter" {
+    targets = discovery.kubernetes.windows_exporter_pods.targets
+
+    // keep only the specified metrics port name, and pods that are Running and ready
+    rule {
+      source_labels = [
+        "__meta_kubernetes_pod_container_init",
+        "__meta_kubernetes_pod_phase",
+        "__meta_kubernetes_pod_ready",
+      ]
+      separator = "@"
+      regex = "false@Running@true"
+      action = "keep"
+    }
+
+    // Set the instance label to the node name
+    rule {
+      source_labels = ["__meta_kubernetes_pod_node_name"]
+      target_label = "instance"
+    }
+
+  } // discovery.relabel "windows_exporter"
+
+  prometheus.scrape "windows_exporter" {
+    targets  = discovery.relabel.windows_exporter.output
+    job_name   = "integrations/windows-exporter"
+    scrape_interval = "60s"
+    scrape_timeout = "10s"
+    scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
+    scrape_classic_histograms = false
+    scrape_native_histograms = false
+    convert_classic_histograms_to_nhcb = false
+    clustering {
+      enabled = true
+    }
+    forward_to = [prometheus.relabel.windows_exporter.receiver]
+  } // prometheus.scrape "windows_exporter"
+
+  prometheus.relabel "windows_exporter" {
+    max_cache_size = 100000
+    rule {
+      source_labels = ["__name__"]
+      regex = "up|scrape_samples_scraped|windows_.*|node_cpu_seconds_total|node_filesystem_size_bytes|node_filesystem_avail_bytes|container_cpu_usage_seconds_total"
+      action = "keep"
+    }
+    forward_to = argument.metrics_destinations.value
+  } // prometheus.relabel "windows_exporter"
+
+  // Energy metrics via Kepler
+  discovery.kubernetes "kepler" {
+    role = "pod"
+    selectors {
+      role = "pod"
+      label = "app.kubernetes.io/name=kepler"
+    }
+    namespaces {
+      names = ["default"]
+    }
+
+  } // discovery.kubernetes "kepler"
+
+  discovery.relabel "kepler" {
+    targets = discovery.kubernetes.kepler.targets
+    rule {
+      source_labels = ["__meta_kubernetes_pod_node_name"]
+      action = "replace"
+      target_label = "instance"
+    }
+
+  } // discovery.relabel "kepler"
+
+  prometheus.scrape "kepler" {
+    targets      = discovery.relabel.kepler.output
+    job_name     = "integrations/kepler"
+    honor_labels = true
+    scrape_interval = "60s"
+    scrape_timeout = "10s"
+    scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
+    scrape_classic_histograms = false
+    scrape_native_histograms = false
+    convert_classic_histograms_to_nhcb = false
+    clustering {
+      enabled = true
+    }
+    forward_to = [prometheus.relabel.kepler.receiver]
+  } // prometheus.scrape "kepler"
+
+  prometheus.relabel "kepler" {
+    max_cache_size = 100000
+    rule {
+      source_labels = ["__name__"]
+      regex = "up|scrape_samples_scraped|kepler_.*"
+      action = "keep"
+    }
+    forward_to = argument.metrics_destinations.value
+  } // prometheus.relabel "kepler"
+} // declare "host_metrics"
+host_metrics "feature" {
+  metrics_destinations = [
+    prometheus.remote_write.localprometheus.receiver,
+  ]
+}
+
+
+
+remote.kubernetes.configmap "version" {
+  name = "k8smon-version"
+  namespace = "toolbox"
+}
+
+// Destination: localPrometheus (prometheus)
+otelcol.exporter.prometheus "localprometheus" {
+  add_metric_suffixes = true
+  resource_to_telemetry_conversion = false
+  keep_identifying_resource_attributes = true
+  forward_to = [prometheus.remote_write.localprometheus.receiver]
+} // otelcol.exporter.prometheus "localprometheus"
+
+prometheus.remote_write "localprometheus" {
+  endpoint {
+    url = "http://prometheus-server.prometheus.svc:9090/api/v1/write"
+    headers = {
+    }
+    basic_auth {
+      username = convert.nonsensitive(remote.kubernetes.secret.localprometheus.data["username"])
+      password = remote.kubernetes.secret.localprometheus.data["password"]
+    }
+    tls_config {
+      insecure_skip_verify = false
+    }
+    send_native_histograms = false
+
+    queue_config {
+      capacity = 10000
+      min_shards = 1
+      max_shards = 50
+      max_samples_per_send = 2000
+      batch_send_deadline = "5s"
+      min_backoff = "30ms"
+      max_backoff = "5s"
+      retry_on_http_429 = true
+      sample_age_limit = "0s"
+    }
+  }
+
+  wal {
+    truncate_frequency = "2h"
+    min_keepalive_time = "5m"
+    max_keepalive_time = "8h"
+  }
+  external_labels = {
+    "cluster" = "patch-upgrade-test",
+    "k8s_cluster_name" = "patch-upgrade-test",
+    chart_version = remote.kubernetes.configmap.version.data["version"],
+  }
+} // prometheus.remote_write "localprometheus"
+
+remote.kubernetes.secret "localprometheus" {
+  name      = "localprometheus-k8smon-k8s-monitoring"
+  namespace = "default"
+} // remote.kubernetes.secret "localprometheus"
+

--- a/charts/k8s-monitoring/tests/integration/upgrade/patch/.rendered/alloy-singleton.alloy
+++ b/charts/k8s-monitoring/tests/integration/upgrade/patch/.rendered/alloy-singleton.alloy
@@ -1,0 +1,219 @@
+// Feature: Cluster Events
+declare "cluster_events" {
+  argument "logs_destinations" {
+    comment = "Must be a list of log destinations where collected logs should be forwarded to"
+  }
+
+  loki.source.kubernetes_events "cluster_events" {
+    job_name   = "integrations/kubernetes/eventhandler"
+    log_format = "logfmt"
+    forward_to = [loki.process.cluster_events.receiver]
+  } // loki.source.kubernetes_events "cluster_events"
+
+  loki.process "cluster_events" {
+
+    // add a static source label to the logs so they can be differentiated / restricted if necessary
+    stage.static_labels {
+      values = {
+        "source" = "kubernetes-events",
+      }
+    }
+
+    // extract some of the fields from the log line, these could be used as labels, structured metadata, etc.
+    stage.logfmt {
+      mapping = {
+        "component" = "sourcecomponent", // map the sourcecomponent field to component
+        "kind" = "",
+        "level" = "type", // most events don't have a level but they do have a "type" i.e. Normal, Warning, Error, etc.
+        "name" = "",
+        "node" = "sourcehost", // map the sourcehost field to node
+        "reason" = "",
+      }
+    }
+    // set the extracted values as labels
+    stage.labels {
+      values = {
+        "kind" = "",
+        "level" = "",
+        "service_name" = "job",
+        "reason" = "reason",
+      }
+    }
+
+    // if kind=Node, set the node label by copying the name field
+    stage.match {
+      selector = "{kind=\"Node\"}"
+
+      stage.labels {
+        values = {
+          "node" = "name",
+        }
+      }
+    }
+
+    // set the level extracted key value as a normalized log level
+    stage.match {
+      selector = "{level=\"Normal\"}"
+
+      stage.static_labels {
+        values = {
+          level = "Info",
+        }
+      }
+    }
+    stage.structured_metadata {
+      values = {
+        "name" = "name",
+        "node" = "node",
+      }
+    }
+
+    // Drop pipeline-only labels that are not needed in the final output.
+    stage.label_drop {
+      values = ["kind"]
+    }
+
+    forward_to = argument.logs_destinations.value
+  } // loki.process "cluster_events"
+} // declare "cluster_events"
+cluster_events "feature" {
+  logs_destinations = [
+    loki.write.localloki.receiver,
+  ]
+}
+// Self Reporting
+prometheus.exporter.unix "kubernetes_monitoring_telemetry" {
+  set_collectors = ["textfile"]
+  textfile {
+    directory = "/etc/release-info"
+  }
+} // prometheus.exporter.unix "kubernetes_monitoring_telemetry"
+
+discovery.relabel "kubernetes_monitoring_telemetry" {
+  targets = prometheus.exporter.unix.kubernetes_monitoring_telemetry.targets
+  rule {
+    target_label = "instance"
+    action = "replace"
+    replacement = "k8smon"
+  }
+  rule {
+    target_label = "job"
+    action = "replace"
+    replacement = "integrations/kubernetes/kubernetes_monitoring_telemetry"
+  }
+} // discovery.relabel "kubernetes_monitoring_telemetry"
+
+prometheus.scrape "kubernetes_monitoring_telemetry" {
+  job_name   = "integrations/kubernetes/kubernetes_monitoring_telemetry"
+  targets    = discovery.relabel.kubernetes_monitoring_telemetry.output
+  scrape_interval = "60s"
+  clustering {
+    enabled = true
+  }
+  forward_to = [prometheus.relabel.kubernetes_monitoring_telemetry.receiver]
+} // prometheus.scrape "kubernetes_monitoring_telemetry"
+
+prometheus.relabel "kubernetes_monitoring_telemetry" {
+  rule {
+    source_labels = ["__name__"]
+    regex = "grafana_kubernetes_monitoring_.*"
+    action = "keep"
+  }
+  forward_to = [
+    prometheus.remote_write.localprometheus.receiver,
+  ]
+} // prometheus.relabel "kubernetes_monitoring_telemetry"
+
+
+
+remote.kubernetes.configmap "version" {
+  name = "k8smon-version"
+  namespace = "toolbox"
+}
+
+// Destination: localLoki (loki)
+otelcol.exporter.loki "localloki" {
+  forward_to = [loki.write.localloki.receiver]
+} // otelcol.exporter.loki "localloki"
+
+loki.write "localloki" {
+  endpoint {
+    url = "http://loki.loki.svc:3100/loki/api/v1/push"
+    retry_on_http_429 = true
+    tenant_id = convert.nonsensitive(remote.kubernetes.secret.localloki.data["tenantId"])
+    basic_auth {
+      username = convert.nonsensitive(remote.kubernetes.secret.localloki.data["username"])
+      password = remote.kubernetes.secret.localloki.data["password"]
+    }
+    tls_config {
+      insecure_skip_verify = false
+    }
+    min_backoff_period = "500ms"
+    max_backoff_period = "5m"
+    max_backoff_retries = "10"
+  }
+  external_labels = {
+    "cluster" = "patch-upgrade-test",
+    "k8s_cluster_name" = "patch-upgrade-test",
+    chart_version = remote.kubernetes.configmap.version.data["version"],
+  }
+} // loki.write "localloki"
+
+remote.kubernetes.secret "localloki" {
+  name      = "localloki-k8smon-k8s-monitoring"
+  namespace = "default"
+} // remote.kubernetes.secret "localloki"
+
+
+// Destination: localPrometheus (prometheus)
+otelcol.exporter.prometheus "localprometheus" {
+  add_metric_suffixes = true
+  resource_to_telemetry_conversion = false
+  keep_identifying_resource_attributes = true
+  forward_to = [prometheus.remote_write.localprometheus.receiver]
+} // otelcol.exporter.prometheus "localprometheus"
+
+prometheus.remote_write "localprometheus" {
+  endpoint {
+    url = "http://prometheus-server.prometheus.svc:9090/api/v1/write"
+    headers = {
+    }
+    basic_auth {
+      username = convert.nonsensitive(remote.kubernetes.secret.localprometheus.data["username"])
+      password = remote.kubernetes.secret.localprometheus.data["password"]
+    }
+    tls_config {
+      insecure_skip_verify = false
+    }
+    send_native_histograms = false
+
+    queue_config {
+      capacity = 10000
+      min_shards = 1
+      max_shards = 50
+      max_samples_per_send = 2000
+      batch_send_deadline = "5s"
+      min_backoff = "30ms"
+      max_backoff = "5s"
+      retry_on_http_429 = true
+      sample_age_limit = "0s"
+    }
+  }
+
+  wal {
+    truncate_frequency = "2h"
+    min_keepalive_time = "5m"
+    max_keepalive_time = "8h"
+  }
+  external_labels = {
+    "cluster" = "patch-upgrade-test",
+    "k8s_cluster_name" = "patch-upgrade-test",
+    chart_version = remote.kubernetes.configmap.version.data["version"],
+  }
+} // prometheus.remote_write "localprometheus"
+
+remote.kubernetes.secret "localprometheus" {
+  name      = "localprometheus-k8smon-k8s-monitoring"
+  namespace = "default"
+} // remote.kubernetes.secret "localprometheus"
+

--- a/charts/k8s-monitoring/tests/integration/upgrade/storage/.rendered/alloy-metrics.alloy
+++ b/charts/k8s-monitoring/tests/integration/upgrade/storage/.rendered/alloy-metrics.alloy
@@ -1,0 +1,389 @@
+// Feature: Cluster Metrics
+declare "cluster_metrics" {
+  argument "metrics_destinations" {
+    comment = "Must be a list of metric destinations where collected metrics should be forwarded to"
+  }
+  discovery.kubernetes "nodes" {
+    role = "node"
+  } // discovery.kubernetes "nodes"
+
+  discovery.relabel "nodes" {
+    targets = discovery.kubernetes.nodes.targets
+    rule {
+      source_labels = ["__meta_kubernetes_node_name"]
+      target_label  = "node"
+    }
+
+    rule {
+      replacement = "kubernetes"
+      target_label = "source"
+    }
+  } // discovery.relabel "nodes"
+
+  // Kubelet
+  discovery.relabel "kubelet" {
+    targets = discovery.relabel.nodes.output
+  } // discovery.relabel "kubelet"
+
+  prometheus.scrape "kubelet" {
+    targets  = discovery.relabel.kubelet.output
+    job_name = "integrations/kubernetes/kubelet"
+    scheme   = "https"
+    scrape_interval = "60s"
+    scrape_timeout = "10s"
+    scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
+    scrape_classic_histograms = false
+    scrape_native_histograms = false
+    convert_classic_histograms_to_nhcb = false
+    bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+
+    tls_config {
+      ca_file = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+      insecure_skip_verify = true
+      server_name = "kubernetes"
+    }
+
+    clustering {
+      enabled = true
+    }
+
+    forward_to = [prometheus.relabel.kubelet.receiver]
+  } // prometheus.scrape "kubelet"
+
+  prometheus.relabel "kubelet" {
+    max_cache_size = 100000
+    rule {
+      source_labels = ["__name__"]
+      regex = "up|scrape_samples_scraped|go_goroutines|kubelet_certificate_manager_client_expiration_renew_errors|kubelet_certificate_manager_client_ttl_seconds|kubelet_certificate_manager_server_ttl_seconds|kubelet_cgroup_manager_duration_seconds_bucket|kubelet_cgroup_manager_duration_seconds_count|kubelet_node_config_error|kubelet_node_name|kubelet_pleg_relist_duration_seconds_bucket|kubelet_pleg_relist_duration_seconds_count|kubelet_pleg_relist_interval_seconds_bucket|kubelet_pod_start_duration_seconds_bucket|kubelet_pod_start_duration_seconds_count|kubelet_pod_worker_duration_seconds_bucket|kubelet_pod_worker_duration_seconds_count|kubelet_running_container_count|kubelet_running_containers|kubelet_running_pod_count|kubelet_running_pods|kubelet_runtime_operations_errors_total|kubelet_runtime_operations_total|kubelet_server_expiration_renew_errors|kubelet_volume_stats_available_bytes|kubelet_volume_stats_capacity_bytes|kubelet_volume_stats_inodes|kubelet_volume_stats_inodes_free|kubelet_volume_stats_inodes_used|kubelet_volume_stats_used_bytes|kubernetes_build_info|namespace_workload_pod|process_cpu_seconds_total|process_resident_memory_bytes|rest_client_requests_total|storage_operation_duration_seconds_count|storage_operation_errors_total|volume_manager_total_volumes"
+      action = "keep"
+    }
+
+    forward_to = argument.metrics_destinations.value
+  } // prometheus.relabel "kubelet"
+
+  // Kubelet Resources
+  discovery.relabel "kubelet_resources" {
+    targets = discovery.relabel.nodes.output
+    rule {
+      replacement   = "/metrics/resource"
+      target_label  = "__metrics_path__"
+    }
+  } // discovery.relabel "kubelet_resources"
+
+  prometheus.scrape "kubelet_resources" {
+    targets = discovery.relabel.kubelet_resources.output
+    job_name = "integrations/kubernetes/resources"
+    scheme   = "https"
+    scrape_interval = "60s"
+    scrape_timeout = "10s"
+    scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
+    scrape_classic_histograms = false
+    scrape_native_histograms = false
+    convert_classic_histograms_to_nhcb = false
+    bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+
+    tls_config {
+      ca_file = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+      insecure_skip_verify = true
+      server_name = "kubernetes"
+    }
+
+    clustering {
+      enabled = true
+    }
+
+    forward_to = [prometheus.relabel.kubelet_resources.receiver]
+  } // prometheus.scrape "kubelet_resources"
+
+  prometheus.relabel "kubelet_resources" {
+    max_cache_size = 100000
+    rule {
+      source_labels = ["__name__"]
+      regex = "up|scrape_samples_scraped|node_cpu_usage_seconds_total|node_memory_working_set_bytes"
+      action = "keep"
+    }
+
+    forward_to = argument.metrics_destinations.value
+  } // prometheus.relabel "kubelet_resources"
+
+  // cAdvisor
+  discovery.relabel "cadvisor" {
+    targets = discovery.relabel.nodes.output
+    rule {
+      replacement   = "/metrics/cadvisor"
+      target_label  = "__metrics_path__"
+    }
+  } // discovery.relabel "cadvisor"
+
+  prometheus.scrape "cadvisor" {
+    targets = discovery.relabel.cadvisor.output
+    job_name = "integrations/kubernetes/cadvisor"
+    scheme = "https"
+    scrape_interval = "60s"
+    scrape_timeout = "10s"
+    scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
+    scrape_classic_histograms = false
+    scrape_native_histograms = false
+    convert_classic_histograms_to_nhcb = false
+    bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+
+    tls_config {
+      ca_file = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+      insecure_skip_verify = true
+      server_name = "kubernetes"
+    }
+
+    clustering {
+      enabled = true
+    }
+
+    forward_to = [prometheus.relabel.cadvisor.receiver]
+  } // prometheus.scrape "cadvisor"
+
+  prometheus.relabel "cadvisor" {
+    max_cache_size = 100000
+    rule {
+      source_labels = ["__name__"]
+      regex = "up|scrape_samples_scraped|container_cpu_cfs_periods_total|container_cpu_cfs_throttled_periods_total|container_cpu_usage_seconds_total|container_fs_reads_bytes_total|container_fs_reads_total|container_fs_writes_bytes_total|container_fs_writes_total|container_memory_cache|container_memory_rss|container_memory_swap|container_memory_usage_bytes|container_memory_working_set_bytes|container_network_receive_bytes_total|container_network_receive_packets_dropped_total|container_network_receive_packets_total|container_network_transmit_bytes_total|container_network_transmit_packets_dropped_total|container_network_transmit_packets_total|machine_memory_bytes"
+      action = "keep"
+    }
+    // Drop empty container labels, addressing https://github.com/google/cadvisor/issues/2688
+    rule {
+      source_labels = ["__name__","container"]
+      separator = "@"
+      regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_pressure_.*)@"
+      action = "drop"
+    }
+    // Drop empty image labels, addressing https://github.com/google/cadvisor/issues/2688
+    rule {
+      source_labels = ["__name__","image"]
+      separator = "@"
+      regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_network_.*|container_pressure_.*)@"
+      action = "drop"
+    }
+    // Normalizing unimportant labels (not deleting to continue satisfying <label>!="" checks)
+    rule {
+      source_labels = ["__name__", "boot_id"]
+      separator = "@"
+      regex = "machine_memory_bytes@.*"
+      target_label = "boot_id"
+      replacement = "NA"
+    }
+    rule {
+      source_labels = ["__name__", "system_uuid"]
+      separator = "@"
+      regex = "machine_memory_bytes@.*"
+      target_label = "system_uuid"
+      replacement = "NA"
+    }
+    // Filter out non-physical devices/interfaces
+    rule {
+      source_labels = ["__name__", "device"]
+      separator = "@"
+      regex = "container_fs_.*@(/dev/)?(mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dasd.+)"
+      target_label = "__keepme"
+      replacement = "1"
+    }
+    rule {
+      source_labels = ["__name__", "__keepme"]
+      separator = "@"
+      regex = "container_fs_.*@"
+      action = "drop"
+    }
+    rule {
+      source_labels = ["__name__"]
+      regex = "container_fs_.*"
+      target_label = "__keepme"
+      replacement = ""
+    }
+    rule {
+      source_labels = ["__name__", "interface"]
+      separator = "@"
+      regex = "container_network_.*@(en[ospx][0-9].*|wlan[0-9].*|eth[0-9].*)"
+      target_label = "__keepme"
+      replacement = "1"
+    }
+    rule {
+      source_labels = ["__name__", "__keepme"]
+      separator = "@"
+      regex = "container_network_.*@"
+      action = "drop"
+    }
+    rule {
+      source_labels = ["__name__"]
+      regex = "container_network_.*"
+      target_label = "__keepme"
+      replacement = ""
+    }
+    forward_to = argument.metrics_destinations.value
+  } // prometheus.relabel "cadvisor"
+  discovery.kubernetes "kube_state_metrics" {
+    role = "endpoints"
+
+    selectors {
+      role = "endpoints"
+      label = "release=k8smon,app.kubernetes.io/name=kube-state-metrics"
+    }
+    namespaces {
+      names = ["default"]
+    }
+  } // discovery.kubernetes "kube_state_metrics"
+
+  discovery.relabel "kube_state_metrics" {
+    targets = discovery.kubernetes.kube_state_metrics.targets
+
+    rule {
+      action = "replace"
+      replacement = "kubernetes"
+      target_label = "source"
+    }
+
+  } // discovery.relabel "kube_state_metrics"
+
+  prometheus.scrape "kube_state_metrics" {
+    targets = discovery.relabel.kube_state_metrics.output
+    job_name = "integrations/kubernetes/kube-state-metrics"
+    scrape_interval = "60s"
+    scrape_timeout = "10s"
+    scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
+    scrape_classic_histograms = false
+    scrape_native_histograms = false
+    convert_classic_histograms_to_nhcb = false
+    scheme = "http"
+    bearer_token_file = ""
+    tls_config {
+      insecure_skip_verify = true
+    }
+
+    clustering {
+      enabled = true
+    }
+    forward_to = [prometheus.relabel.kube_state_metrics.receiver]
+  } // prometheus.scrape "kube_state_metrics"
+
+  prometheus.relabel "kube_state_metrics" {
+    max_cache_size = 100000
+    rule {
+      source_labels = ["__name__"]
+      regex = "up|scrape_samples_scraped|kube_configmap_info|kube_configmap_metadata_resource_version|kube_cronjob.*|kube_daemonset.*|kube_deployment_metadata_generation|kube_deployment_spec_replicas|kube_deployment_status_condition|kube_deployment_status_observed_generation|kube_deployment_status_replicas_available|kube_deployment_status_replicas_updated|kube_horizontalpodautoscaler_spec_max_replicas|kube_horizontalpodautoscaler_spec_min_replicas|kube_horizontalpodautoscaler_status_current_replicas|kube_horizontalpodautoscaler_status_desired_replicas|kube_job.*|kube_namespace_status_phase|kube_node.*|kube_persistentvolume_status_phase|kube_persistentvolumeclaim_access_mode|kube_persistentvolumeclaim_info|kube_persistentvolumeclaim_labels|kube_persistentvolumeclaim_resource_requests_storage_bytes|kube_persistentvolumeclaim_status_phase|kube_pod_completion_time|kube_pod_container_info|kube_pod_container_resource_limits|kube_pod_container_resource_requests|kube_pod_container_status_last_terminated_reason|kube_pod_container_status_last_terminated_timestamp|kube_pod_container_status_restarts_total|kube_pod_container_status_waiting_reason|kube_pod_info|kube_pod_owner|kube_pod_restart_policy|kube_pod_spec_volumes_persistentvolumeclaims_info|kube_pod_start_time|kube_pod_status_phase|kube_pod_status_reason|kube_pod_init_.*|kube_replicaset.*|kube_resourcequota|kube_secret_metadata_resource_version|kube_statefulset.*"
+      action = "keep"
+    }
+    forward_to = argument.metrics_destinations.value
+  } // prometheus.relabel "kube_state_metrics"
+} // declare "cluster_metrics"
+cluster_metrics "feature" {
+  metrics_destinations = [
+    prometheus.remote_write.localprometheus.receiver,
+  ]
+}
+
+
+
+
+
+
+
+
+
+
+
+
+
+// Self Reporting
+prometheus.exporter.unix "kubernetes_monitoring_telemetry" {
+  set_collectors = ["textfile"]
+  textfile {
+    directory = "/etc/release-info"
+  }
+} // prometheus.exporter.unix "kubernetes_monitoring_telemetry"
+
+discovery.relabel "kubernetes_monitoring_telemetry" {
+  targets = prometheus.exporter.unix.kubernetes_monitoring_telemetry.targets
+  rule {
+    target_label = "instance"
+    action = "replace"
+    replacement = "k8smon"
+  }
+  rule {
+    target_label = "job"
+    action = "replace"
+    replacement = "integrations/kubernetes/kubernetes_monitoring_telemetry"
+  }
+} // discovery.relabel "kubernetes_monitoring_telemetry"
+
+prometheus.scrape "kubernetes_monitoring_telemetry" {
+  job_name   = "integrations/kubernetes/kubernetes_monitoring_telemetry"
+  targets    = discovery.relabel.kubernetes_monitoring_telemetry.output
+  scrape_interval = "60s"
+  clustering {
+    enabled = true
+  }
+  forward_to = [prometheus.relabel.kubernetes_monitoring_telemetry.receiver]
+} // prometheus.scrape "kubernetes_monitoring_telemetry"
+
+prometheus.relabel "kubernetes_monitoring_telemetry" {
+  rule {
+    source_labels = ["__name__"]
+    regex = "grafana_kubernetes_monitoring_.*"
+    action = "keep"
+  }
+  forward_to = [
+    prometheus.remote_write.localprometheus.receiver,
+  ]
+} // prometheus.relabel "kubernetes_monitoring_telemetry"
+
+
+
+
+
+// Destination: localPrometheus (prometheus)
+otelcol.exporter.prometheus "localprometheus" {
+  add_metric_suffixes = true
+  resource_to_telemetry_conversion = false
+  keep_identifying_resource_attributes = true
+  forward_to = [prometheus.remote_write.localprometheus.receiver]
+} // otelcol.exporter.prometheus "localprometheus"
+
+prometheus.remote_write "localprometheus" {
+  endpoint {
+    url = "http://prometheus-server.prometheus.svc:9090/api/v1/write"
+    headers = {
+    }
+    basic_auth {
+      username = convert.nonsensitive(remote.kubernetes.secret.localprometheus.data["username"])
+      password = remote.kubernetes.secret.localprometheus.data["password"]
+    }
+    tls_config {
+      insecure_skip_verify = false
+    }
+    send_native_histograms = false
+
+    queue_config {
+      capacity = 10000
+      min_shards = 1
+      max_shards = 50
+      max_samples_per_send = 2000
+      batch_send_deadline = "5s"
+      min_backoff = "30ms"
+      max_backoff = "5s"
+      retry_on_http_429 = true
+      sample_age_limit = "0s"
+    }
+  }
+
+  wal {
+    truncate_frequency = "2h"
+    min_keepalive_time = "5m"
+    max_keepalive_time = "8h"
+  }
+  external_labels = {
+    "cluster" = "storage-upgrade-test",
+    "k8s_cluster_name" = "storage-upgrade-test",
+  }
+} // prometheus.remote_write "localprometheus"
+
+remote.kubernetes.secret "localprometheus" {
+  name      = "localprometheus-k8smon-k8s-monitoring"
+  namespace = "default"
+} // remote.kubernetes.secret "localprometheus"
+

--- a/charts/k8s-monitoring/tests/platform/aks/.rendered/alloy-logs.alloy
+++ b/charts/k8s-monitoring/tests/platform/aks/.rendered/alloy-logs.alloy
@@ -1,0 +1,239 @@
+// Feature: Pod Logs (Loki)
+declare "pod_logs_via_loki" {
+  argument "logs_destinations" {
+    comment = "Must be a list of log destinations where collected logs should be forwarded to"
+  }
+
+  discovery.kubernetes "pods" {
+    role = "pod"
+    selectors {
+      role = "pod"
+      field = "spec.nodeName=" + sys.env("HOSTNAME")
+    }
+  } // discovery.kubernetes "pods"
+
+  discovery.relabel "filtered_pods" {
+    targets = discovery.kubernetes.pods.targets
+    rule {
+      source_labels = ["__meta_kubernetes_namespace"]
+      action = "replace"
+      target_label = "namespace"
+    }
+    rule {  // Drop anything with a "falsy" annotation value
+      source_labels = ["__meta_kubernetes_pod_annotation_logs_grafana_com_pods_enabled"]
+      regex = "(false|no|skip)"
+      action = "drop"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_pod_name"]
+      target_label = "pod"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_pod_container_name"]
+      target_label = "container"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_namespace", "__meta_kubernetes_pod_container_name"]
+      separator = "/"
+      replacement = "$1"
+      target_label = "job"
+    }
+
+    // set the container runtime as a label
+    rule {
+      source_labels = ["__meta_kubernetes_pod_container_id"]
+      regex = "^(\\S+):\\/\\/.+$"
+      replacement = "$1"
+      target_label = "tmp_container_runtime"
+    }
+    // explicitly set service_name. if not set, loki will automatically try to populate a default.
+    // see https://grafana.com/docs/loki/latest/get-started/labels/#default-labels-for-all-users
+    //
+    // choose the first value found from the following ordered list:
+    // - pod.annotation[resource.opentelemetry.io/service.name]
+    // - pod.label[app.kubernetes.io/name]
+    // - k8s.container.name
+    rule {
+      source_labels = [
+        "__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_name",
+        "__meta_kubernetes_pod_label_app_kubernetes_io_name",
+        "__meta_kubernetes_pod_container_name",
+      ]
+      separator = ";"
+      regex = "^(?:;*)?([^;]+).*$"
+      replacement = "$1"
+      target_label = "service_name"
+    }
+
+    // explicitly set service_namespace.
+    //
+    // choose the first value found from the following ordered list:
+    // - pod.annotation[resource.opentelemetry.io/service.namespace]
+    // - pod.namespace
+    rule {
+      source_labels = [
+        "__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_namespace",
+        "namespace",
+      ]
+      separator = ";"
+      regex = "^(?:;*)?([^;]+).*$"
+      replacement = "$1"
+      target_label = "service_namespace"
+    }
+
+    // explicitly set service_instance_id.
+    //
+    // choose the first value found from the following ordered list:
+    // - pod.annotation[resource.opentelemetry.io/service.instance.id]
+    // - concat([k8s.namespace.name, k8s.pod.name, k8s.container.name], '.')
+    rule {
+      source_labels = ["__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_instance_id"]
+      target_label = "service_instance_id"
+    }
+    rule {
+      source_labels = ["service_instance_id", "namespace", "pod", "container"]
+      separator = "."
+      regex = "^\\.([^.]+\\.[^.]+\\.[^.]+)$"
+      target_label = "service_instance_id"
+    }
+
+    // set resource attributes
+    rule {
+      action = "labelmap"
+      regex = "__meta_kubernetes_pod_annotation_resource_opentelemetry_io_(.+)"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_job"]
+      regex = "(.+)"
+      target_label = "job"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+      regex = "(.+)"
+      target_label = "app_kubernetes_io_name"
+    }
+
+    // Set the pod log path.
+    rule {
+      source_labels = ["__meta_kubernetes_pod_uid", "__meta_kubernetes_pod_container_name"]
+      separator = "/"
+      replacement = "/var/log/pods/*$1/*.log"
+      target_label = "__path__"
+    }
+
+    // If kubernetes.io/config.mirror is set, this is a static pod, created by the kubelet.
+    // It's logs live on a different path.
+    rule {
+      source_labels = ["__meta_kubernetes_pod_annotation_kubernetes_io_config_mirror", "__meta_kubernetes_pod_container_name"]
+      separator = "/"
+      regex = "(.+/.+)"
+      replacement = "/var/log/pods/*$1/*.log"
+      target_label = "__path__"
+    }
+  } // discovery.relabel "filtered_pods"
+
+  local.file_match "pod_logs" {
+    path_targets = discovery.relabel.filtered_pods.output
+  } // local.file_match "pod_logs"
+
+  loki.source.file "pod_logs" {
+    targets    = local.file_match.pod_logs.targets
+    tail_from_end = true
+    forward_to = [loki.process.pod_logs.receiver]
+  } // loki.source.file "pod_logs"
+
+  loki.process "pod_logs" {
+    stage.match {
+      selector = "{tmp_container_runtime=~\"containerd|cri-o|\"}"
+      // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
+      stage.cri {
+        max_partial_lines = 100
+      }
+
+      // Set the extract flags and stream values as labels
+      stage.labels {
+        values = {
+          flags  = "",
+          stream  = "",
+        }
+      }
+    }
+
+    stage.match {
+      selector = "{tmp_container_runtime=\"docker\"}"
+      // the docker processing stage extracts the following k/v pairs: log, stream, time
+      stage.docker {}
+
+      // Set the extract stream value as a label
+      stage.labels {
+        values = {
+          stream  = "",
+        }
+      }
+    }
+
+    // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
+    // namespace, pod, and container labels. Drop any structured metadata. Also drop the temporary
+    // container runtime label as it is no longer needed.
+    stage.label_drop {
+      values = [
+        "filename",
+        "tmp_container_runtime",
+      ]
+    }
+    stage.structured_metadata {
+      values = {
+        "k8s_pod_name" = "k8s_pod_name",
+        "pod" = "pod",
+        "service_instance_id" = "service_instance_id",
+      }
+    }
+
+    forward_to = argument.logs_destinations.value
+  } // loki.secretfilter "pod_logs"
+} // declare "pod_logs_via_loki"
+pod_logs_via_loki "feature" {
+  logs_destinations = [
+    loki.write.grafana_cloud_logs.receiver,
+  ]
+}
+
+
+
+
+
+// Destination: grafana-cloud-logs (loki)
+otelcol.exporter.loki "grafana_cloud_logs" {
+  forward_to = [loki.write.grafana_cloud_logs.receiver]
+} // otelcol.exporter.loki "grafana_cloud_logs"
+
+loki.write "grafana_cloud_logs" {
+  endpoint {
+    url = "https://logs-prod-006.grafana.net/loki/api/v1/push"
+    retry_on_http_429 = true
+    tenant_id = convert.nonsensitive(remote.kubernetes.secret.grafana_cloud_logs.data["tenantId"])
+    basic_auth {
+      username = convert.nonsensitive(remote.kubernetes.secret.grafana_cloud_logs.data["LOKI_USER"])
+      password = remote.kubernetes.secret.grafana_cloud_logs.data["LOKI_PASS"]
+    }
+    tls_config {
+      insecure_skip_verify = false
+      ca_pem = convert.nonsensitive(remote.kubernetes.secret.grafana_cloud_logs.data["ca"])
+      cert_pem = convert.nonsensitive(remote.kubernetes.secret.grafana_cloud_logs.data["cert"])
+      key_pem = remote.kubernetes.secret.grafana_cloud_logs.data["key"]
+    }
+    min_backoff_period = "500ms"
+    max_backoff_period = "5m"
+    max_backoff_retries = "10"
+  }
+  external_labels = {
+    "cluster" = "aks-test",
+    "k8s_cluster_name" = "aks-test",
+  }
+} // loki.write "grafana_cloud_logs"
+
+remote.kubernetes.secret "grafana_cloud_logs" {
+  name      = "grafana-cloud-credentials"
+  namespace = "default"
+} // remote.kubernetes.secret "grafana_cloud_logs"
+

--- a/charts/k8s-monitoring/tests/platform/aks/.rendered/alloy-metrics.alloy
+++ b/charts/k8s-monitoring/tests/platform/aks/.rendered/alloy-metrics.alloy
@@ -1,0 +1,876 @@
+// Feature: Cluster Metrics
+declare "cluster_metrics" {
+  argument "metrics_destinations" {
+    comment = "Must be a list of metric destinations where collected metrics should be forwarded to"
+  }
+  discovery.kubernetes "nodes" {
+    role = "node"
+  } // discovery.kubernetes "nodes"
+
+  discovery.relabel "nodes" {
+    targets = discovery.kubernetes.nodes.targets
+    rule {
+      source_labels = ["__meta_kubernetes_node_name"]
+      target_label  = "node"
+    }
+
+    rule {
+      replacement = "kubernetes"
+      target_label = "source"
+    }
+  } // discovery.relabel "nodes"
+
+  // Kubelet
+  discovery.relabel "kubelet" {
+    targets = discovery.relabel.nodes.output
+  } // discovery.relabel "kubelet"
+
+  prometheus.scrape "kubelet" {
+    targets  = discovery.relabel.kubelet.output
+    job_name = "integrations/kubernetes/kubelet"
+    scheme   = "https"
+    scrape_interval = "60s"
+    scrape_timeout = "10s"
+    scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
+    scrape_classic_histograms = false
+    scrape_native_histograms = false
+    convert_classic_histograms_to_nhcb = false
+    bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+
+    tls_config {
+      ca_file = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+      insecure_skip_verify = true
+      server_name = "kubernetes"
+    }
+
+    clustering {
+      enabled = true
+    }
+
+    forward_to = [prometheus.relabel.kubelet.receiver]
+  } // prometheus.scrape "kubelet"
+
+  prometheus.relabel "kubelet" {
+    max_cache_size = 100000
+    rule {
+      source_labels = ["__name__"]
+      regex = "up|scrape_samples_scraped|go_goroutines|kubelet_certificate_manager_client_expiration_renew_errors|kubelet_certificate_manager_client_ttl_seconds|kubelet_certificate_manager_server_ttl_seconds|kubelet_cgroup_manager_duration_seconds_bucket|kubelet_cgroup_manager_duration_seconds_count|kubelet_node_config_error|kubelet_node_name|kubelet_pleg_relist_duration_seconds_bucket|kubelet_pleg_relist_duration_seconds_count|kubelet_pleg_relist_interval_seconds_bucket|kubelet_pod_start_duration_seconds_bucket|kubelet_pod_start_duration_seconds_count|kubelet_pod_worker_duration_seconds_bucket|kubelet_pod_worker_duration_seconds_count|kubelet_running_container_count|kubelet_running_containers|kubelet_running_pod_count|kubelet_running_pods|kubelet_runtime_operations_errors_total|kubelet_runtime_operations_total|kubelet_server_expiration_renew_errors|kubelet_volume_stats_available_bytes|kubelet_volume_stats_capacity_bytes|kubelet_volume_stats_inodes|kubelet_volume_stats_inodes_free|kubelet_volume_stats_inodes_used|kubelet_volume_stats_used_bytes|kubernetes_build_info|namespace_workload_pod|process_cpu_seconds_total|process_resident_memory_bytes|rest_client_requests_total|storage_operation_duration_seconds_count|storage_operation_errors_total|volume_manager_total_volumes"
+      action = "keep"
+    }
+
+    forward_to = argument.metrics_destinations.value
+  } // prometheus.relabel "kubelet"
+
+  // Kubelet Resources
+  discovery.relabel "kubelet_resources" {
+    targets = discovery.relabel.nodes.output
+    rule {
+      replacement   = "/metrics/resource"
+      target_label  = "__metrics_path__"
+    }
+  } // discovery.relabel "kubelet_resources"
+
+  prometheus.scrape "kubelet_resources" {
+    targets = discovery.relabel.kubelet_resources.output
+    job_name = "integrations/kubernetes/resources"
+    scheme   = "https"
+    scrape_interval = "60s"
+    scrape_timeout = "10s"
+    scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
+    scrape_classic_histograms = false
+    scrape_native_histograms = false
+    convert_classic_histograms_to_nhcb = false
+    bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+
+    tls_config {
+      ca_file = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+      insecure_skip_verify = true
+      server_name = "kubernetes"
+    }
+
+    clustering {
+      enabled = true
+    }
+
+    forward_to = [prometheus.relabel.kubelet_resources.receiver]
+  } // prometheus.scrape "kubelet_resources"
+
+  prometheus.relabel "kubelet_resources" {
+    max_cache_size = 100000
+    rule {
+      source_labels = ["__name__"]
+      regex = "up|scrape_samples_scraped|node_cpu_usage_seconds_total|node_memory_working_set_bytes"
+      action = "keep"
+    }
+
+    forward_to = argument.metrics_destinations.value
+  } // prometheus.relabel "kubelet_resources"
+
+  // cAdvisor
+  discovery.relabel "cadvisor" {
+    targets = discovery.relabel.nodes.output
+    rule {
+      replacement   = "/metrics/cadvisor"
+      target_label  = "__metrics_path__"
+    }
+  } // discovery.relabel "cadvisor"
+
+  prometheus.scrape "cadvisor" {
+    targets = discovery.relabel.cadvisor.output
+    job_name = "integrations/kubernetes/cadvisor"
+    scheme = "https"
+    scrape_interval = "60s"
+    scrape_timeout = "10s"
+    scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
+    scrape_classic_histograms = false
+    scrape_native_histograms = false
+    convert_classic_histograms_to_nhcb = false
+    bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+
+    tls_config {
+      ca_file = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+      insecure_skip_verify = true
+      server_name = "kubernetes"
+    }
+
+    clustering {
+      enabled = true
+    }
+
+    forward_to = [prometheus.relabel.cadvisor.receiver]
+  } // prometheus.scrape "cadvisor"
+
+  prometheus.relabel "cadvisor" {
+    max_cache_size = 100000
+    rule {
+      source_labels = ["__name__"]
+      regex = "up|scrape_samples_scraped|container_cpu_cfs_periods_total|container_cpu_cfs_throttled_periods_total|container_cpu_usage_seconds_total|container_fs_reads_bytes_total|container_fs_reads_total|container_fs_writes_bytes_total|container_fs_writes_total|container_memory_cache|container_memory_rss|container_memory_swap|container_memory_usage_bytes|container_memory_working_set_bytes|container_network_receive_bytes_total|container_network_receive_packets_dropped_total|container_network_receive_packets_total|container_network_transmit_bytes_total|container_network_transmit_packets_dropped_total|container_network_transmit_packets_total|machine_memory_bytes"
+      action = "keep"
+    }
+    // Drop empty container labels, addressing https://github.com/google/cadvisor/issues/2688
+    rule {
+      source_labels = ["__name__","container"]
+      separator = "@"
+      regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_pressure_.*)@"
+      action = "drop"
+    }
+    // Drop empty image labels, addressing https://github.com/google/cadvisor/issues/2688
+    rule {
+      source_labels = ["__name__","image"]
+      separator = "@"
+      regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_network_.*|container_pressure_.*)@"
+      action = "drop"
+    }
+    // Normalizing unimportant labels (not deleting to continue satisfying <label>!="" checks)
+    rule {
+      source_labels = ["__name__", "boot_id"]
+      separator = "@"
+      regex = "machine_memory_bytes@.*"
+      target_label = "boot_id"
+      replacement = "NA"
+    }
+    rule {
+      source_labels = ["__name__", "system_uuid"]
+      separator = "@"
+      regex = "machine_memory_bytes@.*"
+      target_label = "system_uuid"
+      replacement = "NA"
+    }
+    // Filter out non-physical devices/interfaces
+    rule {
+      source_labels = ["__name__", "device"]
+      separator = "@"
+      regex = "container_fs_.*@(/dev/)?(mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dasd.+)"
+      target_label = "__keepme"
+      replacement = "1"
+    }
+    rule {
+      source_labels = ["__name__", "__keepme"]
+      separator = "@"
+      regex = "container_fs_.*@"
+      action = "drop"
+    }
+    rule {
+      source_labels = ["__name__"]
+      regex = "container_fs_.*"
+      target_label = "__keepme"
+      replacement = ""
+    }
+    rule {
+      source_labels = ["__name__", "interface"]
+      separator = "@"
+      regex = "container_network_.*@(en[ospx][0-9].*|wlan[0-9].*|eth[0-9].*)"
+      target_label = "__keepme"
+      replacement = "1"
+    }
+    rule {
+      source_labels = ["__name__", "__keepme"]
+      separator = "@"
+      regex = "container_network_.*@"
+      action = "drop"
+    }
+    rule {
+      source_labels = ["__name__"]
+      regex = "container_network_.*"
+      target_label = "__keepme"
+      replacement = ""
+    }
+    forward_to = argument.metrics_destinations.value
+  } // prometheus.relabel "cadvisor"
+  discovery.kubernetes "kube_state_metrics" {
+    role = "endpoints"
+
+    selectors {
+      role = "endpoints"
+      label = "release=k8smon,app.kubernetes.io/name=kube-state-metrics"
+    }
+    namespaces {
+      names = ["default"]
+    }
+  } // discovery.kubernetes "kube_state_metrics"
+
+  discovery.relabel "kube_state_metrics" {
+    targets = discovery.kubernetes.kube_state_metrics.targets
+
+    rule {
+      action = "replace"
+      replacement = "kubernetes"
+      target_label = "source"
+    }
+
+  } // discovery.relabel "kube_state_metrics"
+
+  prometheus.scrape "kube_state_metrics" {
+    targets = discovery.relabel.kube_state_metrics.output
+    job_name = "integrations/kubernetes/kube-state-metrics"
+    scrape_interval = "60s"
+    scrape_timeout = "10s"
+    scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
+    scrape_classic_histograms = false
+    scrape_native_histograms = false
+    convert_classic_histograms_to_nhcb = false
+    scheme = "http"
+    bearer_token_file = ""
+    tls_config {
+      insecure_skip_verify = true
+    }
+
+    clustering {
+      enabled = true
+    }
+    forward_to = [prometheus.relabel.kube_state_metrics.receiver]
+  } // prometheus.scrape "kube_state_metrics"
+
+  prometheus.relabel "kube_state_metrics" {
+    max_cache_size = 100000
+    rule {
+      source_labels = ["__name__"]
+      regex = "up|scrape_samples_scraped|kube_configmap_info|kube_configmap_metadata_resource_version|kube_cronjob.*|kube_daemonset.*|kube_deployment_metadata_generation|kube_deployment_spec_replicas|kube_deployment_status_condition|kube_deployment_status_observed_generation|kube_deployment_status_replicas_available|kube_deployment_status_replicas_updated|kube_horizontalpodautoscaler_spec_max_replicas|kube_horizontalpodautoscaler_spec_min_replicas|kube_horizontalpodautoscaler_status_current_replicas|kube_horizontalpodautoscaler_status_desired_replicas|kube_job.*|kube_namespace_status_phase|kube_node.*|kube_persistentvolume_status_phase|kube_persistentvolumeclaim_access_mode|kube_persistentvolumeclaim_info|kube_persistentvolumeclaim_labels|kube_persistentvolumeclaim_resource_requests_storage_bytes|kube_persistentvolumeclaim_status_phase|kube_pod_completion_time|kube_pod_container_info|kube_pod_container_resource_limits|kube_pod_container_resource_requests|kube_pod_container_status_last_terminated_reason|kube_pod_container_status_last_terminated_timestamp|kube_pod_container_status_restarts_total|kube_pod_container_status_waiting_reason|kube_pod_info|kube_pod_owner|kube_pod_restart_policy|kube_pod_spec_volumes_persistentvolumeclaims_info|kube_pod_start_time|kube_pod_status_phase|kube_pod_status_reason|kube_pod_init_.*|kube_replicaset.*|kube_resourcequota|kube_secret_metadata_resource_version|kube_statefulset.*"
+      action = "keep"
+    }
+    forward_to = argument.metrics_destinations.value
+  } // prometheus.relabel "kube_state_metrics"
+} // declare "cluster_metrics"
+cluster_metrics "feature" {
+  metrics_destinations = [
+    prometheus.remote_write.grafana_cloud_metrics.receiver,
+  ]
+}
+// Feature: Host Metrics
+declare "host_metrics" {
+  argument "metrics_destinations" {
+    comment = "Must be a list of metric destinations where collected metrics should be forwarded to"
+  }
+
+  // Linux hosts via Node Exporter
+  discovery.kubernetes "node_exporter" {
+    role = "pod"
+    selectors {
+      role = "pod"
+      label = "release=k8smon,app.kubernetes.io/name=node-exporter"
+    }
+    namespaces {
+      names = ["default"]
+    }
+
+  } // discovery.kubernetes "node_exporter"
+
+  discovery.relabel "node_exporter" {
+    targets = discovery.kubernetes.node_exporter.targets
+
+    // keep only the specified metrics port name, and pods that are Running and ready
+    rule {
+      source_labels = [
+        "__meta_kubernetes_pod_container_init",
+        "__meta_kubernetes_pod_phase",
+        "__meta_kubernetes_pod_ready",
+      ]
+      separator = "@"
+      regex = "false@Running@true"
+      action = "keep"
+    }
+
+    // Set the instance label to the node name
+    rule {
+      source_labels = ["__meta_kubernetes_pod_node_name"]
+      target_label = "instance"
+    }
+
+    rule {
+      source_labels = ["__meta_kubernetes_namespace"]
+      target_label  = "namespace"
+    }
+
+    rule {
+      source_labels = ["__meta_kubernetes_pod_name"]
+      target_label  = "pod"
+    }
+
+    rule {
+      source_labels = ["__meta_kubernetes_pod_container_name"]
+      target_label  = "container"
+    }
+
+    // set a workload label
+    rule {
+      source_labels = [
+        "__meta_kubernetes_pod_controller_kind",
+        "__meta_kubernetes_pod_controller_name",
+      ]
+      separator = "/"
+      target_label  = "workload"
+    }
+    // remove the hash from the ReplicaSet
+    rule {
+      source_labels = ["workload"]
+      regex = "(ReplicaSet/.+)-.+"
+      target_label  = "workload"
+    }
+
+    // Set the app label.
+    //
+    // Choose the first value found from the following ordered list:
+    // - pod.label[app.kubernetes.io/name]
+    // - pod.label[k8s-app]
+    // - pod.label[app]
+    rule {
+      source_labels = [
+        "__meta_kubernetes_pod_label_app_kubernetes_io_name",
+        "__meta_kubernetes_pod_label_k8s_app",
+        "__meta_kubernetes_pod_label_app",
+      ]
+      separator = ";"
+      regex = "^(?:;*)?([^;]+).*$"
+      replacement = "$1"
+      target_label = "app"
+    }
+
+    // Set the component label.
+    //
+    // Choose the first value found from the following ordered list:
+    // - pod.label[app.kubernetes.io/component]
+    // - pod.label[k8s-component]
+    // - pod.label[component]
+    rule {
+      source_labels = [
+        "__meta_kubernetes_pod_label_app_kubernetes_io_component",
+        "__meta_kubernetes_pod_label_k8s_component",
+        "__meta_kubernetes_pod_label_component",
+      ]
+      regex = "^(?:;*)?([^;]+).*$"
+      replacement = "$1"
+      target_label = "component"
+    }
+
+    rule {
+      target_label = "source"
+      replacement = "kubernetes"
+    }
+
+  } // discovery.relabel "node_exporter"
+
+  prometheus.scrape "node_exporter" {
+    targets = discovery.relabel.node_exporter.output
+    job_name = "integrations/node_exporter"
+    scrape_interval = "60s"
+    scrape_timeout = "10s"
+    scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
+    scrape_classic_histograms = false
+    scrape_native_histograms = false
+    convert_classic_histograms_to_nhcb = false
+    scheme = "http"
+    tls_config {
+      insecure_skip_verify = true
+    }
+
+    clustering {
+      enabled = true
+    }
+    forward_to = [prometheus.relabel.node_exporter.receiver]
+  } // prometheus.scrape "node_exporter"
+
+  prometheus.relabel "node_exporter" {
+    max_cache_size = 100000
+    rule {
+      source_labels = ["__name__"]
+      regex = "up|scrape_samples_scraped|node_cpu.*|node_exporter_build_info|node_filesystem.*|node_memory.*|node_network_receive_bytes_total|node_network_receive_drop_total|node_network_transmit_bytes_total|node_network_transmit_drop_total|process_cpu_seconds_total|process_resident_memory_bytes"
+      action = "keep"
+    }
+    // Drop metrics for certain file systems
+    rule {
+      source_labels = ["__name__", "fstype"]
+      separator = "@"
+      regex = "node_filesystem.*@(ramfs|tmpfs)"
+      action = "drop"
+    }
+    forward_to = argument.metrics_destinations.value
+  } // prometheus.relabel "node_exporter"
+
+  // Windows hosts via Windows Exporter
+  discovery.kubernetes "windows_exporter_pods" {
+    role = "pod"
+    selectors {
+      role = "pod"
+      label = "release=k8smon,app.kubernetes.io/name=windows-exporter"
+    }
+    namespaces {
+      names = ["default"]
+    }
+
+  } // discovery.kubernetes "windows_exporter_pods"
+
+  discovery.relabel "windows_exporter" {
+    targets = discovery.kubernetes.windows_exporter_pods.targets
+
+    // keep only the specified metrics port name, and pods that are Running and ready
+    rule {
+      source_labels = [
+        "__meta_kubernetes_pod_container_init",
+        "__meta_kubernetes_pod_phase",
+        "__meta_kubernetes_pod_ready",
+      ]
+      separator = "@"
+      regex = "false@Running@true"
+      action = "keep"
+    }
+
+    // Set the instance label to the node name
+    rule {
+      source_labels = ["__meta_kubernetes_pod_node_name"]
+      target_label = "instance"
+    }
+
+  } // discovery.relabel "windows_exporter"
+
+  prometheus.scrape "windows_exporter" {
+    targets  = discovery.relabel.windows_exporter.output
+    job_name   = "integrations/windows-exporter"
+    scrape_interval = "60s"
+    scrape_timeout = "10s"
+    scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
+    scrape_classic_histograms = false
+    scrape_native_histograms = false
+    convert_classic_histograms_to_nhcb = false
+    clustering {
+      enabled = true
+    }
+    forward_to = [prometheus.relabel.windows_exporter.receiver]
+  } // prometheus.scrape "windows_exporter"
+
+  prometheus.relabel "windows_exporter" {
+    max_cache_size = 100000
+    rule {
+      source_labels = ["__name__"]
+      regex = "up|scrape_samples_scraped|windows_.*|node_cpu_seconds_total|node_filesystem_size_bytes|node_filesystem_avail_bytes|container_cpu_usage_seconds_total"
+      action = "keep"
+    }
+    forward_to = argument.metrics_destinations.value
+  } // prometheus.relabel "windows_exporter"
+} // declare "host_metrics"
+host_metrics "feature" {
+  metrics_destinations = [
+    prometheus.remote_write.grafana_cloud_metrics.receiver,
+  ]
+}
+declare "alloy_integration" {
+  argument "metrics_destinations" {
+    comment = "Must be a list of metric destinations where collected metrics should be forwarded to"
+  }
+
+  declare "alloy_integration_discovery" {
+    argument "namespaces" {
+      comment = "The namespaces to look for targets in (default: [] is all namespaces)"
+      optional = true
+    }
+
+    argument "field_selectors" {
+      comment = "The field selectors to use to find matching targets (default: [])"
+      optional = true
+    }
+
+    argument "label_selectors" {
+      comment = "The label selectors to use to find matching targets (default: [\"app.kubernetes.io/name=alloy\"])"
+      optional = true
+    }
+
+    argument "port_name" {
+      comment = "The of the port to scrape metrics from (default: http-metrics)"
+      optional = true
+    }
+
+    // Alloy service discovery for all of the pods
+    discovery.kubernetes "alloy_pods" {
+      role = "pod"
+
+      selectors {
+        role = "pod"
+        field = string.join(coalesce(argument.field_selectors.value, []), ",")
+        label = string.join(coalesce(argument.label_selectors.value, ["app.kubernetes.io/name=alloy"]), ",")
+      }
+
+      namespaces {
+        names = coalesce(argument.namespaces.value, [])
+      }
+
+    } // discovery.kubernetes "alloy_pods"
+
+    // alloy relabelings (pre-scrape)
+    discovery.relabel "alloy_pods" {
+      targets = discovery.kubernetes.alloy_pods.targets
+
+      // keep only the specified metrics port name, and pods that are Running and ready
+      rule {
+        source_labels = [
+          "__meta_kubernetes_pod_container_port_name",
+          "__meta_kubernetes_pod_phase",
+          "__meta_kubernetes_pod_ready",
+          "__meta_kubernetes_pod_container_init",
+        ]
+        separator = "@"
+        regex = coalesce(argument.port_name.value, "metrics") + "@Running@true@false"
+        action = "keep"
+      }
+
+      rule {
+        source_labels = ["__meta_kubernetes_namespace"]
+        target_label  = "namespace"
+      }
+
+      rule {
+        source_labels = ["__meta_kubernetes_pod_name"]
+        target_label  = "pod"
+      }
+
+      rule {
+        source_labels = ["__meta_kubernetes_pod_container_name"]
+        target_label  = "container"
+      }
+
+      // set the workload to the controller kind and name
+      rule {
+        action = "lowercase"
+        source_labels = ["__meta_kubernetes_pod_controller_kind"]
+        target_label  = "workload_type"
+      }
+
+      rule {
+        source_labels = ["__meta_kubernetes_pod_controller_name"]
+        target_label  = "workload"
+      }
+
+      // remove the hash from the ReplicaSet
+      rule {
+        source_labels = [
+          "workload_type",
+          "workload",
+        ]
+        separator = "/"
+        regex = "replicaset/(.+)-.+$"
+        target_label  = "workload"
+      }
+
+      // set the app name if specified as metadata labels "app:" or "app.kubernetes.io/name:" or "k8s-app:"
+      rule {
+        action = "replace"
+        source_labels = [
+          "__meta_kubernetes_pod_label_app_kubernetes_io_name",
+          "__meta_kubernetes_pod_label_k8s_app",
+          "__meta_kubernetes_pod_label_app",
+        ]
+        separator = ";"
+        regex = "^(?:;*)?([^;]+).*$"
+        replacement = "$1"
+        target_label = "app"
+      }
+
+      // set the component if specified as metadata labels "component:" or "app.kubernetes.io/component:" or "k8s-component:"
+      rule {
+        action = "replace"
+        source_labels = [
+          "__meta_kubernetes_pod_label_app_kubernetes_io_component",
+          "__meta_kubernetes_pod_label_k8s_component",
+          "__meta_kubernetes_pod_label_component",
+        ]
+        regex = "^(?:;*)?([^;]+).*$"
+        replacement = "$1"
+        target_label = "component"
+      }
+
+      // set a source label
+      rule {
+        action = "replace"
+        replacement = "kubernetes"
+        target_label = "source"
+      }
+
+    } // discovery.relabel "alloy_pods"
+
+    export "output" {
+      value = discovery.relabel.alloy_pods.output
+    }
+  }
+
+  declare "alloy_integration_scrape" {
+    argument "targets" {
+      comment = "Must be a list() of targets"
+    }
+
+    argument "forward_to" {
+      comment = "Must be a list(MetricsReceiver) where collected metrics should be forwarded to"
+    }
+
+    argument "job_label" {
+      comment = "The job label to add for all Alloy metrics (default: integrations/alloy)"
+      optional = true
+    }
+
+    argument "keep_metrics" {
+      comment = "A regular expression of metrics to keep (default: see below)"
+      optional = true
+    }
+
+    argument "drop_metrics" {
+      comment = "A regular expression of metrics to drop (default: see below)"
+      optional = true
+    }
+
+    argument "scrape_interval" {
+      comment = "How often to scrape metrics from the targets (default: 60s)"
+      optional = true
+    }
+
+    argument "scrape_timeout" {
+      comment = "The timeout for scraping metrics from the targets (default: 10s)"
+      optional = true
+    }
+
+    argument "scrape_protocols" {
+      comment = "The scrape protocols to use for scraping metrics"
+      optional = true
+    }
+
+    argument "scrape_classic_histograms" {
+      comment = "Whether to scrape classic histograms (default: false)."
+      optional = true
+    }
+
+    argument "scrape_native_histograms" {
+      comment = "Whether to scrape native histograms (default: false)."
+      optional = true
+    }
+
+    argument "max_cache_size" {
+      comment = "The maximum number of elements to hold in the relabeling cache (default: 100000).  This should be at least 2x-5x your largest scrape target or samples appended rate."
+      optional = true
+    }
+
+    argument "clustering" {
+      comment = "Whether or not clustering should be enabled (default: false)"
+      optional = true
+    }
+
+    prometheus.scrape "alloy" {
+      job_name = coalesce(argument.job_label.value, "integrations/alloy")
+      forward_to = [prometheus.relabel.alloy.receiver]
+      targets = argument.targets.value
+      scrape_interval = coalesce(argument.scrape_interval.value, "60s")
+      scrape_timeout = coalesce(argument.scrape_timeout.value, "10s")
+      scrape_protocols = argument.scrape_protocols.value
+      scrape_classic_histograms = argument.scrape_classic_histograms.value
+      scrape_native_histograms = argument.scrape_native_histograms.value
+
+      clustering {
+        enabled = coalesce(argument.clustering.value, false)
+      }
+    } // prometheus.scrape "alloy"
+
+    // alloy metric relabelings (post-scrape)
+    prometheus.relabel "alloy" {
+      forward_to = argument.forward_to.value
+      max_cache_size = coalesce(argument.max_cache_size.value, 100000)
+
+      // drop metrics that match the drop_metrics regex
+      rule {
+        source_labels = ["__name__"]
+        regex = coalesce(argument.drop_metrics.value, "")
+        action = "drop"
+      }
+
+      // keep only metrics that match the keep_metrics regex
+      rule {
+        source_labels = ["__name__"]
+        regex = coalesce(argument.keep_metrics.value, ".*")
+        action = "keep"
+      }
+
+      // remove the component_id label from any metric that starts with log_bytes or log_lines, these are custom metrics that are generated
+      // as part of the log annotation modules in this repo
+      rule {
+        action = "replace"
+        source_labels = ["__name__"]
+        regex = "^log_(bytes|lines).+"
+        replacement = ""
+        target_label = "component_id"
+      }
+
+      // set the namespace label to that of the exported_namespace
+      rule {
+        action = "replace"
+        source_labels = ["__name__", "exported_namespace"]
+        separator = "@"
+        regex = "^log_(bytes|lines).+@(.+)"
+        replacement = "$2"
+        target_label = "namespace"
+      }
+
+      // set the pod label to that of the exported_pod
+      rule {
+        action = "replace"
+        source_labels = ["__name__", "exported_pod"]
+        separator = "@"
+        regex = "^log_(bytes|lines).+@(.+)"
+        replacement = "$2"
+        target_label = "pod"
+      }
+
+      // set the container label to that of the exported_container
+      rule {
+        action = "replace"
+        source_labels = ["__name__", "exported_container"]
+        separator = "@"
+        regex = "^log_(bytes|lines).+@(.+)"
+        replacement = "$2"
+        target_label = "container"
+      }
+
+      // set the job label to that of the exported_job
+      rule {
+        action = "replace"
+        source_labels = ["__name__", "exported_job"]
+        separator = "@"
+        regex = "^log_(bytes|lines).+@(.+)"
+        replacement = "$2"
+        target_label = "job"
+      }
+
+      // set the instance label to that of the exported_instance
+      rule {
+        action = "replace"
+        source_labels = ["__name__", "exported_instance"]
+        separator = "@"
+        regex = "^log_(bytes|lines).+@(.+)"
+        replacement = "$2"
+        target_label = "instance"
+      }
+
+      rule {
+        action = "labeldrop"
+        regex = "exported_(namespace|pod|container|job|instance)"
+      }
+    } // prometheus.relabel "alloy"
+  }
+
+  alloy_integration_discovery "alloy" {
+    port_name = "http-metrics"
+    label_selectors = ["app.kubernetes.io/name in (alloy-metrics,alloy-singleton,alloy-logs)"]
+  }
+
+  alloy_integration_scrape "alloy" {
+    targets = alloy_integration_discovery.alloy.output
+    job_label = "integrations/alloy"
+    clustering = true
+    keep_metrics = "up|scrape_samples_scraped|alloy_build_info|alloy_component_controller_running_components|alloy_component_dependencies_wait_seconds|alloy_component_dependencies_wait_seconds_bucket|alloy_component_evaluation_seconds|alloy_component_evaluation_seconds_bucket|alloy_component_evaluation_seconds_count|alloy_component_evaluation_seconds_sum|alloy_component_evaluation_slow_seconds|alloy_config_hash|alloy_resources_machine_rx_bytes_total|alloy_resources_machine_tx_bytes_total|alloy_resources_process_cpu_seconds_total|alloy_resources_process_resident_memory_bytes|alloy_tcp_connections|alloy_wal_samples_appended_total|alloy_wal_storage_active_series|cluster_node_gossip_health_score|cluster_node_gossip_proto_version|cluster_node_gossip_received_events_total|cluster_node_info|cluster_node_lamport_time|cluster_node_peers|cluster_node_update_observers|cluster_transport_rx_bytes_total|cluster_transport_rx_packet_queue_length|cluster_transport_rx_packets_failed_total|cluster_transport_rx_packets_total|cluster_transport_stream_rx_bytes_total|cluster_transport_stream_rx_packets_failed_total|cluster_transport_stream_rx_packets_total|cluster_transport_stream_tx_bytes_total|cluster_transport_stream_tx_packets_failed_total|cluster_transport_stream_tx_packets_total|cluster_transport_streams|cluster_transport_tx_bytes_total|cluster_transport_tx_packet_queue_length|cluster_transport_tx_packets_failed_total|cluster_transport_tx_packets_total|otelcol_exporter_send_failed_spans_total|otelcol_exporter_sent_spans_total|go_gc_duration_seconds_count|go_goroutines|go_memstats_heap_inuse_bytes|loki_process_dropped_lines_total|loki_write_batch_retries_total|loki_write_dropped_bytes_total|loki_write_dropped_entries_total|loki_write_encoded_bytes_total|loki_write_mutated_bytes_total|loki_write_mutated_entries_total|loki_write_request_duration_seconds_bucket|loki_write_sent_bytes_total|loki_write_sent_entries_total|process_cpu_seconds_total|process_start_time_seconds|otelcol_processor_batch_batch_send_size_bucket|otelcol_processor_batch_metadata_cardinality|otelcol_processor_batch_timeout_trigger_send_total|prometheus_remote_storage_bytes_total|prometheus_remote_storage_enqueue_retries_total|prometheus_remote_storage_highest_timestamp_in_seconds|prometheus_remote_storage_metadata_bytes_total|prometheus_remote_storage_queue_highest_sent_timestamp_seconds|prometheus_remote_storage_samples_dropped_total|prometheus_remote_storage_samples_failed_total|prometheus_remote_storage_samples_pending|prometheus_remote_storage_samples_retried_total|prometheus_remote_storage_samples_total|prometheus_remote_storage_sent_batch_duration_seconds_bucket|prometheus_remote_storage_sent_batch_duration_seconds_count|prometheus_remote_storage_sent_batch_duration_seconds_sum|prometheus_remote_storage_shard_capacity|prometheus_remote_storage_shards|prometheus_remote_storage_shards_desired|prometheus_remote_storage_shards_max|prometheus_remote_storage_shards_min|prometheus_remote_storage_succeeded_samples_total|prometheus_remote_write_wal_samples_appended_total|prometheus_remote_write_wal_storage_active_series|prometheus_sd_discovered_targets|prometheus_target_interval_length_seconds_count|prometheus_target_interval_length_seconds_sum|prometheus_target_scrapes_exceeded_sample_limit_total|prometheus_target_scrapes_sample_duplicate_timestamp_total|prometheus_target_scrapes_sample_out_of_bounds_total|prometheus_target_scrapes_sample_out_of_order_total|prometheus_target_sync_length_seconds_sum|prometheus_wal_watcher_current_segment|otelcol_receiver_accepted_spans_total|otelcol_receiver_refused_spans_total|rpc_server_duration_milliseconds_bucket|scrape_duration_seconds|traces_exporter_send_failed_spans|traces_exporter_send_failed_spans_total|traces_exporter_sent_spans|traces_exporter_sent_spans_total|traces_loadbalancer_backend_outcome|traces_loadbalancer_num_backends|traces_receiver_accepted_spans|traces_receiver_accepted_spans_total|traces_receiver_refused_spans|traces_receiver_refused_spans_total"
+    scrape_interval = "60s"
+    scrape_timeout = "10s"
+    scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
+    scrape_classic_histograms = false
+    scrape_native_histograms = false
+    max_cache_size = 100000
+    forward_to = argument.metrics_destinations.value
+  }
+}
+alloy_integration "integration" {
+  metrics_destinations = [
+    prometheus.remote_write.grafana_cloud_metrics.receiver,
+  ]
+}
+
+
+
+
+
+// Destination: grafana-cloud-metrics (prometheus)
+otelcol.exporter.prometheus "grafana_cloud_metrics" {
+  add_metric_suffixes = true
+  resource_to_telemetry_conversion = false
+  keep_identifying_resource_attributes = true
+  forward_to = [prometheus.remote_write.grafana_cloud_metrics.receiver]
+} // otelcol.exporter.prometheus "grafana_cloud_metrics"
+
+prometheus.remote_write "grafana_cloud_metrics" {
+  endpoint {
+    url = "https://prometheus-prod-13-prod-us-east-0.grafana.net/api/prom/push"
+    headers = {
+      "X-Scope-OrgID" = convert.nonsensitive(remote.kubernetes.secret.grafana_cloud_metrics.data["tenantId"]),
+    }
+    basic_auth {
+      username = convert.nonsensitive(remote.kubernetes.secret.grafana_cloud_metrics.data["PROMETHEUS_USER"])
+      password = remote.kubernetes.secret.grafana_cloud_metrics.data["PROMETHEUS_PASS"]
+    }
+    tls_config {
+      insecure_skip_verify = false
+      ca_pem = convert.nonsensitive(remote.kubernetes.secret.grafana_cloud_metrics.data["ca"])
+      cert_pem = convert.nonsensitive(remote.kubernetes.secret.grafana_cloud_metrics.data["cert"])
+      key_pem = remote.kubernetes.secret.grafana_cloud_metrics.data["key"]
+    }
+    send_native_histograms = false
+
+    queue_config {
+      capacity = 10000
+      min_shards = 1
+      max_shards = 50
+      max_samples_per_send = 2000
+      batch_send_deadline = "5s"
+      min_backoff = "30ms"
+      max_backoff = "5s"
+      retry_on_http_429 = true
+      sample_age_limit = "0s"
+    }
+  }
+
+  wal {
+    truncate_frequency = "2h"
+    min_keepalive_time = "5m"
+    max_keepalive_time = "8h"
+  }
+  external_labels = {
+    "cluster" = "aks-test",
+    "k8s_cluster_name" = "aks-test",
+  }
+} // prometheus.remote_write "grafana_cloud_metrics"
+
+remote.kubernetes.secret "grafana_cloud_metrics" {
+  name      = "grafana-cloud-credentials"
+  namespace = "default"
+} // remote.kubernetes.secret "grafana_cloud_metrics"
+

--- a/charts/k8s-monitoring/tests/platform/aks/.rendered/alloy-singleton.alloy
+++ b/charts/k8s-monitoring/tests/platform/aks/.rendered/alloy-singleton.alloy
@@ -1,0 +1,221 @@
+// Feature: Cluster Events
+declare "cluster_events" {
+  argument "logs_destinations" {
+    comment = "Must be a list of log destinations where collected logs should be forwarded to"
+  }
+
+  loki.source.kubernetes_events "cluster_events" {
+    job_name   = "integrations/kubernetes/eventhandler"
+    log_format = "logfmt"
+    forward_to = [loki.process.cluster_events.receiver]
+  } // loki.source.kubernetes_events "cluster_events"
+
+  loki.process "cluster_events" {
+
+    // add a static source label to the logs so they can be differentiated / restricted if necessary
+    stage.static_labels {
+      values = {
+        "source" = "kubernetes-events",
+      }
+    }
+
+    // extract some of the fields from the log line, these could be used as labels, structured metadata, etc.
+    stage.logfmt {
+      mapping = {
+        "component" = "sourcecomponent", // map the sourcecomponent field to component
+        "kind" = "",
+        "level" = "type", // most events don't have a level but they do have a "type" i.e. Normal, Warning, Error, etc.
+        "name" = "",
+        "node" = "sourcehost", // map the sourcehost field to node
+        "reason" = "",
+      }
+    }
+    // set the extracted values as labels
+    stage.labels {
+      values = {
+        "kind" = "",
+        "level" = "",
+        "service_name" = "job",
+        "reason" = "reason",
+      }
+    }
+
+    // if kind=Node, set the node label by copying the name field
+    stage.match {
+      selector = "{kind=\"Node\"}"
+
+      stage.labels {
+        values = {
+          "node" = "name",
+        }
+      }
+    }
+
+    // set the level extracted key value as a normalized log level
+    stage.match {
+      selector = "{level=\"Normal\"}"
+
+      stage.static_labels {
+        values = {
+          level = "Info",
+        }
+      }
+    }
+    stage.structured_metadata {
+      values = {
+        "name" = "name",
+        "node" = "node",
+      }
+    }
+
+    // Drop pipeline-only labels that are not needed in the final output.
+    stage.label_drop {
+      values = ["kind"]
+    }
+
+    forward_to = argument.logs_destinations.value
+  } // loki.process "cluster_events"
+} // declare "cluster_events"
+cluster_events "feature" {
+  logs_destinations = [
+    loki.write.grafana_cloud_logs.receiver,
+  ]
+}
+// Self Reporting
+prometheus.exporter.unix "kubernetes_monitoring_telemetry" {
+  set_collectors = ["textfile"]
+  textfile {
+    directory = "/etc/release-info"
+  }
+} // prometheus.exporter.unix "kubernetes_monitoring_telemetry"
+
+discovery.relabel "kubernetes_monitoring_telemetry" {
+  targets = prometheus.exporter.unix.kubernetes_monitoring_telemetry.targets
+  rule {
+    target_label = "instance"
+    action = "replace"
+    replacement = "k8smon"
+  }
+  rule {
+    target_label = "job"
+    action = "replace"
+    replacement = "integrations/kubernetes/kubernetes_monitoring_telemetry"
+  }
+} // discovery.relabel "kubernetes_monitoring_telemetry"
+
+prometheus.scrape "kubernetes_monitoring_telemetry" {
+  job_name   = "integrations/kubernetes/kubernetes_monitoring_telemetry"
+  targets    = discovery.relabel.kubernetes_monitoring_telemetry.output
+  scrape_interval = "60s"
+  clustering {
+    enabled = true
+  }
+  forward_to = [prometheus.relabel.kubernetes_monitoring_telemetry.receiver]
+} // prometheus.scrape "kubernetes_monitoring_telemetry"
+
+prometheus.relabel "kubernetes_monitoring_telemetry" {
+  rule {
+    source_labels = ["__name__"]
+    regex = "grafana_kubernetes_monitoring_.*"
+    action = "keep"
+  }
+  forward_to = [
+    prometheus.remote_write.grafana_cloud_metrics.receiver,
+  ]
+} // prometheus.relabel "kubernetes_monitoring_telemetry"
+
+
+
+
+
+// Destination: grafana-cloud-logs (loki)
+otelcol.exporter.loki "grafana_cloud_logs" {
+  forward_to = [loki.write.grafana_cloud_logs.receiver]
+} // otelcol.exporter.loki "grafana_cloud_logs"
+
+loki.write "grafana_cloud_logs" {
+  endpoint {
+    url = "https://logs-prod-006.grafana.net/loki/api/v1/push"
+    retry_on_http_429 = true
+    tenant_id = convert.nonsensitive(remote.kubernetes.secret.grafana_cloud_logs.data["tenantId"])
+    basic_auth {
+      username = convert.nonsensitive(remote.kubernetes.secret.grafana_cloud_logs.data["LOKI_USER"])
+      password = remote.kubernetes.secret.grafana_cloud_logs.data["LOKI_PASS"]
+    }
+    tls_config {
+      insecure_skip_verify = false
+      ca_pem = convert.nonsensitive(remote.kubernetes.secret.grafana_cloud_logs.data["ca"])
+      cert_pem = convert.nonsensitive(remote.kubernetes.secret.grafana_cloud_logs.data["cert"])
+      key_pem = remote.kubernetes.secret.grafana_cloud_logs.data["key"]
+    }
+    min_backoff_period = "500ms"
+    max_backoff_period = "5m"
+    max_backoff_retries = "10"
+  }
+  external_labels = {
+    "cluster" = "aks-test",
+    "k8s_cluster_name" = "aks-test",
+  }
+} // loki.write "grafana_cloud_logs"
+
+remote.kubernetes.secret "grafana_cloud_logs" {
+  name      = "grafana-cloud-credentials"
+  namespace = "default"
+} // remote.kubernetes.secret "grafana_cloud_logs"
+
+
+// Destination: grafana-cloud-metrics (prometheus)
+otelcol.exporter.prometheus "grafana_cloud_metrics" {
+  add_metric_suffixes = true
+  resource_to_telemetry_conversion = false
+  keep_identifying_resource_attributes = true
+  forward_to = [prometheus.remote_write.grafana_cloud_metrics.receiver]
+} // otelcol.exporter.prometheus "grafana_cloud_metrics"
+
+prometheus.remote_write "grafana_cloud_metrics" {
+  endpoint {
+    url = "https://prometheus-prod-13-prod-us-east-0.grafana.net/api/prom/push"
+    headers = {
+      "X-Scope-OrgID" = convert.nonsensitive(remote.kubernetes.secret.grafana_cloud_metrics.data["tenantId"]),
+    }
+    basic_auth {
+      username = convert.nonsensitive(remote.kubernetes.secret.grafana_cloud_metrics.data["PROMETHEUS_USER"])
+      password = remote.kubernetes.secret.grafana_cloud_metrics.data["PROMETHEUS_PASS"]
+    }
+    tls_config {
+      insecure_skip_verify = false
+      ca_pem = convert.nonsensitive(remote.kubernetes.secret.grafana_cloud_metrics.data["ca"])
+      cert_pem = convert.nonsensitive(remote.kubernetes.secret.grafana_cloud_metrics.data["cert"])
+      key_pem = remote.kubernetes.secret.grafana_cloud_metrics.data["key"]
+    }
+    send_native_histograms = false
+
+    queue_config {
+      capacity = 10000
+      min_shards = 1
+      max_shards = 50
+      max_samples_per_send = 2000
+      batch_send_deadline = "5s"
+      min_backoff = "30ms"
+      max_backoff = "5s"
+      retry_on_http_429 = true
+      sample_age_limit = "0s"
+    }
+  }
+
+  wal {
+    truncate_frequency = "2h"
+    min_keepalive_time = "5m"
+    max_keepalive_time = "8h"
+  }
+  external_labels = {
+    "cluster" = "aks-test",
+    "k8s_cluster_name" = "aks-test",
+  }
+} // prometheus.remote_write "grafana_cloud_metrics"
+
+remote.kubernetes.secret "grafana_cloud_metrics" {
+  name      = "grafana-cloud-credentials"
+  namespace = "default"
+} // remote.kubernetes.secret "grafana_cloud_metrics"
+

--- a/charts/k8s-monitoring/tests/platform/eks-fargate/.rendered/alloy-logs.alloy
+++ b/charts/k8s-monitoring/tests/platform/eks-fargate/.rendered/alloy-logs.alloy
@@ -1,0 +1,423 @@
+// Feature: Pod Logs (Loki)
+declare "pod_logs_via_loki" {
+  argument "logs_destinations" {
+    comment = "Must be a list of log destinations where collected logs should be forwarded to"
+  }
+
+  discovery.kubernetes "pods" {
+    role = "pod"
+    selectors {
+      role = "pod"
+      field = "spec.nodeName=" + sys.env("HOSTNAME")
+    }
+  } // discovery.kubernetes "pods"
+
+  discovery.relabel "filtered_pods" {
+    targets = discovery.kubernetes.pods.targets
+    rule {
+      source_labels = ["__meta_kubernetes_namespace"]
+      action = "replace"
+      target_label = "namespace"
+    }
+    rule {  // Drop anything with a "falsy" annotation value
+      source_labels = ["__meta_kubernetes_pod_annotation_logs_grafana_com_pods_enabled"]
+      regex = "(false|no|skip)"
+      action = "drop"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_pod_name"]
+      target_label = "pod"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_pod_container_name"]
+      target_label = "container"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_namespace", "__meta_kubernetes_pod_container_name"]
+      separator = "/"
+      replacement = "$1"
+      target_label = "job"
+    }
+
+    // set the container runtime as a label
+    rule {
+      source_labels = ["__meta_kubernetes_pod_container_id"]
+      regex = "^(\\S+):\\/\\/.+$"
+      replacement = "$1"
+      target_label = "tmp_container_runtime"
+    }
+    // explicitly set service_name. if not set, loki will automatically try to populate a default.
+    // see https://grafana.com/docs/loki/latest/get-started/labels/#default-labels-for-all-users
+    //
+    // choose the first value found from the following ordered list:
+    // - pod.annotation[resource.opentelemetry.io/service.name]
+    // - pod.label[app.kubernetes.io/name]
+    // - k8s.container.name
+    rule {
+      source_labels = [
+        "__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_name",
+        "__meta_kubernetes_pod_label_app_kubernetes_io_name",
+        "__meta_kubernetes_pod_container_name",
+      ]
+      separator = ";"
+      regex = "^(?:;*)?([^;]+).*$"
+      replacement = "$1"
+      target_label = "service_name"
+    }
+
+    // explicitly set service_namespace.
+    //
+    // choose the first value found from the following ordered list:
+    // - pod.annotation[resource.opentelemetry.io/service.namespace]
+    // - pod.namespace
+    rule {
+      source_labels = [
+        "__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_namespace",
+        "namespace",
+      ]
+      separator = ";"
+      regex = "^(?:;*)?([^;]+).*$"
+      replacement = "$1"
+      target_label = "service_namespace"
+    }
+
+    // explicitly set service_instance_id.
+    //
+    // choose the first value found from the following ordered list:
+    // - pod.annotation[resource.opentelemetry.io/service.instance.id]
+    // - concat([k8s.namespace.name, k8s.pod.name, k8s.container.name], '.')
+    rule {
+      source_labels = ["__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_instance_id"]
+      target_label = "service_instance_id"
+    }
+    rule {
+      source_labels = ["service_instance_id", "namespace", "pod", "container"]
+      separator = "."
+      regex = "^\\.([^.]+\\.[^.]+\\.[^.]+)$"
+      target_label = "service_instance_id"
+    }
+
+    // set resource attributes
+    rule {
+      action = "labelmap"
+      regex = "__meta_kubernetes_pod_annotation_resource_opentelemetry_io_(.+)"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_job"]
+      regex = "(.+)"
+      target_label = "job"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+      regex = "(.+)"
+      target_label = "app_kubernetes_io_name"
+    }
+
+    // Set the pod log path.
+    rule {
+      source_labels = ["__meta_kubernetes_pod_uid", "__meta_kubernetes_pod_container_name"]
+      separator = "/"
+      replacement = "/var/log/pods/*$1/*.log"
+      target_label = "__path__"
+    }
+
+    // If kubernetes.io/config.mirror is set, this is a static pod, created by the kubelet.
+    // It's logs live on a different path.
+    rule {
+      source_labels = ["__meta_kubernetes_pod_annotation_kubernetes_io_config_mirror", "__meta_kubernetes_pod_container_name"]
+      separator = "/"
+      regex = "(.+/.+)"
+      replacement = "/var/log/pods/*$1/*.log"
+      target_label = "__path__"
+    }
+  } // discovery.relabel "filtered_pods"
+
+  local.file_match "pod_logs" {
+    path_targets = discovery.relabel.filtered_pods.output
+  } // local.file_match "pod_logs"
+
+  loki.source.file "pod_logs" {
+    targets    = local.file_match.pod_logs.targets
+    tail_from_end = true
+    forward_to = [loki.process.pod_logs.receiver]
+  } // loki.source.file "pod_logs"
+
+  loki.process "pod_logs" {
+    stage.match {
+      selector = "{tmp_container_runtime=~\"containerd|cri-o|\"}"
+      // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
+      stage.cri {
+        max_partial_lines = 100
+      }
+
+      // Set the extract flags and stream values as labels
+      stage.labels {
+        values = {
+          flags  = "",
+          stream  = "",
+        }
+      }
+    }
+
+    stage.match {
+      selector = "{tmp_container_runtime=\"docker\"}"
+      // the docker processing stage extracts the following k/v pairs: log, stream, time
+      stage.docker {}
+
+      // Set the extract stream value as a label
+      stage.labels {
+        values = {
+          stream  = "",
+        }
+      }
+    }
+
+    // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
+    // namespace, pod, and container labels. Drop any structured metadata. Also drop the temporary
+    // container runtime label as it is no longer needed.
+    stage.label_drop {
+      values = [
+        "filename",
+        "tmp_container_runtime",
+      ]
+    }
+    stage.structured_metadata {
+      values = {
+        "k8s_pod_name" = "k8s_pod_name",
+        "pod" = "pod",
+        "service_instance_id" = "service_instance_id",
+      }
+    }
+
+    forward_to = argument.logs_destinations.value
+  } // loki.secretfilter "pod_logs"
+} // declare "pod_logs_via_loki"
+pod_logs_via_loki "feature" {
+  logs_destinations = [
+    loki.write.grafana_cloud_logs.receiver,
+  ]
+}
+// Feature: Pod Logs via Kubernetes API
+declare "pod_logs_via_kubernetes_api" {
+  argument "logs_destinations" {
+    comment = "Must be a list of log destinations where collected logs should be forwarded to"
+  }
+
+  discovery.kubernetes "pods" {
+    role = "pod"
+    selectors {
+      role = "node"
+      label = "eks.amazonaws.com/compute-type=fargate"
+    }
+    attach_metadata {
+      node = true
+    }
+  } // discovery.kubernetes "pods"
+
+  discovery.relabel "filtered_pods" {
+    targets = discovery.kubernetes.pods.targets
+    rule {
+      source_labels = ["__meta_kubernetes_namespace"]
+      action = "replace"
+      target_label = "namespace"
+    }
+    rule {  // Drop anything with a "falsy" annotation value
+      source_labels = ["__meta_kubernetes_pod_annotation_logs_grafana_com_pods_enabled"]
+      regex = "(false|no|skip)"
+      action = "drop"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_pod_name"]
+      target_label = "pod"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_pod_container_name"]
+      target_label = "container"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_namespace", "__meta_kubernetes_pod_container_name"]
+      separator = "/"
+      target_label = "job"
+    }
+
+    // set the container runtime as a label
+    rule {
+      source_labels = ["__meta_kubernetes_pod_container_id"]
+      regex = "^(\\S+):\\/\\/.+$"
+      target_label = "tmp_container_runtime"
+    }
+
+    // explicitly set service_name. if not set, loki will automatically try to populate a default.
+    // see https://grafana.com/docs/loki/latest/get-started/labels/#default-labels-for-all-users
+    //
+    // choose the first value found from the following ordered list:
+    // - pod.annotation[resource.opentelemetry.io/service.name]
+    // - pod.label[app.kubernetes.io/name]
+    // - k8s.pod.name
+    // - k8s.container.name
+    rule {
+      action = "replace"
+      source_labels = [
+        "__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_name",
+        "__meta_kubernetes_pod_label_app_kubernetes_io_name",
+        "container",
+      ]
+      separator = ";"
+      regex = "^(?:;*)?([^;]+).*$"
+      replacement = "$1"
+      target_label = "service_name"
+    }
+
+    // explicitly set service_namespace.
+    //
+    // choose the first value found from the following ordered list:
+    // - pod.annotation[resource.opentelemetry.io/service.namespace]
+    // - pod.namespace
+    rule {
+      action = "replace"
+      source_labels = [
+        "__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_namespace",
+        "namespace",
+      ]
+      separator = ";"
+      regex = "^(?:;*)?([^;]+).*$"
+      replacement = "$1"
+      target_label = "service_namespace"
+    }
+
+    // explicitly set service_instance_id.
+    //
+    // choose the first value found from the following ordered list:
+    // - pod.annotation[resource.opentelemetry.io/service.instance.id]
+    // - concat([k8s.namespace.name, k8s.pod.name, k8s.container.name], '.')
+    rule {
+      source_labels = ["__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_instance_id"]
+      target_label = "service_instance_id"
+    }
+    rule {
+      source_labels = ["service_instance_id", "namespace", "pod", "container"]
+      separator = "."
+      regex = "^\\.([^.]+\\.[^.]+\\.[^.]+)$"
+      target_label = "service_instance_id"
+    }
+
+    // set resource attributes
+    rule {
+      action = "labelmap"
+      regex = "__meta_kubernetes_pod_annotation_resource_opentelemetry_io_(.+)"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_job"]
+      regex = "(.+)"
+      target_label = "job"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+      regex = "(.+)"
+      target_label = "app_kubernetes_io_name"
+    }
+  } // discovery.relabel "filtered_pods"
+
+  loki.source.kubernetes "pod_logs" {
+    targets = discovery.relabel.filtered_pods.output
+    clustering {
+      enabled = true
+    }
+    forward_to = [loki.process.pod_logs.receiver]
+  } // loki.source.kubernetes "pod_logs"
+
+  loki.process "pod_logs" {
+    stage.match {
+      selector = "{tmp_container_runtime=~\"containerd|cri-o|\"}"
+      // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
+      stage.cri {
+        max_partial_lines = 100
+      }
+
+      // Set the extract flags and stream values as labels
+      stage.labels {
+        values = {
+          flags  = "",
+          stream  = "",
+        }
+      }
+    }
+
+    stage.match {
+      selector = "{tmp_container_runtime=\"docker\"}"
+      // the docker processing stage extracts the following k/v pairs: log, stream, time
+      stage.docker {}
+
+      // Set the extract stream value as a label
+      stage.labels {
+        values = {
+          stream  = "",
+        }
+      }
+    }
+
+    // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
+    // namespace, pod, and container labels. Drop any structured metadata. Also drop the temporary
+    // container runtime label as it is no longer needed.
+    stage.label_drop {
+      values = [
+        "filename",
+        "tmp_container_runtime",
+      ]
+    }
+    stage.structured_metadata {
+      values = {
+        "k8s_pod_name" = "k8s_pod_name",
+        "pod" = "pod",
+        "service_instance_id" = "service_instance_id",
+      }
+    }
+
+    forward_to = argument.logs_destinations.value
+  } // loki.secretfilter "pod_logs"
+} // declare "pod_logs_via_kubernetes_api"
+pod_logs_via_kubernetes_api "feature" {
+  logs_destinations = [
+    loki.write.grafana_cloud_logs.receiver,
+  ]
+}
+
+
+
+
+
+// Destination: grafana-cloud-logs (loki)
+otelcol.exporter.loki "grafana_cloud_logs" {
+  forward_to = [loki.write.grafana_cloud_logs.receiver]
+} // otelcol.exporter.loki "grafana_cloud_logs"
+
+loki.write "grafana_cloud_logs" {
+  endpoint {
+    url = "https://logs-prod-006.grafana.net/loki/api/v1/push"
+    retry_on_http_429 = true
+    tenant_id = convert.nonsensitive(remote.kubernetes.secret.grafana_cloud_logs.data["tenantId"])
+    basic_auth {
+      username = convert.nonsensitive(remote.kubernetes.secret.grafana_cloud_logs.data["LOKI_USER"])
+      password = remote.kubernetes.secret.grafana_cloud_logs.data["LOKI_PASS"]
+    }
+    tls_config {
+      insecure_skip_verify = false
+      ca_pem = convert.nonsensitive(remote.kubernetes.secret.grafana_cloud_logs.data["ca"])
+      cert_pem = convert.nonsensitive(remote.kubernetes.secret.grafana_cloud_logs.data["cert"])
+      key_pem = remote.kubernetes.secret.grafana_cloud_logs.data["key"]
+    }
+    min_backoff_period = "500ms"
+    max_backoff_period = "5m"
+    max_backoff_retries = "10"
+  }
+  external_labels = {
+    "cluster" = "eks-fargate-test",
+    "k8s_cluster_name" = "eks-fargate-test",
+  }
+} // loki.write "grafana_cloud_logs"
+
+remote.kubernetes.secret "grafana_cloud_logs" {
+  name      = "grafana-cloud-credentials"
+  namespace = "monitoring"
+} // remote.kubernetes.secret "grafana_cloud_logs"
+

--- a/charts/k8s-monitoring/tests/platform/eks-fargate/.rendered/alloy-metrics.alloy
+++ b/charts/k8s-monitoring/tests/platform/eks-fargate/.rendered/alloy-metrics.alloy
@@ -1,0 +1,815 @@
+// Feature: Cluster Metrics
+declare "cluster_metrics" {
+  argument "metrics_destinations" {
+    comment = "Must be a list of metric destinations where collected metrics should be forwarded to"
+  }
+  discovery.kubernetes "nodes" {
+    role = "node"
+  } // discovery.kubernetes "nodes"
+
+  discovery.relabel "nodes" {
+    targets = discovery.kubernetes.nodes.targets
+    rule {
+      source_labels = ["__meta_kubernetes_node_name"]
+      target_label  = "node"
+    }
+
+    rule {
+      replacement = "kubernetes"
+      target_label = "source"
+    }
+  } // discovery.relabel "nodes"
+
+  // Kubelet
+  discovery.relabel "kubelet" {
+    targets = discovery.relabel.nodes.output
+  } // discovery.relabel "kubelet"
+
+  prometheus.scrape "kubelet" {
+    targets  = discovery.relabel.kubelet.output
+    job_name = "integrations/kubernetes/kubelet"
+    scheme   = "https"
+    scrape_interval = "60s"
+    scrape_timeout = "10s"
+    scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
+    scrape_classic_histograms = false
+    scrape_native_histograms = false
+    convert_classic_histograms_to_nhcb = false
+    bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+
+    tls_config {
+      ca_file = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+      insecure_skip_verify = true
+      server_name = "kubernetes"
+    }
+
+    clustering {
+      enabled = true
+    }
+
+    forward_to = [prometheus.relabel.kubelet.receiver]
+  } // prometheus.scrape "kubelet"
+
+  prometheus.relabel "kubelet" {
+    max_cache_size = 100000
+    rule {
+      source_labels = ["__name__"]
+      regex = "up|scrape_samples_scraped|go_goroutines|kubelet_certificate_manager_client_expiration_renew_errors|kubelet_certificate_manager_client_ttl_seconds|kubelet_certificate_manager_server_ttl_seconds|kubelet_cgroup_manager_duration_seconds_bucket|kubelet_cgroup_manager_duration_seconds_count|kubelet_node_config_error|kubelet_node_name|kubelet_pleg_relist_duration_seconds_bucket|kubelet_pleg_relist_duration_seconds_count|kubelet_pleg_relist_interval_seconds_bucket|kubelet_pod_start_duration_seconds_bucket|kubelet_pod_start_duration_seconds_count|kubelet_pod_worker_duration_seconds_bucket|kubelet_pod_worker_duration_seconds_count|kubelet_running_container_count|kubelet_running_containers|kubelet_running_pod_count|kubelet_running_pods|kubelet_runtime_operations_errors_total|kubelet_runtime_operations_total|kubelet_server_expiration_renew_errors|kubelet_volume_stats_available_bytes|kubelet_volume_stats_capacity_bytes|kubelet_volume_stats_inodes|kubelet_volume_stats_inodes_free|kubelet_volume_stats_inodes_used|kubelet_volume_stats_used_bytes|kubernetes_build_info|namespace_workload_pod|process_cpu_seconds_total|process_resident_memory_bytes|rest_client_requests_total|storage_operation_duration_seconds_count|storage_operation_errors_total|volume_manager_total_volumes"
+      action = "keep"
+    }
+
+    forward_to = argument.metrics_destinations.value
+  } // prometheus.relabel "kubelet"
+
+  // Kubelet Resources
+  discovery.relabel "kubelet_resources" {
+    targets = discovery.relabel.nodes.output
+    rule {
+      replacement   = "/metrics/resource"
+      target_label  = "__metrics_path__"
+    }
+  } // discovery.relabel "kubelet_resources"
+
+  prometheus.scrape "kubelet_resources" {
+    targets = discovery.relabel.kubelet_resources.output
+    job_name = "integrations/kubernetes/resources"
+    scheme   = "https"
+    scrape_interval = "60s"
+    scrape_timeout = "10s"
+    scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
+    scrape_classic_histograms = false
+    scrape_native_histograms = false
+    convert_classic_histograms_to_nhcb = false
+    bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+
+    tls_config {
+      ca_file = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+      insecure_skip_verify = true
+      server_name = "kubernetes"
+    }
+
+    clustering {
+      enabled = true
+    }
+
+    forward_to = [prometheus.relabel.kubelet_resources.receiver]
+  } // prometheus.scrape "kubelet_resources"
+
+  prometheus.relabel "kubelet_resources" {
+    max_cache_size = 100000
+    rule {
+      source_labels = ["__name__"]
+      regex = "up|scrape_samples_scraped|node_cpu_usage_seconds_total|node_memory_working_set_bytes"
+      action = "keep"
+    }
+
+    forward_to = argument.metrics_destinations.value
+  } // prometheus.relabel "kubelet_resources"
+
+  // cAdvisor
+  discovery.relabel "cadvisor" {
+    targets = discovery.relabel.nodes.output
+    rule {
+      replacement   = "/metrics/cadvisor"
+      target_label  = "__metrics_path__"
+    }
+  } // discovery.relabel "cadvisor"
+
+  prometheus.scrape "cadvisor" {
+    targets = discovery.relabel.cadvisor.output
+    job_name = "integrations/kubernetes/cadvisor"
+    scheme = "https"
+    scrape_interval = "60s"
+    scrape_timeout = "10s"
+    scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
+    scrape_classic_histograms = false
+    scrape_native_histograms = false
+    convert_classic_histograms_to_nhcb = false
+    bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+
+    tls_config {
+      ca_file = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+      insecure_skip_verify = true
+      server_name = "kubernetes"
+    }
+
+    clustering {
+      enabled = true
+    }
+
+    forward_to = [prometheus.relabel.cadvisor.receiver]
+  } // prometheus.scrape "cadvisor"
+
+  prometheus.relabel "cadvisor" {
+    max_cache_size = 100000
+    rule {
+      source_labels = ["__name__"]
+      regex = "up|scrape_samples_scraped|container_cpu_cfs_periods_total|container_cpu_cfs_throttled_periods_total|container_cpu_usage_seconds_total|container_fs_reads_bytes_total|container_fs_reads_total|container_fs_writes_bytes_total|container_fs_writes_total|container_memory_cache|container_memory_rss|container_memory_swap|container_memory_usage_bytes|container_memory_working_set_bytes|container_network_receive_bytes_total|container_network_receive_packets_dropped_total|container_network_receive_packets_total|container_network_transmit_bytes_total|container_network_transmit_packets_dropped_total|container_network_transmit_packets_total|machine_memory_bytes"
+      action = "keep"
+    }
+    // Drop empty container labels, addressing https://github.com/google/cadvisor/issues/2688
+    rule {
+      source_labels = ["__name__","container"]
+      separator = "@"
+      regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_pressure_.*)@"
+      action = "drop"
+    }
+    // Drop empty image labels, addressing https://github.com/google/cadvisor/issues/2688
+    rule {
+      source_labels = ["__name__","image"]
+      separator = "@"
+      regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_network_.*|container_pressure_.*)@"
+      action = "drop"
+    }
+    // Normalizing unimportant labels (not deleting to continue satisfying <label>!="" checks)
+    rule {
+      source_labels = ["__name__", "boot_id"]
+      separator = "@"
+      regex = "machine_memory_bytes@.*"
+      target_label = "boot_id"
+      replacement = "NA"
+    }
+    rule {
+      source_labels = ["__name__", "system_uuid"]
+      separator = "@"
+      regex = "machine_memory_bytes@.*"
+      target_label = "system_uuid"
+      replacement = "NA"
+    }
+    // Filter out non-physical devices/interfaces
+    rule {
+      source_labels = ["__name__", "device"]
+      separator = "@"
+      regex = "container_fs_.*@(/dev/)?(mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dasd.+)"
+      target_label = "__keepme"
+      replacement = "1"
+    }
+    rule {
+      source_labels = ["__name__", "__keepme"]
+      separator = "@"
+      regex = "container_fs_.*@"
+      action = "drop"
+    }
+    rule {
+      source_labels = ["__name__"]
+      regex = "container_fs_.*"
+      target_label = "__keepme"
+      replacement = ""
+    }
+    rule {
+      source_labels = ["__name__", "interface"]
+      separator = "@"
+      regex = "container_network_.*@(en[ospx][0-9].*|wlan[0-9].*|eth[0-9].*)"
+      target_label = "__keepme"
+      replacement = "1"
+    }
+    rule {
+      source_labels = ["__name__", "__keepme"]
+      separator = "@"
+      regex = "container_network_.*@"
+      action = "drop"
+    }
+    rule {
+      source_labels = ["__name__"]
+      regex = "container_network_.*"
+      target_label = "__keepme"
+      replacement = ""
+    }
+    forward_to = argument.metrics_destinations.value
+  } // prometheus.relabel "cadvisor"
+  discovery.kubernetes "kube_state_metrics" {
+    role = "endpoints"
+
+    selectors {
+      role = "endpoints"
+      label = "release=k8smon,app.kubernetes.io/name=kube-state-metrics"
+    }
+    namespaces {
+      names = ["default"]
+    }
+  } // discovery.kubernetes "kube_state_metrics"
+
+  discovery.relabel "kube_state_metrics" {
+    targets = discovery.kubernetes.kube_state_metrics.targets
+
+    rule {
+      action = "replace"
+      replacement = "kubernetes"
+      target_label = "source"
+    }
+
+  } // discovery.relabel "kube_state_metrics"
+
+  prometheus.scrape "kube_state_metrics" {
+    targets = discovery.relabel.kube_state_metrics.output
+    job_name = "integrations/kubernetes/kube-state-metrics"
+    scrape_interval = "60s"
+    scrape_timeout = "10s"
+    scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
+    scrape_classic_histograms = false
+    scrape_native_histograms = false
+    convert_classic_histograms_to_nhcb = false
+    scheme = "http"
+    bearer_token_file = ""
+    tls_config {
+      insecure_skip_verify = true
+    }
+
+    clustering {
+      enabled = true
+    }
+    forward_to = [prometheus.relabel.kube_state_metrics.receiver]
+  } // prometheus.scrape "kube_state_metrics"
+
+  prometheus.relabel "kube_state_metrics" {
+    max_cache_size = 100000
+    rule {
+      source_labels = ["__name__"]
+      regex = "up|scrape_samples_scraped|kube_configmap_info|kube_configmap_metadata_resource_version|kube_cronjob.*|kube_daemonset.*|kube_deployment_metadata_generation|kube_deployment_spec_replicas|kube_deployment_status_condition|kube_deployment_status_observed_generation|kube_deployment_status_replicas_available|kube_deployment_status_replicas_updated|kube_horizontalpodautoscaler_spec_max_replicas|kube_horizontalpodautoscaler_spec_min_replicas|kube_horizontalpodautoscaler_status_current_replicas|kube_horizontalpodautoscaler_status_desired_replicas|kube_job.*|kube_namespace_status_phase|kube_node.*|kube_persistentvolume_status_phase|kube_persistentvolumeclaim_access_mode|kube_persistentvolumeclaim_info|kube_persistentvolumeclaim_labels|kube_persistentvolumeclaim_resource_requests_storage_bytes|kube_persistentvolumeclaim_status_phase|kube_pod_completion_time|kube_pod_container_info|kube_pod_container_resource_limits|kube_pod_container_resource_requests|kube_pod_container_status_last_terminated_reason|kube_pod_container_status_last_terminated_timestamp|kube_pod_container_status_restarts_total|kube_pod_container_status_waiting_reason|kube_pod_info|kube_pod_owner|kube_pod_restart_policy|kube_pod_spec_volumes_persistentvolumeclaims_info|kube_pod_start_time|kube_pod_status_phase|kube_pod_status_reason|kube_pod_init_.*|kube_replicaset.*|kube_resourcequota|kube_secret_metadata_resource_version|kube_statefulset.*"
+      action = "keep"
+    }
+    forward_to = argument.metrics_destinations.value
+  } // prometheus.relabel "kube_state_metrics"
+} // declare "cluster_metrics"
+cluster_metrics "feature" {
+  metrics_destinations = [
+    prometheus.remote_write.grafana_cloud_metrics.receiver,
+  ]
+}
+// Feature: Host Metrics
+declare "host_metrics" {
+  argument "metrics_destinations" {
+    comment = "Must be a list of metric destinations where collected metrics should be forwarded to"
+  }
+
+  // Linux hosts via Node Exporter
+  discovery.kubernetes "node_exporter" {
+    role = "pod"
+    selectors {
+      role = "pod"
+      label = "release=k8smon,app.kubernetes.io/name=node-exporter"
+    }
+    namespaces {
+      names = ["default"]
+    }
+
+  } // discovery.kubernetes "node_exporter"
+
+  discovery.relabel "node_exporter" {
+    targets = discovery.kubernetes.node_exporter.targets
+
+    // keep only the specified metrics port name, and pods that are Running and ready
+    rule {
+      source_labels = [
+        "__meta_kubernetes_pod_container_init",
+        "__meta_kubernetes_pod_phase",
+        "__meta_kubernetes_pod_ready",
+      ]
+      separator = "@"
+      regex = "false@Running@true"
+      action = "keep"
+    }
+
+    // Set the instance label to the node name
+    rule {
+      source_labels = ["__meta_kubernetes_pod_node_name"]
+      target_label = "instance"
+    }
+
+    rule {
+      source_labels = ["__meta_kubernetes_namespace"]
+      target_label  = "namespace"
+    }
+
+    rule {
+      source_labels = ["__meta_kubernetes_pod_name"]
+      target_label  = "pod"
+    }
+
+    rule {
+      source_labels = ["__meta_kubernetes_pod_container_name"]
+      target_label  = "container"
+    }
+
+    // set a workload label
+    rule {
+      source_labels = [
+        "__meta_kubernetes_pod_controller_kind",
+        "__meta_kubernetes_pod_controller_name",
+      ]
+      separator = "/"
+      target_label  = "workload"
+    }
+    // remove the hash from the ReplicaSet
+    rule {
+      source_labels = ["workload"]
+      regex = "(ReplicaSet/.+)-.+"
+      target_label  = "workload"
+    }
+
+    // Set the app label.
+    //
+    // Choose the first value found from the following ordered list:
+    // - pod.label[app.kubernetes.io/name]
+    // - pod.label[k8s-app]
+    // - pod.label[app]
+    rule {
+      source_labels = [
+        "__meta_kubernetes_pod_label_app_kubernetes_io_name",
+        "__meta_kubernetes_pod_label_k8s_app",
+        "__meta_kubernetes_pod_label_app",
+      ]
+      separator = ";"
+      regex = "^(?:;*)?([^;]+).*$"
+      replacement = "$1"
+      target_label = "app"
+    }
+
+    // Set the component label.
+    //
+    // Choose the first value found from the following ordered list:
+    // - pod.label[app.kubernetes.io/component]
+    // - pod.label[k8s-component]
+    // - pod.label[component]
+    rule {
+      source_labels = [
+        "__meta_kubernetes_pod_label_app_kubernetes_io_component",
+        "__meta_kubernetes_pod_label_k8s_component",
+        "__meta_kubernetes_pod_label_component",
+      ]
+      regex = "^(?:;*)?([^;]+).*$"
+      replacement = "$1"
+      target_label = "component"
+    }
+
+    rule {
+      target_label = "source"
+      replacement = "kubernetes"
+    }
+
+  } // discovery.relabel "node_exporter"
+
+  prometheus.scrape "node_exporter" {
+    targets = discovery.relabel.node_exporter.output
+    job_name = "integrations/node_exporter"
+    scrape_interval = "60s"
+    scrape_timeout = "10s"
+    scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
+    scrape_classic_histograms = false
+    scrape_native_histograms = false
+    convert_classic_histograms_to_nhcb = false
+    scheme = "http"
+    tls_config {
+      insecure_skip_verify = true
+    }
+
+    clustering {
+      enabled = true
+    }
+    forward_to = [prometheus.relabel.node_exporter.receiver]
+  } // prometheus.scrape "node_exporter"
+
+  prometheus.relabel "node_exporter" {
+    max_cache_size = 100000
+    rule {
+      source_labels = ["__name__"]
+      regex = "up|scrape_samples_scraped|node_cpu.*|node_exporter_build_info|node_filesystem.*|node_memory.*|node_network_receive_bytes_total|node_network_receive_drop_total|node_network_transmit_bytes_total|node_network_transmit_drop_total|process_cpu_seconds_total|process_resident_memory_bytes"
+      action = "keep"
+    }
+    // Drop metrics for certain file systems
+    rule {
+      source_labels = ["__name__", "fstype"]
+      separator = "@"
+      regex = "node_filesystem.*@(ramfs|tmpfs)"
+      action = "drop"
+    }
+    forward_to = argument.metrics_destinations.value
+  } // prometheus.relabel "node_exporter"
+} // declare "host_metrics"
+host_metrics "feature" {
+  metrics_destinations = [
+    prometheus.remote_write.grafana_cloud_metrics.receiver,
+  ]
+}
+declare "alloy_integration" {
+  argument "metrics_destinations" {
+    comment = "Must be a list of metric destinations where collected metrics should be forwarded to"
+  }
+
+  declare "alloy_integration_discovery" {
+    argument "namespaces" {
+      comment = "The namespaces to look for targets in (default: [] is all namespaces)"
+      optional = true
+    }
+
+    argument "field_selectors" {
+      comment = "The field selectors to use to find matching targets (default: [])"
+      optional = true
+    }
+
+    argument "label_selectors" {
+      comment = "The label selectors to use to find matching targets (default: [\"app.kubernetes.io/name=alloy\"])"
+      optional = true
+    }
+
+    argument "port_name" {
+      comment = "The of the port to scrape metrics from (default: http-metrics)"
+      optional = true
+    }
+
+    // Alloy service discovery for all of the pods
+    discovery.kubernetes "alloy_pods" {
+      role = "pod"
+
+      selectors {
+        role = "pod"
+        field = string.join(coalesce(argument.field_selectors.value, []), ",")
+        label = string.join(coalesce(argument.label_selectors.value, ["app.kubernetes.io/name=alloy"]), ",")
+      }
+
+      namespaces {
+        names = coalesce(argument.namespaces.value, [])
+      }
+
+    } // discovery.kubernetes "alloy_pods"
+
+    // alloy relabelings (pre-scrape)
+    discovery.relabel "alloy_pods" {
+      targets = discovery.kubernetes.alloy_pods.targets
+
+      // keep only the specified metrics port name, and pods that are Running and ready
+      rule {
+        source_labels = [
+          "__meta_kubernetes_pod_container_port_name",
+          "__meta_kubernetes_pod_phase",
+          "__meta_kubernetes_pod_ready",
+          "__meta_kubernetes_pod_container_init",
+        ]
+        separator = "@"
+        regex = coalesce(argument.port_name.value, "metrics") + "@Running@true@false"
+        action = "keep"
+      }
+
+      rule {
+        source_labels = ["__meta_kubernetes_namespace"]
+        target_label  = "namespace"
+      }
+
+      rule {
+        source_labels = ["__meta_kubernetes_pod_name"]
+        target_label  = "pod"
+      }
+
+      rule {
+        source_labels = ["__meta_kubernetes_pod_container_name"]
+        target_label  = "container"
+      }
+
+      // set the workload to the controller kind and name
+      rule {
+        action = "lowercase"
+        source_labels = ["__meta_kubernetes_pod_controller_kind"]
+        target_label  = "workload_type"
+      }
+
+      rule {
+        source_labels = ["__meta_kubernetes_pod_controller_name"]
+        target_label  = "workload"
+      }
+
+      // remove the hash from the ReplicaSet
+      rule {
+        source_labels = [
+          "workload_type",
+          "workload",
+        ]
+        separator = "/"
+        regex = "replicaset/(.+)-.+$"
+        target_label  = "workload"
+      }
+
+      // set the app name if specified as metadata labels "app:" or "app.kubernetes.io/name:" or "k8s-app:"
+      rule {
+        action = "replace"
+        source_labels = [
+          "__meta_kubernetes_pod_label_app_kubernetes_io_name",
+          "__meta_kubernetes_pod_label_k8s_app",
+          "__meta_kubernetes_pod_label_app",
+        ]
+        separator = ";"
+        regex = "^(?:;*)?([^;]+).*$"
+        replacement = "$1"
+        target_label = "app"
+      }
+
+      // set the component if specified as metadata labels "component:" or "app.kubernetes.io/component:" or "k8s-component:"
+      rule {
+        action = "replace"
+        source_labels = [
+          "__meta_kubernetes_pod_label_app_kubernetes_io_component",
+          "__meta_kubernetes_pod_label_k8s_component",
+          "__meta_kubernetes_pod_label_component",
+        ]
+        regex = "^(?:;*)?([^;]+).*$"
+        replacement = "$1"
+        target_label = "component"
+      }
+
+      // set a source label
+      rule {
+        action = "replace"
+        replacement = "kubernetes"
+        target_label = "source"
+      }
+
+    } // discovery.relabel "alloy_pods"
+
+    export "output" {
+      value = discovery.relabel.alloy_pods.output
+    }
+  }
+
+  declare "alloy_integration_scrape" {
+    argument "targets" {
+      comment = "Must be a list() of targets"
+    }
+
+    argument "forward_to" {
+      comment = "Must be a list(MetricsReceiver) where collected metrics should be forwarded to"
+    }
+
+    argument "job_label" {
+      comment = "The job label to add for all Alloy metrics (default: integrations/alloy)"
+      optional = true
+    }
+
+    argument "keep_metrics" {
+      comment = "A regular expression of metrics to keep (default: see below)"
+      optional = true
+    }
+
+    argument "drop_metrics" {
+      comment = "A regular expression of metrics to drop (default: see below)"
+      optional = true
+    }
+
+    argument "scrape_interval" {
+      comment = "How often to scrape metrics from the targets (default: 60s)"
+      optional = true
+    }
+
+    argument "scrape_timeout" {
+      comment = "The timeout for scraping metrics from the targets (default: 10s)"
+      optional = true
+    }
+
+    argument "scrape_protocols" {
+      comment = "The scrape protocols to use for scraping metrics"
+      optional = true
+    }
+
+    argument "scrape_classic_histograms" {
+      comment = "Whether to scrape classic histograms (default: false)."
+      optional = true
+    }
+
+    argument "scrape_native_histograms" {
+      comment = "Whether to scrape native histograms (default: false)."
+      optional = true
+    }
+
+    argument "max_cache_size" {
+      comment = "The maximum number of elements to hold in the relabeling cache (default: 100000).  This should be at least 2x-5x your largest scrape target or samples appended rate."
+      optional = true
+    }
+
+    argument "clustering" {
+      comment = "Whether or not clustering should be enabled (default: false)"
+      optional = true
+    }
+
+    prometheus.scrape "alloy" {
+      job_name = coalesce(argument.job_label.value, "integrations/alloy")
+      forward_to = [prometheus.relabel.alloy.receiver]
+      targets = argument.targets.value
+      scrape_interval = coalesce(argument.scrape_interval.value, "60s")
+      scrape_timeout = coalesce(argument.scrape_timeout.value, "10s")
+      scrape_protocols = argument.scrape_protocols.value
+      scrape_classic_histograms = argument.scrape_classic_histograms.value
+      scrape_native_histograms = argument.scrape_native_histograms.value
+
+      clustering {
+        enabled = coalesce(argument.clustering.value, false)
+      }
+    } // prometheus.scrape "alloy"
+
+    // alloy metric relabelings (post-scrape)
+    prometheus.relabel "alloy" {
+      forward_to = argument.forward_to.value
+      max_cache_size = coalesce(argument.max_cache_size.value, 100000)
+
+      // drop metrics that match the drop_metrics regex
+      rule {
+        source_labels = ["__name__"]
+        regex = coalesce(argument.drop_metrics.value, "")
+        action = "drop"
+      }
+
+      // keep only metrics that match the keep_metrics regex
+      rule {
+        source_labels = ["__name__"]
+        regex = coalesce(argument.keep_metrics.value, ".*")
+        action = "keep"
+      }
+
+      // remove the component_id label from any metric that starts with log_bytes or log_lines, these are custom metrics that are generated
+      // as part of the log annotation modules in this repo
+      rule {
+        action = "replace"
+        source_labels = ["__name__"]
+        regex = "^log_(bytes|lines).+"
+        replacement = ""
+        target_label = "component_id"
+      }
+
+      // set the namespace label to that of the exported_namespace
+      rule {
+        action = "replace"
+        source_labels = ["__name__", "exported_namespace"]
+        separator = "@"
+        regex = "^log_(bytes|lines).+@(.+)"
+        replacement = "$2"
+        target_label = "namespace"
+      }
+
+      // set the pod label to that of the exported_pod
+      rule {
+        action = "replace"
+        source_labels = ["__name__", "exported_pod"]
+        separator = "@"
+        regex = "^log_(bytes|lines).+@(.+)"
+        replacement = "$2"
+        target_label = "pod"
+      }
+
+      // set the container label to that of the exported_container
+      rule {
+        action = "replace"
+        source_labels = ["__name__", "exported_container"]
+        separator = "@"
+        regex = "^log_(bytes|lines).+@(.+)"
+        replacement = "$2"
+        target_label = "container"
+      }
+
+      // set the job label to that of the exported_job
+      rule {
+        action = "replace"
+        source_labels = ["__name__", "exported_job"]
+        separator = "@"
+        regex = "^log_(bytes|lines).+@(.+)"
+        replacement = "$2"
+        target_label = "job"
+      }
+
+      // set the instance label to that of the exported_instance
+      rule {
+        action = "replace"
+        source_labels = ["__name__", "exported_instance"]
+        separator = "@"
+        regex = "^log_(bytes|lines).+@(.+)"
+        replacement = "$2"
+        target_label = "instance"
+      }
+
+      rule {
+        action = "labeldrop"
+        regex = "exported_(namespace|pod|container|job|instance)"
+      }
+    } // prometheus.relabel "alloy"
+  }
+
+  alloy_integration_discovery "alloy" {
+    port_name = "http-metrics"
+    label_selectors = ["app.kubernetes.io/name in (alloy-metrics,alloy-singleton,alloy-logs)"]
+  }
+
+  alloy_integration_scrape "alloy" {
+    targets = alloy_integration_discovery.alloy.output
+    job_label = "integrations/alloy"
+    clustering = true
+    keep_metrics = "up|scrape_samples_scraped|alloy_build_info|alloy_component_controller_running_components|alloy_component_dependencies_wait_seconds|alloy_component_dependencies_wait_seconds_bucket|alloy_component_evaluation_seconds|alloy_component_evaluation_seconds_bucket|alloy_component_evaluation_seconds_count|alloy_component_evaluation_seconds_sum|alloy_component_evaluation_slow_seconds|alloy_config_hash|alloy_resources_machine_rx_bytes_total|alloy_resources_machine_tx_bytes_total|alloy_resources_process_cpu_seconds_total|alloy_resources_process_resident_memory_bytes|alloy_tcp_connections|alloy_wal_samples_appended_total|alloy_wal_storage_active_series|cluster_node_gossip_health_score|cluster_node_gossip_proto_version|cluster_node_gossip_received_events_total|cluster_node_info|cluster_node_lamport_time|cluster_node_peers|cluster_node_update_observers|cluster_transport_rx_bytes_total|cluster_transport_rx_packet_queue_length|cluster_transport_rx_packets_failed_total|cluster_transport_rx_packets_total|cluster_transport_stream_rx_bytes_total|cluster_transport_stream_rx_packets_failed_total|cluster_transport_stream_rx_packets_total|cluster_transport_stream_tx_bytes_total|cluster_transport_stream_tx_packets_failed_total|cluster_transport_stream_tx_packets_total|cluster_transport_streams|cluster_transport_tx_bytes_total|cluster_transport_tx_packet_queue_length|cluster_transport_tx_packets_failed_total|cluster_transport_tx_packets_total|otelcol_exporter_send_failed_spans_total|otelcol_exporter_sent_spans_total|go_gc_duration_seconds_count|go_goroutines|go_memstats_heap_inuse_bytes|loki_process_dropped_lines_total|loki_write_batch_retries_total|loki_write_dropped_bytes_total|loki_write_dropped_entries_total|loki_write_encoded_bytes_total|loki_write_mutated_bytes_total|loki_write_mutated_entries_total|loki_write_request_duration_seconds_bucket|loki_write_sent_bytes_total|loki_write_sent_entries_total|process_cpu_seconds_total|process_start_time_seconds|otelcol_processor_batch_batch_send_size_bucket|otelcol_processor_batch_metadata_cardinality|otelcol_processor_batch_timeout_trigger_send_total|prometheus_remote_storage_bytes_total|prometheus_remote_storage_enqueue_retries_total|prometheus_remote_storage_highest_timestamp_in_seconds|prometheus_remote_storage_metadata_bytes_total|prometheus_remote_storage_queue_highest_sent_timestamp_seconds|prometheus_remote_storage_samples_dropped_total|prometheus_remote_storage_samples_failed_total|prometheus_remote_storage_samples_pending|prometheus_remote_storage_samples_retried_total|prometheus_remote_storage_samples_total|prometheus_remote_storage_sent_batch_duration_seconds_bucket|prometheus_remote_storage_sent_batch_duration_seconds_count|prometheus_remote_storage_sent_batch_duration_seconds_sum|prometheus_remote_storage_shard_capacity|prometheus_remote_storage_shards|prometheus_remote_storage_shards_desired|prometheus_remote_storage_shards_max|prometheus_remote_storage_shards_min|prometheus_remote_storage_succeeded_samples_total|prometheus_remote_write_wal_samples_appended_total|prometheus_remote_write_wal_storage_active_series|prometheus_sd_discovered_targets|prometheus_target_interval_length_seconds_count|prometheus_target_interval_length_seconds_sum|prometheus_target_scrapes_exceeded_sample_limit_total|prometheus_target_scrapes_sample_duplicate_timestamp_total|prometheus_target_scrapes_sample_out_of_bounds_total|prometheus_target_scrapes_sample_out_of_order_total|prometheus_target_sync_length_seconds_sum|prometheus_wal_watcher_current_segment|otelcol_receiver_accepted_spans_total|otelcol_receiver_refused_spans_total|rpc_server_duration_milliseconds_bucket|scrape_duration_seconds|traces_exporter_send_failed_spans|traces_exporter_send_failed_spans_total|traces_exporter_sent_spans|traces_exporter_sent_spans_total|traces_loadbalancer_backend_outcome|traces_loadbalancer_num_backends|traces_receiver_accepted_spans|traces_receiver_accepted_spans_total|traces_receiver_refused_spans|traces_receiver_refused_spans_total"
+    scrape_interval = "60s"
+    scrape_timeout = "10s"
+    scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
+    scrape_classic_histograms = false
+    scrape_native_histograms = false
+    max_cache_size = 100000
+    forward_to = argument.metrics_destinations.value
+  }
+}
+alloy_integration "integration" {
+  metrics_destinations = [
+    prometheus.remote_write.grafana_cloud_metrics.receiver,
+  ]
+}
+
+
+
+
+
+// Destination: grafana-cloud-metrics (prometheus)
+otelcol.exporter.prometheus "grafana_cloud_metrics" {
+  add_metric_suffixes = true
+  resource_to_telemetry_conversion = false
+  keep_identifying_resource_attributes = true
+  forward_to = [prometheus.remote_write.grafana_cloud_metrics.receiver]
+} // otelcol.exporter.prometheus "grafana_cloud_metrics"
+
+prometheus.remote_write "grafana_cloud_metrics" {
+  endpoint {
+    url = "https://prometheus-prod-13-prod-us-east-0.grafana.net/api/prom/push"
+    headers = {
+      "X-Scope-OrgID" = convert.nonsensitive(remote.kubernetes.secret.grafana_cloud_metrics.data["tenantId"]),
+    }
+    basic_auth {
+      username = convert.nonsensitive(remote.kubernetes.secret.grafana_cloud_metrics.data["PROMETHEUS_USER"])
+      password = remote.kubernetes.secret.grafana_cloud_metrics.data["PROMETHEUS_PASS"]
+    }
+    tls_config {
+      insecure_skip_verify = false
+      ca_pem = convert.nonsensitive(remote.kubernetes.secret.grafana_cloud_metrics.data["ca"])
+      cert_pem = convert.nonsensitive(remote.kubernetes.secret.grafana_cloud_metrics.data["cert"])
+      key_pem = remote.kubernetes.secret.grafana_cloud_metrics.data["key"]
+    }
+    send_native_histograms = false
+
+    queue_config {
+      capacity = 10000
+      min_shards = 1
+      max_shards = 50
+      max_samples_per_send = 2000
+      batch_send_deadline = "5s"
+      min_backoff = "30ms"
+      max_backoff = "5s"
+      retry_on_http_429 = true
+      sample_age_limit = "0s"
+    }
+  }
+
+  wal {
+    truncate_frequency = "2h"
+    min_keepalive_time = "5m"
+    max_keepalive_time = "8h"
+  }
+  external_labels = {
+    "cluster" = "eks-fargate-test",
+    "k8s_cluster_name" = "eks-fargate-test",
+  }
+} // prometheus.remote_write "grafana_cloud_metrics"
+
+remote.kubernetes.secret "grafana_cloud_metrics" {
+  name      = "grafana-cloud-credentials"
+  namespace = "monitoring"
+} // remote.kubernetes.secret "grafana_cloud_metrics"
+

--- a/charts/k8s-monitoring/tests/platform/eks-fargate/.rendered/alloy-singleton.alloy
+++ b/charts/k8s-monitoring/tests/platform/eks-fargate/.rendered/alloy-singleton.alloy
@@ -1,0 +1,221 @@
+// Feature: Cluster Events
+declare "cluster_events" {
+  argument "logs_destinations" {
+    comment = "Must be a list of log destinations where collected logs should be forwarded to"
+  }
+
+  loki.source.kubernetes_events "cluster_events" {
+    job_name   = "integrations/kubernetes/eventhandler"
+    log_format = "logfmt"
+    forward_to = [loki.process.cluster_events.receiver]
+  } // loki.source.kubernetes_events "cluster_events"
+
+  loki.process "cluster_events" {
+
+    // add a static source label to the logs so they can be differentiated / restricted if necessary
+    stage.static_labels {
+      values = {
+        "source" = "kubernetes-events",
+      }
+    }
+
+    // extract some of the fields from the log line, these could be used as labels, structured metadata, etc.
+    stage.logfmt {
+      mapping = {
+        "component" = "sourcecomponent", // map the sourcecomponent field to component
+        "kind" = "",
+        "level" = "type", // most events don't have a level but they do have a "type" i.e. Normal, Warning, Error, etc.
+        "name" = "",
+        "node" = "sourcehost", // map the sourcehost field to node
+        "reason" = "",
+      }
+    }
+    // set the extracted values as labels
+    stage.labels {
+      values = {
+        "kind" = "",
+        "level" = "",
+        "service_name" = "job",
+        "reason" = "reason",
+      }
+    }
+
+    // if kind=Node, set the node label by copying the name field
+    stage.match {
+      selector = "{kind=\"Node\"}"
+
+      stage.labels {
+        values = {
+          "node" = "name",
+        }
+      }
+    }
+
+    // set the level extracted key value as a normalized log level
+    stage.match {
+      selector = "{level=\"Normal\"}"
+
+      stage.static_labels {
+        values = {
+          level = "Info",
+        }
+      }
+    }
+    stage.structured_metadata {
+      values = {
+        "name" = "name",
+        "node" = "node",
+      }
+    }
+
+    // Drop pipeline-only labels that are not needed in the final output.
+    stage.label_drop {
+      values = ["kind"]
+    }
+
+    forward_to = argument.logs_destinations.value
+  } // loki.process "cluster_events"
+} // declare "cluster_events"
+cluster_events "feature" {
+  logs_destinations = [
+    loki.write.grafana_cloud_logs.receiver,
+  ]
+}
+// Self Reporting
+prometheus.exporter.unix "kubernetes_monitoring_telemetry" {
+  set_collectors = ["textfile"]
+  textfile {
+    directory = "/etc/release-info"
+  }
+} // prometheus.exporter.unix "kubernetes_monitoring_telemetry"
+
+discovery.relabel "kubernetes_monitoring_telemetry" {
+  targets = prometheus.exporter.unix.kubernetes_monitoring_telemetry.targets
+  rule {
+    target_label = "instance"
+    action = "replace"
+    replacement = "k8smon"
+  }
+  rule {
+    target_label = "job"
+    action = "replace"
+    replacement = "integrations/kubernetes/kubernetes_monitoring_telemetry"
+  }
+} // discovery.relabel "kubernetes_monitoring_telemetry"
+
+prometheus.scrape "kubernetes_monitoring_telemetry" {
+  job_name   = "integrations/kubernetes/kubernetes_monitoring_telemetry"
+  targets    = discovery.relabel.kubernetes_monitoring_telemetry.output
+  scrape_interval = "60s"
+  clustering {
+    enabled = true
+  }
+  forward_to = [prometheus.relabel.kubernetes_monitoring_telemetry.receiver]
+} // prometheus.scrape "kubernetes_monitoring_telemetry"
+
+prometheus.relabel "kubernetes_monitoring_telemetry" {
+  rule {
+    source_labels = ["__name__"]
+    regex = "grafana_kubernetes_monitoring_.*"
+    action = "keep"
+  }
+  forward_to = [
+    prometheus.remote_write.grafana_cloud_metrics.receiver,
+  ]
+} // prometheus.relabel "kubernetes_monitoring_telemetry"
+
+
+
+
+
+// Destination: grafana-cloud-logs (loki)
+otelcol.exporter.loki "grafana_cloud_logs" {
+  forward_to = [loki.write.grafana_cloud_logs.receiver]
+} // otelcol.exporter.loki "grafana_cloud_logs"
+
+loki.write "grafana_cloud_logs" {
+  endpoint {
+    url = "https://logs-prod-006.grafana.net/loki/api/v1/push"
+    retry_on_http_429 = true
+    tenant_id = convert.nonsensitive(remote.kubernetes.secret.grafana_cloud_logs.data["tenantId"])
+    basic_auth {
+      username = convert.nonsensitive(remote.kubernetes.secret.grafana_cloud_logs.data["LOKI_USER"])
+      password = remote.kubernetes.secret.grafana_cloud_logs.data["LOKI_PASS"]
+    }
+    tls_config {
+      insecure_skip_verify = false
+      ca_pem = convert.nonsensitive(remote.kubernetes.secret.grafana_cloud_logs.data["ca"])
+      cert_pem = convert.nonsensitive(remote.kubernetes.secret.grafana_cloud_logs.data["cert"])
+      key_pem = remote.kubernetes.secret.grafana_cloud_logs.data["key"]
+    }
+    min_backoff_period = "500ms"
+    max_backoff_period = "5m"
+    max_backoff_retries = "10"
+  }
+  external_labels = {
+    "cluster" = "eks-fargate-test",
+    "k8s_cluster_name" = "eks-fargate-test",
+  }
+} // loki.write "grafana_cloud_logs"
+
+remote.kubernetes.secret "grafana_cloud_logs" {
+  name      = "grafana-cloud-credentials"
+  namespace = "monitoring"
+} // remote.kubernetes.secret "grafana_cloud_logs"
+
+
+// Destination: grafana-cloud-metrics (prometheus)
+otelcol.exporter.prometheus "grafana_cloud_metrics" {
+  add_metric_suffixes = true
+  resource_to_telemetry_conversion = false
+  keep_identifying_resource_attributes = true
+  forward_to = [prometheus.remote_write.grafana_cloud_metrics.receiver]
+} // otelcol.exporter.prometheus "grafana_cloud_metrics"
+
+prometheus.remote_write "grafana_cloud_metrics" {
+  endpoint {
+    url = "https://prometheus-prod-13-prod-us-east-0.grafana.net/api/prom/push"
+    headers = {
+      "X-Scope-OrgID" = convert.nonsensitive(remote.kubernetes.secret.grafana_cloud_metrics.data["tenantId"]),
+    }
+    basic_auth {
+      username = convert.nonsensitive(remote.kubernetes.secret.grafana_cloud_metrics.data["PROMETHEUS_USER"])
+      password = remote.kubernetes.secret.grafana_cloud_metrics.data["PROMETHEUS_PASS"]
+    }
+    tls_config {
+      insecure_skip_verify = false
+      ca_pem = convert.nonsensitive(remote.kubernetes.secret.grafana_cloud_metrics.data["ca"])
+      cert_pem = convert.nonsensitive(remote.kubernetes.secret.grafana_cloud_metrics.data["cert"])
+      key_pem = remote.kubernetes.secret.grafana_cloud_metrics.data["key"]
+    }
+    send_native_histograms = false
+
+    queue_config {
+      capacity = 10000
+      min_shards = 1
+      max_shards = 50
+      max_samples_per_send = 2000
+      batch_send_deadline = "5s"
+      min_backoff = "30ms"
+      max_backoff = "5s"
+      retry_on_http_429 = true
+      sample_age_limit = "0s"
+    }
+  }
+
+  wal {
+    truncate_frequency = "2h"
+    min_keepalive_time = "5m"
+    max_keepalive_time = "8h"
+  }
+  external_labels = {
+    "cluster" = "eks-fargate-test",
+    "k8s_cluster_name" = "eks-fargate-test",
+  }
+} // prometheus.remote_write "grafana_cloud_metrics"
+
+remote.kubernetes.secret "grafana_cloud_metrics" {
+  name      = "grafana-cloud-credentials"
+  namespace = "monitoring"
+} // remote.kubernetes.secret "grafana_cloud_metrics"
+

--- a/charts/k8s-monitoring/tests/platform/eks-with-windows/.rendered/alloy-logs.alloy
+++ b/charts/k8s-monitoring/tests/platform/eks-with-windows/.rendered/alloy-logs.alloy
@@ -1,0 +1,608 @@
+// Feature: Node Logs
+declare "node_logs" {
+  argument "logs_destinations" {
+    comment = "Must be a list of log destinations where collected logs should be forwarded to"
+  }
+
+  loki.relabel "journal" {
+
+    rule {
+      action = "replace"
+      source_labels = ["__journal__systemd_unit"]
+      replacement = "$1"
+      target_label = "unit"
+    }
+
+    rule {
+      action = "replace"
+      source_labels = ["__journal_priority_keyword"]
+      replacement = "$1"
+      target_label = "priority_keyword"
+    }
+
+    // the service_name label will be set automatically in loki if not set, and the unit label
+    // will not allow service_name to be set automatically.
+    rule {
+      action = "replace"
+      source_labels = ["__journal__systemd_unit"]
+      replacement = "$1"
+      target_label = "service_name"
+    }
+
+    forward_to = [] // No forward_to is used in this component, the defined rules are used in the loki.source.journal component
+  } // loki.relabel "journal"
+
+  loki.source.journal "worker" {
+    path = "/var/log/journal"
+    format_as_json = false
+    max_age = "8h"
+    relabel_rules = loki.relabel.journal.rules
+    labels = {
+      job = "integrations/kubernetes/journal",
+      instance = sys.env("HOSTNAME"),
+    }
+    forward_to = [loki.process.journal_logs.receiver]
+  } // loki.source.journal "worker"
+
+  loki.process "journal_logs" {
+    stage.static_labels {
+      values = {
+        // add a static source label to the logs so they can be differentiated / restricted if necessary
+        "source" = "journal",
+        // default level to unknown
+        level = "UNKNOWN",
+      }
+    }
+
+    // Attempt to determine the log level, most k8s workers are either in logfmt or klog formats
+    // check to see if the log line matches the klog format (https://github.com/kubernetes/klog)
+    stage.match {
+      // unescaped regex: ([IWED][0-9]{4}\s+[0-9]{2}:[0-9]{2}:[0-9]{2}\.[0-9]+)
+      selector = "{level=\"UNKNOWN\"} |~ \"([IWED][0-9]{4}\\\\s+[0-9]{2}:[0-9]{2}:[0-9]{2}\\\\.[0-9]+)\""
+
+      // extract log level, klog uses a single letter code for the level followed by the month and day i.e. I0119
+      stage.regex {
+        expression = "((?P<level>[A-Z])[0-9])"
+      }
+
+      // if the extracted level is I set INFO
+      stage.replace {
+        source = "level"
+        expression = "(I)"
+        replace = "INFO"
+      }
+
+      // if the extracted level is W set WARN
+      stage.replace {
+        source = "level"
+        expression = "(W)"
+        replace = "WARN"
+      }
+      // standardize on WARN
+      stage.replace {
+        source = "level"
+        expression = "(warning)"
+        replace = "WARN"
+      }
+
+      // if the extracted level is E set ERROR
+      stage.replace {
+        source = "level"
+        expression = "(E)"
+        replace = "ERROR"
+      }
+
+      // if the extracted level is I set INFO
+      stage.replace {
+        source = "level"
+        expression = "(D)"
+        replace = "DEBUG"
+      }
+
+      // set the extracted level to be a label
+      stage.labels {
+        values = {
+          level = "",
+        }
+      }
+    }
+
+    // if the level is still unknown, do one last attempt at detecting it based on common levels
+    stage.match {
+      selector = "{level=\"UNKNOWN\"}"
+
+      // unescaped regex: (?i)(?:"(?:level|loglevel|levelname|lvl|levelText|SeverityText)":\s*"|\s*(?:level|loglevel|levelText|lvl)="?|\s+\[?)(?P<level>(DEBUG?|DBG|INFO?(RMATION)?|WA?RN(ING)?|ERR(OR)?|CRI?T(ICAL)?|FATAL|FTL|NOTICE|TRACE|TRC|PANIC|PNC|ALERT|EMERGENCY))("|\s+|-|\s*\])
+      stage.regex {
+        expression = "(?i)(?:\"(?:level|loglevel|levelname|lvl|levelText|SeverityText)\":\\s*\"|\\s*(?:level|loglevel|levelText|lvl)=\"?|\\s+\\[?)(?P<level>(DEBUG?|DBG|INFO?(RMATION)?|WA?RN(ING)?|ERR(OR)?|CRI?T(ICAL)?|FATAL|FTL|NOTICE|TRACE|TRC|PANIC|PNC|ALERT|EMERGENCY))(\"|\\s+|-|\\s*\\])"
+      }
+
+      // set the extracted level to be a label
+      stage.labels {
+        values = {
+          level = "",
+        }
+      }
+    }
+
+    // Use journald priority metadata as the log level.
+    stage.match {
+      selector = "{level=\"UNKNOWN\", priority_keyword!=\"\"}"
+
+      stage.replace {
+        source = "priority_keyword"
+        expression = "(?i)^(debug)$"
+        replace = "DEBUG"
+      }
+
+      stage.replace {
+        source = "priority_keyword"
+        expression = "(?i)^(info|notice)$"
+        replace = "INFO"
+      }
+
+      stage.replace {
+        source = "priority_keyword"
+        expression = "(?i)^(warning|warn)$"
+        replace = "WARN"
+      }
+
+      stage.replace {
+        source = "priority_keyword"
+        expression = "(?i)^(error|err)$"
+        replace = "ERROR"
+      }
+
+      stage.replace {
+        source = "priority_keyword"
+        expression = "(?i)^(alert|critical|crit|emerg|emergency|fatal)$"
+        replace = "CRIT"
+      }
+
+      stage.labels {
+        values = {
+          level = "priority_keyword",
+        }
+      }
+    }
+
+    // Standardize on upper-case
+    stage.match {
+      selector = "{level!=\"UNKNOWN\"}"
+
+      stage.template {
+        source   = "level"
+        template = "{{ .Value | ToUpper }}"
+      }
+
+      // Set the level after 'ToUpper' as the label
+      stage.labels {
+        values = {
+          level = "",
+        }
+      }
+    }
+
+    forward_to = argument.logs_destinations.value
+  } // loki.process "journal_logs"
+} // declare "node_logs"
+node_logs "feature" {
+  logs_destinations = [
+    loki.write.grafana_cloud_logs.receiver,
+  ]
+}
+// Feature: Pod Logs (Loki)
+declare "pod_logs_via_loki" {
+  argument "logs_destinations" {
+    comment = "Must be a list of log destinations where collected logs should be forwarded to"
+  }
+
+  discovery.kubernetes "pods" {
+    role = "pod"
+    selectors {
+      role = "pod"
+      field = "spec.nodeName=" + sys.env("HOSTNAME")
+    }
+  } // discovery.kubernetes "pods"
+
+  discovery.relabel "filtered_pods" {
+    targets = discovery.kubernetes.pods.targets
+    rule {
+      source_labels = ["__meta_kubernetes_namespace"]
+      action = "replace"
+      target_label = "namespace"
+    }
+    rule {  // Drop anything with a "falsy" annotation value
+      source_labels = ["__meta_kubernetes_pod_annotation_logs_grafana_com_pods_enabled"]
+      regex = "(false|no|skip)"
+      action = "drop"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_pod_name"]
+      target_label = "pod"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_pod_container_name"]
+      target_label = "container"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_namespace", "__meta_kubernetes_pod_container_name"]
+      separator = "/"
+      replacement = "$1"
+      target_label = "job"
+    }
+
+    // set the container runtime as a label
+    rule {
+      source_labels = ["__meta_kubernetes_pod_container_id"]
+      regex = "^(\\S+):\\/\\/.+$"
+      replacement = "$1"
+      target_label = "tmp_container_runtime"
+    }
+    // explicitly set service_name. if not set, loki will automatically try to populate a default.
+    // see https://grafana.com/docs/loki/latest/get-started/labels/#default-labels-for-all-users
+    //
+    // choose the first value found from the following ordered list:
+    // - pod.annotation[resource.opentelemetry.io/service.name]
+    // - pod.label[app.kubernetes.io/name]
+    // - k8s.container.name
+    rule {
+      source_labels = [
+        "__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_name",
+        "__meta_kubernetes_pod_label_app_kubernetes_io_name",
+        "__meta_kubernetes_pod_container_name",
+      ]
+      separator = ";"
+      regex = "^(?:;*)?([^;]+).*$"
+      replacement = "$1"
+      target_label = "service_name"
+    }
+
+    // explicitly set service_namespace.
+    //
+    // choose the first value found from the following ordered list:
+    // - pod.annotation[resource.opentelemetry.io/service.namespace]
+    // - pod.namespace
+    rule {
+      source_labels = [
+        "__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_namespace",
+        "namespace",
+      ]
+      separator = ";"
+      regex = "^(?:;*)?([^;]+).*$"
+      replacement = "$1"
+      target_label = "service_namespace"
+    }
+
+    // explicitly set service_instance_id.
+    //
+    // choose the first value found from the following ordered list:
+    // - pod.annotation[resource.opentelemetry.io/service.instance.id]
+    // - concat([k8s.namespace.name, k8s.pod.name, k8s.container.name], '.')
+    rule {
+      source_labels = ["__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_instance_id"]
+      target_label = "service_instance_id"
+    }
+    rule {
+      source_labels = ["service_instance_id", "namespace", "pod", "container"]
+      separator = "."
+      regex = "^\\.([^.]+\\.[^.]+\\.[^.]+)$"
+      target_label = "service_instance_id"
+    }
+
+    // set resource attributes
+    rule {
+      action = "labelmap"
+      regex = "__meta_kubernetes_pod_annotation_resource_opentelemetry_io_(.+)"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_job"]
+      regex = "(.+)"
+      target_label = "job"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+      regex = "(.+)"
+      target_label = "app_kubernetes_io_name"
+    }
+
+    // Set the pod log path.
+    rule {
+      source_labels = ["__meta_kubernetes_pod_uid", "__meta_kubernetes_pod_container_name"]
+      separator = "/"
+      replacement = "/var/log/pods/*$1/*.log"
+      target_label = "__path__"
+    }
+
+    // If kubernetes.io/config.mirror is set, this is a static pod, created by the kubelet.
+    // It's logs live on a different path.
+    rule {
+      source_labels = ["__meta_kubernetes_pod_annotation_kubernetes_io_config_mirror", "__meta_kubernetes_pod_container_name"]
+      separator = "/"
+      regex = "(.+/.+)"
+      replacement = "/var/log/pods/*$1/*.log"
+      target_label = "__path__"
+    }
+  } // discovery.relabel "filtered_pods"
+
+  local.file_match "pod_logs" {
+    path_targets = discovery.relabel.filtered_pods.output
+  } // local.file_match "pod_logs"
+
+  loki.source.file "pod_logs" {
+    targets    = local.file_match.pod_logs.targets
+    tail_from_end = true
+    forward_to = [loki.process.pod_logs.receiver]
+  } // loki.source.file "pod_logs"
+
+  loki.process "pod_logs" {
+    stage.match {
+      selector = "{tmp_container_runtime=~\"containerd|cri-o|\"}"
+      // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
+      stage.cri {
+        max_partial_lines = 100
+      }
+
+      // Set the extract flags and stream values as labels
+      stage.labels {
+        values = {
+          flags  = "",
+          stream  = "",
+        }
+      }
+    }
+
+    stage.match {
+      selector = "{tmp_container_runtime=\"docker\"}"
+      // the docker processing stage extracts the following k/v pairs: log, stream, time
+      stage.docker {}
+
+      // Set the extract stream value as a label
+      stage.labels {
+        values = {
+          stream  = "",
+        }
+      }
+    }
+
+    // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
+    // namespace, pod, and container labels. Drop any structured metadata. Also drop the temporary
+    // container runtime label as it is no longer needed.
+    stage.label_drop {
+      values = [
+        "filename",
+        "tmp_container_runtime",
+      ]
+    }
+    stage.structured_metadata {
+      values = {
+        "k8s_pod_name" = "k8s_pod_name",
+        "pod" = "pod",
+        "service_instance_id" = "service_instance_id",
+      }
+    }
+
+    forward_to = argument.logs_destinations.value
+  } // loki.secretfilter "pod_logs"
+} // declare "pod_logs_via_loki"
+pod_logs_via_loki "feature" {
+  logs_destinations = [
+    loki.write.grafana_cloud_logs.receiver,
+  ]
+}
+// Feature: Pod Logs via Kubernetes API
+declare "pod_logs_via_kubernetes_api" {
+  argument "logs_destinations" {
+    comment = "Must be a list of log destinations where collected logs should be forwarded to"
+  }
+
+  discovery.kubernetes "pods" {
+    role = "pod"
+  } // discovery.kubernetes "pods"
+
+  discovery.relabel "filtered_pods" {
+    targets = discovery.kubernetes.pods.targets
+    rule {
+      source_labels = ["__meta_kubernetes_namespace"]
+      action = "replace"
+      target_label = "namespace"
+    }
+    rule {  // Drop anything with a "falsy" annotation value
+      source_labels = ["__meta_kubernetes_pod_annotation_logs_grafana_com_pods_enabled"]
+      regex = "(false|no|skip)"
+      action = "drop"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_pod_name"]
+      target_label = "pod"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_pod_container_name"]
+      target_label = "container"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_namespace", "__meta_kubernetes_pod_container_name"]
+      separator = "/"
+      target_label = "job"
+    }
+
+    // set the container runtime as a label
+    rule {
+      source_labels = ["__meta_kubernetes_pod_container_id"]
+      regex = "^(\\S+):\\/\\/.+$"
+      target_label = "tmp_container_runtime"
+    }
+
+    // explicitly set service_name. if not set, loki will automatically try to populate a default.
+    // see https://grafana.com/docs/loki/latest/get-started/labels/#default-labels-for-all-users
+    //
+    // choose the first value found from the following ordered list:
+    // - pod.annotation[resource.opentelemetry.io/service.name]
+    // - pod.label[app.kubernetes.io/name]
+    // - k8s.pod.name
+    // - k8s.container.name
+    rule {
+      action = "replace"
+      source_labels = [
+        "__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_name",
+        "__meta_kubernetes_pod_label_app_kubernetes_io_name",
+        "container",
+      ]
+      separator = ";"
+      regex = "^(?:;*)?([^;]+).*$"
+      replacement = "$1"
+      target_label = "service_name"
+    }
+
+    // explicitly set service_namespace.
+    //
+    // choose the first value found from the following ordered list:
+    // - pod.annotation[resource.opentelemetry.io/service.namespace]
+    // - pod.namespace
+    rule {
+      action = "replace"
+      source_labels = [
+        "__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_namespace",
+        "namespace",
+      ]
+      separator = ";"
+      regex = "^(?:;*)?([^;]+).*$"
+      replacement = "$1"
+      target_label = "service_namespace"
+    }
+
+    // explicitly set service_instance_id.
+    //
+    // choose the first value found from the following ordered list:
+    // - pod.annotation[resource.opentelemetry.io/service.instance.id]
+    // - concat([k8s.namespace.name, k8s.pod.name, k8s.container.name], '.')
+    rule {
+      source_labels = ["__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_instance_id"]
+      target_label = "service_instance_id"
+    }
+    rule {
+      source_labels = ["service_instance_id", "namespace", "pod", "container"]
+      separator = "."
+      regex = "^\\.([^.]+\\.[^.]+\\.[^.]+)$"
+      target_label = "service_instance_id"
+    }
+
+    // set resource attributes
+    rule {
+      action = "labelmap"
+      regex = "__meta_kubernetes_pod_annotation_resource_opentelemetry_io_(.+)"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_job"]
+      regex = "(.+)"
+      target_label = "job"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+      regex = "(.+)"
+      target_label = "app_kubernetes_io_name"
+    }
+  } // discovery.relabel "filtered_pods"
+
+  loki.source.kubernetes "pod_logs" {
+    targets = discovery.relabel.filtered_pods.output
+    clustering {
+      enabled = true
+    }
+    forward_to = [loki.process.pod_logs.receiver]
+  } // loki.source.kubernetes "pod_logs"
+
+  loki.process "pod_logs" {
+    stage.match {
+      selector = "{tmp_container_runtime=~\"containerd|cri-o|\"}"
+      // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
+      stage.cri {
+        max_partial_lines = 100
+      }
+
+      // Set the extract flags and stream values as labels
+      stage.labels {
+        values = {
+          flags  = "",
+          stream  = "",
+        }
+      }
+    }
+
+    stage.match {
+      selector = "{tmp_container_runtime=\"docker\"}"
+      // the docker processing stage extracts the following k/v pairs: log, stream, time
+      stage.docker {}
+
+      // Set the extract stream value as a label
+      stage.labels {
+        values = {
+          stream  = "",
+        }
+      }
+    }
+
+    // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
+    // namespace, pod, and container labels. Drop any structured metadata. Also drop the temporary
+    // container runtime label as it is no longer needed.
+    stage.label_drop {
+      values = [
+        "filename",
+        "tmp_container_runtime",
+      ]
+    }
+    stage.structured_metadata {
+      values = {
+        "k8s_pod_name" = "k8s_pod_name",
+        "pod" = "pod",
+        "service_instance_id" = "service_instance_id",
+      }
+    }
+
+    forward_to = argument.logs_destinations.value
+  } // loki.secretfilter "pod_logs"
+} // declare "pod_logs_via_kubernetes_api"
+pod_logs_via_kubernetes_api "feature" {
+  logs_destinations = [
+    loki.write.grafana_cloud_logs.receiver,
+  ]
+}
+
+
+
+
+
+// Destination: grafana-cloud-logs (loki)
+otelcol.exporter.loki "grafana_cloud_logs" {
+  forward_to = [loki.write.grafana_cloud_logs.receiver]
+} // otelcol.exporter.loki "grafana_cloud_logs"
+
+loki.write "grafana_cloud_logs" {
+  endpoint {
+    url = "https://logs-prod-006.grafana.net/loki/api/v1/push"
+    retry_on_http_429 = true
+    tenant_id = convert.nonsensitive(remote.kubernetes.secret.grafana_cloud_logs.data["tenantId"])
+    basic_auth {
+      username = convert.nonsensitive(remote.kubernetes.secret.grafana_cloud_logs.data["LOKI_USER"])
+      password = remote.kubernetes.secret.grafana_cloud_logs.data["LOKI_PASS"]
+    }
+    tls_config {
+      insecure_skip_verify = false
+      ca_pem = convert.nonsensitive(remote.kubernetes.secret.grafana_cloud_logs.data["ca"])
+      cert_pem = convert.nonsensitive(remote.kubernetes.secret.grafana_cloud_logs.data["cert"])
+      key_pem = remote.kubernetes.secret.grafana_cloud_logs.data["key"]
+    }
+    min_backoff_period = "500ms"
+    max_backoff_period = "5m"
+    max_backoff_retries = "10"
+  }
+  external_labels = {
+    "cluster" = "eks-with-windows-test",
+    "k8s_cluster_name" = "eks-with-windows-test",
+  }
+} // loki.write "grafana_cloud_logs"
+
+remote.kubernetes.secret "grafana_cloud_logs" {
+  name      = "grafana-cloud-credentials"
+  namespace = "default"
+} // remote.kubernetes.secret "grafana_cloud_logs"
+

--- a/charts/k8s-monitoring/tests/platform/eks-with-windows/.rendered/alloy-metrics.alloy
+++ b/charts/k8s-monitoring/tests/platform/eks-with-windows/.rendered/alloy-metrics.alloy
@@ -1,0 +1,918 @@
+// Feature: Cluster Metrics
+declare "cluster_metrics" {
+  argument "metrics_destinations" {
+    comment = "Must be a list of metric destinations where collected metrics should be forwarded to"
+  }
+  discovery.kubernetes "nodes" {
+    role = "node"
+  } // discovery.kubernetes "nodes"
+
+  discovery.relabel "nodes" {
+    targets = discovery.kubernetes.nodes.targets
+    rule {
+      source_labels = ["__meta_kubernetes_node_name"]
+      target_label  = "node"
+    }
+
+    rule {
+      replacement = "kubernetes"
+      target_label = "source"
+    }
+  } // discovery.relabel "nodes"
+
+  // Kubelet
+  discovery.relabel "kubelet" {
+    targets = discovery.relabel.nodes.output
+  } // discovery.relabel "kubelet"
+
+  prometheus.scrape "kubelet" {
+    targets  = discovery.relabel.kubelet.output
+    job_name = "integrations/kubernetes/kubelet"
+    scheme   = "https"
+    scrape_interval = "60s"
+    scrape_timeout = "10s"
+    scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
+    scrape_classic_histograms = false
+    scrape_native_histograms = false
+    convert_classic_histograms_to_nhcb = false
+    bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+
+    tls_config {
+      ca_file = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+      insecure_skip_verify = true
+      server_name = "kubernetes"
+    }
+
+    clustering {
+      enabled = true
+    }
+
+    forward_to = [prometheus.relabel.kubelet.receiver]
+  } // prometheus.scrape "kubelet"
+
+  prometheus.relabel "kubelet" {
+    max_cache_size = 100000
+    rule {
+      source_labels = ["__name__"]
+      regex = "up|scrape_samples_scraped|go_goroutines|kubelet_certificate_manager_client_expiration_renew_errors|kubelet_certificate_manager_client_ttl_seconds|kubelet_certificate_manager_server_ttl_seconds|kubelet_cgroup_manager_duration_seconds_bucket|kubelet_cgroup_manager_duration_seconds_count|kubelet_node_config_error|kubelet_node_name|kubelet_pleg_relist_duration_seconds_bucket|kubelet_pleg_relist_duration_seconds_count|kubelet_pleg_relist_interval_seconds_bucket|kubelet_pod_start_duration_seconds_bucket|kubelet_pod_start_duration_seconds_count|kubelet_pod_worker_duration_seconds_bucket|kubelet_pod_worker_duration_seconds_count|kubelet_running_container_count|kubelet_running_containers|kubelet_running_pod_count|kubelet_running_pods|kubelet_runtime_operations_errors_total|kubelet_runtime_operations_total|kubelet_server_expiration_renew_errors|kubelet_volume_stats_available_bytes|kubelet_volume_stats_capacity_bytes|kubelet_volume_stats_inodes|kubelet_volume_stats_inodes_free|kubelet_volume_stats_inodes_used|kubelet_volume_stats_used_bytes|kubernetes_build_info|namespace_workload_pod|process_cpu_seconds_total|process_resident_memory_bytes|rest_client_requests_total|storage_operation_duration_seconds_count|storage_operation_errors_total|volume_manager_total_volumes"
+      action = "keep"
+    }
+
+    forward_to = argument.metrics_destinations.value
+  } // prometheus.relabel "kubelet"
+
+  // Kubelet Resources
+  discovery.relabel "kubelet_resources" {
+    targets = discovery.relabel.nodes.output
+    rule {
+      replacement   = "/metrics/resource"
+      target_label  = "__metrics_path__"
+    }
+  } // discovery.relabel "kubelet_resources"
+
+  prometheus.scrape "kubelet_resources" {
+    targets = discovery.relabel.kubelet_resources.output
+    job_name = "integrations/kubernetes/resources"
+    scheme   = "https"
+    scrape_interval = "60s"
+    scrape_timeout = "10s"
+    scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
+    scrape_classic_histograms = false
+    scrape_native_histograms = false
+    convert_classic_histograms_to_nhcb = false
+    bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+
+    tls_config {
+      ca_file = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+      insecure_skip_verify = true
+      server_name = "kubernetes"
+    }
+
+    clustering {
+      enabled = true
+    }
+
+    forward_to = [prometheus.relabel.kubelet_resources.receiver]
+  } // prometheus.scrape "kubelet_resources"
+
+  prometheus.relabel "kubelet_resources" {
+    max_cache_size = 100000
+    rule {
+      source_labels = ["__name__"]
+      regex = "up|scrape_samples_scraped|node_cpu_usage_seconds_total|node_memory_working_set_bytes"
+      action = "keep"
+    }
+
+    forward_to = argument.metrics_destinations.value
+  } // prometheus.relabel "kubelet_resources"
+
+  // cAdvisor
+  discovery.relabel "cadvisor" {
+    targets = discovery.relabel.nodes.output
+    rule {
+      replacement   = "/metrics/cadvisor"
+      target_label  = "__metrics_path__"
+    }
+  } // discovery.relabel "cadvisor"
+
+  prometheus.scrape "cadvisor" {
+    targets = discovery.relabel.cadvisor.output
+    job_name = "integrations/kubernetes/cadvisor"
+    scheme = "https"
+    scrape_interval = "60s"
+    scrape_timeout = "10s"
+    scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
+    scrape_classic_histograms = false
+    scrape_native_histograms = false
+    convert_classic_histograms_to_nhcb = false
+    bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+
+    tls_config {
+      ca_file = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+      insecure_skip_verify = true
+      server_name = "kubernetes"
+    }
+
+    clustering {
+      enabled = true
+    }
+
+    forward_to = [prometheus.relabel.cadvisor.receiver]
+  } // prometheus.scrape "cadvisor"
+
+  prometheus.relabel "cadvisor" {
+    max_cache_size = 100000
+    rule {
+      source_labels = ["__name__"]
+      regex = "up|scrape_samples_scraped|container_cpu_cfs_periods_total|container_cpu_cfs_throttled_periods_total|container_cpu_usage_seconds_total|container_fs_reads_bytes_total|container_fs_reads_total|container_fs_writes_bytes_total|container_fs_writes_total|container_memory_cache|container_memory_rss|container_memory_swap|container_memory_usage_bytes|container_memory_working_set_bytes|container_network_receive_bytes_total|container_network_receive_packets_dropped_total|container_network_receive_packets_total|container_network_transmit_bytes_total|container_network_transmit_packets_dropped_total|container_network_transmit_packets_total|machine_memory_bytes"
+      action = "keep"
+    }
+    // Drop empty container labels, addressing https://github.com/google/cadvisor/issues/2688
+    rule {
+      source_labels = ["__name__","container"]
+      separator = "@"
+      regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_pressure_.*)@"
+      action = "drop"
+    }
+    // Drop empty image labels, addressing https://github.com/google/cadvisor/issues/2688
+    rule {
+      source_labels = ["__name__","image"]
+      separator = "@"
+      regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_network_.*|container_pressure_.*)@"
+      action = "drop"
+    }
+    // Normalizing unimportant labels (not deleting to continue satisfying <label>!="" checks)
+    rule {
+      source_labels = ["__name__", "boot_id"]
+      separator = "@"
+      regex = "machine_memory_bytes@.*"
+      target_label = "boot_id"
+      replacement = "NA"
+    }
+    rule {
+      source_labels = ["__name__", "system_uuid"]
+      separator = "@"
+      regex = "machine_memory_bytes@.*"
+      target_label = "system_uuid"
+      replacement = "NA"
+    }
+    // Filter out non-physical devices/interfaces
+    rule {
+      source_labels = ["__name__", "device"]
+      separator = "@"
+      regex = "container_fs_.*@(/dev/)?(mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dasd.+)"
+      target_label = "__keepme"
+      replacement = "1"
+    }
+    rule {
+      source_labels = ["__name__", "__keepme"]
+      separator = "@"
+      regex = "container_fs_.*@"
+      action = "drop"
+    }
+    rule {
+      source_labels = ["__name__"]
+      regex = "container_fs_.*"
+      target_label = "__keepme"
+      replacement = ""
+    }
+    rule {
+      source_labels = ["__name__", "interface"]
+      separator = "@"
+      regex = "container_network_.*@(en[ospx][0-9].*|wlan[0-9].*|eth[0-9].*)"
+      target_label = "__keepme"
+      replacement = "1"
+    }
+    rule {
+      source_labels = ["__name__", "__keepme"]
+      separator = "@"
+      regex = "container_network_.*@"
+      action = "drop"
+    }
+    rule {
+      source_labels = ["__name__"]
+      regex = "container_network_.*"
+      target_label = "__keepme"
+      replacement = ""
+    }
+    forward_to = argument.metrics_destinations.value
+  } // prometheus.relabel "cadvisor"
+  discovery.kubernetes "kube_state_metrics" {
+    role = "endpoints"
+
+    selectors {
+      role = "endpoints"
+      label = "release=k8smon,app.kubernetes.io/name=kube-state-metrics"
+    }
+    namespaces {
+      names = ["default"]
+    }
+  } // discovery.kubernetes "kube_state_metrics"
+
+  discovery.relabel "kube_state_metrics" {
+    targets = discovery.kubernetes.kube_state_metrics.targets
+
+    rule {
+      action = "replace"
+      replacement = "kubernetes"
+      target_label = "source"
+    }
+
+  } // discovery.relabel "kube_state_metrics"
+
+  prometheus.scrape "kube_state_metrics" {
+    targets = discovery.relabel.kube_state_metrics.output
+    job_name = "integrations/kubernetes/kube-state-metrics"
+    scrape_interval = "60s"
+    scrape_timeout = "10s"
+    scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
+    scrape_classic_histograms = false
+    scrape_native_histograms = false
+    convert_classic_histograms_to_nhcb = false
+    scheme = "http"
+    bearer_token_file = ""
+    tls_config {
+      insecure_skip_verify = true
+    }
+
+    clustering {
+      enabled = true
+    }
+    forward_to = [prometheus.relabel.kube_state_metrics.receiver]
+  } // prometheus.scrape "kube_state_metrics"
+
+  prometheus.relabel "kube_state_metrics" {
+    max_cache_size = 100000
+    rule {
+      source_labels = ["__name__"]
+      regex = "up|scrape_samples_scraped|kube_configmap_info|kube_configmap_metadata_resource_version|kube_cronjob.*|kube_daemonset.*|kube_deployment_metadata_generation|kube_deployment_spec_replicas|kube_deployment_status_condition|kube_deployment_status_observed_generation|kube_deployment_status_replicas_available|kube_deployment_status_replicas_updated|kube_horizontalpodautoscaler_spec_max_replicas|kube_horizontalpodautoscaler_spec_min_replicas|kube_horizontalpodautoscaler_status_current_replicas|kube_horizontalpodautoscaler_status_desired_replicas|kube_job.*|kube_namespace_status_phase|kube_node.*|kube_persistentvolume_status_phase|kube_persistentvolumeclaim_access_mode|kube_persistentvolumeclaim_info|kube_persistentvolumeclaim_labels|kube_persistentvolumeclaim_resource_requests_storage_bytes|kube_persistentvolumeclaim_status_phase|kube_pod_completion_time|kube_pod_container_info|kube_pod_container_resource_limits|kube_pod_container_resource_requests|kube_pod_container_status_last_terminated_reason|kube_pod_container_status_last_terminated_timestamp|kube_pod_container_status_restarts_total|kube_pod_container_status_waiting_reason|kube_pod_info|kube_pod_owner|kube_pod_restart_policy|kube_pod_spec_volumes_persistentvolumeclaims_info|kube_pod_start_time|kube_pod_status_phase|kube_pod_status_reason|kube_pod_init_.*|kube_replicaset.*|kube_resourcequota|kube_secret_metadata_resource_version|kube_statefulset.*"
+      action = "keep"
+    }
+    forward_to = argument.metrics_destinations.value
+  } // prometheus.relabel "kube_state_metrics"
+} // declare "cluster_metrics"
+cluster_metrics "feature" {
+  metrics_destinations = [
+    prometheus.relabel.clustermetrics_stamp_metrics_prometheus.receiver,
+  ]
+}
+prometheus.relabel "clustermetrics_stamp_metrics_prometheus" {
+  forward_to = [prometheus.enrich.ec2_tags_in_metrics_prometheus.receiver]
+  rule {
+    target_label = "selected_destinations"
+    replacement  = "grafana-cloud-metrics"
+  }
+}
+// Processor: ec2-tags (ec2Enrichment) — metrics/prometheus
+prometheus.enrich "ec2_tags_in_metrics_prometheus" {
+  targets = discovery.relabel.ec2_tags_instances.output
+  target_to_metric_match = {
+    "__meta_ec2_private_dns_name" = "node",
+  }
+  labels_to_copy = ["team"]
+  forward_to = [prometheus.relabel.ec2_tags_out_metrics_prometheus.receiver]
+} // prometheus.enrich "ec2_tags_in_metrics_prometheus"
+prometheus.relabel "ec2_tags_out_metrics_prometheus" {
+  forward_to = [prometheus.relabel.ec2_tags_grafana_cloud_metrics_gate_metrics_prometheus.receiver]
+}
+prometheus.relabel "ec2_tags_grafana_cloud_metrics_gate_metrics_prometheus" {
+  forward_to = [prometheus.remote_write.grafana_cloud_metrics.receiver]
+  rule {
+    source_labels = ["selected_destinations"]
+    regex         = "(^|.*,)grafana-cloud-metrics(,.*|$)"
+    action        = "keep"
+  }
+  rule {
+    action = "labeldrop"
+    regex  = "selected_destinations"
+  }
+}
+// Feature: Host Metrics
+declare "host_metrics" {
+  argument "metrics_destinations" {
+    comment = "Must be a list of metric destinations where collected metrics should be forwarded to"
+  }
+
+  // Linux hosts via Node Exporter
+  discovery.kubernetes "node_exporter" {
+    role = "pod"
+    selectors {
+      role = "pod"
+      label = "release=k8smon,app.kubernetes.io/name=node-exporter"
+    }
+    namespaces {
+      names = ["default"]
+    }
+
+  } // discovery.kubernetes "node_exporter"
+
+  discovery.relabel "node_exporter" {
+    targets = discovery.kubernetes.node_exporter.targets
+
+    // keep only the specified metrics port name, and pods that are Running and ready
+    rule {
+      source_labels = [
+        "__meta_kubernetes_pod_container_init",
+        "__meta_kubernetes_pod_phase",
+        "__meta_kubernetes_pod_ready",
+      ]
+      separator = "@"
+      regex = "false@Running@true"
+      action = "keep"
+    }
+
+    // Set the instance label to the node name
+    rule {
+      source_labels = ["__meta_kubernetes_pod_node_name"]
+      target_label = "instance"
+    }
+
+    rule {
+      source_labels = ["__meta_kubernetes_namespace"]
+      target_label  = "namespace"
+    }
+
+    rule {
+      source_labels = ["__meta_kubernetes_pod_name"]
+      target_label  = "pod"
+    }
+
+    rule {
+      source_labels = ["__meta_kubernetes_pod_container_name"]
+      target_label  = "container"
+    }
+
+    // set a workload label
+    rule {
+      source_labels = [
+        "__meta_kubernetes_pod_controller_kind",
+        "__meta_kubernetes_pod_controller_name",
+      ]
+      separator = "/"
+      target_label  = "workload"
+    }
+    // remove the hash from the ReplicaSet
+    rule {
+      source_labels = ["workload"]
+      regex = "(ReplicaSet/.+)-.+"
+      target_label  = "workload"
+    }
+
+    // Set the app label.
+    //
+    // Choose the first value found from the following ordered list:
+    // - pod.label[app.kubernetes.io/name]
+    // - pod.label[k8s-app]
+    // - pod.label[app]
+    rule {
+      source_labels = [
+        "__meta_kubernetes_pod_label_app_kubernetes_io_name",
+        "__meta_kubernetes_pod_label_k8s_app",
+        "__meta_kubernetes_pod_label_app",
+      ]
+      separator = ";"
+      regex = "^(?:;*)?([^;]+).*$"
+      replacement = "$1"
+      target_label = "app"
+    }
+
+    // Set the component label.
+    //
+    // Choose the first value found from the following ordered list:
+    // - pod.label[app.kubernetes.io/component]
+    // - pod.label[k8s-component]
+    // - pod.label[component]
+    rule {
+      source_labels = [
+        "__meta_kubernetes_pod_label_app_kubernetes_io_component",
+        "__meta_kubernetes_pod_label_k8s_component",
+        "__meta_kubernetes_pod_label_component",
+      ]
+      regex = "^(?:;*)?([^;]+).*$"
+      replacement = "$1"
+      target_label = "component"
+    }
+
+    rule {
+      target_label = "source"
+      replacement = "kubernetes"
+    }
+
+  } // discovery.relabel "node_exporter"
+
+  prometheus.scrape "node_exporter" {
+    targets = discovery.relabel.node_exporter.output
+    job_name = "integrations/node_exporter"
+    scrape_interval = "60s"
+    scrape_timeout = "10s"
+    scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
+    scrape_classic_histograms = false
+    scrape_native_histograms = false
+    convert_classic_histograms_to_nhcb = false
+    scheme = "http"
+    tls_config {
+      insecure_skip_verify = true
+    }
+
+    clustering {
+      enabled = true
+    }
+    forward_to = [prometheus.relabel.node_exporter.receiver]
+  } // prometheus.scrape "node_exporter"
+
+  prometheus.relabel "node_exporter" {
+    max_cache_size = 100000
+    rule {
+      source_labels = ["__name__"]
+      regex = "up|scrape_samples_scraped|node_cpu.*|node_exporter_build_info|node_filesystem.*|node_memory.*|node_network_receive_bytes_total|node_network_receive_drop_total|node_network_transmit_bytes_total|node_network_transmit_drop_total|process_cpu_seconds_total|process_resident_memory_bytes"
+      action = "keep"
+    }
+    // Drop metrics for certain file systems
+    rule {
+      source_labels = ["__name__", "fstype"]
+      separator = "@"
+      regex = "node_filesystem.*@(ramfs|tmpfs)"
+      action = "drop"
+    }
+    forward_to = argument.metrics_destinations.value
+  } // prometheus.relabel "node_exporter"
+
+  // Windows hosts via Windows Exporter
+  discovery.kubernetes "windows_exporter_pods" {
+    role = "pod"
+    selectors {
+      role = "pod"
+      label = "release=k8smon,app.kubernetes.io/name=windows-exporter"
+    }
+    namespaces {
+      names = ["default"]
+    }
+
+  } // discovery.kubernetes "windows_exporter_pods"
+
+  discovery.relabel "windows_exporter" {
+    targets = discovery.kubernetes.windows_exporter_pods.targets
+
+    // keep only the specified metrics port name, and pods that are Running and ready
+    rule {
+      source_labels = [
+        "__meta_kubernetes_pod_container_init",
+        "__meta_kubernetes_pod_phase",
+        "__meta_kubernetes_pod_ready",
+      ]
+      separator = "@"
+      regex = "false@Running@true"
+      action = "keep"
+    }
+
+    // Set the instance label to the node name
+    rule {
+      source_labels = ["__meta_kubernetes_pod_node_name"]
+      target_label = "instance"
+    }
+
+  } // discovery.relabel "windows_exporter"
+
+  prometheus.scrape "windows_exporter" {
+    targets  = discovery.relabel.windows_exporter.output
+    job_name   = "integrations/windows-exporter"
+    scrape_interval = "60s"
+    scrape_timeout = "10s"
+    scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
+    scrape_classic_histograms = false
+    scrape_native_histograms = false
+    convert_classic_histograms_to_nhcb = false
+    clustering {
+      enabled = true
+    }
+    forward_to = [prometheus.relabel.windows_exporter.receiver]
+  } // prometheus.scrape "windows_exporter"
+
+  prometheus.relabel "windows_exporter" {
+    max_cache_size = 100000
+    rule {
+      source_labels = ["__name__"]
+      regex = "up|scrape_samples_scraped|windows_.*|node_cpu_seconds_total|node_filesystem_size_bytes|node_filesystem_avail_bytes|container_cpu_usage_seconds_total"
+      action = "keep"
+    }
+    forward_to = argument.metrics_destinations.value
+  } // prometheus.relabel "windows_exporter"
+} // declare "host_metrics"
+host_metrics "feature" {
+  metrics_destinations = [
+    prometheus.remote_write.grafana_cloud_metrics.receiver,
+  ]
+}
+declare "alloy_integration" {
+  argument "metrics_destinations" {
+    comment = "Must be a list of metric destinations where collected metrics should be forwarded to"
+  }
+
+  declare "alloy_integration_discovery" {
+    argument "namespaces" {
+      comment = "The namespaces to look for targets in (default: [] is all namespaces)"
+      optional = true
+    }
+
+    argument "field_selectors" {
+      comment = "The field selectors to use to find matching targets (default: [])"
+      optional = true
+    }
+
+    argument "label_selectors" {
+      comment = "The label selectors to use to find matching targets (default: [\"app.kubernetes.io/name=alloy\"])"
+      optional = true
+    }
+
+    argument "port_name" {
+      comment = "The of the port to scrape metrics from (default: http-metrics)"
+      optional = true
+    }
+
+    // Alloy service discovery for all of the pods
+    discovery.kubernetes "alloy_pods" {
+      role = "pod"
+
+      selectors {
+        role = "pod"
+        field = string.join(coalesce(argument.field_selectors.value, []), ",")
+        label = string.join(coalesce(argument.label_selectors.value, ["app.kubernetes.io/name=alloy"]), ",")
+      }
+
+      namespaces {
+        names = coalesce(argument.namespaces.value, [])
+      }
+
+    } // discovery.kubernetes "alloy_pods"
+
+    // alloy relabelings (pre-scrape)
+    discovery.relabel "alloy_pods" {
+      targets = discovery.kubernetes.alloy_pods.targets
+
+      // keep only the specified metrics port name, and pods that are Running and ready
+      rule {
+        source_labels = [
+          "__meta_kubernetes_pod_container_port_name",
+          "__meta_kubernetes_pod_phase",
+          "__meta_kubernetes_pod_ready",
+          "__meta_kubernetes_pod_container_init",
+        ]
+        separator = "@"
+        regex = coalesce(argument.port_name.value, "metrics") + "@Running@true@false"
+        action = "keep"
+      }
+
+      rule {
+        source_labels = ["__meta_kubernetes_namespace"]
+        target_label  = "namespace"
+      }
+
+      rule {
+        source_labels = ["__meta_kubernetes_pod_name"]
+        target_label  = "pod"
+      }
+
+      rule {
+        source_labels = ["__meta_kubernetes_pod_container_name"]
+        target_label  = "container"
+      }
+
+      // set the workload to the controller kind and name
+      rule {
+        action = "lowercase"
+        source_labels = ["__meta_kubernetes_pod_controller_kind"]
+        target_label  = "workload_type"
+      }
+
+      rule {
+        source_labels = ["__meta_kubernetes_pod_controller_name"]
+        target_label  = "workload"
+      }
+
+      // remove the hash from the ReplicaSet
+      rule {
+        source_labels = [
+          "workload_type",
+          "workload",
+        ]
+        separator = "/"
+        regex = "replicaset/(.+)-.+$"
+        target_label  = "workload"
+      }
+
+      // set the app name if specified as metadata labels "app:" or "app.kubernetes.io/name:" or "k8s-app:"
+      rule {
+        action = "replace"
+        source_labels = [
+          "__meta_kubernetes_pod_label_app_kubernetes_io_name",
+          "__meta_kubernetes_pod_label_k8s_app",
+          "__meta_kubernetes_pod_label_app",
+        ]
+        separator = ";"
+        regex = "^(?:;*)?([^;]+).*$"
+        replacement = "$1"
+        target_label = "app"
+      }
+
+      // set the component if specified as metadata labels "component:" or "app.kubernetes.io/component:" or "k8s-component:"
+      rule {
+        action = "replace"
+        source_labels = [
+          "__meta_kubernetes_pod_label_app_kubernetes_io_component",
+          "__meta_kubernetes_pod_label_k8s_component",
+          "__meta_kubernetes_pod_label_component",
+        ]
+        regex = "^(?:;*)?([^;]+).*$"
+        replacement = "$1"
+        target_label = "component"
+      }
+
+      // set a source label
+      rule {
+        action = "replace"
+        replacement = "kubernetes"
+        target_label = "source"
+      }
+
+    } // discovery.relabel "alloy_pods"
+
+    export "output" {
+      value = discovery.relabel.alloy_pods.output
+    }
+  }
+
+  declare "alloy_integration_scrape" {
+    argument "targets" {
+      comment = "Must be a list() of targets"
+    }
+
+    argument "forward_to" {
+      comment = "Must be a list(MetricsReceiver) where collected metrics should be forwarded to"
+    }
+
+    argument "job_label" {
+      comment = "The job label to add for all Alloy metrics (default: integrations/alloy)"
+      optional = true
+    }
+
+    argument "keep_metrics" {
+      comment = "A regular expression of metrics to keep (default: see below)"
+      optional = true
+    }
+
+    argument "drop_metrics" {
+      comment = "A regular expression of metrics to drop (default: see below)"
+      optional = true
+    }
+
+    argument "scrape_interval" {
+      comment = "How often to scrape metrics from the targets (default: 60s)"
+      optional = true
+    }
+
+    argument "scrape_timeout" {
+      comment = "The timeout for scraping metrics from the targets (default: 10s)"
+      optional = true
+    }
+
+    argument "scrape_protocols" {
+      comment = "The scrape protocols to use for scraping metrics"
+      optional = true
+    }
+
+    argument "scrape_classic_histograms" {
+      comment = "Whether to scrape classic histograms (default: false)."
+      optional = true
+    }
+
+    argument "scrape_native_histograms" {
+      comment = "Whether to scrape native histograms (default: false)."
+      optional = true
+    }
+
+    argument "max_cache_size" {
+      comment = "The maximum number of elements to hold in the relabeling cache (default: 100000).  This should be at least 2x-5x your largest scrape target or samples appended rate."
+      optional = true
+    }
+
+    argument "clustering" {
+      comment = "Whether or not clustering should be enabled (default: false)"
+      optional = true
+    }
+
+    prometheus.scrape "alloy" {
+      job_name = coalesce(argument.job_label.value, "integrations/alloy")
+      forward_to = [prometheus.relabel.alloy.receiver]
+      targets = argument.targets.value
+      scrape_interval = coalesce(argument.scrape_interval.value, "60s")
+      scrape_timeout = coalesce(argument.scrape_timeout.value, "10s")
+      scrape_protocols = argument.scrape_protocols.value
+      scrape_classic_histograms = argument.scrape_classic_histograms.value
+      scrape_native_histograms = argument.scrape_native_histograms.value
+
+      clustering {
+        enabled = coalesce(argument.clustering.value, false)
+      }
+    } // prometheus.scrape "alloy"
+
+    // alloy metric relabelings (post-scrape)
+    prometheus.relabel "alloy" {
+      forward_to = argument.forward_to.value
+      max_cache_size = coalesce(argument.max_cache_size.value, 100000)
+
+      // drop metrics that match the drop_metrics regex
+      rule {
+        source_labels = ["__name__"]
+        regex = coalesce(argument.drop_metrics.value, "")
+        action = "drop"
+      }
+
+      // keep only metrics that match the keep_metrics regex
+      rule {
+        source_labels = ["__name__"]
+        regex = coalesce(argument.keep_metrics.value, ".*")
+        action = "keep"
+      }
+
+      // remove the component_id label from any metric that starts with log_bytes or log_lines, these are custom metrics that are generated
+      // as part of the log annotation modules in this repo
+      rule {
+        action = "replace"
+        source_labels = ["__name__"]
+        regex = "^log_(bytes|lines).+"
+        replacement = ""
+        target_label = "component_id"
+      }
+
+      // set the namespace label to that of the exported_namespace
+      rule {
+        action = "replace"
+        source_labels = ["__name__", "exported_namespace"]
+        separator = "@"
+        regex = "^log_(bytes|lines).+@(.+)"
+        replacement = "$2"
+        target_label = "namespace"
+      }
+
+      // set the pod label to that of the exported_pod
+      rule {
+        action = "replace"
+        source_labels = ["__name__", "exported_pod"]
+        separator = "@"
+        regex = "^log_(bytes|lines).+@(.+)"
+        replacement = "$2"
+        target_label = "pod"
+      }
+
+      // set the container label to that of the exported_container
+      rule {
+        action = "replace"
+        source_labels = ["__name__", "exported_container"]
+        separator = "@"
+        regex = "^log_(bytes|lines).+@(.+)"
+        replacement = "$2"
+        target_label = "container"
+      }
+
+      // set the job label to that of the exported_job
+      rule {
+        action = "replace"
+        source_labels = ["__name__", "exported_job"]
+        separator = "@"
+        regex = "^log_(bytes|lines).+@(.+)"
+        replacement = "$2"
+        target_label = "job"
+      }
+
+      // set the instance label to that of the exported_instance
+      rule {
+        action = "replace"
+        source_labels = ["__name__", "exported_instance"]
+        separator = "@"
+        regex = "^log_(bytes|lines).+@(.+)"
+        replacement = "$2"
+        target_label = "instance"
+      }
+
+      rule {
+        action = "labeldrop"
+        regex = "exported_(namespace|pod|container|job|instance)"
+      }
+    } // prometheus.relabel "alloy"
+  }
+
+  alloy_integration_discovery "alloy" {
+    port_name = "http-metrics"
+    label_selectors = ["app.kubernetes.io/name in (alloy-metrics,alloy-singleton,alloy-logs)"]
+  }
+
+  alloy_integration_scrape "alloy" {
+    targets = alloy_integration_discovery.alloy.output
+    job_label = "integrations/alloy"
+    clustering = true
+    keep_metrics = "up|scrape_samples_scraped|alloy_build_info|alloy_component_controller_running_components|alloy_component_dependencies_wait_seconds|alloy_component_dependencies_wait_seconds_bucket|alloy_component_evaluation_seconds|alloy_component_evaluation_seconds_bucket|alloy_component_evaluation_seconds_count|alloy_component_evaluation_seconds_sum|alloy_component_evaluation_slow_seconds|alloy_config_hash|alloy_resources_machine_rx_bytes_total|alloy_resources_machine_tx_bytes_total|alloy_resources_process_cpu_seconds_total|alloy_resources_process_resident_memory_bytes|alloy_tcp_connections|alloy_wal_samples_appended_total|alloy_wal_storage_active_series|cluster_node_gossip_health_score|cluster_node_gossip_proto_version|cluster_node_gossip_received_events_total|cluster_node_info|cluster_node_lamport_time|cluster_node_peers|cluster_node_update_observers|cluster_transport_rx_bytes_total|cluster_transport_rx_packet_queue_length|cluster_transport_rx_packets_failed_total|cluster_transport_rx_packets_total|cluster_transport_stream_rx_bytes_total|cluster_transport_stream_rx_packets_failed_total|cluster_transport_stream_rx_packets_total|cluster_transport_stream_tx_bytes_total|cluster_transport_stream_tx_packets_failed_total|cluster_transport_stream_tx_packets_total|cluster_transport_streams|cluster_transport_tx_bytes_total|cluster_transport_tx_packet_queue_length|cluster_transport_tx_packets_failed_total|cluster_transport_tx_packets_total|otelcol_exporter_send_failed_spans_total|otelcol_exporter_sent_spans_total|go_gc_duration_seconds_count|go_goroutines|go_memstats_heap_inuse_bytes|loki_process_dropped_lines_total|loki_write_batch_retries_total|loki_write_dropped_bytes_total|loki_write_dropped_entries_total|loki_write_encoded_bytes_total|loki_write_mutated_bytes_total|loki_write_mutated_entries_total|loki_write_request_duration_seconds_bucket|loki_write_sent_bytes_total|loki_write_sent_entries_total|process_cpu_seconds_total|process_start_time_seconds|otelcol_processor_batch_batch_send_size_bucket|otelcol_processor_batch_metadata_cardinality|otelcol_processor_batch_timeout_trigger_send_total|prometheus_remote_storage_bytes_total|prometheus_remote_storage_enqueue_retries_total|prometheus_remote_storage_highest_timestamp_in_seconds|prometheus_remote_storage_metadata_bytes_total|prometheus_remote_storage_queue_highest_sent_timestamp_seconds|prometheus_remote_storage_samples_dropped_total|prometheus_remote_storage_samples_failed_total|prometheus_remote_storage_samples_pending|prometheus_remote_storage_samples_retried_total|prometheus_remote_storage_samples_total|prometheus_remote_storage_sent_batch_duration_seconds_bucket|prometheus_remote_storage_sent_batch_duration_seconds_count|prometheus_remote_storage_sent_batch_duration_seconds_sum|prometheus_remote_storage_shard_capacity|prometheus_remote_storage_shards|prometheus_remote_storage_shards_desired|prometheus_remote_storage_shards_max|prometheus_remote_storage_shards_min|prometheus_remote_storage_succeeded_samples_total|prometheus_remote_write_wal_samples_appended_total|prometheus_remote_write_wal_storage_active_series|prometheus_sd_discovered_targets|prometheus_target_interval_length_seconds_count|prometheus_target_interval_length_seconds_sum|prometheus_target_scrapes_exceeded_sample_limit_total|prometheus_target_scrapes_sample_duplicate_timestamp_total|prometheus_target_scrapes_sample_out_of_bounds_total|prometheus_target_scrapes_sample_out_of_order_total|prometheus_target_sync_length_seconds_sum|prometheus_wal_watcher_current_segment|otelcol_receiver_accepted_spans_total|otelcol_receiver_refused_spans_total|rpc_server_duration_milliseconds_bucket|scrape_duration_seconds|traces_exporter_send_failed_spans|traces_exporter_send_failed_spans_total|traces_exporter_sent_spans|traces_exporter_sent_spans_total|traces_loadbalancer_backend_outcome|traces_loadbalancer_num_backends|traces_receiver_accepted_spans|traces_receiver_accepted_spans_total|traces_receiver_refused_spans|traces_receiver_refused_spans_total"
+    scrape_interval = "60s"
+    scrape_timeout = "10s"
+    scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
+    scrape_classic_histograms = false
+    scrape_native_histograms = false
+    max_cache_size = 100000
+    forward_to = argument.metrics_destinations.value
+  }
+}
+alloy_integration "integration" {
+  metrics_destinations = [
+    prometheus.remote_write.grafana_cloud_metrics.receiver,
+  ]
+}
+// Processor: ec2-tags (ec2Enrichment) — shared EC2 instance discovery
+discovery.ec2 "ec2_tags_instances" {
+  region = "ap-northeast-2"
+} // discovery.ec2 "ec2_tags_instances"
+discovery.relabel "ec2_tags_instances" {
+  targets = discovery.ec2.ec2_tags_instances.targets
+  rule {
+    source_labels = ["__meta_ec2_tag_Team"]
+    target_label = "team"
+  }
+} // discovery.relabel "ec2_tags_instances"
+
+
+
+
+
+// Destination: grafana-cloud-metrics (prometheus)
+otelcol.exporter.prometheus "grafana_cloud_metrics" {
+  add_metric_suffixes = true
+  resource_to_telemetry_conversion = false
+  keep_identifying_resource_attributes = true
+  forward_to = [prometheus.remote_write.grafana_cloud_metrics.receiver]
+} // otelcol.exporter.prometheus "grafana_cloud_metrics"
+
+prometheus.remote_write "grafana_cloud_metrics" {
+  endpoint {
+    url = "https://prometheus-prod-13-prod-us-east-0.grafana.net/api/prom/push"
+    headers = {
+      "X-Scope-OrgID" = convert.nonsensitive(remote.kubernetes.secret.grafana_cloud_metrics.data["tenantId"]),
+    }
+    basic_auth {
+      username = convert.nonsensitive(remote.kubernetes.secret.grafana_cloud_metrics.data["PROMETHEUS_USER"])
+      password = remote.kubernetes.secret.grafana_cloud_metrics.data["PROMETHEUS_PASS"]
+    }
+    tls_config {
+      insecure_skip_verify = false
+      ca_pem = convert.nonsensitive(remote.kubernetes.secret.grafana_cloud_metrics.data["ca"])
+      cert_pem = convert.nonsensitive(remote.kubernetes.secret.grafana_cloud_metrics.data["cert"])
+      key_pem = remote.kubernetes.secret.grafana_cloud_metrics.data["key"]
+    }
+    send_native_histograms = false
+
+    queue_config {
+      capacity = 10000
+      min_shards = 1
+      max_shards = 50
+      max_samples_per_send = 2000
+      batch_send_deadline = "5s"
+      min_backoff = "30ms"
+      max_backoff = "5s"
+      retry_on_http_429 = true
+      sample_age_limit = "0s"
+    }
+  }
+
+  wal {
+    truncate_frequency = "2h"
+    min_keepalive_time = "5m"
+    max_keepalive_time = "8h"
+  }
+  external_labels = {
+    "cluster" = "eks-with-windows-test",
+    "k8s_cluster_name" = "eks-with-windows-test",
+  }
+} // prometheus.remote_write "grafana_cloud_metrics"
+
+remote.kubernetes.secret "grafana_cloud_metrics" {
+  name      = "grafana-cloud-credentials"
+  namespace = "default"
+} // remote.kubernetes.secret "grafana_cloud_metrics"
+

--- a/charts/k8s-monitoring/tests/platform/eks-with-windows/.rendered/alloy-singleton.alloy
+++ b/charts/k8s-monitoring/tests/platform/eks-with-windows/.rendered/alloy-singleton.alloy
@@ -1,0 +1,221 @@
+// Feature: Cluster Events
+declare "cluster_events" {
+  argument "logs_destinations" {
+    comment = "Must be a list of log destinations where collected logs should be forwarded to"
+  }
+
+  loki.source.kubernetes_events "cluster_events" {
+    job_name   = "integrations/kubernetes/eventhandler"
+    log_format = "logfmt"
+    forward_to = [loki.process.cluster_events.receiver]
+  } // loki.source.kubernetes_events "cluster_events"
+
+  loki.process "cluster_events" {
+
+    // add a static source label to the logs so they can be differentiated / restricted if necessary
+    stage.static_labels {
+      values = {
+        "source" = "kubernetes-events",
+      }
+    }
+
+    // extract some of the fields from the log line, these could be used as labels, structured metadata, etc.
+    stage.logfmt {
+      mapping = {
+        "component" = "sourcecomponent", // map the sourcecomponent field to component
+        "kind" = "",
+        "level" = "type", // most events don't have a level but they do have a "type" i.e. Normal, Warning, Error, etc.
+        "name" = "",
+        "node" = "sourcehost", // map the sourcehost field to node
+        "reason" = "",
+      }
+    }
+    // set the extracted values as labels
+    stage.labels {
+      values = {
+        "kind" = "",
+        "level" = "",
+        "service_name" = "job",
+        "reason" = "reason",
+      }
+    }
+
+    // if kind=Node, set the node label by copying the name field
+    stage.match {
+      selector = "{kind=\"Node\"}"
+
+      stage.labels {
+        values = {
+          "node" = "name",
+        }
+      }
+    }
+
+    // set the level extracted key value as a normalized log level
+    stage.match {
+      selector = "{level=\"Normal\"}"
+
+      stage.static_labels {
+        values = {
+          level = "Info",
+        }
+      }
+    }
+    stage.structured_metadata {
+      values = {
+        "name" = "name",
+        "node" = "node",
+      }
+    }
+
+    // Drop pipeline-only labels that are not needed in the final output.
+    stage.label_drop {
+      values = ["kind"]
+    }
+
+    forward_to = argument.logs_destinations.value
+  } // loki.process "cluster_events"
+} // declare "cluster_events"
+cluster_events "feature" {
+  logs_destinations = [
+    loki.write.grafana_cloud_logs.receiver,
+  ]
+}
+// Self Reporting
+prometheus.exporter.unix "kubernetes_monitoring_telemetry" {
+  set_collectors = ["textfile"]
+  textfile {
+    directory = "/etc/release-info"
+  }
+} // prometheus.exporter.unix "kubernetes_monitoring_telemetry"
+
+discovery.relabel "kubernetes_monitoring_telemetry" {
+  targets = prometheus.exporter.unix.kubernetes_monitoring_telemetry.targets
+  rule {
+    target_label = "instance"
+    action = "replace"
+    replacement = "k8smon"
+  }
+  rule {
+    target_label = "job"
+    action = "replace"
+    replacement = "integrations/kubernetes/kubernetes_monitoring_telemetry"
+  }
+} // discovery.relabel "kubernetes_monitoring_telemetry"
+
+prometheus.scrape "kubernetes_monitoring_telemetry" {
+  job_name   = "integrations/kubernetes/kubernetes_monitoring_telemetry"
+  targets    = discovery.relabel.kubernetes_monitoring_telemetry.output
+  scrape_interval = "60s"
+  clustering {
+    enabled = true
+  }
+  forward_to = [prometheus.relabel.kubernetes_monitoring_telemetry.receiver]
+} // prometheus.scrape "kubernetes_monitoring_telemetry"
+
+prometheus.relabel "kubernetes_monitoring_telemetry" {
+  rule {
+    source_labels = ["__name__"]
+    regex = "grafana_kubernetes_monitoring_.*"
+    action = "keep"
+  }
+  forward_to = [
+    prometheus.remote_write.grafana_cloud_metrics.receiver,
+  ]
+} // prometheus.relabel "kubernetes_monitoring_telemetry"
+
+
+
+
+
+// Destination: grafana-cloud-logs (loki)
+otelcol.exporter.loki "grafana_cloud_logs" {
+  forward_to = [loki.write.grafana_cloud_logs.receiver]
+} // otelcol.exporter.loki "grafana_cloud_logs"
+
+loki.write "grafana_cloud_logs" {
+  endpoint {
+    url = "https://logs-prod-006.grafana.net/loki/api/v1/push"
+    retry_on_http_429 = true
+    tenant_id = convert.nonsensitive(remote.kubernetes.secret.grafana_cloud_logs.data["tenantId"])
+    basic_auth {
+      username = convert.nonsensitive(remote.kubernetes.secret.grafana_cloud_logs.data["LOKI_USER"])
+      password = remote.kubernetes.secret.grafana_cloud_logs.data["LOKI_PASS"]
+    }
+    tls_config {
+      insecure_skip_verify = false
+      ca_pem = convert.nonsensitive(remote.kubernetes.secret.grafana_cloud_logs.data["ca"])
+      cert_pem = convert.nonsensitive(remote.kubernetes.secret.grafana_cloud_logs.data["cert"])
+      key_pem = remote.kubernetes.secret.grafana_cloud_logs.data["key"]
+    }
+    min_backoff_period = "500ms"
+    max_backoff_period = "5m"
+    max_backoff_retries = "10"
+  }
+  external_labels = {
+    "cluster" = "eks-with-windows-test",
+    "k8s_cluster_name" = "eks-with-windows-test",
+  }
+} // loki.write "grafana_cloud_logs"
+
+remote.kubernetes.secret "grafana_cloud_logs" {
+  name      = "grafana-cloud-credentials"
+  namespace = "default"
+} // remote.kubernetes.secret "grafana_cloud_logs"
+
+
+// Destination: grafana-cloud-metrics (prometheus)
+otelcol.exporter.prometheus "grafana_cloud_metrics" {
+  add_metric_suffixes = true
+  resource_to_telemetry_conversion = false
+  keep_identifying_resource_attributes = true
+  forward_to = [prometheus.remote_write.grafana_cloud_metrics.receiver]
+} // otelcol.exporter.prometheus "grafana_cloud_metrics"
+
+prometheus.remote_write "grafana_cloud_metrics" {
+  endpoint {
+    url = "https://prometheus-prod-13-prod-us-east-0.grafana.net/api/prom/push"
+    headers = {
+      "X-Scope-OrgID" = convert.nonsensitive(remote.kubernetes.secret.grafana_cloud_metrics.data["tenantId"]),
+    }
+    basic_auth {
+      username = convert.nonsensitive(remote.kubernetes.secret.grafana_cloud_metrics.data["PROMETHEUS_USER"])
+      password = remote.kubernetes.secret.grafana_cloud_metrics.data["PROMETHEUS_PASS"]
+    }
+    tls_config {
+      insecure_skip_verify = false
+      ca_pem = convert.nonsensitive(remote.kubernetes.secret.grafana_cloud_metrics.data["ca"])
+      cert_pem = convert.nonsensitive(remote.kubernetes.secret.grafana_cloud_metrics.data["cert"])
+      key_pem = remote.kubernetes.secret.grafana_cloud_metrics.data["key"]
+    }
+    send_native_histograms = false
+
+    queue_config {
+      capacity = 10000
+      min_shards = 1
+      max_shards = 50
+      max_samples_per_send = 2000
+      batch_send_deadline = "5s"
+      min_backoff = "30ms"
+      max_backoff = "5s"
+      retry_on_http_429 = true
+      sample_age_limit = "0s"
+    }
+  }
+
+  wal {
+    truncate_frequency = "2h"
+    min_keepalive_time = "5m"
+    max_keepalive_time = "8h"
+  }
+  external_labels = {
+    "cluster" = "eks-with-windows-test",
+    "k8s_cluster_name" = "eks-with-windows-test",
+  }
+} // prometheus.remote_write "grafana_cloud_metrics"
+
+remote.kubernetes.secret "grafana_cloud_metrics" {
+  name      = "grafana-cloud-credentials"
+  namespace = "default"
+} // remote.kubernetes.secret "grafana_cloud_metrics"
+

--- a/charts/k8s-monitoring/tests/platform/gke-autopilot/.rendered/alloy-logs.alloy
+++ b/charts/k8s-monitoring/tests/platform/gke-autopilot/.rendered/alloy-logs.alloy
@@ -1,0 +1,239 @@
+// Feature: Pod Logs (Loki)
+declare "pod_logs_via_loki" {
+  argument "logs_destinations" {
+    comment = "Must be a list of log destinations where collected logs should be forwarded to"
+  }
+
+  discovery.kubernetes "pods" {
+    role = "pod"
+    selectors {
+      role = "pod"
+      field = "spec.nodeName=" + sys.env("HOSTNAME")
+    }
+  } // discovery.kubernetes "pods"
+
+  discovery.relabel "filtered_pods" {
+    targets = discovery.kubernetes.pods.targets
+    rule {
+      source_labels = ["__meta_kubernetes_namespace"]
+      action = "replace"
+      target_label = "namespace"
+    }
+    rule {  // Drop anything with a "falsy" annotation value
+      source_labels = ["__meta_kubernetes_pod_annotation_logs_grafana_com_pods_enabled"]
+      regex = "(false|no|skip)"
+      action = "drop"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_pod_name"]
+      target_label = "pod"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_pod_container_name"]
+      target_label = "container"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_namespace", "__meta_kubernetes_pod_container_name"]
+      separator = "/"
+      replacement = "$1"
+      target_label = "job"
+    }
+
+    // set the container runtime as a label
+    rule {
+      source_labels = ["__meta_kubernetes_pod_container_id"]
+      regex = "^(\\S+):\\/\\/.+$"
+      replacement = "$1"
+      target_label = "tmp_container_runtime"
+    }
+    // explicitly set service_name. if not set, loki will automatically try to populate a default.
+    // see https://grafana.com/docs/loki/latest/get-started/labels/#default-labels-for-all-users
+    //
+    // choose the first value found from the following ordered list:
+    // - pod.annotation[resource.opentelemetry.io/service.name]
+    // - pod.label[app.kubernetes.io/name]
+    // - k8s.container.name
+    rule {
+      source_labels = [
+        "__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_name",
+        "__meta_kubernetes_pod_label_app_kubernetes_io_name",
+        "__meta_kubernetes_pod_container_name",
+      ]
+      separator = ";"
+      regex = "^(?:;*)?([^;]+).*$"
+      replacement = "$1"
+      target_label = "service_name"
+    }
+
+    // explicitly set service_namespace.
+    //
+    // choose the first value found from the following ordered list:
+    // - pod.annotation[resource.opentelemetry.io/service.namespace]
+    // - pod.namespace
+    rule {
+      source_labels = [
+        "__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_namespace",
+        "namespace",
+      ]
+      separator = ";"
+      regex = "^(?:;*)?([^;]+).*$"
+      replacement = "$1"
+      target_label = "service_namespace"
+    }
+
+    // explicitly set service_instance_id.
+    //
+    // choose the first value found from the following ordered list:
+    // - pod.annotation[resource.opentelemetry.io/service.instance.id]
+    // - concat([k8s.namespace.name, k8s.pod.name, k8s.container.name], '.')
+    rule {
+      source_labels = ["__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_instance_id"]
+      target_label = "service_instance_id"
+    }
+    rule {
+      source_labels = ["service_instance_id", "namespace", "pod", "container"]
+      separator = "."
+      regex = "^\\.([^.]+\\.[^.]+\\.[^.]+)$"
+      target_label = "service_instance_id"
+    }
+
+    // set resource attributes
+    rule {
+      action = "labelmap"
+      regex = "__meta_kubernetes_pod_annotation_resource_opentelemetry_io_(.+)"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_job"]
+      regex = "(.+)"
+      target_label = "job"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+      regex = "(.+)"
+      target_label = "app_kubernetes_io_name"
+    }
+
+    // Set the pod log path.
+    rule {
+      source_labels = ["__meta_kubernetes_pod_uid", "__meta_kubernetes_pod_container_name"]
+      separator = "/"
+      replacement = "/var/log/pods/*$1/*.log"
+      target_label = "__path__"
+    }
+
+    // If kubernetes.io/config.mirror is set, this is a static pod, created by the kubelet.
+    // It's logs live on a different path.
+    rule {
+      source_labels = ["__meta_kubernetes_pod_annotation_kubernetes_io_config_mirror", "__meta_kubernetes_pod_container_name"]
+      separator = "/"
+      regex = "(.+/.+)"
+      replacement = "/var/log/pods/*$1/*.log"
+      target_label = "__path__"
+    }
+  } // discovery.relabel "filtered_pods"
+
+  local.file_match "pod_logs" {
+    path_targets = discovery.relabel.filtered_pods.output
+  } // local.file_match "pod_logs"
+
+  loki.source.file "pod_logs" {
+    targets    = local.file_match.pod_logs.targets
+    tail_from_end = true
+    forward_to = [loki.process.pod_logs.receiver]
+  } // loki.source.file "pod_logs"
+
+  loki.process "pod_logs" {
+    stage.match {
+      selector = "{tmp_container_runtime=~\"containerd|cri-o|\"}"
+      // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
+      stage.cri {
+        max_partial_lines = 100
+      }
+
+      // Set the extract flags and stream values as labels
+      stage.labels {
+        values = {
+          flags  = "",
+          stream  = "",
+        }
+      }
+    }
+
+    stage.match {
+      selector = "{tmp_container_runtime=\"docker\"}"
+      // the docker processing stage extracts the following k/v pairs: log, stream, time
+      stage.docker {}
+
+      // Set the extract stream value as a label
+      stage.labels {
+        values = {
+          stream  = "",
+        }
+      }
+    }
+
+    // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
+    // namespace, pod, and container labels. Drop any structured metadata. Also drop the temporary
+    // container runtime label as it is no longer needed.
+    stage.label_drop {
+      values = [
+        "filename",
+        "tmp_container_runtime",
+      ]
+    }
+    stage.structured_metadata {
+      values = {
+        "k8s_pod_name" = "k8s_pod_name",
+        "pod" = "pod",
+        "service_instance_id" = "service_instance_id",
+      }
+    }
+
+    forward_to = argument.logs_destinations.value
+  } // loki.secretfilter "pod_logs"
+} // declare "pod_logs_via_loki"
+pod_logs_via_loki "feature" {
+  logs_destinations = [
+    loki.write.grafana_cloud_logs.receiver,
+  ]
+}
+
+
+
+
+
+// Destination: grafana-cloud-logs (loki)
+otelcol.exporter.loki "grafana_cloud_logs" {
+  forward_to = [loki.write.grafana_cloud_logs.receiver]
+} // otelcol.exporter.loki "grafana_cloud_logs"
+
+loki.write "grafana_cloud_logs" {
+  endpoint {
+    url = "https://logs-prod-006.grafana.net/loki/api/v1/push"
+    retry_on_http_429 = true
+    tenant_id = convert.nonsensitive(remote.kubernetes.secret.grafana_cloud_logs.data["tenantId"])
+    basic_auth {
+      username = convert.nonsensitive(remote.kubernetes.secret.grafana_cloud_logs.data["LOKI_USER"])
+      password = remote.kubernetes.secret.grafana_cloud_logs.data["LOKI_PASS"]
+    }
+    tls_config {
+      insecure_skip_verify = false
+      ca_pem = convert.nonsensitive(remote.kubernetes.secret.grafana_cloud_logs.data["ca"])
+      cert_pem = convert.nonsensitive(remote.kubernetes.secret.grafana_cloud_logs.data["cert"])
+      key_pem = remote.kubernetes.secret.grafana_cloud_logs.data["key"]
+    }
+    min_backoff_period = "500ms"
+    max_backoff_period = "5m"
+    max_backoff_retries = "10"
+  }
+  external_labels = {
+    "cluster" = "gke-autopilot-test",
+    "k8s_cluster_name" = "gke-autopilot-test",
+  }
+} // loki.write "grafana_cloud_logs"
+
+remote.kubernetes.secret "grafana_cloud_logs" {
+  name      = "grafana-cloud-credentials"
+  namespace = "default"
+} // remote.kubernetes.secret "grafana_cloud_logs"
+

--- a/charts/k8s-monitoring/tests/platform/gke-autopilot/.rendered/alloy-metrics.alloy
+++ b/charts/k8s-monitoring/tests/platform/gke-autopilot/.rendered/alloy-metrics.alloy
@@ -1,0 +1,660 @@
+// Feature: Cluster Metrics
+declare "cluster_metrics" {
+  argument "metrics_destinations" {
+    comment = "Must be a list of metric destinations where collected metrics should be forwarded to"
+  }
+  discovery.kubernetes "nodes" {
+    role = "node"
+  } // discovery.kubernetes "nodes"
+
+  discovery.relabel "nodes" {
+    targets = discovery.kubernetes.nodes.targets
+    rule {
+      source_labels = ["__meta_kubernetes_node_name"]
+      target_label  = "node"
+    }
+
+    rule {
+      replacement = "kubernetes"
+      target_label = "source"
+    }
+  } // discovery.relabel "nodes"
+
+  // Kubelet
+  discovery.relabel "kubelet" {
+    targets = discovery.relabel.nodes.output
+  } // discovery.relabel "kubelet"
+
+  prometheus.scrape "kubelet" {
+    targets  = discovery.relabel.kubelet.output
+    job_name = "integrations/kubernetes/kubelet"
+    scheme   = "https"
+    scrape_interval = "60s"
+    scrape_timeout = "10s"
+    scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
+    scrape_classic_histograms = false
+    scrape_native_histograms = false
+    convert_classic_histograms_to_nhcb = false
+    bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+
+    tls_config {
+      ca_file = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+      insecure_skip_verify = true
+      server_name = "kubernetes"
+    }
+
+    clustering {
+      enabled = true
+    }
+
+    forward_to = [prometheus.relabel.kubelet.receiver]
+  } // prometheus.scrape "kubelet"
+
+  prometheus.relabel "kubelet" {
+    max_cache_size = 100000
+    rule {
+      source_labels = ["__name__"]
+      regex = "up|scrape_samples_scraped|go_goroutines|kubelet_certificate_manager_client_expiration_renew_errors|kubelet_certificate_manager_client_ttl_seconds|kubelet_certificate_manager_server_ttl_seconds|kubelet_cgroup_manager_duration_seconds_bucket|kubelet_cgroup_manager_duration_seconds_count|kubelet_node_config_error|kubelet_node_name|kubelet_pleg_relist_duration_seconds_bucket|kubelet_pleg_relist_duration_seconds_count|kubelet_pleg_relist_interval_seconds_bucket|kubelet_pod_start_duration_seconds_bucket|kubelet_pod_start_duration_seconds_count|kubelet_pod_worker_duration_seconds_bucket|kubelet_pod_worker_duration_seconds_count|kubelet_running_container_count|kubelet_running_containers|kubelet_running_pod_count|kubelet_running_pods|kubelet_runtime_operations_errors_total|kubelet_runtime_operations_total|kubelet_server_expiration_renew_errors|kubelet_volume_stats_available_bytes|kubelet_volume_stats_capacity_bytes|kubelet_volume_stats_inodes|kubelet_volume_stats_inodes_free|kubelet_volume_stats_inodes_used|kubelet_volume_stats_used_bytes|kubernetes_build_info|namespace_workload_pod|process_cpu_seconds_total|process_resident_memory_bytes|rest_client_requests_total|storage_operation_duration_seconds_count|storage_operation_errors_total|volume_manager_total_volumes"
+      action = "keep"
+    }
+
+    forward_to = argument.metrics_destinations.value
+  } // prometheus.relabel "kubelet"
+
+  // Kubelet Resources
+  discovery.relabel "kubelet_resources" {
+    targets = discovery.relabel.nodes.output
+    rule {
+      replacement   = "/metrics/resource"
+      target_label  = "__metrics_path__"
+    }
+  } // discovery.relabel "kubelet_resources"
+
+  prometheus.scrape "kubelet_resources" {
+    targets = discovery.relabel.kubelet_resources.output
+    job_name = "integrations/kubernetes/resources"
+    scheme   = "https"
+    scrape_interval = "60s"
+    scrape_timeout = "10s"
+    scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
+    scrape_classic_histograms = false
+    scrape_native_histograms = false
+    convert_classic_histograms_to_nhcb = false
+    bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+
+    tls_config {
+      ca_file = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+      insecure_skip_verify = true
+      server_name = "kubernetes"
+    }
+
+    clustering {
+      enabled = true
+    }
+
+    forward_to = [prometheus.relabel.kubelet_resources.receiver]
+  } // prometheus.scrape "kubelet_resources"
+
+  prometheus.relabel "kubelet_resources" {
+    max_cache_size = 100000
+    rule {
+      source_labels = ["__name__"]
+      regex = "up|scrape_samples_scraped|node_cpu_usage_seconds_total|node_memory_working_set_bytes"
+      action = "keep"
+    }
+
+    forward_to = argument.metrics_destinations.value
+  } // prometheus.relabel "kubelet_resources"
+
+  // cAdvisor
+  discovery.relabel "cadvisor" {
+    targets = discovery.relabel.nodes.output
+    rule {
+      replacement   = "/metrics/cadvisor"
+      target_label  = "__metrics_path__"
+    }
+  } // discovery.relabel "cadvisor"
+
+  prometheus.scrape "cadvisor" {
+    targets = discovery.relabel.cadvisor.output
+    job_name = "integrations/kubernetes/cadvisor"
+    scheme = "https"
+    scrape_interval = "60s"
+    scrape_timeout = "10s"
+    scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
+    scrape_classic_histograms = false
+    scrape_native_histograms = false
+    convert_classic_histograms_to_nhcb = false
+    bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+
+    tls_config {
+      ca_file = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+      insecure_skip_verify = true
+      server_name = "kubernetes"
+    }
+
+    clustering {
+      enabled = true
+    }
+
+    forward_to = [prometheus.relabel.cadvisor.receiver]
+  } // prometheus.scrape "cadvisor"
+
+  prometheus.relabel "cadvisor" {
+    max_cache_size = 100000
+    rule {
+      source_labels = ["__name__"]
+      regex = "up|scrape_samples_scraped|container_cpu_cfs_periods_total|container_cpu_cfs_throttled_periods_total|container_cpu_usage_seconds_total|container_fs_reads_bytes_total|container_fs_reads_total|container_fs_writes_bytes_total|container_fs_writes_total|container_memory_cache|container_memory_rss|container_memory_swap|container_memory_usage_bytes|container_memory_working_set_bytes|container_network_receive_bytes_total|container_network_receive_packets_dropped_total|container_network_receive_packets_total|container_network_transmit_bytes_total|container_network_transmit_packets_dropped_total|container_network_transmit_packets_total|machine_memory_bytes"
+      action = "keep"
+    }
+    // Drop empty container labels, addressing https://github.com/google/cadvisor/issues/2688
+    rule {
+      source_labels = ["__name__","container"]
+      separator = "@"
+      regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_pressure_.*)@"
+      action = "drop"
+    }
+    // Drop empty image labels, addressing https://github.com/google/cadvisor/issues/2688
+    rule {
+      source_labels = ["__name__","image"]
+      separator = "@"
+      regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_network_.*|container_pressure_.*)@"
+      action = "drop"
+    }
+    // Normalizing unimportant labels (not deleting to continue satisfying <label>!="" checks)
+    rule {
+      source_labels = ["__name__", "boot_id"]
+      separator = "@"
+      regex = "machine_memory_bytes@.*"
+      target_label = "boot_id"
+      replacement = "NA"
+    }
+    rule {
+      source_labels = ["__name__", "system_uuid"]
+      separator = "@"
+      regex = "machine_memory_bytes@.*"
+      target_label = "system_uuid"
+      replacement = "NA"
+    }
+    // Filter out non-physical devices/interfaces
+    rule {
+      source_labels = ["__name__", "device"]
+      separator = "@"
+      regex = "container_fs_.*@(/dev/)?(mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dasd.+)"
+      target_label = "__keepme"
+      replacement = "1"
+    }
+    rule {
+      source_labels = ["__name__", "__keepme"]
+      separator = "@"
+      regex = "container_fs_.*@"
+      action = "drop"
+    }
+    rule {
+      source_labels = ["__name__"]
+      regex = "container_fs_.*"
+      target_label = "__keepme"
+      replacement = ""
+    }
+    rule {
+      source_labels = ["__name__", "interface"]
+      separator = "@"
+      regex = "container_network_.*@(en[ospx][0-9].*|wlan[0-9].*|eth[0-9].*)"
+      target_label = "__keepme"
+      replacement = "1"
+    }
+    rule {
+      source_labels = ["__name__", "__keepme"]
+      separator = "@"
+      regex = "container_network_.*@"
+      action = "drop"
+    }
+    rule {
+      source_labels = ["__name__"]
+      regex = "container_network_.*"
+      target_label = "__keepme"
+      replacement = ""
+    }
+    forward_to = argument.metrics_destinations.value
+  } // prometheus.relabel "cadvisor"
+  discovery.kubernetes "kube_state_metrics" {
+    role = "endpoints"
+
+    selectors {
+      role = "endpoints"
+      label = "release=k8smon,app.kubernetes.io/name=kube-state-metrics"
+    }
+    namespaces {
+      names = ["default"]
+    }
+  } // discovery.kubernetes "kube_state_metrics"
+
+  discovery.relabel "kube_state_metrics" {
+    targets = discovery.kubernetes.kube_state_metrics.targets
+
+    rule {
+      action = "replace"
+      replacement = "kubernetes"
+      target_label = "source"
+    }
+
+  } // discovery.relabel "kube_state_metrics"
+
+  prometheus.scrape "kube_state_metrics" {
+    targets = discovery.relabel.kube_state_metrics.output
+    job_name = "integrations/kubernetes/kube-state-metrics"
+    scrape_interval = "60s"
+    scrape_timeout = "10s"
+    scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
+    scrape_classic_histograms = false
+    scrape_native_histograms = false
+    convert_classic_histograms_to_nhcb = false
+    scheme = "http"
+    bearer_token_file = ""
+    tls_config {
+      insecure_skip_verify = true
+    }
+
+    clustering {
+      enabled = true
+    }
+    forward_to = [prometheus.relabel.kube_state_metrics.receiver]
+  } // prometheus.scrape "kube_state_metrics"
+
+  prometheus.relabel "kube_state_metrics" {
+    max_cache_size = 100000
+    rule {
+      source_labels = ["__name__"]
+      regex = "up|scrape_samples_scraped|kube_configmap_info|kube_configmap_metadata_resource_version|kube_cronjob.*|kube_daemonset.*|kube_deployment_metadata_generation|kube_deployment_spec_replicas|kube_deployment_status_condition|kube_deployment_status_observed_generation|kube_deployment_status_replicas_available|kube_deployment_status_replicas_updated|kube_horizontalpodautoscaler_spec_max_replicas|kube_horizontalpodautoscaler_spec_min_replicas|kube_horizontalpodautoscaler_status_current_replicas|kube_horizontalpodautoscaler_status_desired_replicas|kube_job.*|kube_namespace_status_phase|kube_node.*|kube_persistentvolume_status_phase|kube_persistentvolumeclaim_access_mode|kube_persistentvolumeclaim_info|kube_persistentvolumeclaim_labels|kube_persistentvolumeclaim_resource_requests_storage_bytes|kube_persistentvolumeclaim_status_phase|kube_pod_completion_time|kube_pod_container_info|kube_pod_container_resource_limits|kube_pod_container_resource_requests|kube_pod_container_status_last_terminated_reason|kube_pod_container_status_last_terminated_timestamp|kube_pod_container_status_restarts_total|kube_pod_container_status_waiting_reason|kube_pod_info|kube_pod_owner|kube_pod_restart_policy|kube_pod_spec_volumes_persistentvolumeclaims_info|kube_pod_start_time|kube_pod_status_phase|kube_pod_status_reason|kube_pod_init_.*|kube_replicaset.*|kube_resourcequota|kube_secret_metadata_resource_version|kube_statefulset.*"
+      action = "keep"
+    }
+    forward_to = argument.metrics_destinations.value
+  } // prometheus.relabel "kube_state_metrics"
+} // declare "cluster_metrics"
+cluster_metrics "feature" {
+  metrics_destinations = [
+    prometheus.remote_write.grafana_cloud_metrics.receiver,
+  ]
+}
+declare "alloy_integration" {
+  argument "metrics_destinations" {
+    comment = "Must be a list of metric destinations where collected metrics should be forwarded to"
+  }
+
+  declare "alloy_integration_discovery" {
+    argument "namespaces" {
+      comment = "The namespaces to look for targets in (default: [] is all namespaces)"
+      optional = true
+    }
+
+    argument "field_selectors" {
+      comment = "The field selectors to use to find matching targets (default: [])"
+      optional = true
+    }
+
+    argument "label_selectors" {
+      comment = "The label selectors to use to find matching targets (default: [\"app.kubernetes.io/name=alloy\"])"
+      optional = true
+    }
+
+    argument "port_name" {
+      comment = "The of the port to scrape metrics from (default: http-metrics)"
+      optional = true
+    }
+
+    // Alloy service discovery for all of the pods
+    discovery.kubernetes "alloy_pods" {
+      role = "pod"
+
+      selectors {
+        role = "pod"
+        field = string.join(coalesce(argument.field_selectors.value, []), ",")
+        label = string.join(coalesce(argument.label_selectors.value, ["app.kubernetes.io/name=alloy"]), ",")
+      }
+
+      namespaces {
+        names = coalesce(argument.namespaces.value, [])
+      }
+
+    } // discovery.kubernetes "alloy_pods"
+
+    // alloy relabelings (pre-scrape)
+    discovery.relabel "alloy_pods" {
+      targets = discovery.kubernetes.alloy_pods.targets
+
+      // keep only the specified metrics port name, and pods that are Running and ready
+      rule {
+        source_labels = [
+          "__meta_kubernetes_pod_container_port_name",
+          "__meta_kubernetes_pod_phase",
+          "__meta_kubernetes_pod_ready",
+          "__meta_kubernetes_pod_container_init",
+        ]
+        separator = "@"
+        regex = coalesce(argument.port_name.value, "metrics") + "@Running@true@false"
+        action = "keep"
+      }
+
+      rule {
+        source_labels = ["__meta_kubernetes_namespace"]
+        target_label  = "namespace"
+      }
+
+      rule {
+        source_labels = ["__meta_kubernetes_pod_name"]
+        target_label  = "pod"
+      }
+
+      rule {
+        source_labels = ["__meta_kubernetes_pod_container_name"]
+        target_label  = "container"
+      }
+
+      // set the workload to the controller kind and name
+      rule {
+        action = "lowercase"
+        source_labels = ["__meta_kubernetes_pod_controller_kind"]
+        target_label  = "workload_type"
+      }
+
+      rule {
+        source_labels = ["__meta_kubernetes_pod_controller_name"]
+        target_label  = "workload"
+      }
+
+      // remove the hash from the ReplicaSet
+      rule {
+        source_labels = [
+          "workload_type",
+          "workload",
+        ]
+        separator = "/"
+        regex = "replicaset/(.+)-.+$"
+        target_label  = "workload"
+      }
+
+      // set the app name if specified as metadata labels "app:" or "app.kubernetes.io/name:" or "k8s-app:"
+      rule {
+        action = "replace"
+        source_labels = [
+          "__meta_kubernetes_pod_label_app_kubernetes_io_name",
+          "__meta_kubernetes_pod_label_k8s_app",
+          "__meta_kubernetes_pod_label_app",
+        ]
+        separator = ";"
+        regex = "^(?:;*)?([^;]+).*$"
+        replacement = "$1"
+        target_label = "app"
+      }
+
+      // set the component if specified as metadata labels "component:" or "app.kubernetes.io/component:" or "k8s-component:"
+      rule {
+        action = "replace"
+        source_labels = [
+          "__meta_kubernetes_pod_label_app_kubernetes_io_component",
+          "__meta_kubernetes_pod_label_k8s_component",
+          "__meta_kubernetes_pod_label_component",
+        ]
+        regex = "^(?:;*)?([^;]+).*$"
+        replacement = "$1"
+        target_label = "component"
+      }
+
+      // set a source label
+      rule {
+        action = "replace"
+        replacement = "kubernetes"
+        target_label = "source"
+      }
+
+    } // discovery.relabel "alloy_pods"
+
+    export "output" {
+      value = discovery.relabel.alloy_pods.output
+    }
+  }
+
+  declare "alloy_integration_scrape" {
+    argument "targets" {
+      comment = "Must be a list() of targets"
+    }
+
+    argument "forward_to" {
+      comment = "Must be a list(MetricsReceiver) where collected metrics should be forwarded to"
+    }
+
+    argument "job_label" {
+      comment = "The job label to add for all Alloy metrics (default: integrations/alloy)"
+      optional = true
+    }
+
+    argument "keep_metrics" {
+      comment = "A regular expression of metrics to keep (default: see below)"
+      optional = true
+    }
+
+    argument "drop_metrics" {
+      comment = "A regular expression of metrics to drop (default: see below)"
+      optional = true
+    }
+
+    argument "scrape_interval" {
+      comment = "How often to scrape metrics from the targets (default: 60s)"
+      optional = true
+    }
+
+    argument "scrape_timeout" {
+      comment = "The timeout for scraping metrics from the targets (default: 10s)"
+      optional = true
+    }
+
+    argument "scrape_protocols" {
+      comment = "The scrape protocols to use for scraping metrics"
+      optional = true
+    }
+
+    argument "scrape_classic_histograms" {
+      comment = "Whether to scrape classic histograms (default: false)."
+      optional = true
+    }
+
+    argument "scrape_native_histograms" {
+      comment = "Whether to scrape native histograms (default: false)."
+      optional = true
+    }
+
+    argument "max_cache_size" {
+      comment = "The maximum number of elements to hold in the relabeling cache (default: 100000).  This should be at least 2x-5x your largest scrape target or samples appended rate."
+      optional = true
+    }
+
+    argument "clustering" {
+      comment = "Whether or not clustering should be enabled (default: false)"
+      optional = true
+    }
+
+    prometheus.scrape "alloy" {
+      job_name = coalesce(argument.job_label.value, "integrations/alloy")
+      forward_to = [prometheus.relabel.alloy.receiver]
+      targets = argument.targets.value
+      scrape_interval = coalesce(argument.scrape_interval.value, "60s")
+      scrape_timeout = coalesce(argument.scrape_timeout.value, "10s")
+      scrape_protocols = argument.scrape_protocols.value
+      scrape_classic_histograms = argument.scrape_classic_histograms.value
+      scrape_native_histograms = argument.scrape_native_histograms.value
+
+      clustering {
+        enabled = coalesce(argument.clustering.value, false)
+      }
+    } // prometheus.scrape "alloy"
+
+    // alloy metric relabelings (post-scrape)
+    prometheus.relabel "alloy" {
+      forward_to = argument.forward_to.value
+      max_cache_size = coalesce(argument.max_cache_size.value, 100000)
+
+      // drop metrics that match the drop_metrics regex
+      rule {
+        source_labels = ["__name__"]
+        regex = coalesce(argument.drop_metrics.value, "")
+        action = "drop"
+      }
+
+      // keep only metrics that match the keep_metrics regex
+      rule {
+        source_labels = ["__name__"]
+        regex = coalesce(argument.keep_metrics.value, ".*")
+        action = "keep"
+      }
+
+      // remove the component_id label from any metric that starts with log_bytes or log_lines, these are custom metrics that are generated
+      // as part of the log annotation modules in this repo
+      rule {
+        action = "replace"
+        source_labels = ["__name__"]
+        regex = "^log_(bytes|lines).+"
+        replacement = ""
+        target_label = "component_id"
+      }
+
+      // set the namespace label to that of the exported_namespace
+      rule {
+        action = "replace"
+        source_labels = ["__name__", "exported_namespace"]
+        separator = "@"
+        regex = "^log_(bytes|lines).+@(.+)"
+        replacement = "$2"
+        target_label = "namespace"
+      }
+
+      // set the pod label to that of the exported_pod
+      rule {
+        action = "replace"
+        source_labels = ["__name__", "exported_pod"]
+        separator = "@"
+        regex = "^log_(bytes|lines).+@(.+)"
+        replacement = "$2"
+        target_label = "pod"
+      }
+
+      // set the container label to that of the exported_container
+      rule {
+        action = "replace"
+        source_labels = ["__name__", "exported_container"]
+        separator = "@"
+        regex = "^log_(bytes|lines).+@(.+)"
+        replacement = "$2"
+        target_label = "container"
+      }
+
+      // set the job label to that of the exported_job
+      rule {
+        action = "replace"
+        source_labels = ["__name__", "exported_job"]
+        separator = "@"
+        regex = "^log_(bytes|lines).+@(.+)"
+        replacement = "$2"
+        target_label = "job"
+      }
+
+      // set the instance label to that of the exported_instance
+      rule {
+        action = "replace"
+        source_labels = ["__name__", "exported_instance"]
+        separator = "@"
+        regex = "^log_(bytes|lines).+@(.+)"
+        replacement = "$2"
+        target_label = "instance"
+      }
+
+      rule {
+        action = "labeldrop"
+        regex = "exported_(namespace|pod|container|job|instance)"
+      }
+    } // prometheus.relabel "alloy"
+  }
+
+  alloy_integration_discovery "alloy" {
+    port_name = "http-metrics"
+    label_selectors = ["app.kubernetes.io/name in (alloy-metrics,alloy-singleton,alloy-logs)"]
+  }
+
+  alloy_integration_scrape "alloy" {
+    targets = alloy_integration_discovery.alloy.output
+    job_label = "integrations/alloy"
+    clustering = true
+    keep_metrics = "up|scrape_samples_scraped|alloy_build_info|alloy_component_controller_running_components|alloy_component_dependencies_wait_seconds|alloy_component_dependencies_wait_seconds_bucket|alloy_component_evaluation_seconds|alloy_component_evaluation_seconds_bucket|alloy_component_evaluation_seconds_count|alloy_component_evaluation_seconds_sum|alloy_component_evaluation_slow_seconds|alloy_config_hash|alloy_resources_machine_rx_bytes_total|alloy_resources_machine_tx_bytes_total|alloy_resources_process_cpu_seconds_total|alloy_resources_process_resident_memory_bytes|alloy_tcp_connections|alloy_wal_samples_appended_total|alloy_wal_storage_active_series|cluster_node_gossip_health_score|cluster_node_gossip_proto_version|cluster_node_gossip_received_events_total|cluster_node_info|cluster_node_lamport_time|cluster_node_peers|cluster_node_update_observers|cluster_transport_rx_bytes_total|cluster_transport_rx_packet_queue_length|cluster_transport_rx_packets_failed_total|cluster_transport_rx_packets_total|cluster_transport_stream_rx_bytes_total|cluster_transport_stream_rx_packets_failed_total|cluster_transport_stream_rx_packets_total|cluster_transport_stream_tx_bytes_total|cluster_transport_stream_tx_packets_failed_total|cluster_transport_stream_tx_packets_total|cluster_transport_streams|cluster_transport_tx_bytes_total|cluster_transport_tx_packet_queue_length|cluster_transport_tx_packets_failed_total|cluster_transport_tx_packets_total|otelcol_exporter_send_failed_spans_total|otelcol_exporter_sent_spans_total|go_gc_duration_seconds_count|go_goroutines|go_memstats_heap_inuse_bytes|loki_process_dropped_lines_total|loki_write_batch_retries_total|loki_write_dropped_bytes_total|loki_write_dropped_entries_total|loki_write_encoded_bytes_total|loki_write_mutated_bytes_total|loki_write_mutated_entries_total|loki_write_request_duration_seconds_bucket|loki_write_sent_bytes_total|loki_write_sent_entries_total|process_cpu_seconds_total|process_start_time_seconds|otelcol_processor_batch_batch_send_size_bucket|otelcol_processor_batch_metadata_cardinality|otelcol_processor_batch_timeout_trigger_send_total|prometheus_remote_storage_bytes_total|prometheus_remote_storage_enqueue_retries_total|prometheus_remote_storage_highest_timestamp_in_seconds|prometheus_remote_storage_metadata_bytes_total|prometheus_remote_storage_queue_highest_sent_timestamp_seconds|prometheus_remote_storage_samples_dropped_total|prometheus_remote_storage_samples_failed_total|prometheus_remote_storage_samples_pending|prometheus_remote_storage_samples_retried_total|prometheus_remote_storage_samples_total|prometheus_remote_storage_sent_batch_duration_seconds_bucket|prometheus_remote_storage_sent_batch_duration_seconds_count|prometheus_remote_storage_sent_batch_duration_seconds_sum|prometheus_remote_storage_shard_capacity|prometheus_remote_storage_shards|prometheus_remote_storage_shards_desired|prometheus_remote_storage_shards_max|prometheus_remote_storage_shards_min|prometheus_remote_storage_succeeded_samples_total|prometheus_remote_write_wal_samples_appended_total|prometheus_remote_write_wal_storage_active_series|prometheus_sd_discovered_targets|prometheus_target_interval_length_seconds_count|prometheus_target_interval_length_seconds_sum|prometheus_target_scrapes_exceeded_sample_limit_total|prometheus_target_scrapes_sample_duplicate_timestamp_total|prometheus_target_scrapes_sample_out_of_bounds_total|prometheus_target_scrapes_sample_out_of_order_total|prometheus_target_sync_length_seconds_sum|prometheus_wal_watcher_current_segment|otelcol_receiver_accepted_spans_total|otelcol_receiver_refused_spans_total|rpc_server_duration_milliseconds_bucket|scrape_duration_seconds|traces_exporter_send_failed_spans|traces_exporter_send_failed_spans_total|traces_exporter_sent_spans|traces_exporter_sent_spans_total|traces_loadbalancer_backend_outcome|traces_loadbalancer_num_backends|traces_receiver_accepted_spans|traces_receiver_accepted_spans_total|traces_receiver_refused_spans|traces_receiver_refused_spans_total"
+    scrape_interval = "60s"
+    scrape_timeout = "10s"
+    scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
+    scrape_classic_histograms = false
+    scrape_native_histograms = false
+    max_cache_size = 100000
+    forward_to = argument.metrics_destinations.value
+  }
+}
+alloy_integration "integration" {
+  metrics_destinations = [
+    prometheus.remote_write.grafana_cloud_metrics.receiver,
+  ]
+}
+
+
+
+
+
+// Destination: grafana-cloud-metrics (prometheus)
+otelcol.exporter.prometheus "grafana_cloud_metrics" {
+  add_metric_suffixes = true
+  resource_to_telemetry_conversion = false
+  keep_identifying_resource_attributes = true
+  forward_to = [prometheus.remote_write.grafana_cloud_metrics.receiver]
+} // otelcol.exporter.prometheus "grafana_cloud_metrics"
+
+prometheus.remote_write "grafana_cloud_metrics" {
+  endpoint {
+    url = "https://prometheus-prod-13-prod-us-east-0.grafana.net/api/prom/push"
+    headers = {
+      "X-Scope-OrgID" = convert.nonsensitive(remote.kubernetes.secret.grafana_cloud_metrics.data["tenantId"]),
+    }
+    basic_auth {
+      username = convert.nonsensitive(remote.kubernetes.secret.grafana_cloud_metrics.data["PROMETHEUS_USER"])
+      password = remote.kubernetes.secret.grafana_cloud_metrics.data["PROMETHEUS_PASS"]
+    }
+    tls_config {
+      insecure_skip_verify = false
+      ca_pem = convert.nonsensitive(remote.kubernetes.secret.grafana_cloud_metrics.data["ca"])
+      cert_pem = convert.nonsensitive(remote.kubernetes.secret.grafana_cloud_metrics.data["cert"])
+      key_pem = remote.kubernetes.secret.grafana_cloud_metrics.data["key"]
+    }
+    send_native_histograms = false
+
+    queue_config {
+      capacity = 10000
+      min_shards = 1
+      max_shards = 50
+      max_samples_per_send = 2000
+      batch_send_deadline = "5s"
+      min_backoff = "30ms"
+      max_backoff = "5s"
+      retry_on_http_429 = true
+      sample_age_limit = "0s"
+    }
+  }
+
+  wal {
+    truncate_frequency = "2h"
+    min_keepalive_time = "5m"
+    max_keepalive_time = "8h"
+  }
+  external_labels = {
+    "cluster" = "gke-autopilot-test",
+    "k8s_cluster_name" = "gke-autopilot-test",
+  }
+} // prometheus.remote_write "grafana_cloud_metrics"
+
+remote.kubernetes.secret "grafana_cloud_metrics" {
+  name      = "grafana-cloud-credentials"
+  namespace = "default"
+} // remote.kubernetes.secret "grafana_cloud_metrics"
+

--- a/charts/k8s-monitoring/tests/platform/gke-autopilot/.rendered/alloy-singleton.alloy
+++ b/charts/k8s-monitoring/tests/platform/gke-autopilot/.rendered/alloy-singleton.alloy
@@ -1,0 +1,221 @@
+// Feature: Cluster Events
+declare "cluster_events" {
+  argument "logs_destinations" {
+    comment = "Must be a list of log destinations where collected logs should be forwarded to"
+  }
+
+  loki.source.kubernetes_events "cluster_events" {
+    job_name   = "integrations/kubernetes/eventhandler"
+    log_format = "logfmt"
+    forward_to = [loki.process.cluster_events.receiver]
+  } // loki.source.kubernetes_events "cluster_events"
+
+  loki.process "cluster_events" {
+
+    // add a static source label to the logs so they can be differentiated / restricted if necessary
+    stage.static_labels {
+      values = {
+        "source" = "kubernetes-events",
+      }
+    }
+
+    // extract some of the fields from the log line, these could be used as labels, structured metadata, etc.
+    stage.logfmt {
+      mapping = {
+        "component" = "sourcecomponent", // map the sourcecomponent field to component
+        "kind" = "",
+        "level" = "type", // most events don't have a level but they do have a "type" i.e. Normal, Warning, Error, etc.
+        "name" = "",
+        "node" = "sourcehost", // map the sourcehost field to node
+        "reason" = "",
+      }
+    }
+    // set the extracted values as labels
+    stage.labels {
+      values = {
+        "kind" = "",
+        "level" = "",
+        "service_name" = "job",
+        "reason" = "reason",
+      }
+    }
+
+    // if kind=Node, set the node label by copying the name field
+    stage.match {
+      selector = "{kind=\"Node\"}"
+
+      stage.labels {
+        values = {
+          "node" = "name",
+        }
+      }
+    }
+
+    // set the level extracted key value as a normalized log level
+    stage.match {
+      selector = "{level=\"Normal\"}"
+
+      stage.static_labels {
+        values = {
+          level = "Info",
+        }
+      }
+    }
+    stage.structured_metadata {
+      values = {
+        "name" = "name",
+        "node" = "node",
+      }
+    }
+
+    // Drop pipeline-only labels that are not needed in the final output.
+    stage.label_drop {
+      values = ["kind"]
+    }
+
+    forward_to = argument.logs_destinations.value
+  } // loki.process "cluster_events"
+} // declare "cluster_events"
+cluster_events "feature" {
+  logs_destinations = [
+    loki.write.grafana_cloud_logs.receiver,
+  ]
+}
+// Self Reporting
+prometheus.exporter.unix "kubernetes_monitoring_telemetry" {
+  set_collectors = ["textfile"]
+  textfile {
+    directory = "/etc/release-info"
+  }
+} // prometheus.exporter.unix "kubernetes_monitoring_telemetry"
+
+discovery.relabel "kubernetes_monitoring_telemetry" {
+  targets = prometheus.exporter.unix.kubernetes_monitoring_telemetry.targets
+  rule {
+    target_label = "instance"
+    action = "replace"
+    replacement = "k8smon"
+  }
+  rule {
+    target_label = "job"
+    action = "replace"
+    replacement = "integrations/kubernetes/kubernetes_monitoring_telemetry"
+  }
+} // discovery.relabel "kubernetes_monitoring_telemetry"
+
+prometheus.scrape "kubernetes_monitoring_telemetry" {
+  job_name   = "integrations/kubernetes/kubernetes_monitoring_telemetry"
+  targets    = discovery.relabel.kubernetes_monitoring_telemetry.output
+  scrape_interval = "60s"
+  clustering {
+    enabled = true
+  }
+  forward_to = [prometheus.relabel.kubernetes_monitoring_telemetry.receiver]
+} // prometheus.scrape "kubernetes_monitoring_telemetry"
+
+prometheus.relabel "kubernetes_monitoring_telemetry" {
+  rule {
+    source_labels = ["__name__"]
+    regex = "grafana_kubernetes_monitoring_.*"
+    action = "keep"
+  }
+  forward_to = [
+    prometheus.remote_write.grafana_cloud_metrics.receiver,
+  ]
+} // prometheus.relabel "kubernetes_monitoring_telemetry"
+
+
+
+
+
+// Destination: grafana-cloud-logs (loki)
+otelcol.exporter.loki "grafana_cloud_logs" {
+  forward_to = [loki.write.grafana_cloud_logs.receiver]
+} // otelcol.exporter.loki "grafana_cloud_logs"
+
+loki.write "grafana_cloud_logs" {
+  endpoint {
+    url = "https://logs-prod-006.grafana.net/loki/api/v1/push"
+    retry_on_http_429 = true
+    tenant_id = convert.nonsensitive(remote.kubernetes.secret.grafana_cloud_logs.data["tenantId"])
+    basic_auth {
+      username = convert.nonsensitive(remote.kubernetes.secret.grafana_cloud_logs.data["LOKI_USER"])
+      password = remote.kubernetes.secret.grafana_cloud_logs.data["LOKI_PASS"]
+    }
+    tls_config {
+      insecure_skip_verify = false
+      ca_pem = convert.nonsensitive(remote.kubernetes.secret.grafana_cloud_logs.data["ca"])
+      cert_pem = convert.nonsensitive(remote.kubernetes.secret.grafana_cloud_logs.data["cert"])
+      key_pem = remote.kubernetes.secret.grafana_cloud_logs.data["key"]
+    }
+    min_backoff_period = "500ms"
+    max_backoff_period = "5m"
+    max_backoff_retries = "10"
+  }
+  external_labels = {
+    "cluster" = "gke-autopilot-test",
+    "k8s_cluster_name" = "gke-autopilot-test",
+  }
+} // loki.write "grafana_cloud_logs"
+
+remote.kubernetes.secret "grafana_cloud_logs" {
+  name      = "grafana-cloud-credentials"
+  namespace = "default"
+} // remote.kubernetes.secret "grafana_cloud_logs"
+
+
+// Destination: grafana-cloud-metrics (prometheus)
+otelcol.exporter.prometheus "grafana_cloud_metrics" {
+  add_metric_suffixes = true
+  resource_to_telemetry_conversion = false
+  keep_identifying_resource_attributes = true
+  forward_to = [prometheus.remote_write.grafana_cloud_metrics.receiver]
+} // otelcol.exporter.prometheus "grafana_cloud_metrics"
+
+prometheus.remote_write "grafana_cloud_metrics" {
+  endpoint {
+    url = "https://prometheus-prod-13-prod-us-east-0.grafana.net/api/prom/push"
+    headers = {
+      "X-Scope-OrgID" = convert.nonsensitive(remote.kubernetes.secret.grafana_cloud_metrics.data["tenantId"]),
+    }
+    basic_auth {
+      username = convert.nonsensitive(remote.kubernetes.secret.grafana_cloud_metrics.data["PROMETHEUS_USER"])
+      password = remote.kubernetes.secret.grafana_cloud_metrics.data["PROMETHEUS_PASS"]
+    }
+    tls_config {
+      insecure_skip_verify = false
+      ca_pem = convert.nonsensitive(remote.kubernetes.secret.grafana_cloud_metrics.data["ca"])
+      cert_pem = convert.nonsensitive(remote.kubernetes.secret.grafana_cloud_metrics.data["cert"])
+      key_pem = remote.kubernetes.secret.grafana_cloud_metrics.data["key"]
+    }
+    send_native_histograms = false
+
+    queue_config {
+      capacity = 10000
+      min_shards = 1
+      max_shards = 50
+      max_samples_per_send = 2000
+      batch_send_deadline = "5s"
+      min_backoff = "30ms"
+      max_backoff = "5s"
+      retry_on_http_429 = true
+      sample_age_limit = "0s"
+    }
+  }
+
+  wal {
+    truncate_frequency = "2h"
+    min_keepalive_time = "5m"
+    max_keepalive_time = "8h"
+  }
+  external_labels = {
+    "cluster" = "gke-autopilot-test",
+    "k8s_cluster_name" = "gke-autopilot-test",
+  }
+} // prometheus.remote_write "grafana_cloud_metrics"
+
+remote.kubernetes.secret "grafana_cloud_metrics" {
+  name      = "grafana-cloud-credentials"
+  namespace = "default"
+} // remote.kubernetes.secret "grafana_cloud_metrics"
+

--- a/charts/k8s-monitoring/tests/platform/gke/.rendered/alloy-logs.alloy
+++ b/charts/k8s-monitoring/tests/platform/gke/.rendered/alloy-logs.alloy
@@ -1,0 +1,239 @@
+// Feature: Pod Logs (Loki)
+declare "pod_logs_via_loki" {
+  argument "logs_destinations" {
+    comment = "Must be a list of log destinations where collected logs should be forwarded to"
+  }
+
+  discovery.kubernetes "pods" {
+    role = "pod"
+    selectors {
+      role = "pod"
+      field = "spec.nodeName=" + sys.env("HOSTNAME")
+    }
+  } // discovery.kubernetes "pods"
+
+  discovery.relabel "filtered_pods" {
+    targets = discovery.kubernetes.pods.targets
+    rule {
+      source_labels = ["__meta_kubernetes_namespace"]
+      action = "replace"
+      target_label = "namespace"
+    }
+    rule {  // Drop anything with a "falsy" annotation value
+      source_labels = ["__meta_kubernetes_pod_annotation_logs_grafana_com_pods_enabled"]
+      regex = "(false|no|skip)"
+      action = "drop"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_pod_name"]
+      target_label = "pod"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_pod_container_name"]
+      target_label = "container"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_namespace", "__meta_kubernetes_pod_container_name"]
+      separator = "/"
+      replacement = "$1"
+      target_label = "job"
+    }
+
+    // set the container runtime as a label
+    rule {
+      source_labels = ["__meta_kubernetes_pod_container_id"]
+      regex = "^(\\S+):\\/\\/.+$"
+      replacement = "$1"
+      target_label = "tmp_container_runtime"
+    }
+    // explicitly set service_name. if not set, loki will automatically try to populate a default.
+    // see https://grafana.com/docs/loki/latest/get-started/labels/#default-labels-for-all-users
+    //
+    // choose the first value found from the following ordered list:
+    // - pod.annotation[resource.opentelemetry.io/service.name]
+    // - pod.label[app.kubernetes.io/name]
+    // - k8s.container.name
+    rule {
+      source_labels = [
+        "__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_name",
+        "__meta_kubernetes_pod_label_app_kubernetes_io_name",
+        "__meta_kubernetes_pod_container_name",
+      ]
+      separator = ";"
+      regex = "^(?:;*)?([^;]+).*$"
+      replacement = "$1"
+      target_label = "service_name"
+    }
+
+    // explicitly set service_namespace.
+    //
+    // choose the first value found from the following ordered list:
+    // - pod.annotation[resource.opentelemetry.io/service.namespace]
+    // - pod.namespace
+    rule {
+      source_labels = [
+        "__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_namespace",
+        "namespace",
+      ]
+      separator = ";"
+      regex = "^(?:;*)?([^;]+).*$"
+      replacement = "$1"
+      target_label = "service_namespace"
+    }
+
+    // explicitly set service_instance_id.
+    //
+    // choose the first value found from the following ordered list:
+    // - pod.annotation[resource.opentelemetry.io/service.instance.id]
+    // - concat([k8s.namespace.name, k8s.pod.name, k8s.container.name], '.')
+    rule {
+      source_labels = ["__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_instance_id"]
+      target_label = "service_instance_id"
+    }
+    rule {
+      source_labels = ["service_instance_id", "namespace", "pod", "container"]
+      separator = "."
+      regex = "^\\.([^.]+\\.[^.]+\\.[^.]+)$"
+      target_label = "service_instance_id"
+    }
+
+    // set resource attributes
+    rule {
+      action = "labelmap"
+      regex = "__meta_kubernetes_pod_annotation_resource_opentelemetry_io_(.+)"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_job"]
+      regex = "(.+)"
+      target_label = "job"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+      regex = "(.+)"
+      target_label = "app_kubernetes_io_name"
+    }
+
+    // Set the pod log path.
+    rule {
+      source_labels = ["__meta_kubernetes_pod_uid", "__meta_kubernetes_pod_container_name"]
+      separator = "/"
+      replacement = "/var/log/pods/*$1/*.log"
+      target_label = "__path__"
+    }
+
+    // If kubernetes.io/config.mirror is set, this is a static pod, created by the kubelet.
+    // It's logs live on a different path.
+    rule {
+      source_labels = ["__meta_kubernetes_pod_annotation_kubernetes_io_config_mirror", "__meta_kubernetes_pod_container_name"]
+      separator = "/"
+      regex = "(.+/.+)"
+      replacement = "/var/log/pods/*$1/*.log"
+      target_label = "__path__"
+    }
+  } // discovery.relabel "filtered_pods"
+
+  local.file_match "pod_logs" {
+    path_targets = discovery.relabel.filtered_pods.output
+  } // local.file_match "pod_logs"
+
+  loki.source.file "pod_logs" {
+    targets    = local.file_match.pod_logs.targets
+    tail_from_end = true
+    forward_to = [loki.process.pod_logs.receiver]
+  } // loki.source.file "pod_logs"
+
+  loki.process "pod_logs" {
+    stage.match {
+      selector = "{tmp_container_runtime=~\"containerd|cri-o|\"}"
+      // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
+      stage.cri {
+        max_partial_lines = 100
+      }
+
+      // Set the extract flags and stream values as labels
+      stage.labels {
+        values = {
+          flags  = "",
+          stream  = "",
+        }
+      }
+    }
+
+    stage.match {
+      selector = "{tmp_container_runtime=\"docker\"}"
+      // the docker processing stage extracts the following k/v pairs: log, stream, time
+      stage.docker {}
+
+      // Set the extract stream value as a label
+      stage.labels {
+        values = {
+          stream  = "",
+        }
+      }
+    }
+
+    // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
+    // namespace, pod, and container labels. Drop any structured metadata. Also drop the temporary
+    // container runtime label as it is no longer needed.
+    stage.label_drop {
+      values = [
+        "filename",
+        "tmp_container_runtime",
+      ]
+    }
+    stage.structured_metadata {
+      values = {
+        "k8s_pod_name" = "k8s_pod_name",
+        "pod" = "pod",
+        "service_instance_id" = "service_instance_id",
+      }
+    }
+
+    forward_to = argument.logs_destinations.value
+  } // loki.secretfilter "pod_logs"
+} // declare "pod_logs_via_loki"
+pod_logs_via_loki "feature" {
+  logs_destinations = [
+    loki.write.grafana_cloud_logs.receiver,
+  ]
+}
+
+
+
+
+
+// Destination: grafana-cloud-logs (loki)
+otelcol.exporter.loki "grafana_cloud_logs" {
+  forward_to = [loki.write.grafana_cloud_logs.receiver]
+} // otelcol.exporter.loki "grafana_cloud_logs"
+
+loki.write "grafana_cloud_logs" {
+  endpoint {
+    url = "https://logs-prod-006.grafana.net/loki/api/v1/push"
+    retry_on_http_429 = true
+    tenant_id = convert.nonsensitive(remote.kubernetes.secret.grafana_cloud_logs.data["tenantId"])
+    basic_auth {
+      username = convert.nonsensitive(remote.kubernetes.secret.grafana_cloud_logs.data["LOKI_USER"])
+      password = remote.kubernetes.secret.grafana_cloud_logs.data["LOKI_PASS"]
+    }
+    tls_config {
+      insecure_skip_verify = false
+      ca_pem = convert.nonsensitive(remote.kubernetes.secret.grafana_cloud_logs.data["ca"])
+      cert_pem = convert.nonsensitive(remote.kubernetes.secret.grafana_cloud_logs.data["cert"])
+      key_pem = remote.kubernetes.secret.grafana_cloud_logs.data["key"]
+    }
+    min_backoff_period = "500ms"
+    max_backoff_period = "5m"
+    max_backoff_retries = "10"
+  }
+  external_labels = {
+    "cluster" = "gke-test",
+    "k8s_cluster_name" = "gke-test",
+  }
+} // loki.write "grafana_cloud_logs"
+
+remote.kubernetes.secret "grafana_cloud_logs" {
+  name      = "grafana-cloud-credentials"
+  namespace = "default"
+} // remote.kubernetes.secret "grafana_cloud_logs"
+

--- a/charts/k8s-monitoring/tests/platform/gke/.rendered/alloy-metrics.alloy
+++ b/charts/k8s-monitoring/tests/platform/gke/.rendered/alloy-metrics.alloy
@@ -1,0 +1,872 @@
+// Feature: Cluster Metrics
+declare "cluster_metrics" {
+  argument "metrics_destinations" {
+    comment = "Must be a list of metric destinations where collected metrics should be forwarded to"
+  }
+  discovery.kubernetes "nodes" {
+    role = "node"
+  } // discovery.kubernetes "nodes"
+
+  discovery.relabel "nodes" {
+    targets = discovery.kubernetes.nodes.targets
+    rule {
+      source_labels = ["__meta_kubernetes_node_name"]
+      target_label  = "node"
+    }
+
+    rule {
+      replacement = "kubernetes"
+      target_label = "source"
+    }
+  } // discovery.relabel "nodes"
+
+  // Kubelet
+  discovery.relabel "kubelet" {
+    targets = discovery.relabel.nodes.output
+  } // discovery.relabel "kubelet"
+
+  prometheus.scrape "kubelet" {
+    targets  = discovery.relabel.kubelet.output
+    job_name = "integrations/kubernetes/kubelet"
+    scheme   = "https"
+    scrape_interval = "60s"
+    scrape_timeout = "10s"
+    scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
+    scrape_classic_histograms = false
+    scrape_native_histograms = false
+    convert_classic_histograms_to_nhcb = false
+    bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+
+    tls_config {
+      ca_file = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+      insecure_skip_verify = true
+      server_name = "kubernetes"
+    }
+
+    clustering {
+      enabled = true
+    }
+
+    forward_to = [prometheus.relabel.kubelet.receiver]
+  } // prometheus.scrape "kubelet"
+
+  prometheus.relabel "kubelet" {
+    max_cache_size = 100000
+    rule {
+      source_labels = ["__name__"]
+      regex = "up|scrape_samples_scraped|go_goroutines|kubelet_certificate_manager_client_expiration_renew_errors|kubelet_certificate_manager_client_ttl_seconds|kubelet_certificate_manager_server_ttl_seconds|kubelet_cgroup_manager_duration_seconds_bucket|kubelet_cgroup_manager_duration_seconds_count|kubelet_node_config_error|kubelet_node_name|kubelet_pleg_relist_duration_seconds_bucket|kubelet_pleg_relist_duration_seconds_count|kubelet_pleg_relist_interval_seconds_bucket|kubelet_pod_start_duration_seconds_bucket|kubelet_pod_start_duration_seconds_count|kubelet_pod_worker_duration_seconds_bucket|kubelet_pod_worker_duration_seconds_count|kubelet_running_container_count|kubelet_running_containers|kubelet_running_pod_count|kubelet_running_pods|kubelet_runtime_operations_errors_total|kubelet_runtime_operations_total|kubelet_server_expiration_renew_errors|kubelet_volume_stats_available_bytes|kubelet_volume_stats_capacity_bytes|kubelet_volume_stats_inodes|kubelet_volume_stats_inodes_free|kubelet_volume_stats_inodes_used|kubelet_volume_stats_used_bytes|kubernetes_build_info|namespace_workload_pod|process_cpu_seconds_total|process_resident_memory_bytes|rest_client_requests_total|storage_operation_duration_seconds_count|storage_operation_errors_total|volume_manager_total_volumes"
+      action = "keep"
+    }
+
+    forward_to = argument.metrics_destinations.value
+  } // prometheus.relabel "kubelet"
+
+  // Kubelet Resources
+  discovery.relabel "kubelet_resources" {
+    targets = discovery.relabel.nodes.output
+    rule {
+      replacement   = "/metrics/resource"
+      target_label  = "__metrics_path__"
+    }
+  } // discovery.relabel "kubelet_resources"
+
+  prometheus.scrape "kubelet_resources" {
+    targets = discovery.relabel.kubelet_resources.output
+    job_name = "integrations/kubernetes/resources"
+    scheme   = "https"
+    scrape_interval = "60s"
+    scrape_timeout = "10s"
+    scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
+    scrape_classic_histograms = false
+    scrape_native_histograms = false
+    convert_classic_histograms_to_nhcb = false
+    bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+
+    tls_config {
+      ca_file = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+      insecure_skip_verify = true
+      server_name = "kubernetes"
+    }
+
+    clustering {
+      enabled = true
+    }
+
+    forward_to = [prometheus.relabel.kubelet_resources.receiver]
+  } // prometheus.scrape "kubelet_resources"
+
+  prometheus.relabel "kubelet_resources" {
+    max_cache_size = 100000
+    rule {
+      source_labels = ["__name__"]
+      regex = "up|scrape_samples_scraped|node_cpu_usage_seconds_total|node_memory_working_set_bytes"
+      action = "keep"
+    }
+
+    forward_to = argument.metrics_destinations.value
+  } // prometheus.relabel "kubelet_resources"
+
+  // cAdvisor
+  discovery.relabel "cadvisor" {
+    targets = discovery.relabel.nodes.output
+    rule {
+      replacement   = "/metrics/cadvisor"
+      target_label  = "__metrics_path__"
+    }
+  } // discovery.relabel "cadvisor"
+
+  prometheus.scrape "cadvisor" {
+    targets = discovery.relabel.cadvisor.output
+    job_name = "integrations/kubernetes/cadvisor"
+    scheme = "https"
+    scrape_interval = "60s"
+    scrape_timeout = "10s"
+    scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
+    scrape_classic_histograms = false
+    scrape_native_histograms = false
+    convert_classic_histograms_to_nhcb = false
+    bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+
+    tls_config {
+      ca_file = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+      insecure_skip_verify = true
+      server_name = "kubernetes"
+    }
+
+    clustering {
+      enabled = true
+    }
+
+    forward_to = [prometheus.relabel.cadvisor.receiver]
+  } // prometheus.scrape "cadvisor"
+
+  prometheus.relabel "cadvisor" {
+    max_cache_size = 100000
+    rule {
+      source_labels = ["__name__"]
+      regex = "up|scrape_samples_scraped|container_cpu_cfs_periods_total|container_cpu_cfs_throttled_periods_total|container_cpu_usage_seconds_total|container_fs_reads_bytes_total|container_fs_reads_total|container_fs_writes_bytes_total|container_fs_writes_total|container_memory_cache|container_memory_rss|container_memory_swap|container_memory_usage_bytes|container_memory_working_set_bytes|container_network_receive_bytes_total|container_network_receive_packets_dropped_total|container_network_receive_packets_total|container_network_transmit_bytes_total|container_network_transmit_packets_dropped_total|container_network_transmit_packets_total|machine_memory_bytes"
+      action = "keep"
+    }
+    // Drop empty container labels, addressing https://github.com/google/cadvisor/issues/2688
+    rule {
+      source_labels = ["__name__","container"]
+      separator = "@"
+      regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_pressure_.*)@"
+      action = "drop"
+    }
+    // Drop empty image labels, addressing https://github.com/google/cadvisor/issues/2688
+    rule {
+      source_labels = ["__name__","image"]
+      separator = "@"
+      regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_network_.*|container_pressure_.*)@"
+      action = "drop"
+    }
+    // Normalizing unimportant labels (not deleting to continue satisfying <label>!="" checks)
+    rule {
+      source_labels = ["__name__", "boot_id"]
+      separator = "@"
+      regex = "machine_memory_bytes@.*"
+      target_label = "boot_id"
+      replacement = "NA"
+    }
+    rule {
+      source_labels = ["__name__", "system_uuid"]
+      separator = "@"
+      regex = "machine_memory_bytes@.*"
+      target_label = "system_uuid"
+      replacement = "NA"
+    }
+    // Filter out non-physical devices/interfaces
+    rule {
+      source_labels = ["__name__", "device"]
+      separator = "@"
+      regex = "container_fs_.*@(/dev/)?(mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dasd.+)"
+      target_label = "__keepme"
+      replacement = "1"
+    }
+    rule {
+      source_labels = ["__name__", "__keepme"]
+      separator = "@"
+      regex = "container_fs_.*@"
+      action = "drop"
+    }
+    rule {
+      source_labels = ["__name__"]
+      regex = "container_fs_.*"
+      target_label = "__keepme"
+      replacement = ""
+    }
+    rule {
+      source_labels = ["__name__", "interface"]
+      separator = "@"
+      regex = "container_network_.*@(en[ospx][0-9].*|wlan[0-9].*|eth[0-9].*)"
+      target_label = "__keepme"
+      replacement = "1"
+    }
+    rule {
+      source_labels = ["__name__", "__keepme"]
+      separator = "@"
+      regex = "container_network_.*@"
+      action = "drop"
+    }
+    rule {
+      source_labels = ["__name__"]
+      regex = "container_network_.*"
+      target_label = "__keepme"
+      replacement = ""
+    }
+    forward_to = argument.metrics_destinations.value
+  } // prometheus.relabel "cadvisor"
+  discovery.kubernetes "kube_state_metrics" {
+    role = "endpoints"
+
+    selectors {
+      role = "endpoints"
+      label = "release=k8smon,app.kubernetes.io/name=kube-state-metrics"
+    }
+    namespaces {
+      names = ["default"]
+    }
+  } // discovery.kubernetes "kube_state_metrics"
+
+  discovery.relabel "kube_state_metrics" {
+    targets = discovery.kubernetes.kube_state_metrics.targets
+
+    rule {
+      action = "replace"
+      replacement = "kubernetes"
+      target_label = "source"
+    }
+
+  } // discovery.relabel "kube_state_metrics"
+
+  prometheus.scrape "kube_state_metrics" {
+    targets = discovery.relabel.kube_state_metrics.output
+    job_name = "integrations/kubernetes/kube-state-metrics"
+    scrape_interval = "60s"
+    scrape_timeout = "10s"
+    scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
+    scrape_classic_histograms = false
+    scrape_native_histograms = false
+    convert_classic_histograms_to_nhcb = false
+    scheme = "http"
+    bearer_token_file = ""
+    tls_config {
+      insecure_skip_verify = true
+    }
+
+    clustering {
+      enabled = true
+    }
+    forward_to = [prometheus.relabel.kube_state_metrics.receiver]
+  } // prometheus.scrape "kube_state_metrics"
+
+  prometheus.relabel "kube_state_metrics" {
+    max_cache_size = 100000
+    rule {
+      source_labels = ["__name__"]
+      regex = "up|scrape_samples_scraped|kube_configmap_info|kube_configmap_metadata_resource_version|kube_cronjob.*|kube_daemonset.*|kube_deployment_metadata_generation|kube_deployment_spec_replicas|kube_deployment_status_condition|kube_deployment_status_observed_generation|kube_deployment_status_replicas_available|kube_deployment_status_replicas_updated|kube_horizontalpodautoscaler_spec_max_replicas|kube_horizontalpodautoscaler_spec_min_replicas|kube_horizontalpodautoscaler_status_current_replicas|kube_horizontalpodautoscaler_status_desired_replicas|kube_job.*|kube_namespace_status_phase|kube_node.*|kube_persistentvolume_status_phase|kube_persistentvolumeclaim_access_mode|kube_persistentvolumeclaim_info|kube_persistentvolumeclaim_labels|kube_persistentvolumeclaim_resource_requests_storage_bytes|kube_persistentvolumeclaim_status_phase|kube_pod_completion_time|kube_pod_container_info|kube_pod_container_resource_limits|kube_pod_container_resource_requests|kube_pod_container_status_last_terminated_reason|kube_pod_container_status_last_terminated_timestamp|kube_pod_container_status_restarts_total|kube_pod_container_status_waiting_reason|kube_pod_info|kube_pod_owner|kube_pod_restart_policy|kube_pod_spec_volumes_persistentvolumeclaims_info|kube_pod_start_time|kube_pod_status_phase|kube_pod_status_reason|kube_pod_init_.*|kube_replicaset.*|kube_resourcequota|kube_secret_metadata_resource_version|kube_statefulset.*"
+      action = "keep"
+    }
+    forward_to = argument.metrics_destinations.value
+  } // prometheus.relabel "kube_state_metrics"
+} // declare "cluster_metrics"
+cluster_metrics "feature" {
+  metrics_destinations = [
+    prometheus.remote_write.grafana_cloud_metrics.receiver,
+  ]
+}
+// Feature: Cost Metrics
+declare "cost_metrics" {
+  argument "metrics_destinations" {
+    comment = "Must be a list of metric destinations where collected metrics should be forwarded to"
+  }
+
+  discovery.kubernetes "opencost" {
+    role = "pod"
+    selectors {
+      role = "pod"
+      label = "app.kubernetes.io/instance=k8smon,app.kubernetes.io/name=opencost"
+    }
+    namespaces {
+      names = ["default"]
+    }
+  } // discovery.kubernetes "opencost"
+
+  discovery.relabel "opencost" {
+    targets = discovery.kubernetes.opencost.targets
+    rule {
+      source_labels = ["__meta_kubernetes_pod_node_name"]
+      action = "replace"
+      target_label = "instance"
+    }
+  } // discovery.relabel "opencost"
+
+  prometheus.scrape "opencost" {
+    targets      = discovery.relabel.opencost.output
+    job_name     = "integrations/opencost"
+    honor_labels = true
+    scrape_interval = "60s"
+    scrape_timeout = "10s"
+    scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
+    scrape_classic_histograms = false
+    scrape_native_histograms = false
+    convert_classic_histograms_to_nhcb = false
+    clustering {
+      enabled = true
+    }
+    forward_to = [prometheus.relabel.opencost.receiver]
+  } // prometheus.scrape "opencost"
+
+  prometheus.relabel "opencost" {
+    max_cache_size = 100000
+    rule {
+      source_labels = ["__name__"]
+      regex = "up|scrape_samples_scraped|container_cpu_allocation|container_gpu_allocation|container_memory_allocation_bytes|deployment_match_labels|kubecost_cluster_info|kubecost_cluster_management_cost|kubecost_cluster_memory_working_set_bytes|kubecost_http_requests_total|kubecost_http_response_size_bytes|kubecost_http_response_time_seconds|kubecost_load_balancer_cost|kubecost_network_internet_egress_cost|kubecost_network_region_egress_cost|kubecost_network_zone_egress_cost|kubecost_node_is_spot|node_cpu_hourly_cost|node_gpu_count|node_gpu_hourly_cost|node_ram_hourly_cost|node_total_hourly_cost|opencost_build_info|pod_pvc_allocation|pv_hourly_cost|service_selector_labels|statefulSet_match_labels"
+      action = "keep"
+    }
+    forward_to = argument.metrics_destinations.value
+  } // prometheus.relabel "opencost"
+} // declare "cost_metrics"
+cost_metrics "feature" {
+  metrics_destinations = [
+    prometheus.remote_write.grafana_cloud_metrics.receiver,
+  ]
+}
+// Feature: Host Metrics
+declare "host_metrics" {
+  argument "metrics_destinations" {
+    comment = "Must be a list of metric destinations where collected metrics should be forwarded to"
+  }
+
+  // Linux hosts via Node Exporter
+  discovery.kubernetes "node_exporter" {
+    role = "pod"
+    selectors {
+      role = "pod"
+      label = "release=k8smon,app.kubernetes.io/name=node-exporter"
+    }
+    namespaces {
+      names = ["default"]
+    }
+
+  } // discovery.kubernetes "node_exporter"
+
+  discovery.relabel "node_exporter" {
+    targets = discovery.kubernetes.node_exporter.targets
+
+    // keep only the specified metrics port name, and pods that are Running and ready
+    rule {
+      source_labels = [
+        "__meta_kubernetes_pod_container_init",
+        "__meta_kubernetes_pod_phase",
+        "__meta_kubernetes_pod_ready",
+      ]
+      separator = "@"
+      regex = "false@Running@true"
+      action = "keep"
+    }
+
+    // Set the instance label to the node name
+    rule {
+      source_labels = ["__meta_kubernetes_pod_node_name"]
+      target_label = "instance"
+    }
+
+    rule {
+      source_labels = ["__meta_kubernetes_namespace"]
+      target_label  = "namespace"
+    }
+
+    rule {
+      source_labels = ["__meta_kubernetes_pod_name"]
+      target_label  = "pod"
+    }
+
+    rule {
+      source_labels = ["__meta_kubernetes_pod_container_name"]
+      target_label  = "container"
+    }
+
+    // set a workload label
+    rule {
+      source_labels = [
+        "__meta_kubernetes_pod_controller_kind",
+        "__meta_kubernetes_pod_controller_name",
+      ]
+      separator = "/"
+      target_label  = "workload"
+    }
+    // remove the hash from the ReplicaSet
+    rule {
+      source_labels = ["workload"]
+      regex = "(ReplicaSet/.+)-.+"
+      target_label  = "workload"
+    }
+
+    // Set the app label.
+    //
+    // Choose the first value found from the following ordered list:
+    // - pod.label[app.kubernetes.io/name]
+    // - pod.label[k8s-app]
+    // - pod.label[app]
+    rule {
+      source_labels = [
+        "__meta_kubernetes_pod_label_app_kubernetes_io_name",
+        "__meta_kubernetes_pod_label_k8s_app",
+        "__meta_kubernetes_pod_label_app",
+      ]
+      separator = ";"
+      regex = "^(?:;*)?([^;]+).*$"
+      replacement = "$1"
+      target_label = "app"
+    }
+
+    // Set the component label.
+    //
+    // Choose the first value found from the following ordered list:
+    // - pod.label[app.kubernetes.io/component]
+    // - pod.label[k8s-component]
+    // - pod.label[component]
+    rule {
+      source_labels = [
+        "__meta_kubernetes_pod_label_app_kubernetes_io_component",
+        "__meta_kubernetes_pod_label_k8s_component",
+        "__meta_kubernetes_pod_label_component",
+      ]
+      regex = "^(?:;*)?([^;]+).*$"
+      replacement = "$1"
+      target_label = "component"
+    }
+
+    rule {
+      target_label = "source"
+      replacement = "kubernetes"
+    }
+
+  } // discovery.relabel "node_exporter"
+
+  prometheus.scrape "node_exporter" {
+    targets = discovery.relabel.node_exporter.output
+    job_name = "integrations/node_exporter"
+    scrape_interval = "60s"
+    scrape_timeout = "10s"
+    scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
+    scrape_classic_histograms = false
+    scrape_native_histograms = false
+    convert_classic_histograms_to_nhcb = false
+    scheme = "http"
+    tls_config {
+      insecure_skip_verify = true
+    }
+
+    clustering {
+      enabled = true
+    }
+    forward_to = [prometheus.relabel.node_exporter.receiver]
+  } // prometheus.scrape "node_exporter"
+
+  prometheus.relabel "node_exporter" {
+    max_cache_size = 100000
+    rule {
+      source_labels = ["__name__"]
+      regex = "up|scrape_samples_scraped|node_cpu.*|node_exporter_build_info|node_filesystem.*|node_memory.*|node_network_receive_bytes_total|node_network_receive_drop_total|node_network_transmit_bytes_total|node_network_transmit_drop_total|process_cpu_seconds_total|process_resident_memory_bytes"
+      action = "keep"
+    }
+    // Drop metrics for certain file systems
+    rule {
+      source_labels = ["__name__", "fstype"]
+      separator = "@"
+      regex = "node_filesystem.*@(ramfs|tmpfs)"
+      action = "drop"
+    }
+    forward_to = argument.metrics_destinations.value
+  } // prometheus.relabel "node_exporter"
+} // declare "host_metrics"
+host_metrics "feature" {
+  metrics_destinations = [
+    prometheus.remote_write.grafana_cloud_metrics.receiver,
+  ]
+}
+declare "alloy_integration" {
+  argument "metrics_destinations" {
+    comment = "Must be a list of metric destinations where collected metrics should be forwarded to"
+  }
+
+  declare "alloy_integration_discovery" {
+    argument "namespaces" {
+      comment = "The namespaces to look for targets in (default: [] is all namespaces)"
+      optional = true
+    }
+
+    argument "field_selectors" {
+      comment = "The field selectors to use to find matching targets (default: [])"
+      optional = true
+    }
+
+    argument "label_selectors" {
+      comment = "The label selectors to use to find matching targets (default: [\"app.kubernetes.io/name=alloy\"])"
+      optional = true
+    }
+
+    argument "port_name" {
+      comment = "The of the port to scrape metrics from (default: http-metrics)"
+      optional = true
+    }
+
+    // Alloy service discovery for all of the pods
+    discovery.kubernetes "alloy_pods" {
+      role = "pod"
+
+      selectors {
+        role = "pod"
+        field = string.join(coalesce(argument.field_selectors.value, []), ",")
+        label = string.join(coalesce(argument.label_selectors.value, ["app.kubernetes.io/name=alloy"]), ",")
+      }
+
+      namespaces {
+        names = coalesce(argument.namespaces.value, [])
+      }
+
+    } // discovery.kubernetes "alloy_pods"
+
+    // alloy relabelings (pre-scrape)
+    discovery.relabel "alloy_pods" {
+      targets = discovery.kubernetes.alloy_pods.targets
+
+      // keep only the specified metrics port name, and pods that are Running and ready
+      rule {
+        source_labels = [
+          "__meta_kubernetes_pod_container_port_name",
+          "__meta_kubernetes_pod_phase",
+          "__meta_kubernetes_pod_ready",
+          "__meta_kubernetes_pod_container_init",
+        ]
+        separator = "@"
+        regex = coalesce(argument.port_name.value, "metrics") + "@Running@true@false"
+        action = "keep"
+      }
+
+      rule {
+        source_labels = ["__meta_kubernetes_namespace"]
+        target_label  = "namespace"
+      }
+
+      rule {
+        source_labels = ["__meta_kubernetes_pod_name"]
+        target_label  = "pod"
+      }
+
+      rule {
+        source_labels = ["__meta_kubernetes_pod_container_name"]
+        target_label  = "container"
+      }
+
+      // set the workload to the controller kind and name
+      rule {
+        action = "lowercase"
+        source_labels = ["__meta_kubernetes_pod_controller_kind"]
+        target_label  = "workload_type"
+      }
+
+      rule {
+        source_labels = ["__meta_kubernetes_pod_controller_name"]
+        target_label  = "workload"
+      }
+
+      // remove the hash from the ReplicaSet
+      rule {
+        source_labels = [
+          "workload_type",
+          "workload",
+        ]
+        separator = "/"
+        regex = "replicaset/(.+)-.+$"
+        target_label  = "workload"
+      }
+
+      // set the app name if specified as metadata labels "app:" or "app.kubernetes.io/name:" or "k8s-app:"
+      rule {
+        action = "replace"
+        source_labels = [
+          "__meta_kubernetes_pod_label_app_kubernetes_io_name",
+          "__meta_kubernetes_pod_label_k8s_app",
+          "__meta_kubernetes_pod_label_app",
+        ]
+        separator = ";"
+        regex = "^(?:;*)?([^;]+).*$"
+        replacement = "$1"
+        target_label = "app"
+      }
+
+      // set the component if specified as metadata labels "component:" or "app.kubernetes.io/component:" or "k8s-component:"
+      rule {
+        action = "replace"
+        source_labels = [
+          "__meta_kubernetes_pod_label_app_kubernetes_io_component",
+          "__meta_kubernetes_pod_label_k8s_component",
+          "__meta_kubernetes_pod_label_component",
+        ]
+        regex = "^(?:;*)?([^;]+).*$"
+        replacement = "$1"
+        target_label = "component"
+      }
+
+      // set a source label
+      rule {
+        action = "replace"
+        replacement = "kubernetes"
+        target_label = "source"
+      }
+
+    } // discovery.relabel "alloy_pods"
+
+    export "output" {
+      value = discovery.relabel.alloy_pods.output
+    }
+  }
+
+  declare "alloy_integration_scrape" {
+    argument "targets" {
+      comment = "Must be a list() of targets"
+    }
+
+    argument "forward_to" {
+      comment = "Must be a list(MetricsReceiver) where collected metrics should be forwarded to"
+    }
+
+    argument "job_label" {
+      comment = "The job label to add for all Alloy metrics (default: integrations/alloy)"
+      optional = true
+    }
+
+    argument "keep_metrics" {
+      comment = "A regular expression of metrics to keep (default: see below)"
+      optional = true
+    }
+
+    argument "drop_metrics" {
+      comment = "A regular expression of metrics to drop (default: see below)"
+      optional = true
+    }
+
+    argument "scrape_interval" {
+      comment = "How often to scrape metrics from the targets (default: 60s)"
+      optional = true
+    }
+
+    argument "scrape_timeout" {
+      comment = "The timeout for scraping metrics from the targets (default: 10s)"
+      optional = true
+    }
+
+    argument "scrape_protocols" {
+      comment = "The scrape protocols to use for scraping metrics"
+      optional = true
+    }
+
+    argument "scrape_classic_histograms" {
+      comment = "Whether to scrape classic histograms (default: false)."
+      optional = true
+    }
+
+    argument "scrape_native_histograms" {
+      comment = "Whether to scrape native histograms (default: false)."
+      optional = true
+    }
+
+    argument "max_cache_size" {
+      comment = "The maximum number of elements to hold in the relabeling cache (default: 100000).  This should be at least 2x-5x your largest scrape target or samples appended rate."
+      optional = true
+    }
+
+    argument "clustering" {
+      comment = "Whether or not clustering should be enabled (default: false)"
+      optional = true
+    }
+
+    prometheus.scrape "alloy" {
+      job_name = coalesce(argument.job_label.value, "integrations/alloy")
+      forward_to = [prometheus.relabel.alloy.receiver]
+      targets = argument.targets.value
+      scrape_interval = coalesce(argument.scrape_interval.value, "60s")
+      scrape_timeout = coalesce(argument.scrape_timeout.value, "10s")
+      scrape_protocols = argument.scrape_protocols.value
+      scrape_classic_histograms = argument.scrape_classic_histograms.value
+      scrape_native_histograms = argument.scrape_native_histograms.value
+
+      clustering {
+        enabled = coalesce(argument.clustering.value, false)
+      }
+    } // prometheus.scrape "alloy"
+
+    // alloy metric relabelings (post-scrape)
+    prometheus.relabel "alloy" {
+      forward_to = argument.forward_to.value
+      max_cache_size = coalesce(argument.max_cache_size.value, 100000)
+
+      // drop metrics that match the drop_metrics regex
+      rule {
+        source_labels = ["__name__"]
+        regex = coalesce(argument.drop_metrics.value, "")
+        action = "drop"
+      }
+
+      // keep only metrics that match the keep_metrics regex
+      rule {
+        source_labels = ["__name__"]
+        regex = coalesce(argument.keep_metrics.value, ".*")
+        action = "keep"
+      }
+
+      // remove the component_id label from any metric that starts with log_bytes or log_lines, these are custom metrics that are generated
+      // as part of the log annotation modules in this repo
+      rule {
+        action = "replace"
+        source_labels = ["__name__"]
+        regex = "^log_(bytes|lines).+"
+        replacement = ""
+        target_label = "component_id"
+      }
+
+      // set the namespace label to that of the exported_namespace
+      rule {
+        action = "replace"
+        source_labels = ["__name__", "exported_namespace"]
+        separator = "@"
+        regex = "^log_(bytes|lines).+@(.+)"
+        replacement = "$2"
+        target_label = "namespace"
+      }
+
+      // set the pod label to that of the exported_pod
+      rule {
+        action = "replace"
+        source_labels = ["__name__", "exported_pod"]
+        separator = "@"
+        regex = "^log_(bytes|lines).+@(.+)"
+        replacement = "$2"
+        target_label = "pod"
+      }
+
+      // set the container label to that of the exported_container
+      rule {
+        action = "replace"
+        source_labels = ["__name__", "exported_container"]
+        separator = "@"
+        regex = "^log_(bytes|lines).+@(.+)"
+        replacement = "$2"
+        target_label = "container"
+      }
+
+      // set the job label to that of the exported_job
+      rule {
+        action = "replace"
+        source_labels = ["__name__", "exported_job"]
+        separator = "@"
+        regex = "^log_(bytes|lines).+@(.+)"
+        replacement = "$2"
+        target_label = "job"
+      }
+
+      // set the instance label to that of the exported_instance
+      rule {
+        action = "replace"
+        source_labels = ["__name__", "exported_instance"]
+        separator = "@"
+        regex = "^log_(bytes|lines).+@(.+)"
+        replacement = "$2"
+        target_label = "instance"
+      }
+
+      rule {
+        action = "labeldrop"
+        regex = "exported_(namespace|pod|container|job|instance)"
+      }
+    } // prometheus.relabel "alloy"
+  }
+
+  alloy_integration_discovery "alloy" {
+    port_name = "http-metrics"
+    label_selectors = ["app.kubernetes.io/name in (alloy-metrics,alloy-singleton,alloy-logs)"]
+  }
+
+  alloy_integration_scrape "alloy" {
+    targets = alloy_integration_discovery.alloy.output
+    job_label = "integrations/alloy"
+    clustering = true
+    keep_metrics = "up|scrape_samples_scraped|alloy_build_info|alloy_component_controller_running_components|alloy_component_dependencies_wait_seconds|alloy_component_dependencies_wait_seconds_bucket|alloy_component_evaluation_seconds|alloy_component_evaluation_seconds_bucket|alloy_component_evaluation_seconds_count|alloy_component_evaluation_seconds_sum|alloy_component_evaluation_slow_seconds|alloy_config_hash|alloy_resources_machine_rx_bytes_total|alloy_resources_machine_tx_bytes_total|alloy_resources_process_cpu_seconds_total|alloy_resources_process_resident_memory_bytes|alloy_tcp_connections|alloy_wal_samples_appended_total|alloy_wal_storage_active_series|cluster_node_gossip_health_score|cluster_node_gossip_proto_version|cluster_node_gossip_received_events_total|cluster_node_info|cluster_node_lamport_time|cluster_node_peers|cluster_node_update_observers|cluster_transport_rx_bytes_total|cluster_transport_rx_packet_queue_length|cluster_transport_rx_packets_failed_total|cluster_transport_rx_packets_total|cluster_transport_stream_rx_bytes_total|cluster_transport_stream_rx_packets_failed_total|cluster_transport_stream_rx_packets_total|cluster_transport_stream_tx_bytes_total|cluster_transport_stream_tx_packets_failed_total|cluster_transport_stream_tx_packets_total|cluster_transport_streams|cluster_transport_tx_bytes_total|cluster_transport_tx_packet_queue_length|cluster_transport_tx_packets_failed_total|cluster_transport_tx_packets_total|otelcol_exporter_send_failed_spans_total|otelcol_exporter_sent_spans_total|go_gc_duration_seconds_count|go_goroutines|go_memstats_heap_inuse_bytes|loki_process_dropped_lines_total|loki_write_batch_retries_total|loki_write_dropped_bytes_total|loki_write_dropped_entries_total|loki_write_encoded_bytes_total|loki_write_mutated_bytes_total|loki_write_mutated_entries_total|loki_write_request_duration_seconds_bucket|loki_write_sent_bytes_total|loki_write_sent_entries_total|process_cpu_seconds_total|process_start_time_seconds|otelcol_processor_batch_batch_send_size_bucket|otelcol_processor_batch_metadata_cardinality|otelcol_processor_batch_timeout_trigger_send_total|prometheus_remote_storage_bytes_total|prometheus_remote_storage_enqueue_retries_total|prometheus_remote_storage_highest_timestamp_in_seconds|prometheus_remote_storage_metadata_bytes_total|prometheus_remote_storage_queue_highest_sent_timestamp_seconds|prometheus_remote_storage_samples_dropped_total|prometheus_remote_storage_samples_failed_total|prometheus_remote_storage_samples_pending|prometheus_remote_storage_samples_retried_total|prometheus_remote_storage_samples_total|prometheus_remote_storage_sent_batch_duration_seconds_bucket|prometheus_remote_storage_sent_batch_duration_seconds_count|prometheus_remote_storage_sent_batch_duration_seconds_sum|prometheus_remote_storage_shard_capacity|prometheus_remote_storage_shards|prometheus_remote_storage_shards_desired|prometheus_remote_storage_shards_max|prometheus_remote_storage_shards_min|prometheus_remote_storage_succeeded_samples_total|prometheus_remote_write_wal_samples_appended_total|prometheus_remote_write_wal_storage_active_series|prometheus_sd_discovered_targets|prometheus_target_interval_length_seconds_count|prometheus_target_interval_length_seconds_sum|prometheus_target_scrapes_exceeded_sample_limit_total|prometheus_target_scrapes_sample_duplicate_timestamp_total|prometheus_target_scrapes_sample_out_of_bounds_total|prometheus_target_scrapes_sample_out_of_order_total|prometheus_target_sync_length_seconds_sum|prometheus_wal_watcher_current_segment|otelcol_receiver_accepted_spans_total|otelcol_receiver_refused_spans_total|rpc_server_duration_milliseconds_bucket|scrape_duration_seconds|traces_exporter_send_failed_spans|traces_exporter_send_failed_spans_total|traces_exporter_sent_spans|traces_exporter_sent_spans_total|traces_loadbalancer_backend_outcome|traces_loadbalancer_num_backends|traces_receiver_accepted_spans|traces_receiver_accepted_spans_total|traces_receiver_refused_spans|traces_receiver_refused_spans_total"
+    scrape_interval = "60s"
+    scrape_timeout = "10s"
+    scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
+    scrape_classic_histograms = false
+    scrape_native_histograms = false
+    max_cache_size = 100000
+    forward_to = argument.metrics_destinations.value
+  }
+}
+alloy_integration "integration" {
+  metrics_destinations = [
+    prometheus.remote_write.grafana_cloud_metrics.receiver,
+  ]
+}
+
+
+
+
+
+// Destination: grafana-cloud-metrics (prometheus)
+otelcol.exporter.prometheus "grafana_cloud_metrics" {
+  add_metric_suffixes = true
+  resource_to_telemetry_conversion = false
+  keep_identifying_resource_attributes = true
+  forward_to = [prometheus.remote_write.grafana_cloud_metrics.receiver]
+} // otelcol.exporter.prometheus "grafana_cloud_metrics"
+
+prometheus.remote_write "grafana_cloud_metrics" {
+  endpoint {
+    url = "https://prometheus-prod-13-prod-us-east-0.grafana.net/api/prom/push"
+    headers = {
+      "X-Scope-OrgID" = convert.nonsensitive(remote.kubernetes.secret.grafana_cloud_metrics.data["tenantId"]),
+    }
+    basic_auth {
+      username = convert.nonsensitive(remote.kubernetes.secret.grafana_cloud_metrics.data["PROMETHEUS_USER"])
+      password = remote.kubernetes.secret.grafana_cloud_metrics.data["PROMETHEUS_PASS"]
+    }
+    tls_config {
+      insecure_skip_verify = false
+      ca_pem = convert.nonsensitive(remote.kubernetes.secret.grafana_cloud_metrics.data["ca"])
+      cert_pem = convert.nonsensitive(remote.kubernetes.secret.grafana_cloud_metrics.data["cert"])
+      key_pem = remote.kubernetes.secret.grafana_cloud_metrics.data["key"]
+    }
+    send_native_histograms = false
+
+    queue_config {
+      capacity = 10000
+      min_shards = 1
+      max_shards = 50
+      max_samples_per_send = 2000
+      batch_send_deadline = "5s"
+      min_backoff = "30ms"
+      max_backoff = "5s"
+      retry_on_http_429 = true
+      sample_age_limit = "0s"
+    }
+  }
+
+  wal {
+    truncate_frequency = "2h"
+    min_keepalive_time = "5m"
+    max_keepalive_time = "8h"
+  }
+  external_labels = {
+    "cluster" = "gke-test",
+    "k8s_cluster_name" = "gke-test",
+  }
+} // prometheus.remote_write "grafana_cloud_metrics"
+
+remote.kubernetes.secret "grafana_cloud_metrics" {
+  name      = "grafana-cloud-credentials"
+  namespace = "default"
+} // remote.kubernetes.secret "grafana_cloud_metrics"
+

--- a/charts/k8s-monitoring/tests/platform/gke/.rendered/alloy-singleton.alloy
+++ b/charts/k8s-monitoring/tests/platform/gke/.rendered/alloy-singleton.alloy
@@ -1,0 +1,221 @@
+// Feature: Cluster Events
+declare "cluster_events" {
+  argument "logs_destinations" {
+    comment = "Must be a list of log destinations where collected logs should be forwarded to"
+  }
+
+  loki.source.kubernetes_events "cluster_events" {
+    job_name   = "integrations/kubernetes/eventhandler"
+    log_format = "logfmt"
+    forward_to = [loki.process.cluster_events.receiver]
+  } // loki.source.kubernetes_events "cluster_events"
+
+  loki.process "cluster_events" {
+
+    // add a static source label to the logs so they can be differentiated / restricted if necessary
+    stage.static_labels {
+      values = {
+        "source" = "kubernetes-events",
+      }
+    }
+
+    // extract some of the fields from the log line, these could be used as labels, structured metadata, etc.
+    stage.logfmt {
+      mapping = {
+        "component" = "sourcecomponent", // map the sourcecomponent field to component
+        "kind" = "",
+        "level" = "type", // most events don't have a level but they do have a "type" i.e. Normal, Warning, Error, etc.
+        "name" = "",
+        "node" = "sourcehost", // map the sourcehost field to node
+        "reason" = "",
+      }
+    }
+    // set the extracted values as labels
+    stage.labels {
+      values = {
+        "kind" = "",
+        "level" = "",
+        "service_name" = "job",
+        "reason" = "reason",
+      }
+    }
+
+    // if kind=Node, set the node label by copying the name field
+    stage.match {
+      selector = "{kind=\"Node\"}"
+
+      stage.labels {
+        values = {
+          "node" = "name",
+        }
+      }
+    }
+
+    // set the level extracted key value as a normalized log level
+    stage.match {
+      selector = "{level=\"Normal\"}"
+
+      stage.static_labels {
+        values = {
+          level = "Info",
+        }
+      }
+    }
+    stage.structured_metadata {
+      values = {
+        "name" = "name",
+        "node" = "node",
+      }
+    }
+
+    // Drop pipeline-only labels that are not needed in the final output.
+    stage.label_drop {
+      values = ["kind"]
+    }
+
+    forward_to = argument.logs_destinations.value
+  } // loki.process "cluster_events"
+} // declare "cluster_events"
+cluster_events "feature" {
+  logs_destinations = [
+    loki.write.grafana_cloud_logs.receiver,
+  ]
+}
+// Self Reporting
+prometheus.exporter.unix "kubernetes_monitoring_telemetry" {
+  set_collectors = ["textfile"]
+  textfile {
+    directory = "/etc/release-info"
+  }
+} // prometheus.exporter.unix "kubernetes_monitoring_telemetry"
+
+discovery.relabel "kubernetes_monitoring_telemetry" {
+  targets = prometheus.exporter.unix.kubernetes_monitoring_telemetry.targets
+  rule {
+    target_label = "instance"
+    action = "replace"
+    replacement = "k8smon"
+  }
+  rule {
+    target_label = "job"
+    action = "replace"
+    replacement = "integrations/kubernetes/kubernetes_monitoring_telemetry"
+  }
+} // discovery.relabel "kubernetes_monitoring_telemetry"
+
+prometheus.scrape "kubernetes_monitoring_telemetry" {
+  job_name   = "integrations/kubernetes/kubernetes_monitoring_telemetry"
+  targets    = discovery.relabel.kubernetes_monitoring_telemetry.output
+  scrape_interval = "60s"
+  clustering {
+    enabled = true
+  }
+  forward_to = [prometheus.relabel.kubernetes_monitoring_telemetry.receiver]
+} // prometheus.scrape "kubernetes_monitoring_telemetry"
+
+prometheus.relabel "kubernetes_monitoring_telemetry" {
+  rule {
+    source_labels = ["__name__"]
+    regex = "grafana_kubernetes_monitoring_.*"
+    action = "keep"
+  }
+  forward_to = [
+    prometheus.remote_write.grafana_cloud_metrics.receiver,
+  ]
+} // prometheus.relabel "kubernetes_monitoring_telemetry"
+
+
+
+
+
+// Destination: grafana-cloud-logs (loki)
+otelcol.exporter.loki "grafana_cloud_logs" {
+  forward_to = [loki.write.grafana_cloud_logs.receiver]
+} // otelcol.exporter.loki "grafana_cloud_logs"
+
+loki.write "grafana_cloud_logs" {
+  endpoint {
+    url = "https://logs-prod-006.grafana.net/loki/api/v1/push"
+    retry_on_http_429 = true
+    tenant_id = convert.nonsensitive(remote.kubernetes.secret.grafana_cloud_logs.data["tenantId"])
+    basic_auth {
+      username = convert.nonsensitive(remote.kubernetes.secret.grafana_cloud_logs.data["LOKI_USER"])
+      password = remote.kubernetes.secret.grafana_cloud_logs.data["LOKI_PASS"]
+    }
+    tls_config {
+      insecure_skip_verify = false
+      ca_pem = convert.nonsensitive(remote.kubernetes.secret.grafana_cloud_logs.data["ca"])
+      cert_pem = convert.nonsensitive(remote.kubernetes.secret.grafana_cloud_logs.data["cert"])
+      key_pem = remote.kubernetes.secret.grafana_cloud_logs.data["key"]
+    }
+    min_backoff_period = "500ms"
+    max_backoff_period = "5m"
+    max_backoff_retries = "10"
+  }
+  external_labels = {
+    "cluster" = "gke-test",
+    "k8s_cluster_name" = "gke-test",
+  }
+} // loki.write "grafana_cloud_logs"
+
+remote.kubernetes.secret "grafana_cloud_logs" {
+  name      = "grafana-cloud-credentials"
+  namespace = "default"
+} // remote.kubernetes.secret "grafana_cloud_logs"
+
+
+// Destination: grafana-cloud-metrics (prometheus)
+otelcol.exporter.prometheus "grafana_cloud_metrics" {
+  add_metric_suffixes = true
+  resource_to_telemetry_conversion = false
+  keep_identifying_resource_attributes = true
+  forward_to = [prometheus.remote_write.grafana_cloud_metrics.receiver]
+} // otelcol.exporter.prometheus "grafana_cloud_metrics"
+
+prometheus.remote_write "grafana_cloud_metrics" {
+  endpoint {
+    url = "https://prometheus-prod-13-prod-us-east-0.grafana.net/api/prom/push"
+    headers = {
+      "X-Scope-OrgID" = convert.nonsensitive(remote.kubernetes.secret.grafana_cloud_metrics.data["tenantId"]),
+    }
+    basic_auth {
+      username = convert.nonsensitive(remote.kubernetes.secret.grafana_cloud_metrics.data["PROMETHEUS_USER"])
+      password = remote.kubernetes.secret.grafana_cloud_metrics.data["PROMETHEUS_PASS"]
+    }
+    tls_config {
+      insecure_skip_verify = false
+      ca_pem = convert.nonsensitive(remote.kubernetes.secret.grafana_cloud_metrics.data["ca"])
+      cert_pem = convert.nonsensitive(remote.kubernetes.secret.grafana_cloud_metrics.data["cert"])
+      key_pem = remote.kubernetes.secret.grafana_cloud_metrics.data["key"]
+    }
+    send_native_histograms = false
+
+    queue_config {
+      capacity = 10000
+      min_shards = 1
+      max_shards = 50
+      max_samples_per_send = 2000
+      batch_send_deadline = "5s"
+      min_backoff = "30ms"
+      max_backoff = "5s"
+      retry_on_http_429 = true
+      sample_age_limit = "0s"
+    }
+  }
+
+  wal {
+    truncate_frequency = "2h"
+    min_keepalive_time = "5m"
+    max_keepalive_time = "8h"
+  }
+  external_labels = {
+    "cluster" = "gke-test",
+    "k8s_cluster_name" = "gke-test",
+  }
+} // prometheus.remote_write "grafana_cloud_metrics"
+
+remote.kubernetes.secret "grafana_cloud_metrics" {
+  name      = "grafana-cloud-credentials"
+  namespace = "default"
+} // remote.kubernetes.secret "grafana_cloud_metrics"
+

--- a/charts/k8s-monitoring/tests/platform/gpu/.rendered/alloy-metrics.alloy
+++ b/charts/k8s-monitoring/tests/platform/gpu/.rendered/alloy-metrics.alloy
@@ -1,0 +1,795 @@
+// Feature: Cluster Metrics
+declare "cluster_metrics" {
+  argument "metrics_destinations" {
+    comment = "Must be a list of metric destinations where collected metrics should be forwarded to"
+  }
+  discovery.kubernetes "nodes" {
+    role = "node"
+  } // discovery.kubernetes "nodes"
+
+  discovery.relabel "nodes" {
+    targets = discovery.kubernetes.nodes.targets
+    rule {
+      source_labels = ["__meta_kubernetes_node_name"]
+      target_label  = "node"
+    }
+
+    rule {
+      replacement = "kubernetes"
+      target_label = "source"
+    }
+  } // discovery.relabel "nodes"
+
+  // Kubelet
+  discovery.relabel "kubelet" {
+    targets = discovery.relabel.nodes.output
+  } // discovery.relabel "kubelet"
+
+  prometheus.scrape "kubelet" {
+    targets  = discovery.relabel.kubelet.output
+    job_name = "integrations/kubernetes/kubelet"
+    scheme   = "https"
+    scrape_interval = "60s"
+    scrape_timeout = "10s"
+    scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
+    scrape_classic_histograms = false
+    scrape_native_histograms = false
+    convert_classic_histograms_to_nhcb = false
+    bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+
+    tls_config {
+      ca_file = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+      insecure_skip_verify = true
+      server_name = "kubernetes"
+    }
+
+    clustering {
+      enabled = true
+    }
+
+    forward_to = [prometheus.relabel.kubelet.receiver]
+  } // prometheus.scrape "kubelet"
+
+  prometheus.relabel "kubelet" {
+    max_cache_size = 100000
+    rule {
+      source_labels = ["__name__"]
+      regex = "up|scrape_samples_scraped|go_goroutines|kubelet_certificate_manager_client_expiration_renew_errors|kubelet_certificate_manager_client_ttl_seconds|kubelet_certificate_manager_server_ttl_seconds|kubelet_cgroup_manager_duration_seconds_bucket|kubelet_cgroup_manager_duration_seconds_count|kubelet_node_config_error|kubelet_node_name|kubelet_pleg_relist_duration_seconds_bucket|kubelet_pleg_relist_duration_seconds_count|kubelet_pleg_relist_interval_seconds_bucket|kubelet_pod_start_duration_seconds_bucket|kubelet_pod_start_duration_seconds_count|kubelet_pod_worker_duration_seconds_bucket|kubelet_pod_worker_duration_seconds_count|kubelet_running_container_count|kubelet_running_containers|kubelet_running_pod_count|kubelet_running_pods|kubelet_runtime_operations_errors_total|kubelet_runtime_operations_total|kubelet_server_expiration_renew_errors|kubelet_volume_stats_available_bytes|kubelet_volume_stats_capacity_bytes|kubelet_volume_stats_inodes|kubelet_volume_stats_inodes_free|kubelet_volume_stats_inodes_used|kubelet_volume_stats_used_bytes|kubernetes_build_info|namespace_workload_pod|process_cpu_seconds_total|process_resident_memory_bytes|rest_client_requests_total|storage_operation_duration_seconds_count|storage_operation_errors_total|volume_manager_total_volumes"
+      action = "keep"
+    }
+
+    forward_to = argument.metrics_destinations.value
+  } // prometheus.relabel "kubelet"
+
+  // Kubelet Resources
+  discovery.relabel "kubelet_resources" {
+    targets = discovery.relabel.nodes.output
+    rule {
+      replacement   = "/metrics/resource"
+      target_label  = "__metrics_path__"
+    }
+  } // discovery.relabel "kubelet_resources"
+
+  prometheus.scrape "kubelet_resources" {
+    targets = discovery.relabel.kubelet_resources.output
+    job_name = "integrations/kubernetes/resources"
+    scheme   = "https"
+    scrape_interval = "60s"
+    scrape_timeout = "10s"
+    scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
+    scrape_classic_histograms = false
+    scrape_native_histograms = false
+    convert_classic_histograms_to_nhcb = false
+    bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+
+    tls_config {
+      ca_file = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+      insecure_skip_verify = true
+      server_name = "kubernetes"
+    }
+
+    clustering {
+      enabled = true
+    }
+
+    forward_to = [prometheus.relabel.kubelet_resources.receiver]
+  } // prometheus.scrape "kubelet_resources"
+
+  prometheus.relabel "kubelet_resources" {
+    max_cache_size = 100000
+    rule {
+      source_labels = ["__name__"]
+      regex = "up|scrape_samples_scraped|node_cpu_usage_seconds_total|node_memory_working_set_bytes"
+      action = "keep"
+    }
+
+    forward_to = argument.metrics_destinations.value
+  } // prometheus.relabel "kubelet_resources"
+
+  // cAdvisor
+  discovery.relabel "cadvisor" {
+    targets = discovery.relabel.nodes.output
+    rule {
+      replacement   = "/metrics/cadvisor"
+      target_label  = "__metrics_path__"
+    }
+  } // discovery.relabel "cadvisor"
+
+  prometheus.scrape "cadvisor" {
+    targets = discovery.relabel.cadvisor.output
+    job_name = "integrations/kubernetes/cadvisor"
+    scheme = "https"
+    scrape_interval = "60s"
+    scrape_timeout = "10s"
+    scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
+    scrape_classic_histograms = false
+    scrape_native_histograms = false
+    convert_classic_histograms_to_nhcb = false
+    bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+
+    tls_config {
+      ca_file = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+      insecure_skip_verify = true
+      server_name = "kubernetes"
+    }
+
+    clustering {
+      enabled = true
+    }
+
+    forward_to = [prometheus.relabel.cadvisor.receiver]
+  } // prometheus.scrape "cadvisor"
+
+  prometheus.relabel "cadvisor" {
+    max_cache_size = 100000
+    rule {
+      source_labels = ["__name__"]
+      regex = "up|scrape_samples_scraped|container_cpu_cfs_periods_total|container_cpu_cfs_throttled_periods_total|container_cpu_usage_seconds_total|container_fs_reads_bytes_total|container_fs_reads_total|container_fs_writes_bytes_total|container_fs_writes_total|container_memory_cache|container_memory_rss|container_memory_swap|container_memory_usage_bytes|container_memory_working_set_bytes|container_network_receive_bytes_total|container_network_receive_packets_dropped_total|container_network_receive_packets_total|container_network_transmit_bytes_total|container_network_transmit_packets_dropped_total|container_network_transmit_packets_total|machine_memory_bytes"
+      action = "keep"
+    }
+    // Drop empty container labels, addressing https://github.com/google/cadvisor/issues/2688
+    rule {
+      source_labels = ["__name__","container"]
+      separator = "@"
+      regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_pressure_.*)@"
+      action = "drop"
+    }
+    // Drop empty image labels, addressing https://github.com/google/cadvisor/issues/2688
+    rule {
+      source_labels = ["__name__","image"]
+      separator = "@"
+      regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_network_.*|container_pressure_.*)@"
+      action = "drop"
+    }
+    // Normalizing unimportant labels (not deleting to continue satisfying <label>!="" checks)
+    rule {
+      source_labels = ["__name__", "boot_id"]
+      separator = "@"
+      regex = "machine_memory_bytes@.*"
+      target_label = "boot_id"
+      replacement = "NA"
+    }
+    rule {
+      source_labels = ["__name__", "system_uuid"]
+      separator = "@"
+      regex = "machine_memory_bytes@.*"
+      target_label = "system_uuid"
+      replacement = "NA"
+    }
+    // Filter out non-physical devices/interfaces
+    rule {
+      source_labels = ["__name__", "device"]
+      separator = "@"
+      regex = "container_fs_.*@(/dev/)?(mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dasd.+)"
+      target_label = "__keepme"
+      replacement = "1"
+    }
+    rule {
+      source_labels = ["__name__", "__keepme"]
+      separator = "@"
+      regex = "container_fs_.*@"
+      action = "drop"
+    }
+    rule {
+      source_labels = ["__name__"]
+      regex = "container_fs_.*"
+      target_label = "__keepme"
+      replacement = ""
+    }
+    rule {
+      source_labels = ["__name__", "interface"]
+      separator = "@"
+      regex = "container_network_.*@(en[ospx][0-9].*|wlan[0-9].*|eth[0-9].*)"
+      target_label = "__keepme"
+      replacement = "1"
+    }
+    rule {
+      source_labels = ["__name__", "__keepme"]
+      separator = "@"
+      regex = "container_network_.*@"
+      action = "drop"
+    }
+    rule {
+      source_labels = ["__name__"]
+      regex = "container_network_.*"
+      target_label = "__keepme"
+      replacement = ""
+    }
+    forward_to = argument.metrics_destinations.value
+  } // prometheus.relabel "cadvisor"
+  discovery.kubernetes "kube_state_metrics" {
+    role = "endpoints"
+
+    selectors {
+      role = "endpoints"
+      label = "release=k8smon,app.kubernetes.io/name=kube-state-metrics"
+    }
+    namespaces {
+      names = ["default"]
+    }
+  } // discovery.kubernetes "kube_state_metrics"
+
+  discovery.relabel "kube_state_metrics" {
+    targets = discovery.kubernetes.kube_state_metrics.targets
+
+    rule {
+      action = "replace"
+      replacement = "kubernetes"
+      target_label = "source"
+    }
+
+  } // discovery.relabel "kube_state_metrics"
+
+  prometheus.scrape "kube_state_metrics" {
+    targets = discovery.relabel.kube_state_metrics.output
+    job_name = "integrations/kubernetes/kube-state-metrics"
+    scrape_interval = "60s"
+    scrape_timeout = "10s"
+    scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
+    scrape_classic_histograms = false
+    scrape_native_histograms = false
+    convert_classic_histograms_to_nhcb = false
+    scheme = "http"
+    bearer_token_file = ""
+    tls_config {
+      insecure_skip_verify = true
+    }
+
+    clustering {
+      enabled = true
+    }
+    forward_to = [prometheus.relabel.kube_state_metrics.receiver]
+  } // prometheus.scrape "kube_state_metrics"
+
+  prometheus.relabel "kube_state_metrics" {
+    max_cache_size = 100000
+    rule {
+      source_labels = ["__name__"]
+      regex = "up|scrape_samples_scraped|kube_configmap_info|kube_configmap_metadata_resource_version|kube_cronjob.*|kube_daemonset.*|kube_deployment_metadata_generation|kube_deployment_spec_replicas|kube_deployment_status_condition|kube_deployment_status_observed_generation|kube_deployment_status_replicas_available|kube_deployment_status_replicas_updated|kube_horizontalpodautoscaler_spec_max_replicas|kube_horizontalpodautoscaler_spec_min_replicas|kube_horizontalpodautoscaler_status_current_replicas|kube_horizontalpodautoscaler_status_desired_replicas|kube_job.*|kube_namespace_status_phase|kube_node.*|kube_persistentvolume_status_phase|kube_persistentvolumeclaim_access_mode|kube_persistentvolumeclaim_info|kube_persistentvolumeclaim_labels|kube_persistentvolumeclaim_resource_requests_storage_bytes|kube_persistentvolumeclaim_status_phase|kube_pod_completion_time|kube_pod_container_info|kube_pod_container_resource_limits|kube_pod_container_resource_requests|kube_pod_container_status_last_terminated_reason|kube_pod_container_status_last_terminated_timestamp|kube_pod_container_status_restarts_total|kube_pod_container_status_waiting_reason|kube_pod_info|kube_pod_owner|kube_pod_restart_policy|kube_pod_spec_volumes_persistentvolumeclaims_info|kube_pod_start_time|kube_pod_status_phase|kube_pod_status_reason|kube_pod_init_.*|kube_replicaset.*|kube_resourcequota|kube_secret_metadata_resource_version|kube_statefulset.*"
+      action = "keep"
+    }
+    forward_to = argument.metrics_destinations.value
+  } // prometheus.relabel "kube_state_metrics"
+} // declare "cluster_metrics"
+cluster_metrics "feature" {
+  metrics_destinations = [
+    prometheus.remote_write.grafana_cloud_metrics.receiver,
+  ]
+}
+
+
+// Feature: Host Metrics
+declare "host_metrics" {
+  argument "metrics_destinations" {
+    comment = "Must be a list of metric destinations where collected metrics should be forwarded to"
+  }
+
+  // Linux hosts via Node Exporter
+  discovery.kubernetes "node_exporter" {
+    role = "pod"
+    selectors {
+      role = "pod"
+      label = "release=k8smon,app.kubernetes.io/name=node-exporter"
+    }
+    namespaces {
+      names = ["default"]
+    }
+
+  } // discovery.kubernetes "node_exporter"
+
+  discovery.relabel "node_exporter" {
+    targets = discovery.kubernetes.node_exporter.targets
+
+    // keep only the specified metrics port name, and pods that are Running and ready
+    rule {
+      source_labels = [
+        "__meta_kubernetes_pod_container_init",
+        "__meta_kubernetes_pod_phase",
+        "__meta_kubernetes_pod_ready",
+      ]
+      separator = "@"
+      regex = "false@Running@true"
+      action = "keep"
+    }
+
+    // Set the instance label to the node name
+    rule {
+      source_labels = ["__meta_kubernetes_pod_node_name"]
+      target_label = "instance"
+    }
+
+    rule {
+      source_labels = ["__meta_kubernetes_namespace"]
+      target_label  = "namespace"
+    }
+
+    rule {
+      source_labels = ["__meta_kubernetes_pod_name"]
+      target_label  = "pod"
+    }
+
+    rule {
+      source_labels = ["__meta_kubernetes_pod_container_name"]
+      target_label  = "container"
+    }
+
+    // set a workload label
+    rule {
+      source_labels = [
+        "__meta_kubernetes_pod_controller_kind",
+        "__meta_kubernetes_pod_controller_name",
+      ]
+      separator = "/"
+      target_label  = "workload"
+    }
+    // remove the hash from the ReplicaSet
+    rule {
+      source_labels = ["workload"]
+      regex = "(ReplicaSet/.+)-.+"
+      target_label  = "workload"
+    }
+
+    // Set the app label.
+    //
+    // Choose the first value found from the following ordered list:
+    // - pod.label[app.kubernetes.io/name]
+    // - pod.label[k8s-app]
+    // - pod.label[app]
+    rule {
+      source_labels = [
+        "__meta_kubernetes_pod_label_app_kubernetes_io_name",
+        "__meta_kubernetes_pod_label_k8s_app",
+        "__meta_kubernetes_pod_label_app",
+      ]
+      separator = ";"
+      regex = "^(?:;*)?([^;]+).*$"
+      replacement = "$1"
+      target_label = "app"
+    }
+
+    // Set the component label.
+    //
+    // Choose the first value found from the following ordered list:
+    // - pod.label[app.kubernetes.io/component]
+    // - pod.label[k8s-component]
+    // - pod.label[component]
+    rule {
+      source_labels = [
+        "__meta_kubernetes_pod_label_app_kubernetes_io_component",
+        "__meta_kubernetes_pod_label_k8s_component",
+        "__meta_kubernetes_pod_label_component",
+      ]
+      regex = "^(?:;*)?([^;]+).*$"
+      replacement = "$1"
+      target_label = "component"
+    }
+
+    rule {
+      target_label = "source"
+      replacement = "kubernetes"
+    }
+
+  } // discovery.relabel "node_exporter"
+
+  prometheus.scrape "node_exporter" {
+    targets = discovery.relabel.node_exporter.output
+    job_name = "integrations/node_exporter"
+    scrape_interval = "60s"
+    scrape_timeout = "10s"
+    scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
+    scrape_classic_histograms = false
+    scrape_native_histograms = false
+    convert_classic_histograms_to_nhcb = false
+    scheme = "http"
+    tls_config {
+      insecure_skip_verify = true
+    }
+
+    clustering {
+      enabled = true
+    }
+    forward_to = [prometheus.relabel.node_exporter.receiver]
+  } // prometheus.scrape "node_exporter"
+
+  prometheus.relabel "node_exporter" {
+    max_cache_size = 100000
+    rule {
+      source_labels = ["__name__"]
+      regex = "up|scrape_samples_scraped|node_cpu.*|node_exporter_build_info|node_filesystem.*|node_memory.*|node_network_receive_bytes_total|node_network_receive_drop_total|node_network_transmit_bytes_total|node_network_transmit_drop_total|process_cpu_seconds_total|process_resident_memory_bytes"
+      action = "keep"
+    }
+    // Drop metrics for certain file systems
+    rule {
+      source_labels = ["__name__", "fstype"]
+      separator = "@"
+      regex = "node_filesystem.*@(ramfs|tmpfs)"
+      action = "drop"
+    }
+    forward_to = argument.metrics_destinations.value
+  } // prometheus.relabel "node_exporter"
+} // declare "host_metrics"
+host_metrics "feature" {
+  metrics_destinations = [
+    prometheus.remote_write.grafana_cloud_metrics.receiver,
+  ]
+}
+declare "dcgm_exporter_integration" {
+  argument "metrics_destinations" {
+    comment = "Must be a list of metric destinations where collected metrics should be forwarded to"
+  }
+
+  declare "dcgm_exporter_integration_discovery" {
+    argument "namespaces" {
+      comment = "The namespaces to look for targets in (default: [] is all namespaces)"
+      optional = true
+    }
+
+    argument "field_selectors" {
+      comment = "The field selectors to use to find matching targets (default: [])"
+      optional = true
+    }
+
+    argument "label_selectors" {
+      comment = "The label selectors to use to find matching targets (default: [\"app=nvidia-dcgm-exporter\"])"
+      optional = true
+    }
+
+    argument "port_name" {
+      comment = "The of the port to scrape metrics from (default: metrics)"
+      optional = true
+    }
+
+    // DCGM Exporter service discovery for all of the pods
+    discovery.kubernetes "dcgm_exporter_pods" {
+      role = "pod"
+
+      selectors {
+        role = "pod"
+        field = string.join(coalesce(argument.field_selectors.value, []), ",")
+        label = string.join(coalesce(argument.label_selectors.value, ["app=nvidia-dcgm-exporter"]), ",")
+      }
+
+      namespaces {
+        names = coalesce(argument.namespaces.value, [])
+      }
+
+    } // discovery.kubernetes "dcgm_exporter_pods"
+
+    // DCGM Exporter relabelings (pre-scrape)
+    discovery.relabel "dcgm_exporter_pods" {
+      targets = discovery.kubernetes.dcgm_exporter_pods.targets
+
+      // keep only the specified metrics port name, and pods that are Running and ready
+      rule {
+        source_labels = [
+          "__meta_kubernetes_pod_container_port_name",
+          "__meta_kubernetes_pod_phase",
+          "__meta_kubernetes_pod_ready",
+          "__meta_kubernetes_pod_container_init",
+        ]
+        separator = "@"
+        regex = coalesce(argument.port_name.value, "metrics") + "@Running@true@false"
+        action = "keep"
+      }
+    } // discovery.relabel "dcgm_exporter_pods"
+
+    export "output" {
+      value = discovery.relabel.dcgm_exporter_pods.output
+    }
+  }
+
+  declare "dcgm_exporter_integration_scrape" {
+    argument "targets" {
+      comment = "Must be a list() of targets"
+    }
+
+    argument "forward_to" {
+      comment = "Must be a list(MetricsReceiver) where collected metrics should be forwarded to"
+    }
+
+    argument "job_label" {
+      comment = "The job label to add for all Alloy metrics (default: integrations/dcgm-exporter)"
+      optional = true
+    }
+
+    argument "keep_metrics" {
+      comment = "A regular expression of metrics to keep (default: see below)"
+      optional = true
+    }
+
+    argument "drop_metrics" {
+      comment = "A regular expression of metrics to drop (default: see below)"
+      optional = true
+    }
+
+    argument "scrape_interval" {
+      comment = "How often to scrape metrics from the targets (default: 60s)"
+      optional = true
+    }
+
+    argument "scrape_timeout" {
+      comment = "The timeout for scraping metrics from the targets (default: 10s)"
+      optional = true
+    }
+
+    argument "scrape_protocols" {
+      comment = "The scrape protocols to use for scraping metrics"
+      optional = true
+    }
+
+    argument "scrape_classic_histograms" {
+      comment = "Whether to scrape classic histograms (default: false)."
+      optional = true
+    }
+
+    argument "scrape_native_histograms" {
+      comment = "Whether to scrape native histograms (default: false)."
+      optional = true
+    }
+
+    argument "max_cache_size" {
+      comment = "The maximum number of elements to hold in the relabeling cache (default: 100000).  This should be at least 2x-5x your largest scrape target or samples appended rate."
+      optional = true
+    }
+
+    argument "clustering" {
+      comment = "Whether or not clustering should be enabled (default: false)"
+      optional = true
+    }
+
+    prometheus.scrape "dcgm_exporter" {
+      targets = argument.targets.value
+      job_name = coalesce(argument.job_label.value, "integrations/dcgm-exporter")
+      scrape_interval = coalesce(argument.scrape_interval.value, "60s")
+      scrape_timeout = coalesce(argument.scrape_timeout.value, "10s")
+      scrape_protocols = argument.scrape_protocols.value
+      scrape_classic_histograms = argument.scrape_classic_histograms.value
+      scrape_native_histograms = argument.scrape_native_histograms.value
+
+      clustering {
+        enabled = coalesce(argument.clustering.value, false)
+      }
+
+      forward_to = [prometheus.relabel.dcgm_exporter.receiver]
+    } // prometheus.scrape "dcgm_exporter"
+
+    // DCGM Exporter metric relabelings (post-scrape)
+    prometheus.relabel "dcgm_exporter" {
+      forward_to = argument.forward_to.value
+      max_cache_size = coalesce(argument.max_cache_size.value, 100000)
+
+      // drop metrics that match the drop_metrics regex
+      rule {
+        source_labels = ["__name__"]
+        regex = coalesce(argument.drop_metrics.value, "")
+        action = "drop"
+      }
+
+      // keep only metrics that match the keep_metrics regex
+      rule {
+        source_labels = ["__name__"]
+        regex = coalesce(argument.keep_metrics.value, ".*")
+        action = "keep"
+      }
+
+      // remove the component_id label from any metric that starts with log_bytes or log_lines, these are custom metrics that are generated
+      // as part of the log annotation modules in this repo
+      rule {
+        action = "replace"
+        source_labels = ["__name__"]
+        regex = "^log_(bytes|lines).+"
+        replacement = ""
+        target_label = "component_id"
+      }
+
+      // set the namespace label to that of the exported_namespace
+      rule {
+        action = "replace"
+        source_labels = ["__name__", "exported_namespace"]
+        separator = "@"
+        regex = "^log_(bytes|lines).+@(.+)"
+        replacement = "$2"
+        target_label = "namespace"
+      }
+
+      // set the pod label to that of the exported_pod
+      rule {
+        action = "replace"
+        source_labels = ["__name__", "exported_pod"]
+        separator = "@"
+        regex = "^log_(bytes|lines).+@(.+)"
+        replacement = "$2"
+        target_label = "pod"
+      }
+
+      // set the container label to that of the exported_container
+      rule {
+        action = "replace"
+        source_labels = ["__name__", "exported_container"]
+        separator = "@"
+        regex = "^log_(bytes|lines).+@(.+)"
+        replacement = "$2"
+        target_label = "container"
+      }
+
+      // set the job label to that of the exported_job
+      rule {
+        action = "replace"
+        source_labels = ["__name__", "exported_job"]
+        separator = "@"
+        regex = "^log_(bytes|lines).+@(.+)"
+        replacement = "$2"
+        target_label = "job"
+      }
+
+      // set the instance label to that of the exported_instance
+      rule {
+        action = "replace"
+        source_labels = ["__name__", "exported_instance"]
+        separator = "@"
+        regex = "^log_(bytes|lines).+@(.+)"
+        replacement = "$2"
+        target_label = "instance"
+      }
+
+      rule {
+        action = "labeldrop"
+        regex = "exported_(namespace|pod|container|job|instance)"
+      }
+    } // prometheus.relabel "dcgm_exporter"
+  }
+
+  dcgm_exporter_integration_discovery "dcgm_exporter" {
+    port_name = "metrics"
+    label_selectors = ["app=nvidia-dcgm-exporter"]
+  }
+
+  dcgm_exporter_integration_scrape  "dcgm_exporter" {
+    targets = dcgm_exporter_integration_discovery.dcgm_exporter.output
+    job_label = "integrations/dcgm-exporter"
+    clustering = true
+    scrape_interval = "60s"
+    scrape_timeout = "10s"
+    scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
+    scrape_classic_histograms = false
+    scrape_native_histograms = false
+    max_cache_size = 100000
+    forward_to = argument.metrics_destinations.value
+  }
+}
+dcgm_exporter_integration "integration" {
+  metrics_destinations = [
+    prometheus.remote_write.grafana_cloud_metrics.receiver,
+  ]
+}
+
+
+
+
+
+
+
+
+
+// Self Reporting
+prometheus.exporter.unix "kubernetes_monitoring_telemetry" {
+  set_collectors = ["textfile"]
+  textfile {
+    directory = "/etc/release-info"
+  }
+} // prometheus.exporter.unix "kubernetes_monitoring_telemetry"
+
+discovery.relabel "kubernetes_monitoring_telemetry" {
+  targets = prometheus.exporter.unix.kubernetes_monitoring_telemetry.targets
+  rule {
+    target_label = "instance"
+    action = "replace"
+    replacement = "k8smon"
+  }
+  rule {
+    target_label = "job"
+    action = "replace"
+    replacement = "integrations/kubernetes/kubernetes_monitoring_telemetry"
+  }
+} // discovery.relabel "kubernetes_monitoring_telemetry"
+
+prometheus.scrape "kubernetes_monitoring_telemetry" {
+  job_name   = "integrations/kubernetes/kubernetes_monitoring_telemetry"
+  targets    = discovery.relabel.kubernetes_monitoring_telemetry.output
+  scrape_interval = "60s"
+  clustering {
+    enabled = true
+  }
+  forward_to = [prometheus.relabel.kubernetes_monitoring_telemetry.receiver]
+} // prometheus.scrape "kubernetes_monitoring_telemetry"
+
+prometheus.relabel "kubernetes_monitoring_telemetry" {
+  rule {
+    source_labels = ["__name__"]
+    regex = "grafana_kubernetes_monitoring_.*"
+    action = "keep"
+  }
+  forward_to = [
+    prometheus.remote_write.grafana_cloud_metrics.receiver,
+  ]
+} // prometheus.relabel "kubernetes_monitoring_telemetry"
+
+
+
+
+
+// Destination: grafana-cloud-metrics (prometheus)
+otelcol.exporter.prometheus "grafana_cloud_metrics" {
+  add_metric_suffixes = true
+  resource_to_telemetry_conversion = false
+  keep_identifying_resource_attributes = true
+  forward_to = [prometheus.remote_write.grafana_cloud_metrics.receiver]
+} // otelcol.exporter.prometheus "grafana_cloud_metrics"
+
+prometheus.remote_write "grafana_cloud_metrics" {
+  endpoint {
+    url = "https://prometheus-prod-13-prod-us-east-0.grafana.net./api/prom/push"
+    headers = {
+      "X-Scope-OrgID" = convert.nonsensitive(remote.kubernetes.secret.grafana_cloud_metrics.data["tenantId"]),
+    }
+    basic_auth {
+      username = convert.nonsensitive(remote.kubernetes.secret.grafana_cloud_metrics.data["PROMETHEUS_USER"])
+      password = remote.kubernetes.secret.grafana_cloud_metrics.data["PROMETHEUS_PASS"]
+    }
+    tls_config {
+      insecure_skip_verify = false
+      ca_pem = convert.nonsensitive(remote.kubernetes.secret.grafana_cloud_metrics.data["ca"])
+      cert_pem = convert.nonsensitive(remote.kubernetes.secret.grafana_cloud_metrics.data["cert"])
+      key_pem = remote.kubernetes.secret.grafana_cloud_metrics.data["key"]
+    }
+    send_native_histograms = false
+
+    queue_config {
+      capacity = 10000
+      min_shards = 1
+      max_shards = 50
+      max_samples_per_send = 2000
+      batch_send_deadline = "5s"
+      min_backoff = "30ms"
+      max_backoff = "5s"
+      retry_on_http_429 = true
+      sample_age_limit = "0s"
+    }
+  }
+
+  wal {
+    truncate_frequency = "2h"
+    min_keepalive_time = "5m"
+    max_keepalive_time = "8h"
+  }
+  external_labels = {
+    "cluster" = "gpu-test",
+    "k8s_cluster_name" = "gpu-test",
+  }
+} // prometheus.remote_write "grafana_cloud_metrics"
+
+remote.kubernetes.secret "grafana_cloud_metrics" {
+  name      = "grafana-cloud-credentials"
+  namespace = "default"
+} // remote.kubernetes.secret "grafana_cloud_metrics"
+

--- a/charts/k8s-monitoring/tests/platform/grafana-cloud/app-observability/.rendered/alloy-logs.alloy
+++ b/charts/k8s-monitoring/tests/platform/grafana-cloud/app-observability/.rendered/alloy-logs.alloy
@@ -1,0 +1,445 @@
+// Feature: Pod Logs (Loki)
+declare "pod_logs_via_loki" {
+  argument "logs_destinations" {
+    comment = "Must be a list of log destinations where collected logs should be forwarded to"
+  }
+
+  discovery.kubernetes "pods" {
+    role = "pod"
+    selectors {
+      role = "pod"
+      field = "spec.nodeName=" + sys.env("HOSTNAME")
+    }
+  } // discovery.kubernetes "pods"
+
+  discovery.relabel "filtered_pods" {
+    targets = discovery.kubernetes.pods.targets
+    rule {
+      source_labels = ["__meta_kubernetes_namespace"]
+      action = "replace"
+      target_label = "namespace"
+    }
+    rule {  // Drop anything with a "falsy" annotation value
+      source_labels = ["__meta_kubernetes_pod_annotation_logs_grafana_com_pods_enabled"]
+      regex = "(false|no|skip)"
+      action = "drop"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_pod_name"]
+      target_label = "pod"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_pod_container_name"]
+      target_label = "container"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_namespace", "__meta_kubernetes_pod_container_name"]
+      separator = "/"
+      replacement = "$1"
+      target_label = "job"
+    }
+
+    // set the container runtime as a label
+    rule {
+      source_labels = ["__meta_kubernetes_pod_container_id"]
+      regex = "^(\\S+):\\/\\/.+$"
+      replacement = "$1"
+      target_label = "tmp_container_runtime"
+    }
+    // explicitly set service_name. if not set, loki will automatically try to populate a default.
+    // see https://grafana.com/docs/loki/latest/get-started/labels/#default-labels-for-all-users
+    //
+    // choose the first value found from the following ordered list:
+    // - pod.annotation[resource.opentelemetry.io/service.name]
+    // - pod.label[app.kubernetes.io/name]
+    // - k8s.container.name
+    rule {
+      source_labels = [
+        "__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_name",
+        "__meta_kubernetes_pod_label_app_kubernetes_io_name",
+        "__meta_kubernetes_pod_container_name",
+      ]
+      separator = ";"
+      regex = "^(?:;*)?([^;]+).*$"
+      replacement = "$1"
+      target_label = "service_name"
+    }
+
+    // explicitly set service_namespace.
+    //
+    // choose the first value found from the following ordered list:
+    // - pod.annotation[resource.opentelemetry.io/service.namespace]
+    // - pod.namespace
+    rule {
+      source_labels = [
+        "__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_namespace",
+        "namespace",
+      ]
+      separator = ";"
+      regex = "^(?:;*)?([^;]+).*$"
+      replacement = "$1"
+      target_label = "service_namespace"
+    }
+
+    // explicitly set service_instance_id.
+    //
+    // choose the first value found from the following ordered list:
+    // - pod.annotation[resource.opentelemetry.io/service.instance.id]
+    // - concat([k8s.namespace.name, k8s.pod.name, k8s.container.name], '.')
+    rule {
+      source_labels = ["__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_instance_id"]
+      target_label = "service_instance_id"
+    }
+    rule {
+      source_labels = ["service_instance_id", "namespace", "pod", "container"]
+      separator = "."
+      regex = "^\\.([^.]+\\.[^.]+\\.[^.]+)$"
+      target_label = "service_instance_id"
+    }
+
+    // set resource attributes
+    rule {
+      action = "labelmap"
+      regex = "__meta_kubernetes_pod_annotation_resource_opentelemetry_io_(.+)"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_job"]
+      regex = "(.+)"
+      target_label = "job"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+      regex = "(.+)"
+      target_label = "app_kubernetes_io_name"
+    }
+
+    // Set the pod log path.
+    rule {
+      source_labels = ["__meta_kubernetes_pod_uid", "__meta_kubernetes_pod_container_name"]
+      separator = "/"
+      replacement = "/var/log/pods/*$1/*.log"
+      target_label = "__path__"
+    }
+
+    // If kubernetes.io/config.mirror is set, this is a static pod, created by the kubelet.
+    // It's logs live on a different path.
+    rule {
+      source_labels = ["__meta_kubernetes_pod_annotation_kubernetes_io_config_mirror", "__meta_kubernetes_pod_container_name"]
+      separator = "/"
+      regex = "(.+/.+)"
+      replacement = "/var/log/pods/*$1/*.log"
+      target_label = "__path__"
+    }
+  } // discovery.relabel "filtered_pods"
+
+  local.file_match "pod_logs" {
+    path_targets = discovery.relabel.filtered_pods.output
+  } // local.file_match "pod_logs"
+
+  loki.source.file "pod_logs" {
+    targets    = local.file_match.pod_logs.targets
+    tail_from_end = true
+    forward_to = [loki.process.pod_logs.receiver]
+  } // loki.source.file "pod_logs"
+
+  loki.process "pod_logs" {
+    stage.match {
+      selector = "{tmp_container_runtime=~\"containerd|cri-o|\"}"
+      // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
+      stage.cri {
+        max_partial_lines = 100
+      }
+
+      // Set the extract flags and stream values as labels
+      stage.labels {
+        values = {
+          flags  = "",
+          stream  = "",
+        }
+      }
+    }
+
+    stage.match {
+      selector = "{tmp_container_runtime=\"docker\"}"
+      // the docker processing stage extracts the following k/v pairs: log, stream, time
+      stage.docker {}
+
+      // Set the extract stream value as a label
+      stage.labels {
+        values = {
+          stream  = "",
+        }
+      }
+    }
+
+    // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
+    // namespace, pod, and container labels. Drop any structured metadata. Also drop the temporary
+    // container runtime label as it is no longer needed.
+    stage.label_drop {
+      values = [
+        "filename",
+        "tmp_container_runtime",
+      ]
+    }
+    stage.structured_metadata {
+      values = {
+        "k8s_pod_name" = "k8s_pod_name",
+        "pod" = "pod",
+        "service_instance_id" = "service_instance_id",
+      }
+    }
+
+    forward_to = argument.logs_destinations.value
+  } // loki.secretfilter "pod_logs"
+} // declare "pod_logs_via_loki"
+pod_logs_via_loki "feature" {
+  logs_destinations = [
+    otelcol.receiver.loki.otlp_gateway.receiver,
+  ]
+}
+
+
+
+
+
+// Destination: otlp-gateway (otlp)
+otelcol.receiver.prometheus "otlp_gateway" {
+  output {
+    metrics = [otelcol.processor.transform.otlp_gateway_scrape_normalize.input]
+  }
+} // otelcol.receiver.prometheus "otlp_gateway"
+
+// Repairs artifacts of the Prometheus-to-OTLP conversion performed by
+// otelcol.receiver.prometheus. Only metrics that came from a Prometheus scrape pass
+// through this component; OTLP-native telemetry enters the pipeline further down.
+otelcol.processor.transform "otlp_gateway_scrape_normalize" {
+  error_mode = "ignore"
+  metric_statements {
+    context = "resource"
+    statements = [
+      // The conversion sets service.name to the full Prometheus job label (e.g.
+      // "namespace/workload"). When the scrape target declares its identity explicitly
+      // with a service_name label on its own target_info metric (e.g. Grafana Beyla),
+      // prefer that value and drop the duplicate.
+      `set(attributes["service.name"], attributes["service_name"]) where attributes["service_name"] != nil and attributes["service_name"] != ""`,
+      `delete_key(attributes, "service_name") where attributes["service_name"] == attributes["service.name"]`,
+      // The same conversion turns other flat target_info labels into resource attributes.
+      // Promote them to their OpenTelemetry counterparts and drop the flat duplicates, so
+      // the OTLP endpoint does not receive two conflicting spellings of the same attribute.
+      `set(attributes["service.namespace"], attributes["service_namespace"]) where (attributes["service.namespace"] == nil or attributes["service.namespace"] == "") and attributes["service_namespace"] != nil and attributes["service_namespace"] != ""`,
+      `delete_key(attributes, "service_namespace") where attributes["service_namespace"] == attributes["service.namespace"]`,
+      `set(attributes["deployment.environment"], attributes["deployment_environment"]) where (attributes["deployment.environment"] == nil or attributes["deployment.environment"] == "") and attributes["deployment_environment"] != nil and attributes["deployment_environment"] != ""`,
+      `delete_key(attributes, "deployment_environment") where attributes["deployment_environment"] == attributes["deployment.environment"]`,
+      `set(attributes["deployment.environment.name"], attributes["deployment_environment_name"]) where (attributes["deployment.environment.name"] == nil or attributes["deployment.environment.name"] == "") and attributes["deployment_environment_name"] != nil and attributes["deployment_environment_name"] != ""`,
+      `delete_key(attributes, "deployment_environment_name") where attributes["deployment_environment_name"] == attributes["deployment.environment.name"]`,
+    ]
+  }
+  metric_statements {
+    context = "datapoint"
+    statements = [
+      // Same correction for scrape targets that put service_name on every series
+      // instead of exposing a target_info metric.
+      `set(resource.attributes["service.name"], attributes["service_name"]) where attributes["service_name"] != nil and attributes["service_name"] != ""`,
+    ]
+  }
+  output {
+    metrics = [otelcol.processor.attributes.otlp_gateway.input]
+  }
+} // otelcol.processor.transform "otlp_gateway_scrape_normalize"
+otelcol.receiver.loki "otlp_gateway" {
+  output {
+    logs = [otelcol.processor.attributes.otlp_gateway.input]
+  }
+} // otelcol.receiver.loki "otlp_gateway"
+otelcol.processor.attributes "otlp_gateway" {
+  output {
+    metrics = [otelcol.processor.transform.otlp_gateway.input]
+    logs = [otelcol.processor.transform.otlp_gateway.input]
+    traces = [otelcol.processor.transform.otlp_gateway.input]
+  }
+} // otelcol.processor.attributes "otlp_gateway"
+
+otelcol.processor.transform "otlp_gateway" {
+  error_mode = "ignore"
+  metric_statements {
+    context = "resource"
+    statements = [
+      `set(attributes["cluster"], "application-observability-gc-feature-test")`,
+      `set(attributes["k8s.cluster.name"], "application-observability-gc-feature-test")`,
+      `delete_key(attributes, "process.pid")`,
+      `delete_key(attributes, "process.parent_pid")`,
+      `delete_key(attributes, "process.executable.path")`,
+      `delete_key(attributes, "process.command_line")`,
+      `delete_key(attributes, "process.command_args")`,
+      `delete_key(attributes, "process.owner")`,
+      `delete_key(attributes, "process.runtime.version")`,
+      `delete_key(attributes, "process.runtime.description")`,
+      `delete_key(attributes, "host.ip")`,
+      `delete_key(attributes, "host.mac")`,
+      `delete_key(attributes, "k8s.pod.start_time")`,
+      `delete_key(attributes, "k8s.pod.uid")`,
+      `delete_key(attributes, "container.image.id")`,
+      `delete_key(attributes, "container.image.repo_digests")`,
+      `delete_key(attributes, "os.description")`,
+      `delete_key(attributes, "os.build_id")`,
+      // Scrape targets that expose their own target_info metric (e.g. Grafana Beyla) can
+      // carry a flat k8s_cluster_name resource attribute, which conflicts with the
+      // k8s.cluster.name attribute set above and gets ";"-joined by the Prometheus OTLP
+      // endpoint. Drop the flat copy when the values match.
+      `delete_key(attributes, "k8s_cluster_name") where attributes["k8s_cluster_name"] == attributes["k8s.cluster.name"]`,
+    ]
+  }
+
+  metric_statements {
+    context = "datapoint"
+    statements = [
+      `set(attributes["cluster"], "application-observability-gc-feature-test")`,
+      `set(attributes["k8s.cluster.name"], "application-observability-gc-feature-test")`,
+      `set(resource.attributes["deployment.environment"], attributes["deployment_environment"] ) where resource.attributes["deployment.environment"] == nil and attributes["deployment_environment"] != nil`,
+      `delete_key(attributes, "deployment_environment") where attributes["deployment_environment"] == resource.attributes["deployment.environment"]`,
+      `set(resource.attributes["deployment.environment.name"], attributes["deployment_environment_name"] ) where resource.attributes["deployment.environment.name"] == nil and attributes["deployment_environment_name"] != nil`,
+      `delete_key(attributes, "deployment_environment_name") where attributes["deployment_environment_name"] == resource.attributes["deployment.environment.name"]`,
+      `set(resource.attributes["service.name"], attributes["service_name"] ) where (resource.attributes["service.name"] == nil or resource.attributes["service.name"] == "") and attributes["service_name"] != nil and attributes["service_name"] != ""`,
+      `delete_key(attributes, "service_name") where attributes["service_name"] == resource.attributes["service.name"]`,
+      `set(resource.attributes["service.namespace"], attributes["service_namespace"] ) where (resource.attributes["service.namespace"] == nil or resource.attributes["service.namespace"] == "") and attributes["service_namespace"] != nil and attributes["service_namespace"] != ""`,
+      `delete_key(attributes, "service_namespace") where attributes["service_namespace"] == resource.attributes["service.namespace"]`,
+    ]
+  }
+  log_statements {
+    context = "resource"
+    statements = [
+      `set(attributes["cluster"], "application-observability-gc-feature-test")`,
+      `set(attributes["k8s.cluster.name"], "application-observability-gc-feature-test")`,
+      `delete_key(attributes, "process.pid")`,
+      `delete_key(attributes, "process.parent_pid")`,
+      `delete_key(attributes, "process.executable.path")`,
+      `delete_key(attributes, "process.command_line")`,
+      `delete_key(attributes, "process.command_args")`,
+      `delete_key(attributes, "process.owner")`,
+      `delete_key(attributes, "process.runtime.version")`,
+      `delete_key(attributes, "process.runtime.description")`,
+      `delete_key(attributes, "host.ip")`,
+      `delete_key(attributes, "host.mac")`,
+      `delete_key(attributes, "k8s.pod.start_time")`,
+      `delete_key(attributes, "k8s.pod.uid")`,
+      `delete_key(attributes, "container.image.id")`,
+      `delete_key(attributes, "container.image.repo_digests")`,
+      `delete_key(attributes, "os.description")`,
+      `delete_key(attributes, "os.build_id")`,
+    ]
+  }
+
+  log_statements {
+    context = "log"
+    statements = [
+      `delete_key(attributes, "loki.attribute.labels")`,
+      `delete_key(attributes, "loki.resource.labels")`,
+      `set(resource.attributes["k8s.container.name"], attributes["container"] ) where resource.attributes["k8s.container.name"] == nil and attributes["container"] != nil`,
+      `delete_key(attributes, "container") where attributes["container"] == resource.attributes["k8s.container.name"]`,
+      `set(resource.attributes["k8s.cronjob.name"], attributes["cronjob"] ) where resource.attributes["k8s.cronjob.name"] == nil and attributes["cronjob"] != nil`,
+      `delete_key(attributes, "cronjob") where attributes["cronjob"] == resource.attributes["k8s.cronjob.name"]`,
+      `set(resource.attributes["k8s.daemonset.name"], attributes["daemonset"] ) where resource.attributes["k8s.daemonset.name"] == nil and attributes["daemonset"] != nil`,
+      `delete_key(attributes, "daemonset") where attributes["daemonset"] == resource.attributes["k8s.daemonset.name"]`,
+      `set(resource.attributes["k8s.deployment.name"], attributes["deployment"] ) where resource.attributes["k8s.deployment.name"] == nil and attributes["deployment"] != nil`,
+      `delete_key(attributes, "deployment") where attributes["deployment"] == resource.attributes["k8s.deployment.name"]`,
+      `set(resource.attributes["deployment.environment"], attributes["deployment_environment"] ) where resource.attributes["deployment.environment"] == nil and attributes["deployment_environment"] != nil`,
+      `delete_key(attributes, "deployment_environment") where attributes["deployment_environment"] == resource.attributes["deployment.environment"]`,
+      `set(resource.attributes["deployment.environment.name"], attributes["deployment_environment_name"] ) where resource.attributes["deployment.environment.name"] == nil and attributes["deployment_environment_name"] != nil`,
+      `delete_key(attributes, "deployment_environment_name") where attributes["deployment_environment_name"] == resource.attributes["deployment.environment.name"]`,
+      `set(resource.attributes["k8s.job.name"], attributes["job_name"] ) where resource.attributes["k8s.job.name"] == nil and attributes["job_name"] != nil`,
+      `delete_key(attributes, "job_name") where attributes["job_name"] == resource.attributes["k8s.job.name"]`,
+      `set(resource.attributes["k8s.namespace.name"], attributes["namespace"] ) where resource.attributes["k8s.namespace.name"] == nil and attributes["namespace"] != nil`,
+      `delete_key(attributes, "namespace") where attributes["namespace"] == resource.attributes["k8s.namespace.name"]`,
+      `set(resource.attributes["k8s.pod.name"], attributes["pod"] ) where resource.attributes["k8s.pod.name"] == nil and attributes["pod"] != nil`,
+      `delete_key(attributes, "pod") where attributes["pod"] == resource.attributes["k8s.pod.name"]`,
+      `set(resource.attributes["k8s.replicaset.name"], attributes["replicaset"] ) where resource.attributes["k8s.replicaset.name"] == nil and attributes["replicaset"] != nil`,
+      `delete_key(attributes, "replicaset") where attributes["replicaset"] == resource.attributes["k8s.replicaset.name"]`,
+      `set(resource.attributes["service.name"], attributes["service_name"] ) where (resource.attributes["service.name"] == nil or resource.attributes["service.name"] == "") and attributes["service_name"] != nil and attributes["service_name"] != ""`,
+      `delete_key(attributes, "service_name") where attributes["service_name"] == resource.attributes["service.name"]`,
+      `set(resource.attributes["service.namespace"], attributes["service_namespace"] ) where (resource.attributes["service.namespace"] == nil or resource.attributes["service.namespace"] == "") and attributes["service_namespace"] != nil and attributes["service_namespace"] != ""`,
+      `delete_key(attributes, "service_namespace") where attributes["service_namespace"] == resource.attributes["service.namespace"]`,
+      `set(resource.attributes["k8s.statefulset.name"], attributes["statefulset"] ) where resource.attributes["k8s.statefulset.name"] == nil and attributes["statefulset"] != nil`,
+      `delete_key(attributes, "statefulset") where attributes["statefulset"] == resource.attributes["k8s.statefulset.name"]`,
+    ]
+  }
+
+  trace_statements {
+    context = "resource"
+    statements = [
+      `set(attributes["cluster"], "application-observability-gc-feature-test")`,
+      `set(attributes["k8s.cluster.name"], "application-observability-gc-feature-test")`,
+      `delete_key(attributes, "process.pid")`,
+      `delete_key(attributes, "process.parent_pid")`,
+      `delete_key(attributes, "process.executable.path")`,
+      `delete_key(attributes, "process.command_line")`,
+      `delete_key(attributes, "process.command_args")`,
+      `delete_key(attributes, "process.owner")`,
+      `delete_key(attributes, "process.runtime.version")`,
+      `delete_key(attributes, "process.runtime.description")`,
+      `delete_key(attributes, "host.ip")`,
+      `delete_key(attributes, "host.mac")`,
+      `delete_key(attributes, "k8s.pod.start_time")`,
+      `delete_key(attributes, "k8s.pod.uid")`,
+      `delete_key(attributes, "container.image.id")`,
+      `delete_key(attributes, "container.image.repo_digests")`,
+      `delete_key(attributes, "os.description")`,
+      `delete_key(attributes, "os.build_id")`,
+    ]
+  }
+
+  output {
+    metrics = [otelcol.processor.batch.otlp_gateway.input]
+    logs = [otelcol.processor.batch.otlp_gateway.input]
+    traces = [otelcol.processor.batch.otlp_gateway.input]
+  }
+} // otelcol.processor.transform "otlp_gateway"
+
+otelcol.processor.batch "otlp_gateway" {
+  timeout = "2s"
+  send_batch_size = 4096
+  send_batch_max_size = 4096
+
+  output {
+    metrics = [otelcol.exporter.otlphttp.otlp_gateway.input]
+    logs = [otelcol.exporter.otlphttp.otlp_gateway.input]
+    traces = [otelcol.exporter.otlphttp.otlp_gateway.input]
+  }
+} // otelcol.processor.batch "otlp_gateway"
+otelcol.exporter.otlphttp "otlp_gateway" {
+  client {
+    endpoint = "https://otlp-gateway-prod-us-east-0.grafana.net/otlp"
+    auth = otelcol.auth.basic.otlp_gateway.handler
+    headers = {
+      "X-Scope-OrgID" = convert.nonsensitive(remote.kubernetes.secret.otlp_gateway.data["tenantId"]),
+    }
+    tls {
+      insecure = false
+      insecure_skip_verify = false
+      ca_pem = convert.nonsensitive(remote.kubernetes.secret.otlp_gateway.data["ca"])
+      cert_pem = convert.nonsensitive(remote.kubernetes.secret.otlp_gateway.data["cert"])
+      key_pem = remote.kubernetes.secret.otlp_gateway.data["key"]
+    }
+  }
+
+  retry_on_failure {
+    enabled = true
+    initial_interval = "5s"
+    max_interval = "30s"
+    max_elapsed_time = "5m"
+  }
+
+  sending_queue {
+    enabled = true
+  }
+} // otelcol.exporter.otlphttp "otlp_gateway"
+
+otelcol.auth.basic "otlp_gateway" {
+  username = convert.nonsensitive(remote.kubernetes.secret.otlp_gateway.data["OTLP_GATEWAY_USER"])
+  password = remote.kubernetes.secret.otlp_gateway.data["OTLP_GATEWAY_PASS"]
+} // otelcol.auth.basic "otlp_gateway"
+
+remote.kubernetes.secret "otlp_gateway" {
+  name      = "grafana-cloud-credentials"
+  namespace = "default"
+} // remote.kubernetes.secret "otlp_gateway"
+

--- a/charts/k8s-monitoring/tests/platform/grafana-cloud/app-observability/.rendered/alloy-receiver.alloy
+++ b/charts/k8s-monitoring/tests/platform/grafana-cloud/app-observability/.rendered/alloy-receiver.alloy
@@ -1,0 +1,434 @@
+// Feature: Application Observability
+declare "application_observability" {
+  argument "metrics_destinations" {
+    comment = "Must be a list of metrics destinations where collected metrics should be forwarded to"
+  }
+
+  argument "logs_destinations" {
+    comment = "Must be a list of log destinations where collected logs should be forwarded to"
+  }
+
+  argument "traces_destinations" {
+    comment = "Must be a list of trace destinations where collected trace should be forwarded to"
+  }
+
+  // OTLP Receiver
+  otelcol.receiver.otlp "receiver" {
+    grpc {
+      endpoint = "0.0.0.0:4317"
+      include_metadata = false
+      max_recv_msg_size = "4MiB"
+      read_buffer_size = "512KiB"
+      write_buffer_size = "32KiB"
+    }
+    http {
+      endpoint = "0.0.0.0:4318"
+      include_metadata = false
+      max_request_body_size = "20MiB"
+    }
+    debug_metrics {
+      disable_high_cardinality_metrics = true
+    }
+    output {
+      metrics = [otelcol.processor.resourcedetection.default.input]
+      logs = [otelcol.processor.resourcedetection.default.input]
+      traces = [otelcol.processor.resourcedetection.default.input]
+    }
+  } // otelcol.receiver.otlp "receiver"
+
+  // Resource Detection Processor
+  otelcol.processor.resourcedetection "default" {
+    detectors = ["env","system"]
+    override = true
+
+    system {
+      hostname_sources = ["os"]
+    }
+
+    output {
+      metrics = [otelcol.processor.k8sattributes.default.input]
+      logs = [otelcol.processor.k8sattributes.default.input]
+      traces = [otelcol.processor.k8sattributes.default.input]
+    }
+  }
+
+  // K8s Attributes Processor
+  otelcol.processor.k8sattributes "default" {
+    passthrough = false
+    extract {
+      otel_annotations = true
+      metadata = ["k8s.namespace.name","k8s.pod.name","k8s.deployment.name","k8s.statefulset.name","k8s.daemonset.name","k8s.cronjob.name","k8s.job.name","k8s.node.name","k8s.pod.uid","k8s.pod.start_time"]
+    }
+    pod_association {
+      source {
+        from = "resource_attribute"
+        name = "k8s.pod.ip"
+      }
+    }
+    pod_association {
+      source {
+        from = "resource_attribute"
+        name = "k8s.pod.uid"
+      }
+    }
+    pod_association {
+      source {
+        from = "connection"
+      }
+    }
+
+    output {
+      metrics = [otelcol.processor.transform.default.input]
+      logs = [otelcol.processor.transform.default.input]
+      traces = [otelcol.processor.transform.default.input, otelcol.connector.host_info.default.input]
+    }
+  }
+
+  // Host Info Connector
+  otelcol.connector.host_info "default" {
+    host_identifiers = [ "k8s.node.name" ]
+
+    output {
+      metrics = [otelcol.processor.batch.default.input]
+    }
+  }
+
+  // Transform Processor
+  otelcol.processor.transform "default" {
+    error_mode = "ignore"
+    log_statements {
+      context = "resource"
+      statements = [
+        "set(attributes[\"pod\"], attributes[\"k8s.pod.name\"])",
+        "set(attributes[\"namespace\"], attributes[\"k8s.namespace.name\"])",
+        "set(attributes[\"loki.resource.labels\"], \"cluster, namespace, job, pod\")",
+      ]
+    }
+    trace_statements {
+      context = "span"
+      statements = [
+        "replace_pattern(name, \"\\\\?.*\", \"\")",
+        "replace_match(name, \"GET /api/products/*\", \"GET /api/products/{productId}\")",
+       "set_semconv_span_name(\"1.37.0\", \"original_span_name\")",
+      ]
+    }
+
+    output {
+      metrics = [otelcol.processor.batch.default.input]
+      logs = [otelcol.processor.batch.default.input]
+      traces = [otelcol.processor.batch.default.input]
+    }
+  }
+
+  // Batch Processor
+  otelcol.processor.batch "default" {
+    send_batch_size = 8192
+    send_batch_max_size = 0
+    timeout = "2s"
+
+    output {
+      metrics = argument.metrics_destinations.value
+      logs = argument.logs_destinations.value
+      traces = argument.traces_destinations.value
+    }
+  }
+} // declare "application_observability"
+application_observability "feature" {
+  metrics_destinations = [
+    otelcol.processor.attributes.otlp_gateway.input,
+  ]
+  logs_destinations = [
+    otelcol.processor.attributes.otlp_gateway.input,
+  ]
+  traces_destinations = [
+    otelcol.processor.attributes.otlp_gateway.input,
+  ]
+}
+// Self Reporting
+prometheus.exporter.unix "kubernetes_monitoring_telemetry" {
+  set_collectors = ["textfile"]
+  textfile {
+    directory = "/etc/release-info"
+  }
+} // prometheus.exporter.unix "kubernetes_monitoring_telemetry"
+
+discovery.relabel "kubernetes_monitoring_telemetry" {
+  targets = prometheus.exporter.unix.kubernetes_monitoring_telemetry.targets
+  rule {
+    target_label = "instance"
+    action = "replace"
+    replacement = "k8smon"
+  }
+  rule {
+    target_label = "job"
+    action = "replace"
+    replacement = "integrations/kubernetes/kubernetes_monitoring_telemetry"
+  }
+} // discovery.relabel "kubernetes_monitoring_telemetry"
+
+prometheus.scrape "kubernetes_monitoring_telemetry" {
+  job_name   = "integrations/kubernetes/kubernetes_monitoring_telemetry"
+  targets    = discovery.relabel.kubernetes_monitoring_telemetry.output
+  scrape_interval = "60s"
+  clustering {
+    enabled = true
+  }
+  forward_to = [prometheus.relabel.kubernetes_monitoring_telemetry.receiver]
+} // prometheus.scrape "kubernetes_monitoring_telemetry"
+
+prometheus.relabel "kubernetes_monitoring_telemetry" {
+  rule {
+    source_labels = ["__name__"]
+    regex = "grafana_kubernetes_monitoring_.*"
+    action = "keep"
+  }
+  forward_to = [
+    otelcol.receiver.prometheus.otlp_gateway.receiver,
+  ]
+} // prometheus.relabel "kubernetes_monitoring_telemetry"
+
+
+
+
+
+// Destination: otlp-gateway (otlp)
+otelcol.receiver.prometheus "otlp_gateway" {
+  output {
+    metrics = [otelcol.processor.transform.otlp_gateway_scrape_normalize.input]
+  }
+} // otelcol.receiver.prometheus "otlp_gateway"
+
+// Repairs artifacts of the Prometheus-to-OTLP conversion performed by
+// otelcol.receiver.prometheus. Only metrics that came from a Prometheus scrape pass
+// through this component; OTLP-native telemetry enters the pipeline further down.
+otelcol.processor.transform "otlp_gateway_scrape_normalize" {
+  error_mode = "ignore"
+  metric_statements {
+    context = "resource"
+    statements = [
+      // The conversion sets service.name to the full Prometheus job label (e.g.
+      // "namespace/workload"). When the scrape target declares its identity explicitly
+      // with a service_name label on its own target_info metric (e.g. Grafana Beyla),
+      // prefer that value and drop the duplicate.
+      `set(attributes["service.name"], attributes["service_name"]) where attributes["service_name"] != nil and attributes["service_name"] != ""`,
+      `delete_key(attributes, "service_name") where attributes["service_name"] == attributes["service.name"]`,
+      // The same conversion turns other flat target_info labels into resource attributes.
+      // Promote them to their OpenTelemetry counterparts and drop the flat duplicates, so
+      // the OTLP endpoint does not receive two conflicting spellings of the same attribute.
+      `set(attributes["service.namespace"], attributes["service_namespace"]) where (attributes["service.namespace"] == nil or attributes["service.namespace"] == "") and attributes["service_namespace"] != nil and attributes["service_namespace"] != ""`,
+      `delete_key(attributes, "service_namespace") where attributes["service_namespace"] == attributes["service.namespace"]`,
+      `set(attributes["deployment.environment"], attributes["deployment_environment"]) where (attributes["deployment.environment"] == nil or attributes["deployment.environment"] == "") and attributes["deployment_environment"] != nil and attributes["deployment_environment"] != ""`,
+      `delete_key(attributes, "deployment_environment") where attributes["deployment_environment"] == attributes["deployment.environment"]`,
+      `set(attributes["deployment.environment.name"], attributes["deployment_environment_name"]) where (attributes["deployment.environment.name"] == nil or attributes["deployment.environment.name"] == "") and attributes["deployment_environment_name"] != nil and attributes["deployment_environment_name"] != ""`,
+      `delete_key(attributes, "deployment_environment_name") where attributes["deployment_environment_name"] == attributes["deployment.environment.name"]`,
+    ]
+  }
+  metric_statements {
+    context = "datapoint"
+    statements = [
+      // Same correction for scrape targets that put service_name on every series
+      // instead of exposing a target_info metric.
+      `set(resource.attributes["service.name"], attributes["service_name"]) where attributes["service_name"] != nil and attributes["service_name"] != ""`,
+    ]
+  }
+  output {
+    metrics = [otelcol.processor.attributes.otlp_gateway.input]
+  }
+} // otelcol.processor.transform "otlp_gateway_scrape_normalize"
+otelcol.receiver.loki "otlp_gateway" {
+  output {
+    logs = [otelcol.processor.attributes.otlp_gateway.input]
+  }
+} // otelcol.receiver.loki "otlp_gateway"
+otelcol.processor.attributes "otlp_gateway" {
+  output {
+    metrics = [otelcol.processor.transform.otlp_gateway.input]
+    logs = [otelcol.processor.transform.otlp_gateway.input]
+    traces = [otelcol.processor.transform.otlp_gateway.input]
+  }
+} // otelcol.processor.attributes "otlp_gateway"
+
+otelcol.processor.transform "otlp_gateway" {
+  error_mode = "ignore"
+  metric_statements {
+    context = "resource"
+    statements = [
+      `set(attributes["cluster"], "application-observability-gc-feature-test")`,
+      `set(attributes["k8s.cluster.name"], "application-observability-gc-feature-test")`,
+      `delete_key(attributes, "process.pid")`,
+      `delete_key(attributes, "process.parent_pid")`,
+      `delete_key(attributes, "process.executable.path")`,
+      `delete_key(attributes, "process.command_line")`,
+      `delete_key(attributes, "process.command_args")`,
+      `delete_key(attributes, "process.owner")`,
+      `delete_key(attributes, "process.runtime.version")`,
+      `delete_key(attributes, "process.runtime.description")`,
+      `delete_key(attributes, "host.ip")`,
+      `delete_key(attributes, "host.mac")`,
+      `delete_key(attributes, "k8s.pod.start_time")`,
+      `delete_key(attributes, "k8s.pod.uid")`,
+      `delete_key(attributes, "container.image.id")`,
+      `delete_key(attributes, "container.image.repo_digests")`,
+      `delete_key(attributes, "os.description")`,
+      `delete_key(attributes, "os.build_id")`,
+      // Scrape targets that expose their own target_info metric (e.g. Grafana Beyla) can
+      // carry a flat k8s_cluster_name resource attribute, which conflicts with the
+      // k8s.cluster.name attribute set above and gets ";"-joined by the Prometheus OTLP
+      // endpoint. Drop the flat copy when the values match.
+      `delete_key(attributes, "k8s_cluster_name") where attributes["k8s_cluster_name"] == attributes["k8s.cluster.name"]`,
+    ]
+  }
+
+  metric_statements {
+    context = "datapoint"
+    statements = [
+      `set(attributes["cluster"], "application-observability-gc-feature-test")`,
+      `set(attributes["k8s.cluster.name"], "application-observability-gc-feature-test")`,
+      `set(resource.attributes["deployment.environment"], attributes["deployment_environment"] ) where resource.attributes["deployment.environment"] == nil and attributes["deployment_environment"] != nil`,
+      `delete_key(attributes, "deployment_environment") where attributes["deployment_environment"] == resource.attributes["deployment.environment"]`,
+      `set(resource.attributes["deployment.environment.name"], attributes["deployment_environment_name"] ) where resource.attributes["deployment.environment.name"] == nil and attributes["deployment_environment_name"] != nil`,
+      `delete_key(attributes, "deployment_environment_name") where attributes["deployment_environment_name"] == resource.attributes["deployment.environment.name"]`,
+      `set(resource.attributes["service.name"], attributes["service_name"] ) where (resource.attributes["service.name"] == nil or resource.attributes["service.name"] == "") and attributes["service_name"] != nil and attributes["service_name"] != ""`,
+      `delete_key(attributes, "service_name") where attributes["service_name"] == resource.attributes["service.name"]`,
+      `set(resource.attributes["service.namespace"], attributes["service_namespace"] ) where (resource.attributes["service.namespace"] == nil or resource.attributes["service.namespace"] == "") and attributes["service_namespace"] != nil and attributes["service_namespace"] != ""`,
+      `delete_key(attributes, "service_namespace") where attributes["service_namespace"] == resource.attributes["service.namespace"]`,
+    ]
+  }
+  log_statements {
+    context = "resource"
+    statements = [
+      `set(attributes["cluster"], "application-observability-gc-feature-test")`,
+      `set(attributes["k8s.cluster.name"], "application-observability-gc-feature-test")`,
+      `delete_key(attributes, "process.pid")`,
+      `delete_key(attributes, "process.parent_pid")`,
+      `delete_key(attributes, "process.executable.path")`,
+      `delete_key(attributes, "process.command_line")`,
+      `delete_key(attributes, "process.command_args")`,
+      `delete_key(attributes, "process.owner")`,
+      `delete_key(attributes, "process.runtime.version")`,
+      `delete_key(attributes, "process.runtime.description")`,
+      `delete_key(attributes, "host.ip")`,
+      `delete_key(attributes, "host.mac")`,
+      `delete_key(attributes, "k8s.pod.start_time")`,
+      `delete_key(attributes, "k8s.pod.uid")`,
+      `delete_key(attributes, "container.image.id")`,
+      `delete_key(attributes, "container.image.repo_digests")`,
+      `delete_key(attributes, "os.description")`,
+      `delete_key(attributes, "os.build_id")`,
+    ]
+  }
+
+  log_statements {
+    context = "log"
+    statements = [
+      `delete_key(attributes, "loki.attribute.labels")`,
+      `delete_key(attributes, "loki.resource.labels")`,
+      `set(resource.attributes["k8s.container.name"], attributes["container"] ) where resource.attributes["k8s.container.name"] == nil and attributes["container"] != nil`,
+      `delete_key(attributes, "container") where attributes["container"] == resource.attributes["k8s.container.name"]`,
+      `set(resource.attributes["k8s.cronjob.name"], attributes["cronjob"] ) where resource.attributes["k8s.cronjob.name"] == nil and attributes["cronjob"] != nil`,
+      `delete_key(attributes, "cronjob") where attributes["cronjob"] == resource.attributes["k8s.cronjob.name"]`,
+      `set(resource.attributes["k8s.daemonset.name"], attributes["daemonset"] ) where resource.attributes["k8s.daemonset.name"] == nil and attributes["daemonset"] != nil`,
+      `delete_key(attributes, "daemonset") where attributes["daemonset"] == resource.attributes["k8s.daemonset.name"]`,
+      `set(resource.attributes["k8s.deployment.name"], attributes["deployment"] ) where resource.attributes["k8s.deployment.name"] == nil and attributes["deployment"] != nil`,
+      `delete_key(attributes, "deployment") where attributes["deployment"] == resource.attributes["k8s.deployment.name"]`,
+      `set(resource.attributes["deployment.environment"], attributes["deployment_environment"] ) where resource.attributes["deployment.environment"] == nil and attributes["deployment_environment"] != nil`,
+      `delete_key(attributes, "deployment_environment") where attributes["deployment_environment"] == resource.attributes["deployment.environment"]`,
+      `set(resource.attributes["deployment.environment.name"], attributes["deployment_environment_name"] ) where resource.attributes["deployment.environment.name"] == nil and attributes["deployment_environment_name"] != nil`,
+      `delete_key(attributes, "deployment_environment_name") where attributes["deployment_environment_name"] == resource.attributes["deployment.environment.name"]`,
+      `set(resource.attributes["k8s.job.name"], attributes["job_name"] ) where resource.attributes["k8s.job.name"] == nil and attributes["job_name"] != nil`,
+      `delete_key(attributes, "job_name") where attributes["job_name"] == resource.attributes["k8s.job.name"]`,
+      `set(resource.attributes["k8s.namespace.name"], attributes["namespace"] ) where resource.attributes["k8s.namespace.name"] == nil and attributes["namespace"] != nil`,
+      `delete_key(attributes, "namespace") where attributes["namespace"] == resource.attributes["k8s.namespace.name"]`,
+      `set(resource.attributes["k8s.pod.name"], attributes["pod"] ) where resource.attributes["k8s.pod.name"] == nil and attributes["pod"] != nil`,
+      `delete_key(attributes, "pod") where attributes["pod"] == resource.attributes["k8s.pod.name"]`,
+      `set(resource.attributes["k8s.replicaset.name"], attributes["replicaset"] ) where resource.attributes["k8s.replicaset.name"] == nil and attributes["replicaset"] != nil`,
+      `delete_key(attributes, "replicaset") where attributes["replicaset"] == resource.attributes["k8s.replicaset.name"]`,
+      `set(resource.attributes["service.name"], attributes["service_name"] ) where (resource.attributes["service.name"] == nil or resource.attributes["service.name"] == "") and attributes["service_name"] != nil and attributes["service_name"] != ""`,
+      `delete_key(attributes, "service_name") where attributes["service_name"] == resource.attributes["service.name"]`,
+      `set(resource.attributes["service.namespace"], attributes["service_namespace"] ) where (resource.attributes["service.namespace"] == nil or resource.attributes["service.namespace"] == "") and attributes["service_namespace"] != nil and attributes["service_namespace"] != ""`,
+      `delete_key(attributes, "service_namespace") where attributes["service_namespace"] == resource.attributes["service.namespace"]`,
+      `set(resource.attributes["k8s.statefulset.name"], attributes["statefulset"] ) where resource.attributes["k8s.statefulset.name"] == nil and attributes["statefulset"] != nil`,
+      `delete_key(attributes, "statefulset") where attributes["statefulset"] == resource.attributes["k8s.statefulset.name"]`,
+    ]
+  }
+
+  trace_statements {
+    context = "resource"
+    statements = [
+      `set(attributes["cluster"], "application-observability-gc-feature-test")`,
+      `set(attributes["k8s.cluster.name"], "application-observability-gc-feature-test")`,
+      `delete_key(attributes, "process.pid")`,
+      `delete_key(attributes, "process.parent_pid")`,
+      `delete_key(attributes, "process.executable.path")`,
+      `delete_key(attributes, "process.command_line")`,
+      `delete_key(attributes, "process.command_args")`,
+      `delete_key(attributes, "process.owner")`,
+      `delete_key(attributes, "process.runtime.version")`,
+      `delete_key(attributes, "process.runtime.description")`,
+      `delete_key(attributes, "host.ip")`,
+      `delete_key(attributes, "host.mac")`,
+      `delete_key(attributes, "k8s.pod.start_time")`,
+      `delete_key(attributes, "k8s.pod.uid")`,
+      `delete_key(attributes, "container.image.id")`,
+      `delete_key(attributes, "container.image.repo_digests")`,
+      `delete_key(attributes, "os.description")`,
+      `delete_key(attributes, "os.build_id")`,
+    ]
+  }
+
+  output {
+    metrics = [otelcol.processor.batch.otlp_gateway.input]
+    logs = [otelcol.processor.batch.otlp_gateway.input]
+    traces = [otelcol.processor.batch.otlp_gateway.input]
+  }
+} // otelcol.processor.transform "otlp_gateway"
+
+otelcol.processor.batch "otlp_gateway" {
+  timeout = "2s"
+  send_batch_size = 4096
+  send_batch_max_size = 4096
+
+  output {
+    metrics = [otelcol.exporter.otlphttp.otlp_gateway.input]
+    logs = [otelcol.exporter.otlphttp.otlp_gateway.input]
+    traces = [otelcol.exporter.otlphttp.otlp_gateway.input]
+  }
+} // otelcol.processor.batch "otlp_gateway"
+otelcol.exporter.otlphttp "otlp_gateway" {
+  client {
+    endpoint = "https://otlp-gateway-prod-us-east-0.grafana.net/otlp"
+    auth = otelcol.auth.basic.otlp_gateway.handler
+    headers = {
+      "X-Scope-OrgID" = convert.nonsensitive(remote.kubernetes.secret.otlp_gateway.data["tenantId"]),
+    }
+    tls {
+      insecure = false
+      insecure_skip_verify = false
+      ca_pem = convert.nonsensitive(remote.kubernetes.secret.otlp_gateway.data["ca"])
+      cert_pem = convert.nonsensitive(remote.kubernetes.secret.otlp_gateway.data["cert"])
+      key_pem = remote.kubernetes.secret.otlp_gateway.data["key"]
+    }
+  }
+
+  retry_on_failure {
+    enabled = true
+    initial_interval = "5s"
+    max_interval = "30s"
+    max_elapsed_time = "5m"
+  }
+
+  sending_queue {
+    enabled = true
+  }
+} // otelcol.exporter.otlphttp "otlp_gateway"
+
+otelcol.auth.basic "otlp_gateway" {
+  username = convert.nonsensitive(remote.kubernetes.secret.otlp_gateway.data["OTLP_GATEWAY_USER"])
+  password = remote.kubernetes.secret.otlp_gateway.data["OTLP_GATEWAY_PASS"]
+} // otelcol.auth.basic "otlp_gateway"
+
+remote.kubernetes.secret "otlp_gateway" {
+  name      = "grafana-cloud-credentials"
+  namespace = "default"
+} // remote.kubernetes.secret "otlp_gateway"
+

--- a/charts/k8s-monitoring/tests/platform/grafana-cloud/database-observability/.rendered/alloy-logs.alloy
+++ b/charts/k8s-monitoring/tests/platform/grafana-cloud/database-observability/.rendered/alloy-logs.alloy
@@ -1,0 +1,314 @@
+// Feature: Pod Logs (Loki)
+declare "pod_logs_via_loki" {
+  argument "logs_destinations" {
+    comment = "Must be a list of log destinations where collected logs should be forwarded to"
+  }
+
+  discovery.kubernetes "pods" {
+    role = "pod"
+    selectors {
+      role = "pod"
+      field = "spec.nodeName=" + sys.env("HOSTNAME")
+    }
+  } // discovery.kubernetes "pods"
+
+  discovery.relabel "filtered_pods" {
+    targets = discovery.kubernetes.pods.targets
+    rule {
+      source_labels = ["__meta_kubernetes_namespace"]
+      action = "replace"
+      target_label = "namespace"
+    }
+    rule {  // Drop anything with a "falsy" annotation value
+      source_labels = ["__meta_kubernetes_pod_annotation_logs_grafana_com_pods_enabled"]
+      regex = "(false|no|skip)"
+      action = "drop"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_pod_name"]
+      target_label = "pod"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_pod_container_name"]
+      target_label = "container"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_namespace", "__meta_kubernetes_pod_container_name"]
+      separator = "/"
+      replacement = "$1"
+      target_label = "job"
+    }
+
+    // set the container runtime as a label
+    rule {
+      source_labels = ["__meta_kubernetes_pod_container_id"]
+      regex = "^(\\S+):\\/\\/.+$"
+      replacement = "$1"
+      target_label = "tmp_container_runtime"
+    }
+    // explicitly set service_name. if not set, loki will automatically try to populate a default.
+    // see https://grafana.com/docs/loki/latest/get-started/labels/#default-labels-for-all-users
+    //
+    // choose the first value found from the following ordered list:
+    // - pod.annotation[resource.opentelemetry.io/service.name]
+    // - pod.label[app.kubernetes.io/name]
+    // - k8s.container.name
+    rule {
+      source_labels = [
+        "__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_name",
+        "__meta_kubernetes_pod_label_app_kubernetes_io_name",
+        "__meta_kubernetes_pod_container_name",
+      ]
+      separator = ";"
+      regex = "^(?:;*)?([^;]+).*$"
+      replacement = "$1"
+      target_label = "service_name"
+    }
+
+    // explicitly set service_namespace.
+    //
+    // choose the first value found from the following ordered list:
+    // - pod.annotation[resource.opentelemetry.io/service.namespace]
+    // - pod.namespace
+    rule {
+      source_labels = [
+        "__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_namespace",
+        "namespace",
+      ]
+      separator = ";"
+      regex = "^(?:;*)?([^;]+).*$"
+      replacement = "$1"
+      target_label = "service_namespace"
+    }
+
+    // explicitly set service_instance_id.
+    //
+    // choose the first value found from the following ordered list:
+    // - pod.annotation[resource.opentelemetry.io/service.instance.id]
+    // - concat([k8s.namespace.name, k8s.pod.name, k8s.container.name], '.')
+    rule {
+      source_labels = ["__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_instance_id"]
+      target_label = "service_instance_id"
+    }
+    rule {
+      source_labels = ["service_instance_id", "namespace", "pod", "container"]
+      separator = "."
+      regex = "^\\.([^.]+\\.[^.]+\\.[^.]+)$"
+      target_label = "service_instance_id"
+    }
+
+    // set resource attributes
+    rule {
+      action = "labelmap"
+      regex = "__meta_kubernetes_pod_annotation_resource_opentelemetry_io_(.+)"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_job"]
+      regex = "(.+)"
+      target_label = "job"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+      regex = "(.+)"
+      target_label = "app_kubernetes_io_name"
+    }
+
+    // Set the pod log path.
+    rule {
+      source_labels = ["__meta_kubernetes_pod_uid", "__meta_kubernetes_pod_container_name"]
+      separator = "/"
+      replacement = "/var/log/pods/*$1/*.log"
+      target_label = "__path__"
+    }
+
+    // If kubernetes.io/config.mirror is set, this is a static pod, created by the kubelet.
+    // It's logs live on a different path.
+    rule {
+      source_labels = ["__meta_kubernetes_pod_annotation_kubernetes_io_config_mirror", "__meta_kubernetes_pod_container_name"]
+      separator = "/"
+      regex = "(.+/.+)"
+      replacement = "/var/log/pods/*$1/*.log"
+      target_label = "__path__"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_instance"]
+      separator = ";"
+      regex = "(?:test-mysql-db)"
+      target_label = "integration"
+      replacement = "mysql"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_instance"]
+      separator = ";"
+      regex = "(?:test-mysql-db)"
+      target_label = "instance"
+      replacement = "test-mysql-db"
+    }
+
+    rule {
+      source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_instance"]
+      separator = ";"
+      regex = "(?:test-pg-db)"
+      target_label = "integration"
+      replacement = "postgresql"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_instance"]
+      separator = ";"
+      regex = "(?:test-pg-db)"
+      target_label = "instance"
+      replacement = "test-pg-db"
+    }
+  } // discovery.relabel "filtered_pods"
+
+  local.file_match "pod_logs" {
+    path_targets = discovery.relabel.filtered_pods.output
+  } // local.file_match "pod_logs"
+
+  loki.source.file "pod_logs" {
+    targets    = local.file_match.pod_logs.targets
+    tail_from_end = true
+    forward_to = [loki.process.pod_logs.receiver]
+  } // loki.source.file "pod_logs"
+
+  loki.process "pod_logs" {
+    stage.match {
+      selector = "{tmp_container_runtime=~\"containerd|cri-o|\"}"
+      // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
+      stage.cri {
+        max_partial_lines = 100
+      }
+
+      // Set the extract flags and stream values as labels
+      stage.labels {
+        values = {
+          flags  = "",
+          stream  = "",
+        }
+      }
+    }
+
+    stage.match {
+      selector = "{tmp_container_runtime=\"docker\"}"
+      // the docker processing stage extracts the following k/v pairs: log, stream, time
+      stage.docker {}
+
+      // Set the extract stream value as a label
+      stage.labels {
+        values = {
+          stream  = "",
+        }
+      }
+    }
+
+    // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
+    // namespace, pod, and container labels. Drop any structured metadata. Also drop the temporary
+    // container runtime label as it is no longer needed.
+    stage.label_drop {
+      values = [
+        "filename",
+        "tmp_container_runtime",
+      ]
+    }
+    stage.structured_metadata {
+      values = {
+        "k8s_pod_name" = "k8s_pod_name",
+        "pod" = "pod",
+        "service_instance_id" = "service_instance_id",
+      }
+    }
+    // Integration: MySQL
+    stage.match {
+      selector = "{integration=\"mysql\"}"
+
+      stage.regex {
+        expression = `(?P<timestamp>.+) (?P<thread>[\d]+) \[(?P<label>.+?)\]( \[(?P<err_code>.+?)\] \[(?P<subsystem>.+?)\])? (?P<msg>.+)`
+      }
+
+      stage.labels {
+        values = {
+          level = "label",
+          err_code = "err_code",
+          subsystem = "subsystem",
+        }
+      }
+
+      stage.drop {
+        expression = "^ *$"
+        drop_counter_reason = "drop empty lines"
+      }
+
+      stage.static_labels {
+        values = {
+          job = "integrations/mysql",
+        }
+      }
+
+      stage.label_drop {
+        values = ["integration"]
+      }
+    }
+
+    // Integration: postgresql
+    stage.match {
+      selector = "{integration=\"postgresql\"}"
+
+      stage.static_labels {
+        values = {
+          job = "integrations/postgresql",
+        }
+      }
+
+      stage.label_drop {
+        values = ["integration"]
+      }
+    }
+
+    forward_to = argument.logs_destinations.value
+  } // loki.secretfilter "pod_logs"
+} // declare "pod_logs_via_loki"
+pod_logs_via_loki "feature" {
+  logs_destinations = [
+    loki.write.grafana_cloud_logs.receiver,
+  ]
+}
+
+
+
+
+
+// Destination: grafana-cloud-logs (loki)
+otelcol.exporter.loki "grafana_cloud_logs" {
+  forward_to = [loki.write.grafana_cloud_logs.receiver]
+} // otelcol.exporter.loki "grafana_cloud_logs"
+
+loki.write "grafana_cloud_logs" {
+  endpoint {
+    url = "https://logs-prod-006.grafana.net/loki/api/v1/push"
+    retry_on_http_429 = true
+    tenant_id = convert.nonsensitive(remote.kubernetes.secret.grafana_cloud_logs.data["tenantId"])
+    basic_auth {
+      username = convert.nonsensitive(remote.kubernetes.secret.grafana_cloud_logs.data["logsUser"])
+      password = remote.kubernetes.secret.grafana_cloud_logs.data["grafanaCloudAccessPolicyToken"]
+    }
+    tls_config {
+      insecure_skip_verify = false
+      ca_pem = convert.nonsensitive(remote.kubernetes.secret.grafana_cloud_logs.data["ca"])
+      cert_pem = convert.nonsensitive(remote.kubernetes.secret.grafana_cloud_logs.data["cert"])
+      key_pem = remote.kubernetes.secret.grafana_cloud_logs.data["key"]
+    }
+    min_backoff_period = "500ms"
+    max_backoff_period = "5m"
+    max_backoff_retries = "10"
+  }
+  external_labels = {
+    "cluster" = "database-observability-gc-feature-test",
+    "k8s_cluster_name" = "database-observability-gc-feature-test",
+  }
+} // loki.write "grafana_cloud_logs"
+
+remote.kubernetes.secret "grafana_cloud_logs" {
+  name      = "grafana-cloud-credentials"
+  namespace = "default"
+} // remote.kubernetes.secret "grafana_cloud_logs"
+

--- a/charts/k8s-monitoring/tests/platform/grafana-cloud/database-observability/.rendered/alloy-singleton.alloy
+++ b/charts/k8s-monitoring/tests/platform/grafana-cloud/database-observability/.rendered/alloy-singleton.alloy
@@ -1,0 +1,368 @@
+declare "mysql_integration" {
+  argument "metrics_destinations" {
+    comment = "Must be a list of metric destinations where collected metrics should be forwarded to"
+  }
+  argument "logs_destinations" {
+    comment = "Must be a list of log destinations where collected logs should be forwarded to"
+  }
+
+  remote.kubernetes.secret "test_mysql_db" {
+    name      = "test-mysql-db"
+    namespace = "mysql"
+  } // remote.kubernetes.secret "test_mysql_db"
+
+  prometheus.exporter.mysql "test_mysql_db" {
+    data_source_name = string.format("%s:%s@(%s:%d)/",
+      convert.nonsensitive(remote.kubernetes.secret.test_mysql_db.data["mysql-username"]),
+      convert.nonsensitive(remote.kubernetes.secret.test_mysql_db.data["mysql-root-password"]),
+      "test-mysql-db.mysql.svc",
+      3306,
+    )
+    perf_schema.eventsstatements {
+      text_limit = 0
+    }
+    enable_collectors = ["heartbeat","mysql.user","perf_schema.eventsstatements"]
+  }
+
+  database_observability.mysql "test_mysql_db" {
+    targets = prometheus.exporter.mysql.test_mysql_db.targets
+    data_source_name = string.format("%s:%s@(%s:%d)/",
+      convert.nonsensitive(remote.kubernetes.secret.test_mysql_db.data["mysql-username"]),
+      convert.nonsensitive(remote.kubernetes.secret.test_mysql_db.data["mysql-root-password"]),
+      "test-mysql-db.mysql.svc",
+      3306,
+    )
+    allow_update_performance_schema_settings = false
+    explain_plans {
+      collect_interval = "1m"
+      initial_lookback = "24h"
+      per_collect_ratio = "1"
+    }
+    query_details {
+      collect_interval = "1m"
+    }
+    query_samples {
+      collect_interval = "10s"
+      disable_query_redaction = false
+      auto_enable_setup_consumers = false
+      setup_consumers_check_interval = "1h"
+      sample_min_duration = "0s"
+      wait_event_min_duration = "1us"
+    }
+    schema_details {
+      collect_interval = "1m"
+    }
+    setup_consumers {
+      collect_interval = "1h"
+    }
+    setup_actors {
+      auto_update_setup_actors = false
+      collect_interval = "1h"
+    }
+    enable_collectors = ["explain_plans","query_details","query_samples","schema_details","setup_consumers","setup_actors"]
+    disable_collectors = ["locks"]
+
+    forward_to = [loki.relabel.database_observability_mysql_test_mysql_db.receiver]
+  }
+
+  loki.relabel "database_observability_mysql_test_mysql_db" {
+    forward_to = argument.logs_destinations.value
+    rule {
+      target_label = "job"
+      replacement = "integrations/db-o11y"
+    }
+    rule {
+      source_labels = ["instance"]
+      target_label = "dsn"
+    }
+    rule {
+      target_label = "instance"
+      replacement = "test-mysql-db"
+    }
+  }
+
+  discovery.relabel "database_observability_mysql_test_mysql_db" {
+    targets = database_observability.mysql.test_mysql_db.targets
+    rule {
+      target_label = "job"
+      replacement = "integrations/db-o11y"
+    }
+    rule {
+      source_labels = ["instance"]
+      target_label = "dsn"
+    }
+    rule {
+      target_label = "instance"
+      replacement = "test-mysql-db"
+    }
+  }
+  prometheus.scrape "test_mysql_db" {
+    targets = discovery.relabel.database_observability_mysql_test_mysql_db.output
+    clustering {
+      enabled = true
+    }
+
+    scrape_interval = "60s"
+    scrape_timeout = "10s"
+    scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
+    scrape_classic_histograms = false
+    scrape_native_histograms = false
+    forward_to = argument.metrics_destinations.value
+  }
+}
+mysql_integration "integration" {
+  metrics_destinations = [
+    prometheus.remote_write.grafana_cloud_metrics.receiver,
+  ]
+  logs_destinations = [
+    loki.write.grafana_cloud_logs.receiver,
+  ]
+}
+declare "postgresql_integration" {
+  argument "metrics_destinations" {
+    comment = "Must be a list of metric destinations where collected metrics should be forwarded to"
+  }
+  argument "logs_destinations" {
+    comment = "Must be a list of log destinations where collected logs should be forwarded to"
+  }
+
+  remote.kubernetes.secret "test_pg_db" {
+    name      = "test-postgresql-db"
+    namespace = "postgresql"
+  } // remote.kubernetes.secret "test_pg_db"
+
+  prometheus.exporter.postgres "test_pg_db" {
+    data_source_names = [string.format("postgresql://%s:%s@%s:%d/postgres?sslmode=disable",
+      encoding.url_encode(convert.nonsensitive(remote.kubernetes.secret.test_pg_db.data["postgres-username"])),
+      encoding.url_encode(convert.nonsensitive(remote.kubernetes.secret.test_pg_db.data["postgres-password"])),
+      "test-postgresql-db.postgresql.svc",
+      5432,
+    )]
+    enabled_collectors = ["database","locks","replication","replication_slot","stat_bgwriter","stat_database","stat_progress_vacuum","stat_statements","stat_user_tables","statio_user_tables","wal"]
+    autodiscovery {
+      enabled = true
+    }
+    disable_default_metrics = false
+    disable_settings_metrics = false
+  }
+
+  database_observability.postgres "test_pg_db" {
+    targets = prometheus.exporter.postgres.test_pg_db.targets
+    data_source_name = string.format("postgresql://%s:%s@%s:%d/postgres?sslmode=disable",
+      encoding.url_encode(convert.nonsensitive(remote.kubernetes.secret.test_pg_db.data["postgres-username"])),
+      encoding.url_encode(convert.nonsensitive(remote.kubernetes.secret.test_pg_db.data["postgres-password"])),
+      "test-postgresql-db.postgresql.svc",
+      5432,
+    )
+    exclude_current_user = true
+    explain_plans {
+      collect_interval = "1m"
+      per_collect_ratio = "1"
+    }
+    query_details {
+      collect_interval = "1m"
+    }
+    query_samples {
+      collect_interval = "15s"
+      disable_query_redaction = false
+    }
+    schema_details {
+      collect_interval = "1m"
+    }
+    enable_collectors = ["explain_plans","query_details","query_samples","schema_details"]
+
+    forward_to = [loki.relabel.database_observability_postgres_test_pg_db.receiver]
+  }
+
+  loki.relabel "database_observability_postgres_test_pg_db" {
+    forward_to = argument.logs_destinations.value
+    rule {
+      target_label = "job"
+      replacement = "integrations/db-o11y"
+    }
+    rule {
+      source_labels = ["instance"]
+      target_label = "dsn"
+    }
+    rule {
+      target_label = "instance"
+      replacement = "test-pg-db"
+    }
+  }
+
+  discovery.relabel "database_observability_postgres_test_pg_db" {
+    targets = database_observability.postgres.test_pg_db.targets
+    rule {
+      target_label = "job"
+      replacement = "integrations/db-o11y"
+    }
+    rule {
+      source_labels = ["instance"]
+      target_label = "dsn"
+    }
+    rule {
+      target_label = "instance"
+      replacement = "test-pg-db"
+    }
+  }
+  prometheus.scrape "test_pg_db" {
+    targets = discovery.relabel.database_observability_postgres_test_pg_db.output
+    clustering {
+      enabled = true
+    }
+
+    scrape_interval = "60s"
+    scrape_timeout = "10s"
+    scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
+    scrape_classic_histograms = false
+    scrape_native_histograms = false
+    forward_to = argument.metrics_destinations.value
+  }
+}
+postgresql_integration "integration" {
+  metrics_destinations = [
+    prometheus.remote_write.grafana_cloud_metrics.receiver,
+  ]
+  logs_destinations = [
+    loki.write.grafana_cloud_logs.receiver,
+  ]
+}
+// Self Reporting
+prometheus.exporter.unix "kubernetes_monitoring_telemetry" {
+  set_collectors = ["textfile"]
+  textfile {
+    directory = "/etc/release-info"
+  }
+} // prometheus.exporter.unix "kubernetes_monitoring_telemetry"
+
+discovery.relabel "kubernetes_monitoring_telemetry" {
+  targets = prometheus.exporter.unix.kubernetes_monitoring_telemetry.targets
+  rule {
+    target_label = "instance"
+    action = "replace"
+    replacement = "k8smon"
+  }
+  rule {
+    target_label = "job"
+    action = "replace"
+    replacement = "integrations/kubernetes/kubernetes_monitoring_telemetry"
+  }
+} // discovery.relabel "kubernetes_monitoring_telemetry"
+
+prometheus.scrape "kubernetes_monitoring_telemetry" {
+  job_name   = "integrations/kubernetes/kubernetes_monitoring_telemetry"
+  targets    = discovery.relabel.kubernetes_monitoring_telemetry.output
+  scrape_interval = "60s"
+  clustering {
+    enabled = true
+  }
+  forward_to = [prometheus.relabel.kubernetes_monitoring_telemetry.receiver]
+} // prometheus.scrape "kubernetes_monitoring_telemetry"
+
+prometheus.relabel "kubernetes_monitoring_telemetry" {
+  rule {
+    source_labels = ["__name__"]
+    regex = "grafana_kubernetes_monitoring_.*"
+    action = "keep"
+  }
+  forward_to = [
+    prometheus.remote_write.grafana_cloud_metrics.receiver,
+  ]
+} // prometheus.relabel "kubernetes_monitoring_telemetry"
+
+
+
+
+
+// Destination: grafana-cloud-logs (loki)
+otelcol.exporter.loki "grafana_cloud_logs" {
+  forward_to = [loki.write.grafana_cloud_logs.receiver]
+} // otelcol.exporter.loki "grafana_cloud_logs"
+
+loki.write "grafana_cloud_logs" {
+  endpoint {
+    url = "https://logs-prod-006.grafana.net/loki/api/v1/push"
+    retry_on_http_429 = true
+    tenant_id = convert.nonsensitive(remote.kubernetes.secret.grafana_cloud_logs.data["tenantId"])
+    basic_auth {
+      username = convert.nonsensitive(remote.kubernetes.secret.grafana_cloud_logs.data["logsUser"])
+      password = remote.kubernetes.secret.grafana_cloud_logs.data["grafanaCloudAccessPolicyToken"]
+    }
+    tls_config {
+      insecure_skip_verify = false
+      ca_pem = convert.nonsensitive(remote.kubernetes.secret.grafana_cloud_logs.data["ca"])
+      cert_pem = convert.nonsensitive(remote.kubernetes.secret.grafana_cloud_logs.data["cert"])
+      key_pem = remote.kubernetes.secret.grafana_cloud_logs.data["key"]
+    }
+    min_backoff_period = "500ms"
+    max_backoff_period = "5m"
+    max_backoff_retries = "10"
+  }
+  external_labels = {
+    "cluster" = "database-observability-gc-feature-test",
+    "k8s_cluster_name" = "database-observability-gc-feature-test",
+  }
+} // loki.write "grafana_cloud_logs"
+
+remote.kubernetes.secret "grafana_cloud_logs" {
+  name      = "grafana-cloud-credentials"
+  namespace = "default"
+} // remote.kubernetes.secret "grafana_cloud_logs"
+
+
+// Destination: grafana-cloud-metrics (prometheus)
+otelcol.exporter.prometheus "grafana_cloud_metrics" {
+  add_metric_suffixes = true
+  resource_to_telemetry_conversion = false
+  keep_identifying_resource_attributes = true
+  forward_to = [prometheus.remote_write.grafana_cloud_metrics.receiver]
+} // otelcol.exporter.prometheus "grafana_cloud_metrics"
+
+prometheus.remote_write "grafana_cloud_metrics" {
+  endpoint {
+    url = "https://prometheus-prod-13-prod-us-east-0.grafana.net/api/prom/push"
+    protobuf_message = "io.prometheus.write.v2.Request"
+    headers = {
+      "X-Scope-OrgID" = convert.nonsensitive(remote.kubernetes.secret.grafana_cloud_metrics.data["tenantId"]),
+    }
+    basic_auth {
+      username = convert.nonsensitive(remote.kubernetes.secret.grafana_cloud_metrics.data["metricsUser"])
+      password = remote.kubernetes.secret.grafana_cloud_metrics.data["grafanaCloudAccessPolicyToken"]
+    }
+    tls_config {
+      insecure_skip_verify = false
+      ca_pem = convert.nonsensitive(remote.kubernetes.secret.grafana_cloud_metrics.data["ca"])
+      cert_pem = convert.nonsensitive(remote.kubernetes.secret.grafana_cloud_metrics.data["cert"])
+      key_pem = remote.kubernetes.secret.grafana_cloud_metrics.data["key"]
+    }
+    send_native_histograms = false
+
+    queue_config {
+      capacity = 10000
+      min_shards = 1
+      max_shards = 50
+      max_samples_per_send = 2000
+      batch_send_deadline = "5s"
+      min_backoff = "30ms"
+      max_backoff = "5s"
+      retry_on_http_429 = true
+      sample_age_limit = "0s"
+    }
+  }
+
+  wal {
+    truncate_frequency = "2h"
+    min_keepalive_time = "5m"
+    max_keepalive_time = "8h"
+  }
+  external_labels = {
+    "cluster" = "database-observability-gc-feature-test",
+    "k8s_cluster_name" = "database-observability-gc-feature-test",
+  }
+} // prometheus.remote_write "grafana_cloud_metrics"
+
+remote.kubernetes.secret "grafana_cloud_metrics" {
+  name      = "grafana-cloud-credentials"
+  namespace = "default"
+} // remote.kubernetes.secret "grafana_cloud_metrics"
+

--- a/charts/k8s-monitoring/tests/platform/grafana-cloud/instrumentation-hub/.rendered/alloy.alloy
+++ b/charts/k8s-monitoring/tests/platform/grafana-cloud/instrumentation-hub/.rendered/alloy.alloy
@@ -1,0 +1,33 @@
+remote.kubernetes.secret "alloy_remote_cfg" {
+  name      = "grafana-cloud-credentials"
+  namespace = "default"
+} // remote.kubernetes.secret "alloy_remote_cfg"
+
+remotecfg {
+  id = string.format("k8smon-%s-%s-%s-%s", "instrumentation-hub-test-cluster", "default", "alloy", sys.env("K8S_NODE_NAME"))
+  url = "https://fleet-management-prod-008.grafana.net"
+  basic_auth {
+    username = convert.nonsensitive(remote.kubernetes.secret.alloy_remote_cfg.data["GRAFANA_CLOUD_FLEET_MGMT_USER"])
+    password = remote.kubernetes.secret.alloy_remote_cfg.data["GRAFANA_CLOUD_FLEET_MGMT_TOKEN"]
+  }
+  tls_config {
+    insecure_skip_verify = false
+    ca_pem = convert.nonsensitive(remote.kubernetes.secret.alloy_remote_cfg.data["ca"])
+    cert_pem = convert.nonsensitive(remote.kubernetes.secret.alloy_remote_cfg.data["cert"])
+    key_pem = remote.kubernetes.secret.alloy_remote_cfg.data["key"]
+  }
+  poll_frequency = "30s"
+  attributes = {
+    "cluster" = "instrumentation-hub-test-cluster",
+    "namespace" = "default",
+    "platform" = "kubernetes",
+    "presets" = "root,host-network,host-storage,host-cgroup,host-tracefs,clustered,service-discovery,filesystem-log-reader,otel-receiver,daemonset",
+    "release" = "k8smon",
+    "service-discovery" = "true",
+    "source" = "k8s-monitoring",
+    "sourceVersion" = "4.3.0",
+    "workloadName" = "alloy",
+    "workloadType" = "daemonset",
+  }
+}
+

--- a/charts/k8s-monitoring/tests/platform/grafana-cloud/k8s-monitoring/.rendered/alloy-logs.alloy
+++ b/charts/k8s-monitoring/tests/platform/grafana-cloud/k8s-monitoring/.rendered/alloy-logs.alloy
@@ -1,0 +1,241 @@
+// Feature: Pod Logs (Loki)
+declare "pod_logs_via_loki" {
+  argument "logs_destinations" {
+    comment = "Must be a list of log destinations where collected logs should be forwarded to"
+  }
+
+  discovery.kubernetes "pods" {
+    role = "pod"
+    selectors {
+      role = "pod"
+      field = "spec.nodeName=" + sys.env("HOSTNAME")
+    }
+  } // discovery.kubernetes "pods"
+
+  discovery.relabel "filtered_pods" {
+    targets = discovery.kubernetes.pods.targets
+    rule {
+      source_labels = ["__meta_kubernetes_namespace"]
+      action = "replace"
+      target_label = "namespace"
+    }
+    rule {  // Drop anything with a "falsy" annotation value
+      source_labels = ["__meta_kubernetes_pod_annotation_logs_grafana_com_pods_enabled"]
+      regex = "(false|no|skip)"
+      action = "drop"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_pod_name"]
+      target_label = "pod"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_pod_container_name"]
+      target_label = "container"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_namespace", "__meta_kubernetes_pod_container_name"]
+      separator = "/"
+      replacement = "$1"
+      target_label = "job"
+    }
+
+    // set the container runtime as a label
+    rule {
+      source_labels = ["__meta_kubernetes_pod_container_id"]
+      regex = "^(\\S+):\\/\\/.+$"
+      replacement = "$1"
+      target_label = "tmp_container_runtime"
+    }
+    // explicitly set service_name. if not set, loki will automatically try to populate a default.
+    // see https://grafana.com/docs/loki/latest/get-started/labels/#default-labels-for-all-users
+    //
+    // choose the first value found from the following ordered list:
+    // - pod.annotation[resource.opentelemetry.io/service.name]
+    // - pod.label[app.kubernetes.io/name]
+    // - k8s.container.name
+    rule {
+      source_labels = [
+        "__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_name",
+        "__meta_kubernetes_pod_label_app_kubernetes_io_name",
+        "__meta_kubernetes_pod_container_name",
+      ]
+      separator = ";"
+      regex = "^(?:;*)?([^;]+).*$"
+      replacement = "$1"
+      target_label = "service_name"
+    }
+
+    // explicitly set service_namespace.
+    //
+    // choose the first value found from the following ordered list:
+    // - pod.annotation[resource.opentelemetry.io/service.namespace]
+    // - pod.namespace
+    rule {
+      source_labels = [
+        "__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_namespace",
+        "namespace",
+      ]
+      separator = ";"
+      regex = "^(?:;*)?([^;]+).*$"
+      replacement = "$1"
+      target_label = "service_namespace"
+    }
+
+    // explicitly set service_instance_id.
+    //
+    // choose the first value found from the following ordered list:
+    // - pod.annotation[resource.opentelemetry.io/service.instance.id]
+    // - concat([k8s.namespace.name, k8s.pod.name, k8s.container.name], '.')
+    rule {
+      source_labels = ["__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_instance_id"]
+      target_label = "service_instance_id"
+    }
+    rule {
+      source_labels = ["service_instance_id", "namespace", "pod", "container"]
+      separator = "."
+      regex = "^\\.([^.]+\\.[^.]+\\.[^.]+)$"
+      target_label = "service_instance_id"
+    }
+
+    // set resource attributes
+    rule {
+      action = "labelmap"
+      regex = "__meta_kubernetes_pod_annotation_resource_opentelemetry_io_(.+)"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_job"]
+      regex = "(.+)"
+      target_label = "job"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+      regex = "(.+)"
+      target_label = "app_kubernetes_io_name"
+    }
+
+    // Set the pod log path.
+    rule {
+      source_labels = ["__meta_kubernetes_pod_uid", "__meta_kubernetes_pod_container_name"]
+      separator = "/"
+      replacement = "/var/log/pods/*$1/*.log"
+      target_label = "__path__"
+    }
+
+    // If kubernetes.io/config.mirror is set, this is a static pod, created by the kubelet.
+    // It's logs live on a different path.
+    rule {
+      source_labels = ["__meta_kubernetes_pod_annotation_kubernetes_io_config_mirror", "__meta_kubernetes_pod_container_name"]
+      separator = "/"
+      regex = "(.+/.+)"
+      replacement = "/var/log/pods/*$1/*.log"
+      target_label = "__path__"
+    }
+  } // discovery.relabel "filtered_pods"
+
+  local.file_match "pod_logs" {
+    path_targets = discovery.relabel.filtered_pods.output
+  } // local.file_match "pod_logs"
+
+  loki.source.file "pod_logs" {
+    targets    = local.file_match.pod_logs.targets
+    tail_from_end = true
+    forward_to = [loki.process.pod_logs.receiver]
+  } // loki.source.file "pod_logs"
+
+  loki.process "pod_logs" {
+    stage.match {
+      selector = "{tmp_container_runtime=~\"containerd|cri-o|\"}"
+      // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
+      stage.cri {
+        max_partial_lines = 100
+      }
+
+      // Set the extract flags and stream values as labels
+      stage.labels {
+        values = {
+          flags  = "",
+          stream  = "",
+        }
+      }
+    }
+
+    stage.match {
+      selector = "{tmp_container_runtime=\"docker\"}"
+      // the docker processing stage extracts the following k/v pairs: log, stream, time
+      stage.docker {}
+
+      // Set the extract stream value as a label
+      stage.labels {
+        values = {
+          stream  = "",
+        }
+      }
+    }
+
+    // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
+    // namespace, pod, and container labels. Drop any structured metadata. Also drop the temporary
+    // container runtime label as it is no longer needed.
+    stage.label_drop {
+      values = [
+        "filename",
+        "tmp_container_runtime",
+      ]
+    }
+    stage.structured_metadata {
+      values = {
+        "k8s_pod_name" = "k8s_pod_name",
+        "pod" = "pod",
+        "service_instance_id" = "service_instance_id",
+      }
+    }
+
+    forward_to = argument.logs_destinations.value
+  } // loki.secretfilter "pod_logs"
+} // declare "pod_logs_via_loki"
+pod_logs_via_loki "feature" {
+  logs_destinations = [
+    loki.write.grafana_cloud_logs.receiver,
+  ]
+}
+
+livedebugging {
+  enabled = true
+}
+
+
+
+// Destination: grafana-cloud-logs (loki)
+otelcol.exporter.loki "grafana_cloud_logs" {
+  forward_to = [loki.write.grafana_cloud_logs.receiver]
+} // otelcol.exporter.loki "grafana_cloud_logs"
+
+loki.write "grafana_cloud_logs" {
+  endpoint {
+    url = "https://logs-prod-006.grafana.net/loki/api/v1/push"
+    retry_on_http_429 = true
+    tenant_id = convert.nonsensitive(remote.kubernetes.secret.grafana_cloud_logs.data["tenantId"])
+    basic_auth {
+      username = convert.nonsensitive(remote.kubernetes.secret.grafana_cloud_logs.data["logsUser"])
+      password = remote.kubernetes.secret.grafana_cloud_logs.data["grafanaCloudAccessPolicyToken"]
+    }
+    tls_config {
+      insecure_skip_verify = false
+      ca_pem = convert.nonsensitive(remote.kubernetes.secret.grafana_cloud_logs.data["ca"])
+      cert_pem = convert.nonsensitive(remote.kubernetes.secret.grafana_cloud_logs.data["cert"])
+      key_pem = remote.kubernetes.secret.grafana_cloud_logs.data["key"]
+    }
+    min_backoff_period = "500ms"
+    max_backoff_period = "5m"
+    max_backoff_retries = "10"
+  }
+  external_labels = {
+    "cluster" = "k8s-monitoring-gc-feature-test",
+    "k8s_cluster_name" = "k8s-monitoring-gc-feature-test",
+  }
+} // loki.write "grafana_cloud_logs"
+
+remote.kubernetes.secret "grafana_cloud_logs" {
+  name      = "grafana-cloud-credentials"
+  namespace = "default"
+} // remote.kubernetes.secret "grafana_cloud_logs"
+

--- a/charts/k8s-monitoring/tests/platform/grafana-cloud/k8s-monitoring/.rendered/alloy-metrics.alloy
+++ b/charts/k8s-monitoring/tests/platform/grafana-cloud/k8s-monitoring/.rendered/alloy-metrics.alloy
@@ -1,0 +1,1046 @@
+// Feature: Auto-Instrumentation
+declare "auto_instrumentation" {
+  argument "metrics_destinations" {
+    comment = "Must be a list of metric destinations where collected metrics should be forwarded to"
+  }
+
+  discovery.kubernetes "beyla_pods" {
+    role = "pod"
+    namespaces {
+      own_namespace = true
+    }
+    selectors {
+      role = "pod"
+      label = "app.kubernetes.io/name=beyla"
+    }
+  } // discovery.kubernetes "beyla_pods"
+
+  discovery.relabel "beyla_pods" {
+    targets = discovery.kubernetes.beyla_pods.targets
+    rule {
+      source_labels = ["__meta_kubernetes_pod_node_name"]
+      action = "replace"
+      target_label = "instance"
+    }
+  } // discovery.relabel "beyla_pods"
+
+  prometheus.scrape "beyla_applications" {
+    targets         = discovery.relabel.beyla_pods.output
+    honor_labels    = true
+    scrape_interval = "60s"
+    scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
+    scrape_classic_histograms = false
+    scrape_native_histograms = false
+    convert_classic_histograms_to_nhcb = false
+    clustering {
+      enabled = true
+    }
+    forward_to = argument.metrics_destinations.value
+  } // prometheus.scrape "beyla_applications"
+
+  prometheus.scrape "beyla_internal" {
+    targets         = discovery.relabel.beyla_pods.output
+    metrics_path    = "/internal/metrics"
+    job_name        = "integrations/beyla"
+    honor_labels    = true
+    scrape_interval = "60s"
+    scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
+    scrape_classic_histograms = false
+    scrape_native_histograms = false
+    convert_classic_histograms_to_nhcb = false
+    clustering {
+      enabled = true
+    }
+    forward_to = argument.metrics_destinations.value
+  } // prometheus.relabel "beyla"
+} // declare "auto_instrumentation"
+auto_instrumentation "feature" {
+  metrics_destinations = [
+    prometheus.remote_write.grafana_cloud_metrics.receiver,
+  ]
+}
+// Feature: Cluster Metrics
+declare "cluster_metrics" {
+  argument "metrics_destinations" {
+    comment = "Must be a list of metric destinations where collected metrics should be forwarded to"
+  }
+  discovery.kubernetes "nodes" {
+    role = "node"
+  } // discovery.kubernetes "nodes"
+
+  discovery.relabel "nodes" {
+    targets = discovery.kubernetes.nodes.targets
+    rule {
+      source_labels = ["__meta_kubernetes_node_name"]
+      target_label  = "node"
+    }
+
+    rule {
+      replacement = "kubernetes"
+      target_label = "source"
+    }
+  } // discovery.relabel "nodes"
+
+  // Kubelet
+  discovery.relabel "kubelet" {
+    targets = discovery.relabel.nodes.output
+  } // discovery.relabel "kubelet"
+
+  prometheus.scrape "kubelet" {
+    targets  = discovery.relabel.kubelet.output
+    job_name = "integrations/kubernetes/kubelet"
+    scheme   = "https"
+    scrape_interval = "60s"
+    scrape_timeout = "10s"
+    scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
+    scrape_classic_histograms = false
+    scrape_native_histograms = false
+    convert_classic_histograms_to_nhcb = false
+    bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+
+    tls_config {
+      ca_file = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+      insecure_skip_verify = true
+      server_name = "kubernetes"
+    }
+
+    clustering {
+      enabled = true
+    }
+
+    forward_to = [prometheus.relabel.kubelet.receiver]
+  } // prometheus.scrape "kubelet"
+
+  prometheus.relabel "kubelet" {
+    max_cache_size = 100000
+    rule {
+      source_labels = ["__name__"]
+      regex = "up|scrape_samples_scraped|go_goroutines|kubelet_certificate_manager_client_expiration_renew_errors|kubelet_certificate_manager_client_ttl_seconds|kubelet_certificate_manager_server_ttl_seconds|kubelet_cgroup_manager_duration_seconds_bucket|kubelet_cgroup_manager_duration_seconds_count|kubelet_node_config_error|kubelet_node_name|kubelet_pleg_relist_duration_seconds_bucket|kubelet_pleg_relist_duration_seconds_count|kubelet_pleg_relist_interval_seconds_bucket|kubelet_pod_start_duration_seconds_bucket|kubelet_pod_start_duration_seconds_count|kubelet_pod_worker_duration_seconds_bucket|kubelet_pod_worker_duration_seconds_count|kubelet_running_container_count|kubelet_running_containers|kubelet_running_pod_count|kubelet_running_pods|kubelet_runtime_operations_errors_total|kubelet_runtime_operations_total|kubelet_server_expiration_renew_errors|kubelet_volume_stats_available_bytes|kubelet_volume_stats_capacity_bytes|kubelet_volume_stats_inodes|kubelet_volume_stats_inodes_free|kubelet_volume_stats_inodes_used|kubelet_volume_stats_used_bytes|kubernetes_build_info|namespace_workload_pod|process_cpu_seconds_total|process_resident_memory_bytes|rest_client_requests_total|storage_operation_duration_seconds_count|storage_operation_errors_total|volume_manager_total_volumes"
+      action = "keep"
+    }
+
+    forward_to = argument.metrics_destinations.value
+  } // prometheus.relabel "kubelet"
+
+  // Kubelet Resources
+  discovery.relabel "kubelet_resources" {
+    targets = discovery.relabel.nodes.output
+    rule {
+      replacement   = "/metrics/resource"
+      target_label  = "__metrics_path__"
+    }
+  } // discovery.relabel "kubelet_resources"
+
+  prometheus.scrape "kubelet_resources" {
+    targets = discovery.relabel.kubelet_resources.output
+    job_name = "integrations/kubernetes/resources"
+    scheme   = "https"
+    scrape_interval = "60s"
+    scrape_timeout = "10s"
+    scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
+    scrape_classic_histograms = false
+    scrape_native_histograms = false
+    convert_classic_histograms_to_nhcb = false
+    bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+
+    tls_config {
+      ca_file = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+      insecure_skip_verify = true
+      server_name = "kubernetes"
+    }
+
+    clustering {
+      enabled = true
+    }
+
+    forward_to = [prometheus.relabel.kubelet_resources.receiver]
+  } // prometheus.scrape "kubelet_resources"
+
+  prometheus.relabel "kubelet_resources" {
+    max_cache_size = 100000
+    rule {
+      source_labels = ["__name__"]
+      regex = "up|scrape_samples_scraped|node_cpu_usage_seconds_total|node_memory_working_set_bytes"
+      action = "keep"
+    }
+
+    forward_to = argument.metrics_destinations.value
+  } // prometheus.relabel "kubelet_resources"
+
+  // cAdvisor
+  discovery.relabel "cadvisor" {
+    targets = discovery.relabel.nodes.output
+    rule {
+      replacement   = "/metrics/cadvisor"
+      target_label  = "__metrics_path__"
+    }
+  } // discovery.relabel "cadvisor"
+
+  prometheus.scrape "cadvisor" {
+    targets = discovery.relabel.cadvisor.output
+    job_name = "integrations/kubernetes/cadvisor"
+    scheme = "https"
+    scrape_interval = "60s"
+    scrape_timeout = "10s"
+    scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
+    scrape_classic_histograms = false
+    scrape_native_histograms = false
+    convert_classic_histograms_to_nhcb = false
+    bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+
+    tls_config {
+      ca_file = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+      insecure_skip_verify = true
+      server_name = "kubernetes"
+    }
+
+    clustering {
+      enabled = true
+    }
+
+    forward_to = [prometheus.relabel.cadvisor.receiver]
+  } // prometheus.scrape "cadvisor"
+
+  prometheus.relabel "cadvisor" {
+    max_cache_size = 100000
+    rule {
+      source_labels = ["__name__"]
+      regex = "up|scrape_samples_scraped|container_cpu_cfs_periods_total|container_cpu_cfs_throttled_periods_total|container_cpu_usage_seconds_total|container_fs_reads_bytes_total|container_fs_reads_total|container_fs_writes_bytes_total|container_fs_writes_total|container_memory_cache|container_memory_rss|container_memory_swap|container_memory_usage_bytes|container_memory_working_set_bytes|container_network_receive_bytes_total|container_network_receive_packets_dropped_total|container_network_receive_packets_total|container_network_transmit_bytes_total|container_network_transmit_packets_dropped_total|container_network_transmit_packets_total|machine_memory_bytes"
+      action = "keep"
+    }
+    // Drop empty container labels, addressing https://github.com/google/cadvisor/issues/2688
+    rule {
+      source_labels = ["__name__","container"]
+      separator = "@"
+      regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_pressure_.*)@"
+      action = "drop"
+    }
+    // Drop empty image labels, addressing https://github.com/google/cadvisor/issues/2688
+    rule {
+      source_labels = ["__name__","image"]
+      separator = "@"
+      regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_network_.*|container_pressure_.*)@"
+      action = "drop"
+    }
+    // Normalizing unimportant labels (not deleting to continue satisfying <label>!="" checks)
+    rule {
+      source_labels = ["__name__", "boot_id"]
+      separator = "@"
+      regex = "machine_memory_bytes@.*"
+      target_label = "boot_id"
+      replacement = "NA"
+    }
+    rule {
+      source_labels = ["__name__", "system_uuid"]
+      separator = "@"
+      regex = "machine_memory_bytes@.*"
+      target_label = "system_uuid"
+      replacement = "NA"
+    }
+    // Filter out non-physical devices/interfaces
+    rule {
+      source_labels = ["__name__", "device"]
+      separator = "@"
+      regex = "container_fs_.*@(/dev/)?(mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dasd.+)"
+      target_label = "__keepme"
+      replacement = "1"
+    }
+    rule {
+      source_labels = ["__name__", "__keepme"]
+      separator = "@"
+      regex = "container_fs_.*@"
+      action = "drop"
+    }
+    rule {
+      source_labels = ["__name__"]
+      regex = "container_fs_.*"
+      target_label = "__keepme"
+      replacement = ""
+    }
+    rule {
+      source_labels = ["__name__", "interface"]
+      separator = "@"
+      regex = "container_network_.*@(en[ospx][0-9].*|wlan[0-9].*|eth[0-9].*)"
+      target_label = "__keepme"
+      replacement = "1"
+    }
+    rule {
+      source_labels = ["__name__", "__keepme"]
+      separator = "@"
+      regex = "container_network_.*@"
+      action = "drop"
+    }
+    rule {
+      source_labels = ["__name__"]
+      regex = "container_network_.*"
+      target_label = "__keepme"
+      replacement = ""
+    }
+    forward_to = argument.metrics_destinations.value
+  } // prometheus.relabel "cadvisor"
+  discovery.kubernetes "kube_state_metrics" {
+    role = "endpoints"
+
+    selectors {
+      role = "endpoints"
+      label = "release=k8smon,app.kubernetes.io/name=kube-state-metrics"
+    }
+    namespaces {
+      names = ["default"]
+    }
+  } // discovery.kubernetes "kube_state_metrics"
+
+  discovery.relabel "kube_state_metrics" {
+    targets = discovery.kubernetes.kube_state_metrics.targets
+
+    rule {
+      action = "replace"
+      replacement = "kubernetes"
+      target_label = "source"
+    }
+
+  } // discovery.relabel "kube_state_metrics"
+
+  prometheus.scrape "kube_state_metrics" {
+    targets = discovery.relabel.kube_state_metrics.output
+    job_name = "integrations/kubernetes/kube-state-metrics"
+    scrape_interval = "60s"
+    scrape_timeout = "10s"
+    scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
+    scrape_classic_histograms = false
+    scrape_native_histograms = false
+    convert_classic_histograms_to_nhcb = false
+    scheme = "http"
+    bearer_token_file = ""
+    tls_config {
+      insecure_skip_verify = true
+    }
+
+    clustering {
+      enabled = true
+    }
+    forward_to = [prometheus.relabel.kube_state_metrics.receiver]
+  } // prometheus.scrape "kube_state_metrics"
+
+  prometheus.relabel "kube_state_metrics" {
+    max_cache_size = 100000
+    rule {
+      source_labels = ["__name__"]
+      regex = "up|scrape_samples_scraped|kube_configmap_info|kube_configmap_metadata_resource_version|kube_cronjob.*|kube_daemonset.*|kube_deployment_metadata_generation|kube_deployment_spec_replicas|kube_deployment_status_condition|kube_deployment_status_observed_generation|kube_deployment_status_replicas_available|kube_deployment_status_replicas_updated|kube_horizontalpodautoscaler_spec_max_replicas|kube_horizontalpodautoscaler_spec_min_replicas|kube_horizontalpodautoscaler_status_current_replicas|kube_horizontalpodautoscaler_status_desired_replicas|kube_job.*|kube_namespace_status_phase|kube_node.*|kube_persistentvolume_status_phase|kube_persistentvolumeclaim_access_mode|kube_persistentvolumeclaim_info|kube_persistentvolumeclaim_labels|kube_persistentvolumeclaim_resource_requests_storage_bytes|kube_persistentvolumeclaim_status_phase|kube_pod_completion_time|kube_pod_container_info|kube_pod_container_resource_limits|kube_pod_container_resource_requests|kube_pod_container_status_last_terminated_reason|kube_pod_container_status_last_terminated_timestamp|kube_pod_container_status_restarts_total|kube_pod_container_status_waiting_reason|kube_pod_info|kube_pod_owner|kube_pod_restart_policy|kube_pod_spec_volumes_persistentvolumeclaims_info|kube_pod_start_time|kube_pod_status_phase|kube_pod_status_reason|kube_pod_init_.*|kube_replicaset.*|kube_resourcequota|kube_secret_metadata_resource_version|kube_statefulset.*"
+      action = "keep"
+    }
+    forward_to = argument.metrics_destinations.value
+  } // prometheus.relabel "kube_state_metrics"
+} // declare "cluster_metrics"
+cluster_metrics "feature" {
+  metrics_destinations = [
+    prometheus.remote_write.grafana_cloud_metrics.receiver,
+  ]
+}
+// Feature: Cost Metrics
+declare "cost_metrics" {
+  argument "metrics_destinations" {
+    comment = "Must be a list of metric destinations where collected metrics should be forwarded to"
+  }
+
+  discovery.kubernetes "opencost" {
+    role = "pod"
+    selectors {
+      role = "pod"
+      label = "app.kubernetes.io/instance=k8smon,app.kubernetes.io/name=opencost"
+    }
+    namespaces {
+      names = ["default"]
+    }
+  } // discovery.kubernetes "opencost"
+
+  discovery.relabel "opencost" {
+    targets = discovery.kubernetes.opencost.targets
+    rule {
+      source_labels = ["__meta_kubernetes_pod_node_name"]
+      action = "replace"
+      target_label = "instance"
+    }
+  } // discovery.relabel "opencost"
+
+  prometheus.scrape "opencost" {
+    targets      = discovery.relabel.opencost.output
+    job_name     = "integrations/opencost"
+    honor_labels = true
+    scrape_interval = "60s"
+    scrape_timeout = "10s"
+    scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
+    scrape_classic_histograms = false
+    scrape_native_histograms = false
+    convert_classic_histograms_to_nhcb = false
+    clustering {
+      enabled = true
+    }
+    forward_to = [prometheus.relabel.opencost.receiver]
+  } // prometheus.scrape "opencost"
+
+  prometheus.relabel "opencost" {
+    max_cache_size = 100000
+    rule {
+      source_labels = ["__name__"]
+      regex = "up|scrape_samples_scraped|container_cpu_allocation|container_gpu_allocation|container_memory_allocation_bytes|deployment_match_labels|kubecost_cluster_info|kubecost_cluster_management_cost|kubecost_cluster_memory_working_set_bytes|kubecost_http_requests_total|kubecost_http_response_size_bytes|kubecost_http_response_time_seconds|kubecost_load_balancer_cost|kubecost_network_internet_egress_cost|kubecost_network_region_egress_cost|kubecost_network_zone_egress_cost|kubecost_node_is_spot|node_cpu_hourly_cost|node_gpu_count|node_gpu_hourly_cost|node_ram_hourly_cost|node_total_hourly_cost|opencost_build_info|pod_pvc_allocation|pv_hourly_cost|service_selector_labels|statefulSet_match_labels"
+      action = "keep"
+    }
+    forward_to = argument.metrics_destinations.value
+  } // prometheus.relabel "opencost"
+} // declare "cost_metrics"
+cost_metrics "feature" {
+  metrics_destinations = [
+    prometheus.remote_write.grafana_cloud_metrics.receiver,
+  ]
+}
+// Feature: Host Metrics
+declare "host_metrics" {
+  argument "metrics_destinations" {
+    comment = "Must be a list of metric destinations where collected metrics should be forwarded to"
+  }
+
+  // Linux hosts via Node Exporter
+  discovery.kubernetes "node_exporter" {
+    role = "pod"
+    selectors {
+      role = "pod"
+      label = "release=k8smon,app.kubernetes.io/name=node-exporter"
+    }
+    namespaces {
+      names = ["default"]
+    }
+
+  } // discovery.kubernetes "node_exporter"
+
+  discovery.relabel "node_exporter" {
+    targets = discovery.kubernetes.node_exporter.targets
+
+    // keep only the specified metrics port name, and pods that are Running and ready
+    rule {
+      source_labels = [
+        "__meta_kubernetes_pod_container_init",
+        "__meta_kubernetes_pod_phase",
+        "__meta_kubernetes_pod_ready",
+      ]
+      separator = "@"
+      regex = "false@Running@true"
+      action = "keep"
+    }
+
+    // Set the instance label to the node name
+    rule {
+      source_labels = ["__meta_kubernetes_pod_node_name"]
+      target_label = "instance"
+    }
+
+    rule {
+      source_labels = ["__meta_kubernetes_namespace"]
+      target_label  = "namespace"
+    }
+
+    rule {
+      source_labels = ["__meta_kubernetes_pod_name"]
+      target_label  = "pod"
+    }
+
+    rule {
+      source_labels = ["__meta_kubernetes_pod_container_name"]
+      target_label  = "container"
+    }
+
+    // set a workload label
+    rule {
+      source_labels = [
+        "__meta_kubernetes_pod_controller_kind",
+        "__meta_kubernetes_pod_controller_name",
+      ]
+      separator = "/"
+      target_label  = "workload"
+    }
+    // remove the hash from the ReplicaSet
+    rule {
+      source_labels = ["workload"]
+      regex = "(ReplicaSet/.+)-.+"
+      target_label  = "workload"
+    }
+
+    // Set the app label.
+    //
+    // Choose the first value found from the following ordered list:
+    // - pod.label[app.kubernetes.io/name]
+    // - pod.label[k8s-app]
+    // - pod.label[app]
+    rule {
+      source_labels = [
+        "__meta_kubernetes_pod_label_app_kubernetes_io_name",
+        "__meta_kubernetes_pod_label_k8s_app",
+        "__meta_kubernetes_pod_label_app",
+      ]
+      separator = ";"
+      regex = "^(?:;*)?([^;]+).*$"
+      replacement = "$1"
+      target_label = "app"
+    }
+
+    // Set the component label.
+    //
+    // Choose the first value found from the following ordered list:
+    // - pod.label[app.kubernetes.io/component]
+    // - pod.label[k8s-component]
+    // - pod.label[component]
+    rule {
+      source_labels = [
+        "__meta_kubernetes_pod_label_app_kubernetes_io_component",
+        "__meta_kubernetes_pod_label_k8s_component",
+        "__meta_kubernetes_pod_label_component",
+      ]
+      regex = "^(?:;*)?([^;]+).*$"
+      replacement = "$1"
+      target_label = "component"
+    }
+
+    rule {
+      target_label = "source"
+      replacement = "kubernetes"
+    }
+
+  } // discovery.relabel "node_exporter"
+
+  prometheus.scrape "node_exporter" {
+    targets = discovery.relabel.node_exporter.output
+    job_name = "integrations/node_exporter"
+    scrape_interval = "60s"
+    scrape_timeout = "10s"
+    scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
+    scrape_classic_histograms = false
+    scrape_native_histograms = false
+    convert_classic_histograms_to_nhcb = false
+    scheme = "http"
+    tls_config {
+      insecure_skip_verify = true
+    }
+
+    clustering {
+      enabled = true
+    }
+    forward_to = [prometheus.relabel.node_exporter.receiver]
+  } // prometheus.scrape "node_exporter"
+
+  prometheus.relabel "node_exporter" {
+    max_cache_size = 100000
+    rule {
+      source_labels = ["__name__"]
+      regex = "up|scrape_samples_scraped|node_cpu.*|node_exporter_build_info|node_filesystem.*|node_memory.*|node_network_receive_bytes_total|node_network_receive_drop_total|node_network_transmit_bytes_total|node_network_transmit_drop_total|process_cpu_seconds_total|process_resident_memory_bytes"
+      action = "keep"
+    }
+    // Drop metrics for certain file systems
+    rule {
+      source_labels = ["__name__", "fstype"]
+      separator = "@"
+      regex = "node_filesystem.*@(ramfs|tmpfs)"
+      action = "drop"
+    }
+    forward_to = argument.metrics_destinations.value
+  } // prometheus.relabel "node_exporter"
+
+  // Windows hosts via Windows Exporter
+  discovery.kubernetes "windows_exporter_pods" {
+    role = "pod"
+    selectors {
+      role = "pod"
+      label = "release=k8smon,app.kubernetes.io/name=windows-exporter"
+    }
+    namespaces {
+      names = ["default"]
+    }
+
+  } // discovery.kubernetes "windows_exporter_pods"
+
+  discovery.relabel "windows_exporter" {
+    targets = discovery.kubernetes.windows_exporter_pods.targets
+
+    // keep only the specified metrics port name, and pods that are Running and ready
+    rule {
+      source_labels = [
+        "__meta_kubernetes_pod_container_init",
+        "__meta_kubernetes_pod_phase",
+        "__meta_kubernetes_pod_ready",
+      ]
+      separator = "@"
+      regex = "false@Running@true"
+      action = "keep"
+    }
+
+    // Set the instance label to the node name
+    rule {
+      source_labels = ["__meta_kubernetes_pod_node_name"]
+      target_label = "instance"
+    }
+
+  } // discovery.relabel "windows_exporter"
+
+  prometheus.scrape "windows_exporter" {
+    targets  = discovery.relabel.windows_exporter.output
+    job_name   = "integrations/windows-exporter"
+    scrape_interval = "60s"
+    scrape_timeout = "10s"
+    scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
+    scrape_classic_histograms = false
+    scrape_native_histograms = false
+    convert_classic_histograms_to_nhcb = false
+    clustering {
+      enabled = true
+    }
+    forward_to = [prometheus.relabel.windows_exporter.receiver]
+  } // prometheus.scrape "windows_exporter"
+
+  prometheus.relabel "windows_exporter" {
+    max_cache_size = 100000
+    rule {
+      source_labels = ["__name__"]
+      regex = "up|scrape_samples_scraped|windows_.*|node_cpu_seconds_total|node_filesystem_size_bytes|node_filesystem_avail_bytes|container_cpu_usage_seconds_total"
+      action = "keep"
+    }
+    forward_to = argument.metrics_destinations.value
+  } // prometheus.relabel "windows_exporter"
+
+  // Energy metrics via Kepler
+  discovery.kubernetes "kepler" {
+    role = "pod"
+    selectors {
+      role = "pod"
+      label = "app.kubernetes.io/name=kepler"
+    }
+    namespaces {
+      names = ["default"]
+    }
+
+  } // discovery.kubernetes "kepler"
+
+  discovery.relabel "kepler" {
+    targets = discovery.kubernetes.kepler.targets
+    rule {
+      source_labels = ["__meta_kubernetes_pod_node_name"]
+      action = "replace"
+      target_label = "instance"
+    }
+
+  } // discovery.relabel "kepler"
+
+  prometheus.scrape "kepler" {
+    targets      = discovery.relabel.kepler.output
+    job_name     = "integrations/kepler"
+    honor_labels = true
+    scrape_interval = "60s"
+    scrape_timeout = "10s"
+    scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
+    scrape_classic_histograms = false
+    scrape_native_histograms = false
+    convert_classic_histograms_to_nhcb = false
+    clustering {
+      enabled = true
+    }
+    forward_to = [prometheus.relabel.kepler.receiver]
+  } // prometheus.scrape "kepler"
+
+  prometheus.relabel "kepler" {
+    max_cache_size = 100000
+    rule {
+      source_labels = ["__name__"]
+      regex = "up|scrape_samples_scraped|kepler_.*"
+      action = "keep"
+    }
+    forward_to = argument.metrics_destinations.value
+  } // prometheus.relabel "kepler"
+} // declare "host_metrics"
+host_metrics "feature" {
+  metrics_destinations = [
+    prometheus.remote_write.grafana_cloud_metrics.receiver,
+  ]
+}
+declare "alloy_integration" {
+  argument "metrics_destinations" {
+    comment = "Must be a list of metric destinations where collected metrics should be forwarded to"
+  }
+
+  declare "alloy_integration_discovery" {
+    argument "namespaces" {
+      comment = "The namespaces to look for targets in (default: [] is all namespaces)"
+      optional = true
+    }
+
+    argument "field_selectors" {
+      comment = "The field selectors to use to find matching targets (default: [])"
+      optional = true
+    }
+
+    argument "label_selectors" {
+      comment = "The label selectors to use to find matching targets (default: [\"app.kubernetes.io/name=alloy\"])"
+      optional = true
+    }
+
+    argument "port_name" {
+      comment = "The of the port to scrape metrics from (default: http-metrics)"
+      optional = true
+    }
+
+    // Alloy service discovery for all of the pods
+    discovery.kubernetes "alloy_pods" {
+      role = "pod"
+
+      selectors {
+        role = "pod"
+        field = string.join(coalesce(argument.field_selectors.value, []), ",")
+        label = string.join(coalesce(argument.label_selectors.value, ["app.kubernetes.io/name=alloy"]), ",")
+      }
+
+      namespaces {
+        names = coalesce(argument.namespaces.value, [])
+      }
+
+    } // discovery.kubernetes "alloy_pods"
+
+    // alloy relabelings (pre-scrape)
+    discovery.relabel "alloy_pods" {
+      targets = discovery.kubernetes.alloy_pods.targets
+
+      // keep only the specified metrics port name, and pods that are Running and ready
+      rule {
+        source_labels = [
+          "__meta_kubernetes_pod_container_port_name",
+          "__meta_kubernetes_pod_phase",
+          "__meta_kubernetes_pod_ready",
+          "__meta_kubernetes_pod_container_init",
+        ]
+        separator = "@"
+        regex = coalesce(argument.port_name.value, "metrics") + "@Running@true@false"
+        action = "keep"
+      }
+
+      rule {
+        source_labels = ["__meta_kubernetes_namespace"]
+        target_label  = "namespace"
+      }
+
+      rule {
+        source_labels = ["__meta_kubernetes_pod_name"]
+        target_label  = "pod"
+      }
+
+      rule {
+        source_labels = ["__meta_kubernetes_pod_container_name"]
+        target_label  = "container"
+      }
+
+      // set the workload to the controller kind and name
+      rule {
+        action = "lowercase"
+        source_labels = ["__meta_kubernetes_pod_controller_kind"]
+        target_label  = "workload_type"
+      }
+
+      rule {
+        source_labels = ["__meta_kubernetes_pod_controller_name"]
+        target_label  = "workload"
+      }
+
+      // remove the hash from the ReplicaSet
+      rule {
+        source_labels = [
+          "workload_type",
+          "workload",
+        ]
+        separator = "/"
+        regex = "replicaset/(.+)-.+$"
+        target_label  = "workload"
+      }
+
+      // set the app name if specified as metadata labels "app:" or "app.kubernetes.io/name:" or "k8s-app:"
+      rule {
+        action = "replace"
+        source_labels = [
+          "__meta_kubernetes_pod_label_app_kubernetes_io_name",
+          "__meta_kubernetes_pod_label_k8s_app",
+          "__meta_kubernetes_pod_label_app",
+        ]
+        separator = ";"
+        regex = "^(?:;*)?([^;]+).*$"
+        replacement = "$1"
+        target_label = "app"
+      }
+
+      // set the component if specified as metadata labels "component:" or "app.kubernetes.io/component:" or "k8s-component:"
+      rule {
+        action = "replace"
+        source_labels = [
+          "__meta_kubernetes_pod_label_app_kubernetes_io_component",
+          "__meta_kubernetes_pod_label_k8s_component",
+          "__meta_kubernetes_pod_label_component",
+        ]
+        regex = "^(?:;*)?([^;]+).*$"
+        replacement = "$1"
+        target_label = "component"
+      }
+
+      // set a source label
+      rule {
+        action = "replace"
+        replacement = "kubernetes"
+        target_label = "source"
+      }
+
+    } // discovery.relabel "alloy_pods"
+
+    export "output" {
+      value = discovery.relabel.alloy_pods.output
+    }
+  }
+
+  declare "alloy_integration_scrape" {
+    argument "targets" {
+      comment = "Must be a list() of targets"
+    }
+
+    argument "forward_to" {
+      comment = "Must be a list(MetricsReceiver) where collected metrics should be forwarded to"
+    }
+
+    argument "job_label" {
+      comment = "The job label to add for all Alloy metrics (default: integrations/alloy)"
+      optional = true
+    }
+
+    argument "keep_metrics" {
+      comment = "A regular expression of metrics to keep (default: see below)"
+      optional = true
+    }
+
+    argument "drop_metrics" {
+      comment = "A regular expression of metrics to drop (default: see below)"
+      optional = true
+    }
+
+    argument "scrape_interval" {
+      comment = "How often to scrape metrics from the targets (default: 60s)"
+      optional = true
+    }
+
+    argument "scrape_timeout" {
+      comment = "The timeout for scraping metrics from the targets (default: 10s)"
+      optional = true
+    }
+
+    argument "scrape_protocols" {
+      comment = "The scrape protocols to use for scraping metrics"
+      optional = true
+    }
+
+    argument "scrape_classic_histograms" {
+      comment = "Whether to scrape classic histograms (default: false)."
+      optional = true
+    }
+
+    argument "scrape_native_histograms" {
+      comment = "Whether to scrape native histograms (default: false)."
+      optional = true
+    }
+
+    argument "max_cache_size" {
+      comment = "The maximum number of elements to hold in the relabeling cache (default: 100000).  This should be at least 2x-5x your largest scrape target or samples appended rate."
+      optional = true
+    }
+
+    argument "clustering" {
+      comment = "Whether or not clustering should be enabled (default: false)"
+      optional = true
+    }
+
+    prometheus.scrape "alloy" {
+      job_name = coalesce(argument.job_label.value, "integrations/alloy")
+      forward_to = [prometheus.relabel.alloy.receiver]
+      targets = argument.targets.value
+      scrape_interval = coalesce(argument.scrape_interval.value, "60s")
+      scrape_timeout = coalesce(argument.scrape_timeout.value, "10s")
+      scrape_protocols = argument.scrape_protocols.value
+      scrape_classic_histograms = argument.scrape_classic_histograms.value
+      scrape_native_histograms = argument.scrape_native_histograms.value
+
+      clustering {
+        enabled = coalesce(argument.clustering.value, false)
+      }
+    } // prometheus.scrape "alloy"
+
+    // alloy metric relabelings (post-scrape)
+    prometheus.relabel "alloy" {
+      forward_to = argument.forward_to.value
+      max_cache_size = coalesce(argument.max_cache_size.value, 100000)
+
+      // drop metrics that match the drop_metrics regex
+      rule {
+        source_labels = ["__name__"]
+        regex = coalesce(argument.drop_metrics.value, "")
+        action = "drop"
+      }
+
+      // keep only metrics that match the keep_metrics regex
+      rule {
+        source_labels = ["__name__"]
+        regex = coalesce(argument.keep_metrics.value, ".*")
+        action = "keep"
+      }
+
+      // remove the component_id label from any metric that starts with log_bytes or log_lines, these are custom metrics that are generated
+      // as part of the log annotation modules in this repo
+      rule {
+        action = "replace"
+        source_labels = ["__name__"]
+        regex = "^log_(bytes|lines).+"
+        replacement = ""
+        target_label = "component_id"
+      }
+
+      // set the namespace label to that of the exported_namespace
+      rule {
+        action = "replace"
+        source_labels = ["__name__", "exported_namespace"]
+        separator = "@"
+        regex = "^log_(bytes|lines).+@(.+)"
+        replacement = "$2"
+        target_label = "namespace"
+      }
+
+      // set the pod label to that of the exported_pod
+      rule {
+        action = "replace"
+        source_labels = ["__name__", "exported_pod"]
+        separator = "@"
+        regex = "^log_(bytes|lines).+@(.+)"
+        replacement = "$2"
+        target_label = "pod"
+      }
+
+      // set the container label to that of the exported_container
+      rule {
+        action = "replace"
+        source_labels = ["__name__", "exported_container"]
+        separator = "@"
+        regex = "^log_(bytes|lines).+@(.+)"
+        replacement = "$2"
+        target_label = "container"
+      }
+
+      // set the job label to that of the exported_job
+      rule {
+        action = "replace"
+        source_labels = ["__name__", "exported_job"]
+        separator = "@"
+        regex = "^log_(bytes|lines).+@(.+)"
+        replacement = "$2"
+        target_label = "job"
+      }
+
+      // set the instance label to that of the exported_instance
+      rule {
+        action = "replace"
+        source_labels = ["__name__", "exported_instance"]
+        separator = "@"
+        regex = "^log_(bytes|lines).+@(.+)"
+        replacement = "$2"
+        target_label = "instance"
+      }
+
+      rule {
+        action = "labeldrop"
+        regex = "exported_(namespace|pod|container|job|instance)"
+      }
+    } // prometheus.relabel "alloy"
+  }
+
+  alloy_integration_discovery "alloy" {
+    port_name = "http-metrics"
+    label_selectors = ["app.kubernetes.io/name in (alloy-metrics,alloy-singleton,alloy-logs)"]
+  }
+
+  alloy_integration_scrape "alloy" {
+    targets = alloy_integration_discovery.alloy.output
+    job_label = "integrations/alloy"
+    clustering = true
+    keep_metrics = "up|scrape_samples_scraped|alloy_build_info|alloy_component_controller_running_components|alloy_component_dependencies_wait_seconds|alloy_component_dependencies_wait_seconds_bucket|alloy_component_evaluation_seconds|alloy_component_evaluation_seconds_bucket|alloy_component_evaluation_seconds_count|alloy_component_evaluation_seconds_sum|alloy_component_evaluation_slow_seconds|alloy_config_hash|alloy_resources_machine_rx_bytes_total|alloy_resources_machine_tx_bytes_total|alloy_resources_process_cpu_seconds_total|alloy_resources_process_resident_memory_bytes|alloy_tcp_connections|alloy_wal_samples_appended_total|alloy_wal_storage_active_series|cluster_node_gossip_health_score|cluster_node_gossip_proto_version|cluster_node_gossip_received_events_total|cluster_node_info|cluster_node_lamport_time|cluster_node_peers|cluster_node_update_observers|cluster_transport_rx_bytes_total|cluster_transport_rx_packet_queue_length|cluster_transport_rx_packets_failed_total|cluster_transport_rx_packets_total|cluster_transport_stream_rx_bytes_total|cluster_transport_stream_rx_packets_failed_total|cluster_transport_stream_rx_packets_total|cluster_transport_stream_tx_bytes_total|cluster_transport_stream_tx_packets_failed_total|cluster_transport_stream_tx_packets_total|cluster_transport_streams|cluster_transport_tx_bytes_total|cluster_transport_tx_packet_queue_length|cluster_transport_tx_packets_failed_total|cluster_transport_tx_packets_total|otelcol_exporter_send_failed_spans_total|otelcol_exporter_sent_spans_total|go_gc_duration_seconds_count|go_goroutines|go_memstats_heap_inuse_bytes|loki_process_dropped_lines_total|loki_write_batch_retries_total|loki_write_dropped_bytes_total|loki_write_dropped_entries_total|loki_write_encoded_bytes_total|loki_write_mutated_bytes_total|loki_write_mutated_entries_total|loki_write_request_duration_seconds_bucket|loki_write_sent_bytes_total|loki_write_sent_entries_total|process_cpu_seconds_total|process_start_time_seconds|otelcol_processor_batch_batch_send_size_bucket|otelcol_processor_batch_metadata_cardinality|otelcol_processor_batch_timeout_trigger_send_total|prometheus_remote_storage_bytes_total|prometheus_remote_storage_enqueue_retries_total|prometheus_remote_storage_highest_timestamp_in_seconds|prometheus_remote_storage_metadata_bytes_total|prometheus_remote_storage_queue_highest_sent_timestamp_seconds|prometheus_remote_storage_samples_dropped_total|prometheus_remote_storage_samples_failed_total|prometheus_remote_storage_samples_pending|prometheus_remote_storage_samples_retried_total|prometheus_remote_storage_samples_total|prometheus_remote_storage_sent_batch_duration_seconds_bucket|prometheus_remote_storage_sent_batch_duration_seconds_count|prometheus_remote_storage_sent_batch_duration_seconds_sum|prometheus_remote_storage_shard_capacity|prometheus_remote_storage_shards|prometheus_remote_storage_shards_desired|prometheus_remote_storage_shards_max|prometheus_remote_storage_shards_min|prometheus_remote_storage_succeeded_samples_total|prometheus_remote_write_wal_samples_appended_total|prometheus_remote_write_wal_storage_active_series|prometheus_sd_discovered_targets|prometheus_target_interval_length_seconds_count|prometheus_target_interval_length_seconds_sum|prometheus_target_scrapes_exceeded_sample_limit_total|prometheus_target_scrapes_sample_duplicate_timestamp_total|prometheus_target_scrapes_sample_out_of_bounds_total|prometheus_target_scrapes_sample_out_of_order_total|prometheus_target_sync_length_seconds_sum|prometheus_wal_watcher_current_segment|otelcol_receiver_accepted_spans_total|otelcol_receiver_refused_spans_total|rpc_server_duration_milliseconds_bucket|scrape_duration_seconds|traces_exporter_send_failed_spans|traces_exporter_send_failed_spans_total|traces_exporter_sent_spans|traces_exporter_sent_spans_total|traces_loadbalancer_backend_outcome|traces_loadbalancer_num_backends|traces_receiver_accepted_spans|traces_receiver_accepted_spans_total|traces_receiver_refused_spans|traces_receiver_refused_spans_total"
+    scrape_interval = "60s"
+    scrape_timeout = "10s"
+    scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
+    scrape_classic_histograms = false
+    scrape_native_histograms = false
+    max_cache_size = 100000
+    forward_to = argument.metrics_destinations.value
+  }
+}
+alloy_integration "integration" {
+  metrics_destinations = [
+    prometheus.remote_write.grafana_cloud_metrics.receiver,
+  ]
+}
+
+livedebugging {
+  enabled = true
+}
+
+
+
+// Destination: grafana-cloud-metrics (prometheus)
+otelcol.exporter.prometheus "grafana_cloud_metrics" {
+  add_metric_suffixes = true
+  resource_to_telemetry_conversion = false
+  keep_identifying_resource_attributes = true
+  forward_to = [prometheus.remote_write.grafana_cloud_metrics.receiver]
+} // otelcol.exporter.prometheus "grafana_cloud_metrics"
+
+prometheus.remote_write "grafana_cloud_metrics" {
+  endpoint {
+    url = "https://prometheus-prod-13-prod-us-east-0.grafana.net/api/prom/push"
+    protobuf_message = "io.prometheus.write.v2.Request"
+    headers = {
+      "X-Scope-OrgID" = convert.nonsensitive(remote.kubernetes.secret.grafana_cloud_metrics.data["tenantId"]),
+    }
+    basic_auth {
+      username = convert.nonsensitive(remote.kubernetes.secret.grafana_cloud_metrics.data["metricsUser"])
+      password = remote.kubernetes.secret.grafana_cloud_metrics.data["grafanaCloudAccessPolicyToken"]
+    }
+    tls_config {
+      insecure_skip_verify = false
+      ca_pem = convert.nonsensitive(remote.kubernetes.secret.grafana_cloud_metrics.data["ca"])
+      cert_pem = convert.nonsensitive(remote.kubernetes.secret.grafana_cloud_metrics.data["cert"])
+      key_pem = remote.kubernetes.secret.grafana_cloud_metrics.data["key"]
+    }
+    send_native_histograms = false
+
+    queue_config {
+      capacity = 10000
+      min_shards = 1
+      max_shards = 50
+      max_samples_per_send = 2000
+      batch_send_deadline = "5s"
+      min_backoff = "30ms"
+      max_backoff = "5s"
+      retry_on_http_429 = true
+      sample_age_limit = "0s"
+    }
+  }
+
+  wal {
+    truncate_frequency = "2h"
+    min_keepalive_time = "5m"
+    max_keepalive_time = "8h"
+  }
+  external_labels = {
+    "cluster" = "k8s-monitoring-gc-feature-test",
+    "k8s_cluster_name" = "k8s-monitoring-gc-feature-test",
+  }
+} // prometheus.remote_write "grafana_cloud_metrics"
+
+remote.kubernetes.secret "grafana_cloud_metrics" {
+  name      = "grafana-cloud-credentials"
+  namespace = "default"
+} // remote.kubernetes.secret "grafana_cloud_metrics"
+

--- a/charts/k8s-monitoring/tests/platform/grafana-cloud/k8s-monitoring/.rendered/alloy-receiver.alloy
+++ b/charts/k8s-monitoring/tests/platform/grafana-cloud/k8s-monitoring/.rendered/alloy-receiver.alloy
@@ -1,0 +1,403 @@
+// Feature: Application Observability
+declare "application_observability" {
+  argument "metrics_destinations" {
+    comment = "Must be a list of metrics destinations where collected metrics should be forwarded to"
+  }
+
+  argument "logs_destinations" {
+    comment = "Must be a list of log destinations where collected logs should be forwarded to"
+  }
+
+  argument "traces_destinations" {
+    comment = "Must be a list of trace destinations where collected trace should be forwarded to"
+  }
+
+  // OTLP Receiver
+  otelcol.receiver.otlp "receiver" {
+    grpc {
+      endpoint = "0.0.0.0:4317"
+      include_metadata = false
+      max_recv_msg_size = "4MiB"
+      read_buffer_size = "512KiB"
+      write_buffer_size = "32KiB"
+    }
+    debug_metrics {
+      disable_high_cardinality_metrics = true
+    }
+    output {
+      metrics = [otelcol.processor.resourcedetection.default.input]
+      logs = [otelcol.processor.resourcedetection.default.input]
+      traces = [otelcol.processor.resourcedetection.default.input]
+    }
+  } // otelcol.receiver.otlp "receiver"
+
+  // Resource Detection Processor
+  otelcol.processor.resourcedetection "default" {
+    detectors = ["env","system"]
+    override = true
+
+    system {
+      hostname_sources = ["os"]
+    }
+
+    output {
+      metrics = [otelcol.processor.k8sattributes.default.input]
+      logs = [otelcol.processor.k8sattributes.default.input]
+      traces = [otelcol.processor.k8sattributes.default.input]
+    }
+  }
+
+  // K8s Attributes Processor
+  otelcol.processor.k8sattributes "default" {
+    passthrough = false
+    extract {
+      metadata = ["k8s.namespace.name","k8s.pod.name","k8s.deployment.name","k8s.statefulset.name","k8s.daemonset.name","k8s.cronjob.name","k8s.job.name","k8s.node.name","k8s.pod.uid","k8s.pod.start_time"]
+    }
+    pod_association {
+      source {
+        from = "resource_attribute"
+        name = "k8s.pod.ip"
+      }
+    }
+    pod_association {
+      source {
+        from = "resource_attribute"
+        name = "k8s.pod.uid"
+      }
+    }
+    pod_association {
+      source {
+        from = "connection"
+      }
+    }
+
+    output {
+      metrics = [otelcol.processor.transform.default.input]
+      logs = [otelcol.processor.transform.default.input]
+      traces = [otelcol.processor.transform.default.input, otelcol.connector.host_info.default.input]
+    }
+  }
+
+  // Host Info Connector
+  otelcol.connector.host_info "default" {
+    host_identifiers = [ "k8s.node.name" ]
+
+    output {
+      metrics = [otelcol.processor.batch.default.input]
+    }
+  }
+
+  // Transform Processor
+  otelcol.processor.transform "default" {
+    error_mode = "ignore"
+    log_statements {
+      context = "resource"
+      statements = [
+        "set(attributes[\"pod\"], attributes[\"k8s.pod.name\"])",
+        "set(attributes[\"namespace\"], attributes[\"k8s.namespace.name\"])",
+        "set(attributes[\"loki.resource.labels\"], \"cluster, namespace, job, pod\")",
+      ]
+    }
+    trace_statements {
+      context = "span"
+      statements = [
+       "set_semconv_span_name(\"1.37.0\", \"original_span_name\")",
+      ]
+    }
+
+    output {
+      metrics = [otelcol.processor.batch.default.input]
+      logs = [otelcol.processor.batch.default.input]
+      traces = [otelcol.processor.batch.default.input]
+    }
+  }
+
+  // Batch Processor
+  otelcol.processor.batch "default" {
+    send_batch_size = 8192
+    send_batch_max_size = 0
+    timeout = "2s"
+
+    output {
+      metrics = argument.metrics_destinations.value
+      logs = argument.logs_destinations.value
+      traces = argument.traces_destinations.value
+    }
+  }
+} // declare "application_observability"
+application_observability "feature" {
+  metrics_destinations = [
+    otelcol.processor.attributes.grafana_cloud_otlp_endpoint.input,
+  ]
+  logs_destinations = [
+    otelcol.processor.attributes.grafana_cloud_otlp_endpoint.input,
+  ]
+  traces_destinations = [
+    otelcol.processor.attributes.grafana_cloud_otlp_endpoint.input,
+  ]
+}
+
+livedebugging {
+  enabled = true
+}
+
+
+
+// Destination: grafana-cloud-otlp-endpoint (otlp)
+otelcol.receiver.prometheus "grafana_cloud_otlp_endpoint" {
+  output {
+    metrics = [otelcol.processor.transform.grafana_cloud_otlp_endpoint_scrape_normalize.input]
+  }
+} // otelcol.receiver.prometheus "grafana_cloud_otlp_endpoint"
+
+// Repairs artifacts of the Prometheus-to-OTLP conversion performed by
+// otelcol.receiver.prometheus. Only metrics that came from a Prometheus scrape pass
+// through this component; OTLP-native telemetry enters the pipeline further down.
+otelcol.processor.transform "grafana_cloud_otlp_endpoint_scrape_normalize" {
+  error_mode = "ignore"
+  metric_statements {
+    context = "resource"
+    statements = [
+      // The conversion sets service.name to the full Prometheus job label (e.g.
+      // "namespace/workload"). When the scrape target declares its identity explicitly
+      // with a service_name label on its own target_info metric (e.g. Grafana Beyla),
+      // prefer that value and drop the duplicate.
+      `set(attributes["service.name"], attributes["service_name"]) where attributes["service_name"] != nil and attributes["service_name"] != ""`,
+      `delete_key(attributes, "service_name") where attributes["service_name"] == attributes["service.name"]`,
+      // The same conversion turns other flat target_info labels into resource attributes.
+      // Promote them to their OpenTelemetry counterparts and drop the flat duplicates, so
+      // the OTLP endpoint does not receive two conflicting spellings of the same attribute.
+      `set(attributes["service.namespace"], attributes["service_namespace"]) where (attributes["service.namespace"] == nil or attributes["service.namespace"] == "") and attributes["service_namespace"] != nil and attributes["service_namespace"] != ""`,
+      `delete_key(attributes, "service_namespace") where attributes["service_namespace"] == attributes["service.namespace"]`,
+      `set(attributes["deployment.environment"], attributes["deployment_environment"]) where (attributes["deployment.environment"] == nil or attributes["deployment.environment"] == "") and attributes["deployment_environment"] != nil and attributes["deployment_environment"] != ""`,
+      `delete_key(attributes, "deployment_environment") where attributes["deployment_environment"] == attributes["deployment.environment"]`,
+      `set(attributes["deployment.environment.name"], attributes["deployment_environment_name"]) where (attributes["deployment.environment.name"] == nil or attributes["deployment.environment.name"] == "") and attributes["deployment_environment_name"] != nil and attributes["deployment_environment_name"] != ""`,
+      `delete_key(attributes, "deployment_environment_name") where attributes["deployment_environment_name"] == attributes["deployment.environment.name"]`,
+    ]
+  }
+  metric_statements {
+    context = "datapoint"
+    statements = [
+      // Same correction for scrape targets that put service_name on every series
+      // instead of exposing a target_info metric.
+      `set(resource.attributes["service.name"], attributes["service_name"]) where attributes["service_name"] != nil and attributes["service_name"] != ""`,
+    ]
+  }
+  output {
+    metrics = [otelcol.processor.attributes.grafana_cloud_otlp_endpoint.input]
+  }
+} // otelcol.processor.transform "grafana_cloud_otlp_endpoint_scrape_normalize"
+otelcol.receiver.loki "grafana_cloud_otlp_endpoint" {
+  output {
+    logs = [otelcol.processor.attributes.grafana_cloud_otlp_endpoint.input]
+  }
+} // otelcol.receiver.loki "grafana_cloud_otlp_endpoint"
+otelcol.processor.attributes "grafana_cloud_otlp_endpoint" {
+  output {
+    metrics = [otelcol.processor.transform.grafana_cloud_otlp_endpoint.input]
+    logs = [otelcol.processor.transform.grafana_cloud_otlp_endpoint.input]
+    traces = [otelcol.processor.transform.grafana_cloud_otlp_endpoint.input]
+  }
+} // otelcol.processor.attributes "grafana_cloud_otlp_endpoint"
+
+otelcol.processor.transform "grafana_cloud_otlp_endpoint" {
+  error_mode = "ignore"
+  metric_statements {
+    context = "resource"
+    statements = [
+      `set(attributes["cluster"], "k8s-monitoring-gc-feature-test")`,
+      `set(attributes["k8s.cluster.name"], "k8s-monitoring-gc-feature-test")`,
+      `delete_key(attributes, "process.pid")`,
+      `delete_key(attributes, "process.parent_pid")`,
+      `delete_key(attributes, "process.executable.path")`,
+      `delete_key(attributes, "process.command_line")`,
+      `delete_key(attributes, "process.command_args")`,
+      `delete_key(attributes, "process.owner")`,
+      `delete_key(attributes, "process.runtime.version")`,
+      `delete_key(attributes, "process.runtime.description")`,
+      `delete_key(attributes, "host.ip")`,
+      `delete_key(attributes, "host.mac")`,
+      `delete_key(attributes, "k8s.pod.start_time")`,
+      `delete_key(attributes, "k8s.pod.uid")`,
+      `delete_key(attributes, "container.image.id")`,
+      `delete_key(attributes, "container.image.repo_digests")`,
+      `delete_key(attributes, "os.description")`,
+      `delete_key(attributes, "os.build_id")`,
+      // Scrape targets that expose their own target_info metric (e.g. Grafana Beyla) can
+      // carry a flat k8s_cluster_name resource attribute, which conflicts with the
+      // k8s.cluster.name attribute set above and gets ";"-joined by the Prometheus OTLP
+      // endpoint. Drop the flat copy when the values match.
+      `delete_key(attributes, "k8s_cluster_name") where attributes["k8s_cluster_name"] == attributes["k8s.cluster.name"]`,
+    ]
+  }
+
+  metric_statements {
+    context = "datapoint"
+    statements = [
+      `set(attributes["cluster"], "k8s-monitoring-gc-feature-test")`,
+      `set(attributes["k8s.cluster.name"], "k8s-monitoring-gc-feature-test")`,
+      `set(resource.attributes["deployment.environment"], attributes["deployment_environment"] ) where resource.attributes["deployment.environment"] == nil and attributes["deployment_environment"] != nil`,
+      `delete_key(attributes, "deployment_environment") where attributes["deployment_environment"] == resource.attributes["deployment.environment"]`,
+      `set(resource.attributes["deployment.environment.name"], attributes["deployment_environment_name"] ) where resource.attributes["deployment.environment.name"] == nil and attributes["deployment_environment_name"] != nil`,
+      `delete_key(attributes, "deployment_environment_name") where attributes["deployment_environment_name"] == resource.attributes["deployment.environment.name"]`,
+      `set(resource.attributes["service.name"], attributes["service_name"] ) where (resource.attributes["service.name"] == nil or resource.attributes["service.name"] == "") and attributes["service_name"] != nil and attributes["service_name"] != ""`,
+      `delete_key(attributes, "service_name") where attributes["service_name"] == resource.attributes["service.name"]`,
+      `set(resource.attributes["service.namespace"], attributes["service_namespace"] ) where (resource.attributes["service.namespace"] == nil or resource.attributes["service.namespace"] == "") and attributes["service_namespace"] != nil and attributes["service_namespace"] != ""`,
+      `delete_key(attributes, "service_namespace") where attributes["service_namespace"] == resource.attributes["service.namespace"]`,
+    ]
+  }
+  log_statements {
+    context = "resource"
+    statements = [
+      `set(attributes["cluster"], "k8s-monitoring-gc-feature-test")`,
+      `set(attributes["k8s.cluster.name"], "k8s-monitoring-gc-feature-test")`,
+      `delete_key(attributes, "process.pid")`,
+      `delete_key(attributes, "process.parent_pid")`,
+      `delete_key(attributes, "process.executable.path")`,
+      `delete_key(attributes, "process.command_line")`,
+      `delete_key(attributes, "process.command_args")`,
+      `delete_key(attributes, "process.owner")`,
+      `delete_key(attributes, "process.runtime.version")`,
+      `delete_key(attributes, "process.runtime.description")`,
+      `delete_key(attributes, "host.ip")`,
+      `delete_key(attributes, "host.mac")`,
+      `delete_key(attributes, "k8s.pod.start_time")`,
+      `delete_key(attributes, "k8s.pod.uid")`,
+      `delete_key(attributes, "container.image.id")`,
+      `delete_key(attributes, "container.image.repo_digests")`,
+      `delete_key(attributes, "os.description")`,
+      `delete_key(attributes, "os.build_id")`,
+    ]
+  }
+
+  log_statements {
+    context = "log"
+    statements = [
+      `delete_key(attributes, "loki.attribute.labels")`,
+      `delete_key(attributes, "loki.resource.labels")`,
+      `set(resource.attributes["k8s.container.name"], attributes["container"] ) where resource.attributes["k8s.container.name"] == nil and attributes["container"] != nil`,
+      `delete_key(attributes, "container") where attributes["container"] == resource.attributes["k8s.container.name"]`,
+      `set(resource.attributes["k8s.cronjob.name"], attributes["cronjob"] ) where resource.attributes["k8s.cronjob.name"] == nil and attributes["cronjob"] != nil`,
+      `delete_key(attributes, "cronjob") where attributes["cronjob"] == resource.attributes["k8s.cronjob.name"]`,
+      `set(resource.attributes["k8s.daemonset.name"], attributes["daemonset"] ) where resource.attributes["k8s.daemonset.name"] == nil and attributes["daemonset"] != nil`,
+      `delete_key(attributes, "daemonset") where attributes["daemonset"] == resource.attributes["k8s.daemonset.name"]`,
+      `set(resource.attributes["k8s.deployment.name"], attributes["deployment"] ) where resource.attributes["k8s.deployment.name"] == nil and attributes["deployment"] != nil`,
+      `delete_key(attributes, "deployment") where attributes["deployment"] == resource.attributes["k8s.deployment.name"]`,
+      `set(resource.attributes["deployment.environment"], attributes["deployment_environment"] ) where resource.attributes["deployment.environment"] == nil and attributes["deployment_environment"] != nil`,
+      `delete_key(attributes, "deployment_environment") where attributes["deployment_environment"] == resource.attributes["deployment.environment"]`,
+      `set(resource.attributes["deployment.environment.name"], attributes["deployment_environment_name"] ) where resource.attributes["deployment.environment.name"] == nil and attributes["deployment_environment_name"] != nil`,
+      `delete_key(attributes, "deployment_environment_name") where attributes["deployment_environment_name"] == resource.attributes["deployment.environment.name"]`,
+      `set(resource.attributes["k8s.job.name"], attributes["job_name"] ) where resource.attributes["k8s.job.name"] == nil and attributes["job_name"] != nil`,
+      `delete_key(attributes, "job_name") where attributes["job_name"] == resource.attributes["k8s.job.name"]`,
+      `set(resource.attributes["k8s.namespace.name"], attributes["namespace"] ) where resource.attributes["k8s.namespace.name"] == nil and attributes["namespace"] != nil`,
+      `delete_key(attributes, "namespace") where attributes["namespace"] == resource.attributes["k8s.namespace.name"]`,
+      `set(resource.attributes["k8s.pod.name"], attributes["pod"] ) where resource.attributes["k8s.pod.name"] == nil and attributes["pod"] != nil`,
+      `delete_key(attributes, "pod") where attributes["pod"] == resource.attributes["k8s.pod.name"]`,
+      `set(resource.attributes["k8s.replicaset.name"], attributes["replicaset"] ) where resource.attributes["k8s.replicaset.name"] == nil and attributes["replicaset"] != nil`,
+      `delete_key(attributes, "replicaset") where attributes["replicaset"] == resource.attributes["k8s.replicaset.name"]`,
+      `set(resource.attributes["service.name"], attributes["service_name"] ) where (resource.attributes["service.name"] == nil or resource.attributes["service.name"] == "") and attributes["service_name"] != nil and attributes["service_name"] != ""`,
+      `delete_key(attributes, "service_name") where attributes["service_name"] == resource.attributes["service.name"]`,
+      `set(resource.attributes["service.namespace"], attributes["service_namespace"] ) where (resource.attributes["service.namespace"] == nil or resource.attributes["service.namespace"] == "") and attributes["service_namespace"] != nil and attributes["service_namespace"] != ""`,
+      `delete_key(attributes, "service_namespace") where attributes["service_namespace"] == resource.attributes["service.namespace"]`,
+      `set(resource.attributes["k8s.statefulset.name"], attributes["statefulset"] ) where resource.attributes["k8s.statefulset.name"] == nil and attributes["statefulset"] != nil`,
+      `delete_key(attributes, "statefulset") where attributes["statefulset"] == resource.attributes["k8s.statefulset.name"]`,
+    ]
+  }
+
+  trace_statements {
+    context = "resource"
+    statements = [
+      `set(attributes["cluster"], "k8s-monitoring-gc-feature-test")`,
+      `set(attributes["k8s.cluster.name"], "k8s-monitoring-gc-feature-test")`,
+      `delete_key(attributes, "process.pid")`,
+      `delete_key(attributes, "process.parent_pid")`,
+      `delete_key(attributes, "process.executable.path")`,
+      `delete_key(attributes, "process.command_line")`,
+      `delete_key(attributes, "process.command_args")`,
+      `delete_key(attributes, "process.owner")`,
+      `delete_key(attributes, "process.runtime.version")`,
+      `delete_key(attributes, "process.runtime.description")`,
+      `delete_key(attributes, "host.ip")`,
+      `delete_key(attributes, "host.mac")`,
+      `delete_key(attributes, "k8s.pod.start_time")`,
+      `delete_key(attributes, "k8s.pod.uid")`,
+      `delete_key(attributes, "container.image.id")`,
+      `delete_key(attributes, "container.image.repo_digests")`,
+      `delete_key(attributes, "os.description")`,
+      `delete_key(attributes, "os.build_id")`,
+    ]
+  }
+
+  output {
+    metrics = [otelcol.processor.batch.grafana_cloud_otlp_endpoint.input]
+    logs = [otelcol.processor.batch.grafana_cloud_otlp_endpoint.input]
+    traces = [otelcol.exporter.loadbalancing.grafana_cloud_otlp_endpoint_sampler.input]
+  }
+} // otelcol.processor.transform "grafana_cloud_otlp_endpoint"
+
+otelcol.exporter.loadbalancing "grafana_cloud_otlp_endpoint_sampler" {
+  resolver {
+    kubernetes {
+      service = "k8smon-grafana-cloud-otlp-endpoint-sampler"
+    }
+  }
+  protocol {
+    otlp {
+      client {
+        tls {
+          insecure = true
+        }
+      }
+    }
+  }
+} // otelcol.exporter.loadbalancing "grafana_cloud_otlp_endpoint_sampler"
+
+otelcol.processor.batch "grafana_cloud_otlp_endpoint" {
+  timeout = "2s"
+  send_batch_size = 8192
+  send_batch_max_size = 0
+
+  output {
+    metrics = [otelcol.exporter.otlphttp.grafana_cloud_otlp_endpoint.input]
+    logs = [otelcol.exporter.otlphttp.grafana_cloud_otlp_endpoint.input]
+    traces = [otelcol.exporter.otlphttp.grafana_cloud_otlp_endpoint.input]
+  }
+} // otelcol.processor.batch "grafana_cloud_otlp_endpoint"
+otelcol.exporter.otlphttp "grafana_cloud_otlp_endpoint" {
+  client {
+    endpoint = "https://otlp-gateway-prod-us-east-0.grafana.net./otlp"
+    auth = otelcol.auth.basic.grafana_cloud_otlp_endpoint.handler
+    headers = {
+      "X-Scope-OrgID" = convert.nonsensitive(remote.kubernetes.secret.grafana_cloud_otlp_endpoint.data["tenantId"]),
+    }
+    tls {
+      insecure = false
+      insecure_skip_verify = false
+      ca_pem = convert.nonsensitive(remote.kubernetes.secret.grafana_cloud_otlp_endpoint.data["ca"])
+      cert_pem = convert.nonsensitive(remote.kubernetes.secret.grafana_cloud_otlp_endpoint.data["cert"])
+      key_pem = remote.kubernetes.secret.grafana_cloud_otlp_endpoint.data["key"]
+    }
+  }
+
+  retry_on_failure {
+    enabled = true
+    initial_interval = "5s"
+    max_interval = "30s"
+    max_elapsed_time = "5m"
+  }
+
+  sending_queue {
+    enabled = true
+  }
+} // otelcol.exporter.otlphttp "grafana_cloud_otlp_endpoint"
+
+otelcol.auth.basic "grafana_cloud_otlp_endpoint" {
+  username = convert.nonsensitive(remote.kubernetes.secret.grafana_cloud_otlp_endpoint.data["otlpUser"])
+  password = remote.kubernetes.secret.grafana_cloud_otlp_endpoint.data["grafanaCloudAccessPolicyToken"]
+} // otelcol.auth.basic "grafana_cloud_otlp_endpoint"
+
+remote.kubernetes.secret "grafana_cloud_otlp_endpoint" {
+  name      = "grafana-cloud-credentials"
+  namespace = "default"
+} // remote.kubernetes.secret "grafana_cloud_otlp_endpoint"
+

--- a/charts/k8s-monitoring/tests/platform/grafana-cloud/k8s-monitoring/.rendered/alloy-singleton.alloy
+++ b/charts/k8s-monitoring/tests/platform/grafana-cloud/k8s-monitoring/.rendered/alloy-singleton.alloy
@@ -1,0 +1,224 @@
+// Feature: Cluster Events
+declare "cluster_events" {
+  argument "logs_destinations" {
+    comment = "Must be a list of log destinations where collected logs should be forwarded to"
+  }
+
+  loki.source.kubernetes_events "cluster_events" {
+    job_name   = "integrations/kubernetes/eventhandler"
+    log_format = "logfmt"
+    forward_to = [loki.process.cluster_events.receiver]
+  } // loki.source.kubernetes_events "cluster_events"
+
+  loki.process "cluster_events" {
+
+    // add a static source label to the logs so they can be differentiated / restricted if necessary
+    stage.static_labels {
+      values = {
+        "source" = "kubernetes-events",
+      }
+    }
+
+    // extract some of the fields from the log line, these could be used as labels, structured metadata, etc.
+    stage.logfmt {
+      mapping = {
+        "component" = "sourcecomponent", // map the sourcecomponent field to component
+        "kind" = "",
+        "level" = "type", // most events don't have a level but they do have a "type" i.e. Normal, Warning, Error, etc.
+        "name" = "",
+        "node" = "sourcehost", // map the sourcehost field to node
+        "reason" = "",
+      }
+    }
+    // set the extracted values as labels
+    stage.labels {
+      values = {
+        "kind" = "",
+        "level" = "",
+        "service_name" = "job",
+        "reason" = "reason",
+      }
+    }
+
+    // if kind=Node, set the node label by copying the name field
+    stage.match {
+      selector = "{kind=\"Node\"}"
+
+      stage.labels {
+        values = {
+          "node" = "name",
+        }
+      }
+    }
+
+    // set the level extracted key value as a normalized log level
+    stage.match {
+      selector = "{level=\"Normal\"}"
+
+      stage.static_labels {
+        values = {
+          level = "Info",
+        }
+      }
+    }
+    stage.structured_metadata {
+      values = {
+        "name" = "name",
+        "node" = "node",
+      }
+    }
+
+    // Drop pipeline-only labels that are not needed in the final output.
+    stage.label_drop {
+      values = ["kind"]
+    }
+
+    forward_to = argument.logs_destinations.value
+  } // loki.process "cluster_events"
+} // declare "cluster_events"
+cluster_events "feature" {
+  logs_destinations = [
+    loki.write.grafana_cloud_logs.receiver,
+  ]
+}
+// Self Reporting
+prometheus.exporter.unix "kubernetes_monitoring_telemetry" {
+  set_collectors = ["textfile"]
+  textfile {
+    directory = "/etc/release-info"
+  }
+} // prometheus.exporter.unix "kubernetes_monitoring_telemetry"
+
+discovery.relabel "kubernetes_monitoring_telemetry" {
+  targets = prometheus.exporter.unix.kubernetes_monitoring_telemetry.targets
+  rule {
+    target_label = "instance"
+    action = "replace"
+    replacement = "k8smon"
+  }
+  rule {
+    target_label = "job"
+    action = "replace"
+    replacement = "integrations/kubernetes/kubernetes_monitoring_telemetry"
+  }
+} // discovery.relabel "kubernetes_monitoring_telemetry"
+
+prometheus.scrape "kubernetes_monitoring_telemetry" {
+  job_name   = "integrations/kubernetes/kubernetes_monitoring_telemetry"
+  targets    = discovery.relabel.kubernetes_monitoring_telemetry.output
+  scrape_interval = "60s"
+  clustering {
+    enabled = true
+  }
+  forward_to = [prometheus.relabel.kubernetes_monitoring_telemetry.receiver]
+} // prometheus.scrape "kubernetes_monitoring_telemetry"
+
+prometheus.relabel "kubernetes_monitoring_telemetry" {
+  rule {
+    source_labels = ["__name__"]
+    regex = "grafana_kubernetes_monitoring_.*"
+    action = "keep"
+  }
+  forward_to = [
+    prometheus.remote_write.grafana_cloud_metrics.receiver,
+  ]
+} // prometheus.relabel "kubernetes_monitoring_telemetry"
+
+livedebugging {
+  enabled = true
+}
+
+
+
+// Destination: grafana-cloud-logs (loki)
+otelcol.exporter.loki "grafana_cloud_logs" {
+  forward_to = [loki.write.grafana_cloud_logs.receiver]
+} // otelcol.exporter.loki "grafana_cloud_logs"
+
+loki.write "grafana_cloud_logs" {
+  endpoint {
+    url = "https://logs-prod-006.grafana.net/loki/api/v1/push"
+    retry_on_http_429 = true
+    tenant_id = convert.nonsensitive(remote.kubernetes.secret.grafana_cloud_logs.data["tenantId"])
+    basic_auth {
+      username = convert.nonsensitive(remote.kubernetes.secret.grafana_cloud_logs.data["logsUser"])
+      password = remote.kubernetes.secret.grafana_cloud_logs.data["grafanaCloudAccessPolicyToken"]
+    }
+    tls_config {
+      insecure_skip_verify = false
+      ca_pem = convert.nonsensitive(remote.kubernetes.secret.grafana_cloud_logs.data["ca"])
+      cert_pem = convert.nonsensitive(remote.kubernetes.secret.grafana_cloud_logs.data["cert"])
+      key_pem = remote.kubernetes.secret.grafana_cloud_logs.data["key"]
+    }
+    min_backoff_period = "500ms"
+    max_backoff_period = "5m"
+    max_backoff_retries = "10"
+  }
+  external_labels = {
+    "cluster" = "k8s-monitoring-gc-feature-test",
+    "k8s_cluster_name" = "k8s-monitoring-gc-feature-test",
+  }
+} // loki.write "grafana_cloud_logs"
+
+remote.kubernetes.secret "grafana_cloud_logs" {
+  name      = "grafana-cloud-credentials"
+  namespace = "default"
+} // remote.kubernetes.secret "grafana_cloud_logs"
+
+
+// Destination: grafana-cloud-metrics (prometheus)
+otelcol.exporter.prometheus "grafana_cloud_metrics" {
+  add_metric_suffixes = true
+  resource_to_telemetry_conversion = false
+  keep_identifying_resource_attributes = true
+  forward_to = [prometheus.remote_write.grafana_cloud_metrics.receiver]
+} // otelcol.exporter.prometheus "grafana_cloud_metrics"
+
+prometheus.remote_write "grafana_cloud_metrics" {
+  endpoint {
+    url = "https://prometheus-prod-13-prod-us-east-0.grafana.net/api/prom/push"
+    protobuf_message = "io.prometheus.write.v2.Request"
+    headers = {
+      "X-Scope-OrgID" = convert.nonsensitive(remote.kubernetes.secret.grafana_cloud_metrics.data["tenantId"]),
+    }
+    basic_auth {
+      username = convert.nonsensitive(remote.kubernetes.secret.grafana_cloud_metrics.data["metricsUser"])
+      password = remote.kubernetes.secret.grafana_cloud_metrics.data["grafanaCloudAccessPolicyToken"]
+    }
+    tls_config {
+      insecure_skip_verify = false
+      ca_pem = convert.nonsensitive(remote.kubernetes.secret.grafana_cloud_metrics.data["ca"])
+      cert_pem = convert.nonsensitive(remote.kubernetes.secret.grafana_cloud_metrics.data["cert"])
+      key_pem = remote.kubernetes.secret.grafana_cloud_metrics.data["key"]
+    }
+    send_native_histograms = false
+
+    queue_config {
+      capacity = 10000
+      min_shards = 1
+      max_shards = 50
+      max_samples_per_send = 2000
+      batch_send_deadline = "5s"
+      min_backoff = "30ms"
+      max_backoff = "5s"
+      retry_on_http_429 = true
+      sample_age_limit = "0s"
+    }
+  }
+
+  wal {
+    truncate_frequency = "2h"
+    min_keepalive_time = "5m"
+    max_keepalive_time = "8h"
+  }
+  external_labels = {
+    "cluster" = "k8s-monitoring-gc-feature-test",
+    "k8s_cluster_name" = "k8s-monitoring-gc-feature-test",
+  }
+} // prometheus.remote_write "grafana_cloud_metrics"
+
+remote.kubernetes.secret "grafana_cloud_metrics" {
+  name      = "grafana-cloud-credentials"
+  namespace = "default"
+} // remote.kubernetes.secret "grafana_cloud_metrics"
+

--- a/charts/k8s-monitoring/tests/platform/openshift/.rendered/alloy-logs.alloy
+++ b/charts/k8s-monitoring/tests/platform/openshift/.rendered/alloy-logs.alloy
@@ -1,0 +1,239 @@
+// Feature: Pod Logs (Loki)
+declare "pod_logs_via_loki" {
+  argument "logs_destinations" {
+    comment = "Must be a list of log destinations where collected logs should be forwarded to"
+  }
+
+  discovery.kubernetes "pods" {
+    role = "pod"
+    selectors {
+      role = "pod"
+      field = "spec.nodeName=" + sys.env("HOSTNAME")
+    }
+  } // discovery.kubernetes "pods"
+
+  discovery.relabel "filtered_pods" {
+    targets = discovery.kubernetes.pods.targets
+    rule {
+      source_labels = ["__meta_kubernetes_namespace"]
+      action = "replace"
+      target_label = "namespace"
+    }
+    rule {  // Drop anything with a "falsy" annotation value
+      source_labels = ["__meta_kubernetes_pod_annotation_logs_grafana_com_pods_enabled"]
+      regex = "(false|no|skip)"
+      action = "drop"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_pod_name"]
+      target_label = "pod"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_pod_container_name"]
+      target_label = "container"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_namespace", "__meta_kubernetes_pod_container_name"]
+      separator = "/"
+      replacement = "$1"
+      target_label = "job"
+    }
+
+    // set the container runtime as a label
+    rule {
+      source_labels = ["__meta_kubernetes_pod_container_id"]
+      regex = "^(\\S+):\\/\\/.+$"
+      replacement = "$1"
+      target_label = "tmp_container_runtime"
+    }
+    // explicitly set service_name. if not set, loki will automatically try to populate a default.
+    // see https://grafana.com/docs/loki/latest/get-started/labels/#default-labels-for-all-users
+    //
+    // choose the first value found from the following ordered list:
+    // - pod.annotation[resource.opentelemetry.io/service.name]
+    // - pod.label[app.kubernetes.io/name]
+    // - k8s.container.name
+    rule {
+      source_labels = [
+        "__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_name",
+        "__meta_kubernetes_pod_label_app_kubernetes_io_name",
+        "__meta_kubernetes_pod_container_name",
+      ]
+      separator = ";"
+      regex = "^(?:;*)?([^;]+).*$"
+      replacement = "$1"
+      target_label = "service_name"
+    }
+
+    // explicitly set service_namespace.
+    //
+    // choose the first value found from the following ordered list:
+    // - pod.annotation[resource.opentelemetry.io/service.namespace]
+    // - pod.namespace
+    rule {
+      source_labels = [
+        "__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_namespace",
+        "namespace",
+      ]
+      separator = ";"
+      regex = "^(?:;*)?([^;]+).*$"
+      replacement = "$1"
+      target_label = "service_namespace"
+    }
+
+    // explicitly set service_instance_id.
+    //
+    // choose the first value found from the following ordered list:
+    // - pod.annotation[resource.opentelemetry.io/service.instance.id]
+    // - concat([k8s.namespace.name, k8s.pod.name, k8s.container.name], '.')
+    rule {
+      source_labels = ["__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_instance_id"]
+      target_label = "service_instance_id"
+    }
+    rule {
+      source_labels = ["service_instance_id", "namespace", "pod", "container"]
+      separator = "."
+      regex = "^\\.([^.]+\\.[^.]+\\.[^.]+)$"
+      target_label = "service_instance_id"
+    }
+
+    // set resource attributes
+    rule {
+      action = "labelmap"
+      regex = "__meta_kubernetes_pod_annotation_resource_opentelemetry_io_(.+)"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_job"]
+      regex = "(.+)"
+      target_label = "job"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+      regex = "(.+)"
+      target_label = "app_kubernetes_io_name"
+    }
+
+    // Set the pod log path.
+    rule {
+      source_labels = ["__meta_kubernetes_pod_uid", "__meta_kubernetes_pod_container_name"]
+      separator = "/"
+      replacement = "/var/log/pods/*$1/*.log"
+      target_label = "__path__"
+    }
+
+    // If kubernetes.io/config.mirror is set, this is a static pod, created by the kubelet.
+    // It's logs live on a different path.
+    rule {
+      source_labels = ["__meta_kubernetes_pod_annotation_kubernetes_io_config_mirror", "__meta_kubernetes_pod_container_name"]
+      separator = "/"
+      regex = "(.+/.+)"
+      replacement = "/var/log/pods/*$1/*.log"
+      target_label = "__path__"
+    }
+  } // discovery.relabel "filtered_pods"
+
+  local.file_match "pod_logs" {
+    path_targets = discovery.relabel.filtered_pods.output
+  } // local.file_match "pod_logs"
+
+  loki.source.file "pod_logs" {
+    targets    = local.file_match.pod_logs.targets
+    tail_from_end = true
+    forward_to = [loki.process.pod_logs.receiver]
+  } // loki.source.file "pod_logs"
+
+  loki.process "pod_logs" {
+    stage.match {
+      selector = "{tmp_container_runtime=~\"containerd|cri-o|\"}"
+      // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
+      stage.cri {
+        max_partial_lines = 100
+      }
+
+      // Set the extract flags and stream values as labels
+      stage.labels {
+        values = {
+          flags  = "",
+          stream  = "",
+        }
+      }
+    }
+
+    stage.match {
+      selector = "{tmp_container_runtime=\"docker\"}"
+      // the docker processing stage extracts the following k/v pairs: log, stream, time
+      stage.docker {}
+
+      // Set the extract stream value as a label
+      stage.labels {
+        values = {
+          stream  = "",
+        }
+      }
+    }
+
+    // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
+    // namespace, pod, and container labels. Drop any structured metadata. Also drop the temporary
+    // container runtime label as it is no longer needed.
+    stage.label_drop {
+      values = [
+        "filename",
+        "tmp_container_runtime",
+      ]
+    }
+    stage.structured_metadata {
+      values = {
+        "k8s_pod_name" = "k8s_pod_name",
+        "pod" = "pod",
+        "service_instance_id" = "service_instance_id",
+      }
+    }
+
+    forward_to = argument.logs_destinations.value
+  } // loki.secretfilter "pod_logs"
+} // declare "pod_logs_via_loki"
+pod_logs_via_loki "feature" {
+  logs_destinations = [
+    loki.write.grafanacloudlogs.receiver,
+  ]
+}
+
+
+
+
+
+// Destination: grafanaCloudLogs (loki)
+otelcol.exporter.loki "grafanacloudlogs" {
+  forward_to = [loki.write.grafanacloudlogs.receiver]
+} // otelcol.exporter.loki "grafanacloudlogs"
+
+loki.write "grafanacloudlogs" {
+  endpoint {
+    url = "https://logs-prod-006.grafana.net/loki/api/v1/push"
+    retry_on_http_429 = true
+    tenant_id = convert.nonsensitive(remote.kubernetes.secret.grafanacloudlogs.data["tenantId"])
+    basic_auth {
+      username = convert.nonsensitive(remote.kubernetes.secret.grafanacloudlogs.data["LOKI_USER"])
+      password = remote.kubernetes.secret.grafanacloudlogs.data["LOKI_PASS"]
+    }
+    tls_config {
+      insecure_skip_verify = false
+      ca_pem = convert.nonsensitive(remote.kubernetes.secret.grafanacloudlogs.data["ca"])
+      cert_pem = convert.nonsensitive(remote.kubernetes.secret.grafanacloudlogs.data["cert"])
+      key_pem = remote.kubernetes.secret.grafanacloudlogs.data["key"]
+    }
+    min_backoff_period = "500ms"
+    max_backoff_period = "5m"
+    max_backoff_retries = "10"
+  }
+  external_labels = {
+    "cluster" = "openshift-test",
+    "k8s_cluster_name" = "openshift-test",
+  }
+} // loki.write "grafanacloudlogs"
+
+remote.kubernetes.secret "grafanacloudlogs" {
+  name      = "grafana-cloud-credentials"
+  namespace = "default"
+} // remote.kubernetes.secret "grafanacloudlogs"
+

--- a/charts/k8s-monitoring/tests/platform/openshift/.rendered/alloy-metrics.alloy
+++ b/charts/k8s-monitoring/tests/platform/openshift/.rendered/alloy-metrics.alloy
@@ -1,0 +1,877 @@
+// Feature: Auto-Instrumentation
+declare "auto_instrumentation" {
+  argument "metrics_destinations" {
+    comment = "Must be a list of metric destinations where collected metrics should be forwarded to"
+  }
+
+  discovery.kubernetes "beyla_pods" {
+    role = "pod"
+    namespaces {
+      own_namespace = true
+    }
+    selectors {
+      role = "pod"
+      label = "app.kubernetes.io/name=beyla"
+    }
+  } // discovery.kubernetes "beyla_pods"
+
+  discovery.relabel "beyla_pods" {
+    targets = discovery.kubernetes.beyla_pods.targets
+    rule {
+      source_labels = ["__meta_kubernetes_pod_node_name"]
+      action = "replace"
+      target_label = "instance"
+    }
+  } // discovery.relabel "beyla_pods"
+
+  prometheus.scrape "beyla_applications" {
+    targets         = discovery.relabel.beyla_pods.output
+    honor_labels    = true
+    scrape_interval = "60s"
+    scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
+    scrape_classic_histograms = false
+    scrape_native_histograms = false
+    convert_classic_histograms_to_nhcb = false
+    clustering {
+      enabled = true
+    }
+    forward_to = argument.metrics_destinations.value
+  } // prometheus.scrape "beyla_applications"
+
+  prometheus.scrape "beyla_internal" {
+    targets         = discovery.relabel.beyla_pods.output
+    metrics_path    = "/internal/metrics"
+    job_name        = "integrations/beyla"
+    honor_labels    = true
+    scrape_interval = "60s"
+    scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
+    scrape_classic_histograms = false
+    scrape_native_histograms = false
+    convert_classic_histograms_to_nhcb = false
+    clustering {
+      enabled = true
+    }
+    forward_to = argument.metrics_destinations.value
+  } // prometheus.relabel "beyla"
+} // declare "auto_instrumentation"
+auto_instrumentation "feature" {
+  metrics_destinations = [
+    prometheus.remote_write.grafanacloudmetrics.receiver,
+  ]
+}
+// Feature: Cluster Metrics
+declare "cluster_metrics" {
+  argument "metrics_destinations" {
+    comment = "Must be a list of metric destinations where collected metrics should be forwarded to"
+  }
+  discovery.kubernetes "nodes" {
+    role = "node"
+  } // discovery.kubernetes "nodes"
+
+  discovery.relabel "nodes" {
+    targets = discovery.kubernetes.nodes.targets
+    rule {
+      source_labels = ["__meta_kubernetes_node_name"]
+      target_label  = "node"
+    }
+
+    rule {
+      replacement = "kubernetes"
+      target_label = "source"
+    }
+  } // discovery.relabel "nodes"
+
+  // Kubelet
+  discovery.relabel "kubelet" {
+    targets = discovery.relabel.nodes.output
+  } // discovery.relabel "kubelet"
+
+  prometheus.scrape "kubelet" {
+    targets  = discovery.relabel.kubelet.output
+    job_name = "integrations/kubernetes/kubelet"
+    scheme   = "https"
+    scrape_interval = "60s"
+    scrape_timeout = "10s"
+    scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
+    scrape_classic_histograms = false
+    scrape_native_histograms = false
+    convert_classic_histograms_to_nhcb = false
+    bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+
+    tls_config {
+      ca_file = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+      insecure_skip_verify = true
+      server_name = "kubernetes"
+    }
+
+    clustering {
+      enabled = true
+    }
+
+    forward_to = [prometheus.relabel.kubelet.receiver]
+  } // prometheus.scrape "kubelet"
+
+  prometheus.relabel "kubelet" {
+    max_cache_size = 100000
+    rule {
+      source_labels = ["__name__"]
+      regex = "up|scrape_samples_scraped|go_goroutines|kubelet_certificate_manager_client_expiration_renew_errors|kubelet_certificate_manager_client_ttl_seconds|kubelet_certificate_manager_server_ttl_seconds|kubelet_cgroup_manager_duration_seconds_bucket|kubelet_cgroup_manager_duration_seconds_count|kubelet_node_config_error|kubelet_node_name|kubelet_pleg_relist_duration_seconds_bucket|kubelet_pleg_relist_duration_seconds_count|kubelet_pleg_relist_interval_seconds_bucket|kubelet_pod_start_duration_seconds_bucket|kubelet_pod_start_duration_seconds_count|kubelet_pod_worker_duration_seconds_bucket|kubelet_pod_worker_duration_seconds_count|kubelet_running_container_count|kubelet_running_containers|kubelet_running_pod_count|kubelet_running_pods|kubelet_runtime_operations_errors_total|kubelet_runtime_operations_total|kubelet_server_expiration_renew_errors|kubelet_volume_stats_available_bytes|kubelet_volume_stats_capacity_bytes|kubelet_volume_stats_inodes|kubelet_volume_stats_inodes_free|kubelet_volume_stats_inodes_used|kubelet_volume_stats_used_bytes|kubernetes_build_info|namespace_workload_pod|process_cpu_seconds_total|process_resident_memory_bytes|rest_client_requests_total|storage_operation_duration_seconds_count|storage_operation_errors_total|volume_manager_total_volumes"
+      action = "keep"
+    }
+
+    forward_to = argument.metrics_destinations.value
+  } // prometheus.relabel "kubelet"
+
+  // Kubelet Resources
+  discovery.relabel "kubelet_resources" {
+    targets = discovery.relabel.nodes.output
+    rule {
+      replacement   = "/metrics/resource"
+      target_label  = "__metrics_path__"
+    }
+  } // discovery.relabel "kubelet_resources"
+
+  prometheus.scrape "kubelet_resources" {
+    targets = discovery.relabel.kubelet_resources.output
+    job_name = "integrations/kubernetes/resources"
+    scheme   = "https"
+    scrape_interval = "60s"
+    scrape_timeout = "10s"
+    scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
+    scrape_classic_histograms = false
+    scrape_native_histograms = false
+    convert_classic_histograms_to_nhcb = false
+    bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+
+    tls_config {
+      ca_file = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+      insecure_skip_verify = true
+      server_name = "kubernetes"
+    }
+
+    clustering {
+      enabled = true
+    }
+
+    forward_to = [prometheus.relabel.kubelet_resources.receiver]
+  } // prometheus.scrape "kubelet_resources"
+
+  prometheus.relabel "kubelet_resources" {
+    max_cache_size = 100000
+    rule {
+      source_labels = ["__name__"]
+      regex = "up|scrape_samples_scraped|node_cpu_usage_seconds_total|node_memory_working_set_bytes"
+      action = "keep"
+    }
+
+    forward_to = argument.metrics_destinations.value
+  } // prometheus.relabel "kubelet_resources"
+
+  // cAdvisor
+  discovery.relabel "cadvisor" {
+    targets = discovery.relabel.nodes.output
+    rule {
+      replacement   = "/metrics/cadvisor"
+      target_label  = "__metrics_path__"
+    }
+  } // discovery.relabel "cadvisor"
+
+  prometheus.scrape "cadvisor" {
+    targets = discovery.relabel.cadvisor.output
+    job_name = "integrations/kubernetes/cadvisor"
+    scheme = "https"
+    scrape_interval = "60s"
+    scrape_timeout = "10s"
+    scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
+    scrape_classic_histograms = false
+    scrape_native_histograms = false
+    convert_classic_histograms_to_nhcb = false
+    bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+
+    tls_config {
+      ca_file = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+      insecure_skip_verify = true
+      server_name = "kubernetes"
+    }
+
+    clustering {
+      enabled = true
+    }
+
+    forward_to = [prometheus.relabel.cadvisor.receiver]
+  } // prometheus.scrape "cadvisor"
+
+  prometheus.relabel "cadvisor" {
+    max_cache_size = 100000
+    rule {
+      source_labels = ["__name__"]
+      regex = "up|scrape_samples_scraped|container_cpu_cfs_periods_total|container_cpu_cfs_throttled_periods_total|container_cpu_usage_seconds_total|container_fs_reads_bytes_total|container_fs_reads_total|container_fs_writes_bytes_total|container_fs_writes_total|container_memory_cache|container_memory_rss|container_memory_swap|container_memory_usage_bytes|container_memory_working_set_bytes|container_network_receive_bytes_total|container_network_receive_packets_dropped_total|container_network_receive_packets_total|container_network_transmit_bytes_total|container_network_transmit_packets_dropped_total|container_network_transmit_packets_total|machine_memory_bytes"
+      action = "keep"
+    }
+    // Drop empty container labels, addressing https://github.com/google/cadvisor/issues/2688
+    rule {
+      source_labels = ["__name__","container"]
+      separator = "@"
+      regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_pressure_.*)@"
+      action = "drop"
+    }
+    // Drop empty image labels, addressing https://github.com/google/cadvisor/issues/2688
+    rule {
+      source_labels = ["__name__","image"]
+      separator = "@"
+      regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_network_.*|container_pressure_.*)@"
+      action = "drop"
+    }
+    // Normalizing unimportant labels (not deleting to continue satisfying <label>!="" checks)
+    rule {
+      source_labels = ["__name__", "boot_id"]
+      separator = "@"
+      regex = "machine_memory_bytes@.*"
+      target_label = "boot_id"
+      replacement = "NA"
+    }
+    rule {
+      source_labels = ["__name__", "system_uuid"]
+      separator = "@"
+      regex = "machine_memory_bytes@.*"
+      target_label = "system_uuid"
+      replacement = "NA"
+    }
+    // Filter out non-physical devices/interfaces
+    rule {
+      source_labels = ["__name__", "device"]
+      separator = "@"
+      regex = "container_fs_.*@(/dev/)?(mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dasd.+)"
+      target_label = "__keepme"
+      replacement = "1"
+    }
+    rule {
+      source_labels = ["__name__", "__keepme"]
+      separator = "@"
+      regex = "container_fs_.*@"
+      action = "drop"
+    }
+    rule {
+      source_labels = ["__name__"]
+      regex = "container_fs_.*"
+      target_label = "__keepme"
+      replacement = ""
+    }
+    rule {
+      source_labels = ["__name__", "interface"]
+      separator = "@"
+      regex = "container_network_.*@(en[ospx][0-9].*|wlan[0-9].*|eth[0-9].*)"
+      target_label = "__keepme"
+      replacement = "1"
+    }
+    rule {
+      source_labels = ["__name__", "__keepme"]
+      separator = "@"
+      regex = "container_network_.*@"
+      action = "drop"
+    }
+    rule {
+      source_labels = ["__name__"]
+      regex = "container_network_.*"
+      target_label = "__keepme"
+      replacement = ""
+    }
+    forward_to = argument.metrics_destinations.value
+  } // prometheus.relabel "cadvisor"
+  discovery.kubernetes "kube_state_metrics" {
+    role = "endpoints"
+
+    selectors {
+      role = "endpoints"
+      label = "app.kubernetes.io/name=kube-state-metrics"
+    }
+    namespaces {
+      names = ["openshift-monitoring"]
+    }
+  } // discovery.kubernetes "kube_state_metrics"
+
+  discovery.relabel "kube_state_metrics" {
+    targets = discovery.kubernetes.kube_state_metrics.targets
+
+    rule {
+      action = "replace"
+      replacement = "kubernetes"
+      target_label = "source"
+    }
+
+  } // discovery.relabel "kube_state_metrics"
+
+  prometheus.scrape "kube_state_metrics" {
+    targets = discovery.relabel.kube_state_metrics.output
+    job_name = "integrations/kubernetes/kube-state-metrics"
+    scrape_interval = "60s"
+    scrape_timeout = "10s"
+    scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
+    scrape_classic_histograms = false
+    scrape_native_histograms = false
+    convert_classic_histograms_to_nhcb = false
+    scheme = "https"
+    bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+    tls_config {
+      insecure_skip_verify = true
+    }
+
+    clustering {
+      enabled = true
+    }
+    forward_to = [prometheus.relabel.kube_state_metrics.receiver]
+  } // prometheus.scrape "kube_state_metrics"
+
+  prometheus.relabel "kube_state_metrics" {
+    max_cache_size = 100000
+    rule {
+      source_labels = ["__name__"]
+      regex = "up|scrape_samples_scraped|kube_configmap_info|kube_configmap_metadata_resource_version|kube_cronjob.*|kube_daemonset.*|kube_deployment_metadata_generation|kube_deployment_spec_replicas|kube_deployment_status_condition|kube_deployment_status_observed_generation|kube_deployment_status_replicas_available|kube_deployment_status_replicas_updated|kube_horizontalpodautoscaler_spec_max_replicas|kube_horizontalpodautoscaler_spec_min_replicas|kube_horizontalpodautoscaler_status_current_replicas|kube_horizontalpodautoscaler_status_desired_replicas|kube_job.*|kube_namespace_status_phase|kube_node.*|kube_persistentvolume_status_phase|kube_persistentvolumeclaim_access_mode|kube_persistentvolumeclaim_info|kube_persistentvolumeclaim_labels|kube_persistentvolumeclaim_resource_requests_storage_bytes|kube_persistentvolumeclaim_status_phase|kube_pod_completion_time|kube_pod_container_info|kube_pod_container_resource_limits|kube_pod_container_resource_requests|kube_pod_container_status_last_terminated_reason|kube_pod_container_status_last_terminated_timestamp|kube_pod_container_status_restarts_total|kube_pod_container_status_waiting_reason|kube_pod_info|kube_pod_owner|kube_pod_restart_policy|kube_pod_spec_volumes_persistentvolumeclaims_info|kube_pod_start_time|kube_pod_status_phase|kube_pod_status_reason|kube_pod_init_.*|kube_replicaset.*|kube_resourcequota|kube_secret_metadata_resource_version|kube_statefulset.*"
+      action = "keep"
+    }
+    forward_to = argument.metrics_destinations.value
+  } // prometheus.relabel "kube_state_metrics"
+} // declare "cluster_metrics"
+cluster_metrics "feature" {
+  metrics_destinations = [
+    prometheus.remote_write.grafanacloudmetrics.receiver,
+  ]
+}
+// Feature: Host Metrics
+declare "host_metrics" {
+  argument "metrics_destinations" {
+    comment = "Must be a list of metric destinations where collected metrics should be forwarded to"
+  }
+
+  // Linux hosts via Node Exporter
+  discovery.kubernetes "node_exporter" {
+    role = "pod"
+    selectors {
+      role = "pod"
+      label = "app.kubernetes.io/name=node-exporter"
+    }
+    namespaces {
+      names = ["openshift-monitoring"]
+    }
+
+  } // discovery.kubernetes "node_exporter"
+
+  discovery.relabel "node_exporter" {
+    targets = discovery.kubernetes.node_exporter.targets
+
+    // keep only the specified metrics port name, and pods that are Running and ready
+    rule {
+      source_labels = [
+        "__meta_kubernetes_pod_container_init",
+        "__meta_kubernetes_pod_phase",
+        "__meta_kubernetes_pod_ready",
+      ]
+      separator = "@"
+      regex = "false@Running@true"
+      action = "keep"
+    }
+
+    // Set the instance label to the node name
+    rule {
+      source_labels = ["__meta_kubernetes_pod_node_name"]
+      target_label = "instance"
+    }
+
+    rule {
+      source_labels = ["__meta_kubernetes_namespace"]
+      target_label  = "namespace"
+    }
+
+    rule {
+      source_labels = ["__meta_kubernetes_pod_name"]
+      target_label  = "pod"
+    }
+
+    rule {
+      source_labels = ["__meta_kubernetes_pod_container_name"]
+      target_label  = "container"
+    }
+
+    // set a workload label
+    rule {
+      source_labels = [
+        "__meta_kubernetes_pod_controller_kind",
+        "__meta_kubernetes_pod_controller_name",
+      ]
+      separator = "/"
+      target_label  = "workload"
+    }
+    // remove the hash from the ReplicaSet
+    rule {
+      source_labels = ["workload"]
+      regex = "(ReplicaSet/.+)-.+"
+      target_label  = "workload"
+    }
+
+    // Set the app label.
+    //
+    // Choose the first value found from the following ordered list:
+    // - pod.label[app.kubernetes.io/name]
+    // - pod.label[k8s-app]
+    // - pod.label[app]
+    rule {
+      source_labels = [
+        "__meta_kubernetes_pod_label_app_kubernetes_io_name",
+        "__meta_kubernetes_pod_label_k8s_app",
+        "__meta_kubernetes_pod_label_app",
+      ]
+      separator = ";"
+      regex = "^(?:;*)?([^;]+).*$"
+      replacement = "$1"
+      target_label = "app"
+    }
+
+    // Set the component label.
+    //
+    // Choose the first value found from the following ordered list:
+    // - pod.label[app.kubernetes.io/component]
+    // - pod.label[k8s-component]
+    // - pod.label[component]
+    rule {
+      source_labels = [
+        "__meta_kubernetes_pod_label_app_kubernetes_io_component",
+        "__meta_kubernetes_pod_label_k8s_component",
+        "__meta_kubernetes_pod_label_component",
+      ]
+      regex = "^(?:;*)?([^;]+).*$"
+      replacement = "$1"
+      target_label = "component"
+    }
+
+    rule {
+      target_label = "source"
+      replacement = "kubernetes"
+    }
+
+  } // discovery.relabel "node_exporter"
+
+  prometheus.scrape "node_exporter" {
+    targets = discovery.relabel.node_exporter.output
+    job_name = "integrations/node_exporter"
+    scrape_interval = "60s"
+    scrape_timeout = "10s"
+    scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
+    scrape_classic_histograms = false
+    scrape_native_histograms = false
+    convert_classic_histograms_to_nhcb = false
+    scheme = "https"
+    bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+    tls_config {
+      insecure_skip_verify = true
+    }
+
+    clustering {
+      enabled = true
+    }
+    forward_to = [prometheus.relabel.node_exporter.receiver]
+  } // prometheus.scrape "node_exporter"
+
+  prometheus.relabel "node_exporter" {
+    max_cache_size = 100000
+    rule {
+      source_labels = ["__name__"]
+      regex = "up|scrape_samples_scraped|node_cpu.*|node_exporter_build_info|node_filesystem.*|node_memory.*|node_network_receive_bytes_total|node_network_receive_drop_total|node_network_transmit_bytes_total|node_network_transmit_drop_total|process_cpu_seconds_total|process_resident_memory_bytes"
+      action = "keep"
+    }
+    // Drop metrics for certain file systems
+    rule {
+      source_labels = ["__name__", "fstype"]
+      separator = "@"
+      regex = "node_filesystem.*@(ramfs|tmpfs)"
+      action = "drop"
+    }
+    forward_to = argument.metrics_destinations.value
+  } // prometheus.relabel "node_exporter"
+} // declare "host_metrics"
+host_metrics "feature" {
+  metrics_destinations = [
+    prometheus.remote_write.grafanacloudmetrics.receiver,
+  ]
+}
+declare "alloy_integration" {
+  argument "metrics_destinations" {
+    comment = "Must be a list of metric destinations where collected metrics should be forwarded to"
+  }
+
+  declare "alloy_integration_discovery" {
+    argument "namespaces" {
+      comment = "The namespaces to look for targets in (default: [] is all namespaces)"
+      optional = true
+    }
+
+    argument "field_selectors" {
+      comment = "The field selectors to use to find matching targets (default: [])"
+      optional = true
+    }
+
+    argument "label_selectors" {
+      comment = "The label selectors to use to find matching targets (default: [\"app.kubernetes.io/name=alloy\"])"
+      optional = true
+    }
+
+    argument "port_name" {
+      comment = "The of the port to scrape metrics from (default: http-metrics)"
+      optional = true
+    }
+
+    // Alloy service discovery for all of the pods
+    discovery.kubernetes "alloy_pods" {
+      role = "pod"
+
+      selectors {
+        role = "pod"
+        field = string.join(coalesce(argument.field_selectors.value, []), ",")
+        label = string.join(coalesce(argument.label_selectors.value, ["app.kubernetes.io/name=alloy"]), ",")
+      }
+
+      namespaces {
+        names = coalesce(argument.namespaces.value, [])
+      }
+
+    } // discovery.kubernetes "alloy_pods"
+
+    // alloy relabelings (pre-scrape)
+    discovery.relabel "alloy_pods" {
+      targets = discovery.kubernetes.alloy_pods.targets
+
+      // keep only the specified metrics port name, and pods that are Running and ready
+      rule {
+        source_labels = [
+          "__meta_kubernetes_pod_container_port_name",
+          "__meta_kubernetes_pod_phase",
+          "__meta_kubernetes_pod_ready",
+          "__meta_kubernetes_pod_container_init",
+        ]
+        separator = "@"
+        regex = coalesce(argument.port_name.value, "metrics") + "@Running@true@false"
+        action = "keep"
+      }
+
+      rule {
+        source_labels = ["__meta_kubernetes_namespace"]
+        target_label  = "namespace"
+      }
+
+      rule {
+        source_labels = ["__meta_kubernetes_pod_name"]
+        target_label  = "pod"
+      }
+
+      rule {
+        source_labels = ["__meta_kubernetes_pod_container_name"]
+        target_label  = "container"
+      }
+
+      // set the workload to the controller kind and name
+      rule {
+        action = "lowercase"
+        source_labels = ["__meta_kubernetes_pod_controller_kind"]
+        target_label  = "workload_type"
+      }
+
+      rule {
+        source_labels = ["__meta_kubernetes_pod_controller_name"]
+        target_label  = "workload"
+      }
+
+      // remove the hash from the ReplicaSet
+      rule {
+        source_labels = [
+          "workload_type",
+          "workload",
+        ]
+        separator = "/"
+        regex = "replicaset/(.+)-.+$"
+        target_label  = "workload"
+      }
+
+      // set the app name if specified as metadata labels "app:" or "app.kubernetes.io/name:" or "k8s-app:"
+      rule {
+        action = "replace"
+        source_labels = [
+          "__meta_kubernetes_pod_label_app_kubernetes_io_name",
+          "__meta_kubernetes_pod_label_k8s_app",
+          "__meta_kubernetes_pod_label_app",
+        ]
+        separator = ";"
+        regex = "^(?:;*)?([^;]+).*$"
+        replacement = "$1"
+        target_label = "app"
+      }
+
+      // set the component if specified as metadata labels "component:" or "app.kubernetes.io/component:" or "k8s-component:"
+      rule {
+        action = "replace"
+        source_labels = [
+          "__meta_kubernetes_pod_label_app_kubernetes_io_component",
+          "__meta_kubernetes_pod_label_k8s_component",
+          "__meta_kubernetes_pod_label_component",
+        ]
+        regex = "^(?:;*)?([^;]+).*$"
+        replacement = "$1"
+        target_label = "component"
+      }
+
+      // set a source label
+      rule {
+        action = "replace"
+        replacement = "kubernetes"
+        target_label = "source"
+      }
+
+    } // discovery.relabel "alloy_pods"
+
+    export "output" {
+      value = discovery.relabel.alloy_pods.output
+    }
+  }
+
+  declare "alloy_integration_scrape" {
+    argument "targets" {
+      comment = "Must be a list() of targets"
+    }
+
+    argument "forward_to" {
+      comment = "Must be a list(MetricsReceiver) where collected metrics should be forwarded to"
+    }
+
+    argument "job_label" {
+      comment = "The job label to add for all Alloy metrics (default: integrations/alloy)"
+      optional = true
+    }
+
+    argument "keep_metrics" {
+      comment = "A regular expression of metrics to keep (default: see below)"
+      optional = true
+    }
+
+    argument "drop_metrics" {
+      comment = "A regular expression of metrics to drop (default: see below)"
+      optional = true
+    }
+
+    argument "scrape_interval" {
+      comment = "How often to scrape metrics from the targets (default: 60s)"
+      optional = true
+    }
+
+    argument "scrape_timeout" {
+      comment = "The timeout for scraping metrics from the targets (default: 10s)"
+      optional = true
+    }
+
+    argument "scrape_protocols" {
+      comment = "The scrape protocols to use for scraping metrics"
+      optional = true
+    }
+
+    argument "scrape_classic_histograms" {
+      comment = "Whether to scrape classic histograms (default: false)."
+      optional = true
+    }
+
+    argument "scrape_native_histograms" {
+      comment = "Whether to scrape native histograms (default: false)."
+      optional = true
+    }
+
+    argument "max_cache_size" {
+      comment = "The maximum number of elements to hold in the relabeling cache (default: 100000).  This should be at least 2x-5x your largest scrape target or samples appended rate."
+      optional = true
+    }
+
+    argument "clustering" {
+      comment = "Whether or not clustering should be enabled (default: false)"
+      optional = true
+    }
+
+    prometheus.scrape "alloy" {
+      job_name = coalesce(argument.job_label.value, "integrations/alloy")
+      forward_to = [prometheus.relabel.alloy.receiver]
+      targets = argument.targets.value
+      scrape_interval = coalesce(argument.scrape_interval.value, "60s")
+      scrape_timeout = coalesce(argument.scrape_timeout.value, "10s")
+      scrape_protocols = argument.scrape_protocols.value
+      scrape_classic_histograms = argument.scrape_classic_histograms.value
+      scrape_native_histograms = argument.scrape_native_histograms.value
+
+      clustering {
+        enabled = coalesce(argument.clustering.value, false)
+      }
+    } // prometheus.scrape "alloy"
+
+    // alloy metric relabelings (post-scrape)
+    prometheus.relabel "alloy" {
+      forward_to = argument.forward_to.value
+      max_cache_size = coalesce(argument.max_cache_size.value, 100000)
+
+      // drop metrics that match the drop_metrics regex
+      rule {
+        source_labels = ["__name__"]
+        regex = coalesce(argument.drop_metrics.value, "")
+        action = "drop"
+      }
+
+      // keep only metrics that match the keep_metrics regex
+      rule {
+        source_labels = ["__name__"]
+        regex = coalesce(argument.keep_metrics.value, ".*")
+        action = "keep"
+      }
+
+      // remove the component_id label from any metric that starts with log_bytes or log_lines, these are custom metrics that are generated
+      // as part of the log annotation modules in this repo
+      rule {
+        action = "replace"
+        source_labels = ["__name__"]
+        regex = "^log_(bytes|lines).+"
+        replacement = ""
+        target_label = "component_id"
+      }
+
+      // set the namespace label to that of the exported_namespace
+      rule {
+        action = "replace"
+        source_labels = ["__name__", "exported_namespace"]
+        separator = "@"
+        regex = "^log_(bytes|lines).+@(.+)"
+        replacement = "$2"
+        target_label = "namespace"
+      }
+
+      // set the pod label to that of the exported_pod
+      rule {
+        action = "replace"
+        source_labels = ["__name__", "exported_pod"]
+        separator = "@"
+        regex = "^log_(bytes|lines).+@(.+)"
+        replacement = "$2"
+        target_label = "pod"
+      }
+
+      // set the container label to that of the exported_container
+      rule {
+        action = "replace"
+        source_labels = ["__name__", "exported_container"]
+        separator = "@"
+        regex = "^log_(bytes|lines).+@(.+)"
+        replacement = "$2"
+        target_label = "container"
+      }
+
+      // set the job label to that of the exported_job
+      rule {
+        action = "replace"
+        source_labels = ["__name__", "exported_job"]
+        separator = "@"
+        regex = "^log_(bytes|lines).+@(.+)"
+        replacement = "$2"
+        target_label = "job"
+      }
+
+      // set the instance label to that of the exported_instance
+      rule {
+        action = "replace"
+        source_labels = ["__name__", "exported_instance"]
+        separator = "@"
+        regex = "^log_(bytes|lines).+@(.+)"
+        replacement = "$2"
+        target_label = "instance"
+      }
+
+      rule {
+        action = "labeldrop"
+        regex = "exported_(namespace|pod|container|job|instance)"
+      }
+    } // prometheus.relabel "alloy"
+  }
+
+  alloy_integration_discovery "alloy" {
+    port_name = "http-metrics"
+    label_selectors = ["app.kubernetes.io/name in (alloy-metrics,alloy-singleton,alloy-logs)"]
+  }
+
+  alloy_integration_scrape "alloy" {
+    targets = alloy_integration_discovery.alloy.output
+    job_label = "integrations/alloy"
+    clustering = true
+    keep_metrics = "up|scrape_samples_scraped|alloy_build_info|alloy_component_controller_running_components|alloy_component_dependencies_wait_seconds|alloy_component_dependencies_wait_seconds_bucket|alloy_component_evaluation_seconds|alloy_component_evaluation_seconds_bucket|alloy_component_evaluation_seconds_count|alloy_component_evaluation_seconds_sum|alloy_component_evaluation_slow_seconds|alloy_config_hash|alloy_resources_machine_rx_bytes_total|alloy_resources_machine_tx_bytes_total|alloy_resources_process_cpu_seconds_total|alloy_resources_process_resident_memory_bytes|alloy_tcp_connections|alloy_wal_samples_appended_total|alloy_wal_storage_active_series|cluster_node_gossip_health_score|cluster_node_gossip_proto_version|cluster_node_gossip_received_events_total|cluster_node_info|cluster_node_lamport_time|cluster_node_peers|cluster_node_update_observers|cluster_transport_rx_bytes_total|cluster_transport_rx_packet_queue_length|cluster_transport_rx_packets_failed_total|cluster_transport_rx_packets_total|cluster_transport_stream_rx_bytes_total|cluster_transport_stream_rx_packets_failed_total|cluster_transport_stream_rx_packets_total|cluster_transport_stream_tx_bytes_total|cluster_transport_stream_tx_packets_failed_total|cluster_transport_stream_tx_packets_total|cluster_transport_streams|cluster_transport_tx_bytes_total|cluster_transport_tx_packet_queue_length|cluster_transport_tx_packets_failed_total|cluster_transport_tx_packets_total|otelcol_exporter_send_failed_spans_total|otelcol_exporter_sent_spans_total|go_gc_duration_seconds_count|go_goroutines|go_memstats_heap_inuse_bytes|loki_process_dropped_lines_total|loki_write_batch_retries_total|loki_write_dropped_bytes_total|loki_write_dropped_entries_total|loki_write_encoded_bytes_total|loki_write_mutated_bytes_total|loki_write_mutated_entries_total|loki_write_request_duration_seconds_bucket|loki_write_sent_bytes_total|loki_write_sent_entries_total|process_cpu_seconds_total|process_start_time_seconds|otelcol_processor_batch_batch_send_size_bucket|otelcol_processor_batch_metadata_cardinality|otelcol_processor_batch_timeout_trigger_send_total|prometheus_remote_storage_bytes_total|prometheus_remote_storage_enqueue_retries_total|prometheus_remote_storage_highest_timestamp_in_seconds|prometheus_remote_storage_metadata_bytes_total|prometheus_remote_storage_queue_highest_sent_timestamp_seconds|prometheus_remote_storage_samples_dropped_total|prometheus_remote_storage_samples_failed_total|prometheus_remote_storage_samples_pending|prometheus_remote_storage_samples_retried_total|prometheus_remote_storage_samples_total|prometheus_remote_storage_sent_batch_duration_seconds_bucket|prometheus_remote_storage_sent_batch_duration_seconds_count|prometheus_remote_storage_sent_batch_duration_seconds_sum|prometheus_remote_storage_shard_capacity|prometheus_remote_storage_shards|prometheus_remote_storage_shards_desired|prometheus_remote_storage_shards_max|prometheus_remote_storage_shards_min|prometheus_remote_storage_succeeded_samples_total|prometheus_remote_write_wal_samples_appended_total|prometheus_remote_write_wal_storage_active_series|prometheus_sd_discovered_targets|prometheus_target_interval_length_seconds_count|prometheus_target_interval_length_seconds_sum|prometheus_target_scrapes_exceeded_sample_limit_total|prometheus_target_scrapes_sample_duplicate_timestamp_total|prometheus_target_scrapes_sample_out_of_bounds_total|prometheus_target_scrapes_sample_out_of_order_total|prometheus_target_sync_length_seconds_sum|prometheus_wal_watcher_current_segment|otelcol_receiver_accepted_spans_total|otelcol_receiver_refused_spans_total|rpc_server_duration_milliseconds_bucket|scrape_duration_seconds|traces_exporter_send_failed_spans|traces_exporter_send_failed_spans_total|traces_exporter_sent_spans|traces_exporter_sent_spans_total|traces_loadbalancer_backend_outcome|traces_loadbalancer_num_backends|traces_receiver_accepted_spans|traces_receiver_accepted_spans_total|traces_receiver_refused_spans|traces_receiver_refused_spans_total"
+    scrape_interval = "60s"
+    scrape_timeout = "10s"
+    scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
+    scrape_classic_histograms = false
+    scrape_native_histograms = false
+    max_cache_size = 100000
+    forward_to = argument.metrics_destinations.value
+  }
+}
+alloy_integration "integration" {
+  metrics_destinations = [
+    prometheus.remote_write.grafanacloudmetrics.receiver,
+  ]
+}
+
+
+
+
+
+// Destination: grafanaCloudMetrics (prometheus)
+otelcol.exporter.prometheus "grafanacloudmetrics" {
+  add_metric_suffixes = true
+  resource_to_telemetry_conversion = false
+  keep_identifying_resource_attributes = true
+  forward_to = [prometheus.remote_write.grafanacloudmetrics.receiver]
+} // otelcol.exporter.prometheus "grafanacloudmetrics"
+
+prometheus.remote_write "grafanacloudmetrics" {
+  endpoint {
+    url = "https://prometheus-prod-13-prod-us-east-0.grafana.net/api/prom/push"
+    headers = {
+      "X-Scope-OrgID" = convert.nonsensitive(remote.kubernetes.secret.grafanacloudmetrics.data["tenantId"]),
+    }
+    basic_auth {
+      username = convert.nonsensitive(remote.kubernetes.secret.grafanacloudmetrics.data["PROMETHEUS_USER"])
+      password = remote.kubernetes.secret.grafanacloudmetrics.data["PROMETHEUS_PASS"]
+    }
+    tls_config {
+      insecure_skip_verify = false
+      ca_pem = convert.nonsensitive(remote.kubernetes.secret.grafanacloudmetrics.data["ca"])
+      cert_pem = convert.nonsensitive(remote.kubernetes.secret.grafanacloudmetrics.data["cert"])
+      key_pem = remote.kubernetes.secret.grafanacloudmetrics.data["key"]
+    }
+    send_native_histograms = false
+
+    queue_config {
+      capacity = 10000
+      min_shards = 1
+      max_shards = 50
+      max_samples_per_send = 2000
+      batch_send_deadline = "5s"
+      min_backoff = "30ms"
+      max_backoff = "5s"
+      retry_on_http_429 = true
+      sample_age_limit = "0s"
+    }
+  }
+
+  wal {
+    truncate_frequency = "2h"
+    min_keepalive_time = "5m"
+    max_keepalive_time = "8h"
+  }
+  external_labels = {
+    "cluster" = "openshift-test",
+    "k8s_cluster_name" = "openshift-test",
+  }
+} // prometheus.remote_write "grafanacloudmetrics"
+
+remote.kubernetes.secret "grafanacloudmetrics" {
+  name      = "grafana-cloud-credentials"
+  namespace = "default"
+} // remote.kubernetes.secret "grafanacloudmetrics"
+

--- a/charts/k8s-monitoring/tests/platform/openshift/.rendered/alloy-singleton.alloy
+++ b/charts/k8s-monitoring/tests/platform/openshift/.rendered/alloy-singleton.alloy
@@ -1,0 +1,221 @@
+// Feature: Cluster Events
+declare "cluster_events" {
+  argument "logs_destinations" {
+    comment = "Must be a list of log destinations where collected logs should be forwarded to"
+  }
+
+  loki.source.kubernetes_events "cluster_events" {
+    job_name   = "integrations/kubernetes/eventhandler"
+    log_format = "logfmt"
+    forward_to = [loki.process.cluster_events.receiver]
+  } // loki.source.kubernetes_events "cluster_events"
+
+  loki.process "cluster_events" {
+
+    // add a static source label to the logs so they can be differentiated / restricted if necessary
+    stage.static_labels {
+      values = {
+        "source" = "kubernetes-events",
+      }
+    }
+
+    // extract some of the fields from the log line, these could be used as labels, structured metadata, etc.
+    stage.logfmt {
+      mapping = {
+        "component" = "sourcecomponent", // map the sourcecomponent field to component
+        "kind" = "",
+        "level" = "type", // most events don't have a level but they do have a "type" i.e. Normal, Warning, Error, etc.
+        "name" = "",
+        "node" = "sourcehost", // map the sourcehost field to node
+        "reason" = "",
+      }
+    }
+    // set the extracted values as labels
+    stage.labels {
+      values = {
+        "kind" = "",
+        "level" = "",
+        "service_name" = "job",
+        "reason" = "reason",
+      }
+    }
+
+    // if kind=Node, set the node label by copying the name field
+    stage.match {
+      selector = "{kind=\"Node\"}"
+
+      stage.labels {
+        values = {
+          "node" = "name",
+        }
+      }
+    }
+
+    // set the level extracted key value as a normalized log level
+    stage.match {
+      selector = "{level=\"Normal\"}"
+
+      stage.static_labels {
+        values = {
+          level = "Info",
+        }
+      }
+    }
+    stage.structured_metadata {
+      values = {
+        "name" = "name",
+        "node" = "node",
+      }
+    }
+
+    // Drop pipeline-only labels that are not needed in the final output.
+    stage.label_drop {
+      values = ["kind"]
+    }
+
+    forward_to = argument.logs_destinations.value
+  } // loki.process "cluster_events"
+} // declare "cluster_events"
+cluster_events "feature" {
+  logs_destinations = [
+    loki.write.grafanacloudlogs.receiver,
+  ]
+}
+// Self Reporting
+prometheus.exporter.unix "kubernetes_monitoring_telemetry" {
+  set_collectors = ["textfile"]
+  textfile {
+    directory = "/etc/release-info"
+  }
+} // prometheus.exporter.unix "kubernetes_monitoring_telemetry"
+
+discovery.relabel "kubernetes_monitoring_telemetry" {
+  targets = prometheus.exporter.unix.kubernetes_monitoring_telemetry.targets
+  rule {
+    target_label = "instance"
+    action = "replace"
+    replacement = "k8smon"
+  }
+  rule {
+    target_label = "job"
+    action = "replace"
+    replacement = "integrations/kubernetes/kubernetes_monitoring_telemetry"
+  }
+} // discovery.relabel "kubernetes_monitoring_telemetry"
+
+prometheus.scrape "kubernetes_monitoring_telemetry" {
+  job_name   = "integrations/kubernetes/kubernetes_monitoring_telemetry"
+  targets    = discovery.relabel.kubernetes_monitoring_telemetry.output
+  scrape_interval = "60s"
+  clustering {
+    enabled = true
+  }
+  forward_to = [prometheus.relabel.kubernetes_monitoring_telemetry.receiver]
+} // prometheus.scrape "kubernetes_monitoring_telemetry"
+
+prometheus.relabel "kubernetes_monitoring_telemetry" {
+  rule {
+    source_labels = ["__name__"]
+    regex = "grafana_kubernetes_monitoring_.*"
+    action = "keep"
+  }
+  forward_to = [
+    prometheus.remote_write.grafanacloudmetrics.receiver,
+  ]
+} // prometheus.relabel "kubernetes_monitoring_telemetry"
+
+
+
+
+
+// Destination: grafanaCloudLogs (loki)
+otelcol.exporter.loki "grafanacloudlogs" {
+  forward_to = [loki.write.grafanacloudlogs.receiver]
+} // otelcol.exporter.loki "grafanacloudlogs"
+
+loki.write "grafanacloudlogs" {
+  endpoint {
+    url = "https://logs-prod-006.grafana.net/loki/api/v1/push"
+    retry_on_http_429 = true
+    tenant_id = convert.nonsensitive(remote.kubernetes.secret.grafanacloudlogs.data["tenantId"])
+    basic_auth {
+      username = convert.nonsensitive(remote.kubernetes.secret.grafanacloudlogs.data["LOKI_USER"])
+      password = remote.kubernetes.secret.grafanacloudlogs.data["LOKI_PASS"]
+    }
+    tls_config {
+      insecure_skip_verify = false
+      ca_pem = convert.nonsensitive(remote.kubernetes.secret.grafanacloudlogs.data["ca"])
+      cert_pem = convert.nonsensitive(remote.kubernetes.secret.grafanacloudlogs.data["cert"])
+      key_pem = remote.kubernetes.secret.grafanacloudlogs.data["key"]
+    }
+    min_backoff_period = "500ms"
+    max_backoff_period = "5m"
+    max_backoff_retries = "10"
+  }
+  external_labels = {
+    "cluster" = "openshift-test",
+    "k8s_cluster_name" = "openshift-test",
+  }
+} // loki.write "grafanacloudlogs"
+
+remote.kubernetes.secret "grafanacloudlogs" {
+  name      = "grafana-cloud-credentials"
+  namespace = "default"
+} // remote.kubernetes.secret "grafanacloudlogs"
+
+
+// Destination: grafanaCloudMetrics (prometheus)
+otelcol.exporter.prometheus "grafanacloudmetrics" {
+  add_metric_suffixes = true
+  resource_to_telemetry_conversion = false
+  keep_identifying_resource_attributes = true
+  forward_to = [prometheus.remote_write.grafanacloudmetrics.receiver]
+} // otelcol.exporter.prometheus "grafanacloudmetrics"
+
+prometheus.remote_write "grafanacloudmetrics" {
+  endpoint {
+    url = "https://prometheus-prod-13-prod-us-east-0.grafana.net/api/prom/push"
+    headers = {
+      "X-Scope-OrgID" = convert.nonsensitive(remote.kubernetes.secret.grafanacloudmetrics.data["tenantId"]),
+    }
+    basic_auth {
+      username = convert.nonsensitive(remote.kubernetes.secret.grafanacloudmetrics.data["PROMETHEUS_USER"])
+      password = remote.kubernetes.secret.grafanacloudmetrics.data["PROMETHEUS_PASS"]
+    }
+    tls_config {
+      insecure_skip_verify = false
+      ca_pem = convert.nonsensitive(remote.kubernetes.secret.grafanacloudmetrics.data["ca"])
+      cert_pem = convert.nonsensitive(remote.kubernetes.secret.grafanacloudmetrics.data["cert"])
+      key_pem = remote.kubernetes.secret.grafanacloudmetrics.data["key"]
+    }
+    send_native_histograms = false
+
+    queue_config {
+      capacity = 10000
+      min_shards = 1
+      max_shards = 50
+      max_samples_per_send = 2000
+      batch_send_deadline = "5s"
+      min_backoff = "30ms"
+      max_backoff = "5s"
+      retry_on_http_429 = true
+      sample_age_limit = "0s"
+    }
+  }
+
+  wal {
+    truncate_frequency = "2h"
+    min_keepalive_time = "5m"
+    max_keepalive_time = "8h"
+  }
+  external_labels = {
+    "cluster" = "openshift-test",
+    "k8s_cluster_name" = "openshift-test",
+  }
+} // prometheus.remote_write "grafanacloudmetrics"
+
+remote.kubernetes.secret "grafanacloudmetrics" {
+  name      = "grafana-cloud-credentials"
+  namespace = "default"
+} // remote.kubernetes.secret "grafanacloudmetrics"
+

--- a/charts/k8s-monitoring/tests/platform/otlp-gateway/.rendered/alloy.alloy
+++ b/charts/k8s-monitoring/tests/platform/otlp-gateway/.rendered/alloy.alloy
@@ -1,0 +1,1339 @@
+// Feature: Cluster Metrics
+declare "cluster_metrics" {
+  argument "metrics_destinations" {
+    comment = "Must be a list of metric destinations where collected metrics should be forwarded to"
+  }
+  discovery.kubernetes "nodes" {
+    role = "node"
+  } // discovery.kubernetes "nodes"
+
+  discovery.relabel "nodes" {
+    targets = discovery.kubernetes.nodes.targets
+    rule {
+      source_labels = ["__meta_kubernetes_node_name"]
+      target_label  = "node"
+    }
+
+    rule {
+      replacement = "kubernetes"
+      target_label = "source"
+    }
+  } // discovery.relabel "nodes"
+
+  // Kubelet
+  discovery.relabel "kubelet" {
+    targets = discovery.relabel.nodes.output
+  } // discovery.relabel "kubelet"
+
+  prometheus.scrape "kubelet" {
+    targets  = discovery.relabel.kubelet.output
+    job_name = "integrations/kubernetes/kubelet"
+    scheme   = "https"
+    scrape_interval = "60s"
+    scrape_timeout = "10s"
+    scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
+    scrape_classic_histograms = false
+    scrape_native_histograms = false
+    convert_classic_histograms_to_nhcb = false
+    bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+
+    tls_config {
+      ca_file = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+      insecure_skip_verify = true
+      server_name = "kubernetes"
+    }
+
+    clustering {
+      enabled = true
+    }
+
+    forward_to = [prometheus.relabel.kubelet.receiver]
+  } // prometheus.scrape "kubelet"
+
+  prometheus.relabel "kubelet" {
+    max_cache_size = 100000
+    rule {
+      source_labels = ["__name__"]
+      regex = "up|scrape_samples_scraped|go_goroutines|kubelet_certificate_manager_client_expiration_renew_errors|kubelet_certificate_manager_client_ttl_seconds|kubelet_certificate_manager_server_ttl_seconds|kubelet_cgroup_manager_duration_seconds_bucket|kubelet_cgroup_manager_duration_seconds_count|kubelet_node_config_error|kubelet_node_name|kubelet_pleg_relist_duration_seconds_bucket|kubelet_pleg_relist_duration_seconds_count|kubelet_pleg_relist_interval_seconds_bucket|kubelet_pod_start_duration_seconds_bucket|kubelet_pod_start_duration_seconds_count|kubelet_pod_worker_duration_seconds_bucket|kubelet_pod_worker_duration_seconds_count|kubelet_running_container_count|kubelet_running_containers|kubelet_running_pod_count|kubelet_running_pods|kubelet_runtime_operations_errors_total|kubelet_runtime_operations_total|kubelet_server_expiration_renew_errors|kubelet_volume_stats_available_bytes|kubelet_volume_stats_capacity_bytes|kubelet_volume_stats_inodes|kubelet_volume_stats_inodes_free|kubelet_volume_stats_inodes_used|kubelet_volume_stats_used_bytes|kubernetes_build_info|namespace_workload_pod|process_cpu_seconds_total|process_resident_memory_bytes|rest_client_requests_total|storage_operation_duration_seconds_count|storage_operation_errors_total|volume_manager_total_volumes"
+      action = "keep"
+    }
+
+    forward_to = argument.metrics_destinations.value
+  } // prometheus.relabel "kubelet"
+
+  // Kubelet Resources
+  discovery.relabel "kubelet_resources" {
+    targets = discovery.relabel.nodes.output
+    rule {
+      replacement   = "/metrics/resource"
+      target_label  = "__metrics_path__"
+    }
+  } // discovery.relabel "kubelet_resources"
+
+  prometheus.scrape "kubelet_resources" {
+    targets = discovery.relabel.kubelet_resources.output
+    job_name = "integrations/kubernetes/resources"
+    scheme   = "https"
+    scrape_interval = "60s"
+    scrape_timeout = "10s"
+    scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
+    scrape_classic_histograms = false
+    scrape_native_histograms = false
+    convert_classic_histograms_to_nhcb = false
+    bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+
+    tls_config {
+      ca_file = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+      insecure_skip_verify = true
+      server_name = "kubernetes"
+    }
+
+    clustering {
+      enabled = true
+    }
+
+    forward_to = [prometheus.relabel.kubelet_resources.receiver]
+  } // prometheus.scrape "kubelet_resources"
+
+  prometheus.relabel "kubelet_resources" {
+    max_cache_size = 100000
+    rule {
+      source_labels = ["__name__"]
+      regex = "up|scrape_samples_scraped|node_cpu_usage_seconds_total|node_memory_working_set_bytes"
+      action = "keep"
+    }
+
+    forward_to = argument.metrics_destinations.value
+  } // prometheus.relabel "kubelet_resources"
+
+  // cAdvisor
+  discovery.relabel "cadvisor" {
+    targets = discovery.relabel.nodes.output
+    rule {
+      replacement   = "/metrics/cadvisor"
+      target_label  = "__metrics_path__"
+    }
+  } // discovery.relabel "cadvisor"
+
+  prometheus.scrape "cadvisor" {
+    targets = discovery.relabel.cadvisor.output
+    job_name = "integrations/kubernetes/cadvisor"
+    scheme = "https"
+    scrape_interval = "60s"
+    scrape_timeout = "10s"
+    scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
+    scrape_classic_histograms = false
+    scrape_native_histograms = false
+    convert_classic_histograms_to_nhcb = false
+    bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+
+    tls_config {
+      ca_file = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+      insecure_skip_verify = true
+      server_name = "kubernetes"
+    }
+
+    clustering {
+      enabled = true
+    }
+
+    forward_to = [prometheus.relabel.cadvisor.receiver]
+  } // prometheus.scrape "cadvisor"
+
+  prometheus.relabel "cadvisor" {
+    max_cache_size = 100000
+    rule {
+      source_labels = ["__name__"]
+      regex = "up|scrape_samples_scraped|container_cpu_cfs_periods_total|container_cpu_cfs_throttled_periods_total|container_cpu_usage_seconds_total|container_fs_reads_bytes_total|container_fs_reads_total|container_fs_writes_bytes_total|container_fs_writes_total|container_memory_cache|container_memory_rss|container_memory_swap|container_memory_usage_bytes|container_memory_working_set_bytes|container_network_receive_bytes_total|container_network_receive_packets_dropped_total|container_network_receive_packets_total|container_network_transmit_bytes_total|container_network_transmit_packets_dropped_total|container_network_transmit_packets_total|machine_memory_bytes"
+      action = "keep"
+    }
+    // Drop empty container labels, addressing https://github.com/google/cadvisor/issues/2688
+    rule {
+      source_labels = ["__name__","container"]
+      separator = "@"
+      regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_pressure_.*)@"
+      action = "drop"
+    }
+    // Drop empty image labels, addressing https://github.com/google/cadvisor/issues/2688
+    rule {
+      source_labels = ["__name__","image"]
+      separator = "@"
+      regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_network_.*|container_pressure_.*)@"
+      action = "drop"
+    }
+    // Normalizing unimportant labels (not deleting to continue satisfying <label>!="" checks)
+    rule {
+      source_labels = ["__name__", "boot_id"]
+      separator = "@"
+      regex = "machine_memory_bytes@.*"
+      target_label = "boot_id"
+      replacement = "NA"
+    }
+    rule {
+      source_labels = ["__name__", "system_uuid"]
+      separator = "@"
+      regex = "machine_memory_bytes@.*"
+      target_label = "system_uuid"
+      replacement = "NA"
+    }
+    // Filter out non-physical devices/interfaces
+    rule {
+      source_labels = ["__name__", "device"]
+      separator = "@"
+      regex = "container_fs_.*@(/dev/)?(mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dasd.+)"
+      target_label = "__keepme"
+      replacement = "1"
+    }
+    rule {
+      source_labels = ["__name__", "__keepme"]
+      separator = "@"
+      regex = "container_fs_.*@"
+      action = "drop"
+    }
+    rule {
+      source_labels = ["__name__"]
+      regex = "container_fs_.*"
+      target_label = "__keepme"
+      replacement = ""
+    }
+    rule {
+      source_labels = ["__name__", "interface"]
+      separator = "@"
+      regex = "container_network_.*@(en[ospx][0-9].*|wlan[0-9].*|eth[0-9].*)"
+      target_label = "__keepme"
+      replacement = "1"
+    }
+    rule {
+      source_labels = ["__name__", "__keepme"]
+      separator = "@"
+      regex = "container_network_.*@"
+      action = "drop"
+    }
+    rule {
+      source_labels = ["__name__"]
+      regex = "container_network_.*"
+      target_label = "__keepme"
+      replacement = ""
+    }
+    forward_to = argument.metrics_destinations.value
+  } // prometheus.relabel "cadvisor"
+  discovery.kubernetes "kube_state_metrics" {
+    role = "endpoints"
+
+    selectors {
+      role = "endpoints"
+      label = "release=k8smon,app.kubernetes.io/name=kube-state-metrics"
+    }
+    namespaces {
+      names = ["default"]
+    }
+  } // discovery.kubernetes "kube_state_metrics"
+
+  discovery.relabel "kube_state_metrics" {
+    targets = discovery.kubernetes.kube_state_metrics.targets
+
+    rule {
+      action = "replace"
+      replacement = "kubernetes"
+      target_label = "source"
+    }
+
+  } // discovery.relabel "kube_state_metrics"
+
+  prometheus.scrape "kube_state_metrics" {
+    targets = discovery.relabel.kube_state_metrics.output
+    job_name = "integrations/kubernetes/kube-state-metrics"
+    scrape_interval = "60s"
+    scrape_timeout = "10s"
+    scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
+    scrape_classic_histograms = false
+    scrape_native_histograms = false
+    convert_classic_histograms_to_nhcb = false
+    scheme = "http"
+    bearer_token_file = ""
+    tls_config {
+      insecure_skip_verify = true
+    }
+
+    clustering {
+      enabled = true
+    }
+    forward_to = [prometheus.relabel.kube_state_metrics.receiver]
+  } // prometheus.scrape "kube_state_metrics"
+
+  prometheus.relabel "kube_state_metrics" {
+    max_cache_size = 100000
+    rule {
+      source_labels = ["__name__"]
+      regex = "up|scrape_samples_scraped|kube_configmap_info|kube_configmap_metadata_resource_version|kube_cronjob.*|kube_daemonset.*|kube_deployment_metadata_generation|kube_deployment_spec_replicas|kube_deployment_status_condition|kube_deployment_status_observed_generation|kube_deployment_status_replicas_available|kube_deployment_status_replicas_updated|kube_horizontalpodautoscaler_spec_max_replicas|kube_horizontalpodautoscaler_spec_min_replicas|kube_horizontalpodautoscaler_status_current_replicas|kube_horizontalpodautoscaler_status_desired_replicas|kube_job.*|kube_namespace_status_phase|kube_node.*|kube_persistentvolume_status_phase|kube_persistentvolumeclaim_access_mode|kube_persistentvolumeclaim_info|kube_persistentvolumeclaim_labels|kube_persistentvolumeclaim_resource_requests_storage_bytes|kube_persistentvolumeclaim_status_phase|kube_pod_completion_time|kube_pod_container_info|kube_pod_container_resource_limits|kube_pod_container_resource_requests|kube_pod_container_status_last_terminated_reason|kube_pod_container_status_last_terminated_timestamp|kube_pod_container_status_restarts_total|kube_pod_container_status_waiting_reason|kube_pod_info|kube_pod_owner|kube_pod_restart_policy|kube_pod_spec_volumes_persistentvolumeclaims_info|kube_pod_start_time|kube_pod_status_phase|kube_pod_status_reason|kube_pod_init_.*|kube_replicaset.*|kube_resourcequota|kube_secret_metadata_resource_version|kube_statefulset.*"
+      action = "keep"
+    }
+    forward_to = argument.metrics_destinations.value
+  } // prometheus.relabel "kube_state_metrics"
+} // declare "cluster_metrics"
+cluster_metrics "feature" {
+  metrics_destinations = [
+    otelcol.receiver.prometheus.otlp_gateway.receiver,
+  ]
+}
+// Feature: Cluster Events
+declare "cluster_events" {
+  argument "logs_destinations" {
+    comment = "Must be a list of log destinations where collected logs should be forwarded to"
+  }
+
+  loki.source.kubernetes_events "cluster_events" {
+    job_name   = "integrations/kubernetes/eventhandler"
+    log_format = "logfmt"
+    clustering {
+      enabled = true
+    }
+    forward_to = [loki.process.cluster_events.receiver]
+  } // loki.source.kubernetes_events "cluster_events"
+
+  loki.process "cluster_events" {
+
+    // add a static source label to the logs so they can be differentiated / restricted if necessary
+    stage.static_labels {
+      values = {
+        "source" = "kubernetes-events",
+      }
+    }
+
+    // extract some of the fields from the log line, these could be used as labels, structured metadata, etc.
+    stage.logfmt {
+      mapping = {
+        "component" = "sourcecomponent", // map the sourcecomponent field to component
+        "kind" = "",
+        "level" = "type", // most events don't have a level but they do have a "type" i.e. Normal, Warning, Error, etc.
+        "name" = "",
+        "node" = "sourcehost", // map the sourcehost field to node
+        "reason" = "",
+      }
+    }
+    // set the extracted values as labels
+    stage.labels {
+      values = {
+        "kind" = "",
+        "level" = "",
+        "service_name" = "job",
+        "reason" = "reason",
+        "resources.k8s.object.kind" = "kind",
+        "resources.k8s.object.name" = "name",
+      }
+    }
+
+    // if kind=Node, set the node label by copying the name field
+    stage.match {
+      selector = "{kind=\"Node\"}"
+
+      stage.labels {
+        values = {
+          "node" = "name",
+        }
+      }
+    }
+
+    // set the level extracted key value as a normalized log level
+    stage.match {
+      selector = "{level=\"Normal\"}"
+
+      stage.static_labels {
+        values = {
+          level = "Info",
+        }
+      }
+    }
+    stage.structured_metadata {
+      values = {
+        "name" = "name",
+        "node" = "node",
+      }
+    }
+
+    // Drop pipeline-only labels that are not needed in the final output.
+    stage.label_drop {
+      values = ["kind"]
+    }
+
+    forward_to = argument.logs_destinations.value
+  } // loki.process "cluster_events"
+} // declare "cluster_events"
+cluster_events "feature" {
+  logs_destinations = [
+    otelcol.receiver.loki.otlp_gateway.receiver,
+  ]
+}
+
+// Feature: Host Metrics
+declare "host_metrics" {
+  argument "metrics_destinations" {
+    comment = "Must be a list of metric destinations where collected metrics should be forwarded to"
+  }
+
+  // Linux hosts via Node Exporter
+  discovery.kubernetes "node_exporter" {
+    role = "pod"
+    selectors {
+      role = "pod"
+      label = "release=k8smon,app.kubernetes.io/name=node-exporter"
+    }
+    namespaces {
+      names = ["default"]
+    }
+
+  } // discovery.kubernetes "node_exporter"
+
+  discovery.relabel "node_exporter" {
+    targets = discovery.kubernetes.node_exporter.targets
+
+    // keep only the specified metrics port name, and pods that are Running and ready
+    rule {
+      source_labels = [
+        "__meta_kubernetes_pod_container_init",
+        "__meta_kubernetes_pod_phase",
+        "__meta_kubernetes_pod_ready",
+      ]
+      separator = "@"
+      regex = "false@Running@true"
+      action = "keep"
+    }
+
+    // Set the instance label to the node name
+    rule {
+      source_labels = ["__meta_kubernetes_pod_node_name"]
+      target_label = "instance"
+    }
+
+    rule {
+      source_labels = ["__meta_kubernetes_namespace"]
+      target_label  = "namespace"
+    }
+
+    rule {
+      source_labels = ["__meta_kubernetes_pod_name"]
+      target_label  = "pod"
+    }
+
+    rule {
+      source_labels = ["__meta_kubernetes_pod_container_name"]
+      target_label  = "container"
+    }
+
+    // set a workload label
+    rule {
+      source_labels = [
+        "__meta_kubernetes_pod_controller_kind",
+        "__meta_kubernetes_pod_controller_name",
+      ]
+      separator = "/"
+      target_label  = "workload"
+    }
+    // remove the hash from the ReplicaSet
+    rule {
+      source_labels = ["workload"]
+      regex = "(ReplicaSet/.+)-.+"
+      target_label  = "workload"
+    }
+
+    // Set the app label.
+    //
+    // Choose the first value found from the following ordered list:
+    // - pod.label[app.kubernetes.io/name]
+    // - pod.label[k8s-app]
+    // - pod.label[app]
+    rule {
+      source_labels = [
+        "__meta_kubernetes_pod_label_app_kubernetes_io_name",
+        "__meta_kubernetes_pod_label_k8s_app",
+        "__meta_kubernetes_pod_label_app",
+      ]
+      separator = ";"
+      regex = "^(?:;*)?([^;]+).*$"
+      replacement = "$1"
+      target_label = "app"
+    }
+
+    // Set the component label.
+    //
+    // Choose the first value found from the following ordered list:
+    // - pod.label[app.kubernetes.io/component]
+    // - pod.label[k8s-component]
+    // - pod.label[component]
+    rule {
+      source_labels = [
+        "__meta_kubernetes_pod_label_app_kubernetes_io_component",
+        "__meta_kubernetes_pod_label_k8s_component",
+        "__meta_kubernetes_pod_label_component",
+      ]
+      regex = "^(?:;*)?([^;]+).*$"
+      replacement = "$1"
+      target_label = "component"
+    }
+
+    rule {
+      target_label = "source"
+      replacement = "kubernetes"
+    }
+
+  } // discovery.relabel "node_exporter"
+
+  prometheus.scrape "node_exporter" {
+    targets = discovery.relabel.node_exporter.output
+    job_name = "integrations/node_exporter"
+    scrape_interval = "60s"
+    scrape_timeout = "10s"
+    scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
+    scrape_classic_histograms = false
+    scrape_native_histograms = false
+    convert_classic_histograms_to_nhcb = false
+    scheme = "http"
+    tls_config {
+      insecure_skip_verify = true
+    }
+
+    clustering {
+      enabled = true
+    }
+    forward_to = [prometheus.relabel.node_exporter.receiver]
+  } // prometheus.scrape "node_exporter"
+
+  prometheus.relabel "node_exporter" {
+    max_cache_size = 100000
+    rule {
+      source_labels = ["__name__"]
+      regex = "up|scrape_samples_scraped|node_cpu.*|node_exporter_build_info|node_filesystem.*|node_memory.*|node_network_receive_bytes_total|node_network_receive_drop_total|node_network_transmit_bytes_total|node_network_transmit_drop_total|process_cpu_seconds_total|process_resident_memory_bytes"
+      action = "keep"
+    }
+    // Drop metrics for certain file systems
+    rule {
+      source_labels = ["__name__", "fstype"]
+      separator = "@"
+      regex = "node_filesystem.*@(ramfs|tmpfs)"
+      action = "drop"
+    }
+    forward_to = argument.metrics_destinations.value
+  } // prometheus.relabel "node_exporter"
+} // declare "host_metrics"
+host_metrics "feature" {
+  metrics_destinations = [
+    otelcol.receiver.prometheus.otlp_gateway.receiver,
+  ]
+}
+declare "alloy_integration" {
+  argument "metrics_destinations" {
+    comment = "Must be a list of metric destinations where collected metrics should be forwarded to"
+  }
+
+  declare "alloy_integration_discovery" {
+    argument "namespaces" {
+      comment = "The namespaces to look for targets in (default: [] is all namespaces)"
+      optional = true
+    }
+
+    argument "field_selectors" {
+      comment = "The field selectors to use to find matching targets (default: [])"
+      optional = true
+    }
+
+    argument "label_selectors" {
+      comment = "The label selectors to use to find matching targets (default: [\"app.kubernetes.io/name=alloy\"])"
+      optional = true
+    }
+
+    argument "port_name" {
+      comment = "The of the port to scrape metrics from (default: http-metrics)"
+      optional = true
+    }
+
+    // Alloy service discovery for all of the pods
+    discovery.kubernetes "alloy_pods" {
+      role = "pod"
+
+      selectors {
+        role = "pod"
+        field = string.join(coalesce(argument.field_selectors.value, []), ",")
+        label = string.join(coalesce(argument.label_selectors.value, ["app.kubernetes.io/name=alloy"]), ",")
+      }
+
+      namespaces {
+        names = coalesce(argument.namespaces.value, [])
+      }
+
+    } // discovery.kubernetes "alloy_pods"
+
+    // alloy relabelings (pre-scrape)
+    discovery.relabel "alloy_pods" {
+      targets = discovery.kubernetes.alloy_pods.targets
+
+      // keep only the specified metrics port name, and pods that are Running and ready
+      rule {
+        source_labels = [
+          "__meta_kubernetes_pod_container_port_name",
+          "__meta_kubernetes_pod_phase",
+          "__meta_kubernetes_pod_ready",
+          "__meta_kubernetes_pod_container_init",
+        ]
+        separator = "@"
+        regex = coalesce(argument.port_name.value, "metrics") + "@Running@true@false"
+        action = "keep"
+      }
+
+      rule {
+        source_labels = ["__meta_kubernetes_namespace"]
+        target_label  = "namespace"
+      }
+
+      rule {
+        source_labels = ["__meta_kubernetes_pod_name"]
+        target_label  = "pod"
+      }
+
+      rule {
+        source_labels = ["__meta_kubernetes_pod_container_name"]
+        target_label  = "container"
+      }
+
+      // set the workload to the controller kind and name
+      rule {
+        action = "lowercase"
+        source_labels = ["__meta_kubernetes_pod_controller_kind"]
+        target_label  = "workload_type"
+      }
+
+      rule {
+        source_labels = ["__meta_kubernetes_pod_controller_name"]
+        target_label  = "workload"
+      }
+
+      // remove the hash from the ReplicaSet
+      rule {
+        source_labels = [
+          "workload_type",
+          "workload",
+        ]
+        separator = "/"
+        regex = "replicaset/(.+)-.+$"
+        target_label  = "workload"
+      }
+
+      // set the app name if specified as metadata labels "app:" or "app.kubernetes.io/name:" or "k8s-app:"
+      rule {
+        action = "replace"
+        source_labels = [
+          "__meta_kubernetes_pod_label_app_kubernetes_io_name",
+          "__meta_kubernetes_pod_label_k8s_app",
+          "__meta_kubernetes_pod_label_app",
+        ]
+        separator = ";"
+        regex = "^(?:;*)?([^;]+).*$"
+        replacement = "$1"
+        target_label = "app"
+      }
+
+      // set the component if specified as metadata labels "component:" or "app.kubernetes.io/component:" or "k8s-component:"
+      rule {
+        action = "replace"
+        source_labels = [
+          "__meta_kubernetes_pod_label_app_kubernetes_io_component",
+          "__meta_kubernetes_pod_label_k8s_component",
+          "__meta_kubernetes_pod_label_component",
+        ]
+        regex = "^(?:;*)?([^;]+).*$"
+        replacement = "$1"
+        target_label = "component"
+      }
+
+      // set a source label
+      rule {
+        action = "replace"
+        replacement = "kubernetes"
+        target_label = "source"
+      }
+
+    } // discovery.relabel "alloy_pods"
+
+    export "output" {
+      value = discovery.relabel.alloy_pods.output
+    }
+  }
+
+  declare "alloy_integration_scrape" {
+    argument "targets" {
+      comment = "Must be a list() of targets"
+    }
+
+    argument "forward_to" {
+      comment = "Must be a list(MetricsReceiver) where collected metrics should be forwarded to"
+    }
+
+    argument "job_label" {
+      comment = "The job label to add for all Alloy metrics (default: integrations/alloy)"
+      optional = true
+    }
+
+    argument "keep_metrics" {
+      comment = "A regular expression of metrics to keep (default: see below)"
+      optional = true
+    }
+
+    argument "drop_metrics" {
+      comment = "A regular expression of metrics to drop (default: see below)"
+      optional = true
+    }
+
+    argument "scrape_interval" {
+      comment = "How often to scrape metrics from the targets (default: 60s)"
+      optional = true
+    }
+
+    argument "scrape_timeout" {
+      comment = "The timeout for scraping metrics from the targets (default: 10s)"
+      optional = true
+    }
+
+    argument "scrape_protocols" {
+      comment = "The scrape protocols to use for scraping metrics"
+      optional = true
+    }
+
+    argument "scrape_classic_histograms" {
+      comment = "Whether to scrape classic histograms (default: false)."
+      optional = true
+    }
+
+    argument "scrape_native_histograms" {
+      comment = "Whether to scrape native histograms (default: false)."
+      optional = true
+    }
+
+    argument "max_cache_size" {
+      comment = "The maximum number of elements to hold in the relabeling cache (default: 100000).  This should be at least 2x-5x your largest scrape target or samples appended rate."
+      optional = true
+    }
+
+    argument "clustering" {
+      comment = "Whether or not clustering should be enabled (default: false)"
+      optional = true
+    }
+
+    prometheus.scrape "alloy" {
+      job_name = coalesce(argument.job_label.value, "integrations/alloy")
+      forward_to = [prometheus.relabel.alloy.receiver]
+      targets = argument.targets.value
+      scrape_interval = coalesce(argument.scrape_interval.value, "60s")
+      scrape_timeout = coalesce(argument.scrape_timeout.value, "10s")
+      scrape_protocols = argument.scrape_protocols.value
+      scrape_classic_histograms = argument.scrape_classic_histograms.value
+      scrape_native_histograms = argument.scrape_native_histograms.value
+
+      clustering {
+        enabled = coalesce(argument.clustering.value, false)
+      }
+    } // prometheus.scrape "alloy"
+
+    // alloy metric relabelings (post-scrape)
+    prometheus.relabel "alloy" {
+      forward_to = argument.forward_to.value
+      max_cache_size = coalesce(argument.max_cache_size.value, 100000)
+
+      // drop metrics that match the drop_metrics regex
+      rule {
+        source_labels = ["__name__"]
+        regex = coalesce(argument.drop_metrics.value, "")
+        action = "drop"
+      }
+
+      // keep only metrics that match the keep_metrics regex
+      rule {
+        source_labels = ["__name__"]
+        regex = coalesce(argument.keep_metrics.value, ".*")
+        action = "keep"
+      }
+
+      // remove the component_id label from any metric that starts with log_bytes or log_lines, these are custom metrics that are generated
+      // as part of the log annotation modules in this repo
+      rule {
+        action = "replace"
+        source_labels = ["__name__"]
+        regex = "^log_(bytes|lines).+"
+        replacement = ""
+        target_label = "component_id"
+      }
+
+      // set the namespace label to that of the exported_namespace
+      rule {
+        action = "replace"
+        source_labels = ["__name__", "exported_namespace"]
+        separator = "@"
+        regex = "^log_(bytes|lines).+@(.+)"
+        replacement = "$2"
+        target_label = "namespace"
+      }
+
+      // set the pod label to that of the exported_pod
+      rule {
+        action = "replace"
+        source_labels = ["__name__", "exported_pod"]
+        separator = "@"
+        regex = "^log_(bytes|lines).+@(.+)"
+        replacement = "$2"
+        target_label = "pod"
+      }
+
+      // set the container label to that of the exported_container
+      rule {
+        action = "replace"
+        source_labels = ["__name__", "exported_container"]
+        separator = "@"
+        regex = "^log_(bytes|lines).+@(.+)"
+        replacement = "$2"
+        target_label = "container"
+      }
+
+      // set the job label to that of the exported_job
+      rule {
+        action = "replace"
+        source_labels = ["__name__", "exported_job"]
+        separator = "@"
+        regex = "^log_(bytes|lines).+@(.+)"
+        replacement = "$2"
+        target_label = "job"
+      }
+
+      // set the instance label to that of the exported_instance
+      rule {
+        action = "replace"
+        source_labels = ["__name__", "exported_instance"]
+        separator = "@"
+        regex = "^log_(bytes|lines).+@(.+)"
+        replacement = "$2"
+        target_label = "instance"
+      }
+
+      rule {
+        action = "labeldrop"
+        regex = "exported_(namespace|pod|container|job|instance)"
+      }
+    } // prometheus.relabel "alloy"
+  }
+
+  alloy_integration_discovery "alloy" {
+    port_name = "http-metrics"
+    label_selectors = ["app.kubernetes.io/name in (alloy)"]
+  }
+
+  alloy_integration_scrape "alloy" {
+    targets = alloy_integration_discovery.alloy.output
+    job_label = "integrations/alloy"
+    clustering = true
+    keep_metrics = "up|scrape_samples_scraped|alloy_build_info|alloy_component_controller_running_components|alloy_component_dependencies_wait_seconds|alloy_component_dependencies_wait_seconds_bucket|alloy_component_evaluation_seconds|alloy_component_evaluation_seconds_bucket|alloy_component_evaluation_seconds_count|alloy_component_evaluation_seconds_sum|alloy_component_evaluation_slow_seconds|alloy_config_hash|alloy_resources_machine_rx_bytes_total|alloy_resources_machine_tx_bytes_total|alloy_resources_process_cpu_seconds_total|alloy_resources_process_resident_memory_bytes|alloy_tcp_connections|alloy_wal_samples_appended_total|alloy_wal_storage_active_series|cluster_node_gossip_health_score|cluster_node_gossip_proto_version|cluster_node_gossip_received_events_total|cluster_node_info|cluster_node_lamport_time|cluster_node_peers|cluster_node_update_observers|cluster_transport_rx_bytes_total|cluster_transport_rx_packet_queue_length|cluster_transport_rx_packets_failed_total|cluster_transport_rx_packets_total|cluster_transport_stream_rx_bytes_total|cluster_transport_stream_rx_packets_failed_total|cluster_transport_stream_rx_packets_total|cluster_transport_stream_tx_bytes_total|cluster_transport_stream_tx_packets_failed_total|cluster_transport_stream_tx_packets_total|cluster_transport_streams|cluster_transport_tx_bytes_total|cluster_transport_tx_packet_queue_length|cluster_transport_tx_packets_failed_total|cluster_transport_tx_packets_total|otelcol_exporter_send_failed_spans_total|otelcol_exporter_sent_spans_total|go_gc_duration_seconds_count|go_goroutines|go_memstats_heap_inuse_bytes|loki_process_dropped_lines_total|loki_write_batch_retries_total|loki_write_dropped_bytes_total|loki_write_dropped_entries_total|loki_write_encoded_bytes_total|loki_write_mutated_bytes_total|loki_write_mutated_entries_total|loki_write_request_duration_seconds_bucket|loki_write_sent_bytes_total|loki_write_sent_entries_total|process_cpu_seconds_total|process_start_time_seconds|otelcol_processor_batch_batch_send_size_bucket|otelcol_processor_batch_metadata_cardinality|otelcol_processor_batch_timeout_trigger_send_total|prometheus_remote_storage_bytes_total|prometheus_remote_storage_enqueue_retries_total|prometheus_remote_storage_highest_timestamp_in_seconds|prometheus_remote_storage_metadata_bytes_total|prometheus_remote_storage_queue_highest_sent_timestamp_seconds|prometheus_remote_storage_samples_dropped_total|prometheus_remote_storage_samples_failed_total|prometheus_remote_storage_samples_pending|prometheus_remote_storage_samples_retried_total|prometheus_remote_storage_samples_total|prometheus_remote_storage_sent_batch_duration_seconds_bucket|prometheus_remote_storage_sent_batch_duration_seconds_count|prometheus_remote_storage_sent_batch_duration_seconds_sum|prometheus_remote_storage_shard_capacity|prometheus_remote_storage_shards|prometheus_remote_storage_shards_desired|prometheus_remote_storage_shards_max|prometheus_remote_storage_shards_min|prometheus_remote_storage_succeeded_samples_total|prometheus_remote_write_wal_samples_appended_total|prometheus_remote_write_wal_storage_active_series|prometheus_sd_discovered_targets|prometheus_target_interval_length_seconds_count|prometheus_target_interval_length_seconds_sum|prometheus_target_scrapes_exceeded_sample_limit_total|prometheus_target_scrapes_sample_duplicate_timestamp_total|prometheus_target_scrapes_sample_out_of_bounds_total|prometheus_target_scrapes_sample_out_of_order_total|prometheus_target_sync_length_seconds_sum|prometheus_wal_watcher_current_segment|otelcol_receiver_accepted_spans_total|otelcol_receiver_refused_spans_total|rpc_server_duration_milliseconds_bucket|scrape_duration_seconds|traces_exporter_send_failed_spans|traces_exporter_send_failed_spans_total|traces_exporter_sent_spans|traces_exporter_sent_spans_total|traces_loadbalancer_backend_outcome|traces_loadbalancer_num_backends|traces_receiver_accepted_spans|traces_receiver_accepted_spans_total|traces_receiver_refused_spans|traces_receiver_refused_spans_total"
+    scrape_interval = "60s"
+    scrape_timeout = "10s"
+    scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
+    scrape_classic_histograms = false
+    scrape_native_histograms = false
+    max_cache_size = 100000
+    forward_to = argument.metrics_destinations.value
+  }
+}
+alloy_integration "integration" {
+  metrics_destinations = [
+    otelcol.receiver.prometheus.otlp_gateway.receiver,
+  ]
+}
+
+
+// Feature: Pod Logs (Loki)
+declare "pod_logs_via_loki" {
+  argument "logs_destinations" {
+    comment = "Must be a list of log destinations where collected logs should be forwarded to"
+  }
+
+  discovery.kubernetes "pods" {
+    role = "pod"
+    selectors {
+      role = "pod"
+      field = "spec.nodeName=" + sys.env("HOSTNAME")
+    }
+  } // discovery.kubernetes "pods"
+
+  discovery.relabel "filtered_pods" {
+    targets = discovery.kubernetes.pods.targets
+    rule {
+      source_labels = ["__meta_kubernetes_namespace"]
+      action = "replace"
+      target_label = "namespace"
+    }
+    rule {  // Drop anything with a "falsy" annotation value
+      source_labels = ["__meta_kubernetes_pod_annotation_logs_grafana_com_pods_enabled"]
+      regex = "(false|no|skip)"
+      action = "drop"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_pod_name"]
+      target_label = "pod"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_pod_container_name"]
+      target_label = "container"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_namespace", "__meta_kubernetes_pod_container_name"]
+      separator = "/"
+      replacement = "$1"
+      target_label = "job"
+    }
+
+    // set the container runtime as a label
+    rule {
+      source_labels = ["__meta_kubernetes_pod_container_id"]
+      regex = "^(\\S+):\\/\\/.+$"
+      replacement = "$1"
+      target_label = "tmp_container_runtime"
+    }
+    // explicitly set service_name. if not set, loki will automatically try to populate a default.
+    // see https://grafana.com/docs/loki/latest/get-started/labels/#default-labels-for-all-users
+    //
+    // choose the first value found from the following ordered list:
+    // - pod.annotation[resource.opentelemetry.io/service.name]
+    // - pod.label[app.kubernetes.io/name]
+    // - k8s.container.name
+    rule {
+      source_labels = [
+        "__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_name",
+        "__meta_kubernetes_pod_label_app_kubernetes_io_name",
+        "__meta_kubernetes_pod_container_name",
+      ]
+      separator = ";"
+      regex = "^(?:;*)?([^;]+).*$"
+      replacement = "$1"
+      target_label = "service_name"
+    }
+
+    // explicitly set service_namespace.
+    //
+    // choose the first value found from the following ordered list:
+    // - pod.annotation[resource.opentelemetry.io/service.namespace]
+    // - pod.namespace
+    rule {
+      source_labels = [
+        "__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_namespace",
+        "namespace",
+      ]
+      separator = ";"
+      regex = "^(?:;*)?([^;]+).*$"
+      replacement = "$1"
+      target_label = "service_namespace"
+    }
+
+    // explicitly set service_instance_id.
+    //
+    // choose the first value found from the following ordered list:
+    // - pod.annotation[resource.opentelemetry.io/service.instance.id]
+    // - concat([k8s.namespace.name, k8s.pod.name, k8s.container.name], '.')
+    rule {
+      source_labels = ["__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_instance_id"]
+      target_label = "service_instance_id"
+    }
+    rule {
+      source_labels = ["service_instance_id", "namespace", "pod", "container"]
+      separator = "."
+      regex = "^\\.([^.]+\\.[^.]+\\.[^.]+)$"
+      target_label = "service_instance_id"
+    }
+
+    // set resource attributes
+    rule {
+      action = "labelmap"
+      regex = "__meta_kubernetes_pod_annotation_resource_opentelemetry_io_(.+)"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_job"]
+      regex = "(.+)"
+      target_label = "job"
+    }
+    rule {
+      source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+      regex = "(.+)"
+      target_label = "app_kubernetes_io_name"
+    }
+
+    // Set the pod log path.
+    rule {
+      source_labels = ["__meta_kubernetes_pod_uid", "__meta_kubernetes_pod_container_name"]
+      separator = "/"
+      replacement = "/var/log/pods/*$1/*.log"
+      target_label = "__path__"
+    }
+
+    // If kubernetes.io/config.mirror is set, this is a static pod, created by the kubelet.
+    // It's logs live on a different path.
+    rule {
+      source_labels = ["__meta_kubernetes_pod_annotation_kubernetes_io_config_mirror", "__meta_kubernetes_pod_container_name"]
+      separator = "/"
+      regex = "(.+/.+)"
+      replacement = "/var/log/pods/*$1/*.log"
+      target_label = "__path__"
+    }
+  } // discovery.relabel "filtered_pods"
+
+  local.file_match "pod_logs" {
+    path_targets = discovery.relabel.filtered_pods.output
+  } // local.file_match "pod_logs"
+
+  loki.source.file "pod_logs" {
+    targets    = local.file_match.pod_logs.targets
+    tail_from_end = true
+    forward_to = [loki.process.pod_logs.receiver]
+  } // loki.source.file "pod_logs"
+
+  loki.process "pod_logs" {
+    stage.match {
+      selector = "{tmp_container_runtime=~\"containerd|cri-o|\"}"
+      // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
+      stage.cri {
+        max_partial_lines = 100
+      }
+
+      // Set the extract flags and stream values as labels
+      stage.labels {
+        values = {
+          flags  = "",
+          stream  = "",
+        }
+      }
+    }
+
+    stage.match {
+      selector = "{tmp_container_runtime=\"docker\"}"
+      // the docker processing stage extracts the following k/v pairs: log, stream, time
+      stage.docker {}
+
+      // Set the extract stream value as a label
+      stage.labels {
+        values = {
+          stream  = "",
+        }
+      }
+    }
+
+    // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
+    // namespace, pod, and container labels. Drop any structured metadata. Also drop the temporary
+    // container runtime label as it is no longer needed.
+    stage.label_drop {
+      values = [
+        "filename",
+        "tmp_container_runtime",
+      ]
+    }
+    stage.structured_metadata {
+      values = {
+        "k8s_pod_name" = "k8s_pod_name",
+        "pod" = "pod",
+        "service_instance_id" = "service_instance_id",
+      }
+    }
+
+    forward_to = argument.logs_destinations.value
+  } // loki.secretfilter "pod_logs"
+} // declare "pod_logs_via_loki"
+pod_logs_via_loki "feature" {
+  logs_destinations = [
+    otelcol.receiver.loki.otlp_gateway.receiver,
+  ]
+}
+
+
+
+
+
+
+// Self Reporting
+prometheus.exporter.unix "kubernetes_monitoring_telemetry" {
+  set_collectors = ["textfile"]
+  textfile {
+    directory = "/etc/release-info"
+  }
+} // prometheus.exporter.unix "kubernetes_monitoring_telemetry"
+
+discovery.relabel "kubernetes_monitoring_telemetry" {
+  targets = prometheus.exporter.unix.kubernetes_monitoring_telemetry.targets
+  rule {
+    target_label = "instance"
+    action = "replace"
+    replacement = "k8smon"
+  }
+  rule {
+    target_label = "job"
+    action = "replace"
+    replacement = "integrations/kubernetes/kubernetes_monitoring_telemetry"
+  }
+} // discovery.relabel "kubernetes_monitoring_telemetry"
+
+prometheus.scrape "kubernetes_monitoring_telemetry" {
+  job_name   = "integrations/kubernetes/kubernetes_monitoring_telemetry"
+  targets    = discovery.relabel.kubernetes_monitoring_telemetry.output
+  scrape_interval = "60s"
+  clustering {
+    enabled = true
+  }
+  forward_to = [prometheus.relabel.kubernetes_monitoring_telemetry.receiver]
+} // prometheus.scrape "kubernetes_monitoring_telemetry"
+
+prometheus.relabel "kubernetes_monitoring_telemetry" {
+  rule {
+    source_labels = ["__name__"]
+    regex = "grafana_kubernetes_monitoring_.*"
+    action = "keep"
+  }
+  forward_to = [
+    otelcol.receiver.prometheus.otlp_gateway.receiver,
+  ]
+} // prometheus.relabel "kubernetes_monitoring_telemetry"
+
+
+
+
+
+// Destination: otlp-gateway (otlp)
+otelcol.receiver.prometheus "otlp_gateway" {
+  output {
+    metrics = [otelcol.processor.transform.otlp_gateway_scrape_normalize.input]
+  }
+} // otelcol.receiver.prometheus "otlp_gateway"
+
+// Repairs artifacts of the Prometheus-to-OTLP conversion performed by
+// otelcol.receiver.prometheus. Only metrics that came from a Prometheus scrape pass
+// through this component; OTLP-native telemetry enters the pipeline further down.
+otelcol.processor.transform "otlp_gateway_scrape_normalize" {
+  error_mode = "ignore"
+  metric_statements {
+    context = "resource"
+    statements = [
+      // The conversion sets service.name to the full Prometheus job label (e.g.
+      // "namespace/workload"). When the scrape target declares its identity explicitly
+      // with a service_name label on its own target_info metric (e.g. Grafana Beyla),
+      // prefer that value and drop the duplicate.
+      `set(attributes["service.name"], attributes["service_name"]) where attributes["service_name"] != nil and attributes["service_name"] != ""`,
+      `delete_key(attributes, "service_name") where attributes["service_name"] == attributes["service.name"]`,
+      // The same conversion turns other flat target_info labels into resource attributes.
+      // Promote them to their OpenTelemetry counterparts and drop the flat duplicates, so
+      // the OTLP endpoint does not receive two conflicting spellings of the same attribute.
+      `set(attributes["service.namespace"], attributes["service_namespace"]) where (attributes["service.namespace"] == nil or attributes["service.namespace"] == "") and attributes["service_namespace"] != nil and attributes["service_namespace"] != ""`,
+      `delete_key(attributes, "service_namespace") where attributes["service_namespace"] == attributes["service.namespace"]`,
+      `set(attributes["deployment.environment"], attributes["deployment_environment"]) where (attributes["deployment.environment"] == nil or attributes["deployment.environment"] == "") and attributes["deployment_environment"] != nil and attributes["deployment_environment"] != ""`,
+      `delete_key(attributes, "deployment_environment") where attributes["deployment_environment"] == attributes["deployment.environment"]`,
+      `set(attributes["deployment.environment.name"], attributes["deployment_environment_name"]) where (attributes["deployment.environment.name"] == nil or attributes["deployment.environment.name"] == "") and attributes["deployment_environment_name"] != nil and attributes["deployment_environment_name"] != ""`,
+      `delete_key(attributes, "deployment_environment_name") where attributes["deployment_environment_name"] == attributes["deployment.environment.name"]`,
+    ]
+  }
+  metric_statements {
+    context = "datapoint"
+    statements = [
+      // Same correction for scrape targets that put service_name on every series
+      // instead of exposing a target_info metric.
+      `set(resource.attributes["service.name"], attributes["service_name"]) where attributes["service_name"] != nil and attributes["service_name"] != ""`,
+    ]
+  }
+  output {
+    metrics = [otelcol.processor.attributes.otlp_gateway.input]
+  }
+} // otelcol.processor.transform "otlp_gateway_scrape_normalize"
+otelcol.receiver.loki "otlp_gateway" {
+  output {
+    logs = [otelcol.processor.attributes.otlp_gateway.input]
+  }
+} // otelcol.receiver.loki "otlp_gateway"
+otelcol.processor.attributes "otlp_gateway" {
+  output {
+    metrics = [otelcol.processor.transform.otlp_gateway.input]
+    logs = [otelcol.processor.transform.otlp_gateway.input]
+    traces = [otelcol.processor.transform.otlp_gateway.input]
+  }
+} // otelcol.processor.attributes "otlp_gateway"
+
+otelcol.processor.transform "otlp_gateway" {
+  error_mode = "ignore"
+  metric_statements {
+    context = "resource"
+    statements = [
+      `set(attributes["cluster"], "otlp-gateway-test")`,
+      `set(attributes["k8s.cluster.name"], "otlp-gateway-test")`,
+      `delete_key(attributes, "process.pid")`,
+      `delete_key(attributes, "process.parent_pid")`,
+      `delete_key(attributes, "process.executable.path")`,
+      `delete_key(attributes, "process.command_line")`,
+      `delete_key(attributes, "process.command_args")`,
+      `delete_key(attributes, "process.owner")`,
+      `delete_key(attributes, "process.runtime.version")`,
+      `delete_key(attributes, "process.runtime.description")`,
+      `delete_key(attributes, "host.ip")`,
+      `delete_key(attributes, "host.mac")`,
+      `delete_key(attributes, "k8s.pod.start_time")`,
+      `delete_key(attributes, "k8s.pod.uid")`,
+      `delete_key(attributes, "container.image.id")`,
+      `delete_key(attributes, "container.image.repo_digests")`,
+      `delete_key(attributes, "os.description")`,
+      `delete_key(attributes, "os.build_id")`,
+      // Scrape targets that expose their own target_info metric (e.g. Grafana Beyla) can
+      // carry a flat k8s_cluster_name resource attribute, which conflicts with the
+      // k8s.cluster.name attribute set above and gets ";"-joined by the Prometheus OTLP
+      // endpoint. Drop the flat copy when the values match.
+      `delete_key(attributes, "k8s_cluster_name") where attributes["k8s_cluster_name"] == attributes["k8s.cluster.name"]`,
+    ]
+  }
+
+  metric_statements {
+    context = "datapoint"
+    statements = [
+      `set(attributes["cluster"], "otlp-gateway-test")`,
+      `set(attributes["k8s.cluster.name"], "otlp-gateway-test")`,
+      `set(resource.attributes["deployment.environment"], attributes["deployment_environment"] ) where resource.attributes["deployment.environment"] == nil and attributes["deployment_environment"] != nil`,
+      `delete_key(attributes, "deployment_environment") where attributes["deployment_environment"] == resource.attributes["deployment.environment"]`,
+      `set(resource.attributes["deployment.environment.name"], attributes["deployment_environment_name"] ) where resource.attributes["deployment.environment.name"] == nil and attributes["deployment_environment_name"] != nil`,
+      `delete_key(attributes, "deployment_environment_name") where attributes["deployment_environment_name"] == resource.attributes["deployment.environment.name"]`,
+      `set(resource.attributes["service.name"], attributes["service_name"] ) where (resource.attributes["service.name"] == nil or resource.attributes["service.name"] == "") and attributes["service_name"] != nil and attributes["service_name"] != ""`,
+      `delete_key(attributes, "service_name") where attributes["service_name"] == resource.attributes["service.name"]`,
+      `set(resource.attributes["service.namespace"], attributes["service_namespace"] ) where (resource.attributes["service.namespace"] == nil or resource.attributes["service.namespace"] == "") and attributes["service_namespace"] != nil and attributes["service_namespace"] != ""`,
+      `delete_key(attributes, "service_namespace") where attributes["service_namespace"] == resource.attributes["service.namespace"]`,
+    ]
+  }
+  log_statements {
+    context = "resource"
+    statements = [
+      `set(attributes["cluster"], "otlp-gateway-test")`,
+      `set(attributes["k8s.cluster.name"], "otlp-gateway-test")`,
+      `delete_key(attributes, "process.pid")`,
+      `delete_key(attributes, "process.parent_pid")`,
+      `delete_key(attributes, "process.executable.path")`,
+      `delete_key(attributes, "process.command_line")`,
+      `delete_key(attributes, "process.command_args")`,
+      `delete_key(attributes, "process.owner")`,
+      `delete_key(attributes, "process.runtime.version")`,
+      `delete_key(attributes, "process.runtime.description")`,
+      `delete_key(attributes, "host.ip")`,
+      `delete_key(attributes, "host.mac")`,
+      `delete_key(attributes, "k8s.pod.start_time")`,
+      `delete_key(attributes, "k8s.pod.uid")`,
+      `delete_key(attributes, "container.image.id")`,
+      `delete_key(attributes, "container.image.repo_digests")`,
+      `delete_key(attributes, "os.description")`,
+      `delete_key(attributes, "os.build_id")`,
+    ]
+  }
+
+  log_statements {
+    context = "log"
+    statements = [
+      `delete_key(attributes, "loki.attribute.labels")`,
+      `delete_key(attributes, "loki.resource.labels")`,
+      `set(resource.attributes["k8s.container.name"], attributes["container"] ) where resource.attributes["k8s.container.name"] == nil and attributes["container"] != nil`,
+      `delete_key(attributes, "container") where attributes["container"] == resource.attributes["k8s.container.name"]`,
+      `set(resource.attributes["k8s.cronjob.name"], attributes["cronjob"] ) where resource.attributes["k8s.cronjob.name"] == nil and attributes["cronjob"] != nil`,
+      `delete_key(attributes, "cronjob") where attributes["cronjob"] == resource.attributes["k8s.cronjob.name"]`,
+      `set(resource.attributes["k8s.daemonset.name"], attributes["daemonset"] ) where resource.attributes["k8s.daemonset.name"] == nil and attributes["daemonset"] != nil`,
+      `delete_key(attributes, "daemonset") where attributes["daemonset"] == resource.attributes["k8s.daemonset.name"]`,
+      `set(resource.attributes["k8s.deployment.name"], attributes["deployment"] ) where resource.attributes["k8s.deployment.name"] == nil and attributes["deployment"] != nil`,
+      `delete_key(attributes, "deployment") where attributes["deployment"] == resource.attributes["k8s.deployment.name"]`,
+      `set(resource.attributes["deployment.environment"], attributes["deployment_environment"] ) where resource.attributes["deployment.environment"] == nil and attributes["deployment_environment"] != nil`,
+      `delete_key(attributes, "deployment_environment") where attributes["deployment_environment"] == resource.attributes["deployment.environment"]`,
+      `set(resource.attributes["deployment.environment.name"], attributes["deployment_environment_name"] ) where resource.attributes["deployment.environment.name"] == nil and attributes["deployment_environment_name"] != nil`,
+      `delete_key(attributes, "deployment_environment_name") where attributes["deployment_environment_name"] == resource.attributes["deployment.environment.name"]`,
+      `set(resource.attributes["k8s.job.name"], attributes["job_name"] ) where resource.attributes["k8s.job.name"] == nil and attributes["job_name"] != nil`,
+      `delete_key(attributes, "job_name") where attributes["job_name"] == resource.attributes["k8s.job.name"]`,
+      `set(resource.attributes["k8s.namespace.name"], attributes["namespace"] ) where resource.attributes["k8s.namespace.name"] == nil and attributes["namespace"] != nil`,
+      `delete_key(attributes, "namespace") where attributes["namespace"] == resource.attributes["k8s.namespace.name"]`,
+      `set(resource.attributes["k8s.pod.name"], attributes["pod"] ) where resource.attributes["k8s.pod.name"] == nil and attributes["pod"] != nil`,
+      `delete_key(attributes, "pod") where attributes["pod"] == resource.attributes["k8s.pod.name"]`,
+      `set(resource.attributes["k8s.replicaset.name"], attributes["replicaset"] ) where resource.attributes["k8s.replicaset.name"] == nil and attributes["replicaset"] != nil`,
+      `delete_key(attributes, "replicaset") where attributes["replicaset"] == resource.attributes["k8s.replicaset.name"]`,
+      `set(resource.attributes["service.name"], attributes["service_name"] ) where (resource.attributes["service.name"] == nil or resource.attributes["service.name"] == "") and attributes["service_name"] != nil and attributes["service_name"] != ""`,
+      `delete_key(attributes, "service_name") where attributes["service_name"] == resource.attributes["service.name"]`,
+      `set(resource.attributes["service.namespace"], attributes["service_namespace"] ) where (resource.attributes["service.namespace"] == nil or resource.attributes["service.namespace"] == "") and attributes["service_namespace"] != nil and attributes["service_namespace"] != ""`,
+      `delete_key(attributes, "service_namespace") where attributes["service_namespace"] == resource.attributes["service.namespace"]`,
+      `set(resource.attributes["k8s.statefulset.name"], attributes["statefulset"] ) where resource.attributes["k8s.statefulset.name"] == nil and attributes["statefulset"] != nil`,
+      `delete_key(attributes, "statefulset") where attributes["statefulset"] == resource.attributes["k8s.statefulset.name"]`,
+    ]
+  }
+
+  trace_statements {
+    context = "resource"
+    statements = [
+      `set(attributes["cluster"], "otlp-gateway-test")`,
+      `set(attributes["k8s.cluster.name"], "otlp-gateway-test")`,
+      `delete_key(attributes, "process.pid")`,
+      `delete_key(attributes, "process.parent_pid")`,
+      `delete_key(attributes, "process.executable.path")`,
+      `delete_key(attributes, "process.command_line")`,
+      `delete_key(attributes, "process.command_args")`,
+      `delete_key(attributes, "process.owner")`,
+      `delete_key(attributes, "process.runtime.version")`,
+      `delete_key(attributes, "process.runtime.description")`,
+      `delete_key(attributes, "host.ip")`,
+      `delete_key(attributes, "host.mac")`,
+      `delete_key(attributes, "k8s.pod.start_time")`,
+      `delete_key(attributes, "k8s.pod.uid")`,
+      `delete_key(attributes, "container.image.id")`,
+      `delete_key(attributes, "container.image.repo_digests")`,
+      `delete_key(attributes, "os.description")`,
+      `delete_key(attributes, "os.build_id")`,
+    ]
+  }
+
+  output {
+    metrics = [otelcol.processor.batch.otlp_gateway.input]
+    logs = [otelcol.processor.batch.otlp_gateway.input]
+    traces = [otelcol.processor.batch.otlp_gateway.input]
+  }
+} // otelcol.processor.transform "otlp_gateway"
+
+otelcol.processor.batch "otlp_gateway" {
+  timeout = "2s"
+  send_batch_size = 8192
+  send_batch_max_size = 0
+
+  output {
+    metrics = [otelcol.exporter.otlphttp.otlp_gateway.input]
+    logs = [otelcol.exporter.otlphttp.otlp_gateway.input]
+    traces = [otelcol.exporter.otlphttp.otlp_gateway.input]
+  }
+} // otelcol.processor.batch "otlp_gateway"
+otelcol.exporter.otlphttp "otlp_gateway" {
+  client {
+    endpoint = "https://otlp-gateway-prod-us-east-0.grafana.net/otlp"
+    auth = otelcol.auth.basic.otlp_gateway.handler
+    headers = {
+      "X-Scope-OrgID" = convert.nonsensitive(remote.kubernetes.secret.otlp_gateway.data["tenantId"]),
+    }
+    tls {
+      insecure = false
+      insecure_skip_verify = false
+      ca_pem = convert.nonsensitive(remote.kubernetes.secret.otlp_gateway.data["ca"])
+      cert_pem = convert.nonsensitive(remote.kubernetes.secret.otlp_gateway.data["cert"])
+      key_pem = remote.kubernetes.secret.otlp_gateway.data["key"]
+    }
+  }
+
+  retry_on_failure {
+    enabled = true
+    initial_interval = "5s"
+    max_interval = "30s"
+    max_elapsed_time = "5m"
+  }
+
+  sending_queue {
+    enabled = true
+  }
+} // otelcol.exporter.otlphttp "otlp_gateway"
+
+otelcol.auth.basic "otlp_gateway" {
+  username = convert.nonsensitive(remote.kubernetes.secret.otlp_gateway.data["OTLP_GATEWAY_USER"])
+  password = remote.kubernetes.secret.otlp_gateway.data["OTLP_GATEWAY_PASS"]
+} // otelcol.auth.basic "otlp_gateway"
+
+remote.kubernetes.secret "otlp_gateway" {
+  name      = "grafana-cloud-credentials"
+  namespace = "default"
+} // remote.kubernetes.secret "otlp_gateway"
+

--- a/charts/k8s-monitoring/tests/platform/remote-config/.rendered/alloy-logs.alloy
+++ b/charts/k8s-monitoring/tests/platform/remote-config/.rendered/alloy-logs.alloy
@@ -1,0 +1,32 @@
+remote.kubernetes.secret "alloy_logs_remote_cfg" {
+  name      = "grafana-cloud-credentials"
+  namespace = "default"
+} // remote.kubernetes.secret "alloy_logs_remote_cfg"
+
+remotecfg {
+  id = string.format("k8smon-%s-%s-%s-%s", "remote-config-test", "default", "alloy-logs", sys.env("K8S_NODE_NAME"))
+  url = "https://fleet-management-prod-008.grafana.net"
+  basic_auth {
+    username = convert.nonsensitive(remote.kubernetes.secret.alloy_logs_remote_cfg.data["GRAFANA_CLOUD_FLEET_MGMT_USER"])
+    password = remote.kubernetes.secret.alloy_logs_remote_cfg.data["GRAFANA_CLOUD_FLEET_MGMT_TOKEN"]
+  }
+  tls_config {
+    insecure_skip_verify = false
+    ca_pem = convert.nonsensitive(remote.kubernetes.secret.alloy_logs_remote_cfg.data["ca"])
+    cert_pem = convert.nonsensitive(remote.kubernetes.secret.alloy_logs_remote_cfg.data["cert"])
+    key_pem = remote.kubernetes.secret.alloy_logs_remote_cfg.data["key"]
+  }
+  poll_frequency = "30s"
+  attributes = {
+    "cluster" = "remote-config-test",
+    "namespace" = "default",
+    "platform" = "kubernetes",
+    "presets" = "filesystem-log-reader,daemonset",
+    "release" = "k8smon",
+    "source" = "k8s-monitoring",
+    "sourceVersion" = "4.3.0",
+    "workloadName" = "alloy-logs",
+    "workloadType" = "daemonset",
+  }
+}
+

--- a/charts/k8s-monitoring/tests/platform/remote-config/.rendered/alloy-metrics.alloy
+++ b/charts/k8s-monitoring/tests/platform/remote-config/.rendered/alloy-metrics.alloy
@@ -1,0 +1,32 @@
+remote.kubernetes.secret "alloy_metrics_remote_cfg" {
+  name      = "grafana-cloud-credentials"
+  namespace = "default"
+} // remote.kubernetes.secret "alloy_metrics_remote_cfg"
+
+remotecfg {
+  id = string.format("k8smon-%s-%s-%s", "remote-config-test", "default", constants.hostname)
+  url = "https://fleet-management-prod-008.grafana.net"
+  basic_auth {
+    username = convert.nonsensitive(remote.kubernetes.secret.alloy_metrics_remote_cfg.data["GRAFANA_CLOUD_FLEET_MGMT_USER"])
+    password = remote.kubernetes.secret.alloy_metrics_remote_cfg.data["GRAFANA_CLOUD_FLEET_MGMT_TOKEN"]
+  }
+  tls_config {
+    insecure_skip_verify = false
+    ca_pem = convert.nonsensitive(remote.kubernetes.secret.alloy_metrics_remote_cfg.data["ca"])
+    cert_pem = convert.nonsensitive(remote.kubernetes.secret.alloy_metrics_remote_cfg.data["cert"])
+    key_pem = remote.kubernetes.secret.alloy_metrics_remote_cfg.data["key"]
+  }
+  poll_frequency = "30s"
+  attributes = {
+    "cluster" = "remote-config-test",
+    "namespace" = "default",
+    "platform" = "kubernetes",
+    "presets" = "clustered,statefulset",
+    "release" = "k8smon",
+    "source" = "k8s-monitoring",
+    "sourceVersion" = "4.3.0",
+    "workloadName" = "alloy-metrics",
+    "workloadType" = "statefulset",
+  }
+}
+


### PR DESCRIPTION
# Description

Big improvements to the makefiles:

* All docker images have their versions set and extracted, along with comments that will let Renovate know how to update them.
* Dependencies have been improved in charts/k8s-monitoring/Makefile, so it's fully compatible with `-j $(nproc)`, so you can clean, then run a build in parallel without issues.
* Telemetry service's signed chart verification will cache results for 24 hours, so repeat builds don't take ~8s.
* Other minor improvements to reduce irrelevant calls.

## Results:

#### Remaking charts/k8s-monitoring/README.md when only the README.md.gotmpl file has changed:

```shell
$ touch README.md.gotmpl
$ time make README.md
```

| `main` | `petewall/optimize-makefile-variables` | Improvement |
| --- | --- | --- |
| 4.078s | 0.885s | 78% |

#### Full rebuild (using nproc)

```shell
$ make clean
$ time make -j $(nproc) build
```

| `main` | `petewall/optimize-makefile-variables` | Improvement |
| --- | --- | --- |
| 38.726 (had to run twice) | 32.538s | 16% |

#### Build with no changes

```shell
$ make build  # ensure everything is up to date
$ time make -j $(nproc) build
```

| `main` | `petewall/optimize-makefile-variables` | Improvement |
| --- | --- | --- |
| 9.921s | 0.917 | 91% |

## Authorship

-   [X] I, a human, wrote this pull request description myself.

<!--Please delete paragraphs that you did not use before submitting.-->
