### PR TITLE
Fix applicationObservability exemplars.maxPerDataPoint schema

### DIFF
--- a/charts/k8s-monitoring/charts/feature-application-observability/README.md
+++ b/charts/k8s-monitoring/charts/feature-application-observability/README.md
@@ -115,7 +115,7 @@ Be sure perform actual integration testing in a live environment in the main [k8
 | connectors.spanMetrics.events.enabled | bool | `false` | Capture events metrics, which track span events. |
 | connectors.spanMetrics.excludeDimensions | list | `[]` | List of dimensions to be excluded from the default set of dimensions. |
 | connectors.spanMetrics.exemplars.enabled | bool | `false` | Attach exemplars to histograms. |
-| connectors.spanMetrics.exemplars.maxPerDataPoint | number | `nil` | Limits the number of exemplars that can be added to a unique dimension set. |
+| connectors.spanMetrics.exemplars.maxPerDataPoint | int | `nil` | Limits the number of exemplars that can be added to a unique dimension set. |
 | connectors.spanMetrics.histogram.enabled | bool | `true` | Capture histogram metrics, derived from spans’ durations. |
 | connectors.spanMetrics.histogram.explicit.buckets | list | `["2ms","4ms","6ms","8ms","10ms","50ms","100ms","200ms","400ms","800ms","1s","1400ms","2s","5s","10s","15s"]` | The histogram buckets to use. |
 | connectors.spanMetrics.histogram.exponential.maxSize | int | `160` | Maximum number of buckets per positive or negative number range. |

--- a/charts/k8s-monitoring/charts/feature-application-observability/schema-mods/types-and-enums.json
+++ b/charts/k8s-monitoring/charts/feature-application-observability/schema-mods/types-and-enums.json
@@ -4,6 +4,7 @@
       "properties": {
         "spanMetrics": {
           "properties": {
+            "exemplars": {"properties": {"maxPerDataPoint": {"type": ["integer", "null"]}}},
             "histogram": {"properties": {"type": {"enum": ["explicit", "exponential"]}}},
             "metricsExpiration": {"type": ["string", "null"]},
             "seriesExpiration": {"type": ["string", "null"]}

--- a/charts/k8s-monitoring/charts/feature-application-observability/values.schema.json
+++ b/charts/k8s-monitoring/charts/feature-application-observability/values.schema.json
@@ -78,7 +78,10 @@
                                     "type": "boolean"
                                 },
                                 "maxPerDataPoint": {
-                                    "type": "null"
+                                    "type": [
+                                        "integer",
+                                        "null"
+                                    ]
                                 }
                             }
                         },

--- a/charts/k8s-monitoring/charts/feature-application-observability/values.yaml
+++ b/charts/k8s-monitoring/charts/feature-application-observability/values.yaml
@@ -405,7 +405,7 @@ connectors:
       # @section -- Connectors: Span Metrics
       enabled: false
 
-      # -- (number) Limits the number of exemplars that can be added to a unique dimension set.
+      # -- (int) Limits the number of exemplars that can be added to a unique dimension set.
       # @section -- Connectors: Span Metrics
       maxPerDataPoint:
 


### PR DESCRIPTION
<!--Describe what this change does and why.-->
# Description

Fixes applicationObservability schema restriction disallowing valid/expected values for `connectors.spanMetrics.exemplars.maxPerDataPoint`

Retained the original `null` type in schema as well so the existing default null value remains valid.

Fixes #2894 

<!--Authorship attestation. See AGENTS.md for details. AI agents must not check this box on behalf
of the user; the human author must check it themselves before the PR is ready for review.-->
## Authorship

-   [x] I, a human, wrote this pull request description myself.

<!--Please delete paragraphs that you did not use before submitting.-->
