### PR TITLE
Add a flag to override `unknown_service` service names

### DIFF
--- a/charts/k8s-monitoring/CHANGELOG.md
+++ b/charts/k8s-monitoring/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+*   Add an `overrideUnknownServiceNames` option to the Application Observability feature. When enabled, the `service.name` resource attribute will be overridden if its value is `unknown_service*`. (@petewall)
 *   Update Windows Exporter to 0.12.8 (@petewall)
 
 ## 4.3.1

--- a/charts/k8s-monitoring/charts/feature-application-observability/README.md
+++ b/charts/k8s-monitoring/charts/feature-application-observability/README.md
@@ -45,7 +45,10 @@ When the flag is enabled, `service.name` is set to the first value found from th
 application, then the `resource.opentelemetry.io/service.namespace` pod annotation, then the pod namespace.
 
 Note: OpenTelemetry SDKs that are not configured with a service name report `unknown_service:<language>`. Because that
-counts as a reported value, the fallback list does not apply to it.
+counts as a reported value, the fallback list does not apply to it. Set `overrideUnknownServiceNames: true` to delete
+the `service.name` resource attribute whenever it matches this `unknown_service` default, so it is treated as unset. When
+combined with `alignServiceNameWithOTelSemConv`, the fallback list above then fills in a meaningful name instead of
+leaving `unknown_service:<language>`.
 
 To pin a specific service name for a workload, set the `resource.opentelemetry.io/service.name` annotation on the pod.
 
@@ -84,6 +87,7 @@ Be sure perform actual integration testing in a live environment in the main [k8
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | alignServiceNameWithOTelSemConv | bool | `false` | Align the `service.name` and `service.namespace` resource attributes with the [OpenTelemetry semantic conventions for Kubernetes attributes](https://opentelemetry.io/docs/specs/semconv/non-normative/k8s-attributes/) (which is what Grafana Beyla uses) when the application has not reported them itself. When enabled, the detection chain becomes: pod annotation `resource.opentelemetry.io/service.name` → pod label `app.kubernetes.io/instance` → pod label `app.kubernetes.io/name` → owner workload name (Deployment, StatefulSet, etc.) → pod name. Enabling this also enables `processors.k8sattributes.otelAnnotations`. |
+| overrideUnknownServiceNames | bool | `false` | If the incoming `service.name` attribute is `unknown_service`, then override it with a value based on Kubernetes annotations, attributes, or names. This can happen if the application is using an OpenTelemetry SDKs but did not configure with a service name. Most useful when combined with `alignServiceNameWithOTelSemConv`. |
 
 ### Connectors: Grafana Cloud Host Info
 

--- a/charts/k8s-monitoring/charts/feature-application-observability/README.md.gotmpl
+++ b/charts/k8s-monitoring/charts/feature-application-observability/README.md.gotmpl
@@ -47,7 +47,10 @@ When the flag is enabled, `service.name` is set to the first value found from th
 application, then the `resource.opentelemetry.io/service.namespace` pod annotation, then the pod namespace.
 
 Note: OpenTelemetry SDKs that are not configured with a service name report `unknown_service:<language>`. Because that
-counts as a reported value, the fallback list does not apply to it.
+counts as a reported value, the fallback list does not apply to it. Set `overrideUnknownServiceNames: true` to delete
+the `service.name` resource attribute whenever it matches this `unknown_service` default, so it is treated as unset. When
+combined with `alignServiceNameWithOTelSemConv`, the fallback list above then fills in a meaningful name instead of
+leaving `unknown_service:<language>`.
 
 To pin a specific service name for a workload, set the `resource.opentelemetry.io/service.name` annotation on the pod.
 

--- a/charts/k8s-monitoring/charts/feature-application-observability/templates/_processor_transform.tpl
+++ b/charts/k8s-monitoring/charts/feature-application-observability/templates/_processor_transform.tpl
@@ -1,6 +1,7 @@
 {{/* Inputs: Values (values) metricsOutput, logsOutput, tracesOutput, name */}}
 {{/* https://grafana.com/docs/alloy/latest/reference/components/otelcol/otelcol.processor.transform/ */}}
 {{- define "feature.applicationObservability.processor.transform.alloy.target" }}otelcol.processor.transform.{{ .name | default "default" }}.input{{ end }}
+
 {{/*
 Fallback statements to detect service.name and service.namespace when not set by the application or by the
 resource.opentelemetry.io/* pod annotations (extracted by the k8sattributes processor). Follows the OpenTelemetry
@@ -32,21 +33,30 @@ semantic conventions for Kubernetes service names: instance label, name label, w
 `delete_key(resource.attributes, "k8s_monitoring.tmp.instance")`,
 `delete_key(resource.attributes, "k8s_monitoring.tmp.name")`,
 {{- end }}
+
+{{/*
+Delete the service.name resource attribute when it is an OpenTelemetry SDK default (unknown_service*), so the value is
+treated as unset. This runs before the service.name detection statements, so the fallback detection can populate a
+meaningful name in its place.
+*/}}
+{{- define "feature.applicationObservability.processor.transform.overrideUnknownServiceNameStatements" }}
+// Drop the OpenTelemetry SDK default service.name (unknown_service*) so it is treated as unset
+`delete_key(resource.attributes, "service.name") where resource.attributes["service.name"] != nil and IsMatch(resource.attributes["service.name"], "^unknown_service")`,
+{{- end }}
 {{- define "feature.applicationObservability.processor.transform.alloy" }}
 otelcol.processor.transform "{{ .name | default "default" }}" {
   error_mode = {{ .Values.processors.transform.errorMode | quote }}
 
 {{- if .Values.metrics.enabled }}
-{{- if or .Values.metrics.transforms.resource .Values.alignServiceNameWithOTelSemConv }}
+{{- if or .Values.metrics.transforms.resource .Values.alignServiceNameWithOTelSemConv .Values.overrideUnknownServiceNames }}
   metric_statements {
     context = "resource"
     statements = [
 {{- range $transform := .Values.metrics.transforms.resource }}
 {{ $transform | quote | indent 6 }},
 {{- end }}
-{{- if .Values.alignServiceNameWithOTelSemConv }}
-{{- include "feature.applicationObservability.processor.transform.serviceDetectionStatements" . | indent 6 }}
-{{- end }}
+{{- if .Values.overrideUnknownServiceNames }}{{- include "feature.applicationObservability.processor.transform.overrideUnknownServiceNameStatements" . | indent 6 }}{{- end }}
+{{- if .Values.alignServiceNameWithOTelSemConv }}{{- include "feature.applicationObservability.processor.transform.serviceDetectionStatements" . | indent 6 }}{{- end }}
     ]
   }
 {{- end }}
@@ -83,9 +93,8 @@ otelcol.processor.transform "{{ .name | default "default" }}" {
       "set(attributes[\"pod\"], attributes[\"k8s.pod.name\"])",
       "set(attributes[\"namespace\"], attributes[\"k8s.namespace.name\"])",
       "set(attributes[\"loki.resource.labels\"], \"{{ .Values.logs.transforms.labels | join ", " }}\")",
-{{- if .Values.alignServiceNameWithOTelSemConv }}
-{{- include "feature.applicationObservability.processor.transform.serviceDetectionStatements" . | indent 6 }}
-{{- end }}
+{{- if .Values.overrideUnknownServiceNames }}{{- include "feature.applicationObservability.processor.transform.overrideUnknownServiceNameStatements" . | indent 6 }}{{- end }}
+{{- if .Values.alignServiceNameWithOTelSemConv }}{{- include "feature.applicationObservability.processor.transform.serviceDetectionStatements" . | indent 6 }}{{- end }}
     ]
   }
 {{- if .Values.logs.transforms.log }}
@@ -100,16 +109,15 @@ otelcol.processor.transform "{{ .name | default "default" }}" {
 {{- end }}
 {{- end }}
 {{- if .Values.traces.enabled }}
-{{- if or .Values.traces.transforms.resource .Values.alignServiceNameWithOTelSemConv }}
+{{- if or .Values.traces.transforms.resource .Values.alignServiceNameWithOTelSemConv .Values.overrideUnknownServiceNames }}
   trace_statements {
     context = "resource"
     statements = [
 {{- range $transform := .Values.traces.transforms.resource }}
 {{ $transform | quote | indent 6 }},
 {{- end }}
-{{- if .Values.alignServiceNameWithOTelSemConv }}
-{{- include "feature.applicationObservability.processor.transform.serviceDetectionStatements" . | indent 6 }}
-{{- end }}
+{{- if .Values.overrideUnknownServiceNames }}{{- include "feature.applicationObservability.processor.transform.overrideUnknownServiceNameStatements" . | indent 6 }}{{- end }}
+{{- if .Values.alignServiceNameWithOTelSemConv }}{{- include "feature.applicationObservability.processor.transform.serviceDetectionStatements" . | indent 6 }}{{- end }}
     ]
   }
 {{- end }}

--- a/charts/k8s-monitoring/charts/feature-application-observability/tests/__snapshot__/override-unknown-service-names_test.yaml.snap
+++ b/charts/k8s-monitoring/charts/feature-application-observability/tests/__snapshot__/override-unknown-service-names_test.yaml.snap
@@ -1,0 +1,375 @@
+deletes unknown_service service names across metrics, logs, and traces:
+  1: |
+    |-
+      declare "application_observability" {
+        argument "metrics_destinations" {
+          comment = "Must be a list of metrics destinations where collected metrics should be forwarded to"
+        }
+
+        argument "logs_destinations" {
+          comment = "Must be a list of log destinations where collected logs should be forwarded to"
+        }
+
+        argument "traces_destinations" {
+          comment = "Must be a list of trace destinations where collected trace should be forwarded to"
+        }
+
+        // OTLP Receiver
+        otelcol.receiver.otlp "receiver" {
+          grpc {
+            endpoint = "0.0.0.0:4317"
+            include_metadata = false
+            max_recv_msg_size = "4MiB"
+            read_buffer_size = "512KiB"
+            write_buffer_size = "32KiB"
+          }
+          debug_metrics {
+            disable_high_cardinality_metrics = true
+          }
+          output {
+            metrics = [otelcol.processor.resourcedetection.default.input]
+            logs = [otelcol.processor.resourcedetection.default.input]
+            traces = [otelcol.processor.resourcedetection.default.input]
+          }
+        } // otelcol.receiver.otlp "receiver"
+
+        // Resource Detection Processor
+        otelcol.processor.resourcedetection "default" {
+          detectors = ["env","system"]
+          override = true
+
+          system {
+            hostname_sources = ["os"]
+          }
+
+          output {
+            metrics = [otelcol.processor.k8sattributes.default.input]
+            logs = [otelcol.processor.k8sattributes.default.input]
+            traces = [otelcol.processor.k8sattributes.default.input]
+          }
+        }
+
+        // K8s Attributes Processor
+        otelcol.processor.k8sattributes "default" {
+          passthrough = false
+          extract {
+            metadata = ["k8s.namespace.name","k8s.pod.name","k8s.deployment.name","k8s.statefulset.name","k8s.daemonset.name","k8s.cronjob.name","k8s.job.name","k8s.node.name","k8s.pod.uid","k8s.pod.start_time"]
+          }
+          pod_association {
+            source {
+              from = "resource_attribute"
+              name = "k8s.pod.ip"
+            }
+          }
+          pod_association {
+            source {
+              from = "resource_attribute"
+              name = "k8s.pod.uid"
+            }
+          }
+          pod_association {
+            source {
+              from = "connection"
+            }
+          }
+
+          output {
+            metrics = [otelcol.processor.transform.default.input]
+            logs = [otelcol.processor.transform.default.input]
+            traces = [otelcol.processor.transform.default.input, otelcol.connector.host_info.default.input]
+          }
+        }
+
+        // Host Info Connector
+        otelcol.connector.host_info "default" {
+          host_identifiers = [ "k8s.node.name" ]
+
+          output {
+            metrics = [otelcol.processor.batch.default.input]
+          }
+        }
+
+        // Transform Processor
+        otelcol.processor.transform "default" {
+          error_mode = "ignore"
+          metric_statements {
+            context = "resource"
+            statements = [
+              // Drop the OpenTelemetry SDK default service.name (unknown_service*) so it is treated as unset
+              `delete_key(resource.attributes, "service.name") where resource.attributes["service.name"] != nil and IsMatch(resource.attributes["service.name"], "^unknown_service")`,
+            ]
+          }
+          log_statements {
+            context = "resource"
+            statements = [
+              "set(attributes[\"pod\"], attributes[\"k8s.pod.name\"])",
+              "set(attributes[\"namespace\"], attributes[\"k8s.namespace.name\"])",
+              "set(attributes[\"loki.resource.labels\"], \"cluster, namespace, job, pod\")",
+              // Drop the OpenTelemetry SDK default service.name (unknown_service*) so it is treated as unset
+              `delete_key(resource.attributes, "service.name") where resource.attributes["service.name"] != nil and IsMatch(resource.attributes["service.name"], "^unknown_service")`,
+            ]
+          }
+          trace_statements {
+            context = "resource"
+            statements = [
+              // Drop the OpenTelemetry SDK default service.name (unknown_service*) so it is treated as unset
+              `delete_key(resource.attributes, "service.name") where resource.attributes["service.name"] != nil and IsMatch(resource.attributes["service.name"], "^unknown_service")`,
+            ]
+          }
+          trace_statements {
+            context = "span"
+            statements = [
+             "set_semconv_span_name(\"1.37.0\", \"original_span_name\")",
+            ]
+          }
+
+          output {
+            metrics = [otelcol.processor.batch.default.input]
+            logs = [otelcol.processor.batch.default.input]
+            traces = [otelcol.processor.batch.default.input]
+          }
+        }
+
+        // Batch Processor
+        otelcol.processor.batch "default" {
+          send_batch_size = 8192
+          send_batch_max_size = 0
+          timeout = "2s"
+
+          output {
+            metrics = argument.metrics_destinations.value
+            logs = argument.logs_destinations.value
+            traces = argument.traces_destinations.value
+          }
+        }
+      } // declare "application_observability"
+runs before service name detection when combined with alignServiceNameWithOTelSemConv:
+  1: |
+    |-
+      declare "application_observability" {
+        argument "metrics_destinations" {
+          comment = "Must be a list of metrics destinations where collected metrics should be forwarded to"
+        }
+
+        argument "logs_destinations" {
+          comment = "Must be a list of log destinations where collected logs should be forwarded to"
+        }
+
+        argument "traces_destinations" {
+          comment = "Must be a list of trace destinations where collected trace should be forwarded to"
+        }
+
+        // OTLP Receiver
+        otelcol.receiver.otlp "receiver" {
+          grpc {
+            endpoint = "0.0.0.0:4317"
+            include_metadata = false
+            max_recv_msg_size = "4MiB"
+            read_buffer_size = "512KiB"
+            write_buffer_size = "32KiB"
+          }
+          debug_metrics {
+            disable_high_cardinality_metrics = true
+          }
+          output {
+            metrics = [otelcol.processor.resourcedetection.default.input]
+            logs = [otelcol.processor.resourcedetection.default.input]
+            traces = [otelcol.processor.resourcedetection.default.input]
+          }
+        } // otelcol.receiver.otlp "receiver"
+
+        // Resource Detection Processor
+        otelcol.processor.resourcedetection "default" {
+          detectors = ["env","system"]
+          override = true
+
+          system {
+            hostname_sources = ["os"]
+          }
+
+          output {
+            metrics = [otelcol.processor.k8sattributes.default.input]
+            logs = [otelcol.processor.k8sattributes.default.input]
+            traces = [otelcol.processor.k8sattributes.default.input]
+          }
+        }
+
+        // K8s Attributes Processor
+        otelcol.processor.k8sattributes "default" {
+          passthrough = false
+          extract {
+            otel_annotations = true
+            metadata = ["k8s.namespace.name","k8s.pod.name","k8s.deployment.name","k8s.statefulset.name","k8s.daemonset.name","k8s.cronjob.name","k8s.job.name","k8s.node.name","k8s.pod.uid","k8s.pod.start_time"]
+            // Extracted into temporary attributes for service.name detection, then deleted in the transform processor.
+            // Temporary names are used so the cleanup never deletes an `app.kubernetes.io/*` attribute the user extracted.
+            label {
+              tag_name = "k8s_monitoring.tmp.instance"
+              key = "app.kubernetes.io/instance"
+              from = "pod"
+            }
+            label {
+              tag_name = "k8s_monitoring.tmp.name"
+              key = "app.kubernetes.io/name"
+              from = "pod"
+            }
+          }
+          pod_association {
+            source {
+              from = "resource_attribute"
+              name = "k8s.pod.ip"
+            }
+          }
+          pod_association {
+            source {
+              from = "resource_attribute"
+              name = "k8s.pod.uid"
+            }
+          }
+          pod_association {
+            source {
+              from = "connection"
+            }
+          }
+
+          output {
+            metrics = [otelcol.processor.transform.default.input]
+            logs = [otelcol.processor.transform.default.input]
+            traces = [otelcol.processor.transform.default.input, otelcol.connector.host_info.default.input]
+          }
+        }
+
+        // Host Info Connector
+        otelcol.connector.host_info "default" {
+          host_identifiers = [ "k8s.node.name" ]
+
+          output {
+            metrics = [otelcol.processor.batch.default.input]
+          }
+        }
+
+        // Transform Processor
+        otelcol.processor.transform "default" {
+          error_mode = "ignore"
+          metric_statements {
+            context = "resource"
+            statements = [
+              // Drop the OpenTelemetry SDK default service.name (unknown_service*) so it is treated as unset
+              `delete_key(resource.attributes, "service.name") where resource.attributes["service.name"] != nil and IsMatch(resource.attributes["service.name"], "^unknown_service")`,
+              // Set service.name by choosing the first value found from the following ordered list:
+              // - service.name as reported by the application or set from the resource.opentelemetry.io/service.name annotation
+              // - pod.label[app.kubernetes.io/instance]
+              // - pod.label[app.kubernetes.io/name]
+              // - k8s.workload.name (Deployment, StatefulSet, DaemonSet, CronJob, Job, ...)
+              // - k8s.pod.name
+              // The instance/name pod labels are read from temporary attributes (k8s_monitoring.tmp.*) extracted by the
+              // k8sattributes processor, so the cleanup below only ever deletes attributes this feature added.
+              `set(resource.attributes["service.name"], resource.attributes["k8s_monitoring.tmp.instance"]) where (resource.attributes["service.name"] == nil or resource.attributes["service.name"] == "") and resource.attributes["k8s_monitoring.tmp.instance"] != nil and resource.attributes["k8s_monitoring.tmp.instance"] != ""`,
+              `set(resource.attributes["service.name"], resource.attributes["k8s_monitoring.tmp.name"]) where (resource.attributes["service.name"] == nil or resource.attributes["service.name"] == "") and resource.attributes["k8s_monitoring.tmp.name"] != nil and resource.attributes["k8s_monitoring.tmp.name"] != ""`,
+              `set(resource.attributes["service.name"], resource.attributes["k8s.deployment.name"]) where (resource.attributes["service.name"] == nil or resource.attributes["service.name"] == "") and resource.attributes["k8s.deployment.name"] != nil and resource.attributes["k8s.deployment.name"] != ""`,
+              `set(resource.attributes["service.name"], resource.attributes["k8s.replicaset.name"]) where (resource.attributes["service.name"] == nil or resource.attributes["service.name"] == "") and resource.attributes["k8s.replicaset.name"] != nil and resource.attributes["k8s.replicaset.name"] != ""`,
+              `set(resource.attributes["service.name"], resource.attributes["k8s.statefulset.name"]) where (resource.attributes["service.name"] == nil or resource.attributes["service.name"] == "") and resource.attributes["k8s.statefulset.name"] != nil and resource.attributes["k8s.statefulset.name"] != ""`,
+              `set(resource.attributes["service.name"], resource.attributes["k8s.daemonset.name"]) where (resource.attributes["service.name"] == nil or resource.attributes["service.name"] == "") and resource.attributes["k8s.daemonset.name"] != nil and resource.attributes["k8s.daemonset.name"] != ""`,
+              `set(resource.attributes["service.name"], resource.attributes["k8s.cronjob.name"]) where (resource.attributes["service.name"] == nil or resource.attributes["service.name"] == "") and resource.attributes["k8s.cronjob.name"] != nil and resource.attributes["k8s.cronjob.name"] != ""`,
+              `set(resource.attributes["service.name"], resource.attributes["k8s.job.name"]) where (resource.attributes["service.name"] == nil or resource.attributes["service.name"] == "") and resource.attributes["k8s.job.name"] != nil and resource.attributes["k8s.job.name"] != ""`,
+              `set(resource.attributes["service.name"], resource.attributes["k8s.pod.name"]) where (resource.attributes["service.name"] == nil or resource.attributes["service.name"] == "") and resource.attributes["k8s.pod.name"] != nil and resource.attributes["k8s.pod.name"] != ""`,
+
+              // Set service.namespace to the pod namespace if not already set
+              `set(resource.attributes["service.namespace"], resource.attributes["k8s.namespace.name"]) where (resource.attributes["service.namespace"] == nil or resource.attributes["service.namespace"] == "") and resource.attributes["k8s.namespace.name"] != nil and resource.attributes["k8s.namespace.name"] != ""`,
+
+              // Remove the temporary attributes used for service.name detection
+              `delete_key(resource.attributes, "k8s_monitoring.tmp.instance")`,
+              `delete_key(resource.attributes, "k8s_monitoring.tmp.name")`,
+            ]
+          }
+          log_statements {
+            context = "resource"
+            statements = [
+              "set(attributes[\"pod\"], attributes[\"k8s.pod.name\"])",
+              "set(attributes[\"namespace\"], attributes[\"k8s.namespace.name\"])",
+              "set(attributes[\"loki.resource.labels\"], \"cluster, namespace, job, pod\")",
+              // Drop the OpenTelemetry SDK default service.name (unknown_service*) so it is treated as unset
+              `delete_key(resource.attributes, "service.name") where resource.attributes["service.name"] != nil and IsMatch(resource.attributes["service.name"], "^unknown_service")`,
+              // Set service.name by choosing the first value found from the following ordered list:
+              // - service.name as reported by the application or set from the resource.opentelemetry.io/service.name annotation
+              // - pod.label[app.kubernetes.io/instance]
+              // - pod.label[app.kubernetes.io/name]
+              // - k8s.workload.name (Deployment, StatefulSet, DaemonSet, CronJob, Job, ...)
+              // - k8s.pod.name
+              // The instance/name pod labels are read from temporary attributes (k8s_monitoring.tmp.*) extracted by the
+              // k8sattributes processor, so the cleanup below only ever deletes attributes this feature added.
+              `set(resource.attributes["service.name"], resource.attributes["k8s_monitoring.tmp.instance"]) where (resource.attributes["service.name"] == nil or resource.attributes["service.name"] == "") and resource.attributes["k8s_monitoring.tmp.instance"] != nil and resource.attributes["k8s_monitoring.tmp.instance"] != ""`,
+              `set(resource.attributes["service.name"], resource.attributes["k8s_monitoring.tmp.name"]) where (resource.attributes["service.name"] == nil or resource.attributes["service.name"] == "") and resource.attributes["k8s_monitoring.tmp.name"] != nil and resource.attributes["k8s_monitoring.tmp.name"] != ""`,
+              `set(resource.attributes["service.name"], resource.attributes["k8s.deployment.name"]) where (resource.attributes["service.name"] == nil or resource.attributes["service.name"] == "") and resource.attributes["k8s.deployment.name"] != nil and resource.attributes["k8s.deployment.name"] != ""`,
+              `set(resource.attributes["service.name"], resource.attributes["k8s.replicaset.name"]) where (resource.attributes["service.name"] == nil or resource.attributes["service.name"] == "") and resource.attributes["k8s.replicaset.name"] != nil and resource.attributes["k8s.replicaset.name"] != ""`,
+              `set(resource.attributes["service.name"], resource.attributes["k8s.statefulset.name"]) where (resource.attributes["service.name"] == nil or resource.attributes["service.name"] == "") and resource.attributes["k8s.statefulset.name"] != nil and resource.attributes["k8s.statefulset.name"] != ""`,
+              `set(resource.attributes["service.name"], resource.attributes["k8s.daemonset.name"]) where (resource.attributes["service.name"] == nil or resource.attributes["service.name"] == "") and resource.attributes["k8s.daemonset.name"] != nil and resource.attributes["k8s.daemonset.name"] != ""`,
+              `set(resource.attributes["service.name"], resource.attributes["k8s.cronjob.name"]) where (resource.attributes["service.name"] == nil or resource.attributes["service.name"] == "") and resource.attributes["k8s.cronjob.name"] != nil and resource.attributes["k8s.cronjob.name"] != ""`,
+              `set(resource.attributes["service.name"], resource.attributes["k8s.job.name"]) where (resource.attributes["service.name"] == nil or resource.attributes["service.name"] == "") and resource.attributes["k8s.job.name"] != nil and resource.attributes["k8s.job.name"] != ""`,
+              `set(resource.attributes["service.name"], resource.attributes["k8s.pod.name"]) where (resource.attributes["service.name"] == nil or resource.attributes["service.name"] == "") and resource.attributes["k8s.pod.name"] != nil and resource.attributes["k8s.pod.name"] != ""`,
+
+              // Set service.namespace to the pod namespace if not already set
+              `set(resource.attributes["service.namespace"], resource.attributes["k8s.namespace.name"]) where (resource.attributes["service.namespace"] == nil or resource.attributes["service.namespace"] == "") and resource.attributes["k8s.namespace.name"] != nil and resource.attributes["k8s.namespace.name"] != ""`,
+
+              // Remove the temporary attributes used for service.name detection
+              `delete_key(resource.attributes, "k8s_monitoring.tmp.instance")`,
+              `delete_key(resource.attributes, "k8s_monitoring.tmp.name")`,
+            ]
+          }
+          trace_statements {
+            context = "resource"
+            statements = [
+              // Drop the OpenTelemetry SDK default service.name (unknown_service*) so it is treated as unset
+              `delete_key(resource.attributes, "service.name") where resource.attributes["service.name"] != nil and IsMatch(resource.attributes["service.name"], "^unknown_service")`,
+              // Set service.name by choosing the first value found from the following ordered list:
+              // - service.name as reported by the application or set from the resource.opentelemetry.io/service.name annotation
+              // - pod.label[app.kubernetes.io/instance]
+              // - pod.label[app.kubernetes.io/name]
+              // - k8s.workload.name (Deployment, StatefulSet, DaemonSet, CronJob, Job, ...)
+              // - k8s.pod.name
+              // The instance/name pod labels are read from temporary attributes (k8s_monitoring.tmp.*) extracted by the
+              // k8sattributes processor, so the cleanup below only ever deletes attributes this feature added.
+              `set(resource.attributes["service.name"], resource.attributes["k8s_monitoring.tmp.instance"]) where (resource.attributes["service.name"] == nil or resource.attributes["service.name"] == "") and resource.attributes["k8s_monitoring.tmp.instance"] != nil and resource.attributes["k8s_monitoring.tmp.instance"] != ""`,
+              `set(resource.attributes["service.name"], resource.attributes["k8s_monitoring.tmp.name"]) where (resource.attributes["service.name"] == nil or resource.attributes["service.name"] == "") and resource.attributes["k8s_monitoring.tmp.name"] != nil and resource.attributes["k8s_monitoring.tmp.name"] != ""`,
+              `set(resource.attributes["service.name"], resource.attributes["k8s.deployment.name"]) where (resource.attributes["service.name"] == nil or resource.attributes["service.name"] == "") and resource.attributes["k8s.deployment.name"] != nil and resource.attributes["k8s.deployment.name"] != ""`,
+              `set(resource.attributes["service.name"], resource.attributes["k8s.replicaset.name"]) where (resource.attributes["service.name"] == nil or resource.attributes["service.name"] == "") and resource.attributes["k8s.replicaset.name"] != nil and resource.attributes["k8s.replicaset.name"] != ""`,
+              `set(resource.attributes["service.name"], resource.attributes["k8s.statefulset.name"]) where (resource.attributes["service.name"] == nil or resource.attributes["service.name"] == "") and resource.attributes["k8s.statefulset.name"] != nil and resource.attributes["k8s.statefulset.name"] != ""`,
+              `set(resource.attributes["service.name"], resource.attributes["k8s.daemonset.name"]) where (resource.attributes["service.name"] == nil or resource.attributes["service.name"] == "") and resource.attributes["k8s.daemonset.name"] != nil and resource.attributes["k8s.daemonset.name"] != ""`,
+              `set(resource.attributes["service.name"], resource.attributes["k8s.cronjob.name"]) where (resource.attributes["service.name"] == nil or resource.attributes["service.name"] == "") and resource.attributes["k8s.cronjob.name"] != nil and resource.attributes["k8s.cronjob.name"] != ""`,
+              `set(resource.attributes["service.name"], resource.attributes["k8s.job.name"]) where (resource.attributes["service.name"] == nil or resource.attributes["service.name"] == "") and resource.attributes["k8s.job.name"] != nil and resource.attributes["k8s.job.name"] != ""`,
+              `set(resource.attributes["service.name"], resource.attributes["k8s.pod.name"]) where (resource.attributes["service.name"] == nil or resource.attributes["service.name"] == "") and resource.attributes["k8s.pod.name"] != nil and resource.attributes["k8s.pod.name"] != ""`,
+
+              // Set service.namespace to the pod namespace if not already set
+              `set(resource.attributes["service.namespace"], resource.attributes["k8s.namespace.name"]) where (resource.attributes["service.namespace"] == nil or resource.attributes["service.namespace"] == "") and resource.attributes["k8s.namespace.name"] != nil and resource.attributes["k8s.namespace.name"] != ""`,
+
+              // Remove the temporary attributes used for service.name detection
+              `delete_key(resource.attributes, "k8s_monitoring.tmp.instance")`,
+              `delete_key(resource.attributes, "k8s_monitoring.tmp.name")`,
+            ]
+          }
+          trace_statements {
+            context = "span"
+            statements = [
+             "set_semconv_span_name(\"1.37.0\", \"original_span_name\")",
+            ]
+          }
+
+          output {
+            metrics = [otelcol.processor.batch.default.input]
+            logs = [otelcol.processor.batch.default.input]
+            traces = [otelcol.processor.batch.default.input]
+          }
+        }
+
+        // Batch Processor
+        otelcol.processor.batch "default" {
+          send_batch_size = 8192
+          send_batch_max_size = 0
+          timeout = "2s"
+
+          output {
+            metrics = argument.metrics_destinations.value
+            logs = argument.logs_destinations.value
+            traces = argument.traces_destinations.value
+          }
+        }
+      } // declare "application_observability"

--- a/charts/k8s-monitoring/charts/feature-application-observability/tests/override-unknown-service-names_test.yaml
+++ b/charts/k8s-monitoring/charts/feature-application-observability/tests/override-unknown-service-names_test.yaml
@@ -1,0 +1,33 @@
+# yamllint disable rule:document-start rule:line-length rule:trailing-spaces
+suite: Feature - Application Observability - Override Unknown Service Names
+templates:
+  - test/configmap.yaml
+tests:
+  - it: deletes unknown_service service names across metrics, logs, and traces
+    set:
+      testing: {enabled: true}
+      overrideUnknownServiceNames: true
+      receivers:
+        otlp:
+          grpc:
+            enabled: true
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - matchSnapshot:
+          path: data["module.alloy"]
+
+  - it: runs before service name detection when combined with alignServiceNameWithOTelSemConv
+    set:
+      testing: {enabled: true}
+      overrideUnknownServiceNames: true
+      alignServiceNameWithOTelSemConv: true
+      receivers:
+        otlp:
+          grpc:
+            enabled: true
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - matchSnapshot:
+          path: data["module.alloy"]

--- a/charts/k8s-monitoring/charts/feature-application-observability/values.schema.json
+++ b/charts/k8s-monitoring/charts/feature-application-observability/values.schema.json
@@ -232,6 +232,9 @@
                 }
             }
         },
+        "overrideUnknownServiceNames": {
+            "type": "boolean"
+        },
         "processors": {
             "type": "object",
             "properties": {

--- a/charts/k8s-monitoring/charts/feature-application-observability/values.yaml
+++ b/charts/k8s-monitoring/charts/feature-application-observability/values.yaml
@@ -13,6 +13,12 @@ global:
 # @section -- General
 alignServiceNameWithOTelSemConv: false
 
+# -- If the incoming `service.name` attribute is `unknown_service`, then override it with a value based on Kubernetes
+# annotations, attributes, or names. This can happen if the application is using an OpenTelemetry SDKs but did not
+# configure with a service name. Most useful when combined with `alignServiceNameWithOTelSemConv`.
+# @section -- General
+overrideUnknownServiceNames: false
+
 receivers:
   otlp:
     # The OTLP gRPC receiver configuration.


### PR DESCRIPTION
# Description

If an application is instrumented with the OpenTelemetry SDK, but the user forgets to set the service name, the SDK will default it to `unknown_service:<language>`, but when it is delivered to the Alloy (in the application observability pipeline), we didn't know the difference between `unknown_service` and an unset value.

This flag allows Alloy to override the `unknown_service:*` service name with the a better default pulled from the Kubernetes annotations, labels, or names.

## Authorship

-   [X] I, a human, wrote this pull request description myself.

