### PR TITLE
Add the ability to set extra resource attributes in the otlp destination

### DIFF
--- a/charts/k8s-monitoring/CHANGELOG.md
+++ b/charts/k8s-monitoring/CHANGELOG.md
@@ -6,7 +6,6 @@
 
 ## 4.3.2
 
-attributes in the otlp destination)
 *   Fix chart schemas where the only valid type was `null`. (#2926) (@petewall)
 *   Validate `replaceComponent` entries across collectors, and make it possible to mark them as optional. (#2912) (@petewall)
 *   Fix the comment on the closing brace of generated Alloy config components so it always names the component that opened the block. (@petewall)

--- a/charts/k8s-monitoring/CHANGELOG.md
+++ b/charts/k8s-monitoring/CHANGELOG.md
@@ -2,8 +2,11 @@
 
 ## Unreleased
 
+*   Add `extraResourceAttributes` and `extraResourceAttributesFrom` options to the OTLP destination. (#2913) (@petewall)
+
 ## 4.3.2
 
+attributes in the otlp destination)
 *   Fix chart schemas where the only valid type was `null`. (#2926) (@petewall)
 *   Validate `replaceComponent` entries across collectors, and make it possible to mark them as optional. (#2912) (@petewall)
 *   Fix the comment on the closing brace of generated Alloy config components so it always names the component that opened the block. (@petewall)

--- a/charts/k8s-monitoring/destinations/otlp-values.yaml
+++ b/charts/k8s-monitoring/destinations/otlp-values.yaml
@@ -82,6 +82,15 @@ extraHeadersFrom: {}
 # @section -- General
 clusterLabels: [cluster, k8s.cluster.name]
 
+# -- Extra resource attributes to be set on all telemetry before delivering to the destination.
+# All values are treated as strings and automatically quoted.
+# @section -- General
+extraResourceAttributes: {}
+# -- Extra resource attributes to be set on all telemetry using a dynamic reference before delivering to the
+# destination. All values are treated as raw strings and not quoted.
+# @section -- General
+extraResourceAttributesFrom: {}
+
 auth:
   # -- The type of authentication to do.
   # Options are "none", "basic", "bearerToken", "oauth2", "sigv4". When unset, defaults to "basic" if a username and

--- a/charts/k8s-monitoring/docs/destinations/otlp.md
+++ b/charts/k8s-monitoring/docs/destinations/otlp.md
@@ -76,6 +76,8 @@ This defines the options for defining a destination for OpenTelemetry data that 
 | disabled | bool | `false` | Set to `true` to disable this destination. Disabled destinations are excluded from all telemetry data flows, which is useful for removing a destination that was defined in a shared or parent values file. |
 | extraHeaders | object | `{}` | Extra headers to be set when sending data. All values are treated as strings and automatically quoted. |
 | extraHeadersFrom | object | `{}` | Extra headers to be set when sending data through a dynamic reference. All values are treated as raw strings and not quoted. |
+| extraResourceAttributes | object | `{}` | Extra resource attributes to be set on all telemetry before delivering to the destination. All values are treated as strings and automatically quoted. |
+| extraResourceAttributesFrom | object | `{}` | Extra resource attributes to be set on all telemetry using a dynamic reference before delivering to the destination. All values are treated as raw strings and not quoted. |
 | logs.path | string | `""` | A custom path to append to the URL when sending logs. Only used when `protocol` is `http`. Overrides the default `/v1/logs` path. For example, set `path: v2/log/otlp` to send logs to `<url>/v2/log/otlp`. |
 | metrics.path | string | `""` | A custom path to append to the URL when sending metrics. Only used when `protocol` is `http`. Overrides the default `/v1/metrics` path. For example, set `path: v2/metric/otlp` to send metrics to `<url>/v2/metric/otlp`. |
 | name | string | `""` | The name for this OTLP destination. |

--- a/charts/k8s-monitoring/schema-mods/definitions/otlp-destination.schema.json
+++ b/charts/k8s-monitoring/schema-mods/definitions/otlp-destination.schema.json
@@ -146,6 +146,12 @@
         "extraHeadersFrom": {
             "type": "object"
         },
+        "extraResourceAttributes": {
+            "type": "object"
+        },
+        "extraResourceAttributesFrom": {
+            "type": "object"
+        },
         "logs": {
             "type": "object",
             "properties": {

--- a/charts/k8s-monitoring/templates/destinations/_destination_otlp.tpl
+++ b/charts/k8s-monitoring/templates/destinations/_destination_otlp.tpl
@@ -119,6 +119,12 @@ otelcol.processor.transform {{ include "helper.alloy_name" $.destinationName | q
       `set(attributes[{{ $label | quote }}], {{ $.Values.cluster.name | quote }})`,
 {{- end }}
 {{- end }}
+{{- range $key, $value := .extraResourceAttributes }}
+      `set(attributes[{{ $key | quote }}], {{ $value | quote }})`,
+{{- end }}
+{{- range $key, $value := .extraResourceAttributesFrom }}
+      string.format(`set(attributes[%q], %q)`, {{ $key | quote }}, {{ $value }}),
+{{- end }}
 {{- range $resourceAttribute := $resourceAttributesToRemove }}
       `delete_key(attributes, {{ $resourceAttribute | quote }})`,
 {{- end }}
@@ -193,6 +199,12 @@ otelcol.processor.transform {{ include "helper.alloy_name" $.destinationName | q
       `set(attributes[{{ $label | quote }}], {{ $.Values.cluster.name | quote }})`,
 {{- end }}
 {{- end }}
+{{- range $key, $value := .extraResourceAttributes }}
+      `set(attributes[{{ $key | quote }}], {{ $value | quote }})`,
+{{- end }}
+{{- range $key, $value := .extraResourceAttributesFrom }}
+      string.format(`set(attributes[%q], %q)`, {{ $key | quote }}, {{ $value }}),
+{{- end }}
 {{- range $resourceAttribute := $resourceAttributesToRemove }}
       `delete_key(attributes, {{ $resourceAttribute | quote }})`,
 {{- end }}
@@ -255,6 +267,12 @@ otelcol.processor.transform {{ include "helper.alloy_name" $.destinationName | q
 {{- else }}
       `set(attributes[{{ $label | quote }}], {{ $.Values.cluster.name | quote }})`,
 {{- end }}
+{{- end }}
+{{- range $key, $value := .extraResourceAttributes }}
+      `set(attributes[{{ $key | quote }}], {{ $value | quote }})`,
+{{- end }}
+{{- range $key, $value := .extraResourceAttributesFrom }}
+      string.format(`set(attributes[%q], %q)`, {{ $key | quote }}, {{ $value }}),
 {{- end }}
 {{- range $resourceAttribute := $resourceAttributesToRemove }}
       `delete_key(attributes, {{ $resourceAttribute | quote }})`,

--- a/charts/k8s-monitoring/tests/__snapshot__/destination_otlp_test.yaml.snap
+++ b/charts/k8s-monitoring/tests/__snapshot__/destination_otlp_test.yaml.snap
@@ -678,6 +678,241 @@ allows you to set a timeout when using http:
           enabled = true
         }
       } // otelcol.exporter.otlphttp "test"
+allows you to set extra resource attributes:
+  1: |
+    |
+      // Destination: test (otlp)
+      otelcol.receiver.prometheus "test" {
+        output {
+          metrics = [otelcol.processor.transform.test_scrape_normalize.input]
+        }
+      } // otelcol.receiver.prometheus "test"
+
+      // Repairs artifacts of the Prometheus-to-OTLP conversion performed by
+      // otelcol.receiver.prometheus. Only metrics that came from a Prometheus scrape pass
+      // through this component; OTLP-native telemetry enters the pipeline further down.
+      otelcol.processor.transform "test_scrape_normalize" {
+        error_mode = "ignore"
+        metric_statements {
+          context = "resource"
+          statements = [
+            // The conversion sets service.name to the full Prometheus job label (e.g.
+            // "namespace/workload"). When the scrape target declares its identity explicitly
+            // with a service_name label on its own target_info metric (e.g. Grafana Beyla),
+            // prefer that value and drop the duplicate.
+            `set(attributes["service.name"], attributes["service_name"]) where attributes["service_name"] != nil and attributes["service_name"] != ""`,
+            `delete_key(attributes, "service_name") where attributes["service_name"] == attributes["service.name"]`,
+            // The same conversion turns other flat target_info labels into resource attributes.
+            // Promote them to their OpenTelemetry counterparts and drop the flat duplicates, so
+            // the OTLP endpoint does not receive two conflicting spellings of the same attribute.
+            `set(attributes["service.namespace"], attributes["service_namespace"]) where (attributes["service.namespace"] == nil or attributes["service.namespace"] == "") and attributes["service_namespace"] != nil and attributes["service_namespace"] != ""`,
+            `delete_key(attributes, "service_namespace") where attributes["service_namespace"] == attributes["service.namespace"]`,
+            `set(attributes["deployment.environment"], attributes["deployment_environment"]) where (attributes["deployment.environment"] == nil or attributes["deployment.environment"] == "") and attributes["deployment_environment"] != nil and attributes["deployment_environment"] != ""`,
+            `delete_key(attributes, "deployment_environment") where attributes["deployment_environment"] == attributes["deployment.environment"]`,
+            `set(attributes["deployment.environment.name"], attributes["deployment_environment_name"]) where (attributes["deployment.environment.name"] == nil or attributes["deployment.environment.name"] == "") and attributes["deployment_environment_name"] != nil and attributes["deployment_environment_name"] != ""`,
+            `delete_key(attributes, "deployment_environment_name") where attributes["deployment_environment_name"] == attributes["deployment.environment.name"]`,
+          ]
+        }
+        metric_statements {
+          context = "datapoint"
+          statements = [
+            // Same correction for scrape targets that put service_name on every series
+            // instead of exposing a target_info metric.
+            `set(resource.attributes["service.name"], attributes["service_name"]) where attributes["service_name"] != nil and attributes["service_name"] != ""`,
+          ]
+        }
+        output {
+          metrics = [otelcol.processor.attributes.test.input]
+        }
+      } // otelcol.processor.transform "test_scrape_normalize"
+      otelcol.receiver.loki "test" {
+        output {
+          logs = [otelcol.processor.attributes.test.input]
+        }
+      } // otelcol.receiver.loki "test"
+      otelcol.processor.attributes "test" {
+        output {
+          metrics = [otelcol.processor.transform.test.input]
+          logs = [otelcol.processor.transform.test.input]
+          traces = [otelcol.processor.transform.test.input]
+        }
+      } // otelcol.processor.attributes "test"
+
+      otelcol.processor.transform "test" {
+        error_mode = "ignore"
+        metric_statements {
+          context = "resource"
+          statements = [
+            `set(attributes["cluster"], "test-cluster")`,
+            `set(attributes["k8s.cluster.name"], "test-cluster")`,
+            `set(attributes["environment"], "production")`,
+            `set(attributes["product"], "shopping-cart")`,
+            string.format(`set(attributes[%q], %q)`, "region", sys.env("REGION")),
+            `delete_key(attributes, "process.pid")`,
+            `delete_key(attributes, "process.parent_pid")`,
+            `delete_key(attributes, "process.executable.path")`,
+            `delete_key(attributes, "process.command_line")`,
+            `delete_key(attributes, "process.command_args")`,
+            `delete_key(attributes, "process.owner")`,
+            `delete_key(attributes, "process.runtime.version")`,
+            `delete_key(attributes, "process.runtime.description")`,
+            `delete_key(attributes, "host.ip")`,
+            `delete_key(attributes, "host.mac")`,
+            `delete_key(attributes, "k8s.pod.start_time")`,
+            `delete_key(attributes, "k8s.pod.uid")`,
+            `delete_key(attributes, "container.image.id")`,
+            `delete_key(attributes, "container.image.repo_digests")`,
+            `delete_key(attributes, "os.description")`,
+            `delete_key(attributes, "os.build_id")`,
+            // Scrape targets that expose their own target_info metric (e.g. Grafana Beyla) can
+            // carry a flat k8s_cluster_name resource attribute, which conflicts with the
+            // k8s.cluster.name attribute set above and gets ";"-joined by the Prometheus OTLP
+            // endpoint. Drop the flat copy when the values match.
+            `delete_key(attributes, "k8s_cluster_name") where attributes["k8s_cluster_name"] == attributes["k8s.cluster.name"]`,
+          ]
+        }
+
+        metric_statements {
+          context = "datapoint"
+          statements = [
+            `set(attributes["cluster"], "test-cluster")`,
+            `set(attributes["k8s.cluster.name"], "test-cluster")`,
+            `set(resource.attributes["deployment.environment"], attributes["deployment_environment"] ) where resource.attributes["deployment.environment"] == nil and attributes["deployment_environment"] != nil`,
+            `delete_key(attributes, "deployment_environment") where attributes["deployment_environment"] == resource.attributes["deployment.environment"]`,
+            `set(resource.attributes["deployment.environment.name"], attributes["deployment_environment_name"] ) where resource.attributes["deployment.environment.name"] == nil and attributes["deployment_environment_name"] != nil`,
+            `delete_key(attributes, "deployment_environment_name") where attributes["deployment_environment_name"] == resource.attributes["deployment.environment.name"]`,
+            `set(resource.attributes["service.name"], attributes["service_name"] ) where (resource.attributes["service.name"] == nil or resource.attributes["service.name"] == "") and attributes["service_name"] != nil and attributes["service_name"] != ""`,
+            `delete_key(attributes, "service_name") where attributes["service_name"] == resource.attributes["service.name"]`,
+            `set(resource.attributes["service.namespace"], attributes["service_namespace"] ) where (resource.attributes["service.namespace"] == nil or resource.attributes["service.namespace"] == "") and attributes["service_namespace"] != nil and attributes["service_namespace"] != ""`,
+            `delete_key(attributes, "service_namespace") where attributes["service_namespace"] == resource.attributes["service.namespace"]`,
+          ]
+        }
+        log_statements {
+          context = "resource"
+          statements = [
+            `set(attributes["cluster"], "test-cluster")`,
+            `set(attributes["k8s.cluster.name"], "test-cluster")`,
+            `set(attributes["environment"], "production")`,
+            `set(attributes["product"], "shopping-cart")`,
+            string.format(`set(attributes[%q], %q)`, "region", sys.env("REGION")),
+            `delete_key(attributes, "process.pid")`,
+            `delete_key(attributes, "process.parent_pid")`,
+            `delete_key(attributes, "process.executable.path")`,
+            `delete_key(attributes, "process.command_line")`,
+            `delete_key(attributes, "process.command_args")`,
+            `delete_key(attributes, "process.owner")`,
+            `delete_key(attributes, "process.runtime.version")`,
+            `delete_key(attributes, "process.runtime.description")`,
+            `delete_key(attributes, "host.ip")`,
+            `delete_key(attributes, "host.mac")`,
+            `delete_key(attributes, "k8s.pod.start_time")`,
+            `delete_key(attributes, "k8s.pod.uid")`,
+            `delete_key(attributes, "container.image.id")`,
+            `delete_key(attributes, "container.image.repo_digests")`,
+            `delete_key(attributes, "os.description")`,
+            `delete_key(attributes, "os.build_id")`,
+          ]
+        }
+
+        log_statements {
+          context = "log"
+          statements = [
+            `delete_key(attributes, "loki.attribute.labels")`,
+            `delete_key(attributes, "loki.resource.labels")`,
+            `set(resource.attributes["k8s.container.name"], attributes["container"] ) where resource.attributes["k8s.container.name"] == nil and attributes["container"] != nil`,
+            `delete_key(attributes, "container") where attributes["container"] == resource.attributes["k8s.container.name"]`,
+            `set(resource.attributes["k8s.cronjob.name"], attributes["cronjob"] ) where resource.attributes["k8s.cronjob.name"] == nil and attributes["cronjob"] != nil`,
+            `delete_key(attributes, "cronjob") where attributes["cronjob"] == resource.attributes["k8s.cronjob.name"]`,
+            `set(resource.attributes["k8s.daemonset.name"], attributes["daemonset"] ) where resource.attributes["k8s.daemonset.name"] == nil and attributes["daemonset"] != nil`,
+            `delete_key(attributes, "daemonset") where attributes["daemonset"] == resource.attributes["k8s.daemonset.name"]`,
+            `set(resource.attributes["k8s.deployment.name"], attributes["deployment"] ) where resource.attributes["k8s.deployment.name"] == nil and attributes["deployment"] != nil`,
+            `delete_key(attributes, "deployment") where attributes["deployment"] == resource.attributes["k8s.deployment.name"]`,
+            `set(resource.attributes["deployment.environment"], attributes["deployment_environment"] ) where resource.attributes["deployment.environment"] == nil and attributes["deployment_environment"] != nil`,
+            `delete_key(attributes, "deployment_environment") where attributes["deployment_environment"] == resource.attributes["deployment.environment"]`,
+            `set(resource.attributes["deployment.environment.name"], attributes["deployment_environment_name"] ) where resource.attributes["deployment.environment.name"] == nil and attributes["deployment_environment_name"] != nil`,
+            `delete_key(attributes, "deployment_environment_name") where attributes["deployment_environment_name"] == resource.attributes["deployment.environment.name"]`,
+            `set(resource.attributes["k8s.job.name"], attributes["job_name"] ) where resource.attributes["k8s.job.name"] == nil and attributes["job_name"] != nil`,
+            `delete_key(attributes, "job_name") where attributes["job_name"] == resource.attributes["k8s.job.name"]`,
+            `set(resource.attributes["k8s.namespace.name"], attributes["namespace"] ) where resource.attributes["k8s.namespace.name"] == nil and attributes["namespace"] != nil`,
+            `delete_key(attributes, "namespace") where attributes["namespace"] == resource.attributes["k8s.namespace.name"]`,
+            `set(resource.attributes["k8s.pod.name"], attributes["pod"] ) where resource.attributes["k8s.pod.name"] == nil and attributes["pod"] != nil`,
+            `delete_key(attributes, "pod") where attributes["pod"] == resource.attributes["k8s.pod.name"]`,
+            `set(resource.attributes["k8s.replicaset.name"], attributes["replicaset"] ) where resource.attributes["k8s.replicaset.name"] == nil and attributes["replicaset"] != nil`,
+            `delete_key(attributes, "replicaset") where attributes["replicaset"] == resource.attributes["k8s.replicaset.name"]`,
+            `set(resource.attributes["service.name"], attributes["service_name"] ) where (resource.attributes["service.name"] == nil or resource.attributes["service.name"] == "") and attributes["service_name"] != nil and attributes["service_name"] != ""`,
+            `delete_key(attributes, "service_name") where attributes["service_name"] == resource.attributes["service.name"]`,
+            `set(resource.attributes["service.namespace"], attributes["service_namespace"] ) where (resource.attributes["service.namespace"] == nil or resource.attributes["service.namespace"] == "") and attributes["service_namespace"] != nil and attributes["service_namespace"] != ""`,
+            `delete_key(attributes, "service_namespace") where attributes["service_namespace"] == resource.attributes["service.namespace"]`,
+            `set(resource.attributes["k8s.statefulset.name"], attributes["statefulset"] ) where resource.attributes["k8s.statefulset.name"] == nil and attributes["statefulset"] != nil`,
+            `delete_key(attributes, "statefulset") where attributes["statefulset"] == resource.attributes["k8s.statefulset.name"]`,
+          ]
+        }
+
+        trace_statements {
+          context = "resource"
+          statements = [
+            `set(attributes["cluster"], "test-cluster")`,
+            `set(attributes["k8s.cluster.name"], "test-cluster")`,
+            `set(attributes["environment"], "production")`,
+            `set(attributes["product"], "shopping-cart")`,
+            string.format(`set(attributes[%q], %q)`, "region", sys.env("REGION")),
+            `delete_key(attributes, "process.pid")`,
+            `delete_key(attributes, "process.parent_pid")`,
+            `delete_key(attributes, "process.executable.path")`,
+            `delete_key(attributes, "process.command_line")`,
+            `delete_key(attributes, "process.command_args")`,
+            `delete_key(attributes, "process.owner")`,
+            `delete_key(attributes, "process.runtime.version")`,
+            `delete_key(attributes, "process.runtime.description")`,
+            `delete_key(attributes, "host.ip")`,
+            `delete_key(attributes, "host.mac")`,
+            `delete_key(attributes, "k8s.pod.start_time")`,
+            `delete_key(attributes, "k8s.pod.uid")`,
+            `delete_key(attributes, "container.image.id")`,
+            `delete_key(attributes, "container.image.repo_digests")`,
+            `delete_key(attributes, "os.description")`,
+            `delete_key(attributes, "os.build_id")`,
+          ]
+        }
+
+        output {
+          metrics = [otelcol.processor.batch.test.input]
+          logs = [otelcol.processor.batch.test.input]
+          traces = [otelcol.processor.batch.test.input]
+        }
+      } // otelcol.processor.transform "test"
+
+      otelcol.processor.batch "test" {
+        timeout = "2s"
+        send_batch_size = 8192
+        send_batch_max_size = 0
+
+        output {
+          metrics = [otelcol.exporter.otlp.test.input]
+          logs = [otelcol.exporter.otlp.test.input]
+          traces = [otelcol.exporter.otlp.test.input]
+        }
+      } // otelcol.processor.batch "test"
+      otelcol.exporter.otlp "test" {
+        client {
+          endpoint = "https://otlp.example.com"
+          tls {
+            insecure = false
+            insecure_skip_verify = false
+          }
+        }
+
+        retry_on_failure {
+          enabled = true
+          initial_interval = "5s"
+          max_interval = "30s"
+          max_elapsed_time = "5m"
+        }
+
+        sending_queue {
+          enabled = true
+        }
+      } // otelcol.exporter.otlp "test"
 allows you to set per-signal paths when using http:
   1: |
     |

--- a/charts/k8s-monitoring/tests/destination_otlp_test.yaml
+++ b/charts/k8s-monitoring/tests/destination_otlp_test.yaml
@@ -146,3 +146,23 @@ tests:
           of: ConfigMap
       - matchSnapshot:
           path: data["config.alloy"]
+
+  - it: allows you to set extra resource attributes
+    set:
+      cluster: {name: test-cluster}
+      collectors: {alloy-singleton: {extraConfig: " ", includeDestinations: ["test"]}}
+      selfReporting: {enabled: false}
+      destinations:
+        test:
+          type: otlp
+          url: https://otlp.example.com
+          extraResourceAttributes:
+            environment: production
+            product: shopping-cart
+          extraResourceAttributesFrom:
+            region: sys.env("REGION")
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - matchSnapshot:
+          path: data["config.alloy"]

--- a/charts/k8s-monitoring/values.schema.json
+++ b/charts/k8s-monitoring/values.schema.json
@@ -1816,6 +1816,12 @@
                 "extraHeadersFrom": {
                     "type": "object"
                 },
+                "extraResourceAttributes": {
+                    "type": "object"
+                },
+                "extraResourceAttributesFrom": {
+                    "type": "object"
+                },
                 "logs": {
                     "type": "object",
                     "properties": {


### PR DESCRIPTION
# Description

Other destination types (prometheus, loki, pyroscope) let you set extra labels using `extraLabels` and `extraLabelsFrom`, but the `otlp` destination did not. This PR adds the equivalent option, but more semantically correct with `extraResourceAttributes` and `extraResourceAttributesFrom`.

Fixes #2913

## Authorship

-   [x] I, a human, wrote this pull request description myself.

<!--Please delete paragraphs that you did not use before submitting.-->
