### PR TITLE
feat(pod-logs-via-loki): support regex patterns for namespaces

### DIFF
--- a/charts/k8s-monitoring/charts/feature-pod-logs-via-loki/README.md
+++ b/charts/k8s-monitoring/charts/feature-pod-logs-via-loki/README.md
@@ -87,10 +87,10 @@ Be sure perform actual integration testing in a live environment in the main [k8
 | annotationSelector | string | `"logs.grafana.com/pods.enabled"` | Pod annotation to use for controlling log discovery. If a pod has this annotation, it will either enable or disable gathering of logs, depending on the value of the discoveryMethod. |
 | attachNamespaceMetadata | bool | `false` | Attach namespace metadata to pod discovery targets. When enabled, all namespace labels are available as log labels via `__meta_kubernetes_namespace_label_*`. |
 | discoveryMethod | string | `"all"` | Controls the behavior of discovering pods for logs. Possible values: `all`, `annotation`. When set to "all", every pod (filtered by the namespace and label selectors) will have their logs gathered. When set to "annotation", only pods with the annotation selector set to something other than "false", "no" or "skip" will have their logs gathered. |
-| excludeNamespaces | list | `[]` | Do not capture logs from any pods in these namespaces. |
+| excludeNamespaces | list | `[]` | Do not capture logs from pods in namespaces matching these regular expressions. Each entry is matched as a RE2 regular expression against the full namespace name (e.g. `team-.*`). |
 | extraDiscoveryRules | string | `""` | Rules to filter pods for log gathering. Only used for "volumes" or "kubernetesApi" gather methods. |
 | labelSelectors | object | `{}` | Filter the list of discovered pods and services by labels. Only for the "volumes" gather method. Example: `labelSelectors: { 'app': 'myapp' }` will only discover pods with the label `app=myapp`. Example: `labelSelectors: { 'app': ['myapp', 'myotherapp'] }` will only discover pods with the label `app=myapp` or `app=myotherapp`. |
-| namespaces | list | `[]` | Only capture logs from pods in these namespaces (`[]` means all namespaces). |
+| namespaces | list | `[]` | Only capture logs from pods in namespaces matching these regular expressions (`[]` means all namespaces). Each entry is matched as a RE2 regular expression against the full namespace name (e.g. `team-.*`). |
 | nodeSelectors | object | `{}` | Filter the list of discovered nodes by labels. Only for the "volumes" gather method. Example: `nodeSelectors: { 'kubernetes.io/os': 'linux' }` |
 
 ### Processing settings

--- a/charts/k8s-monitoring/charts/feature-pod-logs-via-loki/templates/_discovery.alloy.tpl
+++ b/charts/k8s-monitoring/charts/feature-pod-logs-via-loki/templates/_discovery.alloy.tpl
@@ -21,11 +21,6 @@ discovery.kubernetes "pods" {
     role = "pod"
     field = "spec.nodeName=" + sys.env("HOSTNAME")
   }
-{{- if .Values.namespaces }}
-  namespaces {
-    names = {{ .Values.namespaces | toJson }}
-  }
-{{- end }}
 {{- if $labelSelectors }}
     selectors {
       role = "pod"
@@ -66,6 +61,13 @@ discovery.relabel "filtered_pods" {
     action = "replace"
     target_label = "namespace"
   }
+{{- if .Values.namespaces }}
+  rule {
+    source_labels = ["namespace"]
+    regex = "{{ .Values.namespaces | join "|" }}"
+    action = "keep"
+  }
+{{- end }}
 {{- if .Values.excludeNamespaces }}
   rule {
     source_labels = ["namespace"]

--- a/charts/k8s-monitoring/charts/feature-pod-logs-via-loki/tests/__snapshot__/default_test.yaml.snap
+++ b/charts/k8s-monitoring/charts/feature-pod-logs-via-loki/tests/__snapshot__/default_test.yaml.snap
@@ -1,3 +1,204 @@
+should allow multiple namespace patterns, matched as alternation:
+  1: |
+    |-
+      declare "pod_logs_via_loki" {
+        argument "logs_destinations" {
+          comment = "Must be a list of log destinations where collected logs should be forwarded to"
+        }
+
+        discovery.kubernetes "pods" {
+          role = "pod"
+          selectors {
+            role = "pod"
+            field = "spec.nodeName=" + sys.env("HOSTNAME")
+          }
+        } // discovery.kubernetes "pods"
+
+        discovery.relabel "filtered_pods" {
+          targets = discovery.kubernetes.pods.targets
+          rule {
+            source_labels = ["__meta_kubernetes_namespace"]
+            action = "replace"
+            target_label = "namespace"
+          }
+          rule {
+            source_labels = ["namespace"]
+            regex = "team-a|team-b.*"
+            action = "keep"
+          }
+          rule {  // Drop anything with a "falsy" annotation value
+            source_labels = ["__meta_kubernetes_pod_annotation_logs_grafana_com_pods_enabled"]
+            regex = "(false|no|skip)"
+            action = "drop"
+          }
+          rule {
+            source_labels = ["__meta_kubernetes_pod_name"]
+            target_label = "pod"
+          }
+          rule {
+            source_labels = ["__meta_kubernetes_pod_container_name"]
+            target_label = "container"
+          }
+          rule {
+            source_labels = ["__meta_kubernetes_namespace", "__meta_kubernetes_pod_container_name"]
+            separator = "/"
+            replacement = "$1"
+            target_label = "job"
+          }
+
+          // set the container runtime as a label
+          rule {
+            source_labels = ["__meta_kubernetes_pod_container_id"]
+            regex = "^(\\S+):\\/\\/.+$"
+            replacement = "$1"
+            target_label = "tmp_container_runtime"
+          }
+          // explicitly set service_name. if not set, loki will automatically try to populate a default.
+          // see https://grafana.com/docs/loki/latest/get-started/labels/#default-labels-for-all-users
+          //
+          // choose the first value found from the following ordered list:
+          // - pod.annotation[resource.opentelemetry.io/service.name]
+          // - pod.label[app.kubernetes.io/name]
+          // - k8s.container.name
+          rule {
+            source_labels = [
+              "__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_name",
+              "__meta_kubernetes_pod_label_app_kubernetes_io_name",
+              "__meta_kubernetes_pod_container_name",
+            ]
+            separator = ";"
+            regex = "^(?:;*)?([^;]+).*$"
+            replacement = "$1"
+            target_label = "service_name"
+          }
+
+          // explicitly set service_namespace.
+          //
+          // choose the first value found from the following ordered list:
+          // - pod.annotation[resource.opentelemetry.io/service.namespace]
+          // - pod.namespace
+          rule {
+            source_labels = [
+              "__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_namespace",
+              "namespace",
+            ]
+            separator = ";"
+            regex = "^(?:;*)?([^;]+).*$"
+            replacement = "$1"
+            target_label = "service_namespace"
+          }
+
+          // explicitly set service_instance_id.
+          //
+          // choose the first value found from the following ordered list:
+          // - pod.annotation[resource.opentelemetry.io/service.instance.id]
+          // - concat([k8s.namespace.name, k8s.pod.name, k8s.container.name], '.')
+          rule {
+            source_labels = ["__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_instance_id"]
+            target_label = "service_instance_id"
+          }
+          rule {
+            source_labels = ["service_instance_id", "namespace", "pod", "container"]
+            separator = "."
+            regex = "^\\.([^.]+\\.[^.]+\\.[^.]+)$"
+            target_label = "service_instance_id"
+          }
+
+          // set resource attributes
+          rule {
+            action = "labelmap"
+            regex = "__meta_kubernetes_pod_annotation_resource_opentelemetry_io_(.+)"
+          }
+          rule {
+            source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_job"]
+            regex = "(.+)"
+            target_label = "job"
+          }
+          rule {
+            source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+            regex = "(.+)"
+            target_label = "app_kubernetes_io_name"
+          }
+
+          // Set the pod log path.
+          rule {
+            source_labels = ["__meta_kubernetes_pod_uid", "__meta_kubernetes_pod_container_name"]
+            separator = "/"
+            replacement = "/var/log/pods/*$1/*.log"
+            target_label = "__path__"
+          }
+
+          // If kubernetes.io/config.mirror is set, this is a static pod, created by the kubelet.
+          // It's logs live on a different path.
+          rule {
+            source_labels = ["__meta_kubernetes_pod_annotation_kubernetes_io_config_mirror", "__meta_kubernetes_pod_container_name"]
+            separator = "/"
+            regex = "(.+/.+)"
+            replacement = "/var/log/pods/*$1/*.log"
+            target_label = "__path__"
+          }
+        } // discovery.relabel "filtered_pods"
+
+        local.file_match "pod_logs" {
+          path_targets = discovery.relabel.filtered_pods.output
+        } // local.file_match "pod_logs"
+
+        loki.source.file "pod_logs" {
+          targets    = local.file_match.pod_logs.targets
+          tail_from_end = true
+          forward_to = [loki.process.pod_logs.receiver]
+        } // loki.source.file "pod_logs"
+
+        loki.process "pod_logs" {
+          stage.match {
+            selector = "{tmp_container_runtime=~\"containerd|cri-o|\"}"
+            // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
+            stage.cri {
+              max_partial_lines = 100
+            }
+
+            // Set the extract flags and stream values as labels
+            stage.labels {
+              values = {
+                flags  = "",
+                stream  = "",
+              }
+            }
+          }
+
+          stage.match {
+            selector = "{tmp_container_runtime=\"docker\"}"
+            // the docker processing stage extracts the following k/v pairs: log, stream, time
+            stage.docker {}
+
+            // Set the extract stream value as a label
+            stage.labels {
+              values = {
+                stream  = "",
+              }
+            }
+          }
+
+          // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
+          // namespace, pod, and container labels. Drop any structured metadata. Also drop the temporary
+          // container runtime label as it is no longer needed.
+          stage.label_drop {
+            values = [
+              "filename",
+              "tmp_container_runtime",
+            ]
+          }
+          stage.structured_metadata {
+            values = {
+              "k8s_pod_name" = "k8s_pod_name",
+              "pod" = "pod",
+              "service_instance_id" = "service_instance_id",
+            }
+          }
+
+          forward_to = argument.logs_destinations.value
+        } // loki.secretfilter "pod_logs"
+      } // declare "pod_logs_via_loki"
 should allow setting static labels:
   1: |
     |-
@@ -1643,6 +1844,408 @@ should allow using the secret filter with an inclusion filter, to split which lo
 
         loki.secretfilter "pod_logs" {
           redact_percent = 80
+          forward_to = argument.logs_destinations.value
+        } // loki.secretfilter "pod_logs"
+      } // declare "pod_logs_via_loki"
+should exclude namespaces matching a regular expression:
+  1: |
+    |-
+      declare "pod_logs_via_loki" {
+        argument "logs_destinations" {
+          comment = "Must be a list of log destinations where collected logs should be forwarded to"
+        }
+
+        discovery.kubernetes "pods" {
+          role = "pod"
+          selectors {
+            role = "pod"
+            field = "spec.nodeName=" + sys.env("HOSTNAME")
+          }
+        } // discovery.kubernetes "pods"
+
+        discovery.relabel "filtered_pods" {
+          targets = discovery.kubernetes.pods.targets
+          rule {
+            source_labels = ["__meta_kubernetes_namespace"]
+            action = "replace"
+            target_label = "namespace"
+          }
+          rule {
+            source_labels = ["namespace"]
+            regex = "kube-.*"
+            action = "drop"
+          }
+          rule {  // Drop anything with a "falsy" annotation value
+            source_labels = ["__meta_kubernetes_pod_annotation_logs_grafana_com_pods_enabled"]
+            regex = "(false|no|skip)"
+            action = "drop"
+          }
+          rule {
+            source_labels = ["__meta_kubernetes_pod_name"]
+            target_label = "pod"
+          }
+          rule {
+            source_labels = ["__meta_kubernetes_pod_container_name"]
+            target_label = "container"
+          }
+          rule {
+            source_labels = ["__meta_kubernetes_namespace", "__meta_kubernetes_pod_container_name"]
+            separator = "/"
+            replacement = "$1"
+            target_label = "job"
+          }
+
+          // set the container runtime as a label
+          rule {
+            source_labels = ["__meta_kubernetes_pod_container_id"]
+            regex = "^(\\S+):\\/\\/.+$"
+            replacement = "$1"
+            target_label = "tmp_container_runtime"
+          }
+          // explicitly set service_name. if not set, loki will automatically try to populate a default.
+          // see https://grafana.com/docs/loki/latest/get-started/labels/#default-labels-for-all-users
+          //
+          // choose the first value found from the following ordered list:
+          // - pod.annotation[resource.opentelemetry.io/service.name]
+          // - pod.label[app.kubernetes.io/name]
+          // - k8s.container.name
+          rule {
+            source_labels = [
+              "__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_name",
+              "__meta_kubernetes_pod_label_app_kubernetes_io_name",
+              "__meta_kubernetes_pod_container_name",
+            ]
+            separator = ";"
+            regex = "^(?:;*)?([^;]+).*$"
+            replacement = "$1"
+            target_label = "service_name"
+          }
+
+          // explicitly set service_namespace.
+          //
+          // choose the first value found from the following ordered list:
+          // - pod.annotation[resource.opentelemetry.io/service.namespace]
+          // - pod.namespace
+          rule {
+            source_labels = [
+              "__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_namespace",
+              "namespace",
+            ]
+            separator = ";"
+            regex = "^(?:;*)?([^;]+).*$"
+            replacement = "$1"
+            target_label = "service_namespace"
+          }
+
+          // explicitly set service_instance_id.
+          //
+          // choose the first value found from the following ordered list:
+          // - pod.annotation[resource.opentelemetry.io/service.instance.id]
+          // - concat([k8s.namespace.name, k8s.pod.name, k8s.container.name], '.')
+          rule {
+            source_labels = ["__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_instance_id"]
+            target_label = "service_instance_id"
+          }
+          rule {
+            source_labels = ["service_instance_id", "namespace", "pod", "container"]
+            separator = "."
+            regex = "^\\.([^.]+\\.[^.]+\\.[^.]+)$"
+            target_label = "service_instance_id"
+          }
+
+          // set resource attributes
+          rule {
+            action = "labelmap"
+            regex = "__meta_kubernetes_pod_annotation_resource_opentelemetry_io_(.+)"
+          }
+          rule {
+            source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_job"]
+            regex = "(.+)"
+            target_label = "job"
+          }
+          rule {
+            source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+            regex = "(.+)"
+            target_label = "app_kubernetes_io_name"
+          }
+
+          // Set the pod log path.
+          rule {
+            source_labels = ["__meta_kubernetes_pod_uid", "__meta_kubernetes_pod_container_name"]
+            separator = "/"
+            replacement = "/var/log/pods/*$1/*.log"
+            target_label = "__path__"
+          }
+
+          // If kubernetes.io/config.mirror is set, this is a static pod, created by the kubelet.
+          // It's logs live on a different path.
+          rule {
+            source_labels = ["__meta_kubernetes_pod_annotation_kubernetes_io_config_mirror", "__meta_kubernetes_pod_container_name"]
+            separator = "/"
+            regex = "(.+/.+)"
+            replacement = "/var/log/pods/*$1/*.log"
+            target_label = "__path__"
+          }
+        } // discovery.relabel "filtered_pods"
+
+        local.file_match "pod_logs" {
+          path_targets = discovery.relabel.filtered_pods.output
+        } // local.file_match "pod_logs"
+
+        loki.source.file "pod_logs" {
+          targets    = local.file_match.pod_logs.targets
+          tail_from_end = true
+          forward_to = [loki.process.pod_logs.receiver]
+        } // loki.source.file "pod_logs"
+
+        loki.process "pod_logs" {
+          stage.match {
+            selector = "{tmp_container_runtime=~\"containerd|cri-o|\"}"
+            // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
+            stage.cri {
+              max_partial_lines = 100
+            }
+
+            // Set the extract flags and stream values as labels
+            stage.labels {
+              values = {
+                flags  = "",
+                stream  = "",
+              }
+            }
+          }
+
+          stage.match {
+            selector = "{tmp_container_runtime=\"docker\"}"
+            // the docker processing stage extracts the following k/v pairs: log, stream, time
+            stage.docker {}
+
+            // Set the extract stream value as a label
+            stage.labels {
+              values = {
+                stream  = "",
+              }
+            }
+          }
+
+          // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
+          // namespace, pod, and container labels. Drop any structured metadata. Also drop the temporary
+          // container runtime label as it is no longer needed.
+          stage.label_drop {
+            values = [
+              "filename",
+              "tmp_container_runtime",
+            ]
+          }
+          stage.structured_metadata {
+            values = {
+              "k8s_pod_name" = "k8s_pod_name",
+              "pod" = "pod",
+              "service_instance_id" = "service_instance_id",
+            }
+          }
+
+          forward_to = argument.logs_destinations.value
+        } // loki.secretfilter "pod_logs"
+      } // declare "pod_logs_via_loki"
+should filter to namespaces matching a regular expression:
+  1: |
+    |-
+      declare "pod_logs_via_loki" {
+        argument "logs_destinations" {
+          comment = "Must be a list of log destinations where collected logs should be forwarded to"
+        }
+
+        discovery.kubernetes "pods" {
+          role = "pod"
+          selectors {
+            role = "pod"
+            field = "spec.nodeName=" + sys.env("HOSTNAME")
+          }
+        } // discovery.kubernetes "pods"
+
+        discovery.relabel "filtered_pods" {
+          targets = discovery.kubernetes.pods.targets
+          rule {
+            source_labels = ["__meta_kubernetes_namespace"]
+            action = "replace"
+            target_label = "namespace"
+          }
+          rule {
+            source_labels = ["namespace"]
+            regex = "team-.*"
+            action = "keep"
+          }
+          rule {  // Drop anything with a "falsy" annotation value
+            source_labels = ["__meta_kubernetes_pod_annotation_logs_grafana_com_pods_enabled"]
+            regex = "(false|no|skip)"
+            action = "drop"
+          }
+          rule {
+            source_labels = ["__meta_kubernetes_pod_name"]
+            target_label = "pod"
+          }
+          rule {
+            source_labels = ["__meta_kubernetes_pod_container_name"]
+            target_label = "container"
+          }
+          rule {
+            source_labels = ["__meta_kubernetes_namespace", "__meta_kubernetes_pod_container_name"]
+            separator = "/"
+            replacement = "$1"
+            target_label = "job"
+          }
+
+          // set the container runtime as a label
+          rule {
+            source_labels = ["__meta_kubernetes_pod_container_id"]
+            regex = "^(\\S+):\\/\\/.+$"
+            replacement = "$1"
+            target_label = "tmp_container_runtime"
+          }
+          // explicitly set service_name. if not set, loki will automatically try to populate a default.
+          // see https://grafana.com/docs/loki/latest/get-started/labels/#default-labels-for-all-users
+          //
+          // choose the first value found from the following ordered list:
+          // - pod.annotation[resource.opentelemetry.io/service.name]
+          // - pod.label[app.kubernetes.io/name]
+          // - k8s.container.name
+          rule {
+            source_labels = [
+              "__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_name",
+              "__meta_kubernetes_pod_label_app_kubernetes_io_name",
+              "__meta_kubernetes_pod_container_name",
+            ]
+            separator = ";"
+            regex = "^(?:;*)?([^;]+).*$"
+            replacement = "$1"
+            target_label = "service_name"
+          }
+
+          // explicitly set service_namespace.
+          //
+          // choose the first value found from the following ordered list:
+          // - pod.annotation[resource.opentelemetry.io/service.namespace]
+          // - pod.namespace
+          rule {
+            source_labels = [
+              "__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_namespace",
+              "namespace",
+            ]
+            separator = ";"
+            regex = "^(?:;*)?([^;]+).*$"
+            replacement = "$1"
+            target_label = "service_namespace"
+          }
+
+          // explicitly set service_instance_id.
+          //
+          // choose the first value found from the following ordered list:
+          // - pod.annotation[resource.opentelemetry.io/service.instance.id]
+          // - concat([k8s.namespace.name, k8s.pod.name, k8s.container.name], '.')
+          rule {
+            source_labels = ["__meta_kubernetes_pod_annotation_resource_opentelemetry_io_service_instance_id"]
+            target_label = "service_instance_id"
+          }
+          rule {
+            source_labels = ["service_instance_id", "namespace", "pod", "container"]
+            separator = "."
+            regex = "^\\.([^.]+\\.[^.]+\\.[^.]+)$"
+            target_label = "service_instance_id"
+          }
+
+          // set resource attributes
+          rule {
+            action = "labelmap"
+            regex = "__meta_kubernetes_pod_annotation_resource_opentelemetry_io_(.+)"
+          }
+          rule {
+            source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_logs_job"]
+            regex = "(.+)"
+            target_label = "job"
+          }
+          rule {
+            source_labels = ["__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+            regex = "(.+)"
+            target_label = "app_kubernetes_io_name"
+          }
+
+          // Set the pod log path.
+          rule {
+            source_labels = ["__meta_kubernetes_pod_uid", "__meta_kubernetes_pod_container_name"]
+            separator = "/"
+            replacement = "/var/log/pods/*$1/*.log"
+            target_label = "__path__"
+          }
+
+          // If kubernetes.io/config.mirror is set, this is a static pod, created by the kubelet.
+          // It's logs live on a different path.
+          rule {
+            source_labels = ["__meta_kubernetes_pod_annotation_kubernetes_io_config_mirror", "__meta_kubernetes_pod_container_name"]
+            separator = "/"
+            regex = "(.+/.+)"
+            replacement = "/var/log/pods/*$1/*.log"
+            target_label = "__path__"
+          }
+        } // discovery.relabel "filtered_pods"
+
+        local.file_match "pod_logs" {
+          path_targets = discovery.relabel.filtered_pods.output
+        } // local.file_match "pod_logs"
+
+        loki.source.file "pod_logs" {
+          targets    = local.file_match.pod_logs.targets
+          tail_from_end = true
+          forward_to = [loki.process.pod_logs.receiver]
+        } // loki.source.file "pod_logs"
+
+        loki.process "pod_logs" {
+          stage.match {
+            selector = "{tmp_container_runtime=~\"containerd|cri-o|\"}"
+            // the cri processing stage extracts the following k/v pairs: log, stream, time, flags
+            stage.cri {
+              max_partial_lines = 100
+            }
+
+            // Set the extract flags and stream values as labels
+            stage.labels {
+              values = {
+                flags  = "",
+                stream  = "",
+              }
+            }
+          }
+
+          stage.match {
+            selector = "{tmp_container_runtime=\"docker\"}"
+            // the docker processing stage extracts the following k/v pairs: log, stream, time
+            stage.docker {}
+
+            // Set the extract stream value as a label
+            stage.labels {
+              values = {
+                stream  = "",
+              }
+            }
+          }
+
+          // Drop the filename label, since it's not really useful in the context of Kubernetes, where we already have cluster,
+          // namespace, pod, and container labels. Drop any structured metadata. Also drop the temporary
+          // container runtime label as it is no longer needed.
+          stage.label_drop {
+            values = [
+              "filename",
+              "tmp_container_runtime",
+            ]
+          }
+          stage.structured_metadata {
+            values = {
+              "k8s_pod_name" = "k8s_pod_name",
+              "pod" = "pod",
+              "service_instance_id" = "service_instance_id",
+            }
+          }
+
           forward_to = argument.logs_destinations.value
         } // loki.secretfilter "pod_logs"
       } // declare "pod_logs_via_loki"

--- a/charts/k8s-monitoring/charts/feature-pod-logs-via-loki/tests/__snapshot__/namespace_metadata_test.yaml.snap
+++ b/charts/k8s-monitoring/charts/feature-pod-logs-via-loki/tests/__snapshot__/namespace_metadata_test.yaml.snap
@@ -12,10 +12,10 @@ should attach both namespace and node metadata when both are enabled:
             role = "pod"
             field = "spec.nodeName=" + sys.env("HOSTNAME")
           }
-            attach_metadata {
-              namespace = true
-              node = true
-            }
+          attach_metadata {
+            namespace = true
+            node = true
+          }
         } // discovery.kubernetes "pods"
 
         discovery.relabel "filtered_pods" {
@@ -52,7 +52,6 @@ should attach both namespace and node metadata when both are enabled:
             replacement = "$1"
             target_label = "tmp_container_runtime"
           }
-
           // explicitly set service_name. if not set, loki will automatically try to populate a default.
           // see https://grafana.com/docs/loki/latest/get-started/labels/#default-labels-for-all-users
           //
@@ -225,9 +224,9 @@ should attach namespace metadata when attachNamespaceMetadata is enabled:
             role = "pod"
             field = "spec.nodeName=" + sys.env("HOSTNAME")
           }
-            attach_metadata {
-              namespace = true
-            }
+          attach_metadata {
+            namespace = true
+          }
         } // discovery.kubernetes "pods"
 
         discovery.relabel "filtered_pods" {
@@ -264,7 +263,6 @@ should attach namespace metadata when attachNamespaceMetadata is enabled:
             replacement = "$1"
             target_label = "tmp_container_runtime"
           }
-
           // explicitly set service_name. if not set, loki will automatically try to populate a default.
           // see https://grafana.com/docs/loki/latest/get-started/labels/#default-labels-for-all-users
           //

--- a/charts/k8s-monitoring/charts/feature-pod-logs-via-loki/tests/default_test.yaml
+++ b/charts/k8s-monitoring/charts/feature-pod-logs-via-loki/tests/default_test.yaml
@@ -101,3 +101,45 @@ tests:
           of: ConfigMap
       - matchSnapshot:
           path: data["module.alloy"]
+
+  - it: should filter to namespaces matching a regular expression
+    set:
+      testing: {enabled: true}
+      namespaces: ["team-.*"]
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - matchRegex:
+          path: data["module.alloy"]
+          pattern: 'rule \{\s*source_labels = \["namespace"\]\s*regex = "team-\.\*"\s*action = "keep"\s*\}'
+      - notMatchRegex:
+          path: data["module.alloy"]
+          pattern: 'namespaces \{'
+      - matchSnapshot:
+          path: data["module.alloy"]
+
+  - it: should allow multiple namespace patterns, matched as alternation
+    set:
+      testing: {enabled: true}
+      namespaces: ["team-a", "team-b.*"]
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - matchRegex:
+          path: data["module.alloy"]
+          pattern: 'rule \{\s*source_labels = \["namespace"\]\s*regex = "team-a\|team-b\.\*"\s*action = "keep"\s*\}'
+      - matchSnapshot:
+          path: data["module.alloy"]
+
+  - it: should exclude namespaces matching a regular expression
+    set:
+      testing: {enabled: true}
+      excludeNamespaces: ["kube-.*"]
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - matchRegex:
+          path: data["module.alloy"]
+          pattern: 'rule \{\s*source_labels = \["namespace"\]\s*regex = "kube-\.\*"\s*action = "drop"\s*\}'
+      - matchSnapshot:
+          path: data["module.alloy"]

--- a/charts/k8s-monitoring/charts/feature-pod-logs-via-loki/values.yaml
+++ b/charts/k8s-monitoring/charts/feature-pod-logs-via-loki/values.yaml
@@ -4,11 +4,13 @@ global:
   # @section -- Global Settings
   namespaceOverride: ""
 
-# -- Only capture logs from pods in these namespaces (`[]` means all namespaces).
+# -- Only capture logs from pods in namespaces matching these regular expressions (`[]` means all namespaces).
+# Each entry is matched as a RE2 regular expression against the full namespace name (e.g. `team-.*`).
 # @section -- Discovery Settings
 namespaces: []
 
-# -- Do not capture logs from any pods in these namespaces.
+# -- Do not capture logs from pods in namespaces matching these regular expressions.
+# Each entry is matched as a RE2 regular expression against the full namespace name (e.g. `team-.*`).
 # @section -- Discovery Settings
 excludeNamespaces: []
 

--- a/charts/k8s-monitoring/docs/examples/dataProcessors/custom/scrub-log-pii/alloy-logs.alloy
+++ b/charts/k8s-monitoring/docs/examples/dataProcessors/custom/scrub-log-pii/alloy-logs.alloy
@@ -10,9 +10,6 @@ declare "pod_logs_via_loki" {
       role = "pod"
       field = "spec.nodeName=" + sys.env("HOSTNAME")
     }
-    namespaces {
-      names = ["workload"]
-    }
   } // discovery.kubernetes "pods"
 
   discovery.relabel "filtered_pods" {
@@ -21,6 +18,11 @@ declare "pod_logs_via_loki" {
       source_labels = ["__meta_kubernetes_namespace"]
       action = "replace"
       target_label = "namespace"
+    }
+    rule {
+      source_labels = ["namespace"]
+      regex = "workload"
+      action = "keep"
     }
     rule {  // Drop anything with a "falsy" annotation value
       source_labels = ["__meta_kubernetes_pod_annotation_logs_grafana_com_pods_enabled"]

--- a/charts/k8s-monitoring/docs/examples/dataProcessors/custom/scrub-log-pii/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/dataProcessors/custom/scrub-log-pii/output.yaml
@@ -57,9 +57,6 @@ data:
           role = "pod"
           field = "spec.nodeName=" + sys.env("HOSTNAME")
         }
-        namespaces {
-          names = ["workload"]
-        }
       } // discovery.kubernetes "pods"
     
       discovery.relabel "filtered_pods" {
@@ -68,6 +65,11 @@ data:
           source_labels = ["__meta_kubernetes_namespace"]
           action = "replace"
           target_label = "namespace"
+        }
+        rule {
+          source_labels = ["namespace"]
+          regex = "workload"
+          action = "keep"
         }
         rule {  // Drop anything with a "falsy" annotation value
           source_labels = ["__meta_kubernetes_pod_annotation_logs_grafana_com_pods_enabled"]

--- a/charts/k8s-monitoring/docs/examples/destinations/custom/debug/alloy-logs.alloy
+++ b/charts/k8s-monitoring/docs/examples/destinations/custom/debug/alloy-logs.alloy
@@ -10,9 +10,6 @@ declare "pod_logs_via_loki" {
       role = "pod"
       field = "spec.nodeName=" + sys.env("HOSTNAME")
     }
-    namespaces {
-      names = ["default"]
-    }
       selectors {
         role = "pod"
         label = "app.kubernetes.io/name=alloy-metrics"
@@ -25,6 +22,11 @@ declare "pod_logs_via_loki" {
       source_labels = ["__meta_kubernetes_namespace"]
       action = "replace"
       target_label = "namespace"
+    }
+    rule {
+      source_labels = ["namespace"]
+      regex = "default"
+      action = "keep"
     }
     rule {  // Drop anything with a "falsy" annotation value
       source_labels = ["__meta_kubernetes_pod_annotation_logs_grafana_com_pods_enabled"]

--- a/charts/k8s-monitoring/docs/examples/destinations/custom/debug/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/destinations/custom/debug/output.yaml
@@ -45,9 +45,6 @@ data:
           role = "pod"
           field = "spec.nodeName=" + sys.env("HOSTNAME")
         }
-        namespaces {
-          names = ["default"]
-        }
           selectors {
             role = "pod"
             label = "app.kubernetes.io/name=alloy-metrics"
@@ -60,6 +57,11 @@ data:
           source_labels = ["__meta_kubernetes_namespace"]
           action = "replace"
           target_label = "namespace"
+        }
+        rule {
+          source_labels = ["namespace"]
+          regex = "default"
+          action = "keep"
         }
         rule {  // Drop anything with a "falsy" annotation value
           source_labels = ["__meta_kubernetes_pod_annotation_logs_grafana_com_pods_enabled"]

--- a/charts/k8s-monitoring/docs/examples/include-by-namespace/alloy-logs.alloy
+++ b/charts/k8s-monitoring/docs/examples/include-by-namespace/alloy-logs.alloy
@@ -10,9 +10,6 @@ declare "pod_logs_via_loki" {
       role = "pod"
       field = "spec.nodeName=" + sys.env("HOSTNAME")
     }
-    namespaces {
-      names = ["alpha","bravo","delta"]
-    }
   } // discovery.kubernetes "pods"
 
   discovery.relabel "filtered_pods" {
@@ -21,6 +18,11 @@ declare "pod_logs_via_loki" {
       source_labels = ["__meta_kubernetes_namespace"]
       action = "replace"
       target_label = "namespace"
+    }
+    rule {
+      source_labels = ["namespace"]
+      regex = "alpha|bravo|delta"
+      action = "keep"
     }
     rule {  // Drop anything with a "falsy" annotation value
       source_labels = ["__meta_kubernetes_pod_annotation_logs_grafana_com_pods_enabled"]

--- a/charts/k8s-monitoring/docs/examples/include-by-namespace/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/include-by-namespace/output.yaml
@@ -134,9 +134,6 @@ data:
           role = "pod"
           field = "spec.nodeName=" + sys.env("HOSTNAME")
         }
-        namespaces {
-          names = ["alpha","bravo","delta"]
-        }
       } // discovery.kubernetes "pods"
     
       discovery.relabel "filtered_pods" {
@@ -145,6 +142,11 @@ data:
           source_labels = ["__meta_kubernetes_namespace"]
           action = "replace"
           target_label = "namespace"
+        }
+        rule {
+          source_labels = ["namespace"]
+          regex = "alpha|bravo|delta"
+          action = "keep"
         }
         rule {  // Drop anything with a "falsy" annotation value
           source_labels = ["__meta_kubernetes_pod_annotation_logs_grafana_com_pods_enabled"]

--- a/charts/k8s-monitoring/docs/examples/meta-monitoring/alloy.alloy
+++ b/charts/k8s-monitoring/docs/examples/meta-monitoring/alloy.alloy
@@ -1833,9 +1833,6 @@ declare "pod_logs_via_loki" {
       role = "pod"
       field = "spec.nodeName=" + sys.env("HOSTNAME")
     }
-    namespaces {
-      names = ["collectors","logs","metrics","o11y"]
-    }
     attach_metadata {
       node = true
     }
@@ -1847,6 +1844,11 @@ declare "pod_logs_via_loki" {
       source_labels = ["__meta_kubernetes_namespace"]
       action = "replace"
       target_label = "namespace"
+    }
+    rule {
+      source_labels = ["namespace"]
+      regex = "collectors|logs|metrics|o11y"
+      action = "keep"
     }
     rule {  // Drop anything with a "falsy" annotation value
       source_labels = ["__meta_kubernetes_pod_annotation_logs_grafana_com_pods_enabled"]

--- a/charts/k8s-monitoring/docs/examples/meta-monitoring/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/meta-monitoring/output.yaml
@@ -1890,9 +1890,6 @@ data:
           role = "pod"
           field = "spec.nodeName=" + sys.env("HOSTNAME")
         }
-        namespaces {
-          names = ["collectors","logs","metrics","o11y"]
-        }
         attach_metadata {
           node = true
         }
@@ -1904,6 +1901,11 @@ data:
           source_labels = ["__meta_kubernetes_namespace"]
           action = "replace"
           target_label = "namespace"
+        }
+        rule {
+          source_labels = ["namespace"]
+          regex = "collectors|logs|metrics|o11y"
+          action = "keep"
         }
         rule {  // Drop anything with a "falsy" annotation value
           source_labels = ["__meta_kubernetes_pod_annotation_logs_grafana_com_pods_enabled"]

--- a/charts/k8s-monitoring/docs/examples/rbac-no-cluster-roles/alloy-logs.alloy
+++ b/charts/k8s-monitoring/docs/examples/rbac-no-cluster-roles/alloy-logs.alloy
@@ -10,9 +10,6 @@ declare "pod_logs_via_loki" {
       role = "pod"
       field = "spec.nodeName=" + sys.env("HOSTNAME")
     }
-    namespaces {
-      names = ["default"]
-    }
   } // discovery.kubernetes "pods"
 
   discovery.relabel "filtered_pods" {
@@ -21,6 +18,11 @@ declare "pod_logs_via_loki" {
       source_labels = ["__meta_kubernetes_namespace"]
       action = "replace"
       target_label = "namespace"
+    }
+    rule {
+      source_labels = ["namespace"]
+      regex = "default"
+      action = "keep"
     }
     rule {  // Drop anything with a "falsy" annotation value
       source_labels = ["__meta_kubernetes_pod_annotation_logs_grafana_com_pods_enabled"]

--- a/charts/k8s-monitoring/docs/examples/rbac-no-cluster-roles/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/rbac-no-cluster-roles/output.yaml
@@ -118,9 +118,6 @@ data:
           role = "pod"
           field = "spec.nodeName=" + sys.env("HOSTNAME")
         }
-        namespaces {
-          names = ["default"]
-        }
       } // discovery.kubernetes "pods"
     
       discovery.relabel "filtered_pods" {
@@ -129,6 +126,11 @@ data:
           source_labels = ["__meta_kubernetes_namespace"]
           action = "replace"
           target_label = "namespace"
+        }
+        rule {
+          source_labels = ["namespace"]
+          regex = "default"
+          action = "keep"
         }
         rule {  // Drop anything with a "falsy" annotation value
           source_labels = ["__meta_kubernetes_pod_annotation_logs_grafana_com_pods_enabled"]


### PR DESCRIPTION
Move namespace inclusion from discovery.kubernetes's exact-match namespaces.names field to a discovery.relabel keep rule with a regex, mirroring how excludeNamespaces already works. This lets podLogsViaLoki.namespaces match namespaces by pattern (e.g. team-.*) instead of requiring an exhaustive list of exact names.

Fixes #2860

<!--Authorship attestation. See AGENTS.md for details. AI agents must not check this box on behalf
of the user; the human author must check it themselves before the PR is ready for review.-->
## Authorship

-   [ ] I, a human, wrote this pull request description myself.

<!--Please delete paragraphs that you did not use before submitting.-->
Code written with the help of Claude and reviewed by me
