### PR TITLE
fix: let KEDA own Alloy replica count

### DIFF
--- a/charts/k8s-monitoring/docs/examples/scalability/keda-autoscaling/README.md
+++ b/charts/k8s-monitoring/docs/examples/scalability/keda-autoscaling/README.md
@@ -10,8 +10,9 @@ series Alloy is buffering in its write-ahead log on the way to the Prometheus de
 signal of telemetry workload than CPU or memory alone.
 
 The Alloy integration is enabled so Alloy scrapes its own metrics and ships them to Prometheus, where KEDA
-queries them through a Prometheus trigger on a `ScaledObject`. The native Alloy autoscaling is not used
-because KEDA creates and manages its own HorizontalPodAutoscaler.
+queries them through a Prometheus trigger on a `ScaledObject`. The collector enables
+`controller.autoscaling.horizontal.externalHPA` so the Alloy Operator omits `spec.replicas` and allows KEDA's
+HorizontalPodAutoscaler to own the replica count.
 
 ## Prerequisites
 
@@ -52,11 +53,13 @@ collectors:
         requests:
           cpu: "1m"
           memory: "500Mi"
-    # Native HPA is intentionally disabled. KEDA's ScaledObject below creates and manages an HPA
-    # that scales on Alloy's own custom metric (active series in the Prometheus remote_write WAL).
+    # Allow KEDA's ScaledObject below to own the replica count without the Alloy Operator reverting it.
+    # KEDA scales on Alloy's own custom metric (active series in the Prometheus remote_write WAL).
     controller:
       autoscaling:
-        enabled: false
+        horizontal:
+          enabled: false
+          externalHPA: true
 
 telemetryServices:
   kube-state-metrics:

--- a/charts/k8s-monitoring/docs/examples/scalability/keda-autoscaling/description.txt
+++ b/charts/k8s-monitoring/docs/examples/scalability/keda-autoscaling/description.txt
@@ -6,8 +6,9 @@ series Alloy is buffering in its write-ahead log on the way to the Prometheus de
 signal of telemetry workload than CPU or memory alone.
 
 The Alloy integration is enabled so Alloy scrapes its own metrics and ships them to Prometheus, where KEDA
-queries them through a Prometheus trigger on a `ScaledObject`. The native Alloy autoscaling is not used
-because KEDA creates and manages its own HorizontalPodAutoscaler.
+queries them through a Prometheus trigger on a `ScaledObject`. The collector enables
+`controller.autoscaling.horizontal.externalHPA` so the Alloy Operator omits `spec.replicas` and allows KEDA's
+HorizontalPodAutoscaler to own the replica count.
 
 ## Prerequisites
 

--- a/charts/k8s-monitoring/docs/examples/scalability/keda-autoscaling/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/scalability/keda-autoscaling/output.yaml
@@ -1550,7 +1550,9 @@ spec:
         type: RuntimeDefault
   controller:
     autoscaling:
-      enabled: false
+      horizontal:
+        enabled: false
+        externalHPA: true
     nodeSelector:
       kubernetes.io/os: linux
     podAnnotations:

--- a/charts/k8s-monitoring/docs/examples/scalability/keda-autoscaling/values.yaml
+++ b/charts/k8s-monitoring/docs/examples/scalability/keda-autoscaling/values.yaml
@@ -28,11 +28,13 @@ collectors:
         requests:
           cpu: "1m"
           memory: "500Mi"
-    # Native HPA is intentionally disabled. KEDA's ScaledObject below creates and manages an HPA
-    # that scales on Alloy's own custom metric (active series in the Prometheus remote_write WAL).
+    # Allow KEDA's ScaledObject below to own the replica count without the Alloy Operator reverting it.
+    # KEDA scales on Alloy's own custom metric (active series in the Prometheus remote_write WAL).
     controller:
       autoscaling:
-        enabled: false
+        horizontal:
+          enabled: false
+          externalHPA: true
 
 telemetryServices:
   kube-state-metrics:

--- a/charts/k8s-monitoring/tests/example-checks/spec/keda_autoscaling_spec.sh
+++ b/charts/k8s-monitoring/tests/example-checks/spec/keda_autoscaling_spec.sh
@@ -1,0 +1,9 @@
+Describe 'KEDA Autoscaling Check'
+  Describe 'Using an externally managed HPA'
+    It 'configures the Alloy collector to let KEDA own the replica count'
+      When call grep -F 'externalHPA: true' ../../docs/examples/scalability/keda-autoscaling/output.yaml
+      The status should be success
+      The output should equal '        externalHPA: true'
+    End
+  End
+End


### PR DESCRIPTION
Fixes: #2920

## Changes

- Updated the KEDA autoscaling example to enable `controller.autoscaling.horizontal.externalHPA`.
- This causes the Alloy Operator to omit `spec.replicas`, allowing KEDA's HPA to control the replica count.
- Updated the generated example README and rendered manifests.
- Added a ShellSpec regression check for `externalHPA: true`.

## Verified testing

- ShellSpec example checks: 5 examples, 0 failures.
- Rendered the example with Helm 3.14.4 and confirmed it matches the committed `output.yaml`.
- Regenerated the example README and confirmed it matches the committed file.

## Upstream changes

- https://github.com/grafana/alloy/pull/6311
- https://github.com/grafana/alloy/pull/6396
- https://github.com/grafana/alloy-operator/pull/187

<!--Authorship attestation. See AGENTS.md for details. AI agents must not check this box on behalf
of the user; the human author must check it themselves before the PR is ready for review.-->
## Authorship

-   [x] I, a human, wrote this pull request description myself.