### PR TITLE
fix: router-aware destination validation errors and NOTES whitespace cleanup

### DIFF
--- a/charts/k8s-monitoring/CHANGELOG.md
+++ b/charts/k8s-monitoring/CHANGELOG.md
@@ -8,6 +8,8 @@
 *   Add a `windows-scrapeable` preset, which opens the Alloy metrics port on the Windows Node's host firewall so other collectors can scrape it. (@petewall)
 *   Add the `router` destination, which routes telemetry to different destinations based on the value of a resource attribute or label (default `k8s.namespace.name`). Routes are evaluated in order and the first match wins; unmatched data goes to the required `defaultDestinations`. (#2849) (@mbaykara)
 *   Update Windows Exporter to 0.12.8 (@petewall)
+*   Improve the "No destinations found" validation error: when capable destinations exist but are only reachable through a `router` destination, the error now lists those destinations, names the signal-capable router(s), and shows the exact `destinations:` setting to opt the feature in. (#2924) (@mbaykara)
+*   Fix stray blank lines in the post-install notes output when the Host Metrics feature is enabled. (#2924) (@mbaykara)
 
 ## 4.3.1
 

--- a/charts/k8s-monitoring/charts/feature-host-metrics/templates/_notes.tpl
+++ b/charts/k8s-monitoring/charts/feature-host-metrics/templates/_notes.tpl
@@ -5,39 +5,39 @@ Scrape Kubernetes Host metrics
 {{- end }}
 
 {{- define "feature.hostMetrics.notes.actions" }}
-{{/*{{- $serviceMonitorScrapingEnabled := and .Values.prometheusOperatorObjects.enabled (dig "serviceMonitors" "enabled" true .Values.prometheusOperatorObjects)}}*/}}
-{{/*{{- $checkForKSMServiceMonitors := and (index .Values.clusterMetrics "kube-state-metrics").enabled (index .Values.clusterMetrics "kube-state-metrics").checkForPotentialServiceMonitorConflicts }}*/}}
-{{/*{{- $checkForNodeExporterServiceMonitors := and (index .Values.clusterMetrics "node-exporter").enabled (index .Values.clusterMetrics "node-exporter").checkForPotentialServiceMonitorConflicts }}*/}}
-{{/*{{- if and $serviceMonitorScrapingEnabled (or $checkForKSMServiceMonitors $checkForNodeExporterServiceMonitors) }}*/}}
-{{/*  {{- $values := .Values.clusterMetrics }}*/}}
-{{/*  {{- if (.Capabilities.APIVersions.Has "monitoring.coreos.com/v1/ServiceMonitor") }}*/}}
-{{/*    {{- $namespaces := list }}*/}}
-{{/*    {{- range $serviceMonitor := (lookup "monitoring.coreos.com/v1" "ServiceMonitor" "" "").items }}*/}}
-{{/*      {{- if contains "kube-state-metrics" $serviceMonitor.metadata.name }}*/}}
-{{/*        {{- if $checkForKSMServiceMonitors }}*/}}
-{{/*          {{- $namespaces = append $namespaces $serviceMonitor.metadata.namespace }}*/}}
-{{/*⚠️ Detected a ServiceMonitor named {{ $serviceMonitor.metadata.name }} in namespace {{ $serviceMonitor.metadata.namespace }}, but this chart has already enabled the Cluster Metrics feature. This might result in duplicated metrics from kube-state-metrics.*/}}
-{{/*        {{- end }}*/}}
-{{/*      {{- end }}*/}}
-{{/*      {{- if contains "node-exporter" $serviceMonitor.metadata.name }}*/}}
-{{/*        {{- if $checkForNodeExporterServiceMonitors }}*/}}
-{{/*          {{- $namespaces = append $namespaces $serviceMonitor.metadata.namespace }}*/}}
-{{/*⚠️ Detected a ServiceMonitor named {{ $serviceMonitor.metadata.name }} in namespace {{ $serviceMonitor.metadata.namespace }}, but this chart has already enabled the Cluster Metrics feature. This might result in duplicated metrics from Node Exporter.*/}}
-{{/*        {{- end }}*/}}
-{{/*      {{- end }}*/}}
-{{/*    {{- end }}*/}}
-{{/*  {{- if $namespaces }}*/}}
-{{/*To prevent duplicate metrics, either delete the ServiceMonitor, or filter them out with:*/}}
-{{/*prometheusOperatorObjects:*/}}
-{{/*  serviceMonitors:*/}}
-{{/*    excludeNamespaces:{{ $namespaces | uniq | toYaml | nindent 6 }}*/}}
-{{/*OR*/}}
-{{/*prometheusOperatorObjects:*/}}
-{{/*  serviceMonitors:*/}}
-{{/*    labelExpressions: <label expression to exclude the ServiceMonitor>*/}}
-{{/*  {{- end }}*/}}
-{{/*  {{- end }}*/}}
-{{/*{{- end }}*/}}
+{{- /*{{- $serviceMonitorScrapingEnabled := and .Values.prometheusOperatorObjects.enabled (dig "serviceMonitors" "enabled" true .Values.prometheusOperatorObjects)}}*/}}
+{{- /*{{- $checkForKSMServiceMonitors := and (index .Values.clusterMetrics "kube-state-metrics").enabled (index .Values.clusterMetrics "kube-state-metrics").checkForPotentialServiceMonitorConflicts }}*/}}
+{{- /*{{- $checkForNodeExporterServiceMonitors := and (index .Values.clusterMetrics "node-exporter").enabled (index .Values.clusterMetrics "node-exporter").checkForPotentialServiceMonitorConflicts }}*/}}
+{{- /*{{- if and $serviceMonitorScrapingEnabled (or $checkForKSMServiceMonitors $checkForNodeExporterServiceMonitors) }}*/}}
+{{- /*  {{- $values := .Values.clusterMetrics }}*/}}
+{{- /*  {{- if (.Capabilities.APIVersions.Has "monitoring.coreos.com/v1/ServiceMonitor") }}*/}}
+{{- /*    {{- $namespaces := list }}*/}}
+{{- /*    {{- range $serviceMonitor := (lookup "monitoring.coreos.com/v1" "ServiceMonitor" "" "").items }}*/}}
+{{- /*      {{- if contains "kube-state-metrics" $serviceMonitor.metadata.name }}*/}}
+{{- /*        {{- if $checkForKSMServiceMonitors }}*/}}
+{{- /*          {{- $namespaces = append $namespaces $serviceMonitor.metadata.namespace }}*/}}
+{{- /*⚠️ Detected a ServiceMonitor named {{ $serviceMonitor.metadata.name }} in namespace {{ $serviceMonitor.metadata.namespace }}, but this chart has already enabled the Cluster Metrics feature. This might result in duplicated metrics from kube-state-metrics.*/}}
+{{- /*        {{- end }}*/}}
+{{- /*      {{- end }}*/}}
+{{- /*      {{- if contains "node-exporter" $serviceMonitor.metadata.name }}*/}}
+{{- /*        {{- if $checkForNodeExporterServiceMonitors }}*/}}
+{{- /*          {{- $namespaces = append $namespaces $serviceMonitor.metadata.namespace }}*/}}
+{{- /*⚠️ Detected a ServiceMonitor named {{ $serviceMonitor.metadata.name }} in namespace {{ $serviceMonitor.metadata.namespace }}, but this chart has already enabled the Cluster Metrics feature. This might result in duplicated metrics from Node Exporter.*/}}
+{{- /*        {{- end }}*/}}
+{{- /*      {{- end }}*/}}
+{{- /*    {{- end }}*/}}
+{{- /*  {{- if $namespaces }}*/}}
+{{- /*To prevent duplicate metrics, either delete the ServiceMonitor, or filter them out with:*/}}
+{{- /*prometheusOperatorObjects:*/}}
+{{- /*  serviceMonitors:*/}}
+{{- /*    excludeNamespaces:{{ $namespaces | uniq | toYaml | nindent 6 }}*/}}
+{{- /*OR*/}}
+{{- /*prometheusOperatorObjects:*/}}
+{{- /*  serviceMonitors:*/}}
+{{- /*    labelExpressions: <label expression to exclude the ServiceMonitor>*/}}
+{{- /*  {{- end }}*/}}
+{{- /*  {{- end }}*/}}
+{{- /*{{- end }}*/}}
 {{- end }}
 
 {{- define "feature.hostMetrics.summary" }}

--- a/charts/k8s-monitoring/templates/destinations/_destination_validations.tpl
+++ b/charts/k8s-monitoring/templates/destinations/_destination_validations.tpl
@@ -16,12 +16,82 @@
   {{- end }}
 {{- end }}
 
-{{/* Inputs: destinations (array of destination names), type (string), featureName (string) */}}
+{{/* Inputs: destinations (array of destination names), type (string), featureName (string),
+     Values (optional, the chart's .Values), featureKey (optional, this feature's values key).
+
+     When Values and featureKey are supplied and the empty list was caused by router shadowing --
+     every destination that could have carried this signal sits behind a router, and routers are
+     excluded from implicit selection (see the F7 comment on destinations.get) -- say so and
+     suggest naming the router, instead of the default "add a destination" advice. Without that
+     branch the message tells the user to add a destination of a type they already have, which is
+     the one situation where the generic advice is actively wrong. */}}
 {{- define "destinations.validate.destinationListNotEmpty" }}
 {{- if empty .destinations }}
+  {{- $routerCandidates := list }}
+  {{- $shadowedButCapable := list }}
+  {{- if and .Values .featureKey }}
+    {{- /* Shadowing only suppresses IMPLICIT selection. When the feature sets its own
+           `destinations` filter, destinations.get honours that filter verbatim and never consults
+           the shadow set (see the explicit-filter branch of destinations.get), so an empty result
+           means the filter itself is wrong -- a typo, or a destination that does not carry this
+           signal. Blaming a router there would tell the user to overwrite a choice they made
+           deliberately, so fall through to the generic advice. */}}
+    {{- $featureValues := index $.Values .featureKey | default dict }}
+    {{- $filter := $featureValues.destinations | default list }}
+    {{- if empty $filter }}
+      {{- $enabledDestinations := include "destinations.getEnabled" ($.Values.destinations | default dict) | fromYaml }}
+      {{- /* Real destinations that carry this signal. Routers are excluded: their supports_<signal>
+             is unconditionally true, so counting them would treat a router as its own downstream.
+             Capability is checked against the raw destination values, matching how
+             destinations.get decides what it would have selected. */}}
+      {{- $capable := dict }}
+      {{- range $destinationName, $destination := $enabledDestinations }}
+        {{- if ne $destination.type "router" }}
+          {{- if eq (include (printf "destinations.%s.supports_%s" $destination.type $.type) $destination) "true" }}
+            {{- $_ := set $capable $destinationName true }}
+          {{- end }}
+        {{- end }}
+      {{- end }}
+      {{- /* Keep each router paired with the capable destinations IT shadows. Merging every
+             router's downstreams into one set would let us suggest a router whose downstreams
+             cannot carry this signal at all -- which passes validation and then silently
+             misroutes, because destinations.router.supports_<signal> always reports true. */}}
+      {{- $reachable := dict }}
+      {{- range $routerName, $router := $enabledDestinations }}
+        {{- if eq $router.type "router" }}
+          {{- $downstream := $router.defaultDestinations | default list }}
+          {{- range $route := ($router.routes | default list) }}
+            {{- $downstream = concat $downstream ($route.destinations | default list) }}
+          {{- end }}
+          {{- $matched := false }}
+          {{- range $d := $downstream }}
+            {{- if hasKey $capable $d }}
+              {{- $_ := set $reachable $d true }}
+              {{- $matched = true }}
+            {{- end }}
+          {{- end }}
+          {{- if $matched }}
+            {{- $routerCandidates = append $routerCandidates $routerName }}
+          {{- end }}
+        {{- end }}
+      {{- end }}
+      {{- $shadowedButCapable = keys $reachable | sortAlpha }}
+      {{- $routerCandidates = $routerCandidates | sortAlpha }}
+    {{- end }}
+  {{- end }}
   {{- $msg := list "" (printf "No destinations found that can accept %s from the %s feature." .type .featureName) }}
-  {{- $msg = append $msg (printf "Please add a destination with %s support." .type) }}
-  {{- $msg = append $msg "See https://github.com/grafana/k8s-monitoring-helm/blob/main/charts/k8s-monitoring/docs/destinations/README.md for more details." }}
+  {{- if and $routerCandidates $shadowedButCapable }}
+    {{- $msg = append $msg (printf "These destinations support %s, but are only reachable through a router: %s." .type (join ", " $shadowedButCapable)) }}
+    {{- $msg = append $msg (printf "Routers are excluded from implicit destination selection, so this feature must name the router it should send through: %s." (join ", " $routerCandidates)) }}
+    {{- $msg = append $msg "Please set:" }}
+    {{- $msg = append $msg (printf "%s:" .featureKey) }}
+    {{- $msg = append $msg "  destinations:" }}
+    {{- $msg = append $msg (printf "    - %s" (first $routerCandidates)) }}
+    {{- $msg = append $msg "See https://github.com/grafana/k8s-monitoring-helm/blob/main/charts/k8s-monitoring/docs/DestinationRouting.md for more details." }}
+  {{- else }}
+    {{- $msg = append $msg (printf "Please add a destination with %s support." .type) }}
+    {{- $msg = append $msg "See https://github.com/grafana/k8s-monitoring-helm/blob/main/charts/k8s-monitoring/docs/destinations/README.md for more details." }}
+  {{- end }}
   {{- fail (join "\n" $msg) }}
 {{- end }}
 {{- end }}

--- a/charts/k8s-monitoring/templates/features/_feature_annotation_autodiscovery.tpl
+++ b/charts/k8s-monitoring/templates/features/_feature_annotation_autodiscovery.tpl
@@ -40,7 +40,7 @@ annotation_autodiscovery "feature" {
   {{- $featureName := "Annotation Autodiscovery" }}
 
   {{- $destinations := include "features.annotationAutodiscovery.destinations" . | fromYamlArray }}
-  {{- include "destinations.validate.destinationListNotEmpty" (dict "destinations" $destinations "type" "metrics" "ecosystem" "prometheus" "featureName" $featureName) }}
+  {{- include "destinations.validate.destinationListNotEmpty" (dict "destinations" $destinations "type" "metrics" "ecosystem" "prometheus" "featureName" $featureName "Values" $.Values "featureKey" $featureKey) }}
   {{- include "dataProcessors.validate.feature" (dict "root" $ "featureKey" "annotationAutodiscovery" "featureName" $featureName "type" "metrics" "ecosystem" "prometheus") }}
 
   {{- $collectorName := include "collectors.getCollectorForFeature" (dict "Values" $.Values "featureKey" $featureKey) }}

--- a/charts/k8s-monitoring/templates/features/_feature_application_observability.tpl
+++ b/charts/k8s-monitoring/templates/features/_feature_application_observability.tpl
@@ -101,19 +101,19 @@ application_observability "feature" {
   {{/* Destination validations */}}
   {{- if .Values.applicationObservability.metrics.enabled -}}
     {{- $metricDestinations := include "destinations.get" (dict "destinations" $.Values.destinations "type" "metrics" "ecosystem" "otlp" "filter" $.Values.applicationObservability.destinations) | fromYamlArray -}}
-    {{- include "destinations.validate.destinationListNotEmpty" (dict "destinations" $metricDestinations "type" "metrics" "ecosystem" "otlp" "featureName" $featureName) }}
+    {{- include "destinations.validate.destinationListNotEmpty" (dict "destinations" $metricDestinations "type" "metrics" "ecosystem" "otlp" "featureName" $featureName "Values" $.Values "featureKey" $featureKey) }}
     {{- include "dataProcessors.validate.feature" (dict "root" $ "featureKey" $featureKey "featureName" $featureName "type" "metrics" "ecosystem" "otlp") }}
   {{- end -}}
 
   {{- if .Values.applicationObservability.logs.enabled -}}
     {{- $logDestinations := include "destinations.get" (dict "destinations" $.Values.destinations "type" "logs" "ecosystem" "otlp" "filter" $.Values.applicationObservability.destinations) | fromYamlArray -}}
-    {{- include "destinations.validate.destinationListNotEmpty" (dict "destinations" $logDestinations "type" "logs" "ecosystem" "otlp" "featureName" $featureName) }}
+    {{- include "destinations.validate.destinationListNotEmpty" (dict "destinations" $logDestinations "type" "logs" "ecosystem" "otlp" "featureName" $featureName "Values" $.Values "featureKey" $featureKey) }}
     {{- include "dataProcessors.validate.feature" (dict "root" $ "featureKey" $featureKey "featureName" $featureName "type" "logs" "ecosystem" "otlp") }}
   {{- end -}}
 
   {{- if .Values.applicationObservability.traces.enabled -}}
     {{- $traceDestinations := include "destinations.get" (dict "destinations" $.Values.destinations "type" "traces" "ecosystem" "otlp" "filter" $.Values.applicationObservability.destinations) | fromYamlArray -}}
-    {{- include "destinations.validate.destinationListNotEmpty" (dict "destinations" $traceDestinations "type" "traces" "ecosystem" "otlp" "featureName" $featureName) }}
+    {{- include "destinations.validate.destinationListNotEmpty" (dict "destinations" $traceDestinations "type" "traces" "ecosystem" "otlp" "featureName" $featureName "Values" $.Values "featureKey" $featureKey) }}
     {{- include "dataProcessors.validate.feature" (dict "root" $ "featureKey" $featureKey "featureName" $featureName "type" "traces" "ecosystem" "otlp") }}
   {{- end -}}
 

--- a/charts/k8s-monitoring/templates/features/_feature_auto_instrumentation.tpl
+++ b/charts/k8s-monitoring/templates/features/_feature_auto_instrumentation.tpl
@@ -19,7 +19,7 @@ auto_instrumentation "feature" {
 {{- $featureKey := "autoInstrumentation" }}
 {{- $featureName := "Auto-Instrumentation" }}
 {{- $destinations := include "features.autoInstrumentation.destinations" . | fromYamlArray }}
-{{- include "destinations.validate.destinationListNotEmpty" (dict "destinations" $destinations "type" "metrics" "ecosystem" "prometheus" "featureName" $featureName) }}
+{{- include "destinations.validate.destinationListNotEmpty" (dict "destinations" $destinations "type" "metrics" "ecosystem" "prometheus" "featureName" $featureName "Values" $.Values "featureKey" $featureKey) }}
 {{- include "dataProcessors.validate.feature" (dict "root" $ "featureKey" "autoInstrumentation" "featureName" $featureName "type" "metrics" "ecosystem" "prometheus") }}
 {{- $collectorName := include "collectors.getCollectorForFeature" (dict "Values" $.Values "featureKey" $featureKey) }}
 {{- include "collectors.validate.collectorIsAssigned" (dict "Values" $.Values "collectorName" $collectorName "featureKey" $featureKey "featureName" $featureName) }}

--- a/charts/k8s-monitoring/templates/features/_feature_cluster_events.tpl
+++ b/charts/k8s-monitoring/templates/features/_feature_cluster_events.tpl
@@ -41,7 +41,7 @@ cluster_events "feature" {
 {{- $featureKey := "clusterEvents" }}
 {{- $featureName := "Kubernetes Cluster events" }}
 {{- $destinationNames := include "features.clusterEvents.destinations" . | fromYamlArray }}
-{{- include "destinations.validate.destinationListNotEmpty" (dict "destinations" $destinationNames "type" "logs" "ecosystem" "loki" "featureName" $featureName) }}
+{{- include "destinations.validate.destinationListNotEmpty" (dict "destinations" $destinationNames "type" "logs" "ecosystem" "loki" "featureName" $featureName "Values" $.Values "featureKey" $featureKey) }}
 {{- include "dataProcessors.validate.feature" (dict "root" $ "featureKey" "clusterEvents" "featureName" $featureName "type" "logs" "ecosystem" "loki") }}
 {{- $collectorName := include "collectors.getCollectorForFeature" (dict "Values" $.Values "featureKey" $featureKey) }}
 {{- include "collectors.validate.collectorIsAssigned" (dict "Values" $.Values "collectorName" $collectorName "featureKey" $featureKey "featureName" $featureName) }}

--- a/charts/k8s-monitoring/templates/features/_feature_cluster_metrics.tpl
+++ b/charts/k8s-monitoring/templates/features/_feature_cluster_metrics.tpl
@@ -41,7 +41,7 @@ cluster_metrics "feature" {
   {{- $featureKey := "clusterMetrics" }}
   {{- $featureName := "Kubernetes Cluster metrics" }}
   {{- $destinations := include "features.clusterMetrics.destinations" . | fromYamlArray }}
-  {{- include "destinations.validate.destinationListNotEmpty" (dict "destinations" $destinations "type" "metrics" "ecosystem" "prometheus" "featureName" $featureName) }}
+  {{- include "destinations.validate.destinationListNotEmpty" (dict "destinations" $destinations "type" "metrics" "ecosystem" "prometheus" "featureName" $featureName "Values" $.Values "featureKey" $featureKey) }}
   {{- include "dataProcessors.validate.feature" (dict "root" $ "featureKey" $featureKey "featureName" $featureName "type" "metrics" "ecosystem" "prometheus") }}
 
   {{- $collectorName := include "collectors.getCollectorForFeature" (dict "Values" $.Values "featureKey" $featureKey) }}

--- a/charts/k8s-monitoring/templates/features/_feature_cost_metrics.tpl
+++ b/charts/k8s-monitoring/templates/features/_feature_cost_metrics.tpl
@@ -41,7 +41,7 @@ cost_metrics "feature" {
   {{- $featureKey := "costMetrics" }}
   {{- $featureName := "Kubernetes Cluster metrics" }}
   {{- $destinations := include "features.costMetrics.destinations" . | fromYamlArray }}
-  {{- include "destinations.validate.destinationListNotEmpty" (dict "destinations" $destinations "type" "metrics" "ecosystem" "prometheus" "featureName" $featureName) }}
+  {{- include "destinations.validate.destinationListNotEmpty" (dict "destinations" $destinations "type" "metrics" "ecosystem" "prometheus" "featureName" $featureName "Values" $.Values "featureKey" $featureKey) }}
   {{- include "dataProcessors.validate.feature" (dict "root" $ "featureKey" "costMetrics" "featureName" $featureName "type" "metrics" "ecosystem" "prometheus") }}
 
   {{- $collectorName := include "collectors.getCollectorForFeature" (dict "Values" $.Values "featureKey" $featureKey) }}

--- a/charts/k8s-monitoring/templates/features/_feature_host_metrics.tpl
+++ b/charts/k8s-monitoring/templates/features/_feature_host_metrics.tpl
@@ -41,7 +41,7 @@ host_metrics "feature" {
   {{- $featureKey := "hostMetrics" }}
   {{- $featureName := "Kubernetes Host metrics" }}
   {{- $destinations := include "features.hostMetrics.destinations" . | fromYamlArray }}
-  {{- include "destinations.validate.destinationListNotEmpty" (dict "destinations" $destinations "type" "metrics" "ecosystem" "prometheus" "featureName" $featureName) }}
+  {{- include "destinations.validate.destinationListNotEmpty" (dict "destinations" $destinations "type" "metrics" "ecosystem" "prometheus" "featureName" $featureName "Values" $.Values "featureKey" $featureKey) }}
   {{- include "dataProcessors.validate.feature" (dict "root" $ "featureKey" "hostMetrics" "featureName" $featureName "type" "metrics" "ecosystem" "prometheus") }}
 
   {{- $collectorName := include "collectors.getCollectorForFeature" (dict "Values" $.Values "featureKey" $featureKey) }}

--- a/charts/k8s-monitoring/templates/features/_feature_integrations.tpl
+++ b/charts/k8s-monitoring/templates/features/_feature_integrations.tpl
@@ -46,13 +46,13 @@
 
 {{- define "features.integrations.destinations.isTranslating" }}
 {{- $isTranslating := false -}}
-{{/*{{- $destinations := include "features.integrations.destinations" . | fromYamlArray -}}*/}}
-{{/*{{ range $destination := $destinations -}}*/}}
-{{/*  {{- $destinationEcosystem := include "destination.getEcosystem" (deepCopy $ | merge (dict "destination" $destination)) -}}*/}}
-{{/*  {{- if ne $destinationEcosystem "prometheus" -}}*/}}
-{{/*    {{- $isTranslating = true -}}*/}}
-{{/*  {{- end -}}*/}}
-{{/*{{- end -}}*/}}
+{{- /*{{- $destinations := include "features.integrations.destinations" . | fromYamlArray -}}*/}}
+{{- /*{{ range $destination := $destinations -}}*/}}
+{{- /*  {{- $destinationEcosystem := include "destination.getEcosystem" (deepCopy $ | merge (dict "destination" $destination)) -}}*/}}
+{{- /*  {{- if ne $destinationEcosystem "prometheus" -}}*/}}
+{{- /*    {{- $isTranslating = true -}}*/}}
+{{- /*  {{- end -}}*/}}
+{{- /*{{- end -}}*/}}
 {{- $isTranslating -}}
 {{- end -}}
 
@@ -87,7 +87,7 @@
 {{- $metricIntegrations := include "feature.integrations.configured.metrics" (dict "Values" .Values.integrations "Files" $.Subcharts.integrations.Files) | fromYamlArray }}
 {{- $destinations := include "features.integrations.destinations" . | fromYamlArray }}
 {{- if $metricIntegrations }}
-  {{- include "destinations.validate.destinationListNotEmpty" (dict "destinations" $destinations "type" "metrics" "ecosystem" "prometheus" "featureName" $featureName) }}
+  {{- include "destinations.validate.destinationListNotEmpty" (dict "destinations" $destinations "type" "metrics" "ecosystem" "prometheus" "featureName" $featureName "Values" $.Values "featureKey" "integrations") }}
   {{- include "dataProcessors.validate.feature" (dict "root" $ "featureKey" "integrations" "featureName" $featureName "type" "metrics" "ecosystem" "prometheus") }}
   {{- $collectorName := $.Values.integrations.collector }}
   {{- include "collectors.validate.clusteringEnabled" (dict "Values" $.Values "Files" $.Files "collectorName" $collectorName "featureName" $featureName) }}
@@ -95,7 +95,7 @@
 
 {{- $logOutputIntegrations := include "feature.integrations.configured.logOutput" (dict "Values" .Values.integrations "Files" $.Subcharts.integrations.Files) | fromYamlArray }}
 {{- if $logOutputIntegrations }}
-  {{- include "destinations.validate.destinationListNotEmpty" (dict "destinations" $destinations "type" "logs" "ecosystem" "loki" "featureName" $featureName) }}
+  {{- include "destinations.validate.destinationListNotEmpty" (dict "destinations" $destinations "type" "logs" "ecosystem" "loki" "featureName" $featureName "Values" $.Values "featureKey" "integrations") }}
   {{- include "dataProcessors.validate.feature" (dict "root" $ "featureKey" "integrations" "featureName" $featureName "type" "logs" "ecosystem" "loki") }}
 {{- end }}
 

--- a/charts/k8s-monitoring/templates/features/_feature_kubernetes_manifests.tpl
+++ b/charts/k8s-monitoring/templates/features/_feature_kubernetes_manifests.tpl
@@ -41,7 +41,7 @@ kubernetes_manifests "feature" {
 {{- $featureKey := "kubernetesManifests" }}
 {{- $featureName := "Kubernetes Manifests" }}
 {{- $destinationNames := include "features.kubernetesManifests.destinations" . | fromYamlArray }}
-{{- include "destinations.validate.destinationListNotEmpty" (dict "destinations" $destinationNames "type" "logs" "ecosystem" "loki" "featureName" $featureName) }}
+{{- include "destinations.validate.destinationListNotEmpty" (dict "destinations" $destinationNames "type" "logs" "ecosystem" "loki" "featureName" $featureName "Values" $.Values "featureKey" $featureKey) }}
 {{- include "dataProcessors.validate.feature" (dict "root" $ "featureKey" "kubernetesManifests" "featureName" $featureName "type" "logs" "ecosystem" "loki") }}
 {{- $collectorName := include "collectors.getCollectorForFeature" (dict "Values" $.Values "featureKey" $featureKey) }}
 {{- include "collectors.validate.collectorIsAssigned" (dict "Values" $.Values "collectorName" $collectorName "featureKey" $featureKey "featureName" $featureName) }}

--- a/charts/k8s-monitoring/templates/features/_feature_node_logs.tpl
+++ b/charts/k8s-monitoring/templates/features/_feature_node_logs.tpl
@@ -42,7 +42,7 @@ node_logs "feature" {
 {{- $featureKey := "nodeLogs" }}
 {{- $featureName := "Kubernetes Node logs" }}
 {{- $destinations := include "features.nodeLogs.destinations" . | fromYamlArray }}
-{{- include "destinations.validate.destinationListNotEmpty" (dict "destinations" $destinations "type" "logs" "ecosystem" "loki" "featureName" $featureName) }}
+{{- include "destinations.validate.destinationListNotEmpty" (dict "destinations" $destinations "type" "logs" "ecosystem" "loki" "featureName" $featureName "Values" $.Values "featureKey" $featureKey) }}
 {{- include "dataProcessors.validate.feature" (dict "root" $ "featureKey" "nodeLogs" "featureName" $featureName "type" "logs" "ecosystem" "loki") }}
 
 {{- $collectorName := include "collectors.getCollectorForFeature" (dict "Values" $.Values "featureKey" $featureKey) }}

--- a/charts/k8s-monitoring/templates/features/_feature_pod_logs_objects.tpl
+++ b/charts/k8s-monitoring/templates/features/_feature_pod_logs_objects.tpl
@@ -53,7 +53,7 @@ pod_logs_objects "feature" {
 {{- $featureKey := "podLogsObjects" }}
 {{- $featureName := "Alloy PodLogs Objects" }}
 {{- $destinations := include "features.podLogsObjects.destinations" . | fromYamlArray }}
-{{- include "destinations.validate.destinationListNotEmpty" (dict "destinations" $destinations "type" "logs" "ecosystem" "loki" "featureName" $featureName) }}
+{{- include "destinations.validate.destinationListNotEmpty" (dict "destinations" $destinations "type" "logs" "ecosystem" "loki" "featureName" $featureName "Values" $.Values "featureKey" $featureKey) }}
 {{- include "dataProcessors.validate.feature" (dict "root" $ "featureKey" "podLogsObjects" "featureName" $featureName "type" "logs" "ecosystem" "loki") }}
 
 {{- $collectorName := include "collectors.getCollectorForFeature" (dict "Values" $.Values "featureKey" $featureKey) }}

--- a/charts/k8s-monitoring/templates/features/_feature_pod_logs_via_kubernetes_api.tpl
+++ b/charts/k8s-monitoring/templates/features/_feature_pod_logs_via_kubernetes_api.tpl
@@ -42,7 +42,7 @@ pod_logs_via_kubernetes_api "feature" {
 {{- $featureKey := "podLogsViaKubernetesApi" }}
 {{- $featureName := "Kubernetes Pod logs via Kubernetes API" }}
 {{- $destinations := include "features.podLogsViaKubernetesApi.destinations" . | fromYamlArray }}
-{{- include "destinations.validate.destinationListNotEmpty" (dict "destinations" $destinations "type" "logs" "ecosystem" "loki" "featureName" $featureName) }}
+{{- include "destinations.validate.destinationListNotEmpty" (dict "destinations" $destinations "type" "logs" "ecosystem" "loki" "featureName" $featureName "Values" $.Values "featureKey" $featureKey) }}
 {{- include "dataProcessors.validate.feature" (dict "root" $ "featureKey" "podLogsViaKubernetesApi" "featureName" $featureName "type" "logs" "ecosystem" "loki") }}
 
 {{- $collectorName := include "collectors.getCollectorForFeature" (dict "Values" $.Values "featureKey" $featureKey) }}

--- a/charts/k8s-monitoring/templates/features/_feature_pod_logs_via_loki.tpl
+++ b/charts/k8s-monitoring/templates/features/_feature_pod_logs_via_loki.tpl
@@ -45,7 +45,7 @@ pod_logs_via_loki "feature" {
 {{- $featureKey := "podLogsViaLoki" }}
 {{- $featureName := "Kubernetes Pod logs" }}
 {{- $destinations := include "features.podLogsViaLoki.destinations" . | fromYamlArray }}
-{{- include "destinations.validate.destinationListNotEmpty" (dict "destinations" $destinations "type" "logs" "ecosystem" "loki" "featureName" $featureName) }}
+{{- include "destinations.validate.destinationListNotEmpty" (dict "destinations" $destinations "type" "logs" "ecosystem" "loki" "featureName" $featureName "Values" $.Values "featureKey" $featureKey) }}
 {{- include "dataProcessors.validate.feature" (dict "root" $ "featureKey" $featureKey "featureName" $featureName "type" "logs" "ecosystem" "loki") }}
 
 {{- $collectorName := include "collectors.getCollectorForFeature" (dict "Values" $.Values "featureKey" $featureKey) }}

--- a/charts/k8s-monitoring/templates/features/_feature_pod_logs_via_opentelemetry.tpl
+++ b/charts/k8s-monitoring/templates/features/_feature_pod_logs_via_opentelemetry.tpl
@@ -42,7 +42,7 @@ pod_logs_via_opentelemetry "feature" {
 {{- $featureKey := "podLogsViaOpenTelemetry" }}
 {{- $featureName := "Kubernetes Pod logs via OpenTelemetry" }}
 {{- $destinations := include "features.podLogsViaOpenTelemetry.destinations" . | fromYamlArray }}
-{{- include "destinations.validate.destinationListNotEmpty" (dict "destinations" $destinations "type" "logs" "ecosystem" "otlp" "featureName" $featureName) }}
+{{- include "destinations.validate.destinationListNotEmpty" (dict "destinations" $destinations "type" "logs" "ecosystem" "otlp" "featureName" $featureName "Values" $.Values "featureKey" $featureKey) }}
 {{- include "dataProcessors.validate.feature" (dict "root" $ "featureKey" $featureKey "featureName" $featureName "type" "logs" "ecosystem" "otlp") }}
 
 {{- $collectorName := include "collectors.getCollectorForFeature" (dict "Values" $.Values "featureKey" $featureKey) }}

--- a/charts/k8s-monitoring/templates/features/_feature_profiles_receiver.tpl
+++ b/charts/k8s-monitoring/templates/features/_feature_profiles_receiver.tpl
@@ -55,7 +55,7 @@ profiles_receiver "feature" {
 
   {{/* Destination validations */}}
   {{- $destinations := include "features.profilesReceiver.destinations" . | fromYamlArray }}
-  {{- include "destinations.validate.destinationListNotEmpty" (dict "destinations" $destinations "type" "profiles" "ecosystem" "pyroscope" "featureName" $featureName) }}
+  {{- include "destinations.validate.destinationListNotEmpty" (dict "destinations" $destinations "type" "profiles" "ecosystem" "pyroscope" "featureName" $featureName "Values" $.Values "featureKey" $featureKey) }}
   {{- include "dataProcessors.validate.feature" (dict "root" $ "featureKey" "profilesReceiver" "featureName" $featureName "type" "profiles" "ecosystem" "pyroscope") }}
 
   {{/* Collector validations */}}

--- a/charts/k8s-monitoring/templates/features/_feature_profiling.tpl
+++ b/charts/k8s-monitoring/templates/features/_feature_profiling.tpl
@@ -41,7 +41,7 @@ profiling "feature" {
 {{- $featureKey := "profiling" }}
 {{- $featureName := "Profiling" }}
 {{- $destinations := include "features.profiling.destinations" . | fromYamlArray }}
-{{- include "destinations.validate.destinationListNotEmpty" (dict "destinations" $destinations "type" "profiles" "ecosystem" "pyroscope" "featureName" $featureName) }}
+{{- include "destinations.validate.destinationListNotEmpty" (dict "destinations" $destinations "type" "profiles" "ecosystem" "pyroscope" "featureName" $featureName "Values" $.Values "featureKey" $featureKey) }}
 {{- include "dataProcessors.validate.feature" (dict "root" $ "featureKey" "profiling" "featureName" $featureName "type" "profiles" "ecosystem" "pyroscope") }}
 {{- $collectorName := include "collectors.getCollectorForFeature" (dict "Values" $.Values "featureKey" $featureKey) }}
 {{- include "collectors.validate.collectorIsAssigned" (dict "Values" $.Values "collectorName" $collectorName "featureKey" $featureKey "featureName" $featureName) }}

--- a/charts/k8s-monitoring/templates/features/_feature_prometheus_operator_obejcts.tpl
+++ b/charts/k8s-monitoring/templates/features/_feature_prometheus_operator_obejcts.tpl
@@ -41,7 +41,7 @@ prometheus_operator_objects "feature" {
 {{- $featureKey := "prometheusOperatorObjects" }}
 {{- $featureName := "Prometheus Operator Objects" }}
 {{- $destinations := include "features.prometheusOperatorObjects.destinations" . | fromYamlArray }}
-{{- include "destinations.validate.destinationListNotEmpty" (dict "destinations" $destinations "type" "metrics" "ecosystem" "prometheus" "featureName" $featureName) }}
+{{- include "destinations.validate.destinationListNotEmpty" (dict "destinations" $destinations "type" "metrics" "ecosystem" "prometheus" "featureName" $featureName "Values" $.Values "featureKey" $featureKey) }}
 {{- include "dataProcessors.validate.feature" (dict "root" $ "featureKey" "prometheusOperatorObjects" "featureName" $featureName "type" "metrics" "ecosystem" "prometheus") }}
 {{- $collectorName := include "collectors.getCollectorForFeature" (dict "Values" $.Values "featureKey" $featureKey) }}
 {{- include "collectors.validate.collectorIsAssigned" (dict "Values" $.Values "collectorName" $collectorName "featureKey" $featureKey "featureName" $featureName) }}

--- a/charts/k8s-monitoring/templates/features/_feature_windows_event_logs.tpl
+++ b/charts/k8s-monitoring/templates/features/_feature_windows_event_logs.tpl
@@ -59,7 +59,7 @@ windows_event_logs "feature" {
 {{- $featureName := "Windows Event Logs" }}
 {{- include "feature.windowsEventLogs.validate" (dict "Values" $.Values.windowsEventLogs) }}
 {{- $destinations := include "features.windowsEventLogs.destinations" . | fromYamlArray }}
-{{- include "destinations.validate.destinationListNotEmpty" (dict "destinations" $destinations "type" "logs" "ecosystem" "loki" "featureName" $featureName) }}
+{{- include "destinations.validate.destinationListNotEmpty" (dict "destinations" $destinations "type" "logs" "ecosystem" "loki" "featureName" $featureName "Values" $.Values "featureKey" $featureKey) }}
 {{- include "dataProcessors.validate.feature" (dict "root" $ "featureKey" "windowsEventLogs" "featureName" $featureName "type" "logs" "ecosystem" "loki") }}
 
 {{- $collectorName := include "collectors.getCollectorForFeature" (dict "Values" $.Values "featureKey" $featureKey) }}

--- a/charts/k8s-monitoring/tests/validations_collectors_test.yaml
+++ b/charts/k8s-monitoring/tests/validations_collectors_test.yaml
@@ -116,9 +116,9 @@ tests:
       - failedTemplate:
           errorMessage: |-
             The feature clusterMetrics is referencing a collector named "does-not-exist" but it does not exist.
-            Please assign the feature to one of these clusters:
+            Please assign the feature to one of these collectors:
             clusterMetrics:
-              collector: [alloy-metrics]
+              collector: alloy-metrics
 
   - it: lists all available collectors when the referenced collector does not exist
     set:
@@ -133,9 +133,9 @@ tests:
       - failedTemplate:
           errorMessage: |-
             The feature clusterMetrics is referencing a collector named "typo-metrics" but it does not exist.
-            Please assign the feature to one of these clusters:
+            Please assign the feature to one of these collectors:
             clusterMetrics:
-              collector: [alloy-logs or alloy-metrics]
+              collector: alloy-logs or alloy-metrics
 
   - it: does not error when a feature references an existing collector
     set:


### PR DESCRIPTION
<!--Describe what this change does and why.-->
# Description

Fixes #
- Helm chart's router destination requires explicit opt-in per feature (destinations: [<router>]); routers and their downstreams are excluded from implicit destination selection.
- Error case: feature without explicit destinations + all capable destinations behind a router → validation fails with "Please add a destination with X support". It was misleading, destinations exist. Made more verbose.
<!--Authorship attestation. See AGENTS.md for details. AI agents must not check this box on behalf
of the user; the human author must check it themselves before the PR is ready for review.-->
## Authorship

-   [x] I, a human, wrote this pull request description myself.

<!--Please delete paragraphs that you did not use before submitting.-->
