### PR TITLE
Fix schema files that only let you set 'null'

### DIFF
--- a/charts/k8s-monitoring/CHANGELOG.md
+++ b/charts/k8s-monitoring/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+*   Fix chart schemas where the only valid type was `null`. (#2926) (@petewall)
 *   Validate `replaceComponent` entries across collectors, and make it possible to mark them as optional. (#2912) (@petewall)
 *   Fix the comment on the closing brace of generated Alloy config components so it always names the component that opened the block. (@petewall)
 *   Add an `overrideUnknownServiceNames` option to the Application Observability feature. When enabled, the `service.name` resource attribute will be overridden if its value is `unknown_service*`. (@petewall)

--- a/charts/k8s-monitoring/charts/feature-annotation-autodiscovery/schema-mods/types-and-enums.json
+++ b/charts/k8s-monitoring/charts/feature-annotation-autodiscovery/schema-mods/types-and-enums.json
@@ -1,0 +1,5 @@
+{
+  "properties": {
+    "maxCacheSize": {"type": ["integer", "null"]}
+  }
+}

--- a/charts/k8s-monitoring/charts/feature-annotation-autodiscovery/values.schema.json
+++ b/charts/k8s-monitoring/charts/feature-annotation-autodiscovery/values.schema.json
@@ -96,7 +96,10 @@
             "type": "object"
         },
         "maxCacheSize": {
-            "type": "null"
+            "type": [
+                "integer",
+                "null"
+            ]
         },
         "metricsTuning": {
             "type": "object",

--- a/charts/k8s-monitoring/charts/feature-application-observability/schema-mods/types-and-enums.json
+++ b/charts/k8s-monitoring/charts/feature-application-observability/schema-mods/types-and-enums.json
@@ -4,6 +4,7 @@
       "properties": {
         "spanMetrics": {
           "properties": {
+            "exemplars": {"properties": {"maxPerDataPoint": {"type": ["integer", "null"]}}},
             "histogram": {"properties": {"type": {"enum": ["explicit", "exponential"]}}},
             "metricsExpiration": {"type": ["string", "null"]},
             "seriesExpiration": {"type": ["string", "null"]}

--- a/charts/k8s-monitoring/charts/feature-application-observability/values.schema.json
+++ b/charts/k8s-monitoring/charts/feature-application-observability/values.schema.json
@@ -78,7 +78,10 @@
                                     "type": "boolean"
                                 },
                                 "maxPerDataPoint": {
-                                    "type": "null"
+                                    "type": [
+                                        "integer",
+                                        "null"
+                                    ]
                                 }
                             }
                         },

--- a/charts/k8s-monitoring/charts/feature-auto-instrumentation/schema-mods/types-and-enums.json
+++ b/charts/k8s-monitoring/charts/feature-auto-instrumentation/schema-mods/types-and-enums.json
@@ -1,5 +1,5 @@
 {
   "properties": {
-    "beyla": {"properties": {"preset": {"enum": ["application", "network"]}}}
+    "beyla": {"properties": {"preset": {"enum": ["application", "network"]}, "maxCacheSize": {"type": ["integer", "null"]}}}
   }
 }

--- a/charts/k8s-monitoring/charts/feature-auto-instrumentation/values.schema.json
+++ b/charts/k8s-monitoring/charts/feature-auto-instrumentation/values.schema.json
@@ -75,7 +75,10 @@
                     }
                 },
                 "maxCacheSize": {
-                    "type": "null"
+                    "type": [
+                        "integer",
+                        "null"
+                    ]
                 },
                 "metricsTuning": {
                     "type": "object",

--- a/charts/k8s-monitoring/charts/feature-cluster-metrics/schema-mods/types-and-enums.json
+++ b/charts/k8s-monitoring/charts/feature-cluster-metrics/schema-mods/types-and-enums.json
@@ -1,15 +1,17 @@
 {
   "properties": {
-    "apiServer": {"properties": {"enabled": {"type": ["null", "boolean"]}}},
-    "cadvisor": {"properties": {"nodeAddressFormat": {"enum": ["direct", "proxy"]}}},
-    "kubeControllerManager": {"properties": {"enabled": {"type": ["null", "boolean"]}}},
-    "kubeDNS": {"properties": {"enabled": {"type": ["null", "boolean"]}}},
-    "kubeProxy": {"properties": {"enabled": {"type": ["null", "boolean"]}}},
-    "kubeScheduler": {"properties": {"enabled": {"type": ["null", "boolean"]}}},
-    "kubelet": {"properties": {"nodeAddressFormat": {"enum": ["direct", "proxy"]}}},
-    "kubeletResource": {"properties": {"nodeAddressFormat": {"enum": ["direct", "proxy"]}}},
+    "apiServer": {"properties": {"enabled": {"type": ["null", "boolean"]}, "maxCacheSize": {"type": ["integer", "null"]}}},
+    "cadvisor": {"properties": {"nodeAddressFormat": {"enum": ["direct", "proxy"]}, "maxCacheSize": {"type": ["integer", "null"]}}},
+    "kubeControllerManager": {"properties": {"enabled": {"type": ["null", "boolean"]}, "maxCacheSize": {"type": ["integer", "null"]}}},
+    "kubeDNS": {"properties": {"enabled": {"type": ["null", "boolean"]}, "maxCacheSize": {"type": ["integer", "null"]}}},
+    "kubeProxy": {"properties": {"enabled": {"type": ["null", "boolean"]}, "maxCacheSize": {"type": ["integer", "null"]}}},
+    "kubeScheduler": {"properties": {"enabled": {"type": ["null", "boolean"]}, "maxCacheSize": {"type": ["integer", "null"]}}},
+    "kubelet": {"properties": {"nodeAddressFormat": {"enum": ["direct", "proxy"]}, "maxCacheSize": {"type": ["integer", "null"]}}},
+    "kubeletProbes": {"properties": {"nodeAddressFormat": {"enum": ["direct", "proxy"]}, "maxCacheSize": {"type": ["integer", "null"]}}},
+    "kubeletResource": {"properties": {"nodeAddressFormat": {"enum": ["direct", "proxy"]}, "maxCacheSize": {"type": ["integer", "null"]}}},
     "kube-state-metrics": {"properties": {
       "discoveryType": {"enum": ["endpoints", "pod", "service"]},
+      "maxCacheSize": {"type": ["integer", "null"]},
       "namespaces": {"type":  ["string", "array"]},
       "namespacesDenylist": {"type":  ["string", "array"]}
     }},

--- a/charts/k8s-monitoring/charts/feature-cluster-metrics/tests/max_cache_size_test.yaml
+++ b/charts/k8s-monitoring/charts/feature-cluster-metrics/tests/max_cache_size_test.yaml
@@ -1,0 +1,27 @@
+# yamllint disable rule:document-start rule:line-length rule:trailing-spaces
+suite: Feature - Cluster Metrics - Max Cache Size Overrides
+templates:
+  - test/configmap.yaml
+tests:
+  - it: should allow overriding the global and per-source maxCacheSize
+    set:
+      testing:
+        enabled: true
+        telemetryServices:
+          kube-state-metrics:
+            deploy: true
+      global:
+        maxCacheSize: 200000
+      cadvisor:
+        maxCacheSize: 400000
+    asserts:
+      - isKind:
+          of: ConfigMap
+      # cadvisor uses its per-source override
+      - matchRegex:
+          path: data["module.alloy"]
+          pattern: max_cache_size = 400000
+      # kubelet has no per-source override, so it falls back to global
+      - matchRegex:
+          path: data["module.alloy"]
+          pattern: max_cache_size = 200000

--- a/charts/k8s-monitoring/charts/feature-cluster-metrics/values.schema.json
+++ b/charts/k8s-monitoring/charts/feature-cluster-metrics/values.schema.json
@@ -21,7 +21,10 @@
                     "type": "string"
                 },
                 "maxCacheSize": {
-                    "type": "null"
+                    "type": [
+                        "integer",
+                        "null"
+                    ]
                 },
                 "metricsTuning": {
                     "type": "object",
@@ -58,7 +61,10 @@
                     "type": "string"
                 },
                 "maxCacheSize": {
-                    "type": "null"
+                    "type": [
+                        "integer",
+                        "null"
+                    ]
                 },
                 "metricsTuning": {
                     "type": "object",
@@ -213,7 +219,10 @@
                     "type": "object"
                 },
                 "maxCacheSize": {
-                    "type": "null"
+                    "type": [
+                        "integer",
+                        "null"
+                    ]
                 },
                 "metricsTuning": {
                     "type": "object",
@@ -279,7 +288,10 @@
                     "type": "string"
                 },
                 "maxCacheSize": {
-                    "type": "null"
+                    "type": [
+                        "integer",
+                        "null"
+                    ]
                 },
                 "metricsTuning": {
                     "type": "object",
@@ -322,7 +334,10 @@
                     "type": "string"
                 },
                 "maxCacheSize": {
-                    "type": "null"
+                    "type": [
+                        "integer",
+                        "null"
+                    ]
                 },
                 "metricsTuning": {
                     "type": "object",
@@ -362,7 +377,10 @@
                     "type": "string"
                 },
                 "maxCacheSize": {
-                    "type": "null"
+                    "type": [
+                        "integer",
+                        "null"
+                    ]
                 },
                 "metricsTuning": {
                     "type": "object",
@@ -408,7 +426,10 @@
                     "type": "string"
                 },
                 "maxCacheSize": {
-                    "type": "null"
+                    "type": [
+                        "integer",
+                        "null"
+                    ]
                 },
                 "metricsTuning": {
                     "type": "object",
@@ -451,7 +472,10 @@
                     "type": "string"
                 },
                 "maxCacheSize": {
-                    "type": "null"
+                    "type": [
+                        "integer",
+                        "null"
+                    ]
                 },
                 "metricsTuning": {
                     "type": "object",
@@ -498,7 +522,10 @@
                     "type": "string"
                 },
                 "maxCacheSize": {
-                    "type": "null"
+                    "type": [
+                        "integer",
+                        "null"
+                    ]
                 },
                 "metricsTuning": {
                     "type": "object",
@@ -515,7 +542,11 @@
                     }
                 },
                 "nodeAddressFormat": {
-                    "type": "string"
+                    "type": "string",
+                    "enum": [
+                        "direct",
+                        "proxy"
+                    ]
                 },
                 "scrapeInterval": {
                     "type": "string"
@@ -541,7 +572,10 @@
                     "type": "string"
                 },
                 "maxCacheSize": {
-                    "type": "null"
+                    "type": [
+                        "integer",
+                        "null"
+                    ]
                 },
                 "metricsTuning": {
                     "type": "object",

--- a/charts/k8s-monitoring/charts/feature-cost-metrics/schema-mods/types-and-enums.json
+++ b/charts/k8s-monitoring/charts/feature-cost-metrics/schema-mods/types-and-enums.json
@@ -1,5 +1,6 @@
 {
   "properties": {
+    "opencost": {"properties": {"maxCacheSize": {"type": ["integer", "null"]}}},
     "global": {"properties": {"platform": {"enum": ["", "openshift"]}}}
   }
 }

--- a/charts/k8s-monitoring/charts/feature-cost-metrics/values.schema.json
+++ b/charts/k8s-monitoring/charts/feature-cost-metrics/values.schema.json
@@ -57,7 +57,10 @@
                     "type": "object"
                 },
                 "maxCacheSize": {
-                    "type": "null"
+                    "type": [
+                        "integer",
+                        "null"
+                    ]
                 },
                 "metricsSource": {
                     "type": "string"

--- a/charts/k8s-monitoring/charts/feature-host-metrics/schema-mods/types-and-enums.json
+++ b/charts/k8s-monitoring/charts/feature-host-metrics/schema-mods/types-and-enums.json
@@ -1,5 +1,7 @@
 {
   "properties": {
-    "linuxHosts": {"properties": {"source": {"enum": ["node-exporter", "alloy"]}}}
+    "energyMetrics": {"properties": {"maxCacheSize": {"type": ["integer", "null"]}}},
+    "linuxHosts": {"properties": {"source": {"enum": ["node-exporter", "alloy"]}, "maxCacheSize": {"type": ["integer", "null"]}}},
+    "windowsHosts": {"properties": {"maxCacheSize": {"type": ["integer", "null"]}}}
   }
 }

--- a/charts/k8s-monitoring/charts/feature-host-metrics/values.schema.json
+++ b/charts/k8s-monitoring/charts/feature-host-metrics/values.schema.json
@@ -21,7 +21,10 @@
                     "type": "object"
                 },
                 "maxCacheSize": {
-                    "type": "null"
+                    "type": [
+                        "integer",
+                        "null"
+                    ]
                 },
                 "metricsTuning": {
                     "type": "object",
@@ -102,7 +105,10 @@
                     "type": "object"
                 },
                 "maxCacheSize": {
-                    "type": "null"
+                    "type": [
+                        "integer",
+                        "null"
+                    ]
                 },
                 "metricsTuning": {
                     "type": "object",
@@ -196,7 +202,10 @@
                     "type": "object"
                 },
                 "maxCacheSize": {
-                    "type": "null"
+                    "type": [
+                        "integer",
+                        "null"
+                    ]
                 },
                 "metricsTuning": {
                     "type": "object",

--- a/charts/k8s-monitoring/charts/feature-pod-logs-objects/schema-mods/types-and-enums.json
+++ b/charts/k8s-monitoring/charts/feature-pod-logs-objects/schema-mods/types-and-enums.json
@@ -1,0 +1,5 @@
+{
+  "properties": {
+    "secretFilter": {"properties": {"redactWith": {"type": ["string", "null"]}}}
+  }
+}

--- a/charts/k8s-monitoring/charts/feature-pod-logs-objects/values.schema.json
+++ b/charts/k8s-monitoring/charts/feature-pod-logs-objects/values.schema.json
@@ -56,7 +56,10 @@
                     "type": "integer"
                 },
                 "redactWith": {
-                    "type": "null"
+                    "type": [
+                        "string",
+                        "null"
+                    ]
                 }
             }
         },

--- a/charts/k8s-monitoring/charts/feature-prometheus-operator-objects/schema-mods/types-and-enums.json
+++ b/charts/k8s-monitoring/charts/feature-prometheus-operator-objects/schema-mods/types-and-enums.json
@@ -1,0 +1,8 @@
+{
+  "properties": {
+    "podMonitors": {"properties": {"maxCacheSize": {"type": ["integer", "null"]}}},
+    "probes": {"properties": {"maxCacheSize": {"type": ["integer", "null"]}}},
+    "scrapeConfigs": {"properties": {"maxCacheSize": {"type": ["integer", "null"]}}},
+    "serviceMonitors": {"properties": {"maxCacheSize": {"type": ["integer", "null"]}}}
+  }
+}

--- a/charts/k8s-monitoring/charts/feature-prometheus-operator-objects/values.schema.json
+++ b/charts/k8s-monitoring/charts/feature-prometheus-operator-objects/values.schema.json
@@ -53,7 +53,10 @@
                     "type": "object"
                 },
                 "maxCacheSize": {
-                    "type": "null"
+                    "type": [
+                        "integer",
+                        "null"
+                    ]
                 },
                 "metricsTuning": {
                     "type": "object",
@@ -99,7 +102,10 @@
                     "type": "object"
                 },
                 "maxCacheSize": {
-                    "type": "null"
+                    "type": [
+                        "integer",
+                        "null"
+                    ]
                 },
                 "metricsTuning": {
                     "type": "object",
@@ -145,7 +151,10 @@
                     "type": "object"
                 },
                 "maxCacheSize": {
-                    "type": "null"
+                    "type": [
+                        "integer",
+                        "null"
+                    ]
                 },
                 "metricsTuning": {
                     "type": "object",
@@ -191,7 +200,10 @@
                     "type": "object"
                 },
                 "maxCacheSize": {
-                    "type": "null"
+                    "type": [
+                        "integer",
+                        "null"
+                    ]
                 },
                 "metricsTuning": {
                     "type": "object",


### PR DESCRIPTION
# Description

Some schema files only let you set `null`. This is because the values file has something like:
```yaml
mySetting: 
```

And the schema generator doesn't know what to do other than use `null`.

Fixes #2926

## Authorship

-   [X] I, a human, wrote this pull request description myself.
