### PR TITLE
feat(database_observability): allow specifying additional labels

### DIFF
--- a/charts/k8s-monitoring/CHANGELOG.md
+++ b/charts/k8s-monitoring/CHANGELOG.md
@@ -7,6 +7,7 @@
 *   Fix the comment on the closing brace of generated Alloy config components so it always names the component that opened the block. (@petewall)
 *   Add an `overrideUnknownServiceNames` option to the Application Observability feature. When enabled, the `service.name` resource attribute will be overridden if its value is `unknown_service*`. (@petewall)
 *   Update Windows Exporter to 0.12.8 (@petewall)
+*   Database Observability: add support for specifying additional custom labels. (#2929) (@cristiangreco)
 
 ## 4.3.1
 

--- a/charts/k8s-monitoring/charts/feature-integrations/docs/integrations/mysql.md
+++ b/charts/k8s-monitoring/charts/feature-integrations/docs/integrations/mysql.md
@@ -93,6 +93,7 @@ integrations:
 | databaseObservability.allowUpdatePerformanceSchemaSettings | bool | `false` | Whether to allow updates to performance_schema settings in any collector. |
 | databaseObservability.enabled | bool | `false` | Whether to gather table, schema, and query information from the database. Requires exporter to be enabled. |
 | databaseObservability.excludeSchemas | list | `[]` | A list of schemas to exclude from monitoring. |
+| databaseObservability.labels | object | `{}` | Additional static labels to add to both metrics and logs produced by Database Observability for this instance. Keys are label names, values are label values. The reserved labels `job`, `instance`, and `dsn` cannot be overridden. |
 
 ### Database Observability - Cloud Provider
 

--- a/charts/k8s-monitoring/charts/feature-integrations/docs/integrations/postgresql.md
+++ b/charts/k8s-monitoring/charts/feature-integrations/docs/integrations/postgresql.md
@@ -112,6 +112,7 @@ integrations:
 | databaseObservability.excludeCurrentUser | bool | `true` | Exclude the user that Alloy uses to connect to the database from monitoring. The resolved username is automatically appended to `excludeUsers`, if not already present. |
 | databaseObservability.excludeDatabases | list | `[]` | A list of databases to exclude from monitoring. |
 | databaseObservability.excludeUsers | list | `[]` | A list of users to exclude from monitoring. |
+| databaseObservability.labels | object | `{}` | Additional static labels to add to both metrics and logs produced by Database Observability for this instance. Keys are label names, values are label values. The reserved labels `job`, `instance`, and `dsn` cannot be overridden. |
 
 ### Exporter Settings
 

--- a/charts/k8s-monitoring/charts/feature-integrations/integrations/mysql-values.yaml
+++ b/charts/k8s-monitoring/charts/feature-integrations/integrations/mysql-values.yaml
@@ -169,6 +169,11 @@ databaseObservability:
   # @section -- Database Observability
   enabled: false
 
+  # -- Additional static labels to add to both metrics and logs produced by Database Observability for this instance.
+  # Keys are label names, values are label values. The reserved labels `job`, `instance`, and `dsn` cannot be overridden.
+  # @section -- Database Observability
+  labels: {}
+
   # -- Whether to allow updates to performance_schema settings in any collector.
   # @section -- Database Observability
   allowUpdatePerformanceSchemaSettings: false

--- a/charts/k8s-monitoring/charts/feature-integrations/integrations/postgresql-values.yaml
+++ b/charts/k8s-monitoring/charts/feature-integrations/integrations/postgresql-values.yaml
@@ -252,6 +252,11 @@ databaseObservability:
   # @section -- Database Observability
   enabled: false
 
+  # -- Additional static labels to add to both metrics and logs produced by Database Observability for this instance.
+  # Keys are label names, values are label values. The reserved labels `job`, `instance`, and `dsn` cannot be overridden.
+  # @section -- Database Observability
+  labels: {}
+
   # -- A list of databases to exclude from monitoring.
   # @section -- Database Observability
   excludeDatabases: []

--- a/charts/k8s-monitoring/charts/feature-integrations/schema-mods/definitions/mysql-integration.schema.json
+++ b/charts/k8s-monitoring/charts/feature-integrations/schema-mods/definitions/mysql-integration.schema.json
@@ -169,6 +169,9 @@
                 },
                 "excludeSchemas": {
                     "type": "array"
+                },
+                "labels": {
+                    "type": "object"
                 }
             }
         },

--- a/charts/k8s-monitoring/charts/feature-integrations/schema-mods/definitions/postgresql-integration.schema.json
+++ b/charts/k8s-monitoring/charts/feature-integrations/schema-mods/definitions/postgresql-integration.schema.json
@@ -121,6 +121,9 @@
                 },
                 "excludeUsers": {
                     "type": "array"
+                },
+                "labels": {
+                    "type": "object"
                 }
             }
         },

--- a/charts/k8s-monitoring/charts/feature-integrations/templates/_integration_mysql.tpl
+++ b/charts/k8s-monitoring/charts/feature-integrations/templates/_integration_mysql.tpl
@@ -43,6 +43,13 @@
   {{- $msg = append $msg "          enabled: true" }}
   {{- fail (join "\n" $msg) }}
 {{- end }}
+{{- if $dbO11yEnabled }}
+  {{- range $label, $_ := (dig "databaseObservability" "labels" dict .instance) }}
+    {{- if has $label (list "job" "instance" "dsn") }}
+      {{- fail (printf "\nThe label %q in databaseObservability.labels for instance %q is reserved and cannot be overridden.\nReserved labels: job, instance, dsn.\nUse `jobLabel` to change the job value." $label $.instance.name) }}
+    {{- end }}
+  {{- end }}
+{{- end }}
 {{- if and .instance.logs.enabled (not .instance.logs.labelSelectors) }}
   {{- $msg := list "" "The MySQL integration requires a label selector" }}
   {{- $msg = append $msg "For example, please set:" }}

--- a/charts/k8s-monitoring/charts/feature-integrations/templates/_integration_mysql_metrics.tpl
+++ b/charts/k8s-monitoring/charts/feature-integrations/templates/_integration_mysql_metrics.tpl
@@ -277,6 +277,12 @@ loki.relabel {{ $dbRelabelName | quote }} {
     target_label = "instance"
     replacement = {{ .name | quote }}
   }
+  {{- range $label, $value := .databaseObservability.labels }}
+  rule {
+    target_label = {{ $label | quote }}
+    replacement = {{ $value | quote }}
+  }
+  {{- end }}
 }
 
 discovery.relabel {{ $dbRelabelName | quote }} {
@@ -293,6 +299,12 @@ discovery.relabel {{ $dbRelabelName | quote }} {
     target_label = "instance"
     replacement = {{ .name | quote }}
   }
+  {{- range $label, $value := .databaseObservability.labels }}
+  rule {
+    target_label = {{ $label | quote }}
+    replacement = {{ $value | quote }}
+  }
+  {{- end }}
 }
 {{- end }}
 

--- a/charts/k8s-monitoring/charts/feature-integrations/templates/_integration_postgresql.tpl
+++ b/charts/k8s-monitoring/charts/feature-integrations/templates/_integration_postgresql.tpl
@@ -43,6 +43,13 @@
   {{- $msg = append $msg "          enabled: true" }}
   {{- fail (join "\n" $msg) }}
 {{- end }}
+{{- if $dbO11yEnabled }}
+  {{- range $label, $_ := (dig "databaseObservability" "labels" dict .instance) }}
+    {{- if has $label (list "job" "instance" "dsn") }}
+      {{- fail (printf "\nThe label %q in databaseObservability.labels for instance %q is reserved and cannot be overridden.\nReserved labels: job, instance, dsn.\nUse `jobLabel` to change the job value." $label $.instance.name) }}
+    {{- end }}
+  {{- end }}
+{{- end }}
 {{- if and .instance.logs.enabled (not .instance.logs.labelSelectors) }}
   {{- $msg := list "" "The PostgreSQL integration requires a label selector" }}
   {{- $msg = append $msg "For example, please set:" }}

--- a/charts/k8s-monitoring/charts/feature-integrations/templates/_integration_postgresql_metrics.tpl
+++ b/charts/k8s-monitoring/charts/feature-integrations/templates/_integration_postgresql_metrics.tpl
@@ -261,6 +261,12 @@ loki.relabel {{ $dbRelabelName | quote }} {
     target_label = "instance"
     replacement = {{ .name | quote }}
   }
+  {{- range $label, $value := .databaseObservability.labels }}
+  rule {
+    target_label = {{ $label | quote }}
+    replacement = {{ $value | quote }}
+  }
+  {{- end }}
 }
 
 discovery.relabel {{ $dbRelabelName | quote }} {
@@ -277,6 +283,12 @@ discovery.relabel {{ $dbRelabelName | quote }} {
     target_label = "instance"
     replacement = {{ .name | quote }}
   }
+  {{- range $label, $value := .databaseObservability.labels }}
+  rule {
+    target_label = {{ $label | quote }}
+    replacement = {{ $value | quote }}
+  }
+  {{- end }}
 }
 {{- end }}
 

--- a/charts/k8s-monitoring/charts/feature-integrations/tests/__snapshot__/mysql_db_o11y_metrics_test.yaml.snap
+++ b/charts/k8s-monitoring/charts/feature-integrations/tests/__snapshot__/mysql_db_o11y_metrics_test.yaml.snap
@@ -1,3 +1,116 @@
+adds custom labels to db o11y metrics and logs:
+  1: |
+    |-
+      declare "mysql_integration" {
+        argument "metrics_destinations" {
+          comment = "Must be a list of metric destinations where collected metrics should be forwarded to"
+        }
+        argument "logs_destinations" {
+          comment = "Must be a list of log destinations where collected logs should be forwarded to"
+        }
+
+        prometheus.exporter.mysql "my_database" {
+          data_source_name = string.format("%s:%d/", "my-db.mysql.svc", 3306)
+          enable_collectors = ["heartbeat","mysql.user"]
+        }
+
+        database_observability.mysql "my_database" {
+          targets = prometheus.exporter.mysql.my_database.targets
+          data_source_name = string.format("%s:%d/", "my-db.mysql.svc", 3306)
+          allow_update_performance_schema_settings = false
+          explain_plans {
+            collect_interval = "1m"
+            initial_lookback = "24h"
+            per_collect_ratio = "1"
+          }
+          query_details {
+            collect_interval = "1m"
+          }
+          query_samples {
+            collect_interval = "10s"
+            disable_query_redaction = false
+            auto_enable_setup_consumers = false
+            setup_consumers_check_interval = "1h"
+            sample_min_duration = "0s"
+            wait_event_min_duration = "1us"
+          }
+          schema_details {
+            collect_interval = "1m"
+          }
+          setup_consumers {
+            collect_interval = "1h"
+          }
+          setup_actors {
+            auto_update_setup_actors = false
+            collect_interval = "1h"
+          }
+          enable_collectors = ["explain_plans","query_details","query_samples","schema_details","setup_consumers","setup_actors"]
+          disable_collectors = ["locks"]
+
+          forward_to = [loki.relabel.database_observability_mysql_my_database.receiver]
+        }
+
+        loki.relabel "database_observability_mysql_my_database" {
+          forward_to = argument.logs_destinations.value
+          rule {
+            target_label = "job"
+            replacement = "integrations/db-o11y"
+          }
+          rule {
+            source_labels = ["instance"]
+            target_label = "dsn"
+          }
+          rule {
+            target_label = "instance"
+            replacement = "my-database"
+          }
+          rule {
+            target_label = "environment"
+            replacement = "production"
+          }
+          rule {
+            target_label = "team"
+            replacement = "payments"
+          }
+        }
+
+        discovery.relabel "database_observability_mysql_my_database" {
+          targets = database_observability.mysql.my_database.targets
+          rule {
+            target_label = "job"
+            replacement = "integrations/db-o11y"
+          }
+          rule {
+            source_labels = ["instance"]
+            target_label = "dsn"
+          }
+          rule {
+            target_label = "instance"
+            replacement = "my-database"
+          }
+          rule {
+            target_label = "environment"
+            replacement = "production"
+          }
+          rule {
+            target_label = "team"
+            replacement = "payments"
+          }
+        }
+        prometheus.scrape "my_database" {
+          targets = discovery.relabel.database_observability_mysql_my_database.output
+          clustering {
+            enabled = true
+          }
+
+          scrape_interval = "60s"
+          scrape_timeout = "10s"
+          scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
+          scrape_classic_histograms = false
+          scrape_native_histograms = false
+          forward_to = argument.metrics_destinations.value
+        }
+      }
 defaults text_limit to 0 for perf_schema.eventsstatements when db o11y is enabled:
   1: |
     |-

--- a/charts/k8s-monitoring/charts/feature-integrations/tests/__snapshot__/postgresql_db_o11y_metrics_test.yaml.snap
+++ b/charts/k8s-monitoring/charts/feature-integrations/tests/__snapshot__/postgresql_db_o11y_metrics_test.yaml.snap
@@ -1,3 +1,206 @@
+adds custom labels to db o11y metrics and logs:
+  1: |
+    |-
+      declare "postgresql_integration" {
+        argument "metrics_destinations" {
+          comment = "Must be a list of metric destinations where collected metrics should be forwarded to"
+        }
+        argument "logs_destinations" {
+          comment = "Must be a list of log destinations where collected logs should be forwarded to"
+        }
+
+        prometheus.exporter.postgres "my_database" {
+          data_source_names = [string.format("postgresql://%s:%d/", "my-db.postgresql.svc", 5432)]
+          enabled_collectors = ["database","locks","replication","replication_slot","stat_bgwriter","stat_database","stat_progress_vacuum","stat_user_tables","statio_user_tables","wal"]
+          disable_default_metrics = false
+          disable_settings_metrics = false
+        }
+
+        database_observability.postgres "my_database" {
+          targets = prometheus.exporter.postgres.my_database.targets
+          data_source_name = string.format("postgresql://%s:%d/", "my-db.postgresql.svc", 5432)
+          exclude_current_user = true
+          explain_plans {
+            collect_interval = "1m"
+            per_collect_ratio = "1"
+          }
+          query_details {
+            collect_interval = "1m"
+          }
+          query_samples {
+            collect_interval = "15s"
+            disable_query_redaction = false
+          }
+          schema_details {
+            collect_interval = "1m"
+          }
+          enable_collectors = ["explain_plans","query_details","query_samples","schema_details"]
+
+          forward_to = [loki.relabel.database_observability_postgres_my_database.receiver]
+        }
+
+        loki.relabel "database_observability_postgres_my_database" {
+          forward_to = argument.logs_destinations.value
+          rule {
+            target_label = "job"
+            replacement = "integrations/db-o11y"
+          }
+          rule {
+            source_labels = ["instance"]
+            target_label = "dsn"
+          }
+          rule {
+            target_label = "instance"
+            replacement = "my-database"
+          }
+          rule {
+            target_label = "environment"
+            replacement = "production"
+          }
+          rule {
+            target_label = "team"
+            replacement = "payments"
+          }
+        }
+
+        discovery.relabel "database_observability_postgres_my_database" {
+          targets = database_observability.postgres.my_database.targets
+          rule {
+            target_label = "job"
+            replacement = "integrations/db-o11y"
+          }
+          rule {
+            source_labels = ["instance"]
+            target_label = "dsn"
+          }
+          rule {
+            target_label = "instance"
+            replacement = "my-database"
+          }
+          rule {
+            target_label = "environment"
+            replacement = "production"
+          }
+          rule {
+            target_label = "team"
+            replacement = "payments"
+          }
+        }
+        prometheus.scrape "my_database" {
+          targets = discovery.relabel.database_observability_postgres_my_database.output
+          clustering {
+            enabled = true
+          }
+
+          scrape_interval = "60s"
+          scrape_timeout = "10s"
+          scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
+          scrape_classic_histograms = false
+          scrape_native_histograms = false
+          forward_to = argument.metrics_destinations.value
+        }
+      }
+honors top-level exclude_current_user:
+  1: |
+    |-
+      declare "postgresql_integration" {
+        argument "metrics_destinations" {
+          comment = "Must be a list of metric destinations where collected metrics should be forwarded to"
+        }
+        argument "logs_destinations" {
+          comment = "Must be a list of log destinations where collected logs should be forwarded to"
+        }
+
+        remote.kubernetes.secret "top_level_excl_db" {
+          name      = "top-level-excl-db-release-name-feature-integrations"
+          namespace = "NAMESPACE"
+        } // remote.kubernetes.secret "top_level_excl_db"
+
+        prometheus.exporter.postgres "top_level_excl_db" {
+          data_source_names = [string.format("postgresql://%s:%s@%s:%d/",
+            encoding.url_encode(convert.nonsensitive(remote.kubernetes.secret.top_level_excl_db.data["username"])),
+            encoding.url_encode(convert.nonsensitive(remote.kubernetes.secret.top_level_excl_db.data["password"])),
+            "top-level-excl-db.postgresql.svc",
+            5432,
+          )]
+          enabled_collectors = ["database","locks","replication","replication_slot","stat_bgwriter","stat_database","stat_progress_vacuum","stat_user_tables","statio_user_tables","wal"]
+          disable_default_metrics = false
+          disable_settings_metrics = false
+        }
+
+        database_observability.postgres "top_level_excl_db" {
+          targets = prometheus.exporter.postgres.top_level_excl_db.targets
+          data_source_name = string.format("postgresql://%s:%s@%s:%d/",
+            encoding.url_encode(convert.nonsensitive(remote.kubernetes.secret.top_level_excl_db.data["username"])),
+            encoding.url_encode(convert.nonsensitive(remote.kubernetes.secret.top_level_excl_db.data["password"])),
+            "top-level-excl-db.postgresql.svc",
+            5432,
+          )
+          exclude_current_user = false
+          explain_plans {
+            collect_interval = "1m"
+            per_collect_ratio = "1"
+          }
+          query_details {
+            collect_interval = "1m"
+          }
+          query_samples {
+            collect_interval = "15s"
+            disable_query_redaction = false
+          }
+          schema_details {
+            collect_interval = "1m"
+          }
+          enable_collectors = ["explain_plans","query_details","query_samples","schema_details"]
+
+          forward_to = [loki.relabel.database_observability_postgres_top_level_excl_db.receiver]
+        }
+
+        loki.relabel "database_observability_postgres_top_level_excl_db" {
+          forward_to = argument.logs_destinations.value
+          rule {
+            target_label = "job"
+            replacement = "integrations/db-o11y"
+          }
+          rule {
+            source_labels = ["instance"]
+            target_label = "dsn"
+          }
+          rule {
+            target_label = "instance"
+            replacement = "top-level-excl-db"
+          }
+        }
+
+        discovery.relabel "database_observability_postgres_top_level_excl_db" {
+          targets = database_observability.postgres.top_level_excl_db.targets
+          rule {
+            target_label = "job"
+            replacement = "integrations/db-o11y"
+          }
+          rule {
+            source_labels = ["instance"]
+            target_label = "dsn"
+          }
+          rule {
+            target_label = "instance"
+            replacement = "top-level-excl-db"
+          }
+        }
+        prometheus.scrape "top_level_excl_db" {
+          targets = discovery.relabel.database_observability_postgres_top_level_excl_db.output
+          clustering {
+            enabled = true
+          }
+
+          scrape_interval = "60s"
+          scrape_timeout = "10s"
+          scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
+          scrape_classic_histograms = false
+          scrape_native_histograms = false
+          forward_to = argument.metrics_destinations.value
+        }
+      }
 keeps prometheus.relabel when metrics tuning is set under db o11y:
   1: |
     |-
@@ -511,107 +714,6 @@ renders new db o11y options (statements_limit):
         }
         prometheus.scrape "limited_db" {
           targets = discovery.relabel.database_observability_postgres_limited_db.output
-          clustering {
-            enabled = true
-          }
-
-          scrape_interval = "60s"
-          scrape_timeout = "10s"
-          scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
-          scrape_classic_histograms = false
-          scrape_native_histograms = false
-          forward_to = argument.metrics_destinations.value
-        }
-      }
-honors top-level exclude_current_user:
-  1: |
-    |-
-      declare "postgresql_integration" {
-        argument "metrics_destinations" {
-          comment = "Must be a list of metric destinations where collected metrics should be forwarded to"
-        }
-        argument "logs_destinations" {
-          comment = "Must be a list of log destinations where collected logs should be forwarded to"
-        }
-
-        remote.kubernetes.secret "top_level_excl_db" {
-          name      = "top-level-excl-db-release-name-feature-integrations"
-          namespace = "NAMESPACE"
-        } // remote.kubernetes.secret "top_level_excl_db"
-
-        prometheus.exporter.postgres "top_level_excl_db" {
-          data_source_names = [string.format("postgresql://%s:%s@%s:%d/",
-            encoding.url_encode(convert.nonsensitive(remote.kubernetes.secret.top_level_excl_db.data["username"])),
-            encoding.url_encode(convert.nonsensitive(remote.kubernetes.secret.top_level_excl_db.data["password"])),
-            "top-level-excl-db.postgresql.svc",
-            5432,
-          )]
-          enabled_collectors = ["database","locks","replication","replication_slot","stat_bgwriter","stat_database","stat_progress_vacuum","stat_user_tables","statio_user_tables","wal"]
-          disable_default_metrics = false
-          disable_settings_metrics = false
-        }
-
-        database_observability.postgres "top_level_excl_db" {
-          targets = prometheus.exporter.postgres.top_level_excl_db.targets
-          data_source_name = string.format("postgresql://%s:%s@%s:%d/",
-            encoding.url_encode(convert.nonsensitive(remote.kubernetes.secret.top_level_excl_db.data["username"])),
-            encoding.url_encode(convert.nonsensitive(remote.kubernetes.secret.top_level_excl_db.data["password"])),
-            "top-level-excl-db.postgresql.svc",
-            5432,
-          )
-          exclude_current_user = false
-          explain_plans {
-            collect_interval = "1m"
-            per_collect_ratio = "1"
-          }
-          query_details {
-            collect_interval = "1m"
-          }
-          query_samples {
-            collect_interval = "15s"
-            disable_query_redaction = false
-          }
-          schema_details {
-            collect_interval = "1m"
-          }
-          enable_collectors = ["explain_plans","query_details","query_samples","schema_details"]
-
-          forward_to = [loki.relabel.database_observability_postgres_top_level_excl_db.receiver]
-        }
-
-        loki.relabel "database_observability_postgres_top_level_excl_db" {
-          forward_to = argument.logs_destinations.value
-          rule {
-            target_label = "job"
-            replacement = "integrations/db-o11y"
-          }
-          rule {
-            source_labels = ["instance"]
-            target_label = "dsn"
-          }
-          rule {
-            target_label = "instance"
-            replacement = "top-level-excl-db"
-          }
-        }
-
-        discovery.relabel "database_observability_postgres_top_level_excl_db" {
-          targets = database_observability.postgres.top_level_excl_db.targets
-          rule {
-            target_label = "job"
-            replacement = "integrations/db-o11y"
-          }
-          rule {
-            source_labels = ["instance"]
-            target_label = "dsn"
-          }
-          rule {
-            target_label = "instance"
-            replacement = "top-level-excl-db"
-          }
-        }
-        prometheus.scrape "top_level_excl_db" {
-          targets = discovery.relabel.database_observability_postgres_top_level_excl_db.output
           clustering {
             enabled = true
           }

--- a/charts/k8s-monitoring/charts/feature-integrations/tests/mysql_db_o11y_metrics_test.yaml
+++ b/charts/k8s-monitoring/charts/feature-integrations/tests/mysql_db_o11y_metrics_test.yaml
@@ -227,6 +227,48 @@ tests:
         matchSnapshot:
           path: data["metrics.alloy"]
 
+  - it: adds custom labels to db o11y metrics and logs
+    set:
+      testing: {enabled: true}
+      mysql:
+        instances:
+          - name: my-database
+            exporter:
+              dataSource:
+                host: my-db.mysql.svc
+            databaseObservability:
+              enabled: true
+              labels:
+                environment: production
+                team: payments
+            logs: {enabled: false}
+    asserts:
+      - template: test/configmap.yaml
+        matchSnapshot:
+          path: data["metrics.alloy"]
+
+  - it: rejects reserved db o11y labels
+    set:
+      testing: {enabled: true}
+      mysql:
+        instances:
+          - name: my-database
+            exporter:
+              dataSource:
+                host: my-db.mysql.svc
+            databaseObservability:
+              enabled: true
+              labels:
+                job: custom
+            logs: {enabled: false}
+    asserts:
+      - template: test/configmap.yaml
+        failedTemplate:
+          errorMessage: |-
+            The label "job" in databaseObservability.labels for instance "my-database" is reserved and cannot be overridden.
+            Reserved labels: job, instance, dsn.
+            Use `jobLabel` to change the job value.
+
   - it: requires metrics
     set:
       testing: {enabled: true}

--- a/charts/k8s-monitoring/charts/feature-integrations/tests/postgresql_db_o11y_metrics_test.yaml
+++ b/charts/k8s-monitoring/charts/feature-integrations/tests/postgresql_db_o11y_metrics_test.yaml
@@ -262,6 +262,48 @@ tests:
         matchSnapshot:
           path: data["metrics.alloy"]
 
+  - it: adds custom labels to db o11y metrics and logs
+    set:
+      testing: {enabled: true}
+      postgresql:
+        instances:
+          - name: my-database
+            exporter:
+              dataSource:
+                host: my-db.postgresql.svc
+            databaseObservability:
+              enabled: true
+              labels:
+                environment: production
+                team: payments
+            logs: {enabled: false}
+    asserts:
+      - template: test/configmap.yaml
+        matchSnapshot:
+          path: data["metrics.alloy"]
+
+  - it: rejects reserved db o11y labels
+    set:
+      testing: {enabled: true}
+      postgresql:
+        instances:
+          - name: my-database
+            exporter:
+              dataSource:
+                host: my-db.postgresql.svc
+            databaseObservability:
+              enabled: true
+              labels:
+                job: custom
+            logs: {enabled: false}
+    asserts:
+      - template: test/configmap.yaml
+        failedTemplate:
+          errorMessage: |-
+            The label "job" in databaseObservability.labels for instance "my-database" is reserved and cannot be overridden.
+            Reserved labels: job, instance, dsn.
+            Use `jobLabel` to change the job value.
+
   - it: requires metrics
     set:
       testing: {enabled: true}

--- a/charts/k8s-monitoring/charts/feature-integrations/values.schema.json
+++ b/charts/k8s-monitoring/charts/feature-integrations/values.schema.json
@@ -1010,6 +1010,9 @@
                         },
                         "excludeSchemas": {
                             "type": "array"
+                        },
+                        "labels": {
+                            "type": "object"
                         }
                     }
                 },
@@ -1323,6 +1326,9 @@
                         },
                         "excludeUsers": {
                             "type": "array"
+                        },
+                        "labels": {
+                            "type": "object"
                         }
                     }
                 },


### PR DESCRIPTION



# Description
With this change we allow specifying additional labels (as simple key-value pairs) to be added to the metrics and logs produced by Database Observability for a given instance.


## Authorship

-   [x] I, a human, wrote this pull request description myself.


