### PR TITLE
Add the ability to access kube controller manager and kube scheduler on EKS clusters

### DIFF
--- a/charts/k8s-monitoring/CHANGELOG.md
+++ b/charts/k8s-monitoring/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+*   Cluster Metrics: add a `discoveryMode` option to `kubeScheduler` and `kubeControllerManager`, `eks-proxy` to scrape the control plane from the Amazon EKS Control Plane Metrics API (`metrics.eks.amazonaws.com`). (#2915) (@petewall)
 *   Add `extraResourceAttributes` and `extraResourceAttributesFrom` options to the OTLP destination. (#2913) (@petewall)
 
 ## 4.3.2

--- a/charts/k8s-monitoring/charts/feature-cluster-metrics/README.md
+++ b/charts/k8s-monitoring/charts/feature-cluster-metrics/README.md
@@ -199,6 +199,7 @@ Be sure perform actual integration testing in a live environment in the main [k8
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
+| kubeControllerManager.discoveryMode | string | `"pod"` | How to discover and scrape the Kube Controller Manager. Options are "pod" (find the component's Pod via the `selectorLabel` in `kube-system`) or "eks-proxy" (scrape the EKS Control Plane Metrics API served at `/apis/metrics.eks.amazonaws.com/v1/kcm/container/metrics` on the Kubernetes API server, used by Amazon EKS where the control plane is managed by AWS and has no discoverable Pods). `eks-proxy` requires Kubernetes 1.28+ and additional RBAC; see the EKS platform example. |
 | kubeControllerManager.enabled | bool | `false` | Scrape metrics from the Kube Controller Manager |
 | kubeControllerManager.extraDiscoveryRules | string | `""` | Rule blocks to be added to the discovery.relabel component for the Kube Controller Manager. These relabeling rules are applied pre-scrape against the targets from service discovery. Before the scrape, any remaining target labels that start with `__` (i.e. `__meta_kubernetes*`) are dropped. ([docs](https://grafana.com/docs/alloy/latest/reference/components/discovery/discovery.relabel/#rule-block)) |
 | kubeControllerManager.extraMetricProcessingRules | string | `""` | Rule blocks to be added to the prometheus.relabel component for the Kube Controller Manager. These relabeling rules are applied post-scrape against the metrics returned from the scraped target, no `__meta*` labels are present. ([docs](https://grafana.com/docs/alloy/latest/reference/components/prometheus/prometheus.relabel/#rule-block)) |
@@ -206,9 +207,9 @@ Be sure perform actual integration testing in a live environment in the main [k8
 | kubeControllerManager.maxCacheSize | string | `nil` | Sets the max_cache_size for the Kube Controller Manager prometheus.relabel component. This should be at least 2x-5x your largest scrape target or samples appended rate. ([docs](https://grafana.com/docs/alloy/latest/reference/components/prometheus/prometheus.relabel/#arguments)). Overrides `global.maxCacheSize`. |
 | kubeControllerManager.metricsTuning.excludeMetrics | list | `[]` | Metrics to drop. Can use regular expressions. |
 | kubeControllerManager.metricsTuning.includeMetrics | list | `[]` | Metrics to keep. Can use regular expressions. An empty list means keep all. |
-| kubeControllerManager.port | int | `10257` | Port number used by the Kube Controller Manager, set by `--secure-port.` |
+| kubeControllerManager.port | int | `10257` | Port number used by the Kube Controller Manager, set by `--secure-port.` Only used when `discoveryMode` is "pod". |
 | kubeControllerManager.scrapeInterval | string | 60s | How frequently to scrape metrics from the Kube Controller Manager. Overrides `global.scrapeInterval`. |
-| kubeControllerManager.selectorLabel | string | `"component=kube-controller-manager"` | Selector label. |
+| kubeControllerManager.selectorLabel | string | `"component=kube-controller-manager"` | Selector label. Only used when `discoveryMode` is "pod". |
 
 ### KubeDNS
 
@@ -244,6 +245,7 @@ Be sure perform actual integration testing in a live environment in the main [k8
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
+| kubeScheduler.discoveryMode | string | `"pod"` | How to discover and scrape the Kube Scheduler. Options are "pod" (find the component's Pod via the `selectorLabel` in `kube-system`) or "eks-proxy" (scrape the EKS Control Plane Metrics API served at `/apis/metrics.eks.amazonaws.com/v1/ksh/container/metrics` on the Kubernetes API server, used by Amazon EKS where the control plane is managed by AWS and has no discoverable Pods). `eks-proxy` requires Kubernetes 1.28+ and additional RBAC; see the EKS platform example. |
 | kubeScheduler.enabled | bool | `false` | Scrape metrics from the Kube Scheduler |
 | kubeScheduler.extraDiscoveryRules | string | `""` | Rule blocks to be added to the discovery.relabel component for the Kube Scheduler. These relabeling rules are applied pre-scrape against the targets from service discovery. Before the scrape, any remaining target labels that start with `__` (i.e. `__meta_kubernetes*`) are dropped. ([docs](https://grafana.com/docs/alloy/latest/reference/components/discovery/discovery.relabel/#rule-block)) |
 | kubeScheduler.extraMetricProcessingRules | string | `""` | Rule blocks to be added to the prometheus.relabel component for the Kube Scheduler. These relabeling rules are applied post-scrape against the metrics returned from the scraped target, no `__meta*` labels are present. ([docs](https://grafana.com/docs/alloy/latest/reference/components/prometheus/prometheus.relabel/#rule-block)) |
@@ -251,10 +253,10 @@ Be sure perform actual integration testing in a live environment in the main [k8
 | kubeScheduler.maxCacheSize | string | `nil` | Sets the max_cache_size for the Kube Scheduler prometheus.relabel component. This should be at least 2x-5x your largest scrape target or samples appended rate. ([docs](https://grafana.com/docs/alloy/latest/reference/components/prometheus/prometheus.relabel/#arguments)). Overrides `global.maxCacheSize`. |
 | kubeScheduler.metricsTuning.excludeMetrics | list | `[]` | Metrics to drop. Can use regular expressions. |
 | kubeScheduler.metricsTuning.includeMetrics | list | `[]` | Metrics to keep. Can use regular expressions. An empty list means keep all. |
-| kubeScheduler.port | int | `10259` | Port number used by the Kube Scheduler, set by `--secure-port`. |
+| kubeScheduler.port | int | `10259` | Port number used by the Kube Scheduler, set by `--secure-port`. Only used when `discoveryMode` is "pod". |
 | kubeScheduler.scrapeInterval | string | 60s | How frequently to scrape metrics from the Kube Scheduler. Overrides `global.scrapeInterval`. |
 | kubeScheduler.scrapeTimeout | string | `10s` | The timeout for scraping Kube Scheduler metrics. Overrides `global.scrapeTimeout`. |
-| kubeScheduler.selectorLabel | string | `"component=kube-scheduler"` | Selector label. |
+| kubeScheduler.selectorLabel | string | `"component=kube-scheduler"` | Selector label. Only used when `discoveryMode` is "pod". |
 
 ### Kubelet
 

--- a/charts/k8s-monitoring/charts/feature-cluster-metrics/schema-mods/types-and-enums.json
+++ b/charts/k8s-monitoring/charts/feature-cluster-metrics/schema-mods/types-and-enums.json
@@ -2,10 +2,10 @@
   "properties": {
     "apiServer": {"properties": {"enabled": {"type": ["null", "boolean"]}, "maxCacheSize": {"type": ["integer", "null"]}}},
     "cadvisor": {"properties": {"nodeAddressFormat": {"enum": ["direct", "proxy"]}, "maxCacheSize": {"type": ["integer", "null"]}}},
-    "kubeControllerManager": {"properties": {"enabled": {"type": ["null", "boolean"]}, "maxCacheSize": {"type": ["integer", "null"]}}},
+    "kubeControllerManager": {"properties": {"enabled": {"type": ["null", "boolean"]}, "discoveryMode": {"enum": ["pod", "eks-proxy"]}, "maxCacheSize": {"type": ["integer", "null"]}}},
     "kubeDNS": {"properties": {"enabled": {"type": ["null", "boolean"]}, "maxCacheSize": {"type": ["integer", "null"]}}},
     "kubeProxy": {"properties": {"enabled": {"type": ["null", "boolean"]}, "maxCacheSize": {"type": ["integer", "null"]}}},
-    "kubeScheduler": {"properties": {"enabled": {"type": ["null", "boolean"]}, "maxCacheSize": {"type": ["integer", "null"]}}},
+    "kubeScheduler": {"properties": {"enabled": {"type": ["null", "boolean"]}, "discoveryMode": {"enum": ["pod", "eks-proxy"]}, "maxCacheSize": {"type": ["integer", "null"]}}},
     "kubelet": {"properties": {"nodeAddressFormat": {"enum": ["direct", "proxy"]}, "maxCacheSize": {"type": ["integer", "null"]}}},
     "kubeletProbes": {"properties": {"nodeAddressFormat": {"enum": ["direct", "proxy"]}, "maxCacheSize": {"type": ["integer", "null"]}}},
     "kubeletResource": {"properties": {"nodeAddressFormat": {"enum": ["direct", "proxy"]}, "maxCacheSize": {"type": ["integer", "null"]}}},

--- a/charts/k8s-monitoring/charts/feature-cluster-metrics/templates/_kube_controller_manager.alloy.tpl
+++ b/charts/k8s-monitoring/charts/feature-cluster-metrics/templates/_kube_controller_manager.alloy.tpl
@@ -2,6 +2,20 @@
 {{- if or .Values.kubeControllerManager.enabled (and .Values.controlPlane.enabled (not (eq .Values.kubeControllerManager.enabled false))) }}
 {{- $metricAllowList := .Values.kubeControllerManager.metricsTuning.includeMetrics }}
 {{- $metricDenyList := .Values.kubeControllerManager.metricsTuning.excludeMetrics }}
+{{- if eq .Values.kubeControllerManager.discoveryMode "eks-proxy" }}
+
+discovery.relabel "kube_controller_manager" {
+  // On Amazon EKS the control plane is managed by AWS and the Kube Controller Manager has no discoverable Pod, so
+  // its metrics are scraped from the EKS Control Plane Metrics API served on the Kubernetes API server.
+  targets = [{
+    __address__      = {{ .Values.global.kubernetesAPIService | default "kubernetes.default.svc.cluster.local:443" | quote }},
+    __metrics_path__ = "/apis/metrics.eks.amazonaws.com/v1/kcm/container/metrics",
+  }]
+{{- if .Values.kubeControllerManager.extraDiscoveryRules }}
+{{ .Values.kubeControllerManager.extraDiscoveryRules | indent 2 }}
+{{- end }}
+} // discovery.relabel "kube_controller_manager"
+{{- else }}
 
 discovery.kubernetes "kube_controller_manager" {
   role = "pod"
@@ -25,6 +39,7 @@ discovery.relabel "kube_controller_manager" {
 {{ .Values.kubeControllerManager.extraDiscoveryRules | indent 2 }}
 {{- end }}
 } // discovery.relabel "kube_controller_manager"
+{{- end }}
 
 prometheus.scrape "kube_controller_manager" {
   targets           = discovery.relabel.kube_controller_manager.output

--- a/charts/k8s-monitoring/charts/feature-cluster-metrics/templates/_kube_scheduler.alloy.tpl
+++ b/charts/k8s-monitoring/charts/feature-cluster-metrics/templates/_kube_scheduler.alloy.tpl
@@ -2,6 +2,20 @@
 {{- if or .Values.kubeScheduler.enabled (and .Values.controlPlane.enabled (not (eq .Values.kubeScheduler.enabled false))) }}
 {{- $metricAllowList := .Values.kubeScheduler.metricsTuning.includeMetrics }}
 {{- $metricDenyList := .Values.kubeScheduler.metricsTuning.excludeMetrics }}
+{{- if eq .Values.kubeScheduler.discoveryMode "eks-proxy" }}
+
+discovery.relabel "kube_scheduler" {
+  // On Amazon EKS the control plane is managed by AWS and the Kube Scheduler has no discoverable Pod, so
+  // its metrics are scraped from the EKS Control Plane Metrics API served on the Kubernetes API server.
+  targets = [{
+    __address__      = {{ .Values.global.kubernetesAPIService | default "kubernetes.default.svc.cluster.local:443" | quote }},
+    __metrics_path__ = "/apis/metrics.eks.amazonaws.com/v1/ksh/container/metrics",
+  }]
+{{- if .Values.kubeScheduler.extraDiscoveryRules }}
+{{ .Values.kubeScheduler.extraDiscoveryRules | indent 2 }}
+{{- end }}
+} // discovery.relabel "kube_scheduler"
+{{- else }}
 
 discovery.kubernetes "kube_scheduler" {
   role = "pod"
@@ -25,6 +39,7 @@ discovery.relabel "kube_scheduler" {
 {{ .Values.kubeScheduler.extraDiscoveryRules | indent 2 }}
 {{- end }}
 } // discovery.relabel "kube_scheduler"
+{{- end }}
 
 prometheus.scrape "kube_scheduler" {
   targets           = discovery.relabel.kube_scheduler.output

--- a/charts/k8s-monitoring/charts/feature-cluster-metrics/tests/__snapshot__/control_plane_test.yaml.snap
+++ b/charts/k8s-monitoring/charts/feature-cluster-metrics/tests/__snapshot__/control_plane_test.yaml.snap
@@ -153,14 +153,14 @@ should render the configuration with control plane components included:
           rule {
             source_labels = ["__name__","container"]
             separator = "@"
-            regex = "(container_cpu_.*|container_fs_.*|container_memory_.*)@"
+            regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_pressure_.*)@"
             action = "drop"
           }
           // Drop empty image labels, addressing https://github.com/google/cadvisor/issues/2688
           rule {
             source_labels = ["__name__","image"]
             separator = "@"
-            regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_network_.*)@"
+            regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_network_.*|container_pressure_.*)@"
             action = "drop"
           }
           // Normalizing unimportant labels (not deleting to continue satisfying <label>!="" checks)
@@ -488,6 +488,286 @@ should render the configuration with control plane components included:
             replacement = "$1:10259"
             target_label = "__address__"
           }
+        } // discovery.relabel "kube_scheduler"
+
+        prometheus.scrape "kube_scheduler" {
+          targets           = discovery.relabel.kube_scheduler.output
+          job_name          = "kube-scheduler"
+          scheme            = "https"
+          scrape_interval   = "60s"
+          scrape_timeout = "10s"
+          scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
+          scrape_classic_histograms = false
+          scrape_native_histograms = false
+          convert_classic_histograms_to_nhcb = false
+          bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+          tls_config {
+            insecure_skip_verify = true
+          }
+          clustering {
+            enabled = true
+          }
+          forward_to = argument.metrics_destinations.value
+        } // prometheus.scrape "kube_scheduler"
+      } // declare "cluster_metrics"
+should scrape the EKS Control Plane Metrics API when discoveryMode is eks-proxy:
+  1: |
+    |-
+      declare "cluster_metrics" {
+        argument "metrics_destinations" {
+          comment = "Must be a list of metric destinations where collected metrics should be forwarded to"
+        }
+        discovery.kubernetes "nodes" {
+          role = "node"
+        } // discovery.kubernetes "nodes"
+
+        discovery.relabel "nodes" {
+          targets = discovery.kubernetes.nodes.targets
+          rule {
+            source_labels = ["__meta_kubernetes_node_name"]
+            target_label  = "node"
+          }
+
+          rule {
+            replacement = "kubernetes"
+            target_label = "source"
+          }
+        } // discovery.relabel "nodes"
+
+        // Kubelet
+        discovery.relabel "kubelet" {
+          targets = discovery.relabel.nodes.output
+        } // discovery.relabel "kubelet"
+
+        prometheus.scrape "kubelet" {
+          targets  = discovery.relabel.kubelet.output
+          job_name = "integrations/kubernetes/kubelet"
+          scheme   = "https"
+          scrape_interval = "60s"
+          scrape_timeout = "10s"
+          scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
+          scrape_classic_histograms = false
+          scrape_native_histograms = false
+          convert_classic_histograms_to_nhcb = false
+          bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+
+          tls_config {
+            ca_file = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+            insecure_skip_verify = true
+            server_name = "kubernetes"
+          }
+
+          clustering {
+            enabled = true
+          }
+
+          forward_to = [prometheus.relabel.kubelet.receiver]
+        } // prometheus.scrape "kubelet"
+
+        prometheus.relabel "kubelet" {
+          max_cache_size = 100000
+          rule {
+            source_labels = ["__name__"]
+            regex = "up|scrape_samples_scraped|go_goroutines|kubelet_certificate_manager_client_expiration_renew_errors|kubelet_certificate_manager_client_ttl_seconds|kubelet_certificate_manager_server_ttl_seconds|kubelet_cgroup_manager_duration_seconds_bucket|kubelet_cgroup_manager_duration_seconds_count|kubelet_node_config_error|kubelet_node_name|kubelet_pleg_relist_duration_seconds_bucket|kubelet_pleg_relist_duration_seconds_count|kubelet_pleg_relist_interval_seconds_bucket|kubelet_pod_start_duration_seconds_bucket|kubelet_pod_start_duration_seconds_count|kubelet_pod_worker_duration_seconds_bucket|kubelet_pod_worker_duration_seconds_count|kubelet_running_container_count|kubelet_running_containers|kubelet_running_pod_count|kubelet_running_pods|kubelet_runtime_operations_errors_total|kubelet_runtime_operations_total|kubelet_server_expiration_renew_errors|kubelet_volume_stats_available_bytes|kubelet_volume_stats_capacity_bytes|kubelet_volume_stats_inodes|kubelet_volume_stats_inodes_free|kubelet_volume_stats_inodes_used|kubelet_volume_stats_used_bytes|kubernetes_build_info|namespace_workload_pod|process_cpu_seconds_total|process_resident_memory_bytes|rest_client_requests_total|storage_operation_duration_seconds_count|storage_operation_errors_total|volume_manager_total_volumes"
+            action = "keep"
+          }
+
+          forward_to = argument.metrics_destinations.value
+        } // prometheus.relabel "kubelet"
+
+        // Kubelet Resources
+        discovery.relabel "kubelet_resources" {
+          targets = discovery.relabel.nodes.output
+          rule {
+            replacement   = "/metrics/resource"
+            target_label  = "__metrics_path__"
+          }
+        } // discovery.relabel "kubelet_resources"
+
+        prometheus.scrape "kubelet_resources" {
+          targets = discovery.relabel.kubelet_resources.output
+          job_name = "integrations/kubernetes/resources"
+          scheme   = "https"
+          scrape_interval = "60s"
+          scrape_timeout = "10s"
+          scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
+          scrape_classic_histograms = false
+          scrape_native_histograms = false
+          convert_classic_histograms_to_nhcb = false
+          bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+
+          tls_config {
+            ca_file = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+            insecure_skip_verify = true
+            server_name = "kubernetes"
+          }
+
+          clustering {
+            enabled = true
+          }
+
+          forward_to = [prometheus.relabel.kubelet_resources.receiver]
+        } // prometheus.scrape "kubelet_resources"
+
+        prometheus.relabel "kubelet_resources" {
+          max_cache_size = 100000
+          rule {
+            source_labels = ["__name__"]
+            regex = "up|scrape_samples_scraped|node_cpu_usage_seconds_total|node_memory_working_set_bytes"
+            action = "keep"
+          }
+
+          forward_to = argument.metrics_destinations.value
+        } // prometheus.relabel "kubelet_resources"
+
+        // cAdvisor
+        discovery.relabel "cadvisor" {
+          targets = discovery.relabel.nodes.output
+          rule {
+            replacement   = "/metrics/cadvisor"
+            target_label  = "__metrics_path__"
+          }
+        } // discovery.relabel "cadvisor"
+
+        prometheus.scrape "cadvisor" {
+          targets = discovery.relabel.cadvisor.output
+          job_name = "integrations/kubernetes/cadvisor"
+          scheme = "https"
+          scrape_interval = "60s"
+          scrape_timeout = "10s"
+          scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
+          scrape_classic_histograms = false
+          scrape_native_histograms = false
+          convert_classic_histograms_to_nhcb = false
+          bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+
+          tls_config {
+            ca_file = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+            insecure_skip_verify = true
+            server_name = "kubernetes"
+          }
+
+          clustering {
+            enabled = true
+          }
+
+          forward_to = [prometheus.relabel.cadvisor.receiver]
+        } // prometheus.scrape "cadvisor"
+
+        prometheus.relabel "cadvisor" {
+          max_cache_size = 100000
+          rule {
+            source_labels = ["__name__"]
+            regex = "up|scrape_samples_scraped|container_cpu_cfs_periods_total|container_cpu_cfs_throttled_periods_total|container_cpu_usage_seconds_total|container_fs_reads_bytes_total|container_fs_reads_total|container_fs_writes_bytes_total|container_fs_writes_total|container_memory_cache|container_memory_rss|container_memory_swap|container_memory_usage_bytes|container_memory_working_set_bytes|container_network_receive_bytes_total|container_network_receive_packets_dropped_total|container_network_receive_packets_total|container_network_transmit_bytes_total|container_network_transmit_packets_dropped_total|container_network_transmit_packets_total|machine_memory_bytes"
+            action = "keep"
+          }
+          // Drop empty container labels, addressing https://github.com/google/cadvisor/issues/2688
+          rule {
+            source_labels = ["__name__","container"]
+            separator = "@"
+            regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_pressure_.*)@"
+            action = "drop"
+          }
+          // Drop empty image labels, addressing https://github.com/google/cadvisor/issues/2688
+          rule {
+            source_labels = ["__name__","image"]
+            separator = "@"
+            regex = "(container_cpu_.*|container_fs_.*|container_memory_.*|container_network_.*|container_pressure_.*)@"
+            action = "drop"
+          }
+          // Normalizing unimportant labels (not deleting to continue satisfying <label>!="" checks)
+          rule {
+            source_labels = ["__name__", "boot_id"]
+            separator = "@"
+            regex = "machine_memory_bytes@.*"
+            target_label = "boot_id"
+            replacement = "NA"
+          }
+          rule {
+            source_labels = ["__name__", "system_uuid"]
+            separator = "@"
+            regex = "machine_memory_bytes@.*"
+            target_label = "system_uuid"
+            replacement = "NA"
+          }
+          // Filter out non-physical devices/interfaces
+          rule {
+            source_labels = ["__name__", "device"]
+            separator = "@"
+            regex = "container_fs_.*@(/dev/)?(mmcblk.p.+|nvme.+|rbd.+|sd.+|vd.+|xvd.+|dasd.+)"
+            target_label = "__keepme"
+            replacement = "1"
+          }
+          rule {
+            source_labels = ["__name__", "__keepme"]
+            separator = "@"
+            regex = "container_fs_.*@"
+            action = "drop"
+          }
+          rule {
+            source_labels = ["__name__"]
+            regex = "container_fs_.*"
+            target_label = "__keepme"
+            replacement = ""
+          }
+          rule {
+            source_labels = ["__name__", "interface"]
+            separator = "@"
+            regex = "container_network_.*@(en[ospx][0-9].*|wlan[0-9].*|eth[0-9].*)"
+            target_label = "__keepme"
+            replacement = "1"
+          }
+          rule {
+            source_labels = ["__name__", "__keepme"]
+            separator = "@"
+            regex = "container_network_.*@"
+            action = "drop"
+          }
+          rule {
+            source_labels = ["__name__"]
+            regex = "container_network_.*"
+            target_label = "__keepme"
+            replacement = ""
+          }
+          forward_to = argument.metrics_destinations.value
+        } // prometheus.relabel "cadvisor"
+
+        discovery.relabel "kube_controller_manager" {
+          // On Amazon EKS the control plane is managed by AWS and the Kube Controller Manager has no discoverable Pod, so
+          // its metrics are scraped from the EKS Control Plane Metrics API served on the Kubernetes API server.
+          targets = [{
+            __address__      = "kubernetes.default.svc.cluster.local:443",
+            __metrics_path__ = "/apis/metrics.eks.amazonaws.com/v1/kcm/container/metrics",
+          }]
+        } // discovery.relabel "kube_controller_manager"
+
+        prometheus.scrape "kube_controller_manager" {
+          targets           = discovery.relabel.kube_controller_manager.output
+          job_name          = "kube-controller-manager"
+          scheme            = "https"
+          scrape_interval   = "60s"
+          scrape_timeout = "10s"
+          scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
+          scrape_classic_histograms = false
+          scrape_native_histograms = false
+          convert_classic_histograms_to_nhcb = false
+          bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+          tls_config {
+            insecure_skip_verify = true
+          }
+          clustering {
+            enabled = true
+          }
+          forward_to = argument.metrics_destinations.value
+        } // prometheus.scrape "kube_controller_manager"
+
+        discovery.relabel "kube_scheduler" {
+          // On Amazon EKS the control plane is managed by AWS and the Kube Scheduler has no discoverable Pod, so
+          // its metrics are scraped from the EKS Control Plane Metrics API served on the Kubernetes API server.
+          targets = [{
+            __address__      = "kubernetes.default.svc.cluster.local:443",
+            __metrics_path__ = "/apis/metrics.eks.amazonaws.com/v1/ksh/container/metrics",
+          }]
         } // discovery.relabel "kube_scheduler"
 
         prometheus.scrape "kube_scheduler" {

--- a/charts/k8s-monitoring/charts/feature-cluster-metrics/tests/control_plane_test.yaml
+++ b/charts/k8s-monitoring/charts/feature-cluster-metrics/tests/control_plane_test.yaml
@@ -15,3 +15,33 @@ tests:
           of: ConfigMap
       - matchSnapshot:
           path: data["module.alloy"]
+
+  - it: should scrape the EKS Control Plane Metrics API when discoveryMode is eks-proxy
+    set:
+      testing: {enabled: true}
+      kubeScheduler:
+        enabled: true
+        discoveryMode: eks-proxy
+      kubeControllerManager:
+        enabled: true
+        discoveryMode: eks-proxy
+      kube-state-metrics:
+        enabled: false
+    asserts:
+      - isKind:
+          of: ConfigMap
+      # eks-proxy mode targets the API server directly, not a Pod discovered in kube-system.
+      - notMatchRegex:
+          path: data["module.alloy"]
+          pattern: 'discovery\.kubernetes "kube_scheduler"'
+      - notMatchRegex:
+          path: data["module.alloy"]
+          pattern: 'discovery\.kubernetes "kube_controller_manager"'
+      - matchRegex:
+          path: data["module.alloy"]
+          pattern: '/apis/metrics\.eks\.amazonaws\.com/v1/ksh/container/metrics'
+      - matchRegex:
+          path: data["module.alloy"]
+          pattern: '/apis/metrics\.eks\.amazonaws\.com/v1/kcm/container/metrics'
+      - matchSnapshot:
+          path: data["module.alloy"]

--- a/charts/k8s-monitoring/charts/feature-cluster-metrics/values.schema.json
+++ b/charts/k8s-monitoring/charts/feature-cluster-metrics/values.schema.json
@@ -272,6 +272,13 @@
         "kubeControllerManager": {
             "type": "object",
             "properties": {
+                "discoveryMode": {
+                    "type": "string",
+                    "enum": [
+                        "pod",
+                        "eks-proxy"
+                    ]
+                },
                 "enabled": {
                     "type": [
                         "null",
@@ -410,6 +417,13 @@
         "kubeScheduler": {
             "type": "object",
             "properties": {
+                "discoveryMode": {
+                    "type": "string",
+                    "enum": [
+                        "pod",
+                        "eks-proxy"
+                    ]
+                },
                 "enabled": {
                     "type": [
                         "null",

--- a/charts/k8s-monitoring/charts/feature-cluster-metrics/values.yaml
+++ b/charts/k8s-monitoring/charts/feature-cluster-metrics/values.yaml
@@ -375,15 +375,23 @@ kubeControllerManager:
   # @section -- Kube Controller Manager
   enabled:
 
+  # -- How to discover and scrape the Kube Controller Manager. Options are "pod" (find the component's Pod via the
+  # `selectorLabel` in `kube-system`) or "eks-proxy" (scrape the EKS Control Plane Metrics API served at
+  # `/apis/metrics.eks.amazonaws.com/v1/kcm/container/metrics` on the Kubernetes API server, used by Amazon EKS where
+  # the control plane is managed by AWS and has no discoverable Pods). `eks-proxy` requires Kubernetes 1.28+ and
+  # additional RBAC; see the EKS platform example.
+  # @section -- Kube Controller Manager
+  discoveryMode: pod
+
   # -- The value for the job label.
   # @section -- Kube Controller Manager
   jobLabel: "kube-controller-manager"
 
-  # -- Selector label.
+  # -- Selector label. Only used when `discoveryMode` is "pod".
   # @section -- Kube Controller Manager
   selectorLabel: "component=kube-controller-manager"
 
-  # -- Port number used by the Kube Controller Manager, set by `--secure-port.`
+  # -- Port number used by the Kube Controller Manager, set by `--secure-port.` Only used when `discoveryMode` is "pod".
   # @section -- Kube Controller Manager
   port: 10257
 
@@ -544,15 +552,23 @@ kubeScheduler:
   # @section -- Kube Scheduler
   enabled:
 
+  # -- How to discover and scrape the Kube Scheduler. Options are "pod" (find the component's Pod via the
+  # `selectorLabel` in `kube-system`) or "eks-proxy" (scrape the EKS Control Plane Metrics API served at
+  # `/apis/metrics.eks.amazonaws.com/v1/ksh/container/metrics` on the Kubernetes API server, used by Amazon EKS where
+  # the control plane is managed by AWS and has no discoverable Pods). `eks-proxy` requires Kubernetes 1.28+ and
+  # additional RBAC; see the EKS platform example.
+  # @section -- Kube Scheduler
+  discoveryMode: pod
+
   # -- The value for the job label.
   # @section -- Kube Scheduler
   jobLabel: "kube-scheduler"
 
-  # -- Selector label.
+  # -- Selector label. Only used when `discoveryMode` is "pod".
   # @section -- Kube Scheduler
   selectorLabel: "component=kube-scheduler"
 
-  # -- Port number used by the Kube Scheduler, set by `--secure-port`.
+  # -- Port number used by the Kube Scheduler, set by `--secure-port`. Only used when `discoveryMode` is "pod".
   # @section -- Kube Scheduler
   port: 10259
 

--- a/charts/k8s-monitoring/tests/platform/eks-with-windows/.rendered/alloy-metrics.alloy
+++ b/charts/k8s-monitoring/tests/platform/eks-with-windows/.rendered/alloy-metrics.alloy
@@ -217,6 +217,274 @@ declare "cluster_metrics" {
     }
     forward_to = argument.metrics_destinations.value
   } // prometheus.relabel "cadvisor"
+
+  discovery.kubernetes "apiserver" {
+    role = "endpointslice"
+
+    selectors {
+      role = "endpointslice"
+      label = "kubernetes.io/service-name=kubernetes"
+    }
+
+    namespaces {
+      names = ["default"]
+    }
+  } // discovery.kubernetes "apiserver"
+
+  discovery.relabel "apiserver" {
+    targets = discovery.kubernetes.apiserver.targets
+
+    rule {
+      source_labels = ["__meta_kubernetes_endpointslice_port_name"]
+      regex = "https"
+      action = "keep"
+    }
+
+    rule {
+      source_labels = ["__meta_kubernetes_namespace"]
+      target_label = "namespace"
+    }
+
+    rule {
+      source_labels = ["__meta_kubernetes_service_name"]
+      target_label = "service"
+    }
+
+    rule {
+      replacement = "kubernetes"
+      target_label = "source"
+    }
+  } // discovery.relabel "apiserver"
+
+  prometheus.scrape "apiserver" {
+    targets = discovery.relabel.apiserver.output
+    job_name = "integrations/kubernetes/kube-apiserver"
+    scheme = "https"
+    scrape_interval = "60s"
+    scrape_timeout = "10s"
+    scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
+    scrape_classic_histograms = false
+    scrape_native_histograms = false
+    convert_classic_histograms_to_nhcb = false
+    bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+
+    tls_config {
+      ca_file = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+      insecure_skip_verify = false
+      server_name = "kubernetes"
+    }
+
+    clustering {
+      enabled = true
+    }
+    forward_to = argument.metrics_destinations.value
+  } // prometheus.scrape "apiserver"
+
+  discovery.relabel "kube_controller_manager" {
+    // On Amazon EKS the control plane is managed by AWS and the Kube Controller Manager has no discoverable Pod, so
+    // its metrics are scraped from the EKS Control Plane Metrics API served on the Kubernetes API server.
+    targets = [{
+      __address__      = "kubernetes.default.svc.cluster.local:443",
+      __metrics_path__ = "/apis/metrics.eks.amazonaws.com/v1/kcm/container/metrics",
+    }]
+  } // discovery.relabel "kube_controller_manager"
+
+  prometheus.scrape "kube_controller_manager" {
+    targets           = discovery.relabel.kube_controller_manager.output
+    job_name          = "kube-controller-manager"
+    scheme            = "https"
+    scrape_interval   = "60s"
+    scrape_timeout = "10s"
+    scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
+    scrape_classic_histograms = false
+    scrape_native_histograms = false
+    convert_classic_histograms_to_nhcb = false
+    bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+    tls_config {
+      insecure_skip_verify = true
+    }
+    clustering {
+      enabled = true
+    }
+    forward_to = argument.metrics_destinations.value
+  } // prometheus.scrape "kube_controller_manager"
+
+  // KubeDNS
+  discovery.kubernetes "kube_dns" {
+    role = "endpointslice"
+    namespaces {
+      names = ["kube-system"]
+    }
+    selectors {
+      role = "endpointslice"
+      label = "kubernetes.io/service-name=kube-dns"
+    }
+  } // discovery.kubernetes "kube_dns"
+
+  discovery.relabel "kube_dns" {
+    targets = discovery.kubernetes.kube_dns.targets
+
+    // keep only the specified metrics port name, and pods that are Running and ready
+    rule {
+      source_labels = [
+        "__meta_kubernetes_pod_container_port_name",
+        "__meta_kubernetes_pod_phase",
+        "__meta_kubernetes_pod_ready",
+      ]
+      separator = "@"
+      regex = "metrics@Running@true"
+      action = "keep"
+    }
+
+    // drop any init containers
+    rule {
+      source_labels = ["__meta_kubernetes_pod_container_init"]
+      regex = "true"
+      action = "drop"
+    }
+
+    // set the namespace label
+    rule {
+      source_labels = ["__meta_kubernetes_namespace"]
+      target_label  = "namespace"
+    }
+
+    // set the pod label
+    rule {
+      source_labels = ["__meta_kubernetes_pod_name"]
+      target_label  = "pod"
+    }
+
+    // set the container label
+    rule {
+      source_labels = ["__meta_kubernetes_pod_container_name"]
+      target_label  = "container"
+    }
+
+    // set a workload label
+    rule {
+      source_labels = [
+        "__meta_kubernetes_pod_controller_kind",
+        "__meta_kubernetes_pod_controller_name",
+      ]
+      separator = "/"
+      target_label  = "workload"
+    }
+    // remove the hash from the ReplicaSet
+    rule {
+      source_labels = ["workload"]
+      regex = "(ReplicaSet/.+)-.+"
+      target_label  = "workload"
+    }
+
+    // set the app name if specified as metadata labels "app:" or "app.kubernetes.io/name:" or "k8s-app:"
+    rule {
+      action = "replace"
+      source_labels = [
+        "__meta_kubernetes_pod_label_app_kubernetes_io_name",
+        "__meta_kubernetes_pod_label_k8s_app",
+        "__meta_kubernetes_pod_label_app",
+      ]
+      separator = ";"
+      regex = "^(?:;*)?([^;]+).*$"
+      replacement = "$1"
+      target_label = "app"
+    }
+
+    // set the service label
+    rule {
+      source_labels = ["__meta_kubernetes_service_name"]
+      target_label  = "service"
+    }
+
+    // set a source label
+    rule {
+      action = "replace"
+      replacement = "kubernetes"
+      target_label = "source"
+    }
+  } // discovery.relabel "kube_dns"
+
+  prometheus.scrape "kube_dns" {
+    targets = discovery.relabel.kube_dns.output
+    job_name = "integrations/kubernetes/kube-dns"
+    scheme = "http"
+    scrape_interval = "60s"
+    scrape_timeout = "10s"
+    scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
+    scrape_classic_histograms = false
+    scrape_native_histograms = false
+    convert_classic_histograms_to_nhcb = false
+    clustering {
+      enabled = true
+    }
+    forward_to = argument.metrics_destinations.value
+  } // prometheus.scrape "kube_dns"
+
+  discovery.kubernetes "kube_proxy" {
+    role = "pod"
+    namespaces {
+      names = ["kube-system"]
+    }
+    selectors {
+      role = "pod"
+      label = "k8s-app=kube-proxy"
+    }
+  } // discovery.kubernetes "kube_proxy"
+
+  discovery.relabel "kube_proxy" {
+    targets = discovery.kubernetes.kube_proxy.targets
+    rule {
+      source_labels = ["__meta_kubernetes_pod_ip"]
+      replacement = "$1:10249"
+      target_label = "__address__"
+    }
+  } // discovery.relabel "kube_proxy"
+
+  prometheus.scrape "kube_proxy" {
+    targets           = discovery.relabel.kube_proxy.output
+    job_name          = "integrations/kubernetes/kube-proxy"
+    scheme            = "http"
+    scrape_interval   = "60s"
+    scrape_timeout = "10s"
+    scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
+    scrape_classic_histograms = false
+    scrape_native_histograms = false
+    convert_classic_histograms_to_nhcb = false
+    clustering {
+      enabled = true
+    }
+    forward_to = argument.metrics_destinations.value
+  } // prometheus.scrape "kube_proxy"
+
+  discovery.relabel "kube_scheduler" {
+    // On Amazon EKS the control plane is managed by AWS and the Kube Scheduler has no discoverable Pod, so
+    // its metrics are scraped from the EKS Control Plane Metrics API served on the Kubernetes API server.
+    targets = [{
+      __address__      = "kubernetes.default.svc.cluster.local:443",
+      __metrics_path__ = "/apis/metrics.eks.amazonaws.com/v1/ksh/container/metrics",
+    }]
+  } // discovery.relabel "kube_scheduler"
+
+  prometheus.scrape "kube_scheduler" {
+    targets           = discovery.relabel.kube_scheduler.output
+    job_name          = "kube-scheduler"
+    scheme            = "https"
+    scrape_interval   = "60s"
+    scrape_timeout = "10s"
+    scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
+    scrape_classic_histograms = false
+    scrape_native_histograms = false
+    convert_classic_histograms_to_nhcb = false
+    bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+    tls_config {
+      insecure_skip_verify = true
+    }
+    clustering {
+      enabled = true
+    }
+    forward_to = argument.metrics_destinations.value
+  } // prometheus.scrape "kube_scheduler"
   discovery.kubernetes "kube_state_metrics" {
     role = "endpoints"
 

--- a/charts/k8s-monitoring/tests/platform/eks-with-windows/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/platform/eks-with-windows/.rendered/output.yaml
@@ -929,6 +929,274 @@ data:
         }
         forward_to = argument.metrics_destinations.value
       } // prometheus.relabel "cadvisor"
+    
+      discovery.kubernetes "apiserver" {
+        role = "endpointslice"
+    
+        selectors {
+          role = "endpointslice"
+          label = "kubernetes.io/service-name=kubernetes"
+        }
+    
+        namespaces {
+          names = ["default"]
+        }
+      } // discovery.kubernetes "apiserver"
+    
+      discovery.relabel "apiserver" {
+        targets = discovery.kubernetes.apiserver.targets
+    
+        rule {
+          source_labels = ["__meta_kubernetes_endpointslice_port_name"]
+          regex = "https"
+          action = "keep"
+        }
+    
+        rule {
+          source_labels = ["__meta_kubernetes_namespace"]
+          target_label = "namespace"
+        }
+    
+        rule {
+          source_labels = ["__meta_kubernetes_service_name"]
+          target_label = "service"
+        }
+    
+        rule {
+          replacement = "kubernetes"
+          target_label = "source"
+        }
+      } // discovery.relabel "apiserver"
+    
+      prometheus.scrape "apiserver" {
+        targets = discovery.relabel.apiserver.output
+        job_name = "integrations/kubernetes/kube-apiserver"
+        scheme = "https"
+        scrape_interval = "60s"
+        scrape_timeout = "10s"
+        scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
+        scrape_classic_histograms = false
+        scrape_native_histograms = false
+        convert_classic_histograms_to_nhcb = false
+        bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+    
+        tls_config {
+          ca_file = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+          insecure_skip_verify = false
+          server_name = "kubernetes"
+        }
+    
+        clustering {
+          enabled = true
+        }
+        forward_to = argument.metrics_destinations.value
+      } // prometheus.scrape "apiserver"
+    
+      discovery.relabel "kube_controller_manager" {
+        // On Amazon EKS the control plane is managed by AWS and the Kube Controller Manager has no discoverable Pod, so
+        // its metrics are scraped from the EKS Control Plane Metrics API served on the Kubernetes API server.
+        targets = [{
+          __address__      = "kubernetes.default.svc.cluster.local:443",
+          __metrics_path__ = "/apis/metrics.eks.amazonaws.com/v1/kcm/container/metrics",
+        }]
+      } // discovery.relabel "kube_controller_manager"
+    
+      prometheus.scrape "kube_controller_manager" {
+        targets           = discovery.relabel.kube_controller_manager.output
+        job_name          = "kube-controller-manager"
+        scheme            = "https"
+        scrape_interval   = "60s"
+        scrape_timeout = "10s"
+        scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
+        scrape_classic_histograms = false
+        scrape_native_histograms = false
+        convert_classic_histograms_to_nhcb = false
+        bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+        tls_config {
+          insecure_skip_verify = true
+        }
+        clustering {
+          enabled = true
+        }
+        forward_to = argument.metrics_destinations.value
+      } // prometheus.scrape "kube_controller_manager"
+    
+      // KubeDNS
+      discovery.kubernetes "kube_dns" {
+        role = "endpointslice"
+        namespaces {
+          names = ["kube-system"]
+        }
+        selectors {
+          role = "endpointslice"
+          label = "kubernetes.io/service-name=kube-dns"
+        }
+      } // discovery.kubernetes "kube_dns"
+    
+      discovery.relabel "kube_dns" {
+        targets = discovery.kubernetes.kube_dns.targets
+    
+        // keep only the specified metrics port name, and pods that are Running and ready
+        rule {
+          source_labels = [
+            "__meta_kubernetes_pod_container_port_name",
+            "__meta_kubernetes_pod_phase",
+            "__meta_kubernetes_pod_ready",
+          ]
+          separator = "@"
+          regex = "metrics@Running@true"
+          action = "keep"
+        }
+    
+        // drop any init containers
+        rule {
+          source_labels = ["__meta_kubernetes_pod_container_init"]
+          regex = "true"
+          action = "drop"
+        }
+    
+        // set the namespace label
+        rule {
+          source_labels = ["__meta_kubernetes_namespace"]
+          target_label  = "namespace"
+        }
+    
+        // set the pod label
+        rule {
+          source_labels = ["__meta_kubernetes_pod_name"]
+          target_label  = "pod"
+        }
+    
+        // set the container label
+        rule {
+          source_labels = ["__meta_kubernetes_pod_container_name"]
+          target_label  = "container"
+        }
+    
+        // set a workload label
+        rule {
+          source_labels = [
+            "__meta_kubernetes_pod_controller_kind",
+            "__meta_kubernetes_pod_controller_name",
+          ]
+          separator = "/"
+          target_label  = "workload"
+        }
+        // remove the hash from the ReplicaSet
+        rule {
+          source_labels = ["workload"]
+          regex = "(ReplicaSet/.+)-.+"
+          target_label  = "workload"
+        }
+    
+        // set the app name if specified as metadata labels "app:" or "app.kubernetes.io/name:" or "k8s-app:"
+        rule {
+          action = "replace"
+          source_labels = [
+            "__meta_kubernetes_pod_label_app_kubernetes_io_name",
+            "__meta_kubernetes_pod_label_k8s_app",
+            "__meta_kubernetes_pod_label_app",
+          ]
+          separator = ";"
+          regex = "^(?:;*)?([^;]+).*$"
+          replacement = "$1"
+          target_label = "app"
+        }
+    
+        // set the service label
+        rule {
+          source_labels = ["__meta_kubernetes_service_name"]
+          target_label  = "service"
+        }
+    
+        // set a source label
+        rule {
+          action = "replace"
+          replacement = "kubernetes"
+          target_label = "source"
+        }
+      } // discovery.relabel "kube_dns"
+    
+      prometheus.scrape "kube_dns" {
+        targets = discovery.relabel.kube_dns.output
+        job_name = "integrations/kubernetes/kube-dns"
+        scheme = "http"
+        scrape_interval = "60s"
+        scrape_timeout = "10s"
+        scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
+        scrape_classic_histograms = false
+        scrape_native_histograms = false
+        convert_classic_histograms_to_nhcb = false
+        clustering {
+          enabled = true
+        }
+        forward_to = argument.metrics_destinations.value
+      } // prometheus.scrape "kube_dns"
+    
+      discovery.kubernetes "kube_proxy" {
+        role = "pod"
+        namespaces {
+          names = ["kube-system"]
+        }
+        selectors {
+          role = "pod"
+          label = "k8s-app=kube-proxy"
+        }
+      } // discovery.kubernetes "kube_proxy"
+    
+      discovery.relabel "kube_proxy" {
+        targets = discovery.kubernetes.kube_proxy.targets
+        rule {
+          source_labels = ["__meta_kubernetes_pod_ip"]
+          replacement = "$1:10249"
+          target_label = "__address__"
+        }
+      } // discovery.relabel "kube_proxy"
+    
+      prometheus.scrape "kube_proxy" {
+        targets           = discovery.relabel.kube_proxy.output
+        job_name          = "integrations/kubernetes/kube-proxy"
+        scheme            = "http"
+        scrape_interval   = "60s"
+        scrape_timeout = "10s"
+        scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
+        scrape_classic_histograms = false
+        scrape_native_histograms = false
+        convert_classic_histograms_to_nhcb = false
+        clustering {
+          enabled = true
+        }
+        forward_to = argument.metrics_destinations.value
+      } // prometheus.scrape "kube_proxy"
+    
+      discovery.relabel "kube_scheduler" {
+        // On Amazon EKS the control plane is managed by AWS and the Kube Scheduler has no discoverable Pod, so
+        // its metrics are scraped from the EKS Control Plane Metrics API served on the Kubernetes API server.
+        targets = [{
+          __address__      = "kubernetes.default.svc.cluster.local:443",
+          __metrics_path__ = "/apis/metrics.eks.amazonaws.com/v1/ksh/container/metrics",
+        }]
+      } // discovery.relabel "kube_scheduler"
+    
+      prometheus.scrape "kube_scheduler" {
+        targets           = discovery.relabel.kube_scheduler.output
+        job_name          = "kube-scheduler"
+        scheme            = "https"
+        scrape_interval   = "60s"
+        scrape_timeout = "10s"
+        scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
+        scrape_classic_histograms = false
+        scrape_native_histograms = false
+        convert_classic_histograms_to_nhcb = false
+        bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+        tls_config {
+          insecure_skip_verify = true
+        }
+        clustering {
+          enabled = true
+        }
+        forward_to = argument.metrics_destinations.value
+      } // prometheus.scrape "kube_scheduler"
       discovery.kubernetes "kube_state_metrics" {
         role = "endpoints"
     
@@ -1871,7 +2139,7 @@ data:
     grafana_kubernetes_monitoring_build_info{version="4.3.2", namespace="default"} 1
     # HELP grafana_kubernetes_monitoring_feature_info A metric to report the enabled features of the Kubernetes Monitoring Helm chart
     # TYPE grafana_kubernetes_monitoring_feature_info gauge
-    grafana_kubernetes_monitoring_feature_info{feature="clusterMetrics", sources="kubelet,kubeletResource,cadvisor,kube-state-metrics", version="1.0.0"} 1
+    grafana_kubernetes_monitoring_feature_info{feature="clusterMetrics", sources="controlPlane,kubelet,kubeletResource,cadvisor,kube-state-metrics", version="1.0.0"} 1
     grafana_kubernetes_monitoring_feature_info{feature="clusterEvents", version="1.0.0"} 1
     grafana_kubernetes_monitoring_feature_info{feature="hostMetrics", sources="linuxHosts,windowsHosts", version="1.0.0"} 1
     grafana_kubernetes_monitoring_feature_info{feature="integrations", sources="alloy", version="1.0.0"} 1
@@ -2841,6 +3109,43 @@ spec:
   crds:
     create: false
   nameOverride: alloy-metrics
+  rbac:
+    clusterRules:
+    - apiGroups:
+      - ""
+      resources:
+      - nodes
+      verbs:
+      - get
+      - list
+      - watch
+    - apiGroups:
+      - ""
+      resources:
+      - nodes/pods
+      verbs:
+      - get
+      - list
+      - watch
+    - apiGroups:
+      - ""
+      resources:
+      - nodes/metrics
+      verbs:
+      - get
+      - list
+      - watch
+    - nonResourceURLs:
+      - /metrics
+      verbs:
+      - get
+    - apiGroups:
+      - metrics.eks.amazonaws.com
+      resources:
+      - ksh/metrics
+      - kcm/metrics
+      verbs:
+      - get
 ---
 # Source: k8s-monitoring/templates/alloy.yaml
 apiVersion: collectors.grafana.com/v1alpha1

--- a/charts/k8s-monitoring/tests/platform/eks-with-windows/test-plan.yaml
+++ b/charts/k8s-monitoring/tests/platform/eks-with-windows/test-plan.yaml
@@ -58,6 +58,12 @@ tests:
               expect:
                 value: 2
 
+            # Control plane metrics via the EKS Control Plane Metrics API (clusterMetrics discoveryMode: eks-proxy)
+            - query: scheduler_pending_pods{cluster="$clusterName", job="kube-scheduler"}
+              type: promql
+            - query: workqueue_adds_total{cluster="$clusterName", job="kube-controller-manager"}
+              type: promql
+
             # EC2 enrichment: the ec2-tags data processor copies each node's EC2 `Team` tag
             # onto node-labeled metrics. Both EC2 instances are tagged `Team=platform-test`,
             # so both nodes' kube_node_info gain `team="platform-test"`.

--- a/charts/k8s-monitoring/tests/platform/eks-with-windows/values.yaml
+++ b/charts/k8s-monitoring/tests/platform/eks-with-windows/values.yaml
@@ -40,6 +40,16 @@ clusterMetrics:
   collector: alloy-metrics
   dataProcessors: [ec2-tags]
 
+  # On EKS the control plane is managed by AWS, so kube-scheduler and kube-controller-manager have no
+  # discoverable Pods. Scrape them from the EKS Control Plane Metrics API instead. This requires
+  # Kubernetes 1.28+ and the metrics.eks.amazonaws.com RBAC rule added to the alloy-metrics collector below.
+  controlPlane:
+    enabled: true
+  kubeScheduler:
+    discoveryMode: eks-proxy
+  kubeControllerManager:
+    discoveryMode: eks-proxy
+
 hostMetrics:
   enabled: true
   collector: alloy-metrics
@@ -79,6 +89,26 @@ collectors:
     presets: [clustered, statefulset]
     alloy:
       stabilityLevel: experimental  # Required for prometheus.enrich (ec2Enrichment processor)
+    rbac:
+      # The chart's default cluster-scoped RBAC rules, plus a rule granting read access to the EKS
+      # Control Plane Metrics API so the `eks-proxy` discoveryMode can scrape kube-scheduler and
+      # kube-controller-manager. Overriding clusterRules replaces the list, so the defaults are repeated here.
+      clusterRules:
+        - apiGroups: [""]
+          resources: [nodes]
+          verbs: [get, list, watch]
+        - apiGroups: [""]
+          resources: [nodes/pods]
+          verbs: [get, list, watch]
+        - apiGroups: [""]
+          resources: [nodes/metrics]
+          verbs: [get, list, watch]
+        - nonResourceURLs: [/metrics]
+          verbs: [get]
+        # EKS Control Plane Metrics API (metrics.eks.amazonaws.com)
+        - apiGroups: [metrics.eks.amazonaws.com]
+          resources: [ksh/metrics, kcm/metrics]
+          verbs: [get]
 
   alloy-singleton:
     presets: [singleton]


### PR DESCRIPTION
# Description

On EKS clusters, the method for getting metrics from the kube-controller-manager and kube-scheduler is different than the typical "find pod, scrape pod". This change adds the ability to find them from the API server just by changing the discovery method.

Fixes #2915

## Authorship

-   [x] I, a human, wrote this pull request description myself.
