### PR TITLE
Add a configuration validator job

### DIFF
--- a/charts/k8s-monitoring/CHANGELOG.md
+++ b/charts/k8s-monitoring/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 *   Fix the Prometheus destination so the cluster label honors `cluster.nameFrom`. (#2963) (@TylerHelmuth)
+*   Route integration instances to different collectors by setting collector on each instance. (#2616) (@TylerHelmuth)
 
 ## 4.4.0
 

--- a/charts/k8s-monitoring/CHANGELOG.md
+++ b/charts/k8s-monitoring/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 *   Fix the Prometheus destination so the cluster label honors `cluster.nameFrom`. (#2963) (@TylerHelmuth)
 *   Route integration instances to different collectors by setting collector on each instance. (#2616) (@TylerHelmuth)
+*   Add an opt-in pre-install/pre-upgrade hook that validates each enabled collector's generated Alloy config via `alloy fmt` and `alloy run`, aborting the install/upgrade on syntax or load errors. Enable with `configValidator.enabled: true`. The validator image and pod settings (`configValidator.image`, `podLabels`, `podAnnotations`, `securityContext`, `resources`, `nodeSelector`, `tolerations`) are configurable like the Alloy Operator hooks; the image defaults to the per-collector Alloy image, then to the Alloy version pinned by this chart. (@petewall)
 
 ## 4.4.0
 

--- a/charts/k8s-monitoring/README.md
+++ b/charts/k8s-monitoring/README.md
@@ -684,6 +684,23 @@ details:
 | windowsEventLogs.destinations | list | `[]` | The destinations where logs will be sent. If empty, all logs-capable destinations will be used. |
 | windowsEventLogs.enabled | bool | `false` | Enable gathering event logs from Windows Kubernetes Cluster Nodes. |
 
+### Config Validator
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| configValidator.enabled | bool | `false` | Run the pre-install/pre-upgrade Alloy config validator. |
+| configValidator.image | object | `{"digest":"","pullPolicy":"IfNotPresent","pullSecrets":[],"registry":"","repository":"","tag":""}` | The image used to validate the generated Alloy config. Each field is optional; when empty it falls back to the per-collector Alloy image, and finally to the Alloy version pinned by this chart's Alloy Operator. |
+| configValidator.serviceAccount | object | `{"name":""}` | ServiceAccount the validator pod runs as. When empty, the namespace default ServiceAccount is used. |
+| configValidator.extraArgs | list | `[]` | Extra arguments passed to `alloy run` during validation. |
+| configValidator.podAnnotations | object | `{}` | Annotations to apply to the validator pod. |
+| configValidator.podLabels | object | `{"linkerd.io/inject":"disabled","sidecar.istio.io/inject":"false"}` | Labels to apply to the validator pod. Service mesh sidecar injection is disabled by default so the short-lived hook pod can run to completion. |
+| configValidator.securityContext | object | `{}` | Security context to apply to the validator container. This can also be set to `null` to remove it entirely, and `runAsUser` can be set to `null` to remove just that field. When running as non-root, keep `readOnlyRootFilesystem` working by leaving the validator's storage path on the writable `emptyDir` this hook mounts. |
+| configValidator.resources | object | `{}` | Resources for the validator pod. |
+| configValidator.nodeSelector | object | `{}` | Node selector applied to the validator pod. |
+| configValidator.tolerations | list | `[]` | Tolerations applied to the validator pod. |
+| configValidator.extraLabels | object | `{}` | Extra labels added to both the validator pod and its ConfigMap. |
+| configValidator.extraAnnotations | object | `{}` | Extra annotations added to both the validator pod and its ConfigMap. |
+
 ### Other Values
 
 | Key | Type | Default | Description |

--- a/charts/k8s-monitoring/charts/feature-integrations/README.md
+++ b/charts/k8s-monitoring/charts/feature-integrations/README.md
@@ -13,7 +13,15 @@ The current integrations that are available from this feature are:
 | --- | --- | --- | --- |
 | [Grafana Alloy](https://grafana.com/docs/alloy/latest/) | Telemetry data collector | Metrics | [Alloy doc](./docs/integrations/alloy.md) |
 | [cert-manager](https://cert-manager.io/) | x.509 certificate management for Kubernetes | Metrics | [Cert manager doc](./docs/integrations/cert-manager.md) |
+| [DCGM Exporter](https://github.com/NVIDIA/dcgm-exporter) | NVIDIA GPU metrics exporter | Metrics | [DCGM Exporter doc](./docs/integrations/dcgm-exporter.md) |
 | [etcd](https://etcd.io/) | Distributed key-value store | Metrics | [etcd doc](./docs/integrations/etcd.md) |
+| [Grafana](https://grafana.com/) | Observability and data visualization platform | Metrics, Logs | [Grafana doc](./docs/integrations/grafana.md) |
+| [Istio](https://istio.io/) | Service mesh | Metrics | [Istio doc](./docs/integrations/istio.md) |
+| [Loki](https://grafana.com/oss/loki/) | Log aggregation system | Metrics, Logs | [Loki doc](./docs/integrations/loki.md) |
+| [Mimir](https://grafana.com/oss/mimir/) | Scalable long-term metrics storage | Metrics, Logs | [Mimir doc](./docs/integrations/mimir.md) |
+| [MySQL](https://www.mysql.com/) | Relational database | Metrics, Logs | [MySQL doc](./docs/integrations/mysql.md) |
+| [PostgreSQL](https://www.postgresql.org/) | Relational database | Metrics, Logs | [PostgreSQL doc](./docs/integrations/postgresql.md) |
+| [Tempo](https://grafana.com/oss/tempo/) | Distributed tracing backend | Metrics, Logs | [Tempo doc](./docs/integrations/tempo.md) |
 
 ## Usage
 

--- a/charts/k8s-monitoring/charts/feature-integrations/README.md.gotmpl
+++ b/charts/k8s-monitoring/charts/feature-integrations/README.md.gotmpl
@@ -15,7 +15,15 @@ The current integrations that are available from this feature are:
 | --- | --- | --- | --- |
 | [Grafana Alloy](https://grafana.com/docs/alloy/latest/) | Telemetry data collector | Metrics | [Alloy doc](./docs/integrations/alloy.md) |
 | [cert-manager](https://cert-manager.io/) | x.509 certificate management for Kubernetes | Metrics | [Cert manager doc](./docs/integrations/cert-manager.md) |
+| [DCGM Exporter](https://github.com/NVIDIA/dcgm-exporter) | NVIDIA GPU metrics exporter | Metrics | [DCGM Exporter doc](./docs/integrations/dcgm-exporter.md) |
 | [etcd](https://etcd.io/) | Distributed key-value store | Metrics | [etcd doc](./docs/integrations/etcd.md) |
+| [Grafana](https://grafana.com/) | Observability and data visualization platform | Metrics, Logs | [Grafana doc](./docs/integrations/grafana.md) |
+| [Istio](https://istio.io/) | Service mesh | Metrics | [Istio doc](./docs/integrations/istio.md) |
+| [Loki](https://grafana.com/oss/loki/) | Log aggregation system | Metrics, Logs | [Loki doc](./docs/integrations/loki.md) |
+| [Mimir](https://grafana.com/oss/mimir/) | Scalable long-term metrics storage | Metrics, Logs | [Mimir doc](./docs/integrations/mimir.md) |
+| [MySQL](https://www.mysql.com/) | Relational database | Metrics, Logs | [MySQL doc](./docs/integrations/mysql.md) |
+| [PostgreSQL](https://www.postgresql.org/) | Relational database | Metrics, Logs | [PostgreSQL doc](./docs/integrations/postgresql.md) |
+| [Tempo](https://grafana.com/oss/tempo/) | Distributed tracing backend | Metrics, Logs | [Tempo doc](./docs/integrations/tempo.md) |
 
 ## Usage
 

--- a/charts/k8s-monitoring/charts/feature-integrations/docs/integrations/alloy.md
+++ b/charts/k8s-monitoring/charts/feature-integrations/docs/integrations/alloy.md
@@ -5,6 +5,14 @@ Alloy instances.
 
 ## Values
 
+### General Settings
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| collector | string | `""` | The collector to assign this instance to. When empty, the feature-level `integrations.collector` is used. |
+| jobLabel | string | `"integrations/alloy"` | The value of the job label for scraped metrics and logs |
+| name | string | `""` | Name for this Alloy instance. |
+
 ### Discovery Settings
 
 | Key | Type | Default | Description |
@@ -14,13 +22,6 @@ Alloy instances.
 | labelSelectors | object | `{}` | Discover Alloy instances based on label selectors. At least one is required. |
 | metrics.portName | string | `"http-metrics"` | Name of the port to scrape metrics from. |
 | namespaces | list | `[]` | Namespaces to look for Alloy instances in. Will automatically look for Alloy instances in all namespaces unless specified here |
-
-### General Settings
-
-| Key | Type | Default | Description |
-|-----|------|---------|-------------|
-| jobLabel | string | `"integrations/alloy"` | The value of the job label for scraped metrics and logs |
-| name | string | `""` | Name for this Alloy instance. |
 
 ### Metric Processing Settings
 

--- a/charts/k8s-monitoring/charts/feature-integrations/docs/integrations/cert-manager.md
+++ b/charts/k8s-monitoring/charts/feature-integrations/docs/integrations/cert-manager.md
@@ -3,6 +3,14 @@
 <!-- textlint-disable terminology -->
 ## Values
 
+### General Settings
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| collector | string | `""` | The collector to assign this instance to. When empty, the feature-level `integrations.collector` is used. |
+| jobLabel | string | `"integrations/cert-manager"` | The value of the job label for scraped metrics and logs |
+| name | string | `""` | Name for this cert-manager instance. |
+
 ### Discovery Settings
 
 | Key | Type | Default | Description |
@@ -12,13 +20,6 @@
 | labelSelectors | object | `{}` | Discover cert-manager instances based on label selectors. At least one is required. |
 | metrics.portName | string | `"http-metrics"` | Name of the port to scrape metrics from. |
 | namespaces | list | `[]` | Namespaces to look for cert-manager instances. Will automatically look for cert-manager instances in all namespaces unless specified here |
-
-### General Settings
-
-| Key | Type | Default | Description |
-|-----|------|---------|-------------|
-| jobLabel | string | `"integrations/cert-manager"` | The value of the job label for scraped metrics and logs |
-| name | string | `""` | Name for this cert-manager instance. |
 
 ### Metric Processing Settings
 

--- a/charts/k8s-monitoring/charts/feature-integrations/docs/integrations/dcgm-exporter.md
+++ b/charts/k8s-monitoring/charts/feature-integrations/docs/integrations/dcgm-exporter.md
@@ -3,6 +3,14 @@
 <!-- textlint-disable terminology -->
 ## Values
 
+### General Settings
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| collector | string | `""` | The collector to assign this instance to. When empty, the feature-level `integrations.collector` is used. |
+| jobLabel | string | `"integrations/dcgm-exporter"` | The value of the job label for scraped metrics |
+| name | string | `""` | Name for this DCGM Exporter instance. |
+
 ### Discovery Settings
 
 | Key | Type | Default | Description |
@@ -12,13 +20,6 @@
 | labelSelectors | object | `{}` | Discover DCGM Exporter instances based on label selectors. At least one is required. |
 | metrics.portName | string | `"metrics"` | Name of the port to scrape metrics from. |
 | namespaces | list | `[]` | Namespaces to look for DCGM Exporter instances in. Will automatically look for DCGM Exporter instances in all namespaces unless specified here |
-
-### General Settings
-
-| Key | Type | Default | Description |
-|-----|------|---------|-------------|
-| jobLabel | string | `"integrations/dcgm-exporter"` | The value of the job label for scraped metrics |
-| name | string | `""` | Name for this DCGM Exporter instance. |
 
 ### Metrics Settings
 

--- a/charts/k8s-monitoring/charts/feature-integrations/docs/integrations/etcd.md
+++ b/charts/k8s-monitoring/charts/feature-integrations/docs/integrations/etcd.md
@@ -3,6 +3,14 @@
 <!-- textlint-disable terminology -->
 ## Values
 
+### General Settings
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| collector | string | `""` | The collector to assign this instance to. When empty, the feature-level `integrations.collector` is used. |
+| jobLabel | string | `"integrations/etcd"` | The value of the job label for scraped metrics and logs |
+| name | string | `""` | Name for this etcd instance. |
+
 ### Discovery Settings
 
 | Key | Type | Default | Description |
@@ -12,13 +20,6 @@
 | labelSelectors | object | `{}` | Discover etcd instances based on label selectors. At least one is required. |
 | metrics.port | int | `2381` | The etcd metrics port number to scrape metrics from. Defined on the etcd pod with: `--listen-metrics-urls=http://127.0.0.1:2381` |
 | namespaces | list | `[]` | Namespaces to look for etcd instances. Will automatically look for etcd instances in all namespaces unless specified here |
-
-### General Settings
-
-| Key | Type | Default | Description |
-|-----|------|---------|-------------|
-| jobLabel | string | `"integrations/etcd"` | The value of the job label for scraped metrics and logs |
-| name | string | `""` | Name for this etcd instance. |
 
 ### Metric Processing Settings
 

--- a/charts/k8s-monitoring/charts/feature-integrations/docs/integrations/grafana.md
+++ b/charts/k8s-monitoring/charts/feature-integrations/docs/integrations/grafana.md
@@ -4,6 +4,14 @@ This integration captures the metrics and logs to understand the health and perf
 
 ## Values
 
+### General Settings
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| collector | string | `""` | The collector to assign this instance to. When empty, the feature-level `integrations.collector` is used. |
+| jobLabel | string | `"integrations/grafana"` | The value of the job label for scraped metrics and logs |
+| name | string | `""` | Name for this Grafana instance. |
+
 ### Discovery Settings
 
 | Key | Type | Default | Description |
@@ -13,13 +21,6 @@ This integration captures the metrics and logs to understand the health and perf
 | labelSelectors | object | `{"app.kubernetes.io/name":"grafana"}` | Discover Grafana instances based on label selectors. |
 | metrics.portName | string | `"grafana"` | Name of the port to scrape metrics from. |
 | namespaces | list | `[]` | The namespaces to look for Grafana instances in. Will automatically look for Grafana instances in all namespaces unless specified here |
-
-### General Settings
-
-| Key | Type | Default | Description |
-|-----|------|---------|-------------|
-| jobLabel | string | `"integrations/grafana"` | The value of the job label for scraped metrics and logs |
-| name | string | `""` | Name for this Grafana instance. |
 
 ### Logs Settings
 

--- a/charts/k8s-monitoring/charts/feature-integrations/docs/integrations/istio.md
+++ b/charts/k8s-monitoring/charts/feature-integrations/docs/integrations/istio.md
@@ -3,6 +3,14 @@
 <!-- textlint-disable terminology -->
 ## Values
 
+### General Settings
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| collector | string | `""` | The collector to assign this instance to. When empty, the feature-level `integrations.collector` is used. |
+| jobLabel | string | `"integration/istio"` | The value of the job label for scraped metrics and logs |
+| name | string | `""` | Name for this Istio integration instance. |
+
 ### Istiod Metrics Settings
 
 | Key | Type | Default | Description |
@@ -18,13 +26,6 @@
 | istiodMetrics.serviceName | string | `"istiod"` | The name of the Istiod Kubernetes service. |
 | istiodMetrics.tuning.excludeMetrics | list | `[]` | Metrics to drop. Can use regular expressions. |
 | istiodMetrics.tuning.includeMetrics | list | `[]` | Metrics to keep. Can use regular expressions. |
-
-### General Settings
-
-| Key | Type | Default | Description |
-|-----|------|---------|-------------|
-| jobLabel | string | `"integration/istio"` | The value of the job label for scraped metrics and logs |
-| name | string | `""` | Name for this Istio integration instance. |
 
 ### Sidecar Metrics Settings
 

--- a/charts/k8s-monitoring/charts/feature-integrations/docs/integrations/loki.md
+++ b/charts/k8s-monitoring/charts/feature-integrations/docs/integrations/loki.md
@@ -4,6 +4,13 @@ This integration captures the metrics and logs to understand the health and perf
 
 ## Values
 
+### General Settings
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| collector | string | `""` | The collector to assign this instance to. When empty, the feature-level `integrations.collector` is used. |
+| name | string | `""` | Name for this Loki instance. |
+
 ### Discovery Settings
 
 | Key | Type | Default | Description |
@@ -46,9 +53,3 @@ This integration captures the metrics and logs to understand the health and perf
 |-----|------|---------|-------------|
 | metrics.scrapeInterval | string | `60s` | How frequently to scrape metrics from Loki. |
 | metrics.scrapeTimeout | string | `10s` | The timeout for scraping metrics from Loki. |
-
-### General Settings
-
-| Key | Type | Default | Description |
-|-----|------|---------|-------------|
-| name | string | `""` | Name for this Loki instance. |

--- a/charts/k8s-monitoring/charts/feature-integrations/docs/integrations/mimir.md
+++ b/charts/k8s-monitoring/charts/feature-integrations/docs/integrations/mimir.md
@@ -4,6 +4,13 @@ This integration captures the metrics and logs to understand the health and perf
 
 ## Values
 
+### General Settings
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| collector | string | `""` | The collector to assign this instance to. When empty, the feature-level `integrations.collector` is used. |
+| name | string | `""` | Name for this Mimir instance. |
+
 ### Discovery Settings
 
 | Key | Type | Default | Description |
@@ -46,9 +53,3 @@ This integration captures the metrics and logs to understand the health and perf
 |-----|------|---------|-------------|
 | metrics.scrapeInterval | string | `60s` | How frequently to scrape metrics from Mimir. |
 | metrics.scrapeTimeout | string | `10s` | The timeout for scraping metrics from Minir. |
-
-### General Settings
-
-| Key | Type | Default | Description |
-|-----|------|---------|-------------|
-| name | string | `""` | Name for this Mimir instance. |

--- a/charts/k8s-monitoring/charts/feature-integrations/docs/integrations/mysql.md
+++ b/charts/k8s-monitoring/charts/feature-integrations/docs/integrations/mysql.md
@@ -86,6 +86,14 @@ integrations:
 
 ## Values
 
+### General Settings
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| collector | string | `""` | The collector to assign this instance to. When empty, the feature-level `integrations.collector` is used. |
+| jobLabel | string | `"integration/mysql"` | The value of the job label for scraped metrics and logs |
+| name | string | `""` | Name for this MySQL instance. |
+
 ### Database Observability
 
 | Key | Type | Default | Description |
@@ -169,13 +177,6 @@ integrations:
 | exporter.collectors.perfSchemaEventsStatements.limit | number | `250` | Limit the number of events statements digests, in descending order by last_seen. |
 | exporter.collectors.perfSchemaEventsStatements.textLimit | number | `120` (`0` when databaseObservability is enabled) | Maximum length of the normalized statement text. |
 | exporter.collectors.perfSchemaEventsStatements.timeLimit | number | `86400` | Limit how old, in seconds, the last_seen events statements can be. |
-
-### General Settings
-
-| Key | Type | Default | Description |
-|-----|------|---------|-------------|
-| jobLabel | string | `"integration/mysql"` | The value of the job label for scraped metrics and logs |
-| name | string | `""` | Name for this MySQL instance. |
 
 ### Logs Settings
 

--- a/charts/k8s-monitoring/charts/feature-integrations/docs/integrations/postgresql.md
+++ b/charts/k8s-monitoring/charts/feature-integrations/docs/integrations/postgresql.md
@@ -74,6 +74,14 @@ integrations:
 
 ## Values
 
+### General Settings
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| collector | string | `""` | The collector to assign this instance to. When empty, the feature-level `integrations.collector` is used. |
+| jobLabel | string | `"integration/postgresql"` | The value of the job label for scraped metrics and logs |
+| name | string | `""` | Name for this PostgreSQL instance. |
+
 ### Database Observability - Cloud Provider
 
 | Key | Type | Default | Description |
@@ -169,13 +177,6 @@ integrations:
 | exporter.collectors.statioUserTables.enabled | bool | `true` | Enable the statio_user_tables collector. |
 | exporter.collectors.wal.enabled | bool | `true` | Enable the wal collector. |
 | exporter.collectors.xlogLocation.enabled | bool | `false` | Enable the xlog_location collector. |
-
-### General Settings
-
-| Key | Type | Default | Description |
-|-----|------|---------|-------------|
-| jobLabel | string | `"integration/postgresql"` | The value of the job label for scraped metrics and logs |
-| name | string | `""` | Name for this PostgreSQL instance. |
 
 ### Logs Settings
 

--- a/charts/k8s-monitoring/charts/feature-integrations/docs/integrations/tempo.md
+++ b/charts/k8s-monitoring/charts/feature-integrations/docs/integrations/tempo.md
@@ -4,6 +4,13 @@ This integration captures the metrics and logs to understand the health and perf
 
 ## Values
 
+### General Settings
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| collector | string | `""` | The collector to assign this instance to. When empty, the feature-level `integrations.collector` is used. |
+| name | string | `""` | Name for this Tempo instance. |
+
 ### Discovery Settings
 
 | Key | Type | Default | Description |
@@ -46,9 +53,3 @@ This integration captures the metrics and logs to understand the health and perf
 |-----|------|---------|-------------|
 | metrics.scrapeInterval | string | `60s` | How frequently to scrape metrics from Tempo. |
 | metrics.scrapeTimeout | string | `10s` | The timeout for scraping metrics from Tempo. |
-
-### General Settings
-
-| Key | Type | Default | Description |
-|-----|------|---------|-------------|
-| name | string | `""` | Name for this Tempo instance. |

--- a/charts/k8s-monitoring/charts/feature-integrations/integrations/alloy-values.yaml
+++ b/charts/k8s-monitoring/charts/feature-integrations/integrations/alloy-values.yaml
@@ -3,6 +3,10 @@
 # @section -- General Settings
 name: ""
 
+# -- The collector to assign this instance to. When empty, the feature-level `integrations.collector` is used.
+# @section -- General Settings
+collector: ""
+
 # -- The value of the job label for scraped metrics and logs
 # @section -- General Settings
 jobLabel: integrations/alloy

--- a/charts/k8s-monitoring/charts/feature-integrations/integrations/cert-manager-values.yaml
+++ b/charts/k8s-monitoring/charts/feature-integrations/integrations/cert-manager-values.yaml
@@ -3,6 +3,10 @@
 # @section -- General Settings
 name: ""
 
+# -- The collector to assign this instance to. When empty, the feature-level `integrations.collector` is used.
+# @section -- General Settings
+collector: ""
+
 # -- The value of the job label for scraped metrics and logs
 # @section -- General Settings
 jobLabel: integrations/cert-manager

--- a/charts/k8s-monitoring/charts/feature-integrations/integrations/dcgm-exporter-values.yaml
+++ b/charts/k8s-monitoring/charts/feature-integrations/integrations/dcgm-exporter-values.yaml
@@ -3,6 +3,10 @@
 # @section -- General Settings
 name: ""
 
+# -- The collector to assign this instance to. When empty, the feature-level `integrations.collector` is used.
+# @section -- General Settings
+collector: ""
+
 # -- The value of the job label for scraped metrics
 # @section -- General Settings
 jobLabel: integrations/dcgm-exporter

--- a/charts/k8s-monitoring/charts/feature-integrations/integrations/etcd-values.yaml
+++ b/charts/k8s-monitoring/charts/feature-integrations/integrations/etcd-values.yaml
@@ -3,6 +3,10 @@
 # @section -- General Settings
 name: ""
 
+# -- The collector to assign this instance to. When empty, the feature-level `integrations.collector` is used.
+# @section -- General Settings
+collector: ""
+
 # -- The value of the job label for scraped metrics and logs
 # @section -- General Settings
 jobLabel: integrations/etcd

--- a/charts/k8s-monitoring/charts/feature-integrations/integrations/grafana-values.yaml
+++ b/charts/k8s-monitoring/charts/feature-integrations/integrations/grafana-values.yaml
@@ -3,6 +3,10 @@
 # @section -- General Settings
 name: ""
 
+# -- The collector to assign this instance to. When empty, the feature-level `integrations.collector` is used.
+# @section -- General Settings
+collector: ""
+
 # -- The value of the job label for scraped metrics and logs
 # @section -- General Settings
 jobLabel: integrations/grafana

--- a/charts/k8s-monitoring/charts/feature-integrations/integrations/istio-values.yaml
+++ b/charts/k8s-monitoring/charts/feature-integrations/integrations/istio-values.yaml
@@ -3,6 +3,10 @@
 # @section -- General Settings
 name: ""
 
+# -- The collector to assign this instance to. When empty, the feature-level `integrations.collector` is used.
+# @section -- General Settings
+collector: ""
+
 # -- The value of the job label for scraped metrics and logs
 # @section -- General Settings
 jobLabel: integration/istio

--- a/charts/k8s-monitoring/charts/feature-integrations/integrations/loki-values.yaml
+++ b/charts/k8s-monitoring/charts/feature-integrations/integrations/loki-values.yaml
@@ -3,6 +3,10 @@
 # @section -- General Settings
 name: ""
 
+# -- The collector to assign this instance to. When empty, the feature-level `integrations.collector` is used.
+# @section -- General Settings
+collector: ""
+
 # -- Namespaces to look for Loki instances in.
 # Will automatically look for Loki instances in all namespaces unless specified here
 # @section -- Discovery Settings

--- a/charts/k8s-monitoring/charts/feature-integrations/integrations/mimir-values.yaml
+++ b/charts/k8s-monitoring/charts/feature-integrations/integrations/mimir-values.yaml
@@ -3,6 +3,10 @@
 # @section -- General Settings
 name: ""
 
+# -- The collector to assign this instance to. When empty, the feature-level `integrations.collector` is used.
+# @section -- General Settings
+collector: ""
+
 # -- Namespaces to look for Mimir instances in.
 # Will automatically look for Mimir instances in all namespaces unless specified here
 # @section -- Discovery Settings

--- a/charts/k8s-monitoring/charts/feature-integrations/integrations/mysql-values.yaml
+++ b/charts/k8s-monitoring/charts/feature-integrations/integrations/mysql-values.yaml
@@ -3,6 +3,10 @@
 # @section -- General Settings
 name: ""
 
+# -- The collector to assign this instance to. When empty, the feature-level `integrations.collector` is used.
+# @section -- General Settings
+collector: ""
+
 # -- The value of the job label for scraped metrics and logs
 # @section -- General Settings
 jobLabel: integration/mysql

--- a/charts/k8s-monitoring/charts/feature-integrations/integrations/postgresql-values.yaml
+++ b/charts/k8s-monitoring/charts/feature-integrations/integrations/postgresql-values.yaml
@@ -3,6 +3,10 @@
 # @section -- General Settings
 name: ""
 
+# -- The collector to assign this instance to. When empty, the feature-level `integrations.collector` is used.
+# @section -- General Settings
+collector: ""
+
 # -- The value of the job label for scraped metrics and logs
 # @section -- General Settings
 jobLabel: integration/postgresql

--- a/charts/k8s-monitoring/charts/feature-integrations/integrations/tempo-values.yaml
+++ b/charts/k8s-monitoring/charts/feature-integrations/integrations/tempo-values.yaml
@@ -3,6 +3,10 @@
 # @section -- General Settings
 name: ""
 
+# -- The collector to assign this instance to. When empty, the feature-level `integrations.collector` is used.
+# @section -- General Settings
+collector: ""
+
 # -- Namespaces to look for Tempo instances in.
 # Will automatically look for Tempo instances in all namespaces unless specified here
 # @section -- Discovery Settings

--- a/charts/k8s-monitoring/charts/feature-integrations/schema-mods/definitions/alloy-integration.schema.json
+++ b/charts/k8s-monitoring/charts/feature-integrations/schema-mods/definitions/alloy-integration.schema.json
@@ -2,6 +2,9 @@
     "$schema": "http://json-schema.org/schema#",
     "type": "object",
     "properties": {
+        "collector": {
+            "type": "string"
+        },
         "extraDiscoveryRules": {
             "type": "string"
         },

--- a/charts/k8s-monitoring/charts/feature-integrations/schema-mods/definitions/cert-manager-integration.schema.json
+++ b/charts/k8s-monitoring/charts/feature-integrations/schema-mods/definitions/cert-manager-integration.schema.json
@@ -2,6 +2,9 @@
     "$schema": "http://json-schema.org/schema#",
     "type": "object",
     "properties": {
+        "collector": {
+            "type": "string"
+        },
         "extraDiscoveryRules": {
             "type": "string"
         },

--- a/charts/k8s-monitoring/charts/feature-integrations/schema-mods/definitions/dcgm-exporter-integration.schema.json
+++ b/charts/k8s-monitoring/charts/feature-integrations/schema-mods/definitions/dcgm-exporter-integration.schema.json
@@ -2,6 +2,9 @@
     "$schema": "http://json-schema.org/schema#",
     "type": "object",
     "properties": {
+        "collector": {
+            "type": "string"
+        },
         "extraDiscoveryRules": {
             "type": "string"
         },

--- a/charts/k8s-monitoring/charts/feature-integrations/schema-mods/definitions/etcd-integration.schema.json
+++ b/charts/k8s-monitoring/charts/feature-integrations/schema-mods/definitions/etcd-integration.schema.json
@@ -2,6 +2,9 @@
     "$schema": "http://json-schema.org/schema#",
     "type": "object",
     "properties": {
+        "collector": {
+            "type": "string"
+        },
         "extraDiscoveryRules": {
             "type": "string"
         },

--- a/charts/k8s-monitoring/charts/feature-integrations/schema-mods/definitions/grafana-integration.schema.json
+++ b/charts/k8s-monitoring/charts/feature-integrations/schema-mods/definitions/grafana-integration.schema.json
@@ -2,6 +2,9 @@
     "$schema": "http://json-schema.org/schema#",
     "type": "object",
     "properties": {
+        "collector": {
+            "type": "string"
+        },
         "extraDiscoveryRules": {
             "type": "string"
         },

--- a/charts/k8s-monitoring/charts/feature-integrations/schema-mods/definitions/istio-integration.schema.json
+++ b/charts/k8s-monitoring/charts/feature-integrations/schema-mods/definitions/istio-integration.schema.json
@@ -2,6 +2,9 @@
     "$schema": "http://json-schema.org/schema#",
     "type": "object",
     "properties": {
+        "collector": {
+            "type": "string"
+        },
         "istiodMetrics": {
             "type": "object",
             "properties": {

--- a/charts/k8s-monitoring/charts/feature-integrations/schema-mods/definitions/loki-integration.schema.json
+++ b/charts/k8s-monitoring/charts/feature-integrations/schema-mods/definitions/loki-integration.schema.json
@@ -2,6 +2,9 @@
     "$schema": "http://json-schema.org/schema#",
     "type": "object",
     "properties": {
+        "collector": {
+            "type": "string"
+        },
         "extraDiscoveryRules": {
             "type": "string"
         },

--- a/charts/k8s-monitoring/charts/feature-integrations/schema-mods/definitions/mimir-integration.schema.json
+++ b/charts/k8s-monitoring/charts/feature-integrations/schema-mods/definitions/mimir-integration.schema.json
@@ -2,6 +2,9 @@
     "$schema": "http://json-schema.org/schema#",
     "type": "object",
     "properties": {
+        "collector": {
+            "type": "string"
+        },
         "extraDiscoveryRules": {
             "type": "string"
         },

--- a/charts/k8s-monitoring/charts/feature-integrations/schema-mods/definitions/mysql-integration.schema.json
+++ b/charts/k8s-monitoring/charts/feature-integrations/schema-mods/definitions/mysql-integration.schema.json
@@ -2,6 +2,9 @@
     "$schema": "http://json-schema.org/schema#",
     "type": "object",
     "properties": {
+        "collector": {
+            "type": "string"
+        },
         "databaseObservability": {
             "type": "object",
             "properties": {

--- a/charts/k8s-monitoring/charts/feature-integrations/schema-mods/definitions/postgresql-integration.schema.json
+++ b/charts/k8s-monitoring/charts/feature-integrations/schema-mods/definitions/postgresql-integration.schema.json
@@ -2,6 +2,9 @@
     "$schema": "http://json-schema.org/schema#",
     "type": "object",
     "properties": {
+        "collector": {
+            "type": "string"
+        },
         "databaseObservability": {
             "type": "object",
             "properties": {

--- a/charts/k8s-monitoring/charts/feature-integrations/schema-mods/definitions/tempo-integration.schema.json
+++ b/charts/k8s-monitoring/charts/feature-integrations/schema-mods/definitions/tempo-integration.schema.json
@@ -2,6 +2,9 @@
     "$schema": "http://json-schema.org/schema#",
     "type": "object",
     "properties": {
+        "collector": {
+            "type": "string"
+        },
         "extraDiscoveryRules": {
             "type": "string"
         },

--- a/charts/k8s-monitoring/charts/feature-integrations/values.schema.json
+++ b/charts/k8s-monitoring/charts/feature-integrations/values.schema.json
@@ -153,6 +153,9 @@
         "alloy-integration": {
             "type": "object",
             "properties": {
+                "collector": {
+                    "type": "string"
+                },
                 "extraDiscoveryRules": {
                     "type": "string"
                 },
@@ -224,6 +227,9 @@
         "cert-manager-integration": {
             "type": "object",
             "properties": {
+                "collector": {
+                    "type": "string"
+                },
                 "extraDiscoveryRules": {
                     "type": "string"
                 },
@@ -292,6 +298,9 @@
         "dcgm-exporter-integration": {
             "type": "object",
             "properties": {
+                "collector": {
+                    "type": "string"
+                },
                 "extraDiscoveryRules": {
                     "type": "string"
                 },
@@ -350,6 +359,9 @@
         "etcd-integration": {
             "type": "object",
             "properties": {
+                "collector": {
+                    "type": "string"
+                },
                 "extraDiscoveryRules": {
                     "type": "string"
                 },
@@ -418,6 +430,9 @@
         "grafana-integration": {
             "type": "object",
             "properties": {
+                "collector": {
+                    "type": "string"
+                },
                 "extraDiscoveryRules": {
                     "type": "string"
                 },
@@ -512,6 +527,9 @@
         "istio-integration": {
             "type": "object",
             "properties": {
+                "collector": {
+                    "type": "string"
+                },
                 "istiodMetrics": {
                     "type": "object",
                     "properties": {
@@ -639,6 +657,9 @@
         "loki-integration": {
             "type": "object",
             "properties": {
+                "collector": {
+                    "type": "string"
+                },
                 "extraDiscoveryRules": {
                     "type": "string"
                 },
@@ -749,6 +770,9 @@
         "mimir-integration": {
             "type": "object",
             "properties": {
+                "collector": {
+                    "type": "string"
+                },
                 "extraDiscoveryRules": {
                     "type": "string"
                 },
@@ -843,6 +867,9 @@
         "mysql-integration": {
             "type": "object",
             "properties": {
+                "collector": {
+                    "type": "string"
+                },
                 "databaseObservability": {
                     "type": "object",
                     "properties": {
@@ -1207,6 +1234,9 @@
         "postgresql-integration": {
             "type": "object",
             "properties": {
+                "collector": {
+                    "type": "string"
+                },
                 "databaseObservability": {
                     "type": "object",
                     "properties": {
@@ -1674,6 +1704,9 @@
         "tempo-integration": {
             "type": "object",
             "properties": {
+                "collector": {
+                    "type": "string"
+                },
                 "extraDiscoveryRules": {
                     "type": "string"
                 },

--- a/charts/k8s-monitoring/templates/alloy-config.yaml
+++ b/charts/k8s-monitoring/templates/alloy-config.yaml
@@ -6,65 +6,10 @@
   {{- end }}
 {{- end }}
 {{- range $collectorName := include "collectors.list.enabled" . | fromYamlArray }}
-{{- $destinationNames := (get $.Values.collectors $collectorName).includeDestinations | default list }}
-{{- $collectorContext := dict "Values" $.Values "Chart" $.Chart "Files" $.Files "Release" $.Release "Subcharts" $.Subcharts "Template" $.Template "Capabilities" $.Capabilities "collectorName" $collectorName }}
-{{- range $featureKey := include "features.list" $ | fromYamlArray }}
-  {{- $featureCollectorNames := include "collectors.getCollectorsForFeature" (dict "Values" $.Values "Files" $.Files "Subcharts" $.Subcharts "featureKey" $featureKey) | fromYamlArray }}
-  {{- if has $collectorName $featureCollectorNames }}
-    {{- $destinationNames = concat $destinationNames ((include (printf "features.%s.destinations" $featureKey) $collectorContext) | fromYamlArray) }}
-  {{- end }}
-{{- end }}
-
-{{/* Router destination type. Any enabled `type: router` destination that ended up in
-     $destinationNames (because a feature pointed at it) fans out to real destinations that are
-     never referenced by a feature directly, so those downstream destinations would otherwise
-     never get a body rendered and the router's gates would dangle. Union them in here, before
-     destinations.alloy.config renders bodies below. Single-level only: a router referencing
-     another router is not resolved transitively by this pass. */}}
-{{- range $routerCandidateName := $destinationNames }}
-  {{- if hasKey $.Values.destinations $routerCandidateName }}
-    {{- $routerCandidate := get $.Values.destinations $routerCandidateName }}
-    {{- if and (eq $routerCandidate.type "router") (not $routerCandidate.disabled) }}
-      {{- range $downstreamName := ($routerCandidate.defaultDestinations | default list) }}
-        {{- if and (hasKey $.Values.destinations $downstreamName) (not (get $.Values.destinations $downstreamName).disabled) }}
-          {{- $destinationNames = append $destinationNames $downstreamName }}
-        {{- end }}
-      {{- end }}
-      {{- range $route := ($routerCandidate.routes | default list) }}
-        {{- range $downstreamName := ($route.destinations | default list) }}
-          {{- if and (hasKey $.Values.destinations $downstreamName) (not (get $.Values.destinations $downstreamName).disabled) }}
-            {{- $destinationNames = append $destinationNames $downstreamName }}
-          {{- end }}
-        {{- end }}
-      {{- end }}
-    {{- end }}
-  {{- end }}
-{{- end }}
-
 {{/* Save the top level object and add the collector name */}}
 {{- $values := dict "Values" $.Values "Chart" $.Chart "Files" $.Files "Release" $.Release "Subcharts" $.Subcharts "Template" $.Template "Capabilities" $.Capabilities "collectorName" $collectorName }}
 {{- $collectorValues := include "collector.alloy.values" $values | fromYaml }}
-{{- $alloyConfig := "" }}
-{{- range $featureKey := include "features.list" . | fromYamlArray }}
-  {{- $featureCollectorNames := include "collectors.getCollectorsForFeature" (dict "Values" $.Values "Files" $.Files "Subcharts" $.Subcharts "featureKey" $featureKey) | fromYamlArray }}
-  {{- if has $collectorName $featureCollectorNames }}
-    {{- $featureConfig := include (printf "features.%s.include" $featureKey) $values | trim }}
-    {{- if $featureConfig }}
-      {{ $alloyConfig = cat $alloyConfig ($featureConfig | nindent 0) }}
-    {{- end }}
-  {{- end }}
-{{- end }}
-{{- $dataProcessorSharedComponents := include "dataProcessors.alloy.collectorComponents" (dict "Values" $.Values "config" $alloyConfig) | trim }}
-{{- if $dataProcessorSharedComponents }}
-  {{- $alloyConfig = cat $alloyConfig ($dataProcessorSharedComponents | nindent 0) }}
-{{- end }}
-{{- $alloyConfig = cat $alloyConfig (include "collectors.logging.alloy" $collectorValues | trim | nindent 0) }}
-{{- $alloyConfig = cat $alloyConfig (include "collectors.liveDebugging.alloy" $collectorValues | trim | nindent 0) }}
-{{- $alloyConfig = cat $alloyConfig (include "collectors.remoteConfig.alloy" $values | trim | nindent 0) }}
-{{- $alloyConfig = cat $alloyConfig (include "collectors.extraConfig.alloy" $values | trim | nindent 0) }}
-{{- $alloyConfig = cat $alloyConfig (include "destinations.alloy.rules" (deepCopy $ | merge (dict "collectorName" $collectorName)) | trim | nindent 0) }}
-{{- $alloyConfig = cat $alloyConfig (include "destinations.alloy.config" (deepCopy $ | merge (dict "destinationNames" ($destinationNames | uniq | sortAlpha))) | trim | nindent 0) }}
-
+{{- $alloyConfig := include "collector.alloy.config" $values }}
 {{- range $replacement := $.Values.replaceComponent }}
   {{- $before := $alloyConfig }}
   {{- $alloyConfig = include "replaceComponent.apply" (dict "config" $alloyConfig "replacement" $replacement) }}

--- a/charts/k8s-monitoring/templates/alloy-config.yaml
+++ b/charts/k8s-monitoring/templates/alloy-config.yaml
@@ -7,10 +7,11 @@
 {{- end }}
 {{- range $collectorName := include "collectors.list.enabled" . | fromYamlArray }}
 {{- $destinationNames := (get $.Values.collectors $collectorName).includeDestinations | default list }}
+{{- $collectorContext := dict "Values" $.Values "Chart" $.Chart "Files" $.Files "Release" $.Release "Subcharts" $.Subcharts "Template" $.Template "Capabilities" $.Capabilities "collectorName" $collectorName }}
 {{- range $featureKey := include "features.list" $ | fromYamlArray }}
-  {{- $featureCollectorName := include "collectors.getCollectorForFeature" (dict "Values" $.Values "Files" $.Files "Subcharts" $.Subcharts "featureKey" $featureKey) }}
-  {{- if eq $collectorName $featureCollectorName }}
-    {{- $destinationNames = concat $destinationNames ((include (printf "features.%s.destinations" $featureKey) $) | fromYamlArray) }}
+  {{- $featureCollectorNames := include "collectors.getCollectorsForFeature" (dict "Values" $.Values "Files" $.Files "Subcharts" $.Subcharts "featureKey" $featureKey) | fromYamlArray }}
+  {{- if has $collectorName $featureCollectorNames }}
+    {{- $destinationNames = concat $destinationNames ((include (printf "features.%s.destinations" $featureKey) $collectorContext) | fromYamlArray) }}
   {{- end }}
 {{- end }}
 
@@ -45,8 +46,8 @@
 {{- $collectorValues := include "collector.alloy.values" $values | fromYaml }}
 {{- $alloyConfig := "" }}
 {{- range $featureKey := include "features.list" . | fromYamlArray }}
-  {{- $featureCollectorName := include "collectors.getCollectorForFeature" (dict "Values" $.Values "Files" $.Files "Subcharts" $.Subcharts "featureKey" $featureKey) }}
-  {{- if eq $collectorName $featureCollectorName }}
+  {{- $featureCollectorNames := include "collectors.getCollectorsForFeature" (dict "Values" $.Values "Files" $.Files "Subcharts" $.Subcharts "featureKey" $featureKey) | fromYamlArray }}
+  {{- if has $collectorName $featureCollectorNames }}
     {{- $featureConfig := include (printf "features.%s.include" $featureKey) $values | trim }}
     {{- if $featureConfig }}
       {{ $alloyConfig = cat $alloyConfig ($featureConfig | nindent 0) }}

--- a/charts/k8s-monitoring/templates/collectors/_collector_helpers.tpl
+++ b/charts/k8s-monitoring/templates/collectors/_collector_helpers.tpl
@@ -268,6 +268,31 @@ app.kubernetes.io/instance: {{ include "collector.alloy.fullname" . }}
 {{- $collectorName }}
 {{- end }}
 
+{{- define "collectors.getCollectorForIntegrationInstance" -}}
+{{- $instanceCollector := dig "collector" "" .instance -}}
+{{- if $instanceCollector -}}
+{{- $instanceCollector -}}
+{{- else -}}
+{{- include "collectors.getCollectorForFeature" (dict "Values" .Values "Files" .Files "Subcharts" .Subcharts "featureKey" "integrations") | trim -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "collectors.getCollectorsForFeature" -}}
+{{- $collectors := list -}}
+{{- if eq .featureKey "integrations" -}}
+{{- $collectors = include "collectors.integrations.assignedCollectors" . | fromYamlArray -}}
+{{- end -}}
+{{- if not $collectors -}}
+{{- $collectorName := include "collectors.getCollectorForFeature" . | trim -}}
+{{- if $collectorName -}}
+{{- $collectors = list $collectorName -}}
+{{- end -}}
+{{- end -}}
+{{- range $collectorName := $collectors }}
+- {{ $collectorName }}
+{{- end -}}
+{{- end -}}
+
 {{ define "collectors.getAllPresets" }}
   {{- range $presetFile, $_ := $.Files.Glob "collectors/presets/*.yaml" }}
 - {{ base $presetFile | trimSuffix (ext $presetFile) | trim }}

--- a/charts/k8s-monitoring/templates/collectors/_collector_helpers.tpl
+++ b/charts/k8s-monitoring/templates/collectors/_collector_helpers.tpl
@@ -307,3 +307,69 @@ app.kubernetes.io/instance: {{ include "collector.alloy.fullname" . }}
   {{- end }}
 {{- end }}
 {{- end }}
+
+{{/* Renders a single collector's Alloy config up to (but not including) replaceComponent substitution
+     and trailing-whitespace trimming. This is the shared source of truth used by both
+     templates/alloy-config.yaml (the collector ConfigMap) and the config-validator pre-install hook.
+     Each caller applies replaceComponent and the final whitespace trim itself — alloy-config.yaml also
+     tracks replacement usage for its "unused replacement" validation — so the validated config stays
+     byte-identical to the deployed config. Input: the per-collector context dict built in
+     alloy-config.yaml, i.e. a dict with keys Values, Chart, Files, Release, Subcharts, Template,
+     Capabilities and collectorName. */}}
+{{- define "collector.alloy.config" -}}
+{{- $collectorName := .collectorName }}
+{{- $destinationNames := (get $.Values.collectors $collectorName).includeDestinations | default list }}
+{{- range $featureKey := include "features.list" $ | fromYamlArray }}
+  {{- $featureCollectorNames := include "collectors.getCollectorsForFeature" (dict "Values" $.Values "Files" $.Files "Subcharts" $.Subcharts "featureKey" $featureKey) | fromYamlArray }}
+  {{- if has $collectorName $featureCollectorNames }}
+    {{- $destinationNames = concat $destinationNames ((include (printf "features.%s.destinations" $featureKey) $) | fromYamlArray) }}
+  {{- end }}
+{{- end }}
+{{- /* Router destination type. Any enabled `type: router` destination that ended up in
+       $destinationNames (because a feature pointed at it) fans out to real destinations that are
+       never referenced by a feature directly, so those downstream destinations would otherwise
+       never get a body rendered and the router's gates would dangle. Union them in here, before
+       destinations.alloy.config renders bodies below. Single-level only: a router referencing
+       another router is not resolved transitively by this pass. */}}
+{{- range $routerCandidateName := $destinationNames }}
+  {{- if hasKey $.Values.destinations $routerCandidateName }}
+    {{- $routerCandidate := get $.Values.destinations $routerCandidateName }}
+    {{- if and (eq $routerCandidate.type "router") (not $routerCandidate.disabled) }}
+      {{- range $downstreamName := ($routerCandidate.defaultDestinations | default list) }}
+        {{- if and (hasKey $.Values.destinations $downstreamName) (not (get $.Values.destinations $downstreamName).disabled) }}
+          {{- $destinationNames = append $destinationNames $downstreamName }}
+        {{- end }}
+      {{- end }}
+      {{- range $route := ($routerCandidate.routes | default list) }}
+        {{- range $downstreamName := ($route.destinations | default list) }}
+          {{- if and (hasKey $.Values.destinations $downstreamName) (not (get $.Values.destinations $downstreamName).disabled) }}
+            {{- $destinationNames = append $destinationNames $downstreamName }}
+          {{- end }}
+        {{- end }}
+      {{- end }}
+    {{- end }}
+  {{- end }}
+{{- end }}
+{{- $collectorValues := include "collector.alloy.values" $ | fromYaml }}
+{{- $alloyConfig := "" }}
+{{- range $featureKey := include "features.list" $ | fromYamlArray }}
+  {{- $featureCollectorNames := include "collectors.getCollectorsForFeature" (dict "Values" $.Values "Files" $.Files "Subcharts" $.Subcharts "featureKey" $featureKey) | fromYamlArray }}
+  {{- if has $collectorName $featureCollectorNames }}
+    {{- $featureConfig := include (printf "features.%s.include" $featureKey) $ | trim }}
+    {{- if $featureConfig }}
+      {{- $alloyConfig = cat $alloyConfig ($featureConfig | nindent 0) }}
+    {{- end }}
+  {{- end }}
+{{- end }}
+{{- $dataProcessorSharedComponents := include "dataProcessors.alloy.collectorComponents" (dict "Values" $.Values "config" $alloyConfig) | trim }}
+{{- if $dataProcessorSharedComponents }}
+  {{- $alloyConfig = cat $alloyConfig ($dataProcessorSharedComponents | nindent 0) }}
+{{- end }}
+{{- $alloyConfig = cat $alloyConfig (include "collectors.logging.alloy" $collectorValues | trim | nindent 0) }}
+{{- $alloyConfig = cat $alloyConfig (include "collectors.liveDebugging.alloy" $collectorValues | trim | nindent 0) }}
+{{- $alloyConfig = cat $alloyConfig (include "collectors.remoteConfig.alloy" $ | trim | nindent 0) }}
+{{- $alloyConfig = cat $alloyConfig (include "collectors.extraConfig.alloy" $ | trim | nindent 0) }}
+{{- $alloyConfig = cat $alloyConfig (include "destinations.alloy.rules" (deepCopy $ | merge (dict "collectorName" $collectorName)) | trim | nindent 0) }}
+{{- $alloyConfig = cat $alloyConfig (include "destinations.alloy.config" (deepCopy $ | merge (dict "destinationNames" ($destinationNames | uniq | sortAlpha))) | trim | nindent 0) }}
+{{- $alloyConfig }}
+{{- end }}

--- a/charts/k8s-monitoring/templates/collectors/_collector_validations.tpl
+++ b/charts/k8s-monitoring/templates/collectors/_collector_validations.tpl
@@ -22,8 +22,8 @@
 {{- define "collectors.validate.featuresEnabled" }}
 {{- $collectorsUtilized := list }}
 {{- range $featureKey := include "features.list.enabled" . | fromYamlArray }}
-  {{- $assignedCollector := include "collectors.getCollectorForFeature" (dict "Values" $.Values "Files" $.Files "Subcharts" $.Subcharts "featureKey" $featureKey) }}
-  {{- $collectorsUtilized = append $collectorsUtilized $assignedCollector }}
+  {{- $assignedCollectors := include "collectors.getCollectorsForFeature" (dict "Values" $.Values "Files" $.Files "Subcharts" $.Subcharts "featureKey" $featureKey) | fromYamlArray }}
+  {{- $collectorsUtilized = concat $collectorsUtilized $assignedCollectors }}
 {{- end }}
 
 {{- range $collectorName := include "collectors.list.enabled" . | fromYamlArray }}

--- a/charts/k8s-monitoring/templates/features/_feature_integrations.tpl
+++ b/charts/k8s-monitoring/templates/features/_feature_integrations.tpl
@@ -1,3 +1,53 @@
+{{- define "collectors.integrations.filterInstancesForCollector" -}}
+{{- $root := .root -}}
+{{- $collectorName := .collectorName -}}
+{{- $integrations := deepCopy $root.Values.integrations -}}
+{{- range $type := include "integrations.types" . | fromYamlArray -}}
+  {{- $typeValues := index $integrations $type -}}
+  {{- if and $typeValues $typeValues.instances -}}
+    {{- $kept := list -}}
+    {{- range $instance := $typeValues.instances -}}
+      {{- $instanceCollector := include "collectors.getCollectorForIntegrationInstance" (dict "Values" $root.Values "Files" $root.Files "Subcharts" $root.Subcharts "instance" $instance) | trim -}}
+      {{- if eq $instanceCollector $collectorName -}}
+        {{- $kept = append $kept $instance -}}
+      {{- end -}}
+    {{- end -}}
+    {{- $_ := set $typeValues "instances" $kept -}}
+  {{- end -}}
+{{- end -}}
+{{- $integrations | toYaml -}}
+{{- end -}}
+
+{{/* Returns "true" if this single instance produces metrics or exporter logs, and so needs an integrations collector. A log-parsing-only instance returns empty. Inputs: type, instance, Files (subchart Files) */}}
+{{- define "collectors.integrations.instanceProducesOutput" -}}
+{{- $slice := dict "Values" (dict .type (dict "instances" (list .instance))) "Files" .Files -}}
+{{- $metrics := include "feature.integrations.configured.metrics" $slice | fromYamlArray -}}
+{{- $logOutput := include "feature.integrations.configured.logOutput" $slice | fromYamlArray -}}
+{{- if or $metrics $logOutput }}true{{ end -}}
+{{- end -}}
+
+{{/* Returns, as a YAML list, every collector assigned to at least one integration instance that produces metrics or exporter logs. Inputs: Values (root), Files, Subcharts */}}
+{{- define "collectors.integrations.assignedCollectors" -}}
+{{- $root := . -}}
+{{- $collectors := list -}}
+{{- range $type := include "integrations.types" . | fromYamlArray -}}
+  {{- $typeValues := index $root.Values.integrations $type -}}
+  {{- if and $typeValues $typeValues.instances -}}
+    {{- range $instance := $typeValues.instances -}}
+      {{- if include "collectors.integrations.instanceProducesOutput" (dict "type" $type "instance" $instance "Files" $root.Subcharts.integrations.Files) -}}
+        {{- $collector := include "collectors.getCollectorForIntegrationInstance" (dict "Values" $root.Values "Files" $root.Files "Subcharts" $root.Subcharts "instance" $instance) | trim -}}
+        {{- if and $collector (not (has $collector $collectors)) -}}
+          {{- $collectors = append $collectors $collector -}}
+        {{- end -}}
+      {{- end -}}
+    {{- end -}}
+  {{- end -}}
+{{- end -}}
+{{- range $collector := $collectors }}
+- {{ $collector }}
+{{- end -}}
+{{- end -}}
+
 {{- define "features.integrations.enabled" }}
 {{- $metricIntegrations := include "feature.integrations.configured.metrics" (dict "Values" .Values.integrations "Files" $.Subcharts.integrations.Files) | fromYamlArray }}
 {{- $logRuleIntegrations := include "feature.integrations.configured.logRules" (dict "Values" .Values.integrations "Files" $.Subcharts.integrations.Files) | fromYamlArray }}
@@ -5,11 +55,12 @@
 {{- end }}
 
 {{- define "features.integrations.metrics.include" }}
-{{- $values := dict "Chart" $.Subcharts.integrations.Chart "Values" .Values.integrations "Files" $.Subcharts.integrations.Files "Release" $.Release }}
+{{- $filteredIntegrations := include "collectors.integrations.filterInstancesForCollector" (dict "root" $ "collectorName" $.collectorName) | fromYaml }}
+{{- $values := dict "Chart" $.Subcharts.integrations.Chart "Values" $filteredIntegrations "Files" $.Subcharts.integrations.Files "Release" $.Release }}
 {{- $metricsDestinations := include "destinations.get" (dict "destinations" $.Values.destinations "type" "metrics" "ecosystem" "prometheus" "filter" $.Values.integrations.destinations) | fromYamlArray }}
 {{- $logsDestinations := include "destinations.get" (dict "destinations" $.Values.destinations "type" "logs" "ecosystem" "loki" "filter" $.Values.integrations.destinations) | fromYamlArray }}
 {{- $metricIntegrations := include "feature.integrations.configured.metrics" $values | fromYamlArray }}
-{{- $logOutputIntegrations := include "feature.integrations.configured.logOutput" (dict "Values" .Values.integrations "Files" $.Subcharts.integrations.Files) | fromYamlArray }}
+{{- $logOutputIntegrations := include "feature.integrations.configured.logOutput" $values | fromYamlArray }}
 {{- range $integrationType := $metricIntegrations }}
 {{- include (printf "integrations.%s.module.metrics" $integrationType) $values | indent 0 }}
 {{ include "helper.alloy_name" $integrationType }}_integration "integration" {
@@ -38,7 +89,14 @@
 
 {{- define "features.integrations.destinations" }}
 {{ include "destinations.get" (dict "destinations" $.Values.destinations "type" "metrics" "ecosystem" "prometheus" "filter" $.Values.integrations.destinations) | nindent 0 }}
-{{- $logOutputIntegrations := include "feature.integrations.configured.logOutput" (dict "Values" .Values.integrations "Files" $.Subcharts.integrations.Files) | fromYamlArray }}
+{{- /* When rendering a specific collector, only wire the logs destination if that collector emits exporter logs,
+       so a metrics-only collector doesn't get an idle loki.write. Without a collector (feature-level validation),
+       use the unfiltered values so the logs destination is still validated. */}}
+{{- $integrationsValues := $.Values.integrations }}
+{{- if $.collectorName }}
+  {{- $integrationsValues = include "collectors.integrations.filterInstancesForCollector" (dict "root" $ "collectorName" $.collectorName) | fromYaml }}
+{{- end }}
+{{- $logOutputIntegrations := include "feature.integrations.configured.logOutput" (dict "Values" $integrationsValues "Files" $.Subcharts.integrations.Files) | fromYamlArray }}
 {{- if $logOutputIntegrations }}
   {{ include "destinations.get" (dict "destinations" $.Values.destinations "type" "logs" "ecosystem" "loki" "filter" $.Values.integrations.destinations) | nindent 0 }}
 {{- end }}
@@ -88,21 +146,57 @@
 
 {{- /*
 Integrations that scrape exporters (metrics) or emit exporter logs (logOutput) run on a dedicated
-collector, so one must be assigned. When it isn't, and more than one collector is enabled, the
-collector auto-selection returns empty and the entire integrations config would be silently dropped;
-validate here so the user gets a clear error instead. Log-parsing integrations (logRules only) attach
-to the Pod Logs feature's collector rather than an integrations collector, so they need no assignment.
+collector, so each instance must resolve to one: its own `collector`, else the feature-level
+`integrations.collector`, else the single enabled collector. An instance naming a disabled/missing
+collector fails; an instance with no collector when auto-selection returns empty also fails, since it
+would be silently dropped. Log-parsing integrations (logRules only) attach to the Pod Logs feature's
+collector, so they need no assignment.
 */}}
 {{- if or $metricIntegrations $logOutputIntegrations }}
-  {{- $collectorName := include "collectors.getCollectorForFeature" (dict "Values" $.Values "Files" $.Files "Subcharts" $.Subcharts "featureKey" "integrations") }}
-  {{- include "collectors.validate.collectorIsAssigned" (dict "Values" $.Values "collectorName" $collectorName "featureKey" "integrations" "featureName" $featureName) }}
+  {{- $enabledCollectors := include "collectors.list.enabled" (dict "Values" $.Values) | fromYamlArray }}
+  {{- $featureCollector := include "collectors.getCollectorForFeature" (dict "Values" $.Values "Files" $.Files "Subcharts" $.Subcharts "featureKey" "integrations") | trim }}
+  {{- range $type := concat $metricIntegrations $logOutputIntegrations | uniq }}
+    {{- range $instance := (index $.Values.integrations $type).instances }}
+      {{- /* Skip log-parsing-only instances: they attach to the Pod Logs collector, not an integrations collector. */}}
+      {{- if include "collectors.integrations.instanceProducesOutput" (dict "type" $type "instance" $instance "Files" $.Subcharts.integrations.Files) }}
+        {{- $instanceCollector := dig "collector" "" $instance }}
+        {{- if $instanceCollector }}
+          {{- if not (has $instanceCollector $enabledCollectors) }}
+            {{- $msg := list "" (printf "The %s feature has an instance %q of type %q assigned to collector %q, but that collector does not exist or is disabled." $featureName (dig "name" "" $instance) $type $instanceCollector) }}
+            {{- $msg = append $msg "Please assign it to one of the enabled collectors:" }}
+            {{- $msg = append $msg (printf "  collector: %s" (include "english_list_or" $enabledCollectors)) }}
+            {{- $msg = append $msg "See https://github.com/grafana/k8s-monitoring-helm/blob/main/charts/k8s-monitoring/docs/collectors/README.md for more details." }}
+            {{- fail (join "\n" $msg) }}
+          {{- end }}
+        {{- else }}
+          {{- include "collectors.validate.collectorIsAssigned" (dict "Values" $.Values "collectorName" $featureCollector "featureKey" "integrations" "featureName" $featureName) }}
+        {{- end }}
+      {{- end }}
+    {{- end }}
+  {{- end }}
 {{- end }}
 
 {{- if $metricIntegrations }}
   {{- include "destinations.validate.destinationListNotEmpty" (dict "destinations" $destinations "type" "metrics" "ecosystem" "prometheus" "featureName" $featureName "Values" $.Values "featureKey" "integrations") }}
   {{- include "dataProcessors.validate.feature" (dict "root" $ "featureKey" "integrations" "featureName" $featureName "type" "metrics" "ecosystem" "prometheus") }}
-  {{- $collectorName := $.Values.integrations.collector }}
-  {{- include "collectors.validate.clusteringEnabled" (dict "Values" $.Values "Files" $.Files "collectorName" $collectorName "featureName" $featureName) }}
+  {{- /* Validate clustering only on explicitly-assigned collectors (feature-level or per-instance). An
+         auto-selected collector is left unchecked, matching the behavior before per-instance routing. */}}
+  {{- $clusteringCollectors := list }}
+  {{- with $.Values.integrations.collector }}{{- $clusteringCollectors = append $clusteringCollectors . }}{{- end }}
+  {{- range $type := concat $metricIntegrations $logOutputIntegrations | uniq }}
+    {{- range $instance := (index $.Values.integrations $type).instances }}
+      {{- /* Skip log-parsing-only instances: they attach to the Pod Logs collector, not an integrations collector. */}}
+      {{- if include "collectors.integrations.instanceProducesOutput" (dict "type" $type "instance" $instance "Files" $.Subcharts.integrations.Files) }}
+        {{- $instanceCollector := dig "collector" "" $instance }}
+        {{- if and $instanceCollector (not (has $instanceCollector $clusteringCollectors)) }}
+          {{- $clusteringCollectors = append $clusteringCollectors $instanceCollector }}
+        {{- end }}
+      {{- end }}
+    {{- end }}
+  {{- end }}
+  {{- range $collectorName := $clusteringCollectors }}
+    {{- include "collectors.validate.clusteringEnabled" (dict "Values" $.Values "Files" $.Files "collectorName" $collectorName "featureName" $featureName) }}
+  {{- end }}
 {{- end }}
 
 {{- if $logOutputIntegrations }}

--- a/charts/k8s-monitoring/templates/hooks/README.md
+++ b/charts/k8s-monitoring/templates/hooks/README.md
@@ -5,6 +5,33 @@
 
 This directory contains Helm hooks that ensure proper deployment order and reliability of the k8s-monitoring chart.
 
+## Pre Install/Upgrade Hooks
+
+### Validate Configuration
+
+This pre-install/pre-upgrade hook validates each enabled collector's generated Alloy config before any chart resources
+are applied. For every enabled collector it creates a hook-annotated `ConfigMap` containing the rendered `config.alloy`
+(byte-identical to the config the collector will run) and a `Pod` that runs the Alloy image. The pod runs `alloy fmt`
+and then `alloy run` against the config; the install or upgrade is aborted on any syntax or load error.
+
+The pod is invoked with `KUBERNETES_SERVICE_HOST` and `KUBERNETES_SERVICE_PORT` deliberately blanked so that Alloy
+exits with a well-known error string after the config has been successfully loaded. Any other error indicates an
+invalid config.
+
+This hook is opt-in. Enable it with `configValidator.enabled: true`. The validator image and pod settings
+(`configValidator.image`, `podLabels`, `podAnnotations`, `securityContext`, `resources`, `nodeSelector`,
+`tolerations`, `serviceAccount`, `extraArgs`) can be set explicitly, mirroring the Alloy Operator hooks. When the
+image is not set, it defaults to the per-collector Alloy image, then to the Alloy version pinned by this chart's
+Alloy Operator. Alloy's storage path is kept on a writable `emptyDir`, so a restrictive `securityContext` (for
+example `readOnlyRootFilesystem: true`) still works.
+
+Steps:
+
+1.  Renders one `ConfigMap` and one `Pod` per enabled collector with the `pre-install,pre-upgrade` hook annotations.
+2.  Pod runs `alloy fmt` on the rendered config, then `alloy run` with `KUBERNETES_SERVICE_*` blanked, expecting the
+    known sentinel error string.
+3.  Any other failure aborts the install or upgrade before normal chart resources are applied.
+
 ## Post Install/Upgrade Hooks
 
 ### Add Finalizer

--- a/charts/k8s-monitoring/templates/hooks/pre-install_validate-config.yaml
+++ b/charts/k8s-monitoring/templates/hooks/pre-install_validate-config.yaml
@@ -1,0 +1,149 @@
+{{- if .Values.configValidator.enabled }}
+{{- $cv := .Values.configValidator }}
+{{- range $collectorName := include "collectors.list.enabled" $ | fromYamlArray }}
+{{- $values := dict "Values" $.Values "Chart" $.Chart "Files" $.Files "Release" $.Release "Subcharts" $.Subcharts "Template" $.Template "Capabilities" $.Capabilities "collectorName" $collectorName }}
+{{- $collectorValues := include "collector.alloy.valuesWithUpstream" $values | fromYaml }}
+{{- $alloyConfig := include "collector.alloy.config" $values }}
+{{- /* Apply replaceComponent substitutions and trim trailing whitespace exactly as alloy-config.yaml does,
+       so the validated config matches the deployed config. Usage tracking is only needed for the
+       "unused replacement" validation in alloy-config.yaml, so it is omitted here. */}}
+{{- range $replacement := $.Values.replaceComponent }}
+  {{- $alloyConfig = include "replaceComponent.apply" (dict "config" $alloyConfig "replacement" $replacement) }}
+{{- end }}
+{{- $alloyConfig = regexReplaceAll `[ \t]+(\r?\n)` $alloyConfig "\n" }}
+{{- $name := printf "%s-validate" (include "collector.alloy.fullname" $values) | trunc 63 | trimSuffix "-" }}
+{{- /* Image resolution: an explicit configValidator.image field wins, then the per-collector Alloy image, then the
+       Alloy version pinned by this chart's Alloy Operator. global.image.registry/pullSecrets keep top precedence. */}}
+{{- $registry := coalesce (dig "image" "registry" "" $.Values.global) $cv.image.registry $collectorValues.image.registry }}
+{{- $repo := $cv.image.repository | default $collectorValues.image.repository }}
+{{- $digest := $cv.image.digest | default $collectorValues.image.digest }}
+{{- $tag := $cv.image.tag | default $collectorValues.image.tag }}
+{{- $imageRef := "" }}
+{{- if $digest }}
+  {{- $imageRef = printf "%s/%s@%s" $registry $repo $digest }}
+{{- else if $tag }}
+  {{- $imageRef = printf "%s/%s:%s" $registry $repo $tag }}
+{{- else }}
+  {{- $imageRef = printf "%s/%s:%s" $registry $repo (include "collector.alloy.pinnedImageTag" $) }}
+{{- end }}
+{{- $pullPolicy := (dig "image" "pullPolicy" "" $.Values.global) | default $cv.image.pullPolicy }}
+{{- $pullSecrets := coalesce (dig "image" "pullSecrets" list $.Values.global) $cv.image.pullSecrets $collectorValues.image.pullSecrets }}
+{{- $stability := dig "alloy" "stabilityLevel" "generally-available" $collectorValues }}
+{{- /* Honor `runAsUser: null` as a request to drop the field entirely (Helm would otherwise render it as null). */}}
+{{- $securityContext := $cv.securityContext }}
+{{- if $securityContext }}
+  {{- if eq (dig "runAsUser" "unset" $securityContext) nil }}
+    {{- $securityContext = unset (deepCopy $securityContext) "runAsUser" }}
+  {{- end }}
+{{- end }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ $name | quote }}
+  namespace: {{ include "helper.namespace" $ }}
+  labels:
+    helm.sh/chart: {{ include "helper.chart" $ }}
+    app.kubernetes.io/managed-by: {{ $.Release.Service }}
+    app.kubernetes.io/instance: {{ $.Release.Name }}
+    {{- range $k, $v := $cv.extraLabels }}
+    {{ $k }}: {{ $v | quote }}
+    {{- end }}
+  annotations:
+    helm.sh/hook: pre-install,pre-upgrade
+    helm.sh/hook-weight: "-5"
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+    {{- range $k, $v := $cv.extraAnnotations }}
+    {{ $k }}: {{ $v | quote }}
+    {{- end }}
+data:
+  config.alloy: |{{ $alloyConfig | trim | nindent 4 }}
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: {{ $name | quote }}
+  namespace: {{ include "helper.namespace" $ }}
+  labels:
+    helm.sh/chart: {{ include "helper.chart" $ }}
+    app.kubernetes.io/managed-by: {{ $.Release.Service }}
+    app.kubernetes.io/instance: {{ $.Release.Name }}
+    {{- range $k, $v := $cv.extraLabels }}
+    {{ $k }}: {{ $v | quote }}
+    {{- end }}
+    {{- range $k, $v := $cv.podLabels }}
+    {{ $k }}: {{ $v | quote }}
+    {{- end }}
+  annotations:
+    helm.sh/hook: pre-install,pre-upgrade
+    helm.sh/hook-weight: "-5"
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+    {{- range $k, $v := $cv.extraAnnotations }}
+    {{ $k }}: {{ $v | quote }}
+    {{- end }}
+    {{- range $k, $v := $cv.podAnnotations }}
+    {{ $k }}: {{ $v | quote }}
+    {{- end }}
+spec:
+  restartPolicy: Never
+  {{- with $cv.serviceAccount.name }}
+  serviceAccountName: {{ . }}
+  {{- end }}
+  {{- with $cv.nodeSelector }}
+  nodeSelector:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with $cv.tolerations }}
+  tolerations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with $pullSecrets }}
+  imagePullSecrets:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  containers:
+    - name: alloy
+      image: {{ $imageRef | quote }}
+      {{- with $pullPolicy }}
+      imagePullPolicy: {{ . }}
+      {{- end }}
+      command:
+        - bash
+        - -c
+        - |
+          echo "Validating Grafana Alloy config for collector {{ $collectorName }}"
+          if ! alloy fmt /etc/alloy/config.alloy > /dev/null; then
+            exit 1
+          fi
+          output=$(alloy run --stability.level {{ $stability }} --storage.path=/tmp/alloy {{ join " " $cv.extraArgs }} "/etc/alloy/config.alloy" 2>&1)
+          if ! echo "${output}" | grep "KUBERNETES_SERVICE_HOST and KUBERNETES_SERVICE_PORT must be defined" >/dev/null; then
+            echo "${output}"
+            exit 1
+          fi
+          echo "Grafana Alloy config file is valid"
+      env:
+        - name: KUBERNETES_SERVICE_HOST  # Intentionally blanked to make Alloy fail in a known way
+          value: ""
+        - name: KUBERNETES_SERVICE_PORT  # Intentionally blanked to make Alloy fail in a known way
+          value: ""
+      {{- with $securityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with $cv.resources }}
+      resources:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      volumeMounts:
+        - name: config
+          mountPath: /etc/alloy
+        - name: alloy-storage
+          mountPath: /tmp/alloy
+  volumes:
+    - name: config
+      configMap:
+        name: {{ $name | quote }}
+    - name: alloy-storage
+      emptyDir: {}
+{{- end }}
+{{- end }}

--- a/charts/k8s-monitoring/tests/__snapshot__/hook_pre-install_validate-config_test.yaml.snap
+++ b/charts/k8s-monitoring/tests/__snapshot__/hook_pre-install_validate-config_test.yaml.snap
@@ -1,0 +1,37 @@
+snapshot of the rendered Pod spec:
+  1: |
+    containers:
+      - command:
+          - bash
+          - -c
+          - |
+            echo "Validating Grafana Alloy config for collector alloy-metrics"
+            if ! alloy fmt /etc/alloy/config.alloy > /dev/null; then
+              exit 1
+            fi
+            output=$(alloy run --stability.level generally-available --storage.path=/tmp/alloy  "/etc/alloy/config.alloy" 2>&1)
+            if ! echo "${output}" | grep "KUBERNETES_SERVICE_HOST and KUBERNETES_SERVICE_PORT must be defined" >/dev/null; then
+              echo "${output}"
+              exit 1
+            fi
+            echo "Grafana Alloy config file is valid"
+        env:
+          - name: KUBERNETES_SERVICE_HOST
+            value: ""
+          - name: KUBERNETES_SERVICE_PORT
+            value: ""
+        image: docker.io/grafana/alloy:v1.18.1
+        imagePullPolicy: IfNotPresent
+        name: alloy
+        volumeMounts:
+          - mountPath: /etc/alloy
+            name: config
+          - mountPath: /tmp/alloy
+            name: alloy-storage
+    restartPolicy: Never
+    volumes:
+      - configMap:
+          name: RELEASE-NAME-alloy-metrics-validate
+        name: config
+      - emptyDir: {}
+        name: alloy-storage

--- a/charts/k8s-monitoring/tests/feature_integrations_test.yaml
+++ b/charts/k8s-monitoring/tests/feature_integrations_test.yaml
@@ -115,6 +115,237 @@ tests:
           path: data["config.alloy"]
           pattern: alloy_integration "integration"
 
+  - it: assigns integration instances to their per-instance collectors
+    template: alloy-config.yaml
+    set:
+      cluster:
+        name: ci-test-cluster
+      selfReporting: {enabled: false}
+      destinations:
+        prom:
+          type: prometheus
+          url: http://prom.prom.svc:9090/api/v1/write
+      collectors:
+        alloy-metrics:
+          presets: [clustered, statefulset]
+        alloy-metrics-2:
+          presets: [clustered, statefulset]
+      integrations:
+        collector: alloy-metrics
+        alloy:
+          instances:
+            # inherits the feature-level collector (alloy-metrics)
+            - name: alloy-a
+              labelSelectors:
+                app.kubernetes.io/name: alloy-a
+            # overrides to a different collector
+            - name: alloy-b
+              collector: alloy-metrics-2
+              labelSelectors:
+                app.kubernetes.io/name: alloy-b
+    asserts:
+      # document 0 is the alloy-metrics collector, document 1 is alloy-metrics-2 (sorted alphabetically)
+      - documentIndex: 0
+        matchRegex:
+          path: data["config.alloy"]
+          pattern: alloy_integration_discovery "alloy_a"
+      - documentIndex: 0
+        notMatchRegex:
+          path: data["config.alloy"]
+          pattern: alloy_integration_discovery "alloy_b"
+      - documentIndex: 1
+        matchRegex:
+          path: data["config.alloy"]
+          pattern: alloy_integration_discovery "alloy_b"
+      - documentIndex: 1
+        notMatchRegex:
+          path: data["config.alloy"]
+          pattern: alloy_integration_discovery "alloy_a"
+
+  - it: allows omitting the feature-level collector when each instance sets its own
+    template: alloy-config.yaml
+    set:
+      cluster:
+        name: ci-test-cluster
+      selfReporting: {enabled: false}
+      destinations:
+        prom:
+          type: prometheus
+          url: http://prom.prom.svc:9090/api/v1/write
+      collectors:
+        alloy-metrics:
+          presets: [clustered, statefulset]
+        alloy-metrics-2:
+          presets: [clustered, statefulset]
+      integrations:
+        alloy:
+          instances:
+            - name: alloy-a
+              collector: alloy-metrics
+              labelSelectors:
+                app.kubernetes.io/name: alloy-a
+            - name: alloy-b
+              collector: alloy-metrics-2
+              labelSelectors:
+                app.kubernetes.io/name: alloy-b
+    asserts:
+      - documentIndex: 0
+        matchRegex:
+          path: data["config.alloy"]
+          pattern: alloy_integration_discovery "alloy_a"
+      - documentIndex: 1
+        matchRegex:
+          path: data["config.alloy"]
+          pattern: alloy_integration_discovery "alloy_b"
+
+  - it: does not require an integrations collector for a log-parsing-only instance
+    template: validations.yaml
+    set:
+      cluster:
+        name: ci-test-cluster
+      destinations:
+        prom:
+          type: prometheus
+          url: http://prom.prom.svc:9090/api/v1/write
+        loki:
+          type: loki
+          url: http://loki.loki.svc:3100/loki/api/v1/push
+      podLogsViaLoki:
+        enabled: true
+        collector: alloy-logs
+      collectors:
+        alloy-metrics:
+          presets: [clustered, statefulset]
+        alloy-logs:
+          presets: [filesystem-log-reader, daemonset]
+      # No feature-level integrations.collector is set on purpose.
+      integrations:
+        mysql:
+          instances:
+            # metrics instance with its own collector
+            - name: db-a
+              collector: alloy-metrics
+              exporter:
+                dataSourceName: "root:password@db-a:3306/"
+              logs: {enabled: false}
+            # log-parsing-only instance: metrics disabled, no collector needed
+            - name: db-b
+              metrics: {enabled: false}
+              exporter:
+                dataSourceName: "root:password@db-b:3306/"
+              logs:
+                enabled: true
+                labelSelectors:
+                  app.kubernetes.io/name: db-b
+    asserts:
+      - notFailedTemplate: {}
+
+  - it: does not clustering-check a log-parsing-only instance's collector
+    template: validations.yaml
+    set:
+      cluster:
+        name: ci-test-cluster
+      destinations:
+        prom:
+          type: prometheus
+          url: http://prom.prom.svc:9090/api/v1/write
+        loki:
+          type: loki
+          url: http://loki.loki.svc:3100/loki/api/v1/push
+      podLogsViaLoki:
+        enabled: true
+        collector: alloy-logs
+      collectors:
+        alloy-metrics:
+          presets: [clustered, statefulset]
+        alloy-logs:
+          presets: [filesystem-log-reader, daemonset]
+      integrations:
+        mysql:
+          instances:
+            # metrics instance on a clustered collector
+            - name: db-a
+              collector: alloy-metrics
+              exporter:
+                dataSourceName: "root:password@db-a:3306/"
+              logs: {enabled: false}
+            # log-parsing-only instance whose collector points at a non-clustered
+            # daemonset; it attaches to Pod Logs, so it must not be clustering-checked
+            - name: db-b
+              collector: alloy-logs
+              metrics: {enabled: false}
+              exporter:
+                dataSourceName: "root:password@db-b:3306/"
+              logs:
+                enabled: true
+                labelSelectors:
+                  app.kubernetes.io/name: db-b
+    asserts:
+      - notFailedTemplate: {}
+
+  - it: fails when an instance names a disabled or missing collector
+    template: validations.yaml
+    set:
+      cluster:
+        name: ci-test-cluster
+      destinations:
+        prom:
+          type: prometheus
+          url: http://prom.prom.svc:9090/api/v1/write
+      collectors:
+        alloy-metrics:
+          presets: [clustered, statefulset]
+        alloy-metrics-2:
+          presets: [clustered, statefulset]
+      integrations:
+        collector: alloy-metrics
+        alloy:
+          instances:
+            - name: alloy-a
+              labelSelectors:
+                app.kubernetes.io/name: alloy-a
+            - name: alloy-b
+              collector: does-not-exist
+              labelSelectors:
+                app.kubernetes.io/name: alloy-b
+    asserts:
+      - failedTemplate:
+          errorMessage: |-
+            The Service Integrations feature has an instance "alloy-b" of type "alloy" assigned to collector "does-not-exist", but that collector does not exist or is disabled.
+            Please assign it to one of the enabled collectors:
+              collector: alloy-metrics or alloy-metrics-2
+            See https://github.com/grafana/k8s-monitoring-helm/blob/main/charts/k8s-monitoring/docs/collectors/README.md for more details.
+
+  - it: fails when an instance inherits a disabled or missing feature-level collector
+    template: validations.yaml
+    set:
+      cluster:
+        name: ci-test-cluster
+      destinations:
+        prom:
+          type: prometheus
+          url: http://prom.prom.svc:9090/api/v1/write
+      collectors:
+        alloy-metrics:
+          presets: [clustered, statefulset]
+        disabled-one:
+          enabled: false
+      integrations:
+        collector: disabled-one
+        alloy:
+          instances:
+            - name: alloy
+              labelSelectors:
+                app.kubernetes.io/name: alloy
+    asserts:
+      - failedTemplate:
+          errorMessage: |-
+            The Service Integrations feature wants to use a collector named "disabled-one", but that collector does not exist or is disabled.
+            Please assign one by setting the following:
+            integrations:
+              collector: alloy-metrics
+            See https://github.com/grafana/k8s-monitoring-helm/blob/main/charts/k8s-monitoring/docs/collectors/README.md for more details.
+
   - it: works with multiple metrics-only integrations
     template: alloy-config.yaml
     set:

--- a/charts/k8s-monitoring/tests/hook_pre-install_validate-config_test.yaml
+++ b/charts/k8s-monitoring/tests/hook_pre-install_validate-config_test.yaml
@@ -1,0 +1,362 @@
+---
+suite: Test pre-install config validator hook
+templates:
+  - templates/hooks/pre-install_validate-config.yaml
+tests:
+  - it: should render nothing by default (opt-in)
+    set:
+      collectors:
+        alloy-metrics:
+          extraConfig: " "
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should render nothing when no collectors enabled
+    set:
+      configValidator:
+        enabled: true
+      collectors: {}
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should render a ConfigMap and a Pod per enabled collector
+    set:
+      configValidator:
+        enabled: true
+      collectors:
+        alloy-metrics:
+          extraConfig: " "
+    asserts:
+      - hasDocuments:
+          count: 2
+      - documentIndex: 0
+        isKind:
+          of: ConfigMap
+      - documentIndex: 1
+        isKind:
+          of: Pod
+      - documentIndex: 0
+        equal:
+          path: metadata.annotations["helm.sh/hook"]
+          value: pre-install,pre-upgrade
+      - documentIndex: 1
+        equal:
+          path: metadata.annotations["helm.sh/hook"]
+          value: pre-install,pre-upgrade
+      - documentIndex: 1
+        equal:
+          path: metadata.annotations["helm.sh/hook-weight"]
+          value: "-5"
+
+  - it: should render a Pod per collector when multiple are enabled
+    set:
+      configValidator:
+        enabled: true
+      collectors:
+        alloy-metrics:
+          extraConfig: " "
+        alloy-singleton:
+          extraConfig: " "
+    asserts:
+      - hasDocuments:
+          count: 4
+
+  - it: should use the default Alloy image tag when neither tag nor digest is set
+    set:
+      configValidator:
+        enabled: true
+      collectors:
+        alloy-metrics:
+          extraConfig: " "
+    asserts:
+      - documentIndex: 1
+        matchRegex:
+          path: spec.containers[0].image
+          pattern: "^docker\\.io/grafana/alloy:v[0-9]+\\.[0-9]+\\.[0-9]+"
+
+  - it: should use per-collector image.tag when set
+    set:
+      configValidator:
+        enabled: true
+      collectors:
+        alloy-metrics:
+          extraConfig: " "
+          image:
+            tag: v9.9.9
+    asserts:
+      - documentIndex: 1
+        equal:
+          path: spec.containers[0].image
+          value: docker.io/grafana/alloy:v9.9.9
+
+  - it: should use per-collector image.digest when set
+    set:
+      configValidator:
+        enabled: true
+      collectors:
+        alloy-metrics:
+          extraConfig: " "
+          image:
+            tag: v9.9.9
+            digest: sha256:deadbeef
+    asserts:
+      - documentIndex: 1
+        equal:
+          path: spec.containers[0].image
+          value: docker.io/grafana/alloy@sha256:deadbeef
+
+  - it: should honor global.image.registry override
+    set:
+      configValidator:
+        enabled: true
+      global:
+        image:
+          registry: my-registry.example.com
+      collectors:
+        alloy-metrics:
+          extraConfig: " "
+    asserts:
+      - documentIndex: 1
+        matchRegex:
+          path: spec.containers[0].image
+          pattern: "^my-registry\\.example\\.com/grafana/alloy:"
+
+  - it: should propagate imagePullSecrets from global
+    set:
+      configValidator:
+        enabled: true
+      global:
+        image:
+          pullSecrets:
+            - name: my-pull-secret
+      collectors:
+        alloy-metrics:
+          extraConfig: " "
+    asserts:
+      - documentIndex: 1
+        equal:
+          path: spec.imagePullSecrets[0].name
+          value: my-pull-secret
+
+  - it: should propagate configValidator pod customization
+    set:
+      configValidator:
+        enabled: true
+        serviceAccount:
+          name: my-sa
+        extraArgs:
+          - --disable-reporting
+        nodeSelector:
+          kubernetes.io/os: linux
+        tolerations:
+          - key: arm
+            operator: Exists
+        extraLabels:
+          team: observability
+        extraAnnotations:
+          example.com/owner: pete
+      collectors:
+        alloy-metrics:
+          extraConfig: " "
+    asserts:
+      - documentIndex: 1
+        equal:
+          path: spec.serviceAccountName
+          value: my-sa
+      - documentIndex: 1
+        equal:
+          path: spec.nodeSelector["kubernetes.io/os"]
+          value: linux
+      - documentIndex: 1
+        equal:
+          path: spec.tolerations[0].key
+          value: arm
+      - documentIndex: 1
+        equal:
+          path: metadata.labels.team
+          value: observability
+      - documentIndex: 1
+        equal:
+          path: metadata.annotations["example.com/owner"]
+          value: pete
+      - documentIndex: 1
+        matchRegex:
+          path: spec.containers[0].command[2]
+          pattern: --disable-reporting
+
+  - it: should apply global namespaceOverride
+    set:
+      configValidator:
+        enabled: true
+      global:
+        namespaceOverride: observability
+      collectors:
+        alloy-metrics:
+          extraConfig: " "
+    asserts:
+      - documentIndex: 0
+        equal:
+          path: metadata.namespace
+          value: observability
+      - documentIndex: 1
+        equal:
+          path: metadata.namespace
+          value: observability
+
+  - it: should use configValidator.image overrides
+    set:
+      configValidator:
+        enabled: true
+        image:
+          registry: my.registry.io
+          repository: custom/alloy
+          tag: v1.99.0
+          pullPolicy: Always
+      collectors:
+        alloy-metrics:
+          extraConfig: " "
+    asserts:
+      - documentIndex: 1
+        equal:
+          path: spec.containers[0].image
+          value: my.registry.io/custom/alloy:v1.99.0
+      - documentIndex: 1
+        equal:
+          path: spec.containers[0].imagePullPolicy
+          value: Always
+
+  - it: should prefer configValidator.image.digest over tag
+    set:
+      configValidator:
+        enabled: true
+        image:
+          digest: sha256:abc123
+      collectors:
+        alloy-metrics:
+          extraConfig: " "
+    asserts:
+      - documentIndex: 1
+        equal:
+          path: spec.containers[0].image
+          value: docker.io/grafana/alloy@sha256:abc123
+
+  - it: should propagate imagePullSecrets from configValidator.image
+    set:
+      configValidator:
+        enabled: true
+        image:
+          pullSecrets:
+            - name: cv-secret
+      collectors:
+        alloy-metrics:
+          extraConfig: " "
+    asserts:
+      - documentIndex: 1
+        equal:
+          path: spec.imagePullSecrets[0].name
+          value: cv-secret
+
+  - it: should apply securityContext and resources to the container
+    set:
+      configValidator:
+        enabled: true
+        securityContext:
+          runAsNonRoot: true
+          runAsUser: 473
+          readOnlyRootFilesystem: true
+        resources:
+          requests:
+            cpu: 10m
+            memory: 64Mi
+      collectors:
+        alloy-metrics:
+          extraConfig: " "
+    asserts:
+      - documentIndex: 1
+        equal:
+          path: spec.containers[0].securityContext.runAsUser
+          value: 473
+      - documentIndex: 1
+        equal:
+          path: spec.containers[0].securityContext.readOnlyRootFilesystem
+          value: true
+      - documentIndex: 1
+        equal:
+          path: spec.containers[0].resources.requests.cpu
+          value: 10m
+
+  - it: should drop runAsUser when explicitly set to null
+    set:
+      configValidator:
+        enabled: true
+        securityContext:
+          runAsNonRoot: true
+          runAsUser: null
+      collectors:
+        alloy-metrics:
+          extraConfig: " "
+    asserts:
+      - documentIndex: 1
+        notExists:
+          path: spec.containers[0].securityContext.runAsUser
+      - documentIndex: 1
+        equal:
+          path: spec.containers[0].securityContext.runAsNonRoot
+          value: true
+
+  - it: should apply podLabels and podAnnotations to the Pod but not the ConfigMap
+    set:
+      configValidator:
+        enabled: true
+        podLabels:
+          lbl.example.com/pod: "true"
+        podAnnotations:
+          ann.example.com/pod: "yes"
+      collectors:
+        alloy-metrics:
+          extraConfig: " "
+    asserts:
+      - documentIndex: 1
+        equal:
+          path: metadata.labels["lbl.example.com/pod"]
+          value: "true"
+      - documentIndex: 1
+        equal:
+          path: metadata.annotations["ann.example.com/pod"]
+          value: "yes"
+      - documentIndex: 0
+        notExists:
+          path: metadata.labels["lbl.example.com/pod"]
+
+  - it: should mount a writable storage emptyDir and point alloy run at it
+    set:
+      configValidator:
+        enabled: true
+      collectors:
+        alloy-metrics:
+          extraConfig: " "
+    asserts:
+      - documentIndex: 1
+        contains:
+          path: spec.volumes
+          content:
+            name: alloy-storage
+            emptyDir: {}
+      - documentIndex: 1
+        matchRegex:
+          path: spec.containers[0].command[2]
+          pattern: --storage.path=/tmp/alloy
+
+  - it: snapshot of the rendered Pod spec
+    set:
+      configValidator:
+        enabled: true
+      collectors:
+        alloy-metrics:
+          extraConfig: " "
+    asserts:
+      - documentIndex: 1
+        matchSnapshot:
+          path: spec

--- a/charts/k8s-monitoring/tests/validations_collectors_clustering_test.yaml
+++ b/charts/k8s-monitoring/tests/validations_collectors_clustering_test.yaml
@@ -133,6 +133,54 @@ tests:
                   clustering:
                     enabled: true
 
+  - it: requires clustering on a collector assigned to an integration instance
+    set:
+      cluster: {name: test-cluster}
+      destinations:
+        prom: {type: prometheus, url: "http://prom:9090"}
+      integrations:
+        collector: alloy-metrics
+        alloy:
+          instances:
+            - name: alloy
+              collector: alloy-metrics-2
+              labelSelectors:
+                app.kubernetes.io/name: alloy
+      collectors:
+        alloy-metrics: {presets: [clustered, statefulset]}
+        alloy-metrics-2: {}
+    asserts:
+      - failedTemplate:
+          errorMessage: |-
+            The Service Integrations feature requires clustering to be enabled on the alloy-metrics-2 collector.
+            Please set:
+            collectors:
+              alloy-metrics-2:
+                presets: [clustered]
+            OR
+              alloy-metrics-2:
+                alloy:
+                  clustering:
+                    enabled: true
+
+  - it: does not require clustering on an auto-selected collector with integrations
+    set:
+      cluster: {name: test-cluster}
+      destinations:
+        prom: {type: prometheus, url: "http://prom:9090"}
+      # No integrations.collector and no per-instance collector: the collector is auto-selected,
+      # so clustering is not validated (preserving behavior from before per-instance routing).
+      integrations:
+        alloy:
+          instances:
+            - name: alloy
+              labelSelectors:
+                app.kubernetes.io/name: alloy
+      collectors:
+        alloy-metrics: {presets: [daemonset]}
+    asserts:
+      - notFailedTemplate: {}
+
   - it: does not require clustering on a singleton collector with integrations
     set:
       cluster: {name: test-cluster}

--- a/charts/k8s-monitoring/values.schema.json
+++ b/charts/k8s-monitoring/values.schema.json
@@ -264,6 +264,72 @@
         "collectors": {
             "type": "object"
         },
+        "configValidator": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean"
+                },
+                "image": {
+                    "type": "object",
+                    "properties": {
+                        "registry": {
+                            "type": "string"
+                        },
+                        "repository": {
+                            "type": "string"
+                        },
+                        "tag": {
+                            "type": "string"
+                        },
+                        "digest": {
+                            "type": "string"
+                        },
+                        "pullPolicy": {
+                            "type": "string"
+                        },
+                        "pullSecrets": {
+                            "type": "array"
+                        }
+                    }
+                },
+                "serviceAccount": {
+                    "type": "object",
+                    "properties": {
+                        "name": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "extraArgs": {
+                    "type": "array"
+                },
+                "podAnnotations": {
+                    "type": "object"
+                },
+                "podLabels": {
+                    "type": "object"
+                },
+                "securityContext": {
+                    "type": ["object", "null"]
+                },
+                "resources": {
+                    "type": "object"
+                },
+                "nodeSelector": {
+                    "type": "object"
+                },
+                "tolerations": {
+                    "type": "array"
+                },
+                "extraLabels": {
+                    "type": "object"
+                },
+                "extraAnnotations": {
+                    "type": "object"
+                }
+            }
+        },
         "costMetrics": {
             "type": "object",
             "properties": {

--- a/charts/k8s-monitoring/values.yaml
+++ b/charts/k8s-monitoring/values.yaml
@@ -799,3 +799,87 @@ extraObjects: []
 #     dataFrom:
 #     - extract:
 #         key: mysecret
+
+#
+# Config Validator
+#
+
+# The Config Validator runs a pre-install/pre-upgrade Helm hook that validates the generated Alloy config for each
+# enabled collector via `alloy fmt` and `alloy run`. The install or upgrade is aborted on any syntax or load error,
+# preventing a broken config from reaching the cluster.
+configValidator:
+  # -- Run the pre-install/pre-upgrade Alloy config validator.
+  # @section -- Config Validator
+  enabled: false
+
+  # -- The image used to validate the generated Alloy config. Each field is optional; when empty it falls back to the
+  # per-collector Alloy image, and finally to the Alloy version pinned by this chart's Alloy Operator.
+  # @section -- Config Validator
+  image:
+    # -- Config validator image registry. When empty, uses `global.image.registry`, then the collector's Alloy registry.
+    registry: ""
+    # -- Config validator image repository. When empty, uses the collector's Alloy image repository (`grafana/alloy`).
+    repository: ""
+    # -- (string) Config validator image tag. When empty, uses the collector's Alloy image tag, then the Alloy version
+    # pinned by this chart.
+    tag: ""
+    # -- Config validator image digest. When set, takes precedence over the tag.
+    digest: ""
+    # -- Config validator image pull policy.
+    pullPolicy: IfNotPresent
+    # -- Config validator image pull secrets. When empty, uses `global.image.pullSecrets`, then the collector's.
+    pullSecrets: []
+
+  # -- ServiceAccount the validator pod runs as. When empty, the namespace default ServiceAccount is used.
+  # @section -- Config Validator
+  serviceAccount:
+    name: ""
+
+  # -- Extra arguments passed to `alloy run` during validation.
+  # @section -- Config Validator
+  extraArgs: []
+
+  # -- Annotations to apply to the validator pod.
+  # @section -- Config Validator
+  podAnnotations: {}
+
+  # -- Labels to apply to the validator pod. Service mesh sidecar injection is disabled by default so the short-lived
+  # hook pod can run to completion.
+  # @section -- Config Validator
+  podLabels:
+    sidecar.istio.io/inject: "false"
+    linkerd.io/inject: disabled
+
+  # -- Security context to apply to the validator container. This can also be set to `null` to remove it entirely, and
+  # `runAsUser` can be set to `null` to remove just that field. When running as non-root, keep `readOnlyRootFilesystem`
+  # working by leaving the validator's storage path on the writable `emptyDir` this hook mounts.
+  # @section -- Config Validator
+  securityContext: {}
+  #  allowPrivilegeEscalation: false
+  #  capabilities:
+  #    drop: ["ALL"]
+  #  readOnlyRootFilesystem: true
+  #  runAsNonRoot: true
+  #  runAsUser: 473
+  #  seccompProfile:
+  #    type: RuntimeDefault
+
+  # -- Resources for the validator pod.
+  # @section -- Config Validator
+  resources: {}
+
+  # -- Node selector applied to the validator pod.
+  # @section -- Config Validator
+  nodeSelector: {}
+
+  # -- Tolerations applied to the validator pod.
+  # @section -- Config Validator
+  tolerations: []
+
+  # -- Extra labels added to both the validator pod and its ConfigMap.
+  # @section -- Config Validator
+  extraLabels: {}
+
+  # -- Extra annotations added to both the validator pod and its ConfigMap.
+  # @section -- Config Validator
+  extraAnnotations: {}

--- a/charts/k8s-monitoring/values.yaml
+++ b/charts/k8s-monitoring/values.yaml
@@ -810,7 +810,8 @@ extraObjects: []
 configValidator:
   # -- Run the pre-install/pre-upgrade Alloy config validator.
   # @section -- Config Validator
-  enabled: false
+  # TEMPORARY: enabled by default to exercise the validator across all integration tests. Revert to false before merge.
+  enabled: true
 
   # -- The image used to validate the generated Alloy config. Each field is optional; when empty it falls back to the
   # per-collector Alloy image, and finally to the Alloy version pinned by this chart's Alloy Operator.


### PR DESCRIPTION
# Description

This was requested by a user. We had this in v1, but removed in in v2.
Bringing it back, but only optionally.

Enabling this will add a pre-commit hook that will validate the configuration during install time, rather than looking for crashing pods.

<!--Authorship attestation. See AGENTS.md for details. AI agents must not check this box on behalf
of the user; the human author must check it themselves before the PR is ready for review.-->
## Authorship

-   [X] I, a human, wrote this pull request description myself.

<!--Please delete paragraphs that you did not use before submitting.-->
