### PR TITLE
chore: use *_conditions for router destination filter gates

### DIFF
--- a/charts/k8s-monitoring/docs/examples/dataProcessors/custom/scrub-log-pii/alloy-logs.alloy
+++ b/charts/k8s-monitoring/docs/examples/dataProcessors/custom/scrub-log-pii/alloy-logs.alloy
@@ -387,9 +387,10 @@ otelcol.processor.batch "scrub_pii_out_logs_otlp" {
 }
 otelcol.processor.filter "scrub_pii_loki_otlp_gate_logs_otlp" {
   error_mode = "ignore"
-  logs {
-    log_record = [
-      "not IsMatch(resource.attributes[\"selected_destinations\"], \"(^|.*,)loki-otlp(,.*|$)\")",
+  log_conditions {
+    context    = "resource"
+    conditions = [
+      "not IsMatch(attributes[\"selected_destinations\"], \"(^|.*,)loki-otlp(,.*|$)\")",
     ]
   }
   output {

--- a/charts/k8s-monitoring/docs/examples/dataProcessors/custom/scrub-log-pii/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/dataProcessors/custom/scrub-log-pii/output.yaml
@@ -434,9 +434,10 @@ data:
     }
     otelcol.processor.filter "scrub_pii_loki_otlp_gate_logs_otlp" {
       error_mode = "ignore"
-      logs {
-        log_record = [
-          "not IsMatch(resource.attributes[\"selected_destinations\"], \"(^|.*,)loki-otlp(,.*|$)\")",
+      log_conditions {
+        context    = "resource"
+        conditions = [
+          "not IsMatch(attributes[\"selected_destinations\"], \"(^|.*,)loki-otlp(,.*|$)\")",
         ]
       }
       output {

--- a/charts/k8s-monitoring/docs/examples/dataProcessors/custom/static-label/alloy-receiver.alloy
+++ b/charts/k8s-monitoring/docs/examples/dataProcessors/custom/static-label/alloy-receiver.alloy
@@ -141,9 +141,10 @@ otelcol.processor.batch "static_label_out_traces_otlp" {
 }
 otelcol.processor.filter "static_label_tempo_gate_traces_otlp" {
   error_mode = "ignore"
-  traces {
-    span = [
-      "not IsMatch(resource.attributes[\"selected_destinations\"], \"(^|.*,)tempo(,.*|$)\")",
+  trace_conditions {
+    context    = "resource"
+    conditions = [
+      "not IsMatch(attributes[\"selected_destinations\"], \"(^|.*,)tempo(,.*|$)\")",
     ]
   }
   output {

--- a/charts/k8s-monitoring/docs/examples/dataProcessors/custom/static-label/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/dataProcessors/custom/static-label/output.yaml
@@ -921,9 +921,10 @@ data:
     }
     otelcol.processor.filter "static_label_tempo_gate_traces_otlp" {
       error_mode = "ignore"
-      traces {
-        span = [
-          "not IsMatch(resource.attributes[\"selected_destinations\"], \"(^|.*,)tempo(,.*|$)\")",
+      trace_conditions {
+        context    = "resource"
+        conditions = [
+          "not IsMatch(attributes[\"selected_destinations\"], \"(^|.*,)tempo(,.*|$)\")",
         ]
       }
       output {

--- a/charts/k8s-monitoring/docs/examples/dataProcessors/kubernetesEnrichment/labels-and-annotations/alloy.alloy
+++ b/charts/k8s-monitoring/docs/examples/dataProcessors/kubernetesEnrichment/labels-and-annotations/alloy.alloy
@@ -184,9 +184,10 @@ otelcol.processor.batch "k8s_metadata_out_metrics_otlp" {
 }
 otelcol.processor.filter "k8s_metadata_prometheus_gate_metrics_otlp" {
   error_mode = "ignore"
-  metrics {
-    metric = [
-      "not IsMatch(resource.attributes[\"selected_destinations\"], \"(^|.*,)prometheus(,.*|$)\")",
+  metric_conditions {
+    context    = "resource"
+    conditions = [
+      "not IsMatch(attributes[\"selected_destinations\"], \"(^|.*,)prometheus(,.*|$)\")",
     ]
   }
   output {
@@ -280,9 +281,10 @@ otelcol.processor.batch "k8s_metadata_out_logs_otlp" {
 }
 otelcol.processor.filter "k8s_metadata_loki_gate_logs_otlp" {
   error_mode = "ignore"
-  logs {
-    log_record = [
-      "not IsMatch(resource.attributes[\"selected_destinations\"], \"(^|.*,)loki(,.*|$)\")",
+  log_conditions {
+    context    = "resource"
+    conditions = [
+      "not IsMatch(attributes[\"selected_destinations\"], \"(^|.*,)loki(,.*|$)\")",
     ]
   }
   output {
@@ -376,9 +378,10 @@ otelcol.processor.batch "k8s_metadata_out_traces_otlp" {
 }
 otelcol.processor.filter "k8s_metadata_tempo_gate_traces_otlp" {
   error_mode = "ignore"
-  traces {
-    span = [
-      "not IsMatch(resource.attributes[\"selected_destinations\"], \"(^|.*,)tempo(,.*|$)\")",
+  trace_conditions {
+    context    = "resource"
+    conditions = [
+      "not IsMatch(attributes[\"selected_destinations\"], \"(^|.*,)tempo(,.*|$)\")",
     ]
   }
   output {

--- a/charts/k8s-monitoring/docs/examples/dataProcessors/kubernetesEnrichment/labels-and-annotations/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/dataProcessors/kubernetesEnrichment/labels-and-annotations/output.yaml
@@ -236,9 +236,10 @@ data:
     }
     otelcol.processor.filter "k8s_metadata_prometheus_gate_metrics_otlp" {
       error_mode = "ignore"
-      metrics {
-        metric = [
-          "not IsMatch(resource.attributes[\"selected_destinations\"], \"(^|.*,)prometheus(,.*|$)\")",
+      metric_conditions {
+        context    = "resource"
+        conditions = [
+          "not IsMatch(attributes[\"selected_destinations\"], \"(^|.*,)prometheus(,.*|$)\")",
         ]
       }
       output {
@@ -332,9 +333,10 @@ data:
     }
     otelcol.processor.filter "k8s_metadata_loki_gate_logs_otlp" {
       error_mode = "ignore"
-      logs {
-        log_record = [
-          "not IsMatch(resource.attributes[\"selected_destinations\"], \"(^|.*,)loki(,.*|$)\")",
+      log_conditions {
+        context    = "resource"
+        conditions = [
+          "not IsMatch(attributes[\"selected_destinations\"], \"(^|.*,)loki(,.*|$)\")",
         ]
       }
       output {
@@ -428,9 +430,10 @@ data:
     }
     otelcol.processor.filter "k8s_metadata_tempo_gate_traces_otlp" {
       error_mode = "ignore"
-      traces {
-        span = [
-          "not IsMatch(resource.attributes[\"selected_destinations\"], \"(^|.*,)tempo(,.*|$)\")",
+      trace_conditions {
+        context    = "resource"
+        conditions = [
+          "not IsMatch(attributes[\"selected_destinations\"], \"(^|.*,)tempo(,.*|$)\")",
         ]
       }
       output {

--- a/charts/k8s-monitoring/docs/examples/destination-router/alloy-logs.alloy
+++ b/charts/k8s-monitoring/docs/examples/destination-router/alloy-logs.alloy
@@ -634,9 +634,10 @@ otelcol.processor.transform "tenantrouter_metrics_otlp" {
 
 otelcol.processor.filter "tenantrouter_platform_gate_metrics_otlp" {
   error_mode = "ignore"
-  metrics {
-    metric = [
-      "not IsMatch(resource.attributes[\"selected_destinations\"], \"(^|.*,)platform(,.*|$)\")",
+  metric_conditions {
+    context    = "resource"
+    conditions = [
+      "not IsMatch(attributes[\"selected_destinations\"], \"(^|.*,)platform(,.*|$)\")",
     ]
   }
   output {
@@ -658,9 +659,10 @@ otelcol.processor.transform "tenantrouter_platform_gate_metrics_otlp_strip" {
 
 otelcol.processor.filter "tenantrouter_stack_a_gate_metrics_otlp" {
   error_mode = "ignore"
-  metrics {
-    metric = [
-      "not IsMatch(resource.attributes[\"selected_destinations\"], \"(^|.*,)stack-a(,.*|$)\")",
+  metric_conditions {
+    context    = "resource"
+    conditions = [
+      "not IsMatch(attributes[\"selected_destinations\"], \"(^|.*,)stack-a(,.*|$)\")",
     ]
   }
   output {
@@ -742,9 +744,10 @@ otelcol.processor.transform "tenantrouter_logs_otlp" {
 
 otelcol.processor.filter "tenantrouter_platform_gate_logs_otlp" {
   error_mode = "ignore"
-  logs {
-    log_record = [
-      "not IsMatch(resource.attributes[\"selected_destinations\"], \"(^|.*,)platform(,.*|$)\")",
+  log_conditions {
+    context    = "resource"
+    conditions = [
+      "not IsMatch(attributes[\"selected_destinations\"], \"(^|.*,)platform(,.*|$)\")",
     ]
   }
   output {
@@ -766,9 +769,10 @@ otelcol.processor.transform "tenantrouter_platform_gate_logs_otlp_strip" {
 
 otelcol.processor.filter "tenantrouter_stack_a_gate_logs_otlp" {
   error_mode = "ignore"
-  logs {
-    log_record = [
-      "not IsMatch(resource.attributes[\"selected_destinations\"], \"(^|.*,)stack-a(,.*|$)\")",
+  log_conditions {
+    context    = "resource"
+    conditions = [
+      "not IsMatch(attributes[\"selected_destinations\"], \"(^|.*,)stack-a(,.*|$)\")",
     ]
   }
   output {
@@ -806,9 +810,10 @@ otelcol.processor.transform "tenantrouter_traces_otlp" {
 
 otelcol.processor.filter "tenantrouter_platform_gate_traces_otlp" {
   error_mode = "ignore"
-  traces {
-    span = [
-      "not IsMatch(resource.attributes[\"selected_destinations\"], \"(^|.*,)platform(,.*|$)\")",
+  trace_conditions {
+    context    = "resource"
+    conditions = [
+      "not IsMatch(attributes[\"selected_destinations\"], \"(^|.*,)platform(,.*|$)\")",
     ]
   }
   output {
@@ -830,9 +835,10 @@ otelcol.processor.transform "tenantrouter_platform_gate_traces_otlp_strip" {
 
 otelcol.processor.filter "tenantrouter_stack_a_gate_traces_otlp" {
   error_mode = "ignore"
-  traces {
-    span = [
-      "not IsMatch(resource.attributes[\"selected_destinations\"], \"(^|.*,)stack-a(,.*|$)\")",
+  trace_conditions {
+    context    = "resource"
+    conditions = [
+      "not IsMatch(attributes[\"selected_destinations\"], \"(^|.*,)stack-a(,.*|$)\")",
     ]
   }
   output {

--- a/charts/k8s-monitoring/docs/examples/destination-router/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/destination-router/output.yaml
@@ -657,9 +657,10 @@ data:
     
     otelcol.processor.filter "tenantrouter_platform_gate_metrics_otlp" {
       error_mode = "ignore"
-      metrics {
-        metric = [
-          "not IsMatch(resource.attributes[\"selected_destinations\"], \"(^|.*,)platform(,.*|$)\")",
+      metric_conditions {
+        context    = "resource"
+        conditions = [
+          "not IsMatch(attributes[\"selected_destinations\"], \"(^|.*,)platform(,.*|$)\")",
         ]
       }
       output {
@@ -681,9 +682,10 @@ data:
     
     otelcol.processor.filter "tenantrouter_stack_a_gate_metrics_otlp" {
       error_mode = "ignore"
-      metrics {
-        metric = [
-          "not IsMatch(resource.attributes[\"selected_destinations\"], \"(^|.*,)stack-a(,.*|$)\")",
+      metric_conditions {
+        context    = "resource"
+        conditions = [
+          "not IsMatch(attributes[\"selected_destinations\"], \"(^|.*,)stack-a(,.*|$)\")",
         ]
       }
       output {
@@ -765,9 +767,10 @@ data:
     
     otelcol.processor.filter "tenantrouter_platform_gate_logs_otlp" {
       error_mode = "ignore"
-      logs {
-        log_record = [
-          "not IsMatch(resource.attributes[\"selected_destinations\"], \"(^|.*,)platform(,.*|$)\")",
+      log_conditions {
+        context    = "resource"
+        conditions = [
+          "not IsMatch(attributes[\"selected_destinations\"], \"(^|.*,)platform(,.*|$)\")",
         ]
       }
       output {
@@ -789,9 +792,10 @@ data:
     
     otelcol.processor.filter "tenantrouter_stack_a_gate_logs_otlp" {
       error_mode = "ignore"
-      logs {
-        log_record = [
-          "not IsMatch(resource.attributes[\"selected_destinations\"], \"(^|.*,)stack-a(,.*|$)\")",
+      log_conditions {
+        context    = "resource"
+        conditions = [
+          "not IsMatch(attributes[\"selected_destinations\"], \"(^|.*,)stack-a(,.*|$)\")",
         ]
       }
       output {
@@ -829,9 +833,10 @@ data:
     
     otelcol.processor.filter "tenantrouter_platform_gate_traces_otlp" {
       error_mode = "ignore"
-      traces {
-        span = [
-          "not IsMatch(resource.attributes[\"selected_destinations\"], \"(^|.*,)platform(,.*|$)\")",
+      trace_conditions {
+        context    = "resource"
+        conditions = [
+          "not IsMatch(attributes[\"selected_destinations\"], \"(^|.*,)platform(,.*|$)\")",
         ]
       }
       output {
@@ -853,9 +858,10 @@ data:
     
     otelcol.processor.filter "tenantrouter_stack_a_gate_traces_otlp" {
       error_mode = "ignore"
-      traces {
-        span = [
-          "not IsMatch(resource.attributes[\"selected_destinations\"], \"(^|.*,)stack-a(,.*|$)\")",
+      trace_conditions {
+        context    = "resource"
+        conditions = [
+          "not IsMatch(attributes[\"selected_destinations\"], \"(^|.*,)stack-a(,.*|$)\")",
         ]
       }
       output {

--- a/charts/k8s-monitoring/templates/dataProcessors/_config.alloy.tpl
+++ b/charts/k8s-monitoring/templates/dataProcessors/_config.alloy.tpl
@@ -242,25 +242,32 @@ loki.relabel {{ $name | quote }} {
   max_cache_size = 100
 }
 {{- else if eq .ecosystem "otlp" }}
-{{- $dropExpr := printf `not IsMatch(resource.attributes["selected_destinations"], "%s")` $keepRegex }}
+{{- $dropExpr := printf `not IsMatch(attributes["selected_destinations"], "%s")` $keepRegex }}
 {{- $block := include "pipeline.alloy.otlp.statementsBlock" .type }}
 otelcol.processor.filter {{ $name | quote }} {
   error_mode = "ignore"
-  {{ .type }} {
-    {{- if eq .type "metrics" }}
-    metric = [
+  {{- if eq .type "metrics" }}
+  metric_conditions {
+    context    = "resource"
+    conditions = [
       {{ $dropExpr | quote }},
     ]
-    {{- else if eq .type "logs" }}
-    log_record = [
-      {{ $dropExpr | quote }},
-    ]
-    {{- else if eq .type "traces" }}
-    span = [
-      {{ $dropExpr | quote }},
-    ]
-    {{- end }}
   }
+  {{- else if eq .type "logs" }}
+  log_conditions {
+    context    = "resource"
+    conditions = [
+      {{ $dropExpr | quote }},
+    ]
+  }
+  {{- else if eq .type "traces" }}
+  trace_conditions {
+    context    = "resource"
+    conditions = [
+      {{ $dropExpr | quote }},
+    ]
+  }
+  {{- end }}
   output {
     {{ .type }} = [otelcol.processor.transform.{{ $name }}_strip.input]
   }


### PR DESCRIPTION
# Description

Updates the filterprocessor config for the router destination to use `*_conditions` to take advantage of the filterprocessors ability to filter at the resource level instead of only at the log level.

Fixes https://github.com/grafana/k8s-monitoring-helm/issues/2937

<!--Authorship attestation. See AGENTS.md for details. AI agents must not check this box on behalf
of the user; the human author must check it themselves before the PR is ready for review.-->
## Authorship

-   [x] I, a human, wrote this pull request description myself.

<!--Please delete paragraphs that you did not use before submitting.-->
