### PR TITLE
annotationAutodiscovery: Add `attachNamespaceMetadata` option

### DIFF
--- a/charts/k8s-monitoring/CHANGELOG.md
+++ b/charts/k8s-monitoring/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+*   Add `attachNamespaceMetadata` to the annotationAutodiscovery feature to add namespace labels available for relabeling rules. (#2874) (@petewall)
 *   Collect Windows host metrics directly with Alloy by setting `hostMetrics.windowsHosts.source: alloy`, which uses the built-in `prometheus.exporter.windows` instead of deploying and scraping a separate Windows Exporter. (@petewall)
 *   Route the Host Metrics sub-features to different collectors. `hostMetrics.linuxHosts`, `hostMetrics.windowsHosts`, and `hostMetrics.energyMetrics` each accept their own `collector`, falling back to the feature-level `hostMetrics.collector`. This makes it possible to collect Linux host metrics on a Linux DaemonSet and Windows host metrics on a Windows DaemonSet at the same time. (@petewall)
 *   Add the `windowsEventLogs` feature, which gathers Windows event logs from Windows Nodes. (@petewall)

--- a/charts/k8s-monitoring/charts/feature-annotation-autodiscovery/README.md
+++ b/charts/k8s-monitoring/charts/feature-annotation-autodiscovery/README.md
@@ -77,6 +77,16 @@ Be sure perform actual integration testing in a live environment in the main [k8
 | annotations.metricsScrapeTimeout | string | `"k8s.grafana.com/metrics.scrapeTimeout"` | Annotation for overriding the scrape timeout for this service or pod. Value should be a duration like "15s, 1m". Overrides metrics.autoDiscover.scrapeTimeout |
 | annotations.scrape | string | `"k8s.grafana.com/scrape"` | Annotation for enabling scraping for this service or pod. Value should be either "true" or "false" |
 
+### Discovery Settings
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| attachNamespaceMetadata | bool | `false` | Attach namespace metadata to discovered pods and services. When enabled, all namespace labels are available for relabeling via `__meta_kubernetes_namespace_label_*`. |
+| excludeNamespaces | list | `[]` | The list of namespaces to exclude from autodiscovery. |
+| extraDiscoveryRules | string | `""` | Rule blocks to be added to the discovery.relabel component for discovered pods and services. These relabeling rules are applied pre-scrape against the targets from service discovery. Before the scrape, any remaining target labels that start with `__` (i.e. `__meta_kubernetes*`) are dropped. ([docs](https://grafana.com/docs/alloy/latest/reference/components/discovery/discovery.relabel/#rule-block)) |
+| labelSelectors | object | `{}` | Filter the list of discovered pods and services by labels. Example: `labelSelectors: { 'app': 'myapp' }` will only discover pods and services with the label `app=myapp`. Example: `labelSelectors: { 'app': ['myapp', 'myotherapp'] }` will only discover pods and services with the label `app=myapp` or `app=myotherapp`. |
+| namespaces | list | `[]` | The list of namespaces to include in autodiscovery. If empty, all namespaces are included. |
+
 ### Scrape Settings
 
 | Key | Type | Default | Description |
@@ -84,15 +94,6 @@ Be sure perform actual integration testing in a live environment in the main [k8
 | bearerToken | object | `{"enabled":true,"token":"/var/run/secrets/kubernetes.io/serviceaccount/token"}` | Sets bearer_token_file line in the prometheus.scrape annotation_autodiscovery. |
 | scrapeInterval | string | 60s | How frequently to scrape metrics from discovered pods and services. Only used if the `k8s.grafana.com/metrics.scrapeInterval` annotation is not set. Overrides `global.scrapeInterval`. |
 | scrapeTimeout | string | 10s | The scrape timeout for discovered pods and services. Only used if the `k8s.grafana.com/metrics.scrapeTimeout` annotation is not set. Overrides `global.scrapeTimeout`. |
-
-### Discovery Settings
-
-| Key | Type | Default | Description |
-|-----|------|---------|-------------|
-| excludeNamespaces | list | `[]` | The list of namespaces to exclude from autodiscovery. |
-| extraDiscoveryRules | string | `""` | Rule blocks to be added to the discovery.relabel component for discovered pods and services. These relabeling rules are applied pre-scrape against the targets from service discovery. Before the scrape, any remaining target labels that start with `__` (i.e. `__meta_kubernetes*`) are dropped. ([docs](https://grafana.com/docs/alloy/latest/reference/components/discovery/discovery.relabel/#rule-block)) |
-| labelSelectors | object | `{}` | Filter the list of discovered pods and services by labels. Example: `labelSelectors: { 'app': 'myapp' }` will only discover pods and services with the label `app=myapp`. Example: `labelSelectors: { 'app': ['myapp', 'myotherapp'] }` will only discover pods and services with the label `app=myapp` or `app=myotherapp`. |
-| namespaces | list | `[]` | The list of namespaces to include in autodiscovery. If empty, all namespaces are included. |
 
 ### Metric Processing Settings
 

--- a/charts/k8s-monitoring/charts/feature-annotation-autodiscovery/templates/_nodes_common.tpl
+++ b/charts/k8s-monitoring/charts/feature-annotation-autodiscovery/templates/_nodes_common.tpl
@@ -1,15 +1,20 @@
-{{- define "feature.annotationAutodiscovery.attachNodeMetadata" }}
-{{- $attachMetadata := false -}}
-{{- $attachMetadata = or $attachMetadata .Values.nodeLabels.nodePool -}}
-{{- $attachMetadata = or $attachMetadata .Values.nodeLabels.region -}}
-{{- $attachMetadata = or $attachMetadata .Values.nodeLabels.availabilityZone -}}
-{{- $attachMetadata = or $attachMetadata .Values.nodeLabels.nodeRole -}}
-{{- $attachMetadata = or $attachMetadata .Values.nodeLabels.nodeOS -}}
-{{- $attachMetadata = or $attachMetadata .Values.nodeLabels.nodeArchitecture -}}
-{{- $attachMetadata = or $attachMetadata .Values.nodeLabels.instanceType -}}
-{{- if eq $attachMetadata true }}
+{{- define "feature.annotationAutodiscovery.attachMetadata" }}
+{{- $attachNodeMetadata := false -}}
+{{- $attachNodeMetadata = or $attachNodeMetadata .Values.nodeLabels.nodePool -}}
+{{- $attachNodeMetadata = or $attachNodeMetadata .Values.nodeLabels.region -}}
+{{- $attachNodeMetadata = or $attachNodeMetadata .Values.nodeLabels.availabilityZone -}}
+{{- $attachNodeMetadata = or $attachNodeMetadata .Values.nodeLabels.nodeRole -}}
+{{- $attachNodeMetadata = or $attachNodeMetadata .Values.nodeLabels.nodeOS -}}
+{{- $attachNodeMetadata = or $attachNodeMetadata .Values.nodeLabels.nodeArchitecture -}}
+{{- $attachNodeMetadata = or $attachNodeMetadata .Values.nodeLabels.instanceType -}}
+{{- if or .Values.attachNamespaceMetadata $attachNodeMetadata }}
 attach_metadata {
+{{- if .Values.attachNamespaceMetadata }}
+  namespace = true
+{{- end }}
+{{- if $attachNodeMetadata }}
   node = true
+{{- end }}
 }
 {{- end }}
 {{- end }}

--- a/charts/k8s-monitoring/charts/feature-annotation-autodiscovery/templates/_pods.alloy.tpl
+++ b/charts/k8s-monitoring/charts/feature-annotation-autodiscovery/templates/_pods.alloy.tpl
@@ -28,7 +28,7 @@ discovery.kubernetes "pods" {
     label = {{ $labelSelectors | join "," | quote }}
   }
 {{- end }}
-{{- include "feature.annotationAutodiscovery.attachNodeMetadata" . | indent 2 }}
+{{- include "feature.annotationAutodiscovery.attachMetadata" . | indent 2 }}
 } // discovery.kubernetes "pods"
 
 discovery.relabel "annotation_autodiscovery_pods" {

--- a/charts/k8s-monitoring/charts/feature-annotation-autodiscovery/templates/_services.alloy.tpl
+++ b/charts/k8s-monitoring/charts/feature-annotation-autodiscovery/templates/_services.alloy.tpl
@@ -28,6 +28,11 @@ discovery.kubernetes "services" {
     label = {{ $labelSelectors | join "," | quote }}
   }
 {{- end }}
+{{- if .Values.attachNamespaceMetadata }}
+  attach_metadata {
+    namespace = true
+  }
+{{- end }}
 } // discovery.kubernetes "services"
 
 discovery.relabel "annotation_autodiscovery_services" {

--- a/charts/k8s-monitoring/charts/feature-annotation-autodiscovery/tests/__snapshot__/namespace_metadata_test.yaml.snap
+++ b/charts/k8s-monitoring/charts/feature-annotation-autodiscovery/tests/__snapshot__/namespace_metadata_test.yaml.snap
@@ -1,0 +1,701 @@
+should attach both namespace and node metadata to pods when both are enabled:
+  1: |
+    |-
+      declare "annotation_autodiscovery" {
+        argument "metrics_destinations" {
+          comment = "Must be a list of metric destinations where collected metrics should be forwarded to"
+        }
+
+        discovery.kubernetes "pods" {
+          role = "pod"
+          attach_metadata {
+            namespace = true
+            node = true
+          }
+        } // discovery.kubernetes "pods"
+
+        discovery.relabel "annotation_autodiscovery_pods" {
+          targets = discovery.kubernetes.pods.targets
+          rule {
+            source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_scrape"]
+            regex = "true"
+            action = "keep"
+          }
+          // Only keep pods that are running, ready, and not init containers.
+          rule {
+            source_labels = [
+              "__meta_kubernetes_pod_phase",
+              "__meta_kubernetes_pod_ready",
+              "__meta_kubernetes_pod_container_init",
+            ]
+            regex = "Running;true;false"
+            action = "keep"
+          }
+          rule {
+            source_labels = ["__meta_kubernetes_pod_name"]
+            target_label = "pod"
+          }
+          rule {
+            source_labels = ["__meta_kubernetes_pod_container_name"]
+            target_label = "container"
+          }
+          rule {
+            source_labels = ["__meta_kubernetes_namespace"]
+            target_label = "namespace"
+          }
+          rule {
+            source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_job"]
+            target_label = "job"
+          }
+          rule {
+            source_labels = ["job", "__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+            regex = ";(.+)"
+            target_label = "job"
+          }
+          rule {
+            source_labels = ["job", "__meta_kubernetes_pod_label_app"]
+            regex = ";(.+)"
+            target_label = "job"
+          }
+          rule {
+            source_labels = ["job", "container"]
+            regex = ";(.+)"
+            target_label = "job"
+          }
+          rule {
+            source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_instance"]
+            target_label = "instance"
+          }
+
+          // Rules to choose the right container
+          rule {
+            source_labels = ["container"]
+            target_label = "__tmp_container"
+          }
+          rule {
+            source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_container"]
+            regex = "(.+)"
+            target_label = "__tmp_container"
+          }
+          rule {
+            source_labels = ["container"]
+            action = "keepequal"
+            target_label = "__tmp_container"
+          }
+          rule {
+            action = "labeldrop"
+            regex = "__tmp_container"
+          }
+
+          // Set metrics path
+          rule {
+            source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_path"]
+            regex = "(.+)"
+            target_label = "__metrics_path__"
+          }
+
+          // Set metrics scraping URL parameters
+          rule {
+            action = "labelmap"
+            regex = "__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_param_(.+)"
+            replacement = "__param_$1"
+          }
+
+          // Choose the pod port
+          // The discovery generates a target for each declared container port of the pod.
+          // If the metricsPortName annotation has value, keep only the target where the port name matches the one of the annotation.
+          rule {
+            source_labels = ["__meta_kubernetes_pod_container_port_name"]
+            target_label = "__tmp_port"
+          }
+          rule {
+            source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_portName"]
+            regex = "(.+)"
+            target_label = "__tmp_port"
+          }
+          rule {
+            source_labels = ["__meta_kubernetes_pod_container_port_name"]
+            action = "keepequal"
+            target_label = "__tmp_port"
+          }
+          rule {
+            action = "labeldrop"
+            regex = "__tmp_port"
+          }
+
+          // If the metrics port number annotation has a value, override the target address to use it, regardless whether it is
+          // one of the declared ports on that Pod.
+          rule {
+            source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_portNumber", "__meta_kubernetes_pod_ip"]
+            regex = "(\\d+);(([A-Fa-f0-9]{1,4}::?){1,7}[A-Fa-f0-9]{1,4})"
+            replacement = "[$2]:$1" // IPv6
+            target_label = "__address__"
+          }
+          rule {
+            source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_portNumber", "__meta_kubernetes_pod_ip"]
+            regex = "(\\d+);((([0-9]+?)(\\.|$)){4})" // IPv4, takes priority over IPv6 when both exists
+            replacement = "$2:$1"
+            target_label = "__address__"
+          }
+
+          rule {
+            source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_scheme"]
+            regex = "(.+)"
+            target_label = "__scheme__"
+          }
+
+          rule {
+            source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_scrapeInterval"]
+            regex = "(.+)"
+            target_label = "__scrape_interval__"
+          }
+          rule {
+            source_labels = ["__scrape_interval__"]
+            regex = ""
+            replacement = "60s"
+            target_label = "__scrape_interval__"
+          }
+          rule {
+            source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_scrapeTimeout"]
+            regex = "(.+)"
+            target_label = "__scrape_timeout__"
+          }
+          rule {
+            source_labels = ["__scrape_timeout__"]
+            regex = ""
+            replacement = "10s"
+            target_label = "__scrape_timeout__"
+          }
+
+          rule {
+            source_labels = [
+              "__meta_kubernetes_node_label_karpenter_sh_nodepool",
+              "__meta_kubernetes_node_label_cloud_google_com_gke_nodepool",
+              "__meta_kubernetes_node_label_eks_amazonaws_com_nodegroup",
+              "__meta_kubernetes_node_label_kubernetes_azure_com_agentpool",
+              "__meta_kubernetes_node_label_agentpool",
+            ]
+            regex = "^(?:;*)?([^;]+).*$"
+            target_label = "nodepool"
+          }
+        } // discovery.relabel "annotation_autodiscovery_pods"
+
+        discovery.kubernetes "services" {
+          role = "service"
+          attach_metadata {
+            namespace = true
+          }
+        } // discovery.kubernetes "services"
+
+        discovery.relabel "annotation_autodiscovery_services" {
+          targets = discovery.kubernetes.services.targets
+          rule {
+            source_labels = ["__meta_kubernetes_service_annotation_k8s_grafana_com_scrape"]
+            regex = "true"
+            action = "keep"
+          }
+          rule {
+            source_labels = ["__meta_kubernetes_service_name"]
+            target_label = "service"
+          }
+          rule {
+            source_labels = ["__meta_kubernetes_namespace"]
+            target_label = "namespace"
+          }
+          rule {
+            source_labels = ["__meta_kubernetes_service_annotation_k8s_grafana_com_job"]
+            target_label = "job"
+          }
+          rule {
+            source_labels = ["job", "__meta_kubernetes_service_label_app_kubernetes_io_name"]
+            regex = ";(.+)"
+            target_label = "job"
+          }
+          rule {
+            source_labels = ["job", "__meta_kubernetes_service_label_app"]
+            regex = ";(.+)"
+            target_label = "job"
+          }
+          rule {
+            source_labels = ["job", "service"]
+            regex = ";(.+)"
+            target_label = "job"
+          }
+          rule {
+            source_labels = ["__meta_kubernetes_service_annotation_k8s_grafana_com_instance"]
+            target_label = "instance"
+          }
+
+          // Set metrics path
+          rule {
+            source_labels = ["__meta_kubernetes_service_annotation_k8s_grafana_com_metrics_path"]
+            target_label = "__metrics_path__"
+          }
+
+          // Set metrics scraping URL parameters
+          rule {
+            action = "labelmap"
+            regex = "__meta_kubernetes_service_annotation_k8s_grafana_com_metrics_param_(.+)"
+            replacement = "__param_$1"
+          }
+
+          // Choose the service port
+          rule {
+            source_labels = ["__meta_kubernetes_service_port_name"]
+            target_label = "__tmp_port"
+          }
+          rule {
+            source_labels = ["__meta_kubernetes_service_annotation_k8s_grafana_com_metrics_portName"]
+            regex = "(.+)"
+            target_label = "__tmp_port"
+          }
+          rule {
+            source_labels = ["__meta_kubernetes_service_port_name"]
+            action = "keepequal"
+            target_label = "__tmp_port"
+          }
+
+          rule {
+            source_labels = ["__meta_kubernetes_service_port_number"]
+            target_label = "__tmp_port"
+          }
+          rule {
+            source_labels = ["__meta_kubernetes_service_annotation_k8s_grafana_com_metrics_portNumber"]
+            regex = "(.+)"
+            target_label = "__tmp_port"
+          }
+          rule {
+            source_labels = ["__meta_kubernetes_service_port_number"]
+            action = "keepequal"
+            target_label = "__tmp_port"
+          }
+          rule {
+            action = "labeldrop"
+            regex = "__tmp_port"
+          }
+
+          rule {
+            source_labels = ["__meta_kubernetes_service_annotation_k8s_grafana_com_metrics_scheme"]
+            regex = "(.+)"
+            target_label = "__scheme__"
+          }
+
+          rule {
+            source_labels = ["__meta_kubernetes_service_annotation_k8s_grafana_com_metrics_scrapeInterval"]
+            regex = "(.+)"
+            target_label = "__scrape_interval__"
+          }
+          rule {
+            source_labels = ["__scrape_interval__"]
+            regex = ""
+            replacement = "60s"
+            target_label = "__scrape_interval__"
+          }
+          rule {
+            source_labels = ["__meta_kubernetes_service_annotation_k8s_grafana_com_metrics_scrapeTimeout"]
+            regex = "(.+)"
+            target_label = "__scrape_timeout__"
+          }
+          rule {
+            source_labels = ["__scrape_timeout__"]
+            regex = ""
+            replacement = "10s"
+            target_label = "__scrape_timeout__"
+          }
+        } // discovery.relabel "annotation_autodiscovery_services"
+
+        discovery.relabel "annotation_autodiscovery_http" {
+          targets = array.concat(discovery.relabel.annotation_autodiscovery_pods.output, discovery.relabel.annotation_autodiscovery_services.output)
+          rule {
+            source_labels = ["__scheme__"]
+            regex = "https"
+            action = "drop"
+          }
+        } // discovery.relabel "annotation_autodiscovery_http"
+
+        discovery.relabel "annotation_autodiscovery_https" {
+          targets = array.concat(discovery.relabel.annotation_autodiscovery_pods.output, discovery.relabel.annotation_autodiscovery_services.output)
+          rule {
+            source_labels = ["__scheme__"]
+            regex = "https"
+            action = "keep"
+          }
+        } // discovery.relabel "annotation_autodiscovery_https"
+
+        prometheus.scrape "annotation_autodiscovery_http" {
+          targets = discovery.relabel.annotation_autodiscovery_http.output
+          honor_labels = true
+          bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+          scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
+          scrape_classic_histograms = false
+          scrape_native_histograms = false
+          convert_classic_histograms_to_nhcb = false
+          clustering {
+            enabled = true
+          }
+
+          forward_to = argument.metrics_destinations.value
+        } // prometheus.scrape "annotation_autodiscovery_http"
+
+        prometheus.scrape "annotation_autodiscovery_https" {
+          targets = discovery.relabel.annotation_autodiscovery_https.output
+          honor_labels = true
+          bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+          tls_config {
+            insecure_skip_verify = true
+          }
+          scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
+          scrape_classic_histograms = false
+          scrape_native_histograms = false
+          convert_classic_histograms_to_nhcb = false
+          clustering {
+            enabled = true
+          }
+
+          forward_to = argument.metrics_destinations.value
+        } // prometheus.scrape "annotation_autodiscovery_https"
+      } // declare "annotation_autodiscovery"
+should attach namespace metadata to pods and services when attachNamespaceMetadata is enabled:
+  1: |
+    |-
+      declare "annotation_autodiscovery" {
+        argument "metrics_destinations" {
+          comment = "Must be a list of metric destinations where collected metrics should be forwarded to"
+        }
+
+        discovery.kubernetes "pods" {
+          role = "pod"
+          attach_metadata {
+            namespace = true
+          }
+        } // discovery.kubernetes "pods"
+
+        discovery.relabel "annotation_autodiscovery_pods" {
+          targets = discovery.kubernetes.pods.targets
+          rule {
+            source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_scrape"]
+            regex = "true"
+            action = "keep"
+          }
+          // Only keep pods that are running, ready, and not init containers.
+          rule {
+            source_labels = [
+              "__meta_kubernetes_pod_phase",
+              "__meta_kubernetes_pod_ready",
+              "__meta_kubernetes_pod_container_init",
+            ]
+            regex = "Running;true;false"
+            action = "keep"
+          }
+          rule {
+            source_labels = ["__meta_kubernetes_pod_name"]
+            target_label = "pod"
+          }
+          rule {
+            source_labels = ["__meta_kubernetes_pod_container_name"]
+            target_label = "container"
+          }
+          rule {
+            source_labels = ["__meta_kubernetes_namespace"]
+            target_label = "namespace"
+          }
+          rule {
+            source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_job"]
+            target_label = "job"
+          }
+          rule {
+            source_labels = ["job", "__meta_kubernetes_pod_label_app_kubernetes_io_name"]
+            regex = ";(.+)"
+            target_label = "job"
+          }
+          rule {
+            source_labels = ["job", "__meta_kubernetes_pod_label_app"]
+            regex = ";(.+)"
+            target_label = "job"
+          }
+          rule {
+            source_labels = ["job", "container"]
+            regex = ";(.+)"
+            target_label = "job"
+          }
+          rule {
+            source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_instance"]
+            target_label = "instance"
+          }
+
+          // Rules to choose the right container
+          rule {
+            source_labels = ["container"]
+            target_label = "__tmp_container"
+          }
+          rule {
+            source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_container"]
+            regex = "(.+)"
+            target_label = "__tmp_container"
+          }
+          rule {
+            source_labels = ["container"]
+            action = "keepequal"
+            target_label = "__tmp_container"
+          }
+          rule {
+            action = "labeldrop"
+            regex = "__tmp_container"
+          }
+
+          // Set metrics path
+          rule {
+            source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_path"]
+            regex = "(.+)"
+            target_label = "__metrics_path__"
+          }
+
+          // Set metrics scraping URL parameters
+          rule {
+            action = "labelmap"
+            regex = "__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_param_(.+)"
+            replacement = "__param_$1"
+          }
+
+          // Choose the pod port
+          // The discovery generates a target for each declared container port of the pod.
+          // If the metricsPortName annotation has value, keep only the target where the port name matches the one of the annotation.
+          rule {
+            source_labels = ["__meta_kubernetes_pod_container_port_name"]
+            target_label = "__tmp_port"
+          }
+          rule {
+            source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_portName"]
+            regex = "(.+)"
+            target_label = "__tmp_port"
+          }
+          rule {
+            source_labels = ["__meta_kubernetes_pod_container_port_name"]
+            action = "keepequal"
+            target_label = "__tmp_port"
+          }
+          rule {
+            action = "labeldrop"
+            regex = "__tmp_port"
+          }
+
+          // If the metrics port number annotation has a value, override the target address to use it, regardless whether it is
+          // one of the declared ports on that Pod.
+          rule {
+            source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_portNumber", "__meta_kubernetes_pod_ip"]
+            regex = "(\\d+);(([A-Fa-f0-9]{1,4}::?){1,7}[A-Fa-f0-9]{1,4})"
+            replacement = "[$2]:$1" // IPv6
+            target_label = "__address__"
+          }
+          rule {
+            source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_portNumber", "__meta_kubernetes_pod_ip"]
+            regex = "(\\d+);((([0-9]+?)(\\.|$)){4})" // IPv4, takes priority over IPv6 when both exists
+            replacement = "$2:$1"
+            target_label = "__address__"
+          }
+
+          rule {
+            source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_scheme"]
+            regex = "(.+)"
+            target_label = "__scheme__"
+          }
+
+          rule {
+            source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_scrapeInterval"]
+            regex = "(.+)"
+            target_label = "__scrape_interval__"
+          }
+          rule {
+            source_labels = ["__scrape_interval__"]
+            regex = ""
+            replacement = "60s"
+            target_label = "__scrape_interval__"
+          }
+          rule {
+            source_labels = ["__meta_kubernetes_pod_annotation_k8s_grafana_com_metrics_scrapeTimeout"]
+            regex = "(.+)"
+            target_label = "__scrape_timeout__"
+          }
+          rule {
+            source_labels = ["__scrape_timeout__"]
+            regex = ""
+            replacement = "10s"
+            target_label = "__scrape_timeout__"
+          }
+        } // discovery.relabel "annotation_autodiscovery_pods"
+
+        discovery.kubernetes "services" {
+          role = "service"
+          attach_metadata {
+            namespace = true
+          }
+        } // discovery.kubernetes "services"
+
+        discovery.relabel "annotation_autodiscovery_services" {
+          targets = discovery.kubernetes.services.targets
+          rule {
+            source_labels = ["__meta_kubernetes_service_annotation_k8s_grafana_com_scrape"]
+            regex = "true"
+            action = "keep"
+          }
+          rule {
+            source_labels = ["__meta_kubernetes_service_name"]
+            target_label = "service"
+          }
+          rule {
+            source_labels = ["__meta_kubernetes_namespace"]
+            target_label = "namespace"
+          }
+          rule {
+            source_labels = ["__meta_kubernetes_service_annotation_k8s_grafana_com_job"]
+            target_label = "job"
+          }
+          rule {
+            source_labels = ["job", "__meta_kubernetes_service_label_app_kubernetes_io_name"]
+            regex = ";(.+)"
+            target_label = "job"
+          }
+          rule {
+            source_labels = ["job", "__meta_kubernetes_service_label_app"]
+            regex = ";(.+)"
+            target_label = "job"
+          }
+          rule {
+            source_labels = ["job", "service"]
+            regex = ";(.+)"
+            target_label = "job"
+          }
+          rule {
+            source_labels = ["__meta_kubernetes_service_annotation_k8s_grafana_com_instance"]
+            target_label = "instance"
+          }
+
+          // Set metrics path
+          rule {
+            source_labels = ["__meta_kubernetes_service_annotation_k8s_grafana_com_metrics_path"]
+            target_label = "__metrics_path__"
+          }
+
+          // Set metrics scraping URL parameters
+          rule {
+            action = "labelmap"
+            regex = "__meta_kubernetes_service_annotation_k8s_grafana_com_metrics_param_(.+)"
+            replacement = "__param_$1"
+          }
+
+          // Choose the service port
+          rule {
+            source_labels = ["__meta_kubernetes_service_port_name"]
+            target_label = "__tmp_port"
+          }
+          rule {
+            source_labels = ["__meta_kubernetes_service_annotation_k8s_grafana_com_metrics_portName"]
+            regex = "(.+)"
+            target_label = "__tmp_port"
+          }
+          rule {
+            source_labels = ["__meta_kubernetes_service_port_name"]
+            action = "keepequal"
+            target_label = "__tmp_port"
+          }
+
+          rule {
+            source_labels = ["__meta_kubernetes_service_port_number"]
+            target_label = "__tmp_port"
+          }
+          rule {
+            source_labels = ["__meta_kubernetes_service_annotation_k8s_grafana_com_metrics_portNumber"]
+            regex = "(.+)"
+            target_label = "__tmp_port"
+          }
+          rule {
+            source_labels = ["__meta_kubernetes_service_port_number"]
+            action = "keepequal"
+            target_label = "__tmp_port"
+          }
+          rule {
+            action = "labeldrop"
+            regex = "__tmp_port"
+          }
+
+          rule {
+            source_labels = ["__meta_kubernetes_service_annotation_k8s_grafana_com_metrics_scheme"]
+            regex = "(.+)"
+            target_label = "__scheme__"
+          }
+
+          rule {
+            source_labels = ["__meta_kubernetes_service_annotation_k8s_grafana_com_metrics_scrapeInterval"]
+            regex = "(.+)"
+            target_label = "__scrape_interval__"
+          }
+          rule {
+            source_labels = ["__scrape_interval__"]
+            regex = ""
+            replacement = "60s"
+            target_label = "__scrape_interval__"
+          }
+          rule {
+            source_labels = ["__meta_kubernetes_service_annotation_k8s_grafana_com_metrics_scrapeTimeout"]
+            regex = "(.+)"
+            target_label = "__scrape_timeout__"
+          }
+          rule {
+            source_labels = ["__scrape_timeout__"]
+            regex = ""
+            replacement = "10s"
+            target_label = "__scrape_timeout__"
+          }
+        } // discovery.relabel "annotation_autodiscovery_services"
+
+        discovery.relabel "annotation_autodiscovery_http" {
+          targets = array.concat(discovery.relabel.annotation_autodiscovery_pods.output, discovery.relabel.annotation_autodiscovery_services.output)
+          rule {
+            source_labels = ["__scheme__"]
+            regex = "https"
+            action = "drop"
+          }
+        } // discovery.relabel "annotation_autodiscovery_http"
+
+        discovery.relabel "annotation_autodiscovery_https" {
+          targets = array.concat(discovery.relabel.annotation_autodiscovery_pods.output, discovery.relabel.annotation_autodiscovery_services.output)
+          rule {
+            source_labels = ["__scheme__"]
+            regex = "https"
+            action = "keep"
+          }
+        } // discovery.relabel "annotation_autodiscovery_https"
+
+        prometheus.scrape "annotation_autodiscovery_http" {
+          targets = discovery.relabel.annotation_autodiscovery_http.output
+          honor_labels = true
+          bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+          scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
+          scrape_classic_histograms = false
+          scrape_native_histograms = false
+          convert_classic_histograms_to_nhcb = false
+          clustering {
+            enabled = true
+          }
+
+          forward_to = argument.metrics_destinations.value
+        } // prometheus.scrape "annotation_autodiscovery_http"
+
+        prometheus.scrape "annotation_autodiscovery_https" {
+          targets = discovery.relabel.annotation_autodiscovery_https.output
+          honor_labels = true
+          bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+          tls_config {
+            insecure_skip_verify = true
+          }
+          scrape_protocols = ["OpenMetricsText1.0.0","OpenMetricsText0.0.1","PrometheusText0.0.4"]
+          scrape_classic_histograms = false
+          scrape_native_histograms = false
+          convert_classic_histograms_to_nhcb = false
+          clustering {
+            enabled = true
+          }
+
+          forward_to = argument.metrics_destinations.value
+        } // prometheus.scrape "annotation_autodiscovery_https"
+      } // declare "annotation_autodiscovery"

--- a/charts/k8s-monitoring/charts/feature-annotation-autodiscovery/tests/namespace_metadata_test.yaml
+++ b/charts/k8s-monitoring/charts/feature-annotation-autodiscovery/tests/namespace_metadata_test.yaml
@@ -1,0 +1,59 @@
+# yamllint disable rule:document-start rule:line-length rule:trailing-spaces
+suite: Feature - Annotation Autodiscovery - Namespace Metadata
+templates:
+  - test/configmap.yaml
+tests:
+  - it: should not add the attach_metadata block by default
+    set:
+      testing: {enabled: true}
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - notMatchRegex:
+          path: data["module.alloy"]
+          pattern: attach_metadata
+
+  - it: should attach namespace metadata to pods and services when attachNamespaceMetadata is enabled
+    set:
+      testing: {enabled: true}
+      attachNamespaceMetadata: true
+    asserts:
+      - isKind:
+          of: ConfigMap
+      # discovery.kubernetes "pods"
+      - matchRegex:
+          path: data["module.alloy"]
+          # The pattern should look like this, but since the regex is escaped, it will be a bit different
+          # attach_metadata {
+          #   namespace = true
+          # }
+          pattern: |-
+            \s*  attach_metadata \{
+            \s*    namespace = true
+            \s*  \}
+      - matchSnapshot:
+          path: data["module.alloy"]
+
+  - it: should attach both namespace and node metadata to pods when both are enabled
+    set:
+      testing: {enabled: true}
+      attachNamespaceMetadata: true
+      nodeLabels:
+        nodePool: true
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - matchRegex:
+          path: data["module.alloy"]
+          # The pattern should look like this, but since the regex is escaped, it will be a bit different
+          # attach_metadata {
+          #   namespace = true
+          #   node = true
+          # }
+          pattern: |-
+            \s*  attach_metadata \{
+            \s*    namespace = true
+            \s*    node = true
+            \s*  \}
+      - matchSnapshot:
+          path: data["module.alloy"]

--- a/charts/k8s-monitoring/charts/feature-annotation-autodiscovery/values.schema.json
+++ b/charts/k8s-monitoring/charts/feature-annotation-autodiscovery/values.schema.json
@@ -40,6 +40,9 @@
                 }
             }
         },
+        "attachNamespaceMetadata": {
+            "type": "boolean"
+        },
         "bearerToken": {
             "type": "object",
             "properties": {

--- a/charts/k8s-monitoring/charts/feature-annotation-autodiscovery/values.yaml
+++ b/charts/k8s-monitoring/charts/feature-annotation-autodiscovery/values.yaml
@@ -90,6 +90,11 @@ excludeNamespaces: []
 # @section -- Discovery Settings
 labelSelectors: {}
 
+# -- Attach namespace metadata to discovered pods and services. When enabled, all namespace labels
+# are available for relabeling via `__meta_kubernetes_namespace_label_*`.
+# @section -- Discovery Settings
+attachNamespaceMetadata: false
+
 # Configures which node labels to attach to the metrics collected for pod autodiscovery jobs
 nodeLabels:
   # -- Whether or not to attach the nodepool label


### PR DESCRIPTION
# Description

This will allow for namespace labels and annotations to be available to the metrics from the pods and services discovered by this feature.

Fixes #2874 

<!--Authorship attestation. See AGENTS.md for details. AI agents must not check this box on behalf
of the user; the human author must check it themselves before the PR is ready for review.-->
## Authorship

-   [X] I, a human, wrote this pull request description myself.

<!--Please delete paragraphs that you did not use before submitting.-->
