### PR TITLE
Fix instance schema in example and testing instructions

### DIFF
--- a/charts/k8s-monitoring/charts/feature-annotation-autodiscovery/README.md
+++ b/charts/k8s-monitoring/charts/feature-annotation-autodiscovery/README.md
@@ -34,7 +34,7 @@ You can use several other annotations to customize the behavior of the scrape co
 
 ## Testing
 
-This chart contains unit tests to verify the generated configuration. The hidden value `deployAsConfigMap` will render
+This chart contains unit tests to verify the generated configuration. The hidden value `testing.enabled` will render
 the generated configuration into a ConfigMap object. While this ConfigMap is not used during regular operation, you can
 use it to show the outcome of a given values file.
 

--- a/charts/k8s-monitoring/charts/feature-annotation-autodiscovery/README.md.gotmpl
+++ b/charts/k8s-monitoring/charts/feature-annotation-autodiscovery/README.md.gotmpl
@@ -36,7 +36,7 @@ You can use several other annotations to customize the behavior of the scrape co
 
 ## Testing
 
-This chart contains unit tests to verify the generated configuration. The hidden value `deployAsConfigMap` will render
+This chart contains unit tests to verify the generated configuration. The hidden value `testing.enabled` will render
 the generated configuration into a ConfigMap object. While this ConfigMap is not used during regular operation, you can
 use it to show the outcome of a given values file.
 

--- a/charts/k8s-monitoring/charts/feature-application-observability/README.md
+++ b/charts/k8s-monitoring/charts/feature-application-observability/README.md
@@ -54,7 +54,7 @@ To pin a specific service name for a workload, set the `resource.opentelemetry.i
 
 ## Testing
 
-This chart contains unit tests to verify the generated configuration. The hidden value `deployAsConfigMap` will render
+This chart contains unit tests to verify the generated configuration. The hidden value `testing.enabled` will render
 the generated configuration into a ConfigMap object. While this ConfigMap is not used during regular operation, you can
 use it to show the outcome of a given values file.
 

--- a/charts/k8s-monitoring/charts/feature-application-observability/README.md.gotmpl
+++ b/charts/k8s-monitoring/charts/feature-application-observability/README.md.gotmpl
@@ -56,7 +56,7 @@ To pin a specific service name for a workload, set the `resource.opentelemetry.i
 
 ## Testing
 
-This chart contains unit tests to verify the generated configuration. The hidden value `deployAsConfigMap` will render
+This chart contains unit tests to verify the generated configuration. The hidden value `testing.enabled` will render
 the generated configuration into a ConfigMap object. While this ConfigMap is not used during regular operation, you can
 use it to show the outcome of a given values file.
 

--- a/charts/k8s-monitoring/charts/feature-auto-instrumentation/README.md
+++ b/charts/k8s-monitoring/charts/feature-auto-instrumentation/README.md
@@ -16,7 +16,7 @@ autoInstrumentation:
 
 ## Testing
 
-This chart contains unit tests to verify the generated configuration. The hidden value `deployAsConfigMap` will render
+This chart contains unit tests to verify the generated configuration. The hidden value `testing.enabled` will render
 the generated configuration into a ConfigMap object. While this ConfigMap is not used during regular operation, you can
 use it to show the outcome of a given values file.
 

--- a/charts/k8s-monitoring/charts/feature-auto-instrumentation/README.md.gotmpl
+++ b/charts/k8s-monitoring/charts/feature-auto-instrumentation/README.md.gotmpl
@@ -18,7 +18,7 @@ autoInstrumentation:
 
 ## Testing
 
-This chart contains unit tests to verify the generated configuration. The hidden value `deployAsConfigMap` will render
+This chart contains unit tests to verify the generated configuration. The hidden value `testing.enabled` will render
 the generated configuration into a ConfigMap object. While this ConfigMap is not used during regular operation, you can
 use it to show the outcome of a given values file.
 

--- a/charts/k8s-monitoring/charts/feature-cluster-events/README.md
+++ b/charts/k8s-monitoring/charts/feature-cluster-events/README.md
@@ -20,7 +20,7 @@ Events are captured as logs and are annotated with additional metadata to make t
 
 ## Testing
 
-This chart contains unit tests to verify the generated configuration. The hidden value `deployAsConfigMap` will render
+This chart contains unit tests to verify the generated configuration. The hidden value `testing.enabled` will render
 the generated configuration into a ConfigMap object. While this ConfigMap is not used during regular operation, you can
 use it to show the outcome of a given values file.
 

--- a/charts/k8s-monitoring/charts/feature-cluster-events/README.md.gotmpl
+++ b/charts/k8s-monitoring/charts/feature-cluster-events/README.md.gotmpl
@@ -22,7 +22,7 @@ Events are captured as logs and are annotated with additional metadata to make t
 
 ## Testing
 
-This chart contains unit tests to verify the generated configuration. The hidden value `deployAsConfigMap` will render
+This chart contains unit tests to verify the generated configuration. The hidden value `testing.enabled` will render
 the generated configuration into a ConfigMap object. While this ConfigMap is not used during regular operation, you can
 use it to show the outcome of a given values file.
 

--- a/charts/k8s-monitoring/charts/feature-cluster-metrics/README.md
+++ b/charts/k8s-monitoring/charts/feature-cluster-metrics/README.md
@@ -79,7 +79,7 @@ To do so, use `extraMetricProcessingRules` section in the values file to add arb
 
 ## Testing
 
-This chart contains unit tests to verify the generated configuration. The hidden value `deployAsConfigMap` will render
+This chart contains unit tests to verify the generated configuration. The hidden value `testing.enabled` will render
 the generated configuration into a ConfigMap object. While this ConfigMap is not used during regular operation, you can
 use it to show the outcome of a given values file.
 

--- a/charts/k8s-monitoring/charts/feature-cluster-metrics/README.md.gotmpl
+++ b/charts/k8s-monitoring/charts/feature-cluster-metrics/README.md.gotmpl
@@ -81,7 +81,7 @@ To do so, use `extraMetricProcessingRules` section in the values file to add arb
 
 ## Testing
 
-This chart contains unit tests to verify the generated configuration. The hidden value `deployAsConfigMap` will render
+This chart contains unit tests to verify the generated configuration. The hidden value `testing.enabled` will render
 the generated configuration into a ConfigMap object. While this ConfigMap is not used during regular operation, you can
 use it to show the outcome of a given values file.
 

--- a/charts/k8s-monitoring/charts/feature-cost-metrics/README.md
+++ b/charts/k8s-monitoring/charts/feature-cost-metrics/README.md
@@ -111,7 +111,7 @@ To do so, use `extraMetricProcessingRules` section in the values file to add arb
 
 ## Testing
 
-This chart contains unit tests to verify the generated configuration. The hidden value `deployAsConfigMap` will render
+This chart contains unit tests to verify the generated configuration. The hidden value `testing.enabled` will render
 the generated configuration into a ConfigMap object. While this ConfigMap is not used during regular operation, you can
 use it to show the outcome of a given values file.
 

--- a/charts/k8s-monitoring/charts/feature-cost-metrics/README.md.gotmpl
+++ b/charts/k8s-monitoring/charts/feature-cost-metrics/README.md.gotmpl
@@ -113,7 +113,7 @@ To do so, use `extraMetricProcessingRules` section in the values file to add arb
 
 ## Testing
 
-This chart contains unit tests to verify the generated configuration. The hidden value `deployAsConfigMap` will render
+This chart contains unit tests to verify the generated configuration. The hidden value `testing.enabled` will render
 the generated configuration into a ConfigMap object. While this ConfigMap is not used during regular operation, you can
 use it to show the outcome of a given values file.
 

--- a/charts/k8s-monitoring/charts/feature-host-metrics/README.md
+++ b/charts/k8s-monitoring/charts/feature-host-metrics/README.md
@@ -100,7 +100,7 @@ To do so, use `extraMetricProcessingRules` section in the values file to add arb
 
 ## Testing
 
-This chart contains unit tests to verify the generated configuration. The hidden value `deployAsConfigMap` will render
+This chart contains unit tests to verify the generated configuration. The hidden value `testing.enabled` will render
 the generated configuration into a ConfigMap object. While this ConfigMap is not used during regular operation, you can
 use it to show the outcome of a given values file.
 

--- a/charts/k8s-monitoring/charts/feature-host-metrics/README.md.gotmpl
+++ b/charts/k8s-monitoring/charts/feature-host-metrics/README.md.gotmpl
@@ -102,7 +102,7 @@ To do so, use `extraMetricProcessingRules` section in the values file to add arb
 
 ## Testing
 
-This chart contains unit tests to verify the generated configuration. The hidden value `deployAsConfigMap` will render
+This chart contains unit tests to verify the generated configuration. The hidden value `testing.enabled` will render
 the generated configuration into a ConfigMap object. While this ConfigMap is not used during regular operation, you can
 use it to show the outcome of a given values file.
 

--- a/charts/k8s-monitoring/charts/feature-integrations/README.md
+++ b/charts/k8s-monitoring/charts/feature-integrations/README.md
@@ -24,7 +24,8 @@ integrations:
   cert-manager:
     instances:
       - name: cert-manager
-        namespace: kube-system
+        namespaces:
+          - kube-system
         labelSelectors:
           app.kubernetes.io/name: cert-manager
 ```
@@ -46,7 +47,7 @@ For all possible values for a specific integration, refer to the previous table 
 
 ## Testing
 
-This chart contains unit tests to verify the generated configuration. The hidden value `deployAsConfigMap` will render
+This chart contains unit tests to verify the generated configuration. The hidden value `testing.enabled` will render
 the generated configuration into a ConfigMap object. While this ConfigMap is not used during regular operation, you can
 use it to show the outcome of a given values file.
 

--- a/charts/k8s-monitoring/charts/feature-integrations/README.md.gotmpl
+++ b/charts/k8s-monitoring/charts/feature-integrations/README.md.gotmpl
@@ -26,7 +26,8 @@ integrations:
   cert-manager:
     instances:
       - name: cert-manager
-        namespace: kube-system
+        namespaces: 
+          - kube-system
         labelSelectors:
           app.kubernetes.io/name: cert-manager
 ```
@@ -48,7 +49,7 @@ For all possible values for a specific integration, refer to the previous table 
 
 ## Testing
 
-This chart contains unit tests to verify the generated configuration. The hidden value `deployAsConfigMap` will render
+This chart contains unit tests to verify the generated configuration. The hidden value `testing.enabled` will render
 the generated configuration into a ConfigMap object. While this ConfigMap is not used during regular operation, you can
 use it to show the outcome of a given values file.
 

--- a/charts/k8s-monitoring/charts/feature-node-logs/README.md
+++ b/charts/k8s-monitoring/charts/feature-node-logs/README.md
@@ -36,7 +36,7 @@ nodeLogs:
 
 ## Testing
 
-This chart contains unit tests to verify the generated configuration. The hidden value `deployAsConfigMap` will render
+This chart contains unit tests to verify the generated configuration. The hidden value `testing.enabled` will render
 the generated configuration into a ConfigMap object. While this ConfigMap is not used during regular operation, you can
 use it to show the outcome of a given values file.
 

--- a/charts/k8s-monitoring/charts/feature-node-logs/README.md.gotmpl
+++ b/charts/k8s-monitoring/charts/feature-node-logs/README.md.gotmpl
@@ -38,7 +38,7 @@ nodeLogs:
 
 ## Testing
 
-This chart contains unit tests to verify the generated configuration. The hidden value `deployAsConfigMap` will render
+This chart contains unit tests to verify the generated configuration. The hidden value `testing.enabled` will render
 the generated configuration into a ConfigMap object. While this ConfigMap is not used during regular operation, you can
 use it to show the outcome of a given values file.
 

--- a/charts/k8s-monitoring/charts/feature-pod-logs-objects/README.md
+++ b/charts/k8s-monitoring/charts/feature-pod-logs-objects/README.md
@@ -15,7 +15,7 @@ podLogsObjects:
 
 ## Testing
 
-This chart contains unit tests to verify the generated configuration. The hidden value `deployAsConfigMap` will render
+This chart contains unit tests to verify the generated configuration. The hidden value `testing.enabled` will render
 the generated configuration into a ConfigMap object. While this ConfigMap is not used during regular operation, you can
 use it to show the outcome of a given values file.
 

--- a/charts/k8s-monitoring/charts/feature-pod-logs-objects/README.md.gotmpl
+++ b/charts/k8s-monitoring/charts/feature-pod-logs-objects/README.md.gotmpl
@@ -17,7 +17,7 @@ podLogsObjects:
 
 ## Testing
 
-This chart contains unit tests to verify the generated configuration. The hidden value `deployAsConfigMap` will render
+This chart contains unit tests to verify the generated configuration. The hidden value `testing.enabled` will render
 the generated configuration into a ConfigMap object. While this ConfigMap is not used during regular operation, you can
 use it to show the outcome of a given values file.
 

--- a/charts/k8s-monitoring/charts/feature-pod-logs-via-kubernetes-api/README.md
+++ b/charts/k8s-monitoring/charts/feature-pod-logs-via-kubernetes-api/README.md
@@ -18,7 +18,7 @@ podLogsViaKubernetesApi:
 
 ## Testing
 
-This chart contains unit tests to verify the generated configuration. The hidden value `deployAsConfigMap` will render
+This chart contains unit tests to verify the generated configuration. The hidden value `testing.enabled` will render
 the generated configuration into a ConfigMap object. While this ConfigMap is not used during regular operation, you can
 use it to show the outcome of a given values file.
 

--- a/charts/k8s-monitoring/charts/feature-pod-logs-via-kubernetes-api/README.md.gotmpl
+++ b/charts/k8s-monitoring/charts/feature-pod-logs-via-kubernetes-api/README.md.gotmpl
@@ -20,7 +20,7 @@ podLogsViaKubernetesApi:
 
 ## Testing
 
-This chart contains unit tests to verify the generated configuration. The hidden value `deployAsConfigMap` will render
+This chart contains unit tests to verify the generated configuration. The hidden value `testing.enabled` will render
 the generated configuration into a ConfigMap object. While this ConfigMap is not used during regular operation, you can
 use it to show the outcome of a given values file.
 

--- a/charts/k8s-monitoring/charts/feature-pod-logs-via-loki/README.md
+++ b/charts/k8s-monitoring/charts/feature-pod-logs-via-loki/README.md
@@ -41,7 +41,7 @@ pod. It takes the highest precedence in every mode.
 
 ## Testing
 
-This chart contains unit tests to verify the generated configuration. The hidden value `deployAsConfigMap` will render
+This chart contains unit tests to verify the generated configuration. The hidden value `testing.enabled` will render
 the generated configuration into a ConfigMap object. While this ConfigMap is not used during regular operation, you can
 use it to show the outcome of a given values file.
 

--- a/charts/k8s-monitoring/charts/feature-pod-logs-via-loki/README.md.gotmpl
+++ b/charts/k8s-monitoring/charts/feature-pod-logs-via-loki/README.md.gotmpl
@@ -43,7 +43,7 @@ pod. It takes the highest precedence in every mode.
 
 ## Testing
 
-This chart contains unit tests to verify the generated configuration. The hidden value `deployAsConfigMap` will render
+This chart contains unit tests to verify the generated configuration. The hidden value `testing.enabled` will render
 the generated configuration into a ConfigMap object. While this ConfigMap is not used during regular operation, you can
 use it to show the outcome of a given values file.
 

--- a/charts/k8s-monitoring/charts/feature-pod-logs-via-opentelemetry/README.md
+++ b/charts/k8s-monitoring/charts/feature-pod-logs-via-opentelemetry/README.md
@@ -43,7 +43,7 @@ pod. It takes the highest precedence in every mode.
 
 ## Testing
 
-This chart contains unit tests to verify the generated configuration. The hidden value `deployAsConfigMap` will render
+This chart contains unit tests to verify the generated configuration. The hidden value `testing.enabled` will render
 the generated configuration into a ConfigMap object. While this ConfigMap is not used during regular operation, you can
 use it to show the outcome of a given values file.
 

--- a/charts/k8s-monitoring/charts/feature-pod-logs-via-opentelemetry/README.md.gotmpl
+++ b/charts/k8s-monitoring/charts/feature-pod-logs-via-opentelemetry/README.md.gotmpl
@@ -45,7 +45,7 @@ pod. It takes the highest precedence in every mode.
 
 ## Testing
 
-This chart contains unit tests to verify the generated configuration. The hidden value `deployAsConfigMap` will render
+This chart contains unit tests to verify the generated configuration. The hidden value `testing.enabled` will render
 the generated configuration into a ConfigMap object. While this ConfigMap is not used during regular operation, you can
 use it to show the outcome of a given values file.
 

--- a/charts/k8s-monitoring/charts/feature-profiles-receiver/README.md
+++ b/charts/k8s-monitoring/charts/feature-profiles-receiver/README.md
@@ -20,7 +20,7 @@ profilesReceiver:
 
 ## Testing
 
-This chart contains unit tests to verify the generated configuration. The hidden value `deployAsConfigMap` will render
+This chart contains unit tests to verify the generated configuration. The hidden value `testing.enabled` will render
 the generated configuration into a ConfigMap object. While this ConfigMap is not used during regular operation, you can
 use it to show the outcome of a given values file.
 

--- a/charts/k8s-monitoring/charts/feature-profiles-receiver/README.md.gotmpl
+++ b/charts/k8s-monitoring/charts/feature-profiles-receiver/README.md.gotmpl
@@ -22,7 +22,7 @@ profilesReceiver:
 
 ## Testing
 
-This chart contains unit tests to verify the generated configuration. The hidden value `deployAsConfigMap` will render
+This chart contains unit tests to verify the generated configuration. The hidden value `testing.enabled` will render
 the generated configuration into a ConfigMap object. While this ConfigMap is not used during regular operation, you can
 use it to show the outcome of a given values file.
 

--- a/charts/k8s-monitoring/charts/feature-profiling/README.md
+++ b/charts/k8s-monitoring/charts/feature-profiling/README.md
@@ -42,7 +42,7 @@ every telemetry path.
 
 ## Testing
 
-This chart contains unit tests to verify the generated configuration. The hidden value `deployAsConfigMap` will render
+This chart contains unit tests to verify the generated configuration. The hidden value `testing.enabled` will render
 the generated configuration into a ConfigMap object. While this ConfigMap is not used during regular operation, you can
 use it to show the outcome of a given values file.
 

--- a/charts/k8s-monitoring/charts/feature-profiling/README.md.gotmpl
+++ b/charts/k8s-monitoring/charts/feature-profiling/README.md.gotmpl
@@ -44,7 +44,7 @@ every telemetry path.
 
 ## Testing
 
-This chart contains unit tests to verify the generated configuration. The hidden value `deployAsConfigMap` will render
+This chart contains unit tests to verify the generated configuration. The hidden value `testing.enabled` will render
 the generated configuration into a ConfigMap object. While this ConfigMap is not used during regular operation, you can
 use it to show the outcome of a given values file.
 

--- a/charts/k8s-monitoring/charts/feature-prometheus-operator-objects/README.md
+++ b/charts/k8s-monitoring/charts/feature-prometheus-operator-objects/README.md
@@ -23,7 +23,7 @@ prometheusOperatorObjects:
 
 ## Testing
 
-This chart contains unit tests to verify the generated configuration. The hidden value `deployAsConfigMap` will render
+This chart contains unit tests to verify the generated configuration. The hidden value `testing.enabled` will render
 the generated configuration into a ConfigMap object. While this ConfigMap is not used during regular operation, you can
 use it to show the outcome of a given values file.
 

--- a/charts/k8s-monitoring/charts/feature-prometheus-operator-objects/README.md.gotmpl
+++ b/charts/k8s-monitoring/charts/feature-prometheus-operator-objects/README.md.gotmpl
@@ -25,7 +25,7 @@ prometheusOperatorObjects:
 
 ## Testing
 
-This chart contains unit tests to verify the generated configuration. The hidden value `deployAsConfigMap` will render
+This chart contains unit tests to verify the generated configuration. The hidden value `testing.enabled` will render
 the generated configuration into a ConfigMap object. While this ConfigMap is not used during regular operation, you can
 use it to show the outcome of a given values file.
 


### PR DESCRIPTION
<!--Describe what this change does and why.-->
# Description

Judging by the [template](https://github.com/grafana/k8s-monitoring-helm/blob/f05ec446174152498cf5a1e52fee297bc5d024b4/charts/k8s-monitoring/charts/feature-integrations/templates/_integration_etcd.tpl#L45), the `integration.namespace` value in the example should be the list `integration.namespaces`.

Also noticed that `testing.enabled` is the "hidden value parameter" that allows rendering the configmap. 
