### PR TITLE
Add a validator to check for Beyla port conflicts

### DIFF
--- a/charts/k8s-monitoring/CHANGELOG.md
+++ b/charts/k8s-monitoring/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+*   Add a validation that detects a host port conflict before the Auto-Instrumentation feature deploys Beyla. Beyla runs with `hostNetwork` enabled, so any existing DaemonSet already binding the same host port would collide with it. Disable with `autoInstrumentation.beyla.portConflictCheck: false`. (#2893) (@petewall)
 *   Add `attachNamespaceMetadata` to the annotationAutodiscovery feature to add namespace labels available for relabeling rules. (#2874) (@petewall)
 *   Collect Windows host metrics directly with Alloy by setting `hostMetrics.windowsHosts.source: alloy`, which uses the built-in `prometheus.exporter.windows` instead of deploying and scraping a separate Windows Exporter. (@petewall)
 *   Route the Host Metrics sub-features to different collectors. `hostMetrics.linuxHosts`, `hostMetrics.windowsHosts`, and `hostMetrics.energyMetrics` each accept their own `collector`, falling back to the feature-level `hostMetrics.collector`. This makes it possible to collect Linux host metrics on a Linux DaemonSet and Windows host metrics on a Windows DaemonSet at the same time. (@petewall)

--- a/charts/k8s-monitoring/charts/feature-auto-instrumentation/README.md
+++ b/charts/k8s-monitoring/charts/feature-auto-instrumentation/README.md
@@ -64,6 +64,7 @@ Be sure perform actual integration testing in a live environment in the main [k8
 | beyla.maxCacheSize | string | 100000 | Sets the max_cache_size for the prometheus.relabel component for Beyla. This should be at least 2x-5x your largest scrape target or samples appended rate. ([docs](https://grafana.com/docs/alloy/latest/reference/components/prometheus/prometheus.relabel/#arguments)). Overrides `global.maxCacheSize`. |
 | beyla.metricsTuning.excludeMetrics | list | `[]` | Metrics to drop. Can use regular expressions. |
 | beyla.metricsTuning.includeMetrics | list | `[]` | Metrics to keep. Can use regular expressions. |
+| beyla.portConflictCheck | bool | `true` | Check for a host port conflict before deploying Beyla. Beyla runs with hostNetwork enabled and binds its port on every node, so any DaemonSet already binding the same host port (another Beyla or an unrelated workload) causes a conflict. If a conflict is detected, the install fails with guidance to pick a unique port. Set to false to skip the check. |
 | beyla.preset | string | `"application"` | The configuration preset to use. Valid options are "application" or "network". |
 | beyla.scrapeInterval | string | 60s | How frequently to scrape metrics from Beyla. Overrides `global.scrapeInterval`. |
 | beyla.service | object | `{"targetPort":9090}` | The port number for the Beyla service. |

--- a/charts/k8s-monitoring/charts/feature-auto-instrumentation/values.schema.json
+++ b/charts/k8s-monitoring/charts/feature-auto-instrumentation/values.schema.json
@@ -110,6 +110,9 @@
                         }
                     }
                 },
+                "portConflictCheck": {
+                    "type": "boolean"
+                },
                 "preset": {
                     "type": "string",
                     "enum": [

--- a/charts/k8s-monitoring/charts/feature-auto-instrumentation/values.yaml
+++ b/charts/k8s-monitoring/charts/feature-auto-instrumentation/values.yaml
@@ -153,6 +153,13 @@ beyla:
   service:
     targetPort: 9090
 
+  # -- Check for a host port conflict before deploying Beyla.
+  # Beyla runs with hostNetwork enabled and binds its port on every node, so any DaemonSet already binding
+  # the same host port (another Beyla or an unrelated workload) causes a conflict. If a conflict is detected,
+  # the install fails with guidance to pick a unique port. Set to false to skip the check.
+  # @section -- Beyla
+  portConflictCheck: true
+
   # @ignored
   podAnnotations:
     k8s.grafana.com/job: default/beyla

--- a/charts/k8s-monitoring/templates/features/_feature_auto_instrumentation.tpl
+++ b/charts/k8s-monitoring/templates/features/_feature_auto_instrumentation.tpl
@@ -23,8 +23,63 @@ auto_instrumentation "feature" {
 {{- include "dataProcessors.validate.feature" (dict "root" $ "featureKey" "autoInstrumentation" "featureName" $featureName "type" "metrics" "ecosystem" "prometheus") }}
 {{- $collectorName := include "collectors.getCollectorForFeature" (dict "Values" $.Values "featureKey" $featureKey) }}
 {{- include "collectors.validate.collectorIsAssigned" (dict "Values" $.Values "collectorName" $collectorName "featureKey" $featureKey "featureName" $featureName) }}
+{{- include "features.autoInstrumentation.validate.beylaPortConflict" . }}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Best-effort check for a host port conflict before Auto-Instrumentation deploys Beyla.
+Beyla runs with hostNetwork enabled and binds its port on every node, so any DaemonSet that already binds the
+same host port — whether another Beyla or an unrelated workload — will collide with it. This scans all
+DaemonSets (not just Beyla-like ones) for one that binds the host port, either via an explicit `hostPort` or
+via `hostNetwork` with a matching `containerPort`. A plain `containerPort` without `hostNetwork`/`hostPort` is
+pod-local and does not conflict, so it is ignored. `lookup` returns nothing during `helm template`/`--dry-run`
+(no cluster connection), so this check is skipped in those cases. If a conflict is found, recommend deploying
+Beyla on a unique port.
+*/}}
+{{- define "features.autoInstrumentation.validate.beylaPortConflict" }}
+{{- $beyla := .Values.autoInstrumentation.beyla | default dict }}
+{{- if dig "portConflictCheck" true $beyla }}
+  {{- $ourPort := dig "service" "targetPort" 9090 $beyla | int }}
+  {{- $conflict := dict }}
+  {{- range $daemonSet := (dig "items" list (lookup "apps/v1" "DaemonSet" "" "" | default dict)) }}
+    {{- if not $conflict.found }}
+      {{- $labels := $daemonSet.metadata.labels | default dict }}
+      {{- /* Skip the Beyla managed by this release (relevant on upgrades) */}}
+      {{- if ne (dig "app.kubernetes.io/instance" "" $labels) $.Release.Name }}
+        {{- $dsHostNetwork := dig "spec" "template" "spec" "hostNetwork" false $daemonSet }}
+        {{- range $container := (dig "spec" "template" "spec" "containers" (list) $daemonSet) }}
+          {{- range $port := (dig "ports" (list) $container) }}
+            {{- if or (eq (int (dig "hostPort" 0 $port)) $ourPort) (and $dsHostNetwork (eq (int (dig "containerPort" 0 $port)) $ourPort)) }}
+              {{- $_ := set $conflict "found" true }}
+              {{- $_ := set $conflict "namespace" $daemonSet.metadata.namespace }}
+              {{- $_ := set $conflict "name" $daemonSet.metadata.name }}
+            {{- end }}
+          {{- end }}
+        {{- end }}
+      {{- end }}
+    {{- end }}
+  {{- end }}
+
+  {{- if $conflict.found }}
+    {{- $msg := list "" (printf "A workload already appears to bind host port %d on this cluster's nodes." $ourPort) }}
+    {{- $msg = append $msg (printf "Found DaemonSet \"%s\" in namespace \"%s\"." $conflict.name $conflict.namespace) }}
+    {{- $msg = append $msg "Beyla runs with hostNetwork enabled and binds this port on every node, so deploying it will cause a host port conflict." }}
+    {{- $msg = append $msg "" }}
+    {{- $msg = append $msg "Deploy Beyla on a different, unused port:" }}
+    {{- $msg = append $msg "autoInstrumentation:" }}
+    {{- $msg = append $msg "  beyla:" }}
+    {{- $msg = append $msg "    service:" }}
+    {{- $msg = append $msg "      targetPort: <unique-port>" }}
+    {{- $msg = append $msg "" }}
+    {{- $msg = append $msg "If this detection is incorrect, you can disable this check:" }}
+    {{- $msg = append $msg "autoInstrumentation:" }}
+    {{- $msg = append $msg "  beyla:" }}
+    {{- $msg = append $msg "    portConflictCheck: false" }}
+    {{- fail (join "\n" $msg) }}
+  {{- end }}
+{{- end }}
+{{- end }}
 
 {{- define "features.autoInstrumentation.destinations" }}
 {{- if .Values.autoInstrumentation.enabled -}}

--- a/charts/k8s-monitoring/tests/validations_beyla_port_conflict_test.yaml
+++ b/charts/k8s-monitoring/tests/validations_beyla_port_conflict_test.yaml
@@ -1,0 +1,544 @@
+# yamllint disable rule:document-start rule:line-length rule:trailing-spaces
+suite: Validations - Beyla port conflict
+templates:
+  - validations.yaml
+tests:
+  - it: fails when another Beyla is found binding the same host port
+    set:
+      cluster:
+        name: ci-test-cluster
+      destinations:
+        metrics-service:
+          type: prometheus
+          url: http://prometheus.prometheus.svc:9090/api/v1/write
+      collectors:
+        alloy-metrics:
+          presets: [clustered]
+      autoInstrumentation:
+        enabled: true
+        collector: alloy-metrics
+    kubernetesProvider:
+      scheme:
+        "v1/Node":
+          gvr:
+            version: "v1"
+            resource: "nodes"
+          namespaced: false
+        "apps/v1/DaemonSet":
+          gvr:
+            group: "apps"
+            version: "v1"
+            resource: "daemonsets"
+          namespaced: true
+        "apps/v1/Deployment":
+          gvr:
+            group: "apps"
+            version: "v1"
+            resource: "deployments"
+          namespaced: true
+      objects:
+        - kind: Node
+          apiVersion: v1
+          metadata:
+            name: node1
+        - kind: Deployment
+          apiVersion: apps/v1
+          metadata:
+            name: some-app
+            namespace: default
+          spec:
+            template:
+              spec:
+                containers:
+                  - name: app
+                    image: registry.k8s.io/pause:3.9
+        - kind: DaemonSet
+          apiVersion: apps/v1
+          metadata:
+            name: beyla
+            namespace: beyla
+            labels:
+              app.kubernetes.io/name: beyla
+          spec:
+            template:
+              spec:
+                hostNetwork: true
+                containers:
+                  - name: beyla
+                    image: docker.io/grafana/beyla:3.25.0
+                    ports:
+                      - name: metrics
+                        containerPort: "9090"
+    asserts:
+      - failedTemplate:
+          errorMessage: |-
+            A workload already appears to bind host port 9090 on this cluster's nodes.
+            Found DaemonSet "beyla" in namespace "beyla".
+            Beyla runs with hostNetwork enabled and binds this port on every node, so deploying it will cause a host port conflict.
+
+            Deploy Beyla on a different, unused port:
+            autoInstrumentation:
+              beyla:
+                service:
+                  targetPort: <unique-port>
+
+            If this detection is incorrect, you can disable this check:
+            autoInstrumentation:
+              beyla:
+                portConflictCheck: false
+
+  - it: fails when an unrelated hostNetwork DaemonSet already binds the same host port
+    set:
+      cluster:
+        name: ci-test-cluster
+      destinations:
+        metrics-service:
+          type: prometheus
+          url: http://prometheus.prometheus.svc:9090/api/v1/write
+      collectors:
+        alloy-metrics:
+          presets: [clustered]
+      autoInstrumentation:
+        enabled: true
+        collector: alloy-metrics
+    kubernetesProvider:
+      scheme:
+        "v1/Node":
+          gvr:
+            version: "v1"
+            resource: "nodes"
+          namespaced: false
+        "apps/v1/DaemonSet":
+          gvr:
+            group: "apps"
+            version: "v1"
+            resource: "daemonsets"
+          namespaced: true
+        "apps/v1/Deployment":
+          gvr:
+            group: "apps"
+            version: "v1"
+            resource: "deployments"
+          namespaced: true
+      objects:
+        - kind: Node
+          apiVersion: v1
+          metadata:
+            name: node1
+        - kind: Deployment
+          apiVersion: apps/v1
+          metadata:
+            name: some-app
+            namespace: default
+          spec:
+            template:
+              spec:
+                containers:
+                  - name: app
+                    image: registry.k8s.io/pause:3.9
+        - kind: DaemonSet
+          apiVersion: apps/v1
+          metadata:
+            name: some-agent
+            namespace: monitoring
+            labels:
+              app.kubernetes.io/name: some-agent
+          spec:
+            template:
+              spec:
+                hostNetwork: true
+                containers:
+                  - name: agent
+                    image: registry.k8s.io/pause:3.9
+                    ports:
+                      - containerPort: "9090"
+    asserts:
+      - failedTemplate:
+          errorMessage: |-
+            A workload already appears to bind host port 9090 on this cluster's nodes.
+            Found DaemonSet "some-agent" in namespace "monitoring".
+            Beyla runs with hostNetwork enabled and binds this port on every node, so deploying it will cause a host port conflict.
+
+            Deploy Beyla on a different, unused port:
+            autoInstrumentation:
+              beyla:
+                service:
+                  targetPort: <unique-port>
+
+            If this detection is incorrect, you can disable this check:
+            autoInstrumentation:
+              beyla:
+                portConflictCheck: false
+
+  - it: detects a conflict on a custom port via hostPort
+    set:
+      cluster:
+        name: ci-test-cluster
+      destinations:
+        metrics-service:
+          type: prometheus
+          url: http://prometheus.prometheus.svc:9090/api/v1/write
+      collectors:
+        alloy-metrics:
+          presets: [clustered]
+      autoInstrumentation:
+        enabled: true
+        collector: alloy-metrics
+        beyla:
+          service:
+            targetPort: 9095
+    kubernetesProvider:
+      scheme:
+        "v1/Node":
+          gvr:
+            version: "v1"
+            resource: "nodes"
+          namespaced: false
+        "apps/v1/DaemonSet":
+          gvr:
+            group: "apps"
+            version: "v1"
+            resource: "daemonsets"
+          namespaced: true
+        "apps/v1/Deployment":
+          gvr:
+            group: "apps"
+            version: "v1"
+            resource: "deployments"
+          namespaced: true
+      objects:
+        - kind: Node
+          apiVersion: v1
+          metadata:
+            name: node1
+        - kind: Deployment
+          apiVersion: apps/v1
+          metadata:
+            name: some-app
+            namespace: default
+          spec:
+            template:
+              spec:
+                containers:
+                  - name: app
+                    image: registry.k8s.io/pause:3.9
+        - kind: DaemonSet
+          apiVersion: apps/v1
+          metadata:
+            name: custom-agent
+            namespace: monitoring
+          spec:
+            template:
+              spec:
+                containers:
+                  - name: agent
+                    image: registry.k8s.io/pause:3.9
+                    ports:
+                      - hostPort: "9095"
+                        containerPort: "9095"
+    asserts:
+      - failedTemplate:
+          errorMessage: |-
+            A workload already appears to bind host port 9095 on this cluster's nodes.
+            Found DaemonSet "custom-agent" in namespace "monitoring".
+            Beyla runs with hostNetwork enabled and binds this port on every node, so deploying it will cause a host port conflict.
+
+            Deploy Beyla on a different, unused port:
+            autoInstrumentation:
+              beyla:
+                service:
+                  targetPort: <unique-port>
+
+            If this detection is incorrect, you can disable this check:
+            autoInstrumentation:
+              beyla:
+                portConflictCheck: false
+
+  - it: does not fail when the existing DaemonSet binds a different host port
+    set:
+      cluster:
+        name: ci-test-cluster
+      destinations:
+        metrics-service:
+          type: prometheus
+          url: http://prometheus.prometheus.svc:9090/api/v1/write
+      collectors:
+        alloy-metrics:
+          presets: [clustered]
+      autoInstrumentation:
+        enabled: true
+        collector: alloy-metrics
+    kubernetesProvider:
+      scheme:
+        "v1/Node":
+          gvr:
+            version: "v1"
+            resource: "nodes"
+          namespaced: false
+        "apps/v1/DaemonSet":
+          gvr:
+            group: "apps"
+            version: "v1"
+            resource: "daemonsets"
+          namespaced: true
+        "apps/v1/Deployment":
+          gvr:
+            group: "apps"
+            version: "v1"
+            resource: "deployments"
+          namespaced: true
+      objects:
+        - kind: Node
+          apiVersion: v1
+          metadata:
+            name: node1
+        - kind: Deployment
+          apiVersion: apps/v1
+          metadata:
+            name: some-app
+            namespace: default
+          spec:
+            template:
+              spec:
+                containers:
+                  - name: app
+                    image: registry.k8s.io/pause:3.9
+        - kind: DaemonSet
+          apiVersion: apps/v1
+          metadata:
+            name: beyla
+            namespace: beyla
+            labels:
+              app.kubernetes.io/name: beyla
+          spec:
+            template:
+              spec:
+                hostNetwork: true
+                containers:
+                  - name: beyla
+                    image: docker.io/grafana/beyla:3.25.0
+                    ports:
+                      - containerPort: "9091"
+    asserts:
+      - notFailedTemplate: {}
+
+  - it: does not fail for a pod-local containerPort with no hostNetwork or hostPort
+    set:
+      cluster:
+        name: ci-test-cluster
+      destinations:
+        metrics-service:
+          type: prometheus
+          url: http://prometheus.prometheus.svc:9090/api/v1/write
+      collectors:
+        alloy-metrics:
+          presets: [clustered]
+      autoInstrumentation:
+        enabled: true
+        collector: alloy-metrics
+    kubernetesProvider:
+      scheme:
+        "v1/Node":
+          gvr:
+            version: "v1"
+            resource: "nodes"
+          namespaced: false
+        "apps/v1/DaemonSet":
+          gvr:
+            group: "apps"
+            version: "v1"
+            resource: "daemonsets"
+          namespaced: true
+        "apps/v1/Deployment":
+          gvr:
+            group: "apps"
+            version: "v1"
+            resource: "deployments"
+          namespaced: true
+      objects:
+        - kind: Node
+          apiVersion: v1
+          metadata:
+            name: node1
+        - kind: Deployment
+          apiVersion: apps/v1
+          metadata:
+            name: some-app
+            namespace: default
+          spec:
+            template:
+              spec:
+                containers:
+                  - name: app
+                    image: registry.k8s.io/pause:3.9
+        - kind: DaemonSet
+          apiVersion: apps/v1
+          metadata:
+            name: some-agent
+            namespace: monitoring
+          spec:
+            template:
+              spec:
+                containers:
+                  - name: agent
+                    image: registry.k8s.io/pause:3.9
+                    ports:
+                      - containerPort: "9090"
+    asserts:
+      - notFailedTemplate: {}
+
+  - it: ignores the Beyla managed by this release
+    set:
+      cluster:
+        name: ci-test-cluster
+      destinations:
+        metrics-service:
+          type: prometheus
+          url: http://prometheus.prometheus.svc:9090/api/v1/write
+      collectors:
+        alloy-metrics:
+          presets: [clustered]
+      autoInstrumentation:
+        enabled: true
+        collector: alloy-metrics
+    kubernetesProvider:
+      scheme:
+        "v1/Node":
+          gvr:
+            version: "v1"
+            resource: "nodes"
+          namespaced: false
+        "apps/v1/DaemonSet":
+          gvr:
+            group: "apps"
+            version: "v1"
+            resource: "daemonsets"
+          namespaced: true
+        "apps/v1/Deployment":
+          gvr:
+            group: "apps"
+            version: "v1"
+            resource: "deployments"
+          namespaced: true
+      objects:
+        - kind: Node
+          apiVersion: v1
+          metadata:
+            name: node1
+        - kind: Deployment
+          apiVersion: apps/v1
+          metadata:
+            name: some-app
+            namespace: default
+          spec:
+            template:
+              spec:
+                containers:
+                  - name: app
+                    image: registry.k8s.io/pause:3.9
+        - kind: DaemonSet
+          apiVersion: apps/v1
+          metadata:
+            name: RELEASE-NAME-beyla
+            namespace: NAMESPACE
+            labels:
+              app.kubernetes.io/name: beyla
+              app.kubernetes.io/instance: RELEASE-NAME
+          spec:
+            template:
+              spec:
+                hostNetwork: true
+                containers:
+                  - name: beyla
+                    image: docker.io/grafana/beyla:3.25.0
+                    ports:
+                      - containerPort: "9090"
+    asserts:
+      - notFailedTemplate: {}
+
+  - it: does not fail when the port conflict check is disabled, even with a conflicting workload
+    set:
+      cluster:
+        name: ci-test-cluster
+      destinations:
+        metrics-service:
+          type: prometheus
+          url: http://prometheus.prometheus.svc:9090/api/v1/write
+      collectors:
+        alloy-metrics:
+          presets: [clustered]
+      autoInstrumentation:
+        enabled: true
+        collector: alloy-metrics
+        beyla:
+          portConflictCheck: false
+    kubernetesProvider:
+      scheme:
+        "v1/Node":
+          gvr:
+            version: "v1"
+            resource: "nodes"
+          namespaced: false
+        "apps/v1/DaemonSet":
+          gvr:
+            group: "apps"
+            version: "v1"
+            resource: "daemonsets"
+          namespaced: true
+        "apps/v1/Deployment":
+          gvr:
+            group: "apps"
+            version: "v1"
+            resource: "deployments"
+          namespaced: true
+      objects:
+        - kind: Node
+          apiVersion: v1
+          metadata:
+            name: node1
+        - kind: Deployment
+          apiVersion: apps/v1
+          metadata:
+            name: some-app
+            namespace: default
+          spec:
+            template:
+              spec:
+                containers:
+                  - name: app
+                    image: registry.k8s.io/pause:3.9
+        - kind: DaemonSet
+          apiVersion: apps/v1
+          metadata:
+            name: beyla
+            namespace: beyla
+            labels:
+              app.kubernetes.io/name: beyla
+          spec:
+            template:
+              spec:
+                hostNetwork: true
+                containers:
+                  - name: beyla
+                    image: docker.io/grafana/beyla:3.25.0
+                    ports:
+                      - containerPort: "9090"
+    asserts:
+      - notFailedTemplate: {}
+
+  - it: does not fail when no conflicting workload is present
+    set:
+      cluster:
+        name: ci-test-cluster
+      destinations:
+        metrics-service:
+          type: prometheus
+          url: http://prometheus.prometheus.svc:9090/api/v1/write
+      collectors:
+        alloy-metrics:
+          presets: [clustered]
+      autoInstrumentation:
+        enabled: true
+        collector: alloy-metrics
+    asserts:
+      - notFailedTemplate: {}


### PR DESCRIPTION
# Description

Adds a validator to check for Beyla port conflicts by looking at daemonsets using the same port that beyla is defined to use.

This is a best-effort validator, and will not catch all possible conflicts, but will hopefully avoid some, especially in the case of deploying two copies of beyla (within or without this helm chart).

Fixes #2893 

## Authorship

-   [X] I, a human, wrote this pull request description myself.
