### PR TITLE
Service Integrations: Fix an issue where validation wouldn't catch if a collector was not assigned.

### DIFF
--- a/charts/k8s-monitoring/CHANGELOG.md
+++ b/charts/k8s-monitoring/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+*   Service Integrations: Fix an issue where validation wouldn't catch if a collector was not assigned. (@petewall)
 *   Cluster Metrics: add a `discoveryMode` option to `kubeScheduler` and `kubeControllerManager`, `eks-proxy` to scrape the control plane from the Amazon EKS Control Plane Metrics API (`metrics.eks.amazonaws.com`). (#2915) (@petewall)
 *   Add `extraResourceAttributes` and `extraResourceAttributesFrom` options to the OTLP destination. (#2913) (@petewall)
 *   Update kube-state-metrics to 8.1.3 and OpenCost to 2.5.29 (@petewall)

--- a/charts/k8s-monitoring/templates/features/_feature_integrations.tpl
+++ b/charts/k8s-monitoring/templates/features/_feature_integrations.tpl
@@ -85,7 +85,21 @@
 {{- $featureName := "Service Integrations" }}
 
 {{- $metricIntegrations := include "feature.integrations.configured.metrics" (dict "Values" .Values.integrations "Files" $.Subcharts.integrations.Files) | fromYamlArray }}
+{{- $logOutputIntegrations := include "feature.integrations.configured.logOutput" (dict "Values" .Values.integrations "Files" $.Subcharts.integrations.Files) | fromYamlArray }}
 {{- $destinations := include "features.integrations.destinations" . | fromYamlArray }}
+
+{{- /*
+Integrations that scrape exporters (metrics) or emit exporter logs (logOutput) run on a dedicated
+collector, so one must be assigned. When it isn't, and more than one collector is enabled, the
+collector auto-selection returns empty and the entire integrations config would be silently dropped;
+validate here so the user gets a clear error instead. Log-parsing integrations (logRules only) attach
+to the Pod Logs feature's collector rather than an integrations collector, so they need no assignment.
+*/}}
+{{- if or $metricIntegrations $logOutputIntegrations }}
+  {{- $collectorName := include "collectors.getCollectorForFeature" (dict "Values" $.Values "Files" $.Files "Subcharts" $.Subcharts "featureKey" "integrations") }}
+  {{- include "collectors.validate.collectorIsAssigned" (dict "Values" $.Values "collectorName" $collectorName "featureKey" "integrations" "featureName" $featureName) }}
+{{- end }}
+
 {{- if $metricIntegrations }}
   {{- include "destinations.validate.destinationListNotEmpty" (dict "destinations" $destinations "type" "metrics" "ecosystem" "prometheus" "featureName" $featureName) }}
   {{- include "dataProcessors.validate.feature" (dict "root" $ "featureKey" "integrations" "featureName" $featureName "type" "metrics" "ecosystem" "prometheus") }}
@@ -93,7 +107,6 @@
   {{- include "collectors.validate.clusteringEnabled" (dict "Values" $.Values "Files" $.Files "collectorName" $collectorName "featureName" $featureName) }}
 {{- end }}
 
-{{- $logOutputIntegrations := include "feature.integrations.configured.logOutput" (dict "Values" .Values.integrations "Files" $.Subcharts.integrations.Files) | fromYamlArray }}
 {{- if $logOutputIntegrations }}
   {{- include "destinations.validate.destinationListNotEmpty" (dict "destinations" $destinations "type" "logs" "ecosystem" "loki" "featureName" $featureName) }}
   {{- include "dataProcessors.validate.feature" (dict "root" $ "featureKey" "integrations" "featureName" $featureName "type" "logs" "ecosystem" "loki") }}

--- a/charts/k8s-monitoring/tests/feature_integrations_test.yaml
+++ b/charts/k8s-monitoring/tests/feature_integrations_test.yaml
@@ -25,6 +25,35 @@ tests:
             Please add a destination with metrics support.
             See https://github.com/grafana/k8s-monitoring-helm/blob/main/charts/k8s-monitoring/docs/destinations/README.md for more details.
 
+  - it: requires a collector to be assigned when multiple collectors are enabled
+    template: validations.yaml
+    set:
+      cluster:
+        name: ci-test-cluster
+      destinations:
+        prom:
+          type: prometheus
+          url: http://prom.prom.svc:9090/api/v1/write
+      collectors:
+        alloy-metrics:
+          presets: [clustered, statefulset]
+        alloy-singleton:
+          enabled: true
+      integrations:
+        alloy:
+          instances:
+            - name: alloy
+              labelSelectors:
+                app.kubernetes.io/name: alloy-metrics
+    asserts:
+      - failedTemplate:
+          errorMessage: |-
+            The Service Integrations feature requires a collector to be assigned.
+            Please assign one by setting the following:
+            integrations:
+              collector: alloy-metrics or alloy-singleton
+            See https://github.com/grafana/k8s-monitoring-helm/blob/main/charts/k8s-monitoring/docs/collectors/README.md for more details.
+
   - it: works with a metrics-only integration
     template: alloy-config.yaml
     set:
@@ -48,6 +77,43 @@ tests:
           of: ConfigMap
       - matchSnapshot:
           path: data["config.alloy"]
+
+  - it: works with an explicitly assigned collector when multiple collectors are enabled
+    template: alloy-config.yaml
+    set:
+      cluster:
+        name: ci-test-cluster
+      destinations:
+        prom:
+          type: prometheus
+          url: http://prom.prom.svc:9090/api/v1/write
+        loki:
+          type: loki
+          url: http://loki.loki.svc:3100/loki/api/v1/push
+      collectors:
+        alloy-metrics:
+          presets: [clustered, statefulset]
+        alloy-singleton:
+          enabled: true
+      # clusterEvents keeps alloy-singleton in use so the render exercises the multi-collector path
+      clusterEvents:
+        enabled: true
+        collector: alloy-singleton
+      integrations:
+        collector: alloy-metrics
+        alloy:
+          instances:
+            - name: alloy
+              labelSelectors:
+                app.kubernetes.io/name: alloy-metrics
+    asserts:
+      - documentIndex: 0
+        isKind:
+          of: ConfigMap
+      - documentIndex: 0
+        matchRegex:
+          path: data["config.alloy"]
+          pattern: alloy_integration "integration"
 
   - it: works with multiple metrics-only integrations
     template: alloy-config.yaml


### PR DESCRIPTION
# Description

If a collector is not set for the `integrations` feature, the validation would not catch it and would silently pass without assigning the configuration to a collector.

Fixes #

## Authorship

-   [X] I, a human, wrote this pull request description myself.

<!--Please delete paragraphs that you did not use before submitting.-->
