### PR TITLE
fix: unreleased windows node metrics collection misconfiguration

### DIFF
--- a/charts/k8s-monitoring/charts/feature-host-metrics/templates/_windows_hosts.alloy.tpl
+++ b/charts/k8s-monitoring/charts/feature-host-metrics/templates/_windows_hosts.alloy.tpl
@@ -64,9 +64,12 @@ prometheus.relabel "windows_exporter" {
 {{- if .Values.windowsHosts.extraMetricProcessingRules }}
   {{- .Values.windowsHosts.extraMetricProcessingRules | nindent 2 }}
 {{- end }}
-{{- end }}
   forward_to = argument.metrics_destinations.value
 } // prometheus.relabel "windows_exporter"
+{{- else }}
+  forward_to = argument.metrics_destinations.value
+} // prometheus.scrape "windows_exporter"
+{{- end }}
 {{- end }}
 {{- end }}
 

--- a/charts/k8s-monitoring/charts/feature-host-metrics/templates/_windows_hosts.alloy.tpl
+++ b/charts/k8s-monitoring/charts/feature-host-metrics/templates/_windows_hosts.alloy.tpl
@@ -159,12 +159,5 @@ discovery.relabel "windows_exporter" {
 {{- if .Values.windowsHosts.extraDiscoveryRules }}
   {{- .Values.windowsHosts.extraDiscoveryRules | nindent 2 }}
 {{- end }}
-{{- if .Values.windowsHosts.extraMetricProcessingRules }}
-  {{- .Values.windowsHosts.extraMetricProcessingRules | nindent 2 }}
-  forward_to = argument.metrics_destinations.value
 } // discovery.relabel "windows_exporter"
-{{- else }}
-  forward_to = argument.metrics_destinations.value
-} // discovery.relabel "windows_exporter"
-{{- end }}
 {{- end }}

--- a/charts/k8s-monitoring/charts/feature-host-metrics/tests/windows_alloy_source_test.yaml
+++ b/charts/k8s-monitoring/charts/feature-host-metrics/tests/windows_alloy_source_test.yaml
@@ -34,3 +34,28 @@ tests:
       - matchRegex:
           path: data["module.alloy"]
           pattern: replacement = sys\.env\("NODE_NAME"\)
+
+  - it: should keep extraMetricProcessingRules in prometheus.relabel and out of discovery.relabel when source is alloy
+    set:
+      testing: {enabled: true}
+      windowsHosts:
+        enabled: true
+        source: alloy
+        extraMetricProcessingRules: |-
+          rule {
+            target_label = "color"
+            replacement = "red"
+          }
+    asserts:
+      # discovery.relabel is a target-discovery component: it must not gain a forward_to
+      # argument (invalid River) nor the metric-processing rules.
+      - notMatchRegex:
+          path: data["module.alloy"]
+          pattern: 'discovery\.relabel "windows_exporter" \{[\s\S]*forward_to[\s\S]*?\} // discovery\.relabel "windows_exporter"'
+      - notMatchRegex:
+          path: data["module.alloy"]
+          pattern: 'discovery\.relabel "windows_exporter" \{[\s\S]*replacement = "red"[\s\S]*?\} // discovery\.relabel "windows_exporter"'
+      # the extra rule belongs in prometheus.relabel, which forwards to the destinations.
+      - matchRegex:
+          path: data["module.alloy"]
+          pattern: 'prometheus\.relabel "windows_exporter" \{[\s\S]*replacement = "red"[\s\S]*forward_to = argument\.metrics_destinations\.value[\s\S]*?\} // prometheus\.relabel "windows_exporter"'

--- a/charts/k8s-monitoring/tests/platform/eks-alloy-on-windows/.rendered/alloy-windows.alloy
+++ b/charts/k8s-monitoring/tests/platform/eks-alloy-on-windows/.rendered/alloy-windows.alloy
@@ -30,7 +30,6 @@ declare "windows_host_metrics" {
       replacement = "kubernetes"
       target_label = "source"
     }
-    forward_to = argument.metrics_destinations.value
   } // discovery.relabel "windows_exporter"
 
   prometheus.scrape "windows_exporter" {

--- a/charts/k8s-monitoring/tests/platform/eks-alloy-on-windows/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/platform/eks-alloy-on-windows/.rendered/output.yaml
@@ -1652,7 +1652,6 @@ data:
           replacement = "kubernetes"
           target_label = "source"
         }
-        forward_to = argument.metrics_destinations.value
       } // discovery.relabel "windows_exporter"
     
       prometheus.scrape "windows_exporter" {


### PR DESCRIPTION
<!--Describe what this change does and why.-->
# Description

Fixes an issue introduced by https://github.com/grafana/k8s-monitoring-helm/pull/2896 where a copy-pasted resulted in some unneeded configuration. The windows pattern not properly matches the linux pattern. There is already a changelog entry for the original feature that is unreleased so this PR does not need a changelog.

Before this fix the test was failing: https://github.com/grafana/k8s-monitoring-helm/actions/runs/31436584292/job/93629455171

<!--Authorship attestation. See AGENTS.md for details. AI agents must not check this box on behalf
of the user; the human author must check it themselves before the PR is ready for review.-->
## Authorship

-   [x] I, a human, wrote this pull request description myself.

<!--Please delete paragraphs that you did not use before submitting.-->
