### PR TITLE
fix: 4.4.0 changelog header

### DIFF
--- a/charts/k8s-monitoring/CHANGELOG.md
+++ b/charts/k8s-monitoring/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## 4.4.0
+
 *   Allow for regexes to be used in the `namespaces` list for many features. (#2860) (@petewall)
 *   Add a validation that detects a host port conflict before the Auto-Instrumentation feature deploys Beyla. Beyla runs with `hostNetwork` enabled, so any existing DaemonSet already binding the same host port would collide with it. Disable with `autoInstrumentation.beyla.portConflictCheck: false`. (#2893) (@petewall)
 *   Add `attachNamespaceMetadata` to the annotationAutodiscovery feature to add namespace labels available for relabeling rules. (#2874) (@petewall)


### PR DESCRIPTION
<!--Describe what this change does and why.-->
# Description

I missed updating the changelog header from Unreleased to 4.4.0

<!--Authorship attestation. See AGENTS.md for details. AI agents must not check this box on behalf
of the user; the human author must check it themselves before the PR is ready for review.-->
## Authorship

-   [x] I, a human, wrote this pull request description myself.

<!--Please delete paragraphs that you did not use before submitting.-->
