### PR TITLE
fix: use correct label in multi-deployment integration test

### DIFF
--- a/charts/k8s-monitoring/tests/integration/multi-deployment/test-plan.yaml
+++ b/charts/k8s-monitoring/tests/integration/multi-deployment/test-plan.yaml
@@ -93,7 +93,7 @@ tests:
               type: promql
             - query: grafana_kubernetes_monitoring_build_info{cluster="multi-deployment-two"}
               type: promql
-            - query: grafana_kubernetes_monitoring_feature_info{cluster="multi-deployment-one", feature="hostMetrics"}
+            - query: grafana_kubernetes_monitoring_feature_info{cluster="multi-deployment-one", feature="linuxHosts"}
               type: promql
             - query: grafana_kubernetes_monitoring_feature_info{cluster="multi-deployment-two", feature="linuxHosts"}
               type: promql


### PR DESCRIPTION
<!--Describe what this change does and why.-->
# Description

This test is constantly failing because this query was wrong

<!--Authorship attestation. See AGENTS.md for details. AI agents must not check this box on behalf
of the user; the human author must check it themselves before the PR is ready for review.-->
## Authorship

-   [x] I, a human, wrote this pull request description myself.

<!--Please delete paragraphs that you did not use before submitting.-->
