### PR TITLE
fix: prometheus destination not honoring cluster.nameFrom

### DIFF
--- a/charts/k8s-monitoring/CHANGELOG.md
+++ b/charts/k8s-monitoring/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+*   Fix the Prometheus destination so the cluster label honors `cluster.nameFrom`. (#2963) (@TylerHelmuth)
+
 ## 4.4.0
 
 *   Allow for regexes to be used in the `namespaces` list for many features. (#2860) (@petewall)

--- a/charts/k8s-monitoring/templates/destinations/_destination_prometheus.tpl
+++ b/charts/k8s-monitoring/templates/destinations/_destination_prometheus.tpl
@@ -269,7 +269,7 @@ prometheus.remote_write {{ include "helper.alloy_name" $.destinationName | quote
 {{- if or .clusterLabels .extraLabels .extraLabelsFrom }}
   external_labels = {
   {{- range $label := .clusterLabels }}
-    {{ include "escape_label" $label | quote }} = {{ $.Values.cluster.name | quote }},
+    {{ include "escape_label" $label | quote }} = {{ $.Values.cluster.nameFrom | default ($.Values.cluster.name | quote) }},
   {{- end }}
   {{- range $key, $value := .extraLabels }}
     {{ $key }} = {{ $value | quote }},

--- a/charts/k8s-monitoring/tests/destination_prometheus_test.yaml
+++ b/charts/k8s-monitoring/tests/destination_prometheus_test.yaml
@@ -41,6 +41,23 @@ tests:
           path: data["config.alloy"]
           pattern: '// Destination: disabledMetrics \(prometheus\)'
 
+  - it: uses cluster.nameFrom for the cluster label
+    set:
+      cluster:
+        nameFrom: sys.env("CLUSTER_NAME")
+      collectors: {alloy-singleton: {extraConfig: " ", includeDestinations: ["test"]}}
+      selfReporting: {enabled: false}
+      destinations:
+        test:
+          type: prometheus
+          url: https://prometheus.example.com
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - matchRegex:
+          path: data["config.alloy"]
+          pattern: '"k8s_cluster_name" = sys\.env\("CLUSTER_NAME"\),'
+
   - it: allows you to disable keepIdentifyingResourceAttributes
     set:
       cluster: {name: test-cluster}


### PR DESCRIPTION
<!--Describe what this change does and why.-->
# Description

- Fixes https://github.com/grafana/k8s-monitoring-helm/issues/2963

<!--Authorship attestation. See AGENTS.md for details. AI agents must not check this box on behalf
of the user; the human author must check it themselves before the PR is ready for review.-->
## Authorship

-   [x] I, a human, wrote this pull request description myself.

<!--Please delete paragraphs that you did not use before submitting.-->
