### PR TITLE
fix: switch gke/openshift tests to new cluster

### DIFF
--- a/charts/k8s-monitoring/tests/platform/gke-autopilot/.envrc
+++ b/charts/k8s-monitoring/tests/platform/gke-autopilot/.envrc
@@ -1,9 +1,9 @@
-export GCP_SERVICE_ACCOUNT=$(op --account grafana.1password.com read "op://Kubernetes Monitoring/GCP k8s-monitoring-helm-cluster-creator/username")
-op --account grafana.1password.com read --out-file sak.json "op://Kubernetes Monitoring/GCP k8s-monitoring-helm-cluster-creator/credential"
+export GCP_SERVICE_ACCOUNT=$(op --account grafana.1password.com read "op://Helm Maintainers/GCP k8s-monitoring-helm-cluster-creator/username")
+op --account grafana.1password.com read --out-file sak.json "op://Helm Maintainers/GCP k8s-monitoring-helm-cluster-creator/credential"
 gcloud auth activate-service-account "${GCP_SERVICE_ACCOUNT}" --key-file=sak.json
 rm sak.json
 
-export CLOUDSDK_CORE_PROJECT=grafana-k8s-monitoring
+export CLOUDSDK_CORE_PROJECT=grafana-helm-chart-tests
 export CLOUDSDK_CONTAINER_USE_DNS_ENDPOINT=true
 export GRAFANA_CLOUD_METRICS_USERNAME=$(op --account grafana.1password.com read "op://Kubernetes Monitoring/helmchart Prometheus/username")
 export GRAFANA_CLOUD_LOGS_USERNAME=$(op --account grafana.1password.com read "op://Kubernetes Monitoring/helmchart Loki/username")

--- a/charts/k8s-monitoring/tests/platform/gke/.envrc
+++ b/charts/k8s-monitoring/tests/platform/gke/.envrc
@@ -1,9 +1,9 @@
-export GCP_SERVICE_ACCOUNT=$(op --account grafana.1password.com read "op://Kubernetes Monitoring/GCP k8s-monitoring-helm-cluster-creator/username")
-op --account grafana.1password.com read --out-file sak.json "op://Kubernetes Monitoring/GCP k8s-monitoring-helm-cluster-creator/credential"
+export GCP_SERVICE_ACCOUNT=$(op --account grafana.1password.com read "op://Helm Maintainers/GCP k8s-monitoring-helm-cluster-creator/username")
+op --account grafana.1password.com read --out-file sak.json "op://Helm Maintainers/GCP k8s-monitoring-helm-cluster-creator/credential"
 gcloud auth activate-service-account "${GCP_SERVICE_ACCOUNT}" --key-file=sak.json
 rm sak.json
 
-export CLOUDSDK_CORE_PROJECT=grafana-k8s-monitoring
+export CLOUDSDK_CORE_PROJECT=grafana-helm-chart-tests
 export CLOUDSDK_CONTAINER_USE_DNS_ENDPOINT=true
 export GRAFANA_CLOUD_METRICS_USERNAME=$(op --account grafana.1password.com read "op://Kubernetes Monitoring/helmchart Prometheus/username")
 export GRAFANA_CLOUD_LOGS_USERNAME=$(op --account grafana.1password.com read "op://Kubernetes Monitoring/helmchart Loki/username")

--- a/charts/k8s-monitoring/tests/platform/openshift/.envrc
+++ b/charts/k8s-monitoring/tests/platform/openshift/.envrc
@@ -1,7 +1,7 @@
-export GCP_SERVICE_ACCOUNT=$(op --account grafana.1password.com read "op://Kubernetes Monitoring/GCP k8s-monitoring-helm-cluster-creator/username")
+export GCP_SERVICE_ACCOUNT=$(op --account grafana.1password.com read "op://Helm Maintainers/GCP k8s-monitoring-helm-cluster-creator/username")
 export GOOGLE_CLOUD_KEYFILE_JSON="$(pwd)/gcp_service_account_key.json"
 if [ ! -f "${GOOGLE_CLOUD_KEYFILE_JSON}" ]; then
-  op --account grafana.1password.com read --out-file "${GOOGLE_CLOUD_KEYFILE_JSON}" "op://Kubernetes Monitoring/GCP k8s-monitoring-helm-cluster-creator/credential"
+  op --account grafana.1password.com read --out-file "${GOOGLE_CLOUD_KEYFILE_JSON}" "op://Helm Maintainers/GCP k8s-monitoring-helm-cluster-creator/credential"
 fi
 
 gcloud auth activate-service-account "${GCP_SERVICE_ACCOUNT}" --key-file="${GOOGLE_CLOUD_KEYFILE_JSON}"

--- a/charts/k8s-monitoring/tests/platform/openshift/openshift-cluster-config.yaml
+++ b/charts/k8s-monitoring/tests/platform/openshift/openshift-cluster-config.yaml
@@ -32,7 +32,7 @@ networking:
     - 172.30.0.0/16
 platform:
   gcp:
-    projectID: grafana-k8s-monitoring
+    projectID: grafana-helm-chart-tests
     region: us-central1
     userLabels:
       - key: source


### PR DESCRIPTION
<!--Describe what this change does and why.-->
# Description

Fixes the openshift platform test by moving to a new cluster that allows external connections. Move GKE with it to be consistent, but the current private node solution for GKE stays.

<!--Authorship attestation. See AGENTS.md for details. AI agents must not check this box on behalf
of the user; the human author must check it themselves before the PR is ready for review.-->
## Authorship

-   [x] I, a human, wrote this pull request description myself.

<!--Please delete paragraphs that you did not use before submitting.-->
