### PR TITLE
feat: support per-collector assignment for profiling feature

### DIFF
--- a/charts/k8s-monitoring/CHANGELOG.md
+++ b/charts/k8s-monitoring/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 *   Fix the Prometheus destination so the cluster label honors `cluster.nameFrom`. (#2963) (@TylerHelmuth)
 *   Route integration instances to different collectors by setting collector on each instance. (#2616) (@TylerHelmuth)
+*   Route the Profiling sub-features to different collectors by setting collector on each sub-feature. (#2949) (@TylerHelmuth)
 
 ## 4.4.0
 

--- a/charts/k8s-monitoring/charts/feature-profiling/README.md
+++ b/charts/k8s-monitoring/charts/feature-profiling/README.md
@@ -81,6 +81,7 @@ Be sure perform actual integration testing in a live environment in the main [k8
 |-----|------|---------|-------------|
 | ebpf.annotationSelectors | object | `{}` | Select pods to profile based on pod annotations. Example: `color: "green"` will select pods with the annotation `color="green"`. Example with multiple values: `color: ["blue", "green"]` will select pods with the annotation `color="blue"` or `color="green"`. |
 | ebpf.annotations.enable | string | `"profiles.grafana.com/cpu.ebpf.enabled"` | The annotation action for enabling or disabling collecting of profiles with eBPF. |
+| ebpf.collector | string | `""` | The collector to which this profiling type is assigned. When empty, the feature-level `profiling.collector` is used. |
 | ebpf.demangle | string | `"none"` | C++ demangle mode. Available options are: none, simplified, templates, full |
 | ebpf.dotnetEnabled | bool | `true` | A flag to enable or disable .NET profiling. |
 | ebpf.enabled | bool | `false` | Gather profiles using eBPF |
@@ -109,6 +110,7 @@ Be sure perform actual integration testing in a live environment in the main [k8
 |-----|------|---------|-------------|
 | java.annotationSelectors | object | `{}` | Select pods to profile based on pod annotations. Example: `color: "green"` will select pods with the annotation `color="green"`. Example with multiple values: `color: ["blue", "green"]` will select pods with the annotation `color="blue"` or `color="green"`. |
 | java.annotations.enable | string | `"enabled"` | The annotation action for enabling or disabling of Java profile collection. |
+| java.collector | string | `""` | The collector to which this profiling type is assigned. When empty, the feature-level `profiling.collector` is used. |
 | java.enabled | bool | `false` | Gather profiles by attaching async-profiler to the Java runtime. |
 | java.excludeNamespaces | list | `[]` | Which namespaces to exclude looking for pods. |
 | java.extraDiscoveryRules | string | `""` | Rule blocks to be added to the discovery.relabel component for Java profile sources. ([docs](https://grafana.com/docs/alloy/latest/reference/components/discovery/discovery.relabel/#rule-block)) |
@@ -134,6 +136,7 @@ Be sure perform actual integration testing in a live environment in the main [k8
 | pprof.annotations.portNumber | string | `"port"` | The annotation action for choosing the port number for scraping profiles of a given type. |
 | pprof.annotations.scheme | string | `"scheme"` | The annotation action for choosing the scheme for scraping profiles of a given type. |
 | pprof.bearerTokenFile | string | `"/var/run/secrets/kubernetes.io/serviceaccount/token"` | The bearer token file to use when scraping profiles. |
+| pprof.collector | string | `""` | The collector to which this profiling type is assigned. When empty, the feature-level `profiling.collector` is used. |
 | pprof.enabled | bool | `false` | Gather profiles by scraping pprof HTTP endpoints |
 | pprof.excludeNamespaces | list | `[]` | Which namespaces to exclude looking for pods. |
 | pprof.extraDiscoveryRules | string | `""` | Rule blocks to be added to the discovery.relabel component for eBPF profile sources. These relabeling rules are applied pre-scrape against the targets from service discovery. Before the scrape, any remaining target labels that start with `__` (i.e. `__meta_kubernetes*`) are dropped. ([docs](https://grafana.com/docs/alloy/latest/reference/components/discovery/discovery.relabel/#rule-block)) |

--- a/charts/k8s-monitoring/charts/feature-profiling/values.schema.json
+++ b/charts/k8s-monitoring/charts/feature-profiling/values.schema.json
@@ -24,6 +24,9 @@
                         }
                     }
                 },
+                "collector": {
+                    "type": "string"
+                },
                 "demangle": {
                     "type": "string",
                     "enum": [
@@ -102,6 +105,9 @@
                             "type": "string"
                         }
                     }
+                },
+                "collector": {
+                    "type": "string"
                 },
                 "enabled": {
                     "type": "boolean"
@@ -185,6 +191,9 @@
                     }
                 },
                 "bearerTokenFile": {
+                    "type": "string"
+                },
+                "collector": {
                     "type": "string"
                 },
                 "enabled": {

--- a/charts/k8s-monitoring/charts/feature-profiling/values.yaml
+++ b/charts/k8s-monitoring/charts/feature-profiling/values.yaml
@@ -16,6 +16,10 @@ ebpf:
   # @section -- eBPF
   enabled: false
 
+  # -- The collector to which this profiling type is assigned. When empty, the feature-level `profiling.collector` is used.
+  # @section -- eBPF
+  collector: ""
+
   # -- How to target pods for collecting profiles with eBPF. Options are `all` and `annotation`. If using `all`, all
   # Kubernetes pods will be targeted for collecting profiles, and you can exclude certain pods by setting the
   # `profiles.grafana.com/cpu.ebpf.enabled="false"` annotation on that pod. If using `annotation`, only pods with the
@@ -101,6 +105,10 @@ java:
   # @section -- Java
   enabled: false
 
+  # -- The collector to which this profiling type is assigned. When empty, the feature-level `profiling.collector` is used.
+  # @section -- Java
+  collector: ""
+
   # -- How to target pods for finding Java profiles. Options are `all` and `annotation`. If using `all`, all Kubernetes
   # pods will be targeted for Java profiles, and you can exclude certain pods by setting the
   # `profiles.grafana.com/java.enabled="false"` annotation on that pod. If using `annotation`, only pods with the
@@ -173,6 +181,10 @@ pprof:
   # -- Gather profiles by scraping pprof HTTP endpoints
   # @section -- pprof
   enabled: false
+
+  # -- The collector to which this profiling type is assigned. When empty, the feature-level `profiling.collector` is used.
+  # @section -- pprof
+  collector: ""
 
   # -- Profile types to gather
   # @section -- pprof

--- a/charts/k8s-monitoring/templates/collectors/_collector_helpers.tpl
+++ b/charts/k8s-monitoring/templates/collectors/_collector_helpers.tpl
@@ -281,6 +281,8 @@ app.kubernetes.io/instance: {{ include "collector.alloy.fullname" . }}
 {{- $collectors := list -}}
 {{- if eq .featureKey "integrations" -}}
 {{- $collectors = include "collectors.integrations.assignedCollectors" . | fromYamlArray -}}
+{{- else if eq .featureKey "profiling" -}}
+{{- $collectors = include "collectors.profiling.assignedCollectors" . | fromYamlArray -}}
 {{- end -}}
 {{- if not $collectors -}}
 {{- $collectorName := include "collectors.getCollectorForFeature" . | trim -}}

--- a/charts/k8s-monitoring/templates/features/_feature_profiling.tpl
+++ b/charts/k8s-monitoring/templates/features/_feature_profiling.tpl
@@ -1,10 +1,55 @@
+{{- define "profiling.subfeatures" -}}
+- ebpf
+- java
+- pprof
+{{- end -}}
+
+{{- define "collectors.profiling.assignedCollectors" -}}
+{{- $root := . -}}
+{{- $collectors := list -}}
+{{- if $root.Values.profiling.enabled -}}
+{{- range $sub := include "profiling.subfeatures" . | fromYamlArray -}}
+  {{- $subValues := get $root.Values.profiling $sub -}}
+  {{- if and $subValues (dig "enabled" false $subValues) -}}
+    {{- $collector := include "collectors.getCollectorForFeature" (dict "Values" $root.Values "Files" $root.Files "Subcharts" $root.Subcharts "featureKey" (printf "profiling_%s" $sub)) | trim -}}
+    {{- if and $collector (not (has $collector $collectors)) -}}
+      {{- $collectors = append $collectors $collector -}}
+    {{- end -}}
+  {{- end -}}
+{{- end -}}
+{{- end -}}
+{{- range $collector := $collectors }}
+- {{ $collector }}
+{{- end -}}
+{{- end -}}
+
+{{- define "collectors.profiling.filterSubfeaturesForCollector" -}}
+{{- $root := .root -}}
+{{- $collectorName := .collectorName -}}
+{{- $profiling := deepCopy $root.Values.profiling -}}
+{{- range $sub := include "profiling.subfeatures" . | fromYamlArray -}}
+  {{- $subValues := get $profiling $sub -}}
+  {{- if and $subValues (dig "enabled" false $subValues) -}}
+    {{- $collector := include "collectors.getCollectorForFeature" (dict "Values" $root.Values "Files" $root.Files "Subcharts" $root.Subcharts "featureKey" (printf "profiling_%s" $sub)) | trim -}}
+    {{- if ne $collector $collectorName -}}
+      {{- $_ := set $subValues "enabled" false -}}
+    {{- end -}}
+  {{- end -}}
+{{- end -}}
+{{- $profiling | toYaml -}}
+{{- end -}}
+
 {{- define "features.profiling.enabled" }}{{ .Values.profiling.enabled }}{{- end }}
 
 {{- define "features.profiling.include" }}
 {{- if .Values.profiling.enabled -}}
 {{- $destinations := include "features.profiling.destinations" . | fromYamlArray }}
+{{- $profilingValues := $.Values.profiling }}
+{{- if $.collectorName }}
+  {{- $profilingValues = include "collectors.profiling.filterSubfeaturesForCollector" (dict "root" $ "collectorName" $.collectorName) | fromYaml }}
+{{- end }}
 // Feature: Profiling
-{{- include "feature.profiling.module" (dict "Values" $.Values.profiling "Files" $.Subcharts.profiling.Files) }}
+{{- include "feature.profiling.module" (dict "Values" $profilingValues "Files" $.Subcharts.profiling.Files) }}
 profiling "feature" {
   profiles_destinations = [
     {{ include "pipeline.alloy.targets.forFeature" (dict "root" $ "featureKey" "profiling" "destinationNames" $destinations "type" "profiles" "ecosystem" "pyroscope") | indent 4 | trim }}
@@ -41,8 +86,25 @@ profiling "feature" {
 {{- $destinations := include "features.profiling.destinations" . | fromYamlArray }}
 {{- include "destinations.validate.destinationListNotEmpty" (dict "destinations" $destinations "type" "profiles" "ecosystem" "pyroscope" "featureName" $featureName "Values" $.Values "featureKey" $featureKey) }}
 {{- include "dataProcessors.validate.feature" (dict "root" $ "featureKey" "profiling" "featureName" $featureName "type" "profiles" "ecosystem" "pyroscope") }}
-{{- $collectorName := include "collectors.getCollectorForFeature" (dict "Values" $.Values "featureKey" $featureKey) }}
-{{- include "collectors.validate.collectorIsAssigned" (dict "Values" $.Values "collectorName" $collectorName "featureKey" $featureKey "featureName" $featureName) }}
+{{- $enabledCollectors := include "collectors.list.enabled" (dict "Values" $.Values) | fromYamlArray }}
+{{- $featureCollector := include "collectors.getCollectorForFeature" (dict "Values" $.Values "featureKey" $featureKey) | trim }}
+{{- range $sub := include "profiling.subfeatures" . | fromYamlArray }}
+  {{- $subValues := get $.Values.profiling $sub }}
+  {{- if and $subValues (dig "enabled" false $subValues) }}
+    {{- $subCollector := dig "collector" "" $subValues }}
+    {{- if $subCollector }}
+      {{- if not (has $subCollector $enabledCollectors) }}
+        {{- $msg := list "" (printf "The %s feature has %q enabled and assigned to collector %q, but that collector does not exist or is disabled." $featureName $sub $subCollector) }}
+        {{- $msg = append $msg "Please assign it to one of the enabled collectors:" }}
+        {{- $msg = append $msg (printf "  collector: %s" (include "english_list_or" $enabledCollectors)) }}
+        {{- $msg = append $msg "See https://github.com/grafana/k8s-monitoring-helm/blob/main/charts/k8s-monitoring/docs/collectors/README.md for more details." }}
+        {{- fail (join "\n" $msg) }}
+      {{- end }}
+    {{- else }}
+      {{- include "collectors.validate.collectorIsAssigned" (dict "Values" $.Values "collectorName" $featureCollector "featureKey" $featureKey "featureName" $featureName) }}
+    {{- end }}
+  {{- end }}
+{{- end }}
 {{- include "feature.profiling.validate" (dict "Values" $.Values.profiling) }}
 {{- end -}}
 {{- end -}}

--- a/charts/k8s-monitoring/tests/feature_profiling_test.yaml
+++ b/charts/k8s-monitoring/tests/feature_profiling_test.yaml
@@ -1,9 +1,11 @@
 # yamllint disable rule:document-start rule:line-length rule:trailing-spaces
 suite: Feature - Profiling
 templates:
+  - alloy-config.yaml
   - validations.yaml
 tests:
   - it: requires at least one profiling sub-type when profiling.enabled is true
+    template: validations.yaml
     set:
       cluster:
         name: ci-test-cluster
@@ -31,6 +33,7 @@ tests:
                 enabled: true
 
   - it: passes validation when ebpf is enabled
+    template: validations.yaml
     set:
       cluster:
         name: ci-test-cluster
@@ -50,6 +53,7 @@ tests:
       - notFailedTemplate: {}
 
   - it: passes validation when java is enabled
+    template: validations.yaml
     set:
       cluster:
         name: ci-test-cluster
@@ -69,6 +73,7 @@ tests:
       - notFailedTemplate: {}
 
   - it: passes validation when pprof is enabled
+    template: validations.yaml
     set:
       cluster:
         name: ci-test-cluster
@@ -88,6 +93,7 @@ tests:
       - notFailedTemplate: {}
 
   - it: does not run profiling validation when profiling.enabled is false
+    template: validations.yaml
     set:
       cluster:
         name: ci-test-cluster
@@ -105,3 +111,172 @@ tests:
           alloy: {clustering: {enabled: true}}
     asserts:
       - notFailedTemplate: {}
+
+  - it: routes profiling sub-features to their per-sub-feature collectors
+    template: alloy-config.yaml
+    set:
+      cluster:
+        name: ci-test-cluster
+      selfReporting: {enabled: false}
+      destinations:
+        pyro:
+          type: pyroscope
+          url: http://pyroscope.pyroscope.svc:4040
+      profiling:
+        enabled: true
+        collector: alloy-profiles
+        # ebpf inherits the feature-level collector (alloy-profiles)
+        ebpf:
+          enabled: true
+        # java overrides to a different collector
+        java:
+          enabled: true
+          collector: alloy-java
+        # pprof overrides to a different collector
+        pprof:
+          enabled: true
+          collector: alloy-pprof
+      collectors:
+        alloy-profiles:
+          presets: [privileged, daemonset]
+        alloy-java:
+          presets: [privileged, daemonset]
+        alloy-pprof:
+          enabled: true
+    asserts:
+      # documents are sorted alphabetically by collector name:
+      # 0 = alloy-java, 1 = alloy-pprof, 2 = alloy-profiles
+      - documentIndex: 0
+        matchRegex:
+          path: data["config.alloy"]
+          pattern: '// Profiles: Java'
+      - documentIndex: 0
+        notMatchRegex:
+          path: data["config.alloy"]
+          pattern: 'discovery.kubernetes "(ebpf|pprof)_pods"'
+      - documentIndex: 1
+        matchRegex:
+          path: data["config.alloy"]
+          pattern: 'discovery.kubernetes "pprof_pods"'
+      - documentIndex: 1
+        notMatchRegex:
+          path: data["config.alloy"]
+          pattern: 'discovery.kubernetes "(ebpf|java)_pods"'
+      - documentIndex: 2
+        matchRegex:
+          path: data["config.alloy"]
+          pattern: 'discovery.kubernetes "ebpf_pods"'
+      - documentIndex: 2
+        notMatchRegex:
+          path: data["config.alloy"]
+          pattern: '// Profiles: (Java|pprof)'
+
+  - it: fails when a sub-feature names a disabled or missing collector
+    template: validations.yaml
+    set:
+      cluster:
+        name: ci-test-cluster
+      destinations:
+        pyro:
+          type: pyroscope
+          url: http://pyroscope.pyroscope.svc:4040
+      profiling:
+        enabled: true
+        collector: alloy-profiles
+        ebpf:
+          enabled: true
+        pprof:
+          enabled: true
+          collector: does-not-exist
+      collectors:
+        alloy-profiles:
+          presets: [privileged, daemonset]
+    asserts:
+      - failedTemplate:
+          errorMessage: |-
+            The Profiling feature has "pprof" enabled and assigned to collector "does-not-exist", but that collector does not exist or is disabled.
+            Please assign it to one of the enabled collectors:
+              collector: alloy-profiles
+            See https://github.com/grafana/k8s-monitoring-helm/blob/main/charts/k8s-monitoring/docs/collectors/README.md for more details.
+
+  - it: fails when a sub-feature has no collector and one cannot be auto-selected
+    template: validations.yaml
+    set:
+      cluster:
+        name: ci-test-cluster
+      destinations:
+        pyro:
+          type: pyroscope
+          url: http://pyroscope.pyroscope.svc:4040
+      # Neither the feature nor the sub-feature sets a collector, and with more than
+      # one enabled collector there is no single collector to fall back to.
+      profiling:
+        enabled: true
+        ebpf:
+          enabled: true
+      collectors:
+        alloy-a:
+          presets: [privileged, daemonset]
+        alloy-b:
+          presets: [privileged, daemonset]
+    asserts:
+      - failedTemplate:
+          errorMessage: |-
+            The Profiling feature requires a collector to be assigned.
+            Please assign one by setting the following:
+            profiling:
+              collector: alloy-a or alloy-b
+            See https://github.com/grafana/k8s-monitoring-helm/blob/main/charts/k8s-monitoring/docs/collectors/README.md for more details.
+
+  - it: co-locates multiple sub-features assigned to the same collector
+    template: alloy-config.yaml
+    set:
+      cluster:
+        name: ci-test-cluster
+      selfReporting: {enabled: false}
+      destinations:
+        pyro:
+          type: pyroscope
+          url: http://pyroscope.pyroscope.svc:4040
+      profiling:
+        enabled: true
+        collector: alloy-shared
+        # ebpf inherits the feature-level collector (alloy-shared)
+        ebpf:
+          enabled: true
+        # java explicitly names the same collector as ebpf
+        java:
+          enabled: true
+          collector: alloy-shared
+        # pprof runs on its own collector
+        pprof:
+          enabled: true
+          collector: alloy-other
+      collectors:
+        alloy-shared:
+          presets: [privileged, daemonset]
+        alloy-other:
+          presets: [privileged, daemonset]
+    asserts:
+      # documents are sorted alphabetically by collector name:
+      # 0 = alloy-other, 1 = alloy-shared
+      - documentIndex: 0
+        matchRegex:
+          path: data["config.alloy"]
+          pattern: 'discovery.kubernetes "pprof_pods"'
+      - documentIndex: 0
+        notMatchRegex:
+          path: data["config.alloy"]
+          pattern: 'discovery.kubernetes "(ebpf|java)_pods"'
+      - documentIndex: 1
+        matchRegex:
+          path: data["config.alloy"]
+          pattern: '// Profiles: eBPF'
+      - documentIndex: 1
+        matchRegex:
+          path: data["config.alloy"]
+          pattern: '// Profiles: Java'
+      - documentIndex: 1
+        notMatchRegex:
+          path: data["config.alloy"]
+          pattern: 'discovery.kubernetes "pprof_pods"'


### PR DESCRIPTION
<!--Describe what this change does and why.-->
# Description

Add ability to specify which collector each subtype of the profiling feature will be added to. This lets you set java/ebpf/pprof be enabled on different collectors instead of all on the same. 

- Closes https://github.com/grafana/k8s-monitoring-helm/issues/2949

<!--Authorship attestation. See AGENTS.md for details. AI agents must not check this box on behalf
of the user; the human author must check it themselves before the PR is ready for review.-->
## Authorship

-   [x] I, a human, wrote this pull request description myself.

<!--Please delete paragraphs that you did not use before submitting.-->
