### PR TITLE
feat: Use prometheus.exporter.static for selfReporting

### DIFF
--- a/charts/k8s-monitoring/CHANGELOG.md
+++ b/charts/k8s-monitoring/CHANGELOG.md
@@ -7,6 +7,7 @@
 *   Fix the Prometheus destination so the cluster label honors `cluster.nameFrom`. (#2963) (@TylerHelmuth)
 *   Route integration instances to different collectors by setting collector on each instance. (#2616) (@TylerHelmuth)
 *   Route the Profiling sub-features to different collectors by setting collector on each sub-feature. (#2949) (@TylerHelmuth)
+*   When collector is experimental, use the new `prometheus.exporter.static` for selfReporting. (#2923) (@petewall)
 
 ## 4.4.0
 

--- a/charts/k8s-monitoring/docs/examples/dataProcessors/ec2Enrichment/alloy.alloy
+++ b/charts/k8s-monitoring/docs/examples/dataProcessors/ec2Enrichment/alloy.alloy
@@ -680,47 +680,36 @@ pod_logs_via_loki "feature" {
   ]
 }
 // Self Reporting
-prometheus.exporter.unix "kubernetes_monitoring_telemetry" {
-  set_collectors = ["textfile"]
-  textfile {
-    directory = "/etc/release-info"
-  }
-} // prometheus.exporter.unix "kubernetes_monitoring_telemetry"
+prometheus.exporter.static "kubernetes_monitoring_telemetry" {
+  text = `
 
-discovery.relabel "kubernetes_monitoring_telemetry" {
-  targets = prometheus.exporter.unix.kubernetes_monitoring_telemetry.targets
-  rule {
-    target_label = "instance"
-    action = "replace"
-    replacement = "k8smon"
-  }
-  rule {
-    target_label = "job"
-    action = "replace"
-    replacement = "integrations/kubernetes/kubernetes_monitoring_telemetry"
-  }
-} // discovery.relabel "kubernetes_monitoring_telemetry"
+# HELP grafana_kubernetes_monitoring_build_info A metric to report the version of the Kubernetes Monitoring Helm chart
+# TYPE grafana_kubernetes_monitoring_build_info gauge
+grafana_kubernetes_monitoring_build_info{version="4.4.0", namespace="default"} 1
+# HELP grafana_kubernetes_monitoring_feature_info A metric to report the enabled features of the Kubernetes Monitoring Helm chart
+# TYPE grafana_kubernetes_monitoring_feature_info gauge
+grafana_kubernetes_monitoring_feature_info{feature="linuxHosts", source="node-exporter", version="1.0.0"} 1
+grafana_kubernetes_monitoring_feature_info{feature="windowsHosts", source="windows-exporter", version="1.0.0"} 1
+grafana_kubernetes_monitoring_feature_info{feature="nodeLogs", version="1.0.0"} 1
+grafana_kubernetes_monitoring_feature_info{feature="podLogsViaLoki", version="1.0.0"} 1
+# HELP grafana_kubernetes_monitoring_collector_info A metric to report the collectors of the Kubernetes Monitoring Helm chart
+# TYPE grafana_kubernetes_monitoring_collector_info gauge
+grafana_kubernetes_monitoring_collector_info{kind="daemonset", name="alloy", presets="clustered,filesystem-log-reader,daemonset", type="alloy"} 1
+# EOF
+  `
+} // prometheus.exporter.static "kubernetes_monitoring_telemetry"
 
 prometheus.scrape "kubernetes_monitoring_telemetry" {
   job_name   = "integrations/kubernetes/kubernetes_monitoring_telemetry"
-  targets    = discovery.relabel.kubernetes_monitoring_telemetry.output
+  targets    = prometheus.exporter.static.kubernetes_monitoring_telemetry.targets
   scrape_interval = "60s"
   clustering {
     enabled = true
   }
-  forward_to = [prometheus.relabel.kubernetes_monitoring_telemetry.receiver]
-} // prometheus.scrape "kubernetes_monitoring_telemetry"
-
-prometheus.relabel "kubernetes_monitoring_telemetry" {
-  rule {
-    source_labels = ["__name__"]
-    regex = "grafana_kubernetes_monitoring_.*"
-    action = "keep"
-  }
   forward_to = [
     prometheus.remote_write.localprometheus.receiver,
   ]
-} // prometheus.relabel "kubernetes_monitoring_telemetry"
+} // prometheus.scrape "kubernetes_monitoring_telemetry"
 // Processor: ec2-tags (ec2Enrichment) — shared EC2 instance discovery
 discovery.ec2 "ec2_tags_instances" {
   region = "ap-northeast-2"

--- a/charts/k8s-monitoring/docs/examples/dataProcessors/ec2Enrichment/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/dataProcessors/ec2Enrichment/output.yaml
@@ -782,47 +782,36 @@ data:
       ]
     }
     // Self Reporting
-    prometheus.exporter.unix "kubernetes_monitoring_telemetry" {
-      set_collectors = ["textfile"]
-      textfile {
-        directory = "/etc/release-info"
-      }
-    } // prometheus.exporter.unix "kubernetes_monitoring_telemetry"
+    prometheus.exporter.static "kubernetes_monitoring_telemetry" {
+      text = `
     
-    discovery.relabel "kubernetes_monitoring_telemetry" {
-      targets = prometheus.exporter.unix.kubernetes_monitoring_telemetry.targets
-      rule {
-        target_label = "instance"
-        action = "replace"
-        replacement = "k8smon"
-      }
-      rule {
-        target_label = "job"
-        action = "replace"
-        replacement = "integrations/kubernetes/kubernetes_monitoring_telemetry"
-      }
-    } // discovery.relabel "kubernetes_monitoring_telemetry"
+    # HELP grafana_kubernetes_monitoring_build_info A metric to report the version of the Kubernetes Monitoring Helm chart
+    # TYPE grafana_kubernetes_monitoring_build_info gauge
+    grafana_kubernetes_monitoring_build_info{version="4.4.0", namespace="default"} 1
+    # HELP grafana_kubernetes_monitoring_feature_info A metric to report the enabled features of the Kubernetes Monitoring Helm chart
+    # TYPE grafana_kubernetes_monitoring_feature_info gauge
+    grafana_kubernetes_monitoring_feature_info{feature="linuxHosts", source="node-exporter", version="1.0.0"} 1
+    grafana_kubernetes_monitoring_feature_info{feature="windowsHosts", source="windows-exporter", version="1.0.0"} 1
+    grafana_kubernetes_monitoring_feature_info{feature="nodeLogs", version="1.0.0"} 1
+    grafana_kubernetes_monitoring_feature_info{feature="podLogsViaLoki", version="1.0.0"} 1
+    # HELP grafana_kubernetes_monitoring_collector_info A metric to report the collectors of the Kubernetes Monitoring Helm chart
+    # TYPE grafana_kubernetes_monitoring_collector_info gauge
+    grafana_kubernetes_monitoring_collector_info{kind="daemonset", name="alloy", presets="clustered,filesystem-log-reader,daemonset", type="alloy"} 1
+    # EOF
+      `
+    } // prometheus.exporter.static "kubernetes_monitoring_telemetry"
     
     prometheus.scrape "kubernetes_monitoring_telemetry" {
       job_name   = "integrations/kubernetes/kubernetes_monitoring_telemetry"
-      targets    = discovery.relabel.kubernetes_monitoring_telemetry.output
+      targets    = prometheus.exporter.static.kubernetes_monitoring_telemetry.targets
       scrape_interval = "60s"
       clustering {
         enabled = true
       }
-      forward_to = [prometheus.relabel.kubernetes_monitoring_telemetry.receiver]
-    } // prometheus.scrape "kubernetes_monitoring_telemetry"
-    
-    prometheus.relabel "kubernetes_monitoring_telemetry" {
-      rule {
-        source_labels = ["__name__"]
-        regex = "grafana_kubernetes_monitoring_.*"
-        action = "keep"
-      }
       forward_to = [
         prometheus.remote_write.localprometheus.receiver,
       ]
-    } // prometheus.relabel "kubernetes_monitoring_telemetry"
+    } // prometheus.scrape "kubernetes_monitoring_telemetry"
     // Processor: ec2-tags (ec2Enrichment) — shared EC2 instance discovery
     discovery.ec2 "ec2_tags_instances" {
       region = "ap-northeast-2"
@@ -1515,10 +1504,6 @@ spec:
       create: false
     mounts:
       dockercontainers: true
-      extra:
-      - mountPath: /etc/release-info
-        name: release-info
-        readOnly: true
       varlog: true
     resources: {}
     securityContext:
@@ -1553,11 +1538,6 @@ spec:
     - effect: NoSchedule
       operator: Exists
     type: daemonset
-    volumes:
-      extra:
-      - configMap:
-          name: k8smon-k8s-monitoring-release-info
-        name: release-info
   crds:
     create: false
   nameOverride: alloy

--- a/charts/k8s-monitoring/docs/examples/dataProcessors/kubernetesEnrichment/labels-and-annotations/alloy.alloy
+++ b/charts/k8s-monitoring/docs/examples/dataProcessors/kubernetesEnrichment/labels-and-annotations/alloy.alloy
@@ -1054,47 +1054,36 @@ pyroscope.relabel "k8s_metadata_pyroscope_gate_profiles_pyroscope" {
   }
 }
 // Self Reporting
-prometheus.exporter.unix "kubernetes_monitoring_telemetry" {
-  set_collectors = ["textfile"]
-  textfile {
-    directory = "/etc/release-info"
-  }
-} // prometheus.exporter.unix "kubernetes_monitoring_telemetry"
+prometheus.exporter.static "kubernetes_monitoring_telemetry" {
+  text = `
 
-discovery.relabel "kubernetes_monitoring_telemetry" {
-  targets = prometheus.exporter.unix.kubernetes_monitoring_telemetry.targets
-  rule {
-    target_label = "instance"
-    action = "replace"
-    replacement = "k8smon"
-  }
-  rule {
-    target_label = "job"
-    action = "replace"
-    replacement = "integrations/kubernetes/kubernetes_monitoring_telemetry"
-  }
-} // discovery.relabel "kubernetes_monitoring_telemetry"
+# HELP grafana_kubernetes_monitoring_build_info A metric to report the version of the Kubernetes Monitoring Helm chart
+# TYPE grafana_kubernetes_monitoring_build_info gauge
+grafana_kubernetes_monitoring_build_info{version="4.4.0", namespace="default"} 1
+# HELP grafana_kubernetes_monitoring_feature_info A metric to report the enabled features of the Kubernetes Monitoring Helm chart
+# TYPE grafana_kubernetes_monitoring_feature_info gauge
+grafana_kubernetes_monitoring_feature_info{feature="applicationObservability", protocols="otlpgrpc", version="1.0.0"} 1
+grafana_kubernetes_monitoring_feature_info{feature="clusterMetrics", sources="kubelet,kubeletResource,cadvisor,kube-state-metrics", version="1.0.0"} 1
+grafana_kubernetes_monitoring_feature_info{feature="podLogsViaLoki", version="1.0.0"} 1
+grafana_kubernetes_monitoring_feature_info{feature="profilesReceiver", version="1.0.0"} 1
+# HELP grafana_kubernetes_monitoring_collector_info A metric to report the collectors of the Kubernetes Monitoring Helm chart
+# TYPE grafana_kubernetes_monitoring_collector_info gauge
+grafana_kubernetes_monitoring_collector_info{kind="daemonset", name="alloy", presets="clustered,filesystem-log-reader,daemonset", type="alloy"} 1
+# EOF
+  `
+} // prometheus.exporter.static "kubernetes_monitoring_telemetry"
 
 prometheus.scrape "kubernetes_monitoring_telemetry" {
   job_name   = "integrations/kubernetes/kubernetes_monitoring_telemetry"
-  targets    = discovery.relabel.kubernetes_monitoring_telemetry.output
+  targets    = prometheus.exporter.static.kubernetes_monitoring_telemetry.targets
   scrape_interval = "60s"
   clustering {
     enabled = true
   }
-  forward_to = [prometheus.relabel.kubernetes_monitoring_telemetry.receiver]
-} // prometheus.scrape "kubernetes_monitoring_telemetry"
-
-prometheus.relabel "kubernetes_monitoring_telemetry" {
-  rule {
-    source_labels = ["__name__"]
-    regex = "grafana_kubernetes_monitoring_.*"
-    action = "keep"
-  }
   forward_to = [
     prometheus.remote_write.prometheus.receiver,
   ]
-} // prometheus.relabel "kubernetes_monitoring_telemetry"
+} // prometheus.scrape "kubernetes_monitoring_telemetry"
 // Processor: k8s-metadata (kubernetesEnrichment) — shared pod discovery
 discovery.kubernetes "k8s_metadata_pods" {
   role = "pod"

--- a/charts/k8s-monitoring/docs/examples/dataProcessors/kubernetesEnrichment/labels-and-annotations/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/dataProcessors/kubernetesEnrichment/labels-and-annotations/output.yaml
@@ -1106,47 +1106,36 @@ data:
       }
     }
     // Self Reporting
-    prometheus.exporter.unix "kubernetes_monitoring_telemetry" {
-      set_collectors = ["textfile"]
-      textfile {
-        directory = "/etc/release-info"
-      }
-    } // prometheus.exporter.unix "kubernetes_monitoring_telemetry"
+    prometheus.exporter.static "kubernetes_monitoring_telemetry" {
+      text = `
     
-    discovery.relabel "kubernetes_monitoring_telemetry" {
-      targets = prometheus.exporter.unix.kubernetes_monitoring_telemetry.targets
-      rule {
-        target_label = "instance"
-        action = "replace"
-        replacement = "k8smon"
-      }
-      rule {
-        target_label = "job"
-        action = "replace"
-        replacement = "integrations/kubernetes/kubernetes_monitoring_telemetry"
-      }
-    } // discovery.relabel "kubernetes_monitoring_telemetry"
+    # HELP grafana_kubernetes_monitoring_build_info A metric to report the version of the Kubernetes Monitoring Helm chart
+    # TYPE grafana_kubernetes_monitoring_build_info gauge
+    grafana_kubernetes_monitoring_build_info{version="4.4.0", namespace="default"} 1
+    # HELP grafana_kubernetes_monitoring_feature_info A metric to report the enabled features of the Kubernetes Monitoring Helm chart
+    # TYPE grafana_kubernetes_monitoring_feature_info gauge
+    grafana_kubernetes_monitoring_feature_info{feature="applicationObservability", protocols="otlpgrpc", version="1.0.0"} 1
+    grafana_kubernetes_monitoring_feature_info{feature="clusterMetrics", sources="kubelet,kubeletResource,cadvisor,kube-state-metrics", version="1.0.0"} 1
+    grafana_kubernetes_monitoring_feature_info{feature="podLogsViaLoki", version="1.0.0"} 1
+    grafana_kubernetes_monitoring_feature_info{feature="profilesReceiver", version="1.0.0"} 1
+    # HELP grafana_kubernetes_monitoring_collector_info A metric to report the collectors of the Kubernetes Monitoring Helm chart
+    # TYPE grafana_kubernetes_monitoring_collector_info gauge
+    grafana_kubernetes_monitoring_collector_info{kind="daemonset", name="alloy", presets="clustered,filesystem-log-reader,daemonset", type="alloy"} 1
+    # EOF
+      `
+    } // prometheus.exporter.static "kubernetes_monitoring_telemetry"
     
     prometheus.scrape "kubernetes_monitoring_telemetry" {
       job_name   = "integrations/kubernetes/kubernetes_monitoring_telemetry"
-      targets    = discovery.relabel.kubernetes_monitoring_telemetry.output
+      targets    = prometheus.exporter.static.kubernetes_monitoring_telemetry.targets
       scrape_interval = "60s"
       clustering {
         enabled = true
       }
-      forward_to = [prometheus.relabel.kubernetes_monitoring_telemetry.receiver]
-    } // prometheus.scrape "kubernetes_monitoring_telemetry"
-    
-    prometheus.relabel "kubernetes_monitoring_telemetry" {
-      rule {
-        source_labels = ["__name__"]
-        regex = "grafana_kubernetes_monitoring_.*"
-        action = "keep"
-      }
       forward_to = [
         prometheus.remote_write.prometheus.receiver,
       ]
-    } // prometheus.relabel "kubernetes_monitoring_telemetry"
+    } // prometheus.scrape "kubernetes_monitoring_telemetry"
     // Processor: k8s-metadata (kubernetesEnrichment) — shared pod discovery
     discovery.kubernetes "k8s_metadata_pods" {
       role = "pod"
@@ -1965,10 +1954,6 @@ spec:
       targetPort: 4317
     mounts:
       dockercontainers: true
-      extra:
-      - mountPath: /etc/release-info
-        name: release-info
-        readOnly: true
       varlog: true
     resources: {}
     securityContext:
@@ -2003,11 +1988,6 @@ spec:
     - effect: NoSchedule
       operator: Exists
     type: daemonset
-    volumes:
-      extra:
-      - configMap:
-          name: k8smon-k8s-monitoring-release-info
-        name: release-info
   crds:
     create: false
   nameOverride: alloy

--- a/charts/k8s-monitoring/docs/examples/destinations/custom/debug/alloy-metrics.alloy
+++ b/charts/k8s-monitoring/docs/examples/destinations/custom/debug/alloy-metrics.alloy
@@ -322,47 +322,35 @@ alloy_integration "integration" {
   ]
 }
 // Self Reporting
-prometheus.exporter.unix "kubernetes_monitoring_telemetry" {
-  set_collectors = ["textfile"]
-  textfile {
-    directory = "/etc/release-info"
-  }
-} // prometheus.exporter.unix "kubernetes_monitoring_telemetry"
+prometheus.exporter.static "kubernetes_monitoring_telemetry" {
+  text = `
 
-discovery.relabel "kubernetes_monitoring_telemetry" {
-  targets = prometheus.exporter.unix.kubernetes_monitoring_telemetry.targets
-  rule {
-    target_label = "instance"
-    action = "replace"
-    replacement = "k8smon"
-  }
-  rule {
-    target_label = "job"
-    action = "replace"
-    replacement = "integrations/kubernetes/kubernetes_monitoring_telemetry"
-  }
-} // discovery.relabel "kubernetes_monitoring_telemetry"
+# HELP grafana_kubernetes_monitoring_build_info A metric to report the version of the Kubernetes Monitoring Helm chart
+# TYPE grafana_kubernetes_monitoring_build_info gauge
+grafana_kubernetes_monitoring_build_info{version="4.4.0", namespace="default"} 1
+# HELP grafana_kubernetes_monitoring_feature_info A metric to report the enabled features of the Kubernetes Monitoring Helm chart
+# TYPE grafana_kubernetes_monitoring_feature_info gauge
+grafana_kubernetes_monitoring_feature_info{feature="integrations", sources="alloy", version="1.0.0"} 1
+grafana_kubernetes_monitoring_feature_info{feature="podLogsViaLoki", version="1.0.0"} 1
+# HELP grafana_kubernetes_monitoring_collector_info A metric to report the collectors of the Kubernetes Monitoring Helm chart
+# TYPE grafana_kubernetes_monitoring_collector_info gauge
+grafana_kubernetes_monitoring_collector_info{kind="daemonset", name="alloy-logs", presets="filesystem-log-reader,daemonset", type="alloy"} 1
+grafana_kubernetes_monitoring_collector_info{kind="statefulset", name="alloy-metrics", presets="clustered,statefulset", replicas="1", type="alloy"} 1
+# EOF
+  `
+} // prometheus.exporter.static "kubernetes_monitoring_telemetry"
 
 prometheus.scrape "kubernetes_monitoring_telemetry" {
   job_name   = "integrations/kubernetes/kubernetes_monitoring_telemetry"
-  targets    = discovery.relabel.kubernetes_monitoring_telemetry.output
+  targets    = prometheus.exporter.static.kubernetes_monitoring_telemetry.targets
   scrape_interval = "60s"
   clustering {
     enabled = true
   }
-  forward_to = [prometheus.relabel.kubernetes_monitoring_telemetry.receiver]
-} // prometheus.scrape "kubernetes_monitoring_telemetry"
-
-prometheus.relabel "kubernetes_monitoring_telemetry" {
-  rule {
-    source_labels = ["__name__"]
-    regex = "grafana_kubernetes_monitoring_.*"
-    action = "keep"
-  }
   forward_to = [
     prometheus.remote_write.prometheus.receiver,
   ]
-} // prometheus.relabel "kubernetes_monitoring_telemetry"
+} // prometheus.scrape "kubernetes_monitoring_telemetry"
 
 
 

--- a/charts/k8s-monitoring/docs/examples/destinations/custom/debug/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/destinations/custom/debug/output.yaml
@@ -608,47 +608,35 @@ data:
       ]
     }
     // Self Reporting
-    prometheus.exporter.unix "kubernetes_monitoring_telemetry" {
-      set_collectors = ["textfile"]
-      textfile {
-        directory = "/etc/release-info"
-      }
-    } // prometheus.exporter.unix "kubernetes_monitoring_telemetry"
+    prometheus.exporter.static "kubernetes_monitoring_telemetry" {
+      text = `
     
-    discovery.relabel "kubernetes_monitoring_telemetry" {
-      targets = prometheus.exporter.unix.kubernetes_monitoring_telemetry.targets
-      rule {
-        target_label = "instance"
-        action = "replace"
-        replacement = "k8smon"
-      }
-      rule {
-        target_label = "job"
-        action = "replace"
-        replacement = "integrations/kubernetes/kubernetes_monitoring_telemetry"
-      }
-    } // discovery.relabel "kubernetes_monitoring_telemetry"
+    # HELP grafana_kubernetes_monitoring_build_info A metric to report the version of the Kubernetes Monitoring Helm chart
+    # TYPE grafana_kubernetes_monitoring_build_info gauge
+    grafana_kubernetes_monitoring_build_info{version="4.4.0", namespace="default"} 1
+    # HELP grafana_kubernetes_monitoring_feature_info A metric to report the enabled features of the Kubernetes Monitoring Helm chart
+    # TYPE grafana_kubernetes_monitoring_feature_info gauge
+    grafana_kubernetes_monitoring_feature_info{feature="integrations", sources="alloy", version="1.0.0"} 1
+    grafana_kubernetes_monitoring_feature_info{feature="podLogsViaLoki", version="1.0.0"} 1
+    # HELP grafana_kubernetes_monitoring_collector_info A metric to report the collectors of the Kubernetes Monitoring Helm chart
+    # TYPE grafana_kubernetes_monitoring_collector_info gauge
+    grafana_kubernetes_monitoring_collector_info{kind="daemonset", name="alloy-logs", presets="filesystem-log-reader,daemonset", type="alloy"} 1
+    grafana_kubernetes_monitoring_collector_info{kind="statefulset", name="alloy-metrics", presets="clustered,statefulset", replicas="1", type="alloy"} 1
+    # EOF
+      `
+    } // prometheus.exporter.static "kubernetes_monitoring_telemetry"
     
     prometheus.scrape "kubernetes_monitoring_telemetry" {
       job_name   = "integrations/kubernetes/kubernetes_monitoring_telemetry"
-      targets    = discovery.relabel.kubernetes_monitoring_telemetry.output
+      targets    = prometheus.exporter.static.kubernetes_monitoring_telemetry.targets
       scrape_interval = "60s"
       clustering {
         enabled = true
       }
-      forward_to = [prometheus.relabel.kubernetes_monitoring_telemetry.receiver]
-    } // prometheus.scrape "kubernetes_monitoring_telemetry"
-    
-    prometheus.relabel "kubernetes_monitoring_telemetry" {
-      rule {
-        source_labels = ["__name__"]
-        regex = "grafana_kubernetes_monitoring_.*"
-        action = "keep"
-      }
       forward_to = [
         prometheus.remote_write.prometheus.receiver,
       ]
-    } // prometheus.relabel "kubernetes_monitoring_telemetry"
+    } // prometheus.scrape "kubernetes_monitoring_telemetry"
     
     
     
@@ -1079,11 +1067,6 @@ spec:
       name: alloy-metrics
     configMap:
       create: false
-    mounts:
-      extra:
-      - mountPath: /etc/release-info
-        name: release-info
-        readOnly: true
     resources: {}
     securityContext:
       allowPrivilegeEscalation: false
@@ -1115,11 +1098,6 @@ spec:
       k8s.grafana.com/logs.job: integrations/alloy
     replicas: 1
     type: statefulset
-    volumes:
-      extra:
-      - configMap:
-          name: k8smon-k8s-monitoring-release-info
-        name: release-info
   crds:
     create: false
   nameOverride: alloy-metrics

--- a/charts/k8s-monitoring/docs/examples/features/database-observability/mysql/alloy-singleton.alloy
+++ b/charts/k8s-monitoring/docs/examples/features/database-observability/mysql/alloy-singleton.alloy
@@ -119,47 +119,35 @@ mysql_integration "integration" {
   ]
 }
 // Self Reporting
-prometheus.exporter.unix "kubernetes_monitoring_telemetry" {
-  set_collectors = ["textfile"]
-  textfile {
-    directory = "/etc/release-info"
-  }
-} // prometheus.exporter.unix "kubernetes_monitoring_telemetry"
+prometheus.exporter.static "kubernetes_monitoring_telemetry" {
+  text = `
 
-discovery.relabel "kubernetes_monitoring_telemetry" {
-  targets = prometheus.exporter.unix.kubernetes_monitoring_telemetry.targets
-  rule {
-    target_label = "instance"
-    action = "replace"
-    replacement = "k8smon"
-  }
-  rule {
-    target_label = "job"
-    action = "replace"
-    replacement = "integrations/kubernetes/kubernetes_monitoring_telemetry"
-  }
-} // discovery.relabel "kubernetes_monitoring_telemetry"
+# HELP grafana_kubernetes_monitoring_build_info A metric to report the version of the Kubernetes Monitoring Helm chart
+# TYPE grafana_kubernetes_monitoring_build_info gauge
+grafana_kubernetes_monitoring_build_info{version="4.4.0", namespace="default"} 1
+# HELP grafana_kubernetes_monitoring_feature_info A metric to report the enabled features of the Kubernetes Monitoring Helm chart
+# TYPE grafana_kubernetes_monitoring_feature_info gauge
+grafana_kubernetes_monitoring_feature_info{feature="integrations", sources="mysql", version="1.0.0"} 1
+grafana_kubernetes_monitoring_feature_info{feature="podLogsViaLoki", version="1.0.0"} 1
+# HELP grafana_kubernetes_monitoring_collector_info A metric to report the collectors of the Kubernetes Monitoring Helm chart
+# TYPE grafana_kubernetes_monitoring_collector_info gauge
+grafana_kubernetes_monitoring_collector_info{kind="daemonset", name="alloy-logs", presets="filesystem-log-reader,daemonset", type="alloy"} 1
+grafana_kubernetes_monitoring_collector_info{kind="deployment", name="alloy-singleton", presets="singleton", replicas="1", type="alloy"} 1
+# EOF
+  `
+} // prometheus.exporter.static "kubernetes_monitoring_telemetry"
 
 prometheus.scrape "kubernetes_monitoring_telemetry" {
   job_name   = "integrations/kubernetes/kubernetes_monitoring_telemetry"
-  targets    = discovery.relabel.kubernetes_monitoring_telemetry.output
+  targets    = prometheus.exporter.static.kubernetes_monitoring_telemetry.targets
   scrape_interval = "60s"
   clustering {
     enabled = true
   }
-  forward_to = [prometheus.relabel.kubernetes_monitoring_telemetry.receiver]
-} // prometheus.scrape "kubernetes_monitoring_telemetry"
-
-prometheus.relabel "kubernetes_monitoring_telemetry" {
-  rule {
-    source_labels = ["__name__"]
-    regex = "grafana_kubernetes_monitoring_.*"
-    action = "keep"
-  }
   forward_to = [
     prometheus.remote_write.prometheus.receiver,
   ]
-} // prometheus.relabel "kubernetes_monitoring_telemetry"
+} // prometheus.scrape "kubernetes_monitoring_telemetry"
 
 
 

--- a/charts/k8s-monitoring/docs/examples/features/database-observability/mysql/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/features/database-observability/mysql/output.yaml
@@ -443,47 +443,35 @@ data:
       ]
     }
     // Self Reporting
-    prometheus.exporter.unix "kubernetes_monitoring_telemetry" {
-      set_collectors = ["textfile"]
-      textfile {
-        directory = "/etc/release-info"
-      }
-    } // prometheus.exporter.unix "kubernetes_monitoring_telemetry"
+    prometheus.exporter.static "kubernetes_monitoring_telemetry" {
+      text = `
     
-    discovery.relabel "kubernetes_monitoring_telemetry" {
-      targets = prometheus.exporter.unix.kubernetes_monitoring_telemetry.targets
-      rule {
-        target_label = "instance"
-        action = "replace"
-        replacement = "k8smon"
-      }
-      rule {
-        target_label = "job"
-        action = "replace"
-        replacement = "integrations/kubernetes/kubernetes_monitoring_telemetry"
-      }
-    } // discovery.relabel "kubernetes_monitoring_telemetry"
+    # HELP grafana_kubernetes_monitoring_build_info A metric to report the version of the Kubernetes Monitoring Helm chart
+    # TYPE grafana_kubernetes_monitoring_build_info gauge
+    grafana_kubernetes_monitoring_build_info{version="4.4.0", namespace="default"} 1
+    # HELP grafana_kubernetes_monitoring_feature_info A metric to report the enabled features of the Kubernetes Monitoring Helm chart
+    # TYPE grafana_kubernetes_monitoring_feature_info gauge
+    grafana_kubernetes_monitoring_feature_info{feature="integrations", sources="mysql", version="1.0.0"} 1
+    grafana_kubernetes_monitoring_feature_info{feature="podLogsViaLoki", version="1.0.0"} 1
+    # HELP grafana_kubernetes_monitoring_collector_info A metric to report the collectors of the Kubernetes Monitoring Helm chart
+    # TYPE grafana_kubernetes_monitoring_collector_info gauge
+    grafana_kubernetes_monitoring_collector_info{kind="daemonset", name="alloy-logs", presets="filesystem-log-reader,daemonset", type="alloy"} 1
+    grafana_kubernetes_monitoring_collector_info{kind="deployment", name="alloy-singleton", presets="singleton", replicas="1", type="alloy"} 1
+    # EOF
+      `
+    } // prometheus.exporter.static "kubernetes_monitoring_telemetry"
     
     prometheus.scrape "kubernetes_monitoring_telemetry" {
       job_name   = "integrations/kubernetes/kubernetes_monitoring_telemetry"
-      targets    = discovery.relabel.kubernetes_monitoring_telemetry.output
+      targets    = prometheus.exporter.static.kubernetes_monitoring_telemetry.targets
       scrape_interval = "60s"
       clustering {
         enabled = true
       }
-      forward_to = [prometheus.relabel.kubernetes_monitoring_telemetry.receiver]
-    } // prometheus.scrape "kubernetes_monitoring_telemetry"
-    
-    prometheus.relabel "kubernetes_monitoring_telemetry" {
-      rule {
-        source_labels = ["__name__"]
-        regex = "grafana_kubernetes_monitoring_.*"
-        action = "keep"
-      }
       forward_to = [
         prometheus.remote_write.prometheus.receiver,
       ]
-    } // prometheus.relabel "kubernetes_monitoring_telemetry"
+    } // prometheus.scrape "kubernetes_monitoring_telemetry"
     
     
     
@@ -917,11 +905,6 @@ spec:
   alloy:
     configMap:
       create: false
-    mounts:
-      extra:
-      - mountPath: /etc/release-info
-        name: release-info
-        readOnly: true
     resources: {}
     securityContext:
       allowPrivilegeEscalation: false
@@ -953,11 +936,6 @@ spec:
       k8s.grafana.com/logs.job: integrations/alloy
     replicas: 1
     type: deployment
-    volumes:
-      extra:
-      - configMap:
-          name: k8smon-k8s-monitoring-release-info
-        name: release-info
   crds:
     create: false
   nameOverride: alloy-singleton

--- a/charts/k8s-monitoring/docs/examples/features/database-observability/postgresql/alloy-singleton.alloy
+++ b/charts/k8s-monitoring/docs/examples/features/database-observability/postgresql/alloy-singleton.alloy
@@ -108,47 +108,35 @@ postgresql_integration "integration" {
   ]
 }
 // Self Reporting
-prometheus.exporter.unix "kubernetes_monitoring_telemetry" {
-  set_collectors = ["textfile"]
-  textfile {
-    directory = "/etc/release-info"
-  }
-} // prometheus.exporter.unix "kubernetes_monitoring_telemetry"
+prometheus.exporter.static "kubernetes_monitoring_telemetry" {
+  text = `
 
-discovery.relabel "kubernetes_monitoring_telemetry" {
-  targets = prometheus.exporter.unix.kubernetes_monitoring_telemetry.targets
-  rule {
-    target_label = "instance"
-    action = "replace"
-    replacement = "k8smon"
-  }
-  rule {
-    target_label = "job"
-    action = "replace"
-    replacement = "integrations/kubernetes/kubernetes_monitoring_telemetry"
-  }
-} // discovery.relabel "kubernetes_monitoring_telemetry"
+# HELP grafana_kubernetes_monitoring_build_info A metric to report the version of the Kubernetes Monitoring Helm chart
+# TYPE grafana_kubernetes_monitoring_build_info gauge
+grafana_kubernetes_monitoring_build_info{version="4.4.0", namespace="default"} 1
+# HELP grafana_kubernetes_monitoring_feature_info A metric to report the enabled features of the Kubernetes Monitoring Helm chart
+# TYPE grafana_kubernetes_monitoring_feature_info gauge
+grafana_kubernetes_monitoring_feature_info{feature="integrations", sources="postgresql", version="1.0.0"} 1
+grafana_kubernetes_monitoring_feature_info{feature="podLogsViaLoki", version="1.0.0"} 1
+# HELP grafana_kubernetes_monitoring_collector_info A metric to report the collectors of the Kubernetes Monitoring Helm chart
+# TYPE grafana_kubernetes_monitoring_collector_info gauge
+grafana_kubernetes_monitoring_collector_info{kind="daemonset", name="alloy-logs", presets="filesystem-log-reader,daemonset", type="alloy"} 1
+grafana_kubernetes_monitoring_collector_info{kind="deployment", name="alloy-singleton", presets="singleton", replicas="1", type="alloy"} 1
+# EOF
+  `
+} // prometheus.exporter.static "kubernetes_monitoring_telemetry"
 
 prometheus.scrape "kubernetes_monitoring_telemetry" {
   job_name   = "integrations/kubernetes/kubernetes_monitoring_telemetry"
-  targets    = discovery.relabel.kubernetes_monitoring_telemetry.output
+  targets    = prometheus.exporter.static.kubernetes_monitoring_telemetry.targets
   scrape_interval = "60s"
   clustering {
     enabled = true
   }
-  forward_to = [prometheus.relabel.kubernetes_monitoring_telemetry.receiver]
-} // prometheus.scrape "kubernetes_monitoring_telemetry"
-
-prometheus.relabel "kubernetes_monitoring_telemetry" {
-  rule {
-    source_labels = ["__name__"]
-    regex = "grafana_kubernetes_monitoring_.*"
-    action = "keep"
-  }
   forward_to = [
     prometheus.remote_write.prometheus.receiver,
   ]
-} // prometheus.relabel "kubernetes_monitoring_telemetry"
+} // prometheus.scrape "kubernetes_monitoring_telemetry"
 
 
 

--- a/charts/k8s-monitoring/docs/examples/features/database-observability/postgresql/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/features/database-observability/postgresql/output.yaml
@@ -415,47 +415,35 @@ data:
       ]
     }
     // Self Reporting
-    prometheus.exporter.unix "kubernetes_monitoring_telemetry" {
-      set_collectors = ["textfile"]
-      textfile {
-        directory = "/etc/release-info"
-      }
-    } // prometheus.exporter.unix "kubernetes_monitoring_telemetry"
+    prometheus.exporter.static "kubernetes_monitoring_telemetry" {
+      text = `
     
-    discovery.relabel "kubernetes_monitoring_telemetry" {
-      targets = prometheus.exporter.unix.kubernetes_monitoring_telemetry.targets
-      rule {
-        target_label = "instance"
-        action = "replace"
-        replacement = "k8smon"
-      }
-      rule {
-        target_label = "job"
-        action = "replace"
-        replacement = "integrations/kubernetes/kubernetes_monitoring_telemetry"
-      }
-    } // discovery.relabel "kubernetes_monitoring_telemetry"
+    # HELP grafana_kubernetes_monitoring_build_info A metric to report the version of the Kubernetes Monitoring Helm chart
+    # TYPE grafana_kubernetes_monitoring_build_info gauge
+    grafana_kubernetes_monitoring_build_info{version="4.4.0", namespace="default"} 1
+    # HELP grafana_kubernetes_monitoring_feature_info A metric to report the enabled features of the Kubernetes Monitoring Helm chart
+    # TYPE grafana_kubernetes_monitoring_feature_info gauge
+    grafana_kubernetes_monitoring_feature_info{feature="integrations", sources="postgresql", version="1.0.0"} 1
+    grafana_kubernetes_monitoring_feature_info{feature="podLogsViaLoki", version="1.0.0"} 1
+    # HELP grafana_kubernetes_monitoring_collector_info A metric to report the collectors of the Kubernetes Monitoring Helm chart
+    # TYPE grafana_kubernetes_monitoring_collector_info gauge
+    grafana_kubernetes_monitoring_collector_info{kind="daemonset", name="alloy-logs", presets="filesystem-log-reader,daemonset", type="alloy"} 1
+    grafana_kubernetes_monitoring_collector_info{kind="deployment", name="alloy-singleton", presets="singleton", replicas="1", type="alloy"} 1
+    # EOF
+      `
+    } // prometheus.exporter.static "kubernetes_monitoring_telemetry"
     
     prometheus.scrape "kubernetes_monitoring_telemetry" {
       job_name   = "integrations/kubernetes/kubernetes_monitoring_telemetry"
-      targets    = discovery.relabel.kubernetes_monitoring_telemetry.output
+      targets    = prometheus.exporter.static.kubernetes_monitoring_telemetry.targets
       scrape_interval = "60s"
       clustering {
         enabled = true
       }
-      forward_to = [prometheus.relabel.kubernetes_monitoring_telemetry.receiver]
-    } // prometheus.scrape "kubernetes_monitoring_telemetry"
-    
-    prometheus.relabel "kubernetes_monitoring_telemetry" {
-      rule {
-        source_labels = ["__name__"]
-        regex = "grafana_kubernetes_monitoring_.*"
-        action = "keep"
-      }
       forward_to = [
         prometheus.remote_write.prometheus.receiver,
       ]
-    } // prometheus.relabel "kubernetes_monitoring_telemetry"
+    } // prometheus.scrape "kubernetes_monitoring_telemetry"
     
     
     
@@ -889,11 +877,6 @@ spec:
   alloy:
     configMap:
       create: false
-    mounts:
-      extra:
-      - mountPath: /etc/release-info
-        name: release-info
-        readOnly: true
     resources: {}
     securityContext:
       allowPrivilegeEscalation: false
@@ -925,11 +908,6 @@ spec:
       k8s.grafana.com/logs.job: integrations/alloy
     replicas: 1
     type: deployment
-    volumes:
-      extra:
-      - configMap:
-          name: k8smon-k8s-monitoring-release-info
-        name: release-info
   crds:
     create: false
   nameOverride: alloy-singleton

--- a/charts/k8s-monitoring/docs/examples/metric-enrichment/alloy-metrics.alloy
+++ b/charts/k8s-monitoring/docs/examples/metric-enrichment/alloy-metrics.alloy
@@ -504,47 +504,35 @@ windows_host_metrics "feature" {
   ]
 }
 // Self Reporting
-prometheus.exporter.unix "kubernetes_monitoring_telemetry" {
-  set_collectors = ["textfile"]
-  textfile {
-    directory = "/etc/release-info"
-  }
-} // prometheus.exporter.unix "kubernetes_monitoring_telemetry"
+prometheus.exporter.static "kubernetes_monitoring_telemetry" {
+  text = `
 
-discovery.relabel "kubernetes_monitoring_telemetry" {
-  targets = prometheus.exporter.unix.kubernetes_monitoring_telemetry.targets
-  rule {
-    target_label = "instance"
-    action = "replace"
-    replacement = "k8smon"
-  }
-  rule {
-    target_label = "job"
-    action = "replace"
-    replacement = "integrations/kubernetes/kubernetes_monitoring_telemetry"
-  }
-} // discovery.relabel "kubernetes_monitoring_telemetry"
+# HELP grafana_kubernetes_monitoring_build_info A metric to report the version of the Kubernetes Monitoring Helm chart
+# TYPE grafana_kubernetes_monitoring_build_info gauge
+grafana_kubernetes_monitoring_build_info{version="4.4.0", namespace="default"} 1
+# HELP grafana_kubernetes_monitoring_feature_info A metric to report the enabled features of the Kubernetes Monitoring Helm chart
+# TYPE grafana_kubernetes_monitoring_feature_info gauge
+grafana_kubernetes_monitoring_feature_info{feature="clusterMetrics", sources="kubelet,kubeletResource,cadvisor,kube-state-metrics", version="1.0.0"} 1
+grafana_kubernetes_monitoring_feature_info{feature="linuxHosts", source="node-exporter", version="1.0.0"} 1
+grafana_kubernetes_monitoring_feature_info{feature="windowsHosts", source="windows-exporter", version="1.0.0"} 1
+# HELP grafana_kubernetes_monitoring_collector_info A metric to report the collectors of the Kubernetes Monitoring Helm chart
+# TYPE grafana_kubernetes_monitoring_collector_info gauge
+grafana_kubernetes_monitoring_collector_info{kind="statefulset", name="alloy-metrics", presets="clustered,statefulset", replicas="1", type="alloy"} 1
+# EOF
+  `
+} // prometheus.exporter.static "kubernetes_monitoring_telemetry"
 
 prometheus.scrape "kubernetes_monitoring_telemetry" {
   job_name   = "integrations/kubernetes/kubernetes_monitoring_telemetry"
-  targets    = discovery.relabel.kubernetes_monitoring_telemetry.output
+  targets    = prometheus.exporter.static.kubernetes_monitoring_telemetry.targets
   scrape_interval = "60s"
   clustering {
     enabled = true
   }
-  forward_to = [prometheus.relabel.kubernetes_monitoring_telemetry.receiver]
-} // prometheus.scrape "kubernetes_monitoring_telemetry"
-
-prometheus.relabel "kubernetes_monitoring_telemetry" {
-  rule {
-    source_labels = ["__name__"]
-    regex = "grafana_kubernetes_monitoring_.*"
-    action = "keep"
-  }
   forward_to = [
     prometheus.relabel.metric_store.receiver,
   ]
-} // prometheus.relabel "kubernetes_monitoring_telemetry"
+} // prometheus.scrape "kubernetes_monitoring_telemetry"
 
 
 

--- a/charts/k8s-monitoring/docs/examples/metric-enrichment/namespace-and-pod-labels/alloy-metrics.alloy
+++ b/charts/k8s-monitoring/docs/examples/metric-enrichment/namespace-and-pod-labels/alloy-metrics.alloy
@@ -504,47 +504,35 @@ windows_host_metrics "feature" {
   ]
 }
 // Self Reporting
-prometheus.exporter.unix "kubernetes_monitoring_telemetry" {
-  set_collectors = ["textfile"]
-  textfile {
-    directory = "/etc/release-info"
-  }
-} // prometheus.exporter.unix "kubernetes_monitoring_telemetry"
+prometheus.exporter.static "kubernetes_monitoring_telemetry" {
+  text = `
 
-discovery.relabel "kubernetes_monitoring_telemetry" {
-  targets = prometheus.exporter.unix.kubernetes_monitoring_telemetry.targets
-  rule {
-    target_label = "instance"
-    action = "replace"
-    replacement = "k8smon"
-  }
-  rule {
-    target_label = "job"
-    action = "replace"
-    replacement = "integrations/kubernetes/kubernetes_monitoring_telemetry"
-  }
-} // discovery.relabel "kubernetes_monitoring_telemetry"
+# HELP grafana_kubernetes_monitoring_build_info A metric to report the version of the Kubernetes Monitoring Helm chart
+# TYPE grafana_kubernetes_monitoring_build_info gauge
+grafana_kubernetes_monitoring_build_info{version="4.4.0", namespace="default"} 1
+# HELP grafana_kubernetes_monitoring_feature_info A metric to report the enabled features of the Kubernetes Monitoring Helm chart
+# TYPE grafana_kubernetes_monitoring_feature_info gauge
+grafana_kubernetes_monitoring_feature_info{feature="clusterMetrics", sources="kubelet,kubeletResource,cadvisor,kube-state-metrics", version="1.0.0"} 1
+grafana_kubernetes_monitoring_feature_info{feature="linuxHosts", source="node-exporter", version="1.0.0"} 1
+grafana_kubernetes_monitoring_feature_info{feature="windowsHosts", source="windows-exporter", version="1.0.0"} 1
+# HELP grafana_kubernetes_monitoring_collector_info A metric to report the collectors of the Kubernetes Monitoring Helm chart
+# TYPE grafana_kubernetes_monitoring_collector_info gauge
+grafana_kubernetes_monitoring_collector_info{kind="statefulset", name="alloy-metrics", presets="clustered,statefulset", replicas="1", type="alloy"} 1
+# EOF
+  `
+} // prometheus.exporter.static "kubernetes_monitoring_telemetry"
 
 prometheus.scrape "kubernetes_monitoring_telemetry" {
   job_name   = "integrations/kubernetes/kubernetes_monitoring_telemetry"
-  targets    = discovery.relabel.kubernetes_monitoring_telemetry.output
+  targets    = prometheus.exporter.static.kubernetes_monitoring_telemetry.targets
   scrape_interval = "60s"
   clustering {
     enabled = true
   }
-  forward_to = [prometheus.relabel.kubernetes_monitoring_telemetry.receiver]
-} // prometheus.scrape "kubernetes_monitoring_telemetry"
-
-prometheus.relabel "kubernetes_monitoring_telemetry" {
-  rule {
-    source_labels = ["__name__"]
-    regex = "grafana_kubernetes_monitoring_.*"
-    action = "keep"
-  }
   forward_to = [
     prometheus.relabel.metric_store.receiver,
   ]
-} // prometheus.relabel "kubernetes_monitoring_telemetry"
+} // prometheus.scrape "kubernetes_monitoring_telemetry"
 
 
 

--- a/charts/k8s-monitoring/docs/examples/metric-enrichment/namespace-and-pod-labels/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/metric-enrichment/namespace-and-pod-labels/output.yaml
@@ -600,47 +600,35 @@ data:
       ]
     }
     // Self Reporting
-    prometheus.exporter.unix "kubernetes_monitoring_telemetry" {
-      set_collectors = ["textfile"]
-      textfile {
-        directory = "/etc/release-info"
-      }
-    } // prometheus.exporter.unix "kubernetes_monitoring_telemetry"
+    prometheus.exporter.static "kubernetes_monitoring_telemetry" {
+      text = `
     
-    discovery.relabel "kubernetes_monitoring_telemetry" {
-      targets = prometheus.exporter.unix.kubernetes_monitoring_telemetry.targets
-      rule {
-        target_label = "instance"
-        action = "replace"
-        replacement = "k8smon"
-      }
-      rule {
-        target_label = "job"
-        action = "replace"
-        replacement = "integrations/kubernetes/kubernetes_monitoring_telemetry"
-      }
-    } // discovery.relabel "kubernetes_monitoring_telemetry"
+    # HELP grafana_kubernetes_monitoring_build_info A metric to report the version of the Kubernetes Monitoring Helm chart
+    # TYPE grafana_kubernetes_monitoring_build_info gauge
+    grafana_kubernetes_monitoring_build_info{version="4.4.0", namespace="default"} 1
+    # HELP grafana_kubernetes_monitoring_feature_info A metric to report the enabled features of the Kubernetes Monitoring Helm chart
+    # TYPE grafana_kubernetes_monitoring_feature_info gauge
+    grafana_kubernetes_monitoring_feature_info{feature="clusterMetrics", sources="kubelet,kubeletResource,cadvisor,kube-state-metrics", version="1.0.0"} 1
+    grafana_kubernetes_monitoring_feature_info{feature="linuxHosts", source="node-exporter", version="1.0.0"} 1
+    grafana_kubernetes_monitoring_feature_info{feature="windowsHosts", source="windows-exporter", version="1.0.0"} 1
+    # HELP grafana_kubernetes_monitoring_collector_info A metric to report the collectors of the Kubernetes Monitoring Helm chart
+    # TYPE grafana_kubernetes_monitoring_collector_info gauge
+    grafana_kubernetes_monitoring_collector_info{kind="statefulset", name="alloy-metrics", presets="clustered,statefulset", replicas="1", type="alloy"} 1
+    # EOF
+      `
+    } // prometheus.exporter.static "kubernetes_monitoring_telemetry"
     
     prometheus.scrape "kubernetes_monitoring_telemetry" {
       job_name   = "integrations/kubernetes/kubernetes_monitoring_telemetry"
-      targets    = discovery.relabel.kubernetes_monitoring_telemetry.output
+      targets    = prometheus.exporter.static.kubernetes_monitoring_telemetry.targets
       scrape_interval = "60s"
       clustering {
         enabled = true
       }
-      forward_to = [prometheus.relabel.kubernetes_monitoring_telemetry.receiver]
-    } // prometheus.scrape "kubernetes_monitoring_telemetry"
-    
-    prometheus.relabel "kubernetes_monitoring_telemetry" {
-      rule {
-        source_labels = ["__name__"]
-        regex = "grafana_kubernetes_monitoring_.*"
-        action = "keep"
-      }
       forward_to = [
         prometheus.relabel.metric_store.receiver,
       ]
-    } // prometheus.relabel "kubernetes_monitoring_telemetry"
+    } // prometheus.scrape "kubernetes_monitoring_telemetry"
     
     
     
@@ -1634,11 +1622,6 @@ spec:
       name: alloy-metrics
     configMap:
       create: false
-    mounts:
-      extra:
-      - mountPath: /etc/release-info
-        name: release-info
-        readOnly: true
     resources: {}
     securityContext:
       allowPrivilegeEscalation: false
@@ -1670,11 +1653,6 @@ spec:
       k8s.grafana.com/logs.job: integrations/alloy
     replicas: 1
     type: statefulset
-    volumes:
-      extra:
-      - configMap:
-          name: k8smon-k8s-monitoring-release-info
-        name: release-info
   crds:
     create: false
   nameOverride: alloy-metrics

--- a/charts/k8s-monitoring/docs/examples/metric-enrichment/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/metric-enrichment/output.yaml
@@ -600,47 +600,35 @@ data:
       ]
     }
     // Self Reporting
-    prometheus.exporter.unix "kubernetes_monitoring_telemetry" {
-      set_collectors = ["textfile"]
-      textfile {
-        directory = "/etc/release-info"
-      }
-    } // prometheus.exporter.unix "kubernetes_monitoring_telemetry"
+    prometheus.exporter.static "kubernetes_monitoring_telemetry" {
+      text = `
     
-    discovery.relabel "kubernetes_monitoring_telemetry" {
-      targets = prometheus.exporter.unix.kubernetes_monitoring_telemetry.targets
-      rule {
-        target_label = "instance"
-        action = "replace"
-        replacement = "k8smon"
-      }
-      rule {
-        target_label = "job"
-        action = "replace"
-        replacement = "integrations/kubernetes/kubernetes_monitoring_telemetry"
-      }
-    } // discovery.relabel "kubernetes_monitoring_telemetry"
+    # HELP grafana_kubernetes_monitoring_build_info A metric to report the version of the Kubernetes Monitoring Helm chart
+    # TYPE grafana_kubernetes_monitoring_build_info gauge
+    grafana_kubernetes_monitoring_build_info{version="4.4.0", namespace="default"} 1
+    # HELP grafana_kubernetes_monitoring_feature_info A metric to report the enabled features of the Kubernetes Monitoring Helm chart
+    # TYPE grafana_kubernetes_monitoring_feature_info gauge
+    grafana_kubernetes_monitoring_feature_info{feature="clusterMetrics", sources="kubelet,kubeletResource,cadvisor,kube-state-metrics", version="1.0.0"} 1
+    grafana_kubernetes_monitoring_feature_info{feature="linuxHosts", source="node-exporter", version="1.0.0"} 1
+    grafana_kubernetes_monitoring_feature_info{feature="windowsHosts", source="windows-exporter", version="1.0.0"} 1
+    # HELP grafana_kubernetes_monitoring_collector_info A metric to report the collectors of the Kubernetes Monitoring Helm chart
+    # TYPE grafana_kubernetes_monitoring_collector_info gauge
+    grafana_kubernetes_monitoring_collector_info{kind="statefulset", name="alloy-metrics", presets="clustered,statefulset", replicas="1", type="alloy"} 1
+    # EOF
+      `
+    } // prometheus.exporter.static "kubernetes_monitoring_telemetry"
     
     prometheus.scrape "kubernetes_monitoring_telemetry" {
       job_name   = "integrations/kubernetes/kubernetes_monitoring_telemetry"
-      targets    = discovery.relabel.kubernetes_monitoring_telemetry.output
+      targets    = prometheus.exporter.static.kubernetes_monitoring_telemetry.targets
       scrape_interval = "60s"
       clustering {
         enabled = true
       }
-      forward_to = [prometheus.relabel.kubernetes_monitoring_telemetry.receiver]
-    } // prometheus.scrape "kubernetes_monitoring_telemetry"
-    
-    prometheus.relabel "kubernetes_monitoring_telemetry" {
-      rule {
-        source_labels = ["__name__"]
-        regex = "grafana_kubernetes_monitoring_.*"
-        action = "keep"
-      }
       forward_to = [
         prometheus.relabel.metric_store.receiver,
       ]
-    } // prometheus.relabel "kubernetes_monitoring_telemetry"
+    } // prometheus.scrape "kubernetes_monitoring_telemetry"
     
     
     
@@ -1626,11 +1614,6 @@ spec:
       name: alloy-metrics
     configMap:
       create: false
-    mounts:
-      extra:
-      - mountPath: /etc/release-info
-        name: release-info
-        readOnly: true
     resources: {}
     securityContext:
       allowPrivilegeEscalation: false
@@ -1662,11 +1645,6 @@ spec:
       k8s.grafana.com/logs.job: integrations/alloy
     replicas: 1
     type: statefulset
-    volumes:
-      extra:
-      - configMap:
-          name: k8smon-k8s-monitoring-release-info
-        name: release-info
   crds:
     create: false
   nameOverride: alloy-metrics

--- a/charts/k8s-monitoring/templates/features/_feature_self_reporting.tpl
+++ b/charts/k8s-monitoring/templates/features/_feature_self_reporting.tpl
@@ -42,11 +42,13 @@
 {{- if eq (include "features.selfReporting.enabled" .) "true" }}
   {{- $collectorName := include "features.selfReporting.chooseCollector" . | trim }}
   {{- $collectorValues := (include "collector.alloy.values" (dict "Values" $.Values "Files" $.Files "collectorName" $collectorName) | fromYaml) }}
-  {{- $configMapName := printf "%s-release-info" (include "helper.fullname" .) }}
-  {{- $extraMounts := deepCopy (dig "alloy" "mounts" "extra" list $collectorValues) }}
-  {{- $extraMounts = append $extraMounts (dict "name" "release-info" "mountPath" "/etc/release-info" "readOnly" true) }}
-  {{- $extraVolumes := deepCopy (dig "controller" "volumes" "extra" list $collectorValues) }}
-  {{- $extraVolumes = append $extraVolumes (dict "name" "release-info" "configMap" (dict "name" $configMapName)) }}
+  {{- $stabilityLevel := dig "alloy" "stabilityLevel" "generally-available" $collectorValues }}
+  {{- if ne $stabilityLevel "experimental" }}
+    {{- $configMapName := printf "%s-release-info" (include "helper.fullname" .) }}
+    {{- $extraMounts := deepCopy (dig "alloy" "mounts" "extra" list $collectorValues) }}
+    {{- $extraMounts = append $extraMounts (dict "name" "release-info" "mountPath" "/etc/release-info" "readOnly" true) }}
+    {{- $extraVolumes := deepCopy (dig "controller" "volumes" "extra" list $collectorValues) }}
+    {{- $extraVolumes = append $extraVolumes (dict "name" "release-info" "configMap" (dict "name" $configMapName)) }}
 collectors:
   {{ $collectorName }}:
     alloy:
@@ -55,12 +57,19 @@ collectors:
     controller:
       volumes:
         extra: {{ $extraVolumes | toYaml | nindent 10 }}
+  {{- end }}
 {{- end }}
 {{- end }}
+
 {{- define "features.selfReporting.validate" }}{{ end }}
+
 {{- define "features.selfReporting.include" }}
 {{- if eq (include "features.selfReporting.enabled" .) "true" }}
-{{- $destinations := include "destinations.get" (dict "destinations" $.Values.destinations "type" "metrics" "ecosystem" "prometheus" "filter" $.Values.selfReporting.destinations) | fromYamlArray -}}
+  {{- $destinations := include "destinations.get" (dict "destinations" $.Values.destinations "type" "metrics" "ecosystem" "prometheus" "filter" $.Values.selfReporting.destinations) | fromYamlArray -}}
+  {{- $collectorName := include "features.selfReporting.chooseCollector" . | trim }}
+  {{- $collectorValues := (include "collector.alloy.values" (dict "Values" $.Values "Files" $.Files "collectorName" $collectorName) | fromYaml) }}
+  {{- $stabilityLevel := dig "alloy" "stabilityLevel" "generally-available" $collectorValues }}
+  {{- if ne $stabilityLevel "experimental" }}
 
 // Self Reporting
 prometheus.exporter.unix "kubernetes_monitoring_telemetry" {
@@ -104,6 +113,26 @@ prometheus.relabel "kubernetes_monitoring_telemetry" {
     {{ include "pipeline.alloy.targets.forFeature" (dict "root" $ "featureKey" "selfReporting" "destinationNames" $destinations "type" "metrics" "ecosystem" "prometheus") | indent 4 | trim }}
   ]
 } // prometheus.relabel "kubernetes_monitoring_telemetry"
+  {{- else }}
+
+// Self Reporting
+prometheus.exporter.static "kubernetes_monitoring_telemetry" {
+  text = `{{ include "features.selfReporting.metrics" . | nindent 0 }}
+  `
+} // prometheus.exporter.static "kubernetes_monitoring_telemetry"
+
+prometheus.scrape "kubernetes_monitoring_telemetry" {
+  job_name   = "integrations/kubernetes/kubernetes_monitoring_telemetry"
+  targets    = prometheus.exporter.static.kubernetes_monitoring_telemetry.targets
+  scrape_interval = {{ .Values.selfReporting.scrapeInterval | default .Values.global.scrapeInterval | quote}}
+  clustering {
+    enabled = true
+  }
+  forward_to = [
+    {{ include "pipeline.alloy.targets.forFeature" (dict "root" $ "featureKey" "selfReporting" "destinationNames" $destinations "type" "metrics" "ecosystem" "prometheus") | indent 4 | trim }}
+  ]
+} // prometheus.scrape "kubernetes_monitoring_telemetry"
+  {{- end }}
 {{- include "pipeline.alloy.feature.render.forFeature" (dict "root" $ "featureKey" "selfReporting" "destinationNames" $destinations "type" "metrics" "ecosystem" "prometheus") }}
 {{- end }}
 {{- end }}

--- a/charts/k8s-monitoring/tests/integration/prometheus-operator-objects/.rendered/alloy-metrics.alloy
+++ b/charts/k8s-monitoring/tests/integration/prometheus-operator-objects/.rendered/alloy-metrics.alloy
@@ -78,47 +78,33 @@ prometheus_operator_objects "feature" {
   ]
 }
 // Self Reporting
-prometheus.exporter.unix "kubernetes_monitoring_telemetry" {
-  set_collectors = ["textfile"]
-  textfile {
-    directory = "/etc/release-info"
-  }
-} // prometheus.exporter.unix "kubernetes_monitoring_telemetry"
+prometheus.exporter.static "kubernetes_monitoring_telemetry" {
+  text = `
 
-discovery.relabel "kubernetes_monitoring_telemetry" {
-  targets = prometheus.exporter.unix.kubernetes_monitoring_telemetry.targets
-  rule {
-    target_label = "instance"
-    action = "replace"
-    replacement = "k8smon"
-  }
-  rule {
-    target_label = "job"
-    action = "replace"
-    replacement = "integrations/kubernetes/kubernetes_monitoring_telemetry"
-  }
-} // discovery.relabel "kubernetes_monitoring_telemetry"
+# HELP grafana_kubernetes_monitoring_build_info A metric to report the version of the Kubernetes Monitoring Helm chart
+# TYPE grafana_kubernetes_monitoring_build_info gauge
+grafana_kubernetes_monitoring_build_info{version="4.4.0", namespace="default"} 1
+# HELP grafana_kubernetes_monitoring_feature_info A metric to report the enabled features of the Kubernetes Monitoring Helm chart
+# TYPE grafana_kubernetes_monitoring_feature_info gauge
+grafana_kubernetes_monitoring_feature_info{feature="prometheusOperatorObjects", sources="ServiceMonitors,PodMonitors,Probes", version="1.0.0"} 1
+# HELP grafana_kubernetes_monitoring_collector_info A metric to report the collectors of the Kubernetes Monitoring Helm chart
+# TYPE grafana_kubernetes_monitoring_collector_info gauge
+grafana_kubernetes_monitoring_collector_info{kind="statefulset", name="alloy-metrics", presets="clustered,statefulset", replicas="1", type="alloy"} 1
+# EOF
+  `
+} // prometheus.exporter.static "kubernetes_monitoring_telemetry"
 
 prometheus.scrape "kubernetes_monitoring_telemetry" {
   job_name   = "integrations/kubernetes/kubernetes_monitoring_telemetry"
-  targets    = discovery.relabel.kubernetes_monitoring_telemetry.output
+  targets    = prometheus.exporter.static.kubernetes_monitoring_telemetry.targets
   scrape_interval = "60s"
   clustering {
     enabled = true
   }
-  forward_to = [prometheus.relabel.kubernetes_monitoring_telemetry.receiver]
-} // prometheus.scrape "kubernetes_monitoring_telemetry"
-
-prometheus.relabel "kubernetes_monitoring_telemetry" {
-  rule {
-    source_labels = ["__name__"]
-    regex = "grafana_kubernetes_monitoring_.*"
-    action = "keep"
-  }
   forward_to = [
     prometheus.remote_write.localprometheus.receiver,
   ]
-} // prometheus.relabel "kubernetes_monitoring_telemetry"
+} // prometheus.scrape "kubernetes_monitoring_telemetry"
 
 
 

--- a/charts/k8s-monitoring/tests/integration/prometheus-operator-objects/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/integration/prometheus-operator-objects/.rendered/output.yaml
@@ -101,47 +101,33 @@ data:
       ]
     }
     // Self Reporting
-    prometheus.exporter.unix "kubernetes_monitoring_telemetry" {
-      set_collectors = ["textfile"]
-      textfile {
-        directory = "/etc/release-info"
-      }
-    } // prometheus.exporter.unix "kubernetes_monitoring_telemetry"
+    prometheus.exporter.static "kubernetes_monitoring_telemetry" {
+      text = `
     
-    discovery.relabel "kubernetes_monitoring_telemetry" {
-      targets = prometheus.exporter.unix.kubernetes_monitoring_telemetry.targets
-      rule {
-        target_label = "instance"
-        action = "replace"
-        replacement = "k8smon"
-      }
-      rule {
-        target_label = "job"
-        action = "replace"
-        replacement = "integrations/kubernetes/kubernetes_monitoring_telemetry"
-      }
-    } // discovery.relabel "kubernetes_monitoring_telemetry"
+    # HELP grafana_kubernetes_monitoring_build_info A metric to report the version of the Kubernetes Monitoring Helm chart
+    # TYPE grafana_kubernetes_monitoring_build_info gauge
+    grafana_kubernetes_monitoring_build_info{version="4.4.0", namespace="default"} 1
+    # HELP grafana_kubernetes_monitoring_feature_info A metric to report the enabled features of the Kubernetes Monitoring Helm chart
+    # TYPE grafana_kubernetes_monitoring_feature_info gauge
+    grafana_kubernetes_monitoring_feature_info{feature="prometheusOperatorObjects", sources="ServiceMonitors,PodMonitors,Probes", version="1.0.0"} 1
+    # HELP grafana_kubernetes_monitoring_collector_info A metric to report the collectors of the Kubernetes Monitoring Helm chart
+    # TYPE grafana_kubernetes_monitoring_collector_info gauge
+    grafana_kubernetes_monitoring_collector_info{kind="statefulset", name="alloy-metrics", presets="clustered,statefulset", replicas="1", type="alloy"} 1
+    # EOF
+      `
+    } // prometheus.exporter.static "kubernetes_monitoring_telemetry"
     
     prometheus.scrape "kubernetes_monitoring_telemetry" {
       job_name   = "integrations/kubernetes/kubernetes_monitoring_telemetry"
-      targets    = discovery.relabel.kubernetes_monitoring_telemetry.output
+      targets    = prometheus.exporter.static.kubernetes_monitoring_telemetry.targets
       scrape_interval = "60s"
       clustering {
         enabled = true
       }
-      forward_to = [prometheus.relabel.kubernetes_monitoring_telemetry.receiver]
-    } // prometheus.scrape "kubernetes_monitoring_telemetry"
-    
-    prometheus.relabel "kubernetes_monitoring_telemetry" {
-      rule {
-        source_labels = ["__name__"]
-        regex = "grafana_kubernetes_monitoring_.*"
-        action = "keep"
-      }
       forward_to = [
         prometheus.remote_write.localprometheus.receiver,
       ]
-    } // prometheus.relabel "kubernetes_monitoring_telemetry"
+    } // prometheus.scrape "kubernetes_monitoring_telemetry"
     
     
     
@@ -492,11 +478,6 @@ spec:
       name: alloy-metrics
     configMap:
       create: false
-    mounts:
-      extra:
-      - mountPath: /etc/release-info
-        name: release-info
-        readOnly: true
     resources: {}
     securityContext:
       allowPrivilegeEscalation: false
@@ -528,11 +509,6 @@ spec:
       k8s.grafana.com/logs.job: integrations/alloy
     replicas: 1
     type: statefulset
-    volumes:
-      extra:
-      - configMap:
-          name: k8smon-k8s-monitoring-release-info
-        name: release-info
   crds:
     create: false
   nameOverride: alloy-metrics

--- a/charts/k8s-monitoring/tests/platform/eks-alloy-on-windows/.rendered/alloy-linux.alloy
+++ b/charts/k8s-monitoring/tests/platform/eks-alloy-on-windows/.rendered/alloy-linux.alloy
@@ -1411,47 +1411,43 @@ pod_logs_via_kubernetes_api "feature" {
   ]
 }
 // Self Reporting
-prometheus.exporter.unix "kubernetes_monitoring_telemetry" {
-  set_collectors = ["textfile"]
-  textfile {
-    directory = "/etc/release-info"
-  }
-} // prometheus.exporter.unix "kubernetes_monitoring_telemetry"
+prometheus.exporter.static "kubernetes_monitoring_telemetry" {
+  text = `
 
-discovery.relabel "kubernetes_monitoring_telemetry" {
-  targets = prometheus.exporter.unix.kubernetes_monitoring_telemetry.targets
-  rule {
-    target_label = "instance"
-    action = "replace"
-    replacement = "k8smon"
-  }
-  rule {
-    target_label = "job"
-    action = "replace"
-    replacement = "integrations/kubernetes/kubernetes_monitoring_telemetry"
-  }
-} // discovery.relabel "kubernetes_monitoring_telemetry"
+# HELP grafana_kubernetes_monitoring_build_info A metric to report the version of the Kubernetes Monitoring Helm chart
+# TYPE grafana_kubernetes_monitoring_build_info gauge
+grafana_kubernetes_monitoring_build_info{version="4.4.0", namespace="default"} 1
+# HELP grafana_kubernetes_monitoring_feature_info A metric to report the enabled features of the Kubernetes Monitoring Helm chart
+# TYPE grafana_kubernetes_monitoring_feature_info gauge
+grafana_kubernetes_monitoring_feature_info{feature="clusterMetrics", sources="kubelet,kubeletResource,cadvisor,kube-state-metrics", version="1.0.0"} 1
+grafana_kubernetes_monitoring_feature_info{feature="clusterEvents", version="1.0.0"} 1
+grafana_kubernetes_monitoring_feature_info{feature="linuxHosts", source="alloy", version="1.0.0"} 1
+grafana_kubernetes_monitoring_feature_info{feature="windowsHosts", source="alloy", version="1.0.0"} 1
+grafana_kubernetes_monitoring_feature_info{feature="energyMetrics", version="1.0.0"} 1
+grafana_kubernetes_monitoring_feature_info{feature="integrations", sources="alloy", version="1.0.0"} 1
+grafana_kubernetes_monitoring_feature_info{feature="nodeLogs", version="1.0.0"} 1
+grafana_kubernetes_monitoring_feature_info{feature="windowsEventLogs", version="1.0.0"} 1
+grafana_kubernetes_monitoring_feature_info{feature="podLogsViaLoki", version="1.0.0"} 1
+grafana_kubernetes_monitoring_feature_info{feature="podLogsViaKubernetesApi", version="1.0.0"} 1
+# HELP grafana_kubernetes_monitoring_collector_info A metric to report the collectors of the Kubernetes Monitoring Helm chart
+# TYPE grafana_kubernetes_monitoring_collector_info gauge
+grafana_kubernetes_monitoring_collector_info{kind="daemonset", name="alloy-linux", presets="clustered,linux-host-monitor,filesystem-log-reader,daemonset", type="alloy"} 1
+grafana_kubernetes_monitoring_collector_info{kind="daemonset", name="alloy-windows", presets="windows,windows-host-process,windows-scrapeable,daemonset", type="alloy"} 1
+# EOF
+  `
+} // prometheus.exporter.static "kubernetes_monitoring_telemetry"
 
 prometheus.scrape "kubernetes_monitoring_telemetry" {
   job_name   = "integrations/kubernetes/kubernetes_monitoring_telemetry"
-  targets    = discovery.relabel.kubernetes_monitoring_telemetry.output
+  targets    = prometheus.exporter.static.kubernetes_monitoring_telemetry.targets
   scrape_interval = "60s"
   clustering {
     enabled = true
   }
-  forward_to = [prometheus.relabel.kubernetes_monitoring_telemetry.receiver]
-} // prometheus.scrape "kubernetes_monitoring_telemetry"
-
-prometheus.relabel "kubernetes_monitoring_telemetry" {
-  rule {
-    source_labels = ["__name__"]
-    regex = "grafana_kubernetes_monitoring_.*"
-    action = "keep"
-  }
   forward_to = [
     prometheus.remote_write.grafana_cloud_metrics.receiver,
   ]
-} // prometheus.relabel "kubernetes_monitoring_telemetry"
+} // prometheus.scrape "kubernetes_monitoring_telemetry"
 // Processor: ec2-tags (ec2Enrichment) — shared EC2 instance discovery
 discovery.ec2 "ec2_tags_instances" {
   region = "ap-northeast-2"

--- a/charts/k8s-monitoring/tests/platform/eks-alloy-on-windows/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/platform/eks-alloy-on-windows/.rendered/output.yaml
@@ -1464,47 +1464,43 @@ data:
       ]
     }
     // Self Reporting
-    prometheus.exporter.unix "kubernetes_monitoring_telemetry" {
-      set_collectors = ["textfile"]
-      textfile {
-        directory = "/etc/release-info"
-      }
-    } // prometheus.exporter.unix "kubernetes_monitoring_telemetry"
+    prometheus.exporter.static "kubernetes_monitoring_telemetry" {
+      text = `
     
-    discovery.relabel "kubernetes_monitoring_telemetry" {
-      targets = prometheus.exporter.unix.kubernetes_monitoring_telemetry.targets
-      rule {
-        target_label = "instance"
-        action = "replace"
-        replacement = "k8smon"
-      }
-      rule {
-        target_label = "job"
-        action = "replace"
-        replacement = "integrations/kubernetes/kubernetes_monitoring_telemetry"
-      }
-    } // discovery.relabel "kubernetes_monitoring_telemetry"
+    # HELP grafana_kubernetes_monitoring_build_info A metric to report the version of the Kubernetes Monitoring Helm chart
+    # TYPE grafana_kubernetes_monitoring_build_info gauge
+    grafana_kubernetes_monitoring_build_info{version="4.4.0", namespace="default"} 1
+    # HELP grafana_kubernetes_monitoring_feature_info A metric to report the enabled features of the Kubernetes Monitoring Helm chart
+    # TYPE grafana_kubernetes_monitoring_feature_info gauge
+    grafana_kubernetes_monitoring_feature_info{feature="clusterMetrics", sources="kubelet,kubeletResource,cadvisor,kube-state-metrics", version="1.0.0"} 1
+    grafana_kubernetes_monitoring_feature_info{feature="clusterEvents", version="1.0.0"} 1
+    grafana_kubernetes_monitoring_feature_info{feature="linuxHosts", source="alloy", version="1.0.0"} 1
+    grafana_kubernetes_monitoring_feature_info{feature="windowsHosts", source="alloy", version="1.0.0"} 1
+    grafana_kubernetes_monitoring_feature_info{feature="energyMetrics", version="1.0.0"} 1
+    grafana_kubernetes_monitoring_feature_info{feature="integrations", sources="alloy", version="1.0.0"} 1
+    grafana_kubernetes_monitoring_feature_info{feature="nodeLogs", version="1.0.0"} 1
+    grafana_kubernetes_monitoring_feature_info{feature="windowsEventLogs", version="1.0.0"} 1
+    grafana_kubernetes_monitoring_feature_info{feature="podLogsViaLoki", version="1.0.0"} 1
+    grafana_kubernetes_monitoring_feature_info{feature="podLogsViaKubernetesApi", version="1.0.0"} 1
+    # HELP grafana_kubernetes_monitoring_collector_info A metric to report the collectors of the Kubernetes Monitoring Helm chart
+    # TYPE grafana_kubernetes_monitoring_collector_info gauge
+    grafana_kubernetes_monitoring_collector_info{kind="daemonset", name="alloy-linux", presets="clustered,linux-host-monitor,filesystem-log-reader,daemonset", type="alloy"} 1
+    grafana_kubernetes_monitoring_collector_info{kind="daemonset", name="alloy-windows", presets="windows,windows-host-process,windows-scrapeable,daemonset", type="alloy"} 1
+    # EOF
+      `
+    } // prometheus.exporter.static "kubernetes_monitoring_telemetry"
     
     prometheus.scrape "kubernetes_monitoring_telemetry" {
       job_name   = "integrations/kubernetes/kubernetes_monitoring_telemetry"
-      targets    = discovery.relabel.kubernetes_monitoring_telemetry.output
+      targets    = prometheus.exporter.static.kubernetes_monitoring_telemetry.targets
       scrape_interval = "60s"
       clustering {
         enabled = true
       }
-      forward_to = [prometheus.relabel.kubernetes_monitoring_telemetry.receiver]
-    } // prometheus.scrape "kubernetes_monitoring_telemetry"
-    
-    prometheus.relabel "kubernetes_monitoring_telemetry" {
-      rule {
-        source_labels = ["__name__"]
-        regex = "grafana_kubernetes_monitoring_.*"
-        action = "keep"
-      }
       forward_to = [
         prometheus.remote_write.grafana_cloud_metrics.receiver,
       ]
-    } // prometheus.relabel "kubernetes_monitoring_telemetry"
+    } // prometheus.scrape "kubernetes_monitoring_telemetry"
     // Processor: ec2-tags (ec2Enrichment) — shared EC2 instance discovery
     discovery.ec2 "ec2_tags_instances" {
       region = "ap-northeast-2"
@@ -2702,9 +2698,6 @@ spec:
       - mountPath: /host/sys
         name: host-sys
         readOnly: true
-      - mountPath: /etc/release-info
-        name: release-info
-        readOnly: true
       varlog: true
     resources: {}
     securityContext:
@@ -2741,9 +2734,6 @@ spec:
           path: /sys
           type: Directory
         name: host-sys
-      - configMap:
-          name: k8smon-k8s-monitoring-release-info
-        name: release-info
   crds:
     create: false
   nameOverride: alloy-linux

--- a/charts/k8s-monitoring/tests/platform/eks-with-windows/.rendered/alloy.alloy
+++ b/charts/k8s-monitoring/tests/platform/eks-with-windows/.rendered/alloy.alloy
@@ -1779,47 +1779,40 @@ pod_logs_via_kubernetes_api "feature" {
   ]
 }
 // Self Reporting
-prometheus.exporter.unix "kubernetes_monitoring_telemetry" {
-  set_collectors = ["textfile"]
-  textfile {
-    directory = "/etc/release-info"
-  }
-} // prometheus.exporter.unix "kubernetes_monitoring_telemetry"
+prometheus.exporter.static "kubernetes_monitoring_telemetry" {
+  text = `
 
-discovery.relabel "kubernetes_monitoring_telemetry" {
-  targets = prometheus.exporter.unix.kubernetes_monitoring_telemetry.targets
-  rule {
-    target_label = "instance"
-    action = "replace"
-    replacement = "k8smon"
-  }
-  rule {
-    target_label = "job"
-    action = "replace"
-    replacement = "integrations/kubernetes/kubernetes_monitoring_telemetry"
-  }
-} // discovery.relabel "kubernetes_monitoring_telemetry"
+# HELP grafana_kubernetes_monitoring_build_info A metric to report the version of the Kubernetes Monitoring Helm chart
+# TYPE grafana_kubernetes_monitoring_build_info gauge
+grafana_kubernetes_monitoring_build_info{version="4.4.0", namespace="default"} 1
+# HELP grafana_kubernetes_monitoring_feature_info A metric to report the enabled features of the Kubernetes Monitoring Helm chart
+# TYPE grafana_kubernetes_monitoring_feature_info gauge
+grafana_kubernetes_monitoring_feature_info{feature="clusterMetrics", sources="controlPlane,kubelet,kubeletResource,cadvisor,kube-state-metrics", version="1.0.0"} 1
+grafana_kubernetes_monitoring_feature_info{feature="clusterEvents", version="1.0.0"} 1
+grafana_kubernetes_monitoring_feature_info{feature="linuxHosts", source="node-exporter", version="1.0.0"} 1
+grafana_kubernetes_monitoring_feature_info{feature="windowsHosts", source="windows-exporter", version="1.0.0"} 1
+grafana_kubernetes_monitoring_feature_info{feature="integrations", sources="alloy", version="1.0.0"} 1
+grafana_kubernetes_monitoring_feature_info{feature="nodeLogs", version="1.0.0"} 1
+grafana_kubernetes_monitoring_feature_info{feature="podLogsViaLoki", version="1.0.0"} 1
+grafana_kubernetes_monitoring_feature_info{feature="podLogsViaKubernetesApi", version="1.0.0"} 1
+# HELP grafana_kubernetes_monitoring_collector_info A metric to report the collectors of the Kubernetes Monitoring Helm chart
+# TYPE grafana_kubernetes_monitoring_collector_info gauge
+grafana_kubernetes_monitoring_collector_info{kind="daemonset", name="alloy", presets="clustered,filesystem-log-reader,daemonset", type="alloy"} 1
+# EOF
+  `
+} // prometheus.exporter.static "kubernetes_monitoring_telemetry"
 
 prometheus.scrape "kubernetes_monitoring_telemetry" {
   job_name   = "integrations/kubernetes/kubernetes_monitoring_telemetry"
-  targets    = discovery.relabel.kubernetes_monitoring_telemetry.output
+  targets    = prometheus.exporter.static.kubernetes_monitoring_telemetry.targets
   scrape_interval = "60s"
   clustering {
     enabled = true
   }
-  forward_to = [prometheus.relabel.kubernetes_monitoring_telemetry.receiver]
-} // prometheus.scrape "kubernetes_monitoring_telemetry"
-
-prometheus.relabel "kubernetes_monitoring_telemetry" {
-  rule {
-    source_labels = ["__name__"]
-    regex = "grafana_kubernetes_monitoring_.*"
-    action = "keep"
-  }
   forward_to = [
     prometheus.remote_write.grafana_cloud_metrics.receiver,
   ]
-} // prometheus.relabel "kubernetes_monitoring_telemetry"
+} // prometheus.scrape "kubernetes_monitoring_telemetry"
 // Processor: ec2-tags (ec2Enrichment) — shared EC2 instance discovery
 discovery.ec2 "ec2_tags_instances" {
   region = "ap-northeast-2"

--- a/charts/k8s-monitoring/tests/platform/eks-with-windows/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/platform/eks-with-windows/.rendered/output.yaml
@@ -1875,47 +1875,40 @@ data:
       ]
     }
     // Self Reporting
-    prometheus.exporter.unix "kubernetes_monitoring_telemetry" {
-      set_collectors = ["textfile"]
-      textfile {
-        directory = "/etc/release-info"
-      }
-    } // prometheus.exporter.unix "kubernetes_monitoring_telemetry"
+    prometheus.exporter.static "kubernetes_monitoring_telemetry" {
+      text = `
     
-    discovery.relabel "kubernetes_monitoring_telemetry" {
-      targets = prometheus.exporter.unix.kubernetes_monitoring_telemetry.targets
-      rule {
-        target_label = "instance"
-        action = "replace"
-        replacement = "k8smon"
-      }
-      rule {
-        target_label = "job"
-        action = "replace"
-        replacement = "integrations/kubernetes/kubernetes_monitoring_telemetry"
-      }
-    } // discovery.relabel "kubernetes_monitoring_telemetry"
+    # HELP grafana_kubernetes_monitoring_build_info A metric to report the version of the Kubernetes Monitoring Helm chart
+    # TYPE grafana_kubernetes_monitoring_build_info gauge
+    grafana_kubernetes_monitoring_build_info{version="4.4.0", namespace="default"} 1
+    # HELP grafana_kubernetes_monitoring_feature_info A metric to report the enabled features of the Kubernetes Monitoring Helm chart
+    # TYPE grafana_kubernetes_monitoring_feature_info gauge
+    grafana_kubernetes_monitoring_feature_info{feature="clusterMetrics", sources="controlPlane,kubelet,kubeletResource,cadvisor,kube-state-metrics", version="1.0.0"} 1
+    grafana_kubernetes_monitoring_feature_info{feature="clusterEvents", version="1.0.0"} 1
+    grafana_kubernetes_monitoring_feature_info{feature="linuxHosts", source="node-exporter", version="1.0.0"} 1
+    grafana_kubernetes_monitoring_feature_info{feature="windowsHosts", source="windows-exporter", version="1.0.0"} 1
+    grafana_kubernetes_monitoring_feature_info{feature="integrations", sources="alloy", version="1.0.0"} 1
+    grafana_kubernetes_monitoring_feature_info{feature="nodeLogs", version="1.0.0"} 1
+    grafana_kubernetes_monitoring_feature_info{feature="podLogsViaLoki", version="1.0.0"} 1
+    grafana_kubernetes_monitoring_feature_info{feature="podLogsViaKubernetesApi", version="1.0.0"} 1
+    # HELP grafana_kubernetes_monitoring_collector_info A metric to report the collectors of the Kubernetes Monitoring Helm chart
+    # TYPE grafana_kubernetes_monitoring_collector_info gauge
+    grafana_kubernetes_monitoring_collector_info{kind="daemonset", name="alloy", presets="clustered,filesystem-log-reader,daemonset", type="alloy"} 1
+    # EOF
+      `
+    } // prometheus.exporter.static "kubernetes_monitoring_telemetry"
     
     prometheus.scrape "kubernetes_monitoring_telemetry" {
       job_name   = "integrations/kubernetes/kubernetes_monitoring_telemetry"
-      targets    = discovery.relabel.kubernetes_monitoring_telemetry.output
+      targets    = prometheus.exporter.static.kubernetes_monitoring_telemetry.targets
       scrape_interval = "60s"
       clustering {
         enabled = true
       }
-      forward_to = [prometheus.relabel.kubernetes_monitoring_telemetry.receiver]
-    } // prometheus.scrape "kubernetes_monitoring_telemetry"
-    
-    prometheus.relabel "kubernetes_monitoring_telemetry" {
-      rule {
-        source_labels = ["__name__"]
-        regex = "grafana_kubernetes_monitoring_.*"
-        action = "keep"
-      }
       forward_to = [
         prometheus.remote_write.grafana_cloud_metrics.receiver,
       ]
-    } // prometheus.relabel "kubernetes_monitoring_telemetry"
+    } // prometheus.scrape "kubernetes_monitoring_telemetry"
     // Processor: ec2-tags (ec2Enrichment) — shared EC2 instance discovery
     discovery.ec2 "ec2_tags_instances" {
       region = "ap-northeast-2"
@@ -2920,10 +2913,6 @@ spec:
       create: false
     mounts:
       dockercontainers: true
-      extra:
-      - mountPath: /etc/release-info
-        name: release-info
-        readOnly: true
       varlog: true
     resources: {}
     securityContext:
@@ -2958,11 +2947,6 @@ spec:
     - effect: NoSchedule
       operator: Exists
     type: daemonset
-    volumes:
-      extra:
-      - configMap:
-          name: k8smon-k8s-monitoring-release-info
-        name: release-info
   crds:
     create: false
   nameOverride: alloy

--- a/charts/k8s-monitoring/tests/platform/grafana-cloud/database-observability/.rendered/alloy-singleton.alloy
+++ b/charts/k8s-monitoring/tests/platform/grafana-cloud/database-observability/.rendered/alloy-singleton.alloy
@@ -228,47 +228,35 @@ postgresql_integration "integration" {
   ]
 }
 // Self Reporting
-prometheus.exporter.unix "kubernetes_monitoring_telemetry" {
-  set_collectors = ["textfile"]
-  textfile {
-    directory = "/etc/release-info"
-  }
-} // prometheus.exporter.unix "kubernetes_monitoring_telemetry"
+prometheus.exporter.static "kubernetes_monitoring_telemetry" {
+  text = `
 
-discovery.relabel "kubernetes_monitoring_telemetry" {
-  targets = prometheus.exporter.unix.kubernetes_monitoring_telemetry.targets
-  rule {
-    target_label = "instance"
-    action = "replace"
-    replacement = "k8smon"
-  }
-  rule {
-    target_label = "job"
-    action = "replace"
-    replacement = "integrations/kubernetes/kubernetes_monitoring_telemetry"
-  }
-} // discovery.relabel "kubernetes_monitoring_telemetry"
+# HELP grafana_kubernetes_monitoring_build_info A metric to report the version of the Kubernetes Monitoring Helm chart
+# TYPE grafana_kubernetes_monitoring_build_info gauge
+grafana_kubernetes_monitoring_build_info{version="4.4.0", namespace="default"} 1
+# HELP grafana_kubernetes_monitoring_feature_info A metric to report the enabled features of the Kubernetes Monitoring Helm chart
+# TYPE grafana_kubernetes_monitoring_feature_info gauge
+grafana_kubernetes_monitoring_feature_info{feature="integrations", sources="mysql,postgresql", version="1.0.0"} 1
+grafana_kubernetes_monitoring_feature_info{feature="podLogsViaLoki", version="1.0.0"} 1
+# HELP grafana_kubernetes_monitoring_collector_info A metric to report the collectors of the Kubernetes Monitoring Helm chart
+# TYPE grafana_kubernetes_monitoring_collector_info gauge
+grafana_kubernetes_monitoring_collector_info{kind="daemonset", name="alloy-logs", presets="filesystem-log-reader,daemonset", type="alloy"} 1
+grafana_kubernetes_monitoring_collector_info{kind="deployment", name="alloy-singleton", presets="singleton", replicas="1", type="alloy"} 1
+# EOF
+  `
+} // prometheus.exporter.static "kubernetes_monitoring_telemetry"
 
 prometheus.scrape "kubernetes_monitoring_telemetry" {
   job_name   = "integrations/kubernetes/kubernetes_monitoring_telemetry"
-  targets    = discovery.relabel.kubernetes_monitoring_telemetry.output
+  targets    = prometheus.exporter.static.kubernetes_monitoring_telemetry.targets
   scrape_interval = "60s"
   clustering {
     enabled = true
   }
-  forward_to = [prometheus.relabel.kubernetes_monitoring_telemetry.receiver]
-} // prometheus.scrape "kubernetes_monitoring_telemetry"
-
-prometheus.relabel "kubernetes_monitoring_telemetry" {
-  rule {
-    source_labels = ["__name__"]
-    regex = "grafana_kubernetes_monitoring_.*"
-    action = "keep"
-  }
   forward_to = [
     prometheus.remote_write.grafana_cloud_metrics.receiver,
   ]
-} // prometheus.relabel "kubernetes_monitoring_telemetry"
+} // prometheus.scrape "kubernetes_monitoring_telemetry"
 
 
 

--- a/charts/k8s-monitoring/tests/platform/grafana-cloud/database-observability/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/platform/grafana-cloud/database-observability/.rendered/output.yaml
@@ -573,47 +573,35 @@ data:
       ]
     }
     // Self Reporting
-    prometheus.exporter.unix "kubernetes_monitoring_telemetry" {
-      set_collectors = ["textfile"]
-      textfile {
-        directory = "/etc/release-info"
-      }
-    } // prometheus.exporter.unix "kubernetes_monitoring_telemetry"
+    prometheus.exporter.static "kubernetes_monitoring_telemetry" {
+      text = `
     
-    discovery.relabel "kubernetes_monitoring_telemetry" {
-      targets = prometheus.exporter.unix.kubernetes_monitoring_telemetry.targets
-      rule {
-        target_label = "instance"
-        action = "replace"
-        replacement = "k8smon"
-      }
-      rule {
-        target_label = "job"
-        action = "replace"
-        replacement = "integrations/kubernetes/kubernetes_monitoring_telemetry"
-      }
-    } // discovery.relabel "kubernetes_monitoring_telemetry"
+    # HELP grafana_kubernetes_monitoring_build_info A metric to report the version of the Kubernetes Monitoring Helm chart
+    # TYPE grafana_kubernetes_monitoring_build_info gauge
+    grafana_kubernetes_monitoring_build_info{version="4.4.0", namespace="default"} 1
+    # HELP grafana_kubernetes_monitoring_feature_info A metric to report the enabled features of the Kubernetes Monitoring Helm chart
+    # TYPE grafana_kubernetes_monitoring_feature_info gauge
+    grafana_kubernetes_monitoring_feature_info{feature="integrations", sources="mysql,postgresql", version="1.0.0"} 1
+    grafana_kubernetes_monitoring_feature_info{feature="podLogsViaLoki", version="1.0.0"} 1
+    # HELP grafana_kubernetes_monitoring_collector_info A metric to report the collectors of the Kubernetes Monitoring Helm chart
+    # TYPE grafana_kubernetes_monitoring_collector_info gauge
+    grafana_kubernetes_monitoring_collector_info{kind="daemonset", name="alloy-logs", presets="filesystem-log-reader,daemonset", type="alloy"} 1
+    grafana_kubernetes_monitoring_collector_info{kind="deployment", name="alloy-singleton", presets="singleton", replicas="1", type="alloy"} 1
+    # EOF
+      `
+    } // prometheus.exporter.static "kubernetes_monitoring_telemetry"
     
     prometheus.scrape "kubernetes_monitoring_telemetry" {
       job_name   = "integrations/kubernetes/kubernetes_monitoring_telemetry"
-      targets    = discovery.relabel.kubernetes_monitoring_telemetry.output
+      targets    = prometheus.exporter.static.kubernetes_monitoring_telemetry.targets
       scrape_interval = "60s"
       clustering {
         enabled = true
       }
-      forward_to = [prometheus.relabel.kubernetes_monitoring_telemetry.receiver]
-    } // prometheus.scrape "kubernetes_monitoring_telemetry"
-    
-    prometheus.relabel "kubernetes_monitoring_telemetry" {
-      rule {
-        source_labels = ["__name__"]
-        regex = "grafana_kubernetes_monitoring_.*"
-        action = "keep"
-      }
       forward_to = [
         prometheus.remote_write.grafana_cloud_metrics.receiver,
       ]
-    } // prometheus.relabel "kubernetes_monitoring_telemetry"
+    } // prometheus.scrape "kubernetes_monitoring_telemetry"
     
     
     
@@ -1064,11 +1052,6 @@ spec:
   alloy:
     configMap:
       create: false
-    mounts:
-      extra:
-      - mountPath: /etc/release-info
-        name: release-info
-        readOnly: true
     resources: {}
     securityContext:
       allowPrivilegeEscalation: false
@@ -1100,11 +1083,6 @@ spec:
       k8s.grafana.com/logs.job: integrations/alloy
     replicas: 1
     type: deployment
-    volumes:
-      extra:
-      - configMap:
-          name: k8smon-k8s-monitoring-release-info
-        name: release-info
   crds:
     create: false
   nameOverride: alloy-singleton

--- a/charts/k8s-monitoring/tests/platform/grafana-cloud/k8s-monitoring/.rendered/alloy-singleton.alloy
+++ b/charts/k8s-monitoring/tests/platform/grafana-cloud/k8s-monitoring/.rendered/alloy-singleton.alloy
@@ -82,47 +82,45 @@ cluster_events "feature" {
   ]
 }
 // Self Reporting
-prometheus.exporter.unix "kubernetes_monitoring_telemetry" {
-  set_collectors = ["textfile"]
-  textfile {
-    directory = "/etc/release-info"
-  }
-} // prometheus.exporter.unix "kubernetes_monitoring_telemetry"
+prometheus.exporter.static "kubernetes_monitoring_telemetry" {
+  text = `
 
-discovery.relabel "kubernetes_monitoring_telemetry" {
-  targets = prometheus.exporter.unix.kubernetes_monitoring_telemetry.targets
-  rule {
-    target_label = "instance"
-    action = "replace"
-    replacement = "k8smon"
-  }
-  rule {
-    target_label = "job"
-    action = "replace"
-    replacement = "integrations/kubernetes/kubernetes_monitoring_telemetry"
-  }
-} // discovery.relabel "kubernetes_monitoring_telemetry"
+# HELP grafana_kubernetes_monitoring_build_info A metric to report the version of the Kubernetes Monitoring Helm chart
+# TYPE grafana_kubernetes_monitoring_build_info gauge
+grafana_kubernetes_monitoring_build_info{version="4.4.0", namespace="default"} 1
+# HELP grafana_kubernetes_monitoring_feature_info A metric to report the enabled features of the Kubernetes Monitoring Helm chart
+# TYPE grafana_kubernetes_monitoring_feature_info gauge
+grafana_kubernetes_monitoring_feature_info{feature="applicationObservability", protocols="otlpgrpc", version="1.0.0"} 1
+grafana_kubernetes_monitoring_feature_info{feature="autoInstrumentation", version="1.0.0"} 1
+grafana_kubernetes_monitoring_feature_info{feature="clusterMetrics", sources="kubelet,kubeletResource,cadvisor,kube-state-metrics", version="1.0.0"} 1
+grafana_kubernetes_monitoring_feature_info{feature="clusterEvents", version="1.0.0"} 1
+grafana_kubernetes_monitoring_feature_info{feature="costMetrics", version="1.0.0"} 1
+grafana_kubernetes_monitoring_feature_info{feature="linuxHosts", source="node-exporter", version="1.0.0"} 1
+grafana_kubernetes_monitoring_feature_info{feature="windowsHosts", source="windows-exporter", version="1.0.0"} 1
+grafana_kubernetes_monitoring_feature_info{feature="energyMetrics", version="1.0.0"} 1
+grafana_kubernetes_monitoring_feature_info{feature="integrations", sources="alloy", version="1.0.0"} 1
+grafana_kubernetes_monitoring_feature_info{feature="podLogsViaLoki", version="1.0.0"} 1
+# HELP grafana_kubernetes_monitoring_collector_info A metric to report the collectors of the Kubernetes Monitoring Helm chart
+# TYPE grafana_kubernetes_monitoring_collector_info gauge
+grafana_kubernetes_monitoring_collector_info{kind="daemonset", name="alloy-logs", presets="filesystem-log-reader,daemonset", type="alloy"} 1
+grafana_kubernetes_monitoring_collector_info{kind="statefulset", name="alloy-metrics", presets="clustered,statefulset", replicas="1", type="alloy"} 1
+grafana_kubernetes_monitoring_collector_info{kind="deployment", name="alloy-receiver", presets="deployment", replicas="1", type="alloy"} 1
+grafana_kubernetes_monitoring_collector_info{kind="deployment", name="alloy-singleton", presets="singleton", replicas="1", type="alloy"} 1
+# EOF
+  `
+} // prometheus.exporter.static "kubernetes_monitoring_telemetry"
 
 prometheus.scrape "kubernetes_monitoring_telemetry" {
   job_name   = "integrations/kubernetes/kubernetes_monitoring_telemetry"
-  targets    = discovery.relabel.kubernetes_monitoring_telemetry.output
+  targets    = prometheus.exporter.static.kubernetes_monitoring_telemetry.targets
   scrape_interval = "60s"
   clustering {
     enabled = true
   }
-  forward_to = [prometheus.relabel.kubernetes_monitoring_telemetry.receiver]
-} // prometheus.scrape "kubernetes_monitoring_telemetry"
-
-prometheus.relabel "kubernetes_monitoring_telemetry" {
-  rule {
-    source_labels = ["__name__"]
-    regex = "grafana_kubernetes_monitoring_.*"
-    action = "keep"
-  }
   forward_to = [
     prometheus.remote_write.grafana_cloud_metrics.receiver,
   ]
-} // prometheus.relabel "kubernetes_monitoring_telemetry"
+} // prometheus.scrape "kubernetes_monitoring_telemetry"
 
 livedebugging {
   enabled = true

--- a/charts/k8s-monitoring/tests/platform/grafana-cloud/k8s-monitoring/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/platform/grafana-cloud/k8s-monitoring/.rendered/output.yaml
@@ -1958,47 +1958,45 @@ data:
       ]
     }
     // Self Reporting
-    prometheus.exporter.unix "kubernetes_monitoring_telemetry" {
-      set_collectors = ["textfile"]
-      textfile {
-        directory = "/etc/release-info"
-      }
-    } // prometheus.exporter.unix "kubernetes_monitoring_telemetry"
+    prometheus.exporter.static "kubernetes_monitoring_telemetry" {
+      text = `
     
-    discovery.relabel "kubernetes_monitoring_telemetry" {
-      targets = prometheus.exporter.unix.kubernetes_monitoring_telemetry.targets
-      rule {
-        target_label = "instance"
-        action = "replace"
-        replacement = "k8smon"
-      }
-      rule {
-        target_label = "job"
-        action = "replace"
-        replacement = "integrations/kubernetes/kubernetes_monitoring_telemetry"
-      }
-    } // discovery.relabel "kubernetes_monitoring_telemetry"
+    # HELP grafana_kubernetes_monitoring_build_info A metric to report the version of the Kubernetes Monitoring Helm chart
+    # TYPE grafana_kubernetes_monitoring_build_info gauge
+    grafana_kubernetes_monitoring_build_info{version="4.4.0", namespace="default"} 1
+    # HELP grafana_kubernetes_monitoring_feature_info A metric to report the enabled features of the Kubernetes Monitoring Helm chart
+    # TYPE grafana_kubernetes_monitoring_feature_info gauge
+    grafana_kubernetes_monitoring_feature_info{feature="applicationObservability", protocols="otlpgrpc", version="1.0.0"} 1
+    grafana_kubernetes_monitoring_feature_info{feature="autoInstrumentation", version="1.0.0"} 1
+    grafana_kubernetes_monitoring_feature_info{feature="clusterMetrics", sources="kubelet,kubeletResource,cadvisor,kube-state-metrics", version="1.0.0"} 1
+    grafana_kubernetes_monitoring_feature_info{feature="clusterEvents", version="1.0.0"} 1
+    grafana_kubernetes_monitoring_feature_info{feature="costMetrics", version="1.0.0"} 1
+    grafana_kubernetes_monitoring_feature_info{feature="linuxHosts", source="node-exporter", version="1.0.0"} 1
+    grafana_kubernetes_monitoring_feature_info{feature="windowsHosts", source="windows-exporter", version="1.0.0"} 1
+    grafana_kubernetes_monitoring_feature_info{feature="energyMetrics", version="1.0.0"} 1
+    grafana_kubernetes_monitoring_feature_info{feature="integrations", sources="alloy", version="1.0.0"} 1
+    grafana_kubernetes_monitoring_feature_info{feature="podLogsViaLoki", version="1.0.0"} 1
+    # HELP grafana_kubernetes_monitoring_collector_info A metric to report the collectors of the Kubernetes Monitoring Helm chart
+    # TYPE grafana_kubernetes_monitoring_collector_info gauge
+    grafana_kubernetes_monitoring_collector_info{kind="daemonset", name="alloy-logs", presets="filesystem-log-reader,daemonset", type="alloy"} 1
+    grafana_kubernetes_monitoring_collector_info{kind="statefulset", name="alloy-metrics", presets="clustered,statefulset", replicas="1", type="alloy"} 1
+    grafana_kubernetes_monitoring_collector_info{kind="deployment", name="alloy-receiver", presets="deployment", replicas="1", type="alloy"} 1
+    grafana_kubernetes_monitoring_collector_info{kind="deployment", name="alloy-singleton", presets="singleton", replicas="1", type="alloy"} 1
+    # EOF
+      `
+    } // prometheus.exporter.static "kubernetes_monitoring_telemetry"
     
     prometheus.scrape "kubernetes_monitoring_telemetry" {
       job_name   = "integrations/kubernetes/kubernetes_monitoring_telemetry"
-      targets    = discovery.relabel.kubernetes_monitoring_telemetry.output
+      targets    = prometheus.exporter.static.kubernetes_monitoring_telemetry.targets
       scrape_interval = "60s"
       clustering {
         enabled = true
       }
-      forward_to = [prometheus.relabel.kubernetes_monitoring_telemetry.receiver]
-    } // prometheus.scrape "kubernetes_monitoring_telemetry"
-    
-    prometheus.relabel "kubernetes_monitoring_telemetry" {
-      rule {
-        source_labels = ["__name__"]
-        regex = "grafana_kubernetes_monitoring_.*"
-        action = "keep"
-      }
       forward_to = [
         prometheus.remote_write.grafana_cloud_metrics.receiver,
       ]
-    } // prometheus.relabel "kubernetes_monitoring_telemetry"
+    } // prometheus.scrape "kubernetes_monitoring_telemetry"
     
     livedebugging {
       enabled = true
@@ -3984,11 +3982,6 @@ spec:
   alloy:
     configMap:
       create: false
-    mounts:
-      extra:
-      - mountPath: /etc/release-info
-        name: release-info
-        readOnly: true
     resources: {}
     securityContext:
       allowPrivilegeEscalation: false
@@ -4021,11 +4014,6 @@ spec:
       source: k8s-monitoring-gc-feature-test
     replicas: 1
     type: deployment
-    volumes:
-      extra:
-      - configMap:
-          name: k8smon-k8s-monitoring-release-info
-        name: release-info
   crds:
     create: false
   nameOverride: alloy-singleton


### PR DESCRIPTION
# Description

When collector is experimental, use prometheus.exporter.static for selfReporting. This avoids using the `prometheus.exporter.unix`, which starts an internal node-exporter and a configmap volume mount, so the pipeline is greatly simplified, and it'll help test this component.

Fixes #2923

<!--Authorship attestation. See AGENTS.md for details. AI agents must not check this box on behalf
of the user; the human author must check it themselves before the PR is ready for review.-->
## Authorship

-   [x] I, a human, wrote this pull request description myself.

<!--Please delete paragraphs that you did not use before submitting.-->
