### PR TITLE
Set scheme and bearerTokenFile for windows exporter

### DIFF
--- a/charts/k8s-monitoring/CHANGELOG.md
+++ b/charts/k8s-monitoring/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 *   Fix the Prometheus destination so the cluster label honors `cluster.nameFrom`. (#2963) (@TylerHelmuth)
 *   Cluster Metrics: when `kubeScheduler.discoveryMode` is `eks-proxy`, collect the EKS Control Plane resource metrics (`kube_pod_resource_request` and `kube_pod_resource_limit`). (#2977)
+*   Host Metrics: honor `windowsHosts.scheme` and `windowsHosts.bearerTokenFile` when scraping an external Windows Exporter. (#2961) (@petewall)
 *   Update Beyla to 1.16.11 and kube-state-metrics to 8.4.0. (@petewall)
 
 ## 4.4.0

--- a/charts/k8s-monitoring/charts/feature-host-metrics/templates/_windows_hosts.alloy.tpl
+++ b/charts/k8s-monitoring/charts/feature-host-metrics/templates/_windows_hosts.alloy.tpl
@@ -37,6 +37,14 @@ prometheus.scrape "windows_exporter" {
   scrape_native_histograms = {{ .Values.global.scrapeNativeHistograms }}
   convert_classic_histograms_to_nhcb = {{ .Values.global.convertClassicHistogramsToNhcb }}
 {{- if ne $source "alloy" }}
+  scheme = {{ .Values.windowsHosts.scheme | quote }}
+  {{- if .Values.windowsHosts.bearerTokenFile }}
+  bearer_token_file = {{ .Values.windowsHosts.bearerTokenFile | quote }}
+  {{- end }}
+  tls_config {
+    insecure_skip_verify = true
+  }
+
   clustering {
     enabled = true
   }

--- a/charts/k8s-monitoring/charts/feature-host-metrics/tests/windows_scheme_test.yaml
+++ b/charts/k8s-monitoring/charts/feature-host-metrics/tests/windows_scheme_test.yaml
@@ -1,0 +1,57 @@
+# yamllint disable rule:document-start rule:line-length rule:trailing-spaces
+suite: Feature - Host Metrics - Windows hosts scheme and bearer token
+templates:
+  - test/configmap.yaml
+tests:
+  - it: should render scheme and bearer_token_file when set on the windows-exporter source
+    set:
+      testing:
+        enabled: true
+        telemetryServices: {windows-exporter: {deploy: true}}
+      windowsHosts:
+        enabled: true
+        scheme: https
+        bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - matchRegex:
+          path: data["module.alloy"]
+          pattern: 'prometheus\.scrape "windows_exporter" \{[\s\S]*scheme = "https"[\s\S]*?\} // prometheus\.scrape "windows_exporter"'
+      - matchRegex:
+          path: data["module.alloy"]
+          pattern: 'prometheus\.scrape "windows_exporter" \{[\s\S]*bearer_token_file = "/var/run/secrets/kubernetes.io/serviceaccount/token"[\s\S]*?\} // prometheus\.scrape "windows_exporter"'
+      - matchRegex:
+          path: data["module.alloy"]
+          pattern: 'prometheus\.scrape "windows_exporter" \{[\s\S]*tls_config \{\s*insecure_skip_verify = true\s*\}[\s\S]*?\} // prometheus\.scrape "windows_exporter"'
+
+  - it: should default scheme to http and omit bearer_token_file when unset
+    set:
+      testing:
+        enabled: true
+        telemetryServices: {windows-exporter: {deploy: true}}
+      windowsHosts:
+        enabled: true
+    asserts:
+      - matchRegex:
+          path: data["module.alloy"]
+          pattern: 'prometheus\.scrape "windows_exporter" \{[\s\S]*scheme = "http"[\s\S]*?\} // prometheus\.scrape "windows_exporter"'
+      - notMatchRegex:
+          path: data["module.alloy"]
+          pattern: bearer_token_file
+
+  - it: should not render scheme or bearer_token_file when source is alloy
+    set:
+      testing: {enabled: true}
+      windowsHosts:
+        enabled: true
+        source: alloy
+        scheme: https
+        bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+    asserts:
+      - notMatchRegex:
+          path: data["module.alloy"]
+          pattern: scheme = "https"
+      - notMatchRegex:
+          path: data["module.alloy"]
+          pattern: bearer_token_file

--- a/charts/k8s-monitoring/docs/examples/auth/oauth2/alloy-metrics.alloy
+++ b/charts/k8s-monitoring/docs/examples/auth/oauth2/alloy-metrics.alloy
@@ -823,6 +823,11 @@ declare "windows_host_metrics" {
     scrape_classic_histograms = false
     scrape_native_histograms = false
     convert_classic_histograms_to_nhcb = false
+    scheme = "http"
+    tls_config {
+      insecure_skip_verify = true
+    }
+
     clustering {
       enabled = true
     }

--- a/charts/k8s-monitoring/docs/examples/auth/oauth2/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/auth/oauth2/output.yaml
@@ -1576,6 +1576,11 @@ data:
         scrape_classic_histograms = false
         scrape_native_histograms = false
         convert_classic_histograms_to_nhcb = false
+        scheme = "http"
+        tls_config {
+          insecure_skip_verify = true
+        }
+    
         clustering {
           enabled = true
         }

--- a/charts/k8s-monitoring/docs/examples/collector-storage/alloy-metrics.alloy
+++ b/charts/k8s-monitoring/docs/examples/collector-storage/alloy-metrics.alloy
@@ -482,6 +482,11 @@ declare "windows_host_metrics" {
     scrape_classic_histograms = false
     scrape_native_histograms = false
     convert_classic_histograms_to_nhcb = false
+    scheme = "http"
+    tls_config {
+      insecure_skip_verify = true
+    }
+
     clustering {
       enabled = true
     }

--- a/charts/k8s-monitoring/docs/examples/collector-storage/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/collector-storage/output.yaml
@@ -812,6 +812,11 @@ data:
         scrape_classic_histograms = false
         scrape_native_histograms = false
         convert_classic_histograms_to_nhcb = false
+        scheme = "http"
+        tls_config {
+          insecure_skip_verify = true
+        }
+    
         clustering {
           enabled = true
         }

--- a/charts/k8s-monitoring/docs/examples/dataProcessors/ec2Enrichment/alloy.alloy
+++ b/charts/k8s-monitoring/docs/examples/dataProcessors/ec2Enrichment/alloy.alloy
@@ -235,6 +235,11 @@ declare "windows_host_metrics" {
     scrape_classic_histograms = false
     scrape_native_histograms = false
     convert_classic_histograms_to_nhcb = false
+    scheme = "http"
+    tls_config {
+      insecure_skip_verify = true
+    }
+
     clustering {
       enabled = true
     }

--- a/charts/k8s-monitoring/docs/examples/dataProcessors/ec2Enrichment/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/dataProcessors/ec2Enrichment/output.yaml
@@ -337,6 +337,11 @@ data:
         scrape_classic_histograms = false
         scrape_native_histograms = false
         convert_classic_histograms_to_nhcb = false
+        scheme = "http"
+        tls_config {
+          insecure_skip_verify = true
+        }
+    
         clustering {
           enabled = true
         }

--- a/charts/k8s-monitoring/docs/examples/destinations/otlp-endpoint/alloy-metrics.alloy
+++ b/charts/k8s-monitoring/docs/examples/destinations/otlp-endpoint/alloy-metrics.alloy
@@ -482,6 +482,11 @@ declare "windows_host_metrics" {
     scrape_classic_histograms = false
     scrape_native_histograms = false
     convert_classic_histograms_to_nhcb = false
+    scheme = "http"
+    tls_config {
+      insecure_skip_verify = true
+    }
+
     clustering {
       enabled = true
     }

--- a/charts/k8s-monitoring/docs/examples/destinations/otlp-endpoint/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/destinations/otlp-endpoint/output.yaml
@@ -1049,6 +1049,11 @@ data:
         scrape_classic_histograms = false
         scrape_native_histograms = false
         convert_classic_histograms_to_nhcb = false
+        scheme = "http"
+        tls_config {
+          insecure_skip_verify = true
+        }
+    
         clustering {
           enabled = true
         }

--- a/charts/k8s-monitoring/docs/examples/extra-rules/alloy-metrics.alloy
+++ b/charts/k8s-monitoring/docs/examples/extra-rules/alloy-metrics.alloy
@@ -488,6 +488,11 @@ declare "windows_host_metrics" {
     scrape_classic_histograms = false
     scrape_native_histograms = false
     convert_classic_histograms_to_nhcb = false
+    scheme = "http"
+    tls_config {
+      insecure_skip_verify = true
+    }
+
     clustering {
       enabled = true
     }

--- a/charts/k8s-monitoring/docs/examples/extra-rules/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/extra-rules/output.yaml
@@ -846,6 +846,11 @@ data:
         scrape_classic_histograms = false
         scrape_native_histograms = false
         convert_classic_histograms_to_nhcb = false
+        scheme = "http"
+        tls_config {
+          insecure_skip_verify = true
+        }
+    
         clustering {
           enabled = true
         }

--- a/charts/k8s-monitoring/docs/examples/features/cluster-metrics/control-plane-monitoring/alloy-metrics.alloy
+++ b/charts/k8s-monitoring/docs/examples/features/cluster-metrics/control-plane-monitoring/alloy-metrics.alloy
@@ -772,6 +772,11 @@ declare "windows_host_metrics" {
     scrape_classic_histograms = false
     scrape_native_histograms = false
     convert_classic_histograms_to_nhcb = false
+    scheme = "http"
+    tls_config {
+      insecure_skip_verify = true
+    }
+
     clustering {
       enabled = true
     }

--- a/charts/k8s-monitoring/docs/examples/features/cluster-metrics/control-plane-monitoring/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/features/cluster-metrics/control-plane-monitoring/output.yaml
@@ -1102,6 +1102,11 @@ data:
         scrape_classic_histograms = false
         scrape_native_histograms = false
         convert_classic_histograms_to_nhcb = false
+        scheme = "http"
+        tls_config {
+          insecure_skip_verify = true
+        }
+    
         clustering {
           enabled = true
         }

--- a/charts/k8s-monitoring/docs/examples/features/host-metrics/default/alloy-metrics.alloy
+++ b/charts/k8s-monitoring/docs/examples/features/host-metrics/default/alloy-metrics.alloy
@@ -204,6 +204,11 @@ declare "windows_host_metrics" {
     scrape_classic_histograms = false
     scrape_native_histograms = false
     convert_classic_histograms_to_nhcb = false
+    scheme = "http"
+    tls_config {
+      insecure_skip_verify = true
+    }
+
     clustering {
       enabled = true
     }

--- a/charts/k8s-monitoring/docs/examples/features/host-metrics/default/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/features/host-metrics/default/output.yaml
@@ -296,6 +296,11 @@ data:
         scrape_classic_histograms = false
         scrape_native_histograms = false
         convert_classic_histograms_to_nhcb = false
+        scheme = "http"
+        tls_config {
+          insecure_skip_verify = true
+        }
+    
         clustering {
           enabled = true
         }

--- a/charts/k8s-monitoring/docs/examples/images/images-by-digest/alloy-metrics.alloy
+++ b/charts/k8s-monitoring/docs/examples/images/images-by-digest/alloy-metrics.alloy
@@ -600,6 +600,11 @@ declare "windows_host_metrics" {
     scrape_classic_histograms = false
     scrape_native_histograms = false
     convert_classic_histograms_to_nhcb = false
+    scheme = "http"
+    tls_config {
+      insecure_skip_verify = true
+    }
+
     clustering {
       enabled = true
     }

--- a/charts/k8s-monitoring/docs/examples/images/images-by-digest/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/images/images-by-digest/output.yaml
@@ -740,6 +740,11 @@ data:
         scrape_classic_histograms = false
         scrape_native_histograms = false
         convert_classic_histograms_to_nhcb = false
+        scheme = "http"
+        tls_config {
+          insecure_skip_verify = true
+        }
+    
         clustering {
           enabled = true
         }

--- a/charts/k8s-monitoring/docs/examples/include-by-namespace/alloy-metrics.alloy
+++ b/charts/k8s-monitoring/docs/examples/include-by-namespace/alloy-metrics.alloy
@@ -895,6 +895,11 @@ declare "windows_host_metrics" {
     scrape_classic_histograms = false
     scrape_native_histograms = false
     convert_classic_histograms_to_nhcb = false
+    scheme = "http"
+    tls_config {
+      insecure_skip_verify = true
+    }
+
     clustering {
       enabled = true
     }

--- a/charts/k8s-monitoring/docs/examples/include-by-namespace/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/include-by-namespace/output.yaml
@@ -1266,6 +1266,11 @@ data:
         scrape_classic_histograms = false
         scrape_native_histograms = false
         convert_classic_histograms_to_nhcb = false
+        scheme = "http"
+        tls_config {
+          insecure_skip_verify = true
+        }
+    
         clustering {
           enabled = true
         }

--- a/charts/k8s-monitoring/docs/examples/istio-ambient/alloy-metrics.alloy
+++ b/charts/k8s-monitoring/docs/examples/istio-ambient/alloy-metrics.alloy
@@ -482,6 +482,11 @@ declare "windows_host_metrics" {
     scrape_classic_histograms = false
     scrape_native_histograms = false
     convert_classic_histograms_to_nhcb = false
+    scheme = "http"
+    tls_config {
+      insecure_skip_verify = true
+    }
+
     clustering {
       enabled = true
     }

--- a/charts/k8s-monitoring/docs/examples/istio-ambient/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/istio-ambient/output.yaml
@@ -845,6 +845,11 @@ data:
         scrape_classic_histograms = false
         scrape_native_histograms = false
         convert_classic_histograms_to_nhcb = false
+        scheme = "http"
+        tls_config {
+          insecure_skip_verify = true
+        }
+    
         clustering {
           enabled = true
         }

--- a/charts/k8s-monitoring/docs/examples/istio-service-mesh/alloy-metrics.alloy
+++ b/charts/k8s-monitoring/docs/examples/istio-service-mesh/alloy-metrics.alloy
@@ -482,6 +482,11 @@ declare "windows_host_metrics" {
     scrape_classic_histograms = false
     scrape_native_histograms = false
     convert_classic_histograms_to_nhcb = false
+    scheme = "http"
+    tls_config {
+      insecure_skip_verify = true
+    }
+
     clustering {
       enabled = true
     }

--- a/charts/k8s-monitoring/docs/examples/istio-service-mesh/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/istio-service-mesh/output.yaml
@@ -845,6 +845,11 @@ data:
         scrape_classic_histograms = false
         scrape_native_histograms = false
         convert_classic_histograms_to_nhcb = false
+        scheme = "http"
+        tls_config {
+          insecure_skip_verify = true
+        }
+    
         clustering {
           enabled = true
         }

--- a/charts/k8s-monitoring/docs/examples/metric-enrichment/alloy-metrics.alloy
+++ b/charts/k8s-monitoring/docs/examples/metric-enrichment/alloy-metrics.alloy
@@ -482,6 +482,11 @@ declare "windows_host_metrics" {
     scrape_classic_histograms = false
     scrape_native_histograms = false
     convert_classic_histograms_to_nhcb = false
+    scheme = "http"
+    tls_config {
+      insecure_skip_verify = true
+    }
+
     clustering {
       enabled = true
     }

--- a/charts/k8s-monitoring/docs/examples/metric-enrichment/namespace-and-pod-labels/alloy-metrics.alloy
+++ b/charts/k8s-monitoring/docs/examples/metric-enrichment/namespace-and-pod-labels/alloy-metrics.alloy
@@ -482,6 +482,11 @@ declare "windows_host_metrics" {
     scrape_classic_histograms = false
     scrape_native_histograms = false
     convert_classic_histograms_to_nhcb = false
+    scheme = "http"
+    tls_config {
+      insecure_skip_verify = true
+    }
+
     clustering {
       enabled = true
     }

--- a/charts/k8s-monitoring/docs/examples/metric-enrichment/namespace-and-pod-labels/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/metric-enrichment/namespace-and-pod-labels/output.yaml
@@ -578,6 +578,11 @@ data:
         scrape_classic_histograms = false
         scrape_native_histograms = false
         convert_classic_histograms_to_nhcb = false
+        scheme = "http"
+        tls_config {
+          insecure_skip_verify = true
+        }
+    
         clustering {
           enabled = true
         }

--- a/charts/k8s-monitoring/docs/examples/metric-enrichment/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/metric-enrichment/output.yaml
@@ -578,6 +578,11 @@ data:
         scrape_classic_histograms = false
         scrape_native_histograms = false
         convert_classic_histograms_to_nhcb = false
+        scheme = "http"
+        tls_config {
+          insecure_skip_verify = true
+        }
+    
         clustering {
           enabled = true
         }

--- a/charts/k8s-monitoring/docs/examples/namespace-labels-and-annotations/alloy-metrics.alloy
+++ b/charts/k8s-monitoring/docs/examples/namespace-labels-and-annotations/alloy-metrics.alloy
@@ -482,6 +482,11 @@ declare "windows_host_metrics" {
     scrape_classic_histograms = false
     scrape_native_histograms = false
     convert_classic_histograms_to_nhcb = false
+    scheme = "http"
+    tls_config {
+      insecure_skip_verify = true
+    }
+
     clustering {
       enabled = true
     }

--- a/charts/k8s-monitoring/docs/examples/namespace-labels-and-annotations/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/namespace-labels-and-annotations/output.yaml
@@ -812,6 +812,11 @@ data:
         scrape_classic_histograms = false
         scrape_native_histograms = false
         convert_classic_histograms_to_nhcb = false
+        scheme = "http"
+        tls_config {
+          insecure_skip_verify = true
+        }
+    
         clustering {
           enabled = true
         }

--- a/charts/k8s-monitoring/docs/examples/pod-labels-and-annotations/alloy-metrics.alloy
+++ b/charts/k8s-monitoring/docs/examples/pod-labels-and-annotations/alloy-metrics.alloy
@@ -482,6 +482,11 @@ declare "windows_host_metrics" {
     scrape_classic_histograms = false
     scrape_native_histograms = false
     convert_classic_histograms_to_nhcb = false
+    scheme = "http"
+    tls_config {
+      insecure_skip_verify = true
+    }
+
     clustering {
       enabled = true
     }

--- a/charts/k8s-monitoring/docs/examples/pod-labels-and-annotations/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/pod-labels-and-annotations/output.yaml
@@ -822,6 +822,11 @@ data:
         scrape_classic_histograms = false
         scrape_native_histograms = false
         convert_classic_histograms_to_nhcb = false
+        scheme = "http"
+        tls_config {
+          insecure_skip_verify = true
+        }
+    
         clustering {
           enabled = true
         }

--- a/charts/k8s-monitoring/docs/examples/private-image-registries/globally/alloy-metrics.alloy
+++ b/charts/k8s-monitoring/docs/examples/private-image-registries/globally/alloy-metrics.alloy
@@ -539,6 +539,11 @@ declare "windows_host_metrics" {
     scrape_classic_histograms = false
     scrape_native_histograms = false
     convert_classic_histograms_to_nhcb = false
+    scheme = "http"
+    tls_config {
+      insecure_skip_verify = true
+    }
+
     clustering {
       enabled = true
     }

--- a/charts/k8s-monitoring/docs/examples/private-image-registries/globally/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/private-image-registries/globally/output.yaml
@@ -903,6 +903,11 @@ data:
         scrape_classic_histograms = false
         scrape_native_histograms = false
         convert_classic_histograms_to_nhcb = false
+        scheme = "http"
+        tls_config {
+          insecure_skip_verify = true
+        }
+    
         clustering {
           enabled = true
         }

--- a/charts/k8s-monitoring/docs/examples/private-image-registries/individual/alloy-metrics.alloy
+++ b/charts/k8s-monitoring/docs/examples/private-image-registries/individual/alloy-metrics.alloy
@@ -600,6 +600,11 @@ declare "windows_host_metrics" {
     scrape_classic_histograms = false
     scrape_native_histograms = false
     convert_classic_histograms_to_nhcb = false
+    scheme = "http"
+    tls_config {
+      insecure_skip_verify = true
+    }
+
     clustering {
       enabled = true
     }

--- a/charts/k8s-monitoring/docs/examples/private-image-registries/individual/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/private-image-registries/individual/output.yaml
@@ -740,6 +740,11 @@ data:
         scrape_classic_histograms = false
         scrape_native_histograms = false
         convert_classic_histograms_to_nhcb = false
+        scheme = "http"
+        tls_config {
+          insecure_skip_verify = true
+        }
+    
         clustering {
           enabled = true
         }

--- a/charts/k8s-monitoring/docs/examples/proxies/alloy-metrics.alloy
+++ b/charts/k8s-monitoring/docs/examples/proxies/alloy-metrics.alloy
@@ -539,6 +539,11 @@ declare "windows_host_metrics" {
     scrape_classic_histograms = false
     scrape_native_histograms = false
     convert_classic_histograms_to_nhcb = false
+    scheme = "http"
+    tls_config {
+      insecure_skip_verify = true
+    }
+
     clustering {
       enabled = true
     }

--- a/charts/k8s-monitoring/docs/examples/proxies/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/proxies/output.yaml
@@ -885,6 +885,11 @@ data:
         scrape_classic_histograms = false
         scrape_native_histograms = false
         convert_classic_histograms_to_nhcb = false
+        scheme = "http"
+        tls_config {
+          insecure_skip_verify = true
+        }
+    
         clustering {
           enabled = true
         }

--- a/charts/k8s-monitoring/docs/examples/rbac-no-cluster-roles/alloy-metrics.alloy
+++ b/charts/k8s-monitoring/docs/examples/rbac-no-cluster-roles/alloy-metrics.alloy
@@ -268,6 +268,11 @@ declare "windows_host_metrics" {
     scrape_classic_histograms = false
     scrape_native_histograms = false
     convert_classic_histograms_to_nhcb = false
+    scheme = "http"
+    tls_config {
+      insecure_skip_verify = true
+    }
+
     clustering {
       enabled = true
     }

--- a/charts/k8s-monitoring/docs/examples/rbac-no-cluster-roles/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/rbac-no-cluster-roles/output.yaml
@@ -623,6 +623,11 @@ data:
         scrape_classic_histograms = false
         scrape_native_histograms = false
         convert_classic_histograms_to_nhcb = false
+        scheme = "http"
+        tls_config {
+          insecure_skip_verify = true
+        }
+    
         clustering {
           enabled = true
         }

--- a/charts/k8s-monitoring/docs/examples/resource-requests-and-limits/alloy-metrics.alloy
+++ b/charts/k8s-monitoring/docs/examples/resource-requests-and-limits/alloy-metrics.alloy
@@ -600,6 +600,11 @@ declare "windows_host_metrics" {
     scrape_classic_histograms = false
     scrape_native_histograms = false
     convert_classic_histograms_to_nhcb = false
+    scheme = "http"
+    tls_config {
+      insecure_skip_verify = true
+    }
+
     clustering {
       enabled = true
     }

--- a/charts/k8s-monitoring/docs/examples/resource-requests-and-limits/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/resource-requests-and-limits/output.yaml
@@ -740,6 +740,11 @@ data:
         scrape_classic_histograms = false
         scrape_native_histograms = false
         convert_classic_histograms_to_nhcb = false
+        scheme = "http"
+        tls_config {
+          insecure_skip_verify = true
+        }
+    
         clustering {
           enabled = true
         }

--- a/charts/k8s-monitoring/docs/examples/scalability/autoscaling/alloy-metrics.alloy
+++ b/charts/k8s-monitoring/docs/examples/scalability/autoscaling/alloy-metrics.alloy
@@ -482,6 +482,11 @@ declare "windows_host_metrics" {
     scrape_classic_histograms = false
     scrape_native_histograms = false
     convert_classic_histograms_to_nhcb = false
+    scheme = "http"
+    tls_config {
+      insecure_skip_verify = true
+    }
+
     clustering {
       enabled = true
     }

--- a/charts/k8s-monitoring/docs/examples/scalability/autoscaling/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/scalability/autoscaling/output.yaml
@@ -578,6 +578,11 @@ data:
         scrape_classic_histograms = false
         scrape_native_histograms = false
         convert_classic_histograms_to_nhcb = false
+        scheme = "http"
+        tls_config {
+          insecure_skip_verify = true
+        }
+    
         clustering {
           enabled = true
         }

--- a/charts/k8s-monitoring/docs/examples/scalability/high-availability-kube-state-metrics/alloy-metrics.alloy
+++ b/charts/k8s-monitoring/docs/examples/scalability/high-availability-kube-state-metrics/alloy-metrics.alloy
@@ -482,6 +482,11 @@ declare "windows_host_metrics" {
     scrape_classic_histograms = false
     scrape_native_histograms = false
     convert_classic_histograms_to_nhcb = false
+    scheme = "http"
+    tls_config {
+      insecure_skip_verify = true
+    }
+
     clustering {
       enabled = true
     }

--- a/charts/k8s-monitoring/docs/examples/scalability/high-availability-kube-state-metrics/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/scalability/high-availability-kube-state-metrics/output.yaml
@@ -578,6 +578,11 @@ data:
         scrape_classic_histograms = false
         scrape_native_histograms = false
         convert_classic_histograms_to_nhcb = false
+        scheme = "http"
+        tls_config {
+          insecure_skip_verify = true
+        }
+    
         clustering {
           enabled = true
         }

--- a/charts/k8s-monitoring/docs/examples/scalability/sharded-kube-state-metrics/alloy-metrics.alloy
+++ b/charts/k8s-monitoring/docs/examples/scalability/sharded-kube-state-metrics/alloy-metrics.alloy
@@ -482,6 +482,11 @@ declare "windows_host_metrics" {
     scrape_classic_histograms = false
     scrape_native_histograms = false
     convert_classic_histograms_to_nhcb = false
+    scheme = "http"
+    tls_config {
+      insecure_skip_verify = true
+    }
+
     clustering {
       enabled = true
     }

--- a/charts/k8s-monitoring/docs/examples/scalability/sharded-kube-state-metrics/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/scalability/sharded-kube-state-metrics/output.yaml
@@ -578,6 +578,11 @@ data:
         scrape_classic_histograms = false
         scrape_native_histograms = false
         convert_classic_histograms_to_nhcb = false
+        scheme = "http"
+        tls_config {
+          insecure_skip_verify = true
+        }
+    
         clustering {
           enabled = true
         }

--- a/charts/k8s-monitoring/docs/examples/tail-sampling/alloy-metrics.alloy
+++ b/charts/k8s-monitoring/docs/examples/tail-sampling/alloy-metrics.alloy
@@ -482,6 +482,11 @@ declare "windows_host_metrics" {
     scrape_classic_histograms = false
     scrape_native_histograms = false
     convert_classic_histograms_to_nhcb = false
+    scheme = "http"
+    tls_config {
+      insecure_skip_verify = true
+    }
+
     clustering {
       enabled = true
     }

--- a/charts/k8s-monitoring/docs/examples/tail-sampling/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/tail-sampling/output.yaml
@@ -812,6 +812,11 @@ data:
         scrape_classic_histograms = false
         scrape_native_histograms = false
         convert_classic_histograms_to_nhcb = false
+        scheme = "http"
+        tls_config {
+          insecure_skip_verify = true
+        }
+    
         clustering {
           enabled = true
         }

--- a/charts/k8s-monitoring/docs/examples/tolerations/alloy-metrics.alloy
+++ b/charts/k8s-monitoring/docs/examples/tolerations/alloy-metrics.alloy
@@ -600,6 +600,11 @@ declare "windows_host_metrics" {
     scrape_classic_histograms = false
     scrape_native_histograms = false
     convert_classic_histograms_to_nhcb = false
+    scheme = "http"
+    tls_config {
+      insecure_skip_verify = true
+    }
+
     clustering {
       enabled = true
     }

--- a/charts/k8s-monitoring/docs/examples/tolerations/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/tolerations/output.yaml
@@ -974,6 +974,11 @@ data:
         scrape_classic_histograms = false
         scrape_native_histograms = false
         convert_classic_histograms_to_nhcb = false
+        scheme = "http"
+        tls_config {
+          insecure_skip_verify = true
+        }
+    
         clustering {
           enabled = true
         }

--- a/charts/k8s-monitoring/tests/integration/uninstall/.rendered/alloy-metrics.alloy
+++ b/charts/k8s-monitoring/tests/integration/uninstall/.rendered/alloy-metrics.alloy
@@ -539,6 +539,11 @@ declare "windows_host_metrics" {
     scrape_classic_histograms = false
     scrape_native_histograms = false
     convert_classic_histograms_to_nhcb = false
+    scheme = "http"
+    tls_config {
+      insecure_skip_verify = true
+    }
+
     clustering {
       enabled = true
     }

--- a/charts/k8s-monitoring/tests/integration/uninstall/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/integration/uninstall/.rendered/output.yaml
@@ -930,6 +930,11 @@ data:
         scrape_classic_histograms = false
         scrape_native_histograms = false
         convert_classic_histograms_to_nhcb = false
+        scheme = "http"
+        tls_config {
+          insecure_skip_verify = true
+        }
+    
         clustering {
           enabled = true
         }

--- a/charts/k8s-monitoring/tests/integration/upgrade/minor/.rendered/alloy-metrics.alloy
+++ b/charts/k8s-monitoring/tests/integration/upgrade/minor/.rendered/alloy-metrics.alloy
@@ -539,6 +539,11 @@ declare "windows_host_metrics" {
     scrape_classic_histograms = false
     scrape_native_histograms = false
     convert_classic_histograms_to_nhcb = false
+    scheme = "http"
+    tls_config {
+      insecure_skip_verify = true
+    }
+
     clustering {
       enabled = true
     }

--- a/charts/k8s-monitoring/tests/integration/upgrade/minor/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/integration/upgrade/minor/.rendered/output.yaml
@@ -934,6 +934,11 @@ data:
         scrape_classic_histograms = false
         scrape_native_histograms = false
         convert_classic_histograms_to_nhcb = false
+        scheme = "http"
+        tls_config {
+          insecure_skip_verify = true
+        }
+    
         clustering {
           enabled = true
         }

--- a/charts/k8s-monitoring/tests/integration/upgrade/patch/.rendered/alloy-metrics.alloy
+++ b/charts/k8s-monitoring/tests/integration/upgrade/patch/.rendered/alloy-metrics.alloy
@@ -539,6 +539,11 @@ declare "windows_host_metrics" {
     scrape_classic_histograms = false
     scrape_native_histograms = false
     convert_classic_histograms_to_nhcb = false
+    scheme = "http"
+    tls_config {
+      insecure_skip_verify = true
+    }
+
     clustering {
       enabled = true
     }

--- a/charts/k8s-monitoring/tests/integration/upgrade/patch/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/integration/upgrade/patch/.rendered/output.yaml
@@ -934,6 +934,11 @@ data:
         scrape_classic_histograms = false
         scrape_native_histograms = false
         convert_classic_histograms_to_nhcb = false
+        scheme = "http"
+        tls_config {
+          insecure_skip_verify = true
+        }
+    
         clustering {
           enabled = true
         }

--- a/charts/k8s-monitoring/tests/platform/aks/.rendered/alloy-metrics.alloy
+++ b/charts/k8s-monitoring/tests/platform/aks/.rendered/alloy-metrics.alloy
@@ -482,6 +482,11 @@ declare "windows_host_metrics" {
     scrape_classic_histograms = false
     scrape_native_histograms = false
     convert_classic_histograms_to_nhcb = false
+    scheme = "http"
+    tls_config {
+      insecure_skip_verify = true
+    }
+
     clustering {
       enabled = true
     }

--- a/charts/k8s-monitoring/tests/platform/aks/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/platform/aks/.rendered/output.yaml
@@ -825,6 +825,11 @@ data:
         scrape_classic_histograms = false
         scrape_native_histograms = false
         convert_classic_histograms_to_nhcb = false
+        scheme = "http"
+        tls_config {
+          insecure_skip_verify = true
+        }
+    
         clustering {
           enabled = true
         }

--- a/charts/k8s-monitoring/tests/platform/eks-with-windows/.rendered/alloy.alloy
+++ b/charts/k8s-monitoring/tests/platform/eks-with-windows/.rendered/alloy.alloy
@@ -870,6 +870,11 @@ declare "windows_host_metrics" {
     scrape_classic_histograms = false
     scrape_native_histograms = false
     convert_classic_histograms_to_nhcb = false
+    scheme = "http"
+    tls_config {
+      insecure_skip_verify = true
+    }
+
     clustering {
       enabled = true
     }

--- a/charts/k8s-monitoring/tests/platform/eks-with-windows/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/platform/eks-with-windows/.rendered/output.yaml
@@ -966,6 +966,11 @@ data:
         scrape_classic_histograms = false
         scrape_native_histograms = false
         convert_classic_histograms_to_nhcb = false
+        scheme = "http"
+        tls_config {
+          insecure_skip_verify = true
+        }
+    
         clustering {
           enabled = true
         }

--- a/charts/k8s-monitoring/tests/platform/grafana-cloud/k8s-monitoring/.rendered/alloy-metrics.alloy
+++ b/charts/k8s-monitoring/tests/platform/grafana-cloud/k8s-monitoring/.rendered/alloy-metrics.alloy
@@ -600,6 +600,11 @@ declare "windows_host_metrics" {
     scrape_classic_histograms = false
     scrape_native_histograms = false
     convert_classic_histograms_to_nhcb = false
+    scheme = "http"
+    tls_config {
+      insecure_skip_verify = true
+    }
+
     clustering {
       enabled = true
     }

--- a/charts/k8s-monitoring/tests/platform/grafana-cloud/k8s-monitoring/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/platform/grafana-cloud/k8s-monitoring/.rendered/output.yaml
@@ -989,6 +989,11 @@ data:
         scrape_classic_histograms = false
         scrape_native_histograms = false
         convert_classic_histograms_to_nhcb = false
+        scheme = "http"
+        tls_config {
+          insecure_skip_verify = true
+        }
+    
         clustering {
           enabled = true
         }


### PR DESCRIPTION
<!--Describe what this change does and why.-->
# Description

Properly sets fields that were documented, but not implemented in the Windows exporter portion of the Host metrics feature.

Fixes #2961

<!--Authorship attestation. See AGENTS.md for details. AI agents must not check this box on behalf
of the user; the human author must check it themselves before the PR is ready for review.-->
## Authorship

-   [X] I, a human, wrote this pull request description myself.

<!--Please delete paragraphs that you did not use before submitting.-->
