### PR TITLE
fix: add unique-id to ihub test cluster

### DIFF
--- a/charts/k8s-monitoring/tests/platform/grafana-cloud/ihub/maximum/Makefile
+++ b/charts/k8s-monitoring/tests/platform/grafana-cloud/ihub/maximum/Makefile
@@ -5,7 +5,9 @@
 # does), and derive the expected Alloy components FM holds (for the in-cluster
 # comparison). `make teardown` removes the per-cluster FM pipelines and is meant
 # to run in an always() CI step. Helpers are bash scripts under ../scripts.
-CLUSTER := $(shell yq eval '.cluster.name' test-plan.yaml)
+# Append a random suffix, written to .random here and reused by helm-test's getClusterName,
+# so provision/teardown and the cluster it creates share one name.
+CLUSTER := $(shell yq eval '.cluster.name' test-plan.yaml)-$(shell [ -f .random ] || shuf -i 100000-999999 -n 1 > .random; cat .random)
 SCRIPTS := ../scripts
 
 export IHUB_APP_NAMESPACE := default
@@ -69,3 +71,4 @@ teardown-direnv:
 	direnv allow .
 	direnv exec . $(MAKE) teardown
 	kind delete cluster --name $(CLUSTER)
+	rm -f .random

--- a/charts/k8s-monitoring/tests/platform/grafana-cloud/ihub/maximum/test-plan.yaml
+++ b/charts/k8s-monitoring/tests/platform/grafana-cloud/ihub/maximum/test-plan.yaml
@@ -20,6 +20,7 @@ subject:
 cluster:
   type: kind
   name: ihub-e2e-maximum
+  appendRandomNumber: true
 
 dependencies:
   - preset: test-parameters

--- a/charts/k8s-monitoring/tests/platform/grafana-cloud/ihub/minimal/Makefile
+++ b/charts/k8s-monitoring/tests/platform/grafana-cloud/ihub/minimal/Makefile
@@ -5,7 +5,9 @@
 # does), and derive the expected Alloy components FM holds (for the in-cluster
 # comparison). `make teardown` removes the per-cluster FM pipelines and is meant
 # to run in an always() CI step. Helpers are bash scripts under ../scripts.
-CLUSTER := $(shell yq eval '.cluster.name' test-plan.yaml)
+# Append a random suffix, written to .random here and reused by helm-test's getClusterName,
+# so provision/teardown and the cluster it creates share one name.
+CLUSTER := $(shell yq eval '.cluster.name' test-plan.yaml)-$(shell [ -f .random ] || shuf -i 100000-999999 -n 1 > .random; cat .random)
 SCRIPTS := ../scripts
 
 export GRAFANA_CLOUD_STACK := helmchart
@@ -68,3 +70,4 @@ teardown-direnv:
 	direnv allow .
 	direnv exec . $(MAKE) teardown
 	kind delete cluster --name $(CLUSTER)
+	rm -f .random

--- a/charts/k8s-monitoring/tests/platform/grafana-cloud/ihub/minimal/test-plan.yaml
+++ b/charts/k8s-monitoring/tests/platform/grafana-cloud/ihub/minimal/test-plan.yaml
@@ -21,6 +21,7 @@ subject:
 cluster:
   type: kind
   name: ihub-e2e-minimal
+  appendRandomNumber: true
 
 dependencies:
   - preset: test-parameters

--- a/charts/k8s-monitoring/tests/platform/grafana-cloud/ihub/standard/Makefile
+++ b/charts/k8s-monitoring/tests/platform/grafana-cloud/ihub/standard/Makefile
@@ -5,7 +5,9 @@
 # does), and derive the expected Alloy components FM holds (for the in-cluster
 # comparison). `make teardown` removes the per-cluster FM pipelines and is meant
 # to run in an always() CI step. Helpers are bash scripts under ../scripts.
-CLUSTER := $(shell yq eval '.cluster.name' test-plan.yaml)
+# Append a random suffix, written to .random here and reused by helm-test's getClusterName,
+# so provision/teardown and the cluster it creates share one name.
+CLUSTER := $(shell yq eval '.cluster.name' test-plan.yaml)-$(shell [ -f .random ] || shuf -i 100000-999999 -n 1 > .random; cat .random)
 SCRIPTS := ../scripts
 
 export IHUB_APP_NAMESPACE := default
@@ -69,3 +71,4 @@ teardown-direnv:
 	direnv allow .
 	direnv exec . $(MAKE) teardown
 	kind delete cluster --name $(CLUSTER)
+	rm -f .random

--- a/charts/k8s-monitoring/tests/platform/grafana-cloud/ihub/standard/test-plan.yaml
+++ b/charts/k8s-monitoring/tests/platform/grafana-cloud/ihub/standard/test-plan.yaml
@@ -8,9 +8,11 @@ name: ihub-standard
 # the survey + k8s-monitoring instrumentation pipelines; the deployment collector
 # receives the otel-receiver pipeline. See the plan for context.
 #
-# cluster.name is fixed (not random): provisioning + expected-component derivation
-# happen in `make all` before the kind cluster exists, so the name must be known
-# up front. Teardown (make teardown) removes the per-cluster FM pipelines.
+# cluster.name gets a random suffix (cluster.appendRandomNumber) so multiple runs
+# can execute concurrently without colliding in Fleet Management. The Makefile and
+# helm-test share that suffix through a gitignored `.random` file, so provisioning
+# (make all, before the kind cluster exists) and the install agree on the name.
+# Teardown (make teardown) removes the per-cluster FM pipelines.
 
 subject:
   releaseName: grafana-cloud
@@ -23,6 +25,7 @@ subject:
 cluster:
   type: kind
   name: ihub-e2e-standard
+  appendRandomNumber: true
 
 dependencies:
   - preset: test-parameters


### PR DESCRIPTION
<!--Describe what this change does and why.-->
# Description

We had a bug in the tests where the cluster provisioned was only based on the test name so if 2 instances of the test ran, or a test was not cleaned up, they would affect each other. This PR updates the makefiles to generate a random number for the cluster name. This number is used by helm-test.

<!--Authorship attestation. See AGENTS.md for details. AI agents must not check this box on behalf
of the user; the human author must check it themselves before the PR is ready for review.-->
## Authorship

-   [x] I, a human, wrote this pull request description myself.

<!--Please delete paragraphs that you did not use before submitting.-->
