### PR TITLE
Update Alloy CRD deployment instructions

### DIFF
--- a/charts/k8s-monitoring/templates/_crd-validation.tpl
+++ b/charts/k8s-monitoring/templates/_crd-validation.tpl
@@ -2,16 +2,10 @@
 {{- $crdURL := printf "https://github.com/grafana/alloy-operator/releases/download/alloy-operator-%s/collectors.grafana.com_alloy.yaml" (index .Subcharts "alloy-operator").Chart.Version }}
 {{- if .Release.IsInstall }}
   {{- if not (.Capabilities.APIVersions.Has "collectors.grafana.com/v1alpha1/Alloy") }}
-    {{- if not (dig "alloy-operator" "crds" "deployAlloyCRD" true .Values.AsMap) }}
-      {{- $msg := list "" (printf "The %s Helm chart v3.0 requires the Alloy CRD to be deployed." .Chart.Name) }}
-      {{- $msg = append $msg "Please set:" }}
-      {{- $msg = append $msg "alloy-operator:" }}
-      {{- $msg = append $msg "  crds:" }}
-      {{- $msg = append $msg "    deployAlloyCRD: true" }}
-      {{- $msg = append $msg "Or install the Alloy CRD manually:" }}
-      {{- $msg = append $msg (printf "kubectl apply -f %s" $crdURL) }}
-      {{- fail (join "\n" $msg) }}
-    {{- end }}
+    {{- $msg := list "" (printf "The %s Helm chart v3.0 requires the Alloy CRD to be deployed." .Chart.Name) }}
+    {{- $msg = append $msg "Please install the Alloy CRD manually:" }}
+    {{- $msg = append $msg (printf "kubectl apply -f %s" $crdURL) }}
+    {{- fail (join "\n" $msg) }}
   {{- end }}
 {{- end }}
 


### PR DESCRIPTION
<!--Describe what this change does and why.-->
# Description

It seems that the help message indicating how to install the Alloy Operator CRDs is no longer accurate.
The value:
```
alloy-operator:
  crds:
    deployAlloyCRD: true
```
has no effect.

<!--Authorship attestation. See AGENTS.md for details. AI agents must not check this box on behalf
of the user; the human author must check it themselves before the PR is ready for review.-->
## Authorship

-   [X] I, a human, wrote this pull request description myself.

<!--Please delete paragraphs that you did not use before submitting.-->
