### PR TITLE
Re-enable the node logs feature integration test

### DIFF
--- a/charts/k8s-monitoring/docs/examples/features/node-logs/default/test/test-plan.yaml
+++ b/charts/k8s-monitoring/docs/examples/features/node-logs/default/test/test-plan.yaml
@@ -67,13 +67,19 @@ tests:
 
           queries:
             # Kubelet logs exist
-            - query: count_over_time({cluster="$CLUSTER", job="integrations/kubernetes/journal", unit="kubelet.service", source="journal"}[1h])
+            # Changing the job label temporarily until this is fixed: https://github.com/grafana/alloy/issues/6980
+            # - query: count_over_time({cluster="$CLUSTER", job="integrations/kubernetes/journal", unit="kubelet.service", source="journal"}[1h])
+            - query: count_over_time({cluster="$CLUSTER", job="node_logs.feature/loki.source.journal.worker", unit="kubelet.service", source="journal"}[1h])
               type: logql
 
             # Containerd logs exist
-            - query: count_over_time({cluster="$CLUSTER", job="integrations/kubernetes/journal", unit="containerd.service", source="journal"}[1h])
+            # Changing the job label temporarily until this is fixed: https://github.com/grafana/alloy/issues/6980
+            # - query: count_over_time({cluster="$CLUSTER", job="integrations/kubernetes/journal", unit="containerd.service", source="journal"}[1h])
+            - query: count_over_time({cluster="$CLUSTER", job="node_logs.feature/loki.source.journal.worker", unit="containerd.service", source="journal"}[1h])
               type: logql
 
             # Level detection is working (at least some logs have a detected level)
-            - query: count_over_time({cluster="$CLUSTER", job="integrations/kubernetes/journal", level!="unknown"}[1h])
+            # Changing the job label temporarily until this is fixed: https://github.com/grafana/alloy/issues/6980
+            # - query: count_over_time({cluster="$CLUSTER", job="integrations/kubernetes/journal", level!="unknown"}[1h])
+            - query: count_over_time({cluster="$CLUSTER", job="node_logs.feature/loki.source.journal.worker", level!="unknown"}[1h])
               type: logql

--- a/charts/k8s-monitoring/docs/examples/features/node-logs/default/test/test-plan.yaml
+++ b/charts/k8s-monitoring/docs/examples/features/node-logs/default/test/test-plan.yaml
@@ -12,26 +12,30 @@ subject:
     nodeLogs:
       journal:
         path: /run/log/journal
-    alloy-logs:
-      alloy:
-        mounts:
-          extra:
-            - name: runlog
-              mountPath: /run/log
-      controller:
-        volumes:
-          extra:
-            - name: runlog
-              hostPath:
-                path: /run/log
-                type: Directory
+    collectors:
+      alloy-logs:
+        alloy:
+          mounts:
+            extra:
+              - name: runlog
+                mountPath: /run/log
+        controller:
+          volumes:
+            extra:
+              - name: runlog
+                hostPath:
+                  path: /run/log
+                  type: Directory
 
 cluster:
   type: minikube
-  driver: qemu
+  # Use the docker driver so this runs on GitHub-hosted runners (and Macs without
+  # qemu/socket_vmnet). minikube's kicbase image runs systemd/journald.
+  driver: docker
   args:
-    - --memory=8192
-    - --cpus=4
+    # Use the containerd runtime so containerd.service logs land in journald; the
+    # docker driver otherwise defaults to the docker runtime (no containerd.service).
+    - --container-runtime=containerd
 
 dependencies:
   - preset: loki

--- a/charts/k8s-monitoring/docs/examples/features/node-logs/default/test/test-plan.yaml
+++ b/charts/k8s-monitoring/docs/examples/features/node-logs/default/test/test-plan.yaml
@@ -29,8 +29,8 @@ subject:
 
 cluster:
   type: minikube
-  # Use the docker driver so this runs on GitHub-hosted runners (and Macs without
-  # qemu/socket_vmnet). minikube's kicbase image runs systemd/journald.
+  # Use the docker driver so this runs on Mac workstations and GitHub-hosted runners.
+  # minikube's kicbase image runs systemd/journald.
   driver: docker
   args:
     # Use the containerd runtime so containerd.service logs land in journald; the
@@ -67,19 +67,13 @@ tests:
 
           queries:
             # Kubelet logs exist
-            # Changing the job label temporarily until this is fixed: https://github.com/grafana/alloy/issues/6980
-            # - query: count_over_time({cluster="$CLUSTER", job="integrations/kubernetes/journal", unit="kubelet.service", source="journal"}[1h])
-            - query: count_over_time({cluster="$CLUSTER", job="node_logs.feature/loki.source.journal.worker", unit="kubelet.service", source="journal"}[1h])
+            - query: count_over_time({cluster="$CLUSTER", job="integrations/kubernetes/journal", unit="kubelet.service", source="journal"}[1h])
               type: logql
 
             # Containerd logs exist
-            # Changing the job label temporarily until this is fixed: https://github.com/grafana/alloy/issues/6980
-            # - query: count_over_time({cluster="$CLUSTER", job="integrations/kubernetes/journal", unit="containerd.service", source="journal"}[1h])
-            - query: count_over_time({cluster="$CLUSTER", job="node_logs.feature/loki.source.journal.worker", unit="containerd.service", source="journal"}[1h])
+            - query: count_over_time({cluster="$CLUSTER", job="integrations/kubernetes/journal", unit="containerd.service", source="journal"}[1h])
               type: logql
 
             # Level detection is working (at least some logs have a detected level)
-            # Changing the job label temporarily until this is fixed: https://github.com/grafana/alloy/issues/6980
-            # - query: count_over_time({cluster="$CLUSTER", job="integrations/kubernetes/journal", level!="unknown"}[1h])
-            - query: count_over_time({cluster="$CLUSTER", job="node_logs.feature/loki.source.journal.worker", level!="unknown"}[1h])
+            - query: count_over_time({cluster="$CLUSTER", job="integrations/kubernetes/journal", level!="unknown"}[1h])
               type: logql


### PR DESCRIPTION
# Description

The `nodeLogs` feature gets node logs from journald. It was always a tricky integration test to get working, because `kind` doesn't create nodes with journald. The answer is to use `minikube`, but the runtime for that is non-trivial.

This test *will* fail. But it's because it's exposing this bug:
https://github.com/grafana/alloy/issues/6980

## Authorship

-   [X] I, a human, wrote this pull request description myself.

<!--Please delete paragraphs that you did not use before submitting.-->
