### PR TITLE
Fix duplicate data processor components

### DIFF
--- a/charts/k8s-monitoring/CHANGELOG.md
+++ b/charts/k8s-monitoring/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+*   Fix issue with duplicate configuration block declarations when the same data processor is used by more than one feature on the same collector. (#3014) (@petewall)
+
 ## 4.5.1
 
 *   Fix incorrect `job` label for nodeLogs feature. (@petewall)

--- a/charts/k8s-monitoring/CHANGELOG.md
+++ b/charts/k8s-monitoring/CHANGELOG.md
@@ -1,11 +1,8 @@
 # Changelog
 
-## Unreleased
-
-*   Fix issue with duplicate configuration block declarations when the same data processor is used by more than one feature on the same collector. (#3014) (@petewall)
-
 ## 4.5.1
 
+*   Fix issue with duplicate configuration block declarations when the same data processor is used by more than one feature on the same collector. (#3014) (@petewall)
 *   Fix incorrect `job` label for nodeLogs feature. (@petewall)
 *   Update Alloy Operator to 0.7.1, kube-state-metrics to 8.4.2, OpenCost to 2.5.30, and Node Exporter to 4.56.3 (@petewall)
 

--- a/charts/k8s-monitoring/docs/examples/dataProcessors/custom/scrub-log-pii/alloy-logs.alloy
+++ b/charts/k8s-monitoring/docs/examples/dataProcessors/custom/scrub-log-pii/alloy-logs.alloy
@@ -208,30 +208,6 @@ loki.process "podlogsvialoki_stamp_logs_loki" {
     }
   }
 }
-// Processor: scrub-pii (custom) — logs/loki
-loki.process "scrub_pii_loki" {
-  stage.replace {
-    expression = "([A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,})"
-    replace    = "[REDACTED-EMAIL]"
-  }
-  forward_to = [loki.process.scrub_pii_out_logs_loki.receiver]
-}
-loki.process "scrub_pii_out_logs_loki" {
-  forward_to = [loki.relabel.scrub_pii_loki_gate_logs_loki.receiver]
-}
-loki.relabel "scrub_pii_loki_gate_logs_loki" {
-  forward_to = [loki.write.loki.receiver]
-  rule {
-    source_labels = ["selected_destinations"]
-    regex         = "(^|.*,)loki(,.*|$)"
-    action        = "keep"
-  }
-  rule {
-    action = "labeldrop"
-    regex  = "selected_destinations"
-  }
-  max_cache_size = 100
-}
 // Feature: Pod Logs (OpenTelemetry)
 declare "pod_logs_via_opentelemetry" {
   argument "logs_destinations" {
@@ -366,6 +342,30 @@ otelcol.processor.transform "podlogsviaopentelemetry_stamp_logs_otlp" {
   output {
     logs = [otelcol.processor.transform.scrub_pii_otlp.input]
   }
+}
+// Processor: scrub-pii (custom) — logs/loki
+loki.process "scrub_pii_loki" {
+  stage.replace {
+    expression = "([A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,})"
+    replace    = "[REDACTED-EMAIL]"
+  }
+  forward_to = [loki.process.scrub_pii_out_logs_loki.receiver]
+}
+loki.process "scrub_pii_out_logs_loki" {
+  forward_to = [loki.relabel.scrub_pii_loki_gate_logs_loki.receiver]
+}
+loki.relabel "scrub_pii_loki_gate_logs_loki" {
+  forward_to = [loki.write.loki.receiver]
+  rule {
+    source_labels = ["selected_destinations"]
+    regex         = "(^|.*,)loki(,.*|$)"
+    action        = "keep"
+  }
+  rule {
+    action = "labeldrop"
+    regex  = "selected_destinations"
+  }
+  max_cache_size = 100
 }
 // Processor: scrub-pii (custom) — logs/otlp
 otelcol.processor.transform "scrub_pii_otlp" {

--- a/charts/k8s-monitoring/docs/examples/dataProcessors/custom/scrub-log-pii/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/dataProcessors/custom/scrub-log-pii/output.yaml
@@ -255,30 +255,6 @@ data:
         }
       }
     }
-    // Processor: scrub-pii (custom) — logs/loki
-    loki.process "scrub_pii_loki" {
-      stage.replace {
-        expression = "([A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,})"
-        replace    = "[REDACTED-EMAIL]"
-      }
-      forward_to = [loki.process.scrub_pii_out_logs_loki.receiver]
-    }
-    loki.process "scrub_pii_out_logs_loki" {
-      forward_to = [loki.relabel.scrub_pii_loki_gate_logs_loki.receiver]
-    }
-    loki.relabel "scrub_pii_loki_gate_logs_loki" {
-      forward_to = [loki.write.loki.receiver]
-      rule {
-        source_labels = ["selected_destinations"]
-        regex         = "(^|.*,)loki(,.*|$)"
-        action        = "keep"
-      }
-      rule {
-        action = "labeldrop"
-        regex  = "selected_destinations"
-      }
-      max_cache_size = 100
-    }
     // Feature: Pod Logs (OpenTelemetry)
     declare "pod_logs_via_opentelemetry" {
       argument "logs_destinations" {
@@ -413,6 +389,30 @@ data:
       output {
         logs = [otelcol.processor.transform.scrub_pii_otlp.input]
       }
+    }
+    // Processor: scrub-pii (custom) — logs/loki
+    loki.process "scrub_pii_loki" {
+      stage.replace {
+        expression = "([A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,})"
+        replace    = "[REDACTED-EMAIL]"
+      }
+      forward_to = [loki.process.scrub_pii_out_logs_loki.receiver]
+    }
+    loki.process "scrub_pii_out_logs_loki" {
+      forward_to = [loki.relabel.scrub_pii_loki_gate_logs_loki.receiver]
+    }
+    loki.relabel "scrub_pii_loki_gate_logs_loki" {
+      forward_to = [loki.write.loki.receiver]
+      rule {
+        source_labels = ["selected_destinations"]
+        regex         = "(^|.*,)loki(,.*|$)"
+        action        = "keep"
+      }
+      rule {
+        action = "labeldrop"
+        regex  = "selected_destinations"
+      }
+      max_cache_size = 100
     }
     // Processor: scrub-pii (custom) — logs/otlp
     otelcol.processor.transform "scrub_pii_otlp" {

--- a/charts/k8s-monitoring/docs/examples/dataProcessors/custom/static-label/alloy-metrics.alloy
+++ b/charts/k8s-monitoring/docs/examples/dataProcessors/custom/static-label/alloy-metrics.alloy
@@ -346,29 +346,6 @@ prometheus.relabel "annotationautodiscovery_stamp_metrics_prometheus" {
     replacement  = "prometheus"
   }
 }
-// Processor: static-label (custom) — metrics/prometheus
-prometheus.relabel "static_label_metrics" {
-  rule {
-    target_label = "region"
-    replacement  = "central"
-  }
-  forward_to = [prometheus.relabel.static_label_out_metrics_prometheus.receiver]
-}
-prometheus.relabel "static_label_out_metrics_prometheus" {
-  forward_to = [prometheus.relabel.static_label_prometheus_gate_metrics_prometheus.receiver]
-}
-prometheus.relabel "static_label_prometheus_gate_metrics_prometheus" {
-  forward_to = [prometheus.remote_write.prometheus.receiver]
-  rule {
-    source_labels = ["selected_destinations"]
-    regex         = "(^|.*,)prometheus(,.*|$)"
-    action        = "keep"
-  }
-  rule {
-    action = "labeldrop"
-    regex  = "selected_destinations"
-  }
-}
 // Self Reporting
 prometheus.exporter.unix "kubernetes_monitoring_telemetry" {
   set_collectors = ["textfile"]
@@ -411,6 +388,29 @@ prometheus.relabel "kubernetes_monitoring_telemetry" {
     prometheus.remote_write.prometheus.receiver,
   ]
 } // prometheus.relabel "kubernetes_monitoring_telemetry"
+// Processor: static-label (custom) — metrics/prometheus
+prometheus.relabel "static_label_metrics" {
+  rule {
+    target_label = "region"
+    replacement  = "central"
+  }
+  forward_to = [prometheus.relabel.static_label_out_metrics_prometheus.receiver]
+}
+prometheus.relabel "static_label_out_metrics_prometheus" {
+  forward_to = [prometheus.relabel.static_label_prometheus_gate_metrics_prometheus.receiver]
+}
+prometheus.relabel "static_label_prometheus_gate_metrics_prometheus" {
+  forward_to = [prometheus.remote_write.prometheus.receiver]
+  rule {
+    source_labels = ["selected_destinations"]
+    regex         = "(^|.*,)prometheus(,.*|$)"
+    action        = "keep"
+  }
+  rule {
+    action = "labeldrop"
+    regex  = "selected_destinations"
+  }
+}
 
 
 

--- a/charts/k8s-monitoring/docs/examples/dataProcessors/custom/static-label/alloy-receiver.alloy
+++ b/charts/k8s-monitoring/docs/examples/dataProcessors/custom/static-label/alloy-receiver.alloy
@@ -121,48 +121,6 @@ otelcol.processor.transform "applicationobservability_stamp_traces_otlp" {
     traces = [otelcol.processor.transform.static_label_traces.input]
   }
 }
-// Processor: static-label (custom) — traces/otlp
-otelcol.processor.transform "static_label_traces" {
-  error_mode = "ignore"
-  trace_statements {
-    context = "resource"
-    statements = [
-      "set(attributes[\"region\"], \"central\")",
-    ]
-  }
-  output {
-    traces = [otelcol.processor.batch.static_label_out_traces_otlp.input]
-  }
-}
-otelcol.processor.batch "static_label_out_traces_otlp" {
-  output {
-    traces = [otelcol.processor.filter.static_label_tempo_gate_traces_otlp.input]
-  }
-}
-otelcol.processor.filter "static_label_tempo_gate_traces_otlp" {
-  error_mode = "ignore"
-  trace_conditions {
-    context    = "resource"
-    conditions = [
-      "not IsMatch(attributes[\"selected_destinations\"], \"(^|.*,)tempo(,.*|$)\")",
-    ]
-  }
-  output {
-    traces = [otelcol.processor.transform.static_label_tempo_gate_traces_otlp_strip.input]
-  }
-}
-otelcol.processor.transform "static_label_tempo_gate_traces_otlp_strip" {
-  error_mode = "ignore"
-  trace_statements {
-    context = "resource"
-    statements = [
-      "delete_key(attributes, \"selected_destinations\")",
-    ]
-  }
-  output {
-    traces = [otelcol.processor.attributes.tempo.input]
-  }
-}
 // Feature: Profiles Receiver
 declare "profiles_receiver" {
   argument "profiles_destinations" {
@@ -211,6 +169,48 @@ pyroscope.relabel "static_label_pyroscope_gate_profiles_pyroscope" {
   rule {
     action = "labeldrop"
     regex  = "selected_destinations"
+  }
+}
+// Processor: static-label (custom) — traces/otlp
+otelcol.processor.transform "static_label_traces" {
+  error_mode = "ignore"
+  trace_statements {
+    context = "resource"
+    statements = [
+      "set(attributes[\"region\"], \"central\")",
+    ]
+  }
+  output {
+    traces = [otelcol.processor.batch.static_label_out_traces_otlp.input]
+  }
+}
+otelcol.processor.batch "static_label_out_traces_otlp" {
+  output {
+    traces = [otelcol.processor.filter.static_label_tempo_gate_traces_otlp.input]
+  }
+}
+otelcol.processor.filter "static_label_tempo_gate_traces_otlp" {
+  error_mode = "ignore"
+  trace_conditions {
+    context    = "resource"
+    conditions = [
+      "not IsMatch(attributes[\"selected_destinations\"], \"(^|.*,)tempo(,.*|$)\")",
+    ]
+  }
+  output {
+    traces = [otelcol.processor.transform.static_label_tempo_gate_traces_otlp_strip.input]
+  }
+}
+otelcol.processor.transform "static_label_tempo_gate_traces_otlp_strip" {
+  error_mode = "ignore"
+  trace_statements {
+    context = "resource"
+    statements = [
+      "delete_key(attributes, \"selected_destinations\")",
+    ]
+  }
+  output {
+    traces = [otelcol.processor.attributes.tempo.input]
   }
 }
 

--- a/charts/k8s-monitoring/docs/examples/dataProcessors/custom/static-label/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/dataProcessors/custom/static-label/output.yaml
@@ -658,29 +658,6 @@ data:
         replacement  = "prometheus"
       }
     }
-    // Processor: static-label (custom) — metrics/prometheus
-    prometheus.relabel "static_label_metrics" {
-      rule {
-        target_label = "region"
-        replacement  = "central"
-      }
-      forward_to = [prometheus.relabel.static_label_out_metrics_prometheus.receiver]
-    }
-    prometheus.relabel "static_label_out_metrics_prometheus" {
-      forward_to = [prometheus.relabel.static_label_prometheus_gate_metrics_prometheus.receiver]
-    }
-    prometheus.relabel "static_label_prometheus_gate_metrics_prometheus" {
-      forward_to = [prometheus.remote_write.prometheus.receiver]
-      rule {
-        source_labels = ["selected_destinations"]
-        regex         = "(^|.*,)prometheus(,.*|$)"
-        action        = "keep"
-      }
-      rule {
-        action = "labeldrop"
-        regex  = "selected_destinations"
-      }
-    }
     // Self Reporting
     prometheus.exporter.unix "kubernetes_monitoring_telemetry" {
       set_collectors = ["textfile"]
@@ -723,6 +700,29 @@ data:
         prometheus.remote_write.prometheus.receiver,
       ]
     } // prometheus.relabel "kubernetes_monitoring_telemetry"
+    // Processor: static-label (custom) — metrics/prometheus
+    prometheus.relabel "static_label_metrics" {
+      rule {
+        target_label = "region"
+        replacement  = "central"
+      }
+      forward_to = [prometheus.relabel.static_label_out_metrics_prometheus.receiver]
+    }
+    prometheus.relabel "static_label_out_metrics_prometheus" {
+      forward_to = [prometheus.relabel.static_label_prometheus_gate_metrics_prometheus.receiver]
+    }
+    prometheus.relabel "static_label_prometheus_gate_metrics_prometheus" {
+      forward_to = [prometheus.remote_write.prometheus.receiver]
+      rule {
+        source_labels = ["selected_destinations"]
+        regex         = "(^|.*,)prometheus(,.*|$)"
+        action        = "keep"
+      }
+      rule {
+        action = "labeldrop"
+        regex  = "selected_destinations"
+      }
+    }
     
     
     
@@ -901,48 +901,6 @@ data:
         traces = [otelcol.processor.transform.static_label_traces.input]
       }
     }
-    // Processor: static-label (custom) — traces/otlp
-    otelcol.processor.transform "static_label_traces" {
-      error_mode = "ignore"
-      trace_statements {
-        context = "resource"
-        statements = [
-          "set(attributes[\"region\"], \"central\")",
-        ]
-      }
-      output {
-        traces = [otelcol.processor.batch.static_label_out_traces_otlp.input]
-      }
-    }
-    otelcol.processor.batch "static_label_out_traces_otlp" {
-      output {
-        traces = [otelcol.processor.filter.static_label_tempo_gate_traces_otlp.input]
-      }
-    }
-    otelcol.processor.filter "static_label_tempo_gate_traces_otlp" {
-      error_mode = "ignore"
-      trace_conditions {
-        context    = "resource"
-        conditions = [
-          "not IsMatch(attributes[\"selected_destinations\"], \"(^|.*,)tempo(,.*|$)\")",
-        ]
-      }
-      output {
-        traces = [otelcol.processor.transform.static_label_tempo_gate_traces_otlp_strip.input]
-      }
-    }
-    otelcol.processor.transform "static_label_tempo_gate_traces_otlp_strip" {
-      error_mode = "ignore"
-      trace_statements {
-        context = "resource"
-        statements = [
-          "delete_key(attributes, \"selected_destinations\")",
-        ]
-      }
-      output {
-        traces = [otelcol.processor.attributes.tempo.input]
-      }
-    }
     // Feature: Profiles Receiver
     declare "profiles_receiver" {
       argument "profiles_destinations" {
@@ -991,6 +949,48 @@ data:
       rule {
         action = "labeldrop"
         regex  = "selected_destinations"
+      }
+    }
+    // Processor: static-label (custom) — traces/otlp
+    otelcol.processor.transform "static_label_traces" {
+      error_mode = "ignore"
+      trace_statements {
+        context = "resource"
+        statements = [
+          "set(attributes[\"region\"], \"central\")",
+        ]
+      }
+      output {
+        traces = [otelcol.processor.batch.static_label_out_traces_otlp.input]
+      }
+    }
+    otelcol.processor.batch "static_label_out_traces_otlp" {
+      output {
+        traces = [otelcol.processor.filter.static_label_tempo_gate_traces_otlp.input]
+      }
+    }
+    otelcol.processor.filter "static_label_tempo_gate_traces_otlp" {
+      error_mode = "ignore"
+      trace_conditions {
+        context    = "resource"
+        conditions = [
+          "not IsMatch(attributes[\"selected_destinations\"], \"(^|.*,)tempo(,.*|$)\")",
+        ]
+      }
+      output {
+        traces = [otelcol.processor.transform.static_label_tempo_gate_traces_otlp_strip.input]
+      }
+    }
+    otelcol.processor.transform "static_label_tempo_gate_traces_otlp_strip" {
+      error_mode = "ignore"
+      trace_statements {
+        context = "resource"
+        statements = [
+          "delete_key(attributes, \"selected_destinations\")",
+        ]
+      }
+      output {
+        traces = [otelcol.processor.attributes.tempo.input]
       }
     }
     

--- a/charts/k8s-monitoring/docs/examples/dataProcessors/ec2Enrichment/alloy.alloy
+++ b/charts/k8s-monitoring/docs/examples/dataProcessors/ec2Enrichment/alloy.alloy
@@ -160,30 +160,6 @@ prometheus.relabel "hostmetrics_stamp_metrics_prometheus" {
     replacement  = "localPrometheus"
   }
 }
-// Processor: ec2-tags (ec2Enrichment) — metrics/prometheus
-prometheus.enrich "ec2_tags_in_metrics_prometheus" {
-  targets = discovery.relabel.ec2_tags_instances.output
-  target_to_metric_match = {
-    "__meta_ec2_private_dns_name" = "node",
-  }
-  labels_to_copy = ["team"]
-  forward_to = [prometheus.relabel.ec2_tags_out_metrics_prometheus.receiver]
-} // prometheus.enrich "ec2_tags_in_metrics_prometheus"
-prometheus.relabel "ec2_tags_out_metrics_prometheus" {
-  forward_to = [prometheus.relabel.ec2_tags_localprometheus_gate_metrics_prometheus.receiver]
-}
-prometheus.relabel "ec2_tags_localprometheus_gate_metrics_prometheus" {
-  forward_to = [prometheus.remote_write.localprometheus.receiver]
-  rule {
-    source_labels = ["selected_destinations"]
-    regex         = "(^|.*,)localPrometheus(,.*|$)"
-    action        = "keep"
-  }
-  rule {
-    action = "labeldrop"
-    regex  = "selected_destinations"
-  }
-}
 // Feature: Host Metrics - Windows Hosts
 declare "windows_host_metrics" {
   argument "metrics_destinations" {
@@ -463,30 +439,6 @@ loki.process "nodelogs_stamp_logs_loki" {
     }
   }
 }
-// Processor: ec2-tags (ec2Enrichment) — logs/loki
-loki.enrich "ec2_tags_in_logs_loki" {
-  targets = discovery.relabel.ec2_tags_instances.output
-  target_match_label = "__meta_ec2_private_dns_name"
-  logs_match_label = "node"
-  labels_to_copy = ["team"]
-  forward_to = [loki.process.ec2_tags_out_logs_loki.receiver]
-} // loki.enrich "ec2_tags_in_logs_loki"
-loki.process "ec2_tags_out_logs_loki" {
-  forward_to = [loki.relabel.ec2_tags_localloki_gate_logs_loki.receiver]
-}
-loki.relabel "ec2_tags_localloki_gate_logs_loki" {
-  forward_to = [loki.write.localloki.receiver]
-  rule {
-    source_labels = ["selected_destinations"]
-    regex         = "(^|.*,)localLoki(,.*|$)"
-    action        = "keep"
-  }
-  rule {
-    action = "labeldrop"
-    regex  = "selected_destinations"
-  }
-  max_cache_size = 100
-}
 // Feature: Pod Logs (Loki)
 declare "pod_logs_via_loki" {
   argument "logs_destinations" {
@@ -717,6 +669,54 @@ prometheus.scrape "kubernetes_monitoring_telemetry" {
     prometheus.remote_write.localprometheus.receiver,
   ]
 } // prometheus.scrape "kubernetes_monitoring_telemetry"
+// Processor: ec2-tags (ec2Enrichment) — logs/loki
+loki.enrich "ec2_tags_in_logs_loki" {
+  targets = discovery.relabel.ec2_tags_instances.output
+  target_match_label = "__meta_ec2_private_dns_name"
+  logs_match_label = "node"
+  labels_to_copy = ["team"]
+  forward_to = [loki.process.ec2_tags_out_logs_loki.receiver]
+} // loki.enrich "ec2_tags_in_logs_loki"
+loki.process "ec2_tags_out_logs_loki" {
+  forward_to = [loki.relabel.ec2_tags_localloki_gate_logs_loki.receiver]
+}
+loki.relabel "ec2_tags_localloki_gate_logs_loki" {
+  forward_to = [loki.write.localloki.receiver]
+  rule {
+    source_labels = ["selected_destinations"]
+    regex         = "(^|.*,)localLoki(,.*|$)"
+    action        = "keep"
+  }
+  rule {
+    action = "labeldrop"
+    regex  = "selected_destinations"
+  }
+  max_cache_size = 100
+}
+// Processor: ec2-tags (ec2Enrichment) — metrics/prometheus
+prometheus.enrich "ec2_tags_in_metrics_prometheus" {
+  targets = discovery.relabel.ec2_tags_instances.output
+  target_to_metric_match = {
+    "__meta_ec2_private_dns_name" = "node",
+  }
+  labels_to_copy = ["team"]
+  forward_to = [prometheus.relabel.ec2_tags_out_metrics_prometheus.receiver]
+} // prometheus.enrich "ec2_tags_in_metrics_prometheus"
+prometheus.relabel "ec2_tags_out_metrics_prometheus" {
+  forward_to = [prometheus.relabel.ec2_tags_localprometheus_gate_metrics_prometheus.receiver]
+}
+prometheus.relabel "ec2_tags_localprometheus_gate_metrics_prometheus" {
+  forward_to = [prometheus.remote_write.localprometheus.receiver]
+  rule {
+    source_labels = ["selected_destinations"]
+    regex         = "(^|.*,)localPrometheus(,.*|$)"
+    action        = "keep"
+  }
+  rule {
+    action = "labeldrop"
+    regex  = "selected_destinations"
+  }
+}
 // Processor: ec2-tags (ec2Enrichment) — shared EC2 instance discovery
 discovery.ec2 "ec2_tags_instances" {
   region = "ap-northeast-2"

--- a/charts/k8s-monitoring/docs/examples/dataProcessors/ec2Enrichment/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/dataProcessors/ec2Enrichment/output.yaml
@@ -262,30 +262,6 @@ data:
         replacement  = "localPrometheus"
       }
     }
-    // Processor: ec2-tags (ec2Enrichment) — metrics/prometheus
-    prometheus.enrich "ec2_tags_in_metrics_prometheus" {
-      targets = discovery.relabel.ec2_tags_instances.output
-      target_to_metric_match = {
-        "__meta_ec2_private_dns_name" = "node",
-      }
-      labels_to_copy = ["team"]
-      forward_to = [prometheus.relabel.ec2_tags_out_metrics_prometheus.receiver]
-    } // prometheus.enrich "ec2_tags_in_metrics_prometheus"
-    prometheus.relabel "ec2_tags_out_metrics_prometheus" {
-      forward_to = [prometheus.relabel.ec2_tags_localprometheus_gate_metrics_prometheus.receiver]
-    }
-    prometheus.relabel "ec2_tags_localprometheus_gate_metrics_prometheus" {
-      forward_to = [prometheus.remote_write.localprometheus.receiver]
-      rule {
-        source_labels = ["selected_destinations"]
-        regex         = "(^|.*,)localPrometheus(,.*|$)"
-        action        = "keep"
-      }
-      rule {
-        action = "labeldrop"
-        regex  = "selected_destinations"
-      }
-    }
     // Feature: Host Metrics - Windows Hosts
     declare "windows_host_metrics" {
       argument "metrics_destinations" {
@@ -565,30 +541,6 @@ data:
         }
       }
     }
-    // Processor: ec2-tags (ec2Enrichment) — logs/loki
-    loki.enrich "ec2_tags_in_logs_loki" {
-      targets = discovery.relabel.ec2_tags_instances.output
-      target_match_label = "__meta_ec2_private_dns_name"
-      logs_match_label = "node"
-      labels_to_copy = ["team"]
-      forward_to = [loki.process.ec2_tags_out_logs_loki.receiver]
-    } // loki.enrich "ec2_tags_in_logs_loki"
-    loki.process "ec2_tags_out_logs_loki" {
-      forward_to = [loki.relabel.ec2_tags_localloki_gate_logs_loki.receiver]
-    }
-    loki.relabel "ec2_tags_localloki_gate_logs_loki" {
-      forward_to = [loki.write.localloki.receiver]
-      rule {
-        source_labels = ["selected_destinations"]
-        regex         = "(^|.*,)localLoki(,.*|$)"
-        action        = "keep"
-      }
-      rule {
-        action = "labeldrop"
-        regex  = "selected_destinations"
-      }
-      max_cache_size = 100
-    }
     // Feature: Pod Logs (Loki)
     declare "pod_logs_via_loki" {
       argument "logs_destinations" {
@@ -819,6 +771,54 @@ data:
         prometheus.remote_write.localprometheus.receiver,
       ]
     } // prometheus.scrape "kubernetes_monitoring_telemetry"
+    // Processor: ec2-tags (ec2Enrichment) — logs/loki
+    loki.enrich "ec2_tags_in_logs_loki" {
+      targets = discovery.relabel.ec2_tags_instances.output
+      target_match_label = "__meta_ec2_private_dns_name"
+      logs_match_label = "node"
+      labels_to_copy = ["team"]
+      forward_to = [loki.process.ec2_tags_out_logs_loki.receiver]
+    } // loki.enrich "ec2_tags_in_logs_loki"
+    loki.process "ec2_tags_out_logs_loki" {
+      forward_to = [loki.relabel.ec2_tags_localloki_gate_logs_loki.receiver]
+    }
+    loki.relabel "ec2_tags_localloki_gate_logs_loki" {
+      forward_to = [loki.write.localloki.receiver]
+      rule {
+        source_labels = ["selected_destinations"]
+        regex         = "(^|.*,)localLoki(,.*|$)"
+        action        = "keep"
+      }
+      rule {
+        action = "labeldrop"
+        regex  = "selected_destinations"
+      }
+      max_cache_size = 100
+    }
+    // Processor: ec2-tags (ec2Enrichment) — metrics/prometheus
+    prometheus.enrich "ec2_tags_in_metrics_prometheus" {
+      targets = discovery.relabel.ec2_tags_instances.output
+      target_to_metric_match = {
+        "__meta_ec2_private_dns_name" = "node",
+      }
+      labels_to_copy = ["team"]
+      forward_to = [prometheus.relabel.ec2_tags_out_metrics_prometheus.receiver]
+    } // prometheus.enrich "ec2_tags_in_metrics_prometheus"
+    prometheus.relabel "ec2_tags_out_metrics_prometheus" {
+      forward_to = [prometheus.relabel.ec2_tags_localprometheus_gate_metrics_prometheus.receiver]
+    }
+    prometheus.relabel "ec2_tags_localprometheus_gate_metrics_prometheus" {
+      forward_to = [prometheus.remote_write.localprometheus.receiver]
+      rule {
+        source_labels = ["selected_destinations"]
+        regex         = "(^|.*,)localPrometheus(,.*|$)"
+        action        = "keep"
+      }
+      rule {
+        action = "labeldrop"
+        regex  = "selected_destinations"
+      }
+    }
     // Processor: ec2-tags (ec2Enrichment) — shared EC2 instance discovery
     discovery.ec2 "ec2_tags_instances" {
       region = "ap-northeast-2"

--- a/charts/k8s-monitoring/docs/examples/dataProcessors/kubernetesEnrichment/labels-and-annotations/alloy.alloy
+++ b/charts/k8s-monitoring/docs/examples/dataProcessors/kubernetesEnrichment/labels-and-annotations/alloy.alloy
@@ -121,91 +121,6 @@ otelcol.processor.transform "applicationobservability_stamp_metrics_otlp" {
     metrics = [otelcol.processor.k8sattributes.k8s_metadata_in_metrics_otlp.input]
   }
 }
-// Processor: k8s-metadata (kubernetesEnrichment) — metrics/otlp
-otelcol.processor.k8sattributes "k8s_metadata_in_metrics_otlp" {
-  extract {
-    metadata = []
-    label {
-      from = "pod"
-      key = "color"
-      tag_name = "color"
-    }
-    annotation {
-      from = "pod"
-      key = "example.com/owner"
-      tag_name = "owner"
-    }
-    label {
-      from = "namespace"
-      key = "team"
-      tag_name = "team"
-    }
-    annotation {
-      from = "namespace"
-      key = "cost-center"
-      tag_name = "cost-center"
-    }
-  }
-  pod_association {
-    source {
-      from = "resource_attribute"
-      name = "k8s.pod.name"
-    }
-    source {
-      from = "resource_attribute"
-      name = "k8s.namespace.name"
-    }
-  }
-  pod_association {
-    source {
-      from = "resource_attribute"
-      name = "k8s.pod.ip"
-    }
-  }
-  pod_association {
-    source {
-      from = "resource_attribute"
-      name = "k8s.pod.uid"
-    }
-  }
-  pod_association {
-    source {
-      from = "connection"
-    }
-  }
-  output {
-    metrics = [otelcol.processor.batch.k8s_metadata_out_metrics_otlp.input]
-  }
-} // otelcol.processor.k8sattributes "k8s_metadata_in_metrics_otlp"
-otelcol.processor.batch "k8s_metadata_out_metrics_otlp" {
-  output {
-    metrics = [otelcol.processor.filter.k8s_metadata_prometheus_gate_metrics_otlp.input]
-  }
-}
-otelcol.processor.filter "k8s_metadata_prometheus_gate_metrics_otlp" {
-  error_mode = "ignore"
-  metric_conditions {
-    context    = "resource"
-    conditions = [
-      "not IsMatch(attributes[\"selected_destinations\"], \"(^|.*,)prometheus(,.*|$)\")",
-    ]
-  }
-  output {
-    metrics = [otelcol.processor.transform.k8s_metadata_prometheus_gate_metrics_otlp_strip.input]
-  }
-}
-otelcol.processor.transform "k8s_metadata_prometheus_gate_metrics_otlp_strip" {
-  error_mode = "ignore"
-  metric_statements {
-    context = "resource"
-    statements = [
-      "delete_key(attributes, \"selected_destinations\")",
-    ]
-  }
-  output {
-    metrics = [otelcol.exporter.prometheus.prometheus.input]
-  }
-}
 otelcol.processor.transform "applicationobservability_stamp_logs_otlp" {
   error_mode = "ignore"
   log_statements {
@@ -218,91 +133,6 @@ otelcol.processor.transform "applicationobservability_stamp_logs_otlp" {
     logs = [otelcol.processor.k8sattributes.k8s_metadata_in_logs_otlp.input]
   }
 }
-// Processor: k8s-metadata (kubernetesEnrichment) — logs/otlp
-otelcol.processor.k8sattributes "k8s_metadata_in_logs_otlp" {
-  extract {
-    metadata = []
-    label {
-      from = "pod"
-      key = "color"
-      tag_name = "color"
-    }
-    annotation {
-      from = "pod"
-      key = "example.com/owner"
-      tag_name = "owner"
-    }
-    label {
-      from = "namespace"
-      key = "team"
-      tag_name = "team"
-    }
-    annotation {
-      from = "namespace"
-      key = "cost-center"
-      tag_name = "cost-center"
-    }
-  }
-  pod_association {
-    source {
-      from = "resource_attribute"
-      name = "k8s.pod.name"
-    }
-    source {
-      from = "resource_attribute"
-      name = "k8s.namespace.name"
-    }
-  }
-  pod_association {
-    source {
-      from = "resource_attribute"
-      name = "k8s.pod.ip"
-    }
-  }
-  pod_association {
-    source {
-      from = "resource_attribute"
-      name = "k8s.pod.uid"
-    }
-  }
-  pod_association {
-    source {
-      from = "connection"
-    }
-  }
-  output {
-    logs = [otelcol.processor.batch.k8s_metadata_out_logs_otlp.input]
-  }
-} // otelcol.processor.k8sattributes "k8s_metadata_in_logs_otlp"
-otelcol.processor.batch "k8s_metadata_out_logs_otlp" {
-  output {
-    logs = [otelcol.processor.filter.k8s_metadata_loki_gate_logs_otlp.input]
-  }
-}
-otelcol.processor.filter "k8s_metadata_loki_gate_logs_otlp" {
-  error_mode = "ignore"
-  log_conditions {
-    context    = "resource"
-    conditions = [
-      "not IsMatch(attributes[\"selected_destinations\"], \"(^|.*,)loki(,.*|$)\")",
-    ]
-  }
-  output {
-    logs = [otelcol.processor.transform.k8s_metadata_loki_gate_logs_otlp_strip.input]
-  }
-}
-otelcol.processor.transform "k8s_metadata_loki_gate_logs_otlp_strip" {
-  error_mode = "ignore"
-  log_statements {
-    context = "resource"
-    statements = [
-      "delete_key(attributes, \"selected_destinations\")",
-    ]
-  }
-  output {
-    logs = [otelcol.exporter.loki.loki.input]
-  }
-}
 otelcol.processor.transform "applicationobservability_stamp_traces_otlp" {
   error_mode = "ignore"
   trace_statements {
@@ -313,91 +143,6 @@ otelcol.processor.transform "applicationobservability_stamp_traces_otlp" {
   }
   output {
     traces = [otelcol.processor.k8sattributes.k8s_metadata_in_traces_otlp.input]
-  }
-}
-// Processor: k8s-metadata (kubernetesEnrichment) — traces/otlp
-otelcol.processor.k8sattributes "k8s_metadata_in_traces_otlp" {
-  extract {
-    metadata = []
-    label {
-      from = "pod"
-      key = "color"
-      tag_name = "color"
-    }
-    annotation {
-      from = "pod"
-      key = "example.com/owner"
-      tag_name = "owner"
-    }
-    label {
-      from = "namespace"
-      key = "team"
-      tag_name = "team"
-    }
-    annotation {
-      from = "namespace"
-      key = "cost-center"
-      tag_name = "cost-center"
-    }
-  }
-  pod_association {
-    source {
-      from = "resource_attribute"
-      name = "k8s.pod.name"
-    }
-    source {
-      from = "resource_attribute"
-      name = "k8s.namespace.name"
-    }
-  }
-  pod_association {
-    source {
-      from = "resource_attribute"
-      name = "k8s.pod.ip"
-    }
-  }
-  pod_association {
-    source {
-      from = "resource_attribute"
-      name = "k8s.pod.uid"
-    }
-  }
-  pod_association {
-    source {
-      from = "connection"
-    }
-  }
-  output {
-    traces = [otelcol.processor.batch.k8s_metadata_out_traces_otlp.input]
-  }
-} // otelcol.processor.k8sattributes "k8s_metadata_in_traces_otlp"
-otelcol.processor.batch "k8s_metadata_out_traces_otlp" {
-  output {
-    traces = [otelcol.processor.filter.k8s_metadata_tempo_gate_traces_otlp.input]
-  }
-}
-otelcol.processor.filter "k8s_metadata_tempo_gate_traces_otlp" {
-  error_mode = "ignore"
-  trace_conditions {
-    context    = "resource"
-    conditions = [
-      "not IsMatch(attributes[\"selected_destinations\"], \"(^|.*,)tempo(,.*|$)\")",
-    ]
-  }
-  output {
-    traces = [otelcol.processor.transform.k8s_metadata_tempo_gate_traces_otlp_strip.input]
-  }
-}
-otelcol.processor.transform "k8s_metadata_tempo_gate_traces_otlp_strip" {
-  error_mode = "ignore"
-  trace_statements {
-    context = "resource"
-    statements = [
-      "delete_key(attributes, \"selected_destinations\")",
-    ]
-  }
-  output {
-    traces = [otelcol.processor.attributes.tempo.input]
   }
 }
 // Feature: Cluster Metrics
@@ -685,50 +430,6 @@ prometheus.relabel "clustermetrics_stamp_metrics_prometheus" {
     replacement  = "prometheus"
   }
 }
-// Processor: k8s-metadata (kubernetesEnrichment) — metrics/prometheus
-prometheus.relabel "k8s_metadata_in_metrics_prometheus" {
-  rule {
-    source_labels = ["namespace", "pod"]
-    regex = "(.+;.+)"
-    target_label = "__meta_kubernetes_namespace_pod"
-  }
-  forward_to = [prometheus.enrich.k8s_metadata_ns_metrics_prometheus.receiver]
-} // prometheus.relabel "k8s_metadata_in_metrics_prometheus"
-prometheus.enrich "k8s_metadata_ns_metrics_prometheus" {
-  targets = discovery.relabel.k8s_metadata_pods.output
-  target_match_label = "__meta_kubernetes_namespace"
-  metrics_match_label = "namespace"
-  labels_to_copy = ["team","cost_center"]
-  forward_to = [prometheus.enrich.k8s_metadata_pod_metrics_prometheus.receiver]
-} // prometheus.enrich "k8s_metadata_ns_metrics_prometheus"
-prometheus.enrich "k8s_metadata_pod_metrics_prometheus" {
-  targets = discovery.relabel.k8s_metadata_pods.output
-  target_match_label = "__meta_kubernetes_namespace_pod"
-  labels_to_copy = ["color","owner"]
-  forward_to = [prometheus.relabel.k8s_metadata_cleanup_metrics_prometheus.receiver]
-} // prometheus.enrich "k8s_metadata_pod_metrics_prometheus"
-prometheus.relabel "k8s_metadata_cleanup_metrics_prometheus" {
-  rule {
-    action = "labeldrop"
-    regex = "__meta_kubernetes_namespace_pod"
-  }
-  forward_to = [prometheus.relabel.k8s_metadata_out_metrics_prometheus.receiver]
-} // prometheus.relabel "k8s_metadata_cleanup_metrics_prometheus"
-prometheus.relabel "k8s_metadata_out_metrics_prometheus" {
-  forward_to = [prometheus.relabel.k8s_metadata_prometheus_gate_metrics_prometheus.receiver]
-}
-prometheus.relabel "k8s_metadata_prometheus_gate_metrics_prometheus" {
-  forward_to = [prometheus.remote_write.prometheus.receiver]
-  rule {
-    source_labels = ["selected_destinations"]
-    regex         = "(^|.*,)prometheus(,.*|$)"
-    action        = "keep"
-  }
-  rule {
-    action = "labeldrop"
-    regex  = "selected_destinations"
-  }
-}
 // Feature: Pod Logs (Loki)
 declare "pod_logs_via_loki" {
   argument "logs_destinations" {
@@ -935,6 +636,64 @@ loki.process "podlogsvialoki_stamp_logs_loki" {
     }
   }
 }
+// Feature: Profiles Receiver
+declare "profiles_receiver" {
+  argument "profiles_destinations" {
+    comment = "Must be a list of profile destinations where collected profiles should be forwarded to"
+  }
+
+  pyroscope.receive_http "default" {
+    http {
+      listen_address = "0.0.0.0"
+      listen_port = "4040"
+    }
+
+    forward_to = argument.profiles_destinations.value
+  } // pyroscope.receive_http "default"
+} // declare "profiles_receiver"
+profiles_receiver "feature" {
+  profiles_destinations = [
+    pyroscope.relabel.profilesreceiver_stamp_profiles_pyroscope.receiver,
+  ]
+}
+pyroscope.relabel "profilesreceiver_stamp_profiles_pyroscope" {
+  forward_to = [pyroscope.relabel.k8s_metadata_in_profiles_pyroscope.receiver]
+  rule {
+    target_label = "selected_destinations"
+    replacement  = "pyroscope"
+  }
+}
+// Self Reporting
+prometheus.exporter.static "kubernetes_monitoring_telemetry" {
+  text = `
+
+# HELP grafana_kubernetes_monitoring_build_info A metric to report the version of the Kubernetes Monitoring Helm chart
+# TYPE grafana_kubernetes_monitoring_build_info gauge
+grafana_kubernetes_monitoring_build_info{version="4.5.1", namespace="default"} 1
+# HELP grafana_kubernetes_monitoring_feature_info A metric to report the enabled features of the Kubernetes Monitoring Helm chart
+# TYPE grafana_kubernetes_monitoring_feature_info gauge
+grafana_kubernetes_monitoring_feature_info{feature="applicationObservability", protocols="otlpgrpc", version="1.0.0"} 1
+grafana_kubernetes_monitoring_feature_info{feature="clusterMetrics", sources="kubelet,kubeletResource,cadvisor,kube-state-metrics", version="1.0.0"} 1
+grafana_kubernetes_monitoring_feature_info{feature="podLogsViaLoki", version="1.0.0"} 1
+grafana_kubernetes_monitoring_feature_info{feature="profilesReceiver", version="1.0.0"} 1
+# HELP grafana_kubernetes_monitoring_collector_info A metric to report the collectors of the Kubernetes Monitoring Helm chart
+# TYPE grafana_kubernetes_monitoring_collector_info gauge
+grafana_kubernetes_monitoring_collector_info{kind="daemonset", name="alloy", presets="clustered,filesystem-log-reader,daemonset", type="alloy"} 1
+# EOF
+  `
+} // prometheus.exporter.static "kubernetes_monitoring_telemetry"
+
+prometheus.scrape "kubernetes_monitoring_telemetry" {
+  job_name   = "integrations/kubernetes/kubernetes_monitoring_telemetry"
+  targets    = prometheus.exporter.static.kubernetes_monitoring_telemetry.targets
+  scrape_interval = "60s"
+  clustering {
+    enabled = true
+  }
+  forward_to = [
+    prometheus.remote_write.prometheus.receiver,
+  ]
+} // prometheus.scrape "kubernetes_monitoring_telemetry"
 // Processor: k8s-metadata (kubernetesEnrichment) — logs/loki
 loki.relabel "k8s_metadata_in_logs_loki" {
   rule {
@@ -982,31 +741,218 @@ loki.relabel "k8s_metadata_loki_gate_logs_loki" {
   }
   max_cache_size = 100
 }
-// Feature: Profiles Receiver
-declare "profiles_receiver" {
-  argument "profiles_destinations" {
-    comment = "Must be a list of profile destinations where collected profiles should be forwarded to"
-  }
-
-  pyroscope.receive_http "default" {
-    http {
-      listen_address = "0.0.0.0"
-      listen_port = "4040"
+// Processor: k8s-metadata (kubernetesEnrichment) — logs/otlp
+otelcol.processor.k8sattributes "k8s_metadata_in_logs_otlp" {
+  extract {
+    metadata = []
+    label {
+      from = "pod"
+      key = "color"
+      tag_name = "color"
     }
-
-    forward_to = argument.profiles_destinations.value
-  } // pyroscope.receive_http "default"
-} // declare "profiles_receiver"
-profiles_receiver "feature" {
-  profiles_destinations = [
-    pyroscope.relabel.profilesreceiver_stamp_profiles_pyroscope.receiver,
-  ]
+    annotation {
+      from = "pod"
+      key = "example.com/owner"
+      tag_name = "owner"
+    }
+    label {
+      from = "namespace"
+      key = "team"
+      tag_name = "team"
+    }
+    annotation {
+      from = "namespace"
+      key = "cost-center"
+      tag_name = "cost-center"
+    }
+  }
+  pod_association {
+    source {
+      from = "resource_attribute"
+      name = "k8s.pod.name"
+    }
+    source {
+      from = "resource_attribute"
+      name = "k8s.namespace.name"
+    }
+  }
+  pod_association {
+    source {
+      from = "resource_attribute"
+      name = "k8s.pod.ip"
+    }
+  }
+  pod_association {
+    source {
+      from = "resource_attribute"
+      name = "k8s.pod.uid"
+    }
+  }
+  pod_association {
+    source {
+      from = "connection"
+    }
+  }
+  output {
+    logs = [otelcol.processor.batch.k8s_metadata_out_logs_otlp.input]
+  }
+} // otelcol.processor.k8sattributes "k8s_metadata_in_logs_otlp"
+otelcol.processor.batch "k8s_metadata_out_logs_otlp" {
+  output {
+    logs = [otelcol.processor.filter.k8s_metadata_loki_gate_logs_otlp.input]
+  }
 }
-pyroscope.relabel "profilesreceiver_stamp_profiles_pyroscope" {
-  forward_to = [pyroscope.relabel.k8s_metadata_in_profiles_pyroscope.receiver]
+otelcol.processor.filter "k8s_metadata_loki_gate_logs_otlp" {
+  error_mode = "ignore"
+  log_conditions {
+    context    = "resource"
+    conditions = [
+      "not IsMatch(attributes[\"selected_destinations\"], \"(^|.*,)loki(,.*|$)\")",
+    ]
+  }
+  output {
+    logs = [otelcol.processor.transform.k8s_metadata_loki_gate_logs_otlp_strip.input]
+  }
+}
+otelcol.processor.transform "k8s_metadata_loki_gate_logs_otlp_strip" {
+  error_mode = "ignore"
+  log_statements {
+    context = "resource"
+    statements = [
+      "delete_key(attributes, \"selected_destinations\")",
+    ]
+  }
+  output {
+    logs = [otelcol.exporter.loki.loki.input]
+  }
+}
+// Processor: k8s-metadata (kubernetesEnrichment) — metrics/otlp
+otelcol.processor.k8sattributes "k8s_metadata_in_metrics_otlp" {
+  extract {
+    metadata = []
+    label {
+      from = "pod"
+      key = "color"
+      tag_name = "color"
+    }
+    annotation {
+      from = "pod"
+      key = "example.com/owner"
+      tag_name = "owner"
+    }
+    label {
+      from = "namespace"
+      key = "team"
+      tag_name = "team"
+    }
+    annotation {
+      from = "namespace"
+      key = "cost-center"
+      tag_name = "cost-center"
+    }
+  }
+  pod_association {
+    source {
+      from = "resource_attribute"
+      name = "k8s.pod.name"
+    }
+    source {
+      from = "resource_attribute"
+      name = "k8s.namespace.name"
+    }
+  }
+  pod_association {
+    source {
+      from = "resource_attribute"
+      name = "k8s.pod.ip"
+    }
+  }
+  pod_association {
+    source {
+      from = "resource_attribute"
+      name = "k8s.pod.uid"
+    }
+  }
+  pod_association {
+    source {
+      from = "connection"
+    }
+  }
+  output {
+    metrics = [otelcol.processor.batch.k8s_metadata_out_metrics_otlp.input]
+  }
+} // otelcol.processor.k8sattributes "k8s_metadata_in_metrics_otlp"
+otelcol.processor.batch "k8s_metadata_out_metrics_otlp" {
+  output {
+    metrics = [otelcol.processor.filter.k8s_metadata_prometheus_gate_metrics_otlp.input]
+  }
+}
+otelcol.processor.filter "k8s_metadata_prometheus_gate_metrics_otlp" {
+  error_mode = "ignore"
+  metric_conditions {
+    context    = "resource"
+    conditions = [
+      "not IsMatch(attributes[\"selected_destinations\"], \"(^|.*,)prometheus(,.*|$)\")",
+    ]
+  }
+  output {
+    metrics = [otelcol.processor.transform.k8s_metadata_prometheus_gate_metrics_otlp_strip.input]
+  }
+}
+otelcol.processor.transform "k8s_metadata_prometheus_gate_metrics_otlp_strip" {
+  error_mode = "ignore"
+  metric_statements {
+    context = "resource"
+    statements = [
+      "delete_key(attributes, \"selected_destinations\")",
+    ]
+  }
+  output {
+    metrics = [otelcol.exporter.prometheus.prometheus.input]
+  }
+}
+// Processor: k8s-metadata (kubernetesEnrichment) — metrics/prometheus
+prometheus.relabel "k8s_metadata_in_metrics_prometheus" {
   rule {
-    target_label = "selected_destinations"
-    replacement  = "pyroscope"
+    source_labels = ["namespace", "pod"]
+    regex = "(.+;.+)"
+    target_label = "__meta_kubernetes_namespace_pod"
+  }
+  forward_to = [prometheus.enrich.k8s_metadata_ns_metrics_prometheus.receiver]
+} // prometheus.relabel "k8s_metadata_in_metrics_prometheus"
+prometheus.enrich "k8s_metadata_ns_metrics_prometheus" {
+  targets = discovery.relabel.k8s_metadata_pods.output
+  target_match_label = "__meta_kubernetes_namespace"
+  metrics_match_label = "namespace"
+  labels_to_copy = ["team","cost_center"]
+  forward_to = [prometheus.enrich.k8s_metadata_pod_metrics_prometheus.receiver]
+} // prometheus.enrich "k8s_metadata_ns_metrics_prometheus"
+prometheus.enrich "k8s_metadata_pod_metrics_prometheus" {
+  targets = discovery.relabel.k8s_metadata_pods.output
+  target_match_label = "__meta_kubernetes_namespace_pod"
+  labels_to_copy = ["color","owner"]
+  forward_to = [prometheus.relabel.k8s_metadata_cleanup_metrics_prometheus.receiver]
+} // prometheus.enrich "k8s_metadata_pod_metrics_prometheus"
+prometheus.relabel "k8s_metadata_cleanup_metrics_prometheus" {
+  rule {
+    action = "labeldrop"
+    regex = "__meta_kubernetes_namespace_pod"
+  }
+  forward_to = [prometheus.relabel.k8s_metadata_out_metrics_prometheus.receiver]
+} // prometheus.relabel "k8s_metadata_cleanup_metrics_prometheus"
+prometheus.relabel "k8s_metadata_out_metrics_prometheus" {
+  forward_to = [prometheus.relabel.k8s_metadata_prometheus_gate_metrics_prometheus.receiver]
+}
+prometheus.relabel "k8s_metadata_prometheus_gate_metrics_prometheus" {
+  forward_to = [prometheus.remote_write.prometheus.receiver]
+  rule {
+    source_labels = ["selected_destinations"]
+    regex         = "(^|.*,)prometheus(,.*|$)"
+    action        = "keep"
+  }
+  rule {
+    action = "labeldrop"
+    regex  = "selected_destinations"
   }
 }
 // Processor: k8s-metadata (kubernetesEnrichment) — profiles/pyroscope
@@ -1053,37 +999,91 @@ pyroscope.relabel "k8s_metadata_pyroscope_gate_profiles_pyroscope" {
     regex  = "selected_destinations"
   }
 }
-// Self Reporting
-prometheus.exporter.static "kubernetes_monitoring_telemetry" {
-  text = `
-
-# HELP grafana_kubernetes_monitoring_build_info A metric to report the version of the Kubernetes Monitoring Helm chart
-# TYPE grafana_kubernetes_monitoring_build_info gauge
-grafana_kubernetes_monitoring_build_info{version="4.5.1", namespace="default"} 1
-# HELP grafana_kubernetes_monitoring_feature_info A metric to report the enabled features of the Kubernetes Monitoring Helm chart
-# TYPE grafana_kubernetes_monitoring_feature_info gauge
-grafana_kubernetes_monitoring_feature_info{feature="applicationObservability", protocols="otlpgrpc", version="1.0.0"} 1
-grafana_kubernetes_monitoring_feature_info{feature="clusterMetrics", sources="kubelet,kubeletResource,cadvisor,kube-state-metrics", version="1.0.0"} 1
-grafana_kubernetes_monitoring_feature_info{feature="podLogsViaLoki", version="1.0.0"} 1
-grafana_kubernetes_monitoring_feature_info{feature="profilesReceiver", version="1.0.0"} 1
-# HELP grafana_kubernetes_monitoring_collector_info A metric to report the collectors of the Kubernetes Monitoring Helm chart
-# TYPE grafana_kubernetes_monitoring_collector_info gauge
-grafana_kubernetes_monitoring_collector_info{kind="daemonset", name="alloy", presets="clustered,filesystem-log-reader,daemonset", type="alloy"} 1
-# EOF
-  `
-} // prometheus.exporter.static "kubernetes_monitoring_telemetry"
-
-prometheus.scrape "kubernetes_monitoring_telemetry" {
-  job_name   = "integrations/kubernetes/kubernetes_monitoring_telemetry"
-  targets    = prometheus.exporter.static.kubernetes_monitoring_telemetry.targets
-  scrape_interval = "60s"
-  clustering {
-    enabled = true
+// Processor: k8s-metadata (kubernetesEnrichment) — traces/otlp
+otelcol.processor.k8sattributes "k8s_metadata_in_traces_otlp" {
+  extract {
+    metadata = []
+    label {
+      from = "pod"
+      key = "color"
+      tag_name = "color"
+    }
+    annotation {
+      from = "pod"
+      key = "example.com/owner"
+      tag_name = "owner"
+    }
+    label {
+      from = "namespace"
+      key = "team"
+      tag_name = "team"
+    }
+    annotation {
+      from = "namespace"
+      key = "cost-center"
+      tag_name = "cost-center"
+    }
   }
-  forward_to = [
-    prometheus.remote_write.prometheus.receiver,
-  ]
-} // prometheus.scrape "kubernetes_monitoring_telemetry"
+  pod_association {
+    source {
+      from = "resource_attribute"
+      name = "k8s.pod.name"
+    }
+    source {
+      from = "resource_attribute"
+      name = "k8s.namespace.name"
+    }
+  }
+  pod_association {
+    source {
+      from = "resource_attribute"
+      name = "k8s.pod.ip"
+    }
+  }
+  pod_association {
+    source {
+      from = "resource_attribute"
+      name = "k8s.pod.uid"
+    }
+  }
+  pod_association {
+    source {
+      from = "connection"
+    }
+  }
+  output {
+    traces = [otelcol.processor.batch.k8s_metadata_out_traces_otlp.input]
+  }
+} // otelcol.processor.k8sattributes "k8s_metadata_in_traces_otlp"
+otelcol.processor.batch "k8s_metadata_out_traces_otlp" {
+  output {
+    traces = [otelcol.processor.filter.k8s_metadata_tempo_gate_traces_otlp.input]
+  }
+}
+otelcol.processor.filter "k8s_metadata_tempo_gate_traces_otlp" {
+  error_mode = "ignore"
+  trace_conditions {
+    context    = "resource"
+    conditions = [
+      "not IsMatch(attributes[\"selected_destinations\"], \"(^|.*,)tempo(,.*|$)\")",
+    ]
+  }
+  output {
+    traces = [otelcol.processor.transform.k8s_metadata_tempo_gate_traces_otlp_strip.input]
+  }
+}
+otelcol.processor.transform "k8s_metadata_tempo_gate_traces_otlp_strip" {
+  error_mode = "ignore"
+  trace_statements {
+    context = "resource"
+    statements = [
+      "delete_key(attributes, \"selected_destinations\")",
+    ]
+  }
+  output {
+    traces = [otelcol.processor.attributes.tempo.input]
+  }
+}
 // Processor: k8s-metadata (kubernetesEnrichment) — shared pod discovery
 discovery.kubernetes "k8s_metadata_pods" {
   role = "pod"

--- a/charts/k8s-monitoring/docs/examples/dataProcessors/kubernetesEnrichment/labels-and-annotations/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/dataProcessors/kubernetesEnrichment/labels-and-annotations/output.yaml
@@ -173,91 +173,6 @@ data:
         metrics = [otelcol.processor.k8sattributes.k8s_metadata_in_metrics_otlp.input]
       }
     }
-    // Processor: k8s-metadata (kubernetesEnrichment) — metrics/otlp
-    otelcol.processor.k8sattributes "k8s_metadata_in_metrics_otlp" {
-      extract {
-        metadata = []
-        label {
-          from = "pod"
-          key = "color"
-          tag_name = "color"
-        }
-        annotation {
-          from = "pod"
-          key = "example.com/owner"
-          tag_name = "owner"
-        }
-        label {
-          from = "namespace"
-          key = "team"
-          tag_name = "team"
-        }
-        annotation {
-          from = "namespace"
-          key = "cost-center"
-          tag_name = "cost-center"
-        }
-      }
-      pod_association {
-        source {
-          from = "resource_attribute"
-          name = "k8s.pod.name"
-        }
-        source {
-          from = "resource_attribute"
-          name = "k8s.namespace.name"
-        }
-      }
-      pod_association {
-        source {
-          from = "resource_attribute"
-          name = "k8s.pod.ip"
-        }
-      }
-      pod_association {
-        source {
-          from = "resource_attribute"
-          name = "k8s.pod.uid"
-        }
-      }
-      pod_association {
-        source {
-          from = "connection"
-        }
-      }
-      output {
-        metrics = [otelcol.processor.batch.k8s_metadata_out_metrics_otlp.input]
-      }
-    } // otelcol.processor.k8sattributes "k8s_metadata_in_metrics_otlp"
-    otelcol.processor.batch "k8s_metadata_out_metrics_otlp" {
-      output {
-        metrics = [otelcol.processor.filter.k8s_metadata_prometheus_gate_metrics_otlp.input]
-      }
-    }
-    otelcol.processor.filter "k8s_metadata_prometheus_gate_metrics_otlp" {
-      error_mode = "ignore"
-      metric_conditions {
-        context    = "resource"
-        conditions = [
-          "not IsMatch(attributes[\"selected_destinations\"], \"(^|.*,)prometheus(,.*|$)\")",
-        ]
-      }
-      output {
-        metrics = [otelcol.processor.transform.k8s_metadata_prometheus_gate_metrics_otlp_strip.input]
-      }
-    }
-    otelcol.processor.transform "k8s_metadata_prometheus_gate_metrics_otlp_strip" {
-      error_mode = "ignore"
-      metric_statements {
-        context = "resource"
-        statements = [
-          "delete_key(attributes, \"selected_destinations\")",
-        ]
-      }
-      output {
-        metrics = [otelcol.exporter.prometheus.prometheus.input]
-      }
-    }
     otelcol.processor.transform "applicationobservability_stamp_logs_otlp" {
       error_mode = "ignore"
       log_statements {
@@ -270,91 +185,6 @@ data:
         logs = [otelcol.processor.k8sattributes.k8s_metadata_in_logs_otlp.input]
       }
     }
-    // Processor: k8s-metadata (kubernetesEnrichment) — logs/otlp
-    otelcol.processor.k8sattributes "k8s_metadata_in_logs_otlp" {
-      extract {
-        metadata = []
-        label {
-          from = "pod"
-          key = "color"
-          tag_name = "color"
-        }
-        annotation {
-          from = "pod"
-          key = "example.com/owner"
-          tag_name = "owner"
-        }
-        label {
-          from = "namespace"
-          key = "team"
-          tag_name = "team"
-        }
-        annotation {
-          from = "namespace"
-          key = "cost-center"
-          tag_name = "cost-center"
-        }
-      }
-      pod_association {
-        source {
-          from = "resource_attribute"
-          name = "k8s.pod.name"
-        }
-        source {
-          from = "resource_attribute"
-          name = "k8s.namespace.name"
-        }
-      }
-      pod_association {
-        source {
-          from = "resource_attribute"
-          name = "k8s.pod.ip"
-        }
-      }
-      pod_association {
-        source {
-          from = "resource_attribute"
-          name = "k8s.pod.uid"
-        }
-      }
-      pod_association {
-        source {
-          from = "connection"
-        }
-      }
-      output {
-        logs = [otelcol.processor.batch.k8s_metadata_out_logs_otlp.input]
-      }
-    } // otelcol.processor.k8sattributes "k8s_metadata_in_logs_otlp"
-    otelcol.processor.batch "k8s_metadata_out_logs_otlp" {
-      output {
-        logs = [otelcol.processor.filter.k8s_metadata_loki_gate_logs_otlp.input]
-      }
-    }
-    otelcol.processor.filter "k8s_metadata_loki_gate_logs_otlp" {
-      error_mode = "ignore"
-      log_conditions {
-        context    = "resource"
-        conditions = [
-          "not IsMatch(attributes[\"selected_destinations\"], \"(^|.*,)loki(,.*|$)\")",
-        ]
-      }
-      output {
-        logs = [otelcol.processor.transform.k8s_metadata_loki_gate_logs_otlp_strip.input]
-      }
-    }
-    otelcol.processor.transform "k8s_metadata_loki_gate_logs_otlp_strip" {
-      error_mode = "ignore"
-      log_statements {
-        context = "resource"
-        statements = [
-          "delete_key(attributes, \"selected_destinations\")",
-        ]
-      }
-      output {
-        logs = [otelcol.exporter.loki.loki.input]
-      }
-    }
     otelcol.processor.transform "applicationobservability_stamp_traces_otlp" {
       error_mode = "ignore"
       trace_statements {
@@ -365,91 +195,6 @@ data:
       }
       output {
         traces = [otelcol.processor.k8sattributes.k8s_metadata_in_traces_otlp.input]
-      }
-    }
-    // Processor: k8s-metadata (kubernetesEnrichment) — traces/otlp
-    otelcol.processor.k8sattributes "k8s_metadata_in_traces_otlp" {
-      extract {
-        metadata = []
-        label {
-          from = "pod"
-          key = "color"
-          tag_name = "color"
-        }
-        annotation {
-          from = "pod"
-          key = "example.com/owner"
-          tag_name = "owner"
-        }
-        label {
-          from = "namespace"
-          key = "team"
-          tag_name = "team"
-        }
-        annotation {
-          from = "namespace"
-          key = "cost-center"
-          tag_name = "cost-center"
-        }
-      }
-      pod_association {
-        source {
-          from = "resource_attribute"
-          name = "k8s.pod.name"
-        }
-        source {
-          from = "resource_attribute"
-          name = "k8s.namespace.name"
-        }
-      }
-      pod_association {
-        source {
-          from = "resource_attribute"
-          name = "k8s.pod.ip"
-        }
-      }
-      pod_association {
-        source {
-          from = "resource_attribute"
-          name = "k8s.pod.uid"
-        }
-      }
-      pod_association {
-        source {
-          from = "connection"
-        }
-      }
-      output {
-        traces = [otelcol.processor.batch.k8s_metadata_out_traces_otlp.input]
-      }
-    } // otelcol.processor.k8sattributes "k8s_metadata_in_traces_otlp"
-    otelcol.processor.batch "k8s_metadata_out_traces_otlp" {
-      output {
-        traces = [otelcol.processor.filter.k8s_metadata_tempo_gate_traces_otlp.input]
-      }
-    }
-    otelcol.processor.filter "k8s_metadata_tempo_gate_traces_otlp" {
-      error_mode = "ignore"
-      trace_conditions {
-        context    = "resource"
-        conditions = [
-          "not IsMatch(attributes[\"selected_destinations\"], \"(^|.*,)tempo(,.*|$)\")",
-        ]
-      }
-      output {
-        traces = [otelcol.processor.transform.k8s_metadata_tempo_gate_traces_otlp_strip.input]
-      }
-    }
-    otelcol.processor.transform "k8s_metadata_tempo_gate_traces_otlp_strip" {
-      error_mode = "ignore"
-      trace_statements {
-        context = "resource"
-        statements = [
-          "delete_key(attributes, \"selected_destinations\")",
-        ]
-      }
-      output {
-        traces = [otelcol.processor.attributes.tempo.input]
       }
     }
     // Feature: Cluster Metrics
@@ -737,50 +482,6 @@ data:
         replacement  = "prometheus"
       }
     }
-    // Processor: k8s-metadata (kubernetesEnrichment) — metrics/prometheus
-    prometheus.relabel "k8s_metadata_in_metrics_prometheus" {
-      rule {
-        source_labels = ["namespace", "pod"]
-        regex = "(.+;.+)"
-        target_label = "__meta_kubernetes_namespace_pod"
-      }
-      forward_to = [prometheus.enrich.k8s_metadata_ns_metrics_prometheus.receiver]
-    } // prometheus.relabel "k8s_metadata_in_metrics_prometheus"
-    prometheus.enrich "k8s_metadata_ns_metrics_prometheus" {
-      targets = discovery.relabel.k8s_metadata_pods.output
-      target_match_label = "__meta_kubernetes_namespace"
-      metrics_match_label = "namespace"
-      labels_to_copy = ["team","cost_center"]
-      forward_to = [prometheus.enrich.k8s_metadata_pod_metrics_prometheus.receiver]
-    } // prometheus.enrich "k8s_metadata_ns_metrics_prometheus"
-    prometheus.enrich "k8s_metadata_pod_metrics_prometheus" {
-      targets = discovery.relabel.k8s_metadata_pods.output
-      target_match_label = "__meta_kubernetes_namespace_pod"
-      labels_to_copy = ["color","owner"]
-      forward_to = [prometheus.relabel.k8s_metadata_cleanup_metrics_prometheus.receiver]
-    } // prometheus.enrich "k8s_metadata_pod_metrics_prometheus"
-    prometheus.relabel "k8s_metadata_cleanup_metrics_prometheus" {
-      rule {
-        action = "labeldrop"
-        regex = "__meta_kubernetes_namespace_pod"
-      }
-      forward_to = [prometheus.relabel.k8s_metadata_out_metrics_prometheus.receiver]
-    } // prometheus.relabel "k8s_metadata_cleanup_metrics_prometheus"
-    prometheus.relabel "k8s_metadata_out_metrics_prometheus" {
-      forward_to = [prometheus.relabel.k8s_metadata_prometheus_gate_metrics_prometheus.receiver]
-    }
-    prometheus.relabel "k8s_metadata_prometheus_gate_metrics_prometheus" {
-      forward_to = [prometheus.remote_write.prometheus.receiver]
-      rule {
-        source_labels = ["selected_destinations"]
-        regex         = "(^|.*,)prometheus(,.*|$)"
-        action        = "keep"
-      }
-      rule {
-        action = "labeldrop"
-        regex  = "selected_destinations"
-      }
-    }
     // Feature: Pod Logs (Loki)
     declare "pod_logs_via_loki" {
       argument "logs_destinations" {
@@ -987,6 +688,64 @@ data:
         }
       }
     }
+    // Feature: Profiles Receiver
+    declare "profiles_receiver" {
+      argument "profiles_destinations" {
+        comment = "Must be a list of profile destinations where collected profiles should be forwarded to"
+      }
+    
+      pyroscope.receive_http "default" {
+        http {
+          listen_address = "0.0.0.0"
+          listen_port = "4040"
+        }
+    
+        forward_to = argument.profiles_destinations.value
+      } // pyroscope.receive_http "default"
+    } // declare "profiles_receiver"
+    profiles_receiver "feature" {
+      profiles_destinations = [
+        pyroscope.relabel.profilesreceiver_stamp_profiles_pyroscope.receiver,
+      ]
+    }
+    pyroscope.relabel "profilesreceiver_stamp_profiles_pyroscope" {
+      forward_to = [pyroscope.relabel.k8s_metadata_in_profiles_pyroscope.receiver]
+      rule {
+        target_label = "selected_destinations"
+        replacement  = "pyroscope"
+      }
+    }
+    // Self Reporting
+    prometheus.exporter.static "kubernetes_monitoring_telemetry" {
+      text = `
+    
+    # HELP grafana_kubernetes_monitoring_build_info A metric to report the version of the Kubernetes Monitoring Helm chart
+    # TYPE grafana_kubernetes_monitoring_build_info gauge
+    grafana_kubernetes_monitoring_build_info{version="4.5.1", namespace="default"} 1
+    # HELP grafana_kubernetes_monitoring_feature_info A metric to report the enabled features of the Kubernetes Monitoring Helm chart
+    # TYPE grafana_kubernetes_monitoring_feature_info gauge
+    grafana_kubernetes_monitoring_feature_info{feature="applicationObservability", protocols="otlpgrpc", version="1.0.0"} 1
+    grafana_kubernetes_monitoring_feature_info{feature="clusterMetrics", sources="kubelet,kubeletResource,cadvisor,kube-state-metrics", version="1.0.0"} 1
+    grafana_kubernetes_monitoring_feature_info{feature="podLogsViaLoki", version="1.0.0"} 1
+    grafana_kubernetes_monitoring_feature_info{feature="profilesReceiver", version="1.0.0"} 1
+    # HELP grafana_kubernetes_monitoring_collector_info A metric to report the collectors of the Kubernetes Monitoring Helm chart
+    # TYPE grafana_kubernetes_monitoring_collector_info gauge
+    grafana_kubernetes_monitoring_collector_info{kind="daemonset", name="alloy", presets="clustered,filesystem-log-reader,daemonset", type="alloy"} 1
+    # EOF
+      `
+    } // prometheus.exporter.static "kubernetes_monitoring_telemetry"
+    
+    prometheus.scrape "kubernetes_monitoring_telemetry" {
+      job_name   = "integrations/kubernetes/kubernetes_monitoring_telemetry"
+      targets    = prometheus.exporter.static.kubernetes_monitoring_telemetry.targets
+      scrape_interval = "60s"
+      clustering {
+        enabled = true
+      }
+      forward_to = [
+        prometheus.remote_write.prometheus.receiver,
+      ]
+    } // prometheus.scrape "kubernetes_monitoring_telemetry"
     // Processor: k8s-metadata (kubernetesEnrichment) — logs/loki
     loki.relabel "k8s_metadata_in_logs_loki" {
       rule {
@@ -1034,31 +793,218 @@ data:
       }
       max_cache_size = 100
     }
-    // Feature: Profiles Receiver
-    declare "profiles_receiver" {
-      argument "profiles_destinations" {
-        comment = "Must be a list of profile destinations where collected profiles should be forwarded to"
-      }
-    
-      pyroscope.receive_http "default" {
-        http {
-          listen_address = "0.0.0.0"
-          listen_port = "4040"
+    // Processor: k8s-metadata (kubernetesEnrichment) — logs/otlp
+    otelcol.processor.k8sattributes "k8s_metadata_in_logs_otlp" {
+      extract {
+        metadata = []
+        label {
+          from = "pod"
+          key = "color"
+          tag_name = "color"
         }
-    
-        forward_to = argument.profiles_destinations.value
-      } // pyroscope.receive_http "default"
-    } // declare "profiles_receiver"
-    profiles_receiver "feature" {
-      profiles_destinations = [
-        pyroscope.relabel.profilesreceiver_stamp_profiles_pyroscope.receiver,
-      ]
+        annotation {
+          from = "pod"
+          key = "example.com/owner"
+          tag_name = "owner"
+        }
+        label {
+          from = "namespace"
+          key = "team"
+          tag_name = "team"
+        }
+        annotation {
+          from = "namespace"
+          key = "cost-center"
+          tag_name = "cost-center"
+        }
+      }
+      pod_association {
+        source {
+          from = "resource_attribute"
+          name = "k8s.pod.name"
+        }
+        source {
+          from = "resource_attribute"
+          name = "k8s.namespace.name"
+        }
+      }
+      pod_association {
+        source {
+          from = "resource_attribute"
+          name = "k8s.pod.ip"
+        }
+      }
+      pod_association {
+        source {
+          from = "resource_attribute"
+          name = "k8s.pod.uid"
+        }
+      }
+      pod_association {
+        source {
+          from = "connection"
+        }
+      }
+      output {
+        logs = [otelcol.processor.batch.k8s_metadata_out_logs_otlp.input]
+      }
+    } // otelcol.processor.k8sattributes "k8s_metadata_in_logs_otlp"
+    otelcol.processor.batch "k8s_metadata_out_logs_otlp" {
+      output {
+        logs = [otelcol.processor.filter.k8s_metadata_loki_gate_logs_otlp.input]
+      }
     }
-    pyroscope.relabel "profilesreceiver_stamp_profiles_pyroscope" {
-      forward_to = [pyroscope.relabel.k8s_metadata_in_profiles_pyroscope.receiver]
+    otelcol.processor.filter "k8s_metadata_loki_gate_logs_otlp" {
+      error_mode = "ignore"
+      log_conditions {
+        context    = "resource"
+        conditions = [
+          "not IsMatch(attributes[\"selected_destinations\"], \"(^|.*,)loki(,.*|$)\")",
+        ]
+      }
+      output {
+        logs = [otelcol.processor.transform.k8s_metadata_loki_gate_logs_otlp_strip.input]
+      }
+    }
+    otelcol.processor.transform "k8s_metadata_loki_gate_logs_otlp_strip" {
+      error_mode = "ignore"
+      log_statements {
+        context = "resource"
+        statements = [
+          "delete_key(attributes, \"selected_destinations\")",
+        ]
+      }
+      output {
+        logs = [otelcol.exporter.loki.loki.input]
+      }
+    }
+    // Processor: k8s-metadata (kubernetesEnrichment) — metrics/otlp
+    otelcol.processor.k8sattributes "k8s_metadata_in_metrics_otlp" {
+      extract {
+        metadata = []
+        label {
+          from = "pod"
+          key = "color"
+          tag_name = "color"
+        }
+        annotation {
+          from = "pod"
+          key = "example.com/owner"
+          tag_name = "owner"
+        }
+        label {
+          from = "namespace"
+          key = "team"
+          tag_name = "team"
+        }
+        annotation {
+          from = "namespace"
+          key = "cost-center"
+          tag_name = "cost-center"
+        }
+      }
+      pod_association {
+        source {
+          from = "resource_attribute"
+          name = "k8s.pod.name"
+        }
+        source {
+          from = "resource_attribute"
+          name = "k8s.namespace.name"
+        }
+      }
+      pod_association {
+        source {
+          from = "resource_attribute"
+          name = "k8s.pod.ip"
+        }
+      }
+      pod_association {
+        source {
+          from = "resource_attribute"
+          name = "k8s.pod.uid"
+        }
+      }
+      pod_association {
+        source {
+          from = "connection"
+        }
+      }
+      output {
+        metrics = [otelcol.processor.batch.k8s_metadata_out_metrics_otlp.input]
+      }
+    } // otelcol.processor.k8sattributes "k8s_metadata_in_metrics_otlp"
+    otelcol.processor.batch "k8s_metadata_out_metrics_otlp" {
+      output {
+        metrics = [otelcol.processor.filter.k8s_metadata_prometheus_gate_metrics_otlp.input]
+      }
+    }
+    otelcol.processor.filter "k8s_metadata_prometheus_gate_metrics_otlp" {
+      error_mode = "ignore"
+      metric_conditions {
+        context    = "resource"
+        conditions = [
+          "not IsMatch(attributes[\"selected_destinations\"], \"(^|.*,)prometheus(,.*|$)\")",
+        ]
+      }
+      output {
+        metrics = [otelcol.processor.transform.k8s_metadata_prometheus_gate_metrics_otlp_strip.input]
+      }
+    }
+    otelcol.processor.transform "k8s_metadata_prometheus_gate_metrics_otlp_strip" {
+      error_mode = "ignore"
+      metric_statements {
+        context = "resource"
+        statements = [
+          "delete_key(attributes, \"selected_destinations\")",
+        ]
+      }
+      output {
+        metrics = [otelcol.exporter.prometheus.prometheus.input]
+      }
+    }
+    // Processor: k8s-metadata (kubernetesEnrichment) — metrics/prometheus
+    prometheus.relabel "k8s_metadata_in_metrics_prometheus" {
       rule {
-        target_label = "selected_destinations"
-        replacement  = "pyroscope"
+        source_labels = ["namespace", "pod"]
+        regex = "(.+;.+)"
+        target_label = "__meta_kubernetes_namespace_pod"
+      }
+      forward_to = [prometheus.enrich.k8s_metadata_ns_metrics_prometheus.receiver]
+    } // prometheus.relabel "k8s_metadata_in_metrics_prometheus"
+    prometheus.enrich "k8s_metadata_ns_metrics_prometheus" {
+      targets = discovery.relabel.k8s_metadata_pods.output
+      target_match_label = "__meta_kubernetes_namespace"
+      metrics_match_label = "namespace"
+      labels_to_copy = ["team","cost_center"]
+      forward_to = [prometheus.enrich.k8s_metadata_pod_metrics_prometheus.receiver]
+    } // prometheus.enrich "k8s_metadata_ns_metrics_prometheus"
+    prometheus.enrich "k8s_metadata_pod_metrics_prometheus" {
+      targets = discovery.relabel.k8s_metadata_pods.output
+      target_match_label = "__meta_kubernetes_namespace_pod"
+      labels_to_copy = ["color","owner"]
+      forward_to = [prometheus.relabel.k8s_metadata_cleanup_metrics_prometheus.receiver]
+    } // prometheus.enrich "k8s_metadata_pod_metrics_prometheus"
+    prometheus.relabel "k8s_metadata_cleanup_metrics_prometheus" {
+      rule {
+        action = "labeldrop"
+        regex = "__meta_kubernetes_namespace_pod"
+      }
+      forward_to = [prometheus.relabel.k8s_metadata_out_metrics_prometheus.receiver]
+    } // prometheus.relabel "k8s_metadata_cleanup_metrics_prometheus"
+    prometheus.relabel "k8s_metadata_out_metrics_prometheus" {
+      forward_to = [prometheus.relabel.k8s_metadata_prometheus_gate_metrics_prometheus.receiver]
+    }
+    prometheus.relabel "k8s_metadata_prometheus_gate_metrics_prometheus" {
+      forward_to = [prometheus.remote_write.prometheus.receiver]
+      rule {
+        source_labels = ["selected_destinations"]
+        regex         = "(^|.*,)prometheus(,.*|$)"
+        action        = "keep"
+      }
+      rule {
+        action = "labeldrop"
+        regex  = "selected_destinations"
       }
     }
     // Processor: k8s-metadata (kubernetesEnrichment) — profiles/pyroscope
@@ -1105,37 +1051,91 @@ data:
         regex  = "selected_destinations"
       }
     }
-    // Self Reporting
-    prometheus.exporter.static "kubernetes_monitoring_telemetry" {
-      text = `
-    
-    # HELP grafana_kubernetes_monitoring_build_info A metric to report the version of the Kubernetes Monitoring Helm chart
-    # TYPE grafana_kubernetes_monitoring_build_info gauge
-    grafana_kubernetes_monitoring_build_info{version="4.5.1", namespace="default"} 1
-    # HELP grafana_kubernetes_monitoring_feature_info A metric to report the enabled features of the Kubernetes Monitoring Helm chart
-    # TYPE grafana_kubernetes_monitoring_feature_info gauge
-    grafana_kubernetes_monitoring_feature_info{feature="applicationObservability", protocols="otlpgrpc", version="1.0.0"} 1
-    grafana_kubernetes_monitoring_feature_info{feature="clusterMetrics", sources="kubelet,kubeletResource,cadvisor,kube-state-metrics", version="1.0.0"} 1
-    grafana_kubernetes_monitoring_feature_info{feature="podLogsViaLoki", version="1.0.0"} 1
-    grafana_kubernetes_monitoring_feature_info{feature="profilesReceiver", version="1.0.0"} 1
-    # HELP grafana_kubernetes_monitoring_collector_info A metric to report the collectors of the Kubernetes Monitoring Helm chart
-    # TYPE grafana_kubernetes_monitoring_collector_info gauge
-    grafana_kubernetes_monitoring_collector_info{kind="daemonset", name="alloy", presets="clustered,filesystem-log-reader,daemonset", type="alloy"} 1
-    # EOF
-      `
-    } // prometheus.exporter.static "kubernetes_monitoring_telemetry"
-    
-    prometheus.scrape "kubernetes_monitoring_telemetry" {
-      job_name   = "integrations/kubernetes/kubernetes_monitoring_telemetry"
-      targets    = prometheus.exporter.static.kubernetes_monitoring_telemetry.targets
-      scrape_interval = "60s"
-      clustering {
-        enabled = true
+    // Processor: k8s-metadata (kubernetesEnrichment) — traces/otlp
+    otelcol.processor.k8sattributes "k8s_metadata_in_traces_otlp" {
+      extract {
+        metadata = []
+        label {
+          from = "pod"
+          key = "color"
+          tag_name = "color"
+        }
+        annotation {
+          from = "pod"
+          key = "example.com/owner"
+          tag_name = "owner"
+        }
+        label {
+          from = "namespace"
+          key = "team"
+          tag_name = "team"
+        }
+        annotation {
+          from = "namespace"
+          key = "cost-center"
+          tag_name = "cost-center"
+        }
       }
-      forward_to = [
-        prometheus.remote_write.prometheus.receiver,
-      ]
-    } // prometheus.scrape "kubernetes_monitoring_telemetry"
+      pod_association {
+        source {
+          from = "resource_attribute"
+          name = "k8s.pod.name"
+        }
+        source {
+          from = "resource_attribute"
+          name = "k8s.namespace.name"
+        }
+      }
+      pod_association {
+        source {
+          from = "resource_attribute"
+          name = "k8s.pod.ip"
+        }
+      }
+      pod_association {
+        source {
+          from = "resource_attribute"
+          name = "k8s.pod.uid"
+        }
+      }
+      pod_association {
+        source {
+          from = "connection"
+        }
+      }
+      output {
+        traces = [otelcol.processor.batch.k8s_metadata_out_traces_otlp.input]
+      }
+    } // otelcol.processor.k8sattributes "k8s_metadata_in_traces_otlp"
+    otelcol.processor.batch "k8s_metadata_out_traces_otlp" {
+      output {
+        traces = [otelcol.processor.filter.k8s_metadata_tempo_gate_traces_otlp.input]
+      }
+    }
+    otelcol.processor.filter "k8s_metadata_tempo_gate_traces_otlp" {
+      error_mode = "ignore"
+      trace_conditions {
+        context    = "resource"
+        conditions = [
+          "not IsMatch(attributes[\"selected_destinations\"], \"(^|.*,)tempo(,.*|$)\")",
+        ]
+      }
+      output {
+        traces = [otelcol.processor.transform.k8s_metadata_tempo_gate_traces_otlp_strip.input]
+      }
+    }
+    otelcol.processor.transform "k8s_metadata_tempo_gate_traces_otlp_strip" {
+      error_mode = "ignore"
+      trace_statements {
+        context = "resource"
+        statements = [
+          "delete_key(attributes, \"selected_destinations\")",
+        ]
+      }
+      output {
+        traces = [otelcol.processor.attributes.tempo.input]
+      }
+    }
     // Processor: k8s-metadata (kubernetesEnrichment) — shared pod discovery
     discovery.kubernetes "k8s_metadata_pods" {
       role = "pod"

--- a/charts/k8s-monitoring/templates/alloy-config.yaml
+++ b/charts/k8s-monitoring/templates/alloy-config.yaml
@@ -1,3 +1,4 @@
+{{- /* Track which required replaceComponent entries match, so we can error on ones that never do. */}}
 {{- $replacementsUsed := dict }}
 {{- range $replacement := .Values.replaceComponent }}
   {{- if not $replacement.optional }}
@@ -5,9 +6,12 @@
     {{- $_ := set $replacementsUsed $key false }}
   {{- end }}
 {{- end }}
+{{- /* Render one Alloy config ConfigMap per enabled collector. */}}
 {{- range $collectorName := include "collectors.list.enabled" . | fromYamlArray }}
+{{- /* Seed the collector's destination list with any explicitly included destinations. */}}
 {{- $destinationNames := (get $.Values.collectors $collectorName).includeDestinations | default list }}
 {{- $collectorContext := dict "Values" $.Values "Chart" $.Chart "Files" $.Files "Release" $.Release "Subcharts" $.Subcharts "Template" $.Template "Capabilities" $.Capabilities "collectorName" $collectorName }}
+{{- /* Add the destinations required by each feature assigned to this collector. */}}
 {{- range $featureKey := include "features.list" $ | fromYamlArray }}
   {{- $featureCollectorNames := include "collectors.getCollectorsForFeature" (dict "Values" $.Values "Files" $.Files "Subcharts" $.Subcharts "featureKey" $featureKey) | fromYamlArray }}
   {{- if has $collectorName $featureCollectorNames }}
@@ -45,6 +49,7 @@
 {{- $values := dict "Values" $.Values "Chart" $.Chart "Files" $.Files "Release" $.Release "Subcharts" $.Subcharts "Template" $.Template "Capabilities" $.Capabilities "collectorName" $collectorName }}
 {{- $collectorValues := include "collector.alloy.values" $values | fromYaml }}
 {{- $alloyConfig := "" }}
+{{- /* Build the collector's config by concatenating the config from each of its assigned features. */}}
 {{- range $featureKey := include "features.list" . | fromYamlArray }}
   {{- $featureCollectorNames := include "collectors.getCollectorsForFeature" (dict "Values" $.Values "Files" $.Files "Subcharts" $.Subcharts "featureKey" $featureKey) | fromYamlArray }}
   {{- if has $collectorName $featureCollectorNames }}
@@ -54,17 +59,26 @@
     {{- end }}
   {{- end }}
 {{- end }}
+{{- /* Append each shared data-processor pipeline once per collector, before collectorComponents needs to see it (issue #3014). */}}
+{{- $dataProcessorChains := include "dataProcessors.pipeline.collectorChains.flush" (dict "root" $ "collectorName" $collectorName) | trim }}
+{{- if $dataProcessorChains }}
+  {{- $alloyConfig = cat $alloyConfig ($dataProcessorChains | nindent 0) }}
+{{- end }}
+{{- /* Append components shared across a processor's pipelines (like Kubernetes discovery), once per collector. */}}
 {{- $dataProcessorSharedComponents := include "dataProcessors.alloy.collectorComponents" (dict "Values" $.Values "config" $alloyConfig) | trim }}
 {{- if $dataProcessorSharedComponents }}
   {{- $alloyConfig = cat $alloyConfig ($dataProcessorSharedComponents | nindent 0) }}
 {{- end }}
+{{- /* Append the collector's logging, live debugging, remote config, and extra config blocks. */}}
 {{- $alloyConfig = cat $alloyConfig (include "collectors.logging.alloy" $collectorValues | trim | nindent 0) }}
 {{- $alloyConfig = cat $alloyConfig (include "collectors.liveDebugging.alloy" $collectorValues | trim | nindent 0) }}
 {{- $alloyConfig = cat $alloyConfig (include "collectors.remoteConfig.alloy" $values | trim | nindent 0) }}
 {{- $alloyConfig = cat $alloyConfig (include "collectors.extraConfig.alloy" $values | trim | nindent 0) }}
+{{- /* Append the write rules and component bodies for the collector's destinations. */}}
 {{- $alloyConfig = cat $alloyConfig (include "destinations.alloy.rules" (deepCopy $ | merge (dict "collectorName" $collectorName)) | trim | nindent 0) }}
 {{- $alloyConfig = cat $alloyConfig (include "destinations.alloy.config" (deepCopy $ | merge (dict "destinationNames" ($destinationNames | uniq | sortAlpha))) | trim | nindent 0) }}
 
+{{- /* Apply any component replacements and record which ones matched. */}}
 {{- range $replacement := $.Values.replaceComponent }}
   {{- $before := $alloyConfig }}
   {{- $alloyConfig = include "replaceComponent.apply" (dict "config" $alloyConfig "replacement" $replacement) }}
@@ -79,6 +93,7 @@
 
 {{/* Ensure the collector's stability level is high enough for the components in the rendered config */}}
 {{- include "collectors.validate.stabilityLevel" (dict "collectorName" $collectorName "config" $alloyConfig "collectorValues" $collectorValues "Files" $.Files) }}
+{{- /* Emit the assembled config as this collector's ConfigMap. */}}
 ---
 apiVersion: v1
 kind: ConfigMap

--- a/charts/k8s-monitoring/templates/dataProcessors/_config.alloy.tpl
+++ b/charts/k8s-monitoring/templates/dataProcessors/_config.alloy.tpl
@@ -11,7 +11,7 @@
          bridges and per-destination gates are owned by the orchestrator.
 
      Inputs: root (.), featureKey (string), destinationNames ([]string), type, ecosystem. */}}
-{{- define "pipeline.alloy.targets.forFeature" -}}
+{{- define "dataProcessors.pipeline.targets.forFeature" -}}
 {{- $root := .root -}}
 {{- $featureKey := .featureKey -}}
 {{- $destinationNames := .destinationNames -}}
@@ -21,7 +21,7 @@
 {{- $chosenDataProcessors := dig "dataProcessors" list (default dict (get $root.Values $featureKey)) }}
 {{- /* Resolve the chain for THIS (type, ecosystem). Only route through a stamper when at
        least one chosen processor actually supports this tuple; otherwise the stamper ref
-       would be emitted here but never rendered by feature.render.forFeature (which branches
+       would be emitted here but never rendered by dataProcessors.pipeline.render.forFeature (which branches
        on the same resolved chain), leaving a dangling Alloy reference. */}}
 {{- $chain := include "dataProcessors.get" (dict "dataProcessors" $dp "chosen" $chosenDataProcessors "type" $type "ecosystem" $ecosystem) | fromYamlArray -}}
 {{- /* Precise router-capability check (replaces the old router-side R10 inference, see
@@ -39,29 +39,112 @@
 {{- if empty $chain -}}
 {{- include "destinations.alloy.targets" (dict "destinations" $root.Values.destinations "destinationNames" $destinationNames "type" $type "ecosystem" $ecosystem) -}}
 {{- else }}
-{{ include "pipeline.alloy.stamper.ref" (dict "feature" $featureKey "type" $type "ecosystem" $ecosystem) }},
+{{ include "dataProcessors.pipeline.stamper.ref" (dict "feature" $featureKey "type" $type "ecosystem" $ecosystem) }},
 {{- end -}}
 {{- end }}
 
-{{/* Convenience wrapper used by feature templates. Renders the chart-owned boundary
-     components (stamper, processor config slices, output sinks, destination gates) for a
-     feature's (type, ecosystem). No-op when the feature has no applicable processors.
+{{/* Convenience wrapper used by feature templates. Emits the feature's per-feature stamper (which
+     the feature's module forwards into) and records the feature's resolved processor chain into a
+     per-collector accumulator. The shared chain body (processor config slices, output sinks,
+     destination gates) is NOT rendered here — it is rendered exactly once per collector by
+     dataProcessors.pipeline.collectorChains.flush. No-op when the feature has no applicable processors.
+
+     Recording the chain instead of rendering its body here is what prevents duplicate block
+     declarations when two features on the same collector share a processor: the slice/sink/gate
+     component names are keyed by (processor, type, ecosystem), not by feature, so rendering them
+     once per feature would collide (issue #3014).
 
      Inputs: root (.), featureKey (string), destinationNames ([]string), type, ecosystem. */}}
-{{- define "pipeline.alloy.feature.render.forFeature" -}}
+{{- define "dataProcessors.pipeline.render.forFeature" -}}
 {{- $dp := default dict .root.Values.dataProcessors -}}
 {{- $chosenDataProcessors := dig "dataProcessors" list (default dict (get .root.Values .featureKey)) }}
 {{- $chain := include "dataProcessors.get" (dict "dataProcessors" $dp "chosen" $chosenDataProcessors "type" .type "ecosystem" .ecosystem) | fromYamlArray -}}
-{{- include "pipeline.alloy.feature.render" (dict "destinations" .root.Values.destinations "destinationNames" .destinationNames "dataProcessors" $dp "processorNames" $chain "feature" .featureKey "type" .type "ecosystem" .ecosystem) -}}
+{{- if not (empty $chain) -}}
+{{- /* Per-feature stamper: emitted inline so each feature's module forwards into its own stamper,
+       which stamps that feature's selected_destinations and forwards into the shared chain. */}}
+{{- include "dataProcessors.pipeline.stamper.forFeature" (dict "destinationNames" .destinationNames "dataProcessors" $dp "processorNames" $chain "feature" .featureKey "type" .type "ecosystem" .ecosystem) -}}
+{{- /* Record the chain for once-per-collector rendering, unioning destinations across the features
+       on this collector that use it. */}}
+{{- include "dataProcessors.pipeline.collectorChains.record" (dict "root" .root "collectorName" .root.collectorName "featureKey" .featureKey "destinationNames" .destinationNames "processorNames" $chain "type" .type "ecosystem" .ecosystem) -}}
+{{- end -}}
+{{- end }}
+
+{{/* Records a feature's resolved chain into the per-collector accumulator stashed on .Values. Entries
+     are keyed by (collector, chain, type, ecosystem); destinationNames are unioned across every
+     feature that resolves the same key so the single shared chain body carries a gate for each
+     destination any contributing feature selected. Populated by dataProcessors.pipeline.render.forFeature
+     as the orchestrator walks the features of a collector; drained by dataProcessors.pipeline.collectorChains.flush.
+
+     A processor's slice/sink components are keyed by (processor, type, ecosystem), so a processor
+     can only be shared across features on a collector when they resolve the SAME chain — otherwise
+     its single set of components would need two different wirings. Such a conflict is detected here
+     and fails with an actionable message rather than emitting a config Alloy rejects as
+     "block ... already declared".
+
+     Inputs: root (.), collectorName, featureKey, destinationNames ([]string), processorNames ([]string), type, ecosystem. */}}
+{{- define "dataProcessors.pipeline.collectorChains.record" -}}
+{{- $acc := .root.Values.__dataProcessorChains -}}
+{{- if not $acc -}}
+{{- $acc = dict -}}
+{{- $_ := set .root.Values "__dataProcessorChains" $acc -}}
+{{- end -}}
+{{- $chainStr := join "|" .processorNames -}}
+{{- $key := printf "%s:::%s:::%s:::%s" .collectorName $chainStr .type .ecosystem -}}
+{{- /* Conflict guard: the same processor may not appear in two different chains on one collector
+       (same type/ecosystem), since its shared components can't carry two wirings. */}}
+{{- $owners := .root.Values.__dataProcessorChainOwners -}}
+{{- if not $owners -}}
+{{- $owners = dict -}}
+{{- $_ := set .root.Values "__dataProcessorChainOwners" $owners -}}
+{{- end -}}
+{{- range $procName := .processorNames -}}
+{{- $ownerKey := printf "%s:::%s:::%s:::%s" $.collectorName $procName $.type $.ecosystem -}}
+{{- if hasKey $owners $ownerKey -}}
+{{- $owner := get $owners $ownerKey -}}
+{{- if ne $owner.chain $chainStr -}}
+{{- $msg := list "" (printf "The data processor %q is used in two different processor chains on collector %q:" $procName $.collectorName) -}}
+{{- $msg = append $msg (printf "  - feature %q uses chain [%s]" $owner.feature (join ", " (splitList "|" $owner.chain))) -}}
+{{- $msg = append $msg (printf "  - feature %q uses chain [%s]" $.featureKey (join ", " $.processorNames)) -}}
+{{- $msg = append $msg "A processor's components are shared per collector, so features that share a processor must use the same chain." -}}
+{{- $msg = append $msg "Give these features identical dataProcessors lists, or define separate processors for each." -}}
+{{- fail (join "\n" $msg) -}}
+{{- end -}}
+{{- else -}}
+{{- $_ := set $owners $ownerKey (dict "chain" $chainStr "feature" $.featureKey) -}}
+{{- end -}}
+{{- end -}}
+{{- if hasKey $acc $key -}}
+{{- $entry := get $acc $key -}}
+{{- $_ := set $entry "destinationNames" (concat $entry.destinationNames .destinationNames | uniq) -}}
+{{- else -}}
+{{- $_ := set $acc $key (dict "collectorName" .collectorName "processorNames" .processorNames "type" .type "ecosystem" .ecosystem "destinationNames" (.destinationNames | uniq)) -}}
+{{- end -}}
+{{- end }}
+
+{{/* Renders every chain body accumulated for a collector, exactly once each. Called once per collector
+     by the orchestrator after the feature modules are assembled and BEFORE
+     dataProcessors.alloy.collectorComponents (which gates shared discovery on the config already
+     referencing it, so the chain body slices must exist by then). Entries are matched by collectorName
+     and emitted in a stable key order for deterministic output.
+
+     Inputs: root (.), collectorName. */}}
+{{- define "dataProcessors.pipeline.collectorChains.flush" -}}
+{{- $acc := default dict .root.Values.__dataProcessorChains -}}
+{{- range $key := (keys $acc | sortAlpha) }}
+{{- $entry := get $acc $key }}
+{{- if eq $entry.collectorName $.collectorName }}
+{{- include "dataProcessors.pipeline.chain.render" (dict "destinations" $.root.Values.destinations "destinationNames" ($entry.destinationNames | uniq | sortAlpha) "dataProcessors" $.root.Values.dataProcessors "processorNames" $entry.processorNames "type" $entry.type "ecosystem" $entry.ecosystem) }}
+{{- end }}
+{{- end }}
 {{- end }}
 
 {{/* Stable Alloy component reference for a feature's selected_destinations stamper.
-     Used by both pipeline.alloy.targets.forFeature (to emit the ref) and the orchestrator (to render
+     Used by both dataProcessors.pipeline.targets.forFeature (to emit the ref) and the orchestrator (to render
      the component under that exact name). Component type is chosen per ecosystem so it can
      attach the routing label/attribute in the data's native form.
 
      Inputs: feature (string), type (string), ecosystem (string). */}}
-{{- define "pipeline.alloy.stamper.ref" -}}
+{{- define "dataProcessors.pipeline.stamper.ref" -}}
 {{- $name := printf "%s_stamp_%s_%s" (include "helper.alloy_name" .feature) .type .ecosystem -}}
 {{- if eq .ecosystem "prometheus" -}}prometheus.relabel.{{ $name }}.receiver
 {{- else if eq .ecosystem "loki" -}}loki.process.{{ $name }}.receiver
@@ -72,7 +155,7 @@
 
 {{/* Maps a telemetry type to the OTTL statements block name used by otelcol.processor.transform.
      Inputs: type (string). */}}
-{{- define "pipeline.alloy.otlp.statementsBlock" -}}
+{{- define "dataProcessors.pipeline.otlp.statementsBlock" -}}
 {{- if eq . "metrics" -}}metric_statements
 {{- else if eq . "logs" -}}log_statements
 {{- else if eq . "traces" -}}trace_statements
@@ -84,7 +167,7 @@
      listing the destinations the feature would have selected on its own, and forwards into
      the first processor in the chain.
 
-     Component type per ecosystem mirrors pipeline.alloy.stamper.ref so the ref and the rendered
+     Component type per ecosystem mirrors dataProcessors.pipeline.stamper.ref so the ref and the rendered
      component always match.
 
      Inputs:
@@ -93,7 +176,7 @@
        ecosystem (string)          — prometheus | otlp | loki | pyroscope
        destinationNames ([]string) — destinations to stamp into selected_destinations
        nextInput (string)          — Alloy ref of the first processor in the chain */}}
-{{- define "pipeline.alloy.stamper.render" }}
+{{- define "dataProcessors.pipeline.stamper.render" }}
 {{- $name := printf "%s_stamp_%s_%s" (include "helper.alloy_name" .feature) .type .ecosystem -}}
 {{- $destList := join "," .destinationNames }}
 {{- if eq .ecosystem "prometheus" }}
@@ -114,7 +197,7 @@ loki.process {{ $name | quote }} {
   }
 }
 {{- else if eq .ecosystem "otlp" }}
-{{- $block := include "pipeline.alloy.otlp.statementsBlock" .type }}
+{{- $block := include "dataProcessors.pipeline.otlp.statementsBlock" .type }}
 otelcol.processor.transform {{ $name | quote }} {
   error_mode = "ignore"
   {{ $block }} {
@@ -144,7 +227,7 @@ pyroscope.relabel {{ $name | quote }} {
      processor's input or to per-destination gates.
 
      Inputs: processor (string), type (string), ecosystem (string). */}}
-{{- define "pipeline.alloy.outputSink.ref" -}}
+{{- define "dataProcessors.pipeline.outputSink.ref" -}}
 {{- $name := printf "%s_out_%s_%s" (include "helper.alloy_name" .processor) .type .ecosystem -}}
 {{- if eq .ecosystem "prometheus" -}}prometheus.relabel.{{ $name }}.receiver
 {{- else if eq .ecosystem "loki" -}}loki.process.{{ $name }}.receiver
@@ -163,7 +246,7 @@ pyroscope.relabel {{ $name | quote }} {
        type (string)
        ecosystem (string)
        nextTargets ([]string) — list of Alloy refs the sink forwards to */}}
-{{- define "pipeline.alloy.outputSink.render" }}
+{{- define "dataProcessors.pipeline.outputSink.render" }}
 {{- $name := printf "%s_out_%s_%s" (include "helper.alloy_name" .processor) .type .ecosystem }}
 {{- $targets := join ", " .nextTargets }}
 {{- if eq .ecosystem "prometheus" }}
@@ -192,7 +275,7 @@ pyroscope.relabel {{ $name | quote }} {
      `selected_destinations` label/attribute doesn't contain this destination.
 
      Inputs: processor (string), destination (string), type (string), ecosystem (string). */}}
-{{- define "pipeline.alloy.gate.ref" -}}
+{{- define "dataProcessors.pipeline.gate.ref" -}}
 {{- $name := printf "%s_%s_gate_%s_%s" (include "helper.alloy_name" .processor) (include "helper.alloy_name" .destination) .type .ecosystem -}}
 {{- if eq .ecosystem "prometheus" -}}prometheus.relabel.{{ $name }}.receiver
 {{- else if eq .ecosystem "loki" -}}loki.relabel.{{ $name }}.receiver
@@ -211,7 +294,7 @@ pyroscope.relabel {{ $name | quote }} {
        type (string)
        ecosystem (string)
        destinationTarget (string) — final destination component ref */}}
-{{- define "pipeline.alloy.gate.render" }}
+{{- define "dataProcessors.pipeline.gate.render" }}
 {{- $name := printf "%s_%s_gate_%s_%s" (include "helper.alloy_name" .processor) (include "helper.alloy_name" .destination) .type .ecosystem }}
 {{- $keepRegex := printf "(^|.*,)%s(,.*|$)" .destination }}
 {{- if eq .ecosystem "prometheus" }}
@@ -243,7 +326,7 @@ loki.relabel {{ $name | quote }} {
 }
 {{- else if eq .ecosystem "otlp" }}
 {{- $dropExpr := printf `not IsMatch(attributes["selected_destinations"], "%s")` $keepRegex }}
-{{- $block := include "pipeline.alloy.otlp.statementsBlock" .type }}
+{{- $block := include "dataProcessors.pipeline.otlp.statementsBlock" .type }}
 otelcol.processor.filter {{ $name | quote }} {
   error_mode = "ignore"
   {{- if eq .type "metrics" }}
@@ -300,35 +383,50 @@ pyroscope.relabel {{ $name | quote }} {
 {{- end }}
 {{- end }}
 
-{{/* Renders, for ONE (feature, type, ecosystem) tuple, all chart-owned boundary components:
-     - stamper (forwards from feature module into the chain)
+{{/* Renders ONLY the per-feature stamper: the feature's module forwards into this component, which
+     stamps the feature's selected_destinations and forwards into the first processor of the shared
+     chain. Kept per-feature (its name is keyed by feature); the chain body it feeds is shared once
+     per collector by dataProcessors.pipeline.chain.render.
+
+     Inputs:
+       destinationNames ([]string)
+       dataProcessors (map)          — .Values.dataProcessors
+       processorNames ([]string)     — feature's chain, already filtered to those supporting
+                                       (type, ecosystem). Must be non-empty.
+       feature (string)
+       type (string)
+       ecosystem (string) */}}
+{{- define "dataProcessors.pipeline.stamper.forFeature" }}
+{{- $chain := .processorNames }}
+{{- $firstName := index $chain 0 }}
+{{- $firstProc := get .dataProcessors $firstName }}
+{{- $firstInput := include (printf "dataProcessors.%s.alloy.%s.%s.input" $firstProc.type .ecosystem .type) (dict "processor" $firstProc "processorName" $firstName) }}
+{{- include "dataProcessors.pipeline.stamper.render" (dict "feature" .feature "type" .type "ecosystem" .ecosystem "destinationNames" .destinationNames "nextInput" $firstInput) }}
+{{- end }}
+
+{{/* Renders, for ONE (chain, type, ecosystem) on a collector, the shared chart-owned components:
      - each processor's user-config slice for this (type, ecosystem)
      - per-position output sinks (one per processor in the chain)
      - per-destination gates (after the terminal processor)
 
-     Slices are emitted per (feature, type, ecosystem), so a processor used by features on
-     different collectors only renders the pipelines each collector actually needs.
+     None of these are keyed by feature, so this body is rendered exactly once per collector per
+     unique chain (see dataProcessors.pipeline.collectorChains.flush) with the UNION of destinations across
+     the features that use the chain. The per-feature stampers (dataProcessors.pipeline.stamper.forFeature)
+     forward into the first processor's input, so multiple features share this single body.
 
      Inputs:
        destinations (map)            — .Values.destinations
-       destinationNames ([]string)
-       processors (map)              — .Values.dataProcessors
-       processorNames ([]string)     — feature's chain, already filtered to those supporting
-                                       (type, ecosystem). Empty = no-op.
-       feature (string)
+       destinationNames ([]string)   — union across features using this chain on the collector
+       dataProcessors (map)          — .Values.dataProcessors
+       processorNames ([]string)     — chain, already filtered to those supporting (type, ecosystem).
+                                       Empty = no-op.
        type (string)
        ecosystem (string) */}}
-{{- define "pipeline.alloy.feature.render" }}
+{{- define "dataProcessors.pipeline.chain.render" }}
 {{- if not (empty .processorNames) }}
 {{- $chain := .processorNames }}
 {{- $chainLen := len $chain }}
-{{- $firstName := index $chain 0 }}
-{{- $firstProc := get .dataProcessors $firstName }}
-{{- $firstInput := include (printf "dataProcessors.%s.alloy.%s.%s.input" $firstProc.type .ecosystem .type) (dict "processor" $firstProc "processorName" $firstName) }}
-{{- /* 1. Stamper: from feature module into the first processor */}}
-{{- include "pipeline.alloy.stamper.render" (dict "feature" .feature "type" .type "ecosystem" .ecosystem "destinationNames" .destinationNames "nextInput" $firstInput) }}
-
-{{- /* 2. For each processor in the chain emit (a) its user-config slice for this
+{{- /* For each processor in the chain emit (a) its user-config slice for this
        (type, ecosystem) and (b) the output sink. The sink forwards to the next
        processor's input or (if terminal) to per-destination gate receivers. */}}
 {{- range $idx, $procName := $chain }}
@@ -344,11 +442,11 @@ pyroscope.relabel {{ $name | quote }} {
     {{- $nextTargets = append $nextTargets $nextInput }}
   {{- else }}
     {{- range $destName := $.destinationNames }}
-      {{- $gateRef := include "pipeline.alloy.gate.ref" (dict "processor" $procName "destination" $destName "type" $.type "ecosystem" $.ecosystem) }}
+      {{- $gateRef := include "dataProcessors.pipeline.gate.ref" (dict "processor" $procName "destination" $destName "type" $.type "ecosystem" $.ecosystem) }}
       {{- $nextTargets = append $nextTargets $gateRef }}
     {{- end }}
   {{- end }}
-  {{- include "pipeline.alloy.outputSink.render" (dict "processor" $procName "type" $.type "ecosystem" $.ecosystem "nextTargets" $nextTargets) }}
+  {{- include "dataProcessors.pipeline.outputSink.render" (dict "processor" $procName "type" $.type "ecosystem" $.ecosystem "nextTargets" $nextTargets) }}
 {{- end }}
 
 {{- /* 3. Destination gates: one per (terminal processor, destination). */}}
@@ -357,7 +455,7 @@ pyroscope.relabel {{ $name | quote }} {
   {{- if hasKey $.destinations $destName }}
     {{- $destination := get $.destinations $destName }}
     {{- $destTarget := include (printf "destinations.%s.alloy.%s.%s.target" $destination.type $.ecosystem $.type) (dict "destination" $destination "destinationName" $destName) | trim }}
-    {{- include "pipeline.alloy.gate.render" (dict "processor" $terminal "destination" $destName "type" $.type "ecosystem" $.ecosystem "destinationTarget" $destTarget) }}
+    {{- include "dataProcessors.pipeline.gate.render" (dict "processor" $terminal "destination" $destName "type" $.type "ecosystem" $.ecosystem "destinationTarget" $destTarget) }}
   {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/k8s-monitoring/templates/dataProcessors/_dataProcessor_ec2Enrichment.tpl
+++ b/charts/k8s-monitoring/templates/dataProcessors/_dataProcessor_ec2Enrichment.tpl
@@ -95,7 +95,7 @@ discovery.relabel {{ $name | quote }} {
        Inputs: processor, processorName */}}
 {{- define "dataProcessors.ec2Enrichment.alloy.enrichMetrics" }}
 {{- $p := include "helper.alloy_name" .processorName }}
-{{- $outputSink := include "pipeline.alloy.outputSink.ref" (dict "processor" .processorName "type" "metrics" "ecosystem" "prometheus") }}
+{{- $outputSink := include "dataProcessors.pipeline.outputSink.ref" (dict "processor" .processorName "type" "metrics" "ecosystem" "prometheus") }}
 {{- $discoveryRef := include "dataProcessors.ec2Enrichment.alloy.discovery.ref" (dict "processorName" .processorName) }}
 prometheus.enrich "{{ $p }}_in_metrics_prometheus" {
   targets = {{ $discoveryRef }}
@@ -116,7 +116,7 @@ prometheus.enrich "{{ $p }}_in_metrics_prometheus" {
        Inputs: processor, processorName */}}
 {{- define "dataProcessors.ec2Enrichment.alloy.enrichLogs" }}
 {{- $p := include "helper.alloy_name" .processorName }}
-{{- $outputSink := include "pipeline.alloy.outputSink.ref" (dict "processor" .processorName "type" "logs" "ecosystem" "loki") }}
+{{- $outputSink := include "dataProcessors.pipeline.outputSink.ref" (dict "processor" .processorName "type" "logs" "ecosystem" "loki") }}
 {{- $discoveryRef := include "dataProcessors.ec2Enrichment.alloy.discovery.ref" (dict "processorName" .processorName) }}
 loki.enrich "{{ $p }}_in_logs_loki" {
   targets = {{ $discoveryRef }}
@@ -136,7 +136,7 @@ loki.enrich "{{ $p }}_in_logs_loki" {
        Inputs: processor, processorName */}}
 {{- define "dataProcessors.ec2Enrichment.alloy.enrichProfiles" }}
 {{- $p := include "helper.alloy_name" .processorName }}
-{{- $outputSink := include "pipeline.alloy.outputSink.ref" (dict "processor" .processorName "type" "profiles" "ecosystem" "pyroscope") }}
+{{- $outputSink := include "dataProcessors.pipeline.outputSink.ref" (dict "processor" .processorName "type" "profiles" "ecosystem" "pyroscope") }}
 {{- $discoveryRef := include "dataProcessors.ec2Enrichment.alloy.discovery.ref" (dict "processorName" .processorName) }}
 pyroscope.enrich "{{ $p }}_in_profiles_pyroscope" {
   targets = {{ $discoveryRef }}

--- a/charts/k8s-monitoring/templates/dataProcessors/_dataProcessor_kubernetesEnrichment.tpl
+++ b/charts/k8s-monitoring/templates/dataProcessors/_dataProcessor_kubernetesEnrichment.tpl
@@ -155,7 +155,7 @@ discovery.relabel {{ $name | quote }} {
 {{- $podAnnotations := default dict (dig "podAnnotations" dict .processor) }}
 {{- $hasNamespaceEnrichment := or (not (empty $namespaceLabels)) (not (empty $namespaceAnnotations)) }}
 {{- $hasPodEnrichment := or (not (empty $podLabels)) (not (empty $podAnnotations)) }}
-{{- $outputSink := include "pipeline.alloy.outputSink.ref" (dict "processor" .processorName "type" .type "ecosystem" .ecosystem) }}
+{{- $outputSink := include "dataProcessors.pipeline.outputSink.ref" (dict "processor" .processorName "type" .type "ecosystem" .ecosystem) }}
 {{- $discoveryRef := include "dataProcessors.kubernetesEnrichment.alloy.discovery.ref" (dict "processorName" .processorName) }}
 {{ .relabelComponent }} "{{ $p }}_in_{{ $suffix }}" {
 {{- if $hasPodEnrichment }}
@@ -214,7 +214,7 @@ discovery.relabel {{ $name | quote }} {
        Inputs: processor, processorName, type (metrics | logs | traces) */}}
 {{- define "dataProcessors.kubernetesEnrichment.alloy.otlpPipeline" }}
 {{- $p := include "helper.alloy_name" .processorName }}
-{{- $outputSink := include "pipeline.alloy.outputSink.ref" (dict "processor" .processorName "type" .type "ecosystem" "otlp") }}
+{{- $outputSink := include "dataProcessors.pipeline.outputSink.ref" (dict "processor" .processorName "type" .type "ecosystem" "otlp") }}
 otelcol.processor.k8sattributes "{{ $p }}_in_{{ .type }}_otlp" {
   extract {
     metadata = []

--- a/charts/k8s-monitoring/templates/destinations/_destination_router.tpl
+++ b/charts/k8s-monitoring/templates/destinations/_destination_router.tpl
@@ -129,12 +129,12 @@ otelcol.processor.transform {{ printf "%s_metrics_otlp" $alloyName | quote }} {
     ]
   }
   output {
-    metrics = [{{ range $d := $metricsDownstream }}{{ include "pipeline.alloy.gate.ref" (dict "processor" $routerName "destination" $d "type" "metrics" "ecosystem" "otlp") }}, {{ end }}]
+    metrics = [{{ range $d := $metricsDownstream }}{{ include "dataProcessors.pipeline.gate.ref" (dict "processor" $routerName "destination" $d "type" "metrics" "ecosystem" "otlp") }}, {{ end }}]
   }
 } // otelcol.processor.transform "{{ $alloyName }}_metrics_otlp"
 {{- range $d := $metricsDownstream }}
 {{- $info := get $downstreamInfo $d }}
-{{ include "pipeline.alloy.gate.render" (dict "processor" $routerName "destination" $d "type" "metrics" "ecosystem" "otlp" "destinationTarget" (include (printf "destinations.%s.alloy.otlp.metrics.target" $info.type) (dict "destination" $info.values "destinationName" $d) | trim)) }}
+{{ include "dataProcessors.pipeline.gate.render" (dict "processor" $routerName "destination" $d "type" "metrics" "ecosystem" "otlp" "destinationTarget" (include (printf "destinations.%s.alloy.otlp.metrics.target" $info.type) (dict "destination" $info.values "destinationName" $d) | trim)) }}
 {{- end }}
 
 {{- /* ---------------- logs/otlp ---------------- */}}
@@ -150,12 +150,12 @@ otelcol.processor.transform {{ printf "%s_logs_otlp" $alloyName | quote }} {
     ]
   }
   output {
-    logs = [{{ range $d := $logsDownstream }}{{ include "pipeline.alloy.gate.ref" (dict "processor" $routerName "destination" $d "type" "logs" "ecosystem" "otlp") }}, {{ end }}]
+    logs = [{{ range $d := $logsDownstream }}{{ include "dataProcessors.pipeline.gate.ref" (dict "processor" $routerName "destination" $d "type" "logs" "ecosystem" "otlp") }}, {{ end }}]
   }
 } // otelcol.processor.transform "{{ $alloyName }}_logs_otlp"
 {{- range $d := $logsDownstream }}
 {{- $info := get $downstreamInfo $d }}
-{{ include "pipeline.alloy.gate.render" (dict "processor" $routerName "destination" $d "type" "logs" "ecosystem" "otlp" "destinationTarget" (include (printf "destinations.%s.alloy.otlp.logs.target" $info.type) (dict "destination" $info.values "destinationName" $d) | trim)) }}
+{{ include "dataProcessors.pipeline.gate.render" (dict "processor" $routerName "destination" $d "type" "logs" "ecosystem" "otlp" "destinationTarget" (include (printf "destinations.%s.alloy.otlp.logs.target" $info.type) (dict "destination" $info.values "destinationName" $d) | trim)) }}
 {{- end }}
 
 {{- /* ---------------- traces/otlp ---------------- */}}
@@ -171,12 +171,12 @@ otelcol.processor.transform {{ printf "%s_traces_otlp" $alloyName | quote }} {
     ]
   }
   output {
-    traces = [{{ range $d := $tracesDownstream }}{{ include "pipeline.alloy.gate.ref" (dict "processor" $routerName "destination" $d "type" "traces" "ecosystem" "otlp") }}, {{ end }}]
+    traces = [{{ range $d := $tracesDownstream }}{{ include "dataProcessors.pipeline.gate.ref" (dict "processor" $routerName "destination" $d "type" "traces" "ecosystem" "otlp") }}, {{ end }}]
   }
 } // otelcol.processor.transform "{{ $alloyName }}_traces_otlp"
 {{- range $d := $tracesDownstream }}
 {{- $info := get $downstreamInfo $d }}
-{{ include "pipeline.alloy.gate.render" (dict "processor" $routerName "destination" $d "type" "traces" "ecosystem" "otlp" "destinationTarget" (include (printf "destinations.%s.alloy.otlp.traces.target" $info.type) (dict "destination" $info.values "destinationName" $d) | trim)) }}
+{{ include "dataProcessors.pipeline.gate.render" (dict "processor" $routerName "destination" $d "type" "traces" "ecosystem" "otlp" "destinationTarget" (include (printf "destinations.%s.alloy.otlp.traces.target" $info.type) (dict "destination" $info.values "destinationName" $d) | trim)) }}
 {{- end }}
 
 {{- else if eq $ecosystem "prometheus" }}
@@ -186,11 +186,11 @@ otelcol.processor.transform {{ printf "%s_traces_otlp" $alloyName | quote }} {
 // based on the route match conditions, and fan out to one gate per downstream destination.
 prometheus.relabel {{ printf "%s_metrics_prometheus" $alloyName | quote }} {
 {{ include "destinations.router.labelRules" (dict "routes" $routes "defaultDestinations" $defaultDestinations "signal" "metrics" "downstreamInfo" $downstreamInfo) | indent 2 }}
-  forward_to = [{{ range $d := $metricsDownstream }}{{ include "pipeline.alloy.gate.ref" (dict "processor" $routerName "destination" $d "type" "metrics" "ecosystem" "prometheus") }}, {{ end }}]
+  forward_to = [{{ range $d := $metricsDownstream }}{{ include "dataProcessors.pipeline.gate.ref" (dict "processor" $routerName "destination" $d "type" "metrics" "ecosystem" "prometheus") }}, {{ end }}]
 } // prometheus.relabel "{{ $alloyName }}_metrics_prometheus"
 {{- range $d := $metricsDownstream }}
 {{- $info := get $downstreamInfo $d }}
-{{ include "pipeline.alloy.gate.render" (dict "processor" $routerName "destination" $d "type" "metrics" "ecosystem" "prometheus" "destinationTarget" (include (printf "destinations.%s.alloy.prometheus.metrics.target" $info.type) (dict "destination" $info.values "destinationName" $d) | trim)) }}
+{{ include "dataProcessors.pipeline.gate.render" (dict "processor" $routerName "destination" $d "type" "metrics" "ecosystem" "prometheus" "destinationTarget" (include (printf "destinations.%s.alloy.prometheus.metrics.target" $info.type) (dict "destination" $info.values "destinationName" $d) | trim)) }}
 {{- end }}
 
 {{- else if eq $ecosystem "loki" }}
@@ -200,11 +200,11 @@ prometheus.relabel {{ printf "%s_metrics_prometheus" $alloyName | quote }} {
 // based on the route match conditions, and fan out to one gate per downstream destination.
 loki.relabel {{ printf "%s_logs_loki" $alloyName | quote }} {
 {{ include "destinations.router.labelRules" (dict "routes" $routes "defaultDestinations" $defaultDestinations "signal" "logs" "downstreamInfo" $downstreamInfo) | indent 2 }}
-  forward_to = [{{ range $d := $logsDownstream }}{{ include "pipeline.alloy.gate.ref" (dict "processor" $routerName "destination" $d "type" "logs" "ecosystem" "loki") }}, {{ end }}]
+  forward_to = [{{ range $d := $logsDownstream }}{{ include "dataProcessors.pipeline.gate.ref" (dict "processor" $routerName "destination" $d "type" "logs" "ecosystem" "loki") }}, {{ end }}]
 } // loki.relabel "{{ $alloyName }}_logs_loki"
 {{- range $d := $logsDownstream }}
 {{- $info := get $downstreamInfo $d }}
-{{ include "pipeline.alloy.gate.render" (dict "processor" $routerName "destination" $d "type" "logs" "ecosystem" "loki" "destinationTarget" (include (printf "destinations.%s.alloy.loki.logs.target" $info.type) (dict "destination" $info.values "destinationName" $d) | trim)) }}
+{{ include "dataProcessors.pipeline.gate.render" (dict "processor" $routerName "destination" $d "type" "logs" "ecosystem" "loki" "destinationTarget" (include (printf "destinations.%s.alloy.loki.logs.target" $info.type) (dict "destination" $info.values "destinationName" $d) | trim)) }}
 {{- end }}
 
 {{- else if eq $ecosystem "pyroscope" }}
@@ -214,11 +214,11 @@ loki.relabel {{ printf "%s_logs_loki" $alloyName | quote }} {
 // based on the route match conditions, and fan out to one gate per downstream destination.
 pyroscope.relabel {{ printf "%s_profiles_pyroscope" $alloyName | quote }} {
 {{ include "destinations.router.labelRules" (dict "routes" $routes "defaultDestinations" $defaultDestinations "signal" "profiles" "downstreamInfo" $downstreamInfo) | indent 2 }}
-  forward_to = [{{ range $d := $profilesDownstream }}{{ include "pipeline.alloy.gate.ref" (dict "processor" $routerName "destination" $d "type" "profiles" "ecosystem" "pyroscope") }}, {{ end }}]
+  forward_to = [{{ range $d := $profilesDownstream }}{{ include "dataProcessors.pipeline.gate.ref" (dict "processor" $routerName "destination" $d "type" "profiles" "ecosystem" "pyroscope") }}, {{ end }}]
 } // pyroscope.relabel "{{ $alloyName }}_profiles_pyroscope"
 {{- range $d := $profilesDownstream }}
 {{- $info := get $downstreamInfo $d }}
-{{ include "pipeline.alloy.gate.render" (dict "processor" $routerName "destination" $d "type" "profiles" "ecosystem" "pyroscope" "destinationTarget" (include (printf "destinations.%s.alloy.pyroscope.profiles.target" $info.type) (dict "destination" $info.values "destinationName" $d) | trim)) }}
+{{ include "dataProcessors.pipeline.gate.render" (dict "processor" $routerName "destination" $d "type" "profiles" "ecosystem" "pyroscope" "destinationTarget" (include (printf "destinations.%s.alloy.pyroscope.profiles.target" $info.type) (dict "destination" $info.values "destinationName" $d) | trim)) }}
 {{- end }}
 
 {{- end }}

--- a/charts/k8s-monitoring/templates/destinations/_destination_router_validations.tpl
+++ b/charts/k8s-monitoring/templates/destinations/_destination_router_validations.tpl
@@ -311,7 +311,7 @@
          only feature actually using the router sends logs. The router itself has no way to know
          which signals a feature will actually forward through it -- only the forwarding seam
          does. See destinations.router.assertCanCarry below, invoked from
-         pipeline.alloy.targets.forFeature (templates/dataProcessors/_config.alloy.tpl) once per
+         dataProcessors.pipeline.targets.forFeature (templates/dataProcessors/_config.alloy.tpl) once per
          (feature, type, ecosystem) a feature actually emits, which is where "signal actually
          sent" and "router capability" can be checked together without guessing. */}}
 
@@ -329,7 +329,7 @@
 
 {{/* Precise, false-positive-free replacement for the old R10 inference: asserts that a router
      destination can actually deliver ONE signal a feature is ACTUALLY forwarding to it. Invoked
-     from pipeline.alloy.targets.forFeature (templates/dataProcessors/_config.alloy.tpl) once per
+     from dataProcessors.pipeline.targets.forFeature (templates/dataProcessors/_config.alloy.tpl) once per
      (feature, type, ecosystem) tuple the feature emits, and only when a router destination is
      among that tuple's resolved destinationNames -- this is the only place in the chart where a
      feature's real per-destination signal is known, so it is the only place this check can be
@@ -344,7 +344,7 @@
      labelRules/ottlStatements only emit a rule for a route when the route covers that signal),
      so its destinations' capability for `.type` is not this check's concern.
 
-     Inputs: root (full Values, i.e. `.root` from pipeline.alloy.targets.forFeature),
+     Inputs: root (full Values, i.e. `.root` from dataProcessors.pipeline.targets.forFeature),
      featureKey (string), routerName (string, a destinations key already confirmed to be
      type: router by the caller), type (metrics|logs|traces|profiles). */}}
 {{- define "destinations.router.assertCanCarry" }}

--- a/charts/k8s-monitoring/templates/features/_feature_annotation_autodiscovery.tpl
+++ b/charts/k8s-monitoring/templates/features/_feature_annotation_autodiscovery.tpl
@@ -7,10 +7,10 @@
 {{- include "feature.annotationAutodiscovery.module" .Subcharts.annotationAutodiscovery }}
 annotation_autodiscovery "feature" {
   metrics_destinations = [
-    {{ include "pipeline.alloy.targets.forFeature" (dict "root" $ "featureKey" "annotationAutodiscovery" "destinationNames" $destinations "type" "metrics" "ecosystem" "prometheus") | indent 4 | trim }}
+    {{ include "dataProcessors.pipeline.targets.forFeature" (dict "root" $ "featureKey" "annotationAutodiscovery" "destinationNames" $destinations "type" "metrics" "ecosystem" "prometheus") | indent 4 | trim }}
   ]
 }
-{{- include "pipeline.alloy.feature.render.forFeature" (dict "root" $ "featureKey" "annotationAutodiscovery" "destinationNames" $destinations "type" "metrics" "ecosystem" "prometheus") }}
+{{- include "dataProcessors.pipeline.render.forFeature" (dict "root" $ "featureKey" "annotationAutodiscovery" "destinationNames" $destinations "type" "metrics" "ecosystem" "prometheus") }}
 {{- end -}}
 {{- end -}}
 

--- a/charts/k8s-monitoring/templates/features/_feature_application_observability.tpl
+++ b/charts/k8s-monitoring/templates/features/_feature_application_observability.tpl
@@ -10,18 +10,18 @@
 {{- include "feature.applicationObservability.module" (dict "Values" $.Values.applicationObservability "Files" $.Subcharts.applicationObservability.Files) }}
 application_observability "feature" {
   metrics_destinations = [
-    {{ include "pipeline.alloy.targets.forFeature" (dict "root" $ "featureKey" "applicationObservability" "destinationNames" $metricsDestinations "type" "metrics" "ecosystem" "otlp") | indent 4 | trim }}
+    {{ include "dataProcessors.pipeline.targets.forFeature" (dict "root" $ "featureKey" "applicationObservability" "destinationNames" $metricsDestinations "type" "metrics" "ecosystem" "otlp") | indent 4 | trim }}
   ]
   logs_destinations = [
-    {{ include "pipeline.alloy.targets.forFeature" (dict "root" $ "featureKey" "applicationObservability" "destinationNames" $logsDestinations "type" "logs" "ecosystem" "otlp") | indent 4 | trim }}
+    {{ include "dataProcessors.pipeline.targets.forFeature" (dict "root" $ "featureKey" "applicationObservability" "destinationNames" $logsDestinations "type" "logs" "ecosystem" "otlp") | indent 4 | trim }}
   ]
   traces_destinations = [
-    {{ include "pipeline.alloy.targets.forFeature" (dict "root" $ "featureKey" "applicationObservability" "destinationNames" $tracesDestinations "type" "traces" "ecosystem" "otlp") | indent 4 | trim }}
+    {{ include "dataProcessors.pipeline.targets.forFeature" (dict "root" $ "featureKey" "applicationObservability" "destinationNames" $tracesDestinations "type" "traces" "ecosystem" "otlp") | indent 4 | trim }}
   ]
 }
-{{- include "pipeline.alloy.feature.render.forFeature" (dict "root" $ "featureKey" "applicationObservability" "destinationNames" $metricsDestinations "type" "metrics" "ecosystem" "otlp") }}
-{{- include "pipeline.alloy.feature.render.forFeature" (dict "root" $ "featureKey" "applicationObservability" "destinationNames" $logsDestinations "type" "logs" "ecosystem" "otlp") }}
-{{- include "pipeline.alloy.feature.render.forFeature" (dict "root" $ "featureKey" "applicationObservability" "destinationNames" $tracesDestinations "type" "traces" "ecosystem" "otlp") }}
+{{- include "dataProcessors.pipeline.render.forFeature" (dict "root" $ "featureKey" "applicationObservability" "destinationNames" $metricsDestinations "type" "metrics" "ecosystem" "otlp") }}
+{{- include "dataProcessors.pipeline.render.forFeature" (dict "root" $ "featureKey" "applicationObservability" "destinationNames" $logsDestinations "type" "logs" "ecosystem" "otlp") }}
+{{- include "dataProcessors.pipeline.render.forFeature" (dict "root" $ "featureKey" "applicationObservability" "destinationNames" $tracesDestinations "type" "traces" "ecosystem" "otlp") }}
 {{- end -}}
 {{- end -}}
 

--- a/charts/k8s-monitoring/templates/features/_feature_auto_instrumentation.tpl
+++ b/charts/k8s-monitoring/templates/features/_feature_auto_instrumentation.tpl
@@ -7,10 +7,10 @@
 {{- include "feature.autoInstrumentation.module" (dict "Values" $.Values.autoInstrumentation "Files" $.Subcharts.autoInstrumentation.Files) }}
 auto_instrumentation "feature" {
   metrics_destinations = [
-    {{ include "pipeline.alloy.targets.forFeature" (dict "root" $ "featureKey" "autoInstrumentation" "destinationNames" $destinations "type" "metrics" "ecosystem" "prometheus") | indent 4 | trim }}
+    {{ include "dataProcessors.pipeline.targets.forFeature" (dict "root" $ "featureKey" "autoInstrumentation" "destinationNames" $destinations "type" "metrics" "ecosystem" "prometheus") | indent 4 | trim }}
   ]
 }
-{{- include "pipeline.alloy.feature.render.forFeature" (dict "root" $ "featureKey" "autoInstrumentation" "destinationNames" $destinations "type" "metrics" "ecosystem" "prometheus") }}
+{{- include "dataProcessors.pipeline.render.forFeature" (dict "root" $ "featureKey" "autoInstrumentation" "destinationNames" $destinations "type" "metrics" "ecosystem" "prometheus") }}
 {{- end -}}
 {{- end -}}
 

--- a/charts/k8s-monitoring/templates/features/_feature_cluster_events.tpl
+++ b/charts/k8s-monitoring/templates/features/_feature_cluster_events.tpl
@@ -7,10 +7,10 @@
 {{- include "feature.clusterEvents.module" (dict "Values" $.Values.clusterEvents "Files" $.Subcharts.clusterEvents.Files "Template" $.Template) }}
 cluster_events "feature" {
   logs_destinations = [
-    {{ include "pipeline.alloy.targets.forFeature" (dict "root" $ "featureKey" "clusterEvents" "destinationNames" $destinations "type" "logs" "ecosystem" "loki") | indent 4 | trim }}
+    {{ include "dataProcessors.pipeline.targets.forFeature" (dict "root" $ "featureKey" "clusterEvents" "destinationNames" $destinations "type" "logs" "ecosystem" "loki") | indent 4 | trim }}
   ]
 }
-{{- include "pipeline.alloy.feature.render.forFeature" (dict "root" $ "featureKey" "clusterEvents" "destinationNames" $destinations "type" "logs" "ecosystem" "loki") }}
+{{- include "dataProcessors.pipeline.render.forFeature" (dict "root" $ "featureKey" "clusterEvents" "destinationNames" $destinations "type" "logs" "ecosystem" "loki") }}
 {{- end -}}
 {{- end -}}
 

--- a/charts/k8s-monitoring/templates/features/_feature_cluster_metrics.tpl
+++ b/charts/k8s-monitoring/templates/features/_feature_cluster_metrics.tpl
@@ -7,10 +7,10 @@
 {{- include "feature.clusterMetrics.module" (dict "Values" $.Values.clusterMetrics "Files" $.Subcharts.clusterMetrics.Files "Release" $.Release "telemetryServices" $.Values.telemetryServices) }}
 cluster_metrics "feature" {
   metrics_destinations = [
-    {{ include "pipeline.alloy.targets.forFeature" (dict "root" $ "featureKey" "clusterMetrics" "destinationNames" $destinations "type" "metrics" "ecosystem" "prometheus") | indent 4 | trim }}
+    {{ include "dataProcessors.pipeline.targets.forFeature" (dict "root" $ "featureKey" "clusterMetrics" "destinationNames" $destinations "type" "metrics" "ecosystem" "prometheus") | indent 4 | trim }}
   ]
 }
-{{- include "pipeline.alloy.feature.render.forFeature" (dict "root" $ "featureKey" "clusterMetrics" "destinationNames" $destinations "type" "metrics" "ecosystem" "prometheus") }}
+{{- include "dataProcessors.pipeline.render.forFeature" (dict "root" $ "featureKey" "clusterMetrics" "destinationNames" $destinations "type" "metrics" "ecosystem" "prometheus") }}
 {{- end -}}
 {{- end -}}
 

--- a/charts/k8s-monitoring/templates/features/_feature_cost_metrics.tpl
+++ b/charts/k8s-monitoring/templates/features/_feature_cost_metrics.tpl
@@ -7,10 +7,10 @@
 {{- include "feature.costMetrics.module" (dict "Values" $.Values.costMetrics "Files" $.Subcharts.clusterMetrics.Files "Release" $.Release "telemetryServices" $.Values.telemetryServices) }}
 cost_metrics "feature" {
   metrics_destinations = [
-    {{ include "pipeline.alloy.targets.forFeature" (dict "root" $ "featureKey" "costMetrics" "destinationNames" $destinations "type" "metrics" "ecosystem" "prometheus") | indent 4 | trim }}
+    {{ include "dataProcessors.pipeline.targets.forFeature" (dict "root" $ "featureKey" "costMetrics" "destinationNames" $destinations "type" "metrics" "ecosystem" "prometheus") | indent 4 | trim }}
   ]
 }
-{{- include "pipeline.alloy.feature.render.forFeature" (dict "root" $ "featureKey" "costMetrics" "destinationNames" $destinations "type" "metrics" "ecosystem" "prometheus") }}
+{{- include "dataProcessors.pipeline.render.forFeature" (dict "root" $ "featureKey" "costMetrics" "destinationNames" $destinations "type" "metrics" "ecosystem" "prometheus") }}
 {{- end -}}
 {{- end -}}
 

--- a/charts/k8s-monitoring/templates/features/_feature_host_metrics-energy_metrics.tpl
+++ b/charts/k8s-monitoring/templates/features/_feature_host_metrics-energy_metrics.tpl
@@ -7,11 +7,11 @@
 {{- include "feature.hostMetrics.energyMetrics.module" (dict "Values" $.Values.hostMetrics "Files" $.Subcharts.hostMetrics.Files "Release" $.Release "telemetryServices" $.Values.telemetryServices) }}
 energy_metrics "feature" {
   metrics_destinations = [
-    {{ include "pipeline.alloy.targets.forFeature" (dict "root" $ "featureKey" "hostMetrics" "destinationNames" $destinations "type" "metrics" "ecosystem" "prometheus") | indent 4 | trim }}
+    {{ include "dataProcessors.pipeline.targets.forFeature" (dict "root" $ "featureKey" "hostMetrics" "destinationNames" $destinations "type" "metrics" "ecosystem" "prometheus") | indent 4 | trim }}
   ]
 }
 {{- if eq (include "features.hostMetrics.pipelineOwner" $) "energyMetrics" }}
-{{- include "pipeline.alloy.feature.render.forFeature" (dict "root" $ "featureKey" "hostMetrics" "destinationNames" $destinations "type" "metrics" "ecosystem" "prometheus") }}
+{{- include "dataProcessors.pipeline.render.forFeature" (dict "root" $ "featureKey" "hostMetrics" "destinationNames" $destinations "type" "metrics" "ecosystem" "prometheus") }}
 {{- end }}
 {{- end -}}
 {{- end -}}

--- a/charts/k8s-monitoring/templates/features/_feature_host_metrics-linux_hosts.tpl
+++ b/charts/k8s-monitoring/templates/features/_feature_host_metrics-linux_hosts.tpl
@@ -7,11 +7,11 @@
 {{- include "feature.hostMetrics.linuxHosts.module" (dict "Values" $.Values.hostMetrics "Files" $.Subcharts.hostMetrics.Files "Release" $.Release "telemetryServices" $.Values.telemetryServices) }}
 linux_host_metrics "feature" {
   metrics_destinations = [
-    {{ include "pipeline.alloy.targets.forFeature" (dict "root" $ "featureKey" "hostMetrics" "destinationNames" $destinations "type" "metrics" "ecosystem" "prometheus") | indent 4 | trim }}
+    {{ include "dataProcessors.pipeline.targets.forFeature" (dict "root" $ "featureKey" "hostMetrics" "destinationNames" $destinations "type" "metrics" "ecosystem" "prometheus") | indent 4 | trim }}
   ]
 }
 {{- if eq (include "features.hostMetrics.pipelineOwner" $) "linuxHosts" }}
-{{- include "pipeline.alloy.feature.render.forFeature" (dict "root" $ "featureKey" "hostMetrics" "destinationNames" $destinations "type" "metrics" "ecosystem" "prometheus") }}
+{{- include "dataProcessors.pipeline.render.forFeature" (dict "root" $ "featureKey" "hostMetrics" "destinationNames" $destinations "type" "metrics" "ecosystem" "prometheus") }}
 {{- end }}
 {{- end -}}
 {{- end -}}

--- a/charts/k8s-monitoring/templates/features/_feature_host_metrics-windows_hosts.tpl
+++ b/charts/k8s-monitoring/templates/features/_feature_host_metrics-windows_hosts.tpl
@@ -7,11 +7,11 @@
 {{- include "feature.hostMetrics.windowsHosts.module" (dict "Values" $.Values.hostMetrics "Files" $.Subcharts.hostMetrics.Files "Release" $.Release "telemetryServices" $.Values.telemetryServices) }}
 windows_host_metrics "feature" {
   metrics_destinations = [
-    {{ include "pipeline.alloy.targets.forFeature" (dict "root" $ "featureKey" "hostMetrics" "destinationNames" $destinations "type" "metrics" "ecosystem" "prometheus") | indent 4 | trim }}
+    {{ include "dataProcessors.pipeline.targets.forFeature" (dict "root" $ "featureKey" "hostMetrics" "destinationNames" $destinations "type" "metrics" "ecosystem" "prometheus") | indent 4 | trim }}
   ]
 }
 {{- if eq (include "features.hostMetrics.pipelineOwner" $) "windowsHosts" }}
-{{- include "pipeline.alloy.feature.render.forFeature" (dict "root" $ "featureKey" "hostMetrics" "destinationNames" $destinations "type" "metrics" "ecosystem" "prometheus") }}
+{{- include "dataProcessors.pipeline.render.forFeature" (dict "root" $ "featureKey" "hostMetrics" "destinationNames" $destinations "type" "metrics" "ecosystem" "prometheus") }}
 {{- end }}
 {{- end -}}
 {{- end -}}

--- a/charts/k8s-monitoring/templates/features/_feature_integrations.tpl
+++ b/charts/k8s-monitoring/templates/features/_feature_integrations.tpl
@@ -65,21 +65,21 @@
 {{- include (printf "integrations.%s.module.metrics" $integrationType) $values | indent 0 }}
 {{ include "helper.alloy_name" $integrationType }}_integration "integration" {
   metrics_destinations = [
-    {{ include "pipeline.alloy.targets.forFeature" (dict "root" $ "featureKey" "integrations" "destinationNames" $metricsDestinations "type" "metrics" "ecosystem" "prometheus") | indent 4 | trim }}
+    {{ include "dataProcessors.pipeline.targets.forFeature" (dict "root" $ "featureKey" "integrations" "destinationNames" $metricsDestinations "type" "metrics" "ecosystem" "prometheus") | indent 4 | trim }}
   ]
 {{- if has $integrationType $logOutputIntegrations }}
   logs_destinations = [
-    {{ include "pipeline.alloy.targets.forFeature" (dict "root" $ "featureKey" "integrations" "destinationNames" $logsDestinations "type" "logs" "ecosystem" "loki") | indent 4 | trim }}
+    {{ include "dataProcessors.pipeline.targets.forFeature" (dict "root" $ "featureKey" "integrations" "destinationNames" $logsDestinations "type" "logs" "ecosystem" "loki") | indent 4 | trim }}
   ]
 {{- end }}
 }
 {{- end }}
 {{- /* Emit the chart-owned pipeline boundary components once for the feature (not per integration), so the shared stamper/sinks/gates aren't duplicated. */}}
 {{- if $metricIntegrations }}
-{{- include "pipeline.alloy.feature.render.forFeature" (dict "root" $ "featureKey" "integrations" "destinationNames" $metricsDestinations "type" "metrics" "ecosystem" "prometheus") }}
+{{- include "dataProcessors.pipeline.render.forFeature" (dict "root" $ "featureKey" "integrations" "destinationNames" $metricsDestinations "type" "metrics" "ecosystem" "prometheus") }}
 {{- end }}
 {{- if $logOutputIntegrations }}
-{{- include "pipeline.alloy.feature.render.forFeature" (dict "root" $ "featureKey" "integrations" "destinationNames" $logsDestinations "type" "logs" "ecosystem" "loki") }}
+{{- include "dataProcessors.pipeline.render.forFeature" (dict "root" $ "featureKey" "integrations" "destinationNames" $logsDestinations "type" "logs" "ecosystem" "loki") }}
 {{- end }}
 {{- end }}
 

--- a/charts/k8s-monitoring/templates/features/_feature_kubernetes_manifests.tpl
+++ b/charts/k8s-monitoring/templates/features/_feature_kubernetes_manifests.tpl
@@ -7,10 +7,10 @@
 {{- include "feature.kubernetesManifests.module" (dict "Values" $.Values.kubernetesManifests "Files" $.Subcharts.kubernetesManifests.Files "Release" $.Release "telemetryServices" $.Values.telemetryServices) }}
 kubernetes_manifests "feature" {
   logs_destinations = [
-    {{ include "pipeline.alloy.targets.forFeature" (dict "root" $ "featureKey" "kubernetesManifests" "destinationNames" $destinations "type" "logs" "ecosystem" "loki") | indent 4 | trim }}
+    {{ include "dataProcessors.pipeline.targets.forFeature" (dict "root" $ "featureKey" "kubernetesManifests" "destinationNames" $destinations "type" "logs" "ecosystem" "loki") | indent 4 | trim }}
   ]
 }
-{{- include "pipeline.alloy.feature.render.forFeature" (dict "root" $ "featureKey" "kubernetesManifests" "destinationNames" $destinations "type" "logs" "ecosystem" "loki") }}
+{{- include "dataProcessors.pipeline.render.forFeature" (dict "root" $ "featureKey" "kubernetesManifests" "destinationNames" $destinations "type" "logs" "ecosystem" "loki") }}
 {{- end -}}
 {{- end -}}
 

--- a/charts/k8s-monitoring/templates/features/_feature_loki_logs_receiver.tpl
+++ b/charts/k8s-monitoring/templates/features/_feature_loki_logs_receiver.tpl
@@ -7,10 +7,10 @@
 {{- include "feature.lokiLogsReceiver.module" (dict "Values" $.Values.lokiLogsReceiver "Files" $.Subcharts.lokiLogsReceiver.Files) }}
 loki_logs_receiver "feature" {
   logs_destinations = [
-    {{ include "pipeline.alloy.targets.forFeature" (dict "root" $ "featureKey" "lokiLogsReceiver" "destinationNames" $destinations "type" "logs" "ecosystem" "loki") | indent 4 | trim }}
+    {{ include "dataProcessors.pipeline.targets.forFeature" (dict "root" $ "featureKey" "lokiLogsReceiver" "destinationNames" $destinations "type" "logs" "ecosystem" "loki") | indent 4 | trim }}
   ]
 }
-{{- include "pipeline.alloy.feature.render.forFeature" (dict "root" $ "featureKey" "lokiLogsReceiver" "destinationNames" $destinations "type" "logs" "ecosystem" "loki") }}
+{{- include "dataProcessors.pipeline.render.forFeature" (dict "root" $ "featureKey" "lokiLogsReceiver" "destinationNames" $destinations "type" "logs" "ecosystem" "loki") }}
 {{- end -}}
 {{- end -}}
 

--- a/charts/k8s-monitoring/templates/features/_feature_node_logs.tpl
+++ b/charts/k8s-monitoring/templates/features/_feature_node_logs.tpl
@@ -8,10 +8,10 @@
 {{- include "feature.nodeLogs.module" (dict "Values" .Values.nodeLogs "Files" $.Subcharts.nodeLogs.Files "Template" $.Template) }}
 node_logs "feature" {
   logs_destinations = [
-    {{ include "pipeline.alloy.targets.forFeature" (dict "root" $ "featureKey" "nodeLogs" "destinationNames" $destinations "type" "logs" "ecosystem" "loki") | indent 4 | trim }}
+    {{ include "dataProcessors.pipeline.targets.forFeature" (dict "root" $ "featureKey" "nodeLogs" "destinationNames" $destinations "type" "logs" "ecosystem" "loki") | indent 4 | trim }}
   ]
 }
-{{- include "pipeline.alloy.feature.render.forFeature" (dict "root" $ "featureKey" "nodeLogs" "destinationNames" $destinations "type" "logs" "ecosystem" "loki") }}
+{{- include "dataProcessors.pipeline.render.forFeature" (dict "root" $ "featureKey" "nodeLogs" "destinationNames" $destinations "type" "logs" "ecosystem" "loki") }}
 {{- end -}}
 {{- end -}}
 

--- a/charts/k8s-monitoring/templates/features/_feature_pod_logs_objects.tpl
+++ b/charts/k8s-monitoring/templates/features/_feature_pod_logs_objects.tpl
@@ -8,10 +8,10 @@
 {{- include "feature.podLogsObjects.module" (dict "Values" .Values.podLogsObjects "Files" $.Subcharts.podLogsObjects.Files "Template" $.Template) }}
 pod_logs_objects "feature" {
   logs_destinations = [
-    {{ include "pipeline.alloy.targets.forFeature" (dict "root" $ "featureKey" "podLogsObjects" "destinationNames" $destinations "type" "logs" "ecosystem" "loki") | indent 4 | trim }}
+    {{ include "dataProcessors.pipeline.targets.forFeature" (dict "root" $ "featureKey" "podLogsObjects" "destinationNames" $destinations "type" "logs" "ecosystem" "loki") | indent 4 | trim }}
   ]
 }
-{{- include "pipeline.alloy.feature.render.forFeature" (dict "root" $ "featureKey" "podLogsObjects" "destinationNames" $destinations "type" "logs" "ecosystem" "loki") }}
+{{- include "dataProcessors.pipeline.render.forFeature" (dict "root" $ "featureKey" "podLogsObjects" "destinationNames" $destinations "type" "logs" "ecosystem" "loki") }}
 {{- end -}}
 {{- end -}}
 

--- a/charts/k8s-monitoring/templates/features/_feature_pod_logs_via_kubernetes_api.tpl
+++ b/charts/k8s-monitoring/templates/features/_feature_pod_logs_via_kubernetes_api.tpl
@@ -8,10 +8,10 @@
 {{- include "feature.podLogsViaKubernetesApi.module" (dict "Values" .Values.podLogsViaKubernetesApi "Files" $.Subcharts.podLogsViaKubernetesApi.Files "Template" $.Template) }}
 pod_logs_via_kubernetes_api "feature" {
   logs_destinations = [
-    {{ include "pipeline.alloy.targets.forFeature" (dict "root" $ "featureKey" "podLogsViaKubernetesApi" "destinationNames" $destinations "type" "logs" "ecosystem" "loki") | indent 4 | trim }}
+    {{ include "dataProcessors.pipeline.targets.forFeature" (dict "root" $ "featureKey" "podLogsViaKubernetesApi" "destinationNames" $destinations "type" "logs" "ecosystem" "loki") | indent 4 | trim }}
   ]
 }
-{{- include "pipeline.alloy.feature.render.forFeature" (dict "root" $ "featureKey" "podLogsViaKubernetesApi" "destinationNames" $destinations "type" "logs" "ecosystem" "loki") }}
+{{- include "dataProcessors.pipeline.render.forFeature" (dict "root" $ "featureKey" "podLogsViaKubernetesApi" "destinationNames" $destinations "type" "logs" "ecosystem" "loki") }}
 {{- end -}}
 {{- end -}}
 

--- a/charts/k8s-monitoring/templates/features/_feature_pod_logs_via_loki.tpl
+++ b/charts/k8s-monitoring/templates/features/_feature_pod_logs_via_loki.tpl
@@ -11,10 +11,10 @@
 {{- include "feature.podLogsViaLoki.module" (dict "Values" $values "Files" $.Subcharts.podLogsViaLoki.Files "Template" $.Template) }}
 pod_logs_via_loki "feature" {
   logs_destinations = [
-    {{ include "pipeline.alloy.targets.forFeature" (dict "root" $ "featureKey" "podLogsViaLoki" "destinationNames" $destinations "type" "logs" "ecosystem" "loki") | indent 4 | trim }}
+    {{ include "dataProcessors.pipeline.targets.forFeature" (dict "root" $ "featureKey" "podLogsViaLoki" "destinationNames" $destinations "type" "logs" "ecosystem" "loki") | indent 4 | trim }}
   ]
 }
-{{- include "pipeline.alloy.feature.render.forFeature" (dict "root" $ "featureKey" "podLogsViaLoki" "destinationNames" $destinations "type" "logs" "ecosystem" "loki") }}
+{{- include "dataProcessors.pipeline.render.forFeature" (dict "root" $ "featureKey" "podLogsViaLoki" "destinationNames" $destinations "type" "logs" "ecosystem" "loki") }}
 {{- end -}}
 {{- end -}}
 

--- a/charts/k8s-monitoring/templates/features/_feature_pod_logs_via_opentelemetry.tpl
+++ b/charts/k8s-monitoring/templates/features/_feature_pod_logs_via_opentelemetry.tpl
@@ -8,10 +8,10 @@
 {{- include "feature.podLogsViaOpenTelemetry.module" (dict "Values" .Values.podLogsViaOpenTelemetry "Files" $.Subcharts.podLogsViaOpenTelemetry.Files) }}
 pod_logs_via_opentelemetry "feature" {
   logs_destinations = [
-    {{ include "pipeline.alloy.targets.forFeature" (dict "root" $ "featureKey" "podLogsViaOpenTelemetry" "destinationNames" $destinations "type" "logs" "ecosystem" "otlp") | indent 4 | trim }}
+    {{ include "dataProcessors.pipeline.targets.forFeature" (dict "root" $ "featureKey" "podLogsViaOpenTelemetry" "destinationNames" $destinations "type" "logs" "ecosystem" "otlp") | indent 4 | trim }}
   ]
 }
-{{- include "pipeline.alloy.feature.render.forFeature" (dict "root" $ "featureKey" "podLogsViaOpenTelemetry" "destinationNames" $destinations "type" "logs" "ecosystem" "otlp") }}
+{{- include "dataProcessors.pipeline.render.forFeature" (dict "root" $ "featureKey" "podLogsViaOpenTelemetry" "destinationNames" $destinations "type" "logs" "ecosystem" "otlp") }}
 {{- end -}}
 {{- end -}}
 

--- a/charts/k8s-monitoring/templates/features/_feature_profiles_receiver.tpl
+++ b/charts/k8s-monitoring/templates/features/_feature_profiles_receiver.tpl
@@ -7,10 +7,10 @@
 {{- include "feature.profilesReceiver.module" (dict "Values" $.Values.profilesReceiver "Files" $.Subcharts.profilesReceiver.Files) }}
 profiles_receiver "feature" {
   profiles_destinations = [
-    {{ include "pipeline.alloy.targets.forFeature" (dict "root" $ "featureKey" "profilesReceiver" "destinationNames" $destinations "type" "profiles" "ecosystem" "pyroscope") | indent 4 | trim }}
+    {{ include "dataProcessors.pipeline.targets.forFeature" (dict "root" $ "featureKey" "profilesReceiver" "destinationNames" $destinations "type" "profiles" "ecosystem" "pyroscope") | indent 4 | trim }}
   ]
 }
-{{- include "pipeline.alloy.feature.render.forFeature" (dict "root" $ "featureKey" "profilesReceiver" "destinationNames" $destinations "type" "profiles" "ecosystem" "pyroscope") }}
+{{- include "dataProcessors.pipeline.render.forFeature" (dict "root" $ "featureKey" "profilesReceiver" "destinationNames" $destinations "type" "profiles" "ecosystem" "pyroscope") }}
 {{- end -}}
 {{- end -}}
 

--- a/charts/k8s-monitoring/templates/features/_feature_profiling.tpl
+++ b/charts/k8s-monitoring/templates/features/_feature_profiling.tpl
@@ -52,10 +52,10 @@
 {{- include "feature.profiling.module" (dict "Values" $profilingValues "Files" $.Subcharts.profiling.Files) }}
 profiling "feature" {
   profiles_destinations = [
-    {{ include "pipeline.alloy.targets.forFeature" (dict "root" $ "featureKey" "profiling" "destinationNames" $destinations "type" "profiles" "ecosystem" "pyroscope") | indent 4 | trim }}
+    {{ include "dataProcessors.pipeline.targets.forFeature" (dict "root" $ "featureKey" "profiling" "destinationNames" $destinations "type" "profiles" "ecosystem" "pyroscope") | indent 4 | trim }}
   ]
 }
-{{- include "pipeline.alloy.feature.render.forFeature" (dict "root" $ "featureKey" "profiling" "destinationNames" $destinations "type" "profiles" "ecosystem" "pyroscope") }}
+{{- include "dataProcessors.pipeline.render.forFeature" (dict "root" $ "featureKey" "profiling" "destinationNames" $destinations "type" "profiles" "ecosystem" "pyroscope") }}
 {{- end -}}
 {{- end -}}
 

--- a/charts/k8s-monitoring/templates/features/_feature_prometheus_metrics_receiver.tpl
+++ b/charts/k8s-monitoring/templates/features/_feature_prometheus_metrics_receiver.tpl
@@ -7,10 +7,10 @@
 {{- include "feature.prometheusMetricsReceiver.module" (dict "Values" $.Values.prometheusMetricsReceiver "Files" $.Subcharts.prometheusMetricsReceiver.Files) }}
 prometheus_metrics_receiver "feature" {
   metrics_destinations = [
-    {{ include "pipeline.alloy.targets.forFeature" (dict "root" $ "featureKey" "prometheusMetricsReceiver" "destinationNames" $destinations "type" "metrics" "ecosystem" "prometheus") | indent 4 | trim }}
+    {{ include "dataProcessors.pipeline.targets.forFeature" (dict "root" $ "featureKey" "prometheusMetricsReceiver" "destinationNames" $destinations "type" "metrics" "ecosystem" "prometheus") | indent 4 | trim }}
   ]
 }
-{{- include "pipeline.alloy.feature.render.forFeature" (dict "root" $ "featureKey" "prometheusMetricsReceiver" "destinationNames" $destinations "type" "metrics" "ecosystem" "prometheus") }}
+{{- include "dataProcessors.pipeline.render.forFeature" (dict "root" $ "featureKey" "prometheusMetricsReceiver" "destinationNames" $destinations "type" "metrics" "ecosystem" "prometheus") }}
 {{- end -}}
 {{- end -}}
 

--- a/charts/k8s-monitoring/templates/features/_feature_prometheus_operator_obejcts.tpl
+++ b/charts/k8s-monitoring/templates/features/_feature_prometheus_operator_obejcts.tpl
@@ -7,10 +7,10 @@
 {{- include "feature.prometheusOperatorObjects.module" (dict "Values" $.Values.prometheusOperatorObjects "Files" $.Subcharts.prometheusOperatorObjects.Files) }}
 prometheus_operator_objects "feature" {
   metrics_destinations = [
-    {{ include "pipeline.alloy.targets.forFeature" (dict "root" $ "featureKey" "prometheusOperatorObjects" "destinationNames" $destinations "type" "metrics" "ecosystem" "prometheus") | indent 4 | trim }}
+    {{ include "dataProcessors.pipeline.targets.forFeature" (dict "root" $ "featureKey" "prometheusOperatorObjects" "destinationNames" $destinations "type" "metrics" "ecosystem" "prometheus") | indent 4 | trim }}
   ]
 }
-{{- include "pipeline.alloy.feature.render.forFeature" (dict "root" $ "featureKey" "prometheusOperatorObjects" "destinationNames" $destinations "type" "metrics" "ecosystem" "prometheus") }}
+{{- include "dataProcessors.pipeline.render.forFeature" (dict "root" $ "featureKey" "prometheusOperatorObjects" "destinationNames" $destinations "type" "metrics" "ecosystem" "prometheus") }}
 {{- end -}}
 {{- end -}}
 

--- a/charts/k8s-monitoring/templates/features/_feature_self_reporting.tpl
+++ b/charts/k8s-monitoring/templates/features/_feature_self_reporting.tpl
@@ -110,7 +110,7 @@ prometheus.relabel "kubernetes_monitoring_telemetry" {
     action = "keep"
   }
   forward_to = [
-    {{ include "pipeline.alloy.targets.forFeature" (dict "root" $ "featureKey" "selfReporting" "destinationNames" $destinations "type" "metrics" "ecosystem" "prometheus") | indent 4 | trim }}
+    {{ include "dataProcessors.pipeline.targets.forFeature" (dict "root" $ "featureKey" "selfReporting" "destinationNames" $destinations "type" "metrics" "ecosystem" "prometheus") | indent 4 | trim }}
   ]
 } // prometheus.relabel "kubernetes_monitoring_telemetry"
   {{- else }}
@@ -129,11 +129,11 @@ prometheus.scrape "kubernetes_monitoring_telemetry" {
     enabled = true
   }
   forward_to = [
-    {{ include "pipeline.alloy.targets.forFeature" (dict "root" $ "featureKey" "selfReporting" "destinationNames" $destinations "type" "metrics" "ecosystem" "prometheus") | indent 4 | trim }}
+    {{ include "dataProcessors.pipeline.targets.forFeature" (dict "root" $ "featureKey" "selfReporting" "destinationNames" $destinations "type" "metrics" "ecosystem" "prometheus") | indent 4 | trim }}
   ]
 } // prometheus.scrape "kubernetes_monitoring_telemetry"
   {{- end }}
-{{- include "pipeline.alloy.feature.render.forFeature" (dict "root" $ "featureKey" "selfReporting" "destinationNames" $destinations "type" "metrics" "ecosystem" "prometheus") }}
+{{- include "dataProcessors.pipeline.render.forFeature" (dict "root" $ "featureKey" "selfReporting" "destinationNames" $destinations "type" "metrics" "ecosystem" "prometheus") }}
 {{- end }}
 {{- end }}
 

--- a/charts/k8s-monitoring/templates/features/_feature_windows_event_logs.tpl
+++ b/charts/k8s-monitoring/templates/features/_feature_windows_event_logs.tpl
@@ -8,10 +8,10 @@
 {{- include "feature.windowsEventLogs.module" (dict "Values" .Values.windowsEventLogs "Files" $.Subcharts.windowsEventLogs.Files "Template" $.Template) }}
 windows_event_logs "feature" {
   logs_destinations = [
-    {{ include "pipeline.alloy.targets.forFeature" (dict "root" $ "featureKey" "windowsEventLogs" "destinationNames" $destinations "type" "logs" "ecosystem" "loki") | indent 4 | trim }}
+    {{ include "dataProcessors.pipeline.targets.forFeature" (dict "root" $ "featureKey" "windowsEventLogs" "destinationNames" $destinations "type" "logs" "ecosystem" "loki") | indent 4 | trim }}
   ]
 }
-{{- include "pipeline.alloy.feature.render.forFeature" (dict "root" $ "featureKey" "windowsEventLogs" "destinationNames" $destinations "type" "logs" "ecosystem" "loki") }}
+{{- include "dataProcessors.pipeline.render.forFeature" (dict "root" $ "featureKey" "windowsEventLogs" "destinationNames" $destinations "type" "logs" "ecosystem" "loki") }}
 {{- end -}}
 {{- end -}}
 

--- a/charts/k8s-monitoring/tests/dataProcessor_kubernetesEnrichment_test.yaml
+++ b/charts/k8s-monitoring/tests/dataProcessor_kubernetesEnrichment_test.yaml
@@ -404,3 +404,162 @@ tests:
     asserts:
       - failedTemplate:
           errorPattern: 'The processor "k8s-enrich" requires Alloy to use the experimental stability level when enriching metrics'
+
+  # Regression test for #3014: when two features on the same collector share a processor, the shared
+  # chain body (slices, output sink, gates, pod discovery) must render exactly once, while each
+  # feature keeps its own stamper. Duplicate block declarations made Alloy fail to load the config.
+  - it: renders a shared processor chain body once when two features on one collector share a processor
+    template: alloy-config.yaml
+    set:
+      cluster: {name: test-cluster}
+      selfReporting: {enabled: false}
+      destinations:
+        prometheus:
+          type: prometheus
+          url: http://prometheus.example.com/api/v1/write
+      dataProcessors:
+        setTenantId:
+          type: kubernetesEnrichment
+          namespaceLabels: {team: team}
+      clusterMetrics:
+        enabled: true
+        collector: alloy-metrics
+        dataProcessors: [setTenantId]
+      annotationAutodiscovery:
+        enabled: true
+        collector: alloy-metrics
+        dataProcessors: [setTenantId]
+      telemetryServices:
+        kube-state-metrics: {deploy: true}
+      collectors:
+        alloy-metrics:
+          presets: [clustered, statefulset]
+          alloy: {stabilityLevel: experimental}
+    asserts:
+      - isKind:
+          of: ConfigMap
+      # Each feature keeps its own stamper (stampers are keyed by feature).
+      - matchRegex:
+          path: data["config.alloy"]
+          pattern: 'prometheus\.relabel "clustermetrics_stamp_metrics_prometheus"'
+      - matchRegex:
+          path: data["config.alloy"]
+          pattern: 'prometheus\.relabel "annotationautodiscovery_stamp_metrics_prometheus"'
+      # The shared chain body (input, enrich, output sink, gate) and pod discovery each appear once.
+      # `\{` anchors to the opening declaration (the closing `} // ...` comment repeats the name).
+      # The (?s) double-declaration pattern must NOT match — that would mean a duplicate block.
+      - matchRegex:
+          path: data["config.alloy"]
+          pattern: 'prometheus\.enrich "settenantid_ns_metrics_prometheus" \{'
+      - notMatchRegex:
+          path: data["config.alloy"]
+          pattern: '(?s)prometheus\.enrich "settenantid_ns_metrics_prometheus" \{.*prometheus\.enrich "settenantid_ns_metrics_prometheus" \{'
+      - notMatchRegex:
+          path: data["config.alloy"]
+          pattern: '(?s)prometheus\.relabel "settenantid_in_metrics_prometheus" \{.*prometheus\.relabel "settenantid_in_metrics_prometheus" \{'
+      - notMatchRegex:
+          path: data["config.alloy"]
+          pattern: '(?s)prometheus\.relabel "settenantid_out_metrics_prometheus" \{.*prometheus\.relabel "settenantid_out_metrics_prometheus" \{'
+      - notMatchRegex:
+          path: data["config.alloy"]
+          pattern: '(?s)prometheus\.relabel "settenantid_prometheus_gate_metrics_prometheus" \{.*prometheus\.relabel "settenantid_prometheus_gate_metrics_prometheus" \{'
+      - notMatchRegex:
+          path: data["config.alloy"]
+          pattern: '(?s)discovery\.kubernetes "settenantid_pods" \{.*discovery\.kubernetes "settenantid_pods" \{'
+      # Stampers forward into the single shared processor input.
+      - matchRegex:
+          path: data["config.alloy"]
+          pattern: 'forward_to = \[prometheus\.relabel\.settenantid_in_metrics_prometheus\.receiver\]'
+
+  # Companion to #3014: two features sharing a processor but sending to different destinations. The
+  # single shared chain body must carry a gate for EACH destination (the union), while each feature's
+  # stamper stamps only its own destination into selected_destinations.
+  - it: unions destinations across features that share a processor on one collector
+    template: alloy-config.yaml
+    set:
+      cluster: {name: test-cluster}
+      selfReporting: {enabled: false}
+      destinations:
+        proma:
+          type: prometheus
+          url: http://proma.example.com/api/v1/write
+        promb:
+          type: prometheus
+          url: http://promb.example.com/api/v1/write
+      dataProcessors:
+        setTenantId:
+          type: kubernetesEnrichment
+          namespaceLabels: {team: team}
+      clusterMetrics:
+        enabled: true
+        collector: alloy-metrics
+        destinations: [proma]
+        dataProcessors: [setTenantId]
+      annotationAutodiscovery:
+        enabled: true
+        collector: alloy-metrics
+        destinations: [promb]
+        dataProcessors: [setTenantId]
+      telemetryServices:
+        kube-state-metrics: {deploy: true}
+      collectors:
+        alloy-metrics:
+          presets: [clustered, statefulset]
+          alloy: {stabilityLevel: experimental}
+    asserts:
+      - isKind:
+          of: ConfigMap
+      # The shared enrich block still renders exactly once.
+      - matchRegex:
+          path: data["config.alloy"]
+          pattern: 'prometheus\.enrich "settenantid_ns_metrics_prometheus" \{'
+      - notMatchRegex:
+          path: data["config.alloy"]
+          pattern: '(?s)prometheus\.enrich "settenantid_ns_metrics_prometheus" \{.*prometheus\.enrich "settenantid_ns_metrics_prometheus" \{'
+      # A gate is emitted for BOTH destinations (the union), off the single shared terminal processor.
+      - matchRegex:
+          path: data["config.alloy"]
+          pattern: 'prometheus\.relabel "settenantid_proma_gate_metrics_prometheus" \{'
+      - matchRegex:
+          path: data["config.alloy"]
+          pattern: 'prometheus\.relabel "settenantid_promb_gate_metrics_prometheus" \{'
+      # Each feature's stamper stamps only its own destination into selected_destinations.
+      - matchRegex:
+          path: data["config.alloy"]
+          pattern: '(?s)prometheus\.relabel "clustermetrics_stamp_metrics_prometheus" \{.*replacement  = "proma"'
+      - matchRegex:
+          path: data["config.alloy"]
+          pattern: '(?s)prometheus\.relabel "annotationautodiscovery_stamp_metrics_prometheus" \{.*replacement  = "promb"'
+
+  # A processor's components are shared per collector, so two features on one collector cannot use the
+  # same processor in different chains — that would require its shared components to carry two wirings.
+  # This must fail fast with a clear message rather than emit a config Alloy rejects.
+  - it: fails when two features on one collector use a processor in different chains
+    template: alloy-config.yaml
+    set:
+      cluster: {name: test-cluster}
+      selfReporting: {enabled: false}
+      destinations:
+        prometheus:
+          type: prometheus
+          url: http://prometheus.example.com/api/v1/write
+      dataProcessors:
+        procA: {type: kubernetesEnrichment, namespaceLabels: {a: a}}
+        procB: {type: kubernetesEnrichment, namespaceLabels: {b: b}}
+      clusterMetrics:
+        enabled: true
+        collector: alloy-metrics
+        dataProcessors: [procA]
+      annotationAutodiscovery:
+        enabled: true
+        collector: alloy-metrics
+        dataProcessors: [procA, procB]
+      telemetryServices:
+        kube-state-metrics: {deploy: true}
+      collectors:
+        alloy-metrics:
+          presets: [clustered, statefulset]
+          alloy: {stabilityLevel: experimental}
+    asserts:
+      - failedTemplate:
+          errorPattern: 'The data processor "procA" is used in two different processor chains on collector "alloy-metrics"'

--- a/charts/k8s-monitoring/tests/destination_router_validations_test.yaml
+++ b/charts/k8s-monitoring/tests/destination_router_validations_test.yaml
@@ -681,7 +681,7 @@ tests:
 # This suite covers destinations.router.assertCanCarry, the seam check that replaced the old,
 # false-positive-prone R10 (see destinations/_destination_router_validations.tpl). Unlike the
 # suite above, these cases need a real, enabled feature forwarding real telemetry through the
-# router -- that is the whole point of the seam (only pipeline.alloy.targets.forFeature knows
+# router -- that is the whole point of the seam (only dataProcessors.pipeline.targets.forFeature knows
 # which signal a feature is actually sending, and via which collection ecosystem) -- so they
 # render alloy-config.yaml, not validations.yaml.
 suite: Validations - Router Destination Seam Check (destinations.router.assertCanCarry)

--- a/charts/k8s-monitoring/tests/platform/eks-alloy-on-windows/.rendered/alloy-linux.alloy
+++ b/charts/k8s-monitoring/tests/platform/eks-alloy-on-windows/.rendered/alloy-linux.alloy
@@ -283,30 +283,6 @@ prometheus.relabel "clustermetrics_stamp_metrics_prometheus" {
     replacement  = "grafana-cloud-metrics"
   }
 }
-// Processor: ec2-tags (ec2Enrichment) — metrics/prometheus
-prometheus.enrich "ec2_tags_in_metrics_prometheus" {
-  targets = discovery.relabel.ec2_tags_instances.output
-  target_to_metric_match = {
-    "__meta_ec2_private_dns_name" = "node",
-  }
-  labels_to_copy = ["team"]
-  forward_to = [prometheus.relabel.ec2_tags_out_metrics_prometheus.receiver]
-} // prometheus.enrich "ec2_tags_in_metrics_prometheus"
-prometheus.relabel "ec2_tags_out_metrics_prometheus" {
-  forward_to = [prometheus.relabel.ec2_tags_grafana_cloud_metrics_gate_metrics_prometheus.receiver]
-}
-prometheus.relabel "ec2_tags_grafana_cloud_metrics_gate_metrics_prometheus" {
-  forward_to = [prometheus.remote_write.grafana_cloud_metrics.receiver]
-  rule {
-    source_labels = ["selected_destinations"]
-    regex         = "(^|.*,)grafana-cloud-metrics(,.*|$)"
-    action        = "keep"
-  }
-  rule {
-    action = "labeldrop"
-    regex  = "selected_destinations"
-  }
-}
 // Feature: Cluster Events
 declare "cluster_events" {
   argument "logs_destinations" {
@@ -1450,6 +1426,30 @@ prometheus.scrape "kubernetes_monitoring_telemetry" {
     prometheus.remote_write.grafana_cloud_metrics.receiver,
   ]
 } // prometheus.scrape "kubernetes_monitoring_telemetry"
+// Processor: ec2-tags (ec2Enrichment) — metrics/prometheus
+prometheus.enrich "ec2_tags_in_metrics_prometheus" {
+  targets = discovery.relabel.ec2_tags_instances.output
+  target_to_metric_match = {
+    "__meta_ec2_private_dns_name" = "node",
+  }
+  labels_to_copy = ["team"]
+  forward_to = [prometheus.relabel.ec2_tags_out_metrics_prometheus.receiver]
+} // prometheus.enrich "ec2_tags_in_metrics_prometheus"
+prometheus.relabel "ec2_tags_out_metrics_prometheus" {
+  forward_to = [prometheus.relabel.ec2_tags_grafana_cloud_metrics_gate_metrics_prometheus.receiver]
+}
+prometheus.relabel "ec2_tags_grafana_cloud_metrics_gate_metrics_prometheus" {
+  forward_to = [prometheus.remote_write.grafana_cloud_metrics.receiver]
+  rule {
+    source_labels = ["selected_destinations"]
+    regex         = "(^|.*,)grafana-cloud-metrics(,.*|$)"
+    action        = "keep"
+  }
+  rule {
+    action = "labeldrop"
+    regex  = "selected_destinations"
+  }
+}
 // Processor: ec2-tags (ec2Enrichment) — shared EC2 instance discovery
 discovery.ec2 "ec2_tags_instances" {
   region = "ap-northeast-2"

--- a/charts/k8s-monitoring/tests/platform/eks-alloy-on-windows/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/platform/eks-alloy-on-windows/.rendered/output.yaml
@@ -336,30 +336,6 @@ data:
         replacement  = "grafana-cloud-metrics"
       }
     }
-    // Processor: ec2-tags (ec2Enrichment) — metrics/prometheus
-    prometheus.enrich "ec2_tags_in_metrics_prometheus" {
-      targets = discovery.relabel.ec2_tags_instances.output
-      target_to_metric_match = {
-        "__meta_ec2_private_dns_name" = "node",
-      }
-      labels_to_copy = ["team"]
-      forward_to = [prometheus.relabel.ec2_tags_out_metrics_prometheus.receiver]
-    } // prometheus.enrich "ec2_tags_in_metrics_prometheus"
-    prometheus.relabel "ec2_tags_out_metrics_prometheus" {
-      forward_to = [prometheus.relabel.ec2_tags_grafana_cloud_metrics_gate_metrics_prometheus.receiver]
-    }
-    prometheus.relabel "ec2_tags_grafana_cloud_metrics_gate_metrics_prometheus" {
-      forward_to = [prometheus.remote_write.grafana_cloud_metrics.receiver]
-      rule {
-        source_labels = ["selected_destinations"]
-        regex         = "(^|.*,)grafana-cloud-metrics(,.*|$)"
-        action        = "keep"
-      }
-      rule {
-        action = "labeldrop"
-        regex  = "selected_destinations"
-      }
-    }
     // Feature: Cluster Events
     declare "cluster_events" {
       argument "logs_destinations" {
@@ -1503,6 +1479,30 @@ data:
         prometheus.remote_write.grafana_cloud_metrics.receiver,
       ]
     } // prometheus.scrape "kubernetes_monitoring_telemetry"
+    // Processor: ec2-tags (ec2Enrichment) — metrics/prometheus
+    prometheus.enrich "ec2_tags_in_metrics_prometheus" {
+      targets = discovery.relabel.ec2_tags_instances.output
+      target_to_metric_match = {
+        "__meta_ec2_private_dns_name" = "node",
+      }
+      labels_to_copy = ["team"]
+      forward_to = [prometheus.relabel.ec2_tags_out_metrics_prometheus.receiver]
+    } // prometheus.enrich "ec2_tags_in_metrics_prometheus"
+    prometheus.relabel "ec2_tags_out_metrics_prometheus" {
+      forward_to = [prometheus.relabel.ec2_tags_grafana_cloud_metrics_gate_metrics_prometheus.receiver]
+    }
+    prometheus.relabel "ec2_tags_grafana_cloud_metrics_gate_metrics_prometheus" {
+      forward_to = [prometheus.remote_write.grafana_cloud_metrics.receiver]
+      rule {
+        source_labels = ["selected_destinations"]
+        regex         = "(^|.*,)grafana-cloud-metrics(,.*|$)"
+        action        = "keep"
+      }
+      rule {
+        action = "labeldrop"
+        regex  = "selected_destinations"
+      }
+    }
     // Processor: ec2-tags (ec2Enrichment) — shared EC2 instance discovery
     discovery.ec2 "ec2_tags_instances" {
       region = "ap-northeast-2"

--- a/charts/k8s-monitoring/tests/platform/eks-with-windows/.rendered/alloy.alloy
+++ b/charts/k8s-monitoring/tests/platform/eks-with-windows/.rendered/alloy.alloy
@@ -554,30 +554,6 @@ prometheus.relabel "clustermetrics_stamp_metrics_prometheus" {
     replacement  = "grafana-cloud-metrics"
   }
 }
-// Processor: ec2-tags (ec2Enrichment) — metrics/prometheus
-prometheus.enrich "ec2_tags_in_metrics_prometheus" {
-  targets = discovery.relabel.ec2_tags_instances.output
-  target_to_metric_match = {
-    "__meta_ec2_private_dns_name" = "node",
-  }
-  labels_to_copy = ["team"]
-  forward_to = [prometheus.relabel.ec2_tags_out_metrics_prometheus.receiver]
-} // prometheus.enrich "ec2_tags_in_metrics_prometheus"
-prometheus.relabel "ec2_tags_out_metrics_prometheus" {
-  forward_to = [prometheus.relabel.ec2_tags_grafana_cloud_metrics_gate_metrics_prometheus.receiver]
-}
-prometheus.relabel "ec2_tags_grafana_cloud_metrics_gate_metrics_prometheus" {
-  forward_to = [prometheus.remote_write.grafana_cloud_metrics.receiver]
-  rule {
-    source_labels = ["selected_destinations"]
-    regex         = "(^|.*,)grafana-cloud-metrics(,.*|$)"
-    action        = "keep"
-  }
-  rule {
-    action = "labeldrop"
-    regex  = "selected_destinations"
-  }
-}
 // Feature: Cluster Events
 declare "cluster_events" {
   argument "logs_destinations" {
@@ -1823,6 +1799,30 @@ prometheus.scrape "kubernetes_monitoring_telemetry" {
     prometheus.remote_write.grafana_cloud_metrics.receiver,
   ]
 } // prometheus.scrape "kubernetes_monitoring_telemetry"
+// Processor: ec2-tags (ec2Enrichment) — metrics/prometheus
+prometheus.enrich "ec2_tags_in_metrics_prometheus" {
+  targets = discovery.relabel.ec2_tags_instances.output
+  target_to_metric_match = {
+    "__meta_ec2_private_dns_name" = "node",
+  }
+  labels_to_copy = ["team"]
+  forward_to = [prometheus.relabel.ec2_tags_out_metrics_prometheus.receiver]
+} // prometheus.enrich "ec2_tags_in_metrics_prometheus"
+prometheus.relabel "ec2_tags_out_metrics_prometheus" {
+  forward_to = [prometheus.relabel.ec2_tags_grafana_cloud_metrics_gate_metrics_prometheus.receiver]
+}
+prometheus.relabel "ec2_tags_grafana_cloud_metrics_gate_metrics_prometheus" {
+  forward_to = [prometheus.remote_write.grafana_cloud_metrics.receiver]
+  rule {
+    source_labels = ["selected_destinations"]
+    regex         = "(^|.*,)grafana-cloud-metrics(,.*|$)"
+    action        = "keep"
+  }
+  rule {
+    action = "labeldrop"
+    regex  = "selected_destinations"
+  }
+}
 // Processor: ec2-tags (ec2Enrichment) — shared EC2 instance discovery
 discovery.ec2 "ec2_tags_instances" {
   region = "ap-northeast-2"

--- a/charts/k8s-monitoring/tests/platform/eks-with-windows/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/platform/eks-with-windows/.rendered/output.yaml
@@ -650,30 +650,6 @@ data:
         replacement  = "grafana-cloud-metrics"
       }
     }
-    // Processor: ec2-tags (ec2Enrichment) — metrics/prometheus
-    prometheus.enrich "ec2_tags_in_metrics_prometheus" {
-      targets = discovery.relabel.ec2_tags_instances.output
-      target_to_metric_match = {
-        "__meta_ec2_private_dns_name" = "node",
-      }
-      labels_to_copy = ["team"]
-      forward_to = [prometheus.relabel.ec2_tags_out_metrics_prometheus.receiver]
-    } // prometheus.enrich "ec2_tags_in_metrics_prometheus"
-    prometheus.relabel "ec2_tags_out_metrics_prometheus" {
-      forward_to = [prometheus.relabel.ec2_tags_grafana_cloud_metrics_gate_metrics_prometheus.receiver]
-    }
-    prometheus.relabel "ec2_tags_grafana_cloud_metrics_gate_metrics_prometheus" {
-      forward_to = [prometheus.remote_write.grafana_cloud_metrics.receiver]
-      rule {
-        source_labels = ["selected_destinations"]
-        regex         = "(^|.*,)grafana-cloud-metrics(,.*|$)"
-        action        = "keep"
-      }
-      rule {
-        action = "labeldrop"
-        regex  = "selected_destinations"
-      }
-    }
     // Feature: Cluster Events
     declare "cluster_events" {
       argument "logs_destinations" {
@@ -1919,6 +1895,30 @@ data:
         prometheus.remote_write.grafana_cloud_metrics.receiver,
       ]
     } // prometheus.scrape "kubernetes_monitoring_telemetry"
+    // Processor: ec2-tags (ec2Enrichment) — metrics/prometheus
+    prometheus.enrich "ec2_tags_in_metrics_prometheus" {
+      targets = discovery.relabel.ec2_tags_instances.output
+      target_to_metric_match = {
+        "__meta_ec2_private_dns_name" = "node",
+      }
+      labels_to_copy = ["team"]
+      forward_to = [prometheus.relabel.ec2_tags_out_metrics_prometheus.receiver]
+    } // prometheus.enrich "ec2_tags_in_metrics_prometheus"
+    prometheus.relabel "ec2_tags_out_metrics_prometheus" {
+      forward_to = [prometheus.relabel.ec2_tags_grafana_cloud_metrics_gate_metrics_prometheus.receiver]
+    }
+    prometheus.relabel "ec2_tags_grafana_cloud_metrics_gate_metrics_prometheus" {
+      forward_to = [prometheus.remote_write.grafana_cloud_metrics.receiver]
+      rule {
+        source_labels = ["selected_destinations"]
+        regex         = "(^|.*,)grafana-cloud-metrics(,.*|$)"
+        action        = "keep"
+      }
+      rule {
+        action = "labeldrop"
+        regex  = "selected_destinations"
+      }
+    }
     // Processor: ec2-tags (ec2Enrichment) — shared EC2 instance discovery
     discovery.ec2 "ec2_tags_instances" {
       region = "ap-northeast-2"


### PR DESCRIPTION
<!--Describe what this change does and why.-->
# Description

If the same data processor is used in multiple features, it could result in duplicate Alloy components inside the configuration for a collector. This separates certain components into their own template functions, so the ones that are used per-collector are rendered once, while the ones attached to the feature are rendered per-feature.

Fixes #3014

<!--Authorship attestation. See AGENTS.md for details. AI agents must not check this box on behalf
of the user; the human author must check it themselves before the PR is ready for review.-->
## Authorship

-   [X] I, a human, wrote this pull request description myself.

<!--Please delete paragraphs that you did not use before submitting.-->
