### PR TITLE
Fix the nodeLogs journal job label

### DIFF
--- a/charts/k8s-monitoring/CHANGELOG.md
+++ b/charts/k8s-monitoring/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 4.5.1
 
+*   Fix incorrect `job` label for nodeLogs feature. (@petewall)
 *   Update Alloy Operator to 0.7.1 (@petewall)
 
 ## 4.5.0

--- a/charts/k8s-monitoring/charts/feature-node-logs/templates/_module.alloy.tpl
+++ b/charts/k8s-monitoring/charts/feature-node-logs/templates/_module.alloy.tpl
@@ -83,6 +83,8 @@ declare "node_logs" {
         "source" = "journal",
         // default level to unknown
         level = "UNKNOWN",
+        // Set the `job` label again. Needed until https://github.com/grafana/alloy/issues/6980 is in a release.
+        job = {{ .Values.journal.jobLabel | quote }},
       }
     }
 

--- a/charts/k8s-monitoring/docs/examples/auth/oauth2/alloy-logs.alloy
+++ b/charts/k8s-monitoring/docs/examples/auth/oauth2/alloy-logs.alloy
@@ -51,6 +51,8 @@ declare "node_logs" {
         "source" = "journal",
         // default level to unknown
         level = "UNKNOWN",
+        // Set the `job` label again. Needed until https://github.com/grafana/alloy/issues/6980 is in a release.
+        job = "integrations/kubernetes/journal",
       }
     }
 

--- a/charts/k8s-monitoring/docs/examples/auth/oauth2/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/auth/oauth2/output.yaml
@@ -157,6 +157,8 @@ data:
             "source" = "journal",
             // default level to unknown
             level = "UNKNOWN",
+            // Set the `job` label again. Needed until https://github.com/grafana/alloy/issues/6980 is in a release.
+            job = "integrations/kubernetes/journal",
           }
         }
     

--- a/charts/k8s-monitoring/docs/examples/dataProcessors/ec2Enrichment/alloy.alloy
+++ b/charts/k8s-monitoring/docs/examples/dataProcessors/ec2Enrichment/alloy.alloy
@@ -314,6 +314,8 @@ declare "node_logs" {
         "source" = "journal",
         // default level to unknown
         level = "UNKNOWN",
+        // Set the `job` label again. Needed until https://github.com/grafana/alloy/issues/6980 is in a release.
+        job = "integrations/kubernetes/journal",
       }
     }
 

--- a/charts/k8s-monitoring/docs/examples/dataProcessors/ec2Enrichment/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/dataProcessors/ec2Enrichment/output.yaml
@@ -416,6 +416,8 @@ data:
             "source" = "journal",
             // default level to unknown
             level = "UNKNOWN",
+            // Set the `job` label again. Needed until https://github.com/grafana/alloy/issues/6980 is in a release.
+            job = "integrations/kubernetes/journal",
           }
         }
     

--- a/charts/k8s-monitoring/docs/examples/features/node-logs/default/alloy-logs.alloy
+++ b/charts/k8s-monitoring/docs/examples/features/node-logs/default/alloy-logs.alloy
@@ -56,6 +56,8 @@ declare "node_logs" {
         "source" = "journal",
         // default level to unknown
         level = "UNKNOWN",
+        // Set the `job` label again. Needed until https://github.com/grafana/alloy/issues/6980 is in a release.
+        job = "integrations/kubernetes/journal",
       }
     }
 

--- a/charts/k8s-monitoring/docs/examples/features/node-logs/default/output.yaml
+++ b/charts/k8s-monitoring/docs/examples/features/node-logs/default/output.yaml
@@ -91,6 +91,8 @@ data:
             "source" = "journal",
             // default level to unknown
             level = "UNKNOWN",
+            // Set the `job` label again. Needed until https://github.com/grafana/alloy/issues/6980 is in a release.
+            job = "integrations/kubernetes/journal",
           }
         }
     

--- a/charts/k8s-monitoring/tests/platform/eks-alloy-on-windows/.rendered/alloy-linux.alloy
+++ b/charts/k8s-monitoring/tests/platform/eks-alloy-on-windows/.rendered/alloy-linux.alloy
@@ -895,6 +895,8 @@ declare "node_logs" {
         "source" = "journal",
         // default level to unknown
         level = "UNKNOWN",
+        // Set the `job` label again. Needed until https://github.com/grafana/alloy/issues/6980 is in a release.
+        job = "integrations/kubernetes/journal",
       }
     }
 

--- a/charts/k8s-monitoring/tests/platform/eks-alloy-on-windows/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/platform/eks-alloy-on-windows/.rendered/output.yaml
@@ -948,6 +948,8 @@ data:
             "source" = "journal",
             // default level to unknown
             level = "UNKNOWN",
+            // Set the `job` label again. Needed until https://github.com/grafana/alloy/issues/6980 is in a release.
+            job = "integrations/kubernetes/journal",
           }
         }
     

--- a/charts/k8s-monitoring/tests/platform/eks-with-windows/.rendered/alloy.alloy
+++ b/charts/k8s-monitoring/tests/platform/eks-with-windows/.rendered/alloy.alloy
@@ -1271,6 +1271,8 @@ declare "node_logs" {
         "source" = "journal",
         // default level to unknown
         level = "UNKNOWN",
+        // Set the `job` label again. Needed until https://github.com/grafana/alloy/issues/6980 is in a release.
+        job = "integrations/kubernetes/journal",
       }
     }
 

--- a/charts/k8s-monitoring/tests/platform/eks-with-windows/.rendered/output.yaml
+++ b/charts/k8s-monitoring/tests/platform/eks-with-windows/.rendered/output.yaml
@@ -1367,6 +1367,8 @@ data:
             "source" = "journal",
             // default level to unknown
             level = "UNKNOWN",
+            // Set the `job` label again. Needed until https://github.com/grafana/alloy/issues/6980 is in a release.
+            job = "integrations/kubernetes/journal",
           }
         }
     


### PR DESCRIPTION
<!--Describe what this change does and why.-->
# Description

Alloy 1.19.0 introduced a regression where the `loki.source.journal` component no longer overwrites the default `job` label if you specify it in the labels list. This PR sets the label in the log processing component.

<!--Authorship attestation. See AGENTS.md for details. AI agents must not check this box on behalf
of the user; the human author must check it themselves before the PR is ready for review.-->
## Authorship

-   [x] I, a human, wrote this pull request description myself.

<!--Please delete paragraphs that you did not use before submitting.-->
