### PR TITLE
docs: document OpenCost exporter proxy env in Proxies example

### DIFF
--- a/charts/k8s-monitoring/docs/examples/proxies/description.txt
+++ b/charts/k8s-monitoring/docs/examples/proxies/description.txt
@@ -29,3 +29,10 @@ Another option which will work for all destination types is to use the `HTTP_PRO
 environment variables. For `prometheus`, `loki`, and `pyroscope` destinations, use the `proxy_from_environment` option
 to indicate that the proxy settings should be read from the environment variables. When using this method, watch out
 for issues connecting to the Kubernetes API service, or other internal services.
+
+## OpenCost exporter
+
+The OpenCost exporter also honors the standard proxy environment variables. Set them under
+`telemetryServices.opencost.opencost.exporter.extraEnv` using `HTTP_PROXY`, `HTTPS_PROXY`, and
+`NO_PROXY` so cost metric queries can reach external services through your proxy while still
+excluding in-cluster endpoints as needed.


### PR DESCRIPTION
Fixes #1611

Documents OpenCost exporter HTTP_PROXY/HTTPS_PROXY/NO_PROXY via telemetryServices.opencost.opencost.exporter.extraEnv. README/output.yaml left for make examples.