### PR TITLE
feat(application-observability): add OTLP HTTP receiver timeout and keep-alive settings

### DIFF
--- a/charts/k8s-monitoring/CHANGELOG.md
+++ b/charts/k8s-monitoring/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 ## 4.5.1
 
+*   Add OTLP HTTP receiver timeout and keep-alive settings for the Application Observability feature. (#3029) (@nlamirault)
 *   Fix issue with duplicate configuration block declarations when the same data processor is used by more than one feature on the same collector. (#3014) (@petewall)
 *   Fix incorrect `job` label for nodeLogs feature. (@petewall)
 *   Update Alloy Operator to 0.7.1, kube-state-metrics to 8.4.2, OpenCost to 2.5.30, and Node Exporter to 4.56.3 (@petewall)

--- a/charts/k8s-monitoring/CHANGELOG.md
+++ b/charts/k8s-monitoring/CHANGELOG.md
@@ -2,12 +2,12 @@
 
 ## Unreleased
 
+*   Add OTLP HTTP receiver timeout and keep-alive settings for the Application Observability feature. (#3029) (@nlamirault)
 *   Adds the native histogram scrape options to all Prometheus Operator object types (PodMonitors, Probes, ServiceMonitors) (@nlamirault)
 *   Fix control-plane (Kube Proxy, Kube Controller Manager, Kube Scheduler) and etcd integration scraping on IPv6/dual-stack clusters by using bracket notation for IPv6 pod addresses. (#2999) (@petewall)
 
 ## 4.5.1
 
-*   Add OTLP HTTP receiver timeout and keep-alive settings for the Application Observability feature. (#3029) (@nlamirault)
 *   Fix issue with duplicate configuration block declarations when the same data processor is used by more than one feature on the same collector. (#3014) (@petewall)
 *   Fix incorrect `job` label for nodeLogs feature. (@petewall)
 *   Update Alloy Operator to 0.7.1, kube-state-metrics to 8.4.2, OpenCost to 2.5.30, and Node Exporter to 4.56.3 (@petewall)

--- a/charts/k8s-monitoring/charts/feature-application-observability/README.md
+++ b/charts/k8s-monitoring/charts/feature-application-observability/README.md
@@ -250,9 +250,14 @@ Be sure perform actual integration testing in a live environment in the main [k8
 | receivers.otlp.grpc.readBufferSize | string | `"512KiB"` | Size of the read buffer the gRPC server will use for reading from clients. |
 | receivers.otlp.grpc.writeBufferSize | string | `"32KiB"` | Size of the write buffer the gRPC server will use for writing to clients. |
 | receivers.otlp.http.enabled | bool | `false` | Accept application data over OTLP HTTP. |
+| receivers.otlp.http.idleTimeout | string | `""` | Maximum idle time before closing a keep-alive connection. Default is 1 minute. |
 | receivers.otlp.http.includeMetadata | bool | `false` | Propagate incoming connection metadata to downstream consumers. |
+| receivers.otlp.http.keepAlivesEnabled | string | `""` | Enable or disable HTTP keep-alives. Default is true. |
 | receivers.otlp.http.maxRequestBodySize | string | `"20MiB"` | Maximum request body size the server will allow. |
 | receivers.otlp.http.port | int | `4318` | The port to listen on for OTLP HTTP requests. |
+| receivers.otlp.http.readHeaderTimeout | string | `""` | Maximum time allowed to read request headers. Default is 1 minute. |
+| receivers.otlp.http.readTimeout | string | `""` | Maximum time allowed to read an HTTP request, including the body. Default is no timeout. |
+| receivers.otlp.http.writeTimeout | string | `""` | Maximum time allowed to write an HTTP response. Default is 30 seconds. |
 | receivers.otlp.includeDebugMetrics | bool | `false` | Whether to include high-cardinality debug metrics. |
 
 ### Receivers: Zipkin

--- a/charts/k8s-monitoring/charts/feature-application-observability/schema-mods/types-and-enums.json
+++ b/charts/k8s-monitoring/charts/feature-application-observability/schema-mods/types-and-enums.json
@@ -12,6 +12,19 @@
         }
       }
     },
+    "receivers": {
+      "properties": {
+        "otlp": {
+          "properties": {
+            "http": {
+              "properties": {
+                "keepAlivesEnabled": {"type": ["boolean", "string"]}
+              }
+            }
+          }
+        }
+      }
+    },
     "processors": {
       "properties": {
         "filter": {

--- a/charts/k8s-monitoring/charts/feature-application-observability/templates/_receiver_otlp.tpl
+++ b/charts/k8s-monitoring/charts/feature-application-observability/templates/_receiver_otlp.tpl
@@ -54,6 +54,21 @@ otelcol.receiver.otlp "receiver" {
     endpoint = "0.0.0.0:{{ .Values.receivers.otlp.http.port | int }}"
     include_metadata = {{ .Values.receivers.otlp.http.includeMetadata }}
     max_request_body_size = {{ .Values.receivers.otlp.http.maxRequestBodySize | quote }}
+    {{- if .Values.receivers.otlp.http.idleTimeout }}
+    idle_timeout = {{ .Values.receivers.otlp.http.idleTimeout | quote }}
+    {{- end }}
+    {{- if .Values.receivers.otlp.http.readTimeout }}
+    read_timeout = {{ .Values.receivers.otlp.http.readTimeout | quote }}
+    {{- end }}
+    {{- if .Values.receivers.otlp.http.readHeaderTimeout }}
+    read_header_timeout = {{ .Values.receivers.otlp.http.readHeaderTimeout | quote }}
+    {{- end }}
+    {{- if .Values.receivers.otlp.http.writeTimeout }}
+    write_timeout = {{ .Values.receivers.otlp.http.writeTimeout | quote }}
+    {{- end }}
+    {{- if ne (toString .Values.receivers.otlp.http.keepAlivesEnabled) "" }}
+    keep_alives_enabled = {{ .Values.receivers.otlp.http.keepAlivesEnabled }}
+    {{- end }}
   }
 {{- end }}
   debug_metrics {

--- a/charts/k8s-monitoring/charts/feature-application-observability/tests/__snapshot__/http-timeouts_test.yaml.snap
+++ b/charts/k8s-monitoring/charts/feature-application-observability/tests/__snapshot__/http-timeouts_test.yaml.snap
@@ -1,0 +1,132 @@
+renders the OTLP HTTP server timeout and keep-alive settings:
+  1: |
+    |-
+      declare "application_observability" {
+        argument "metrics_destinations" {
+          comment = "Must be a list of metrics destinations where collected metrics should be forwarded to"
+        }
+
+        argument "logs_destinations" {
+          comment = "Must be a list of log destinations where collected logs should be forwarded to"
+        }
+
+        argument "traces_destinations" {
+          comment = "Must be a list of trace destinations where collected trace should be forwarded to"
+        }
+
+        // OTLP Receiver
+        otelcol.receiver.otlp "receiver" {
+          http {
+            endpoint = "0.0.0.0:4318"
+            include_metadata = false
+            max_request_body_size = "20MiB"
+            idle_timeout = "10m"
+            read_timeout = "30s"
+            read_header_timeout = "2m"
+            write_timeout = "1m"
+            keep_alives_enabled = false
+          }
+          debug_metrics {
+            disable_high_cardinality_metrics = true
+          }
+          output {
+            metrics = [otelcol.processor.resourcedetection.default.input]
+            logs = [otelcol.processor.resourcedetection.default.input]
+            traces = [otelcol.processor.resourcedetection.default.input]
+          }
+        } // otelcol.receiver.otlp "receiver"
+
+        // Resource Detection Processor
+        otelcol.processor.resourcedetection "default" {
+          detectors = ["env","system"]
+          override = true
+
+          system {
+            hostname_sources = ["os"]
+          }
+
+          output {
+            metrics = [otelcol.processor.k8sattributes.default.input]
+            logs = [otelcol.processor.k8sattributes.default.input]
+            traces = [otelcol.processor.k8sattributes.default.input]
+          }
+        }
+
+        // K8s Attributes Processor
+        otelcol.processor.k8sattributes "default" {
+          passthrough = false
+          extract {
+            metadata = ["k8s.namespace.name","k8s.pod.name","k8s.deployment.name","k8s.statefulset.name","k8s.daemonset.name","k8s.cronjob.name","k8s.job.name","k8s.node.name","k8s.pod.uid","k8s.pod.start_time"]
+          }
+          pod_association {
+            source {
+              from = "resource_attribute"
+              name = "k8s.pod.ip"
+            }
+          }
+          pod_association {
+            source {
+              from = "resource_attribute"
+              name = "k8s.pod.uid"
+            }
+          }
+          pod_association {
+            source {
+              from = "connection"
+            }
+          }
+
+          output {
+            metrics = [otelcol.processor.transform.default.input]
+            logs = [otelcol.processor.transform.default.input]
+            traces = [otelcol.processor.transform.default.input, otelcol.connector.host_info.default.input]
+          }
+        }
+
+        // Host Info Connector
+        otelcol.connector.host_info "default" {
+          host_identifiers = [ "k8s.node.name" ]
+
+          output {
+            metrics = [otelcol.processor.batch.default.input]
+          }
+        }
+
+        // Transform Processor
+        otelcol.processor.transform "default" {
+          error_mode = "ignore"
+          log_statements {
+            context = "resource"
+            statements = [
+              "set(attributes[\"pod\"], attributes[\"k8s.pod.name\"])",
+              "set(attributes[\"namespace\"], attributes[\"k8s.namespace.name\"])",
+              "set(attributes[\"loki.resource.labels\"], \"cluster, namespace, job, pod\")",
+            ]
+          }
+          trace_statements {
+            context = "span"
+            statements = [
+             "set_semconv_span_name(\"1.37.0\", \"original_span_name\")",
+            ]
+          }
+
+          output {
+            metrics = [otelcol.processor.batch.default.input]
+            logs = [otelcol.processor.batch.default.input]
+            traces = [otelcol.processor.batch.default.input]
+          }
+        }
+
+        // Batch Processor
+        otelcol.processor.batch "default" {
+          send_batch_size = 8192
+          send_batch_max_size = 0
+          timeout = "2s"
+
+          output {
+            metrics = argument.metrics_destinations.value
+            logs = argument.logs_destinations.value
+            traces = argument.traces_destinations.value
+          }
+        }
+      } // declare "application_observability"

--- a/charts/k8s-monitoring/charts/feature-application-observability/tests/http-timeouts_test.yaml
+++ b/charts/k8s-monitoring/charts/feature-application-observability/tests/http-timeouts_test.yaml
@@ -1,0 +1,24 @@
+# yamllint disable rule:document-start rule:line-length rule:trailing-spaces
+suite: Feature - Application Observability - HTTP timeout settings
+templates:
+  - test/configmap.yaml
+tests:
+  - it: renders the OTLP HTTP server timeout and keep-alive settings
+    set:
+      testing: {enabled: true}
+      receivers:
+        otlp:
+          grpc:
+            enabled: false
+          http:
+            enabled: true
+            idleTimeout: 10m
+            readTimeout: 30s
+            readHeaderTimeout: 2m
+            writeTimeout: 1m
+            keepAlivesEnabled: false
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - matchSnapshot:
+          path: data["module.alloy"]

--- a/charts/k8s-monitoring/charts/feature-application-observability/values.schema.json
+++ b/charts/k8s-monitoring/charts/feature-application-observability/values.schema.json
@@ -549,14 +549,32 @@
                                 "enabled": {
                                     "type": "boolean"
                                 },
+                                "idleTimeout": {
+                                    "type": "string"
+                                },
                                 "includeMetadata": {
                                     "type": "boolean"
+                                },
+                                "keepAlivesEnabled": {
+                                    "type": [
+                                        "boolean",
+                                        "string"
+                                    ]
                                 },
                                 "maxRequestBodySize": {
                                     "type": "string"
                                 },
                                 "port": {
                                     "type": "integer"
+                                },
+                                "readHeaderTimeout": {
+                                    "type": "string"
+                                },
+                                "readTimeout": {
+                                    "type": "string"
+                                },
+                                "writeTimeout": {
+                                    "type": "string"
                                 }
                             }
                         },

--- a/charts/k8s-monitoring/charts/feature-application-observability/values.yaml
+++ b/charts/k8s-monitoring/charts/feature-application-observability/values.yaml
@@ -97,6 +97,28 @@ receivers:
       # @section -- Receivers: OTLP
       maxRequestBodySize: 20MiB
 
+      # Raise idleTimeout above the client connection-pool keep-alive (okhttp defaults to 5m) to avoid
+      # "unexpected end of stream" errors caused by the server closing pooled connections first.
+      # -- Maximum idle time before closing a keep-alive connection. Default is 1 minute.
+      # @section -- Receivers: OTLP
+      idleTimeout: ""
+
+      # -- Maximum time allowed to read an HTTP request, including the body. Default is no timeout.
+      # @section -- Receivers: OTLP
+      readTimeout: ""
+
+      # -- Maximum time allowed to read request headers. Default is 1 minute.
+      # @section -- Receivers: OTLP
+      readHeaderTimeout: ""
+
+      # -- Maximum time allowed to write an HTTP response. Default is 30 seconds.
+      # @section -- Receivers: OTLP
+      writeTimeout: ""
+
+      # -- Enable or disable HTTP keep-alives. Default is true.
+      # @section -- Receivers: OTLP
+      keepAlivesEnabled: ""
+
     # -- Whether to include high-cardinality debug metrics.
     # @section -- Receivers: OTLP
     includeDebugMetrics: false


### PR DESCRIPTION
## Summary

The Application Observability OTLP **HTTP** receiver only exposes `endpoint`, `include_metadata` and `max_request_body_size`, so there is no way to tune the HTTP server's connection lifecycle. The gRPC receiver already exposes `keepalive.server_parameters`, but HTTP has no equivalent.

This surfaces the HTTP server timeout / keep-alive family that `otelcol.receiver.otlp` supports:

- `idleTimeout` → `idle_timeout`
- `readTimeout` → `read_timeout`
- `readHeaderTimeout` → `read_header_timeout`
- `writeTimeout` → `write_timeout`
- `keepAlivesEnabled` → `keep_alives_enabled`

Each attribute is rendered **only when set**, so existing values keep Alloy's built-in defaults and the rendered config is unchanged for current users (verified: existing snapshots unchanged).

https://grafana.com/docs/alloy/latest/reference/components/otelcol/otelcol.receiver.otlp/#http